### PR TITLE
Use real_t in editor plugins

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -81,8 +81,8 @@ public:
 	SnapDialog() {
 		const int SPIN_BOX_GRID_RANGE = 16384;
 		const int SPIN_BOX_ROTATION_RANGE = 360;
-		const float SPIN_BOX_SCALE_MIN = 0.01f;
-		const float SPIN_BOX_SCALE_MAX = 100;
+		const real_t SPIN_BOX_SCALE_MIN = 0.01;
+		const real_t SPIN_BOX_SCALE_MAX = 100;
 
 		Label *label;
 		VBoxContainer *container;
@@ -210,7 +210,7 @@ public:
 		child_container->add_child(scale_step);
 	}
 
-	void set_fields(const Point2 p_grid_offset, const Point2 p_grid_step, const int p_primary_grid_steps, const float p_rotation_offset, const float p_rotation_step, const float p_scale_step) {
+	void set_fields(const Point2 p_grid_offset, const Point2 p_grid_step, const int p_primary_grid_steps, const real_t p_rotation_offset, const real_t p_rotation_step, const real_t p_scale_step) {
 		grid_offset_x->set_value(p_grid_offset.x);
 		grid_offset_y->set_value(p_grid_offset.y);
 		grid_step_x->set_value(p_grid_step.x);
@@ -221,7 +221,7 @@ public:
 		scale_step->set_value(p_scale_step);
 	}
 
-	void get_fields(Point2 &p_grid_offset, Point2 &p_grid_step, int &p_primary_grid_steps, float &p_rotation_offset, float &p_rotation_step, float &p_scale_step) {
+	void get_fields(Point2 &p_grid_offset, Point2 &p_grid_step, int &p_primary_grid_steps, real_t &p_rotation_offset, real_t &p_rotation_step, real_t &p_scale_step) {
 		p_grid_offset = Point2(grid_offset_x->get_value(), grid_offset_y->get_value());
 		p_grid_step = Point2(grid_step_x->get_value(), grid_step_y->get_value());
 		p_primary_grid_steps = int(primary_grid_steps->get_value());
@@ -249,12 +249,12 @@ bool CanvasItemEditor::_is_node_movable(const Node *p_node, bool p_popup_warning
 }
 
 void CanvasItemEditor::_snap_if_closer_float(
-		float p_value,
-		float &r_current_snap, SnapTarget &r_current_snap_target,
-		float p_target_value, SnapTarget p_snap_target,
-		float p_radius) {
-	float radius = p_radius / zoom;
-	float dist = Math::abs(p_value - p_target_value);
+		const real_t p_value,
+		real_t &r_current_snap, SnapTarget &r_current_snap_target,
+		const real_t p_target_value, const SnapTarget p_snap_target,
+		const real_t p_radius) {
+	const real_t radius = p_radius / zoom;
+	const real_t dist = Math::abs(p_value - p_target_value);
 	if ((p_radius < 0 || dist < radius) && (r_current_snap_target == SNAP_TARGET_NONE || dist < Math::abs(r_current_snap - p_value))) {
 		r_current_snap = p_target_value;
 		r_current_snap_target = p_snap_target;
@@ -264,9 +264,9 @@ void CanvasItemEditor::_snap_if_closer_float(
 void CanvasItemEditor::_snap_if_closer_point(
 		Point2 p_value,
 		Point2 &r_current_snap, SnapTarget (&r_current_snap_target)[2],
-		Point2 p_target_value, SnapTarget p_snap_target,
-		real_t rotation,
-		float p_radius) {
+		Point2 p_target_value, const SnapTarget p_snap_target,
+		const real_t rotation,
+		const real_t p_radius) {
 	Transform2D rot_trans = Transform2D(rotation, Point2());
 	p_value = rot_trans.inverse().xform(p_value);
 	p_target_value = rot_trans.inverse().xform(p_target_value);
@@ -459,7 +459,7 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 	return output;
 }
 
-float CanvasItemEditor::snap_angle(float p_target, float p_start) const {
+real_t CanvasItemEditor::snap_angle(real_t p_target, real_t p_start) const {
 	if (((smart_snap_active || snap_rotation) ^ Input::get_singleton()->is_key_pressed(KEY_CTRL)) && snap_rotation_step != 0) {
 		if (snap_relative) {
 			return Math::snapped(p_target - snap_rotation_offset, snap_rotation_step) + snap_rotation_offset + (p_start - (int)(p_start / snap_rotation_step) * snap_rotation_step);
@@ -923,7 +923,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 			}
 
 			// Hover over guides
-			float minimum = 1e20;
+			real_t minimum = 1e20;
 			is_hovering_h_guide = false;
 			is_hovering_v_guide = false;
 
@@ -1264,7 +1264,7 @@ bool CanvasItemEditor::_gui_input_zoom_or_pan(const Ref<InputEvent> &p_event, bo
 	if (pan_gesture.is_valid() && !p_already_accepted) {
 		// If ctrl key pressed, then zoom instead of pan.
 		if (pan_gesture->is_ctrl_pressed()) {
-			const float factor = pan_gesture->get_delta().y;
+			const real_t factor = pan_gesture->get_delta().y;
 
 			zoom_widget->set_zoom_by_increments(1);
 			if (factor != 1.f) {
@@ -1490,9 +1490,9 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 						anchor_pos[i] = (transform * control->get_global_transform_with_canvas()).xform(_anchor_to_position(control, anchor_pos[i]));
 						anchor_rects[i] = Rect2(anchor_pos[i], anchor_handle->get_size());
 						if (control->is_layout_rtl()) {
-							anchor_rects[i].position -= anchor_handle->get_size() * Vector2(float(i == 1 || i == 2), float(i <= 1));
+							anchor_rects[i].position -= anchor_handle->get_size() * Vector2(real_t(i == 1 || i == 2), real_t(i <= 1));
 						} else {
-							anchor_rects[i].position -= anchor_handle->get_size() * Vector2(float(i == 0 || i == 3), float(i <= 1));
+							anchor_rects[i].position -= anchor_handle->get_size() * Vector2(real_t(i == 0 || i == 3), real_t(i <= 1));
 						}
 					}
 
@@ -1646,7 +1646,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 					};
 
 					DragType resize_drag = DRAG_NONE;
-					float radius = (select_handle->get_size().width / 2) * 1.5;
+					real_t radius = (select_handle->get_size().width / 2) * 1.5;
 
 					for (int i = 0; i < 4; i++) {
 						int prev = (i + 3) % 4;
@@ -1692,7 +1692,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 			bool symmetric = m->is_alt_pressed();
 
 			Rect2 local_rect = canvas_item->_edit_get_rect();
-			float aspect = local_rect.get_size().y / local_rect.get_size().x;
+			real_t aspect = local_rect.get_size().y / local_rect.get_size().x;
 			Point2 current_begin = local_rect.get_position();
 			Point2 current_end = local_rect.get_position() + local_rect.get_size();
 			Point2 max_begin = (symmetric) ? (current_begin + current_end - canvas_item->_edit_get_minimum_size()) / 2.0 : current_end - canvas_item->_edit_get_minimum_size();
@@ -1883,7 +1883,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 
 			Size2 scale = canvas_item->call("get_scale");
 			Size2 original_scale = scale;
-			float ratio = scale.y / scale.x;
+			real_t ratio = scale.y / scale.x;
 			if (drag_type == DRAG_SCALE_BOTH) {
 				Size2 scale_factor = drag_to_local / drag_from_local;
 				if (uniform) {
@@ -2541,7 +2541,7 @@ void CanvasItemEditor::_update_cursor() {
 
 	List<CanvasItem *> selection = _get_edited_canvas_items();
 	if (selection.size() == 1) {
-		float angle = Math::fposmod((double)selection[0]->get_global_transform_with_canvas().get_rotation(), Math_PI);
+		const double angle = Math::fposmod((double)selection[0]->get_global_transform_with_canvas().get_rotation(), Math_PI);
 		if (angle > Math_PI * 7.0 / 8.0) {
 			rotation_array_index = 0;
 		} else if (angle > Math_PI * 5.0 / 8.0) {
@@ -2647,7 +2647,7 @@ void CanvasItemEditor::_draw_margin_at_position(int p_value, Point2 p_position, 
 	}
 }
 
-void CanvasItemEditor::_draw_percentage_at_position(float p_value, Point2 p_position, Side p_side) {
+void CanvasItemEditor::_draw_percentage_at_position(real_t p_value, Point2 p_position, Side p_side) {
 	String str = TS->format_number(vformat("%.1f ", p_value * 100.0)) + TS->percent_sign();
 	if (p_value != 0) {
 		_draw_text_at_position(p_position, str, p_side);
@@ -2672,7 +2672,7 @@ void CanvasItemEditor::_draw_guides() {
 			if (drag_type == DRAG_V_GUIDE && i == dragged_guide_index) {
 				continue;
 			}
-			float x = xform.xform(Point2(vguides[i], 0)).x;
+			real_t x = xform.xform(Point2(vguides[i], 0)).x;
 			viewport->draw_line(Point2(x, 0), Point2(x, viewport->get_size().y), guide_color, Math::round(EDSCALE));
 		}
 	}
@@ -2683,7 +2683,7 @@ void CanvasItemEditor::_draw_guides() {
 			if (drag_type == DRAG_H_GUIDE && i == dragged_guide_index) {
 				continue;
 			}
-			float y = xform.xform(Point2(0, hguides[i])).y;
+			real_t y = xform.xform(Point2(0, hguides[i])).y;
 			viewport->draw_line(Point2(0, y), Point2(viewport->get_size().x, y), guide_color, Math::round(EDSCALE));
 		}
 	}
@@ -2747,7 +2747,7 @@ void CanvasItemEditor::_draw_rulers() {
 			ruler_transform.scale_basis(Point2(2, 2));
 		}
 	} else {
-		float basic_rule = 100;
+		real_t basic_rule = 100;
 		for (int i = 0; basic_rule * zoom > 100; i++) {
 			basic_rule /= (i % 2) ? 5.0 : 2.0;
 		}
@@ -2776,7 +2776,7 @@ void CanvasItemEditor::_draw_rulers() {
 		Point2 position = (transform * ruler_transform * major_subdivide * minor_subdivide).xform(Point2(i, 0)).round();
 		if (i % (major_subdivision * minor_subdivision) == 0) {
 			viewport->draw_line(Point2(position.x, 0), Point2(position.x, RULER_WIDTH), graduation_color, Math::round(EDSCALE));
-			float val = (ruler_transform * major_subdivide * minor_subdivide).xform(Point2(i, 0)).x;
+			real_t val = (ruler_transform * major_subdivide * minor_subdivide).xform(Point2(i, 0)).x;
 			viewport->draw_string(font, Point2(position.x + 2, font->get_height(font_size)), TS->format_number(vformat(((int)val == val) ? "%d" : "%.1f", val)), HALIGN_LEFT, -1, font_size, font_color);
 		} else {
 			if (i % minor_subdivision == 0) {
@@ -2793,7 +2793,7 @@ void CanvasItemEditor::_draw_rulers() {
 		Point2 position = (transform * ruler_transform * major_subdivide * minor_subdivide).xform(Point2(0, i)).round();
 		if (i % (major_subdivision * minor_subdivision) == 0) {
 			viewport->draw_line(Point2(0, position.y), Point2(RULER_WIDTH, position.y), graduation_color, Math::round(EDSCALE));
-			float val = (ruler_transform * major_subdivide * minor_subdivide).xform(Point2(0, i)).y;
+			real_t val = (ruler_transform * major_subdivide * minor_subdivide).xform(Point2(0, i)).y;
 
 			Transform2D text_xform = Transform2D(-Math_PI / 2.0, Point2(font->get_height(font_size), position.y - 2));
 			viewport->draw_set_transform_matrix(viewport->get_transform() * text_xform);
@@ -2926,8 +2926,8 @@ void CanvasItemEditor::_draw_ruler_tool() {
 		viewport->draw_string(font, text_pos, TS->format_number(vformat("%.1f px", length_vector.length())), HALIGN_LEFT, -1, font_size, font_color, outline_size, outline_color);
 
 		if (draw_secondary_lines) {
-			const float horizontal_angle_rad = atan2(length_vector.y, length_vector.x);
-			const float vertical_angle_rad = Math_PI / 2.0 - horizontal_angle_rad;
+			const real_t horizontal_angle_rad = atan2(length_vector.y, length_vector.x);
+			const real_t vertical_angle_rad = Math_PI / 2.0 - horizontal_angle_rad;
 			const int horizontal_angle = round(180 * horizontal_angle_rad / Math_PI);
 			const int vertical_angle = round(180 * vertical_angle_rad / Math_PI);
 
@@ -2963,28 +2963,28 @@ void CanvasItemEditor::_draw_ruler_tool() {
 
 			// Angle arcs
 			int arc_point_count = 8;
-			float arc_radius_max_length_percent = 0.1;
-			float ruler_length = length_vector.length() * zoom;
-			float arc_max_radius = 50.0;
-			float arc_line_width = 2.0;
+			real_t arc_radius_max_length_percent = 0.1;
+			real_t ruler_length = length_vector.length() * zoom;
+			real_t arc_max_radius = 50.0;
+			real_t arc_line_width = 2.0;
 
 			const Vector2 end_to_begin = (end - begin);
 
-			float arc_1_start_angle =
+			real_t arc_1_start_angle =
 					end_to_begin.x < 0 ?
 							  (end_to_begin.y < 0 ? 3.0 * Math_PI / 2.0 - vertical_angle_rad : Math_PI / 2.0) :
 							  (end_to_begin.y < 0 ? 3.0 * Math_PI / 2.0 : Math_PI / 2.0 - vertical_angle_rad);
-			float arc_1_end_angle = arc_1_start_angle + vertical_angle_rad;
+			real_t arc_1_end_angle = arc_1_start_angle + vertical_angle_rad;
 			// Constrain arc to triangle height & max size
-			float arc_1_radius = MIN(MIN(arc_radius_max_length_percent * ruler_length, ABS(end_to_begin.y)), arc_max_radius);
+			real_t arc_1_radius = MIN(MIN(arc_radius_max_length_percent * ruler_length, ABS(end_to_begin.y)), arc_max_radius);
 
-			float arc_2_start_angle =
+			real_t arc_2_start_angle =
 					end_to_begin.x < 0 ?
 							  (end_to_begin.y < 0 ? 0.0 : -horizontal_angle_rad) :
 							  (end_to_begin.y < 0 ? Math_PI - horizontal_angle_rad : Math_PI);
-			float arc_2_end_angle = arc_2_start_angle + horizontal_angle_rad;
+			real_t arc_2_end_angle = arc_2_start_angle + horizontal_angle_rad;
 			// Constrain arc to triangle width & max size
-			float arc_2_radius = MIN(MIN(arc_radius_max_length_percent * ruler_length, ABS(end_to_begin.x)), arc_max_radius);
+			real_t arc_2_radius = MIN(MIN(arc_radius_max_length_percent * ruler_length, ABS(end_to_begin.x)), arc_max_radius);
 
 			viewport->draw_arc(begin, arc_1_radius, arc_1_start_angle, arc_1_end_angle, arc_point_count, ruler_primary_color, Math::round(EDSCALE * arc_line_width));
 			viewport->draw_arc(end, arc_2_radius, arc_2_start_angle, arc_2_end_angle, arc_point_count, ruler_primary_color, Math::round(EDSCALE * arc_line_width));
@@ -3022,7 +3022,7 @@ void CanvasItemEditor::_draw_control_anchors(Control *control) {
 	RID ci = viewport->get_canvas_item();
 	if (tool == TOOL_SELECT && !Object::cast_to<Container>(control->get_parent())) {
 		// Compute the anchors
-		float anchors_values[4];
+		real_t anchors_values[4];
 		anchors_values[0] = control->get_anchor(SIDE_LEFT);
 		anchors_values[1] = control->get_anchor(SIDE_TOP);
 		anchors_values[2] = control->get_anchor(SIDE_RIGHT);
@@ -3061,7 +3061,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 		Color color_base = Color(0.8, 0.8, 0.8, 0.5);
 
 		// Compute the anchors
-		float anchors_values[4];
+		real_t anchors_values[4];
 		anchors_values[0] = control->get_anchor(SIDE_LEFT);
 		anchors_values[1] = control->get_anchor(SIDE_TOP);
 		anchors_values[2] = control->get_anchor(SIDE_RIGHT);
@@ -3107,7 +3107,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			Vector2 line_starts[4];
 			Vector2 line_ends[4];
 			for (int i = 0; i < 4; i++) {
-				float anchor_val = (i >= 2) ? ANCHOR_END - anchors_values[i] : anchors_values[i];
+				real_t anchor_val = (i >= 2) ? ANCHOR_END - anchors_values[i] : anchors_values[i];
 				line_starts[i] = corners_pos[i].lerp(corners_pos[(i + 1) % 4], anchor_val);
 				line_ends[i] = corners_pos[(i + 3) % 4].lerp(corners_pos[(i + 2) % 4], anchor_val);
 				anchor_snapped = anchors_values[i] == 0.0 || anchors_values[i] == 0.5 || anchors_values[i] == 1.0;
@@ -3115,7 +3115,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			}
 
 			// Display the percentages next to the lines
-			float percent_val;
+			real_t percent_val;
 			percent_val = anchors_values[(dragged_anchor + 2) % 4] - anchors_values[dragged_anchor];
 			percent_val = (dragged_anchor >= 2) ? -percent_val : percent_val;
 			_draw_percentage_at_position(percent_val, (anchors_pos[dragged_anchor] + anchors_pos[(dragged_anchor + 1) % 4]) / 2, (Side)((dragged_anchor + 1) % 4));
@@ -3134,9 +3134,9 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 		}
 
 		// Draw the margin values and the node width/height when dragging control side
-		float ratio = 0.33;
+		const real_t ratio = 0.33;
 		Transform2D parent_transform = xform * control->get_transform().affine_inverse();
-		float node_pos_in_parent[4];
+		real_t node_pos_in_parent[4];
 
 		Rect2 parent_rect = control->get_parent_anchorable_rect();
 
@@ -3453,10 +3453,10 @@ void CanvasItemEditor::_draw_straight_line(Point2 p_from, Point2 p_to, Color p_c
 		points.push_back(Point2(0, to.y));
 		points.push_back(Point2(viewport_size.x, to.y));
 	} else {
-		float y_for_zero_x = (to.y * from.x - from.y * to.x) / (from.x - to.x);
-		float x_for_zero_y = (to.x * from.y - from.x * to.y) / (from.y - to.y);
-		float y_for_viewport_x = ((to.y - from.y) * (viewport_size.x - from.x)) / (to.x - from.x) + from.y;
-		float x_for_viewport_y = ((to.x - from.x) * (viewport_size.y - from.y)) / (to.y - from.y) + from.x; // faux
+		real_t y_for_zero_x = (to.y * from.x - from.y * to.x) / (from.x - to.x);
+		real_t x_for_zero_y = (to.x * from.y - from.x * to.y) / (from.y - to.y);
+		real_t y_for_viewport_x = ((to.y - from.y) * (viewport_size.x - from.x)) / (to.x - from.x) + from.y;
+		real_t x_for_viewport_y = ((to.x - from.x) * (viewport_size.y - from.y)) / (to.y - from.y) + from.x; // faux
 
 		//bool start_set = false;
 		if (y_for_zero_x >= 0 && y_for_zero_x <= viewport_size.y) {
@@ -3602,7 +3602,7 @@ void CanvasItemEditor::_draw_locks_and_groups(Node *p_node, const Transform2D &p
 
 	RID viewport_canvas_item = viewport->get_canvas_item();
 	if (canvas_item) {
-		float offset = 0;
+		real_t offset = 0;
 
 		Ref<Texture2D> lock = get_theme_icon(SNAME("LockViewport"), SNAME("EditorIcons"));
 		if (p_node->has_meta("_edit_lock_") && show_edit_locks) {
@@ -3726,7 +3726,7 @@ void CanvasItemEditor::_notification(int p_what) {
 
 			Control *control = Object::cast_to<Control>(canvas_item);
 			if (control) {
-				float anchors[4];
+				real_t anchors[4];
 				Vector2 pivot;
 
 				pivot = control->get_pivot_offset();
@@ -4003,7 +4003,7 @@ void CanvasItemEditor::_update_scrollbars() {
 	bool constrain_editor_view = bool(EditorSettings::get_singleton()->get("editors/2d/constrain_editor_view"));
 
 	if (canvas_item_rect.size.height <= (local_rect.size.y / zoom)) {
-		float centered = -(size.y / 2) / zoom + screen_rect.y / 2;
+		real_t centered = -(size.y / 2) / zoom + screen_rect.y / 2;
 		if (constrain_editor_view && ABS(centered - previous_update_view_offset.y) < ABS(centered - view_offset.y)) {
 			view_offset.y = previous_update_view_offset.y;
 		}
@@ -4024,7 +4024,7 @@ void CanvasItemEditor::_update_scrollbars() {
 	}
 
 	if (canvas_item_rect.size.width <= (local_rect.size.x / zoom)) {
-		float centered = -(size.x / 2) / zoom + screen_rect.x / 2;
+		real_t centered = -(size.x / 2) / zoom + screen_rect.x / 2;
 		if (constrain_editor_view && ABS(centered - previous_update_view_offset.x) < ABS(centered - view_offset.x)) {
 			view_offset.x = previous_update_view_offset.x;
 		}
@@ -4091,7 +4091,7 @@ void CanvasItemEditor::_popup_warning_temporarily(Control *p_control, const floa
 	info_overlay->set_offset(SIDE_LEFT, (show_rulers ? RULER_WIDTH : 0) + 10);
 }
 
-void CanvasItemEditor::_update_scroll(float) {
+void CanvasItemEditor::_update_scroll(real_t) {
 	if (updating_scroll) {
 		return;
 	}
@@ -4185,14 +4185,14 @@ void CanvasItemEditor::_set_anchors_preset(Control::LayoutPreset p_preset) {
 	undo_redo->commit_action();
 }
 
-void CanvasItemEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
+void CanvasItemEditor::_zoom_on_position(real_t p_zoom, Point2 p_position) {
 	p_zoom = CLAMP(p_zoom, MIN_ZOOM, MAX_ZOOM);
 
 	if (p_zoom == zoom) {
 		return;
 	}
 
-	float prev_zoom = zoom;
+	real_t prev_zoom = zoom;
 	zoom = p_zoom;
 
 	view_offset += p_position / prev_zoom - p_position / zoom;
@@ -4201,7 +4201,7 @@ void CanvasItemEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
 	// in small details (texts, lines).
 	// This correction adds a jitter movement when zooming, so we correct only when the
 	// zoom factor is an integer. (in the other cases, all pixels won't be aligned anyway)
-	float closest_zoom_factor = Math::round(zoom);
+	const real_t closest_zoom_factor = Math::round(zoom);
 	if (Math::is_zero_approx(zoom - closest_zoom_factor)) {
 		// make sure scene pixel at view_offset is aligned on a screen pixel
 		Vector2 view_offset_int = view_offset.floor();
@@ -4213,7 +4213,7 @@ void CanvasItemEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
 	update_viewport();
 }
 
-void CanvasItemEditor::_update_zoom(float p_zoom) {
+void CanvasItemEditor::_update_zoom(real_t p_zoom) {
 	_zoom_on_position(p_zoom, viewport_scrollable->get_size() / 2.0);
 }
 
@@ -4898,8 +4898,8 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 	} else { // VIEW_FRAME_TO_SELECTION
 
 		if (rect.size.x > CMP_EPSILON && rect.size.y > CMP_EPSILON) {
-			float scale_x = viewport->get_size().x / rect.size.x;
-			float scale_y = viewport->get_size().y / rect.size.y;
+			real_t scale_x = viewport->get_size().x / rect.size.x;
+			real_t scale_y = viewport->get_size().y / rect.size.y;
 			zoom = scale_x < scale_y ? scale_x : scale_y;
 			zoom *= 0.90;
 			viewport->update();
@@ -4964,7 +4964,7 @@ void CanvasItemEditor::set_state(const Dictionary &p_state) {
 	if (state.has("zoom")) {
 		// Compensate the editor scale, so that the editor scale can be changed
 		// and the zoom level will still be the same (relative to the editor scale).
-		zoom = float(p_state["zoom"]) * MAX(1, EDSCALE);
+		zoom = real_t(p_state["zoom"]) * MAX(1, EDSCALE);
 		zoom_widget->set_zoom(zoom);
 	}
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -48,10 +48,10 @@ class CanvasItemEditorSelectedItem : public Object {
 
 public:
 	Transform2D prev_xform;
-	float prev_rot = 0;
+	real_t prev_rot = 0;
 	Rect2 prev_rect;
 	Vector2 prev_pivot;
-	float prev_anchors[4] = { 0.0f };
+	real_t prev_anchors[4] = { (real_t)0.0 };
 
 	Transform2D pre_drag_xform;
 	Rect2 pre_drag_rect;
@@ -250,7 +250,7 @@ private:
 	bool show_edit_locks;
 	bool show_transformation_gizmos;
 
-	float zoom;
+	real_t zoom;
 	Point2 view_offset;
 	Point2 previous_update_view_offset;
 
@@ -262,9 +262,9 @@ private:
 	int primary_grid_steps;
 	int grid_step_multiplier;
 
-	float snap_rotation_step;
-	float snap_rotation_offset;
-	float snap_scale_step;
+	real_t snap_rotation_step;
+	real_t snap_rotation_offset;
+	real_t snap_scale_step;
 	bool smart_snap_active;
 	bool grid_snap_active;
 
@@ -292,7 +292,7 @@ private:
 
 	struct _SelectResult {
 		CanvasItem *item = nullptr;
-		float z_index = 0;
+		real_t z_index = 0;
 		bool has_z = true;
 		_FORCE_INLINE_ bool operator<(const _SelectResult &p_rr) const {
 			return has_z && p_rr.has_z ? p_rr.z_index < z_index : p_rr.has_z;
@@ -309,7 +309,7 @@ private:
 
 	struct BoneList {
 		Transform2D xform;
-		float length = 0.f;
+		real_t length = 0;
 		uint64_t last_pass = 0;
 	};
 
@@ -332,7 +332,7 @@ private:
 	struct PoseClipboard {
 		Vector2 pos;
 		Vector2 scale;
-		float rot = 0;
+		real_t rot = 0;
 		ObjectID id;
 	};
 	List<PoseClipboard> pose_clipboard;
@@ -432,7 +432,7 @@ private:
 
 	void _popup_callback(int p_op);
 	bool updating_scroll;
-	void _update_scroll(float);
+	void _update_scroll(real_t);
 	void _update_scrollbars();
 	void _append_canvas_item(CanvasItem *p_item);
 	void _snap_changed();
@@ -459,7 +459,7 @@ private:
 
 	void _draw_text_at_position(Point2 p_position, String p_string, Side p_side);
 	void _draw_margin_at_position(int p_value, Point2 p_position, Side p_side);
-	void _draw_percentage_at_position(float p_value, Point2 p_position, Side p_side);
+	void _draw_percentage_at_position(real_t p_value, Point2 p_position, Side p_side);
 	void _draw_straight_line(Point2 p_from, Point2 p_to, Color p_color);
 
 	void _draw_smart_snapping();
@@ -501,16 +501,16 @@ private:
 	SnapTarget snap_target[2];
 	Transform2D snap_transform;
 	void _snap_if_closer_float(
-			float p_value,
-			float &r_current_snap, SnapTarget &r_current_snap_target,
-			float p_target_value, SnapTarget p_snap_target,
-			float p_radius = 10.0);
+			const real_t p_value,
+			real_t &r_current_snap, SnapTarget &r_current_snap_target,
+			const real_t p_target_value, const SnapTarget p_snap_target,
+			const real_t p_radius = 10.0);
 	void _snap_if_closer_point(
 			Point2 p_value,
 			Point2 &r_current_snap, SnapTarget (&r_current_snap_target)[2],
-			Point2 p_target_value, SnapTarget p_snap_target,
-			real_t rotation = 0.0,
-			float p_radius = 10.0);
+			Point2 p_target_value, const SnapTarget p_snap_target,
+			const real_t rotation = 0.0,
+			const real_t p_radius = 10.0);
 	void _snap_other_nodes(
 			const Point2 p_value,
 			const Transform2D p_transform_to_snap,
@@ -527,8 +527,8 @@ private:
 
 	VBoxContainer *controls_vb;
 	EditorZoomWidget *zoom_widget;
-	void _update_zoom(float p_zoom);
-	void _zoom_on_position(float p_zoom, Point2 p_position = Point2());
+	void _update_zoom(real_t p_zoom);
+	void _zoom_on_position(real_t p_zoom, Point2 p_position = Point2());
 	void _button_toggle_smart_snap(bool p_status);
 	void _button_toggle_grid_snap(bool p_status);
 	void _button_override_camera(bool p_pressed);
@@ -557,28 +557,6 @@ protected:
 
 	HBoxContainer *get_panel_hb() { return hb; }
 
-	struct compare_items_x {
-		bool operator()(const CanvasItem *a, const CanvasItem *b) const {
-			return a->get_global_transform().elements[2].x < b->get_global_transform().elements[2].x;
-		}
-	};
-
-	struct compare_items_y {
-		bool operator()(const CanvasItem *a, const CanvasItem *b) const {
-			return a->get_global_transform().elements[2].y < b->get_global_transform().elements[2].y;
-		}
-	};
-
-	struct proj_vector2_x {
-		float get(const Vector2 &v) { return v.x; }
-		void set(Vector2 &v, float f) { v.x = f; }
-	};
-
-	struct proj_vector2_y {
-		float get(const Vector2 &v) { return v.y; }
-		void set(Vector2 &v, float f) { v.y = f; }
-	};
-
 	template <class P, class C>
 	void space_selected_items();
 
@@ -599,7 +577,7 @@ public:
 	};
 
 	Point2 snap_point(Point2 p_target, unsigned int p_modes = SNAP_DEFAULT, unsigned int p_forced_modes = 0, const CanvasItem *p_self_canvas_item = nullptr, List<CanvasItem *> p_other_nodes_exceptions = List<CanvasItem *>());
-	float snap_angle(float p_target, float p_start = 0) const;
+	real_t snap_angle(real_t p_target, real_t p_start = 0) const;
 
 	Transform2D get_canvas_transform() const { return transform; }
 

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -724,7 +724,7 @@ Ref<Texture2D> EditorMeshPreviewPlugin::generate(const RES &p_from, const Size2 
 	xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math_PI * 0.125);
 	xform.basis = Basis().rotated(Vector3(1, 0, 0), Math_PI * 0.125) * xform.basis;
 	AABB rot_aabb = xform.xform(aabb);
-	float m = MAX(rot_aabb.size.x, rot_aabb.size.y) * 0.5;
+	real_t m = MAX(rot_aabb.size.x, rot_aabb.size.y) * 0.5;
 	if (m == 0) {
 		return Ref<Texture2D>();
 	}

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -320,7 +320,7 @@ void EditorNode3DGizmo::add_vertices(const Vector<Vector3> &p_vertices, const Re
 	instances.push_back(ins);
 }
 
-void EditorNode3DGizmo::add_unscaled_billboard(const Ref<Material> &p_material, float p_scale, const Color &p_modulate) {
+void EditorNode3DGizmo::add_unscaled_billboard(const Ref<Material> &p_material, real_t p_scale, const Color &p_modulate) {
 	ERR_FAIL_COND(!spatial_node);
 	Instance ins;
 

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -84,7 +84,7 @@ public:
 	void add_mesh(const Ref<ArrayMesh> &p_mesh, const Ref<Material> &p_material = Ref<Material>(), const Transform3D &p_xform = Transform3D(), const Ref<SkinReference> &p_skin_reference = Ref<SkinReference>());
 	void add_collision_segments(const Vector<Vector3> &p_lines);
 	void add_collision_triangles(const Ref<TriangleMesh> &p_tmesh);
-	void add_unscaled_billboard(const Ref<Material> &p_material, float p_scale = 1, const Color &p_modulate = Color(1, 1, 1));
+	void add_unscaled_billboard(const Ref<Material> &p_material, real_t p_scale = 1, const Color &p_modulate = Color(1, 1, 1));
 	void add_handles(const Vector<Vector3> &p_handles, const Ref<Material> &p_material, const Vector<int> &p_ids = Vector<int>(), bool p_billboard = false, bool p_secondary = false);
 	void add_solid_box(Ref<Material> &p_material, Vector3 p_size, Vector3 p_position = Vector3(), const Transform3D &p_xform = Transform3D());
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -107,8 +107,8 @@ void ViewportRotationControl::_notification(int p_what) {
 }
 
 void ViewportRotationControl::_draw() {
-	Vector2i center = get_size() / 2.0;
-	float radius = get_size().x / 2.0;
+	const Vector2i center = get_size() / 2.0;
+	const real_t radius = get_size().x / 2.0;
 
 	if (focused_axis > -2 || orbiting) {
 		draw_circle(center, radius, Color(0.5, 0.5, 0.5, 0.25));
@@ -149,15 +149,13 @@ void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
 }
 
 void ViewportRotationControl::_get_sorted_axis(Vector<Axis2D> &r_axis) {
-	Vector2i center = get_size() / 2.0;
-	float radius = get_size().x / 2.0;
-
-	float axis_radius = radius - AXIS_CIRCLE_RADIUS - 2.0 * EDSCALE;
-	Basis camera_basis = viewport->to_camera_transform(viewport->cursor).get_basis().inverse();
+	const Vector2i center = get_size() / 2.0;
+	const real_t radius = get_size().x / 2.0 - AXIS_CIRCLE_RADIUS - 2.0 * EDSCALE;
+	const Basis camera_basis = viewport->to_camera_transform(viewport->cursor).get_basis().inverse();
 
 	for (int i = 0; i < 3; ++i) {
 		Vector3 axis_3d = camera_basis.get_axis(i);
-		Vector2i axis_vector = Vector2(axis_3d.x, -axis_3d.y) * axis_radius;
+		Vector2i axis_vector = Vector2(axis_3d.x, -axis_3d.y) * radius;
 
 		if (Math::abs(axis_3d.z) < 1.0) {
 			Axis2D pos_axis;
@@ -259,7 +257,7 @@ void ViewportRotationControl::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_gui_input"), &ViewportRotationControl::_gui_input);
 }
 
-void Node3DEditorViewport::_update_camera(float p_interp_delta) {
+void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 	bool is_orthogonal = camera->get_projection() == Camera3D::PROJECTION_ORTHOGONAL;
 
 	Cursor old_camera_cursor = camera_cursor;
@@ -279,7 +277,7 @@ void Node3DEditorViewport::_update_camera(float p_interp_delta) {
 			// We interpolate a different point here, because in freelook mode the focus point (cursor.pos) orbits around eye_pos
 			camera_cursor.eye_pos = old_camera_cursor.eye_pos.lerp(cursor.eye_pos, CLAMP(factor, 0, 1));
 
-			float orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/orbit_inertia");
+			real_t orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/orbit_inertia");
 			orbit_inertia = MAX(0.0001, orbit_inertia);
 			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 			camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
@@ -297,13 +295,13 @@ void Node3DEditorViewport::_update_camera(float p_interp_delta) {
 
 		} else {
 			//when not being manipulated, move softly
-			float free_orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/orbit_inertia");
-			float free_translation_inertia = EDITOR_GET("editors/3d/navigation_feel/translation_inertia");
+			real_t free_orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/orbit_inertia");
+			real_t free_translation_inertia = EDITOR_GET("editors/3d/navigation_feel/translation_inertia");
 			//when being manipulated, move more quickly
-			float manip_orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/manipulation_orbit_inertia");
-			float manip_translation_inertia = EDITOR_GET("editors/3d/navigation_feel/manipulation_translation_inertia");
+			real_t manip_orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/manipulation_orbit_inertia");
+			real_t manip_translation_inertia = EDITOR_GET("editors/3d/navigation_feel/manipulation_translation_inertia");
 
-			float zoom_inertia = EDITOR_GET("editors/3d/navigation_feel/zoom_inertia");
+			real_t zoom_inertia = EDITOR_GET("editors/3d/navigation_feel/zoom_inertia");
 
 			//determine if being manipulated
 			bool manipulated = Input::get_singleton()->get_mouse_button_mask() & (2 | 4);
@@ -311,8 +309,8 @@ void Node3DEditorViewport::_update_camera(float p_interp_delta) {
 			manipulated |= Input::get_singleton()->is_key_pressed(KEY_ALT);
 			manipulated |= Input::get_singleton()->is_key_pressed(KEY_CTRL);
 
-			float orbit_inertia = MAX(0.00001, manipulated ? manip_orbit_inertia : free_orbit_inertia);
-			float translation_inertia = MAX(0.0001, manipulated ? manip_translation_inertia : free_translation_inertia);
+			real_t orbit_inertia = MAX(0.00001, manipulated ? manip_orbit_inertia : free_orbit_inertia);
+			real_t translation_inertia = MAX(0.0001, manipulated ? manip_translation_inertia : free_translation_inertia);
 			zoom_inertia = MAX(0.0001, zoom_inertia);
 
 			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
@@ -327,7 +325,7 @@ void Node3DEditorViewport::_update_camera(float p_interp_delta) {
 			}
 
 			camera_cursor.pos = old_camera_cursor.pos.lerp(cursor.pos, MIN(1.f, p_interp_delta * (1 / translation_inertia)));
-			camera_cursor.distance = Math::lerp(old_camera_cursor.distance, cursor.distance, MIN(1.f, p_interp_delta * (1 / zoom_inertia)));
+			camera_cursor.distance = Math::lerp(old_camera_cursor.distance, cursor.distance, MIN((real_t)1.0, p_interp_delta * (1 / zoom_inertia)));
 		}
 	}
 
@@ -537,7 +535,7 @@ ObjectID Node3DEditorViewport::_select_ray(const Point2 &p_pos) {
 				continue;
 			}
 
-			float dist = pos.distance_to(point);
+			const real_t dist = pos.distance_to(point);
 
 			if (dist < 0) {
 				continue;
@@ -601,7 +599,7 @@ void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, Vector<_RayRe
 				continue;
 			}
 
-			float dist = pos.distance_to(point);
+			const real_t dist = pos.distance_to(point);
 
 			if (dist < 0) {
 				continue;
@@ -646,7 +644,7 @@ void Node3DEditorViewport::_select_region() {
 		return; //nothing really
 	}
 
-	float z_offset = MAX(0.0, 5.0 - get_znear());
+	const real_t z_offset = MAX(0.0, 5.0 - get_znear());
 
 	Vector3 box[4] = {
 		Vector3(
@@ -912,20 +910,19 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 	Vector3 ray = _get_ray(Vector2(p_screenpos.x, p_screenpos.y));
 
 	Transform3D gt = spatial_editor->get_gizmo_transform();
-	float gs = gizmo_scale;
 
 	if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE) {
 		int col_axis = -1;
-		float col_d = 1e20;
+		real_t col_d = 1e20;
 
 		for (int i = 0; i < 3; i++) {
-			Vector3 grabber_pos = gt.origin + gt.basis.get_axis(i) * gs * (GIZMO_ARROW_OFFSET + (GIZMO_ARROW_SIZE * 0.5));
-			float grabber_radius = gs * GIZMO_ARROW_SIZE;
+			const Vector3 grabber_pos = gt.origin + gt.basis.get_axis(i) * gizmo_scale * (GIZMO_ARROW_OFFSET + (GIZMO_ARROW_SIZE * 0.5));
+			const real_t grabber_radius = gizmo_scale * GIZMO_ARROW_SIZE;
 
 			Vector3 r;
 
 			if (Geometry3D::segment_intersects_sphere(ray_pos, ray_pos + ray * MAX_Z, grabber_pos, grabber_radius, &r)) {
-				float d = r.distance_to(ray_pos);
+				const real_t d = r.distance_to(ray_pos);
 				if (d < col_d) {
 					col_d = d;
 					col_axis = i;
@@ -944,17 +941,17 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 
 				// Allow some tolerance to make the plane easier to click,
 				// even if the click is actually slightly outside the plane.
-				const Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gs * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST * 0.6667);
+				const Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gizmo_scale * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST * 0.6667);
 
 				Vector3 r;
 				Plane plane(gt.origin, gt.basis.get_axis(i).normalized());
 
 				if (plane.intersects_ray(ray_pos, ray, &r)) {
-					float dist = r.distance_to(grabber_pos);
+					const real_t dist = r.distance_to(grabber_pos);
 					// Allow some tolerance to make the plane easier to click,
 					// even if the click is actually slightly outside the plane.
-					if (dist < (gs * GIZMO_PLANE_SIZE * 1.5)) {
-						float d = ray_pos.distance_to(r);
+					if (dist < (gizmo_scale * GIZMO_PLANE_SIZE * 1.5)) {
+						const real_t d = ray_pos.distance_to(r);
 						if (d < col_d) {
 							col_d = d;
 							col_axis = i;
@@ -991,12 +988,12 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 				continue;
 			}
 
-			float dist = r.distance_to(gt.origin);
-			Vector3 r_dir = (r - gt.origin).normalized();
+			const real_t dist = r.distance_to(gt.origin);
+			const Vector3 r_dir = (r - gt.origin).normalized();
 
 			if (_get_camera_normal().dot(r_dir) <= 0.005) {
-				if (dist > gs * (GIZMO_CIRCLE_SIZE - GIZMO_RING_HALF_WIDTH) && dist < gs * (GIZMO_CIRCLE_SIZE + GIZMO_RING_HALF_WIDTH)) {
-					float d = ray_pos.distance_to(r);
+				if (dist > gizmo_scale * (GIZMO_CIRCLE_SIZE - GIZMO_RING_HALF_WIDTH) && dist < gizmo_scale * (GIZMO_CIRCLE_SIZE + GIZMO_RING_HALF_WIDTH)) {
+					const real_t d = ray_pos.distance_to(r);
 					if (d < col_d) {
 						col_d = d;
 						col_axis = i;
@@ -1023,13 +1020,13 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 		float col_d = 1e20;
 
 		for (int i = 0; i < 3; i++) {
-			Vector3 grabber_pos = gt.origin + gt.basis.get_axis(i) * gs * GIZMO_SCALE_OFFSET;
-			float grabber_radius = gs * GIZMO_ARROW_SIZE;
+			const Vector3 grabber_pos = gt.origin + gt.basis.get_axis(i) * gizmo_scale * GIZMO_SCALE_OFFSET;
+			const real_t grabber_radius = gizmo_scale * GIZMO_ARROW_SIZE;
 
 			Vector3 r;
 
 			if (Geometry3D::segment_intersects_sphere(ray_pos, ray_pos + ray * MAX_Z, grabber_pos, grabber_radius, &r)) {
-				float d = r.distance_to(ray_pos);
+				const real_t d = r.distance_to(ray_pos);
 				if (d < col_d) {
 					col_d = d;
 					col_axis = i;
@@ -1043,22 +1040,22 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 			col_d = 1e20;
 
 			for (int i = 0; i < 3; i++) {
-				Vector3 ivec2 = gt.basis.get_axis((i + 1) % 3).normalized();
-				Vector3 ivec3 = gt.basis.get_axis((i + 2) % 3).normalized();
+				const Vector3 ivec2 = gt.basis.get_axis((i + 1) % 3).normalized();
+				const Vector3 ivec3 = gt.basis.get_axis((i + 2) % 3).normalized();
 
 				// Allow some tolerance to make the plane easier to click,
 				// even if the click is actually slightly outside the plane.
-				Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gs * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST * 0.6667);
+				const Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gizmo_scale * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST * 0.6667);
 
 				Vector3 r;
 				Plane plane(gt.origin, gt.basis.get_axis(i).normalized());
 
 				if (plane.intersects_ray(ray_pos, ray, &r)) {
-					float dist = r.distance_to(grabber_pos);
+					const real_t dist = r.distance_to(grabber_pos);
 					// Allow some tolerance to make the plane easier to click,
 					// even if the click is actually slightly outside the plane.
-					if (dist < (gs * GIZMO_PLANE_SIZE * 1.5)) {
-						float d = ray_pos.distance_to(r);
+					if (dist < (gizmo_scale * GIZMO_PLANE_SIZE * 1.5)) {
+						const real_t d = ray_pos.distance_to(r);
 						if (d < col_d) {
 							col_d = d;
 							col_axis = i;
@@ -1293,7 +1290,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	if (b.is_valid()) {
 		emit_signal(SNAME("clicked"), this);
 
-		float zoom_factor = 1 + (ZOOM_FREELOOK_MULTIPLIER - 1) * b->get_factor();
+		const real_t zoom_factor = 1 + (ZOOM_FREELOOK_MULTIPLIER - 1) * b->get_factor();
 		switch (b->get_button_index()) {
 			case MOUSE_BUTTON_WHEEL_UP: {
 				if (is_freelook_active()) {
@@ -1780,13 +1777,13 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							}
 
 						} else {
-							float center_click_dist = click.distance_to(_edit.center);
-							float center_inters_dist = intersection.distance_to(_edit.center);
+							const real_t center_click_dist = click.distance_to(_edit.center);
+							const real_t center_inters_dist = intersection.distance_to(_edit.center);
 							if (center_click_dist == 0) {
 								break;
 							}
 
-							float scale = center_inters_dist - center_click_dist;
+							const real_t scale = center_inters_dist - center_click_dist;
 							motion = Vector3(scale, scale, scale);
 						}
 
@@ -3527,18 +3524,15 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 		return;
 	}
 
-	Vector3 camz = -camera_xform.get_basis().get_axis(2).normalized();
-	Vector3 camy = -camera_xform.get_basis().get_axis(1).normalized();
-	Plane p(camera_xform.origin, camz);
-	float gizmo_d = MAX(Math::abs(p.distance_to(xform.origin)), CMP_EPSILON);
-	float d0 = camera->unproject_position(camera_xform.origin + camz * gizmo_d).y;
-	float d1 = camera->unproject_position(camera_xform.origin + camz * gizmo_d + camy).y;
-	float dd = Math::abs(d0 - d1);
-	if (dd == 0) {
-		dd = 0.0001;
-	}
+	const Vector3 camz = -camera_xform.get_basis().get_axis(2).normalized();
+	const Vector3 camy = -camera_xform.get_basis().get_axis(1).normalized();
+	const Plane p(camera_xform.origin, camz);
+	const real_t gizmo_d = MAX(Math::abs(p.distance_to(xform.origin)), CMP_EPSILON);
+	const real_t d0 = camera->unproject_position(camera_xform.origin + camz * gizmo_d).y;
+	const real_t d1 = camera->unproject_position(camera_xform.origin + camz * gizmo_d + camy).y;
+	const real_t dd = MAX(Math::abs(d0 - d1), CMP_EPSILON);
 
-	float gizmo_size = EditorSettings::get_singleton()->get("editors/3d/manipulator_gizmo_size");
+	const real_t gizmo_size = EditorSettings::get_singleton()->get("editors/3d/manipulator_gizmo_size");
 	// At low viewport heights, multiply the gizmo scale based on the viewport height.
 	// This prevents the gizmo from growing very large and going outside the viewport.
 	const int viewport_base_height = 400 * MAX(1, EDSCALE);
@@ -3794,7 +3788,7 @@ void Node3DEditorViewport::focus_selection() {
 	}
 
 	if (count != 0) {
-		center /= float(count);
+		center /= count;
 	}
 
 	cursor.pos = center;
@@ -4458,14 +4452,14 @@ void Node3DEditorViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (dragging_h) {
-			float new_ratio = drag_begin_ratio.x + (mm->get_position().x - drag_begin_pos.x) / get_size().width;
+			real_t new_ratio = drag_begin_ratio.x + (mm->get_position().x - drag_begin_pos.x) / get_size().width;
 			new_ratio = CLAMP(new_ratio, 40 / get_size().width, (get_size().width - 40) / get_size().width);
 			ratio_h = new_ratio;
 			queue_sort();
 			update();
 		}
 		if (dragging_v) {
-			float new_ratio = drag_begin_ratio.y + (mm->get_position().y - drag_begin_pos.y) / get_size().height;
+			real_t new_ratio = drag_begin_ratio.y + (mm->get_position().y - drag_begin_pos.y) / get_size().height;
 			new_ratio = CLAMP(new_ratio, 40 / get_size().height, (get_size().height - 40) / get_size().height);
 			ratio_v = new_ratio;
 			queue_sort();
@@ -5016,13 +5010,13 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 	}
 
 	if (d.has("zfar")) {
-		settings_zfar->set_value(float(d["zfar"]));
+		settings_zfar->set_value(double(d["zfar"]));
 	}
 	if (d.has("znear")) {
-		settings_znear->set_value(float(d["znear"]));
+		settings_znear->set_value(double(d["znear"]));
 	}
 	if (d.has("fov")) {
-		settings_fov->set_value(float(d["fov"]));
+		settings_fov->set_value(double(d["fov"]));
 	}
 	if (d.has("show_grid")) {
 		bool use = d["show_grid"];
@@ -7623,8 +7617,8 @@ Vector3 Node3DEditor::snap_point(Vector3 p_target, Vector3 p_start) const {
 	return p_target;
 }
 
-float Node3DEditor::get_translate_snap() const {
-	float snap_value;
+double Node3DEditor::get_translate_snap() const {
+	double snap_value;
 	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		snap_value = snap_translate->get_text().to_float() / 10.0;
 	} else {
@@ -7634,8 +7628,8 @@ float Node3DEditor::get_translate_snap() const {
 	return snap_value;
 }
 
-float Node3DEditor::get_rotate_snap() const {
-	float snap_value;
+double Node3DEditor::get_rotate_snap() const {
+	double snap_value;
 	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		snap_value = snap_rotate->get_text().to_float() / 3.0;
 	} else {
@@ -7645,8 +7639,8 @@ float Node3DEditor::get_rotate_snap() const {
 	return snap_value;
 }
 
-float Node3DEditor::get_scale_snap() const {
-	float snap_value;
+double Node3DEditor::get_scale_snap() const {
+	double snap_value;
 	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		snap_value = snap_scale->get_text().to_float() / 2.0;
 	} else {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -201,7 +201,7 @@ private:
 	bool orthogonal;
 	bool auto_orthogonal;
 	bool lock_rotation;
-	float gizmo_scale;
+	real_t gizmo_scale;
 
 	bool freelook_active;
 	real_t freelook_speed;
@@ -221,7 +221,7 @@ private:
 
 	struct _RayResult {
 		Node3D *item = nullptr;
-		float depth = 0;
+		real_t depth = 0;
 		_FORCE_INLINE_ bool operator<(const _RayResult &p_rr) const { return depth < p_rr.depth; }
 	};
 
@@ -306,7 +306,7 @@ private:
 
 	struct Cursor {
 		Vector3 pos;
-		float x_rot, y_rot, distance;
+		real_t x_rot, y_rot, distance;
 		Vector3 eye_pos; // Used in freelook mode
 		bool region_select;
 		Point2 region_begin, region_end;
@@ -340,8 +340,7 @@ private:
 
 	void set_message(String p_message, float p_time = 5);
 
-	//
-	void _update_camera(float p_interp_delta);
+	void _update_camera(real_t p_interp_delta);
 	Transform3D to_camera_transform(const Cursor &p_cursor) const;
 	void _draw();
 
@@ -450,8 +449,8 @@ public:
 private:
 	View view;
 	bool mouseover;
-	float ratio_h;
-	float ratio_v;
+	real_t ratio_h;
+	real_t ratio_v;
 
 	bool hovering_v;
 	bool hovering_h;
@@ -534,9 +533,9 @@ private:
 	Ref<Node3DGizmo> current_hover_gizmo;
 	int current_hover_gizmo_handle;
 
-	float snap_translate_value;
-	float snap_rotate_value;
-	float snap_scale_value;
+	real_t snap_translate_value;
+	real_t snap_rotate_value;
+	real_t snap_scale_value;
 
 	Ref<ArrayMesh> selection_box_xray;
 	Ref<ArrayMesh> selection_box;
@@ -554,7 +553,7 @@ private:
 
 	struct Gizmo {
 		bool visible = false;
-		float scale = 0;
+		real_t scale = 0;
 		Transform3D transform;
 	} gizmo;
 
@@ -752,9 +751,9 @@ public:
 	ToolMode get_tool_mode() const { return tool_mode; }
 	bool are_local_coords_enabled() const { return tool_option_button[Node3DEditor::TOOL_OPT_LOCAL_COORDS]->is_pressed(); }
 	bool is_snap_enabled() const { return snap_enabled ^ snap_key_enabled; }
-	float get_translate_snap() const;
-	float get_rotate_snap() const;
-	float get_scale_snap() const;
+	double get_translate_snap() const;
+	double get_rotate_snap() const;
+	double get_scale_snap() const;
 
 	Ref<ArrayMesh> get_move_gizmo(int idx) const { return move_gizmo[idx]; }
 	Ref<ArrayMesh> get_move_plane_gizmo(int idx) const { return move_plane_gizmo[idx]; }

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -400,25 +400,25 @@ void Polygon2DEditor::_set_show_grid(bool p_show) {
 	uv_edit_draw->update();
 }
 
-void Polygon2DEditor::_set_snap_off_x(float p_val) {
+void Polygon2DEditor::_set_snap_off_x(real_t p_val) {
 	snap_offset.x = p_val;
 	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_offset", snap_offset);
 	uv_edit_draw->update();
 }
 
-void Polygon2DEditor::_set_snap_off_y(float p_val) {
+void Polygon2DEditor::_set_snap_off_y(real_t p_val) {
 	snap_offset.y = p_val;
 	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_offset", snap_offset);
 	uv_edit_draw->update();
 }
 
-void Polygon2DEditor::_set_snap_step_x(float p_val) {
+void Polygon2DEditor::_set_snap_step_x(real_t p_val) {
 	snap_step.x = p_val;
 	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_step", snap_step);
 	uv_edit_draw->update();
 }
 
-void Polygon2DEditor::_set_snap_step_y(float p_val) {
+void Polygon2DEditor::_set_snap_step_y(real_t p_val) {
 	snap_step.y = p_val;
 	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_step", snap_step);
 	uv_edit_draw->update();
@@ -569,11 +569,11 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					}
 
 					int closest = -1;
-					float closest_dist = 1e20;
+					real_t closest_dist = 1e20;
 
 					for (int i = points_prev.size() - internal_vertices; i < points_prev.size(); i++) {
 						Vector2 tuv = mtx.xform(uv_create_poly_prev[i]);
-						float dist = tuv.distance_to(Vector2(mb->get_position().x, mb->get_position().y));
+						real_t dist = tuv.distance_to(Vector2(mb->get_position().x, mb->get_position().y));
 						if (dist < 8 && dist < closest_dist) {
 							closest = i;
 							closest_dist = dist;
@@ -639,11 +639,11 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 
 				if (uv_move_current == UV_MODE_ADD_POLYGON) {
 					int closest = -1;
-					float closest_dist = 1e20;
+					real_t closest_dist = 1e20;
 
 					for (int i = 0; i < points_prev.size(); i++) {
 						Vector2 tuv = mtx.xform(points_prev[i]);
-						float dist = tuv.distance_to(Vector2(mb->get_position().x, mb->get_position().y));
+						real_t dist = tuv.distance_to(Vector2(mb->get_position().x, mb->get_position().y));
 						if (dist < 8 && dist < closest_dist) {
 							closest = i;
 							closest_dist = dist;
@@ -825,7 +825,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					}
 					center /= uv_new.size();
 
-					float angle = (uv_drag_from - mtx.xform(center)).normalized().angle_to((uv_drag_to - mtx.xform(center)).normalized());
+					real_t angle = (uv_drag_from - mtx.xform(center)).normalized().angle_to((uv_drag_to - mtx.xform(center)).normalized());
 
 					for (int i = 0; i < uv_new.size(); i++) {
 						Vector2 rel = points_prev[i] - center;
@@ -848,13 +848,13 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					}
 					center /= uv_new.size();
 
-					float from_dist = uv_drag_from.distance_to(mtx.xform(center));
-					float to_dist = uv_drag_to.distance_to(mtx.xform(center));
+					real_t from_dist = uv_drag_from.distance_to(mtx.xform(center));
+					real_t to_dist = uv_drag_to.distance_to(mtx.xform(center));
 					if (from_dist < 2) {
 						break;
 					}
 
-					float scale = to_dist / from_dist;
+					real_t scale = to_dist / from_dist;
 
 					for (int i = 0; i < uv_new.size(); i++) {
 						Vector2 rel = points_prev[i] - center;
@@ -881,8 +881,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 
 				{
 					int pc = painted_weights.size();
-					float amount = bone_paint_strength->get_value();
-					float radius = bone_paint_radius->get_value() * EDSCALE;
+					real_t amount = bone_paint_strength->get_value();
+					real_t radius = bone_paint_radius->get_value() * EDSCALE;
 
 					if (uv_mode == UV_MODE_CLEAR_WEIGHT) {
 						amount = -amount;
@@ -925,7 +925,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 	}
 }
 
-void Polygon2DEditor::_uv_scroll_changed(float) {
+void Polygon2DEditor::_uv_scroll_changed(real_t) {
 	if (updating_uv_scroll) {
 		return;
 	}

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -95,7 +95,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	void _update_bone_list();
 
 	Vector2 uv_draw_ofs;
-	float uv_draw_zoom;
+	real_t uv_draw_zoom;
 	Vector<Vector2> points_prev;
 	Vector<Vector2> uv_create_uv_prev;
 	Vector<Vector2> uv_create_poly_prev;
@@ -127,17 +127,17 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	void _cancel_editing();
 	void _update_polygon_editing_state();
 
-	void _uv_scroll_changed(float);
+	void _uv_scroll_changed(real_t);
 	void _uv_input(const Ref<InputEvent> &p_input);
 	void _uv_draw();
 	void _uv_mode(int p_mode);
 
 	void _set_use_snap(bool p_use);
 	void _set_show_grid(bool p_show);
-	void _set_snap_off_x(float p_val);
-	void _set_snap_off_y(float p_val);
-	void _set_snap_step_x(float p_val);
-	void _set_snap_step_y(float p_val);
+	void _set_snap_off_x(real_t p_val);
+	void _set_snap_off_y(real_t p_val);
+	void _set_snap_step_x(real_t p_val);
+	void _set_snap_step_y(real_t p_val);
 
 	void _uv_edit_mode_select(int p_mode);
 	void _uv_edit_popup_hide();


### PR DESCRIPTION
This is a subset of #21922, split into its own PR for easy reviewing.

This PR uses `real_t` where appropriate in editor plugins. It also fixes a few other things that I noticed while reviewing this code including fixing places where precision is needlessly lost, using const more often, and deleting dead code in CanvasItemEditor.