### PR TITLE
Update min size on Label::set_text

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -453,6 +453,7 @@ void Label::set_text(const String &p_string) {
 		visible_chars = get_total_character_count() * percent_visible;
 	}
 	update();
+	minimum_size_changed();
 }
 
 void Label::set_text_direction(Control::TextDirection p_text_direction) {


### PR DESCRIPTION
Always update minimum size when text changes. This should happen even if `clip` or `autowrap` is on, because these flags only fix the min width to 1, min height is still based on the text.

Fixes #49773.