### PR TITLE
[3.x] [iOS] Support multiple `plist` types in plugin

### DIFF
--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -367,6 +367,25 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "plugins/" + found_plugins[i].name), false));
 	}
 
+	for (int i = 0; i < found_plugins.size(); i++) {
+		// Editable plugin plist values
+		PluginConfigIOS plugin = found_plugins[i];
+		const String *K = nullptr;
+
+		while ((K = plugin.plist.next(K))) {
+			String key = *K;
+			PluginConfigIOS::PlistItem item = plugin.plist[key];
+			switch (item.type) {
+				case PluginConfigIOS::PlistItemType::STRING_INPUT: {
+					String preset_name = "plugins_plist/" + key;
+					r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, preset_name), item.value));
+				} break;
+				default:
+					continue;
+			}
+		}
+	}
+
 	plugins_changed.clear();
 	plugins = found_plugins;
 
@@ -1336,13 +1355,28 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 
 		while ((K = plugin.plist.next(K))) {
 			String key = *K;
-			String value = plugin.plist[key];
+			PluginConfigIOS::PlistItem item = plugin.plist[key];
+
+			String value;
+
+			switch (item.type) {
+				case PluginConfigIOS::PlistItemType::STRING_INPUT: {
+					String preset_name = "plugins_plist/" + key;
+					String input_value = p_preset->get(preset_name);
+					value = "<string>" + input_value + "</string>";
+				} break;
+				default:
+					value = item.value;
+					break;
+			}
 
 			if (key.empty() || value.empty()) {
 				continue;
 			}
 
-			plist_values[key] = value;
+			String plist_key = "<key>" + key + "</key>";
+
+			plist_values[plist_key] = value;
 		}
 
 		// CPP Code
@@ -1369,7 +1403,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 				continue;
 			}
 
-			p_config_data.plist_content += "<key>" + key + "</key><string>" + value + "</string>\n";
+			p_config_data.plist_content += key + value + "\n";
 		}
 	}
 

--- a/platform/iphone/plugin/godot_plugin_config.h
+++ b/platform/iphone/plugin/godot_plugin_config.h
@@ -70,6 +70,20 @@ struct PluginConfigIOS {
 
 	static const char *PLIST_SECTION;
 
+	enum PlistItemType {
+		UNKNOWN,
+		STRING,
+		INTEGER,
+		BOOLEAN,
+		RAW,
+		STRING_INPUT,
+	};
+
+	struct PlistItem {
+		PlistItemType type;
+		String value;
+	};
+
 	// Set to true when the config file is properly loaded.
 	bool valid_config = false;
 	bool supports_targets = false;
@@ -93,8 +107,10 @@ struct PluginConfigIOS {
 	Vector<String> linker_flags;
 
 	// Optional plist section
-	// Supports only string types for now
-	HashMap<String, String> plist;
+	// String value is default value.
+	// Currently supports `string`, `boolean`, `integer`, `raw`, `string_input` types
+	// <name>:<type> = <value>
+	HashMap<String, PlistItem> plist;
 };
 
 const char *PluginConfigIOS::PLUGIN_CONFIG_EXT = ".gdip";
@@ -291,13 +307,68 @@ static inline PluginConfigIOS load_plugin_config(Ref<ConfigFile> config_file, co
 		config_file->get_section_keys(PluginConfigIOS::PLIST_SECTION, &keys);
 
 		for (int i = 0; i < keys.size(); i++) {
-			String value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], String());
+			Vector<String> key_components = keys[i].split(":");
 
-			if (value.empty()) {
+			String key_value = "";
+			PluginConfigIOS::PlistItemType key_type = PluginConfigIOS::PlistItemType::UNKNOWN;
+
+			if (key_components.size() == 1) {
+				key_value = key_components[0];
+				key_type = PluginConfigIOS::PlistItemType::STRING;
+			} else if (key_components.size() == 2) {
+				key_value = key_components[0];
+
+				if (key_components[1].to_lower() == "string") {
+					key_type = PluginConfigIOS::PlistItemType::STRING;
+				} else if (key_components[1].to_lower() == "integer") {
+					key_type = PluginConfigIOS::PlistItemType::INTEGER;
+				} else if (key_components[1].to_lower() == "boolean") {
+					key_type = PluginConfigIOS::PlistItemType::BOOLEAN;
+				} else if (key_components[1].to_lower() == "raw") {
+					key_type = PluginConfigIOS::PlistItemType::RAW;
+				} else if (key_components[1].to_lower() == "string_input") {
+					key_type = PluginConfigIOS::PlistItemType::STRING_INPUT;
+				}
+			}
+
+			if (key_value.empty() || key_type == PluginConfigIOS::PlistItemType::UNKNOWN) {
 				continue;
 			}
 
-			plugin_config.plist[keys[i]] = value;
+			String value;
+
+			switch (key_type) {
+				case PluginConfigIOS::PlistItemType::STRING: {
+					String raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], String());
+					value = "<string>" + raw_value + "</string>";
+				} break;
+				case PluginConfigIOS::PlistItemType::INTEGER: {
+					int raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], 0);
+					Dictionary value_dictionary;
+					String value_format = "<integer>$value</integer>";
+					value_dictionary["value"] = raw_value;
+					value = value_format.format(value_dictionary, "$_");
+				} break;
+				case PluginConfigIOS::PlistItemType::BOOLEAN:
+					if (config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], false)) {
+						value = "<true/>";
+					} else {
+						value = "<false/>";
+					}
+					break;
+				case PluginConfigIOS::PlistItemType::RAW: {
+					String raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], String());
+					value = raw_value;
+				} break;
+				case PluginConfigIOS::PlistItemType::STRING_INPUT: {
+					String raw_value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], String());
+					value = raw_value;
+				} break;
+				default:
+					continue;
+			}
+
+			plugin_config.plist[key_value] = PluginConfigIOS::PlistItem{ key_type, value };
 		}
 	}
 


### PR DESCRIPTION
Extends current iOS Plugin system and allows to set a specific type for `Info.plist` key-value pairs. 
Implements https://github.com/godotengine/godot-ios-plugins/issues/5
Doesn't break compatibility.

Currently supported types:
* `string` - used as a default if no type is specified
* `integer`
* `boolean`
* `raw` - allows to use arrays or dictionaries
* `string_input` - allows to set `string` value for a key when exporting.


<details>

<summary>
Example
</summary>


`gdip config`
```
[plist]
plist_default="string_value"
plist_string:string="string_value"
plist_integer:integer=101
plist_boolean:boolean=true
plist_raw:raw="
<array>
    <string>UIInterfaceOrientationPortrait</string>
</array>
"
plist_input:string_input="default_input"
```

Editor Export screen:
<img width="450" alt="Снимок экрана 2021-06-21 в 17 45 41" src="https://user-images.githubusercontent.com/3750083/122793667-24ef0800-d2c4-11eb-8988-40301f815b53.png">

Exported `Info.plist`:
<img width="450" alt="Снимок экрана 2021-06-21 в 17 45 20" src="https://user-images.githubusercontent.com/3750083/122793708-2f110680-d2c4-11eb-8925-a0614bbcc025.png">


</details>