### PR TITLE
Initial support for debug adapter protocol (DAP)

### DIFF
--- a/editor/debugger/debug_adapter/SCsub
+++ b/editor/debugger/debug_adapter/SCsub
@@ -3,5 +3,3 @@
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")
-
-SConscript("debug_adapter/SCsub")

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -1,0 +1,257 @@
+/*************************************************************************/
+/*  debug_adapter_parser.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "debug_adapter_parser.h"
+
+#include "editor/editor_node.h"
+
+void DebugAdapterParser::_bind_methods() {
+	// Requests
+	ClassDB::bind_method(D_METHOD("req_initialize", "peer", "params"), &DebugAdapterParser::req_initialize);
+	ClassDB::bind_method(D_METHOD("req_disconnect", "peer", "params"), &DebugAdapterParser::prepare_success_response);
+	ClassDB::bind_method(D_METHOD("req_launch", "peer", "params"), &DebugAdapterParser::req_launch);
+	ClassDB::bind_method(D_METHOD("req_terminate", "peer", "params"), &DebugAdapterParser::req_terminate);
+	ClassDB::bind_method(D_METHOD("req_configurationDone", "peer", "params"), &DebugAdapterParser::prepare_success_response);
+	ClassDB::bind_method(D_METHOD("req_pause", "peer", "params"), &DebugAdapterParser::req_pause);
+	ClassDB::bind_method(D_METHOD("req_continue", "peer", "params"), &DebugAdapterParser::req_continue);
+	ClassDB::bind_method(D_METHOD("req_threads", "peer", "params"), &DebugAdapterParser::req_threads);
+	ClassDB::bind_method(D_METHOD("req_stackTrace", "peer", "params"), &DebugAdapterParser::req_stackTrace);
+}
+
+Dictionary DebugAdapterParser::prepare_base_message(Ref<DAPeer> p_peer) const {
+	Dictionary message;
+	message["seq"] = ++(p_peer->seq);
+
+	return message;
+}
+
+Dictionary DebugAdapterParser::prepare_base_event(Ref<DAPeer> p_peer) const {
+	Dictionary event = prepare_base_message(p_peer);
+	event["type"] = "event";
+
+	return event;
+}
+
+Dictionary DebugAdapterParser::prepare_success_response(Ref<DAPeer> p_peer, const Dictionary &p_params) const {
+	Dictionary response = prepare_base_message(p_peer);
+	response["type"] = "response";
+	response["request_seq"] = p_params["seq"];
+	response["command"] = p_params["command"];
+	response["success"] = true;
+
+	return response;
+}
+
+Dictionary DebugAdapterParser::prepare_error_response(Ref<DAPeer> p_peer, const Dictionary &p_params, DAP::ErrorType err_type) {
+	Dictionary response = prepare_base_message(p_peer);
+	response["type"] = "response";
+	response["request_seq"] = p_params["seq"];
+	response["command"] = p_params["command"];
+	response["success"] = false;
+
+	DAP::Message message;
+	message.id = generate_message_id();
+	String error, error_desc;
+	switch (err_type) {
+		case DAP::ErrorType::UNKNOWN:
+			error = "unknown";
+			error_desc = "An unknown error has ocurred when processing the request.";
+			break;
+	}
+
+	message.format = error_desc;
+	response["message"] = error;
+	response["body"] = message.to_json();
+
+	return response;
+}
+
+Dictionary DebugAdapterParser::req_initialize(Ref<DAPeer> p_peer, const Dictionary &p_params) const {
+	Dictionary response = prepare_success_response(p_peer, p_params);
+	Dictionary args = p_params["arguments"];
+
+	p_peer->linesStartAt1 = args.get("linesStartAt1", false);
+	p_peer->columnsStartAt1 = args.get("columnsStartAt1", false);
+	p_peer->supportsVariableType = args.get("supportsVariableType", false);
+	p_peer->supportsInvalidatedEvent = args.get("supportsInvalidatedEvent", false);
+
+	DAP::Capabilities caps;
+	response["body"] = caps.to_json();
+
+	DebugAdapterProtocol::get_singleton()->notify_initialized();
+
+	return response;
+}
+
+Dictionary DebugAdapterParser::req_launch(Ref<DAPeer> p_peer, const Dictionary &p_params) const {
+	Dictionary response = prepare_success_response(p_peer, p_params);
+	EditorNode::get_singleton()->run_play();
+
+	DebugAdapterProtocol::get_singleton()->notify_process();
+
+	return response;
+}
+
+Dictionary DebugAdapterParser::req_terminate(Ref<DAPeer> p_peer, const Dictionary &p_params) const {
+	Dictionary response = prepare_success_response(p_peer, p_params);
+	EditorNode::get_singleton()->run_stop();
+
+	DebugAdapterProtocol::get_singleton()->notify_terminated();
+	DebugAdapterProtocol::get_singleton()->notify_exited();
+
+	return response;
+}
+
+Dictionary DebugAdapterParser::req_pause(Ref<DAPeer> p_peer, const Dictionary &p_params) const {
+	Dictionary response = prepare_success_response(p_peer, p_params);
+	EditorNode::get_singleton()->get_pause_button()->set_pressed(true);
+	EditorDebuggerNode::get_singleton()->_paused();
+
+	DebugAdapterProtocol::get_singleton()->notify_stopped(DAP::StopReason::PAUSE);
+
+	return response;
+}
+
+Dictionary DebugAdapterParser::req_continue(Ref<DAPeer> p_peer, const Dictionary &p_params) const {
+	Dictionary response = prepare_success_response(p_peer, p_params);
+	EditorNode::get_singleton()->get_pause_button()->set_pressed(false);
+	EditorDebuggerNode::get_singleton()->_paused();
+
+	DebugAdapterProtocol::get_singleton()->notify_continued();
+
+	return response;
+}
+
+Dictionary DebugAdapterParser::req_threads(Ref<DAPeer> p_peer, const Dictionary &p_params) const {
+	Dictionary response = prepare_success_response(p_peer, p_params), body;
+	response["body"] = body;
+
+	Array arr;
+	DAP::Thread thread;
+
+	thread.id = 1; // Hardcoded because Godot only supports debugging one thread at the moment
+	thread.name = "Main";
+	arr.push_back(thread.to_json());
+	body["threads"] = arr;
+
+	return response;
+}
+
+Dictionary DebugAdapterParser::req_stackTrace(Ref<DAPeer> p_peer, const Dictionary &p_params) const {
+	Dictionary response = prepare_success_response(p_peer, p_params), body;
+	response["body"] = body;
+
+	Array arr;
+	body["stackFrames"] = arr;
+
+	return response;
+}
+
+Dictionary DebugAdapterParser::ev_initialized(Ref<DAPeer> p_peer) const {
+	Dictionary event = prepare_base_event(p_peer);
+	event["event"] = "initialized";
+
+	return event;
+}
+
+Dictionary DebugAdapterParser::ev_process(Ref<DAPeer> p_peer, const String &p_command) const {
+	Dictionary event = prepare_base_event(p_peer), body;
+	event["event"] = "process";
+	event["body"] = body;
+
+	body["name"] = OS::get_singleton()->get_executable_path();
+	body["startMethod"] = p_command;
+
+	return event;
+}
+
+Dictionary DebugAdapterParser::ev_terminated(Ref<DAPeer> p_peer) const {
+	Dictionary event = prepare_base_event(p_peer);
+	event["event"] = "terminated";
+
+	return event;
+}
+
+Dictionary DebugAdapterParser::ev_exited(Ref<DAPeer> p_peer, const int &p_exitcode) const {
+	Dictionary event = prepare_base_event(p_peer), body;
+	event["event"] = "exited";
+	event["body"] = body;
+
+	body["exitCode"] = p_exitcode;
+
+	return event;
+}
+
+Dictionary DebugAdapterParser::ev_stopped(Ref<DAPeer> p_peer, DAP::StopReason p_reason) const {
+	Dictionary event = prepare_base_event(p_peer), body;
+	event["event"] = "stopped";
+	event["body"] = body;
+
+	switch (p_reason) {
+		case DAP::StopReason::STEP:
+			body["reason"] = "step";
+			break;
+		case DAP::StopReason::BREAKPOINT:
+			body["reason"] = "breakpoint";
+			break;
+		case DAP::StopReason::EXCEPTION:
+			body["reason"] = "exception";
+			break;
+		case DAP::StopReason::PAUSE:
+			body["reason"] = "pause";
+			break;
+	}
+
+	body["threadId"] = 1;
+
+	return event;
+}
+
+Dictionary DebugAdapterParser::ev_continued(Ref<DAPeer> p_peer) const {
+	Dictionary event = prepare_base_event(p_peer), body;
+	event["event"] = "continued";
+	event["body"] = body;
+
+	body["threadId"] = 1;
+
+	return event;
+}
+
+DebugAdapterParser::DebugAdapterParser() {
+	reset_ids();
+}
+
+void DebugAdapterParser::reset_ids() {
+	messageId = 0;
+}
+
+int DebugAdapterParser::generate_message_id() {
+	return ++messageId;
+}

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -1,0 +1,80 @@
+/*************************************************************************/
+/*  debug_adapter_parser.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef DEBUG_ADAPTER_PARSER_H
+#define DEBUG_ADAPTER_PARSER_H
+
+#include "debug_adapter_protocol.h"
+#include "debug_adapter_types.h"
+
+struct DAPeer;
+class DebugAdapterProtocol;
+
+class DebugAdapterParser : public Object {
+	GDCLASS(DebugAdapterParser, Object);
+
+private:
+	int messageId;
+
+	friend DebugAdapterProtocol;
+
+protected:
+	static void _bind_methods();
+
+	Dictionary prepare_base_message(Ref<DAPeer> p_peer) const;
+	Dictionary prepare_base_event(Ref<DAPeer> p_peer) const;
+	Dictionary prepare_success_response(Ref<DAPeer> p_peer, const Dictionary &p_params) const;
+	Dictionary prepare_error_response(Ref<DAPeer> p_peer, const Dictionary &p_params, DAP::ErrorType err_type);
+
+public:
+	// Requests
+	Dictionary req_initialize(Ref<DAPeer> p_peer, const Dictionary &p_params) const;
+	Dictionary req_launch(Ref<DAPeer> p_peer, const Dictionary &p_params) const;
+	Dictionary req_terminate(Ref<DAPeer> p_peer, const Dictionary &p_params) const;
+	Dictionary req_pause(Ref<DAPeer> p_peer, const Dictionary &p_params) const;
+	Dictionary req_continue(Ref<DAPeer> p_peer, const Dictionary &p_params) const;
+	Dictionary req_threads(Ref<DAPeer> p_peer, const Dictionary &p_params) const;
+	Dictionary req_stackTrace(Ref<DAPeer> p_peer, const Dictionary &p_params) const;
+
+	// Events
+	Dictionary ev_initialized(Ref<DAPeer> p_peer) const;
+	Dictionary ev_process(Ref<DAPeer> p_peer, const String &p_command) const;
+	Dictionary ev_terminated(Ref<DAPeer> p_peer) const;
+	Dictionary ev_exited(Ref<DAPeer> p_peer, const int &p_exitcode) const;
+	Dictionary ev_stopped(Ref<DAPeer> p_peer, DAP::StopReason p_reason) const;
+	Dictionary ev_continued(Ref<DAPeer> p_peer) const;
+
+	DebugAdapterParser();
+
+	void reset_ids();
+	int generate_message_id();
+};
+
+#endif

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -1,0 +1,303 @@
+/*************************************************************************/
+/*  debug_adapter_protocol.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "debug_adapter_protocol.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/json.h"
+#include "editor/debugger/script_editor_debugger.h"
+#include "editor/doc_tools.h"
+#include "editor/editor_log.h"
+#include "editor/editor_node.h"
+
+DebugAdapterProtocol *DebugAdapterProtocol::singleton = nullptr;
+
+Error DAPeer::handle_data() {
+	int read = 0;
+	// Read headers
+	if (!has_header) {
+		while (true) {
+			if (req_pos >= DAP_MAX_BUFFER_SIZE) {
+				req_pos = 0;
+				ERR_FAIL_COND_V_MSG(true, ERR_OUT_OF_MEMORY, "Response header too big");
+			}
+			Error err = connection->get_partial_data(&req_buf[req_pos], 1, read);
+			if (err != OK) {
+				return FAILED;
+			} else if (read != 1) { // Busy, wait until next poll
+				return ERR_BUSY;
+			}
+			char *r = (char *)req_buf;
+			int l = req_pos;
+
+			// End of headers
+			if (l > 3 && r[l] == '\n' && r[l - 1] == '\r' && r[l - 2] == '\n' && r[l - 3] == '\r') {
+				r[l - 3] = '\0'; // Null terminate to read string
+				String header;
+				header.parse_utf8(r);
+				content_length = header.substr(16).to_int();
+				has_header = true;
+				req_pos = 0;
+				break;
+			}
+			req_pos++;
+		}
+	}
+	if (has_header) {
+		while (req_pos < content_length) {
+			if (content_length >= DAP_MAX_BUFFER_SIZE) {
+				req_pos = 0;
+				has_header = false;
+				ERR_FAIL_COND_V_MSG(req_pos >= DAP_MAX_BUFFER_SIZE, ERR_OUT_OF_MEMORY, "Response content too big");
+			}
+			Error err = connection->get_partial_data(&req_buf[req_pos], content_length - req_pos, read);
+			if (err != OK) {
+				return FAILED;
+			} else if (read < content_length - req_pos) {
+				return ERR_BUSY;
+			}
+			req_pos += read;
+		}
+
+		// Parse data
+		String msg;
+		msg.parse_utf8((const char *)req_buf, req_pos);
+
+		// Reset to read again
+		req_pos = 0;
+		has_header = false;
+
+		// Response
+		DebugAdapterProtocol::get_singleton()->process_message(msg);
+	}
+	return OK;
+}
+
+Error DAPeer::send_data() {
+	while (res_queue.size()) {
+		Dictionary data = res_queue.front()->get();
+		String formatted_data = format_output(data);
+
+		int data_sent = 0;
+		while (data_sent < formatted_data.length()) {
+			int curr_sent = 0;
+			Error err = connection->put_partial_data((const uint8_t *)formatted_data.utf8().get_data(), formatted_data.size() - data_sent - 1, curr_sent);
+			if (err != OK) {
+				return err;
+			}
+			data_sent += curr_sent;
+		}
+		res_queue.pop_front();
+	}
+	return OK;
+}
+
+String DAPeer::format_output(const Dictionary &p_params) const {
+	String response = Variant(p_params).to_json_string();
+	String header = "Content-Length: ";
+	CharString charstr = response.utf8();
+	size_t len = charstr.length();
+	header += itos(len);
+	header += "\r\n\r\n";
+
+	return header + response;
+}
+
+Error DebugAdapterProtocol::on_client_connected() {
+	ERR_FAIL_COND_V_MSG(clients.size() >= DAP_MAX_CLIENTS, FAILED, "Max client limits reached");
+	Ref<StreamPeerTCP> tcp_peer = server->take_connection();
+	tcp_peer->set_no_delay(true);
+	Ref<DAPeer> peer = memnew(DAPeer);
+	peer->connection = tcp_peer;
+	clients.push_back(peer);
+	EditorNode::get_log()->add_message("[DAP] Connection Taken", EditorLog::MSG_TYPE_EDITOR);
+	return OK;
+}
+
+void DebugAdapterProtocol::on_client_disconnected(const Ref<DAPeer> &p_peer) {
+	clients.erase(p_peer);
+	if (!clients.size()) {
+		parser->reset_ids();
+	}
+	EditorNode::get_log()->add_message("[DAP] Disconnected", EditorLog::MSG_TYPE_EDITOR);
+}
+
+void DebugAdapterProtocol::reset_current_info() {
+	_current_request = "";
+	_current_args = Dictionary();
+	_current_peer = Ref<DAPeer>(nullptr);
+}
+
+void DebugAdapterProtocol::process_message(const String &p_text) {
+	JSON json;
+	ERR_FAIL_COND_MSG(json.parse(p_text) != OK, "Mal-formed message!");
+	Dictionary params = json.get_data();
+
+	// Append "req_" to any command received; prevents name clash with existing functions, and possibly exploiting
+	String command = "req_" + (String)params["command"];
+	if (parser->has_method(command)) {
+		_current_request = params["command"];
+		_current_args = params["arguments"];
+
+		Array args;
+		args.push_back(_current_peer);
+		args.push_back(params);
+		Dictionary response = parser->callv(command, args);
+		_current_peer->res_queue.push_front(response);
+	}
+
+	reset_current_info();
+}
+
+void DebugAdapterProtocol::notify_initialized() {
+	Dictionary event = parser->ev_initialized(_current_peer);
+	_current_peer->res_queue.push_back(event);
+}
+
+void DebugAdapterProtocol::notify_process() {
+	String launch_mode = _current_request.is_empty() ? "launch" : _current_request;
+
+	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
+		Dictionary event = parser->ev_process(E->get(), launch_mode);
+		E->get()->res_queue.push_back(event);
+	}
+}
+
+void DebugAdapterProtocol::notify_terminated() {
+	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
+		if (_current_request == "launch" && _current_peer == E->get()) {
+			continue;
+		}
+		Dictionary event = parser->ev_terminated(E->get());
+		E->get()->res_queue.push_back(event);
+	}
+}
+
+void DebugAdapterProtocol::notify_exited(const int &p_exitcode) {
+	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
+		if (_current_request == "launch" && _current_peer == E->get()) {
+			continue;
+		}
+		Dictionary event = parser->ev_exited(E->get(), p_exitcode);
+		E->get()->res_queue.push_back(event);
+	}
+}
+
+void DebugAdapterProtocol::notify_stopped(const DAP::StopReason &p_reason) {
+	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
+		Dictionary event = parser->ev_stopped(E->get(), p_reason);
+		E->get()->res_queue.push_back(event);
+	}
+}
+
+void DebugAdapterProtocol::notify_continued() {
+	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
+		if (_current_request == "continue" && E->get() == _current_peer) {
+			continue;
+		}
+		Dictionary event = parser->ev_continued(E->get());
+		E->get()->res_queue.push_back(event);
+	}
+}
+
+void DebugAdapterProtocol::on_debug_paused() {
+	if (EditorNode::get_singleton()->get_pause_button()->is_pressed()) {
+		notify_stopped(DAP::StopReason::PAUSE);
+	} else {
+		notify_continued();
+	}
+}
+
+void DebugAdapterProtocol::on_debug_stopped() {
+	notify_exited();
+	notify_terminated();
+}
+
+void DebugAdapterProtocol::poll() {
+	if (server->is_connection_available()) {
+		on_client_connected();
+	}
+	List<Ref<DAPeer>> to_delete;
+	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
+		Ref<DAPeer> peer = E->get();
+		StreamPeerTCP::Status status = peer->connection->get_status();
+		if (status == StreamPeerTCP::STATUS_NONE || status == StreamPeerTCP::STATUS_ERROR) {
+			to_delete.push_back(peer);
+		} else {
+			_current_peer = peer;
+			if (peer->connection->get_available_bytes() > 0) {
+				Error err = peer->handle_data();
+				if (err != OK && err != ERR_BUSY) {
+					to_delete.push_back(peer);
+				}
+			}
+			Error err = peer->send_data();
+			if (err != OK && err != ERR_BUSY) {
+				to_delete.push_back(peer);
+			}
+		}
+	}
+
+	for (List<Ref<DAPeer>>::Element *E = to_delete.front(); E; E = E->next()) {
+		on_client_disconnected(E->get());
+	}
+	to_delete.clear();
+}
+
+Error DebugAdapterProtocol::start(int p_port, const IPAddress &p_bind_ip) {
+	_initialized = true;
+	return server->listen(p_port, p_bind_ip);
+}
+
+void DebugAdapterProtocol::stop() {
+	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
+		E->get()->connection->disconnect_from_host();
+	}
+
+	clients.clear();
+	server->stop();
+	_initialized = false;
+}
+
+DebugAdapterProtocol::DebugAdapterProtocol() {
+	server.instantiate();
+	singleton = this;
+	parser = memnew(DebugAdapterParser);
+
+	EditorNode *node = EditorNode::get_singleton();
+	node->get_pause_button()->connect("pressed", callable_mp(this, &DebugAdapterProtocol::on_debug_paused));
+
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	debugger_node->get_default_debugger()->connect("stopped", callable_mp(this, &DebugAdapterProtocol::on_debug_stopped));
+}
+
+DebugAdapterProtocol::~DebugAdapterProtocol() {
+	memdelete(parser);
+}

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -1,0 +1,115 @@
+/*************************************************************************/
+/*  debug_adapter_protocol.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef DEBUG_ADAPTER_PROTOCOL_H
+#define DEBUG_ADAPTER_PROTOCOL_H
+
+#include "core/io/stream_peer.h"
+#include "core/io/stream_peer_tcp.h"
+#include "core/io/tcp_server.h"
+
+#include "debug_adapter_parser.h"
+#include "debug_adapter_types.h"
+
+#define DAP_MAX_BUFFER_SIZE 4194304 // 4MB
+#define DAP_MAX_CLIENTS 8
+
+class DebugAdapterParser;
+
+struct DAPeer : RefCounted {
+	Ref<StreamPeerTCP> connection;
+
+	uint8_t req_buf[DAP_MAX_BUFFER_SIZE];
+	int req_pos = 0;
+	bool has_header = false;
+	int content_length = 0;
+	List<Dictionary> res_queue;
+	int seq = 0;
+
+	// Client specific info
+	bool linesStartAt1 = false;
+	bool columnsStartAt1 = false;
+	bool supportsVariableType = false;
+	bool supportsInvalidatedEvent = false;
+
+	Error handle_data();
+	Error send_data();
+	String format_output(const Dictionary &p_params) const;
+};
+
+class DebugAdapterProtocol : public Object {
+	GDCLASS(DebugAdapterProtocol, Object)
+
+private:
+	static DebugAdapterProtocol *singleton;
+	DebugAdapterParser *parser;
+
+	List<Ref<DAPeer>> clients;
+	Ref<TCPServer> server;
+
+	Error on_client_connected();
+	void on_client_disconnected(const Ref<DAPeer> &p_peer);
+
+	void reset_current_info();
+
+	bool _initialized = false;
+	String _current_request;
+	Dictionary _current_args;
+	Ref<DAPeer> _current_peer;
+
+public:
+	_FORCE_INLINE_ static DebugAdapterProtocol *get_singleton() { return singleton; }
+	_FORCE_INLINE_ bool is_active() const { return _initialized && clients.size() > 0; }
+
+	void process_message(const String &p_text);
+
+	String get_current_request() const { return _current_request; }
+	Dictionary get_current_args() const { return _current_args; }
+	Ref<DAPeer> get_current_peer() const { return _current_peer; }
+
+	void notify_initialized();
+	void notify_process();
+	void notify_terminated();
+	void notify_exited(const int &p_exitcode = 0);
+	void notify_stopped(const DAP::StopReason &p_reason);
+	void notify_continued();
+
+	void on_debug_paused();
+	void on_debug_stopped();
+
+	void poll();
+	Error start(int p_port, const IPAddress &p_bind_ip);
+	void stop();
+
+	DebugAdapterProtocol();
+	~DebugAdapterProtocol();
+};
+
+#endif

--- a/editor/debugger/debug_adapter/debug_adapter_server.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_server.cpp
@@ -1,0 +1,102 @@
+/*************************************************************************/
+/*  debug_adapter_server.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "debug_adapter_server.h"
+
+#include "core/os/os.h"
+#include "editor/editor_log.h"
+#include "editor/editor_node.h"
+
+DebugAdapterServer::DebugAdapterServer() {
+	_EDITOR_DEF("network/debug_adapter/remote_port", remote_port);
+	_EDITOR_DEF("network/debug_adapter/use_thread", use_thread);
+}
+
+void DebugAdapterServer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+			start();
+			break;
+		case NOTIFICATION_EXIT_TREE:
+			stop();
+			break;
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			// The main loop can be run again during request processing, which modifies internal state of the protocol.
+			// Thus, "polling" is needed to prevent it from parsing other requests while the current one isn't finished.
+			if (started && !use_thread && !polling) {
+				polling = true;
+				protocol.poll();
+				polling = false;
+			}
+		} break;
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			int remote_port = (int)_EDITOR_GET("network/debug_adapter/remote_port");
+			bool use_thread = (bool)_EDITOR_GET("network/debug_adapter/use_thread");
+			if (remote_port != this->remote_port || use_thread != this->use_thread) {
+				this->stop();
+				this->start();
+			}
+		} break;
+	}
+}
+
+void DebugAdapterServer::thread_func(void *p_userdata) {
+	DebugAdapterServer *self = static_cast<DebugAdapterServer *>(p_userdata);
+	while (self->thread_running) {
+		// Poll 20 times per second
+		self->protocol.poll();
+		OS::get_singleton()->delay_usec(50000);
+	}
+}
+
+void DebugAdapterServer::start() {
+	remote_port = (int)_EDITOR_GET("network/debug_adapter/remote_port");
+	use_thread = (bool)_EDITOR_GET("network/debug_adapter/use_thread");
+	if (protocol.start(remote_port, IPAddress("127.0.0.1")) == OK) {
+		EditorNode::get_log()->add_message("--- Debug adapter server started ---", EditorLog::MSG_TYPE_EDITOR);
+		if (use_thread) {
+			thread_running = true;
+			thread.start(DebugAdapterServer::thread_func, this);
+		}
+		set_process_internal(!use_thread);
+		started = true;
+	}
+}
+
+void DebugAdapterServer::stop() {
+	if (use_thread) {
+		ERR_FAIL_COND(!thread.is_started());
+		thread_running = false;
+		thread.wait_to_finish();
+	}
+	protocol.stop();
+	started = false;
+	EditorNode::get_log()->add_message("--- Debug adapter server stopped ---", EditorLog::MSG_TYPE_EDITOR);
+}

--- a/editor/debugger/debug_adapter/debug_adapter_server.h
+++ b/editor/debugger/debug_adapter/debug_adapter_server.h
@@ -1,0 +1,59 @@
+/*************************************************************************/
+/*  debug_adapter_server.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef DEBUG_ADAPTER_SERVER_H
+#define DEBUG_ADAPTER_SERVER_H
+
+#include "debug_adapter_protocol.h"
+#include "editor/editor_plugin.h"
+
+class DebugAdapterServer : public EditorPlugin {
+	GDCLASS(DebugAdapterServer, EditorPlugin);
+
+	DebugAdapterProtocol protocol;
+
+	Thread thread;
+	int remote_port = 6009;
+	bool thread_running = false;
+	bool started = false;
+	bool use_thread = false;
+	bool polling = false;
+	static void thread_func(void *p_userdata);
+
+private:
+	void _notification(int p_what);
+
+public:
+	DebugAdapterServer();
+	void start();
+	void stop();
+};
+
+#endif

--- a/editor/debugger/debug_adapter/debug_adapter_types.h
+++ b/editor/debugger/debug_adapter/debug_adapter_types.h
@@ -1,0 +1,199 @@
+/*************************************************************************/
+/*  debug_adapter_types.h                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef DEBUG_ADAPTER_TYPES_H
+#define DEBUG_ADAPTER_TYPES_H
+
+#include "core/io/json.h"
+#include "core/variant/dictionary.h"
+
+namespace DAP {
+
+enum ErrorType {
+	UNKNOWN
+};
+
+enum StopReason {
+	STEP,
+	BREAKPOINT,
+	EXCEPTION,
+	PAUSE
+};
+
+struct Source {
+	String name;
+	String path;
+	Array checksums;
+
+	_FORCE_INLINE_ void from_json(const Dictionary &p_params) {
+		name = p_params["name"];
+		path = p_params["path"];
+		checksums = p_params["checksums"];
+	}
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["name"] = name;
+		dict["path"] = path;
+		dict["checksums"] = checksums;
+
+		return dict;
+	}
+};
+
+struct Breakpoint {
+	bool verified;
+	Source source;
+	int line;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["verified"] = verified;
+		dict["source"] = source.to_json();
+		dict["line"] = line;
+
+		return dict;
+	}
+};
+
+struct BreakpointLocation {
+	int line;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["line"] = line;
+
+		return dict;
+	}
+};
+
+struct Capabilities {
+	bool supportsConfigurationDoneRequest = true;
+	bool supportsEvaluateForHovers = true;
+	bool supportsSetVariable = true;
+	String supportedChecksumAlgorithms[2] = { "MD5", "SHA256" };
+	bool supportsRestartRequest = true;
+	bool supportsValueFormattingOptions = true;
+	bool supportTerminateDebuggee = true;
+	bool supportSuspendDebuggee = true;
+	bool supportsTerminateRequest = true;
+	bool supportsBreakpointLocationsRequest = true;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["supportsConfigurationDoneRequest"] = supportsConfigurationDoneRequest;
+		dict["supportsEvaluateForHovers"] = supportsEvaluateForHovers;
+		dict["supportsSetVariable"] = supportsSetVariable;
+		dict["supportsRestartRequest"] = supportsRestartRequest;
+		dict["supportsValueFormattingOptions"] = supportsValueFormattingOptions;
+		dict["supportTerminateDebuggee"] = supportTerminateDebuggee;
+		dict["supportSuspendDebuggee"] = supportSuspendDebuggee;
+		dict["supportsTerminateRequest"] = supportsTerminateRequest;
+		dict["supportsBreakpointLocationsRequest"] = supportsBreakpointLocationsRequest;
+
+		Array arr;
+		arr.push_back(supportedChecksumAlgorithms[0]);
+		arr.push_back(supportedChecksumAlgorithms[1]);
+		dict["supportedChecksumAlgorithms"] = arr;
+
+		return dict;
+	}
+};
+
+struct Checksum {
+	String algorithm;
+	String checksum;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["algorithm"] = algorithm;
+		dict["checksum"] = checksum;
+
+		return dict;
+	}
+};
+
+struct Message {
+	int id;
+	String format;
+	bool sendTelemetry = false; // Just in case :)
+	bool showUser;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["id"] = id;
+		dict["format"] = format;
+		dict["sendTelemetry"] = sendTelemetry;
+		dict["showUser"] = showUser;
+
+		return dict;
+	}
+};
+
+struct SourceBreakpoint {
+	int line;
+
+	_FORCE_INLINE_ void from_json(const Dictionary &p_params) {
+		line = p_params["line"];
+	}
+};
+
+struct StackFrame {
+	int id;
+	String name;
+	Source source;
+	int line;
+	int column;
+
+	_FORCE_INLINE_ void from_json(const Dictionary &p_params) {
+		id = p_params["id"];
+		name = p_params["name"];
+		source.from_json(p_params["source"]);
+		line = p_params["line"];
+		column = p_params["column"];
+	}
+};
+
+struct Thread {
+	int id;
+	String name;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["id"] = id;
+		dict["name"] = name;
+
+		return dict;
+	}
+};
+
+} // namespace DAP
+
+#endif

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -35,6 +35,7 @@
 #include "scene/gui/margin_container.h"
 
 class Button;
+class DebugAdapterParser;
 class EditorDebuggerTree;
 class EditorDebuggerRemoteObject;
 class MenuButton;
@@ -109,6 +110,7 @@ private:
 	EditorDebuggerRemoteObject *get_inspected_remote_object();
 
 	friend class DebuggerEditorPlugin;
+	friend class DebugAdapterParser;
 	static EditorDebuggerNode *singleton;
 	EditorDebuggerNode();
 

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -128,13 +128,13 @@ Error GDScriptLanguageProtocol::on_client_connected() {
 	peer->connection = tcp_peer;
 	clients.set(next_client_id, peer);
 	next_client_id++;
-	EditorNode::get_log()->add_message("Connection Taken", EditorLog::MSG_TYPE_EDITOR);
+	EditorNode::get_log()->add_message("[LSP] Connection Taken", EditorLog::MSG_TYPE_EDITOR);
 	return OK;
 }
 
 void GDScriptLanguageProtocol::on_client_disconnected(const int &p_client_id) {
 	clients.erase(p_client_id);
-	EditorNode::get_log()->add_message("Disconnected", EditorLog::MSG_TYPE_EDITOR);
+	EditorNode::get_log()->add_message("[LSP] Disconnected", EditorLog::MSG_TYPE_EDITOR);
 }
 
 String GDScriptLanguageProtocol::process_message(const String &p_text) {


### PR DESCRIPTION
*[(for GSoC DAP project)](https://summerofcode.withgoogle.com/projects/#6389461815918592)*

This PR introduces support for the [debug adapter protocol](https://microsoft.github.io/debug-adapter-protocol/), starting with some simple commands, such as `connect/disconnect`, `launch/terminate`, and `pause/continue`.

New editor settings have been added into a "Debug Adapter" category, similarly to how **LSP** is implemented:
![image](https://user-images.githubusercontent.com/6501975/122802911-ddfe1400-d2bd-11eb-855e-5c6e15cefb27.png)

I've tested it with VSCode so far, it would be nice to know if other text editor/IDE's can use it without any issue.
