### PR TITLE
NodePath properly updated in the editor in more cases when nodes are moved or renamed

### DIFF
--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -20,6 +20,7 @@
 		@"/root/Main" # If your main scene's root node were named "Main".
 		@"/root/MyAutoload" # If you have an autoloaded node or scene.
 		[/codeblock]
+		[b]Note:[/b] In the editor, [NodePath] properties are automatically updated when moving, renaming or deleting a node in the scene tree, but they are never updated at runtime.
 	</description>
 	<tutorials>
 		<link title="2D Role Playing Game Demo">https://godotengine.org/asset-library/asset/520</link>

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -247,6 +247,9 @@ class SceneTreeDock : public VBoxContainer {
 	static SceneTreeDock *singleton;
 	static void _update_configuration_warning();
 
+	static bool _update_node_path(const NodePath &p_root_path, NodePath &p_node_path, List<Pair<NodePath, NodePath>> *p_renames);
+	static bool _check_node_path_recursive(const NodePath &p_root_path, Variant &p_variant, List<Pair<NodePath, NodePath>> *p_renames);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
Fix more cases of node path needing an update when nodes are renamed or moved in the editor.

**Built-in node properties:**
Before, node paths were checked only for script export variables. Now all properties are checked from the node, which includes built-in node properties.
Allows proper node path updates for nodes like remote transform, physics joints, etc.

**Arrays and dictionaries:**
Node paths nested in array and dictionary properties are now also updated in the editor.

Also update the documentation to be clear about node path update in the editor and at runtime.

Fixes #49810
Fixes #49811

Credits to @latorril for finding the issue and investigating the cause.