### PR TITLE
Fix process mode update when mode owner is set to Inherit

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -70,7 +70,9 @@ void Node::_notification(int p_notification) {
 				if (data.parent) {
 					data.process_owner = data.parent->data.process_owner;
 				} else {
-					data.process_owner = nullptr;
+					ERR_PRINT("The root node can't be set to Inherit process mode, reverting to Pausable instead.");
+					data.process_mode = PROCESS_MODE_PAUSABLE;
+					data.process_owner = this;
 				}
 			} else {
 				data.process_owner = this;
@@ -437,17 +439,17 @@ void Node::set_process_mode(ProcessMode p_mode) {
 	bool prev_can_process = can_process();
 	bool prev_enabled = _is_enabled();
 
-	data.process_mode = p_mode;
-
-	if (data.process_mode == PROCESS_MODE_INHERIT) {
+	if (p_mode == PROCESS_MODE_INHERIT) {
 		if (data.parent) {
-			data.process_owner = data.parent->data.owner;
+			data.process_owner = data.parent->data.process_owner;
 		} else {
-			data.process_owner = nullptr;
+			ERR_FAIL_MSG("The root node can't be set to Inherit process mode.");
 		}
 	} else {
 		data.process_owner = this;
 	}
+
+	data.process_mode = p_mode;
 
 	bool next_can_process = can_process();
 	bool next_enabled = _is_enabled();
@@ -702,6 +704,9 @@ bool Node::_can_process(bool p_paused) const {
 	} else {
 		process_mode = data.process_mode;
 	}
+
+	// The owner can't be set to inherit, must be a bug.
+	ERR_FAIL_COND_V(process_mode == PROCESS_MODE_INHERIT, false);
 
 	if (process_mode == PROCESS_MODE_DISABLED) {
 		return false;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1331,6 +1331,7 @@ SceneTree::SceneTree() {
 	// Create with mainloop.
 
 	root = memnew(Window);
+	root->set_process_mode(Node::PROCESS_MODE_PAUSABLE);
 	root->set_name("root");
 #ifndef _3D_DISABLED
 	if (!root->get_world_3d().is_valid()) {


### PR DESCRIPTION
~When the process mode owner is the root and is set to `PROCESS_MODE_INHERIT`, the mode needs to be considered as the default (`PROCESS_MODE_PAUSABLE`) instead of making the node disabled.~

Fixes #49818

**Edit: refactored based on https://github.com/godotengine/godot/pull/49819#issuecomment-912971626**

Prevent the root node to be set to `PROCESS_MODE_INHERIT`, since it causes undefined behavior.

Fix a case where the process owner node is wrongly set to the directparent instead of the proper node.

Add errors for all unhandled cases.
