### PR TITLE
Split tonemapper out of effects

### DIFF
--- a/servers/rendering/renderer_rd/SCsub
+++ b/servers/rendering/renderer_rd/SCsub
@@ -4,6 +4,7 @@ Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")
 
+SConscript("effects/SCsub")
 SConscript("forward_clustered/SCsub")
 SConscript("forward_mobile/SCsub")
 SConscript("shaders/SCsub")

--- a/servers/rendering/renderer_rd/effects/SCsub
+++ b/servers/rendering/renderer_rd/effects/SCsub
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/renderer_rd/effects/tonemap_rd.cpp
+++ b/servers/rendering/renderer_rd/effects/tonemap_rd.cpp
@@ -1,0 +1,186 @@
+/*************************************************************************/
+/*  tonemap_rd.cpp                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "tonemap_rd.h"
+
+#include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
+
+RID TonemapRD::_get_uniform_set_from_texture(RID p_texture, bool p_use_mipmaps) {
+	if (texture_to_uniform_set_cache.has(p_texture)) {
+		RID uniform_set = texture_to_uniform_set_cache[p_texture];
+		if (RD::get_singleton()->uniform_set_is_valid(uniform_set)) {
+			return uniform_set;
+		}
+	}
+
+	Vector<RD::Uniform> uniforms;
+	RD::Uniform u;
+	u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+	u.binding = 0;
+	u.ids.push_back(p_use_mipmaps ? default_mipmap_sampler : default_sampler);
+	u.ids.push_back(p_texture);
+	uniforms.push_back(u);
+	RID uniform_set = RD::get_singleton()->uniform_set_create(uniforms, shader.version_get_shader(shader_version, 0), 0);
+
+	texture_to_uniform_set_cache[p_texture] = uniform_set;
+
+	return uniform_set;
+}
+
+void TonemapRD::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Settings &p_settings) {
+	memset(&push_constant, 0, sizeof(PushConstant));
+
+	push_constant.use_bcs = p_settings.use_bcs;
+	push_constant.bcs[0] = p_settings.brightness;
+	push_constant.bcs[1] = p_settings.contrast;
+	push_constant.bcs[2] = p_settings.saturation;
+
+	push_constant.use_glow = p_settings.use_glow;
+	push_constant.glow_intensity = p_settings.glow_intensity;
+	push_constant.glow_levels[0] = p_settings.glow_levels[0]; // clean this up to just pass by pointer or something
+	push_constant.glow_levels[1] = p_settings.glow_levels[1];
+	push_constant.glow_levels[2] = p_settings.glow_levels[2];
+	push_constant.glow_levels[3] = p_settings.glow_levels[3];
+	push_constant.glow_levels[4] = p_settings.glow_levels[4];
+	push_constant.glow_levels[5] = p_settings.glow_levels[5];
+	push_constant.glow_levels[6] = p_settings.glow_levels[6];
+	push_constant.glow_texture_size[0] = p_settings.glow_texture_size.x;
+	push_constant.glow_texture_size[1] = p_settings.glow_texture_size.y;
+	push_constant.glow_mode = p_settings.glow_mode;
+
+	int mode = p_settings.glow_use_bicubic_upscale ? TONEMAP_MODE_BICUBIC_GLOW_FILTER : TONEMAP_MODE_NORMAL;
+	if (p_settings.use_1d_color_correction) {
+		mode += 2;
+	}
+
+	push_constant.tonemapper = p_settings.tonemap_mode;
+	push_constant.use_auto_exposure = p_settings.use_auto_exposure;
+	push_constant.exposure = p_settings.exposure;
+	push_constant.white = p_settings.white;
+	push_constant.auto_exposure_grey = p_settings.auto_exposure_grey;
+
+	push_constant.use_color_correction = p_settings.use_color_correction;
+
+	push_constant.use_fxaa = p_settings.use_fxaa;
+	push_constant.use_debanding = p_settings.use_debanding;
+	push_constant.pixel_size[0] = 1.0 / p_settings.texture_size.x;
+	push_constant.pixel_size[1] = 1.0 / p_settings.texture_size.y;
+
+	if (p_settings.view_count > 1) {
+		// Use MULTIVIEW versions
+		mode += 4;
+	}
+
+	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_dst_framebuffer, RD::INITIAL_ACTION_DROP, RD::FINAL_ACTION_READ, RD::INITIAL_ACTION_DROP, RD::FINAL_ACTION_DISCARD);
+	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, pipelines[mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dst_framebuffer)));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, _get_uniform_set_from_texture(p_source_color), 0);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, _get_uniform_set_from_texture(p_settings.exposure_texture), 1);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, _get_uniform_set_from_texture(p_settings.glow_texture, true), 2);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, _get_uniform_set_from_texture(p_settings.color_correction_texture), 3);
+	RD::get_singleton()->draw_list_bind_index_array(draw_list, index_array);
+
+	RD::get_singleton()->draw_list_set_push_constant(draw_list, &push_constant, sizeof(PushConstant));
+	RD::get_singleton()->draw_list_draw(draw_list, true);
+	RD::get_singleton()->draw_list_end();
+}
+
+TonemapRD::TonemapRD() {
+	// Initialize tonemapper
+	Vector<String> modes;
+	modes.push_back("\n");
+	modes.push_back("\n#define USE_GLOW_FILTER_BICUBIC\n");
+	modes.push_back("\n#define USE_1D_LUT\n");
+	modes.push_back("\n#define USE_GLOW_FILTER_BICUBIC\n#define USE_1D_LUT\n");
+
+	// multiview versions of our shaders
+	modes.push_back("\n#define MULTIVIEW\n");
+	modes.push_back("\n#define MULTIVIEW\n#define USE_GLOW_FILTER_BICUBIC\n");
+	modes.push_back("\n#define MULTIVIEW\n#define USE_1D_LUT\n");
+	modes.push_back("\n#define MULTIVIEW\n#define USE_GLOW_FILTER_BICUBIC\n#define USE_1D_LUT\n");
+
+	shader.initialize(modes);
+
+	if (!RendererCompositorRD::singleton->is_xr_enabled()) {
+		shader.set_variant_enabled(TONEMAP_MODE_NORMAL_MULTIVIEW, false);
+		shader.set_variant_enabled(TONEMAP_MODE_BICUBIC_GLOW_FILTER_MULTIVIEW, false);
+		shader.set_variant_enabled(TONEMAP_MODE_1D_LUT_MULTIVIEW, false);
+		shader.set_variant_enabled(TONEMAP_MODE_BICUBIC_GLOW_FILTER_1D_LUT_MULTIVIEW, false);
+	}
+
+	shader_version = shader.version_create();
+
+	for (int i = 0; i < TONEMAP_MODE_MAX; i++) {
+		if (shader.is_variant_enabled(i)) {
+			pipelines[i].setup(shader.version_get_shader(shader_version, i), RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), RD::PipelineDepthStencilState(), RD::PipelineColorBlendState::create_disabled(), 0);
+		} else {
+			pipelines[i].clear();
+		}
+	}
+
+	RD::SamplerState sampler;
+	sampler.mag_filter = RD::SAMPLER_FILTER_LINEAR;
+	sampler.min_filter = RD::SAMPLER_FILTER_LINEAR;
+	sampler.max_lod = 0;
+
+	default_sampler = RD::get_singleton()->sampler_create(sampler);
+	RD::get_singleton()->set_resource_name(default_sampler, "Default Linear Tonemap Sampler");
+
+	sampler.min_filter = RD::SAMPLER_FILTER_LINEAR;
+	sampler.mip_filter = RD::SAMPLER_FILTER_LINEAR;
+	sampler.max_lod = 1e20;
+
+	default_mipmap_sampler = RD::get_singleton()->sampler_create(sampler);
+	RD::get_singleton()->set_resource_name(default_mipmap_sampler, "Default MipMap Tonemap Sampler");
+
+	{ //create index array for copy shaders
+		Vector<uint8_t> pv;
+		pv.resize(6 * 4);
+		{
+			uint8_t *w = pv.ptrw();
+			int *p32 = (int *)w;
+			p32[0] = 0;
+			p32[1] = 1;
+			p32[2] = 2;
+			p32[3] = 0;
+			p32[4] = 2;
+			p32[5] = 3;
+		}
+		index_buffer = RD::get_singleton()->index_buffer_create(6, RenderingDevice::INDEX_BUFFER_FORMAT_UINT32, pv);
+		index_array = RD::get_singleton()->index_array_create(index_buffer, 0, 6);
+	}
+}
+
+TonemapRD::~TonemapRD() {
+	RD::get_singleton()->free(default_sampler);
+	RD::get_singleton()->free(default_mipmap_sampler);
+	RD::get_singleton()->free(index_buffer); //array gets freed as dependency
+
+	shader.version_free(shader_version);
+}

--- a/servers/rendering/renderer_rd/effects/tonemap_rd.h
+++ b/servers/rendering/renderer_rd/effects/tonemap_rd.h
@@ -1,0 +1,149 @@
+/*************************************************************************/
+/*  tonemap_rd.h                                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TONEMAP_RD_H
+#define TONEMAP_RD_H
+
+#include "core/math/camera_matrix.h"
+#include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
+#include "servers/rendering/renderer_rd/shaders/tonemap.glsl.gen.h"
+#include "servers/rendering/renderer_scene_render.h"
+
+#include "servers/rendering_server.h"
+
+class TonemapRD {
+private:
+	// TODO this is shared between various effects and we may need to look into moving it into a base class instead of duplicating
+	RID default_sampler;
+	RID default_mipmap_sampler;
+	RID index_buffer;
+	RID index_array;
+
+	Map<RID, RID> texture_to_uniform_set_cache;
+	RID _get_uniform_set_from_texture(RID p_texture, bool p_use_mipmaps = false);
+
+	// tonemap implementation
+	enum Mode {
+		TONEMAP_MODE_NORMAL,
+		TONEMAP_MODE_BICUBIC_GLOW_FILTER,
+		TONEMAP_MODE_1D_LUT,
+		TONEMAP_MODE_BICUBIC_GLOW_FILTER_1D_LUT,
+
+		TONEMAP_MODE_NORMAL_MULTIVIEW,
+		TONEMAP_MODE_BICUBIC_GLOW_FILTER_MULTIVIEW,
+		TONEMAP_MODE_1D_LUT_MULTIVIEW,
+		TONEMAP_MODE_BICUBIC_GLOW_FILTER_1D_LUT_MULTIVIEW,
+
+		TONEMAP_MODE_MAX
+	};
+
+	struct PushConstant {
+		float bcs[3];
+		uint32_t use_bcs;
+
+		uint32_t use_glow;
+		uint32_t use_auto_exposure;
+		uint32_t use_color_correction;
+		uint32_t tonemapper;
+
+		uint32_t glow_texture_size[2];
+		float glow_intensity;
+		uint32_t pad3;
+
+		uint32_t glow_mode;
+		float glow_levels[7];
+
+		float exposure;
+		float white;
+		float auto_exposure_grey;
+		uint32_t pad2;
+
+		float pixel_size[2];
+		uint32_t use_fxaa;
+		uint32_t use_debanding;
+	};
+
+	/* tonemap actually writes to a framebuffer, which is
+	 * better to do using the raster pipeline rather than
+	 * compute, as that framebuffer might be in different formats
+	 */
+	PushConstant push_constant;
+	TonemapShaderRD shader;
+	RID shader_version;
+	PipelineCacheRD pipelines[TONEMAP_MODE_MAX];
+
+public:
+	struct Settings {
+		bool use_glow = false;
+		enum GlowMode {
+			GLOW_MODE_ADD,
+			GLOW_MODE_SCREEN,
+			GLOW_MODE_SOFTLIGHT,
+			GLOW_MODE_REPLACE,
+			GLOW_MODE_MIX
+		};
+
+		GlowMode glow_mode = GLOW_MODE_ADD;
+		float glow_intensity = 1.0;
+		float glow_levels[7] = { 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0 };
+		Vector2i glow_texture_size;
+		bool glow_use_bicubic_upscale = false;
+		RID glow_texture;
+
+		RS::EnvironmentToneMapper tonemap_mode = RS::ENV_TONE_MAPPER_LINEAR;
+		float exposure = 1.0;
+		float white = 1.0;
+
+		bool use_auto_exposure = false;
+		float auto_exposure_grey = 0.5;
+		RID exposure_texture;
+
+		bool use_bcs = false;
+		float brightness = 1.0;
+		float contrast = 1.0;
+		float saturation = 1.0;
+
+		bool use_color_correction = false;
+		bool use_1d_color_correction = false;
+		RID color_correction_texture;
+
+		bool use_fxaa = false;
+		bool use_debanding = false;
+		Vector2i texture_size;
+		uint32_t view_count = 1;
+	};
+
+	void tonemapper(RID p_source_color, RID p_dst_framebuffer, const Settings &p_settings);
+
+	TonemapRD();
+	~TonemapRD();
+};
+
+#endif // !TONEMAP_RD_H

--- a/servers/rendering/renderer_rd/effects_rd.h
+++ b/servers/rendering/renderer_rd/effects_rd.h
@@ -166,57 +166,6 @@ class EffectsRD {
 		RID pipeline;
 	} roughness;
 
-	enum TonemapMode {
-		TONEMAP_MODE_NORMAL,
-		TONEMAP_MODE_BICUBIC_GLOW_FILTER,
-		TONEMAP_MODE_1D_LUT,
-		TONEMAP_MODE_BICUBIC_GLOW_FILTER_1D_LUT,
-
-		TONEMAP_MODE_NORMAL_MULTIVIEW,
-		TONEMAP_MODE_BICUBIC_GLOW_FILTER_MULTIVIEW,
-		TONEMAP_MODE_1D_LUT_MULTIVIEW,
-		TONEMAP_MODE_BICUBIC_GLOW_FILTER_1D_LUT_MULTIVIEW,
-
-		TONEMAP_MODE_MAX
-	};
-
-	struct TonemapPushConstant {
-		float bcs[3];
-		uint32_t use_bcs;
-
-		uint32_t use_glow;
-		uint32_t use_auto_exposure;
-		uint32_t use_color_correction;
-		uint32_t tonemapper;
-
-		uint32_t glow_texture_size[2];
-		float glow_intensity;
-		uint32_t pad3;
-
-		uint32_t glow_mode;
-		float glow_levels[7];
-
-		float exposure;
-		float white;
-		float auto_exposure_grey;
-		uint32_t pad2;
-
-		float pixel_size[2];
-		uint32_t use_fxaa;
-		uint32_t use_debanding;
-	};
-
-	/* tonemap actually writes to a framebuffer, which is
-	 * better to do using the raster pipeline rather than
-	 * compute, as that framebuffer might be in different formats
-	 */
-	struct Tonemap {
-		TonemapPushConstant push_constant;
-		TonemapShaderRD shader;
-		RID shader_version;
-		PipelineCacheRD pipelines[TONEMAP_MODE_MAX];
-	} tonemap;
-
 	enum LuminanceReduceMode {
 		LUMINANCE_REDUCE_READ,
 		LUMINANCE_REDUCE,
@@ -681,46 +630,6 @@ public:
 	void luminance_reduction(RID p_source_texture, const Size2i p_source_size, const Vector<RID> p_reduce, RID p_prev_luminance, float p_min_luminance, float p_max_luminance, float p_adjust, bool p_set = false);
 	void bokeh_dof(RID p_base_texture, RID p_depth_texture, const Size2i &p_base_texture_size, RID p_secondary_texture, RID p_bokeh_texture1, RID p_bokeh_texture2, bool p_dof_far, float p_dof_far_begin, float p_dof_far_size, bool p_dof_near, float p_dof_near_begin, float p_dof_near_size, float p_bokeh_size, RS::DOFBokehShape p_bokeh_shape, RS::DOFBlurQuality p_quality, bool p_use_jitter, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
 
-	struct TonemapSettings {
-		bool use_glow = false;
-		enum GlowMode {
-			GLOW_MODE_ADD,
-			GLOW_MODE_SCREEN,
-			GLOW_MODE_SOFTLIGHT,
-			GLOW_MODE_REPLACE,
-			GLOW_MODE_MIX
-		};
-
-		GlowMode glow_mode = GLOW_MODE_ADD;
-		float glow_intensity = 1.0;
-		float glow_levels[7] = { 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0 };
-		Vector2i glow_texture_size;
-		bool glow_use_bicubic_upscale = false;
-		RID glow_texture;
-
-		RS::EnvironmentToneMapper tonemap_mode = RS::ENV_TONE_MAPPER_LINEAR;
-		float exposure = 1.0;
-		float white = 1.0;
-
-		bool use_auto_exposure = false;
-		float auto_exposure_grey = 0.5;
-		RID exposure_texture;
-
-		bool use_bcs = false;
-		float brightness = 1.0;
-		float contrast = 1.0;
-		float saturation = 1.0;
-
-		bool use_color_correction = false;
-		bool use_1d_color_correction = false;
-		RID color_correction_texture;
-
-		bool use_fxaa = false;
-		bool use_debanding = false;
-		Vector2i texture_size;
-		uint32_t view_count = 1;
-	};
-
 	struct SSAOSettings {
 		float radius = 1.0;
 		float intensity = 2.0;
@@ -740,8 +649,6 @@ public:
 		Size2i half_screen_size = Size2i();
 		Size2i quarter_screen_size = Size2i();
 	};
-
-	void tonemapper(RID p_source_color, RID p_dst_framebuffer, const TonemapSettings &p_settings);
 
 	void gather_ssao(RD::ComputeListID p_compute_list, const Vector<RID> p_ao_slices, const SSAOSettings &p_settings, bool p_adaptive_base_pass, RID p_gather_uniform_set, RID p_importance_map_uniform_set);
 	void generate_ssao(RID p_depth_buffer, RID p_normal_buffer, RID p_depth_mipmaps_texture, const Vector<RID> &depth_mipmaps, RID p_ao, const Vector<RID> p_ao_slices, RID p_ao_pong, const Vector<RID> p_ao_pong_slices, RID p_upscale_buffer, RID p_importance_map, RID p_importance_map_pong, const CameraMatrix &p_projection, const SSAOSettings &p_settings, bool p_invalidate_uniform_sets, RID &r_downsample_uniform_set, RID &r_gather_uniform_set, RID &r_importance_map_uniform_set);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1803,7 +1803,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 	{
 		//tonemap
-		EffectsRD::TonemapSettings tonemap;
+		TonemapRD::Settings tonemap;
 
 		if (can_use_effects && env && env->auto_exposure && rb->luminance.current.is_valid()) {
 			tonemap.use_auto_exposure = true;
@@ -1815,7 +1815,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 		if (can_use_effects && env && env->glow_enabled) {
 			tonemap.use_glow = true;
-			tonemap.glow_mode = EffectsRD::TonemapSettings::GlowMode(env->glow_blend_mode);
+			tonemap.glow_mode = TonemapRD::Settings::GlowMode(env->glow_blend_mode);
 			tonemap.glow_intensity = env->glow_blend_mode == RS::ENV_GLOW_BLEND_MODE_MIX ? env->glow_mix : env->glow_intensity;
 			for (int i = 0; i < RS::MAX_GLOW_LEVELS; i++) {
 				tonemap.glow_levels[i] = env->glow_levels[i];
@@ -1859,7 +1859,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 		tonemap.view_count = p_render_data->view_count;
 
-		storage->get_effects()->tonemapper(rb->texture, storage->render_target_get_rd_framebuffer(rb->render_target), tonemap);
+		storage->get_tonemap()->tonemapper(rb->texture, storage->render_target_get_rd_framebuffer(rb->render_target), tonemap);
 	}
 
 	storage->render_target_disable_clear_request(rb->render_target);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -8792,6 +8792,10 @@ EffectsRD *RendererStorageRD::get_effects() {
 	return &effects;
 }
 
+TonemapRD *RendererStorageRD::get_tonemap() {
+	return &tonemap;
+}
+
 void RendererStorageRD::capture_timestamps_begin() {
 	RD::get_singleton()->capture_timestamp("Frame Begin");
 }

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -35,6 +35,7 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/rid_owner.h"
 #include "servers/rendering/renderer_compositor.h"
+#include "servers/rendering/renderer_rd/effects/tonemap_rd.h"
 #include "servers/rendering/renderer_rd/effects_rd.h"
 #include "servers/rendering/renderer_rd/shader_compiler_rd.h"
 #include "servers/rendering/renderer_rd/shaders/canvas_sdf.glsl.gen.h"
@@ -1283,6 +1284,7 @@ private:
 	/* EFFECTS */
 
 	EffectsRD effects;
+	TonemapRD tonemap;
 
 public:
 	virtual bool can_create_resources_async() const;
@@ -2371,6 +2373,7 @@ public:
 	static RendererStorageRD *base_singleton;
 
 	EffectsRD *get_effects();
+	TonemapRD *get_tonemap();
 
 	RendererStorageRD();
 	~RendererStorageRD();


### PR DESCRIPTION
Moved tonemap copy shader into its own object. Did this after discussing with @reduz as we will probably introduce a new version of this specific for the mobile renderer that uses subpasses. 

It may be interesting to further split other effects into separate classes as well however we need to either come up with a nicer way to share some of the objects or accept some duplication of logic between the implementations. 

We also likely will have to move the tonemapper out of storage and into the renderer itself and see if we can move the related logic into `RenderForwardClustered` and `RenderForwardMobile` so we can deviate the implementation for the mobile renderer. May postpone that to the PR that will introduce the subpass based solution.