### PR TITLE
Fixed the way arrays were exposed to the editor.

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -95,7 +95,7 @@ enum PropertyHint {
 	PROPERTY_HINT_NODE_PATH_VALID_TYPES,
 	PROPERTY_HINT_SAVE_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,". This opens a save dialog
 	PROPERTY_HINT_INT_IS_OBJECTID,
-	PROPERTY_HINT_ARRAY_TYPE,
+	PROPERTY_HINT_ARRAY_TYPE, ///< A Variant::ARRAY type, hint_text (optionally) sets the type of EditorProperty to be instanced for each element. Can be a variant built-in type e.g. "int", "String", "Color", or a resource type e.g. "RichTextEffect", "StyleBoxFlat"
 	PROPERTY_HINT_MAX,
 	// When updating PropertyHint, also sync the hardcoded list in VisualScriptEditorVariableEdit
 };

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3185,7 +3185,29 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 		} break;
 		case Variant::ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::ARRAY, p_hint_text);
+			Variant::Type subtype = Variant::NIL;
+			PropertyHint hint = p_hint;
+
+			bool found_subtype = false;
+			if (p_hint == PROPERTY_HINT_ARRAY_TYPE) {
+				// Set subtype based on array type string.
+				for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+					if (p_hint_text == Variant::get_type_name(Variant::Type(i))) {
+						subtype = Variant::Type(i);
+						found_subtype = true;
+						break;
+					}
+				}
+
+				// Hint text was not a built-in resource type. If the hint text is valid, then
+				// treat the text as a Resource which will be the type of the array.
+				if (!found_subtype && p_hint_text != String()) {
+					subtype = Variant::OBJECT;
+					hint = PROPERTY_HINT_RESOURCE_TYPE;
+				}
+			}
+
+			editor->setup(Variant::ARRAY, subtype, hint, p_hint_text);
 			add_property_editor(p_path, editor);
 		} break;
 		case Variant::PACKED_BYTE_ARRAY: {

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -547,23 +547,11 @@ void EditorPropertyArray::_length_changed(double p_page) {
 	update_property();
 }
 
-void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint_string) {
+void EditorPropertyArray::setup(Variant::Type p_array_type, Variant::Type p_subtype, PropertyHint p_subtype_hint, const String &p_subtype_hint_string) {
 	array_type = p_array_type;
-
-	if (array_type == Variant::ARRAY && !p_hint_string.is_empty()) {
-		int hint_subtype_separator = p_hint_string.find(":");
-		if (hint_subtype_separator >= 0) {
-			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);
-			int slash_pos = subtype_string.find("/");
-			if (slash_pos >= 0) {
-				subtype_hint = PropertyHint(subtype_string.substr(slash_pos + 1, subtype_string.size() - slash_pos - 1).to_int());
-				subtype_string = subtype_string.substr(0, slash_pos);
-			}
-
-			subtype_hint_string = p_hint_string.substr(hint_subtype_separator + 1, p_hint_string.size() - hint_subtype_separator - 1);
-			subtype = Variant::Type(subtype_string.to_int());
-		}
-	}
+	subtype = p_subtype;
+	subtype_hint = p_subtype_hint;
+	subtype_hint_string = p_subtype_hint_string;
 }
 
 void EditorPropertyArray::_bind_methods() {

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -117,7 +117,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void setup(Variant::Type p_array_type, const String &p_hint_string = "");
+	void setup(Variant::Type p_array_type, Variant::Type p_subtype = Variant::NIL, PropertyHint p_subtype_hint = PROPERTY_HINT_NONE, const String &p_subtype_hint_string = "");
 	virtual void update_property() override;
 	EditorPropertyArray();
 };


### PR DESCRIPTION
Changed the way they are defined in ADD_PROPERTY to be simpler and have a more clear, less error-prone syntax.

Fixes regression made in #40383 and improves the syntax such that the strange and ambiguous `"17/17:RichTextEffect"` property hint strings are no longer required. See my comment here for more details https://github.com/godotengine/godot/pull/40383#issuecomment-865053866

Before, editor does not know what resources to filter for:
![image](https://user-images.githubusercontent.com/41730826/122774054-3946fb00-d2ec-11eb-9e87-8f08d4a75cc9.png)

After, only RichTextEffect is shown:
![image](https://user-images.githubusercontent.com/41730826/122772404-b07b8f80-d2ea-11eb-8f15-f15c32dd74ec.png)

Previously to "correctly" export an array, the property hint string would need to be in the style: `"{PropertyHintEnumValue}/{VariantTypeValue}:{ResourceTypeName}"` which is extremely obtuse, which is what led to #40383 being made in the first place. Additionally, since the enum values were hardcoded, if the enum was added to or removed from, this would break. This actually happened, as `Variant::OBJECT` was changed from `17` to `18`. Now, the subtype `Variant::Type` is inferred from the PropertyHint value. I think this is a good compromise, as anything more would probably require changes to the way arrays are added via `ADD_PROPERTY`.