### PR TITLE
Improve error message when there are no meshes to bake for 3D occlusion

### DIFF
--- a/editor/plugins/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.cpp
@@ -56,7 +56,7 @@ void OccluderInstance3DEditorPlugin::_bake_select_file(const String &p_file) {
 
 			} break;
 			case OccluderInstance3D::BAKE_ERROR_NO_MESHES: {
-				EditorNode::get_singleton()->show_warning(TTR("No meshes to bake."));
+				EditorNode::get_singleton()->show_warning(TTR("No meshes to bake.\nMake sure there is at least one MeshInstance3D node in the scene whose visual layers are part of the OccluderInstance3D's Bake Mask property."));
 				break;
 			}
 			default: {


### PR DESCRIPTION
This should make it clearer that [CSG nodes aren't supported yet](https://github.com/godotengine/godot-proposals/issues/2910) for occluder generation.