### PR TITLE
Fixing mono build after instance() -> instanciate() name change

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -114,12 +114,12 @@ namespace GodotTools.Ides
                         if (Utils.OS.IsMacOS && editorId == ExternalEditorId.VisualStudioForMac)
                         {
                             vsForMacInstance = (vsForMacInstance?.IsDisposed ?? true ? null : vsForMacInstance) ??
-                                               new MonoDevelop.Instantiate(solutionPath, MonoDevelop.EditorId.VisualStudioForMac);
+                                               new MonoDevelop.Instance(solutionPath, MonoDevelop.EditorId.VisualStudioForMac);
                             return vsForMacInstance;
                         }
 
                         monoDevelInstance = (monoDevelInstance?.IsDisposed ?? true ? null : monoDevelInstance) ??
-                                            new MonoDevelop.Instantiate(solutionPath, MonoDevelop.EditorId.MonoDevelop);
+                                            new MonoDevelop.Instance(solutionPath, MonoDevelop.EditorId.MonoDevelop);
                         return monoDevelInstance;
                     }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
@@ -8,9 +8,9 @@ namespace Godot
         /// `Node.NotificationInstanced` notification on the root node.
         /// </summary>
         /// <typeparam name="T">The type to cast to. Should be a descendant of Node.</typeparam>
-        public T Instance<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+        public T Instantiate<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
         {
-            return (T)(object)Instance(editState);
+            return (T)(object)Instantiate(editState);
         }
 
         /// <summary>
@@ -19,9 +19,9 @@ namespace Godot
         /// `Node.NotificationInstanced` notification on the root node.
         /// </summary>
         /// <typeparam name="T">The type to cast to. Should be a descendant of Node.</typeparam>
-        public T InstanceOrNull<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+        public T InstantiateOrNull<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
         {
-            return Instance(editState) as T;
+            return Instantiate(editState) as T;
         }
     }
 }


### PR DESCRIPTION
In PR #49693 verb uses of `instance()` were changed to `instantiate()`, but the change was half-baked for Mono build. Two errors were introduced:
- in editor tools in `GodotIdeManager.cs` a reference to constructor of class `Instance` was changed erroneously,
- in glue extensions in `PackedSceneExtensions.cs` a change in naming was accidentaly omitted.

Both cause mono version of godot with glue enabled to not build.