### PR TITLE
Fixes Mesh2D drawn without modulation

### DIFF
--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -65,7 +65,7 @@ void main() {
 #elif defined(USE_ATTRIBUTES)
 
 	vec2 vertex = vertex_attrib;
-	vec4 color = color_attrib;
+	vec4 color = color_attrib * draw_data.modulation;
 	vec2 uv = uv_attrib;
 
 	uvec4 bones = bone_attrib;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/49824

It works, but I am not sure this is the right solution. Let me explain.

When drawing Mesh2D, the canvas.glsl shader is used with USE_ATTRIBUTES defined. At the top of the shader, this makes it set the color to `color_attrib` (which I guess is provided via an array of colors, one color for each vertex). In such case, the modulation parameter, set using push constant via `RD::get_singleton()->draw_list_set_push_constant(p_draw_list, &push_constant, sizeof(PushConstant));`, is completely ignored. This means that `draw_data.modulation` is never taken into account, causing modulation not to affect the Mesh2D like we would have liked.

Consequently, I made this PR multiply the `color_attrib` value by the `draw_data.modulation` value when using attributes, which makes the modulation work again.

However, what makes me think this PR might not be the right solution is how things are implemented in [renderer_canvas_render_rd.cpp](https://github.com/godotengine/godot/blob/master/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp#L821), as you can see around line 821, we set a bunch of values into `push_constant`, which will then be, as I mentioned before, completely ignored by the shader.

So my question is whether I should instead drop the setup of `push_constant` as it is ignored anyway, and thus integrate the modulation directly into the colors array provided to the shader (I'm not sure how to do it though). Maybe that's not the most efficient solution though.
