### PR TITLE
Tweak script export text in the export dialog to be more explicit (3.x)

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1073,17 +1073,17 @@ ProjectExportDialog::ProjectExportDialog() {
 	VBoxContainer *script_vb = memnew(VBoxContainer);
 	script_vb->set_name(TTR("Script"));
 	script_mode = memnew(OptionButton);
-	script_vb->add_margin_child(TTR("Script Export Mode:"), script_mode);
+	script_vb->add_margin_child(TTR("GDScript Export Mode:"), script_mode);
 	script_mode->add_item(TTR("Text"), (int)EditorExportPreset::MODE_SCRIPT_TEXT);
-	script_mode->add_item(TTR("Compiled"), (int)EditorExportPreset::MODE_SCRIPT_COMPILED);
+	script_mode->add_item(TTR("Compiled Bytecode (Faster Loading)"), (int)EditorExportPreset::MODE_SCRIPT_COMPILED);
 	script_mode->add_item(TTR("Encrypted (Provide Key Below)"), (int)EditorExportPreset::MODE_SCRIPT_ENCRYPTED);
 	script_mode->connect("item_selected", this, "_script_export_mode_changed");
 	script_key = memnew(LineEdit);
 	script_key->connect("text_changed", this, "_script_encryption_key_changed");
 	script_key_error = memnew(Label);
-	script_key_error->set_text("- " + TTR("Invalid Encryption Key (must be 64 characters long)"));
+	script_key_error->set_text("- " + TTR("Invalid Encryption Key (must be 64 hexadecimal characters long)"));
 	script_key_error->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
-	script_vb->add_margin_child(TTR("Script Encryption Key (256-bits as hex):"), script_key);
+	script_vb->add_margin_child(TTR("GDScript Encryption Key (256-bits as hexadecimal):"), script_key);
 	script_vb->add_child(script_key_error);
 	sections->add_child(script_vb);
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/49876.

The Compiled export mode does not actually improve performance, it only speeds up loading like in Python.

See https://github.com/godotengine/godot-proposals/issues/1407#issuecomment-867318479.