### PR TITLE
[Net] New `@rpc` annotation, "sync" is no longer part of mode.

### DIFF
--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -43,14 +43,12 @@ public:
 		RPC_MODE_REMOTE, // Using rpc() on it will call method in all remote peers
 		RPC_MODE_MASTER, // Using rpc() on it will call method on wherever the master is, be it local or remote
 		RPC_MODE_PUPPET, // Using rpc() on it will call method for all puppets
-		RPC_MODE_REMOTESYNC, // Using rpc() on it will call method in all remote peers and locally
-		RPC_MODE_MASTERSYNC, // Using rpc() on it will call method in the master peer and locally
-		RPC_MODE_PUPPETSYNC, // Using rpc() on it will call method in all puppets peers and locally
 	};
 
 	struct RPCConfig {
 		StringName name;
 		RPCMode rpc_mode = RPC_MODE_DISABLED;
+		bool sync = false;
 		MultiplayerPeer::TransferMode transfer_mode = MultiplayerPeer::TRANSFER_MODE_RELIABLE;
 		int channel = 0;
 

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -146,14 +146,5 @@
 		<constant name="RPC_MODE_PUPPET" value="3" enum="RPCMode">
 			Used with [method Node.rpc_config] to set a method to be called or a property to be changed only on puppets for this node. Analogous to the [code]puppet[/code] keyword. Only accepts calls or property changes from the node's network master, see [method Node.set_network_master].
 		</constant>
-		<constant name="RPC_MODE_REMOTESYNC" value="4" enum="RPCMode">
-			Behave like [constant RPC_MODE_REMOTE] but also make the call or property change locally. Analogous to the [code]remotesync[/code] keyword.
-		</constant>
-		<constant name="RPC_MODE_MASTERSYNC" value="5" enum="RPCMode">
-			Behave like [constant RPC_MODE_MASTER] but also make the call or property change locally. Analogous to the [code]mastersync[/code] keyword.
-		</constant>
-		<constant name="RPC_MODE_PUPPETSYNC" value="6" enum="RPCMode">
-			Behave like [constant RPC_MODE_PUPPET] but also make the call or property change locally. Analogous to the [code]puppetsync[/code] keyword.
-		</constant>
 	</constants>
 </class>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1165,15 +1165,11 @@ void GDScript::_init_rpc_methods_properties() {
 	while (cscript) {
 		// RPC Methods
 		for (Map<StringName, GDScriptFunction *>::Element *E = cscript->member_functions.front(); E; E = E->next()) {
-			if (E->get()->get_rpc_mode() != MultiplayerAPI::RPC_MODE_DISABLED) {
-				MultiplayerAPI::RPCConfig nd;
-				nd.name = E->key();
-				nd.rpc_mode = E->get()->get_rpc_mode();
-				// TODO
-				nd.transfer_mode = MultiplayerPeer::TRANSFER_MODE_RELIABLE;
-				nd.channel = 0;
-				if (-1 == rpc_functions.find(nd)) {
-					rpc_functions.push_back(nd);
+			MultiplayerAPI::RPCConfig config = E->get()->get_rpc_config();
+			if (config.rpc_mode != MultiplayerAPI::RPC_MODE_DISABLED) {
+				config.name = E->get()->get_name();
+				if (rpc_functions.find(config) == -1) {
+					rpc_functions.push_back(config);
 				}
 			}
 		}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -64,7 +64,6 @@ class GDScript : public Script {
 		int index = 0;
 		StringName setter;
 		StringName getter;
-		MultiplayerAPI::RPCMode rpc_mode;
 		GDScriptDataType data_type;
 	};
 

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -155,7 +155,7 @@ void GDScriptByteCodeGenerator::end_parameters() {
 	function->default_arguments.reverse();
 }
 
-void GDScriptByteCodeGenerator::write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, MultiplayerAPI::RPCMode p_rpc_mode, const GDScriptDataType &p_return_type) {
+void GDScriptByteCodeGenerator::write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, MultiplayerAPI::RPCConfig p_rpc_config, const GDScriptDataType &p_return_type) {
 	function = memnew(GDScriptFunction);
 	debug_stack = EngineDebugger::is_active();
 
@@ -170,7 +170,7 @@ void GDScriptByteCodeGenerator::write_start(GDScript *p_script, const StringName
 
 	function->_static = p_static;
 	function->return_type = p_return_type;
-	function->rpc_mode = p_rpc_mode;
+	function->rpc_config = p_rpc_config;
 	function->_argument_count = 0;
 }
 

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -419,7 +419,7 @@ public:
 	virtual void start_block() override;
 	virtual void end_block() override;
 
-	virtual void write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, MultiplayerAPI::RPCMode p_rpc_mode, const GDScriptDataType &p_return_type) override;
+	virtual void write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, MultiplayerAPI::RPCConfig p_rpc_config, const GDScriptDataType &p_return_type) override;
 	virtual GDScriptFunction *write_end() override;
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -80,7 +80,7 @@ public:
 	virtual void start_block() = 0;
 	virtual void end_block() = 0;
 
-	virtual void write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, MultiplayerAPI::RPCMode p_rpc_mode, const GDScriptDataType &p_return_type) = 0;
+	virtual void write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, MultiplayerAPI::RPCConfig p_rpc_config, const GDScriptDataType &p_return_type) = 0;
 	virtual GDScriptFunction *write_end() = 0;
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1859,7 +1859,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 
 	StringName func_name;
 	bool is_static = false;
-	MultiplayerAPI::RPCMode rpc_mode = MultiplayerAPI::RPC_MODE_DISABLED;
+	MultiplayerAPI::RPCConfig rpc_config;
 	GDScriptDataType return_type;
 	return_type.has_type = true;
 	return_type.kind = GDScriptDataType::BUILTIN;
@@ -1872,7 +1872,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 			func_name = "<anonymous lambda>";
 		}
 		is_static = p_func->is_static;
-		rpc_mode = p_func->rpc_mode;
+		rpc_config = p_func->rpc_config;
 		return_type = _gdtype_from_datatype(p_func->get_datatype(), p_script);
 	} else {
 		if (p_for_ready) {
@@ -1883,7 +1883,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	}
 
 	codegen.function_name = func_name;
-	codegen.generator->write_start(p_script, func_name, is_static, rpc_mode, return_type);
+	codegen.generator->write_start(p_script, func_name, is_static, rpc_config, return_type);
 
 	int optional_parameters = 0;
 
@@ -2088,7 +2088,7 @@ Error GDScriptCompiler::_parse_setter_getter(GDScript *p_script, const GDScriptP
 		return_type = _gdtype_from_datatype(p_variable->get_datatype(), p_script);
 	}
 
-	codegen.generator->write_start(p_script, func_name, false, p_variable->rpc_mode, return_type);
+	codegen.generator->write_start(p_script, func_name, false, MultiplayerAPI::RPCConfig(), return_type);
 
 	if (p_is_setter) {
 		uint32_t par_addr = codegen.generator->add_parameter(p_variable->setter_parameter->name, false, _gdtype_from_datatype(p_variable->get_datatype()));
@@ -2268,7 +2268,6 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 						}
 						break;
 				}
-				minfo.rpc_mode = variable->rpc_mode;
 				minfo.data_type = _gdtype_from_datatype(variable->get_datatype(), p_script);
 
 				PropertyInfo prop_info = minfo.data_type;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -472,7 +472,7 @@ private:
 
 	int _initial_line = 0;
 	bool _static = false;
-	MultiplayerAPI::RPCMode rpc_mode = MultiplayerAPI::RPC_MODE_DISABLED;
+	MultiplayerAPI::RPCConfig rpc_config;
 
 	GDScript *_script = nullptr;
 
@@ -592,7 +592,7 @@ public:
 	void disassemble(const Vector<String> &p_code_lines) const;
 #endif
 
-	_FORCE_INLINE_ MultiplayerAPI::RPCMode get_rpc_mode() const { return rpc_mode; }
+	_FORCE_INLINE_ MultiplayerAPI::RPCConfig get_rpc_config() const { return rpc_config; }
 	GDScriptFunction();
 	~GDScriptFunction();
 };

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -729,7 +729,7 @@ public:
 		SuiteNode *body = nullptr;
 		bool is_static = false;
 		bool is_coroutine = false;
-		MultiplayerAPI::RPCMode rpc_mode = MultiplayerAPI::RPC_MODE_DISABLED;
+		MultiplayerAPI::RPCConfig rpc_config;
 		MethodInfo info;
 		LambdaNode *source_lambda = nullptr;
 #ifdef TOOLS_ENABLED
@@ -1117,7 +1117,6 @@ public:
 		bool exported = false;
 		bool onready = false;
 		PropertyInfo export_info;
-		MultiplayerAPI::RPCMode rpc_mode = MultiplayerAPI::RPC_MODE_DISABLED;
 		int assignments = 0;
 		int usages = 0;
 		bool use_conversion_assign = false;

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -695,7 +695,9 @@ Dictionary ExtendGDScriptParser::dump_function_api(const GDScriptParser::Functio
 	ERR_FAIL_NULL_V(p_func, func);
 	func["name"] = p_func->identifier->name;
 	func["return_type"] = p_func->get_datatype().to_string();
-	func["rpc_mode"] = p_func->rpc_mode;
+	func["rpc_mode"] = p_func->rpc_config.rpc_mode;
+	func["rpc_transfer_mode"] = p_func->rpc_config.transfer_mode;
+	func["rpc_transfer_channel"] = p_func->rpc_config.channel;
 	Array parameters;
 	for (int i = 0; i < p_func->parameters.size(); i++) {
 		Dictionary arg;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3472,15 +3472,6 @@ MultiplayerAPI::RPCMode CSharpScript::_member_get_rpc_mode(IMonoClassMember *p_m
 	if (p_member->has_attribute(CACHED_CLASS(PuppetAttribute))) {
 		return MultiplayerAPI::RPC_MODE_PUPPET;
 	}
-	if (p_member->has_attribute(CACHED_CLASS(RemoteSyncAttribute))) {
-		return MultiplayerAPI::RPC_MODE_REMOTESYNC;
-	}
-	if (p_member->has_attribute(CACHED_CLASS(MasterSyncAttribute))) {
-		return MultiplayerAPI::RPC_MODE_MASTERSYNC;
-	}
-	if (p_member->has_attribute(CACHED_CLASS(PuppetSyncAttribute))) {
-		return MultiplayerAPI::RPC_MODE_PUPPETSYNC;
-	}
 
 	return MultiplayerAPI::RPC_MODE_DISABLED;
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttributes.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttributes.cs
@@ -2,21 +2,12 @@ using System;
 
 namespace Godot
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Method)]
     public class RemoteAttribute : Attribute {}
 
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Method)]
     public class MasterAttribute : Attribute {}
 
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Method)]
     public class PuppetAttribute : Attribute {}
-
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
-    public class RemoteSyncAttribute : Attribute {}
-
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
-    public class MasterSyncAttribute : Attribute {}
-
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
-    public class PuppetSyncAttribute : Attribute {}
 }

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -143,9 +143,6 @@ void CachedData::clear_godot_api_cache() {
 	class_RemoteAttribute = nullptr;
 	class_MasterAttribute = nullptr;
 	class_PuppetAttribute = nullptr;
-	class_RemoteSyncAttribute = nullptr;
-	class_MasterSyncAttribute = nullptr;
-	class_PuppetSyncAttribute = nullptr;
 	class_GodotMethodAttribute = nullptr;
 	field_GodotMethodAttribute_methodName = nullptr;
 	class_ScriptPathAttribute = nullptr;
@@ -272,9 +269,6 @@ void update_godot_api_cache() {
 	CACHE_CLASS_AND_CHECK(RemoteAttribute, GODOT_API_CLASS(RemoteAttribute));
 	CACHE_CLASS_AND_CHECK(MasterAttribute, GODOT_API_CLASS(MasterAttribute));
 	CACHE_CLASS_AND_CHECK(PuppetAttribute, GODOT_API_CLASS(PuppetAttribute));
-	CACHE_CLASS_AND_CHECK(RemoteSyncAttribute, GODOT_API_CLASS(RemoteSyncAttribute));
-	CACHE_CLASS_AND_CHECK(MasterSyncAttribute, GODOT_API_CLASS(MasterSyncAttribute));
-	CACHE_CLASS_AND_CHECK(PuppetSyncAttribute, GODOT_API_CLASS(PuppetSyncAttribute));
 	CACHE_CLASS_AND_CHECK(GodotMethodAttribute, GODOT_API_CLASS(GodotMethodAttribute));
 	CACHE_FIELD_AND_CHECK(GodotMethodAttribute, methodName, CACHED_CLASS(GodotMethodAttribute)->get_field("methodName"));
 	CACHE_CLASS_AND_CHECK(ScriptPathAttribute, GODOT_API_CLASS(ScriptPathAttribute));

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -114,9 +114,6 @@ struct CachedData {
 	GDMonoClass *class_RemoteAttribute;
 	GDMonoClass *class_MasterAttribute;
 	GDMonoClass *class_PuppetAttribute;
-	GDMonoClass *class_RemoteSyncAttribute;
-	GDMonoClass *class_MasterSyncAttribute;
-	GDMonoClass *class_PuppetSyncAttribute;
 	GDMonoClass *class_GodotMethodAttribute;
 	GDMonoField *field_GodotMethodAttribute_methodName;
 	GDMonoClass *class_ScriptPathAttribute;


### PR DESCRIPTION
Move the "sync" property for RPCs to RPCConfig.

Implement GDScript annotation arguments parsing.
Only one annotation: `@rpc`:
- The first parameter is the RPC mode (`any`, `master`, `puppet`).
- The second parameter is the "sync"/"nosync" option (calls the function locally too when RPCing).
- The third parameter is the transfer mode (one of reliable, unreliable, ordered).
- The last parameter is the transfer channel (not used by the MultiplayerAPI for now, need implementation).

E.g.:

```gdscript
# defaults are master, no sync, reliable, "default channel" (i.e. 0).
@rpc
func ping():
	print("Ping from: ", multiplayer.get_rpc_sender_id())
```

```gdscript
# makes the RPC callable by anyone, "sync", use "unreliable" transfer, channel 1 
@rpc(any, sync, unreliable, 1)
func ping():
	print("Ping from: ", multiplayer.get_rpc_sender_id())
```

@vnen WDYT?

<details>
  <summary>Old implementation</summary>
Implement GDScript annotation arguments parsing.

Three annotations (remote, master, puppet):
- The first parameter is the "sync" option (calls the function locally too when RPCing).
- The second parameter is the transfer mode (one of reliable, unreliable, ordered).
- The third parameter is the channel (still not used by the MultiplayerAPI).

E.g.:

```gdscript
# defaults are no sync, reliable, "default channel" (i.e. 0).
@remote
func ping():
	print("Ping from: ", multiplayer.get_rpc_sender_id())
```

```gdscript
# makes the RPC "sync", use "unreliable" transfer, channel 1 
@remote(sync, unreliable, 1)
func ping():
	print("Ping from: ", multiplayer.get_rpc_sender_id())
```

We could also make the annotation just `@rpc` and add a new parameter (first) which must be one of "remote", "master", "puppet" instead.
</details>