### PR TITLE
Implement Framebuffer Subpass support

### DIFF
--- a/doc/classes/RDFramebufferPass.xml
+++ b/doc/classes/RDFramebufferPass.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RDFramebufferPass" inherits="RefCounted" version="4.0">
+	<brief_description>
+		Framebuffer pass attachment description.
+	</brief_description>
+	<description>
+		This class contains the list of attachment descriptions for a framebuffer pass. Each points with an index to a previously supplied list of texture attachments.
+	Multipass framebuffers can optimize some configurations in mobile, on desktop they provide little to no advantage.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="color_attachments" type="PackedInt32Array" setter="set_color_attachments" getter="get_color_attachments" default="PackedInt32Array()">
+			Color attachments in order starting from 0. If this attachment is not used by the shader, pass ATTACHMENT_UNUSED to skip.
+		</member>
+		<member name="depth_attachment" type="int" setter="set_depth_attachment" getter="get_depth_attachment" default="-1">
+			Depth attachment. ATTACHMENT_UNUSED should be used if no depth buffer is required for this pass.
+		</member>
+		<member name="input_attachments" type="PackedInt32Array" setter="set_input_attachments" getter="get_input_attachments" default="PackedInt32Array()">
+			Used for multipass framebuffers (more than one render pass). Converts an attachment to an input. Make sure to also supply it properly in the [RDUniform] for the uniform set.
+		</member>
+		<member name="preserve_attachments" type="PackedInt32Array" setter="set_preserve_attachments" getter="get_preserve_attachments" default="PackedInt32Array()">
+			Attachments to preserve in this pass (otherwise they are erased).
+		</member>
+		<member name="resolve_attachments" type="PackedInt32Array" setter="set_resolve_attachments" getter="get_resolve_attachments" default="PackedInt32Array()">
+			If the color attachments are multisampled, non-multisampled resolve attachments can be provided.
+		</member>
+	</members>
+	<constants>
+		<constant name="ATTACHMENT_UNUSED" value="-1">
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -341,12 +341,28 @@
 			<description>
 			</description>
 		</method>
+		<method name="draw_list_switch_to_next_pass">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="draw_list_switch_to_next_pass_split">
+			<return type="PackedInt64Array">
+			</return>
+			<argument index="0" name="splits" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="framebuffer_create">
 			<return type="RID">
 			</return>
-			<argument index="0" name="textures" type="Array">
+			<argument index="0" name="textures" type="RID[]">
 			</argument>
 			<argument index="1" name="validate_with_format" type="int" default="-1">
+			</argument>
+			<argument index="2" name="view_count" type="int" default="1">
 			</argument>
 			<description>
 			</description>
@@ -363,10 +379,26 @@
 			<description>
 			</description>
 		</method>
+		<method name="framebuffer_create_multipass">
+			<return type="RID">
+			</return>
+			<argument index="0" name="textures" type="RID[]">
+			</argument>
+			<argument index="1" name="passes" type="RDFramebufferPass[]">
+			</argument>
+			<argument index="2" name="validate_with_format" type="int" default="-1">
+			</argument>
+			<argument index="3" name="view_count" type="int" default="1">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="framebuffer_format_create">
 			<return type="int">
 			</return>
 			<argument index="0" name="attachments" type="RDAttachmentFormat[]">
+			</argument>
+			<argument index="1" name="view_count" type="int" default="1">
 			</argument>
 			<description>
 			</description>
@@ -379,10 +411,24 @@
 			<description>
 			</description>
 		</method>
+		<method name="framebuffer_format_create_multipass">
+			<return type="int">
+			</return>
+			<argument index="0" name="attachments" type="RDAttachmentFormat[]">
+			</argument>
+			<argument index="1" name="passes" type="RDFramebufferPass[]">
+			</argument>
+			<argument index="2" name="view_count" type="int" default="1">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="framebuffer_format_get_texture_samples">
 			<return type="int" enum="RenderingDevice.TextureSamples">
 			</return>
 			<argument index="0" name="format" type="int">
+			</argument>
+			<argument index="1" name="render_pass" type="int" default="0">
 			</argument>
 			<description>
 			</description>
@@ -523,6 +569,8 @@
 			<argument index="7" name="color_blend_state" type="RDPipelineColorBlendState">
 			</argument>
 			<argument index="8" name="dynamic_state_flags" type="int" default="0">
+			</argument>
+			<argument index="9" name="for_render_pass" type="int" default="0">
 			</argument>
 			<description>
 			</description>

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -194,6 +194,7 @@ void register_server_types() {
 	ClassDB::register_class<RDTextureFormat>();
 	ClassDB::register_class<RDTextureView>();
 	ClassDB::register_class<RDAttachmentFormat>();
+	ClassDB::register_class<RDFramebufferPass>();
 	ClassDB::register_class<RDSamplerState>();
 	ClassDB::register_class<RDVertexAttribute>();
 	ClassDB::register_class<RDUniform>();

--- a/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
@@ -31,20 +31,21 @@
 #include "pipeline_cache_rd.h"
 #include "core/os/memory.h"
 
-RID PipelineCacheRD::_generate_version(RD::VertexFormatID p_vertex_format_id, RD::FramebufferFormatID p_framebuffer_format_id, bool p_wireframe) {
+RID PipelineCacheRD::_generate_version(RD::VertexFormatID p_vertex_format_id, RD::FramebufferFormatID p_framebuffer_format_id, bool p_wireframe, uint32_t p_render_pass) {
 	RD::PipelineMultisampleState multisample_state_version = multisample_state;
-	multisample_state_version.sample_count = RD::get_singleton()->framebuffer_format_get_texture_samples(p_framebuffer_format_id);
+	multisample_state_version.sample_count = RD::get_singleton()->framebuffer_format_get_texture_samples(p_framebuffer_format_id, p_render_pass);
 
 	RD::PipelineRasterizationState raster_state_version = rasterization_state;
 	raster_state_version.wireframe = p_wireframe;
 
-	RID pipeline = RD::get_singleton()->render_pipeline_create(shader, p_framebuffer_format_id, p_vertex_format_id, render_primitive, raster_state_version, multisample_state_version, depth_stencil_state, blend_state, dynamic_state_flags);
+	RID pipeline = RD::get_singleton()->render_pipeline_create(shader, p_framebuffer_format_id, p_vertex_format_id, render_primitive, raster_state_version, multisample_state_version, depth_stencil_state, blend_state, dynamic_state_flags, p_render_pass);
 	ERR_FAIL_COND_V(pipeline.is_null(), RID());
 	versions = (Version *)memrealloc(versions, sizeof(Version) * (version_count + 1));
 	versions[version_count].framebuffer_id = p_framebuffer_format_id;
 	versions[version_count].vertex_id = p_vertex_format_id;
 	versions[version_count].wireframe = p_wireframe;
 	versions[version_count].pipeline = pipeline;
+	versions[version_count].render_pass = p_render_pass;
 	version_count++;
 	return pipeline;
 }

--- a/servers/rendering/renderer_rd/pipeline_cache_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.h
@@ -50,6 +50,7 @@ class PipelineCacheRD {
 	struct Version {
 		RD::VertexFormatID vertex_id;
 		RD::FramebufferFormatID framebuffer_id;
+		uint32_t render_pass;
 		bool wireframe;
 		RID pipeline;
 	};
@@ -57,7 +58,7 @@ class PipelineCacheRD {
 	Version *versions;
 	uint32_t version_count;
 
-	RID _generate_version(RD::VertexFormatID p_vertex_format_id, RD::FramebufferFormatID p_framebuffer_format_id, bool p_wireframe);
+	RID _generate_version(RD::VertexFormatID p_vertex_format_id, RD::FramebufferFormatID p_framebuffer_format_id, bool p_wireframe, uint32_t p_render_pass);
 
 	void _clear();
 
@@ -65,7 +66,7 @@ public:
 	void setup(RID p_shader, RD::RenderPrimitive p_primitive, const RD::PipelineRasterizationState &p_rasterization_state, RD::PipelineMultisampleState p_multisample, const RD::PipelineDepthStencilState &p_depth_stencil_state, const RD::PipelineColorBlendState &p_blend_state, int p_dynamic_state_flags = 0);
 	void update_shader(RID p_shader);
 
-	_FORCE_INLINE_ RID get_render_pipeline(RD::VertexFormatID p_vertex_format_id, RD::FramebufferFormatID p_framebuffer_format_id, bool p_wireframe = false) {
+	_FORCE_INLINE_ RID get_render_pipeline(RD::VertexFormatID p_vertex_format_id, RD::FramebufferFormatID p_framebuffer_format_id, bool p_wireframe = false, uint32_t p_render_pass = 0) {
 #ifdef DEBUG_ENABLED
 		ERR_FAIL_COND_V_MSG(shader.is_null(), RID(),
 				"Attempted to use an unused shader variant (shader is null),");
@@ -74,13 +75,13 @@ public:
 		spin_lock.lock();
 		RID result;
 		for (uint32_t i = 0; i < version_count; i++) {
-			if (versions[i].vertex_id == p_vertex_format_id && versions[i].framebuffer_id == p_framebuffer_format_id && versions[i].wireframe == p_wireframe) {
+			if (versions[i].vertex_id == p_vertex_format_id && versions[i].framebuffer_id == p_framebuffer_format_id && versions[i].wireframe == p_wireframe && versions[i].render_pass == p_render_pass) {
 				result = versions[i].pipeline;
 				spin_lock.unlock();
 				return result;
 			}
 		}
-		result = _generate_version(p_vertex_format_id, p_framebuffer_format_id, p_wireframe);
+		result = _generate_version(p_vertex_format_id, p_framebuffer_format_id, p_wireframe, p_render_pass);
 		spin_lock.unlock();
 		return result;
 	}

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -47,6 +47,7 @@ class RDPipelineRasterizationState;
 class RDPipelineMultisampleState;
 class RDPipelineDepthStencilState;
 class RDPipelineColorBlendState;
+class RDFramebufferPass;
 
 class RenderingDevice : public Object {
 	GDCLASS(RenderingDevice, Object)
@@ -517,10 +518,23 @@ public:
 
 	// This ID is warranted to be unique for the same formats, does not need to be freed
 	virtual FramebufferFormatID framebuffer_format_create(const Vector<AttachmentFormat> &p_format, uint32_t p_view_count = 1) = 0;
+	struct FramebufferPass {
+		enum {
+			ATTACHMENT_UNUSED = -1
+		};
+		Vector<int32_t> color_attachments;
+		Vector<int32_t> input_attachments;
+		Vector<int32_t> resolve_attachments;
+		Vector<int32_t> preserve_attachments;
+		int32_t depth_attachment = ATTACHMENT_UNUSED;
+	};
+
+	virtual FramebufferFormatID framebuffer_format_create_multipass(const Vector<AttachmentFormat> &p_attachments, Vector<FramebufferPass> &p_passes, uint32_t p_view_count = 1) = 0;
 	virtual FramebufferFormatID framebuffer_format_create_empty(TextureSamples p_samples = TEXTURE_SAMPLES_1) = 0;
-	virtual TextureSamples framebuffer_format_get_texture_samples(FramebufferFormatID p_format) = 0;
+	virtual TextureSamples framebuffer_format_get_texture_samples(FramebufferFormatID p_format, uint32_t p_pass = 0) = 0;
 
 	virtual RID framebuffer_create(const Vector<RID> &p_texture_attachments, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1) = 0;
+	virtual RID framebuffer_create_multipass(const Vector<RID> &p_texture_attachments, Vector<FramebufferPass> &p_passes, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1) = 0;
 	virtual RID framebuffer_create_empty(const Size2i &p_size, TextureSamples p_samples = TEXTURE_SAMPLES_1, FramebufferFormatID p_format_check = INVALID_ID) = 0;
 
 	virtual FramebufferFormatID framebuffer_get_format(RID p_framebuffer) = 0;
@@ -962,7 +976,7 @@ public:
 	};
 
 	virtual bool render_pipeline_is_valid(RID p_pipeline) = 0;
-	virtual RID render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const PipelineRasterizationState &p_rasterization_state, const PipelineMultisampleState &p_multisample_state, const PipelineDepthStencilState &p_depth_stencil_state, const PipelineColorBlendState &p_blend_state, int p_dynamic_state_flags = 0) = 0;
+	virtual RID render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const PipelineRasterizationState &p_rasterization_state, const PipelineMultisampleState &p_multisample_state, const PipelineDepthStencilState &p_depth_stencil_state, const PipelineColorBlendState &p_blend_state, int p_dynamic_state_flags = 0, uint32_t p_for_render_pass = 0) = 0;
 
 	/**************************/
 	/**** COMPUTE PIPELINE ****/
@@ -1017,6 +1031,9 @@ public:
 
 	virtual void draw_list_enable_scissor(DrawListID p_list, const Rect2 &p_rect) = 0;
 	virtual void draw_list_disable_scissor(DrawListID p_list) = 0;
+
+	virtual DrawListID draw_list_switch_to_next_pass() = 0;
+	virtual Error draw_list_switch_to_next_pass_split(uint32_t p_splits, DrawListID *r_split_ids) = 0;
 
 	virtual void draw_list_end(uint32_t p_post_barrier = BARRIER_MASK_ALL) = 0;
 
@@ -1134,8 +1151,10 @@ protected:
 	RID _texture_create_shared(const Ref<RDTextureView> &p_view, RID p_with_texture);
 	RID _texture_create_shared_from_slice(const Ref<RDTextureView> &p_view, RID p_with_texture, uint32_t p_layer, uint32_t p_mipmap, TextureSliceType p_slice_type = TEXTURE_SLICE_2D);
 
-	FramebufferFormatID _framebuffer_format_create(const TypedArray<RDAttachmentFormat> &p_attachments);
-	RID _framebuffer_create(const Array &p_textures, FramebufferFormatID p_format_check = INVALID_ID);
+	FramebufferFormatID _framebuffer_format_create(const TypedArray<RDAttachmentFormat> &p_attachments, uint32_t p_view_count);
+	FramebufferFormatID _framebuffer_format_create_multipass(const TypedArray<RDAttachmentFormat> &p_attachments, const TypedArray<RDFramebufferPass> &p_passes, uint32_t p_view_count);
+	RID _framebuffer_create(const TypedArray<RID> &p_textures, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1);
+	RID _framebuffer_create_multipass(const TypedArray<RID> &p_textures, const TypedArray<RDFramebufferPass> &p_passes, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1);
 	RID _sampler_create(const Ref<RDSamplerState> &p_state);
 	VertexFormatID _vertex_format_create(const TypedArray<RDVertexAttribute> &p_vertex_formats);
 	RID _vertex_array_create(uint32_t p_vertex_count, VertexFormatID p_vertex_format, const TypedArray<RID> &p_src_buffers);
@@ -1146,11 +1165,12 @@ protected:
 
 	Error _buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const Vector<uint8_t> &p_data, uint32_t p_post_barrier = BARRIER_MASK_ALL);
 
-	RID _render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const Ref<RDPipelineRasterizationState> &p_rasterization_state, const Ref<RDPipelineMultisampleState> &p_multisample_state, const Ref<RDPipelineDepthStencilState> &p_depth_stencil_state, const Ref<RDPipelineColorBlendState> &p_blend_state, int p_dynamic_state_flags = 0);
+	RID _render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const Ref<RDPipelineRasterizationState> &p_rasterization_state, const Ref<RDPipelineMultisampleState> &p_multisample_state, const Ref<RDPipelineDepthStencilState> &p_depth_stencil_state, const Ref<RDPipelineColorBlendState> &p_blend_state, int p_dynamic_state_flags = 0, uint32_t p_for_render_pass = 0);
 
 	Vector<int64_t> _draw_list_begin_split(RID p_framebuffer, uint32_t p_splits, InitialAction p_initial_color_action, FinalAction p_final_color_action, InitialAction p_initial_depth_action, FinalAction p_final_depth_action, const Vector<Color> &p_clear_color_values = Vector<Color>(), float p_clear_depth = 1.0, uint32_t p_clear_stencil = 0, const Rect2 &p_region = Rect2(), const TypedArray<RID> &p_storage_textures = TypedArray<RID>());
 	void _draw_list_set_push_constant(DrawListID p_list, const Vector<uint8_t> &p_data, uint32_t p_data_size);
 	void _compute_list_set_push_constant(ComputeListID p_list, const Vector<uint8_t> &p_data, uint32_t p_data_size);
+	Vector<int64_t> _draw_list_switch_to_next_pass_split(uint32_t p_splits);
 };
 
 VARIANT_ENUM_CAST(RenderingDevice::ShaderStage)

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -128,6 +128,34 @@ protected:
 	}
 };
 
+class RDFramebufferPass : public RefCounted {
+	GDCLASS(RDFramebufferPass, RefCounted)
+	friend class RenderingDevice;
+
+	RD::FramebufferPass base;
+
+public:
+	RD_SETGET(PackedInt32Array, color_attachments)
+	RD_SETGET(PackedInt32Array, input_attachments)
+	RD_SETGET(PackedInt32Array, resolve_attachments)
+	RD_SETGET(PackedInt32Array, preserve_attachments)
+	RD_SETGET(int32_t, depth_attachment)
+protected:
+	enum {
+		ATTACHMENT_UNUSED = -1
+	};
+
+	static void _bind_methods() {
+		RD_BIND(Variant::PACKED_INT32_ARRAY, RDFramebufferPass, color_attachments);
+		RD_BIND(Variant::PACKED_INT32_ARRAY, RDFramebufferPass, input_attachments);
+		RD_BIND(Variant::PACKED_INT32_ARRAY, RDFramebufferPass, resolve_attachments);
+		RD_BIND(Variant::PACKED_INT32_ARRAY, RDFramebufferPass, preserve_attachments);
+		RD_BIND(Variant::INT, RDFramebufferPass, depth_attachment);
+
+		BIND_CONSTANT(ATTACHMENT_UNUSED);
+	}
+};
+
 class RDSamplerState : public RefCounted {
 	GDCLASS(RDSamplerState, RefCounted)
 	friend class RenderingDevice;


### PR DESCRIPTION
* Required for better optimizing mobile platforms
* Will be used by the Vulkan mobile renderer.
* Everything properly exposed in RenderingDevice

RenderingDevice changes:

![image](https://user-images.githubusercontent.com/6265307/123279550-55aa8980-d4de-11eb-8de1-223a4c2408aa.png)

![image](https://user-images.githubusercontent.com/6265307/123279679-7672df00-d4de-11eb-8434-396cec408324.png)

