### PR TITLE
Strip query string when parsing HTTP request line for path

### DIFF
--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -135,8 +135,11 @@ public:
 		// Wrong protocol
 		ERR_FAIL_COND_MSG(req[0] != "GET" || req[2] != "HTTP/1.1", "Invalid method or HTTP version.");
 
-		const String req_file = req[1].get_file();
-		const String req_ext = req[1].get_extension();
+		const int query_index = req[1].find_char('?');
+		const String path = (query_index == -1) ? req[1] : req[1].substr(0, query_index);
+
+		const String req_file = path.get_file();
+		const String req_ext = path.get_extension();
 		const String cache_path = EditorPaths::get_singleton()->get_cache_dir().plus_file("web");
 		const String filepath = cache_path.plus_file(req_file);
 


### PR DESCRIPTION
The HTTP server used the request-target part of request line directly to locate the file to be served. Query string is allowed in the request-target, so the server generated 404 when I visit `http://localhost:8060/tmp_js_export.html?test=true`.

Fixes #49868, and also applies to 3.x.