### PR TITLE
Avoid using a nullptr root in Tree._range_click_timeout().

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2135,6 +2135,10 @@ void Tree::_range_click_timeout() {
 			}
 		}
 
+		if (!root) {
+			return;
+		}
+
 		click_handled = false;
 		Ref<InputEventMouseButton> mb;
 		mb.instantiate();


### PR DESCRIPTION
Fixes #46648