### PR TITLE
Fix crash when writing $. in the editor

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2728,6 +2728,9 @@ void GDScriptAnalyzer::reduce_self(GDScriptParser::SelfNode *p_self) {
 }
 
 void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscript) {
+	if (p_subscript->base == nullptr) {
+		return;
+	}
 	if (p_subscript->base->type == GDScriptParser::Node::IDENTIFIER) {
 		reduce_identifier(static_cast<GDScriptParser::IdentifierNode *>(p_subscript->base), true);
 	} else {


### PR DESCRIPTION
Fixes #49764 and fixes #50259

When writing $. in the editor, the analyzer expect an expression like object.attribute, but in this case, object is $, which is a get_node on nothing, so converted to nullptr, making the base null.
This PR only adds a check on nullptr to avoid the crash.