### PR TITLE
Validate image formats, check if resize_to_po2 failed

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2380,6 +2380,8 @@ Error Image::decompress() {
 }
 
 Error Image::compress(CompressMode p_mode, CompressSource p_source, float p_lossy_quality) {
+	ERR_FAIL_INDEX_V_MSG(p_mode, COMPRESS_MAX, ERR_INVALID_PARAMETER, "Invalid compress mode.");
+	ERR_FAIL_INDEX_V_MSG(p_source, COMPRESS_SOURCE_MAX, ERR_INVALID_PARAMETER, "Invalid compress source.");
 	return compress_from_channels(p_mode, detect_used_channels(p_source), p_lossy_quality);
 }
 
@@ -2404,6 +2406,9 @@ Error Image::compress_from_channels(CompressMode p_mode, UsedChannels p_channels
 		case COMPRESS_BPTC: {
 			ERR_FAIL_COND_V(!_image_compress_bptc_func, ERR_UNAVAILABLE);
 			_image_compress_bptc_func(this, p_lossy_quality, p_channels);
+		} break;
+		case COMPRESS_MAX: {
+			ERR_FAIL_V(ERR_INVALID_PARAMETER);
 		} break;
 	}
 

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -336,11 +336,13 @@ public:
 		COMPRESS_ETC,
 		COMPRESS_ETC2,
 		COMPRESS_BPTC,
+		COMPRESS_MAX,
 	};
 	enum CompressSource {
 		COMPRESS_SOURCE_GENERIC,
 		COMPRESS_SOURCE_SRGB,
-		COMPRESS_SOURCE_NORMAL
+		COMPRESS_SOURCE_NORMAL,
+		COMPRESS_SOURCE_MAX,
 	};
 
 	Error compress(CompressMode p_mode, CompressSource p_source = COMPRESS_SOURCE_GENERIC, float p_lossy_quality = 0.7);

--- a/modules/pvr/image_compress_pvrtc.cpp
+++ b/modules/pvr/image_compress_pvrtc.cpp
@@ -43,6 +43,10 @@ static void _compress_pvrtc1_4bpp(Image *p_img) {
 	if (!img->is_size_po2() || img->get_width() != img->get_height()) {
 		make_mipmaps = img->has_mipmaps();
 		img->resize_to_po2(true);
+		// Resizing can fail for some formats
+		if (!img->is_size_po2() || img->get_width() != img->get_height()) {
+			ERR_FAIL_MSG("Failed to resize the image for compression.");
+		}
 	}
 	img->convert(Image::FORMAT_RGBA8);
 	if (!img->has_mipmaps() && make_mipmaps) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This should fix #46480. The main problem was that we resize an image in `modules/pvr/image_compress_pvrtc.cpp` and assume that it always works. However, the resizing can fail for some formats. I've figured we can fix this in 2 ways:
* change the signature of the `resize_to_po2` method to return `Error` instead of `void` and check that error in `modules/pvr/image_compress_pvrtc.cpp` to stop the method if the resizing failed
* repeat the initial check to see if the conditions that caused the resizing have been fixed and if not, stop the method

Changing the signature seemed like a big step, so I went with the second approach :) Let me know if it's acceptable.

I've also added some checks to make sure that methods like `compress` are called with proper formats. To do this, I've introduced new values to some enums. Let me know if this is ok or if I need to update some docs as well (the values are not really meant to be used, they just represent the max value, but maybe we want them in the documentation anyway).