### PR TITLE
Improvements to 3D editor and gizmos

### DIFF
--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -4,7 +4,7 @@
 		Custom gizmo for editing Node3D objects.
 	</brief_description>
 	<description>
-		Custom gizmo that is used for providing custom visualization and editing (handles) for Node3D objects. See [EditorNode3DGizmoPlugin] for more information.
+		Gizmo that is used for providing custom visualization and editing (handles) for Node3D objects. Can be overridden to create custom gizmos, but for simple gizmos creating a [EditorNode3DGizmoPlugin] is usually recommended.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -12,64 +12,113 @@
 		<method name="_commit_handle" qualifiers="virtual">
 			<return type="void">
 			</return>
-			<argument index="0" name="index" type="int">
+			<argument index="0" name="group_id" type="int">
 			</argument>
-			<argument index="1" name="restore" type="Variant">
+			<argument index="1" name="id" type="int">
 			</argument>
-			<argument index="2" name="cancel" type="bool" default="false">
+			<argument index="2" name="restore" type="Variant">
+			</argument>
+			<argument index="3" name="cancel" type="bool" default="false">
 			</argument>
 			<description>
-				Commit a handle being edited (handles must have been previously added by [method add_handles]).
-				If the [code]cancel[/code] parameter is [code]true[/code], an option to restore the edited value to the original is provided.
+				Override this method to commit a handle being edited (handles must have been previously added by [method add_handle_group]). This usually means creating an [UndoRedo] action for the change, using the current handle value as "do" and the [code]restore[/code] argument as "undo".
+				If the [code]cancel[/code] argument is [code]true[/code], the [code]restore[/code] value should be directly set, without any [UndoRedo] action.
+			</description>
+		</method>
+		<method name="_commit_transform_handle" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="group_id" type="int">
+			</argument>
+			<argument index="1" name="id" type="int">
+			</argument>
+			<argument index="2" name="restore" type="Transform3D">
+			</argument>
+			<argument index="3" name="cancel" type="bool" default="false">
+			</argument>
+			<description>
+				Override this method to commit a transform handle being edited (handles must have been previously added by [method add_transform_handle_group]). This usually means creating an [UndoRedo] action for the change, using the current handle value as "do" and the [code]restore[/code] argument as "undo".
+				If the [code]cancel[/code] argument is [code]true[/code], the [code]restore[/code] value should be directly set, without any [UndoRedo] action.
 			</description>
 		</method>
 		<method name="_get_handle_name" qualifiers="virtual">
 			<return type="String">
 			</return>
-			<argument index="0" name="index" type="int">
+			<argument index="0" name="group_id" type="int">
+			</argument>
+			<argument index="1" name="id" type="int">
 			</argument>
 			<description>
-				Gets the name of an edited handle (handles must have been previously added by [method add_handles]).
+				Override this method to return the name of an edited handle (handles must have been previously added by [method add_handle_group] or [method add_transform_handle_group]).
 				Handles can be named for reference to the user when editing.
 			</description>
 		</method>
 		<method name="_get_handle_value" qualifiers="virtual">
 			<return type="Variant">
 			</return>
-			<argument index="0" name="index" type="int">
+			<argument index="0" name="group_id" type="int">
+			</argument>
+			<argument index="1" name="id" type="int">
 			</argument>
 			<description>
-				Gets actual value of a handle. This value can be anything and used for eventually undoing the motion when calling [method _commit_handle].
+				Override this method to return the actual value of a handle. This value will be requested at the start of an edit and used as the [code]restore[/code] argument in [method _commit_handle].
+			</description>
+		</method>
+		<method name="_get_transform_handle_value" qualifiers="virtual">
+			<return type="Transform3D">
+			</return>
+			<argument index="0" name="group_id" type="int">
+			</argument>
+			<argument index="1" name="id" type="int">
+			</argument>
+			<description>
+				Override this method to return the actual value of a transform handle. This value will be used to update the 3D transform gizmo. It will also be requested at the start of an edit and used as the [code]restore[/code] argument in [method _commit_handle].
 			</description>
 		</method>
 		<method name="_is_handle_highlighted" qualifiers="virtual">
 			<return type="bool">
 			</return>
-			<argument index="0" name="index" type="int">
+			<argument index="0" name="group_id" type="int">
+			</argument>
+			<argument index="1" name="id" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the handle at index [code]index[/code] is highlighted by being hovered with the mouse.
+				Override this method to return [code]true[/code] whenever to given handle should be highlighted in the editor.
 			</description>
 		</method>
 		<method name="_redraw" qualifiers="virtual">
 			<return type="void">
 			</return>
 			<description>
-				This function is called when the [Node3D] this gizmo refers to changes (the [method Node3D.update_gizmo] is called).
+				Override this method to add all the gizmo elements whenever a gizmo update is requested.
 			</description>
 		</method>
 		<method name="_set_handle" qualifiers="virtual">
 			<return type="void">
 			</return>
-			<argument index="0" name="index" type="int">
+			<argument index="0" name="group_id" type="int">
 			</argument>
-			<argument index="1" name="camera" type="Camera3D">
+			<argument index="1" name="id" type="int">
 			</argument>
-			<argument index="2" name="point" type="Vector2">
+			<argument index="2" name="camera" type="Camera3D">
+			</argument>
+			<argument index="3" name="point" type="Vector2">
 			</argument>
 			<description>
-				This function is used when the user drags a gizmo handle (previously added with [method add_handles]) in screen coordinates.
-				The [Camera3D] is also provided so screen coordinates can be converted to raycasts.
+				Override this method to update the node properties when the user drags a gizmo handle (previously added with [method add_handle_group]). The provided [code]point[/code] is the mouse position in screen coordinates and the [code]camera[/code] can be used to convert it to raycasts.
+			</description>
+		</method>
+		<method name="_set_transform_handle" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="group_id" type="int">
+			</argument>
+			<argument index="1" name="id" type="int">
+			</argument>
+			<argument index="2" name="transform" type="Transform3D">
+			</argument>
+			<description>
+				Override this method to update the node properties when the user manipulates a transform handle (previously added with [method add_transform_handle_group]).
 			</description>
 		</method>
 		<method name="add_collision_segments">
@@ -78,7 +127,7 @@
 			<argument index="0" name="segments" type="PackedVector3Array">
 			</argument>
 			<description>
-				Adds the specified [code]segments[/code] to the gizmo's collision shape for picking. Call this function during [method _redraw].
+				Adds the specified [code]segments[/code] to the gizmo's collision shape for picking. Call this method during [method _redraw].
 			</description>
 		</method>
 		<method name="add_collision_triangles">
@@ -87,7 +136,30 @@
 			<argument index="0" name="triangles" type="TriangleMesh">
 			</argument>
 			<description>
-				Adds collision triangles to the gizmo for picking. A [TriangleMesh] can be generated from a regular [Mesh] too. Call this function during [method _redraw].
+				Adds collision triangles to the gizmo for picking. A [TriangleMesh] can be generated from a regular [Mesh] too. Call this method during [method _redraw].
+			</description>
+		</method>
+		<method name="add_handle_group">
+			<return type="void">
+			</return>
+			<argument index="0" name="group_id" type="int">
+			</argument>
+			<argument index="1" name="material" type="Material">
+			</argument>
+			<argument index="2" name="positions" type="PackedVector3Array">
+			</argument>
+			<argument index="3" name="ids" type="PackedInt32Array" default="PackedInt32Array()">
+			</argument>
+			<argument index="4" name="billboard" type="bool" default="false">
+			</argument>
+			<argument index="5" name="shift_priority" type="bool" default="false">
+			</argument>
+			<description>
+				Adds a group of handles to this gizmo. These handles are displayed in the 3D editor and can be used to edit the node the gizmo is attached to, by overriding the handle-related methods in this class.
+				Handle positions are defined in local space using the [code]positions[/code] argument, if [code]billboard[/code] is [code]true[/code] the local Z axis will always face the camera.
+				The handle group is identified by the provided [code]group_id[/code] and each individual handle can have it own ID using the [code]ids[/code] argument. If [code]ids[/code] is empty, the array index will be used as the handle identifier.
+				If [code]shift_priority[/code] is [code]true[/code] this handle group will have selection priority over others when the user is holding shift, this is useful when multiple handles share the same position.
+				Call this method during [method _redraw].
 			</description>
 		</method>
 		<method name="add_handles">
@@ -99,11 +171,12 @@
 			</argument>
 			<argument index="2" name="billboard" type="bool" default="false">
 			</argument>
-			<argument index="3" name="secondary" type="bool" default="false">
+			<argument index="3" name="shift_priority" type="bool" default="false">
 			</argument>
 			<description>
-				Adds a list of handles (points) which can be used to deform the object being edited.
-				There are virtual functions which will be called upon editing of these handles. Call this function during [method _redraw].
+				This method was left for compatibility with the old handle system. Use [method add_handle_group] instead.
+				Adds a list of handles (points) which can be used to modify the object being edited.
+				There are virtual methods which will be called upon editing of these handles. Call this method during [method _redraw].
 			</description>
 		</method>
 		<method name="add_lines">
@@ -118,7 +191,7 @@
 			<argument index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
-				Adds lines to the gizmo (as sets of 2 points), with a given material. The lines are used for visualizing the gizmo. Call this function during [method _redraw].
+				Adds lines to the gizmo (as sets of 2 points), with a given material. The lines are used for visualizing the gizmo. Call this method during [method _redraw].
 			</description>
 		</method>
 		<method name="add_mesh">
@@ -126,14 +199,32 @@
 			</return>
 			<argument index="0" name="mesh" type="ArrayMesh">
 			</argument>
-			<argument index="1" name="billboard" type="bool" default="false">
+			<argument index="1" name="material" type="Material" default="null">
 			</argument>
 			<argument index="2" name="skeleton" type="SkinReference" default="null">
 			</argument>
-			<argument index="3" name="material" type="Material" default="null">
+			<description>
+			</description>
+		</method>
+		<method name="add_transform_handle_group">
+			<return type="void">
+			</return>
+			<argument index="0" name="group_id" type="int">
+			</argument>
+			<argument index="1" name="material" type="Material">
+			</argument>
+			<argument index="2" name="transforms" type="Array">
+			</argument>
+			<argument index="3" name="ids" type="PackedInt32Array" default="PackedInt32Array()">
+			</argument>
+			<argument index="4" name="shift_priority" type="bool" default="false">
 			</argument>
 			<description>
-				Adds a mesh to the gizmo with the specified [code]billboard[/code] state, [code]skeleton[/code] and [code]material[/code]. If [code]billboard[/code] is [code]true[/code], the mesh will rotate to always face the camera. Call this function during [method _redraw].
+				Adds a group of transform handles to this gizmo. These handles are displayed in the 3D editor and can be selected by the user to then modify them using the 3D transform tools.
+				Handle transforms are defined in local space using the [code]transforms[/code] argument.
+				The transform handle group is identified by the provided [code]group_id[/code] and each individual handle can have it own ID using the [code]ids[/code] argument. If [code]ids[/code] is empty, the array index will be used as the handle identifier.
+				If [code]shift_priority[/code] is [code]true[/code] this handle group will have selection priority over others when the user is holding shift, this is useful when multiple handles share the same position.
+				Call this method during [method _redraw].
 			</description>
 		</method>
 		<method name="add_unscaled_billboard">
@@ -146,7 +237,7 @@
 			<argument index="2" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
 			</argument>
 			<description>
-				Adds an unscaled billboard for visualization. Call this function during [method _redraw].
+				Adds an unscaled billboard for visualization and selection. Call this method during [method _redraw].
 			</description>
 		</method>
 		<method name="clear">

--- a/doc/classes/EditorNode3DGizmoPlugin.xml
+++ b/doc/classes/EditorNode3DGizmoPlugin.xml
@@ -14,7 +14,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Override this method to define whether the gizmo can be hidden or not. Returns [code]true[/code] if not overridden.
+				Override this method to define whether the gizmos handled by this plugin can be hidden or not. Returns [code]true[/code] if not overridden.
 			</description>
 		</method>
 		<method name="_commit_handle" qualifiers="virtual">
@@ -22,14 +22,35 @@
 			</return>
 			<argument index="0" name="gizmo" type="EditorNode3DGizmo">
 			</argument>
-			<argument index="1" name="index" type="int">
+			<argument index="1" name="group_id" type="int">
 			</argument>
-			<argument index="2" name="restore" type="Variant">
+			<argument index="2" name="id" type="int">
 			</argument>
-			<argument index="3" name="cancel" type="bool" default="false">
+			<argument index="3" name="restore" type="Variant">
+			</argument>
+			<argument index="4" name="cancel" type="bool" default="false">
 			</argument>
 			<description>
-				Override this method to commit gizmo handles. Called for this plugin's active gizmos.
+				Override this method to commit a handle being edited (handles must have been previously added by [method EditorNode3DGizmo.add_handle_group] during [method _redraw]). This usually means creating an [UndoRedo] action for the change, using the current handle value as "do" and the [code]restore[/code] argument as "undo".
+				If the [code]cancel[/code] argument is [code]true[/code], the [code]restore[/code] value should be directly set, without any [UndoRedo] action. Called for this plugin's active gizmos.
+			</description>
+		</method>
+		<method name="_commit_transform_handle" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="gizmo" type="EditorNode3DGizmo">
+			</argument>
+			<argument index="1" name="group_id" type="int">
+			</argument>
+			<argument index="2" name="id" type="int">
+			</argument>
+			<argument index="3" name="restore" type="Transform3D">
+			</argument>
+			<argument index="4" name="cancel" type="bool" default="false">
+			</argument>
+			<description>
+				Override this method to commit a transform handle being edited (handles must have been previously added by [method EditorNode3DGizmo.add_transform_handle_group] during [method _redraw]). This usually means creating an [UndoRedo] action for the change, using the current handle value as "do" and the [code]restore[/code] argument as "undo".
+				If the [code]cancel[/code] argument is [code]true[/code], the [code]restore[/code] value should be directly set, without any [UndoRedo] action. Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_create_gizmo" qualifiers="virtual">
@@ -53,7 +74,9 @@
 			</return>
 			<argument index="0" name="gizmo" type="EditorNode3DGizmo">
 			</argument>
-			<argument index="1" name="index" type="int">
+			<argument index="1" name="group_id" type="int">
+			</argument>
+			<argument index="2" name="id" type="int">
 			</argument>
 			<description>
 				Override this method to provide gizmo's handle names. Called for this plugin's active gizmos.
@@ -64,18 +87,33 @@
 			</return>
 			<argument index="0" name="gizmo" type="EditorNode3DGizmo">
 			</argument>
-			<argument index="1" name="index" type="int">
+			<argument index="1" name="group_id" type="int">
+			</argument>
+			<argument index="2" name="id" type="int">
 			</argument>
 			<description>
-				Gets actual value of a handle from gizmo. Called for this plugin's active gizmos.
+				Override this method to return the actual value of a handle. This value will be requested at the start of an edit and used as the [code]restore[/code] argument in [method _commit_handle]. Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_get_priority" qualifiers="virtual">
 			<return type="int">
 			</return>
 			<description>
-				Override this method to set the gizmo's priority. Higher values correspond to higher priority. If a gizmo with higher priority conflicts with another gizmo, only the gizmo with higher priority will be used.
+				Override this method to set the gizmo's priority, since a [Node3D] can only have one gizmo. Higher values correspond to higher priority. If a gizmo with higher priority conflicts with another gizmo, only the gizmo with higher priority will be used.
 				All built-in editor gizmos return a priority of [code]-1[/code]. If not overridden, this method will return [code]0[/code], which means custom gizmos will automatically override built-in gizmos.
+			</description>
+		</method>
+		<method name="_get_transform_handle_value" qualifiers="virtual">
+			<return type="Transform3D">
+			</return>
+			<argument index="0" name="gizmo" type="EditorNode3DGizmo">
+			</argument>
+			<argument index="1" name="group_id" type="int">
+			</argument>
+			<argument index="2" name="id" type="int">
+			</argument>
+			<description>
+				Override this method to return the actual value of a transform handle. This value will be used to update the 3D transform gizmo. It will also be requested at the start of an edit and used as the [code]restore[/code] argument in [method _commit_handle]. Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_has_gizmo" qualifiers="virtual">
@@ -92,10 +130,12 @@
 			</return>
 			<argument index="0" name="gizmo" type="EditorNode3DGizmo">
 			</argument>
-			<argument index="1" name="index" type="int">
+			<argument index="1" name="group_id" type="int">
+			</argument>
+			<argument index="2" name="id" type="int">
 			</argument>
 			<description>
-				Gets whether a handle is highlighted or not. Called for this plugin's active gizmos.
+				Override this method to return [code]true[/code] whenever to given handle should be highlighted in the editor. Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_is_selectable_when_hidden" qualifiers="virtual">
@@ -111,7 +151,7 @@
 			<argument index="0" name="gizmo" type="EditorNode3DGizmo">
 			</argument>
 			<description>
-				Callback to redraw the provided gizmo. Called for this plugin's active gizmos.
+				Override this method to add all the gizmo elements whenever a gizmo update is requested. Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_set_handle" qualifiers="virtual">
@@ -119,14 +159,31 @@
 			</return>
 			<argument index="0" name="gizmo" type="EditorNode3DGizmo">
 			</argument>
-			<argument index="1" name="index" type="int">
+			<argument index="1" name="group_id" type="int">
 			</argument>
-			<argument index="2" name="camera" type="Camera3D">
+			<argument index="2" name="id" type="int">
 			</argument>
-			<argument index="3" name="point" type="Vector2">
+			<argument index="3" name="camera" type="Camera3D">
+			</argument>
+			<argument index="4" name="point" type="Vector2">
 			</argument>
 			<description>
-				Update the value of a handle after it has been updated. Called for this plugin's active gizmos.
+				Override this method to update the node properties when the user drags a gizmo handle (previously added with [method EditorNode3DGizmo.add_handle_group]). The provided [code]point[/code] is the mouse position in screen coordinates and the [code]camera[/code] can be used to convert it to raycasts. Called for this plugin's active gizmos.
+			</description>
+		</method>
+		<method name="_set_transform_handle" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="gizmo" type="EditorNode3DGizmo">
+			</argument>
+			<argument index="1" name="group_id" type="int">
+			</argument>
+			<argument index="2" name="id" type="int">
+			</argument>
+			<argument index="3" name="transform" type="Transform3D">
+			</argument>
+			<description>
+				Override this method to update the node properties when the user manipulates a transform handle (previously added with [method EditorNode3DGizmo.add_transform_handle_group]).  Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="add_material">

--- a/editor/node_3d_editor_gizmos.h
+++ b/editor/node_3d_editor_gizmos.h
@@ -28,13 +28,161 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SPATIAL_EDITOR_GIZMOS_H
-#define SPATIAL_EDITOR_GIZMOS_H
+#ifndef NODE_3D_EDITOR_GIZMOS_H
+#define NODE_3D_EDITOR_GIZMOS_H
 
-#include "editor/plugins/node_3d_editor_plugin.h"
-#include "scene/3d/camera_3d.h"
+#include "core/templates/ordered_hash_map.h"
+#include "scene/3d/node_3d.h"
+#include "scene/3d/skeleton_3d.h"
 
 class Camera3D;
+class Timer;
+class EditorNode3DGizmoPlugin;
+
+class EditorNode3DGizmo : public Node3DGizmo {
+	GDCLASS(EditorNode3DGizmo, Node3DGizmo);
+
+	struct Instance {
+		RID instance;
+		Ref<ArrayMesh> mesh;
+		Ref<Material> material;
+		Ref<SkinReference> skin_reference;
+		bool extra_margin = false;
+
+		void create_instance(Node3D *p_base, bool p_hidden = false);
+	};
+
+	struct HandleGroup {
+		Vector<Transform3D> transforms;
+		Vector<Vector3> positions;
+		Vector<int> ids;
+		bool billboard = false;
+		bool shift_priority = false;
+	};
+
+	const int COMPAT_HANDLE_GROUP_ID = -998;
+	const int COMPAT_SEC_HANDLE_GROUP_ID = -999;
+
+	bool selected;
+
+	Vector<Vector3> collision_segments;
+	Ref<TriangleMesh> collision_mesh;
+
+	OrderedHashMap<int, HandleGroup> handle_groups;
+
+	float selectable_icon_size;
+	bool billboard_handle;
+
+	bool valid;
+	bool hidden;
+	Vector<Instance> instances;
+	Node3D *spatial_node;
+
+	void _set_spatial_node(Node *p_node) { set_spatial_node(Object::cast_to<Node3D>(p_node)); }
+
+protected:
+	static void _bind_methods();
+
+	EditorNode3DGizmoPlugin *gizmo_plugin;
+
+public:
+	void add_lines(const Vector<Vector3> &p_lines, const Ref<Material> &p_material, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1));
+	void add_vertices(const Vector<Vector3> &p_vertices, const Ref<Material> &p_material, Mesh::PrimitiveType p_primitive_type, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1));
+	void add_mesh(const Ref<ArrayMesh> &p_mesh, const Ref<Material> &p_material = Ref<Material>(), const Ref<SkinReference> &p_skin_reference = Ref<SkinReference>());
+	void add_collision_segments(const Vector<Vector3> &p_lines);
+	void add_collision_triangles(const Ref<TriangleMesh> &p_tmesh);
+	void add_unscaled_billboard(const Ref<Material> &p_material, float p_scale = 1, const Color &p_modulate = Color(1, 1, 1));
+	void add_handles(const Vector<Vector3> &p_handles, const Ref<Material> &p_material, bool p_billboard = false, bool p_secondary = false); // Compat with old handles system, prefer add_handle_group() instead
+	void _add_handle_group_mesh(int p_group_id, const Vector<Vector3> &p_positions, const Vector<int> &p_ids, const Ref<Material> p_material, bool p_billboard = false);
+	void add_handle_group(int p_group_id, const Ref<Material> &p_material, const Vector<Vector3> &p_positions, const Vector<int> &p_ids = Vector<int>(), bool p_billboard = false, bool p_shift_priority = false);
+	void _add_transform_handle_group(int p_group_id, const Ref<Material> &p_material, const Array &p_transforms, const Vector<int> &p_ids = Vector<int>(), bool p_shift_priority = false); // Binding version
+	void add_transform_handle_group(int p_group_id, const Ref<Material> &p_material, const Vector<Transform3D> &p_transforms, const Vector<int> &p_ids = Vector<int>(), bool p_shift_priority = false);
+	void add_solid_box(Ref<Material> &p_material, Vector3 p_size, Vector3 p_position = Vector3());
+
+	virtual bool is_handle_highlighted(int p_group_id, int p_id) const;
+	virtual String get_handle_name(int p_group_id, int p_id) const;
+	virtual Variant get_handle_value(int p_group_id, int p_id) const;
+	virtual void set_handle(int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const;
+	virtual void commit_handle(int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const;
+	virtual Transform3D get_transform_handle_value(int p_group_id, int p_id) const;
+	virtual void set_transform_handle(int p_group_id, int p_id, const Transform3D &p_transform) const;
+	virtual void commit_transform_handle(int p_group_id, int p_id, const Transform3D &p_restore, bool p_cancel = false) const;
+
+	void set_selected(bool p_selected) { selected = p_selected; }
+	bool is_selected() const { return selected; }
+
+	void set_spatial_node(Node3D *p_node);
+	Node3D *get_spatial_node() const { return spatial_node; }
+	Ref<EditorNode3DGizmoPlugin> get_plugin() const { return gizmo_plugin; }
+	bool intersect_frustum(const Camera3D *p_camera, const Vector<Plane> &p_frustum);
+	bool _handle_group_intersect_ray(const HandleGroup &p_handle_group, const Transform3D &p_xform, const Camera3D *p_camera, const Point2 &p_point, float &r_min_distance, int &r_idx);
+	void handles_intersect_ray(Camera3D *p_camera, const Vector2 &p_point, bool p_shift_pressed, int &r_group_id, int &r_idx);
+	bool intersect_ray(Camera3D *p_camera, const Point2 &p_point, Vector3 &r_pos, Vector3 &r_normal);
+	bool is_handle_group_transform(int p_group_id);
+
+	virtual void clear() override;
+	virtual void create() override;
+	virtual void transform() override;
+	virtual void redraw() override;
+	virtual void free() override;
+
+	virtual bool is_editable() const;
+
+	void set_hidden(bool p_hidden);
+	void set_plugin(EditorNode3DGizmoPlugin *p_plugin);
+
+	EditorNode3DGizmo();
+	~EditorNode3DGizmo();
+};
+
+class EditorNode3DGizmoPlugin : public Resource {
+	GDCLASS(EditorNode3DGizmoPlugin, Resource);
+
+public:
+	static const int VISIBLE = 0;
+	static const int HIDDEN = 1;
+	static const int ON_TOP = 2;
+
+protected:
+	int current_state;
+	List<EditorNode3DGizmo *> current_gizmos;
+	HashMap<String, Vector<Ref<StandardMaterial3D>>> materials;
+
+	static void _bind_methods();
+	virtual bool has_gizmo(Node3D *p_spatial);
+	virtual Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_spatial);
+
+public:
+	void create_material(const String &p_name, const Color &p_color, bool p_billboard = false, bool p_on_top = false, bool p_use_vertex_color = false);
+	void create_icon_material(const String &p_name, const Ref<Texture2D> &p_texture, bool p_on_top = false, const Color &p_albedo = Color(1, 1, 1, 1));
+	void create_handle_material(const String &p_name, bool p_billboard = false, const Ref<Texture2D> &p_texture = nullptr);
+	void add_material(const String &p_name, Ref<StandardMaterial3D> p_material);
+
+	Ref<StandardMaterial3D> get_material(const String &p_name, const Ref<EditorNode3DGizmo> &p_gizmo = Ref<EditorNode3DGizmo>());
+
+	virtual String get_gizmo_name() const;
+	virtual int get_priority() const;
+	virtual bool can_be_hidden() const;
+	virtual bool is_selectable_when_hidden() const;
+
+	virtual void redraw(EditorNode3DGizmo *p_gizmo);
+	virtual bool is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const;
+	virtual String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const;
+	virtual Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const;
+	virtual void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const;
+	virtual void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const;
+	virtual Transform3D get_transform_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const;
+	virtual void set_transform_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Transform3D &p_transform) const;
+	virtual void commit_transform_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Transform3D &p_restore, bool p_cancel = false) const;
+
+	Ref<EditorNode3DGizmo> get_gizmo(Node3D *p_spatial);
+	void set_state(int p_state);
+	int get_state() const;
+	void unregister_gizmo(EditorNode3DGizmo *p_gizmo);
+
+	EditorNode3DGizmoPlugin();
+	virtual ~EditorNode3DGizmoPlugin();
+};
 
 class Light3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(Light3DGizmoPlugin, EditorNode3DGizmoPlugin);
@@ -44,10 +192,10 @@ public:
 	String get_gizmo_name() const override;
 	int get_priority() const override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
 	Light3DGizmoPlugin();
@@ -61,10 +209,10 @@ public:
 	String get_gizmo_name() const override;
 	int get_priority() const override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
 	AudioStreamPlayer3DGizmoPlugin();
@@ -78,10 +226,10 @@ public:
 	String get_gizmo_name() const override;
 	int get_priority() const override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
 	Camera3DGizmoPlugin();
@@ -210,10 +358,10 @@ public:
 	bool is_selectable_when_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) override;
-	bool is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int idx) const override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
+	bool is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
 
 	SoftBody3DGizmoPlugin();
 };
@@ -227,10 +375,10 @@ public:
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 
 	VisibleOnScreenNotifier3DGizmoPlugin();
 };
@@ -257,10 +405,10 @@ public:
 	bool is_selectable_when_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 
 	GPUParticles3DGizmoPlugin();
 };
@@ -274,10 +422,10 @@ public:
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 
 	GPUParticlesCollision3DGizmoPlugin();
 };
@@ -291,10 +439,10 @@ public:
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 
 	ReflectionProbeGizmoPlugin();
 };
@@ -308,10 +456,10 @@ public:
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 
 	DecalGizmoPlugin();
 };
@@ -325,10 +473,10 @@ public:
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 
 	VoxelGIGizmoPlugin();
 };
@@ -342,10 +490,10 @@ public:
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 
 	LightmapGIGizmoPlugin();
 };
@@ -359,10 +507,10 @@ public:
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 
 	LightmapProbeGizmoPlugin();
 };
@@ -388,10 +536,10 @@ public:
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id) const override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, Camera3D *p_camera, const Point2 &p_point) const override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_id, const Variant &p_restore, bool p_cancel = false) const override;
 
 	CollisionShape3DGizmoPlugin();
 };
@@ -489,4 +637,4 @@ public:
 	Joint3DGizmoPlugin();
 };
 
-#endif // SPATIAL_EDITOR_GIZMOS_H
+#endif // NODE_3D_EDITOR_GIZMOS_H

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -34,106 +34,15 @@
 #include "editor/editor_node.h"
 #include "editor/editor_plugin.h"
 #include "editor/editor_scale.h"
-#include "scene/3d/immediate_geometry_3d.h"
-#include "scene/3d/light_3d.h"
-#include "scene/3d/visual_instance_3d.h"
-#include "scene/3d/world_environment.h"
-#include "scene/gui/panel_container.h"
-#include "scene/resources/environment.h"
+#include "editor/node_3d_editor_gizmos.h"
 #include "scene/resources/sky_material.h"
 
 class Camera3D;
 class Node3DEditor;
-class EditorNode3DGizmoPlugin;
 class Node3DEditorViewport;
 class SubViewportContainer;
-
-class EditorNode3DGizmo : public Node3DGizmo {
-	GDCLASS(EditorNode3DGizmo, Node3DGizmo);
-
-	bool selected;
-	bool instantiated;
-
-public:
-	void set_selected(bool p_selected) { selected = p_selected; }
-	bool is_selected() const { return selected; }
-
-	struct Instance {
-		RID instance;
-		Ref<ArrayMesh> mesh;
-		Ref<Material> material;
-		Ref<SkinReference> skin_reference;
-		RID skeleton;
-		bool billboard = false;
-		bool unscaled = false;
-		bool can_intersect = false;
-		bool extra_margin = false;
-
-		void create_instance(Node3D *p_base, bool p_hidden = false);
-	};
-
-	Vector<Vector3> collision_segments;
-	Ref<TriangleMesh> collision_mesh;
-
-	struct Handle {
-		Vector3 pos;
-		bool billboard = false;
-	};
-
-	Vector<Vector3> handles;
-	Vector<Vector3> secondary_handles;
-	float selectable_icon_size;
-	bool billboard_handle;
-
-	bool valid;
-	bool hidden;
-	Node3D *base;
-	Vector<Instance> instances;
-	Node3D *spatial_node;
-	EditorNode3DGizmoPlugin *gizmo_plugin;
-
-	void _set_spatial_node(Node *p_node) { set_spatial_node(Object::cast_to<Node3D>(p_node)); }
-
-protected:
-	static void _bind_methods();
-
-public:
-	void add_lines(const Vector<Vector3> &p_lines, const Ref<Material> &p_material, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1));
-	void add_vertices(const Vector<Vector3> &p_vertices, const Ref<Material> &p_material, Mesh::PrimitiveType p_primitive_type, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1));
-	void add_mesh(const Ref<ArrayMesh> &p_mesh, bool p_billboard = false, const Ref<SkinReference> &p_skin_reference = Ref<SkinReference>(), const Ref<Material> &p_material = Ref<Material>());
-	void add_collision_segments(const Vector<Vector3> &p_lines);
-	void add_collision_triangles(const Ref<TriangleMesh> &p_tmesh);
-	void add_unscaled_billboard(const Ref<Material> &p_material, float p_scale = 1, const Color &p_modulate = Color(1, 1, 1));
-	void add_handles(const Vector<Vector3> &p_handles, const Ref<Material> &p_material, bool p_billboard = false, bool p_secondary = false);
-	void add_solid_box(Ref<Material> &p_material, Vector3 p_size, Vector3 p_position = Vector3());
-
-	virtual bool is_handle_highlighted(int p_idx) const;
-	virtual String get_handle_name(int p_idx) const;
-	virtual Variant get_handle_value(int p_idx);
-	virtual void set_handle(int p_idx, Camera3D *p_camera, const Point2 &p_point);
-	virtual void commit_handle(int p_idx, const Variant &p_restore, bool p_cancel = false);
-
-	void set_spatial_node(Node3D *p_node);
-	Node3D *get_spatial_node() const { return spatial_node; }
-	Ref<EditorNode3DGizmoPlugin> get_plugin() const { return gizmo_plugin; }
-	Vector3 get_handle_pos(int p_idx) const;
-	bool intersect_frustum(const Camera3D *p_camera, const Vector<Plane> &p_frustum);
-	bool intersect_ray(Camera3D *p_camera, const Point2 &p_point, Vector3 &r_pos, Vector3 &r_normal, int *r_gizmo_handle = nullptr, bool p_sec_first = false);
-
-	virtual void clear() override;
-	virtual void create() override;
-	virtual void transform() override;
-	virtual void redraw() override;
-	virtual void free() override;
-
-	virtual bool is_editable() const;
-
-	void set_hidden(bool p_hidden);
-	void set_plugin(EditorNode3DGizmoPlugin *p_plugin);
-
-	EditorNode3DGizmo();
-	~EditorNode3DGizmo();
-};
+class DirectionalLight3D;
+class WorldEnvironment;
 
 class ViewportRotationControl : public Control {
 	GDCLASS(ViewportRotationControl, Control);
@@ -315,10 +224,9 @@ private:
 	void _update_name();
 	void _compute_edit(const Point2 &p_point);
 	void _clear_selected();
-	void _select_clicked(bool p_append, bool p_single, bool p_allow_locked = false);
-	void _select(Node *p_node, bool p_append, bool p_single);
-	ObjectID _select_ray(const Point2 &p_pos, bool p_append, bool &r_includes_current, int *r_gizmo_handle = nullptr, bool p_alt_select = false);
-	void _find_items_at_pos(const Point2 &p_pos, bool &r_includes_current, Vector<_RayResult> &results, bool p_alt_select = false);
+	void _select_clicked();
+	ObjectID _select_ray(const Point2 &p_pos);
+	void _find_items_at_pos(const Point2 &p_pos, Vector<_RayResult> &r_results);
 	Vector3 _get_ray_pos(const Vector2 &p_pos) const;
 	Vector3 _get_ray(const Vector2 &p_pos) const;
 	Point2 _point_to_screen(const Vector3 &p_point);
@@ -330,7 +238,8 @@ private:
 	Vector3 _get_screen_to_space(const Vector3 &p_vector3);
 
 	void _select_region();
-	bool _gizmo_select(const Vector2 &p_screenpos, bool p_highlight_only = false);
+	bool _transform_gizmo_select(const Vector2 &p_screenpos, bool p_highlight_only = false);
+	void _transform_gizmo_apply(Node3D *p_node, const Transform3D &p_transform, bool p_local);
 
 	void _nav_pan(Ref<InputEventWithModifiers> p_event, const Vector2 &p_relative);
 	void _nav_zoom(Ref<InputEventWithModifiers> p_event, const Vector2 &p_relative);
@@ -384,15 +293,13 @@ private:
 		Vector3 click_ray;
 		Vector3 click_ray_pos;
 		Vector3 center;
-		Vector3 orig_gizmo_pos;
-		int edited_gizmo = 0;
 		Point2 mouse_pos;
 		Point2 original_mouse_pos;
 		bool snap = false;
 		Ref<EditorNode3DGizmo> gizmo;
 		int gizmo_handle = 0;
+		int gizmo_handle_group = 0;
 		Variant gizmo_initial_value;
-		Vector3 gizmo_initial_pos;
 	} _edit;
 
 	struct Cursor {
@@ -621,6 +528,7 @@ private:
 	Ref<ShaderMaterial> rotate_gizmo_color_hl[3];
 
 	int over_gizmo_handle;
+	int over_gizmo_handle_group;
 	float snap_translate_value;
 	float snap_rotate_value;
 	float snap_scale_value;
@@ -691,7 +599,6 @@ private:
 	LineEdit *snap_translate;
 	LineEdit *snap_rotate;
 	LineEdit *snap_scale;
-	PanelContainer *menu_panel;
 
 	LineEdit *xform_translate[3];
 	LineEdit *xform_rotate[3];
@@ -735,6 +642,8 @@ private:
 	Ref<Environment> viewport_environment;
 
 	Node3D *selected;
+	int selected_gizmo_handle;
+	int selected_gizmo_handle_group;
 
 	void _request_gizmo(Object *p_obj);
 
@@ -751,6 +660,7 @@ private:
 
 	bool is_any_freelook_active() const;
 
+	void _selection_changed();
 	void _refresh_menu_icons();
 
 	// Preview Sun and Environment
@@ -866,8 +776,21 @@ public:
 
 	Node3D *get_selected() { return selected; }
 
+	void set_selected_gizmo_handle(int p_group_id, int p_idx) {
+		selected_gizmo_handle_group = p_group_id;
+		selected_gizmo_handle = p_idx;
+	}
+
+	int get_selected_gizmo_handle() const { return selected_gizmo_handle; }
+	int get_selected_gizmo_handle_group() const { return selected_gizmo_handle_group; }
+
+	void set_over_gizmo_handle(int p_group_id, int p_idx) {
+		over_gizmo_handle_group = p_group_id;
+		over_gizmo_handle = p_idx;
+	}
+
 	int get_over_gizmo_handle() const { return over_gizmo_handle; }
-	void set_over_gizmo_handle(int idx) { over_gizmo_handle = idx; }
+	int get_over_gizmo_handle_group() const { return over_gizmo_handle_group; }
 
 	void set_can_preview(Camera3D *p_preview);
 
@@ -908,52 +831,6 @@ public:
 
 	Node3DEditorPlugin(EditorNode *p_node);
 	~Node3DEditorPlugin();
-};
-
-class EditorNode3DGizmoPlugin : public Resource {
-	GDCLASS(EditorNode3DGizmoPlugin, Resource);
-
-public:
-	static const int VISIBLE = 0;
-	static const int HIDDEN = 1;
-	static const int ON_TOP = 2;
-
-protected:
-	int current_state;
-	List<EditorNode3DGizmo *> current_gizmos;
-	HashMap<String, Vector<Ref<StandardMaterial3D>>> materials;
-
-	static void _bind_methods();
-	virtual bool has_gizmo(Node3D *p_spatial);
-	virtual Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_spatial);
-
-public:
-	void create_material(const String &p_name, const Color &p_color, bool p_billboard = false, bool p_on_top = false, bool p_use_vertex_color = false);
-	void create_icon_material(const String &p_name, const Ref<Texture2D> &p_texture, bool p_on_top = false, const Color &p_albedo = Color(1, 1, 1, 1));
-	void create_handle_material(const String &p_name, bool p_billboard = false, const Ref<Texture2D> &p_texture = nullptr);
-	void add_material(const String &p_name, Ref<StandardMaterial3D> p_material);
-
-	Ref<StandardMaterial3D> get_material(const String &p_name, const Ref<EditorNode3DGizmo> &p_gizmo = Ref<EditorNode3DGizmo>());
-
-	virtual String get_gizmo_name() const;
-	virtual int get_priority() const;
-	virtual bool can_be_hidden() const;
-	virtual bool is_selectable_when_hidden() const;
-
-	virtual void redraw(EditorNode3DGizmo *p_gizmo);
-	virtual String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const;
-	virtual Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const;
-	virtual void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point);
-	virtual void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false);
-	virtual bool is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int p_idx) const;
-
-	Ref<EditorNode3DGizmo> get_gizmo(Node3D *p_spatial);
-	void set_state(int p_state);
-	int get_state() const;
-	void unregister_gizmo(EditorNode3DGizmo *p_gizmo);
-
-	EditorNode3DGizmoPlugin();
-	virtual ~EditorNode3DGizmoPlugin();
 };
 
 #endif // NODE_3D_EDITOR_PLUGIN_H

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -36,7 +36,7 @@
 #include "node_3d_editor_plugin.h"
 #include "scene/resources/curve.h"
 
-String Path3DGizmo::get_handle_name(int p_idx) const {
+String Path3DGizmo::get_handle_name(int p_group_id, int p_idx) const {
 	Ref<Curve3D> c = path->get_curve();
 	if (c.is_null()) {
 		return "";
@@ -60,7 +60,7 @@ String Path3DGizmo::get_handle_name(int p_idx) const {
 	return n;
 }
 
-Variant Path3DGizmo::get_handle_value(int p_idx) {
+Variant Path3DGizmo::get_handle_value(int p_group_id, int p_idx) const {
 	Ref<Curve3D> c = path->get_curve();
 	if (c.is_null()) {
 		return Variant();
@@ -88,7 +88,7 @@ Variant Path3DGizmo::get_handle_value(int p_idx) {
 	return ofs;
 }
 
-void Path3DGizmo::set_handle(int p_idx, Camera3D *p_camera, const Point2 &p_point) {
+void Path3DGizmo::set_handle(int p_group_id, int p_idx, Camera3D *p_camera, const Point2 &p_point) const {
 	Ref<Curve3D> c = path->get_curve();
 	if (c.is_null()) {
 		return;
@@ -157,7 +157,7 @@ void Path3DGizmo::set_handle(int p_idx, Camera3D *p_camera, const Point2 &p_poin
 	}
 }
 
-void Path3DGizmo::commit_handle(int p_idx, const Variant &p_restore, bool p_cancel) {
+void Path3DGizmo::commit_handle(int p_group_id, int p_idx, const Variant &p_restore, bool p_cancel) const {
 	Ref<Curve3D> c = path->get_curve();
 	if (c.is_null()) {
 		return;

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -31,7 +31,9 @@
 #ifndef PATH_EDITOR_PLUGIN_H
 #define PATH_EDITOR_PLUGIN_H
 
+#include "editor/editor_plugin.h"
 #include "editor/node_3d_editor_gizmos.h"
+#include "scene/3d/camera_3d.h"
 #include "scene/3d/path_3d.h"
 
 class Path3DGizmo : public EditorNode3DGizmo {
@@ -43,10 +45,10 @@ class Path3DGizmo : public EditorNode3DGizmo {
 	mutable float orig_out_length;
 
 public:
-	virtual String get_handle_name(int p_idx) const override;
-	virtual Variant get_handle_value(int p_idx) override;
-	virtual void set_handle(int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	virtual void commit_handle(int p_idx, const Variant &p_restore, bool p_cancel = false) override;
+	virtual String get_handle_name(int p_group_id, int p_idx) const override;
+	virtual Variant get_handle_value(int p_group_id, int p_idx) const override;
+	virtual void set_handle(int p_group_id, int p_idx, Camera3D *p_camera, const Point2 &p_point) const override;
+	virtual void commit_handle(int p_group_id, int p_idx, const Variant &p_restore, bool p_cancel = false) const override;
 
 	virtual void redraw() override;
 	Path3DGizmo(Path3D *p_path = nullptr);

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -29,6 +29,8 @@
 /*************************************************************************/
 
 #include "csg_gizmos.h"
+#include "editor/plugins/node_3d_editor_plugin.h"
+#include "scene/3d/camera_3d.h"
 
 ///////////
 
@@ -48,7 +50,7 @@ CSGShape3DGizmoPlugin::CSGShape3DGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-String CSGShape3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
+String CSGShape3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_idx) const {
 	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_spatial_node());
 
 	if (Object::cast_to<CSGSphere3D>(cs)) {
@@ -70,7 +72,7 @@ String CSGShape3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, 
 	return "";
 }
 
-Variant CSGShape3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
+Variant CSGShape3DGizmoPlugin::get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_idx) const {
 	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_spatial_node());
 
 	if (Object::cast_to<CSGSphere3D>(cs)) {
@@ -96,7 +98,7 @@ Variant CSGShape3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int 
 	return Variant();
 }
 
-void CSGShape3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
+void CSGShape3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_idx, Camera3D *p_camera, const Point2 &p_point) const {
 	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_spatial_node());
 
 	Transform3D gt = cs->get_global_transform();
@@ -193,7 +195,7 @@ void CSGShape3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Ca
 	}
 }
 
-void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
+void CSGShape3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_idx, const Variant &p_restore, bool p_cancel) const {
 	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_spatial_node());
 
 	if (Object::cast_to<CSGSphere3D>(cs)) {
@@ -356,7 +358,7 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 				break;
 		}
 
-		p_gizmo->add_mesh(mesh, false, Ref<SkinReference>(), solid_material);
+		p_gizmo->add_mesh(mesh, solid_material);
 	}
 
 	if (Object::cast_to<CSGSphere3D>(cs)) {

--- a/modules/csg/csg_gizmos.h
+++ b/modules/csg/csg_gizmos.h
@@ -39,16 +39,16 @@ class CSGShape3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(CSGShape3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
 public:
-	bool has_gizmo(Node3D *p_spatial) override;
-	String get_gizmo_name() const override;
-	int get_priority() const override;
-	bool is_selectable_when_hidden() const override;
-	void redraw(EditorNode3DGizmo *p_gizmo) override;
+	virtual bool has_gizmo(Node3D *p_spatial) override;
+	virtual String get_gizmo_name() const override;
+	virtual int get_priority() const override;
+	virtual bool is_selectable_when_hidden() const override;
+	virtual void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	Variant get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const override;
-	void set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) override;
-	void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) override;
+	virtual String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_idx) const override;
+	virtual Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_idx) const override;
+	virtual void set_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_idx, Camera3D *p_camera, const Point2 &p_point) const override;
+	virtual void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_group_id, int p_idx, const Variant &p_restore, bool p_cancel) const override;
 
 	CSGShape3DGizmoPlugin();
 };


### PR DESCRIPTION
Refactor the 3D editor selection code as well as the gizmo handle system.

Selection of nodes in the 3D viewport should now be more consistent with how selection works in the 2D viewport, and gizmos should be correctly updated when multiple nodes are selected.

The new gizmo handles can be added in separate groups, and an identifier can be set for each individual handle, making working with handles much easier.

This commit also adds the possibility of adding transform handles, which the user can select and modify using the 3D transformation tool. This is not used in any gizmo yet, but opens up the door for improvements to many of the current gizmos.

Note: this PR will most likely generate conflicts with #48307 and #49783, but since this is a bigger refactor, it would be great if we can merge this first. I can take a look at rebasing the other PRs if needed.
