### PR TITLE
Remove clips_input() method and use clip_content

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -50,14 +50,6 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="_clips_input" qualifiers="virtual">
-			<return type="bool">
-			</return>
-			<description>
-				Virtual method to be implemented by the user. Returns whether [method _gui_input] should not be called for children controls outside this control's rectangle. Input will be clipped to the Rect of this [Control]. Similar to [member rect_clip_content], but doesn't affect visibility.
-				If not overridden, defaults to [code]false[/code].
-			</description>
-		</method>
 		<method name="_drop_data" qualifiers="virtual">
 			<return type="void">
 			</return>
@@ -155,7 +147,7 @@
 				* control has [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
 				* control is obstructed by another [Control] on top of it, which doesn't have [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
 				* control's parent has [member mouse_filter] set to [constant MOUSE_FILTER_STOP] or has accepted the event;
-				* it happens outside parent's rectangle and the parent has either [member rect_clip_content] or [method _clips_input] enabled.
+				* it happens outside parent's rectangle and the parent has either [member rect_clip_content] enabled.
 			</description>
 		</method>
 		<method name="_has_point" qualifiers="virtual">
@@ -1135,7 +1127,7 @@
 			Offsets are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Offsets update automatically when you move or resize the node.
 		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" default="false">
-			Enables whether rendering of [CanvasItem] based children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visibly outside of this control's rectangle will not be rendered.
+			Enables whether rendering of [CanvasItem] based children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visibly outside of this control's rectangle will not be rendered and won't receive input.
 		</member>
 		<member name="rect_global_position" type="Vector2" setter="_set_global_position" getter="get_global_position">
 			The node's global position, relative to the world (usually to the top-left corner of the window).

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -650,13 +650,6 @@ void Control::_notification(int p_notification) {
 	}
 }
 
-bool Control::clips_input() const {
-	if (get_script_instance()) {
-		return get_script_instance()->call(SceneStringNames::get_singleton()->_clips_input);
-	}
-	return false;
-}
-
 bool Control::has_point(const Point2 &p_point) const {
 	if (get_script_instance()) {
 		Variant v = p_point;
@@ -2784,7 +2777,6 @@ void Control::_bind_methods() {
 	BIND_VMETHOD(MethodInfo(
 			PropertyInfo(Variant::OBJECT, "control", PROPERTY_HINT_RESOURCE_TYPE, "Control"),
 			"_make_custom_tooltip", PropertyInfo(Variant::STRING, "for_text")));
-	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_clips_input"));
 
 	ADD_GROUP("Anchor", "anchor_");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anchor_left", PROPERTY_HINT_RANGE, "0,1,0.001,or_lesser,or_greater"), "_set_anchor", "get_anchor", SIDE_LEFT);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -329,7 +329,6 @@ public:
 	virtual Size2 get_minimum_size() const;
 	virtual Size2 get_combined_minimum_size() const;
 	virtual bool has_point(const Point2 &p_point) const;
-	virtual bool clips_input() const;
 	virtual void set_drag_forwarding(Control *p_target);
 	virtual Variant get_drag_data(const Point2 &p_point);
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -239,10 +239,6 @@ void GraphEdit::disconnect_node(const StringName &p_from, int p_from_port, const
 	}
 }
 
-bool GraphEdit::clips_input() const {
-	return true;
-}
-
 void GraphEdit::get_connection_list(List<Connection> *r_connections) const {
 	*r_connections = connections;
 }

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -235,7 +235,6 @@ protected:
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;
 	void _notification(int p_what);
-	virtual bool clips_input() const override;
 
 public:
 	Error connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -32,10 +32,6 @@
 #include "core/os/os.h"
 #include "scene/main/window.h"
 
-bool ScrollContainer::clips_input() const {
-	return true;
-}
-
 Size2 ScrollContainer::get_minimum_size() const {
 	Ref<StyleBox> sb = get_theme_stylebox("bg");
 	Size2 min_size;

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -108,8 +108,6 @@ public:
 	VScrollBar *get_v_scrollbar();
 	void ensure_control_visible(Control *p_control);
 
-	virtual bool clips_input() const override;
-
 	TypedArray<String> get_configuration_warnings() const override;
 
 	ScrollContainer();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1746,7 +1746,7 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 
 	Control *c = Object::cast_to<Control>(p_node);
 
-	if (!c || !c->clips_input() || c->has_point(matrix.affine_inverse().xform(p_global))) {
+	if (!c || !c->is_clipping_contents() || c->has_point(matrix.affine_inverse().xform(p_global))) {
 		for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
 			CanvasItem *ci = Object::cast_to<CanvasItem>(p_node->get_child(i));
 			if (!ci || ci->is_set_as_top_level()) {

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -103,7 +103,6 @@ SceneStringNames::SceneStringNames() {
 	_update_scroll = StaticCString::create("_update_scroll");
 	_update_xform = StaticCString::create("_update_xform");
 
-	_clips_input = StaticCString::create("_clips_input");
 	_structured_text_parser = StaticCString::create("_structured_text_parser");
 
 	_proxgroup_add = StaticCString::create("_proxgroup_add");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -129,7 +129,6 @@ public:
 	StringName _update_scroll;
 	StringName _update_xform;
 
-	StringName _clips_input;
 	StringName _structured_text_parser;
 
 	StringName _proxgroup_add;


### PR DESCRIPTION
It was decided on the chat that these two things should be merged into one (you don't want to clip content but not input, and clipping input only is not very useful).

Supersedes #43468
Closes #5172