### PR TITLE
Add GDNative libraries to Android custom Gradle builds

### DIFF
--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -96,14 +96,6 @@ Error create_directory(const String &p_dir) {
 	return OK;
 }
 
-// Implementation of EditorExportSaveSharedObject.
-// This method will only be called as an input to export_project_files.
-// This method lets the .so files for all ABIs to be copied
-// into the gradle project from the .AAR file
-Error ignore_so_file(void *p_userdata, const SharedObject &p_so) {
-	return OK;
-}
-
 // Writes p_data into a file at p_path, creating directories if necessary.
 // Note: this will overwrite the file at p_path if it already exists.
 Error store_file_at_path(const String &p_path, const Vector<uint8_t> &p_data) {


### PR DESCRIPTION
Currently, GDNative libraries are not being copied into the custom build project directories when doing an Android Custom Build. The files are simply ignored:
https://github.com/godotengine/godot/blob/c8444c3ee078e33c33287cf879aa5daecb962a80/platform/android/export/gradle_export_util.h#L103-L105

This PR ensures the GDNative libraries are copied to the correct directory; so that they're automatically included when Gradle builds the project.

Fixes #49878
