### PR TITLE
Print time taken and request attention when lightmaps are done baking (3.x)

### DIFF
--- a/editor/plugins/baked_lightmap_editor_plugin.h
+++ b/editor/plugins/baked_lightmap_editor_plugin.h
@@ -50,7 +50,7 @@ class BakedLightmapEditorPlugin : public EditorPlugin {
 
 	static bool bake_func_step(float p_progress, const String &p_description, void *, bool p_force_refresh);
 	static bool bake_func_substep(float p_progress, const String &p_description, void *, bool p_force_refresh);
-	static void bake_func_end();
+	static void bake_func_end(uint32_t p_time_started);
 
 	void _bake_select_file(const String &p_file);
 	void _bake();


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/56367. Follow-up to https://github.com/godotengine/godot/pull/49913.

Since lightmap baking can take a very long time, printing the time spent can be useful for users tweaking the lightmap settings to optimize bake times. The message printed is visible in the editor's Output dialog and looks like this:

```
Done baking lightmaps in 00:01:33.
```

Completing lightmap baking will also request attention using the OS window manager, which is useful if you're doing something else while waiting for lightmaps to bake.

~~If we agree on the design of this PR, I can make a similar PR for `master`.~~
**Edit:** Done in https://github.com/godotengine/godot/pull/56367.