### PR TITLE
Allow disabling scrolling in Tree and implement horizontal scrolling

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -372,6 +372,12 @@
 			If [code]true[/code], the tree's root is hidden.
 		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
+		<member name="scroll_horizontal_enabled" type="bool" setter="set_h_scroll_enabled" getter="is_h_scroll_enabled" default="true">
+			If [code]true[/code], enables horizontal scrolling.
+		</member>
+		<member name="scroll_vertical_enabled" type="bool" setter="set_v_scroll_enabled" getter="is_v_scroll_enabled" default="true">
+			If [code]true[/code], enables vertical scrolling.
+		</member>
 		<member name="select_mode" type="int" setter="set_select_mode" getter="get_select_mode" enum="Tree.SelectMode" default="0">
 			Allows single or multiple selection. See the [enum SelectMode] constants.
 		</member>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -232,7 +232,7 @@
 				Returns the last pressed button's index.
 			</description>
 		</method>
-		<method name="get_root">
+		<method name="get_root" qualifiers="const">
 			<return type="TreeItem">
 			</return>
 			<description>
@@ -272,6 +272,17 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_column_custom_minimum_width">
+			<return type="void">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<argument index="1" name="min_width" type="int">
+			</argument>
+			<description>
+				Overrides the calculated minimum width of a column. It can be set to `0` to restore the default behavior. Columns that have the "Expand" flag will use their "min_width" in a similar fashion to [member Control.size_flags_stretch_ratio].
+			</description>
+		</method>
 		<method name="set_column_expand">
 			<return type="void">
 			</return>
@@ -281,17 +292,6 @@
 			</argument>
 			<description>
 				If [code]true[/code], the column will have the "Expand" flag of [Control]. Columns that have the "Expand" flag will use their "min_width" in a similar fashion to [member Control.size_flags_stretch_ratio].
-			</description>
-		</method>
-		<method name="set_column_min_width">
-			<return type="void">
-			</return>
-			<argument index="0" name="column" type="int">
-			</argument>
-			<argument index="1" name="min_width" type="int">
-			</argument>
-			<description>
-				Sets the minimum width of a column. Columns that have the "Expand" flag will use their "min_width" in a similar fashion to [member Control.size_flags_stretch_ratio].
 			</description>
 		</method>
 		<method name="set_column_title">

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -192,7 +192,7 @@
 				Returns [code]true[/code] if [code]expand_right[/code] is set.
 			</description>
 		</method>
-		<method name="get_first_child">
+		<method name="get_first_child" qualifiers="const">
 			<return type="TreeItem">
 			</return>
 			<description>
@@ -260,7 +260,7 @@
 				Returns the metadata value that was set for the given column using [method set_metadata].
 			</description>
 		</method>
-		<method name="get_next">
+		<method name="get_next" qualifiers="const">
 			<return type="TreeItem">
 			</return>
 			<description>
@@ -288,7 +288,7 @@
 				Returns OpenType feature [code]tag[/code] of the item's text.
 			</description>
 		</method>
-		<method name="get_parent">
+		<method name="get_parent" qualifiers="const">
 			<return type="TreeItem">
 			</return>
 			<description>
@@ -391,7 +391,7 @@
 				Returns the given column's tooltip.
 			</description>
 		</method>
-		<method name="get_tree">
+		<method name="get_tree" qualifiers="const">
 			<return type="Tree">
 			</return>
 			<description>

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -1125,9 +1125,9 @@ ActionMapEditor::ActionMapEditor() {
 	action_tree->set_column_title(0, TTR("Action"));
 	action_tree->set_column_title(1, TTR("Deadzone"));
 	action_tree->set_column_expand(1, false);
-	action_tree->set_column_min_width(1, 80 * EDSCALE);
+	action_tree->set_column_custom_minimum_width(1, 80 * EDSCALE);
 	action_tree->set_column_expand(2, false);
-	action_tree->set_column_min_width(2, 50 * EDSCALE);
+	action_tree->set_column_custom_minimum_width(2, 50 * EDSCALE);
 	action_tree->connect("item_edited", callable_mp(this, &ActionMapEditor::_action_edited));
 	action_tree->connect("item_activated", callable_mp(this, &ActionMapEditor::_tree_item_activated));
 	action_tree->connect("button_pressed", callable_mp(this, &ActionMapEditor::_tree_button_pressed));

--- a/editor/debugger/editor_network_profiler.cpp
+++ b/editor/debugger/editor_network_profiler.cpp
@@ -178,19 +178,19 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	counters_display->set_column_titles_visible(true);
 	counters_display->set_column_title(0, TTR("Node"));
 	counters_display->set_column_expand(0, true);
-	counters_display->set_column_min_width(0, 60 * EDSCALE);
+	counters_display->set_column_custom_minimum_width(0, 60 * EDSCALE);
 	counters_display->set_column_title(1, TTR("Incoming RPC"));
 	counters_display->set_column_expand(1, false);
-	counters_display->set_column_min_width(1, 120 * EDSCALE);
+	counters_display->set_column_custom_minimum_width(1, 120 * EDSCALE);
 	counters_display->set_column_title(2, TTR("Incoming RSET"));
 	counters_display->set_column_expand(2, false);
-	counters_display->set_column_min_width(2, 120 * EDSCALE);
+	counters_display->set_column_custom_minimum_width(2, 120 * EDSCALE);
 	counters_display->set_column_title(3, TTR("Outgoing RPC"));
 	counters_display->set_column_expand(3, false);
-	counters_display->set_column_min_width(3, 120 * EDSCALE);
+	counters_display->set_column_custom_minimum_width(3, 120 * EDSCALE);
 	counters_display->set_column_title(4, TTR("Outgoing RSET"));
 	counters_display->set_column_expand(4, false);
-	counters_display->set_column_min_width(4, 120 * EDSCALE);
+	counters_display->set_column_custom_minimum_width(4, 120 * EDSCALE);
 	add_child(counters_display);
 
 	frame_delay = memnew(Timer);

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -631,13 +631,13 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_titles_visible(true);
 	variables->set_column_title(0, TTR("Name"));
 	variables->set_column_expand(0, true);
-	variables->set_column_min_width(0, 60 * EDSCALE);
+	variables->set_column_custom_minimum_width(0, 60 * EDSCALE);
 	variables->set_column_title(1, TTR("Time"));
 	variables->set_column_expand(1, false);
-	variables->set_column_min_width(1, 100 * EDSCALE);
+	variables->set_column_custom_minimum_width(1, 100 * EDSCALE);
 	variables->set_column_title(2, TTR("Calls"));
 	variables->set_column_expand(2, false);
-	variables->set_column_min_width(2, 60 * EDSCALE);
+	variables->set_column_custom_minimum_width(2, 60 * EDSCALE);
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
 
 	graph = memnew(TextureRect);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -773,13 +773,13 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->set_column_titles_visible(true);
 	variables->set_column_title(0, TTR("Name"));
 	variables->set_column_expand(0, true);
-	variables->set_column_min_width(0, 60);
+	variables->set_column_custom_minimum_width(0, 60);
 	variables->set_column_title(1, TTR("CPU"));
 	variables->set_column_expand(1, false);
-	variables->set_column_min_width(1, 60 * EDSCALE);
+	variables->set_column_custom_minimum_width(1, 60 * EDSCALE);
 	variables->set_column_title(2, TTR("GPU"));
 	variables->set_column_expand(2, false);
-	variables->set_column_min_width(2, 60 * EDSCALE);
+	variables->set_column_custom_minimum_width(2, 60 * EDSCALE);
 	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
 
 	graph = memnew(TextureRect);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1643,7 +1643,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		error_tree->set_columns(2);
 
 		error_tree->set_column_expand(0, false);
-		error_tree->set_column_min_width(0, 140);
+		error_tree->set_column_custom_minimum_width(0, 140);
 
 		error_tree->set_column_expand(1, true);
 
@@ -1731,13 +1731,13 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		vmem_tree->set_column_expand(0, true);
 		vmem_tree->set_column_expand(1, false);
 		vmem_tree->set_column_title(1, TTR("Type"));
-		vmem_tree->set_column_min_width(1, 100 * EDSCALE);
+		vmem_tree->set_column_custom_minimum_width(1, 100 * EDSCALE);
 		vmem_tree->set_column_expand(2, false);
 		vmem_tree->set_column_title(2, TTR("Format"));
-		vmem_tree->set_column_min_width(2, 150 * EDSCALE);
+		vmem_tree->set_column_custom_minimum_width(2, 150 * EDSCALE);
 		vmem_tree->set_column_expand(3, false);
 		vmem_tree->set_column_title(3, TTR("Usage"));
-		vmem_tree->set_column_min_width(3, 80 * EDSCALE);
+		vmem_tree->set_column_custom_minimum_width(3, 80 * EDSCALE);
 		vmem_tree->set_hide_root(true);
 
 		tabs->add_child(vmem_vb);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -769,7 +769,7 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 	files = memnew(Tree);
 	files->set_columns(2);
 	files->set_column_titles_visible(true);
-	files->set_column_min_width(1, 100);
+	files->set_column_custom_minimum_width(1, 100);
 	files->set_column_expand(0, true);
 	files->set_column_expand(1, false);
 	files->set_column_title(0, TTR("Resource"));

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -882,19 +882,19 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	tree->set_column_title(0, TTR("Name"));
 	tree->set_column_expand(0, true);
-	tree->set_column_min_width(0, 100 * EDSCALE);
+	tree->set_column_custom_minimum_width(0, 100 * EDSCALE);
 
 	tree->set_column_title(1, TTR("Path"));
 	tree->set_column_expand(1, true);
-	tree->set_column_min_width(1, 100 * EDSCALE);
+	tree->set_column_custom_minimum_width(1, 100 * EDSCALE);
 
 	tree->set_column_title(2, TTR("Global Variable"));
 	tree->set_column_expand(2, false);
 	// Reserve enough space for translations of "Global Variable" which may be longer.
-	tree->set_column_min_width(2, 150 * EDSCALE);
+	tree->set_column_custom_minimum_width(2, 150 * EDSCALE);
 
 	tree->set_column_expand(3, false);
-	tree->set_column_min_width(3, 120 * EDSCALE);
+	tree->set_column_custom_minimum_width(3, 120 * EDSCALE);
 
 	tree->connect("cell_selected", callable_mp(this, &EditorAutoloadSettings::_autoload_selected));
 	tree->connect("item_edited", callable_mp(this, &EditorAutoloadSettings::_autoload_edited));

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -239,7 +239,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	results_tree->set_column_title(0, TTR("Name"));
 	results_tree->set_column_title(1, TTR("Member Type"));
 	results_tree->set_column_expand(1, false);
-	results_tree->set_column_min_width(1, 150 * EDSCALE);
+	results_tree->set_column_custom_minimum_width(1, 150 * EDSCALE);
 	results_tree->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
 	results_tree->set_hide_root(true);
 	results_tree->set_select_mode(Tree::SELECT_ROW);

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -216,10 +216,10 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list->set_column_expand(2, false);
 	plugin_list->set_column_expand(3, false);
 	plugin_list->set_column_expand(4, false);
-	plugin_list->set_column_min_width(1, 100 * EDSCALE);
-	plugin_list->set_column_min_width(2, 250 * EDSCALE);
-	plugin_list->set_column_min_width(3, 80 * EDSCALE);
-	plugin_list->set_column_min_width(4, 40 * EDSCALE);
+	plugin_list->set_column_custom_minimum_width(1, 100 * EDSCALE);
+	plugin_list->set_column_custom_minimum_width(2, 250 * EDSCALE);
+	plugin_list->set_column_custom_minimum_width(3, 80 * EDSCALE);
+	plugin_list->set_column_custom_minimum_width(4, 40 * EDSCALE);
 	plugin_list->set_hide_root(true);
 	plugin_list->connect("item_edited", callable_mp(this, &EditorPluginSettings::_plugin_activity_changed));
 

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -638,7 +638,7 @@ void FindInFilesPanel::set_with_replace(bool with_replace) {
 		// Results show checkboxes on their left so they can be opted out
 		_results_display->set_columns(2);
 		_results_display->set_column_expand(0, false);
-		_results_display->set_column_min_width(0, 48 * EDSCALE);
+		_results_display->set_column_custom_minimum_width(0, 48 * EDSCALE);
 
 	} else {
 		// Results are single-cell items

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -1163,13 +1163,13 @@ SceneImportSettings::SceneImportSettings() {
 	external_path_tree->set_columns(3);
 	external_path_tree->set_column_titles_visible(true);
 	external_path_tree->set_column_expand(0, true);
-	external_path_tree->set_column_min_width(0, 100 * EDSCALE);
+	external_path_tree->set_column_custom_minimum_width(0, 100 * EDSCALE);
 	external_path_tree->set_column_title(0, TTR("Resource"));
 	external_path_tree->set_column_expand(1, true);
-	external_path_tree->set_column_min_width(1, 100 * EDSCALE);
+	external_path_tree->set_column_custom_minimum_width(1, 100 * EDSCALE);
 	external_path_tree->set_column_title(1, TTR("Path"));
 	external_path_tree->set_column_expand(2, false);
-	external_path_tree->set_column_min_width(2, 200 * EDSCALE);
+	external_path_tree->set_column_custom_minimum_width(2, 200 * EDSCALE);
 	external_path_tree->set_column_title(2, TTR("Status"));
 	save_path = memnew(EditorFileDialog);
 	save_path->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -729,7 +729,7 @@ LocalizationEditor::LocalizationEditor() {
 		translation_remap_options->set_column_titles_visible(true);
 		translation_remap_options->set_column_expand(0, true);
 		translation_remap_options->set_column_expand(1, false);
-		translation_remap_options->set_column_min_width(1, 200);
+		translation_remap_options->set_column_custom_minimum_width(1, 200);
 		translation_remap_options->connect("item_edited", callable_mp(this, &LocalizationEditor::_translation_res_option_changed));
 		translation_remap_options->connect("button_pressed", callable_mp(this, &LocalizationEditor::_translation_res_option_delete));
 		tmc->add_child(translation_remap_options);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -569,8 +569,8 @@ void AnimationPlayerEditor::_animation_blend() {
 	blend_editor.dialog->popup_centered(Size2(400, 400) * EDSCALE);
 
 	blend_editor.tree->set_hide_root(true);
-	blend_editor.tree->set_column_min_width(0, 10);
-	blend_editor.tree->set_column_min_width(1, 3);
+	blend_editor.tree->set_column_custom_minimum_width(0, 10);
+	blend_editor.tree->set_column_custom_minimum_width(1, 3);
 
 	List<StringName> anims;
 	player->get_animation_list(&anims);

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -367,8 +367,8 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	tree = memnew(Tree);
 	tree->connect("button_pressed", callable_mp(this, &ResourcePreloaderEditor::_cell_button_pressed));
 	tree->set_columns(2);
-	tree->set_column_min_width(0, 2);
-	tree->set_column_min_width(1, 3);
+	tree->set_column_custom_minimum_width(0, 2);
+	tree->set_column_custom_minimum_width(1, 3);
 	tree->set_column_expand(0, true);
 	tree->set_column_expand(1, true);
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -932,9 +932,9 @@ ThemeItemImportTree::ThemeItemImportTree() {
 	import_items_tree->set_column_expand(0, true);
 	import_items_tree->set_column_expand(IMPORT_ITEM, false);
 	import_items_tree->set_column_expand(IMPORT_ITEM_DATA, false);
-	import_items_tree->set_column_min_width(0, 160 * EDSCALE);
-	import_items_tree->set_column_min_width(IMPORT_ITEM, 80 * EDSCALE);
-	import_items_tree->set_column_min_width(IMPORT_ITEM_DATA, 80 * EDSCALE);
+	import_items_tree->set_column_custom_minimum_width(0, 160 * EDSCALE);
+	import_items_tree->set_column_custom_minimum_width(IMPORT_ITEM, 80 * EDSCALE);
+	import_items_tree->set_column_custom_minimum_width(IMPORT_ITEM_DATA, 80 * EDSCALE);
 
 	ScrollContainer *import_bulk_sc = memnew(ScrollContainer);
 	import_bulk_sc->set_custom_minimum_size(Size2(260.0, 0.0) * EDSCALE);

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -356,12 +356,12 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 	tree->set_column_titles_visible(true);
 	tree->set_columns(4);
 	tree->set_column_expand(0, false);
-	tree->set_column_min_width(0, int(200 * EDSCALE));
+	tree->set_column_custom_minimum_width(0, int(200 * EDSCALE));
 	tree->set_column_title(0, TTR("Platform"));
 	tree->set_column_title(1, TTR("Dynamic Library"));
 	tree->set_column_title(2, TTR("Dependencies"));
 	tree->set_column_expand(3, false);
-	tree->set_column_min_width(3, int(110 * EDSCALE));
+	tree->set_column_custom_minimum_width(3, int(110 * EDSCALE));
 	tree->connect("button_pressed", callable_mp(this, &GDNativeLibraryEditor::_on_item_button));
 	tree->connect("item_collapsed", callable_mp(this, &GDNativeLibraryEditor::_on_item_collapsed));
 	tree->connect("item_activated", callable_mp(this, &GDNativeLibraryEditor::_on_item_activated));

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -545,6 +545,8 @@ private:
 	void _scroll_moved(float p_value);
 	HScrollBar *h_scroll;
 	VScrollBar *v_scroll;
+	bool h_scroll_enabled = true;
+	bool v_scroll_enabled = true;
 
 	Size2 get_internal_min_size() const;
 	void update_cache();
@@ -679,6 +681,10 @@ public:
 
 	Point2 get_scroll() const;
 	void scroll_to_item(TreeItem *p_item);
+	void set_h_scroll_enabled(bool p_enable);
+	bool is_h_scroll_enabled() const;
+	void set_v_scroll_enabled(bool p_enable);
+	bool is_v_scroll_enabled() const;
 
 	void set_cursor_can_exit_tree(bool p_enable);
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -315,16 +315,18 @@ public:
 	void set_disable_folding(bool p_disable);
 	bool is_folding_disabled() const;
 
+	Size2 get_minimum_size(int p_column);
+
 	/* Item manipulation */
 
 	TreeItem *create_child(int p_idx = -1);
 
-	Tree *get_tree();
+	Tree *get_tree() const;
 
 	TreeItem *get_prev();
-	TreeItem *get_next();
-	TreeItem *get_parent();
-	TreeItem *get_first_child();
+	TreeItem *get_next() const;
+	TreeItem *get_parent() const;
+	TreeItem *get_first_child() const;
 
 	TreeItem *get_prev_visible(bool p_wrap = false);
 	TreeItem *get_next_visible(bool p_wrap = false);
@@ -408,7 +410,7 @@ private:
 	int drop_mode_flags = 0;
 
 	struct ColumnInfo {
-		int min_width = 1;
+		int custom_min_width = 0;
 		bool expand = true;
 		String title;
 		Ref<TextLine> text_buf;
@@ -625,11 +627,12 @@ public:
 	void clear();
 
 	TreeItem *create_item(TreeItem *p_parent = nullptr, int p_idx = -1);
-	TreeItem *get_root();
-	TreeItem *get_last_item();
+	TreeItem *get_root() const;
+	TreeItem *get_last_item() const;
 
-	void set_column_min_width(int p_column, int p_min_width);
+	void set_column_custom_minimum_width(int p_column, int p_min_width);
 	void set_column_expand(int p_column, bool p_expand);
+	int get_column_minimum_width(int p_column) const;
 	int get_column_width(int p_column) const;
 
 	void set_hide_root(bool p_enabled);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Similar to what's done in ScrollContainer, this adds a way to disable scroling for the Tree node. In this case, it has a minimum size. I need it for the TileSet editor rework. See how it works:
![Peek 25-06-2021 21-34](https://user-images.githubusercontent.com/6093119/123476577-30606d00-d5fd-11eb-9fc6-1d422c9aa4b1.gif)

Edit: Also, this PR now also fix the computation of the internal minimum width. It also renames `set_column_min_width` to `set_column_custom_minimum_width`.



Closes godotengine/godot-proposals#2571.
Closes https://github.com/godotengine/godot-proposals/issues/2357
Closes https://github.com/godotengine/godot-proposals/issues/1793