### PR TITLE
Update `Label.clip_text()` Method Description

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -79,7 +79,7 @@
 			If [code]true[/code], wraps the text inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text.
 		</member>
 		<member name="clip_text" type="bool" setter="set_clip_text" getter="is_clipping_text" default="false">
-			If [code]true[/code], the Label only shows the text that fits inside its bounding rectangle. It also lets you scale the node down freely.
+			If [code]true[/code], the Label only shows the text that fits inside its bounding rectangle and will clip text horizontally.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.


### PR DESCRIPTION
This update fixes an inconsistency in the documentation about the `clip_text()` method. The text is only clipped horizontally. The original description is misleading and this update makes it more clear what it actually does.

This resolves: #49893