### PR TITLE
Focusable Tabs and TabContainer, tabs can be changed using keyboard and gamepad

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -146,6 +146,7 @@
 		<member name="drag_to_rearrange_enabled" type="bool" setter="set_drag_to_rearrange_enabled" getter="get_drag_to_rearrange_enabled" default="false">
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="tab_align" type="int" setter="set_tab_align" getter="get_tab_align" enum="TabContainer.TabAlign" default="1">
 			The alignment of all tabs in the tab container. See the [enum TabAlign] constants for details.
 		</member>
@@ -194,6 +195,8 @@
 		</theme_item>
 		<theme_item name="decrement_highlight" type="Texture2D">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
+		</theme_item>
+		<theme_item name="focus" type="StyleBox">
 		</theme_item>
 		<theme_item name="font" type="Font">
 			The font used to draw tab names.

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -147,6 +147,9 @@
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
+		<member name="rollover" type="bool" setter="set_rollover" getter="get_rollover" default="false">
+			If [code]true[/code], pressing [code]ui_right[/code] on the last tab will select the first tab and pressing [code]ui_left[/code] on the first tab will select the last one.
+		</member>
 		<member name="tab_align" type="int" setter="set_tab_align" getter="get_tab_align" enum="TabContainer.TabAlign" default="1">
 			The alignment of all tabs in the tab container. See the [enum TabAlign] constants for details.
 		</member>
@@ -197,6 +200,7 @@
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
+			[StyleBox] used on the selected tab when the [TabContainer] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="font" type="Font">
 			The font used to draw tab names.

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -263,6 +263,7 @@
 		<member name="drag_to_rearrange_enabled" type="bool" setter="set_drag_to_rearrange_enabled" getter="get_drag_to_rearrange_enabled" default="false">
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="scrolling_enabled" type="bool" setter="set_scrolling_enabled" getter="get_scrolling_enabled" default="true">
 			if [code]true[/code], the mouse's scroll wheel can be used to navigate the scroll view.
 		</member>
@@ -358,6 +359,8 @@
 		</theme_item>
 		<theme_item name="decrement_highlight" type="Texture2D">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
+		</theme_item>
+		<theme_item name="focus" type="StyleBox">
 		</theme_item>
 		<theme_item name="font" type="Font">
 			The font used to draw tab names.

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -264,6 +264,9 @@
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
+		<member name="rollover" type="bool" setter="set_rollover" getter="get_rollover" default="false">
+			If [code]true[/code], pressing [code]ui_right[/code] on the last tab will select the first tab and pressing [code]ui_left[/code] on the first tab will select the last one.
+		</member>
 		<member name="scrolling_enabled" type="bool" setter="set_scrolling_enabled" getter="get_scrolling_enabled" default="true">
 			if [code]true[/code], the mouse's scroll wheel can be used to navigate the scroll view.
 		</member>
@@ -361,6 +364,7 @@
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
+			[StyleBox] used on the selected tab when the [Tabs] node is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="font" type="Font">
 			The font used to draw tab names.

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -298,8 +298,7 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 		else if (p_event->is_action_pressed("ui_down")) {
 			Control* next = find_next_valid_focus();
-			if (next)
-			{
+			if (next) {
 				next->grab_focus();
 				accept_event();
 			}

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -283,6 +283,28 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 	}
+	if (!mm.is_valid() && !mb.is_valid()) {
+		if (p_event->is_action_pressed("ui_right")) {
+			int next_tab = (get_current_tab() + 1) % get_tab_count();
+			set_current_tab(next_tab);
+			accept_event();
+			return;
+		}
+		else if (p_event->is_action_pressed("ui_left")) {
+			int prev_tab = (get_current_tab() > 0) ? (get_current_tab() - 1) : (get_tab_count() - 1);
+			set_current_tab(prev_tab);
+			accept_event();
+			return;
+		}
+		else if (p_event->is_action_pressed("ui_down")) {
+			Control* next = find_next_valid_focus();
+			if (next)
+			{
+				next->grab_focus();
+				accept_event();
+			}
+		}
+	}
 }
 
 void TabContainer::_notification(int p_what) {
@@ -548,6 +570,10 @@ void TabContainer::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, in
 	Rect2 tab_rect(p_x, 0, tab_width, header_height);
 	p_tab_style->draw(canvas, tab_rect);
 
+	if (p_index == current && has_focus()) {
+		Ref<StyleBox> style2 = get_theme_stylebox("focus");
+		style2->draw(canvas, tab_rect);
+	}
 	// Draw the tab contents.
 	Control *control = Object::cast_to<Control>(tabs[p_index]);
 	String text = control->has_meta("_tab_name") ? String(tr(String(control->get_meta("_tab_name")))) : String(tr(control->get_name()));
@@ -1249,4 +1275,5 @@ void TabContainer::_bind_methods() {
 
 TabContainer::TabContainer() {
 	connect("mouse_exited", callable_mp(this, &TabContainer::_on_mouse_exited));
+	set_focus_mode(FOCUS_ALL);
 }

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -338,12 +338,6 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 				set_current_tab(prev_tab);
 				accept_event();
 			}
-		} else if (p_event->is_action_pressed("ui_down")) {
-			Control *next = find_next_valid_focus();
-			if (next) {
-				next->grab_focus();
-				accept_event();
-			}
 		}
 	}
 }

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -285,15 +285,59 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 	}
 	if (!mm.is_valid() && !mb.is_valid()) {
 		if (p_event->is_action_pressed("ui_right")) {
-			int next_tab = (get_current_tab() + 1) % get_tab_count();
-			set_current_tab(next_tab);
-			accept_event();
-			return;
+			int next_tab = get_current_tab() + 1;
+			bool valid = true;
+			while (valid) {
+				if (next_tab == get_current_tab()) {
+					valid = false;
+					break;
+				}
+
+				if (next_tab < get_tab_count()) {
+					if (get_tab_disabled(next_tab)) {
+						++next_tab;
+					} else {
+						break;
+					}
+				} else {
+					if (rollover) {
+						next_tab = 0;
+					} else {
+						valid = false;
+					}
+				}
+			}
+			if (valid) {
+				set_current_tab(next_tab);
+				accept_event();
+			}
 		} else if (p_event->is_action_pressed("ui_left")) {
-			int prev_tab = (get_current_tab() > 0) ? (get_current_tab() - 1) : (get_tab_count() - 1);
-			set_current_tab(prev_tab);
-			accept_event();
-			return;
+			int prev_tab = get_current_tab() - 1;
+			bool valid = true;
+			while (valid) {
+				if (prev_tab == get_current_tab()) {
+					valid = false;
+					break;
+				}
+
+				if (prev_tab >= 0) {
+					if (get_tab_disabled(prev_tab)) {
+						--prev_tab;
+					} else {
+						break;
+					}
+				} else {
+					if (rollover) {
+						prev_tab = get_tab_count() - 1;
+					} else {
+						valid = false;
+					}
+				}
+			}
+			if (valid) {
+				set_current_tab(prev_tab);
+				accept_event();
+			}
 		} else if (p_event->is_action_pressed("ui_down")) {
 			Control *next = find_next_valid_focus();
 			if (next) {
@@ -1221,6 +1265,14 @@ bool TabContainer::get_use_hidden_tabs_for_min_size() const {
 	return use_hidden_tabs_for_min_size;
 }
 
+void TabContainer::set_rollover(bool p_enabled) {
+	rollover = p_enabled;
+}
+
+bool TabContainer::get_rollover() const {
+	return rollover;
+}
+
 void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_gui_input"), &TabContainer::_gui_input);
 	ClassDB::bind_method(D_METHOD("get_tab_count"), &TabContainer::get_tab_count);
@@ -1251,6 +1303,9 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_hidden_tabs_for_min_size", "enabled"), &TabContainer::set_use_hidden_tabs_for_min_size);
 	ClassDB::bind_method(D_METHOD("get_use_hidden_tabs_for_min_size"), &TabContainer::get_use_hidden_tabs_for_min_size);
 
+	ClassDB::bind_method(D_METHOD("set_rollover", "enabled"), &TabContainer::set_rollover);
+	ClassDB::bind_method(D_METHOD("get_rollover"), &TabContainer::get_rollover);
+
 	ClassDB::bind_method(D_METHOD("_on_theme_changed"), &TabContainer::_on_theme_changed);
 	ClassDB::bind_method(D_METHOD("_update_current_tab"), &TabContainer::_update_current_tab);
 
@@ -1264,6 +1319,7 @@ void TabContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "all_tabs_in_front"), "set_all_tabs_in_front", "is_all_tabs_in_front");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_to_rearrange_enabled"), "set_drag_to_rearrange_enabled", "get_drag_to_rearrange_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hidden_tabs_for_min_size"), "set_use_hidden_tabs_for_min_size", "get_use_hidden_tabs_for_min_size");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rollover"), "set_rollover", "get_rollover");
 
 	BIND_ENUM_CONSTANT(ALIGN_LEFT);
 	BIND_ENUM_CONSTANT(ALIGN_CENTER);
@@ -1271,6 +1327,6 @@ void TabContainer::_bind_methods() {
 }
 
 TabContainer::TabContainer() {
-	connect("mouse_exited", callable_mp(this, &TabContainer::_on_mouse_exited));
 	set_focus_mode(FOCUS_ALL);
+	connect("mouse_exited", callable_mp(this, &TabContainer::_on_mouse_exited));
 }

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -289,17 +289,14 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 			set_current_tab(next_tab);
 			accept_event();
 			return;
-		}
-		else if (p_event->is_action_pressed("ui_left")) {
+		} else if (p_event->is_action_pressed("ui_left")) {
 			int prev_tab = (get_current_tab() > 0) ? (get_current_tab() - 1) : (get_tab_count() - 1);
 			set_current_tab(prev_tab);
 			accept_event();
 			return;
-		}
-		else if (p_event->is_action_pressed("ui_down")) {
+		} else if (p_event->is_action_pressed("ui_down")) {
 			Control* next = find_next_valid_focus();
-			if (next)
-			{
+			if (next) {
 				next->grab_focus();
 				accept_event();
 			}

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -63,6 +63,7 @@ private:
 	bool drag_to_rearrange_enabled = false;
 	bool use_hidden_tabs_for_min_size = false;
 	int tabs_rearrange_group = -1;
+	bool rollover = false;
 
 	Vector<Ref<TextLine>> text_buf;
 	Vector<Control *> _get_tabs() const;
@@ -134,6 +135,8 @@ public:
 	void set_use_hidden_tabs_for_min_size(bool p_use_hidden_tabs);
 	bool get_use_hidden_tabs_for_min_size() const;
 
+	void set_rollover(bool p_enabled);
+	bool get_rollover() const;
 	TabContainer();
 };
 

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -365,7 +365,7 @@ void Tabs::_notification(int p_what) {
 					sb_rect = Rect2(w, 0, tabs[i].size_cache, h);
 				}
 				sb->draw(ci, sb_rect);
-				
+
 				if (i == current && has_focus()) {
 					Ref<StyleBox> style2 = get_theme_stylebox("focus");
 					style2->draw(ci, sb_rect);

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -1251,5 +1251,4 @@ void Tabs::_bind_methods() {
 Tabs::Tabs() {
 	set_focus_mode(FOCUS_ALL);
 	connect("mouse_exited", callable_mp(this, &Tabs::_on_mouse_exited));
-	
 }

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -233,6 +233,20 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 	}
+	if (!mm.is_valid() && !mb.is_valid()) {
+		if (p_event->is_action_pressed("ui_right")) {
+			int next_tab = (get_current_tab() + 1) % get_tab_count();
+			set_current_tab(next_tab);
+			accept_event();
+			return;
+		}
+		else if (p_event->is_action_pressed("ui_left")) {
+			int prev_tab = (get_current_tab() > 0) ? (get_current_tab() - 1) : (get_tab_count() - 1);
+			set_current_tab(prev_tab);
+			accept_event();
+			return;
+		}
+	}
 }
 
 void Tabs::_shape(int p_tab) {
@@ -351,6 +365,11 @@ void Tabs::_notification(int p_what) {
 					sb_rect = Rect2(w, 0, tabs[i].size_cache, h);
 				}
 				sb->draw(ci, sb_rect);
+				
+				if (i == current && has_focus()) {
+					Ref<StyleBox> style2 = get_theme_stylebox("focus");
+					style2->draw(ci, sb_rect);
+				}
 
 				w += sb->get_margin(SIDE_LEFT);
 
@@ -1176,4 +1195,5 @@ void Tabs::_bind_methods() {
 
 Tabs::Tabs() {
 	connect("mouse_exited", callable_mp(this, &Tabs::_on_mouse_exited));
+	set_focus_mode(FOCUS_ALL);
 }

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -239,8 +239,7 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 			set_current_tab(next_tab);
 			accept_event();
 			return;
-		}
-		else if (p_event->is_action_pressed("ui_left")) {
+		} else if (p_event->is_action_pressed("ui_left")) {
 			int prev_tab = (get_current_tab() > 0) ? (get_current_tab() - 1) : (get_tab_count() - 1);
 			set_current_tab(prev_tab);
 			accept_event();
@@ -365,7 +364,7 @@ void Tabs::_notification(int p_what) {
 					sb_rect = Rect2(w, 0, tabs[i].size_cache, h);
 				}
 				sb->draw(ci, sb_rect);
-				
+
 				if (i == current && has_focus()) {
 					Ref<StyleBox> style2 = get_theme_stylebox("focus");
 					style2->draw(ci, sb_rect);

--- a/scene/gui/tabs.h
+++ b/scene/gui/tabs.h
@@ -100,6 +100,7 @@ private:
 	bool scrolling_enabled = true;
 	bool drag_to_rearrange_enabled = false;
 	int tabs_rearrange_group = -1;
+	bool rollover = false;
 
 	int get_tab_width(int p_idx) const;
 	void _ensure_no_over_offset();
@@ -181,6 +182,8 @@ public:
 	void set_select_with_rmb(bool p_enabled);
 	bool get_select_with_rmb() const;
 
+	void set_rollover(bool p_enabled);
+	bool get_rollover() const;
 	void ensure_tab_visible(int p_idx);
 	void set_min_width(int p_width);
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -765,6 +765,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("tab_unselected", "TabContainer", sb_expand(make_stylebox(tab_behind_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
 	theme->set_stylebox("tab_disabled", "TabContainer", sb_expand(make_stylebox(tab_disabled_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
 	theme->set_stylebox("panel", "TabContainer", tc_sb);
+	theme->set_stylebox("focus", "TabContainer", sb_expand(make_stylebox(button_focus_png, 4, 4, 4, 4, 6, 2, 6, 2), 2, 2, 2, 2));
 
 	theme->set_icon("increment", "TabContainer", make_icon(scroll_button_right_png));
 	theme->set_icon("increment_highlight", "TabContainer", make_icon(scroll_button_right_hl_png));
@@ -792,6 +793,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("tab_disabled", "Tabs", sb_expand(make_stylebox(tab_disabled_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
 	theme->set_stylebox("button_pressed", "Tabs", make_stylebox(button_pressed_png, 4, 4, 4, 4));
 	theme->set_stylebox("button", "Tabs", make_stylebox(button_normal_png, 4, 4, 4, 4));
+	theme->set_stylebox("focus", "Tabs", sb_expand(make_stylebox(button_focus_png, 4, 4, 4, 4, 6, 2, 6, 2), 2, 2, 2, 2));
 
 	theme->set_icon("increment", "Tabs", make_icon(scroll_button_right_png));
 	theme->set_icon("increment_highlight", "Tabs", make_icon(scroll_button_right_hl_png));


### PR DESCRIPTION
This PR adds support for UI focus Tabs and TabContainer so they can be navigated using keyboard and gamepad. Related issues: #25877 #46111
**Changes:**
- Tab and TabContainer focus mode is now set to "All" by default
- When Tab/TabContainer node has focus it will render a blue rectangle (the same as the button) 
![image](https://user-images.githubusercontent.com/69091976/123520941-d1116400-d6b3-11eb-802a-cd3b91b8fb65.png)
- When Tab/TabContainer node has focus pressing ui_left will switch to the tab on the left of the currently selected, if the first tab is currently selected it will loop over and choose the last tab
- Similary when pressing ui_right the tab on the right be selected, if the last tab is currently selected, it will loop over and select first tab
- ~~Pressing ui_down when TabContainer has focus will in practice have the same effect as pressing ui_focus_next, more details in the Known issues section.~~ (refer to my second comment for more information)

**Known issues:**
- [x] - Because of the way TabContainer is implemented, changing focus from the TabContainer and Control inside the tab (child) is tricky. Engine for some reason doesn't treat TabContainer and child Control as valid neighbours. Switching from TabContainer to a child can be achieved using the find_next_valid_focus, but might cause issues in a more advanced UI design. Switching from child to TabContainer can be accomplished by explictly setting the Neighbor Top/Left/Right/Bottom parameter.
- [x] - Current implementation doesn't check if the tab is disabled, before switching to it.
- [x] - Behavior for looping over from last to first tab or vice versa might not be desired and should be enabled by a new property
- [ ] - Focus graphic is the same as button focus graphic, it looks okay, but if the PR gets approved it should propably use its own graphic