### PR TITLE
Define UV2 in primitive meshes

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -404,6 +404,8 @@ void CapsuleMesh::_create_mesh_array(Array &p_arr) const {
 	p_arr[RS::ARRAY_NORMAL] = normals;
 	p_arr[RS::ARRAY_TANGENT] = tangents;
 	p_arr[RS::ARRAY_TEX_UV] = uvs;
+	// Reuse UV as UV2 since it doesn't have any overlapping areas, making it suited for lightmapping.
+	p_arr[RS::ARRAY_TEX_UV2] = uvs;
 	p_arr[RS::ARRAY_INDEX] = indices;
 }
 
@@ -655,6 +657,8 @@ void BoxMesh::_create_mesh_array(Array &p_arr) const {
 	p_arr[RS::ARRAY_NORMAL] = normals;
 	p_arr[RS::ARRAY_TANGENT] = tangents;
 	p_arr[RS::ARRAY_TEX_UV] = uvs;
+	// Reuse UV as UV2 since it doesn't have any overlapping areas, making it suited for lightmapping.
+	p_arr[RS::ARRAY_TEX_UV2] = uvs;
 	p_arr[RS::ARRAY_INDEX] = indices;
 }
 
@@ -850,6 +854,8 @@ void CylinderMesh::_create_mesh_array(Array &p_arr) const {
 	p_arr[RS::ARRAY_NORMAL] = normals;
 	p_arr[RS::ARRAY_TANGENT] = tangents;
 	p_arr[RS::ARRAY_TEX_UV] = uvs;
+	// Reuse UV as UV2 since it doesn't have any overlapping areas, making it suited for lightmapping.
+	p_arr[RS::ARRAY_TEX_UV2] = uvs;
 	p_arr[RS::ARRAY_INDEX] = indices;
 }
 
@@ -982,6 +988,8 @@ void PlaneMesh::_create_mesh_array(Array &p_arr) const {
 	p_arr[RS::ARRAY_NORMAL] = normals;
 	p_arr[RS::ARRAY_TANGENT] = tangents;
 	p_arr[RS::ARRAY_TEX_UV] = uvs;
+	// Reuse UV as UV2 since it doesn't have any overlapping areas, making it suited for lightmapping.
+	p_arr[RS::ARRAY_TEX_UV2] = uvs;
 	p_arr[RS::ARRAY_INDEX] = indices;
 }
 
@@ -1237,6 +1245,8 @@ void PrismMesh::_create_mesh_array(Array &p_arr) const {
 	p_arr[RS::ARRAY_NORMAL] = normals;
 	p_arr[RS::ARRAY_TANGENT] = tangents;
 	p_arr[RS::ARRAY_TEX_UV] = uvs;
+	// Reuse UV as UV2 since it doesn't have any overlapping areas, making it suited for lightmapping.
+	p_arr[RS::ARRAY_TEX_UV2] = uvs;
 	p_arr[RS::ARRAY_INDEX] = indices;
 }
 
@@ -1360,6 +1370,8 @@ void QuadMesh::_create_mesh_array(Array &p_arr) const {
 	p_arr[RS::ARRAY_NORMAL] = normals;
 	p_arr[RS::ARRAY_TANGENT] = tangents;
 	p_arr[RS::ARRAY_TEX_UV] = uvs;
+	// Reuse UV as UV2 since it doesn't have any overlapping areas, making it suited for lightmapping.
+	p_arr[RS::ARRAY_TEX_UV2] = uvs;
 }
 
 void QuadMesh::_bind_methods() {
@@ -1452,6 +1464,8 @@ void SphereMesh::_create_mesh_array(Array &p_arr) const {
 	p_arr[RS::ARRAY_NORMAL] = normals;
 	p_arr[RS::ARRAY_TANGENT] = tangents;
 	p_arr[RS::ARRAY_TEX_UV] = uvs;
+	// Reuse UV as UV2 since it doesn't have any overlapping areas, making it suited for lightmapping.
+	p_arr[RS::ARRAY_TEX_UV2] = uvs;
 	p_arr[RS::ARRAY_INDEX] = indices;
 }
 


### PR DESCRIPTION
This allows using the lightmapper without using a mesh exported from a 3D DCC. Simply enable **Use In Baked Light** in the MeshInstance properties and lights will be baked.

This is especially useful for prototyping or testing the lightmapper itself.

I'm marking this PR as a draft. While it works as intended, the lack of padding in the UV causes lightmaps to bleed noticeably. There is surely a way to fix this, but I'd like to reuse the existing UV as a base as much as possible. Do I have to do all the calculations manually?

Stretched meshes such as boxes will also have lower lightmap resolution on the longer axis. You can see this on the stretched box on the screenshots. I'm not sure how to fix this.

## Preview

*Screenshots taken from a project using the `3.x` branch CPU lightmapper.*

**Testing project:** [test_primitive_uv2.zip](https://github.com/godotengine/godot/files/6720778/test_primitive_uv2.zip) (`3.x` with this PR, will not work in vanilla `3.x`)

### Without UV1 texture

*The large cube on the left is exported from Blender and has a good, padded UV generated by xatlas. The two large cubes on the right are primitive meshes with UV1 used as UV2.*

![Without UV1 texture](https://user-images.githubusercontent.com/180032/123527249-22364d80-d6de-11eb-9ac3-3c55ee4eb6fd.png)

### With UV1 texture

![With UV1 texture](https://user-images.githubusercontent.com/180032/123527251-24001100-d6de-11eb-8b73-6aaf96d0a466.png)