### PR TITLE
Added EditorInspectorPlugin to aid in editing InputEvents in resources and shortcuts

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -38,6 +38,7 @@ const int InputEvent::DEVICE_ID_INTERNAL = -2;
 
 void InputEvent::set_device(int p_device) {
 	device = p_device;
+	emit_changed();
 }
 
 int InputEvent::get_device() const {
@@ -131,6 +132,7 @@ void InputEventFromWindow::_bind_methods() {
 
 void InputEventFromWindow::set_window_id(int64_t p_id) {
 	window_id = p_id;
+	emit_changed();
 }
 
 int64_t InputEventFromWindow::get_window_id() const {
@@ -141,6 +143,7 @@ int64_t InputEventFromWindow::get_window_id() const {
 
 void InputEventWithModifiers::set_store_command(bool p_enabled) {
 	store_command = p_enabled;
+	emit_changed();
 }
 
 bool InputEventWithModifiers::is_storing_command() const {
@@ -149,6 +152,7 @@ bool InputEventWithModifiers::is_storing_command() const {
 
 void InputEventWithModifiers::set_shift_pressed(bool p_enabled) {
 	shift_pressed = p_enabled;
+	emit_changed();
 }
 
 bool InputEventWithModifiers::is_shift_pressed() const {
@@ -157,6 +161,7 @@ bool InputEventWithModifiers::is_shift_pressed() const {
 
 void InputEventWithModifiers::set_alt_pressed(bool p_enabled) {
 	alt_pressed = p_enabled;
+	emit_changed();
 }
 
 bool InputEventWithModifiers::is_alt_pressed() const {
@@ -165,6 +170,7 @@ bool InputEventWithModifiers::is_alt_pressed() const {
 
 void InputEventWithModifiers::set_ctrl_pressed(bool p_enabled) {
 	ctrl_pressed = p_enabled;
+	emit_changed();
 }
 
 bool InputEventWithModifiers::is_ctrl_pressed() const {
@@ -173,6 +179,7 @@ bool InputEventWithModifiers::is_ctrl_pressed() const {
 
 void InputEventWithModifiers::set_meta_pressed(bool p_enabled) {
 	meta_pressed = p_enabled;
+	emit_changed();
 }
 
 bool InputEventWithModifiers::is_meta_pressed() const {
@@ -181,6 +188,7 @@ bool InputEventWithModifiers::is_meta_pressed() const {
 
 void InputEventWithModifiers::set_command_pressed(bool p_enabled) {
 	command_pressed = p_enabled;
+	emit_changed();
 }
 
 bool InputEventWithModifiers::is_command_pressed() const {
@@ -291,6 +299,7 @@ void InputEventWithModifiers::_validate_property(PropertyInfo &property) const {
 
 void InputEventKey::set_pressed(bool p_pressed) {
 	pressed = p_pressed;
+	emit_changed();
 }
 
 bool InputEventKey::is_pressed() const {
@@ -299,6 +308,7 @@ bool InputEventKey::is_pressed() const {
 
 void InputEventKey::set_keycode(uint32_t p_keycode) {
 	keycode = p_keycode;
+	emit_changed();
 }
 
 uint32_t InputEventKey::get_keycode() const {
@@ -307,6 +317,7 @@ uint32_t InputEventKey::get_keycode() const {
 
 void InputEventKey::set_physical_keycode(uint32_t p_keycode) {
 	physical_keycode = p_keycode;
+	emit_changed();
 }
 
 uint32_t InputEventKey::get_physical_keycode() const {
@@ -315,6 +326,7 @@ uint32_t InputEventKey::get_physical_keycode() const {
 
 void InputEventKey::set_unicode(uint32_t p_unicode) {
 	unicode = p_unicode;
+	emit_changed();
 }
 
 uint32_t InputEventKey::get_unicode() const {
@@ -323,6 +335,7 @@ uint32_t InputEventKey::get_unicode() const {
 
 void InputEventKey::set_echo(bool p_enable) {
 	echo = p_enable;
+	emit_changed();
 }
 
 bool InputEventKey::is_echo() const {
@@ -469,6 +482,7 @@ void InputEventKey::_bind_methods() {
 
 void InputEventMouse::set_button_mask(int p_mask) {
 	button_mask = p_mask;
+	emit_changed();
 }
 
 int InputEventMouse::get_button_mask() const {
@@ -518,6 +532,7 @@ float InputEventMouseButton::get_factor() const {
 
 void InputEventMouseButton::set_button_index(MouseButton p_index) {
 	button_index = p_index;
+	emit_changed();
 }
 
 MouseButton InputEventMouseButton::get_button_index() const {
@@ -847,6 +862,7 @@ void InputEventMouseMotion::_bind_methods() {
 
 void InputEventJoypadMotion::set_axis(JoyAxis p_axis) {
 	axis = p_axis;
+	emit_changed();
 }
 
 JoyAxis InputEventJoypadMotion::get_axis() const {
@@ -855,6 +871,7 @@ JoyAxis InputEventJoypadMotion::get_axis() const {
 
 void InputEventJoypadMotion::set_axis_value(float p_value) {
 	axis_value = p_value;
+	emit_changed();
 }
 
 float InputEventJoypadMotion::get_axis_value() const {
@@ -949,6 +966,7 @@ void InputEventJoypadMotion::_bind_methods() {
 
 void InputEventJoypadButton::set_button_index(JoyButton p_index) {
 	button_index = p_index;
+	emit_changed();
 }
 
 JoyButton InputEventJoypadButton::get_button_index() const {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -137,6 +137,7 @@
 #include "editor/plugins/gpu_particles_3d_editor_plugin.h"
 #include "editor/plugins/gpu_particles_collision_sdf_editor_plugin.h"
 #include "editor/plugins/gradient_editor_plugin.h"
+#include "editor/plugins/input_event_editor_plugin.h"
 #include "editor/plugins/item_list_editor_plugin.h"
 #include "editor/plugins/light_occluder_2d_editor_plugin.h"
 #include "editor/plugins/lightmap_gi_editor_plugin.h"
@@ -6816,6 +6817,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(MeshEditorPlugin(this)));
 	add_editor_plugin(memnew(MaterialEditorPlugin(this)));
 	add_editor_plugin(memnew(GPUParticlesCollisionSDFEditorPlugin(this)));
+	add_editor_plugin(memnew(InputEventEditorPlugin(this)));
 
 	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
 		add_editor_plugin(EditorPlugins::create(i, this));

--- a/editor/plugins/input_event_editor_plugin.cpp
+++ b/editor/plugins/input_event_editor_plugin.cpp
@@ -1,0 +1,122 @@
+/*************************************************************************/
+/*  input_event_editor_plugin.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "input_event_editor_plugin.h"
+
+void InputEventConfigContainer::_bind_methods() {
+}
+
+void InputEventConfigContainer::_configure_pressed() {
+	config_dialog->popup_and_configure(input_event);
+}
+
+void InputEventConfigContainer::_event_changed() {
+	input_event_text->set_text(input_event->as_text());
+}
+
+void InputEventConfigContainer::_config_dialog_confirmed() {
+	Ref<InputEvent> ie = config_dialog->get_event();
+	input_event->copy_from(ie);
+	_event_changed();
+}
+
+Size2 InputEventConfigContainer::get_minimum_size() const {
+	// Don't bother with a minimum x size for the control - we don't want the inspector
+	// to jump in size if a long text is placed in the label (e.g. Joypad Axis description)
+	return Size2(0, HBoxContainer::get_minimum_size().y);
+}
+
+void InputEventConfigContainer::set_event(const Ref<InputEvent> &p_event) {
+	Ref<InputEventKey> k = p_event;
+	Ref<InputEventMouseButton> m = p_event;
+	Ref<InputEventJoypadButton> jb = p_event;
+	Ref<InputEventJoypadMotion> jm = p_event;
+
+	if (k.is_valid()) {
+		config_dialog->set_allowed_input_types(InputEventConfigurationDialog::InputType::INPUT_KEY);
+	} else if (m.is_valid()) {
+		config_dialog->set_allowed_input_types(InputEventConfigurationDialog::InputType::INPUT_MOUSE_BUTTON);
+	} else if (jb.is_valid()) {
+		config_dialog->set_allowed_input_types(InputEventConfigurationDialog::InputType::INPUT_JOY_BUTTON);
+	} else if (jm.is_valid()) {
+		config_dialog->set_allowed_input_types(InputEventConfigurationDialog::InputType::INPUT_JOY_MOTION);
+	}
+
+	input_event = p_event;
+	_event_changed();
+	input_event->connect("changed", callable_mp(this, &InputEventConfigContainer::_event_changed));
+}
+
+InputEventConfigContainer::InputEventConfigContainer() {
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->add_theme_constant_override("margin_left", 10);
+	mc->add_theme_constant_override("margin_right", 10);
+	mc->add_theme_constant_override("margin_top", 10);
+	mc->add_theme_constant_override("margin_bottom", 10);
+	add_child(mc);
+
+	HBoxContainer *hb = memnew(HBoxContainer);
+	mc->add_child(hb);
+
+	open_config_button = memnew(Button);
+	open_config_button->set_text("Configure");
+	open_config_button->connect("pressed", callable_mp(this, &InputEventConfigContainer::_configure_pressed));
+	hb->add_child(open_config_button);
+
+	input_event_text = memnew(Label);
+	hb->add_child(input_event_text);
+
+	config_dialog = memnew(InputEventConfigurationDialog);
+	config_dialog->connect("confirmed", callable_mp(this, &InputEventConfigContainer::_config_dialog_confirmed));
+	add_child(config_dialog);
+}
+
+bool EditorInspectorPluginInputEvent::can_handle(Object *p_object) {
+	Ref<InputEventKey> k = Ref<InputEventKey>(p_object);
+	Ref<InputEventMouseButton> m = Ref<InputEventMouseButton>(p_object);
+	Ref<InputEventJoypadButton> jb = Ref<InputEventJoypadButton>(p_object);
+	Ref<InputEventJoypadMotion> jm = Ref<InputEventJoypadMotion>(p_object);
+
+	return k.is_valid() || m.is_valid() || jb.is_valid() || jm.is_valid();
+}
+
+void EditorInspectorPluginInputEvent::parse_begin(Object *p_object) {
+	Ref<InputEvent> ie = Ref<InputEvent>(p_object);
+
+	InputEventConfigContainer *picker_controls = memnew(InputEventConfigContainer);
+	picker_controls->set_event(ie);
+	add_custom_control(picker_controls);
+}
+
+InputEventEditorPlugin::InputEventEditorPlugin(EditorNode *p_node) {
+	Ref<EditorInspectorPluginInputEvent> plugin;
+	plugin.instantiate();
+	add_inspector_plugin(plugin);
+}

--- a/editor/plugins/input_event_editor_plugin.h
+++ b/editor/plugins/input_event_editor_plugin.h
@@ -1,0 +1,79 @@
+/*************************************************************************/
+/*  input_event_editor_plugin.h                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef INPUT_EVENT_EDITOR_PLUGIN_H
+#define INPUT_EVENT_EDITOR_PLUGIN_H
+
+#include "editor/action_map_editor.h"
+#include "editor/editor_inspector.h"
+#include "editor/editor_node.h"
+
+class InputEventConfigContainer : public HBoxContainer {
+	GDCLASS(InputEventConfigContainer, HBoxContainer);
+
+	Label *input_event_text;
+	Button *open_config_button;
+
+	Ref<InputEvent> input_event;
+	InputEventConfigurationDialog *config_dialog;
+
+	void _config_dialog_confirmed();
+	void _configure_pressed();
+
+	void _event_changed();
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual Size2 get_minimum_size() const override;
+	void set_event(const Ref<InputEvent> &p_event);
+
+	InputEventConfigContainer();
+};
+
+class EditorInspectorPluginInputEvent : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginInputEvent, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual void parse_begin(Object *p_object) override;
+};
+
+class InputEventEditorPlugin : public EditorPlugin {
+	GDCLASS(InputEventEditorPlugin, EditorPlugin);
+
+public:
+	virtual String get_name() const override { return "InputEvent"; }
+
+	InputEventEditorPlugin(EditorNode *p_node);
+};
+
+#endif // INPUT_EVENT_EDITOR_PLUGIN_H


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2890

Uses `InputEventConfigurationDialog` added in #44181 to allow for easy editing of InputEvent's in the inspector. Works for the same things the configuration dialog works for: Keys, MouseButtons and Joypad Button/Motion.

https://user-images.githubusercontent.com/41730826/123548168-08147200-d7a7-11eb-9527-9010c9e2a7f3.mp4

