### PR TITLE
Tweak LightmapGI defaults to be closer to the CPU lightmapper

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -17,7 +17,7 @@
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="0.0005">
 			The bias to use when computing shadows. Increasing [member bias] can fix shadow acne on the resulting baked lightmap, but can introduce peter-panning (shadows not connecting to their casters). Real-time [Light3D] shadows are not affected by this [member bias] property.
 		</member>
-		<member name="bounces" type="int" setter="set_bounces" getter="get_bounces" default="1">
+		<member name="bounces" type="int" setter="set_bounces" getter="get_bounces" default="3">
 			Number of light bounces that are taken into account during baking. Higher values result in brighter, more realistic lighting, at the cost of longer bake times. If set to [code]0[/code], only environment lighting, direct light and emissive lighting is baked.
 		</member>
 		<member name="camera_attributes" type="CameraAttributes" setter="set_camera_attributes" getter="get_camera_attributes">
@@ -36,10 +36,10 @@
 		<member name="environment_custom_sky" type="Sky" setter="set_environment_custom_sky" getter="get_environment_custom_sky">
 			The sky to use as a source of environment lighting. Only effective if [member environment_mode] is [constant ENVIRONMENT_MODE_CUSTOM_SKY].
 		</member>
-		<member name="environment_mode" type="int" setter="set_environment_mode" getter="get_environment_mode" enum="LightmapGI.EnvironmentMode" default="0">
+		<member name="environment_mode" type="int" setter="set_environment_mode" getter="get_environment_mode" enum="LightmapGI.EnvironmentMode" default="1">
 			The environment mode to use when baking lightmaps.
 		</member>
-		<member name="generate_probes_subdiv" type="int" setter="set_generate_probes" getter="get_generate_probes" enum="LightmapGI.GenerateProbes" default="0">
+		<member name="generate_probes_subdiv" type="int" setter="set_generate_probes" getter="get_generate_probes" enum="LightmapGI.GenerateProbes" default="2">
 			The level of subdivision to use when automatically generating [LightmapProbe]s for dynamic object lighting. Higher values result in more accurate indirect lighting on dynamic objects, at the cost of longer bake times and larger file sizes.
 			[b]Note:[/b] Automatically generated [LightmapProbe]s are not visible as nodes in the Scene tree dock, and cannot be modified this way after they are generated.
 			[b]Note:[/b] Regardless of [member generate_probes_subdiv], direct lighting on dynamic objects is always applied using [Light3D] nodes in real-time.

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1418,7 +1418,8 @@ float LightmapGI::get_bias() const {
 }
 
 void LightmapGI::set_max_texture_size(int p_size) {
-	ERR_FAIL_COND(p_size < 2048);
+	ERR_FAIL_COND_MSG(p_size < 2048, vformat("The LightmapGI maximum texture size supplied (%d) is too small. The minimum allowed value is 2048.", p_size));
+	ERR_FAIL_COND_MSG(p_size > 16384, vformat("The LightmapGI maximum texture size supplied (%d) is too large. The maximum allowed value is 16384.", p_size));
 	max_texture_size = p_size;
 }
 
@@ -1506,7 +1507,7 @@ void LightmapGI::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interior"), "set_interior", "is_interior");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_denoiser"), "set_use_denoiser", "is_using_denoiser");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0.00001,0.1,0.00001,or_greater"), "set_bias", "get_bias");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_texture_size"), "set_max_texture_size", "get_max_texture_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_texture_size", PROPERTY_HINT_RANGE, "2048,16384,1"), "set_max_texture_size", "get_max_texture_size");
 	ADD_GROUP("Environment", "environment_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "environment_mode", PROPERTY_HINT_ENUM, "Disabled,Scene,Custom Sky,Custom Color"), "set_environment_mode", "get_environment_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "environment_custom_sky", PROPERTY_HINT_RESOURCE_TYPE, "Sky"), "set_environment_custom_sky", "get_environment_custom_sky");

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -142,16 +142,16 @@ public:
 private:
 	BakeQuality bake_quality = BAKE_QUALITY_MEDIUM;
 	bool use_denoiser = true;
-	int bounces = 1;
+	int bounces = 3;
 	float bias = 0.0005;
 	int max_texture_size = 16384;
 	bool interior = false;
-	EnvironmentMode environment_mode = ENVIRONMENT_MODE_DISABLED;
+	EnvironmentMode environment_mode = ENVIRONMENT_MODE_SCENE;
 	Ref<Sky> environment_custom_sky;
-	Color environment_custom_color = Color(0.2, 0.7, 1.0);
+	Color environment_custom_color = Color(1, 1, 1);
 	float environment_custom_energy = 1.0;
 	bool directional = false;
-	GenerateProbes gen_probes = GENERATE_PROBES_DISABLED;
+	GenerateProbes gen_probes = GENERATE_PROBES_SUBDIV_8;
 	Ref<CameraAttributes> camera_attributes;
 
 	Ref<LightmapGIData> light_data;


### PR DESCRIPTION
- Use 3 bounces by default. This is slower but gives significantly better results out of the box. The GPU lightmapper is very fast compared to the CPU lightmapper anyway.
- Enable environment lighting from the scene by default.
  - This is not done in `3.x` for compatibility with existing projects, but it makes sense to do this by default since pretty much all outdoor scenes benefit from this.
- Set the custom environment color to white (like ReflectionProbe).
  - Its default energy is still 0, so it's invisible by default.
- Enable the generation of dynamic object probes by default.
- Tweak the `max_texture_size` property hint for better usability.
- Improve error messages when passing invalid sizes to `LightmapGI.set_max_texture_size()`.

## Preview

*Using the **All** bake mode for the DirectionalLight, which means both direct and indirect lighting are baked.*

**Testing project:** [test_lightmap_normalmap_2.zip](https://github.com/godotengine/godot/files/6721779/test_lightmap_normalmap_2.zip) (`master` only, won't work in `3.x`)

### Before

![Before](https://user-images.githubusercontent.com/180032/123549444-530f9480-d769-11eb-95ae-7cf4627fab25.png)

### After

![After](https://user-images.githubusercontent.com/180032/123549445-5440c180-d769-11eb-9db4-126d83eb7731.png)