### PR TITLE
Prevent setting too big or too small Collision Mask and Layer (3.x)

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -87,6 +87,7 @@ uint32_t CSGShape::get_collision_mask() const {
 }
 
 void CSGShape::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -97,20 +98,23 @@ void CSGShape::set_collision_mask_bit(int p_bit, bool p_value) {
 }
 
 bool CSGShape::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 
 void CSGShape::set_collision_layer_bit(int p_bit, bool p_value) {
-	uint32_t mask = get_collision_layer();
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision layer bit must be between 0 and 31 inclusive.");
+	uint32_t layer = get_collision_layer();
 	if (p_value) {
-		mask |= 1 << p_bit;
+		layer |= 1 << p_bit;
 	} else {
-		mask &= ~(1 << p_bit);
+		layer &= ~(1 << p_bit);
 	}
-	set_collision_layer(mask);
+	set_collision_layer(layer);
 }
 
 bool CSGShape::get_collision_layer_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision layer bit must be between 0 and 31 inclusive.");
 	return get_collision_layer() & (1 << p_bit);
 }
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -151,6 +151,7 @@ uint32_t GridMap::get_collision_mask() const {
 }
 
 void GridMap::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -161,20 +162,23 @@ void GridMap::set_collision_mask_bit(int p_bit, bool p_value) {
 }
 
 bool GridMap::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 
 void GridMap::set_collision_layer_bit(int p_bit, bool p_value) {
-	uint32_t mask = get_collision_layer();
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision layer bit must be between 0 and 31 inclusive.");
+	uint32_t layer = get_collision_layer();
 	if (p_value) {
-		mask |= 1 << p_bit;
+		layer |= 1 << p_bit;
 	} else {
-		mask &= ~(1 << p_bit);
+		layer &= ~(1 << p_bit);
 	}
-	set_collision_layer(mask);
+	set_collision_layer(layer);
 }
 
 bool GridMap::get_collision_layer_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision layer bit must be between 0 and 31 inclusive.");
 	return get_collision_layer() & (1 << p_bit);
 }
 

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -127,6 +127,7 @@ uint32_t CollisionObject2D::get_collision_mask() const {
 }
 
 void CollisionObject2D::set_collision_layer_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision layer bit must be between 0 and 31 inclusive.");
 	uint32_t collision_layer = get_collision_layer();
 	if (p_value) {
 		collision_layer |= 1 << p_bit;
@@ -137,10 +138,12 @@ void CollisionObject2D::set_collision_layer_bit(int p_bit, bool p_value) {
 }
 
 bool CollisionObject2D::get_collision_layer_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision layer bit must be between 0 and 31 inclusive.");
 	return get_collision_layer() & (1 << p_bit);
 }
 
 void CollisionObject2D::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -151,6 +154,7 @@ void CollisionObject2D::set_collision_mask_bit(int p_bit, bool p_value) {
 }
 
 bool CollisionObject2D::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -55,6 +55,7 @@ uint32_t RayCast2D::get_collision_mask() const {
 }
 
 void RayCast2D::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -65,6 +66,7 @@ void RayCast2D::set_collision_mask_bit(int p_bit, bool p_value) {
 }
 
 bool RayCast2D::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1282,6 +1282,7 @@ void TileMap::set_collision_mask(uint32_t p_mask) {
 }
 
 void TileMap::set_collision_layer_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision layer bit must be between 0 and 31 inclusive.");
 	uint32_t layer = get_collision_layer();
 	if (p_value) {
 		layer |= 1 << p_bit;
@@ -1292,6 +1293,7 @@ void TileMap::set_collision_layer_bit(int p_bit, bool p_value) {
 }
 
 void TileMap::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -1372,10 +1374,12 @@ uint32_t TileMap::get_collision_mask() const {
 }
 
 bool TileMap::get_collision_layer_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision layer bit must be between 0 and 31 inclusive.");
 	return get_collision_layer() & (1 << p_bit);
 }
 
 bool TileMap::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -771,6 +771,7 @@ uint32_t ClippedCamera::get_collision_mask() const {
 }
 
 void ClippedCamera::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision layer bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -781,6 +782,7 @@ void ClippedCamera::set_collision_mask_bit(int p_bit, bool p_value) {
 }
 
 bool ClippedCamera::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -123,6 +123,7 @@ uint32_t CollisionObject::get_collision_mask() const {
 }
 
 void CollisionObject::set_collision_layer_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision layer bit must be between 0 and 31 inclusive.");
 	uint32_t collision_layer = get_collision_layer();
 	if (p_value) {
 		collision_layer |= 1 << p_bit;
@@ -133,10 +134,12 @@ void CollisionObject::set_collision_layer_bit(int p_bit, bool p_value) {
 }
 
 bool CollisionObject::get_collision_layer_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision layer bit must be between 0 and 31 inclusive.");
 	return get_collision_layer() & (1 << p_bit);
 }
 
 void CollisionObject::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -147,6 +150,7 @@ void CollisionObject::set_collision_mask_bit(int p_bit, bool p_value) {
 }
 
 bool CollisionObject::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 

--- a/scene/3d/navigation_mesh.cpp
+++ b/scene/3d/navigation_mesh.cpp
@@ -94,6 +94,7 @@ uint32_t NavigationMesh::get_collision_mask() const {
 }
 
 void NavigationMesh::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -104,6 +105,7 @@ void NavigationMesh::set_collision_mask_bit(int p_bit, bool p_value) {
 }
 
 bool NavigationMesh::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -61,6 +61,7 @@ uint32_t RayCast::get_collision_mask() const {
 }
 
 void RayCast::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -71,6 +72,7 @@ void RayCast::set_collision_mask_bit(int p_bit, bool p_value) {
 }
 
 bool RayCast::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -512,6 +512,7 @@ uint32_t SoftBody::get_collision_layer() const {
 }
 
 void SoftBody::set_collision_mask_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
@@ -522,10 +523,12 @@ void SoftBody::set_collision_mask_bit(int p_bit, bool p_value) {
 }
 
 bool SoftBody::get_collision_mask_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
 	return get_collision_mask() & (1 << p_bit);
 }
 
 void SoftBody::set_collision_layer_bit(int p_bit, bool p_value) {
+	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision layer bit must be between 0 and 31 inclusive.");
 	uint32_t layer = get_collision_layer();
 	if (p_value) {
 		layer |= 1 << p_bit;
@@ -536,6 +539,7 @@ void SoftBody::set_collision_layer_bit(int p_bit, bool p_value) {
 }
 
 bool SoftBody::get_collision_layer_bit(int p_bit) const {
+	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision layer bit must be between 0 and 31 inclusive.");
 	return get_collision_layer() & (1 << p_bit);
 }
 

--- a/servers/physics_2d_server.cpp
+++ b/servers/physics_2d_server.cpp
@@ -166,10 +166,11 @@ float Physics2DShapeQueryParameters::get_margin() const {
 	return margin;
 }
 
-void Physics2DShapeQueryParameters::set_collision_mask(int p_collision_mask) {
+void Physics2DShapeQueryParameters::set_collision_mask(uint32_t p_collision_mask) {
 	collision_mask = p_collision_mask;
 }
-int Physics2DShapeQueryParameters::get_collision_mask() const {
+
+uint32_t Physics2DShapeQueryParameters::get_collision_mask() const {
 	return collision_mask;
 }
 

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -125,8 +125,8 @@ public:
 	void set_margin(float p_margin);
 	float get_margin() const;
 
-	void set_collision_mask(int p_collision_mask);
-	int get_collision_mask() const;
+	void set_collision_mask(uint32_t p_mask);
+	uint32_t get_collision_mask() const;
 
 	void set_collide_with_bodies(bool p_enable);
 	bool is_collide_with_bodies_enabled() const;

--- a/servers/physics_server.cpp
+++ b/servers/physics_server.cpp
@@ -164,10 +164,11 @@ float PhysicsShapeQueryParameters::get_margin() const {
 	return margin;
 }
 
-void PhysicsShapeQueryParameters::set_collision_mask(int p_collision_mask) {
+void PhysicsShapeQueryParameters::set_collision_mask(uint32_t p_collision_mask) {
 	collision_mask = p_collision_mask;
 }
-int PhysicsShapeQueryParameters::get_collision_mask() const {
+
+uint32_t PhysicsShapeQueryParameters::get_collision_mask() const {
 	return collision_mask;
 }
 

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -123,8 +123,8 @@ public:
 	void set_margin(float p_margin);
 	float get_margin() const;
 
-	void set_collision_mask(int p_collision_mask);
-	int get_collision_mask() const;
+	void set_collision_mask(uint32_t p_collision_mask);
+	uint32_t get_collision_mask() const;
 
 	void set_exclude(const Vector<RID> &p_exclude);
 	Vector<RID> get_exclude() const;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/34823. Thanks @qarmin :slightly_smiling_face:

This closes https://github.com/godotengine/godot/issues/49934.