### PR TITLE
Improve error reporting in WebSocketServer

### DIFF
--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -97,26 +97,31 @@ bool WSLServer::PendingPeer::_parse_request(const Vector<String> p_protocols) {
 
 Error WSLServer::PendingPeer::do_handshake(const Vector<String> p_protocols, uint64_t p_timeout) {
 	if (OS::get_singleton()->get_ticks_msec() - time > p_timeout) {
+		print_verbose(vformat("WebSocket handshake timed out after %.3f seconds.", p_timeout * 0.001));
 		return ERR_TIMEOUT;
 	}
+
 	if (use_ssl) {
 		Ref<StreamPeerSSL> ssl = static_cast<Ref<StreamPeerSSL>>(connection);
 		if (ssl.is_null()) {
-			return FAILED;
+			ERR_FAIL_V_MSG(ERR_BUG, "Couldn't get StreamPeerSSL for WebSocket handshake.");
 		}
 		ssl->poll();
 		if (ssl->get_status() == StreamPeerSSL::STATUS_HANDSHAKING) {
 			return ERR_BUSY;
 		} else if (ssl->get_status() != StreamPeerSSL::STATUS_CONNECTED) {
+			print_verbose(vformat("WebSocket SSL connection error during handshake (StreamPeerSSL status code %d).", ssl->get_status()));
 			return FAILED;
 		}
 	}
+
 	if (!has_request) {
 		int read = 0;
 		while (true) {
-			ERR_FAIL_COND_V_MSG(req_pos >= WSL_MAX_HEADER_SIZE, ERR_OUT_OF_MEMORY, "Response headers too big.");
+			ERR_FAIL_COND_V_MSG(req_pos >= WSL_MAX_HEADER_SIZE, ERR_OUT_OF_MEMORY, "WebSocket response headers are too big.");
 			Error err = connection->get_partial_data(&req_buf[req_pos], 1, read);
 			if (err != OK) { // Got an error
+				print_verbose(vformat("WebSocket error while getting partial data (StreamPeer error code %d).", err));
 				return FAILED;
 			} else if (read != 1) { // Busy, wait next poll
 				return ERR_BUSY;
@@ -143,17 +148,21 @@ Error WSLServer::PendingPeer::do_handshake(const Vector<String> p_protocols, uin
 			req_pos += 1;
 		}
 	}
+
 	if (has_request && response_sent < response.size() - 1) {
 		int sent = 0;
 		Error err = connection->put_partial_data((const uint8_t *)response.get_data() + response_sent, response.size() - response_sent - 1, sent);
 		if (err != OK) {
+			print_verbose(vformat("WebSocket error while putting partial data (StreamPeer error code %d).", err));
 			return err;
 		}
 		response_sent += sent;
 	}
+
 	if (response_sent < response.size() - 1) {
 		return ERR_BUSY;
 	}
+
 	return OK;
 }
 


### PR DESCRIPTION
This should make troubleshooting easier. Note that I didn't add messages for the `ERR_BUSY` returns – let me know if that should be done.

See https://github.com/godotengine/godot/issues/45681.