### PR TITLE
[Net] Fix WebSocketClient path parsing.

### DIFF
--- a/modules/websocket/websocket_client.cpp
+++ b/modules/websocket/websocket_client.cpp
@@ -42,9 +42,9 @@ Error WebSocketClient::connect_to_url(String p_url, const Vector<String> p_proto
 	_is_multiplayer = gd_mp_api;
 
 	String host = p_url;
-	String path = "/";
-	String scheme = "";
-	int port = 80;
+	String path;
+	String scheme;
+	int port = 0;
 	Error err = p_url.parse_url(scheme, host, port, path);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Invalid URL: " + p_url);
 
@@ -54,6 +54,9 @@ Error WebSocketClient::connect_to_url(String p_url, const Vector<String> p_proto
 	}
 	if (port == 0) {
 		port = ssl ? 443 : 80;
+	}
+	if (path.is_empty()) {
+		path = "/";
 	}
 	return connect_to_host(host, path, port, ssl, p_protocols, p_custom_headers);
 }

--- a/modules/websocket/wsl_client.cpp
+++ b/modules/websocket/wsl_client.cpp
@@ -158,6 +158,7 @@ bool WSLClient::_verify_headers(String &r_protocol) {
 
 Error WSLClient::connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, const Vector<String> p_protocols, const Vector<String> p_custom_headers) {
 	ERR_FAIL_COND_V(_connection.is_valid(), ERR_ALREADY_IN_USE);
+	ERR_FAIL_COND_V(p_path.is_empty(), ERR_INVALID_PARAMETER);
 
 	_peer = Ref<WSLPeer>(memnew(WSLPeer));
 	IPAddress addr;


### PR DESCRIPTION
Recent changes to `parse_url` (#48205) caused the client to make invalid HTTP requests if no path was specified.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
