### PR TITLE
[Net] Add WebSocketServer handshake_timeout property.

### DIFF
--- a/modules/websocket/doc_classes/WebSocketServer.xml
+++ b/modules/websocket/doc_classes/WebSocketServer.xml
@@ -89,6 +89,9 @@
 		<member name="ca_chain" type="X509Certificate" setter="set_ca_chain" getter="get_ca_chain">
 			When using SSL (see [member private_key] and [member ssl_certificate]), you can set this to a valid [X509Certificate] to be provided as additional CA chain information during the SSL handshake.
 		</member>
+		<member name="handshake_timeout" type="float" setter="set_handshake_timeout" getter="get_handshake_timeout" default="3.0">
+			The time in seconds before a pending client (i.e. a client that has not yet finished the HTTP handshake) is considered stale and forcefully disconnected.
+		</member>
 		<member name="private_key" type="CryptoKey" setter="set_private_key" getter="get_private_key">
 			When set to a valid [CryptoKey] (along with [member ssl_certificate]) will cause the server to require SSL instead of regular TCP (i.e. the [code]wss://[/code] protocol).
 		</member>

--- a/modules/websocket/websocket_server.cpp
+++ b/modules/websocket/websocket_server.cpp
@@ -65,6 +65,10 @@ void WebSocketServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ca_chain"), &WebSocketServer::set_ca_chain);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "ca_chain", PROPERTY_HINT_RESOURCE_TYPE, "X509Certificate", PROPERTY_USAGE_NONE), "set_ca_chain", "get_ca_chain");
 
+	ClassDB::bind_method(D_METHOD("get_handshake_timeout"), &WebSocketServer::get_handshake_timeout);
+	ClassDB::bind_method(D_METHOD("set_handshake_timeout", "timeout"), &WebSocketServer::set_handshake_timeout);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "handshake_timeout"), "set_handshake_timeout", "get_handshake_timeout");
+
 	ADD_SIGNAL(MethodInfo("client_close_request", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::INT, "code"), PropertyInfo(Variant::STRING, "reason")));
 	ADD_SIGNAL(MethodInfo("client_disconnected", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::BOOL, "was_clean_close")));
 	ADD_SIGNAL(MethodInfo("client_connected", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "protocol")));
@@ -106,6 +110,15 @@ Ref<X509Certificate> WebSocketServer::get_ca_chain() const {
 void WebSocketServer::set_ca_chain(Ref<X509Certificate> p_ca_chain) {
 	ERR_FAIL_COND(is_listening());
 	ca_chain = p_ca_chain;
+}
+
+float WebSocketServer::get_handshake_timeout() const {
+	return handshake_timeout / 1000.0;
+}
+
+void WebSocketServer::set_handshake_timeout(float p_timeout) {
+	ERR_FAIL_COND(p_timeout <= 0.0);
+	handshake_timeout = p_timeout * 1000;
 }
 
 NetworkedMultiplayerPeer::ConnectionStatus WebSocketServer::get_connection_status() const {

--- a/modules/websocket/websocket_server.h
+++ b/modules/websocket/websocket_server.h
@@ -48,6 +48,7 @@ protected:
 	Ref<CryptoKey> private_key;
 	Ref<X509Certificate> ssl_cert;
 	Ref<X509Certificate> ca_chain;
+	uint32_t handshake_timeout = 3000;
 
 public:
 	virtual Error listen(int p_port, const Vector<String> p_protocols = Vector<String>(), bool gd_mp_api = false) = 0;
@@ -77,6 +78,9 @@ public:
 
 	Ref<X509Certificate> get_ca_chain() const;
 	void set_ca_chain(Ref<X509Certificate> p_ca_chain);
+
+	float get_handshake_timeout() const;
+	void set_handshake_timeout(float p_timeout);
 
 	WebSocketServer();
 	~WebSocketServer();

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -95,8 +95,8 @@ bool WSLServer::PendingPeer::_parse_request(const Vector<String> p_protocols) {
 	return true;
 }
 
-Error WSLServer::PendingPeer::do_handshake(const Vector<String> p_protocols) {
-	if (OS::get_singleton()->get_ticks_msec() - time > WSL_SERVER_TIMEOUT) {
+Error WSLServer::PendingPeer::do_handshake(const Vector<String> p_protocols, uint64_t p_timeout) {
+	if (OS::get_singleton()->get_ticks_msec() - time > p_timeout) {
 		return ERR_TIMEOUT;
 	}
 	if (use_ssl) {
@@ -188,7 +188,7 @@ void WSLServer::poll() {
 	List<Ref<PendingPeer>> remove_peers;
 	for (List<Ref<PendingPeer>>::Element *E = _pending.front(); E; E = E->next()) {
 		Ref<PendingPeer> ppeer = E->get();
-		Error err = ppeer->do_handshake(_protocols);
+		Error err = ppeer->do_handshake(_protocols, handshake_timeout);
 		if (err == ERR_BUSY) {
 			continue;
 		} else if (err != OK) {

--- a/modules/websocket/wsl_server.h
+++ b/modules/websocket/wsl_server.h
@@ -40,8 +40,6 @@
 #include "core/io/stream_peer_tcp.h"
 #include "core/io/tcp_server.h"
 
-#define WSL_SERVER_TIMEOUT 1000
-
 class WSLServer : public WebSocketServer {
 	GDCIIMPL(WSLServer, WebSocketServer);
 
@@ -64,7 +62,7 @@ private:
 		CharString response;
 		int response_sent = 0;
 
-		Error do_handshake(const Vector<String> p_protocols);
+		Error do_handshake(const Vector<String> p_protocols, uint64_t p_timeout);
 	};
 
 	int _in_buf_size = DEF_BUF_SHIFT;


### PR DESCRIPTION
Allows customization of the maximum time a client is allowed to stay in the the "pending" state (i.e. awaiting HTTP handshake).

This used to be 1 second by before, the new default is 3 seconds.

See #45681