### PR TITLE
Print a warning for Viewports that have 2D usage and HDR enabled

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -315,6 +315,7 @@
 		</member>
 		<member name="usage" type="int" setter="set_usage" getter="get_usage" enum="Viewport.Usage" default="2">
 			The rendering mode of viewport.
+			[b]Note:[/b] If set to [constant USAGE_2D] or [constant USAGE_2D_NO_SAMPLING], [member hdr] will have no effect when enabled since HDR is not supported for 2D.
 		</member>
 		<member name="world" type="World" setter="set_world" getter="get_world">
 			The custom [World] which can be used as 3D environment source.

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2928,11 +2928,6 @@ Control *Viewport::get_modal_stack_top() const {
 }
 
 String Viewport::get_configuration_warning() const {
-	/*if (get_parent() && !Object::cast_to<Control>(get_parent()) && !render_target) {
-
-		return TTR("This viewport is not set as render target. If you intend for it to display its contents directly to the screen, make it a child of a Control so it can obtain a size. Otherwise, make it a RenderTarget and assign its internal texture to some node for display.");
-	}*/
-
 	String warning = Node::get_configuration_warning();
 
 	if (size.x == 0 || size.y == 0) {
@@ -2941,6 +2936,14 @@ String Viewport::get_configuration_warning() const {
 		}
 		warning += TTR("Viewport size must be greater than 0 to render anything.");
 	}
+
+	if (hdr && (usage == USAGE_2D || usage == USAGE_2D_NO_SAMPLING)) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("This Viewport has HDR enabled, but its Usage is set to 2D or 2D No-Sampling.\nHDR is only supported in Viewports that have their Usage set to 3D or 3D No-Effects.\nHDR will be disabled for this Viewport.");
+	}
+
 	return warning;
 }
 
@@ -2995,6 +2998,7 @@ void Viewport::set_hdr(bool p_hdr) {
 
 	hdr = p_hdr;
 	VS::get_singleton()->viewport_set_hdr(viewport, p_hdr);
+	update_configuration_warning();
 }
 
 bool Viewport::get_hdr() const {
@@ -3002,8 +3006,13 @@ bool Viewport::get_hdr() const {
 }
 
 void Viewport::set_usage(Usage p_usage) {
+	if (usage == p_usage) {
+		return;
+	}
+
 	usage = p_usage;
 	VS::get_singleton()->viewport_set_usage(viewport, VS::ViewportUsage(p_usage));
+	update_configuration_warning();
 }
 
 Viewport::Usage Viewport::get_usage() const {


### PR DESCRIPTION
2D usage + HDR isn't supported, so the usage must be changed to 3D to be able to use HDR.

I wanted to print the node path using [KoBeWi's suggested solution](https://github.com/godotengine/godot/pull/48164#issuecomment-846984050), but that didn't work either.

See https://github.com/godotengine/godot/issues/41151 and https://github.com/Zylann/godot_heightmap_plugin/issues/269.

**Note:** Not applicable to the `master` branch as the notion of viewport usage is gone there.