### PR TITLE
Fix GraphNode port position when the control has the Expand flag

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -757,7 +757,7 @@ void GraphNode::_connpos_update() {
 			continue;
 		}
 
-		Size2i size = c->get_combined_minimum_size();
+		Size2i size = c->get_rect().size;
 
 		int y = sb->get_margin(SIDE_TOP) + vofs;
 		int h = size.y;


### PR DESCRIPTION
Follow up of #39810

When a GraphNode child has the (vertical) Expand size flag enabled, the port icon position and the get_connection_*_position are different, resulting in the following artifacts:

![before](https://user-images.githubusercontent.com/33117082/123676080-c5ed3e00-d843-11eb-858a-0122a16875e5.png)
(The bigger Godot logo has the Expand flag)

I fix this by using the full control size, and not just the minimum one.

![after](https://user-images.githubusercontent.com/33117082/123676692-90952000-d844-11eb-90f9-70232307a655.png)

I don't test Visual Script and Visual Shader, but if the control size is the same of `Control.get_combined_minimum_size` (which seems to be the default behaviour), there shouldn't be any regression.

Test scene:
[graphedit.zip](https://github.com/godotengine/godot/files/6728161/graphedit.zip)
