### PR TITLE
[3.x] Add a project setting to control the minimum ReflectionProbe roughness

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1257,6 +1257,12 @@
 			Limits the size of the irradiance map which is normally determined by [member Sky.radiance_size]. A higher size results in a higher quality irradiance map similarly to [member rendering/quality/reflections/high_quality_ggx]. Use a higher value when using high-frequency HDRI maps, otherwise keep this as low as possible.
 			[b]Note:[/b] Low and mid range hardware do not support complex irradiance maps well and may crash if this is set too high.
 		</member>
+		<member name="rendering/quality/reflections/reflection_probe_min_roughness" type="float" setter="" getter="" default="0.05">
+			When generating [ReflectionProbe] cubemaps, the value specified here will be used as a minimum roughness value. This means materials with a roughness value below this setting will use blurrier reflections than they logically should, which acts as a form of antialiasing. With the default value, reflections on smooth surfaces will appear blurrier than they could, but will exhibit less aliasing.
+			To get the sharpest possible reflections at the cost of aliasing, decrease this setting to [code]0.0[/code]. You can increase this value above the default to get even smoother reflections, but it will make reflections on smooth materials even blurrier.
+			[b]Note:[/b] Only effective when using the GLES3 rendering backend.
+			[b]Note:[/b] This setting can be changed at run-time, but [ReflectionProbe] cubemaps generated before changing this setting will keep their old minimum roughness value. You can update old [ReflectionProbe] cubemaps by moving the node around slightly.
+		</member>
 		<member name="rendering/quality/reflections/texture_array_reflections" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], uses texture arrays instead of mipmaps for reflection probes and panorama backgrounds (sky). This reduces jitter noise on reflections, but costs more performance and memory.
 		</member>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -727,7 +727,10 @@ bool RasterizerSceneGLES3::reflection_probe_instance_postprocess_step(RID p_inst
 	storage->shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::LOW_QUALITY, rpi->probe_ptr->update_mode == VS::REFLECTION_PROBE_UPDATE_ALWAYS);
 	for (int i = 0; i < 2; i++) {
 		storage->shaders.cubemap_filter.set_uniform(CubemapFilterShaderGLES3::Z_FLIP, i == 0);
-		storage->shaders.cubemap_filter.set_uniform(CubemapFilterShaderGLES3::ROUGHNESS, rpi->render_step / 5.0);
+		// Use minimum roughness to provide antialiasing for reflection probes
+		// on materials with low roughness values. The end result is blurrier,
+		// but it often looks better than sharp aliased reflections in practice.
+		storage->shaders.cubemap_filter.set_uniform(CubemapFilterShaderGLES3::ROUGHNESS, MAX(reflection_probe_min_roughness, rpi->render_step / 5.0));
 
 		uint32_t local_width = width, local_height = height;
 		uint32_t local_x = x, local_y = y;
@@ -5219,6 +5222,7 @@ void RasterizerSceneGLES3::iteration() {
 	subsurface_scatter_weight_samples = GLOBAL_GET("rendering/quality/subsurface_scattering/weight_samples");
 	subsurface_scatter_quality = SubSurfaceScatterQuality(int(GLOBAL_GET("rendering/quality/subsurface_scattering/quality")));
 	subsurface_scatter_size = GLOBAL_GET("rendering/quality/subsurface_scattering/scale");
+	reflection_probe_min_roughness = GLOBAL_GET("rendering/quality/reflections/reflection_probe_min_roughness");
 
 	storage->config.use_lightmap_filter_bicubic = GLOBAL_GET("rendering/quality/lightmapping/use_bicubic_sampling");
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHTMAP_FILTER_BICUBIC, storage->config.use_lightmap_filter_bicubic);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -69,6 +69,8 @@ public:
 	bool subsurface_scatter_follow_surface;
 	bool subsurface_scatter_weight_samples;
 
+	float reflection_probe_min_roughness;
+
 	uint64_t render_pass;
 	uint64_t scene_pass;
 	uint32_t current_material_index;

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2284,6 +2284,8 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/quality/reflections/high_quality_ggx.mobile", false);
 	GLOBAL_DEF("rendering/quality/reflections/irradiance_max_size", 128);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/reflections/irradiance_max_size", PropertyInfo(Variant::INT, "rendering/quality/reflections/irradiance_max_size", PROPERTY_HINT_RANGE, "32,2048"));
+	GLOBAL_DEF("rendering/quality/reflections/reflection_probe_min_roughness", 0.05);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/reflections/reflection_probe_min_roughness", PropertyInfo(Variant::REAL, "rendering/quality/reflections/reflection_probe_min_roughness", PROPERTY_HINT_RANGE, "0.0,1.0,0.001"));
 
 	GLOBAL_DEF("rendering/quality/shading/force_vertex_shading", false);
 	GLOBAL_DEF("rendering/quality/shading/force_vertex_shading.mobile", true);


### PR DESCRIPTION
This can be used as a form of antialiasing with very little performance cost.

The default value removes almost all aliasing present in ReflectionProbes while still keeping reflections fairly sharp for real world use cases.

I could only get it working in GLES3, so the feature is limited to GLES3. The default value for the minimum roughness is `0.05` and can be changed at run-time.

This closes https://github.com/godotengine/godot/issues/49789.

## Preview

*Reflective materials have Roughness = 0, Metallic = 1.*

### Before (Min Roughness = 0.0)

![Before](https://user-images.githubusercontent.com/180032/123697450-36ed1f80-d85d-11eb-9cbe-b30bc6363692.png)

### After (Min Roughness = 0.05)

![After](https://user-images.githubusercontent.com/180032/123697452-38b6e300-d85d-11eb-89c2-44c1a5b290de.png)