### PR TITLE
[3.x] Allow reading shaders from `.gdshader` files

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1024,6 +1024,7 @@ ProjectSettings::ProjectSettings() {
 	if (Engine::get_singleton()->has_singleton("GodotSharp")) {
 		extensions.push_back("cs");
 	}
+	extensions.push_back("gdshader");
 	extensions.push_back("shader");
 
 	GLOBAL_DEF("editor/main_run_args", "");

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -528,7 +528,7 @@
 		<member name="editor/script_templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
 			Search path for project-specific script templates. Godot will search for script templates both in the editor-specific path and in this project-specific path.
 		</member>
-		<member name="editor/search_in_file_extensions" type="PoolStringArray" setter="" getter="" default="PoolStringArray( &quot;gd&quot;, &quot;shader&quot; )">
+		<member name="editor/search_in_file_extensions" type="PoolStringArray" setter="" getter="" default="PoolStringArray( &quot;gd&quot;, &quot;gdshader&quot;, &quot;shader&quot; )">
 			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.
 		</member>
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -156,6 +156,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 		extension_guess["glb"] = tree->get_icon("PackedScene", "EditorIcons");
 
 		extension_guess["gdshader"] = tree->get_icon("Shader", "EditorIcons");
+		extension_guess["shader"] = tree->get_icon("Shader", "EditorIcons");
 		extension_guess["gd"] = tree->get_icon("GDScript", "EditorIcons");
 		if (Engine::get_singleton()->has_singleton("GodotSharp")) {
 			extension_guess["cs"] = tree->get_icon("CSharpScript", "EditorIcons");

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2975,7 +2975,7 @@ void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_numb
 	if (ResourceLoader::exists(fpath)) {
 		RES res = ResourceLoader::load(fpath);
 
-		if (fpath.get_extension() == "shader") {
+		if (fpath.get_extension() == "gdshader" || fpath.get_extension() == "shader") {
 			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));
 			shader_editor->edit(res.ptr());
 			shader_editor->make_visible(true);

--- a/misc/dist/linux/org.godotengine.Godot.xml
+++ b/misc/dist/linux/org.godotengine.Godot.xml
@@ -21,6 +21,12 @@
     <glob pattern="*.escn"/>
   </mime-type>
 
+  <mime-type type="application/x-godot-shader">
+    <comment>Godot Engine shader</comment>
+    <icon name="x-godot-shader" />
+    <glob pattern="*.gdshader"/>
+  </mime-type>
+
   <mime-type type="application/x-gdscript">
     <comment>GDScript script</comment>
     <icon name="x-gdscript" />

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -204,6 +204,7 @@ RES ResourceFormatLoaderShader::load(const String &p_path, const String &p_origi
 }
 
 void ResourceFormatLoaderShader::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("gdshader");
 	p_extensions->push_back("shader");
 }
 
@@ -213,7 +214,7 @@ bool ResourceFormatLoaderShader::handles_type(const String &p_type) const {
 
 String ResourceFormatLoaderShader::get_resource_type(const String &p_path) const {
 	String el = p_path.get_extension().to_lower();
-	if (el == "shader") {
+	if (el == "gdshader" || el == "shader") {
 		return "Shader";
 	}
 	return "";
@@ -244,10 +245,12 @@ Error ResourceFormatSaverShader::save(const String &p_path, const RES &p_resourc
 void ResourceFormatSaverShader::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
 	if (const Shader *shader = Object::cast_to<Shader>(*p_resource)) {
 		if (shader->is_text_shader()) {
+			p_extensions->push_back("gdshader");
 			p_extensions->push_back("shader");
 		}
 	}
 }
+
 bool ResourceFormatSaverShader::recognize(const RES &p_resource) const {
 	return p_resource->get_class_name() == "Shader"; //only shader, not inherited
 }


### PR DESCRIPTION
This PR adds support for reading `.gdshader` files, which adds forwards compatibility with #47336.

Shaders seem to be the same between 3.x and the current master (at least the code for simple ones hasn't changed), it's only the file extension that changed. Since only `.gdshader` can be read in 4.0, once that comes out, shader authors will likely use `.gdshader`. If we allow 3.x to read these files, then these shaders can be easily used in 3.x without renaming the files. This will also make it easier for people to future-proof their projects for eventual conversion to Godot 4.0 (at the cost of the shaders not being able to be read in Godot 3.3.2 or lower). But for now I would still recommend users use `.shader` (or `.tres`).

When saving, the default file extension is `.tres` (same as the current 3.x), and both `.shader` and `.gdshader` are options.