### PR TITLE
Fixes crash in case no column in tree is expanded and has minimum size

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3885,8 +3885,11 @@ int Tree::get_column_width(int p_column) const {
 		}
 
 		ERR_FAIL_COND_V(expanding_columns == 0, -1); // shouldn't happen
-
-		return expand_area * get_column_minimum_width(p_column) / expanding_total;
+		if (expanding_total == 0) {
+			return 0;
+		} else {
+			return expand_area * get_column_minimum_width(p_column) / expanding_total;
+		}
 	} else {
 		return get_column_minimum_width(p_column);
 	}


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes https://github.com/godotengine/godot/issues/49988