### PR TITLE
Improve RID_Owner memory usage

### DIFF
--- a/modules/gdnavigation/gd_navigation_server.cpp
+++ b/modules/gdnavigation/gd_navigation_server.cpp
@@ -132,8 +132,8 @@ void GdNavigationServer::add_command(SetCommand *command) const {
 RID GdNavigationServer::map_create() const {
 	GdNavigationServer *mut_this = const_cast<GdNavigationServer *>(this);
 	MutexLock lock(mut_this->operations_mutex);
-	NavMap *space = memnew(NavMap);
-	RID rid = map_owner.make_rid(space);
+	RID rid = map_owner.make_rid();
+	NavMap *space = map_owner.getornull(rid);
 	space->set_self(rid);
 	return rid;
 }
@@ -242,8 +242,8 @@ RID GdNavigationServer::map_get_closest_point_owner(RID p_map, const Vector3 &p_
 RID GdNavigationServer::region_create() const {
 	GdNavigationServer *mut_this = const_cast<GdNavigationServer *>(this);
 	MutexLock lock(mut_this->operations_mutex);
-	NavRegion *reg = memnew(NavRegion);
-	RID rid = region_owner.make_rid(reg);
+	RID rid = region_owner.make_rid();
+	NavRegion *reg = region_owner.getornull(rid);
 	reg->set_self(rid);
 	return rid;
 }
@@ -332,8 +332,8 @@ Vector3 GdNavigationServer::region_get_connection_pathway_end(RID p_region, int 
 RID GdNavigationServer::agent_create() const {
 	GdNavigationServer *mut_this = const_cast<GdNavigationServer *>(this);
 	MutexLock lock(mut_this->operations_mutex);
-	RvoAgent *agent = memnew(RvoAgent());
-	RID rid = agent_owner.make_rid(agent);
+	RID rid = agent_owner.make_rid();
+	RvoAgent *agent = agent_owner.getornull(rid);
 	agent->set_self(rid);
 	return rid;
 }
@@ -472,7 +472,6 @@ COMMAND_1(free, RID, p_object) {
 		active_maps.remove(map_index);
 		active_maps_update_id.remove(map_index);
 		map_owner.free(p_object);
-		memdelete(map);
 
 	} else if (region_owner.owns(p_object)) {
 		NavRegion *region = region_owner.getornull(p_object);
@@ -484,7 +483,6 @@ COMMAND_1(free, RID, p_object) {
 		}
 
 		region_owner.free(p_object);
-		memdelete(region);
 
 	} else if (agent_owner.owns(p_object)) {
 		RvoAgent *agent = agent_owner.getornull(p_object);
@@ -496,7 +494,6 @@ COMMAND_1(free, RID, p_object) {
 		}
 
 		agent_owner.free(p_object);
-		memdelete(agent);
 
 	} else {
 		ERR_FAIL_COND("Invalid ID.");

--- a/modules/gdnavigation/gd_navigation_server.h
+++ b/modules/gdnavigation/gd_navigation_server.h
@@ -75,9 +75,9 @@ class GdNavigationServer : public NavigationServer3D {
 
 	std::vector<SetCommand *> commands;
 
-	mutable RID_PtrOwner<NavMap> map_owner;
-	mutable RID_PtrOwner<NavRegion> region_owner;
-	mutable RID_PtrOwner<RvoAgent> agent_owner;
+	mutable RID_Owner<NavMap> map_owner;
+	mutable RID_Owner<NavRegion> region_owner;
+	mutable RID_Owner<RvoAgent> agent_owner;
 
 	bool active = true;
 	LocalVector<NavMap *> active_maps;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -97,7 +97,7 @@ void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, Transform2
 	}
 }
 
-void _mark_ysort_dirty(RendererCanvasCull::Item *ysort_owner, RID_PtrOwner<RendererCanvasCull::Item, true> &canvas_item_owner) {
+void _mark_ysort_dirty(RendererCanvasCull::Item *ysort_owner, RID_Owner<RendererCanvasCull::Item, true> &canvas_item_owner) {
 	do {
 		ysort_owner->ysort_children_count = -1;
 		ysort_owner = canvas_item_owner.owns(ysort_owner->parent) ? canvas_item_owner.getornull(ysort_owner->parent) : nullptr;
@@ -392,8 +392,7 @@ RID RendererCanvasCull::canvas_allocate() {
 	return canvas_owner.allocate_rid();
 }
 void RendererCanvasCull::canvas_initialize(RID p_rid) {
-	Canvas *canvas = memnew(Canvas);
-	canvas_owner.initialize_rid(p_rid, canvas);
+	canvas_owner.initialize_rid(p_rid);
 }
 
 void RendererCanvasCull::canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring) {
@@ -429,8 +428,7 @@ RID RendererCanvasCull::canvas_item_allocate() {
 	return canvas_item_owner.allocate_rid();
 }
 void RendererCanvasCull::canvas_item_initialize(RID p_rid) {
-	Item *canvas_item = memnew(Item);
-	canvas_item_owner.initialize_rid(p_rid, canvas_item);
+	canvas_item_owner.initialize_rid(p_rid);
 }
 
 void RendererCanvasCull::canvas_item_set_parent(RID p_item, RID p_parent) {
@@ -1171,9 +1169,9 @@ RID RendererCanvasCull::canvas_light_allocate() {
 	return canvas_light_owner.allocate_rid();
 }
 void RendererCanvasCull::canvas_light_initialize(RID p_rid) {
-	RendererCanvasRender::Light *clight = memnew(RendererCanvasRender::Light);
+	canvas_light_owner.initialize_rid(p_rid);
+	RendererCanvasRender::Light *clight = canvas_light_owner.getornull(p_rid);
 	clight->light_internal = RSG::canvas_render->light_create();
-	return canvas_light_owner.initialize_rid(p_rid, clight);
 }
 
 void RendererCanvasCull::canvas_light_set_mode(RID p_light, RS::CanvasLightMode p_mode) {
@@ -1367,9 +1365,7 @@ RID RendererCanvasCull::canvas_light_occluder_allocate() {
 	return canvas_light_occluder_owner.allocate_rid();
 }
 void RendererCanvasCull::canvas_light_occluder_initialize(RID p_rid) {
-	RendererCanvasRender::LightOccluderInstance *occluder = memnew(RendererCanvasRender::LightOccluderInstance);
-
-	return canvas_light_occluder_owner.initialize_rid(p_rid, occluder);
+	return canvas_light_occluder_owner.initialize_rid(p_rid);
 }
 
 void RendererCanvasCull::canvas_light_occluder_attach_to_canvas(RID p_occluder, RID p_canvas) {
@@ -1451,9 +1447,9 @@ RID RendererCanvasCull::canvas_occluder_polygon_allocate() {
 	return canvas_light_occluder_polygon_owner.allocate_rid();
 }
 void RendererCanvasCull::canvas_occluder_polygon_initialize(RID p_rid) {
-	LightOccluderPolygon *occluder_poly = memnew(LightOccluderPolygon);
+	canvas_light_occluder_polygon_owner.initialize_rid(p_rid);
+	LightOccluderPolygon *occluder_poly = canvas_light_occluder_polygon_owner.getornull(p_rid);
 	occluder_poly->occluder = RSG::canvas_render->occluder_polygon_create();
-	return canvas_light_occluder_polygon_owner.initialize_rid(p_rid, occluder_poly);
 }
 
 void RendererCanvasCull::canvas_occluder_polygon_set_shape(RID p_occluder_polygon, const Vector<Vector2> &p_shape, bool p_closed) {
@@ -1596,8 +1592,6 @@ bool RendererCanvasCull::free(RID p_rid) {
 
 		canvas_owner.free(p_rid);
 
-		memdelete(canvas);
-
 	} else if (canvas_item_owner.owns(p_rid)) {
 		Item *canvas_item = canvas_item_owner.getornull(p_rid);
 		ERR_FAIL_COND_V(!canvas_item, true);
@@ -1632,8 +1626,6 @@ bool RendererCanvasCull::free(RID p_rid) {
 
 		canvas_item_owner.free(p_rid);
 
-		memdelete(canvas_item);
-
 	} else if (canvas_light_owner.owns(p_rid)) {
 		RendererCanvasRender::Light *canvas_light = canvas_light_owner.getornull(p_rid);
 		ERR_FAIL_COND_V(!canvas_light, true);
@@ -1648,7 +1640,6 @@ bool RendererCanvasCull::free(RID p_rid) {
 		RSG::canvas_render->free(canvas_light->light_internal);
 
 		canvas_light_owner.free(p_rid);
-		memdelete(canvas_light);
 
 	} else if (canvas_light_occluder_owner.owns(p_rid)) {
 		RendererCanvasRender::LightOccluderInstance *occluder = canvas_light_occluder_owner.getornull(p_rid);
@@ -1667,7 +1658,6 @@ bool RendererCanvasCull::free(RID p_rid) {
 		}
 
 		canvas_light_occluder_owner.free(p_rid);
-		memdelete(occluder);
 
 	} else if (canvas_light_occluder_polygon_owner.owns(p_rid)) {
 		LightOccluderPolygon *occluder_poly = canvas_light_occluder_polygon_owner.getornull(p_rid);
@@ -1680,7 +1670,6 @@ bool RendererCanvasCull::free(RID p_rid) {
 		}
 
 		canvas_light_occluder_polygon_owner.free(p_rid);
-		memdelete(occluder_poly);
 	} else {
 		return false;
 	}

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -116,9 +116,9 @@ public:
 		}
 	};
 
-	RID_PtrOwner<LightOccluderPolygon, true> canvas_light_occluder_polygon_owner;
+	RID_Owner<LightOccluderPolygon, true> canvas_light_occluder_polygon_owner;
 
-	RID_PtrOwner<RendererCanvasRender::LightOccluderInstance, true> canvas_light_occluder_owner;
+	RID_Owner<RendererCanvasRender::LightOccluderInstance, true> canvas_light_occluder_owner;
 
 	struct Canvas : public RendererViewport::CanvasBase {
 		Set<RID> viewports;
@@ -163,9 +163,9 @@ public:
 		}
 	};
 
-	mutable RID_PtrOwner<Canvas, true> canvas_owner;
-	RID_PtrOwner<Item, true> canvas_item_owner;
-	RID_PtrOwner<RendererCanvasRender::Light, true> canvas_light_owner;
+	mutable RID_Owner<Canvas, true> canvas_owner;
+	RID_Owner<Item, true> canvas_item_owner;
+	RID_Owner<RendererCanvasRender::Light, true> canvas_light_owner;
 
 	bool disable_scale;
 	bool sdf_used = false;

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -1234,7 +1234,7 @@ RID RendererStorageRD::canvas_texture_allocate() {
 	return canvas_texture_owner.allocate_rid();
 }
 void RendererStorageRD::canvas_texture_initialize(RID p_rid) {
-	canvas_texture_owner.initialize_rid(p_rid, memnew(CanvasTexture));
+	canvas_texture_owner.initialize_rid(p_rid);
 }
 
 void RendererStorageRD::canvas_texture_set_channel(RID p_canvas_texture, RS::CanvasTextureChannel p_channel, RID p_texture) {
@@ -2934,7 +2934,8 @@ RID RendererStorageRD::mesh_instance_create(RID p_base) {
 	Mesh *mesh = mesh_owner.getornull(p_base);
 	ERR_FAIL_COND_V(!mesh, RID());
 
-	MeshInstance *mi = memnew(MeshInstance);
+	RID rid = mesh_instance_owner.make_rid();
+	MeshInstance *mi = mesh_instance_owner.getornull(rid);
 
 	mi->mesh = mesh;
 
@@ -2946,7 +2947,7 @@ RID RendererStorageRD::mesh_instance_create(RID p_base) {
 
 	mi->dirty = true;
 
-	return mesh_instance_owner.make_rid(mi);
+	return rid;
 }
 void RendererStorageRD::mesh_instance_set_skeleton(RID p_mesh_instance, RID p_skeleton) {
 	MeshInstance *mi = mesh_instance_owner.getornull(p_mesh_instance);
@@ -8657,8 +8658,6 @@ bool RendererStorageRD::free(RID p_rid) {
 		texture_owner.free(p_rid);
 
 	} else if (canvas_texture_owner.owns(p_rid)) {
-		CanvasTexture *ct = canvas_texture_owner.getornull(p_rid);
-		memdelete(ct);
 		canvas_texture_owner.free(p_rid);
 	} else if (shader_owner.owns(p_rid)) {
 		Shader *shader = shader_owner.getornull(p_rid);
@@ -8704,7 +8703,6 @@ bool RendererStorageRD::free(RID p_rid) {
 		mi->I = nullptr;
 
 		mesh_instance_owner.free(p_rid);
-		memdelete(mi);
 
 	} else if (multimesh_owner.owns(p_rid)) {
 		_update_dirty_multimeshes();

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -221,7 +221,7 @@ private:
 		~CanvasTexture();
 	};
 
-	RID_PtrOwner<CanvasTexture, true> canvas_texture_owner;
+	RID_Owner<CanvasTexture, true> canvas_texture_owner;
 
 	/* TEXTURE API */
 	struct Texture {
@@ -513,7 +513,7 @@ private:
 	void _mesh_instance_clear(MeshInstance *mi);
 	void _mesh_instance_add_surface(MeshInstance *mi, Mesh *mesh, uint32_t p_surface);
 
-	mutable RID_PtrOwner<MeshInstance> mesh_instance_owner;
+	mutable RID_Owner<MeshInstance> mesh_instance_owner;
 
 	SelfList<MeshInstance>::List dirty_mesh_instance_weights;
 	SelfList<MeshInstance>::List dirty_mesh_instance_arrays;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -97,7 +97,7 @@ public:
 		}
 	};
 
-	mutable RID_PtrOwner<Camera, true> camera_owner;
+	mutable RID_Owner<Camera, true> camera_owner;
 
 	virtual RID camera_allocate();
 	virtual void camera_initialize(RID p_rid);
@@ -345,7 +345,7 @@ public:
 
 	int indexer_update_iterations = 0;
 
-	mutable RID_PtrOwner<Scenario, true> scenario_owner;
+	mutable RID_Owner<Scenario, true> scenario_owner;
 
 	static void _instance_pair(Instance *p_A, Instance *p_B);
 	static void _instance_unpair(Instance *p_A, Instance *p_B);
@@ -895,7 +895,7 @@ public:
 
 	uint32_t thread_cull_threshold = 200;
 
-	RID_PtrOwner<Instance, true> instance_owner;
+	RID_Owner<Instance, true> instance_owner;
 
 	uint32_t geometry_instance_pair_mask; // used in traditional forward, unnecessary on clustered
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -630,15 +630,14 @@ RID RendererViewport::viewport_allocate() {
 }
 
 void RendererViewport::viewport_initialize(RID p_rid) {
-	Viewport *viewport = memnew(Viewport);
+	viewport_owner.initialize_rid(p_rid);
+	Viewport *viewport = viewport_owner.getornull(p_rid);
 	viewport->self = p_rid;
 	viewport->hide_scenario = false;
 	viewport->hide_canvas = false;
 	viewport->render_target = RSG::storage->render_target_create();
 	viewport->shadow_atlas = RSG::scene->shadow_atlas_create();
 	viewport->viewport_render_direct_to_screen = false;
-
-	viewport_owner.initialize_rid(p_rid, viewport);
 }
 
 void RendererViewport::viewport_set_use_xr(RID p_viewport, bool p_use_xr) {
@@ -1085,7 +1084,6 @@ bool RendererViewport::free(RID p_rid) {
 		}
 
 		viewport_owner.free(p_rid);
-		memdelete(viewport);
 
 		return true;
 	}

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -172,7 +172,7 @@ public:
 
 	uint64_t draw_viewports_pass = 0;
 
-	mutable RID_PtrOwner<Viewport, true> viewport_owner;
+	mutable RID_Owner<Viewport, true> viewport_owner;
 
 	struct ViewportSort {
 		_FORCE_INLINE_ bool operator()(const Viewport *p_left, const Viewport *p_right) const {


### PR DESCRIPTION
* Ability to allocate empty objects in RID_Owner, so RID_PtrOwner is not needed in most cases.
* Improves cache usage, as objects are now allocated together
* Minimum block size in RID_Owner incremented to 64k, so more objects can be packed together by default.
* Should improve performance in 2D rendering