### PR TITLE
[3.x] Improve cursor placement when clicking on text in LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1230,7 +1230,13 @@ void LineEdit::set_cursor_at_pixel_pos(int p_x) {
 		}
 		pixel_ofs += char_w;
 
-		if (pixel_ofs > p_x) { // Found what we look for.
+		if (pixel_ofs > p_x) {
+			// We found what we look for.
+			// If the click was done more than (roughly) halfway through the character, move the cursor to the next character like in TextEdit.
+			if (pixel_ofs - p_x < font->get_char_size(text[ofs]).width * 0.55) {
+				ofs++;
+			}
+
 			break;
 		}
 


### PR DESCRIPTION
This implements behavior similar to TextEdit when clicking on text.

This partially addresses https://github.com/godotengine/godot-proposals/issues/125.

**Testing project (3.x):** [test_lineedit_select_cursor_3.x.zip](https://github.com/godotengine/godot/files/11880447/test_lineedit_select_cursor_3.x.zip)

## Preview

*The topmost LineEdit is scaled to `(2.5, 2.5)`, while other LineEdits are unscaled and use various font sizes. I've also tested this PR with the `2d` stretch mode and non-default window sizes, and it works as expected.*

### Before

https://github.com/godotengine/godot/assets/180032/e6fed6f9-154a-45d1-94b7-d9707a4e8def

### After

https://github.com/godotengine/godot/assets/180032/93540b83-efe7-4160-8392-736e9f8f153b