### PR TITLE
Fix unchecked call to put() warning in GodotInputHandler.java

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/Joystick.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/Joystick.java
@@ -46,7 +46,7 @@ class Joystick {
 	/*
 	 * Keep track of values so we can prevent flooding the engine with useless events.
 	 */
-	protected final SparseArray axesValues = new SparseArray<Float>(4);
+	protected final SparseArray<Float> axesValues = new SparseArray<Float>(4);
 	protected int hatX;
 	protected int hatY;
 }


### PR DESCRIPTION
Currently, when building the Godot Android library, an `unchecked call to put()` warning is generated:
```
platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java|233|warning: [unchecked] unchecked call to put(int,E) as a member of the raw type SparseArray
```
https://github.com/godotengine/godot/blob/bb409efa1cdcf314c3c0ece2a957b750869e4b09/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java#L233

This is due to the `Joystick` class' `axesValues` `SparseArray` not being given a type when it is declared:
https://github.com/godotengine/godot/blob/bb409efa1cdcf314c3c0ece2a957b750869e4b09/platform/android/java/lib/src/org/godotengine/godot/input/Joystick.java#L49

This PR gives the `axesValues` `SparseArray` the `Float` type that its constructor uses.

Note: Introduced in #45771 cc @michael-conrad 
