### PR TITLE
Add Callable.is_valid() analogous to FuncRef.is_valid() from 3.x

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -89,6 +89,10 @@ Callable Callable::unbind(int p_argcount) const {
 	return Callable(memnew(CallableCustomUnbind(*this, p_argcount)));
 }
 
+bool Callable::is_valid() const {
+	return get_object() && (is_custom() || get_object()->has_method(get_method()));
+}
+
 Object *Callable::get_object() const {
 	if (is_null()) {
 		return nullptr;

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -81,6 +81,7 @@ public:
 	_FORCE_INLINE_ bool is_standard() const {
 		return method != StringName();
 	}
+	bool is_valid() const;
 
 	Callable bind(const Variant **p_arguments, int p_argcount) const;
 	Callable unbind(int p_argcount) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1630,6 +1630,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Callable, is_null, sarray(), varray());
 	bind_method(Callable, is_custom, sarray(), varray());
 	bind_method(Callable, is_standard, sarray(), varray());
+	bind_method(Callable, is_valid, sarray(), varray());
 	bind_method(Callable, get_object, sarray(), varray());
 	bind_method(Callable, get_object_id, sarray(), varray());
 	bind_method(Callable, get_method, sarray(), varray());

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -133,6 +133,13 @@
 				Returns [code]true[/code] if this [Callable] is a standard callable, referencing an object and a method using a [StringName].
 			</description>
 		</method>
+		<method name="is_valid" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the object exists and has a valid function assigned, or is a custom callable.
+			</description>
+		</method>
 		<method name="operator !=" qualifiers="operator">
 			<return type="bool">
 			</return>


### PR DESCRIPTION
I was porting GDScript code from 3.x which used `FuncRef.is_valid()` to determine if a function existed in the target object. It occurred to me that no easy way exists to do this with `Callable`.

The logic here is similar to the old FuncRef.is_valid(): it checks if the object is not null and has the method, but we must also consider "custom" callables valid.

For comparison, here is the code of is_valid() from 3.x:
```cpp
bool FuncRef::is_valid() const {
	if (id == 0)
		return false;

	Object *obj = ObjectDB::get_instance(id);
	if (!obj)
		return false;

	return obj->has_method(function);
}
```