### PR TITLE
Android: Add `isGame` application attribute, default to true

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -892,6 +892,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		int xr_mode_index = p_preset->get("xr_features/xr_mode");
 
 		bool backup_allowed = p_preset->get("user_data_backup/allow");
+		bool classify_as_game = p_preset->get("package/classify_as_game");
 
 		Vector<String> perms;
 		// Write permissions into the perms variable.
@@ -987,6 +988,10 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 						if (tname == "application" && attrname == "allowBackup") {
 							encode_uint32(backup_allowed, &p_manifest.write[iofs + 16]);
+						}
+
+						if (tname == "application" && attrname == "isGame") {
+							encode_uint32(classify_as_game, &p_manifest.write[iofs + 16]);
 						}
 
 						if (tname == "instrumentation" && attrname == "targetPackage") {
@@ -1707,6 +1712,7 @@ public:
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/unique_name", PROPERTY_HINT_PLACEHOLDER_TEXT, "ext.domain.name"), "org.godotengine.$genname"));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name [default if blank]"), ""));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/signed"), true));
+		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/classify_as_game"), true));
 
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_icon_option, PROPERTY_HINT_FILE, "*.png"), ""));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_adaptive_icon_foreground_option, PROPERTY_HINT_FILE, "*.png"), ""));

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -252,9 +252,13 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset) {
 	String manifest_application_text = vformat(
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
-			"        android:allowBackup=\"%s\" tools:ignore=\"GoogleAppIndexingWarning\"\n"
-			"        android:icon=\"@mipmap/icon\">\n\n",
-			bool_to_string(p_preset->get("user_data_backup/allow")));
+			"        android:allowBackup=\"%s\"\n"
+			"        android:icon=\"@mipmap/icon\"\n"
+			"        android:isGame=\"%s\"\n"
+			"        tools:replace=\"android:allowBackup,android:isGame\"\n"
+			"        tools:ignore=\"GoogleAppIndexingWarning\">\n\n",
+			bool_to_string(p_preset->get("user_data_backup/allow")),
+			bool_to_string(p_preset->get("package/classify_as_game")));
 
 	manifest_application_text += _get_activity_tag(p_preset);
 	manifest_application_text += "    </application>\n";

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -19,8 +19,9 @@
     <application
         android:label="@string/godot_project_name_string"
         android:allowBackup="false"
-        tools:ignore="GoogleAppIndexingWarning"
-        android:icon="@mipmap/icon" >
+        android:icon="@mipmap/icon"
+        android:isGame="true"
+        tools:ignore="GoogleAppIndexingWarning" >
 
         <!-- Records the version of the Godot editor used for building -->
         <meta-data


### PR DESCRIPTION
It can be turned off in the export preset with `package/classify_as_game`.

Upstream definition: https://developer.android.com/guide/topics/manifest/application-element#isGame

> `android:isGame`
>
> Whether or not the application is a game. The system may group together
> applications classifed as games or display them separately from other
> applications.

---

Supersedes #48547.

`needs testing` as I haven't tested this code yet, just wrote it by analogy with the `allowBackup` attribute.