### PR TITLE
Add right-to-left layout support for `EditorSpinSlider`.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1182,15 +1182,19 @@ void EditorInspectorSection::_notification(int p_what) {
 
 		Size2 size = get_size();
 		Point2 offset;
+		Rect2 rect;
 		offset.y = font->get_height(font_size);
 		if (arrow.is_valid()) {
 			offset.y = MAX(offset.y, arrow->get_height());
 		}
 
 		offset.y += get_theme_constant("vseparation", "Tree");
-		offset.x += get_theme_constant("inspector_margin", "Editor");
-
-		Rect2 rect(offset, size - offset);
+		if (is_layout_rtl()) {
+			rect = Rect2(offset, size - offset - Vector2(get_theme_constant("inspector_margin", "Editor"), 0));
+		} else {
+			offset.x += get_theme_constant("inspector_margin", "Editor");
+			rect = Rect2(offset, size - offset);
+		}
 
 		//set children
 		for (int i = 0; i < get_child_count(); i++) {


### PR DESCRIPTION
Add RTL layout support for `EditorSpinSlider`.
Property suffix is separated by thin space (one-fifth of an em).
Fix editor inspector margin for RTL layout.

<img width="339" alt="Screenshot_LTR" src="https://user-images.githubusercontent.com/7645683/124020812-764d7480-d9f3-11eb-9b81-7f6d6165d5ad.png">
<img width="339" alt="Screenshot_RTL" src="https://user-images.githubusercontent.com/7645683/124020815-76e60b00-d9f3-11eb-8a47-5371d84aae81.png">

*Note: Localized suffixes are not implemented, one on the screenshot was hard-coded for testing only.*