### PR TITLE
Import mesh colors in 8BPC

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -565,11 +565,11 @@ void Sprite3D::_draw() {
 		v_tangent = value;
 	}
 
-	uint16_t v_color[4] = {
-		Math::make_half_float(color.r),
-		Math::make_half_float(color.g),
-		Math::make_half_float(color.b),
-		Math::make_half_float(color.a),
+	uint8_t v_color[4] = {
+		uint8_t(CLAMP(color.r * 255.0, 0.0, 255.0)),
+		uint8_t(CLAMP(color.g * 255.0, 0.0, 255.0)),
+		uint8_t(CLAMP(color.b * 255.0, 0.0, 255.0)),
+		uint8_t(CLAMP(color.a * 255.0, 0.0, 255.0))
 	};
 
 	for (int i = 0; i < 4; i++) {
@@ -591,7 +591,7 @@ void Sprite3D::_draw() {
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_NORMAL]], &v_normal, 4);
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_TANGENT]], &v_tangent, 4);
-		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_COLOR]], v_color, 8);
+		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_COLOR]], v_color, 4);
 	}
 
 	RID mesh = get_mesh();
@@ -931,11 +931,11 @@ void AnimatedSprite3D::_draw() {
 		v_tangent = value;
 	}
 
-	uint16_t v_color[4] = {
-		Math::make_half_float(color.r),
-		Math::make_half_float(color.g),
-		Math::make_half_float(color.b),
-		Math::make_half_float(color.a),
+	uint8_t v_color[4] = {
+		uint8_t(CLAMP(color.r * 255.0, 0.0, 255.0)),
+		uint8_t(CLAMP(color.g * 255.0, 0.0, 255.0)),
+		uint8_t(CLAMP(color.b * 255.0, 0.0, 255.0)),
+		uint8_t(CLAMP(color.a * 255.0, 0.0, 255.0))
 	};
 
 	for (int i = 0; i < 4; i++) {
@@ -956,7 +956,7 @@ void AnimatedSprite3D::_draw() {
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_NORMAL]], &v_normal, 4);
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_TANGENT]], &v_tangent, 4);
-		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_COLOR]], v_color, 8);
+		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_COLOR]], v_color, 4);
 	}
 
 	RID mesh = get_mesh();

--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -223,7 +223,7 @@ void ImmediateMesh::surface_end() {
 
 		if (uses_colors) {
 			format |= ARRAY_FORMAT_COLOR;
-			attribute_stride += sizeof(uint16_t) * 4;
+			attribute_stride += sizeof(uint8_t) * 4;
 		}
 		uint32_t uv_offset = 0;
 		if (uses_uvs) {
@@ -244,25 +244,25 @@ void ImmediateMesh::surface_end() {
 
 		for (uint32_t i = 0; i < vertices.size(); i++) {
 			if (uses_colors) {
-				uint16_t *color16 = (uint16_t *)&surface_attribute_ptr[i * attribute_stride];
+				uint8_t *color8 = (uint8_t *)&surface_attribute_ptr[i * attribute_stride];
 
-				color16[0] = Math::make_half_float(colors[i].r);
-				color16[1] = Math::make_half_float(colors[i].g);
-				color16[2] = Math::make_half_float(colors[i].b);
-				color16[3] = Math::make_half_float(colors[i].a);
+				color8[0] = uint8_t(CLAMP(colors[i].r * 255.0, 0.0, 255.0));
+				color8[1] = uint8_t(CLAMP(colors[i].g * 255.0, 0.0, 255.0));
+				color8[2] = uint8_t(CLAMP(colors[i].b * 255.0, 0.0, 255.0));
+				color8[3] = uint8_t(CLAMP(colors[i].a * 255.0, 0.0, 255.0));
 			}
 			if (uses_uvs) {
 				float *uv = (float *)&surface_attribute_ptr[i * attribute_stride + uv_offset];
 
 				uv[0] = uvs[i].x;
-				uv[0] = uvs[i].y;
+				uv[1] = uvs[i].y;
 			}
 
 			if (uses_uv2s) {
 				float *uv2 = (float *)&surface_attribute_ptr[i * attribute_stride + uv2_offset];
 
 				uv2[0] = uv2s[i].x;
-				uv2[0] = uv2s[i].y;
+				uv2[1] = uv2s[i].y;
 			}
 		}
 	}

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -3258,8 +3258,8 @@ void RendererStorageRD::_mesh_surface_generate_version_for_input_mask(Mesh::Surf
 				case RS::ARRAY_COLOR: {
 					vd.offset = attribute_stride;
 
-					vd.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
-					attribute_stride += sizeof(int16_t) * 4;
+					vd.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+					attribute_stride += sizeof(int8_t) * 4;
 					buffer = s->attribute_buffer;
 				} break;
 				case RS::ARRAY_TEX_UV: {


### PR DESCRIPTION
* Colors were imported as 16BPC (half float)
* Far most common use cases only require 8BPC, so currently this is wasteful.
* If you need higher data precision, use a custom array, which are supported now.

**WARNING**: 3D Scenes imported in 4.0 **are no longer compatible** with this new format. You **need to re-import them** (erase them from `res://.godot/import`)