### PR TITLE
Clean up RenderingServer and its bindings

### DIFF
--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -61,10 +61,8 @@
 			</return>
 			<argument index="0" name="image" type="Image">
 			</argument>
-			<argument index="1" name="immediate" type="bool" default="false">
-			</argument>
 			<description>
-				Replaces the texture's data with a new [Image]. If [code]immediate[/code] is [code]true[/code], it will take effect immediately after the call.
+				Replaces the texture's data with a new [Image].
 				[b]Note:[/b] The texture has to be initialized first with the [method create_from_image] method before it can be updated. The new image dimensions, format, and mipmaps configuration should match the existing texture's image configuration, otherwise it has to be re-created with the [method create_from_image] method.
 				Use this method over [method create_from_image] if you need to update the texture frequently, which is faster than allocating additional memory for a new texture each time.
 			</description>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -18,34 +18,16 @@
 		<link title="Optimization using Servers">https://docs.godotengine.org/en/latest/tutorials/optimization/using_servers.html</link>
 	</tutorials>
 	<methods>
-		<method name="black_bars_set_images">
-			<return type="void">
+		<method name="bake_render_uv2">
+			<return type="Image[]">
 			</return>
-			<argument index="0" name="left" type="RID">
+			<argument index="0" name="base" type="RID">
 			</argument>
-			<argument index="1" name="top" type="RID">
+			<argument index="1" name="material_overrides" type="Array">
 			</argument>
-			<argument index="2" name="right" type="RID">
-			</argument>
-			<argument index="3" name="bottom" type="RID">
+			<argument index="2" name="image_size" type="Vector2i">
 			</argument>
 			<description>
-				Sets images to be rendered in the window margin.
-			</description>
-		</method>
-		<method name="black_bars_set_margins">
-			<return type="void">
-			</return>
-			<argument index="0" name="left" type="int">
-			</argument>
-			<argument index="1" name="top" type="int">
-			</argument>
-			<argument index="2" name="right" type="int">
-			</argument>
-			<argument index="3" name="bottom" type="int">
-			</argument>
-			<description>
-				Sets margin size, where black bars (or images, if [method black_bars_set_images] was used) are rendered.
 			</description>
 		</method>
 		<method name="camera_create">
@@ -54,6 +36,74 @@
 			<description>
 				Creates a camera and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]camera_*[/code] RenderingServer functions.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
+			</description>
+		</method>
+		<method name="camera_effects_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="camera_effects_set_custom_exposure">
+			<return type="void">
+			</return>
+			<argument index="0" name="camera_effects" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<argument index="2" name="exposure" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="camera_effects_set_dof_blur">
+			<return type="void">
+			</return>
+			<argument index="0" name="camera_effects" type="RID">
+			</argument>
+			<argument index="1" name="far_enable" type="bool">
+			</argument>
+			<argument index="2" name="far_distance" type="float">
+			</argument>
+			<argument index="3" name="far_transition" type="float">
+			</argument>
+			<argument index="4" name="near_enable" type="bool">
+			</argument>
+			<argument index="5" name="near_distance" type="float">
+			</argument>
+			<argument index="6" name="near_transition" type="float">
+			</argument>
+			<argument index="7" name="amount" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="camera_effects_set_dof_blur_bokeh_shape">
+			<return type="void">
+			</return>
+			<argument index="0" name="shape" type="int" enum="RenderingServer.DOFBokehShape">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="camera_effects_set_dof_blur_quality">
+			<return type="void">
+			</return>
+			<argument index="0" name="quality" type="int" enum="RenderingServer.DOFBlurQuality">
+			</argument>
+			<argument index="1" name="use_jitter" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="camera_set_camera_effects">
+			<return type="void">
+			</return>
+			<argument index="0" name="camera" type="RID">
+			</argument>
+			<argument index="1" name="effects" type="RID">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="camera_set_cull_mask">
@@ -155,6 +205,246 @@
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
 			</description>
 		</method>
+		<method name="canvas_item_add_circle">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="pos" type="Vector2">
+			</argument>
+			<argument index="2" name="radius" type="float">
+			</argument>
+			<argument index="3" name="color" type="Color">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_clip_ignore">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="ignore" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_line">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="from" type="Vector2">
+			</argument>
+			<argument index="2" name="to" type="Vector2">
+			</argument>
+			<argument index="3" name="color" type="Color">
+			</argument>
+			<argument index="4" name="width" type="float" default="1.0">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_mesh">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="mesh" type="RID">
+			</argument>
+			<argument index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)">
+			</argument>
+			<argument index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
+			</argument>
+			<argument index="4" name="texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_multimesh">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="mesh" type="RID">
+			</argument>
+			<argument index="2" name="texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_nine_patch">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="rect" type="Rect2">
+			</argument>
+			<argument index="2" name="source" type="Rect2">
+			</argument>
+			<argument index="3" name="texture" type="RID">
+			</argument>
+			<argument index="4" name="topleft" type="Vector2">
+			</argument>
+			<argument index="5" name="bottomright" type="Vector2">
+			</argument>
+			<argument index="6" name="x_axis_mode" type="int" enum="RenderingServer.NinePatchAxisMode" default="0">
+			</argument>
+			<argument index="7" name="y_axis_mode" type="int" enum="RenderingServer.NinePatchAxisMode" default="0">
+			</argument>
+			<argument index="8" name="draw_center" type="bool" default="true">
+			</argument>
+			<argument index="9" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_particles">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="particles" type="RID">
+			</argument>
+			<argument index="2" name="texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_polygon">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="points" type="PackedVector2Array">
+			</argument>
+			<argument index="2" name="colors" type="PackedColorArray">
+			</argument>
+			<argument index="3" name="uvs" type="PackedVector2Array" default="PackedVector2Array()">
+			</argument>
+			<argument index="4" name="texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_polyline">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="points" type="PackedVector2Array">
+			</argument>
+			<argument index="2" name="colors" type="PackedColorArray">
+			</argument>
+			<argument index="3" name="width" type="float" default="1.0">
+			</argument>
+			<argument index="4" name="antialiased" type="bool" default="false">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_primitive">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="points" type="PackedVector2Array">
+			</argument>
+			<argument index="2" name="colors" type="PackedColorArray">
+			</argument>
+			<argument index="3" name="uvs" type="PackedVector2Array">
+			</argument>
+			<argument index="4" name="texture" type="RID">
+			</argument>
+			<argument index="5" name="width" type="float" default="1.0">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_rect">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="rect" type="Rect2">
+			</argument>
+			<argument index="2" name="color" type="Color">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_set_transform">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="transform" type="Transform2D">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_texture_rect">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="rect" type="Rect2">
+			</argument>
+			<argument index="2" name="texture" type="RID">
+			</argument>
+			<argument index="3" name="tile" type="bool" default="false">
+			</argument>
+			<argument index="4" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
+			</argument>
+			<argument index="5" name="transpose" type="bool" default="false">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_texture_rect_region">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="rect" type="Rect2">
+			</argument>
+			<argument index="2" name="texture" type="RID">
+			</argument>
+			<argument index="3" name="src_rect" type="Rect2">
+			</argument>
+			<argument index="4" name="modulate" type="Color" default="Color(1, 1, 1, 1)">
+			</argument>
+			<argument index="5" name="transpose" type="bool" default="false">
+			</argument>
+			<argument index="6" name="clip_uv" type="bool" default="true">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_add_triangle_array">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="indices" type="PackedInt32Array">
+			</argument>
+			<argument index="2" name="points" type="PackedVector2Array">
+			</argument>
+			<argument index="3" name="colors" type="PackedColorArray">
+			</argument>
+			<argument index="4" name="uvs" type="PackedVector2Array" default="PackedVector2Array()">
+			</argument>
+			<argument index="5" name="bones" type="PackedInt32Array" default="PackedInt32Array()">
+			</argument>
+			<argument index="6" name="weights" type="PackedFloat32Array" default="PackedFloat32Array()">
+			</argument>
+			<argument index="7" name="texture" type="RID">
+			</argument>
+			<argument index="8" name="count" type="int" default="-1">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="canvas_item_clear">
 			<return type="void">
 			</return>
@@ -162,6 +452,40 @@
 			</argument>
 			<description>
 				Clears the [CanvasItem] and removes all commands in it.
+			</description>
+		</method>
+		<method name="canvas_item_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_canvas_group_mode">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="mode" type="int" enum="RenderingServer.CanvasGroupMode">
+			</argument>
+			<argument index="2" name="clear_margin" type="float" default="5.0">
+			</argument>
+			<argument index="3" name="fit_empty" type="bool" default="false">
+			</argument>
+			<argument index="4" name="fit_margin" type="float" default="0.0">
+			</argument>
+			<argument index="5" name="blur_mipmaps" type="bool" default="false">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_clip">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="clip" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="canvas_item_set_copy_to_backbuffer">
@@ -177,6 +501,58 @@
 				Sets the [CanvasItem] to copy a rect to the backbuffer.
 			</description>
 		</method>
+		<method name="canvas_item_set_custom_rect">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="use_custom_rect" type="bool">
+			</argument>
+			<argument index="2" name="rect" type="Rect2" default="Rect2(0, 0, 0, 0)">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_default_texture_filter">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="filter" type="int" enum="RenderingServer.CanvasItemTextureFilter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_default_texture_repeat">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="repeat" type="int" enum="RenderingServer.CanvasItemTextureRepeat">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_distance_field_mode">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_draw_behind_parent">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="canvas_item_set_draw_index">
 			<return type="void">
 			</return>
@@ -186,6 +562,16 @@
 			</argument>
 			<description>
 				Sets the index for the [CanvasItem].
+			</description>
+		</method>
+		<method name="canvas_item_set_light_mask">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="mask" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="canvas_item_set_material">
@@ -199,6 +585,56 @@
 				Sets a new material to the [CanvasItem].
 			</description>
 		</method>
+		<method name="canvas_item_set_modulate">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="color" type="Color">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_parent">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="parent" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_self_modulate">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="color" type="Color">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_sort_children_by_y">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_transform">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="transform" type="Transform2D">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="canvas_item_set_use_parent_material">
 			<return type="void">
 			</return>
@@ -208,6 +644,32 @@
 			</argument>
 			<description>
 				Sets if the [CanvasItem] uses its parent's material.
+			</description>
+		</method>
+		<method name="canvas_item_set_visibility_notifier">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<argument index="2" name="area" type="Rect2">
+			</argument>
+			<argument index="3" name="enter_callable" type="Callable">
+			</argument>
+			<argument index="4" name="exit_callable" type="Callable">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_visible">
+			<return type="void">
+			</return>
+			<argument index="0" name="item" type="RID">
+			</argument>
+			<argument index="1" name="visible" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="canvas_item_set_z_as_relative_to_parent">
@@ -268,6 +730,16 @@
 			<description>
 				Creates a light occluder and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]canvas_light_ocluder_*[/code] RenderingServer functions.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
+			</description>
+		</method>
+		<method name="canvas_light_occluder_set_as_sdf_collision">
+			<return type="void">
+			</return>
+			<argument index="0" name="occluder" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="canvas_light_occluder_set_enabled">
@@ -537,6 +1009,14 @@
 				Sets the shape of the occluder polygon.
 			</description>
 		</method>
+		<method name="canvas_set_disable_scale">
+			<return type="void">
+			</return>
+			<argument index="0" name="disable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="canvas_set_item_mirroring">
 			<return type="void">
 			</return>
@@ -561,9 +1041,171 @@
 				Modulates all colors in the given canvas.
 			</description>
 		</method>
+		<method name="canvas_set_shadow_texture_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="size" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_texture_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_texture_set_channel">
+			<return type="void">
+			</return>
+			<argument index="0" name="canvas_texture" type="RID">
+			</argument>
+			<argument index="1" name="channel" type="int" enum="RenderingServer.CanvasTextureChannel">
+			</argument>
+			<argument index="2" name="texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_texture_set_shading_parameters">
+			<return type="void">
+			</return>
+			<argument index="0" name="canvas_texture" type="RID">
+			</argument>
+			<argument index="1" name="base_color" type="Color">
+			</argument>
+			<argument index="2" name="shininess" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_texture_set_texture_filter">
+			<return type="void">
+			</return>
+			<argument index="0" name="canvas_texture" type="RID">
+			</argument>
+			<argument index="1" name="filter" type="int" enum="RenderingServer.CanvasItemTextureFilter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="canvas_texture_set_texture_repeat">
+			<return type="void">
+			</return>
+			<argument index="0" name="canvas_texture" type="RID">
+			</argument>
+			<argument index="1" name="repeat" type="int" enum="RenderingServer.CanvasItemTextureRepeat">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="create_local_rendering_device" qualifiers="const">
 			<return type="RenderingDevice">
 			</return>
+			<description>
+			</description>
+		</method>
+		<method name="decal_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="decal_set_albedo_mix">
+			<return type="void">
+			</return>
+			<argument index="0" name="decal" type="RID">
+			</argument>
+			<argument index="1" name="albedo_mix" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="decal_set_cull_mask">
+			<return type="void">
+			</return>
+			<argument index="0" name="decal" type="RID">
+			</argument>
+			<argument index="1" name="mask" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="decal_set_distance_fade">
+			<return type="void">
+			</return>
+			<argument index="0" name="decal" type="RID">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<argument index="2" name="begin" type="float">
+			</argument>
+			<argument index="3" name="length" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="decal_set_emission_energy">
+			<return type="void">
+			</return>
+			<argument index="0" name="decal" type="RID">
+			</argument>
+			<argument index="1" name="energy" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="decal_set_extents">
+			<return type="void">
+			</return>
+			<argument index="0" name="decal" type="RID">
+			</argument>
+			<argument index="1" name="extents" type="Vector3">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="decal_set_fade">
+			<return type="void">
+			</return>
+			<argument index="0" name="decal" type="RID">
+			</argument>
+			<argument index="1" name="above" type="float">
+			</argument>
+			<argument index="2" name="below" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="decal_set_modulate">
+			<return type="void">
+			</return>
+			<argument index="0" name="decal" type="RID">
+			</argument>
+			<argument index="1" name="color" type="Color">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="decal_set_normal_fade">
+			<return type="void">
+			</return>
+			<argument index="0" name="decal" type="RID">
+			</argument>
+			<argument index="1" name="fade" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="decal_set_texture">
+			<return type="void">
+			</return>
+			<argument index="0" name="decal" type="RID">
+			</argument>
+			<argument index="1" name="type" type="int" enum="RenderingServer.DecalTexture">
+			</argument>
+			<argument index="2" name="texture" type="RID">
+			</argument>
 			<description>
 			</description>
 		</method>
@@ -576,12 +1218,58 @@
 				To place in a scene, attach this directional light to an instance using [method instance_set_base] using the returned RID.
 			</description>
 		</method>
+		<method name="directional_shadow_atlas_set_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="size" type="int">
+			</argument>
+			<argument index="1" name="is_16bits" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="directional_shadow_quality_set">
+			<return type="void">
+			</return>
+			<argument index="0" name="quality" type="int" enum="RenderingServer.ShadowQuality">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="environment_bake_panorama">
+			<return type="Image">
+			</return>
+			<argument index="0" name="environment" type="RID">
+			</argument>
+			<argument index="1" name="bake_irradiance" type="bool">
+			</argument>
+			<argument index="2" name="size" type="Vector2i">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="environment_create">
 			<return type="RID">
 			</return>
 			<description>
 				Creates an environment and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]environment_*[/code] RenderingServer functions.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
+			</description>
+		</method>
+		<method name="environment_glow_set_use_bicubic_upscale">
+			<return type="void">
+			</return>
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="environment_glow_set_use_high_quality">
+			<return type="void">
+			</return>
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="environment_set_adjustment">
@@ -721,6 +1409,58 @@
 			<description>
 			</description>
 		</method>
+		<method name="environment_set_sdfgi">
+			<return type="void">
+			</return>
+			<argument index="0" name="env" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<argument index="2" name="cascades" type="int" enum="RenderingServer.EnvironmentSDFGICascades">
+			</argument>
+			<argument index="3" name="min_cell_size" type="float">
+			</argument>
+			<argument index="4" name="y_scale" type="int" enum="RenderingServer.EnvironmentSDFGIYScale">
+			</argument>
+			<argument index="5" name="use_occlusion" type="bool">
+			</argument>
+			<argument index="6" name="bounce_feedback" type="float">
+			</argument>
+			<argument index="7" name="read_sky" type="bool">
+			</argument>
+			<argument index="8" name="energy" type="float">
+			</argument>
+			<argument index="9" name="normal_bias" type="float">
+			</argument>
+			<argument index="10" name="probe_bias" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="environment_set_sdfgi_frames_to_converge">
+			<return type="void">
+			</return>
+			<argument index="0" name="frames" type="int" enum="RenderingServer.EnvironmentSDFGIFramesToConverge">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="environment_set_sdfgi_frames_to_update_light">
+			<return type="void">
+			</return>
+			<argument index="0" name="frames" type="int" enum="RenderingServer.EnvironmentSDFGIFramesToUpdateLight">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="environment_set_sdfgi_ray_count">
+			<return type="void">
+			</return>
+			<argument index="0" name="ray_count" type="int" enum="RenderingServer.EnvironmentSDFGIRayCount">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="environment_set_sky">
 			<return type="void">
 			</return>
@@ -781,6 +1521,24 @@
 				Sets the variables to be used with the "screen space ambient occlusion" post-process effect. See [Environment] for more details.
 			</description>
 		</method>
+		<method name="environment_set_ssao_quality">
+			<return type="void">
+			</return>
+			<argument index="0" name="quality" type="int" enum="RenderingServer.EnvironmentSSAOQuality">
+			</argument>
+			<argument index="1" name="half_size" type="bool">
+			</argument>
+			<argument index="2" name="adaptive_target" type="float">
+			</argument>
+			<argument index="3" name="blur_passes" type="int">
+			</argument>
+			<argument index="4" name="fadeout_from" type="float">
+			</argument>
+			<argument index="5" name="fadeout_to" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="environment_set_ssr">
 			<return type="void">
 			</return>
@@ -798,6 +1556,14 @@
 			</argument>
 			<description>
 				Sets the variables to be used with the "screen space reflections" post-process effect. See [Environment] for more details.
+			</description>
+		</method>
+		<method name="environment_set_ssr_roughness_quality">
+			<return type="void">
+			</return>
+			<argument index="0" name="quality" type="int" enum="RenderingServer.EnvironmentSSRRoughnessQuality">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="environment_set_tonemap">
@@ -825,11 +1591,48 @@
 				Sets the variables to be used with the "tonemap" post-process effect. See [Environment] for more details.
 			</description>
 		</method>
-		<method name="finish">
+		<method name="environment_set_volumetric_fog">
 			<return type="void">
 			</return>
+			<argument index="0" name="env" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<argument index="2" name="density" type="float">
+			</argument>
+			<argument index="3" name="light" type="Color">
+			</argument>
+			<argument index="4" name="light_energy" type="float">
+			</argument>
+			<argument index="5" name="length" type="float">
+			</argument>
+			<argument index="6" name="p_detail_spread" type="float">
+			</argument>
+			<argument index="7" name="gi_inject" type="float">
+			</argument>
+			<argument index="8" name="temporal_reprojection" type="bool">
+			</argument>
+			<argument index="9" name="temporal_reprojection_amount" type="float">
+			</argument>
 			<description>
-				Removes buffers and clears testcubes.
+			</description>
+		</method>
+		<method name="environment_set_volumetric_fog_filter_active">
+			<return type="void">
+			</return>
+			<argument index="0" name="active" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="environment_set_volumetric_fog_volume_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="size" type="int">
+			</argument>
+			<argument index="1" name="depth" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="force_draw">
@@ -840,14 +1643,12 @@
 			<argument index="1" name="frame_step" type="float" default="0.0">
 			</argument>
 			<description>
-				Forces a frame to be drawn when the function is called. Drawing a frame updates all [Viewport]s that are set to update. Use with extreme caution.
 			</description>
 		</method>
 		<method name="force_sync">
 			<return type="void">
 			</return>
 			<description>
-				Synchronizes threads.
 			</description>
 		</method>
 		<method name="free_rid">
@@ -963,6 +1764,16 @@
 			<description>
 			</description>
 		</method>
+		<method name="global_variable_set_override">
+			<return type="void">
+			</return>
+			<argument index="0" name="name" type="StringName">
+			</argument>
+			<argument index="1" name="value" type="Variant">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="has_changed" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -986,13 +1797,6 @@
 			</argument>
 			<description>
 				Returns [code]true[/code] if the OS supports a certain feature. Features might be [code]s3tc[/code], [code]etc[/code], [code]etc2[/code] and [code]pvrtc[/code].
-			</description>
-		</method>
-		<method name="init">
-			<return type="void">
-			</return>
-			<description>
-				Initializes the rendering server. This function is called internally by platform-dependent code during engine initialization. If called from a running game, it will not do anything.
 			</description>
 		</method>
 		<method name="instance_attach_object_instance_id">
@@ -1038,6 +1842,34 @@
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
 			</description>
 		</method>
+		<method name="instance_geometry_get_shader_parameter" qualifiers="const">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="instance" type="RID">
+			</argument>
+			<argument index="1" name="parameter" type="StringName">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="instance_geometry_get_shader_parameter_default_value" qualifiers="const">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="instance" type="RID">
+			</argument>
+			<argument index="1" name="parameter" type="StringName">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="instance_geometry_get_shader_parameter_list" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="instance" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="instance_geometry_set_cast_shadows_setting">
 			<return type="void">
 			</return>
@@ -1062,6 +1894,30 @@
 				Sets the flag for a given [enum InstanceFlags]. See [enum InstanceFlags] for more details.
 			</description>
 		</method>
+		<method name="instance_geometry_set_lightmap">
+			<return type="void">
+			</return>
+			<argument index="0" name="instance" type="RID">
+			</argument>
+			<argument index="1" name="lightmap" type="RID">
+			</argument>
+			<argument index="2" name="lightmap_uv_scale" type="Rect2">
+			</argument>
+			<argument index="3" name="lightmap_slice" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="instance_geometry_set_lod_bias">
+			<return type="void">
+			</return>
+			<argument index="0" name="instance" type="RID">
+			</argument>
+			<argument index="1" name="lod_bias" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="instance_geometry_set_material_override">
 			<return type="void">
 			</return>
@@ -1071,6 +1927,18 @@
 			</argument>
 			<description>
 				Sets a material that will override the material for all surfaces on the mesh associated with this instance. Equivalent to [member GeometryInstance3D.material_override].
+			</description>
+		</method>
+		<method name="instance_geometry_set_shader_parameter">
+			<return type="void">
+			</return>
+			<argument index="0" name="instance" type="RID">
+			</argument>
+			<argument index="1" name="parameter" type="StringName">
+			</argument>
+			<argument index="2" name="value" type="Variant">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="instance_geometry_set_visibility_range">
@@ -1123,17 +1991,6 @@
 			</argument>
 			<description>
 				Sets a custom AABB to use when culling objects from the view frustum. Equivalent to [method GeometryInstance3D.set_custom_aabb].
-			</description>
-		</method>
-		<method name="instance_set_exterior">
-			<return type="void">
-			</return>
-			<argument index="0" name="instance" type="RID">
-			</argument>
-			<argument index="1" name="enabled" type="bool">
-			</argument>
-			<description>
-				Function not implemented in Godot 3.x.
 			</description>
 		</method>
 		<method name="instance_set_extra_visibility_margin">
@@ -1340,6 +2197,16 @@
 				Sets the cull mask for this Light3D. Lights only affect objects in the selected layers. Equivalent to [member Light3D.light_cull_mask].
 			</description>
 		</method>
+		<method name="light_set_max_sdfgi_cascade">
+			<return type="void">
+			</return>
+			<argument index="0" name="light" type="RID">
+			</argument>
+			<argument index="1" name="cascade" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="light_set_negative">
 			<return type="void">
 			</return>
@@ -1406,6 +2273,100 @@
 			</argument>
 			<description>
 				Sets the color of the shadow cast by the light. Equivalent to [member Light3D.shadow_color].
+			</description>
+		</method>
+		<method name="lightmap_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="lightmap_get_probe_capture_bsp_tree" qualifiers="const">
+			<return type="PackedInt32Array">
+			</return>
+			<argument index="0" name="lightmap" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="lightmap_get_probe_capture_points" qualifiers="const">
+			<return type="PackedVector3Array">
+			</return>
+			<argument index="0" name="lightmap" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="lightmap_get_probe_capture_sh" qualifiers="const">
+			<return type="PackedColorArray">
+			</return>
+			<argument index="0" name="lightmap" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="lightmap_get_probe_capture_tetrahedra" qualifiers="const">
+			<return type="PackedInt32Array">
+			</return>
+			<argument index="0" name="lightmap" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="lightmap_set_probe_bounds">
+			<return type="void">
+			</return>
+			<argument index="0" name="lightmap" type="RID">
+			</argument>
+			<argument index="1" name="bounds" type="AABB">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="lightmap_set_probe_capture_data">
+			<return type="void">
+			</return>
+			<argument index="0" name="lightmap" type="RID">
+			</argument>
+			<argument index="1" name="points" type="PackedVector3Array">
+			</argument>
+			<argument index="2" name="point_sh" type="PackedColorArray">
+			</argument>
+			<argument index="3" name="tetrahedra" type="PackedInt32Array">
+			</argument>
+			<argument index="4" name="bsp_tree" type="PackedInt32Array">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="lightmap_set_probe_capture_update_speed">
+			<return type="void">
+			</return>
+			<argument index="0" name="speed" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="lightmap_set_probe_interior">
+			<return type="void">
+			</return>
+			<argument index="0" name="lightmap" type="RID">
+			</argument>
+			<argument index="1" name="interior" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="lightmap_set_textures">
+			<return type="void">
+			</return>
+			<argument index="0" name="lightmap" type="RID">
+			</argument>
+			<argument index="1" name="light" type="RID">
+			</argument>
+			<argument index="2" name="uses_sh" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="make_sphere_mesh">
@@ -1486,6 +2447,35 @@
 				Sets a shader material's shader.
 			</description>
 		</method>
+		<method name="mesh_add_surface">
+			<return type="void">
+			</return>
+			<argument index="0" name="mesh" type="RID">
+			</argument>
+			<argument index="1" name="surface" type="Dictionary">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="mesh_add_surface_from_arrays">
+			<return type="void">
+			</return>
+			<argument index="0" name="mesh" type="RID">
+			</argument>
+			<argument index="1" name="primitive" type="int" enum="RenderingServer.PrimitiveType">
+			</argument>
+			<argument index="2" name="arrays" type="Array">
+			</argument>
+			<argument index="3" name="blend_shapes" type="Array" default="[]">
+			</argument>
+			<argument index="4" name="lods" type="Dictionary" default="{
+}">
+			</argument>
+			<argument index="5" name="compress_format" type="int" default="0">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="mesh_clear">
 			<return type="void">
 			</return>
@@ -1502,6 +2492,16 @@
 				Creates a new mesh and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]mesh_*[/code] RenderingServer functions.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
 				To place in a scene, attach this mesh to an instance using [method instance_set_base] using the returned RID.
+			</description>
+		</method>
+		<method name="mesh_create_from_surfaces">
+			<return type="RID">
+			</return>
+			<argument index="0" name="surfaces" type="Dictionary[]">
+			</argument>
+			<argument index="1" name="blend_shape_count" type="int" default="0">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="mesh_get_blend_shape_count" qualifiers="const">
@@ -1529,6 +2529,16 @@
 			</argument>
 			<description>
 				Returns a mesh's custom aabb.
+			</description>
+		</method>
+		<method name="mesh_get_surface">
+			<return type="Dictionary">
+			</return>
+			<argument index="0" name="mesh" type="RID">
+			</argument>
+			<argument index="1" name="surface" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="mesh_get_surface_count" qualifiers="const">
@@ -1560,6 +2570,16 @@
 			</argument>
 			<description>
 				Sets a mesh's custom aabb.
+			</description>
+		</method>
+		<method name="mesh_set_shadow_mesh">
+			<return type="void">
+			</return>
+			<argument index="0" name="mesh" type="RID">
+			</argument>
+			<argument index="1" name="shadow_mesh" type="RID">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="mesh_surface_get_arrays" qualifiers="const">
@@ -1648,6 +2668,48 @@
 			</argument>
 			<description>
 				Sets a mesh's surface's material.
+			</description>
+		</method>
+		<method name="mesh_surface_update_attribute_region">
+			<return type="void">
+			</return>
+			<argument index="0" name="mesh" type="RID">
+			</argument>
+			<argument index="1" name="surface" type="int">
+			</argument>
+			<argument index="2" name="offset" type="int">
+			</argument>
+			<argument index="3" name="data" type="PackedByteArray">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="mesh_surface_update_skin_region">
+			<return type="void">
+			</return>
+			<argument index="0" name="mesh" type="RID">
+			</argument>
+			<argument index="1" name="surface" type="int">
+			</argument>
+			<argument index="2" name="offset" type="int">
+			</argument>
+			<argument index="3" name="data" type="PackedByteArray">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="mesh_surface_update_vertex_region">
+			<return type="void">
+			</return>
+			<argument index="0" name="mesh" type="RID">
+			</argument>
+			<argument index="1" name="surface" type="int">
+			</argument>
+			<argument index="2" name="offset" type="int">
+			</argument>
+			<argument index="3" name="data" type="PackedByteArray">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="multimesh_allocate_data">
@@ -1856,11 +2918,11 @@
 		<method name="occluder_set_mesh">
 			<return type="void">
 			</return>
-			<argument index="0" name="arg0" type="RID">
+			<argument index="0" name="occluder" type="RID">
 			</argument>
-			<argument index="1" name="arg1" type="PackedVector3Array">
+			<argument index="1" name="vertices" type="PackedVector3Array">
 			</argument>
-			<argument index="2" name="arg2" type="PackedInt32Array">
+			<argument index="2" name="indices" type="PackedInt32Array">
 			</argument>
 			<description>
 			</description>
@@ -1874,6 +2936,110 @@
 				To place in a scene, attach this omni light to an instance using [method instance_set_base] using the returned RID.
 			</description>
 		</method>
+		<method name="particles_collision_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_height_field_update">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_set_attractor_attenuation">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<argument index="1" name="curve" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_set_attractor_directionality">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<argument index="1" name="amount" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_set_attractor_strength">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<argument index="1" name="setrngth" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_set_box_extents">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<argument index="1" name="extents" type="Vector3">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_set_collision_type">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<argument index="1" name="type" type="int" enum="RenderingServer.ParticlesCollisionType">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_set_cull_mask">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<argument index="1" name="mask" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_set_field_texture">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<argument index="1" name="texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_set_height_field_resolution">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<argument index="1" name="resolution" type="int" enum="RenderingServer.ParticlesCollisionHeightfieldResolution">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_collision_set_sphere_radius">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles_collision" type="RID">
+			</argument>
+			<argument index="1" name="radius" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="particles_create">
 			<return type="RID">
 			</return>
@@ -1881,6 +3047,24 @@
 				Creates a particle system and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]particles_*[/code] RenderingServer functions.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
 				To place in a scene, attach these particles to an instance using [method instance_set_base] using the returned RID.
+			</description>
+		</method>
+		<method name="particles_emit">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles" type="RID">
+			</argument>
+			<argument index="1" name="transform" type="Transform3D">
+			</argument>
+			<argument index="2" name="velocity" type="Vector3">
+			</argument>
+			<argument index="3" name="color" type="Color">
+			</argument>
+			<argument index="4" name="custom" type="Color">
+			</argument>
+			<argument index="5" name="emit_flags" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="particles_get_current_aabb">
@@ -1937,6 +3121,16 @@
 			</argument>
 			<description>
 				Sets the number of particles to be drawn and allocates the memory for them. Equivalent to [member GPUParticles3D.amount].
+			</description>
+		</method>
+		<method name="particles_set_collision_base_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles" type="RID">
+			</argument>
+			<argument index="1" name="size" type="float">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="particles_set_custom_aabb">
@@ -2040,6 +3234,16 @@
 				If [code]true[/code], uses fractional delta which smooths the movement of the particles. Equivalent to [member GPUParticles3D.fract_delta].
 			</description>
 		</method>
+		<method name="particles_set_interpolate">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="particles_set_lifetime">
 			<return type="void">
 			</return>
@@ -2049,6 +3253,16 @@
 			</argument>
 			<description>
 				Sets the lifetime of each particle in the system. Equivalent to [member GPUParticles3D.lifetime].
+			</description>
+		</method>
+		<method name="particles_set_mode">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles" type="RID">
+			</argument>
+			<argument index="1" name="mode" type="int" enum="RenderingServer.ParticlesMode">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="particles_set_one_shot">
@@ -2104,6 +3318,48 @@
 			</argument>
 			<description>
 				Sets the speed scale of the particle system. Equivalent to [member GPUParticles3D.speed_scale].
+			</description>
+		</method>
+		<method name="particles_set_subemitter">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles" type="RID">
+			</argument>
+			<argument index="1" name="subemitter_particles" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_set_trail_bind_poses">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles" type="RID">
+			</argument>
+			<argument index="1" name="bind_poses" type="Transform3D[]">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_set_trails">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<argument index="2" name="length_sec" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="particles_set_transform_align">
+			<return type="void">
+			</return>
+			<argument index="0" name="particles" type="RID">
+			</argument>
+			<argument index="1" name="align" type="int" enum="RenderingServer.ParticlesTransformAlign">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="particles_set_use_local_coordinates">
@@ -2222,6 +3478,16 @@
 				Sets the intensity of the reflection probe. Intensity modulates the strength of the reflection. Equivalent to [member ReflectionProbe.intensity].
 			</description>
 		</method>
+		<method name="reflection_probe_set_lod_threshold">
+			<return type="void">
+			</return>
+			<argument index="0" name="probe" type="RID">
+			</argument>
+			<argument index="1" name="pixels" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="reflection_probe_set_max_distance">
 			<return type="void">
 			</return>
@@ -2242,6 +3508,16 @@
 			</argument>
 			<description>
 				Sets the origin offset to be used when this reflection probe is in box project mode. Equivalent to [member ReflectionProbe.origin_offset].
+			</description>
+		</method>
+		<method name="reflection_probe_set_resolution">
+			<return type="void">
+			</return>
+			<argument index="0" name="probe" type="RID">
+			</argument>
+			<argument index="1" name="resolution" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="reflection_probe_set_update_mode">
@@ -2288,17 +3564,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="scenario_set_debug">
-			<return type="void">
-			</return>
-			<argument index="0" name="scenario" type="RID">
-			</argument>
-			<argument index="1" name="debug_mode" type="int" enum="RenderingServer.ScenarioDebugMode">
-			</argument>
-			<description>
-				Sets the [enum ScenarioDebugMode] for this scenario. See [enum ScenarioDebugMode] for options.
-			</description>
-		</method>
 		<method name="scenario_set_environment">
 			<return type="void">
 			</return>
@@ -2319,6 +3584,18 @@
 			</argument>
 			<description>
 				Sets the fallback environment to be used by this scenario. The fallback environment is used if no environment is set. Internally, this is used by the editor to provide a default environment.
+			</description>
+		</method>
+		<method name="screen_space_roughness_limiter_set_active">
+			<return type="void">
+			</return>
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<argument index="1" name="amount" type="float">
+			</argument>
+			<argument index="2" name="limit" type="float">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_boot_image">
@@ -2376,7 +3653,7 @@
 			</return>
 			<argument index="0" name="shader" type="RID">
 			</argument>
-			<argument index="1" name="name" type="StringName">
+			<argument index="1" name="param" type="StringName">
 			</argument>
 			<description>
 				Returns a default texture from a shader searched by name.
@@ -2385,15 +3662,15 @@
 		<method name="shader_get_param_default" qualifiers="const">
 			<return type="Variant">
 			</return>
-			<argument index="0" name="material" type="RID">
+			<argument index="0" name="shader" type="RID">
 			</argument>
-			<argument index="1" name="parameter" type="StringName">
+			<argument index="1" name="param" type="StringName">
 			</argument>
 			<description>
 			</description>
 		</method>
 		<method name="shader_get_param_list" qualifiers="const">
-			<return type="Array">
+			<return type="Dictionary[]">
 			</return>
 			<argument index="0" name="shader" type="RID">
 			</argument>
@@ -2401,28 +3678,25 @@
 				Returns the parameters of a shader.
 			</description>
 		</method>
-		<method name="shader_set_code">
-			<return type="void">
-			</return>
-			<argument index="0" name="shader" type="RID">
-			</argument>
-			<argument index="1" name="code" type="String">
-			</argument>
-			<description>
-				Sets a shader's code.
-			</description>
-		</method>
 		<method name="shader_set_default_texture_param">
 			<return type="void">
 			</return>
 			<argument index="0" name="shader" type="RID">
 			</argument>
-			<argument index="1" name="name" type="StringName">
+			<argument index="1" name="param" type="StringName">
 			</argument>
 			<argument index="2" name="texture" type="RID">
 			</argument>
 			<description>
 				Sets a shader's default texture. Overwrites the texture given by name.
+			</description>
+		</method>
+		<method name="shadows_quality_set">
+			<return type="void">
+			</return>
+			<argument index="0" name="quality" type="int" enum="RenderingServer.ShadowQuality">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="skeleton_allocate_data">
@@ -2502,6 +3776,30 @@
 				Returns the number of bones allocated for this skeleton.
 			</description>
 		</method>
+		<method name="skeleton_set_base_transform_2d">
+			<return type="void">
+			</return>
+			<argument index="0" name="skeleton" type="RID">
+			</argument>
+			<argument index="1" name="base_transform" type="Transform2D">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="sky_bake_panorama">
+			<return type="Image">
+			</return>
+			<argument index="0" name="sky" type="RID">
+			</argument>
+			<argument index="1" name="energy" type="float">
+			</argument>
+			<argument index="2" name="bake_irradiance" type="bool">
+			</argument>
+			<argument index="3" name="size" type="Vector2i">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="sky_create">
 			<return type="RID">
 			</return>
@@ -2521,6 +3819,26 @@
 				Sets the material that the sky uses to render the background and reflection maps.
 			</description>
 		</method>
+		<method name="sky_set_mode">
+			<return type="void">
+			</return>
+			<argument index="0" name="sky" type="RID">
+			</argument>
+			<argument index="1" name="mode" type="int" enum="RenderingServer.SkyMode">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="sky_set_radiance_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="sky" type="RID">
+			</argument>
+			<argument index="1" name="radiance_size" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="spot_light_create">
 			<return type="RID">
 			</return>
@@ -2528,6 +3846,24 @@
 				Creates a spot light and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID can be used in most [code]light_*[/code] RenderingServer functions.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
 				To place in a scene, attach this spot light to an instance using [method instance_set_base] using the returned RID.
+			</description>
+		</method>
+		<method name="sub_surface_scattering_set_quality">
+			<return type="void">
+			</return>
+			<argument index="0" name="quality" type="int" enum="RenderingServer.SubSurfaceScatteringQuality">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="sub_surface_scattering_set_scale">
+			<return type="void">
+			</return>
+			<argument index="0" name="scale" type="float">
+			</argument>
+			<argument index="1" name="depth_scale" type="float">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="texture_2d_create">
@@ -2542,6 +3878,162 @@
 			<return type="Image">
 			</return>
 			<argument index="0" name="texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_2d_layer_get" qualifiers="const">
+			<return type="Image">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<argument index="1" name="layer" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_2d_layered_create">
+			<return type="RID">
+			</return>
+			<argument index="0" name="layers" type="Image[]">
+			</argument>
+			<argument index="1" name="layered_type" type="int" enum="RenderingServer.TextureLayeredType">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_2d_layered_placeholder_create">
+			<return type="RID">
+			</return>
+			<argument index="0" name="layered_type" type="int" enum="RenderingServer.TextureLayeredType">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_2d_placeholder_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="texture_2d_update">
+			<return type="void">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<argument index="1" name="image" type="Image">
+			</argument>
+			<argument index="2" name="layer" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_3d_create">
+			<return type="RID">
+			</return>
+			<argument index="0" name="format" type="int" enum="Image.Format">
+			</argument>
+			<argument index="1" name="width" type="int">
+			</argument>
+			<argument index="2" name="height" type="int">
+			</argument>
+			<argument index="3" name="depth" type="int">
+			</argument>
+			<argument index="4" name="mipmaps" type="bool">
+			</argument>
+			<argument index="5" name="data" type="Image[]">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_3d_get" qualifiers="const">
+			<return type="Image[]">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_3d_placeholder_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="texture_3d_update">
+			<return type="void">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<argument index="1" name="data" type="Image[]">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_get_path" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_proxy_create">
+			<return type="RID">
+			</return>
+			<argument index="0" name="base" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_proxy_update">
+			<return type="void">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<argument index="1" name="proxy_to" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_replace">
+			<return type="void">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<argument index="1" name="by_texture" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_set_force_redraw_if_visible">
+			<return type="void">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_set_path">
+			<return type="void">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<argument index="1" name="path" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="texture_set_size_override">
+			<return type="void">
+			</return>
+			<argument index="0" name="texture" type="RID">
+			</argument>
+			<argument index="1" name="width" type="int">
+			</argument>
+			<argument index="2" name="height" type="int">
 			</argument>
 			<description>
 			</description>
@@ -2708,6 +4200,47 @@
 				Sets the debug draw mode of a viewport. See [enum ViewportDebugDraw] for options.
 			</description>
 		</method>
+		<method name="viewport_set_default_canvas_item_texture_filter">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="filter" type="int" enum="RenderingServer.CanvasItemTextureFilter">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="viewport_set_default_canvas_item_texture_repeat">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="repeat" type="int" enum="RenderingServer.CanvasItemTextureRepeat">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="viewport_set_disable_2d">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="disable" type="bool">
+			</argument>
+			<description>
+				If [code]true[/code], the viewport's canvas is not rendered.
+			</description>
+		</method>
+		<method name="viewport_set_disable_3d">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="disable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="viewport_set_disable_environment">
 			<return type="void">
 			</return>
@@ -2728,28 +4261,6 @@
 			</argument>
 			<description>
 				Sets the viewport's global transformation matrix.
-			</description>
-		</method>
-		<method name="viewport_set_hide_canvas">
-			<return type="void">
-			</return>
-			<argument index="0" name="viewport" type="RID">
-			</argument>
-			<argument index="1" name="hidden" type="bool">
-			</argument>
-			<description>
-				If [code]true[/code], the viewport's canvas is not rendered.
-			</description>
-		</method>
-		<method name="viewport_set_hide_scenario">
-			<return type="void">
-			</return>
-			<argument index="0" name="viewport" type="RID">
-			</argument>
-			<argument index="1" name="hidden" type="bool">
-			</argument>
-			<description>
-				Currently unimplemented in Godot 3.x.
 			</description>
 		</method>
 		<method name="viewport_set_measure_render_time">
@@ -2820,7 +4331,29 @@
 			</argument>
 			<description>
 				Sets a viewport's scenario.
-				The scenario contains information about the [enum ScenarioDebugMode], environment information, reflection atlas etc.
+				The scenario contains information about environment information, reflection atlas etc.
+			</description>
+		</method>
+		<method name="viewport_set_screen_space_aa">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="mode" type="int" enum="RenderingServer.ViewportScreenSpaceAA">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="viewport_set_sdf_oversize_and_scale">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="oversize" type="int" enum="RenderingServer.ViewportSDFOversize">
+			</argument>
+			<argument index="2" name="scale" type="int" enum="RenderingServer.ViewportSDFScale">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="viewport_set_shadow_atlas_quadrant_subdivision">
@@ -2860,6 +4393,26 @@
 			</argument>
 			<description>
 				Sets the viewport's width and height.
+			</description>
+		</method>
+		<method name="viewport_set_snap_2d_transforms_to_pixel">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="viewport_set_snap_2d_vertices_to_pixel">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="viewport_set_transparent_background">
@@ -2915,6 +4468,188 @@
 				If [code]true[/code], the viewport uses augmented or virtual reality technologies. See [XRInterface].
 			</description>
 		</method>
+		<method name="visibility_notifier_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="visibility_notifier_set_aabb">
+			<return type="void">
+			</return>
+			<argument index="0" name="notifier" type="RID">
+			</argument>
+			<argument index="1" name="aabb" type="AABB">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="visibility_notifier_set_callbacks">
+			<return type="void">
+			</return>
+			<argument index="0" name="notifier" type="RID">
+			</argument>
+			<argument index="1" name="enter_callable" type="Callable">
+			</argument>
+			<argument index="2" name="exit_callable" type="Callable">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_allocate_data">
+			<return type="void">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<argument index="1" name="to_cell_xform" type="Transform3D">
+			</argument>
+			<argument index="2" name="aabb" type="AABB">
+			</argument>
+			<argument index="3" name="octree_size" type="Vector3i">
+			</argument>
+			<argument index="4" name="octree_cells" type="PackedByteArray">
+			</argument>
+			<argument index="5" name="data_cells" type="PackedByteArray">
+			</argument>
+			<argument index="6" name="distance_field" type="PackedByteArray">
+			</argument>
+			<argument index="7" name="level_counts" type="PackedInt32Array">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_create">
+			<return type="RID">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_get_data_cells" qualifiers="const">
+			<return type="PackedByteArray">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_get_distance_field" qualifiers="const">
+			<return type="PackedByteArray">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_get_level_counts" qualifiers="const">
+			<return type="PackedInt32Array">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_get_octree_cells" qualifiers="const">
+			<return type="PackedByteArray">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_get_octree_size" qualifiers="const">
+			<return type="Vector3i">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_get_to_cell_xform" qualifiers="const">
+			<return type="Transform3D">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_set_bias">
+			<return type="void">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<argument index="1" name="bias" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_set_dynamic_range">
+			<return type="void">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<argument index="1" name="range" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_set_energy">
+			<return type="void">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<argument index="1" name="energy" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_set_interior">
+			<return type="void">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_set_normal_bias">
+			<return type="void">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<argument index="1" name="bias" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_set_propagation">
+			<return type="void">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<argument index="1" name="amount" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_set_quality">
+			<return type="void">
+			</return>
+			<argument index="0" name="quality" type="int" enum="RenderingServer.VoxelGIQuality">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_set_use_two_bounces">
+			<return type="void">
+			</return>
+			<argument index="0" name="voxel_gi" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="render_loop_enabled" type="bool" setter="set_render_loop_enabled" getter="is_render_loop_enabled">
@@ -2951,6 +4686,8 @@
 		</constant>
 		<constant name="MAX_CURSORS" value="8">
 			Unused enum in Godot 3.x.
+		</constant>
+		<constant name="MAX_2D_DIRECTIONAL_LIGHTS" value="8">
 		</constant>
 		<constant name="TEXTURE_LAYERED_2D_ARRAY" value="0" enum="TextureLayeredType">
 		</constant>
@@ -3029,6 +4766,26 @@
 		<constant name="ARRAY_MAX" value="13" enum="ArrayType">
 			Represents the size of the [enum ArrayType] enum.
 		</constant>
+		<constant name="ARRAY_CUSTOM_COUNT" value="4">
+		</constant>
+		<constant name="ARRAY_CUSTOM_RGBA8_UNORM" value="0" enum="ArrayCustomFormat">
+		</constant>
+		<constant name="ARRAY_CUSTOM_RGBA8_SNORM" value="1" enum="ArrayCustomFormat">
+		</constant>
+		<constant name="ARRAY_CUSTOM_RG_HALF" value="2" enum="ArrayCustomFormat">
+		</constant>
+		<constant name="ARRAY_CUSTOM_RGBA_HALF" value="3" enum="ArrayCustomFormat">
+		</constant>
+		<constant name="ARRAY_CUSTOM_R_FLOAT" value="4" enum="ArrayCustomFormat">
+		</constant>
+		<constant name="ARRAY_CUSTOM_RG_FLOAT" value="5" enum="ArrayCustomFormat">
+		</constant>
+		<constant name="ARRAY_CUSTOM_RGB_FLOAT" value="6" enum="ArrayCustomFormat">
+		</constant>
+		<constant name="ARRAY_CUSTOM_RGBA_FLOAT" value="7" enum="ArrayCustomFormat">
+		</constant>
+		<constant name="ARRAY_CUSTOM_MAX" value="8" enum="ArrayCustomFormat">
+		</constant>
 		<constant name="ARRAY_FORMAT_VERTEX" value="1" enum="ArrayFormat">
 			Flag used to mark a vertex array.
 		</constant>
@@ -3067,6 +4824,8 @@
 		<constant name="ARRAY_FORMAT_BLEND_SHAPE_MASK" value="2147475463" enum="ArrayFormat">
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM_BASE" value="13" enum="ArrayFormat">
+		</constant>
+		<constant name="ARRAY_FORMAT_CUSTOM_BITS" value="3" enum="ArrayFormat">
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM0_SHIFT" value="13" enum="ArrayFormat">
 		</constant>
@@ -3176,6 +4935,8 @@
 		<constant name="LIGHT_PARAM_SHADOW_BLUR" value="16" enum="LightParam">
 			Blurs the edges of the shadow. Can be used to hide pixel artifacts in low resolution shadow maps. A high value can make shadows appear grainy and can cause other unwanted artifacts. Try to keep as near default as possible.
 		</constant>
+		<constant name="LIGHT_PARAM_SHADOW_VOLUMETRIC_FOG_FADE" value="17" enum="LightParam">
+		</constant>
 		<constant name="LIGHT_PARAM_TRANSMITTANCE_BIAS" value="18" enum="LightParam">
 		</constant>
 		<constant name="LIGHT_PARAM_MAX" value="19" enum="LightParam">
@@ -3208,6 +4969,18 @@
 		<constant name="LIGHT_DIRECTIONAL_SHADOW_DEPTH_RANGE_OPTIMIZED" value="1" enum="LightDirectionalShadowDepthRangeMode">
 			Optimize use of shadow maps, increasing the effective resolution. But may result in shadows moving or flickering slightly.
 		</constant>
+		<constant name="SHADOW_QUALITY_HARD" value="0" enum="ShadowQuality">
+		</constant>
+		<constant name="SHADOW_QUALITY_SOFT_LOW" value="1" enum="ShadowQuality">
+		</constant>
+		<constant name="SHADOW_QUALITY_SOFT_MEDIUM" value="2" enum="ShadowQuality">
+		</constant>
+		<constant name="SHADOW_QUALITY_SOFT_HIGH" value="3" enum="ShadowQuality">
+		</constant>
+		<constant name="SHADOW_QUALITY_SOFT_ULTRA" value="4" enum="ShadowQuality">
+		</constant>
+		<constant name="SHADOW_QUALITY_MAX" value="5" enum="ShadowQuality">
+		</constant>
 		<constant name="REFLECTION_PROBE_UPDATE_ONCE" value="0" enum="ReflectionProbeUpdateMode">
 			Reflection probe will update reflections once and then stop.
 		</constant>
@@ -3230,14 +5003,70 @@
 		</constant>
 		<constant name="DECAL_TEXTURE_MAX" value="4" enum="DecalTexture">
 		</constant>
+		<constant name="VOXEL_GI_QUALITY_LOW" value="0" enum="VoxelGIQuality">
+		</constant>
+		<constant name="VOXEL_GI_QUALITY_HIGH" value="1" enum="VoxelGIQuality">
+		</constant>
+		<constant name="PARTICLES_MODE_2D" value="0" enum="ParticlesMode">
+		</constant>
+		<constant name="PARTICLES_MODE_3D" value="1" enum="ParticlesMode">
+		</constant>
+		<constant name="PARTICLES_TRANSFORM_ALIGN_DISABLED" value="0" enum="ParticlesTransformAlign">
+		</constant>
+		<constant name="PARTICLES_TRANSFORM_ALIGN_Z_BILLBOARD" value="1" enum="ParticlesTransformAlign">
+		</constant>
+		<constant name="PARTICLES_TRANSFORM_ALIGN_Y_TO_VELOCITY" value="2" enum="ParticlesTransformAlign">
+		</constant>
+		<constant name="PARTICLES_TRANSFORM_ALIGN_Z_BILLBOARD_Y_TO_VELOCITY" value="3" enum="ParticlesTransformAlign">
+		</constant>
+		<constant name="PARTICLES_EMIT_FLAG_POSITION" value="1">
+		</constant>
+		<constant name="PARTICLES_EMIT_FLAG_ROTATION_SCALE" value="2">
+		</constant>
+		<constant name="PARTICLES_EMIT_FLAG_VELOCITY" value="4">
+		</constant>
+		<constant name="PARTICLES_EMIT_FLAG_COLOR" value="8">
+		</constant>
+		<constant name="PARTICLES_EMIT_FLAG_CUSTOM" value="16">
+		</constant>
 		<constant name="PARTICLES_DRAW_ORDER_INDEX" value="0" enum="ParticlesDrawOrder">
 			Draw particles in the order that they appear in the particles array.
 		</constant>
 		<constant name="PARTICLES_DRAW_ORDER_LIFETIME" value="1" enum="ParticlesDrawOrder">
 			Sort particles based on their lifetime.
 		</constant>
+		<constant name="PARTICLES_DRAW_ORDER_REVERSE_LIFETIME" value="2" enum="ParticlesDrawOrder">
+		</constant>
 		<constant name="PARTICLES_DRAW_ORDER_VIEW_DEPTH" value="3" enum="ParticlesDrawOrder">
 			Sort particles based on their distance to the camera.
+		</constant>
+		<constant name="PARTICLES_COLLISION_TYPE_SPHERE_ATTRACT" value="0" enum="ParticlesCollisionType">
+		</constant>
+		<constant name="PARTICLES_COLLISION_TYPE_BOX_ATTRACT" value="1" enum="ParticlesCollisionType">
+		</constant>
+		<constant name="PARTICLES_COLLISION_TYPE_VECTOR_FIELD_ATTRACT" value="2" enum="ParticlesCollisionType">
+		</constant>
+		<constant name="PARTICLES_COLLISION_TYPE_SPHERE_COLLIDE" value="3" enum="ParticlesCollisionType">
+		</constant>
+		<constant name="PARTICLES_COLLISION_TYPE_BOX_COLLIDE" value="4" enum="ParticlesCollisionType">
+		</constant>
+		<constant name="PARTICLES_COLLISION_TYPE_SDF_COLLIDE" value="5" enum="ParticlesCollisionType">
+		</constant>
+		<constant name="PARTICLES_COLLISION_TYPE_HEIGHTFIELD_COLLIDE" value="6" enum="ParticlesCollisionType">
+		</constant>
+		<constant name="PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_256" value="0" enum="ParticlesCollisionHeightfieldResolution">
+		</constant>
+		<constant name="PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_512" value="1" enum="ParticlesCollisionHeightfieldResolution">
+		</constant>
+		<constant name="PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_1024" value="2" enum="ParticlesCollisionHeightfieldResolution">
+		</constant>
+		<constant name="PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_2048" value="3" enum="ParticlesCollisionHeightfieldResolution">
+		</constant>
+		<constant name="PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_4096" value="4" enum="ParticlesCollisionHeightfieldResolution">
+		</constant>
+		<constant name="PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_8192" value="5" enum="ParticlesCollisionHeightfieldResolution">
+		</constant>
+		<constant name="PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_MAX" value="6" enum="ParticlesCollisionHeightfieldResolution">
 		</constant>
 		<constant name="VIEWPORT_UPDATE_DISABLED" value="0" enum="ViewportUpdateMode">
 			Do not update the viewport.
@@ -3262,6 +5091,24 @@
 		<constant name="VIEWPORT_CLEAR_ONLY_NEXT_FRAME" value="2" enum="ViewportClearMode">
 			The viewport is cleared once, then the clear mode is set to [constant VIEWPORT_CLEAR_NEVER].
 		</constant>
+		<constant name="VIEWPORT_SDF_OVERSIZE_100_PERCENT" value="0" enum="ViewportSDFOversize">
+		</constant>
+		<constant name="VIEWPORT_SDF_OVERSIZE_120_PERCENT" value="1" enum="ViewportSDFOversize">
+		</constant>
+		<constant name="VIEWPORT_SDF_OVERSIZE_150_PERCENT" value="2" enum="ViewportSDFOversize">
+		</constant>
+		<constant name="VIEWPORT_SDF_OVERSIZE_200_PERCENT" value="3" enum="ViewportSDFOversize">
+		</constant>
+		<constant name="VIEWPORT_SDF_OVERSIZE_MAX" value="4" enum="ViewportSDFOversize">
+		</constant>
+		<constant name="VIEWPORT_SDF_SCALE_100_PERCENT" value="0" enum="ViewportSDFScale">
+		</constant>
+		<constant name="VIEWPORT_SDF_SCALE_50_PERCENT" value="1" enum="ViewportSDFScale">
+		</constant>
+		<constant name="VIEWPORT_SDF_SCALE_25_PERCENT" value="2" enum="ViewportSDFScale">
+		</constant>
+		<constant name="VIEWPORT_SDF_SCALE_MAX" value="3" enum="ViewportSDFScale">
+		</constant>
 		<constant name="VIEWPORT_MSAA_DISABLED" value="0" enum="ViewportMSAA">
 			Multisample antialiasing is disabled.
 		</constant>
@@ -3284,6 +5131,12 @@
 		<constant name="VIEWPORT_SCREEN_SPACE_AA_FXAA" value="1" enum="ViewportScreenSpaceAA">
 		</constant>
 		<constant name="VIEWPORT_SCREEN_SPACE_AA_MAX" value="2" enum="ViewportScreenSpaceAA">
+		</constant>
+		<constant name="VIEWPORT_OCCLUSION_BUILD_QUALITY_LOW" value="0" enum="ViewportOcclusionCullingBuildQuality">
+		</constant>
+		<constant name="VIEWPORT_OCCLUSION_BUILD_QUALITY_MEDIUM" value="1" enum="ViewportOcclusionCullingBuildQuality">
+		</constant>
+		<constant name="VIEWPORT_OCCLUSION_BUILD_QUALITY_HIGH" value="2" enum="ViewportOcclusionCullingBuildQuality">
 		</constant>
 		<constant name="VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME" value="0" enum="ViewportRenderInfo">
 			Number of objects drawn in a single frame.
@@ -3356,10 +5209,24 @@
 		</constant>
 		<constant name="VIEWPORT_DEBUG_DRAW_GI_BUFFER" value="17" enum="ViewportDebugDraw">
 		</constant>
+		<constant name="VIEWPORT_DEBUG_DRAW_DISABLE_LOD" value="18" enum="ViewportDebugDraw">
+		</constant>
+		<constant name="VIEWPORT_DEBUG_DRAW_CLUSTER_OMNI_LIGHTS" value="19" enum="ViewportDebugDraw">
+		</constant>
+		<constant name="VIEWPORT_DEBUG_DRAW_CLUSTER_SPOT_LIGHTS" value="20" enum="ViewportDebugDraw">
+		</constant>
+		<constant name="VIEWPORT_DEBUG_DRAW_CLUSTER_DECALS" value="21" enum="ViewportDebugDraw">
+		</constant>
+		<constant name="VIEWPORT_DEBUG_DRAW_CLUSTER_REFLECTION_PROBES" value="22" enum="ViewportDebugDraw">
+		</constant>
 		<constant name="VIEWPORT_DEBUG_DRAW_OCCLUDERS" value="23" enum="ViewportDebugDraw">
+		</constant>
+		<constant name="SKY_MODE_AUTOMATIC" value="0" enum="SkyMode">
 		</constant>
 		<constant name="SKY_MODE_QUALITY" value="1" enum="SkyMode">
 			Uses high quality importance sampling to process the radiance map. In general, this results in much higher quality than [constant Sky.PROCESS_MODE_REALTIME] but takes much longer to generate. This should not be used if you plan on changing the sky at runtime. If you are finding that the reflection is not blurry enough and is showing sparkles or fireflies, try increasing [member ProjectSettings.rendering/reflections/sky_reflections/ggx_samples].
+		</constant>
+		<constant name="SKY_MODE_INCREMENTAL" value="2" enum="SkyMode">
 		</constant>
 		<constant name="SKY_MODE_REALTIME" value="3" enum="SkyMode">
 			Uses the fast filtering algorithm to process the radiance map. In general this results in lower quality, but substantially faster run times.
@@ -3457,6 +5324,60 @@
 		<constant name="ENV_SSAO_QUALITY_ULTRA" value="4" enum="EnvironmentSSAOQuality">
 			Highest quality screen space ambient occlusion. Uses the adaptive setting which can be dynamically adjusted to smoothly balance performance and visual quality.
 		</constant>
+		<constant name="ENV_SDFGI_CASCADES_4" value="0" enum="EnvironmentSDFGICascades">
+		</constant>
+		<constant name="ENV_SDFGI_CASCADES_6" value="1" enum="EnvironmentSDFGICascades">
+		</constant>
+		<constant name="ENV_SDFGI_CASCADES_8" value="2" enum="EnvironmentSDFGICascades">
+		</constant>
+		<constant name="ENV_SDFGI_Y_SCALE_DISABLED" value="0" enum="EnvironmentSDFGIYScale">
+		</constant>
+		<constant name="ENV_SDFGI_Y_SCALE_75_PERCENT" value="1" enum="EnvironmentSDFGIYScale">
+		</constant>
+		<constant name="ENV_SDFGI_Y_SCALE_50_PERCENT" value="2" enum="EnvironmentSDFGIYScale">
+		</constant>
+		<constant name="ENV_SDFGI_RAY_COUNT_4" value="0" enum="EnvironmentSDFGIRayCount">
+		</constant>
+		<constant name="ENV_SDFGI_RAY_COUNT_8" value="1" enum="EnvironmentSDFGIRayCount">
+		</constant>
+		<constant name="ENV_SDFGI_RAY_COUNT_16" value="2" enum="EnvironmentSDFGIRayCount">
+		</constant>
+		<constant name="ENV_SDFGI_RAY_COUNT_32" value="3" enum="EnvironmentSDFGIRayCount">
+		</constant>
+		<constant name="ENV_SDFGI_RAY_COUNT_64" value="4" enum="EnvironmentSDFGIRayCount">
+		</constant>
+		<constant name="ENV_SDFGI_RAY_COUNT_96" value="5" enum="EnvironmentSDFGIRayCount">
+		</constant>
+		<constant name="ENV_SDFGI_RAY_COUNT_128" value="6" enum="EnvironmentSDFGIRayCount">
+		</constant>
+		<constant name="ENV_SDFGI_RAY_COUNT_MAX" value="7" enum="EnvironmentSDFGIRayCount">
+		</constant>
+		<constant name="ENV_SDFGI_CONVERGE_IN_5_FRAMES" value="0" enum="EnvironmentSDFGIFramesToConverge">
+		</constant>
+		<constant name="ENV_SDFGI_CONVERGE_IN_10_FRAMES" value="1" enum="EnvironmentSDFGIFramesToConverge">
+		</constant>
+		<constant name="ENV_SDFGI_CONVERGE_IN_15_FRAMES" value="2" enum="EnvironmentSDFGIFramesToConverge">
+		</constant>
+		<constant name="ENV_SDFGI_CONVERGE_IN_20_FRAMES" value="3" enum="EnvironmentSDFGIFramesToConverge">
+		</constant>
+		<constant name="ENV_SDFGI_CONVERGE_IN_25_FRAMES" value="4" enum="EnvironmentSDFGIFramesToConverge">
+		</constant>
+		<constant name="ENV_SDFGI_CONVERGE_IN_30_FRAMES" value="5" enum="EnvironmentSDFGIFramesToConverge">
+		</constant>
+		<constant name="ENV_SDFGI_CONVERGE_MAX" value="6" enum="EnvironmentSDFGIFramesToConverge">
+		</constant>
+		<constant name="ENV_SDFGI_UPDATE_LIGHT_IN_1_FRAME" value="0" enum="EnvironmentSDFGIFramesToUpdateLight">
+		</constant>
+		<constant name="ENV_SDFGI_UPDATE_LIGHT_IN_2_FRAMES" value="1" enum="EnvironmentSDFGIFramesToUpdateLight">
+		</constant>
+		<constant name="ENV_SDFGI_UPDATE_LIGHT_IN_4_FRAMES" value="2" enum="EnvironmentSDFGIFramesToUpdateLight">
+		</constant>
+		<constant name="ENV_SDFGI_UPDATE_LIGHT_IN_8_FRAMES" value="3" enum="EnvironmentSDFGIFramesToUpdateLight">
+		</constant>
+		<constant name="ENV_SDFGI_UPDATE_LIGHT_IN_16_FRAMES" value="4" enum="EnvironmentSDFGIFramesToUpdateLight">
+		</constant>
+		<constant name="ENV_SDFGI_UPDATE_LIGHT_MAX" value="5" enum="EnvironmentSDFGIFramesToUpdateLight">
+		</constant>
 		<constant name="SUB_SURFACE_SCATTERING_QUALITY_DISABLED" value="0" enum="SubSurfaceScatteringQuality">
 		</constant>
 		<constant name="SUB_SURFACE_SCATTERING_QUALITY_LOW" value="1" enum="SubSurfaceScatteringQuality">
@@ -3464,6 +5385,15 @@
 		<constant name="SUB_SURFACE_SCATTERING_QUALITY_MEDIUM" value="2" enum="SubSurfaceScatteringQuality">
 		</constant>
 		<constant name="SUB_SURFACE_SCATTERING_QUALITY_HIGH" value="3" enum="SubSurfaceScatteringQuality">
+		</constant>
+		<constant name="DOF_BOKEH_BOX" value="0" enum="DOFBokehShape">
+			Calculate the DOF blur using a box filter. The fastest option, but results in obvious lines in blur pattern.
+		</constant>
+		<constant name="DOF_BOKEH_HEXAGON" value="1" enum="DOFBokehShape">
+			Calculates DOF blur using a hexagon shaped filter.
+		</constant>
+		<constant name="DOF_BOKEH_CIRCLE" value="2" enum="DOFBokehShape">
+			Calculates DOF blur using a circle shaped filter. Best quality and most realistic, but slowest. Use only for areas where a lot of performance can be dedicated to post-processing (e.g. cutscenes).
 		</constant>
 		<constant name="DOF_BLUR_QUALITY_VERY_LOW" value="0" enum="DOFBlurQuality">
 			Lowest quality DOF blur. This is the fastest setting, but you may be able to see filtering artifacts.
@@ -3476,45 +5406,6 @@
 		</constant>
 		<constant name="DOF_BLUR_QUALITY_HIGH" value="3" enum="DOFBlurQuality">
 			Highest quality DOF blur. Results in the smoothest looking blur by taking the most samples, but is also significantly slower.
-		</constant>
-		<constant name="DOF_BOKEH_BOX" value="0" enum="DOFBokehShape">
-			Calculate the DOF blur using a box filter. The fastest option, but results in obvious lines in blur pattern.
-		</constant>
-		<constant name="DOF_BOKEH_HEXAGON" value="1" enum="DOFBokehShape">
-			Calculates DOF blur using a hexagon shaped filter.
-		</constant>
-		<constant name="DOF_BOKEH_CIRCLE" value="2" enum="DOFBokehShape">
-			Calculates DOF blur using a circle shaped filter. Best quality and most realistic, but slowest. Use only for areas where a lot of performance can be dedicated to post-processing (e.g. cutscenes).
-		</constant>
-		<constant name="SHADOW_QUALITY_HARD" value="0" enum="ShadowQuality">
-		</constant>
-		<constant name="SHADOW_QUALITY_SOFT_LOW" value="1" enum="ShadowQuality">
-		</constant>
-		<constant name="SHADOW_QUALITY_SOFT_MEDIUM" value="2" enum="ShadowQuality">
-		</constant>
-		<constant name="SHADOW_QUALITY_SOFT_HIGH" value="3" enum="ShadowQuality">
-		</constant>
-		<constant name="SHADOW_QUALITY_SOFT_ULTRA" value="4" enum="ShadowQuality">
-		</constant>
-		<constant name="SHADOW_QUALITY_MAX" value="5" enum="ShadowQuality">
-		</constant>
-		<constant name="SCENARIO_DEBUG_DISABLED" value="0" enum="ScenarioDebugMode">
-			Do not use a debug mode.
-		</constant>
-		<constant name="SCENARIO_DEBUG_WIREFRAME" value="1" enum="ScenarioDebugMode">
-			Draw all objects as wireframe models.
-		</constant>
-		<constant name="SCENARIO_DEBUG_OVERDRAW" value="2" enum="ScenarioDebugMode">
-			Draw all objects in a way that displays how much overdraw is occurring. Overdraw occurs when a section of pixels is drawn and shaded and then another object covers it up. To optimize a scene, you should reduce overdraw.
-		</constant>
-		<constant name="SCENARIO_DEBUG_SHADELESS" value="3" enum="ScenarioDebugMode">
-			Draw all objects without shading. Equivalent to setting all objects shaders to [code]unshaded[/code].
-		</constant>
-		<constant name="VIEWPORT_OCCLUSION_BUILD_QUALITY_LOW" value="0" enum="ViewportOcclusionCullingBuildQuality">
-		</constant>
-		<constant name="VIEWPORT_OCCLUSION_BUILD_QUALITY_MEDIUM" value="1" enum="ViewportOcclusionCullingBuildQuality">
-		</constant>
-		<constant name="VIEWPORT_OCCLUSION_BUILD_QUALITY_HIGH" value="2" enum="ViewportOcclusionCullingBuildQuality">
 		</constant>
 		<constant name="INSTANCE_NONE" value="0" enum="InstanceType">
 			The instance does not have a type.
@@ -3547,6 +5438,8 @@
 		</constant>
 		<constant name="INSTANCE_OCCLUDER" value="10" enum="InstanceType">
 		</constant>
+		<constant name="INSTANCE_VISIBLITY_NOTIFIER" value="11" enum="InstanceType">
+		</constant>
 		<constant name="INSTANCE_MAX" value="12" enum="InstanceType">
 			Represents the size of the [enum InstanceType] enum.
 		</constant>
@@ -3578,6 +5471,20 @@
 		</constant>
 		<constant name="SHADOW_CASTING_SETTING_SHADOWS_ONLY" value="3" enum="ShadowCastingSetting">
 			Only render the shadows from the object. The object itself will not be drawn.
+		</constant>
+		<constant name="BAKE_CHANNEL_ALBEDO_ALPHA" value="0" enum="BakeChannels">
+		</constant>
+		<constant name="BAKE_CHANNEL_NORMAL" value="1" enum="BakeChannels">
+		</constant>
+		<constant name="BAKE_CHANNEL_ORM" value="2" enum="BakeChannels">
+		</constant>
+		<constant name="BAKE_CHANNEL_EMISSION" value="3" enum="BakeChannels">
+		</constant>
+		<constant name="CANVAS_TEXTURE_CHANNEL_DIFFUSE" value="0" enum="CanvasTextureChannel">
+		</constant>
+		<constant name="CANVAS_TEXTURE_CHANNEL_NORMAL" value="1" enum="CanvasTextureChannel">
+		</constant>
+		<constant name="CANVAS_TEXTURE_CHANNEL_SPECULAR" value="2" enum="CanvasTextureChannel">
 		</constant>
 		<constant name="NINE_PATCH_STRETCH" value="0" enum="NinePatchAxisMode">
 			The nine patch gets stretched where needed.

--- a/doc/classes/VoxelGIData.xml
+++ b/doc/classes/VoxelGIData.xml
@@ -66,12 +66,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="anisotropy_strength" type="float" setter="set_anisotropy_strength" getter="get_anisotropy_strength" default="0.5">
-		</member>
-		<member name="ao" type="float" setter="set_ao" getter="get_ao" default="0.0">
-		</member>
-		<member name="ao_size" type="float" setter="set_ao_size" getter="get_ao_size" default="0.5">
-		</member>
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="1.5">
 		</member>
 		<member name="dynamic_range" type="float" setter="set_dynamic_range" getter="get_dynamic_range" default="4.0">

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -315,7 +315,7 @@ void EditorProfiler::_update_plot() {
 		graph_texture->create_from_image(img);
 	}
 
-	graph_texture->update(img, true);
+	graph_texture->update(img);
 
 	graph->set_texture(graph_texture);
 	graph->update();

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -309,7 +309,7 @@ void EditorVisualProfiler::_update_plot() {
 		graph_texture->create_from_image(img);
 	}
 
-	graph_texture->update(img, true);
+	graph_texture->update(img);
 
 	graph->set_texture(graph_texture);
 	graph->update();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -591,8 +591,7 @@ void EditorNode::_notification(int p_what) {
 				_initializing_addons = false;
 			}
 
-			RenderingServer::get_singleton()->viewport_set_hide_scenario(get_scene_root()->get_viewport_rid(), true);
-			RenderingServer::get_singleton()->viewport_set_hide_canvas(get_scene_root()->get_viewport_rid(), true);
+			RenderingServer::get_singleton()->viewport_set_disable_2d(get_scene_root()->get_viewport_rid(), true);
 			RenderingServer::get_singleton()->viewport_set_disable_environment(get_viewport()->get_viewport_rid(), true);
 
 			feature_profile_manager->notify_changed();
@@ -6119,7 +6118,6 @@ EditorNode::EditorNode() {
 	scene_root->set_embed_subwindows_hint(true);
 	scene_root->set_disable_3d(true);
 
-	RenderingServer::get_singleton()->viewport_set_hide_scenario(scene_root->get_viewport_rid(), true);
 	scene_root->set_disable_input(true);
 	scene_root->set_as_audio_listener_2d(true);
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5623,12 +5623,12 @@ void CanvasItemEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		canvas_item_editor->show();
 		canvas_item_editor->set_physics_process(true);
-		RenderingServer::get_singleton()->viewport_set_hide_canvas(editor->get_scene_root()->get_viewport_rid(), false);
+		RenderingServer::get_singleton()->viewport_set_disable_2d(editor->get_scene_root()->get_viewport_rid(), false);
 
 	} else {
 		canvas_item_editor->hide();
 		canvas_item_editor->set_physics_process(false);
-		RenderingServer::get_singleton()->viewport_set_hide_canvas(editor->get_scene_root()->get_viewport_rid(), true);
+		RenderingServer::get_singleton()->viewport_set_disable_2d(editor->get_scene_root()->get_viewport_rid(), true);
 	}
 }
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7073,8 +7073,6 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 
 	xform_dialog->connect("confirmed", callable_mp(this, &Node3DEditor::_xform_dialog_action));
 
-	scenario_debug = RenderingServer::SCENARIO_DEBUG_DISABLED;
-
 	selected = nullptr;
 
 	set_process_unhandled_key_input(true);

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -600,8 +600,6 @@ private:
 
 	ToolMode tool_mode;
 
-	RenderingServer::ScenarioDebugMode scenario_debug;
-
 	RID origin;
 	RID origin_instance;
 	bool origin_enabled;

--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -185,7 +185,7 @@ void VideoStreamPlaybackGDNative::update_texture() {
 
 	Ref<Image> img = memnew(Image(texture_size.width, texture_size.height, 0, Image::FORMAT_RGBA8, *pba));
 
-	texture->update(img, true);
+	texture->update(img);
 }
 
 // ctor and dtor

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -108,7 +108,7 @@ void VideoStreamPlaybackTheora::video_write() {
 
 	Ref<Image> img = memnew(Image(size.x, size.y, 0, Image::FORMAT_RGBA8, frame_data)); //zero copy image creation
 
-	texture->update(img, true); //zero copy send to visual server
+	texture->update(img); //zero copy send to visual server
 
 	frames_pending = 1;
 }

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -143,15 +143,6 @@ float VoxelGIData::get_propagation() const {
 	return propagation;
 }
 
-void VoxelGIData::set_anisotropy_strength(float p_anisotropy_strength) {
-	RS::get_singleton()->voxel_gi_set_anisotropy_strength(probe, p_anisotropy_strength);
-	anisotropy_strength = p_anisotropy_strength;
-}
-
-float VoxelGIData::get_anisotropy_strength() const {
-	return anisotropy_strength;
-}
-
 void VoxelGIData::set_energy(float p_energy) {
 	RS::get_singleton()->voxel_gi_set_energy(probe, p_energy);
 	energy = p_energy;
@@ -159,24 +150,6 @@ void VoxelGIData::set_energy(float p_energy) {
 
 float VoxelGIData::get_energy() const {
 	return energy;
-}
-
-void VoxelGIData::set_ao(float p_ao) {
-	RS::get_singleton()->voxel_gi_set_ao(probe, p_ao);
-	ao = p_ao;
-}
-
-float VoxelGIData::get_ao() const {
-	return ao;
-}
-
-void VoxelGIData::set_ao_size(float p_ao_size) {
-	RS::get_singleton()->voxel_gi_set_ao_size(probe, p_ao_size);
-	ao_size = p_ao_size;
-}
-
-float VoxelGIData::get_ao_size() const {
-	return ao_size;
 }
 
 void VoxelGIData::set_bias(float p_bias) {
@@ -219,15 +192,6 @@ RID VoxelGIData::get_rid() const {
 	return probe;
 }
 
-void VoxelGIData::_validate_property(PropertyInfo &property) const {
-	if (property.name == "anisotropy_strength") {
-		bool anisotropy_enabled = ProjectSettings::get_singleton()->get("rendering/global_illumination/voxel_gi/anisotropic");
-		if (!anisotropy_enabled) {
-			property.usage = PROPERTY_USAGE_NOEDITOR;
-		}
-	}
-}
-
 void VoxelGIData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("allocate", "to_cell_xform", "aabb", "octree_size", "octree_cells", "data_cells", "distance_field", "level_counts"), &VoxelGIData::allocate);
 
@@ -253,15 +217,6 @@ void VoxelGIData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_propagation", "propagation"), &VoxelGIData::set_propagation);
 	ClassDB::bind_method(D_METHOD("get_propagation"), &VoxelGIData::get_propagation);
 
-	ClassDB::bind_method(D_METHOD("set_anisotropy_strength", "strength"), &VoxelGIData::set_anisotropy_strength);
-	ClassDB::bind_method(D_METHOD("get_anisotropy_strength"), &VoxelGIData::get_anisotropy_strength);
-
-	ClassDB::bind_method(D_METHOD("set_ao", "ao"), &VoxelGIData::set_ao);
-	ClassDB::bind_method(D_METHOD("get_ao"), &VoxelGIData::get_ao);
-
-	ClassDB::bind_method(D_METHOD("set_ao_size", "strength"), &VoxelGIData::set_ao_size);
-	ClassDB::bind_method(D_METHOD("get_ao_size"), &VoxelGIData::get_ao_size);
-
 	ClassDB::bind_method(D_METHOD("set_interior", "interior"), &VoxelGIData::set_interior);
 	ClassDB::bind_method(D_METHOD("is_interior"), &VoxelGIData::is_interior);
 
@@ -278,9 +233,6 @@ void VoxelGIData::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0,8,0.01"), "set_bias", "get_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "normal_bias", PROPERTY_HINT_RANGE, "0,8,0.01"), "set_normal_bias", "get_normal_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "propagation", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_propagation", "get_propagation");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "anisotropy_strength", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_anisotropy_strength", "get_anisotropy_strength");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ao", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_ao", "get_ao");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ao_size", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_ao_size", "get_ao_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_two_bounces"), "set_use_two_bounces", "is_using_two_bounces");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interior"), "set_interior", "is_interior");
 }

--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -51,15 +51,11 @@ class VoxelGIData : public Resource {
 	float bias = 1.5;
 	float normal_bias = 0.0;
 	float propagation = 0.7;
-	float anisotropy_strength = 0.5;
-	float ao = 0.0;
-	float ao_size = 0.5;
 	bool interior = false;
 	bool use_two_bounces = false;
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
 
 public:
 	void allocate(const Transform3D &p_to_cell_xform, const AABB &p_aabb, const Vector3 &p_octree_size, const Vector<uint8_t> &p_octree_cells, const Vector<uint8_t> &p_data_cells, const Vector<uint8_t> &p_distance_field, const Vector<int> &p_level_counts);
@@ -76,15 +72,6 @@ public:
 
 	void set_propagation(float p_propagation);
 	float get_propagation() const;
-
-	void set_anisotropy_strength(float p_anisotropy_strength);
-	float get_anisotropy_strength() const;
-
-	void set_ao(float p_ao);
-	float get_ao() const;
-
-	void set_ao_size(float p_ao_size);
-	float get_ao_size() const;
 
 	void set_energy(float p_energy);
 	float get_energy() const;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -173,7 +173,7 @@ Image::Format ImageTexture::get_format() const {
 	return format;
 }
 
-void ImageTexture::update(const Ref<Image> &p_image, bool p_immediate) {
+void ImageTexture::update(const Ref<Image> &p_image) {
 	ERR_FAIL_COND_MSG(p_image.is_null(), "Invalid image");
 	ERR_FAIL_COND_MSG(texture.is_null(), "Texture is not initialized.");
 	ERR_FAIL_COND_MSG(p_image->get_width() != w || p_image->get_height() != h,
@@ -183,11 +183,7 @@ void ImageTexture::update(const Ref<Image> &p_image, bool p_immediate) {
 	ERR_FAIL_COND_MSG(mipmaps != p_image->has_mipmaps(),
 			"The new image mipmaps configuration must match the texture's image mipmaps configuration");
 
-	if (p_immediate) {
-		RenderingServer::get_singleton()->texture_2d_update_immediate(texture, p_image);
-	} else {
-		RenderingServer::get_singleton()->texture_2d_update(texture, p_image);
-	}
+	RenderingServer::get_singleton()->texture_2d_update(texture, p_image);
 
 	notify_property_list_changed();
 	emit_changed();
@@ -305,7 +301,7 @@ void ImageTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_from_image", "image"), &ImageTexture::create_from_image);
 	ClassDB::bind_method(D_METHOD("get_format"), &ImageTexture::get_format);
 
-	ClassDB::bind_method(D_METHOD("update", "image", "immediate"), &ImageTexture::update, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("update", "image"), &ImageTexture::update);
 	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &ImageTexture::set_size_override);
 	ClassDB::bind_method(D_METHOD("_reload_hook", "rid"), &ImageTexture::_reload_hook);
 }

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -107,7 +107,7 @@ public:
 
 	Image::Format get_format() const;
 
-	void update(const Ref<Image> &p_image, bool p_immediate = false);
+	void update(const Ref<Image> &p_image);
 	Ref<Image> get_image() const override;
 
 	int get_width() const override;

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -225,7 +225,6 @@ public:
 	}
 
 	void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) override {}
-	void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override {}
 	void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override {}
 	void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) override {}
 	void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override {}
@@ -491,12 +490,6 @@ public:
 	void voxel_gi_set_energy(RID p_voxel_gi, float p_range) override {}
 	float voxel_gi_get_energy(RID p_voxel_gi) const override { return 0.0; }
 
-	void voxel_gi_set_ao(RID p_voxel_gi, float p_ao) override {}
-	float voxel_gi_get_ao(RID p_voxel_gi) const override { return 0; }
-
-	void voxel_gi_set_ao_size(RID p_voxel_gi, float p_strength) override {}
-	float voxel_gi_get_ao_size(RID p_voxel_gi) const override { return 0; }
-
 	void voxel_gi_set_bias(RID p_voxel_gi, float p_range) override {}
 	float voxel_gi_get_bias(RID p_voxel_gi) const override { return 0.0; }
 
@@ -718,8 +711,6 @@ public:
 	void occluder_polygon_set_shape(RID p_occluder, const Vector<Vector2> &p_points, bool p_closed) override {}
 	void occluder_polygon_set_cull_mode(RID p_occluder, RS::CanvasOccluderPolygonCullMode p_mode) override {}
 	void set_shadow_texture_size(int p_size) override {}
-
-	void draw_window_margins(int *p_margins, RID *p_margin_textures) override {}
 
 	bool free(RID p_rid) override { return true; }
 	void update() override {}

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -608,8 +608,6 @@ public:
 	virtual void occluder_polygon_set_cull_mode(RID p_occluder, RS::CanvasOccluderPolygonCullMode p_mode) = 0;
 	virtual void set_shadow_texture_size(int p_size) = 0;
 
-	virtual void draw_window_margins(int *p_margins, RID *p_margin_textures) = 0;
-
 	virtual bool free(RID p_rid) = 0;
 	virtual void update() = 0;
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -457,8 +457,6 @@ public:
 
 	void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) {}
 
-	void draw_window_margins(int *p_margins, RID *p_margin_textures) {}
-
 	virtual void set_shadow_texture_size(int p_size);
 
 	void set_time(double p_time);

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
@@ -3078,9 +3078,6 @@ void RendererSceneGIRD::setup_voxel_gi_instances(RID p_render_buffers, const Tra
 				gipd.bias = storage->voxel_gi_get_bias(base_probe);
 				gipd.normal_bias = storage->voxel_gi_get_normal_bias(base_probe);
 				gipd.blend_ambient = !storage->voxel_gi_is_interior(base_probe);
-				gipd.anisotropy_strength = 0;
-				gipd.ao = storage->voxel_gi_get_ao(base_probe);
-				gipd.ao_size = Math::pow(storage->voxel_gi_get_ao_size(base_probe), 4.0f);
 				gipd.mipmaps = gipi->mipmaps.size();
 			}
 

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.h
@@ -611,9 +611,9 @@ public:
 		uint32_t blend_ambient;
 		uint32_t texture_slot;
 
-		float anisotropy_strength;
-		float ao;
-		float ao_size;
+		uint32_t pad0;
+		uint32_t pad1;
+		uint32_t pad2;
 		uint32_t mipmaps;
 	};
 

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -1076,8 +1076,6 @@ private:
 
 		float dynamic_range = 4.0;
 		float energy = 1.0;
-		float ao = 0.0;
-		float ao_size = 0.5;
 		float bias = 1.4;
 		float normal_bias = 0.0;
 		float propagation = 0.7;
@@ -1298,7 +1296,6 @@ public:
 
 	virtual void _texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer, bool p_immediate);
 
-	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0); //mostly used for video and streaming
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0);
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data);
 	virtual void texture_proxy_update(RID p_texture, RID p_proxy_to);
@@ -2039,12 +2036,6 @@ public:
 
 	void voxel_gi_set_energy(RID p_voxel_gi, float p_energy);
 	float voxel_gi_get_energy(RID p_voxel_gi) const;
-
-	void voxel_gi_set_ao(RID p_voxel_gi, float p_ao);
-	float voxel_gi_get_ao(RID p_voxel_gi) const;
-
-	void voxel_gi_set_ao_size(RID p_voxel_gi, float p_strength);
-	float voxel_gi_get_ao_size(RID p_voxel_gi) const;
 
 	void voxel_gi_set_bias(RID p_voxel_gi, float p_bias);
 	float voxel_gi_get_bias(RID p_voxel_gi) const;

--- a/servers/rendering/renderer_rd/shaders/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/gi.glsl
@@ -77,9 +77,9 @@ struct VoxelGIData {
 	bool blend_ambient;
 	uint texture_slot;
 
-	float anisotropy_strength;
-	float ambient_occlusion;
-	float ambient_occlusion_size;
+	uint pad0;
+	uint pad1;
+	uint pad2;
 	uint mipmaps;
 };
 
@@ -549,27 +549,6 @@ void voxel_gi_compute(uint index, vec3 position, vec3 normal, vec3 ref_vec, mat3
 			vec3 dir = normalize(dir_xform * cone_dirs[i]);
 			light += cone_weights[i] * voxel_cone_trace_45_degrees(voxel_gi_textures[index], cell_size, position, dir, max_distance, voxel_gi_instances.data[index].bias);
 		}
-	}
-
-	if (voxel_gi_instances.data[index].ambient_occlusion > 0.001) {
-		float size = 1.0 + voxel_gi_instances.data[index].ambient_occlusion_size * 7.0;
-
-		float taps, blend;
-		blend = modf(size, taps);
-		float ao = 0.0;
-		for (float i = 1.0; i <= taps; i++) {
-			vec3 ofs = (position + normal * (i * 0.5 + 1.0)) * cell_size;
-			ao += textureLod(sampler3D(voxel_gi_textures[index], linear_sampler_with_mipmaps), ofs, i - 1.0).a * i;
-		}
-
-		if (blend > 0.001) {
-			vec3 ofs = (position + normal * ((taps + 1.0) * 0.5 + 1.0)) * cell_size;
-			ao += textureLod(sampler3D(voxel_gi_textures[index], linear_sampler_with_mipmaps), ofs, taps).a * (taps + 1.0) * blend;
-		}
-
-		ao = 1.0 - min(1.0, ao);
-
-		light.rgb = mix(params.ao_color, light.rgb, mix(1.0, ao, voxel_gi_instances.data[index].ambient_occlusion));
 	}
 
 	light.rgb *= voxel_gi_instances.data[index].dynamic_range;

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -56,7 +56,6 @@ public:
 	virtual RID scenario_allocate() = 0;
 	virtual void scenario_initialize(RID p_rid) = 0;
 
-	virtual void scenario_set_debug(RID p_scenario, RS::ScenarioDebugMode p_debug_mode) = 0;
 	virtual void scenario_set_environment(RID p_scenario, RID p_environment) = 0;
 	virtual void scenario_set_camera_effects(RID p_scenario, RID p_fx) = 0;
 	virtual void scenario_set_fallback_environment(RID p_scenario, RID p_environment) = 0;
@@ -81,7 +80,6 @@ public:
 	virtual void instance_set_custom_aabb(RID p_instance, AABB p_aabb) = 0;
 
 	virtual void instance_attach_skeleton(RID p_instance, RID p_skeleton) = 0;
-	virtual void instance_set_exterior(RID p_instance, bool p_enabled) = 0;
 
 	virtual void instance_set_extra_visibility_margin(RID p_instance, real_t p_margin) = 0;
 	virtual void instance_set_visibility_parent(RID p_instance, RID p_parent_instance) = 0;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -330,12 +330,6 @@ void RendererSceneCull::scenario_initialize(RID p_rid) {
 	RendererSceneOcclusionCull::get_singleton()->add_scenario(p_rid);
 }
 
-void RendererSceneCull::scenario_set_debug(RID p_scenario, RS::ScenarioDebugMode p_debug_mode) {
-	Scenario *scenario = scenario_owner.getornull(p_scenario);
-	ERR_FAIL_COND(!scenario);
-	scenario->debug = p_debug_mode;
-}
-
 void RendererSceneCull::scenario_set_environment(RID p_scenario, RID p_environment) {
 	Scenario *scenario = scenario_owner.getornull(p_scenario);
 	ERR_FAIL_COND(!scenario);
@@ -937,9 +931,6 @@ void RendererSceneCull::instance_attach_skeleton(RID p_instance, RID p_skeleton)
 		InstanceGeometryData *geom = static_cast<InstanceGeometryData *>(instance->base_data);
 		scene_render->geometry_instance_set_skeleton(geom->geometry_instance, p_skeleton);
 	}
-}
-
-void RendererSceneCull::instance_set_exterior(RID p_instance, bool p_enabled) {
 }
 
 void RendererSceneCull::instance_set_extra_visibility_margin(RID p_instance, real_t p_margin) {

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -315,7 +315,6 @@ public:
 
 		DynamicBVH indexers[INDEXER_MAX];
 
-		RS::ScenarioDebugMode debug;
 		RID self;
 
 		List<Instance *> directional_lights;
@@ -338,7 +337,6 @@ public:
 		Scenario() {
 			indexers[INDEXER_GEOMETRY].set_index(INDEXER_GEOMETRY);
 			indexers[INDEXER_VOLUMES].set_index(INDEXER_VOLUMES);
-			debug = RS::SCENARIO_DEBUG_DISABLED;
 			used_viewport_visibility_bits = 0;
 		}
 	};
@@ -355,7 +353,6 @@ public:
 	virtual RID scenario_allocate();
 	virtual void scenario_initialize(RID p_rid);
 
-	virtual void scenario_set_debug(RID p_scenario, RS::ScenarioDebugMode p_debug_mode);
 	virtual void scenario_set_environment(RID p_scenario, RID p_environment);
 	virtual void scenario_set_camera_effects(RID p_scenario, RID p_fx);
 	virtual void scenario_set_fallback_environment(RID p_scenario, RID p_environment);
@@ -914,7 +911,6 @@ public:
 	virtual void instance_set_custom_aabb(RID p_instance, AABB p_aabb);
 
 	virtual void instance_attach_skeleton(RID p_instance, RID p_skeleton);
-	virtual void instance_set_exterior(RID p_instance, bool p_enabled);
 
 	virtual void instance_set_extra_visibility_margin(RID p_instance, real_t p_margin);
 

--- a/servers/rendering/renderer_scene_occlusion_cull.cpp
+++ b/servers/rendering/renderer_scene_occlusion_cull.cpp
@@ -185,7 +185,7 @@ RID RendererSceneOcclusionCull::HZBuffer::get_debug_texture() {
 	if (debug_texture.is_null()) {
 		debug_texture = RS::get_singleton()->texture_2d_create(debug_image);
 	} else {
-		RenderingServer::get_singleton()->texture_2d_update_immediate(debug_texture, debug_image);
+		RenderingServer::get_singleton()->texture_2d_update(debug_texture, debug_image);
 	}
 
 	return debug_texture;

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -130,7 +130,6 @@ public:
 	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) = 0;
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) = 0; //all slices, then all the mipmaps, must be coherent
 
-	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0; //mostly used for video and streaming
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) = 0;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) = 0;
@@ -421,12 +420,6 @@ public:
 
 	virtual void voxel_gi_set_energy(RID p_voxel_gi, float p_energy) = 0;
 	virtual float voxel_gi_get_energy(RID p_voxel_gi) const = 0;
-
-	virtual void voxel_gi_set_ao(RID p_voxel_gi, float p_ao) = 0;
-	virtual float voxel_gi_get_ao(RID p_voxel_gi) const = 0;
-
-	virtual void voxel_gi_set_ao_size(RID p_voxel_gi, float p_strength) = 0;
-	virtual float voxel_gi_get_ao_size(RID p_voxel_gi) const = 0;
 
 	virtual void voxel_gi_set_bias(RID p_voxel_gi, float p_bias) = 0;
 	virtual float voxel_gi_get_bias(RID p_voxel_gi) const = 0;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -114,7 +114,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport, uint32_t p_view_coun
 
 	Color bgcolor = RSG::storage->get_default_clear_color();
 
-	if (!p_viewport->hide_canvas && !p_viewport->disable_environment && RSG::scene->is_scenario(p_viewport->scenario)) {
+	if (!p_viewport->disable_2d && !p_viewport->disable_environment && RSG::scene->is_scenario(p_viewport->scenario)) {
 		RID environment = RSG::scene->scenario_get_environment(p_viewport->scenario);
 		if (RSG::scene->is_environment(environment)) {
 			scenario_draw_canvas_bg = RSG::scene->environment_get_background(environment) == RS::ENV_BG_CANVAS;
@@ -145,7 +145,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport, uint32_t p_view_coun
 		_draw_3d(p_viewport);
 	}
 
-	if (!p_viewport->hide_canvas) {
+	if (!p_viewport->disable_2d) {
 		int i = 0;
 
 		Map<Viewport::CanvasKey, Viewport::CanvasData *> canvas_map;
@@ -633,8 +633,6 @@ void RendererViewport::viewport_initialize(RID p_rid) {
 	viewport_owner.initialize_rid(p_rid);
 	Viewport *viewport = viewport_owner.getornull(p_rid);
 	viewport->self = p_rid;
-	viewport->hide_scenario = false;
-	viewport->hide_canvas = false;
 	viewport->render_target = RSG::storage->render_target_create();
 	viewport->shadow_atlas = RSG::scene->shadow_atlas_create();
 	viewport->viewport_render_direct_to_screen = false;
@@ -791,18 +789,11 @@ RID RendererViewport::viewport_get_occluder_debug_texture(RID p_viewport) const 
 	return RID();
 }
 
-void RendererViewport::viewport_set_hide_scenario(RID p_viewport, bool p_hide) {
+void RendererViewport::viewport_set_disable_2d(RID p_viewport, bool p_disable) {
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);
 
-	viewport->hide_scenario = p_hide;
-}
-
-void RendererViewport::viewport_set_hide_canvas(RID p_viewport, bool p_hide) {
-	Viewport *viewport = viewport_owner.getornull(p_viewport);
-	ERR_FAIL_COND(!viewport);
-
-	viewport->hide_canvas = p_hide;
+	viewport->disable_2d = p_disable;
 }
 
 void RendererViewport::viewport_set_disable_environment(RID p_viewport, bool p_disable) {

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -68,9 +68,8 @@ public:
 		Rect2 viewport_to_screen_rect;
 		bool viewport_render_direct_to_screen;
 
-		bool hide_scenario;
-		bool hide_canvas;
-		bool disable_environment;
+		bool disable_2d = false;
+		bool disable_environment = false;
 		bool disable_3d = false;
 		bool measure_render_time;
 
@@ -138,7 +137,7 @@ public:
 			update_mode = RS::VIEWPORT_UPDATE_WHEN_VISIBLE;
 			clear_mode = RS::VIEWPORT_CLEAR_ALWAYS;
 			transparent_bg = false;
-			disable_environment = false;
+
 			viewport_to_screen = DisplayServer::INVALID_WINDOW_ID;
 			shadow_atlas_size = 0;
 			measure_render_time = false;
@@ -218,8 +217,7 @@ public:
 	RID viewport_get_texture(RID p_viewport) const;
 	RID viewport_get_occluder_debug_texture(RID p_viewport) const;
 
-	void viewport_set_hide_scenario(RID p_viewport, bool p_hide);
-	void viewport_set_hide_canvas(RID p_viewport, bool p_hide);
+	void viewport_set_disable_2d(RID p_viewport, bool p_disable);
 	void viewport_set_disable_environment(RID p_viewport, bool p_disable);
 	void viewport_set_disable_3d(RID p_viewport, bool p_disable);
 

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -42,26 +42,6 @@
 
 int RenderingServerDefault::changes = 0;
 
-/* BLACK BARS */
-
-void RenderingServerDefault::black_bars_set_margins(int p_left, int p_top, int p_right, int p_bottom) {
-	black_margin[SIDE_LEFT] = p_left;
-	black_margin[SIDE_TOP] = p_top;
-	black_margin[SIDE_RIGHT] = p_right;
-	black_margin[SIDE_BOTTOM] = p_bottom;
-}
-
-void RenderingServerDefault::black_bars_set_images(RID p_left, RID p_top, RID p_right, RID p_bottom) {
-	black_image[SIDE_LEFT] = p_left;
-	black_image[SIDE_TOP] = p_top;
-	black_image[SIDE_RIGHT] = p_right;
-	black_image[SIDE_BOTTOM] = p_bottom;
-}
-
-void RenderingServerDefault::_draw_margins() {
-	RSG::canvas_render->draw_window_margins(black_margin, black_image);
-};
-
 /* FREE */
 
 void RenderingServerDefault::_free(RID p_rid) {
@@ -114,7 +94,6 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	RSG::viewport->draw_viewports();
 	RSG::canvas_render->update();
 
-	_draw_margins();
 	RSG::rasterizer->end_frame(p_swap_buffers);
 
 	RSG::canvas->update_visibility_notifiers();
@@ -410,11 +389,6 @@ RenderingServerDefault::RenderingServerDefault(bool p_create_thread) :
 	sr->set_scene_render(RSG::rasterizer->get_scene());
 
 	frame_profile_frame = 0;
-
-	for (int i = 0; i < 4; i++) {
-		black_margin[i] = 0;
-		black_image[i] = RID();
-	}
 }
 
 RenderingServerDefault::~RenderingServerDefault() {

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -58,9 +58,6 @@ class RenderingServerDefault : public RenderingServer {
 	static int changes;
 	RID test_cube;
 
-	int black_margin[4];
-	RID black_image[4];
-
 	struct FrameDrawnCallbacks {
 		ObjectID object;
 		StringName method;
@@ -69,7 +66,6 @@ class RenderingServerDefault : public RenderingServer {
 
 	List<FrameDrawnCallbacks> frame_drawn_callbacks;
 
-	void _draw_margins();
 	static void _changes_changed() {}
 
 	uint64_t frame_profile_frame;
@@ -192,8 +188,6 @@ public:
 	FUNCRIDTEX6(texture_3d, Image::Format, int, int, int, bool, const Vector<Ref<Image>> &)
 	FUNCRIDTEX1(texture_proxy, RID)
 
-	//goes pass-through
-	FUNC3(texture_2d_update_immediate, RID, const Ref<Image> &, int)
 	//these go through command queue if they are in another thread
 	FUNC3(texture_2d_update, RID, const Ref<Image> &, int)
 	FUNC2(texture_3d_update, RID, const Vector<Ref<Image>> &)
@@ -418,34 +412,12 @@ public:
 	FUNC1RC(Transform3D, voxel_gi_get_to_cell_xform, RID)
 
 	FUNC2(voxel_gi_set_dynamic_range, RID, float)
-	FUNC1RC(float, voxel_gi_get_dynamic_range, RID)
-
 	FUNC2(voxel_gi_set_propagation, RID, float)
-	FUNC1RC(float, voxel_gi_get_propagation, RID)
-
 	FUNC2(voxel_gi_set_energy, RID, float)
-	FUNC1RC(float, voxel_gi_get_energy, RID)
-
-	FUNC2(voxel_gi_set_ao, RID, float)
-	FUNC1RC(float, voxel_gi_get_ao, RID)
-
-	FUNC2(voxel_gi_set_ao_size, RID, float)
-	FUNC1RC(float, voxel_gi_get_ao_size, RID)
-
 	FUNC2(voxel_gi_set_bias, RID, float)
-	FUNC1RC(float, voxel_gi_get_bias, RID)
-
 	FUNC2(voxel_gi_set_normal_bias, RID, float)
-	FUNC1RC(float, voxel_gi_get_normal_bias, RID)
-
 	FUNC2(voxel_gi_set_interior, RID, bool)
-	FUNC1RC(bool, voxel_gi_is_interior, RID)
-
 	FUNC2(voxel_gi_set_use_two_bounces, RID, bool)
-	FUNC1RC(bool, voxel_gi_is_using_two_bounces, RID)
-
-	FUNC2(voxel_gi_set_anisotropy_strength, RID, float)
-	FUNC1RC(float, voxel_gi_get_anisotropy_strength, RID)
 
 	/* LIGHTMAP */
 
@@ -569,8 +541,7 @@ public:
 
 	FUNC1RC(RID, viewport_get_texture, RID)
 
-	FUNC2(viewport_set_hide_scenario, RID, bool)
-	FUNC2(viewport_set_hide_canvas, RID, bool)
+	FUNC2(viewport_set_disable_2d, RID, bool)
 	FUNC2(viewport_set_disable_environment, RID, bool)
 	FUNC2(viewport_set_disable_3d, RID, bool)
 
@@ -697,7 +668,6 @@ public:
 
 	FUNCRIDSPLIT(scenario)
 
-	FUNC2(scenario_set_debug, RID, ScenarioDebugMode)
 	FUNC2(scenario_set_environment, RID, RID)
 	FUNC2(scenario_set_camera_effects, RID, RID)
 	FUNC2(scenario_set_fallback_environment, RID, RID)
@@ -717,7 +687,6 @@ public:
 	FUNC2(instance_set_custom_aabb, RID, AABB)
 
 	FUNC2(instance_attach_skeleton, RID, RID)
-	FUNC2(instance_set_exterior, RID, bool)
 
 	FUNC2(instance_set_extra_visibility_margin, RID, real_t)
 	FUNC2(instance_set_visibility_parent, RID, RID)
@@ -884,11 +853,6 @@ public:
 #undef ServerName
 #undef WRITE_ACTION
 #undef SYNC_DEBUG
-
-	/* BLACK BARS */
-
-	virtual void black_bars_set_margins(int p_left, int p_top, int p_right, int p_bottom) override;
-	virtual void black_bars_set_images(RID p_left, RID p_top, RID p_right, RID p_bottom) override;
 
 	/* FREE */
 


### PR DESCRIPTION
* Rewrote bindings for RenderingServer.
* They are now all up to date.
* Several unused methods and deprecated features were cleaned up.

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/18621 and closes https://github.com/godotengine/godot/pull/49762 by superseding it.*