### PR TITLE
LocalVector: Don't error if `from` >= `count`

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -178,7 +178,6 @@ public:
 	}
 
 	int64_t find(const T &p_val, U p_from = 0) const {
-		ERR_FAIL_UNSIGNED_INDEX_V(p_from, count, -1);
 		for (U i = p_from; i < count; i++) {
 			if (data[i] == p_val) {
 				return int64_t(i);


### PR DESCRIPTION
Vector handles this silently by returning -1, and we should do the same here.
Otherwise we get errors when calling `find()` on e.g. a LocalVector of size 0,
while `find()` is expected to always work (if the parameters are invalid then
it doesn't find anything, so -1).

Fixup to #49925.