### PR TITLE
Renamed `Vector3.BACK` to `BACKWARD`

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2007,7 +2007,7 @@ static void _register_variant_builtin_methods() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "DOWN", Vector3(0, -1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "FORWARD", Vector3(0, 0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACK", Vector3(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACKWARD", Vector3(0, 0, 1));
 
 	_VariantCall::add_constant(Variant::VECTOR3I, "AXIS_X", Vector3i::AXIS_X);
 	_VariantCall::add_constant(Variant::VECTOR3I, "AXIS_Y", Vector3i::AXIS_Y);
@@ -2020,7 +2020,7 @@ static void _register_variant_builtin_methods() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "UP", Vector3i(0, 1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "DOWN", Vector3i(0, -1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "FORWARD", Vector3i(0, 0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "BACK", Vector3i(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "BACKWARD", Vector3i(0, 0, 1));
 
 	_VariantCall::add_constant(Variant::VECTOR2, "AXIS_X", Vector2::AXIS_X);
 	_VariantCall::add_constant(Variant::VECTOR2, "AXIS_Y", Vector2::AXIS_Y);

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -580,8 +580,8 @@
 		<constant name="FORWARD" value="Vector3(0, 0, -1)">
 			Forward unit vector. Represents the local direction of forward, and the global direction of north.
 		</constant>
-		<constant name="BACK" value="Vector3(0, 0, 1)">
-			Back unit vector. Represents the local direction of back, and the global direction of south.
+		<constant name="BACKWARD" value="Vector3(0, 0, 1)">
+			Backward unit vector. Represents the local direction of back, and the global direction of south.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -281,8 +281,8 @@
 		<constant name="FORWARD" value="Vector3i(0, 0, -1)">
 			Forward unit vector. Represents the local direction of forward, and the global direction of north.
 		</constant>
-		<constant name="BACK" value="Vector3i(0, 0, 1)">
-			Back unit vector. Represents the local direction of back, and the global direction of south.
+		<constant name="BACKWARD" value="Vector3i(0, 0, 1)">
+			Backward unit vector. Represents the local direction of back, and the global direction of south.
 		</constant>
 	</constants>
 </class>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -599,7 +599,7 @@ namespace Godot
         private static readonly Vector3 _right = new Vector3(1, 0, 0);
         private static readonly Vector3 _left = new Vector3(-1, 0, 0);
         private static readonly Vector3 _forward = new Vector3(0, 0, -1);
-        private static readonly Vector3 _back = new Vector3(0, 0, 1);
+        private static readonly Vector3 _backward = new Vector3(0, 0, 1);
 
         /// <summary>
         /// Zero vector, a vector with all components set to `0`.
@@ -646,11 +646,11 @@ namespace Godot
         /// <value>Equivalent to `new Vector3(0, 0, -1)`</value>
         public static Vector3 Forward { get { return _forward; } }
         /// <summary>
-        /// Back unit vector. Represents the local direction of back,
+        /// Backward unit vector. Represents the local direction of back,
         /// and the global direction of south.
         /// </summary>
         /// <value>Equivalent to `new Vector3(0, 0, 1)`</value>
-        public static Vector3 Back { get { return _back; } }
+        public static Vector3 Backward { get { return _backward; } }
 
         /// <summary>
         /// Constructs a new <see cref="Vector3"/> with the given components.


### PR DESCRIPTION
Fix for better compatibility with `FORWARD`: (https://github.com/godotengine/godot/issues/16863#issuecomment-872036846).
