### PR TITLE
Remove unused code related to Travis CI

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -41,19 +41,7 @@
 #include <windows.h>
 #include <ws2tcpip.h>
 #ifndef UWP_ENABLED
-#if defined(__MINGW32__) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 4)
-// MinGW-w64 on Ubuntu 12.04 (our Travis build env) has bugs in this code where
-// some includes are missing in dependencies of iphlpapi.h for WINVER >= 0x0600 (Vista).
-// We don't use this Vista code for now, so working it around by disabling it.
-// MinGW-w64 >= 4.0 seems to be better judging by its headers.
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0501 // Windows XP, disable Vista API
 #include <iphlpapi.h>
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600 // Re-enable Vista API
-#else
-#include <iphlpapi.h>
-#endif // MINGW hack
 #endif
 #else // UNIX
 #include <netdb.h>

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -101,12 +101,6 @@ def configure(env, env_mono):
 
     mono_lib_names = ["mono-2.0-sgen", "monosgen-2.0"]
 
-    is_travis = os.environ.get("TRAVIS") == "true"
-
-    if is_travis:
-        # Travis CI may have a Mono version lower than 5.12
-        env_mono.Append(CPPDEFINES=["NO_PENDING_EXCEPTIONS"])
-
     if is_android and not env["android_arch"] in android_arch_dirs:
         raise RuntimeError("This module does not support the specified 'android_arch': " + env["android_arch"])
 


### PR DESCRIPTION
We switched to GitHub Actions in 2020.

While we're at it, is this part still relevant today? https://github.com/godotengine/godot/blob/9f30638d4bbc5a30c6f4f5cff99910bf8e19c2e3/drivers/unix/ip_unix.cpp#L60-L63