### PR TITLE
Fix GridMap erasing octants in the wrong order

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -780,7 +780,7 @@ void GridMap::_update_octants_callback() {
 
 	while (to_delete.front()) {
 		octant_map.erase(to_delete.front()->get());
-		to_delete.pop_back();
+		to_delete.pop_front();
 	}
 
 	_update_visibility();


### PR DESCRIPTION
Fix GridMap problem issues:  [#33648](https://github.com/godotengine/godot/issues/33648), [#43712](https://github.com/godotengine/godot/issues/43712) and [#49995 ](https://github.com/godotengine/godot/issues/49995)

*Bugsquad edit:* fixes #33648, fixes #43712, fixes #49995 