### PR TITLE
Implement Curve3Texture

### DIFF
--- a/doc/classes/Curve3Texture.xml
+++ b/doc/classes/Curve3Texture.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Curve3Texture" inherits="Texture2D" version="4.0">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="curve_x" type="Curve" setter="set_curve_x" getter="get_curve_x">
+		</member>
+		<member name="curve_y" type="Curve" setter="set_curve_y" getter="get_curve_y">
+		</member>
+		<member name="curve_z" type="Curve" setter="set_curve_z" getter="get_curve_z">
+		</member>
+		<member name="width" type="int" setter="set_width" getter="get_width" default="2048">
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/CurveTexture.xml
+++ b/doc/classes/CurveTexture.xml
@@ -14,10 +14,16 @@
 		<member name="curve" type="Curve" setter="set_curve" getter="get_curve">
 			The [code]curve[/code] rendered onto the texture.
 		</member>
+		<member name="texture_mode" type="int" setter="set_texture_mode" getter="get_texture_mode" enum="CurveTexture.TextureMode" default="0">
+		</member>
 		<member name="width" type="int" setter="set_width" getter="get_width" default="2048">
 			The width of the texture.
 		</member>
 	</members>
 	<constants>
+		<constant name="TEXTURE_MODE_RGB" value="0" enum="TextureMode">
+		</constant>
+		<constant name="TEXTURE_MODE_RED" value="1" enum="TextureMode">
+		</constant>
 	</constants>
 </class>

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -774,6 +774,7 @@ void register_scene_types() {
 	ClassDB::register_class<AtlasTexture>();
 	ClassDB::register_class<MeshTexture>();
 	ClassDB::register_class<CurveTexture>();
+	ClassDB::register_class<Curve3Texture>();
 	ClassDB::register_class<GradientTexture>();
 	ClassDB::register_class<ProxyTexture>();
 	ClassDB::register_class<AnimatedTexture>();

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -586,11 +586,19 @@ public:
 class CurveTexture : public Texture2D {
 	GDCLASS(CurveTexture, Texture2D);
 	RES_BASE_EXTENSION("curvetex")
+public:
+	enum TextureMode {
+		TEXTURE_MODE_RGB,
+		TEXTURE_MODE_RED,
+	};
 
 private:
 	mutable RID _texture;
 	Ref<Curve> _curve;
 	int _width = 2048;
+	int _current_width = 0;
+	TextureMode texture_mode = TEXTURE_MODE_RGB;
+	TextureMode _current_texture_mode = TEXTURE_MODE_RGB;
 
 	void _update();
 
@@ -600,6 +608,9 @@ protected:
 public:
 	void set_width(int p_width);
 	int get_width() const override;
+
+	void set_texture_mode(TextureMode p_mode);
+	TextureMode get_texture_mode() const;
 
 	void ensure_default_setup(float p_min = 0, float p_max = 1);
 
@@ -614,18 +625,49 @@ public:
 	CurveTexture();
 	~CurveTexture();
 };
-/*
-	enum CubeMapSide {
-		CUBEMAP_LEFT,
-		CUBEMAP_RIGHT,
-		CUBEMAP_BOTTOM,
-		CUBEMAP_TOP,
-		CUBEMAP_FRONT,
-		CUBEMAP_BACK,
-	};
 
-*/
-//VARIANT_ENUM_CAST( Texture::CubeMapSide );
+VARIANT_ENUM_CAST(CurveTexture::TextureMode)
+
+class Curve3Texture : public Texture2D {
+	GDCLASS(Curve3Texture, Texture2D);
+	RES_BASE_EXTENSION("curvetex")
+
+private:
+	mutable RID _texture;
+	Ref<Curve> _curve_x;
+	Ref<Curve> _curve_y;
+	Ref<Curve> _curve_z;
+	int _width = 2048;
+	int _current_width = 0;
+
+	void _update();
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_width(int p_width);
+	int get_width() const override;
+
+	void ensure_default_setup(float p_min = 0, float p_max = 1);
+
+	void set_curve_x(Ref<Curve> p_curve);
+	Ref<Curve> get_curve_x() const;
+
+	void set_curve_y(Ref<Curve> p_curve);
+	Ref<Curve> get_curve_y() const;
+
+	void set_curve_z(Ref<Curve> p_curve);
+	Ref<Curve> get_curve_z() const;
+
+	virtual RID get_rid() const override;
+
+	virtual int get_height() const override { return 1; }
+	virtual bool has_alpha() const override { return false; }
+
+	Curve3Texture();
+	~Curve3Texture();
+};
 
 class GradientTexture : public Texture2D {
 	GDCLASS(GradientTexture, Texture2D);


### PR DESCRIPTION
* This was required by users in some scenarios, such as animating individual axes over time with a single texture.
* Examples: Shaders, Particles, etc.
* CurveTexture now defaults to RGB, can be changed to Red if needed, this allows to freely exchange them.

![image](https://user-images.githubusercontent.com/6265307/124173010-e524df00-da80-11eb-99bf-046fd416b894.png)
