### PR TITLE
Add `action_get_deadzone()` method to `InputMap`

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -45,6 +45,7 @@ void InputMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("erase_action", "action"), &InputMap::erase_action);
 
 	ClassDB::bind_method(D_METHOD("action_set_deadzone", "action", "deadzone"), &InputMap::action_set_deadzone);
+	ClassDB::bind_method(D_METHOD("action_get_deadzone", "action"), &InputMap::action_get_deadzone);
 	ClassDB::bind_method(D_METHOD("action_add_event", "action", "event"), &InputMap::action_add_event);
 	ClassDB::bind_method(D_METHOD("action_has_event", "action", "event"), &InputMap::action_has_event);
 	ClassDB::bind_method(D_METHOD("action_erase_event", "action", "event"), &InputMap::action_erase_event);

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -41,6 +41,15 @@
 				Removes all events from an action.
 			</description>
 		</method>
+		<method name="action_get_deadzone">
+			<return type="float">
+			</return>
+			<argument index="0" name="action" type="StringName">
+			</argument>
+			<description>
+				Returns a deadzone value for the action.
+			</description>
+		</method>
 		<method name="action_get_events">
 			<return type="Array">
 			</return>


### PR DESCRIPTION
This pull request adds a new method to the `InputMap` class, allowing the user to get the value of an action's dead zone as a float.

Resolves: #50061

<img width="560" alt="get_dead_zone script" src="https://user-images.githubusercontent.com/62965063/124218854-175a2f00-dac9-11eb-8b63-4ba2832376ed.PNG">
<img width="418" alt="get_dead_zone output" src="https://user-images.githubusercontent.com/62965063/124218861-1b864c80-dac9-11eb-96ca-56db7b8dc85d.PNG">
<img width="464" alt="action_get_deadzone() method description" src="https://user-images.githubusercontent.com/62965063/124221452-cf89d680-dacd-11eb-8ff1-eb6a006a65fa.PNG">
