### PR TITLE
Add Method description for `action_get_deadzone()` in `InputMap`

### DIFF
--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -72,6 +72,15 @@
 				Sets a deadzone value for the action.
 			</description>
 		</method>
+		<method name="action_get_deadzone">
+			<return type="float">
+			</return>
+			<argument index="0" name="action" type="StringName">
+			</argument>
+			<description>
+				Returns a deadzone value for the action.
+			</description>
+		</method>
 		<method name="add_action">
 			<return type="void">
 			</return>


### PR DESCRIPTION
Adds a description for a new method  `action_get_deadzone()`

See #50065.

<img width="464" alt="action_get_deadzone() method description" src="https://user-images.githubusercontent.com/62965063/124220704-4c1bb580-dacc-11eb-9576-312791087baa.PNG">