### PR TITLE
Add numpad emulation in 3D viewport

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -631,6 +631,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/3d/navigation/zoom_style", 0);
 	hints["editors/3d/navigation/zoom_style"] = PropertyInfo(Variant::INT, "editors/3d/navigation/zoom_style", PROPERTY_HINT_ENUM, "Vertical, Horizontal");
 
+	_initial_set("editors/3d/navigation/emulate_numpad", false);
 	_initial_set("editors/3d/navigation/emulate_3_button_mouse", false);
 	_initial_set("editors/3d/navigation/orbit_modifier", 0);
 	hints["editors/3d/navigation/orbit_modifier"] = PropertyInfo(Variant::INT, "editors/3d/navigation/orbit_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1967,6 +1967,13 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
+		if (EditorSettings::get_singleton()->get("editors/3d/navigation/emulate_numpad")) {
+			const uint32_t code = k->get_keycode();
+			if (code >= KEY_0 && code <= KEY_9) {
+				k->set_keycode(code - KEY_0 + KEY_KP_0);
+			}
+		}
+
 		if (ED_IS_SHORTCUT("spatial_editor/snap", p_event)) {
 			if (_edit.mode != TRANSFORM_NONE) {
 				_edit.snap = !_edit.snap;


### PR DESCRIPTION
Makes life easier to work on laptops.

* Controlled by editor setting `editors/3d/navigation/emulate_numpad`, defaults to false.
* Maps 0-9 to numpad 0-9 before processing the shortcuts.
* Previously, ALT+1 in 3D editor will bring up the 2D editor. When numpad emulation is on, this will switch the viewport to back view, as ALT+1 will be interpreted as ALT+KP1. I think this is reasonable.

It's basically the same for 3.x, but `node_3d_editor_plugin.cpp`  → `spatial_editor_plugin.cpp` and `keycode` → `scancode`.