### PR TITLE
Remove unnecessary semicolons from Android Java code

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Dictionary.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Dictionary.java
@@ -43,10 +43,10 @@ public class Dictionary extends HashMap<String, Object> {
 		for (String key : keys) {
 			ret[i] = key;
 			i++;
-		};
+		}
 
 		return ret;
-	};
+	}
 
 	public Object[] get_values() {
 		Object[] ret = new Object[size()];
@@ -55,21 +55,21 @@ public class Dictionary extends HashMap<String, Object> {
 		for (String key : keys) {
 			ret[i] = get(key);
 			i++;
-		};
+		}
 
 		return ret;
-	};
+	}
 
 	public void set_keys(String[] keys) {
 		keys_cache = keys;
-	};
+	}
 
 	public void set_values(Object[] vals) {
 		int i = 0;
 		for (String key : keys_cache) {
 			put(key, vals[i]);
 			i++;
-		};
+		}
 		keys_cache = null;
-	};
-};
+	}
+}

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -220,7 +220,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		for (int i = 0; i < permissions.length; i++) {
 			GodotLib.requestPermissionResult(permissions[i], grantResults[i] == PackageManager.PERMISSION_GRANTED);
 		}
-	};
+	}
 
 	/**
 	 * Invoked on the render thread when the Godot setup is complete.

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -408,12 +408,12 @@ public class GodotIO {
 
 		//InputMethodManager inputMgr = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
 		//inputMgr.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
-	};
+	}
 
 	public void hideKeyboard() {
 		if (edit != null)
 			edit.hideKeyboard();
-	};
+	}
 
 	public void setScreenOrientation(int p_orientation) {
 		switch (p_orientation) {


### PR DESCRIPTION
There are a number of stray semicolons in the Android Java code that are treated as empty statements or declarations. This PR removes them.