### PR TITLE
Remove redundant interface modifiers from Android Java code

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -175,7 +175,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	public static GodotNetUtils netUtils;
 
 	public interface ResultCallback {
-		public void callback(int requestCode, int resultCode, Intent data);
+		void callback(int requestCode, int resultCode, Intent data);
 	}
 	public ResultCallback result_callback;
 

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotRenderView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotRenderView.java
@@ -35,18 +35,18 @@ import org.godotengine.godot.input.GodotInputHandler;
 import android.view.SurfaceView;
 
 public interface GodotRenderView {
-	abstract public SurfaceView getView();
+	SurfaceView getView();
 
-	abstract public void initInputDevices();
+	void initInputDevices();
 
-	abstract public void queueOnRenderThread(Runnable event);
+	void queueOnRenderThread(Runnable event);
 
-	abstract public void onActivityPaused();
-	abstract public void onActivityResumed();
+	void onActivityPaused();
+	void onActivityResumed();
 
-	abstract public void onBackPressed();
+	void onBackPressed();
 
-	abstract public GodotInputHandler getInputHandler();
+	GodotInputHandler getInputHandler();
 
-	abstract public void setPointerIcon(int pointerType);
+	void setPointerIcon(int pointerType);
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/input/InputManagerCompat.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/InputManagerCompat.java
@@ -28,14 +28,14 @@ public interface InputManagerCompat {
 	 * @param id The device id
 	 * @return The input device or null if not found
 	 */
-	public InputDevice getInputDevice(int id);
+	InputDevice getInputDevice(int id);
 
 	/**
 	 * Gets the ids of all input devices in the system.
 	 *
 	 * @return The input device ids.
 	 */
-	public int[] getInputDeviceIds();
+	int[] getInputDeviceIds();
 
 	/**
 	 * Registers an input device listener to receive notifications about when
@@ -46,7 +46,7 @@ public interface InputManagerCompat {
 	 *            null if the listener should be invoked on the calling thread's
 	 *            looper.
 	 */
-	public void registerInputDeviceListener(InputManagerCompat.InputDeviceListener listener,
+	void registerInputDeviceListener(InputManagerCompat.InputDeviceListener listener,
 			Handler handler);
 
 	/**
@@ -54,7 +54,7 @@ public interface InputManagerCompat {
 	 *
 	 * @param listener The listener to unregister.
 	 */
-	public void unregisterInputDeviceListener(InputManagerCompat.InputDeviceListener listener);
+	void unregisterInputDeviceListener(InputManagerCompat.InputDeviceListener listener);
 
 	/*
 	 * The following three calls are to simulate V16 behavior on pre-Jellybean
@@ -69,7 +69,7 @@ public interface InputManagerCompat {
 	 *
 	 * @param event the motion event from the app
 	 */
-	public void onGenericMotionEvent(MotionEvent event);
+	void onGenericMotionEvent(MotionEvent event);
 
 	/**
 	 * Tell the V9 input manager that it should stop polling for disconnected
@@ -77,7 +77,7 @@ public interface InputManagerCompat {
 	 * might want to call it whenever your game is not active (or whenever you
 	 * don't care about being notified of new input devices)
 	 */
-	public void onPause();
+	void onPause();
 
 	/**
 	 * Tell the V9 input manager that it should start polling for disconnected
@@ -85,9 +85,9 @@ public interface InputManagerCompat {
 	 * might want to call it less often (only when the gameplay is actually
 	 * active)
 	 */
-	public void onResume();
+	void onResume();
 
-	public interface InputDeviceListener {
+	interface InputDeviceListener {
 		/**
 		 * Called whenever the input manager detects that a device has been
 		 * added. This will only be called in the V9 version when a motion event
@@ -119,7 +119,7 @@ public interface InputManagerCompat {
 	/**
 	 * Use this to construct a compatible InputManager.
 	 */
-	public static class Factory {
+	class Factory {
 		/**
 		 * Constructs and returns a compatible InputManger
 		 *


### PR DESCRIPTION
All methods in a Java interface are implicitly `public` and `abstract`. Similarly, all interfaces and classes inside of interfaces are `public` and `static`. Therefore, these modifiers are redundant, their use is obsolete, and the Java Language Specification discourages their use[[1](https://docs.oracle.com/javase/specs/jls/se16/html/jls-9.html#jls-9.1.1)].

This PR removes the redundant interface modifiers from the Godot Java code.
