### PR TITLE
Android: Initialize mouse mode

### DIFF
--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -92,7 +92,7 @@ private:
 		1003, //CURSOR_HELP
 	};
 	const int CURSOR_TYPE_NULL = 0;
-	MouseMode mouse_mode;
+	MouseMode mouse_mode = MouseMode::MOUSE_MODE_VISIBLE;
 
 	bool keep_screen_on;
 


### PR DESCRIPTION
All display servers initialize mouse mode to visible which not doing so make things not checking it correcty (specificly the editor) 