### PR TITLE
Fix raw use of parameterized Class

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
@@ -136,7 +136,7 @@ public abstract class GodotPlugin {
 		nativeRegisterSingleton(pluginName, pluginObject);
 
 		Set<Method> filteredMethods = new HashSet<>();
-		Class clazz = pluginObject.getClass();
+		Class<?> clazz = pluginObject.getClass();
 
 		Method[] methods = clazz.getDeclaredMethods();
 		for (Method method : methods) {
@@ -157,8 +157,8 @@ public abstract class GodotPlugin {
 		for (Method method : filteredMethods) {
 			List<String> ptr = new ArrayList<>();
 
-			Class[] paramTypes = method.getParameterTypes();
-			for (Class c : paramTypes) {
+			Class<?>[] paramTypes = method.getParameterTypes();
+			for (Class<?> c : paramTypes) {
 				ptr.add(c.getName());
 			}
 


### PR DESCRIPTION
Android's [`Object.getClass()`](https://developer.android.com/reference/java/lang/Object#getClass()) method returns a parametrized `Class<?>`,  not a raw `Class`. Technically, it returns `Class<? extends |X|>` _"where `|X|` is is the erasure of the static type of the expression on which `getClass()` is called"_.  Similarly, Android's [`Method.getParameterTypes()`](https://developer.android.com/reference/java/lang/reflect/Method#getParameterTypes()) returns `Class<?>[]`, not a raw `Class[]`.

This PR replaces the uses of a raw `Class` with the correct parametrized versions.
