### PR TITLE
Use StringBuilder instead StringBuffer in Godot Java code

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -897,7 +897,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 			byte[] messageDigest = complete.digest();
 
 			// Create Hex String
-			StringBuffer hexString = new StringBuffer();
+			StringBuilder hexString = new StringBuilder();
 			for (int i = 0; i < messageDigest.length; i++) {
 				String s = Integer.toHexString(0xFF & messageDigest[i]);
 

--- a/platform/android/java/lib/src/org/godotengine/godot/utils/Crypt.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/Crypt.java
@@ -42,7 +42,7 @@ public class Crypt {
 			byte[] messageDigest = digest.digest();
 
 			// Create Hex String
-			StringBuffer hexString = new StringBuffer();
+			StringBuilder hexString = new StringBuilder();
 			for (int i = 0; i < messageDigest.length; i++)
 				hexString.append(Integer.toHexString(0xFF & messageDigest[i]));
 			return hexString.toString();


### PR DESCRIPTION
Android's `StringBuffer` is only needed for thread-safe creation of a `String`. If a `String` is built on a single thread `StringBuilder` should be used, _"as it supports all of the same operations but it is faster, as it performs no synchronization."_[[1](https://developer.android.com/reference/java/lang/StringBuffer)]

This PR replaces the uses of `StringBuffer` with `StringBuilder`.