### PR TITLE
Remove redundant explicit types in Godot Java code

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -532,7 +532,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		String main_pack_md5 = null;
 		String main_pack_key = null;
 
-		List<String> new_args = new LinkedList<String>();
+		List<String> new_args = new LinkedList<>();
 
 		for (int i = 0; i < command_line.length; i++) {
 			boolean has_extra = i < command_line.length - 1;

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -321,8 +321,8 @@ public class GodotIO {
 		am = p_activity.getAssets();
 		activity = p_activity;
 		//streams = new HashMap<Integer, AssetData>();
-		streams = new SparseArray<AssetData>();
-		dirs = new SparseArray<AssetDir>();
+		streams = new SparseArray<>();
+		dirs = new SparseArray<>();
 	}
 
 	/////////////////////////

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
@@ -60,7 +60,7 @@ public class GodotInputHandler implements InputDeviceListener {
 	private final String tag = this.getClass().getSimpleName();
 
 	private final SparseIntArray mJoystickIds = new SparseIntArray(4);
-	private final SparseArray<Joystick> mJoysticksDevices = new SparseArray<Joystick>(4);
+	private final SparseArray<Joystick> mJoysticksDevices = new SparseArray<>(4);
 
 	public GodotInputHandler(GodotRenderView godotView) {
 		mRenderView = godotView;
@@ -329,7 +329,7 @@ public class GodotInputHandler implements InputDeviceListener {
 		//Helps with creating new joypad mappings.
 		Log.i(tag, "=== New Input Device: " + joystick.name);
 
-		Set<Integer> already = new HashSet<Integer>();
+		Set<Integer> already = new HashSet<>();
 		for (InputDevice.MotionRange range : device.getMotionRanges()) {
 			boolean isJoystick = range.isFromSource(InputDevice.SOURCE_JOYSTICK);
 			boolean isGamepad = range.isFromSource(InputDevice.SOURCE_GAMEPAD);

--- a/platform/android/java/lib/src/org/godotengine/godot/input/InputManagerV16.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/InputManagerV16.java
@@ -34,7 +34,7 @@ public class InputManagerV16 implements InputManagerCompat {
 
 	public InputManagerV16(Context context) {
 		mInputManager = (InputManager)context.getSystemService(Context.INPUT_SERVICE);
-		mListeners = new HashMap<InputManagerCompat.InputDeviceListener, V16InputDeviceListener>();
+		mListeners = new HashMap<>();
 	}
 
 	@Override

--- a/platform/android/java/lib/src/org/godotengine/godot/input/Joystick.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/Joystick.java
@@ -41,12 +41,12 @@ import java.util.List;
 class Joystick {
 	int device_id;
 	String name;
-	List<Integer> axes = new ArrayList<Integer>();
+	List<Integer> axes = new ArrayList<>();
 	protected boolean hasAxisHat = false;
 	/*
 	 * Keep track of values so we can prevent flooding the engine with useless events.
 	 */
-	protected final SparseArray<Float> axesValues = new SparseArray<Float>(4);
+	protected final SparseArray<Float> axesValues = new SparseArray<>(4);
 	protected int hatX;
 	protected int hatY;
 }


### PR DESCRIPTION
Since Java 1.7, the constructor type is inferred from the variable type[[1](https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.9.3)]. The constructor type is ignored. Therefore, explicitly specifying the constructor type is redundant. This PR removes the redundant type specifiers.
