### PR TITLE
Make invisible `SplitContainer` nodes correctly calculate the minimal size of its children

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -38,7 +38,7 @@ Control *SplitContainer::_getch(int p_idx) const {
 
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = Object::cast_to<Control>(get_child(i));
-		if (!c || !c->is_visible_in_tree()) {
+		if (!c || !c->is_visible()) {
 			continue;
 		}
 		if (c->is_set_as_top_level()) {


### PR DESCRIPTION
This is necessary for a future PR towards giving the editor's windows reasonable minimal sizes.