### PR TITLE
Expose `Window.get_contents_minimum_size()` to scripts

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -19,6 +19,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_contents_minimum_size" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<description>
+				Returns the combined minimum size from the child [Control] nodes of the window.
+			</description>
+		</method>
 		<method name="get_flag" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1393,6 +1393,8 @@ void Window::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_embedded"), &Window::is_embedded);
 
+	ClassDB::bind_method(D_METHOD("get_contents_minimum_size"), &Window::get_contents_minimum_size);
+
 	ClassDB::bind_method(D_METHOD("set_content_scale_size", "size"), &Window::set_content_scale_size);
 	ClassDB::bind_method(D_METHOD("get_content_scale_size"), &Window::get_content_scale_size);
 


### PR DESCRIPTION
This is good to have if you want the minimum size of your windows to be same of its `Control`s.