### PR TITLE
Use static inner classes in Godot Java code

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -71,7 +71,7 @@ public class GodotIO {
 
 	public int last_file_id = 1;
 
-	class AssetData {
+	static class AssetData {
 		public boolean eof = false;
 		public String path;
 		public InputStream is;
@@ -230,7 +230,7 @@ public class GodotIO {
 	/// DIRECTORIES
 	/////////////////////////
 
-	class AssetDir {
+	static class AssetDir {
 		public String[] files;
 		public int current;
 		public String path;


### PR DESCRIPTION
Java inner classes that don't require access to their outer class should be made static. This not only eliminates the inner class' hidden field and method for getting access to the outer class and its methods (saving memory), but also eliminates the risk that the outer class won't be garbage collected, because an inner class still exists and holds a reference to it (a potential memory leak).
