### PR TITLE
Remove Android onKeyMultiple override

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
@@ -96,14 +96,6 @@ public abstract class FullScreenGodotApp extends FragmentActivity implements God
 		}
 	}
 
-	@Override
-	public boolean onKeyMultiple(final int inKeyCode, int repeatCount, KeyEvent event) {
-		if (godotFragment != null && godotFragment.onKeyMultiple(inKeyCode, repeatCount, event)) {
-			return true;
-		}
-		return super.onKeyMultiple(inKeyCode, repeatCount, event);
-	}
-
 	/**
 	 * Used to initialize the Godot fragment instance in {@link FullScreenGodotApp#onCreate(Bundle)}.
 	 */

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -886,31 +886,6 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		}
 	}
 
-	public boolean onKeyMultiple(final int inKeyCode, int repeatCount, KeyEvent event) {
-		String s = event.getCharacters();
-		if (s == null || s.length() == 0)
-			return false;
-
-		final char[] cc = s.toCharArray();
-		int cnt = 0;
-		for (int i = cc.length; --i >= 0; cnt += cc[i] != 0 ? 1 : 0)
-			;
-		if (cnt == 0)
-			return false;
-		// This method will be called on the rendering thread:
-		mRenderView.queueOnRenderThread(() -> {
-			for (int i = 0, n = cc.length; i < n; i++) {
-				int keyCode;
-				if ((keyCode = cc[i]) != 0) {
-					// Simulate key down and up...
-					GodotLib.key(0, 0, keyCode, true);
-					GodotLib.key(0, 0, keyCode, false);
-				}
-			}
-		});
-		return true;
-	}
-
 	public boolean requestPermission(String p_name) {
 		return PermissionsUtil.requestPermission(p_name, getActivity());
 	}


### PR DESCRIPTION
AFAICT The Android `onKeyMultiple()` override isn't doing anything and should be removed (or fixed).

The event is never handled, because [`KeyEvent.getCharacters()`](https://developer.android.com/reference/android/view/KeyEvent#getCharacters()) will always return `null` except _"For the special case of a ACTION_MULTIPLE event with key code of KEYCODE_UNKNOWN..."_: https://github.com/godotengine/godot/blob/a8fb450b3ce568fa8e3c9c013821f9046b9a0396/platform/android/java/lib/src/org/godotengine/godot/Godot.java#L919-L922
Furthermore, `KeyEvent.getCharacters()` is deprecated and should be replaced anyway.

That been said, I don't believe it's worth fixing. The [`onKeyMultiple`](https://developer.android.com/reference/android/view/KeyEvent.Callback#onKeyMultiple(int,%20int,%20android.view.KeyEvent)) event is probably never called, because it is only called _"when a user's interaction with an analog control, such as flinging a trackball, generates simulated down/up events for the same key multiple times in quick succession."_ However, "flinging a trackball" is not going to generate key events, it will generate [`MotionEvent`](https://developer.android.com/reference/android/view/MotionEvent)s. I haven't been able to find any description of device that would generate a `KeyMultiple` event.

Therefore, this PR removes the `onKeyMultiple()` override.

Note: For reference, this was added in #192 as part of fixing Android `KeyEvent`s in general.