### PR TITLE
Most recently added current Camera2D takes precedence

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -245,9 +245,13 @@ void Camera2D::_notification(int p_what) {
 			canvas = get_canvas();
 
 			_setup_viewport();
-
 			_update_process_mode();
-			_update_scroll();
+
+			// if a camera enters the tree that is set to current,
+			// it should take over as the current camera, and mark
+			// all other cameras as non current
+			_set_current(current);
+
 			first = true;
 
 		} break;


### PR DESCRIPTION
The situation when multiple current Camera2Ds were in the scene was not dealt with. This could leave several cameras with their current bool set, and each competing to update the viewport scroll, in a random / accidental fashion.

This PR standardises the rule that the most recent current Camera2D added to the scene tree takes over the current status, and sets all other current cameras in the scene tree to non-current. This makes the bools correct, and also prevents the competition over viewport scroll.

Fixes #50091

## Notes
* This is made on the assumption that we want precedence to go to the most recently added current Camera2D
* The `_update_scroll` is removed because it is called as part of `make_current` if the camera is current (if not current, the `_update_scroll` would be a noop anyway.
* `_set_current` does also call `update()`. I'm not clear on whether this is absolutely necessary (i.e. we could call `make_current` directly), but I'm erring on the side of having as much updated as possible when entering the tree, which should be a rare event.
* I can make PR for 4.x as well if we agree on this approach.
* This is potentially a breaking change .. however the current behaviour is likely to be semi-random which isn't ideal.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
