### PR TITLE
Few improvements for constants in visual shader

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -73,7 +73,6 @@ private:
 		Map<int, Port> output_ports;
 		VBoxContainer *preview_box = nullptr;
 		LineEdit *uniform_name = nullptr;
-		OptionButton *const_op = nullptr;
 		CodeEdit *expression_edit = nullptr;
 		CurveEditor *curve_editors[3] = { nullptr, nullptr, nullptr };
 	};
@@ -95,7 +94,6 @@ public:
 	void register_output_port(int p_id, int p_port, TextureButton *p_button);
 	void register_uniform_name(int p_id, LineEdit *p_uniform_name);
 	void register_default_input_button(int p_node_id, int p_port_id, Button *p_button);
-	void register_constant_option_btn(int p_node_id, OptionButton *p_button);
 	void register_expression_edit(int p_node_id, CodeEdit *p_expression_edit);
 	void register_curve_editor(int p_node_id, int p_index, CurveEditor *p_curve_editor);
 	void clear_links();
@@ -118,7 +116,6 @@ public:
 	void set_uniform_name(VisualShader::Type p_type, int p_node_id, const String &p_name);
 	void update_curve(int p_node_id);
 	void update_curve_xyz(int p_node_id);
-	void update_constant(VisualShader::Type p_type, int p_node_id);
 	void set_expression(VisualShader::Type p_type, int p_node_id, const String &p_expression);
 	int get_constant_index(float p_constant) const;
 	void update_node_size(int p_node_id);
@@ -164,6 +161,7 @@ class VisualShaderEditor : public VBoxContainer {
 
 	ConfirmationDialog *members_dialog;
 	PopupMenu *popup_menu;
+	PopupMenu *constants_submenu = nullptr;
 	MenuButton *tools;
 
 	PopupPanel *comment_title_change_popup = nullptr;
@@ -214,6 +212,7 @@ class VisualShaderEditor : public VBoxContainer {
 		DELETE,
 		DUPLICATE,
 		SEPARATOR2, // ignore
+		FLOAT_CONSTANTS,
 		CONVERT_CONSTANTS_TO_UNIFORMS,
 		CONVERT_UNIFORMS_TO_CONSTANTS,
 		SEPARATOR3, // ignore
@@ -347,6 +346,7 @@ class VisualShaderEditor : public VBoxContainer {
 	Set<int> selected_constants;
 	Set<int> selected_uniforms;
 	int selected_comment = -1;
+	int selected_float_constant = -1;
 
 	void _convert_constants_to_uniforms(bool p_vice_versa);
 	void _replace_node(VisualShader::Type p_type_id, int p_node_id, const StringName &p_from, const StringName &p_to);
@@ -396,7 +396,7 @@ class VisualShaderEditor : public VBoxContainer {
 	void _input_select_item(Ref<VisualShaderNodeInput> input, String name);
 	void _uniform_select_item(Ref<VisualShaderNodeUniformRef> p_uniform, String p_name);
 
-	void _float_constant_selected(int p_index, int p_node);
+	void _float_constant_selected(int p_which);
 
 	VisualShader::Type get_current_shader_type() const;
 

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -38,7 +38,7 @@ VisualShaderNodeConstant::VisualShaderNodeConstant() {
 ////////////// Scalar(Float)
 
 String VisualShaderNodeFloatConstant::get_caption() const {
-	return "ScalarFloat";
+	return "FloatConstant";
 }
 
 int VisualShaderNodeFloatConstant::get_input_port_count() const {
@@ -97,7 +97,7 @@ VisualShaderNodeFloatConstant::VisualShaderNodeFloatConstant() {
 ////////////// Scalar(Int)
 
 String VisualShaderNodeIntConstant::get_caption() const {
-	return "ScalarInt";
+	return "IntConstant";
 }
 
 int VisualShaderNodeIntConstant::get_input_port_count() const {
@@ -156,7 +156,7 @@ VisualShaderNodeIntConstant::VisualShaderNodeIntConstant() {
 ////////////// Boolean
 
 String VisualShaderNodeBooleanConstant::get_caption() const {
-	return "Boolean";
+	return "BooleanConstant";
 }
 
 int VisualShaderNodeBooleanConstant::get_input_port_count() const {
@@ -215,7 +215,7 @@ VisualShaderNodeBooleanConstant::VisualShaderNodeBooleanConstant() {
 ////////////// Color
 
 String VisualShaderNodeColorConstant::get_caption() const {
-	return "Color";
+	return "ColorConstant";
 }
 
 int VisualShaderNodeColorConstant::get_input_port_count() const {
@@ -285,7 +285,7 @@ VisualShaderNodeColorConstant::VisualShaderNodeColorConstant() {
 ////////////// Vector
 
 String VisualShaderNodeVec3Constant::get_caption() const {
-	return "Vector";
+	return "VectorConstant";
 }
 
 int VisualShaderNodeVec3Constant::get_input_port_count() const {
@@ -344,7 +344,7 @@ VisualShaderNodeVec3Constant::VisualShaderNodeVec3Constant() {
 ////////////// Transform3D
 
 String VisualShaderNodeTransformConstant::get_caption() const {
-	return "Transform3D";
+	return "TransformConstant";
 }
 
 int VisualShaderNodeTransformConstant::get_input_port_count() const {


### PR DESCRIPTION
Changes:
- Removed drop-down list from `FloatConstant` - instead added a new option 'Float Constants' to the context menu:
![image](https://user-images.githubusercontent.com/3036176/124347920-b0836580-dbef-11eb-84db-cf3fe1a8a58b.png)
maybe it should be named `Predefined constants` but I think it's also fine

- Changed constants caption like: Boolean -> BooleanConstant, Vector -> VectorConstant etc. to prevent confusion for the users