### PR TITLE
Migrate remaining features into CodeEdit

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -30,6 +30,18 @@
 				Override this method to define what happens when the user requests code completion. If [code]force[/code] is true, any checks should be bypassed.
 			</description>
 		</method>
+		<method name="add_auto_brace_completion_pair">
+			<return type="void">
+			</return>
+			<argument index="0" name="start_key" type="String">
+			</argument>
+			<argument index="1" name="end_key" type="String">
+			</argument>
+			<description>
+				Adds a brace pair.
+				Both the start and end keys must be symbols. Only the start key has to be unique.
+			</description>
+		</method>
 		<method name="add_code_completion_option">
 			<return type="void" />
 			<argument index="0" name="type" type="int" enum="CodeEdit.CodeCompletionKind" />
@@ -137,6 +149,15 @@
 				Folds the given line, if possible (see [method can_fold_line]).
 			</description>
 		</method>
+		<method name="get_auto_brace_completion_close_key" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="open_key" type="String">
+			</argument>
+			<description>
+				Gets the matching auto brace close key for [code]open_key[/code].
+			</description>
+		</method>
 		<method name="get_bookmarked_lines" qualifiers="const">
 			<return type="Array" />
 			<description>
@@ -217,6 +238,24 @@
 			<return type="String" />
 			<description>
 				Returns the full text with char [code]0xFFFF[/code] at the caret location.
+			</description>
+		</method>
+		<method name="has_auto_brace_completion_close_key" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="close_key" type="String">
+			</argument>
+			<description>
+				Returns [code]true[/code] if close key [code]close_key[/code] exists.
+			</description>
+		</method>
+		<method name="has_auto_brace_completion_open_key" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="open_key" type="String">
+			</argument>
+			<description>
+				Returns [code]true[/code] if open key [code]open_key[/code] exists.
 			</description>
 		</method>
 		<method name="has_comment_delimiter" qualifiers="const">
@@ -378,6 +417,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="auto_brace_completion_enabled" type="bool" setter="set_auto_brace_completion_enabled" getter="is_auto_brace_completion_enabled" default="false">
+			Sets whether brace pairs should be autocompleted.
+		</member>
+		<member name="auto_brace_completion_pairs" type="Dictionary" setter="set_auto_brace_completion_pairs" getter="get_auto_brace_completion_pairs" default="{&quot;\&quot;&quot;: &quot;\&quot;&quot;,&quot;&apos;&quot;: &quot;&apos;&quot;,&quot;(&quot;: &quot;)&quot;,&quot;[&quot;: &quot;]&quot;,&quot;{&quot;: &quot;}&quot;}">
+			Sets the brace pairs to be autocompleted.
+		</member>
 		<member name="code_completion_enabled" type="bool" setter="set_code_completion_enabled" getter="is_code_completion_enabled" default="false">
 			Sets whether code completion is allowed.
 		</member>

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="CodeEdit" inherits="TextEdit" version="4.0">
 	<brief_description>
+		Multiline text control intended for editing code.
 	</brief_description>
 	<description>
+		CodeEdit is a specialised [TextEdit] designed for editing plain text code files. It contains a bunch of features commonly found in code editors such as line numbers, line folding, code completion, indent management and string / comment management.
 		[b]Note[/b]: By default [CodeEdit] always use left-to-right text direction to correctly display source code.
 	</description>
 	<tutorials>
@@ -31,12 +33,9 @@
 			</description>
 		</method>
 		<method name="add_auto_brace_completion_pair">
-			<return type="void">
-			</return>
-			<argument index="0" name="start_key" type="String">
-			</argument>
-			<argument index="1" name="end_key" type="String">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="start_key" type="String" />
+			<argument index="1" name="end_key" type="String" />
 			<description>
 				Adds a brace pair.
 				Both the start and end keys must be symbols. Only the start key has to be unique.
@@ -93,11 +92,13 @@
 		<method name="clear_bookmarked_lines">
 			<return type="void" />
 			<description>
+				Clears all bookmarked lines.
 			</description>
 		</method>
 		<method name="clear_breakpointed_lines">
 			<return type="void" />
 			<description>
+				Clears all breakpointed lines.
 			</description>
 		</method>
 		<method name="clear_comment_delimiters">
@@ -109,6 +110,7 @@
 		<method name="clear_executing_lines">
 			<return type="void" />
 			<description>
+				Clears all executed lines.
 			</description>
 		</method>
 		<method name="clear_string_delimiters">
@@ -150,10 +152,8 @@
 			</description>
 		</method>
 		<method name="get_auto_brace_completion_close_key" qualifiers="const">
-			<return type="String">
-			</return>
-			<argument index="0" name="open_key" type="String">
-			</argument>
+			<return type="String" />
+			<argument index="0" name="open_key" type="String" />
 			<description>
 				Gets the matching auto brace close key for [code]open_key[/code].
 			</description>
@@ -161,11 +161,13 @@
 		<method name="get_bookmarked_lines" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Gets all bookmarked lines.
 			</description>
 		</method>
 		<method name="get_breakpointed_lines" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Gets all breakpointed lines.
 			</description>
 		</method>
 		<method name="get_code_completion_option" qualifiers="const">
@@ -226,6 +228,7 @@
 		<method name="get_executing_lines" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Gets all executing lines.
 			</description>
 		</method>
 		<method name="get_folded_lines" qualifiers="const">
@@ -241,26 +244,21 @@
 			</description>
 		</method>
 		<method name="get_text_for_symbol_lookup">
-			<return type="String">
-			</return>
+			<return type="String" />
 			<description>
 				Returns the full text with char [code]0xFFFF[/code] at the cursor location.
 			</description>
 		</method>
 		<method name="has_auto_brace_completion_close_key" qualifiers="const">
-			<return type="bool">
-			</return>
-			<argument index="0" name="close_key" type="String">
-			</argument>
+			<return type="bool" />
+			<argument index="0" name="close_key" type="String" />
 			<description>
 				Returns [code]true[/code] if close key [code]close_key[/code] exists.
 			</description>
 		</method>
 		<method name="has_auto_brace_completion_open_key" qualifiers="const">
-			<return type="bool">
-			</return>
-			<argument index="0" name="open_key" type="String">
-			</argument>
+			<return type="bool" />
+			<argument index="0" name="open_key" type="String" />
 			<description>
 				Returns [code]true[/code] if open key [code]open_key[/code] exists.
 			</description>
@@ -305,18 +303,21 @@
 			<return type="bool" />
 			<argument index="0" name="line" type="int" />
 			<description>
+				Returns whether the line at the specified index is bookmarked or not.
 			</description>
 		</method>
 		<method name="is_line_breakpointed" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="line" type="int" />
 			<description>
+				Returns whether the line at the specified index is breakpointed or not.
 			</description>
 		</method>
 		<method name="is_line_executing" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="line" type="int" />
 			<description>
+				Returns whether the line at the specified index is marked as executing or not.
 			</description>
 		</method>
 		<method name="is_line_folded" qualifiers="const">
@@ -373,6 +374,7 @@
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="bookmarked" type="bool" />
 			<description>
+				Sets the line as bookmarked.
 			</description>
 		</method>
 		<method name="set_line_as_breakpoint">
@@ -380,6 +382,7 @@
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="breakpointed" type="bool" />
 			<description>
+				Sets the line as breakpointed.
 			</description>
 		</method>
 		<method name="set_line_as_executing">
@@ -387,13 +390,12 @@
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="executing" type="bool" />
 			<description>
+				Sets the line as executing.
 			</description>
 		</method>
 		<method name="set_symbol_lookup_word_as_valid">
-			<return type="void">
-			</return>
-			<argument index="0" name="valid" type="bool">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="valid" type="bool" />
 			<description>
 				Sets the symbol emitted by [signal symbol_validate] as a valid lookup.
 			</description>
@@ -408,6 +410,7 @@
 		<method name="unfold_all_lines">
 			<return type="void" />
 			<description>
+				Unfolds all lines, folded or not.
 			</description>
 		</method>
 		<method name="unfold_line">
@@ -451,18 +454,26 @@
 		<member name="delimiter_comments" type="String[]" setter="set_comment_delimiters" getter="get_comment_delimiters" default="[]">
 			Sets the comment delimiters. All existing comment delimiters will be removed.
 		</member>
-		<member name="delimiter_strings" type="String[]" setter="set_string_delimiters" getter="get_string_delimiters" default="[]">
+		<member name="delimiter_strings" type="String[]" setter="set_string_delimiters" getter="get_string_delimiters" default="[&quot;&apos; &apos;&quot;, &quot;\&quot; \&quot;&quot;]">
 			Sets the string delimiters. All existing string delimiters will be removed.
 		</member>
-		<member name="draw_bookmarks" type="bool" setter="set_draw_bookmarks_gutter" getter="is_drawing_bookmarks_gutter" default="false">
+		<member name="gutters_draw_bookmarks" type="bool" setter="set_draw_bookmarks_gutter" getter="is_drawing_bookmarks_gutter" default="false">
+			Sets if bookmarked should be drawn in the gutter. This gutter is shared with breakpoints and executing lines.
 		</member>
-		<member name="draw_breakpoints_gutter" type="bool" setter="set_draw_breakpoints_gutter" getter="is_drawing_breakpoints_gutter" default="false">
+		<member name="gutters_draw_breakpoints_gutter" type="bool" setter="set_draw_breakpoints_gutter" getter="is_drawing_breakpoints_gutter" default="false">
+			Sets if breakpoints should be drawn in the gutter. This gutter is shared with bookmarks and executing lines.
 		</member>
-		<member name="draw_executing_lines" type="bool" setter="set_draw_executing_lines_gutter" getter="is_drawing_executing_lines_gutter" default="false">
+		<member name="gutters_draw_executing_lines" type="bool" setter="set_draw_executing_lines_gutter" getter="is_drawing_executing_lines_gutter" default="false">
+			Sets if executing lines should be marked in the gutter. This gutter is shared with breakpoints and bookmarks lines.
 		</member>
-		<member name="draw_fold_gutter" type="bool" setter="set_draw_fold_gutter" getter="is_drawing_fold_gutter" default="false">
+		<member name="gutters_draw_fold_gutter" type="bool" setter="set_draw_fold_gutter" getter="is_drawing_fold_gutter" default="false">
+			Sets if foldable lines icons should be drawn in the gutter.
 		</member>
-		<member name="draw_line_numbers" type="bool" setter="set_draw_line_numbers" getter="is_draw_line_numbers_enabled" default="false">
+		<member name="gutters_draw_line_numbers" type="bool" setter="set_draw_line_numbers" getter="is_draw_line_numbers_enabled" default="false">
+			Sets if line numbers should be drawn in the gutter.
+		</member>
+		<member name="gutters_zero_pad_line_numbers" type="bool" setter="set_line_numbers_zero_padded" getter="is_line_numbers_zero_padded" default="false">
+			Sets if line numbers drawn in the gutter are zero padded.
 		</member>
 		<member name="indent_automatic" type="bool" setter="set_auto_indent_enabled" getter="is_auto_indent_enabled" default="false">
 			Sets whether automatic indent are enabled, this will add an extra indent if a prefix or brace is found.
@@ -477,23 +488,23 @@
 			Use spaces instead of tabs for indentation.
 		</member>
 		<member name="layout_direction" type="int" setter="set_layout_direction" getter="get_layout_direction" override="true" enum="Control.LayoutDirection" default="2" />
-		<member name="line_folding" type="bool" setter="set_line_folding_enabled" getter="is_line_folding_enabled" default="true">
+		<member name="line_folding" type="bool" setter="set_line_folding_enabled" getter="is_line_folding_enabled" default="false">
 			Sets whether line folding is allowed.
 		</member>
 		<member name="line_length_guidelines" type="int[]" setter="set_line_length_guidelines" getter="get_line_length_guidelines" default="[]">
+			Draws vertical lines at the provided columns. The first entry is considered a main hard guideline and is draw more prominently
 		</member>
 		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" override="true" default="[]" />
 		<member name="symbol_lookup_on_click" type="bool" setter="set_symbol_lookup_on_click_enabled" getter="is_symbol_lookup_on_click_enabled" default="false">
 			Set when a validated word from [signal symbol_validate] is clicked, the [signal symbol_lookup] should be emitted.
 		</member>
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" override="true" enum="Control.TextDirection" default="1" />
-		<member name="zero_pad_line_numbers" type="bool" setter="set_line_numbers_zero_padded" getter="is_line_numbers_zero_padded" default="false">
-		</member>
 	</members>
 	<signals>
 		<signal name="breakpoint_toggled">
 			<argument index="0" name="line" type="int" />
 			<description>
+				Emitted when a breakpoint is added or removed from a line. If the line is moved via backspace a removed is emitted at the old line.
 			</description>
 		</signal>
 		<signal name="request_code_completion">
@@ -502,19 +513,15 @@
 			</description>
 		</signal>
 		<signal name="symbol_lookup">
-			<argument index="0" name="symbol" type="String">
-			</argument>
-			<argument index="1" name="line" type="int">
-			</argument>
-			<argument index="2" name="column" type="int">
-			</argument>
+			<argument index="0" name="symbol" type="String" />
+			<argument index="1" name="line" type="int" />
+			<argument index="2" name="column" type="int" />
 			<description>
 				Emitted when the user has clicked on a valid symbol.
 			</description>
 		</signal>
 		<signal name="symbol_validate">
-			<argument index="0" name="symbol" type="String">
-			</argument>
+			<argument index="0" name="symbol" type="String" />
 			<description>
 				Emitted when the user hovers over a symbol. The symbol should be validated and responded to, by calling [method set_symbol_lookup_word_as_valid].
 			</description>
@@ -522,114 +529,159 @@
 	</signals>
 	<constants>
 		<constant name="KIND_CLASS" value="0" enum="CodeCompletionKind">
+			Marks the option as a class.
 		</constant>
 		<constant name="KIND_FUNCTION" value="1" enum="CodeCompletionKind">
+			Marks the option as a function.
 		</constant>
 		<constant name="KIND_SIGNAL" value="2" enum="CodeCompletionKind">
+			Marks the option as a Godot signal.
 		</constant>
 		<constant name="KIND_VARIABLE" value="3" enum="CodeCompletionKind">
+			Marks the option as a variable.
 		</constant>
 		<constant name="KIND_MEMBER" value="4" enum="CodeCompletionKind">
+			Marks the option as a member.
 		</constant>
 		<constant name="KIND_ENUM" value="5" enum="CodeCompletionKind">
+			Marks the option as a enum entry.
 		</constant>
 		<constant name="KIND_CONSTANT" value="6" enum="CodeCompletionKind">
+			Marks the option as a constant.
 		</constant>
 		<constant name="KIND_NODE_PATH" value="7" enum="CodeCompletionKind">
+			Marks the option as a Godot node path.
 		</constant>
 		<constant name="KIND_FILE_PATH" value="8" enum="CodeCompletionKind">
+			Marks the option as a file path.
 		</constant>
 		<constant name="KIND_PLAIN_TEXT" value="9" enum="CodeCompletionKind">
+			Marks the option as unclassified or plain text.
 		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="background_color" type="Color" default="Color(0, 0, 0, 0)">
+			Sets the background [Color].
 		</theme_item>
 		<theme_item name="bookmark" type="Texture2D">
+			Sets a custom [Texture2D] to draw in the bookmark gutter for bookmarked lines.
 		</theme_item>
 		<theme_item name="bookmark_color" type="Color" default="Color(0.5, 0.64, 1, 0.8)">
+			[Color] of the bookmark icon for bookmarked lines.
 		</theme_item>
 		<theme_item name="brace_mismatch_color" type="Color" default="Color(1, 0.2, 0.2, 1)">
+			[Color] of the text to highlight mismatched braces.
 		</theme_item>
 		<theme_item name="breakpoint" type="Texture2D">
+			Sets a custom [Texture2D] to draw in the breakpoint gutter for breakpointed lines.
 		</theme_item>
 		<theme_item name="breakpoint_color" type="Color" default="Color(0.9, 0.29, 0.3, 1)">
+			[Color] of the breakpoint icon for bookmarked lines.
 		</theme_item>
 		<theme_item name="can_fold" type="Texture2D">
+			Sets a custom [Texture2D] to draw in the line folding gutter when a line can be folded.
 		</theme_item>
 		<theme_item name="caret_background_color" type="Color" default="Color(0, 0, 0, 1)">
+			[Color] of the text behind the caret when block caret is enabled.
 		</theme_item>
 		<theme_item name="caret_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+			[Color] of the caret.
 		</theme_item>
 		<theme_item name="code_folding_color" type="Color" default="Color(0.8, 0.8, 0.8, 0.8)">
+			[Color] for all icons related to line folding.
 		</theme_item>
 		<theme_item name="completion" type="StyleBox">
+			[StyleBox] for the code completion popup.
 		</theme_item>
 		<theme_item name="completion_background_color" type="Color" default="Color(0.17, 0.16, 0.2, 1)">
+			Sets the background [Color] for the code completion popup.
 		</theme_item>
 		<theme_item name="completion_existing_color" type="Color" default="Color(0.87, 0.87, 0.87, 0.13)">
+			Background highlight [Color] for matching text in code completion options.
 		</theme_item>
 		<theme_item name="completion_font_color" type="Color" default="Color(0.67, 0.67, 0.67, 1)">
+			Font [Color] for the code completion popup.
 		</theme_item>
 		<theme_item name="completion_lines" type="int" default="7">
+			Max number of options to display in the code completion popup at any one time.
 		</theme_item>
 		<theme_item name="completion_max_width" type="int" default="50">
+			Max width of options in the code completion popup. Options longer then this will be cut off.
 		</theme_item>
 		<theme_item name="completion_scroll_color" type="Color" default="Color(1, 1, 1, 1)">
+			[Color] of the scrollbar in the code completion popup.
 		</theme_item>
 		<theme_item name="completion_scroll_width" type="int" default="3">
+			Width of the scrollbar in the code completion popup.
 		</theme_item>
 		<theme_item name="completion_selected_color" type="Color" default="Color(0.26, 0.26, 0.27, 1)">
+			Background highlight [Color] for the current selected option item in the code completion popup.
 		</theme_item>
 		<theme_item name="current_line_color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">
+			Background [Color] of the line containing the caret.
 		</theme_item>
 		<theme_item name="executing_line" type="Texture2D">
+			Icon to draw in the executing gutter for executing lines.
 		</theme_item>
 		<theme_item name="executing_line_color" type="Color" default="Color(0.98, 0.89, 0.27, 1)">
+			[Color] of the executing icon for executing lines.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
+			Sets the [StyleBox] when in focus.
 		</theme_item>
 		<theme_item name="folded" type="Texture2D">
+			Sets a custom [Texture2D] to draw in the line folding gutter when a line is folded and can be unfolded.
 		</theme_item>
 		<theme_item name="folded_eol_icon" type="Texture2D">
+			Sets a custom [Texture2D] to draw at the end of a folded line.
 		</theme_item>
 		<theme_item name="font" type="Font">
+			Sets the default [Font].
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+			Sets the font [Color].
 		</theme_item>
 		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [CodeEdit].
 		</theme_item>
 		<theme_item name="font_readonly_color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
+			Sets the font [Color] when [member readonly] is enabled.
 		</theme_item>
 		<theme_item name="font_selected_color" type="Color" default="Color(0, 0, 0, 1)">
+			Sets the [Color] of the selected text. [member override_selected_font_color] has to be enabled.
 		</theme_item>
 		<theme_item name="font_size" type="int">
-			Font size of the [CodeEdit]'s text.
+			Sets default font size.
 		</theme_item>
 		<theme_item name="line_length_guideline_color" type="Color" default="Color(0.3, 0.5, 0.8, 0.1)">
-			Color of the main line length guideline, secondary guidelines will have 50% alpha applied.
+			[Color] of the main line length guideline, secondary guidelines will have 50% alpha applied.
 		</theme_item>
 		<theme_item name="line_number_color" type="Color" default="Color(0.67, 0.67, 0.67, 0.4)">
+			Sets the [Color] of line numbers.
 		</theme_item>
 		<theme_item name="line_spacing" type="int" default="4">
+			Sets the spacing between the lines.
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+			Sets the [StyleBox].
 		</theme_item>
 		<theme_item name="outline_size" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
 		<theme_item name="read_only" type="StyleBox">
-		</theme_item>
-		<theme_item name="safe_line_number_color" type="Color" default="Color(0.67, 0.78, 0.67, 0.6)">
+			Sets the [StyleBox] when [member readonly] is enabled.
 		</theme_item>
 		<theme_item name="selection_color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
+			Sets the highlight [Color] of text selections.
 		</theme_item>
 		<theme_item name="space" type="Texture2D">
+			Sets a custom [Texture2D] for space text characters.
 		</theme_item>
 		<theme_item name="tab" type="Texture2D">
+			Sets a custom [Texture2D] for tab text characters.
 		</theme_item>
 		<theme_item name="word_highlighted_color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
+			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -240,6 +240,13 @@
 				Returns the full text with char [code]0xFFFF[/code] at the caret location.
 			</description>
 		</method>
+		<method name="get_text_for_symbol_lookup">
+			<return type="String">
+			</return>
+			<description>
+				Returns the full text with char [code]0xFFFF[/code] at the cursor location.
+			</description>
+		</method>
 		<method name="has_auto_brace_completion_close_key" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -382,6 +389,15 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_symbol_lookup_word_as_valid">
+			<return type="void">
+			</return>
+			<argument index="0" name="valid" type="bool">
+			</argument>
+			<description>
+				Sets the symbol emitted by [signal symbol_validate] as a valid lookup.
+			</description>
+		</method>
 		<method name="toggle_foldable_line">
 			<return type="void" />
 			<argument index="0" name="line" type="int" />
@@ -466,8 +482,10 @@
 		</member>
 		<member name="line_length_guidelines" type="int[]" setter="set_line_length_guidelines" getter="get_line_length_guidelines" default="[]">
 		</member>
-			Draws vertical lines at the provided columns. The first entry is considered a main hard guideline and is draw more prominently.
 		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" override="true" default="[]" />
+		<member name="symbol_lookup_on_click" type="bool" setter="set_symbol_lookup_on_click_enabled" getter="is_symbol_lookup_on_click_enabled" default="false">
+			Set when a validated word from [signal symbol_validate] is clicked, the [signal symbol_lookup] should be emitted.
+		</member>
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" override="true" enum="Control.TextDirection" default="1" />
 		<member name="zero_pad_line_numbers" type="bool" setter="set_line_numbers_zero_padded" getter="is_line_numbers_zero_padded" default="false">
 		</member>
@@ -481,6 +499,24 @@
 		<signal name="request_code_completion">
 			<description>
 				Emitted when the user requests code completion.
+			</description>
+		</signal>
+		<signal name="symbol_lookup">
+			<argument index="0" name="symbol" type="String">
+			</argument>
+			<argument index="1" name="line" type="int">
+			</argument>
+			<argument index="2" name="column" type="int">
+			</argument>
+			<description>
+				Emitted when the user has clicked on a valid symbol.
+			</description>
+		</signal>
+		<signal name="symbol_validate">
+			<argument index="0" name="symbol" type="String">
+			</argument>
+			<description>
+				Emitted when the user hovers over a symbol. The symbol should be validated and responded to, by calling [method set_symbol_lookup_word_as_valid].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -420,6 +420,9 @@
 		<member name="auto_brace_completion_enabled" type="bool" setter="set_auto_brace_completion_enabled" getter="is_auto_brace_completion_enabled" default="false">
 			Sets whether brace pairs should be autocompleted.
 		</member>
+		<member name="auto_brace_completion_highlight_matching" type="bool" setter="set_highlight_matching_braces_enabled" getter="is_highlight_matching_braces_enabled" default="false">
+			Highlight mismatching brace pairs.
+		</member>
 		<member name="auto_brace_completion_pairs" type="Dictionary" setter="set_auto_brace_completion_pairs" getter="get_auto_brace_completion_pairs" default="{&quot;\&quot;&quot;: &quot;\&quot;&quot;,&quot;&apos;&quot;: &quot;&apos;&quot;,&quot;(&quot;: &quot;)&quot;,&quot;[&quot;: &quot;]&quot;,&quot;{&quot;: &quot;}&quot;}">
 			Sets the brace pairs to be autocompleted.
 		</member>

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -464,6 +464,9 @@
 		<member name="line_folding" type="bool" setter="set_line_folding_enabled" getter="is_line_folding_enabled" default="true">
 			Sets whether line folding is allowed.
 		</member>
+		<member name="line_length_guidelines" type="int[]" setter="set_line_length_guidelines" getter="get_line_length_guidelines" default="[]">
+		</member>
+			Draws vertical lines at the provided columns. The first entry is considered a main hard guideline and is draw more prominently.
 		<member name="structured_text_bidi_override_options" type="Array" setter="set_structured_text_bidi_override_options" getter="get_structured_text_bidi_override_options" override="true" default="[]" />
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" override="true" enum="Control.TextDirection" default="1" />
 		<member name="zero_pad_line_numbers" type="bool" setter="set_line_numbers_zero_padded" getter="is_line_numbers_zero_padded" default="false">
@@ -567,6 +570,9 @@
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the [CodeEdit]'s text.
+		</theme_item>
+		<theme_item name="line_length_guideline_color" type="Color" default="Color(0.3, 0.5, 0.8, 0.1)">
+			Color of the main line length guideline, secondary guidelines will have 50% alpha applied.
 		</theme_item>
 		<theme_item name="line_number_color" type="Color" default="Color(0.67, 0.67, 0.67, 0.4)">
 		</theme_item>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -798,8 +798,6 @@
 		<theme_item name="background_color" type="Color" default="Color(0, 0, 0, 0)">
 			Sets the background [Color] of this [TextEdit].
 		</theme_item>
-		<theme_item name="brace_mismatch_color" type="Color" default="Color(1, 0.2, 0.2, 1)">
-		</theme_item>
 		<theme_item name="caret_background_color" type="Color" default="Color(0, 0, 0, 1)">
 		</theme_item>
 		<theme_item name="caret_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -295,6 +295,12 @@
 				Returns [code]true[/code] if the caret is visible on the screen.
 			</description>
 		</method>
+		<method name="is_dragging_cursor" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="is_gutter_clickable" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="gutter" type="int" />
@@ -665,18 +671,6 @@
 		<signal name="lines_edited_from">
 			<argument index="0" name="from_line" type="int" />
 			<argument index="1" name="to_line" type="int" />
-			<description>
-			</description>
-		</signal>
-		<signal name="symbol_lookup">
-			<argument index="0" name="symbol" type="String" />
-			<argument index="1" name="row" type="int" />
-			<argument index="2" name="column" type="int" />
-			<description>
-			</description>
-		</signal>
-		<signal name="symbol_validate">
-			<argument index="0" name="symbol" type="String" />
 			<description>
 			</description>
 		</signal>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -17,10 +17,8 @@
 			</description>
 		</method>
 		<method name="_handle_unicode_input" qualifiers="virtual">
-			<return type="void">
-			</return>
-			<argument index="0" name="unicode" type="int">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="unicode" type="int" />
 			<description>
 			</description>
 		</method>
@@ -265,8 +263,7 @@
 			</description>
 		</method>
 		<method name="get_total_gutter_width" qualifiers="const">
-			<return type="int">
-			</return>
+			<return type="int" />
 			<description>
 			</description>
 		</method>
@@ -296,8 +293,7 @@
 			</description>
 		</method>
 		<method name="is_dragging_cursor" qualifiers="const">
-			<return type="bool">
-			</return>
+			<return type="bool" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -16,6 +16,14 @@
 				A virtual method that is called whenever backspace is triggered.
 			</description>
 		</method>
+		<method name="_handle_unicode_input" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="unicode" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="add_gutter">
 			<return type="void" />
 			<argument index="0" name="at" type="int" default="-1" />

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -264,6 +264,12 @@
 				Returns the [TextEdit]'s' tab size.
 			</description>
 		</method>
+		<method name="get_total_gutter_width" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_visible_line_count" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -951,14 +951,20 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_line_folding_enabled(EditorSettings::get_singleton()->get("text_editor/appearance/code_folding"));
 	text_editor->set_draw_fold_gutter(EditorSettings::get_singleton()->get("text_editor/appearance/code_folding"));
 	text_editor->set_wrap_enabled(EditorSettings::get_singleton()->get("text_editor/appearance/word_wrap"));
-	text_editor->set_show_line_length_guidelines(EditorSettings::get_singleton()->get("text_editor/appearance/show_line_length_guidelines"));
-	text_editor->set_line_length_guideline_soft_column(EditorSettings::get_singleton()->get("text_editor/appearance/line_length_guideline_soft_column"));
-	text_editor->set_line_length_guideline_hard_column(EditorSettings::get_singleton()->get("text_editor/appearance/line_length_guideline_hard_column"));
 	text_editor->set_scroll_pass_end_of_file(EditorSettings::get_singleton()->get("text_editor/cursor/scroll_past_end_of_file"));
 	text_editor->cursor_set_block_mode(EditorSettings::get_singleton()->get("text_editor/cursor/block_caret"));
 	text_editor->cursor_set_blink_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink"));
 	text_editor->cursor_set_blink_speed(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink_speed"));
 	text_editor->set_auto_brace_completion_enabled(EditorSettings::get_singleton()->get("text_editor/completion/auto_brace_complete"));
+
+	if (EditorSettings::get_singleton()->get("text_editor/appearance/show_line_length_guidelines")) {
+		TypedArray<int> guideline_cols;
+		guideline_cols.append(EditorSettings::get_singleton()->get("text_editor/appearance/line_length_guideline_hard_column"));
+		if (EditorSettings::get_singleton()->get("text_editor/appearance/line_length_guideline_soft_column") != guideline_cols[0]) {
+			guideline_cols.append(EditorSettings::get_singleton()->get("text_editor/appearance/line_length_guideline_soft_column"));
+		}
+		text_editor->set_line_length_guidelines(guideline_cols);
+	}
 }
 
 void CodeTextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -958,7 +958,7 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->cursor_set_block_mode(EditorSettings::get_singleton()->get("text_editor/cursor/block_caret"));
 	text_editor->cursor_set_blink_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink"));
 	text_editor->cursor_set_blink_speed(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink_speed"));
-	text_editor->set_auto_brace_completion(EditorSettings::get_singleton()->get("text_editor/completion/auto_brace_complete"));
+	text_editor->set_auto_brace_completion_enabled(EditorSettings::get_singleton()->get("text_editor/completion/auto_brace_complete"));
 }
 
 void CodeTextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {
@@ -1609,16 +1609,9 @@ void CodeTextEditor::_apply_settings_change() {
 		} break;
 	}
 
-	// Auto brace completion.
-	text_editor->set_auto_brace_completion(
-			EDITOR_GET("text_editor/completion/auto_brace_complete"));
-
-	code_complete_timer->set_wait_time(
-			EDITOR_GET("text_editor/completion/code_complete_delay"));
-
-	// Call hint settings.
 	text_editor->set_code_hint_draw_below(EDITOR_GET("text_editor/completion/put_callhint_tooltip_below_current_line"));
 
+	code_complete_timer->set_wait_time(EDITOR_GET("text_editor/completion/code_complete_delay"));
 	idle->set_wait_time(EDITOR_GET("text_editor/completion/idle_parse_delay"));
 }
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1825,7 +1825,7 @@ CodeTextEditor::CodeTextEditor() {
 	}
 
 	text_editor->set_draw_line_numbers(true);
-	text_editor->set_brace_matching(true);
+	text_editor->set_highlight_matching_braces_enabled(true);
 	text_editor->set_auto_indent_enabled(true);
 
 	status_bar = memnew(HBoxContainer);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -750,7 +750,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 			EditorNode::get_singleton()->load_resource(p_symbol);
 		}
 
-	} else if (script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_lookup_completion(), p_symbol, script->get_path(), base, result) == OK) {
+	} else if (script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_symbol_lookup(), p_symbol, script->get_path(), base, result) == OK) {
 		_goto_line(p_row);
 
 		result.class_name = result.class_name.trim_prefix("_");
@@ -853,18 +853,17 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 	}
 
 	ScriptLanguage::LookupResult result;
-	if (ScriptServer::is_global_class(p_symbol) || p_symbol.is_resource_file() || script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_lookup_completion(), p_symbol, script->get_path(), base, result) == OK || (ProjectSettings::get_singleton()->has_autoload(p_symbol) && ProjectSettings::get_singleton()->get_autoload(p_symbol).is_singleton)) {
-		text_edit->set_highlighted_word(p_symbol);
+	if (ScriptServer::is_global_class(p_symbol) || p_symbol.is_resource_file() || script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_symbol_lookup(), p_symbol, script->get_path(), base, result) == OK || (ProjectSettings::get_singleton()->has_autoload(p_symbol) && ProjectSettings::get_singleton()->get_autoload(p_symbol).is_singleton)) {
+		text_edit->set_symbol_lookup_word_as_valid(true);
 	} else if (p_symbol.is_rel_path()) {
 		String path = _get_absolute_path(p_symbol);
 		if (FileAccess::exists(path)) {
-			text_edit->set_highlighted_word(p_symbol);
+			text_edit->set_symbol_lookup_word_as_valid(true);
 		} else {
-			text_edit->set_highlighted_word(String());
+			text_edit->set_symbol_lookup_word_as_valid(false);
 		}
-
 	} else {
-		text_edit->set_highlighted_word(String());
+		text_edit->set_symbol_lookup_word_as_valid(false);
 	}
 }
 
@@ -1552,7 +1551,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 				base = _find_node_for_script(base, base, script);
 			}
 			ScriptLanguage::LookupResult result;
-			if (script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_lookup_completion(), word_at_pos, script->get_path(), base, result) == OK) {
+			if (script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_symbol_lookup(), word_at_pos, script->get_path(), base, result) == OK) {
 				open_docs = true;
 			}
 		}
@@ -1837,7 +1836,7 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	code_editor->get_text_editor()->set_code_hint_draw_below(EditorSettings::get_singleton()->get("text_editor/completion/put_callhint_tooltip_below_current_line"));
 
-	code_editor->get_text_editor()->set_select_identifiers_on_hover(true);
+	code_editor->get_text_editor()->set_symbol_lookup_on_click_enabled(true);
 	code_editor->get_text_editor()->set_context_menu_enabled(false);
 
 	context_menu = memnew(PopupMenu);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -204,7 +204,9 @@ void ScriptTextEditor::_set_theme_for_script() {
 	for (const String &string : strings) {
 		String beg = string.get_slice(" ", 0);
 		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
-		text_edit->add_string_delimiter(beg, end, end == "");
+		if (!text_edit->has_string_delimiter(beg)) {
+			text_edit->add_string_delimiter(beg, end, end == "");
+		}
 
 		if (!end.is_empty() && !text_edit->has_auto_brace_completion_open_key(beg)) {
 			text_edit->add_auto_brace_completion_pair(beg, end);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -205,6 +205,10 @@ void ScriptTextEditor::_set_theme_for_script() {
 		String beg = string.get_slice(" ", 0);
 		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
 		text_edit->add_string_delimiter(beg, end, end == "");
+
+		if (!end.is_empty() && !text_edit->has_auto_brace_completion_open_key(beg)) {
+			text_edit->add_auto_brace_completion_pair(beg, end);
+		}
 	}
 
 	List<String> comments;
@@ -214,6 +218,10 @@ void ScriptTextEditor::_set_theme_for_script() {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
 		text_edit->add_comment_delimiter(beg, end, end == "");
+
+		if (!end.is_empty() && !text_edit->has_auto_brace_completion_open_key(beg)) {
+			text_edit->add_auto_brace_completion_pair(beg, end);
+		}
 	}
 }
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -158,6 +158,10 @@ void ShaderTextEditor::_load_theme_settings() {
 	text_editor->add_comment_delimiter("/*", "*/", false);
 	text_editor->add_comment_delimiter("//", "", true);
 
+	if (!text_editor->has_auto_brace_completion_open_key("/*")) {
+		text_editor->add_auto_brace_completion_pair("/*", "*/");
+	}
+
 	if (warnings_panel) {
 		// Warnings panel
 		warnings_panel->add_theme_font_override("normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("main"), SNAME("EditorFonts")));

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -663,7 +663,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 
 	shader_editor->get_text_editor()->set_code_hint_draw_below(EditorSettings::get_singleton()->get("text_editor/completion/put_callhint_tooltip_below_current_line"));
 
-	shader_editor->get_text_editor()->set_select_identifiers_on_hover(true);
+	shader_editor->get_text_editor()->set_symbol_lookup_on_click_enabled(true);
 	shader_editor->get_text_editor()->set_context_menu_enabled(false);
 	shader_editor->get_text_editor()->connect("gui_input", callable_mp(this, &ShaderEditor::_text_edit_gui_input));
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -921,6 +921,10 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		expression_box->add_comment_delimiter("/*", "*/", false);
 		expression_box->add_comment_delimiter("//", "", true);
 
+		if (!expression_box->has_auto_brace_completion_open_key("/*")) {
+			expression_box->add_auto_brace_completion_pair("/*", "*/");
+		}
+
 		expression_box->set_text(expression);
 		expression_box->set_context_menu_enabled(false);
 		expression_box->set_draw_line_numbers(true);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2173,21 +2173,21 @@ void CodeEdit::_bind_methods() {
 
 	/* Inspector */
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "symbol_lookup_on_click"), "set_symbol_lookup_on_click_enabled", "is_symbol_lookup_on_click_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "line_folding"), "set_line_folding_enabled", "is_line_folding_enabled");
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "line_length_guidelines"), "set_line_length_guidelines", "get_line_length_guidelines");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_breakpoints_gutter"), "set_draw_breakpoints_gutter", "is_drawing_breakpoints_gutter");
+	ADD_GROUP("Gutters", "gutters_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_breakpoints_gutter"), "set_draw_breakpoints_gutter", "is_drawing_breakpoints_gutter");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_bookmarks"), "set_draw_bookmarks_gutter", "is_drawing_bookmarks_gutter");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_bookmarks"), "set_draw_bookmarks_gutter", "is_drawing_bookmarks_gutter");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_executing_lines"), "set_draw_executing_lines_gutter", "is_drawing_executing_lines_gutter");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_executing_lines"), "set_draw_executing_lines_gutter", "is_drawing_executing_lines_gutter");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_line_numbers"), "set_draw_line_numbers", "is_draw_line_numbers_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "zero_pad_line_numbers"), "set_line_numbers_zero_padded", "is_line_numbers_zero_padded");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_line_numbers"), "set_draw_line_numbers", "is_draw_line_numbers_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_zero_pad_line_numbers"), "set_line_numbers_zero_padded", "is_line_numbers_zero_padded");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_fold_gutter"), "set_draw_fold_gutter", "is_drawing_fold_gutter");
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "line_folding"), "set_line_folding_enabled", "is_line_folding_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_fold_gutter"), "set_draw_fold_gutter", "is_drawing_fold_gutter");
 
 	ADD_GROUP("Delimiters", "delimiter_");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "delimiter_strings"), "set_string_delimiters", "get_string_delimiters");
@@ -2901,6 +2901,10 @@ CodeEdit::CodeEdit() {
 	add_auto_brace_completion_pair("[", "]");
 	add_auto_brace_completion_pair("\"", "\"");
 	add_auto_brace_completion_pair("\'", "\'");
+
+	/* Delimiter traking */
+	add_string_delimiter("\"", "\"", false);
+	add_string_delimiter("\'", "\'", false);
 
 	/* Text Direction */
 	set_layout_direction(LAYOUT_DIRECTION_LTR);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -937,6 +937,15 @@ bool CodeEdit::is_auto_brace_completion_enabled() const {
 	return auto_brace_completion_enabled;
 }
 
+void CodeEdit::set_highlight_matching_braces_enabled(bool p_enabled) {
+	highlight_matching_braces_enabled = p_enabled;
+	update();
+}
+
+bool CodeEdit::is_highlight_matching_braces_enabled() const {
+	return highlight_matching_braces_enabled;
+}
+
 void CodeEdit::add_auto_brace_completion_pair(const String &p_open_key, const String &p_close_key) {
 	ERR_FAIL_COND_MSG(p_open_key.is_empty(), "auto brace completion open key cannot be empty");
 	ERR_FAIL_COND_MSG(p_close_key.is_empty(), "auto brace completion close key cannot be empty");
@@ -1881,6 +1890,9 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_auto_brace_completion_enabled", "enable"), &CodeEdit::set_auto_brace_completion_enabled);
 	ClassDB::bind_method(D_METHOD("is_auto_brace_completion_enabled"), &CodeEdit::is_auto_brace_completion_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_highlight_matching_braces_enabled", "enable"), &CodeEdit::set_highlight_matching_braces_enabled);
+	ClassDB::bind_method(D_METHOD("is_highlight_matching_braces_enabled"), &CodeEdit::is_highlight_matching_braces_enabled);
+
 	ClassDB::bind_method(D_METHOD("add_auto_brace_completion_pair", "start_key", "end_key"), &CodeEdit::add_auto_brace_completion_pair);
 	ClassDB::bind_method(D_METHOD("set_auto_brace_completion_pairs", "pairs"), &CodeEdit::set_auto_brace_completion_pairs);
 	ClassDB::bind_method(D_METHOD("get_auto_brace_completion_pairs"), &CodeEdit::get_auto_brace_completion_pairs);
@@ -2048,6 +2060,7 @@ void CodeEdit::_bind_methods() {
 
 	ADD_GROUP("Auto brace completion", "auto_brace_completion_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_brace_completion_enabled"), "set_auto_brace_completion_enabled", "is_auto_brace_completion_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_brace_completion_highlight_matching"), "set_highlight_matching_braces_enabled", "is_highlight_matching_braces_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "auto_brace_completion_pairs"), "set_auto_brace_completion_pairs", "get_auto_brace_completion_pairs");
 
 	/* Signals */

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -66,6 +66,19 @@ private:
 
 	void _new_line(bool p_split_current_line = true, bool p_above = false);
 
+	/* Auto brace completion */
+	bool auto_brace_completion_enabled = false;
+
+	/* BracePair open_key must be uniquie and ordered by length. */
+	struct BracePair {
+		String open_key = "";
+		String close_key = "";
+	};
+	Vector<BracePair> auto_brace_completion_pairs;
+
+	int _get_auto_brace_pair_open_at_pos(int p_line, int p_col);
+	int _get_auto_brace_pair_close_at_pos(int p_line, int p_col);
+
 	/* Main Gutter */
 	enum MainGutterType {
 		MAIN_GUTTER_BREAKPOINT = 0x01,
@@ -217,7 +230,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	/* General overrides */
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
+	virtual void handle_unicode_input(uint32_t p_unicode) override;
 
 	/* Indent management */
 	void set_indent_size(const int p_size);
@@ -239,6 +254,19 @@ public:
 	void unindent_lines();
 
 	virtual void backspace() override;
+
+	/* Auto brace completion */
+	void set_auto_brace_completion_enabled(bool p_enabled);
+	bool is_auto_brace_completion_enabled() const;
+
+	void add_auto_brace_completion_pair(const String &p_open_key, const String &p_close_key);
+	void set_auto_brace_completion_pairs(const Dictionary &p_auto_brace_completion_pairs);
+	Dictionary get_auto_brace_completion_pairs() const;
+
+	bool has_auto_brace_completion_open_key(const String &p_open_key) const;
+	bool has_auto_brace_completion_close_key(const String &p_close_key) const;
+
+	String get_auto_brace_completion_close_key(const String &p_open_key) const;
 
 	/* Main Gutter */
 	void set_draw_breakpoints_gutter(bool p_draw);

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -223,6 +223,10 @@ private:
 
 	void _lines_edited_from(int p_from_line, int p_to_line);
 
+	/* Line length guidelines */
+	TypedArray<int> line_length_guideline_columns;
+	Color line_length_guideline_color;
+
 protected:
 	void _gui_input(const Ref<InputEvent> &p_gui_input) override;
 	void _notification(int p_what);
@@ -377,6 +381,10 @@ public:
 
 	void confirm_code_completion(bool p_replace = false);
 	void cancel_code_completion();
+
+	/* Line length guidelines */
+	void set_line_length_guidelines(TypedArray<int> p_guideline_columns);
+	TypedArray<int> get_line_length_guidelines() const;
 
 	CodeEdit();
 	~CodeEdit();

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -259,6 +259,9 @@ public:
 	void set_auto_brace_completion_enabled(bool p_enabled);
 	bool is_auto_brace_completion_enabled() const;
 
+	void set_highlight_matching_braces_enabled(bool p_enabled);
+	bool is_highlight_matching_braces_enabled() const;
+
 	void add_auto_brace_completion_pair(const String &p_open_key, const String &p_close_key);
 	void set_auto_brace_completion_pairs(const Dictionary &p_auto_brace_completion_pairs);
 	Dictionary get_auto_brace_completion_pairs() const;

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -227,6 +227,12 @@ private:
 	TypedArray<int> line_length_guideline_columns;
 	Color line_length_guideline_color;
 
+	/* Symbol lookup */
+	bool symbol_lookup_on_click_enabled = false;
+
+	String symbol_lookup_new_word = "";
+	String symbol_lookup_word = "";
+
 protected:
 	void _gui_input(const Ref<InputEvent> &p_gui_input) override;
 	void _notification(int p_what);
@@ -385,6 +391,14 @@ public:
 	/* Line length guidelines */
 	void set_line_length_guidelines(TypedArray<int> p_guideline_columns);
 	TypedArray<int> get_line_length_guidelines() const;
+
+	/* Symbol lookup */
+	void set_symbol_lookup_on_click_enabled(bool p_enabled);
+	bool is_symbol_lookup_on_click_enabled() const;
+
+	String get_text_for_symbol_lookup();
+
+	void set_symbol_lookup_word_as_valid(bool p_valid);
 
 	CodeEdit();
 	~CodeEdit();

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -125,7 +125,7 @@ private:
 	void _update_gutter_indexes();
 
 	/* Line Folding */
-	bool line_folding_enabled = true;
+	bool line_folding_enabled = false;
 
 	/* Delimiters */
 	enum DelimiterType {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -626,7 +626,7 @@ void TextEdit::_notification(int p_what) {
 			bool brace_close_matching = false;
 			bool brace_close_mismatch = false;
 
-			if (brace_matching_enabled && cursor.line >= 0 && cursor.line < text.size() && cursor.column >= 0) {
+			if (highlight_matching_braces_enabled && cursor.line >= 0 && cursor.line < text.size() && cursor.column >= 0) {
 				if (cursor.column < text[cursor.line].length()) {
 					// Check for open.
 					char32_t c = text[cursor.line][cursor.column];
@@ -1269,7 +1269,7 @@ void TextEdit::_notification(int p_what) {
 
 						int char_pos = char_ofs + char_margin + ofs_x;
 						if (char_pos >= xmargin_beg) {
-							if (brace_matching_enabled) {
+							if (highlight_matching_braces_enabled) {
 								if ((brace_open_match_line == line && brace_open_match_column == glyphs[j].start) ||
 										(cursor.column == glyphs[j].start && cursor.line == line && cursor_wrap_index == line_wrap_index && (brace_open_matching || brace_open_mismatch))) {
 									if (brace_open_mismatch) {
@@ -3838,7 +3838,7 @@ void TextEdit::_update_caches() {
 	cache.current_line_color = get_theme_color(SNAME("current_line_color"));
 	cache.line_length_guideline_color = get_theme_color(SNAME("line_length_guideline_color"));
 	cache.code_folding_color = get_theme_color(SNAME("code_folding_color"), SNAME("CodeEdit"));
-	cache.brace_mismatch_color = get_theme_color(SNAME("brace_mismatch_color"));
+	cache.brace_mismatch_color = get_theme_color(SNAME("brace_mismatch_color"), SNAME("CodeEdit"));
 	cache.word_highlighted_color = get_theme_color(SNAME("word_highlighted_color"));
 	cache.search_result_color = get_theme_color(SNAME("search_result_color"));
 	cache.search_result_border_color = get_theme_color(SNAME("search_result_border_color"));

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -594,29 +594,6 @@ void TextEdit::_notification(int p_what) {
 				RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2i(), get_size()), cache.background_color);
 			}
 
-			if (line_length_guidelines) {
-				const int hard_x = xmargin_beg + (int)cache.font->get_char_size('0', 0, cache.font_size).width * line_length_guideline_hard_col - cursor.x_ofs;
-				if (hard_x > xmargin_beg && hard_x < xmargin_end) {
-					if (rtl) {
-						RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2(size.width - hard_x, 0), Point2(size.width - hard_x, size.height), cache.line_length_guideline_color);
-					} else {
-						RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2(hard_x, 0), Point2(hard_x, size.height), cache.line_length_guideline_color);
-					}
-				}
-
-				// Draw a "Soft" line length guideline, less visible than the hard line length guideline.
-				// It's usually set to a lower column compared to the hard line length guideline.
-				// Only drawn if its column differs from the hard line length guideline.
-				const int soft_x = xmargin_beg + (int)cache.font->get_char_size('0', 0, cache.font_size).width * line_length_guideline_soft_col - cursor.x_ofs;
-				if (hard_x != soft_x && soft_x > xmargin_beg && soft_x < xmargin_end) {
-					if (rtl) {
-						RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2(size.width - soft_x, 0), Point2(size.width - soft_x, size.height), cache.line_length_guideline_color * Color(1, 1, 1, 0.5));
-					} else {
-						RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2(soft_x, 0), Point2(soft_x, size.height), cache.line_length_guideline_color * Color(1, 1, 1, 0.5));
-					}
-				}
-			}
-
 			int brace_open_match_line = -1;
 			int brace_open_match_column = -1;
 			bool brace_open_matching = false;
@@ -3836,7 +3813,6 @@ void TextEdit::_update_caches() {
 	cache.font_readonly_color = get_theme_color(SNAME("font_readonly_color"));
 	cache.selection_color = get_theme_color(SNAME("selection_color"));
 	cache.current_line_color = get_theme_color(SNAME("current_line_color"));
-	cache.line_length_guideline_color = get_theme_color(SNAME("line_length_guideline_color"));
 	cache.code_folding_color = get_theme_color(SNAME("code_folding_color"), SNAME("CodeEdit"));
 	cache.brace_mismatch_color = get_theme_color(SNAME("brace_mismatch_color"), SNAME("CodeEdit"));
 	cache.word_highlighted_color = get_theme_color(SNAME("word_highlighted_color"));
@@ -5145,21 +5121,6 @@ void TextEdit::insert_at(const String &p_text, int at) {
 	}
 }
 
-void TextEdit::set_show_line_length_guidelines(bool p_show) {
-	line_length_guidelines = p_show;
-	update();
-}
-
-void TextEdit::set_line_length_guideline_soft_column(int p_column) {
-	line_length_guideline_soft_col = p_column;
-	update();
-}
-
-void TextEdit::set_line_length_guideline_hard_column(int p_column) {
-	line_length_guideline_hard_col = p_column;
-	update();
-}
-
 void TextEdit::set_draw_minimap(bool p_draw) {
 	if (draw_minimap != p_draw) {
 		draw_minimap = p_draw;
@@ -5599,6 +5560,7 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_gutter_overwritable", "gutter"), &TextEdit::is_gutter_overwritable);
 	ClassDB::bind_method(D_METHOD("merge_gutters", "from_line", "to_line"), &TextEdit::merge_gutters);
 	ClassDB::bind_method(D_METHOD("set_gutter_custom_draw", "column", "object", "callback"), &TextEdit::set_gutter_custom_draw);
+	ClassDB::bind_method(D_METHOD("get_total_gutter_width"), &TextEdit::get_total_gutter_width);
 
 	// Line gutters.
 	ClassDB::bind_method(D_METHOD("set_line_gutter_metadata", "line", "gutter", "metadata"), &TextEdit::set_line_gutter_metadata);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -305,7 +305,7 @@ private:
 	float target_v_scroll = 0.0;
 	float v_scroll_speed = 80.0;
 
-	String highlighted_word;
+	String lookup_symbol_word;
 
 	uint64_t last_dblclk = 0;
 
@@ -382,7 +382,6 @@ private:
 	Size2 get_minimum_size() const override;
 	int _get_control_height() const;
 
-	Point2 _get_local_mouse_pos() const;
 	int _get_menu_action_accelerator(const String &p_action);
 
 	void _reset_caret_blink_timer();
@@ -472,6 +471,8 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+	void _set_symbol_lookup_word(const String &p_symbol);
 
 public:
 	/* Syntax Highlighting. */
@@ -567,8 +568,10 @@ public:
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
 
+	Point2 _get_local_mouse_pos() const;
 	void _get_mouse_pos(const Point2i &p_mouse, int &r_row, int &r_col) const;
 	void _get_minimap_mouse_row(const Point2i &p_mouse, int &r_row) const;
+	bool is_dragging_cursor() const;
 
 	//void delete_char();
 	//void delete_line();
@@ -597,7 +600,6 @@ public:
 	void set_structured_text_bidi_override_options(Array p_args);
 	Array get_structured_text_bidi_override_options() const;
 
-	void set_highlighted_word(const String &new_word);
 	void set_text(String p_text);
 	void insert_text_at_cursor(const String &p_text);
 	void insert_at(const String &p_text, int at);
@@ -746,9 +748,6 @@ public:
 
 	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
 
-	void set_select_identifiers_on_hover(bool p_enable);
-	bool is_selecting_identifiers_on_hover_enabled() const;
-
 	void set_context_menu_enabled(bool p_enable);
 	bool is_context_menu_enabled();
 
@@ -763,8 +762,6 @@ public:
 
 	bool is_menu_visible() const;
 	PopupMenu *get_menu() const;
-
-	String get_text_for_lookup_completion();
 
 	virtual bool is_text_field() const override;
 	TextEdit();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -431,11 +431,8 @@ private:
 	void _delete(bool p_word = false, bool p_all_to_right = false);
 	void _move_cursor_document_start(bool p_select);
 	void _move_cursor_document_end(bool p_select);
-	void _handle_unicode_character(uint32_t unicode, bool p_had_selection);
 
 protected:
-	bool auto_brace_completion_enabled = false;
-
 	struct Cache {
 		Ref<Texture2D> tab_icon;
 		Ref<Texture2D> space_icon;
@@ -470,12 +467,8 @@ protected:
 
 	void _insert_text(int p_line, int p_char, const String &p_text, int *r_end_line = nullptr, int *r_end_char = nullptr);
 	void _remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
-	void _insert_text_at_cursor(const String &p_text);
 	virtual void _gui_input(const Ref<InputEvent> &p_gui_input);
 	void _notification(int p_what);
-
-	void _consume_pair_symbol(char32_t ch);
-	void _consume_backspace_for_pair_symbol(int prev_line, int prev_column);
 
 	static void _bind_methods();
 
@@ -635,9 +628,6 @@ public:
 		scroll_past_end_of_file_enabled = p_enabled;
 		update();
 	}
-	inline void set_auto_brace_completion(bool p_enabled) {
-		auto_brace_completion_enabled = p_enabled;
-	}
 	inline void set_brace_matching(bool p_enabled) {
 		brace_matching_enabled = p_enabled;
 		update();
@@ -686,6 +676,7 @@ public:
 
 	void delete_selection();
 
+	virtual void handle_unicode_input(uint32_t p_unicode);
 	virtual void backspace();
 	void cut();
 	void copy();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -291,7 +291,6 @@ private:
 
 	bool highlight_all_occurrences = false;
 	bool scroll_past_end_of_file_enabled = false;
-	bool brace_matching_enabled = false;
 	bool highlight_current_line = false;
 
 	String cut_copy_line;
@@ -433,6 +432,8 @@ private:
 	void _move_cursor_document_end(bool p_select);
 
 protected:
+	bool highlight_matching_braces_enabled = false;
+
 	struct Cache {
 		Ref<Texture2D> tab_icon;
 		Ref<Texture2D> space_icon;
@@ -626,10 +627,6 @@ public:
 
 	inline void set_scroll_pass_end_of_file(bool p_enabled) {
 		scroll_past_end_of_file_enabled = p_enabled;
-		update();
-	}
-	inline void set_brace_matching(bool p_enabled) {
-		brace_matching_enabled = p_enabled;
 		update();
 	}
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -280,9 +280,6 @@ private:
 	bool cursor_changed_dirty = false;
 	bool text_changed_dirty = false;
 	bool undo_enabled = true;
-	bool line_length_guidelines = false;
-	int line_length_guideline_soft_col = 80;
-	int line_length_guideline_hard_col = 100;
 	bool hiding_enabled = false;
 	bool draw_minimap = false;
 	int minimap_width = 80;
@@ -453,7 +450,6 @@ protected:
 		Color selection_color;
 		Color code_folding_color;
 		Color current_line_color;
-		Color line_length_guideline_color;
 		Color brace_mismatch_color;
 		Color word_highlighted_color;
 		Color search_result_color;
@@ -738,10 +734,6 @@ public:
 
 	void set_highlight_current_line(bool p_enabled);
 	bool is_highlight_current_line_enabled() const;
-
-	void set_show_line_length_guidelines(bool p_show);
-	void set_line_length_guideline_soft_column(int p_column);
-	void set_line_length_guideline_hard_column(int p_column);
 
 	void set_draw_minimap(bool p_draw);
 	bool is_drawing_minimap() const;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -457,7 +457,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("current_line_color", "TextEdit", Color(0.25, 0.25, 0.26, 0.8));
 	theme->set_color("caret_color", "TextEdit", control_font_color);
 	theme->set_color("caret_background_color", "TextEdit", Color(0, 0, 0));
-	theme->set_color("brace_mismatch_color", "TextEdit", Color(1, 0.2, 0.2));
 	theme->set_color("word_highlighted_color", "TextEdit", Color(0.8, 0.9, 0.9, 0.15));
 
 	theme->set_constant("line_spacing", "TextEdit", 4 * scale);

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -501,7 +501,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("caret_background_color", "CodeEdit", Color(0, 0, 0));
 	theme->set_color("brace_mismatch_color", "CodeEdit", Color(1, 0.2, 0.2));
 	theme->set_color("line_number_color", "CodeEdit", Color(0.67, 0.67, 0.67, 0.4));
-	theme->set_color("safe_line_number_color", "CodeEdit", Color(0.67, 0.78, 0.67, 0.6));
 	theme->set_color("word_highlighted_color", "CodeEdit", Color(0.8, 0.9, 0.9, 0.15));
 	theme->set_color("line_length_guideline_color", "CodeEdit", Color(0.3, 0.5, 0.8, 0.1));
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -503,6 +503,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("line_number_color", "CodeEdit", Color(0.67, 0.67, 0.67, 0.4));
 	theme->set_color("safe_line_number_color", "CodeEdit", Color(0.67, 0.78, 0.67, 0.6));
 	theme->set_color("word_highlighted_color", "CodeEdit", Color(0.8, 0.9, 0.9, 0.15));
+	theme->set_color("line_length_guideline_color", "CodeEdit", Color(0.3, 0.5, 0.8, 0.1));
 
 	theme->set_constant("completion_lines", "CodeEdit", 7);
 	theme->set_constant("completion_max_width", "CodeEdit", 50);


### PR DESCRIPTION
Continuation of #31739

---

Apologies for the larger PR was going to limit this to brace completion, but the remaining features seemed small enough to bundle in here.

After this PR, I consider `CodeEdit` good enough for 4.0 and beyond. Next steps will be cleaning up `TextEdit` and prepping the API similarly, before bug fixes / optimisation. After this point we can consider #31739 done and can create smaller tasks for the remaining parts, as they will not have an affect on the outward facing API.

The only remaining "code like" feature in `TextEdit` is highlighting all occurrences of the selected text. I did not consider this a strong enough feature to consider migrating to `CodeEdit`, though am happy to do so if others think this should be the case.

---

Firstly, this PR migrates auto brace completion. This has been made to use strings rather then single chars to allow handling of larger symbols such as gdscript multiline comments / strings. And has exposed to the API. A new overridable method `handle_unicode_input` has been added, which is called when the user types a char. This way the child class does not need to check all shortcuts before handling the input.

For Brace matching, only the API has been migrated and exposed, until drawing can be somewhat controlled in `CodeEdit`. As such could be classed as "incomplete", in the sense that only hardcoded chars are highlighted and not everything added in auto brace completion.

Secondly, line length guidelines have been moved and exposed. Rather then a soft and hard limit it now takes an array of columns. The first entry is a "hard" limit, the following entries are a "soft" limit and drawn at 50% opacity.

The last feature is symbol lookup, this has been reconfigured and exposed to the API. At the moment, underline drawing is still handled by `TextEdit`, however everything else is in `CodeEdit`

Finally, cleaned up the inspector a little by moving gutters into a sub category and changing a few default values. On top of this finished up all the remaining `CodeEdit` docs.

---

closes #41361