### PR TITLE
Automatically install assets that have no conflicting files

### DIFF
--- a/editor/editor_asset_installer.h
+++ b/editor/editor_asset_installer.h
@@ -40,10 +40,12 @@ class EditorAssetInstaller : public ConfirmationDialog {
 	String package_path;
 	AcceptDialog *error;
 	Map<String, TreeItem *> status_map;
+	Vector<String> excluded_paths;
 	bool updating;
 	void _update_subitems(TreeItem *p_item, bool p_check, bool p_first = false);
 	void _uncheck_parent(TreeItem *p_item);
 	void _item_edited();
+	bool _is_file_excluded(const String &p_path);
 	virtual void ok_pressed() override;
 
 protected:


### PR DESCRIPTION
Should be merged with https://github.com/godotengine/godot/pull/47667.

This makes it possible to install most assets with less clicks.

To make this behavior less annoying, specific files will automatically be excluded when installing assets:

- Files whose name begin with a period, except `.gdignore` since the engine uses that file to prevent resource importing.
- Common repository top-level files (README, LICENSE, ...).
  - This does not apply to files in subfolders since these can't cause confusion or break existing projects.

This change does not affect installing templates from the Project Manager.

## Preview

Install dialog now appears only if there are conflicts:

![image](https://user-images.githubusercontent.com/180032/124362145-97040d00-dc33-11eb-966b-c668845b32da.png)
