### PR TITLE
Fix Boot Splash

### DIFF
--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -50,6 +50,7 @@ protected:
 		BLIT_MODE_NORMAL,
 		BLIT_MODE_USE_LAYER,
 		BLIT_MODE_LENS,
+		BLIT_MODE_NORMAL_ALPHA,
 		BLIT_MODE_MAX
 	};
 
@@ -88,7 +89,7 @@ public:
 	RendererCanvasRender *get_canvas() { return canvas; }
 	RendererSceneRender *get_scene() { return scene; }
 
-	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {}
+	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter);
 
 	void initialize();
 	void begin_frame(double frame_step);


### PR DESCRIPTION
* Implements the code to show the boot splash on load using RenderingDevice
* Does not work on X11 when maximized (this never really worked well, but now it seems to not even show anything), some platform specific hack will be needed there, unrelated to this PR.
* Seems to work fine on Windows and likely does on other platforms.