### PR TITLE
Decrease opacity of the overdraw debug draw mode

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -781,7 +781,8 @@ void SceneShaderForwardClustered::init(RendererStorageRD *p_storage, const Strin
 	{
 		overdraw_material_shader = storage->shader_allocate();
 		storage->shader_initialize(overdraw_material_shader);
-		storage->shader_set_code(overdraw_material_shader, "shader_type spatial;\nrender_mode blend_add,unshaded;\n void fragment() { ALBEDO=vec3(0.4,0.8,0.8); ALPHA=0.2; }");
+		// Use relatively low opacity so that more "layers" of overlapping objects can be distinguished.
+		storage->shader_set_code(overdraw_material_shader, "shader_type spatial;\nrender_mode blend_add,unshaded;\n void fragment() { ALBEDO=vec3(0.4,0.8,0.8); ALPHA=0.1; }");
 		overdraw_material = storage->material_allocate();
 		storage->material_initialize(overdraw_material);
 		storage->material_set_shader(overdraw_material, overdraw_material_shader);

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -767,7 +767,8 @@ void SceneShaderForwardMobile::init(RendererStorageRD *p_storage, const String p
 	{
 		overdraw_material_shader = storage->shader_allocate();
 		storage->shader_initialize(overdraw_material_shader);
-		storage->shader_set_code(overdraw_material_shader, "shader_type spatial;\nrender_mode blend_add,unshaded;\n void fragment() { ALBEDO=vec3(0.4,0.8,0.8); ALPHA=0.2; }");
+		// Use relatively low opacity so that more "layers" of overlapping objects can be distinguished.
+		storage->shader_set_code(overdraw_material_shader, "shader_type spatial;\nrender_mode blend_add,unshaded;\n void fragment() { ALBEDO=vec3(0.4,0.8,0.8); ALPHA=0.1; }");
 		overdraw_material = storage->material_allocate();
 		storage->material_initialize(overdraw_material);
 		storage->material_set_shader(overdraw_material, overdraw_material_shader);


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/50140.

This allows distinguishing higher amounts of overlapping objects.

## Preview

*The gains aren't that obvious on a simple scene, but they would be on a more complex scene such as the one showcased in https://github.com/godotengine/godot/pull/50133.*

### Before

![2021-07-04_00 17 54](https://user-images.githubusercontent.com/180032/124368089-a39d5b00-dc5d-11eb-8419-defeacb430e1.png)

### After

![2021-07-04_00 17 08](https://user-images.githubusercontent.com/180032/124368088-a26c2e00-dc5d-11eb-8576-1bd23c4f6661.png)