### PR TITLE
Decrease opacity of the overdraw debug draw mode (3.x)

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -4129,7 +4129,8 @@ void RasterizerSceneGLES2::initialize() {
 		//default material and shader
 
 		default_overdraw_shader = storage->shader_create();
-		storage->shader_set_code(default_overdraw_shader, "shader_type spatial;\nrender_mode blend_add,unshaded;\n void fragment() { ALBEDO=vec3(0.4,0.8,0.8); ALPHA=0.2; }");
+		// Use relatively low opacity so that more "layers" of overlapping objects can be distinguished.
+		storage->shader_set_code(default_overdraw_shader, "shader_type spatial;\nrender_mode blend_add,unshaded;\n void fragment() { ALBEDO=vec3(0.4,0.8,0.8); ALPHA=0.1; }");
 		default_overdraw_material = storage->material_create();
 		storage->material_set_shader(default_overdraw_material, default_overdraw_shader);
 	}

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4924,7 +4924,8 @@ void RasterizerSceneGLES3::initialize() {
 		//default material and shader
 
 		default_overdraw_shader = storage->shader_create();
-		storage->shader_set_code(default_overdraw_shader, "shader_type spatial;\nrender_mode blend_add,unshaded;\n void fragment() { ALBEDO=vec3(0.4,0.8,0.8); ALPHA=0.2; }");
+		// Use relatively low opacity so that more "layers" of overlapping objects can be distinguished.
+		storage->shader_set_code(default_overdraw_shader, "shader_type spatial;\nrender_mode blend_add,unshaded;\n void fragment() { ALBEDO=vec3(0.4,0.8,0.8); ALPHA=0.1; }");
 		default_overdraw_material = storage->material_create();
 		storage->material_set_shader(default_overdraw_material, default_overdraw_shader);
 	}


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50138.

This allows distinguishing higher amounts of overlapping objects.