### PR TITLE
Minor cleanup of the "New Script" dialog

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -40,38 +40,35 @@
 #include "editor/editor_scale.h"
 #include "editor_file_system.h"
 
-void ScriptCreateDialog::_theme_changed() {
-	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-		String lang = ScriptServer::get_language(i)->get_type();
-		Ref<Texture2D> lang_icon = gc->get_theme_icon(lang, "EditorIcons");
-		if (lang_icon.is_valid()) {
-			language_menu->set_item_icon(i, lang_icon);
-		}
-	}
-
-	String last_lang = EditorSettings::get_singleton()->get_project_metadata("script_setup", "last_selected_language", "");
-	if (!last_lang.is_empty()) {
-		for (int i = 0; i < language_menu->get_item_count(); i++) {
-			if (language_menu->get_item_text(i) == last_lang) {
-				language_menu->select(i);
-				current_language = i;
-				break;
-			}
-		}
-	} else {
-		language_menu->select(default_language);
-	}
-
-	path_button->set_icon(gc->get_theme_icon("Folder", "EditorIcons"));
-	parent_browse_button->set_icon(gc->get_theme_icon("Folder", "EditorIcons"));
-	parent_search_button->set_icon(gc->get_theme_icon("ClassList", "EditorIcons"));
-	status_panel->add_theme_style_override("panel", gc->get_theme_stylebox("bg", "Tree"));
-}
-
 void ScriptCreateDialog::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			_theme_changed();
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+				String lang = ScriptServer::get_language(i)->get_type();
+				Ref<Texture2D> lang_icon = get_theme_icon(lang, "EditorIcons");
+				if (lang_icon.is_valid()) {
+					language_menu->set_item_icon(i, lang_icon);
+				}
+			}
+
+			String last_lang = EditorSettings::get_singleton()->get_project_metadata("script_setup", "last_selected_language", "");
+			if (!last_lang.is_empty()) {
+				for (int i = 0; i < language_menu->get_item_count(); i++) {
+					if (language_menu->get_item_text(i) == last_lang) {
+						language_menu->select(i);
+						current_language = i;
+						break;
+					}
+				}
+			} else {
+				language_menu->select(default_language);
+			}
+
+			path_button->set_icon(get_theme_icon("Folder", "EditorIcons"));
+			parent_browse_button->set_icon(get_theme_icon("Folder", "EditorIcons"));
+			parent_search_button->set_icon(get_theme_icon("ClassList", "EditorIcons"));
+			status_panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
 		} break;
 	}
 }
@@ -451,7 +448,7 @@ void ScriptCreateDialog::_lang_changed(int l) {
 					override_info += ", ";
 				}
 			}
-			template_menu->set_item_icon(extended.id, gc->get_theme_icon("Override", "EditorIcons"));
+			template_menu->set_item_icon(extended.id, get_theme_icon("Override", "EditorIcons"));
 			template_menu->get_popup()->set_item_tooltip(extended.id, override_info.as_string());
 		}
 		// Reselect last selected template
@@ -609,18 +606,18 @@ void ScriptCreateDialog::_path_submitted(const String &p_path) {
 void ScriptCreateDialog::_msg_script_valid(bool valid, const String &p_msg) {
 	error_label->set_text("- " + p_msg);
 	if (valid) {
-		error_label->add_theme_color_override("font_color", gc->get_theme_color("success_color", "Editor"));
+		error_label->add_theme_color_override("font_color", get_theme_color("success_color", "Editor"));
 	} else {
-		error_label->add_theme_color_override("font_color", gc->get_theme_color("error_color", "Editor"));
+		error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
 	}
 }
 
 void ScriptCreateDialog::_msg_path_valid(bool valid, const String &p_msg) {
 	path_error_label->set_text("- " + p_msg);
 	if (valid) {
-		path_error_label->add_theme_color_override("font_color", gc->get_theme_color("success_color", "Editor"));
+		path_error_label->add_theme_color_override("font_color", get_theme_color("success_color", "Editor"));
 	} else {
-		path_error_label->add_theme_color_override("font_color", gc->get_theme_color("error_color", "Editor"));
+		path_error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
 	}
 }
 
@@ -748,14 +745,10 @@ void ScriptCreateDialog::_bind_methods() {
 }
 
 ScriptCreateDialog::ScriptCreateDialog() {
-	/* DIALOG */
-
 	/* Main Controls */
 
-	gc = memnew(GridContainer);
+	GridContainer *gc = memnew(GridContainer);
 	gc->set_columns(2);
-
-	gc->connect("theme_changed", callable_mp(this, &ScriptCreateDialog::_theme_changed));
 
 	/* Error Messages Field */
 
@@ -832,7 +825,6 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	parent_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hb->add_child(parent_name);
 	parent_search_button = memnew(Button);
-	parent_search_button->set_flat(true);
 	parent_search_button->connect("pressed", callable_mp(this, &ScriptCreateDialog::_browse_class_in_tree));
 	hb->add_child(parent_search_button);
 	parent_browse_button = memnew(Button);

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -45,7 +45,6 @@ class CreateDialog;
 class ScriptCreateDialog : public ConfirmationDialog {
 	GDCLASS(ScriptCreateDialog, ConfirmationDialog);
 
-	GridContainer *gc;
 	LineEdit *class_name;
 	Label *error_label;
 	Label *path_error_label;
@@ -127,7 +126,6 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	void _update_dialog();
 
 protected:
-	void _theme_changed();
 	void _notification(int p_what);
 	static void _bind_methods();
 


### PR DESCRIPTION
- Make so that it stops doing theme related stuff through its `GridContainer` (why the hell it was doing that in the first place?).
- Untoggle the "Parent Search" as `flat`, since no other button in the dialog is.