### PR TITLE
Clean up Tree

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -96,6 +96,14 @@
 				Returns the column index at [code]position[/code], or -1 if no item is there.
 			</description>
 		</method>
+		<method name="get_column_expand_ratio" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_column_title" qualifiers="const">
 			<return type="String">
 			</return>
@@ -264,10 +272,36 @@
 				To tell whether a column of an item is selected, use [method TreeItem.is_selected].
 			</description>
 		</method>
+		<method name="is_column_clipping_content" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="is_column_expanding" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="scroll_to_item">
 			<return type="void">
 			</return>
 			<argument index="0" name="item" type="Object">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_column_clip_content">
+			<return type="void">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
 			</description>
@@ -292,6 +326,16 @@
 			</argument>
 			<description>
 				If [code]true[/code], the column will have the "Expand" flag of [Control]. Columns that have the "Expand" flag will use their "min_width" in a similar fashion to [member Control.size_flags_stretch_ratio].
+			</description>
+		</method>
+		<method name="set_column_expand_ratio">
+			<return type="void">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<argument index="1" name="ratio" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_column_title">

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -1123,6 +1123,7 @@ ActionMapEditor::ActionMapEditor() {
 	action_tree->set_hide_root(true);
 	action_tree->set_column_titles_visible(true);
 	action_tree->set_column_title(0, TTR("Action"));
+	action_tree->set_column_clip_content(0, true);
 	action_tree->set_column_title(1, TTR("Deadzone"));
 	action_tree->set_column_expand(1, false);
 	action_tree->set_column_custom_minimum_width(1, 80 * EDSCALE);

--- a/editor/debugger/editor_network_profiler.cpp
+++ b/editor/debugger/editor_network_profiler.cpp
@@ -178,18 +178,23 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	counters_display->set_column_titles_visible(true);
 	counters_display->set_column_title(0, TTR("Node"));
 	counters_display->set_column_expand(0, true);
+	counters_display->set_column_clip_content(0, true);
 	counters_display->set_column_custom_minimum_width(0, 60 * EDSCALE);
 	counters_display->set_column_title(1, TTR("Incoming RPC"));
 	counters_display->set_column_expand(1, false);
+	counters_display->set_column_clip_content(1, true);
 	counters_display->set_column_custom_minimum_width(1, 120 * EDSCALE);
 	counters_display->set_column_title(2, TTR("Incoming RSET"));
 	counters_display->set_column_expand(2, false);
+	counters_display->set_column_clip_content(2, true);
 	counters_display->set_column_custom_minimum_width(2, 120 * EDSCALE);
 	counters_display->set_column_title(3, TTR("Outgoing RPC"));
 	counters_display->set_column_expand(3, false);
+	counters_display->set_column_clip_content(3, true);
 	counters_display->set_column_custom_minimum_width(3, 120 * EDSCALE);
 	counters_display->set_column_title(4, TTR("Outgoing RSET"));
 	counters_display->set_column_expand(4, false);
+	counters_display->set_column_clip_content(4, true);
 	counters_display->set_column_custom_minimum_width(4, 120 * EDSCALE);
 	add_child(counters_display);
 

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -631,13 +631,16 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_titles_visible(true);
 	variables->set_column_title(0, TTR("Name"));
 	variables->set_column_expand(0, true);
-	variables->set_column_custom_minimum_width(0, 60 * EDSCALE);
+	variables->set_column_clip_content(0, true);
+	variables->set_column_expand_ratio(0, 60);
 	variables->set_column_title(1, TTR("Time"));
 	variables->set_column_expand(1, false);
-	variables->set_column_custom_minimum_width(1, 100 * EDSCALE);
+	variables->set_column_clip_content(1, true);
+	variables->set_column_expand_ratio(1, 100);
 	variables->set_column_title(2, TTR("Calls"));
 	variables->set_column_expand(2, false);
-	variables->set_column_custom_minimum_width(2, 60 * EDSCALE);
+	variables->set_column_clip_content(2, true);
+	variables->set_column_expand_ratio(2, 60);
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
 
 	graph = memnew(TextureRect);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -773,12 +773,15 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->set_column_titles_visible(true);
 	variables->set_column_title(0, TTR("Name"));
 	variables->set_column_expand(0, true);
+	variables->set_column_clip_content(0, true);
 	variables->set_column_custom_minimum_width(0, 60);
 	variables->set_column_title(1, TTR("CPU"));
 	variables->set_column_expand(1, false);
+	variables->set_column_clip_content(1, true);
 	variables->set_column_custom_minimum_width(1, 60 * EDSCALE);
 	variables->set_column_title(2, TTR("GPU"));
 	variables->set_column_expand(2, false);
+	variables->set_column_clip_content(2, true);
 	variables->set_column_custom_minimum_width(2, 60 * EDSCALE);
 	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1644,8 +1644,10 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 		error_tree->set_column_expand(0, false);
 		error_tree->set_column_custom_minimum_width(0, 140);
+		error_tree->set_column_clip_content(0, true);
 
 		error_tree->set_column_expand(1, true);
+		error_tree->set_column_clip_content(1, true);
 
 		error_tree->set_select_mode(Tree::SELECT_ROW);
 		error_tree->set_hide_root(true);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -226,7 +226,11 @@ DependencyEditor::DependencyEditor() {
 	tree->set_columns(2);
 	tree->set_column_titles_visible(true);
 	tree->set_column_title(0, TTR("Resource"));
+	tree->set_column_clip_content(0, true);
+	tree->set_column_expand_ratio(0, 2);
 	tree->set_column_title(1, TTR("Path"));
+	tree->set_column_clip_content(1, true);
+	tree->set_column_expand_ratio(1, 1);
 	tree->set_hide_root(true);
 	tree->connect("button_pressed", callable_mp(this, &DependencyEditor::_load_pressed));
 
@@ -769,9 +773,11 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 	files = memnew(Tree);
 	files->set_columns(2);
 	files->set_column_titles_visible(true);
-	files->set_column_custom_minimum_width(1, 100);
+	files->set_column_custom_minimum_width(1, 100 * EDSCALE);
 	files->set_column_expand(0, true);
+	files->set_column_clip_content(0, true);
 	files->set_column_expand(1, false);
+	files->set_column_clip_content(1, true);
 	files->set_column_title(0, TTR("Resource"));
 	files->set_column_title(1, TTR("Owns"));
 	files->set_hide_root(true);

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -882,19 +882,17 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	tree->set_column_title(0, TTR("Name"));
 	tree->set_column_expand(0, true);
-	tree->set_column_custom_minimum_width(0, 100 * EDSCALE);
+	tree->set_column_expand_ratio(0, 1);
 
 	tree->set_column_title(1, TTR("Path"));
 	tree->set_column_expand(1, true);
-	tree->set_column_custom_minimum_width(1, 100 * EDSCALE);
+	tree->set_column_clip_content(1, true);
+	tree->set_column_expand_ratio(1, 2);
 
 	tree->set_column_title(2, TTR("Global Variable"));
 	tree->set_column_expand(2, false);
-	// Reserve enough space for translations of "Global Variable" which may be longer.
-	tree->set_column_custom_minimum_width(2, 150 * EDSCALE);
 
 	tree->set_column_expand(3, false);
-	tree->set_column_custom_minimum_width(3, 120 * EDSCALE);
 
 	tree->connect("cell_selected", callable_mp(this, &EditorAutoloadSettings::_autoload_selected));
 	tree->connect("item_edited", callable_mp(this, &EditorAutoloadSettings::_autoload_edited));

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -237,9 +237,11 @@ EditorHelpSearch::EditorHelpSearch() {
 	results_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	results_tree->set_columns(2);
 	results_tree->set_column_title(0, TTR("Name"));
+	results_tree->set_column_clip_content(0, true);
 	results_tree->set_column_title(1, TTR("Member Type"));
 	results_tree->set_column_expand(1, false);
 	results_tree->set_column_custom_minimum_width(1, 150 * EDSCALE);
+	results_tree->set_column_clip_content(1, true);
 	results_tree->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
 	results_tree->set_hide_root(true);
 	results_tree->set_select_mode(Tree::SELECT_ROW);

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -212,10 +212,15 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list->set_column_title(3, TTR("Status:"));
 	plugin_list->set_column_title(4, TTR("Edit:"));
 	plugin_list->set_column_expand(0, true);
+	plugin_list->set_column_clip_content(0, true);
 	plugin_list->set_column_expand(1, false);
+	plugin_list->set_column_clip_content(1, true);
 	plugin_list->set_column_expand(2, false);
+	plugin_list->set_column_clip_content(2, true);
 	plugin_list->set_column_expand(3, false);
+	plugin_list->set_column_clip_content(3, true);
 	plugin_list->set_column_expand(4, false);
+	plugin_list->set_column_clip_content(4, true);
 	plugin_list->set_column_custom_minimum_width(1, 100 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(2, 250 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(3, 80 * EDSCALE);

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -728,7 +728,9 @@ LocalizationEditor::LocalizationEditor() {
 		translation_remap_options->set_column_title(1, TTR("Locale"));
 		translation_remap_options->set_column_titles_visible(true);
 		translation_remap_options->set_column_expand(0, true);
+		translation_remap_options->set_column_clip_content(0, true);
 		translation_remap_options->set_column_expand(1, false);
+		translation_remap_options->set_column_clip_content(1, true);
 		translation_remap_options->set_column_custom_minimum_width(1, 200);
 		translation_remap_options->connect("item_edited", callable_mp(this, &LocalizationEditor::_translation_res_option_changed));
 		translation_remap_options->connect("button_pressed", callable_mp(this, &LocalizationEditor::_translation_res_option_delete));

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -569,8 +569,10 @@ void AnimationPlayerEditor::_animation_blend() {
 	blend_editor.dialog->popup_centered(Size2(400, 400) * EDSCALE);
 
 	blend_editor.tree->set_hide_root(true);
-	blend_editor.tree->set_column_custom_minimum_width(0, 10);
-	blend_editor.tree->set_column_custom_minimum_width(1, 3);
+	blend_editor.tree->set_column_expand_ratio(0, 10);
+	blend_editor.tree->set_column_clip_content(0, true);
+	blend_editor.tree->set_column_expand_ratio(1, 3);
+	blend_editor.tree->set_column_clip_content(1, true);
 
 	List<StringName> anims;
 	player->get_animation_list(&anims);

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -367,8 +367,10 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	tree = memnew(Tree);
 	tree->connect("button_pressed", callable_mp(this, &ResourcePreloaderEditor::_cell_button_pressed));
 	tree->set_columns(2);
-	tree->set_column_custom_minimum_width(0, 2);
-	tree->set_column_custom_minimum_width(1, 3);
+	tree->set_column_expand_ratio(0, 2);
+	tree->set_column_clip_content(0, true);
+	tree->set_column_expand_ratio(1, 3);
+	tree->set_column_clip_content(1, true);
 	tree->set_column_expand(0, true);
 	tree->set_column_expand(1, true);
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -930,11 +930,14 @@ ThemeItemImportTree::ThemeItemImportTree() {
 	import_items_tree->set_column_title(IMPORT_ITEM, TTR("Import"));
 	import_items_tree->set_column_title(IMPORT_ITEM_DATA, TTR("With Data"));
 	import_items_tree->set_column_expand(0, true);
+	import_items_tree->set_column_clip_content(0, true);
 	import_items_tree->set_column_expand(IMPORT_ITEM, false);
 	import_items_tree->set_column_expand(IMPORT_ITEM_DATA, false);
 	import_items_tree->set_column_custom_minimum_width(0, 160 * EDSCALE);
 	import_items_tree->set_column_custom_minimum_width(IMPORT_ITEM, 80 * EDSCALE);
 	import_items_tree->set_column_custom_minimum_width(IMPORT_ITEM_DATA, 80 * EDSCALE);
+	import_items_tree->set_column_clip_content(1, true);
+	import_items_tree->set_column_clip_content(2, true);
 
 	ScrollContainer *import_bulk_sc = memnew(ScrollContainer);
 	import_bulk_sc->set_custom_minimum_size(Size2(260.0, 0.0) * EDSCALE);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -411,7 +411,9 @@ private:
 
 	struct ColumnInfo {
 		int custom_min_width = 0;
+		int expand_ratio = 1;
 		bool expand = true;
+		bool clip_content = false;
 		String title;
 		Ref<TextLine> text_buf;
 		Dictionary opentype_features;
@@ -450,7 +452,7 @@ private:
 	void draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Color &p_color, const Color &p_icon_color, int p_ol_size, const Color &p_ol_color);
 	int draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item);
 	void select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_col, TreeItem *p_prev = nullptr, bool *r_in_range = nullptr, bool p_force_deselect = false);
-	int propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool p_double_click, TreeItem *p_item, int p_button, const Ref<InputEventWithModifiers> &p_mod);
+	int propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int x_limit, bool p_double_click, TreeItem *p_item, int p_button, const Ref<InputEventWithModifiers> &p_mod);
 	void _text_editor_submit(String p_text);
 	void _text_editor_modal_close();
 	void value_editor_changed(double p_value);
@@ -504,6 +506,7 @@ private:
 		Color parent_hl_line_color;
 		Color children_hl_line_color;
 		Color custom_button_font_highlight;
+		Color font_outline_color;
 
 		int hseparation = 0;
 		int vseparation = 0;
@@ -518,6 +521,7 @@ private:
 		int draw_guides = 0;
 		int scroll_border = 0;
 		int scroll_speed = 0;
+		int font_outline_size = 0;
 
 		enum ClickType {
 			CLICK_NONE,
@@ -540,6 +544,8 @@ private:
 
 		Point2i text_editor_position;
 
+		bool rtl = false;
+
 	} cache;
 
 	int _get_title_button_height() const;
@@ -547,6 +553,7 @@ private:
 	void _scroll_moved(float p_value);
 	HScrollBar *h_scroll;
 	VScrollBar *v_scroll;
+
 	bool h_scroll_enabled = true;
 	bool v_scroll_enabled = true;
 
@@ -632,8 +639,14 @@ public:
 
 	void set_column_custom_minimum_width(int p_column, int p_min_width);
 	void set_column_expand(int p_column, bool p_expand);
+	void set_column_expand_ratio(int p_column, int p_ratio);
+	void set_column_clip_content(int p_column, bool p_fit);
 	int get_column_minimum_width(int p_column) const;
 	int get_column_width(int p_column) const;
+	int get_column_expand_ratio(int p_column) const;
+
+	bool is_column_expanding(int p_column) const;
+	bool is_column_clipping_content(int p_column) const;
 
 	void set_hide_root(bool p_enabled);
 	bool is_root_hidden() const;


### PR DESCRIPTION
Fixes some problems introduced by #49917

* Tree used minimum size as a stretch ratio, so it forced a minimum size of 1.
* Minimum size redone, stretch ratio moved to a separate setting, this is more intuitive and allows minimum size to be 0.
* Fitting to contents (column width minimum size is contents width) was enforced, this is more intuitive, but in many situations this is undesired.
* Added a clip content option for situations where fit to contents does not apply.
* Column separation not being accounted for in new code, added it back.
* Icon would scroll with the item, making it invislbe if the item is too long.
* Made icon always appear to the right (or left if RTL is enabled) of the visible item space.
* Fixed the editor in general in situations where the new behavior breaks.


https://user-images.githubusercontent.com/6265307/124390316-5ce14c80-dcc1-11eb-9b61-57e231247f70.mp4