### PR TITLE
Added Curve3Texture to Visual Shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -110,6 +110,7 @@ void VisualShaderGraphPlugin::_bind_methods() {
 	ClassDB::bind_method("set_uniform_name", &VisualShaderGraphPlugin::set_uniform_name);
 	ClassDB::bind_method("set_expression", &VisualShaderGraphPlugin::set_expression);
 	ClassDB::bind_method("update_curve", &VisualShaderGraphPlugin::update_curve);
+	ClassDB::bind_method("update_curve3", &VisualShaderGraphPlugin::update_curve3);
 	ClassDB::bind_method("update_constant", &VisualShaderGraphPlugin::update_constant);
 }
 
@@ -211,9 +212,19 @@ void VisualShaderGraphPlugin::set_uniform_name(VisualShader::Type p_type, int p_
 }
 
 void VisualShaderGraphPlugin::update_curve(int p_node_id) {
-	if (links.has(p_node_id) && links[p_node_id].curve_editor) {
+	if (links.has(p_node_id) && links[p_node_id].curve_editors[0]) {
 		if (((VisualShaderNodeCurveTexture *)links[p_node_id].visual_node)->get_texture().is_valid()) {
-			links[p_node_id].curve_editor->set_curve(((VisualShaderNodeCurveTexture *)links[p_node_id].visual_node)->get_texture()->get_curve());
+			links[p_node_id].curve_editors[0]->set_curve(((VisualShaderNodeCurveTexture *)links[p_node_id].visual_node)->get_texture()->get_curve());
+		}
+	}
+}
+
+void VisualShaderGraphPlugin::update_curve3(int p_node_id) {
+	if (links.has(p_node_id) && links[p_node_id].curve_editors[0] && links[p_node_id].curve_editors[1] && links[p_node_id].curve_editors[2]) {
+		if (((VisualShaderNodeCurve3Texture *)links[p_node_id].visual_node)->get_texture().is_valid()) {
+			links[p_node_id].curve_editors[0]->set_curve(((VisualShaderNodeCurve3Texture *)links[p_node_id].visual_node)->get_texture()->get_curve_x());
+			links[p_node_id].curve_editors[1]->set_curve(((VisualShaderNodeCurve3Texture *)links[p_node_id].visual_node)->get_texture()->get_curve_y());
+			links[p_node_id].curve_editors[2]->set_curve(((VisualShaderNodeCurve3Texture *)links[p_node_id].visual_node)->get_texture()->get_curve_z());
 		}
 	}
 }
@@ -265,8 +276,8 @@ void VisualShaderGraphPlugin::register_expression_edit(int p_node_id, CodeEdit *
 	links[p_node_id].expression_edit = p_expression_edit;
 }
 
-void VisualShaderGraphPlugin::register_curve_editor(int p_node_id, CurveEditor *p_curve_editor) {
-	links[p_node_id].curve_editor = p_curve_editor;
+void VisualShaderGraphPlugin::register_curve_editor(int p_node_id, int p_index, CurveEditor *p_curve_editor) {
+	links[p_node_id].curve_editors[p_index] = p_curve_editor;
 }
 
 void VisualShaderGraphPlugin::update_uniform_refs() {
@@ -312,7 +323,7 @@ void VisualShaderGraphPlugin::make_dirty(bool p_enabled) {
 }
 
 void VisualShaderGraphPlugin::register_link(VisualShader::Type p_type, int p_id, VisualShaderNode *p_visual_node, GraphNode *p_graph_node) {
-	links.insert(p_id, { p_type, p_visual_node, p_graph_node, p_visual_node->get_output_port_for_preview() != -1, -1, Map<int, InputPort>(), Map<int, Port>(), nullptr, nullptr, nullptr, nullptr, nullptr });
+	links.insert(p_id, { p_type, p_visual_node, p_graph_node, p_visual_node->get_output_port_for_preview() != -1, -1, Map<int, InputPort>(), Map<int, Port>(), nullptr, nullptr, nullptr, nullptr, { nullptr, nullptr, nullptr } });
 }
 
 void VisualShaderGraphPlugin::register_output_port(int p_node_id, int p_port, TextureButton *p_button) {
@@ -472,6 +483,18 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		custom_editor = hbox;
 	}
 
+	Ref<VisualShaderNodeCurve3Texture> curve3 = vsnode;
+	if (curve3.is_valid()) {
+		if (curve3->get_texture().is_valid() && !curve3->get_texture()->is_connected("changed", callable_mp(VisualShaderEditor::get_singleton()->get_graph_plugin(), &VisualShaderGraphPlugin::update_curve3))) {
+			curve3->get_texture()->connect("changed", callable_mp(VisualShaderEditor::get_singleton()->get_graph_plugin(), &VisualShaderGraphPlugin::update_curve3), varray(p_id));
+		}
+
+		HBoxContainer *hbox = memnew(HBoxContainer);
+		custom_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		hbox->add_child(custom_editor);
+		custom_editor = hbox;
+	}
+
 	Ref<VisualShaderNodeFloatConstant> float_const = vsnode;
 	if (float_const.is_valid()) {
 		HBoxContainer *hbox = memnew(HBoxContainer);
@@ -495,18 +518,11 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		port_offset++;
 		node->add_child(custom_editor);
 
-		if (curve.is_valid()) {
+		bool is_curve = curve.is_valid() || curve3.is_valid();
+
+		if (is_curve) {
 			VisualShaderEditor::get_singleton()->graph->add_child(node);
 			VisualShaderEditor::get_singleton()->_update_created_node(node);
-
-			CurveEditor *curve_editor = memnew(CurveEditor);
-			node->add_child(curve_editor);
-			register_curve_editor(p_id, curve_editor);
-			curve_editor->set_custom_minimum_size(Size2(300, 0));
-			curve_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-			if (curve->get_texture().is_valid()) {
-				curve_editor->set_curve(curve->get_texture()->get_curve());
-			}
 
 			TextureButton *preview = memnew(TextureButton);
 			preview->set_toggle_mode(true);
@@ -519,12 +535,59 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			preview->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_preview_select_port), varray(p_id, 0), CONNECT_DEFERRED);
 			custom_editor->add_child(preview);
 
+			if (vsnode->get_output_port_for_preview() >= 0) {
+				show_port_preview(p_type, p_id, vsnode->get_output_port_for_preview());
+			}
+		}
+
+		if (curve.is_valid()) {
+			CurveEditor *curve_editor = memnew(CurveEditor);
+			node->add_child(curve_editor);
+			register_curve_editor(p_id, 0, curve_editor);
+			curve_editor->set_custom_minimum_size(Size2(300, 0));
+			curve_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			if (curve->get_texture().is_valid()) {
+				curve_editor->set_curve(curve->get_texture()->get_curve());
+			}
+		}
+
+		if (curve3.is_valid()) {
+			CurveEditor *curve_editor_x = memnew(CurveEditor);
+			node->add_child(curve_editor_x);
+			register_curve_editor(p_id, 0, curve_editor_x);
+			curve_editor_x->set_custom_minimum_size(Size2(300, 0));
+			curve_editor_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			if (curve3->get_texture().is_valid()) {
+				curve_editor_x->set_curve(curve3->get_texture()->get_curve_x());
+			}
+
+			CurveEditor *curve_editor_y = memnew(CurveEditor);
+			node->add_child(curve_editor_y);
+			register_curve_editor(p_id, 1, curve_editor_y);
+			curve_editor_y->set_custom_minimum_size(Size2(300, 0));
+			curve_editor_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			if (curve3->get_texture().is_valid()) {
+				curve_editor_y->set_curve(curve3->get_texture()->get_curve_y());
+			}
+
+			CurveEditor *curve_editor_z = memnew(CurveEditor);
+			node->add_child(curve_editor_z);
+			register_curve_editor(p_id, 2, curve_editor_z);
+			curve_editor_z->set_custom_minimum_size(Size2(300, 0));
+			curve_editor_z->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			if (curve3->get_texture().is_valid()) {
+				curve_editor_z->set_curve(curve3->get_texture()->get_curve_z());
+			}
+		}
+
+		if (is_curve) {
 			VisualShaderNode::PortType port_left = vsnode->get_input_port_type(0);
 			VisualShaderNode::PortType port_right = vsnode->get_output_port_type(0);
 			node->set_slot(0, true, port_left, type_color[port_left], true, port_right, type_color[port_right]);
 
 			VisualShaderEditor::get_singleton()->call_deferred("_set_node_size", (int)p_type, p_id, size);
 		}
+
 		if (vsnode->is_use_prop_slots()) {
 			return;
 		}
@@ -2380,6 +2443,11 @@ void VisualShaderEditor::_add_node(int p_idx, int p_op_idx, String p_resource_pa
 		graph_plugin->call_deferred("update_curve", id_to_use);
 	}
 
+	VisualShaderNodeCurve3Texture *curve3 = Object::cast_to<VisualShaderNodeCurve3Texture>(vsnode.ptr());
+	if (curve3) {
+		graph_plugin->call_deferred("update_curve3", id_to_use);
+	}
+
 	if (p_resource_path.is_empty()) {
 		undo_redo->commit_action();
 	} else {
@@ -2388,7 +2456,7 @@ void VisualShaderEditor::_add_node(int p_idx, int p_op_idx, String p_resource_pa
 		VisualShaderNodeTexture *texture2d = Object::cast_to<VisualShaderNodeTexture>(vsnode.ptr());
 		VisualShaderNodeTexture3D *texture3d = Object::cast_to<VisualShaderNodeTexture3D>(vsnode.ptr());
 
-		if (texture2d || texture3d || curve) {
+		if (texture2d || texture3d || curve || curve3) {
 			undo_redo->add_do_method(vsnode.ptr(), "set_texture", ResourceLoader::load(p_resource_path));
 			return;
 		}
@@ -3583,6 +3651,10 @@ void VisualShaderEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 						saved_node_pos = p_point + Vector2(0, i * 250 * EDSCALE);
 						saved_node_pos_dirty = true;
 						_add_node(curve_node_option_idx, -1, arr[i], i);
+					} else if (type == "Curve3Texture") {
+						saved_node_pos = p_point + Vector2(0, i * 250 * EDSCALE);
+						saved_node_pos_dirty = true;
+						_add_node(curve3_node_option_idx, -1, arr[i], i);
 					} else if (ClassDB::get_parent_class(type) == "Texture2D") {
 						saved_node_pos = p_point + Vector2(0, i * 250 * EDSCALE);
 						saved_node_pos_dirty = true;
@@ -4304,6 +4376,8 @@ VisualShaderEditor::VisualShaderEditor() {
 	add_options.push_back(AddOption("CubeMap", "Textures", "Functions", "VisualShaderNodeCubemap", TTR("Perform the cubic texture lookup."), -1, -1));
 	curve_node_option_idx = add_options.size();
 	add_options.push_back(AddOption("CurveTexture", "Textures", "Functions", "VisualShaderNodeCurveTexture", TTR("Perform the curve texture lookup."), -1, -1));
+	curve3_node_option_idx = add_options.size();
+	add_options.push_back(AddOption("CurveTexture3", "Textures", "Functions", "VisualShaderNodeCurve3Texture", TTR("Perform the ternary curve texture lookup."), -1, -1));
 	texture2d_node_option_idx = add_options.size();
 	add_options.push_back(AddOption("Texture2D", "Textures", "Functions", "VisualShaderNodeTexture", TTR("Perform the 2D texture lookup."), -1, -1));
 	texture2d_array_node_option_idx = add_options.size();

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -75,7 +75,7 @@ private:
 		LineEdit *uniform_name = nullptr;
 		OptionButton *const_op = nullptr;
 		CodeEdit *expression_edit = nullptr;
-		CurveEditor *curve_editor = nullptr;
+		CurveEditor *curve_editors[3] = { nullptr, nullptr, nullptr };
 	};
 
 	Ref<VisualShader> visual_shader;
@@ -97,7 +97,7 @@ public:
 	void register_default_input_button(int p_node_id, int p_port_id, Button *p_button);
 	void register_constant_option_btn(int p_node_id, OptionButton *p_button);
 	void register_expression_edit(int p_node_id, CodeEdit *p_expression_edit);
-	void register_curve_editor(int p_node_id, CurveEditor *p_curve_editor);
+	void register_curve_editor(int p_node_id, int p_index, CurveEditor *p_curve_editor);
 	void clear_links();
 	void set_shader_type(VisualShader::Type p_type);
 	bool is_preview_visible(int p_id) const;
@@ -117,6 +117,7 @@ public:
 	void update_uniform_refs();
 	void set_uniform_name(VisualShader::Type p_type, int p_node_id, const String &p_name);
 	void update_curve(int p_node_id);
+	void update_curve3(int p_node_id);
 	void update_constant(VisualShader::Type p_type, int p_node_id);
 	void set_expression(VisualShader::Type p_type, int p_node_id, const String &p_expression);
 	int get_constant_index(float p_constant) const;
@@ -289,6 +290,7 @@ class VisualShaderEditor : public VBoxContainer {
 	int texture3d_node_option_idx;
 	int custom_node_option_idx;
 	int curve_node_option_idx;
+	int curve3_node_option_idx;
 	List<String> keyword_list;
 
 	List<VisualShaderNodeUniformRef> uniform_refs;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -586,6 +586,7 @@ void register_scene_types() {
 	ClassDB::register_class<VisualShaderNodeTransformDecompose>();
 	ClassDB::register_class<VisualShaderNodeTexture>();
 	ClassDB::register_class<VisualShaderNodeCurveTexture>();
+	ClassDB::register_class<VisualShaderNodeCurve3Texture>();
 	ClassDB::register_virtual_class<VisualShaderNodeSample3D>();
 	ClassDB::register_class<VisualShaderNodeTexture2DArray>();
 	ClassDB::register_class<VisualShaderNodeTexture3D>();

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -805,7 +805,7 @@ void VisualShaderNodeTexture::_bind_methods() {
 VisualShaderNodeTexture::VisualShaderNodeTexture() {
 }
 
-////////////// Curve
+////////////// CurveTexture
 
 String VisualShaderNodeCurveTexture::get_caption() const {
 	return "CurveTexture";
@@ -885,6 +885,90 @@ bool VisualShaderNodeCurveTexture::is_use_prop_slots() const {
 }
 
 VisualShaderNodeCurveTexture::VisualShaderNodeCurveTexture() {
+	simple_decl = true;
+	allow_v_resize = false;
+}
+
+////////////// Curve3Texture
+
+String VisualShaderNodeCurve3Texture::get_caption() const {
+	return "Curve3Texture";
+}
+
+int VisualShaderNodeCurve3Texture::get_input_port_count() const {
+	return 1;
+}
+
+VisualShaderNodeCurve3Texture::PortType VisualShaderNodeCurve3Texture::get_input_port_type(int p_port) const {
+	return PORT_TYPE_SCALAR;
+}
+
+String VisualShaderNodeCurve3Texture::get_input_port_name(int p_port) const {
+	return String();
+}
+
+int VisualShaderNodeCurve3Texture::get_output_port_count() const {
+	return 1;
+}
+
+VisualShaderNodeCurve3Texture::PortType VisualShaderNodeCurve3Texture::get_output_port_type(int p_port) const {
+	return PORT_TYPE_VECTOR;
+}
+
+String VisualShaderNodeCurve3Texture::get_output_port_name(int p_port) const {
+	return String();
+}
+
+void VisualShaderNodeCurve3Texture::set_texture(Ref<Curve3Texture> p_texture) {
+	texture = p_texture;
+	emit_changed();
+}
+
+Ref<Curve3Texture> VisualShaderNodeCurve3Texture::get_texture() const {
+	return texture;
+}
+
+Vector<StringName> VisualShaderNodeCurve3Texture::get_editable_properties() const {
+	Vector<StringName> props;
+	props.push_back("texture");
+	return props;
+}
+
+String VisualShaderNodeCurve3Texture::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
+	return "uniform sampler2D " + make_unique_id(p_type, p_id, "curve3d") + ";\n";
+}
+
+String VisualShaderNodeCurve3Texture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
+	if (p_input_vars[0] == String()) {
+		return "\t" + p_output_vars[0] + " = vec3(0.0);\n";
+	}
+	String id = make_unique_id(p_type, p_id, "curve3d");
+	String code;
+	code += "\t" + p_output_vars[0] + " = texture(" + id + ", vec2(" + p_input_vars[0] + ")).rgb;\n";
+	return code;
+}
+
+Vector<VisualShader::DefaultTextureParam> VisualShaderNodeCurve3Texture::get_default_texture_parameters(VisualShader::Type p_type, int p_id) const {
+	VisualShader::DefaultTextureParam dtp;
+	dtp.name = make_unique_id(p_type, p_id, "curve3d");
+	dtp.param = texture;
+	Vector<VisualShader::DefaultTextureParam> ret;
+	ret.push_back(dtp);
+	return ret;
+}
+
+void VisualShaderNodeCurve3Texture::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &VisualShaderNodeCurve3Texture::set_texture);
+	ClassDB::bind_method(D_METHOD("get_texture"), &VisualShaderNodeCurve3Texture::get_texture);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Curve3Texture"), "set_texture", "get_texture");
+}
+
+bool VisualShaderNodeCurve3Texture::is_use_prop_slots() const {
+	return true;
+}
+
+VisualShaderNodeCurve3Texture::VisualShaderNodeCurve3Texture() {
 	simple_decl = true;
 	allow_v_resize = false;
 }

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -338,6 +338,39 @@ public:
 
 ///////////////////////////////////////
 
+class VisualShaderNodeCurve3Texture : public VisualShaderNodeResizableBase {
+	GDCLASS(VisualShaderNodeCurve3Texture, VisualShaderNodeResizableBase);
+	Ref<Curve3Texture> texture;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual String get_caption() const override;
+
+	virtual int get_input_port_count() const override;
+	virtual PortType get_input_port_type(int p_port) const override;
+	virtual String get_input_port_name(int p_port) const override;
+
+	virtual int get_output_port_count() const override;
+	virtual PortType get_output_port_type(int p_port) const override;
+	virtual String get_output_port_name(int p_port) const override;
+
+	virtual Vector<VisualShader::DefaultTextureParam> get_default_texture_parameters(VisualShader::Type p_type, int p_id) const override;
+	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
+
+	void set_texture(Ref<Curve3Texture> p_value);
+	Ref<Curve3Texture> get_texture() const;
+
+	virtual Vector<StringName> get_editable_properties() const override;
+	virtual bool is_use_prop_slots() const override;
+
+	VisualShaderNodeCurve3Texture();
+};
+
+///////////////////////////////////////
+
 class VisualShaderNodeSample3D : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeSample3D, VisualShaderNode);
 


### PR DESCRIPTION
Implementation of Curve3Texture: https://github.com/godotengine/godot/pull/50054 to Visual Shaders:

![vs_curve3d](https://user-images.githubusercontent.com/3036176/124379401-708bb380-dcbf-11eb-989e-072429185701.gif)
