### PR TITLE
Fixed CPU Lightmapper BakedLightmap crash

### DIFF
--- a/editor/plugins/baked_lightmap_editor_plugin.cpp
+++ b/editor/plugins/baked_lightmap_editor_plugin.cpp
@@ -59,7 +59,7 @@ void BakedLightmapEditorPlugin::_bake_select_file(const String &p_file) {
 
 			} break;
 			case BakedLightmap::BAKE_ERROR_NO_MESHES:
-				EditorNode::get_singleton()->show_warning(TTR("No meshes to bake. Make sure they contain an UV2 channel and that the 'Bake Light' flag is on."));
+				EditorNode::get_singleton()->show_warning(TTR("No meshes to bake. Make sure they contain an UV2 channel and that the 'Use In Baked Light' and 'Generate Lightmap' flags are on."));
 				break;
 			case BakedLightmap::BAKE_ERROR_CANT_CREATE_IMAGE:
 				EditorNode::get_singleton()->show_warning(TTR("Failed creating lightmap images, make sure path is writable."));

--- a/modules/lightmapper_cpu/lightmapper_cpu.cpp
+++ b/modules/lightmapper_cpu/lightmapper_cpu.cpp
@@ -1261,9 +1261,18 @@ LightmapperCPU::BakeError LightmapperCPU::bake(BakeQuality p_quality, bool p_use
 		}
 	}
 
+	bool has_baked_mesh = false;
 	for (unsigned int i = 0; i < mesh_instances.size(); i++) {
+		if (mesh_instances[i].generate_lightmap) {
+			has_baked_mesh = true;
+		}
 		raycaster->add_mesh(mesh_instances[i].data.points, mesh_instances[i].data.normal, mesh_instances[i].data.uv2, i);
 	}
+
+	if (!has_baked_mesh) {
+		return BAKE_ERROR_NO_MESHES;
+	}
+
 	raycaster->commit();
 
 	scene_lightmaps.resize(mesh_instances.size());
@@ -1454,7 +1463,6 @@ LightmapperCPU::BakeError LightmapperCPU::bake(BakeQuality p_quality, bool p_use
 	}
 
 	{
-		int j = 0;
 		for (unsigned int i = 0; i < mesh_instances.size(); i++) {
 			if (!mesh_instances[i].generate_lightmap) {
 				continue;
@@ -1463,9 +1471,8 @@ LightmapperCPU::BakeError LightmapperCPU::bake(BakeQuality p_quality, bool p_use
 			if (p_generate_atlas) {
 				_blit_lightmap(lightmaps_data[i], mesh_instances[i].size, bake_textures[mesh_instances[i].slice], mesh_instances[i].offset.x, mesh_instances[i].offset.y, true);
 			} else {
-				_blit_lightmap(lightmaps_data[i], mesh_instances[i].size, bake_textures[j], 0, 0, false);
+				_blit_lightmap(lightmaps_data[i], mesh_instances[i].size, bake_textures[i], 0, 0, false);
 			}
-			j++;
 		}
 	}
 


### PR DESCRIPTION
Fix CPU Lightmapper baked [#49881](https://github.com/godotengine/godot/issues/49881)

*Bugsquad edit:* Fixes #49881.