### PR TITLE
Some fixes to runtime navmesh baking

### DIFF
--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -164,15 +164,18 @@ void NavigationMeshGenerator::_parse_geometry(Transform3D p_accumulated_transfor
 		StaticBody3D *static_body = Object::cast_to<StaticBody3D>(p_node);
 
 		if (static_body->get_collision_layer() & p_collision_mask) {
-			for (int i = 0; i < p_node->get_child_count(); ++i) {
-				Node *child = p_node->get_child(i);
-				if (Object::cast_to<CollisionShape3D>(child)) {
-					CollisionShape3D *col_shape = Object::cast_to<CollisionShape3D>(child);
-
-					Transform3D transform = p_accumulated_transform * static_body->get_transform() * col_shape->get_transform();
+			List<uint32_t> shape_owners;
+			static_body->get_shape_owners(&shape_owners);
+			for (List<uint32_t>::Element *E = shape_owners.front(); E; E = E->next()) {
+				int shape_count = static_body->shape_owner_get_shape_count(E->get());
+				for (int i = 0; i < shape_count; i++) {
+					Ref<Shape3D> s = static_body->shape_owner_get_shape(E->get(), i);
+					if (s.is_null()) {
+						continue;
+					}
+					Transform3D transform = p_accumulated_transform * static_body->get_transform() * static_body->shape_owner_get_transform(E->get());
 
 					Ref<Mesh> mesh;
-					Ref<Shape3D> s = col_shape->get_shape();
 
 					BoxShape3D *box = Object::cast_to<BoxShape3D>(*s);
 					if (box) {

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -168,7 +168,11 @@ void NavigationRegion3D::bake_navigation_mesh() {
 	BakeThreadsArgs *args = memnew(BakeThreadsArgs);
 	args->nav_region = this;
 
-	bake_thread.start(_bake_navigation_mesh, args);
+	if (Engine::get_singleton()->is_editor_hint()) {
+		_bake_navigation_mesh(args);
+	} else {
+		bake_thread.start(_bake_navigation_mesh, args);
+	}
 }
 
 void NavigationRegion3D::_bake_finished(Ref<NavigationMesh> p_nav_mesh) {


### PR DESCRIPTION
Fix some issues when baking the navigation mesh using `NavigationRegion3D.bake_navigation_mesh`.

- Don't bake the navmesh in a thread when calling `NavigationRegion3D.bake_navigation_mesh` from a tool script to prevent a crash (has the side effect to show the progress dialog).
- Use CollisionObject3D API when baking the navmesh with static colliders, instead of collecting CollisionShape3D nodes.