### PR TITLE
Add a comment at the top of generated shaders

### DIFF
--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -30,6 +30,8 @@
 
 #include "canvas_item_material.h"
 
+#include "core/version.h"
+
 Mutex CanvasItemMaterial::material_mutex;
 SelfList<CanvasItemMaterial>::List *CanvasItemMaterial::dirty_materials = nullptr;
 Map<CanvasItemMaterial::MaterialKey, CanvasItemMaterial::ShaderData> CanvasItemMaterial::shader_map;
@@ -78,7 +80,10 @@ void CanvasItemMaterial::_update_shader() {
 
 	//must create a shader!
 
-	String code = "shader_type canvas_item;\nrender_mode ";
+	// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
+	String code = "// NOTE: Shader automatically converted from " VERSION_NAME " " VERSION_FULL_CONFIG "'s CanvasItemMaterial.\n\n";
+
+	code += "shader_type canvas_item;\nrender_mode ";
 	switch (blend_mode) {
 		case BLEND_MODE_MIX:
 			code += "blend_mix";

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -31,6 +31,7 @@
 #include "material.h"
 
 #include "core/config/engine.h"
+#include "core/version.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_settings.h"
@@ -469,7 +470,12 @@ void BaseMaterial3D::_update_shader() {
 
 	//must create a shader!
 
-	String code = "shader_type spatial;\nrender_mode ";
+	// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
+	String code = vformat(
+			"// NOTE: Shader automatically converted from " VERSION_NAME " " VERSION_FULL_CONFIG "'s %s.\n\n",
+			orm ? "ORMMaterial3D" : "StandardMaterial3D");
+
+	code += "shader_type spatial;\nrender_mode ";
 	switch (blend_mode) {
 		case BLEND_MODE_MIX:
 			code += "blend_mix";

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -30,6 +30,8 @@
 
 #include "particles_material.h"
 
+#include "core/version.h"
+
 Mutex ParticlesMaterial::material_mutex;
 SelfList<ParticlesMaterial>::List *ParticlesMaterial::dirty_materials = nullptr;
 Map<ParticlesMaterial::MaterialKey, ParticlesMaterial::ShaderData> ParticlesMaterial::shader_map;
@@ -141,7 +143,10 @@ void ParticlesMaterial::_update_shader() {
 
 	//must create a shader!
 
-	String code = "shader_type particles;\n";
+	// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
+	String code = "// NOTE: Shader automatically converted from " VERSION_NAME " " VERSION_FULL_CONFIG "'s ParticlesMaterial.\n\n";
+
+	code += "shader_type particles;\n";
 
 	if (collision_scale) {
 		code += "render_mode collision_use_scale;\n";

--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -30,6 +30,8 @@
 
 #include "sky_material.h"
 
+#include "core/version.h"
+
 Mutex ProceduralSkyMaterial::shader_mutex;
 RID ProceduralSkyMaterial::shader;
 
@@ -204,7 +206,10 @@ void ProceduralSkyMaterial::_update_shader() {
 	if (shader.is_null()) {
 		shader = RS::get_singleton()->shader_create();
 
+		// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
 		RS::get_singleton()->shader_set_code(shader, R"(
+// NOTE: Shader automatically converted from )" VERSION_NAME " " VERSION_FULL_CONFIG R"('s ProceduralSkyMaterial.
+
 shader_type sky;
 
 uniform vec4 sky_top_color : hint_color = vec4(0.35, 0.46, 0.71, 1.0);
@@ -350,7 +355,10 @@ void PanoramaSkyMaterial::_update_shader() {
 	if (shader.is_null()) {
 		shader = RS::get_singleton()->shader_create();
 
+		// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
 		RS::get_singleton()->shader_set_code(shader, R"(
+// NOTE: Shader automatically converted from )" VERSION_NAME " " VERSION_FULL_CONFIG R"('s PanoramaSkyMaterial.
+
 shader_type sky;
 
 uniform sampler2D source_panorama : filter_linear;
@@ -561,7 +569,10 @@ void PhysicalSkyMaterial::_update_shader() {
 	if (shader.is_null()) {
 		shader = RS::get_singleton()->shader_create();
 
+		// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
 		RS::get_singleton()->shader_set_code(shader, R"(
+// NOTE: Shader automatically converted from )" VERSION_NAME " " VERSION_FULL_CONFIG R"('s PhysicalSkyMaterial.
+
 shader_type sky;
 
 uniform float rayleigh : hint_range(0, 64) = 2.0;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51746.

This comment is useful to determine the origin of ShaderMaterials converted from built-in material types (such as CanvasItemMaterial or StandardMaterial3D).

The Godot version is also included in case the shader needs to be regenerated with a newer engine version.

I tested this with all shader types, although I noticed there's no way to assign a new ORMMaterial3D to a material slot in a MeshInstance3D node.
**Edit:** PR opened to allow using ORMMaterial3D: https://github.com/godotengine/godot/pull/50162

If there's additional information we should include, feel free to tell me :slightly_smiling_face:

## Preview

![image](https://user-images.githubusercontent.com/180032/124390710-20c3e100-dced-11eb-893d-65facf6cd60e.png)