### PR TITLE
Improve visibility rect/AABB generation usability in GPUParticles

### DIFF
--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -60,13 +60,16 @@ void GPUParticles2DEditorPlugin::_file_selected(const String &p_file) {
 void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 	switch (p_idx) {
 		case MENU_GENERATE_VISIBILITY_RECT: {
-			double gen_time = particles->get_lifetime();
-			if (gen_time < 1.0) {
-				generate_seconds->set_value(1.0);
+			// Add one second to the default generation lifetime, since the progress is updated every second.
+			generate_seconds->set_value(MAX(1.0, trunc(particles->get_lifetime()) + 1.0));
+
+			if (generate_seconds->get_value() >= 11.0 + CMP_EPSILON) {
+				// Only pop up the time dialog if the particle's lifetime is long enough to warrant shortening it.
+				generate_visibility_rect->popup_centered();
 			} else {
-				generate_seconds->set_value(trunc(gen_time) + 1.0);
+				// Generate the visibility rect immediately.
+				_generate_visibility_rect();
 			}
-			generate_visibility_rect->popup_centered();
 		} break;
 		case MENU_LOAD_EMISSION_MASK: {
 			file->popup_file_dialog();
@@ -104,7 +107,7 @@ void GPUParticles2DEditorPlugin::_generate_visibility_rect() {
 
 	float running = 0.0;
 
-	EditorProgress ep("gen_vrect", TTR("Generating Visibility Rect"), int(time));
+	EditorProgress ep("gen_vrect", TTR("Generating Visibility Rect (Waiting for Particle Simulation)"), int(time));
 
 	bool was_emitting = particles->is_emitting();
 	if (!was_emitting) {

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -238,14 +238,16 @@ void GPUParticles3DEditor::_notification(int p_notification) {
 void GPUParticles3DEditor::_menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_OPTION_GENERATE_AABB: {
-			float gen_time = node->get_lifetime();
+			// Add one second to the default generation lifetime, since the progress is updated every second.
+			generate_seconds->set_value(MAX(1.0, trunc(node->get_lifetime()) + 1.0));
 
-			if (gen_time < 1.0) {
-				generate_seconds->set_value(1.0);
+			if (generate_seconds->get_value() >= 11.0 + CMP_EPSILON) {
+				// Only pop up the time dialog if the particle's lifetime is long enough to warrant shortening it.
+				generate_aabb->popup_centered();
 			} else {
-				generate_seconds->set_value(trunc(gen_time) + 1.0);
+				// Generate the visibility AABB immediately.
+				_generate_aabb();
 			}
-			generate_aabb->popup_centered();
 		} break;
 		case MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_NODE: {
 			Ref<ParticlesMaterial> material = node->get_process_material();
@@ -286,7 +288,7 @@ void GPUParticles3DEditor::_generate_aabb() {
 
 	double running = 0.0;
 
-	EditorProgress ep("gen_aabb", TTR("Generating AABB"), int(time));
+	EditorProgress ep("gen_aabb", TTR("Generating Visibility AABB (Waiting for Particle Simulation)"), int(time));
 
 	bool was_emitting = node->is_emitting();
 	if (!was_emitting) {


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/50180

- Don't display the time dialog if the automatically calculated generation time is short enough.
- Clarify the purpose of waiting in the progress dialog.