### PR TITLE
Fix MeshInstance3D doesn't update when material textures are changed

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -392,9 +392,10 @@ void BaseMaterial3D::_update_shader() {
 	dirty_materials->remove(&element);
 
 	MaterialKey mk = _compute_key();
-	if (mk == current_key) {
+	if (mk == current_key && !textures_changed) { //material dont changed and textures dont updated
 		return; //no update required in the end
 	}
+	textures_changed = false;
 
 	if (shader_map.has(current_key)) {
 		shader_map[current_key].users--;
@@ -1650,6 +1651,7 @@ void BaseMaterial3D::set_texture(TextureParam p_param, const Ref<Texture2D> &p_t
 		RS::get_singleton()->material_set_param(_get_material(), shader_names->albedo_texture_size,
 				Vector2i(p_texture->get_width(), p_texture->get_height()));
 	}
+	textures_changed = true;
 	notify_property_list_changed();
 	_queue_shader_change();
 }

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -521,6 +521,7 @@ private:
 	bool features[FEATURE_MAX] = {};
 
 	Ref<Texture2D> textures[TEXTURE_MAX];
+	bool textures_changed = false;
 
 	_FORCE_INLINE_ void _validate_feature(const String &text, Feature feature, PropertyInfo &property) const;
 


### PR DESCRIPTION

Fix MeshInstance3D doesn't update when material textures are changed. Issue: [#48886](https://github.com/godotengine/godot/issues/48886)
The MaterialKey does not contain any information about updating the texture. Therefore, the conditions are always true.
I added a flag, maybe it should have been called "force_update"