### PR TITLE
[3.x] Project manager code cleanup

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -61,867 +61,244 @@ static inline String get_project_key_from_path(const String &dir) {
 	return dir.replace("/", "::");
 }
 
-class ProjectDialog : public ConfirmationDialog {
-	GDCLASS(ProjectDialog, ConfirmationDialog);
-
-public:
-	enum Mode {
-		MODE_NEW,
-		MODE_IMPORT,
-		MODE_INSTALL,
-		MODE_RENAME
-	};
+class CreateProjectDialog : public ConfirmationDialog {
+	GDCLASS(CreateProjectDialog, ConfirmationDialog);
 
 private:
-	enum MessageType {
-		MESSAGE_ERROR,
-		MESSAGE_WARNING,
-		MESSAGE_SUCCESS
-	};
+	Ref<ButtonGroup> renderer_button_group;
 
-	enum InputType {
-		PROJECT_PATH,
-		INSTALL_PATH
-	};
+	// We don't need to store a reference to the gles3 button because if it's not
+	// gles2 then it must be gles3.
+	CheckBox *gles2_checkbox;
 
-	Mode mode;
-	Button *browse;
-	Button *install_browse;
-	Button *create_dir;
-	Container *name_container;
-	Container *path_container;
-	Container *install_path_container;
-	Container *rasterizer_container;
-	Ref<ButtonGroup> rasterizer_button_group;
-	Label *msg;
-	LineEdit *project_path;
-	LineEdit *project_name;
-	LineEdit *install_path;
-	TextureRect *status_rect;
-	TextureRect *install_status_rect;
-	FileDialog *fdialog;
-	FileDialog *fdialog_install;
-	String zip_path;
-	String zip_title;
-	AcceptDialog *dialog_error;
-	String fav_dir;
+	LineEdit *project_name_line_edit;
+	LineEdit *project_path_line_edit;
+	Button *project_path_picker;
+	CheckBox *use_custom_project_path_checkbox;
 
-	String created_folder_path;
+	// Used to warn the user of any invalid settings (such as an invalid project path).
+	Label *error_label;
 
-	void set_message(const String &p_msg, MessageType p_type = MESSAGE_SUCCESS, InputType input_type = PROJECT_PATH) {
-		msg->set_text(p_msg);
-		Ref<Texture> current_path_icon = status_rect->get_texture();
-		Ref<Texture> current_install_icon = install_status_rect->get_texture();
-		Ref<Texture> new_icon;
+	String default_project_folder_path;
 
-		switch (p_type) {
-			case MESSAGE_ERROR: {
-				msg->add_color_override("font_color", get_color("error_color", "Editor"));
-				msg->set_modulate(Color(1, 1, 1, 1));
-				new_icon = get_icon("StatusError", "EditorIcons");
-
-			} break;
-			case MESSAGE_WARNING: {
-				msg->add_color_override("font_color", get_color("warning_color", "Editor"));
-				msg->set_modulate(Color(1, 1, 1, 1));
-				new_icon = get_icon("StatusWarning", "EditorIcons");
-
-			} break;
-			case MESSAGE_SUCCESS: {
-				msg->set_modulate(Color(1, 1, 1, 0));
-				new_icon = get_icon("StatusSuccess", "EditorIcons");
-
-			} break;
+	void _use_custom_project_path_toggled(bool p_use_custom_project_path) {
+		project_path_line_edit->set_editable(p_use_custom_project_path);
+		project_path_picker->set_disabled(!p_use_custom_project_path);
+		if (!p_use_custom_project_path) {
+			_set_path(default_project_folder_path.plus_file(project_name_line_edit->get_text()));
 		}
-
-		if (current_path_icon != new_icon && input_type == PROJECT_PATH) {
-			status_rect->set_texture(new_icon);
-		} else if (current_install_icon != new_icon && input_type == INSTALL_PATH) {
-			install_status_rect->set_texture(new_icon);
-		}
-
-		set_size(Size2(500, 0) * EDSCALE);
 	}
 
-	String _test_path() {
-		DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		String valid_path, valid_install_path;
-		if (d->change_dir(project_path->get_text()) == OK) {
-			valid_path = project_path->get_text();
-		} else if (d->change_dir(project_path->get_text().strip_edges()) == OK) {
-			valid_path = project_path->get_text().strip_edges();
-		} else if (project_path->get_text().ends_with(".zip")) {
-			if (d->file_exists(project_path->get_text())) {
-				valid_path = project_path->get_text();
-			}
-		} else if (project_path->get_text().strip_edges().ends_with(".zip")) {
-			if (d->file_exists(project_path->get_text().strip_edges())) {
-				valid_path = project_path->get_text().strip_edges();
-			}
+	void _project_name_line_edit_changed(const String &p_new_text) {
+		if (!use_custom_project_path_checkbox->is_pressed()) {
+			_set_path(default_project_folder_path.plus_file(p_new_text));
+		}
+	}
+
+	// Updates `project_path_line_edit` and validates the new path,
+	// because calling `set_text()` doesn't emit `text_changed()`.
+	void _set_path(const String &p_path) {
+		project_path_line_edit->set_text(p_path);
+		_validate_path(p_path);
+	}
+
+	void _validate_path(const String &p_path) {
+		bool path_valid = true;
+
+		DirAccessRef dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		String project_folder_path = p_path.left(p_path.find_last("/"));
+		String project_folder_name = p_path.right(p_path.find_last("/") + 1);
+		if (!dir_access->dir_exists(project_folder_path)) {
+			error_label->set_text(vformat(TTR("Path does not exist: \"%s\""), project_folder_path));
+			path_valid = false;
+		}
+		if (!project_folder_name.is_valid_filename()) {
+			error_label->set_text(vformat(TTR("Invalid project folder name: \"%s\""), project_folder_name));
+			path_valid = false;
 		}
 
-		if (valid_path == "") {
-			set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR);
-			memdelete(d);
-			get_ok()->set_disabled(true);
-			return "";
-		}
-
-		if (mode == MODE_IMPORT && valid_path.ends_with(".zip")) {
-			if (d->change_dir(install_path->get_text()) == OK) {
-				valid_install_path = install_path->get_text();
-			} else if (d->change_dir(install_path->get_text().strip_edges()) == OK) {
-				valid_install_path = install_path->get_text().strip_edges();
-			}
-
-			if (valid_install_path == "") {
-				set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR, INSTALL_PATH);
-				memdelete(d);
-				get_ok()->set_disabled(true);
-				return "";
-			}
-		}
-
-		if (mode == MODE_IMPORT || mode == MODE_RENAME) {
-			if (valid_path != "" && !d->file_exists("project.godot")) {
-				if (valid_path.ends_with(".zip")) {
-					FileAccess *src_f = nullptr;
-					zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
-
-					unzFile pkg = unzOpen2(valid_path.utf8().get_data(), &io);
-					if (!pkg) {
-						set_message(TTR("Error opening package file (it's not in ZIP format)."), MESSAGE_ERROR);
-						memdelete(d);
-						get_ok()->set_disabled(true);
-						unzClose(pkg);
-						return "";
-					}
-
-					int ret = unzGoToFirstFile(pkg);
-					while (ret == UNZ_OK) {
-						unz_file_info info;
-						char fname[16384];
-						ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
-
-						if (String(fname).ends_with("project.godot")) {
-							break;
-						}
-
-						ret = unzGoToNextFile(pkg);
-					}
-
-					if (ret == UNZ_END_OF_LIST_OF_FILE) {
-						set_message(TTR("Invalid \".zip\" project file; it doesn't contain a \"project.godot\" file."), MESSAGE_ERROR);
-						memdelete(d);
-						get_ok()->set_disabled(true);
-						unzClose(pkg);
-						return "";
-					}
-
-					unzClose(pkg);
-
-					// check if the specified install folder is empty, even though this is not an error, it is good to check here
-					d->list_dir_begin();
-					bool is_empty = true;
-					String n = d->get_next();
-					while (n != String()) {
-						if (!n.begins_with(".")) {
-							// Allow `.`, `..` (reserved current/parent folder names)
-							// and hidden files/folders to be present.
-							// For instance, this lets users initialize a Git repository
-							// and still be able to create a project in the directory afterwards.
-							is_empty = false;
-							break;
-						}
-						n = d->get_next();
-					}
-					d->list_dir_end();
-
-					if (!is_empty) {
-						set_message(TTR("Please choose an empty folder."), MESSAGE_WARNING, INSTALL_PATH);
-						memdelete(d);
-						get_ok()->set_disabled(true);
-						return "";
-					}
-
-				} else {
-					set_message(TTR("Please choose a \"project.godot\" or \".zip\" file."), MESSAGE_ERROR);
-					memdelete(d);
-					install_path_container->hide();
-					get_ok()->set_disabled(true);
-					return "";
-				}
-
-			} else if (valid_path.ends_with("zip")) {
-				set_message(TTR("This directory already contains a Godot project."), MESSAGE_ERROR, INSTALL_PATH);
-				memdelete(d);
-				get_ok()->set_disabled(true);
-				return "";
-			}
-
-		} else {
-			// check if the specified folder is empty, even though this is not an error, it is good to check here
-			d->list_dir_begin();
-			bool is_empty = true;
-			String n = d->get_next();
-			while (n != String()) {
-				if (!n.begins_with(".")) {
-					// Allow `.`, `..` (reserved current/parent folder names)
-					// and hidden files/folders to be present.
-					// For instance, this lets users initialize a Git repository
-					// and still be able to create a project in the directory afterwards.
-					is_empty = false;
+		// Make sure (if the project folder already exist),
+		// that it doesn't already contain a Godot project.
+		if (dir_access->dir_exists(p_path)) {
+			PoolStringArray reserved_files;
+			reserved_files.push_back("project.godot");
+			reserved_files.push_back("default_env.tres");
+			reserved_files.push_back("icon.png");
+			for (int i = 0; i < reserved_files.size(); i++) {
+				const String &reserved_file = reserved_files[i];
+				if (dir_access->file_exists(p_path.plus_file(reserved_file))) {
+					error_label->set_text(vformat(TTR("Folder contains files that would be overwritten: \"%s\""), reserved_file));
+					path_valid = false;
 					break;
 				}
-				n = d->get_next();
-			}
-			d->list_dir_end();
-
-			if (!is_empty) {
-				set_message(TTR("Please choose an empty folder."), MESSAGE_ERROR);
-				memdelete(d);
-				get_ok()->set_disabled(true);
-				return "";
 			}
 		}
 
-		set_message("");
-		set_message("", MESSAGE_SUCCESS, INSTALL_PATH);
-		memdelete(d);
-		get_ok()->set_disabled(false);
-		return valid_path;
-	}
-
-	void _path_text_changed(const String &p_path) {
-		String sp = _test_path();
-		if (sp != "") {
-			// If the project name is empty or default, infer the project name from the selected folder name
-			if (project_name->get_text().strip_edges() == "" || project_name->get_text().strip_edges() == TTR("New Game Project")) {
-				sp = sp.replace("\\", "/");
-				int lidx = sp.find_last("/");
-
-				if (lidx != -1) {
-					sp = sp.substr(lidx + 1, sp.length()).capitalize();
-				}
-				if (sp == "" && mode == MODE_IMPORT) {
-					sp = TTR("Imported Project");
-				}
-
-				project_name->set_text(sp);
-				_text_changed(sp);
-			}
-		}
-
-		if (created_folder_path != "" && created_folder_path != p_path) {
-			_remove_created_folder();
-		}
-	}
-
-	void _file_selected(const String &p_path) {
-		String p = p_path;
-		if (mode == MODE_IMPORT) {
-			if (p.ends_with("project.godot")) {
-				p = p.get_base_dir();
-				install_path_container->hide();
-				get_ok()->set_disabled(false);
-			} else if (p.ends_with(".zip")) {
-				install_path->set_text(p.get_base_dir());
-				install_path_container->show();
-				get_ok()->set_disabled(false);
-			} else {
-				set_message(TTR("Please choose a \"project.godot\" or \".zip\" file."), MESSAGE_ERROR);
-				get_ok()->set_disabled(true);
-				return;
-			}
-		}
-		String sp = p.simplify_path();
-		project_path->set_text(sp);
-		_path_text_changed(sp);
-		if (p.ends_with(".zip")) {
-			install_path->call_deferred("grab_focus");
-		} else {
-			get_ok()->call_deferred("grab_focus");
-		}
-	}
-
-	void _path_selected(const String &p_path) {
-		String sp = p_path.simplify_path();
-		project_path->set_text(sp);
-		_path_text_changed(sp);
-		get_ok()->call_deferred("grab_focus");
-	}
-
-	void _install_path_selected(const String &p_path) {
-		String sp = p_path.simplify_path();
-		install_path->set_text(sp);
-		_path_text_changed(sp);
-		get_ok()->call_deferred("grab_focus");
-	}
-
-	void _browse_path() {
-		fdialog->set_current_dir(project_path->get_text());
-
-		if (mode == MODE_IMPORT) {
-			fdialog->set_mode(FileDialog::MODE_OPEN_FILE);
-			fdialog->clear_filters();
-			fdialog->add_filter(vformat("project.godot ; %s %s", VERSION_NAME, TTR("Project")));
-			fdialog->add_filter("*.zip ; " + TTR("ZIP File"));
-		} else {
-			fdialog->set_mode(FileDialog::MODE_OPEN_DIR);
-		}
-		fdialog->popup_centered_ratio();
-	}
-
-	void _browse_install_path() {
-		fdialog_install->set_current_dir(install_path->get_text());
-		fdialog_install->set_mode(FileDialog::MODE_OPEN_DIR);
-		fdialog_install->popup_centered_ratio();
-	}
-
-	void _create_folder() {
-		const String project_name_no_edges = project_name->get_text().strip_edges();
-		if (project_name_no_edges == "" || created_folder_path != "" || project_name_no_edges.ends_with(".")) {
-			set_message(TTR("Invalid project name."), MESSAGE_WARNING);
-			return;
-		}
-
-		DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		if (d->change_dir(project_path->get_text()) == OK) {
-			if (!d->dir_exists(project_name_no_edges)) {
-				if (d->make_dir(project_name_no_edges) == OK) {
-					d->change_dir(project_name_no_edges);
-					String dir_str = d->get_current_dir();
-					project_path->set_text(dir_str);
-					_path_text_changed(dir_str);
-					created_folder_path = d->get_current_dir();
-					create_dir->set_disabled(true);
-				} else {
-					dialog_error->set_text(TTR("Couldn't create folder."));
-					dialog_error->popup_centered_minsize();
-				}
-			} else {
-				dialog_error->set_text(TTR("There is already a folder in this path with the specified name."));
-				dialog_error->popup_centered_minsize();
-			}
-		}
-
-		memdelete(d);
-	}
-
-	void _text_changed(const String &p_text) {
-		if (mode != MODE_NEW) {
-			return;
-		}
-
-		_test_path();
-
-		if (p_text.strip_edges() == "") {
-			set_message(TTR("It would be a good idea to name your project."), MESSAGE_ERROR);
-		}
-	}
-
-	void ok_pressed() {
-		String dir = project_path->get_text();
-
-		if (mode == MODE_RENAME) {
-			String dir2 = _test_path();
-			if (dir2 == "") {
-				set_message(TTR("Invalid project path (changed anything?)."), MESSAGE_ERROR);
-				return;
-			}
-
-			ProjectSettings *current = memnew(ProjectSettings);
-
-			int err = current->setup(dir2, "");
-			if (err != OK) {
-				set_message(vformat(TTR("Couldn't load project.godot in project path (error %d). It may be missing or corrupted."), err), MESSAGE_ERROR);
-			} else {
-				ProjectSettings::CustomMap edited_settings;
-				edited_settings["application/config/name"] = project_name->get_text().strip_edges();
-
-				if (current->save_custom(dir2.plus_file("project.godot"), edited_settings, Vector<String>(), true) != OK) {
-					set_message(TTR("Couldn't edit project.godot in project path."), MESSAGE_ERROR);
-				}
-			}
-
-			hide();
-			emit_signal("projects_updated");
-
-		} else {
-			if (mode == MODE_IMPORT) {
-				if (project_path->get_text().ends_with(".zip")) {
-					mode = MODE_INSTALL;
-					ok_pressed();
-
-					return;
-				}
-
-			} else {
-				if (mode == MODE_NEW) {
-					ProjectSettings::CustomMap initial_settings;
-					if (rasterizer_button_group->get_pressed_button()->get_meta("driver_name") == "GLES3") {
-						initial_settings["rendering/quality/driver/driver_name"] = "GLES3";
-					} else {
-						initial_settings["rendering/quality/driver/driver_name"] = "GLES2";
-						initial_settings["rendering/vram_compression/import_etc2"] = false;
-						initial_settings["rendering/vram_compression/import_etc"] = true;
-					}
-					initial_settings["application/config/name"] = project_name->get_text().strip_edges();
-					initial_settings["application/config/icon"] = "res://icon.png";
-					initial_settings["rendering/environment/default_environment"] = "res://default_env.tres";
-					initial_settings["physics/common/enable_pause_aware_picking"] = true;
-
-					if (ProjectSettings::get_singleton()->save_custom(dir.plus_file("project.godot"), initial_settings, Vector<String>(), false) != OK) {
-						set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
-					} else {
-						ResourceSaver::save(dir.plus_file("icon.png"), create_unscaled_default_project_icon());
-
-						FileAccess *f = FileAccess::open(dir.plus_file("default_env.tres"), FileAccess::WRITE);
-						if (!f) {
-							set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
-						} else {
-							f->store_line("[gd_resource type=\"Environment\" load_steps=2 format=2]");
-							f->store_line("[sub_resource type=\"ProceduralSky\" id=1]");
-							f->store_line("[resource]");
-							f->store_line("background_mode = 2");
-							f->store_line("background_sky = SubResource( 1 )");
-							memdelete(f);
-						}
-					}
-
-				} else if (mode == MODE_INSTALL) {
-					if (project_path->get_text().ends_with(".zip")) {
-						dir = install_path->get_text();
-						zip_path = project_path->get_text();
-					}
-
-					FileAccess *src_f = nullptr;
-					zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
-
-					unzFile pkg = unzOpen2(zip_path.utf8().get_data(), &io);
-					if (!pkg) {
-						dialog_error->set_text(TTR("Error opening package file, not in ZIP format."));
-						dialog_error->popup_centered_minsize();
-						return;
-					}
-
-					// Find the zip_root
-					String zip_root;
-					int ret = unzGoToFirstFile(pkg);
-					while (ret == UNZ_OK) {
-						unz_file_info info;
-						char fname[16384];
-						unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
-
-						String name = fname;
-						if (name.ends_with("project.godot")) {
-							zip_root = name.substr(0, name.rfind("project.godot"));
-							break;
-						}
-
-						ret = unzGoToNextFile(pkg);
-					}
-
-					ret = unzGoToFirstFile(pkg);
-
-					Vector<String> failed_files;
-
-					int idx = 0;
-					while (ret == UNZ_OK) {
-						//get filename
-						unz_file_info info;
-						char fname[16384];
-						ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
-
-						String path = fname;
-
-						if (path == String() || path == zip_root || !zip_root.is_subsequence_of(path)) {
-							//
-						} else if (path.ends_with("/")) { // a dir
-
-							path = path.substr(0, path.length() - 1);
-							String rel_path = path.substr(zip_root.length());
-
-							DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-							da->make_dir(dir.plus_file(rel_path));
-							memdelete(da);
-
-						} else {
-							Vector<uint8_t> data;
-							data.resize(info.uncompressed_size);
-							String rel_path = path.substr(zip_root.length());
-
-							//read
-							unzOpenCurrentFile(pkg);
-							unzReadCurrentFile(pkg, data.ptrw(), data.size());
-							unzCloseCurrentFile(pkg);
-
-							FileAccess *f = FileAccess::open(dir.plus_file(rel_path), FileAccess::WRITE);
-
-							if (f) {
-								f->store_buffer(data.ptr(), data.size());
-								memdelete(f);
-							} else {
-								failed_files.push_back(rel_path);
-							}
-						}
-
-						idx++;
-						ret = unzGoToNextFile(pkg);
-					}
-
-					unzClose(pkg);
-
-					if (failed_files.size()) {
-						String msg = TTR("The following files failed extraction from package:") + "\n\n";
-						for (int i = 0; i < failed_files.size(); i++) {
-							if (i > 15) {
-								msg += "\nAnd " + itos(failed_files.size() - i) + " more files.";
-								break;
-							}
-							msg += failed_files[i] + "\n";
-						}
-
-						dialog_error->set_text(msg);
-						dialog_error->popup_centered_minsize();
-
-					} else if (!project_path->get_text().ends_with(".zip")) {
-						dialog_error->set_text(TTR("Package installed successfully!"));
-						dialog_error->popup_centered_minsize();
-					}
-				}
-			}
-
-			dir = dir.replace("\\", "/");
-			if (dir.ends_with("/")) {
-				dir = dir.substr(0, dir.length() - 1);
-			}
-			String proj = get_project_key_from_path(dir);
-			EditorSettings::get_singleton()->set("projects/" + proj, dir);
-			EditorSettings::get_singleton()->save();
-
-			hide();
-			emit_signal("project_created", dir);
-		}
-	}
-
-	void _remove_created_folder() {
-		if (created_folder_path != "") {
-			DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-			d->remove(created_folder_path);
-			memdelete(d);
-
-			create_dir->set_disabled(false);
-			created_folder_path = "";
-		}
-	}
-
-	void cancel_pressed() {
-		_remove_created_folder();
-
-		project_path->clear();
-		_path_text_changed("");
-		project_name->clear();
-		_text_changed("");
-
-		if (status_rect->get_texture() == get_icon("StatusError", "EditorIcons")) {
-			msg->show();
-		}
-
-		if (install_status_rect->get_texture() == get_icon("StatusError", "EditorIcons")) {
-			msg->show();
-		}
-	}
-
-	void _notification(int p_what) {
-		if (p_what == MainLoop::NOTIFICATION_WM_QUIT_REQUEST) {
-			_remove_created_folder();
-		}
+		error_label->set_modulate(Color(1.0f, 1.0f, 1.0f, path_valid ? 0.0f : 1.0f));
+		// Disable the "Create & Edit" button until all errors have been resolved.
+		get_ok()->set_disabled(!path_valid);
 	}
 
 protected:
 	static void _bind_methods() {
-		ClassDB::bind_method("_browse_path", &ProjectDialog::_browse_path);
-		ClassDB::bind_method("_create_folder", &ProjectDialog::_create_folder);
-		ClassDB::bind_method("_text_changed", &ProjectDialog::_text_changed);
-		ClassDB::bind_method("_path_text_changed", &ProjectDialog::_path_text_changed);
-		ClassDB::bind_method("_path_selected", &ProjectDialog::_path_selected);
-		ClassDB::bind_method("_file_selected", &ProjectDialog::_file_selected);
-		ClassDB::bind_method("_install_path_selected", &ProjectDialog::_install_path_selected);
-		ClassDB::bind_method("_browse_install_path", &ProjectDialog::_browse_install_path);
-		ADD_SIGNAL(MethodInfo("project_created"));
-		ADD_SIGNAL(MethodInfo("projects_updated"));
+		ClassDB::bind_method("_project_name_line_edit_changed", &CreateProjectDialog::_project_name_line_edit_changed);
+		ClassDB::bind_method("_use_custom_project_path_toggled", &CreateProjectDialog::_use_custom_project_path_toggled);
+		ClassDB::bind_method("_set_path", &CreateProjectDialog::_set_path);
+		ClassDB::bind_method("_validate_path", &CreateProjectDialog::_validate_path);
+		ClassDB::bind_method("create_project_popup", &CreateProjectDialog::create_project_popup);
 	}
 
 public:
-	void set_zip_path(const String &p_path) {
-		zip_path = p_path;
-	}
-	void set_zip_title(const String &p_title) {
-		zip_title = p_title;
+	String get_new_project_name() {
+		return project_name_line_edit->get_text();
 	}
 
-	void set_mode(Mode p_mode) {
-		mode = p_mode;
+	String get_new_project_path() {
+		return project_path_line_edit->get_text();
 	}
 
-	void set_project_path(const String &p_path) {
-		project_path->set_text(p_path);
+	bool should_new_project_use_gles2() {
+		return renderer_button_group->get_pressed_button() == gles2_checkbox;
 	}
 
-	void show_dialog() {
-		if (mode == MODE_RENAME) {
-			project_path->set_editable(false);
-			browse->hide();
-			install_browse->hide();
+	void create_project_popup() {
+		popup_centered();
 
-			set_title(TTR("Rename Project"));
-			get_ok()->set_text(TTR("Rename"));
-			name_container->show();
-			status_rect->hide();
-			msg->hide();
-			install_path_container->hide();
-			install_status_rect->hide();
-			rasterizer_container->hide();
-			get_ok()->set_disabled(false);
+		project_name_line_edit->select_all();
+		project_name_line_edit->grab_focus();
+	}
 
-			ProjectSettings *current = memnew(ProjectSettings);
-
-			int err = current->setup(project_path->get_text(), "");
-			if (err != OK) {
-				set_message(vformat(TTR("Couldn't load project.godot in project path (error %d). It may be missing or corrupted."), err), MESSAGE_ERROR);
-				status_rect->show();
-				msg->show();
-				get_ok()->set_disabled(true);
-			} else if (current->has_setting("application/config/name")) {
-				String proj = current->get("application/config/name");
-				project_name->set_text(proj);
-				_text_changed(proj);
-			}
-
-			project_name->call_deferred("grab_focus");
-
-			create_dir->hide();
-
-		} else {
-			fav_dir = EditorSettings::get_singleton()->get("filesystem/directories/default_project_path");
-			if (fav_dir != "") {
-				project_path->set_text(fav_dir);
-				fdialog->set_current_dir(fav_dir);
-			} else {
-				DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-				project_path->set_text(d->get_current_dir());
-				fdialog->set_current_dir(d->get_current_dir());
-				memdelete(d);
-			}
-			String proj = TTR("New Game Project");
-			project_name->set_text(proj);
-			_text_changed(proj);
-
-			project_path->set_editable(true);
-			browse->set_disabled(false);
-			browse->show();
-			install_browse->set_disabled(false);
-			install_browse->show();
-			create_dir->show();
-			status_rect->show();
-			install_status_rect->show();
-			msg->show();
-
-			if (mode == MODE_IMPORT) {
-				set_title(TTR("Import Existing Project"));
-				get_ok()->set_text(TTR("Import & Edit"));
-				name_container->hide();
-				install_path_container->hide();
-				rasterizer_container->hide();
-				project_path->grab_focus();
-
-			} else if (mode == MODE_NEW) {
-				set_title(TTR("Create New Project"));
-				get_ok()->set_text(TTR("Create & Edit"));
-				name_container->show();
-				install_path_container->hide();
-				rasterizer_container->show();
-				project_name->call_deferred("grab_focus");
-				project_name->call_deferred("select_all");
-
-			} else if (mode == MODE_INSTALL) {
-				set_title(TTR("Install Project:") + " " + zip_title);
-				get_ok()->set_text(TTR("Install & Edit"));
-				project_name->set_text(zip_title);
-				name_container->show();
-				install_path_container->hide();
-				rasterizer_container->hide();
-				project_path->grab_focus();
-			}
-
-			_test_path();
+	void _notification(int p_what) {
+		if (p_what == NOTIFICATION_READY) {
+			project_path_picker->set_icon(get_icon("Load", "EditorIcons"));
+			error_label->add_color_override("font_color", error_label->get_color("error_color", "Editor"));
 		}
-
-		// Reset the dialog to its initial size. Otherwise, the dialog window would be too large
-		// when opening a small dialog after closing a large dialog.
-		set_size(get_minimum_size());
-		popup_centered_minsize(Size2(500, 0) * EDSCALE);
 	}
 
-	ProjectDialog() {
-		VBoxContainer *vb = memnew(VBoxContainer);
-		add_child(vb);
+	CreateProjectDialog() {
+		String default_project_name = TTR("New Godot Project");
+		default_project_folder_path = EDITOR_GET("filesystem/directories/default_project_path");
+		default_project_folder_path.replace("\\", "/");
 
-		name_container = memnew(VBoxContainer);
-		vb->add_child(name_container);
+		set_title(TTR("Create new project"));
+		get_ok()->set_text(TTR("Create & Edit"));
 
-		Label *l = memnew(Label);
-		l->set_text(TTR("Project Name:"));
-		name_container->add_child(l);
+		VBoxContainer *vbox = memnew(VBoxContainer);
+		add_child(vbox);
 
-		HBoxContainer *pnhb = memnew(HBoxContainer);
-		name_container->add_child(pnhb);
+		Label *project_name_label = memnew(Label);
+		project_name_label->set_text(TTR("Project name:"));
+		vbox->add_child(project_name_label);
 
-		project_name = memnew(LineEdit);
-		project_name->set_h_size_flags(SIZE_EXPAND_FILL);
-		pnhb->add_child(project_name);
+		project_name_line_edit = memnew(LineEdit);
+		project_name_line_edit->set_text(default_project_name);
+		project_name_line_edit->connect("text_changed", this, "_project_name_line_edit_changed");
+		vbox->add_child(project_name_line_edit);
 
-		create_dir = memnew(Button);
-		pnhb->add_child(create_dir);
-		create_dir->set_text(TTR("Create Folder"));
-		create_dir->connect("pressed", this, "_create_folder");
+		HBoxContainer *project_path_label_hbox = memnew(HBoxContainer);
+		vbox->add_child(project_path_label_hbox);
 
-		path_container = memnew(VBoxContainer);
-		vb->add_child(path_container);
+		Label *project_path_label = memnew(Label);
+		project_path_label->set_text(TTR("Project path:"));
+		project_path_label_hbox->add_child(project_path_label);
 
-		l = memnew(Label);
-		l->set_text(TTR("Project Path:"));
-		path_container->add_child(l);
+		use_custom_project_path_checkbox = memnew(CheckBox);
+		use_custom_project_path_checkbox->set_text(TTR("Use custom"));
+		use_custom_project_path_checkbox->set_h_size_flags(SIZE_EXPAND | SIZE_SHRINK_END);
+		use_custom_project_path_checkbox->connect("toggled", this, "_use_custom_project_path_toggled");
+		project_path_label_hbox->add_child(use_custom_project_path_checkbox);
 
-		HBoxContainer *pphb = memnew(HBoxContainer);
-		path_container->add_child(pphb);
+		HBoxContainer *project_path_line_edit_hbox = memnew(HBoxContainer);
+		vbox->add_child(project_path_line_edit_hbox);
 
-		project_path = memnew(LineEdit);
-		project_path->set_h_size_flags(SIZE_EXPAND_FILL);
-		pphb->add_child(project_path);
+		project_path_line_edit = memnew(LineEdit);
+		// Text gets set farther down, after `error_label` is created.
+		project_path_line_edit->set_editable(false);
+		project_path_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
+		project_path_line_edit->connect("text_changed", this, "_validate_path");
+		project_path_line_edit_hbox->add_child(project_path_line_edit);
 
-		install_path_container = memnew(VBoxContainer);
-		vb->add_child(install_path_container);
+		FileDialog *project_path_file_dialog = memnew(FileDialog);
+		project_path_file_dialog->set_access(FileDialog::ACCESS_FILESYSTEM);
+		project_path_file_dialog->set_mode(FileDialog::MODE_OPEN_DIR);
+		project_path_file_dialog->set_current_dir(default_project_folder_path);
+		project_path_file_dialog->connect("dir_selected", this, "_set_path");
+		add_child(project_path_file_dialog);
 
-		l = memnew(Label);
-		l->set_text(TTR("Project Installation Path:"));
-		install_path_container->add_child(l);
+		project_path_picker = memnew(Button);
+		project_path_picker->set_disabled(true);
+		project_path_picker->connect("pressed", project_path_file_dialog, "popup_centered_ratio");
+		project_path_line_edit_hbox->add_child(project_path_picker);
 
-		HBoxContainer *iphb = memnew(HBoxContainer);
-		install_path_container->add_child(iphb);
+		error_label = memnew(Label);
+		error_label->set_autowrap(true);
+		error_label->set_align(Label::ALIGN_CENTER);
+		error_label->set_modulate(Color(1.0f, 1.0f, 1.0f, 0.0f));
+		vbox->add_child(error_label);
 
-		install_path = memnew(LineEdit);
-		install_path->set_h_size_flags(SIZE_EXPAND_FILL);
-		iphb->add_child(install_path);
+		// Validate, in case `default_project_folder_path` got set to something weird.
+		// `error_label` has to be created before `_set_path()` can be called,
+		// which is why it's here and not farther up.
+		_set_path(default_project_folder_path.plus_file(default_project_name));
 
-		// status icon
-		status_rect = memnew(TextureRect);
-		status_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
-		pphb->add_child(status_rect);
+		Label *renderer_label = memnew(Label);
+		renderer_label->set_text(TTR("Renderer:"));
+		vbox->add_child(renderer_label);
 
-		browse = memnew(Button);
-		browse->set_text(TTR("Browse"));
-		browse->connect("pressed", this, "_browse_path");
-		pphb->add_child(browse);
+		HBoxContainer *renderer_hbox = memnew(HBoxContainer);
+		vbox->add_child(renderer_hbox);
 
-		// install status icon
-		install_status_rect = memnew(TextureRect);
-		install_status_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
-		iphb->add_child(install_status_rect);
+		renderer_button_group.instance();
 
-		install_browse = memnew(Button);
-		install_browse->set_text(TTR("Browse"));
-		install_browse->connect("pressed", this, "_browse_install_path");
-		iphb->add_child(install_browse);
+		VBoxContainer *gles3_vbox = memnew(VBoxContainer);
+		gles3_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+		renderer_hbox->add_child(gles3_vbox);
 
-		msg = memnew(Label);
-		msg->set_align(Label::ALIGN_CENTER);
-		vb->add_child(msg);
-
-		// rasterizer selection
-		rasterizer_container = memnew(VBoxContainer);
-		vb->add_child(rasterizer_container);
-		l = memnew(Label);
-		l->set_text(TTR("Renderer:"));
-		rasterizer_container->add_child(l);
-		Container *rshb = memnew(HBoxContainer);
-		rasterizer_container->add_child(rshb);
-		rasterizer_button_group.instance();
+		CheckBox *gles3_checkbox = memnew(CheckBox);
+		gles3_checkbox->set_text(TTR("OpenGL ES 3.0"));
+		gles3_checkbox->set_button_group(renderer_button_group);
+		gles3_vbox->add_child(gles3_checkbox);
 
 		// Enable GLES3 by default as it's the default value for the project setting.
 #ifndef SERVER_ENABLED
 		bool gles3_viable = RasterizerGLES3::is_viable() == OK;
-#else
-		// Whatever, project manager isn't even used in headless builds.
-		bool gles3_viable = false;
-#endif
 
-		Container *rvb = memnew(VBoxContainer);
-		rvb->set_h_size_flags(SIZE_EXPAND_FILL);
-		rshb->add_child(rvb);
-		Button *rs_button = memnew(CheckBox);
-		rs_button->set_button_group(rasterizer_button_group);
-		rs_button->set_text(TTR("OpenGL ES 3.0"));
-		rs_button->set_meta("driver_name", "GLES3");
-		rvb->add_child(rs_button);
 		if (gles3_viable) {
-			rs_button->set_pressed(true);
+			gles3_checkbox->set_pressed(true);
 		} else {
 			// If GLES3 can't be used, don't let users shoot themselves in the foot.
-			rs_button->set_disabled(true);
-			l = memnew(Label);
-			l->set_text(TTR("Not supported by your GPU drivers."));
-			rvb->add_child(l);
+			gles3_checkbox->set_disabled(true);
+			Label *gles3_not_supported_label = memnew(Label);
+			gles3_not_supported_label->set_text(TTR("Not supported by your GPU drivers."));
+			gles3_vbox->add_child(gles3_not_supported_label);
 		}
-		l = memnew(Label);
-		l->set_text(TTR("Higher visual quality\nAll features available\nIncompatible with older hardware\nNot recommended for web games"));
-		rvb->add_child(l);
+#endif
 
-		rshb->add_child(memnew(VSeparator));
+		Label *gles3_description = memnew(Label);
+		gles3_description->set_text(TTR("Higher visual quality\nAll features available\nIncompatible with older hardware\nNot recommended for web games"));
+		gles3_vbox->add_child(gles3_description);
 
-		rvb = memnew(VBoxContainer);
-		rvb->set_h_size_flags(SIZE_EXPAND_FILL);
-		rshb->add_child(rvb);
-		rs_button = memnew(CheckBox);
-		rs_button->set_button_group(rasterizer_button_group);
-		rs_button->set_text(TTR("OpenGL ES 2.0"));
-		rs_button->set_meta("driver_name", "GLES2");
-		rs_button->set_pressed(!gles3_viable);
-		rvb->add_child(rs_button);
-		l = memnew(Label);
-		l->set_text(TTR("Lower visual quality\nSome features not available\nWorks on most hardware\nRecommended for web games"));
-		rvb->add_child(l);
+		VSeparator *v_separator = memnew(VSeparator);
+		renderer_hbox->add_child(v_separator);
 
-		l = memnew(Label);
-		l->set_text(TTR("Renderer can be changed later, but scenes may need to be adjusted."));
-		l->set_align(Label::ALIGN_CENTER);
-		rasterizer_container->add_child(l);
+		VBoxContainer *gles2_vbox = memnew(VBoxContainer);
+		gles2_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+		renderer_hbox->add_child(gles2_vbox);
 
-		fdialog = memnew(FileDialog);
-		fdialog->set_access(FileDialog::ACCESS_FILESYSTEM);
-		fdialog_install = memnew(FileDialog);
-		fdialog_install->set_access(FileDialog::ACCESS_FILESYSTEM);
-		add_child(fdialog);
-		add_child(fdialog_install);
-		project_name->connect("text_changed", this, "_text_changed");
-		project_path->connect("text_changed", this, "_path_text_changed");
-		install_path->connect("text_changed", this, "_path_text_changed");
-		fdialog->connect("dir_selected", this, "_path_selected");
-		fdialog->connect("file_selected", this, "_file_selected");
-		fdialog_install->connect("dir_selected", this, "_install_path_selected");
-		fdialog_install->connect("file_selected", this, "_install_path_selected");
+		gles2_checkbox = memnew(CheckBox);
+		gles2_checkbox->set_text(TTR("OpenGL ES 2.0"));
+		gles2_checkbox->set_button_group(renderer_button_group);
+		gles2_vbox->add_child(gles2_checkbox);
 
-		set_hide_on_ok(false);
-		mode = MODE_NEW;
-
-		dialog_error = memnew(AcceptDialog);
-		add_child(dialog_error);
+		Label *gles2_description = memnew(Label);
+		gles2_description->set_text(TTR("Lower visual quality\nSome features not available\nWorks on most hardware\nRecommended for web games"));
+		gles2_vbox->add_child(gles2_description);
 	}
 };
 
 class ProjectListItemControl : public HBoxContainer {
 	GDCLASS(ProjectListItemControl, HBoxContainer)
+
 public:
 	TextureButton *favorite_button;
 	TextureRect *icon;
@@ -941,6 +318,7 @@ public:
 		favorite_button->set_modulate(fav ? Color(1, 1, 1, 1) : Color(1, 1, 1, 0.2));
 	}
 
+	//refactor me
 	void _notification(int p_what) {
 		switch (p_what) {
 			case NOTIFICATION_MOUSE_ENTER: {
@@ -960,653 +338,7 @@ public:
 	}
 };
 
-class ProjectList : public ScrollContainer {
-	GDCLASS(ProjectList, ScrollContainer)
-public:
-	static const char *SIGNAL_SELECTION_CHANGED;
-	static const char *SIGNAL_PROJECT_ASK_OPEN;
-
-	enum MenuOptions {
-		GLOBAL_NEW_WINDOW,
-		GLOBAL_OPEN_PROJECT
-	};
-
-	// Can often be passed by copy
-	struct Item {
-		String project_key;
-		String project_name;
-		String description;
-		String path;
-		String icon;
-		String main_scene;
-		uint64_t last_modified;
-		bool favorite;
-		bool grayed;
-		bool missing;
-		int version;
-
-		ProjectListItemControl *control;
-
-		Item() {}
-
-		Item(const String &p_project,
-				const String &p_name,
-				const String &p_description,
-				const String &p_path,
-				const String &p_icon,
-				const String &p_main_scene,
-				uint64_t p_last_modified,
-				bool p_favorite,
-				bool p_grayed,
-				bool p_missing,
-				int p_version) {
-			project_key = p_project;
-			project_name = p_name;
-			description = p_description;
-			path = p_path;
-			icon = p_icon;
-			main_scene = p_main_scene;
-			last_modified = p_last_modified;
-			favorite = p_favorite;
-			grayed = p_grayed;
-			missing = p_missing;
-			version = p_version;
-			control = nullptr;
-		}
-
-		_FORCE_INLINE_ bool operator==(const Item &l) const {
-			return project_key == l.project_key;
-		}
-	};
-
-	ProjectList();
-	~ProjectList();
-
-	void update_dock_menu();
-	void load_projects();
-	void set_search_term(String p_search_term);
-	void set_order_option(ProjectListFilter::FilterOption p_option);
-	void sort_projects();
-	int get_project_count() const;
-	void select_project(int p_index);
-	void erase_selected_projects();
-	Vector<Item> get_selected_projects() const;
-	const Set<String> &get_selected_project_keys() const;
-	void ensure_project_visible(int p_index);
-	int get_single_selected_index() const;
-	bool is_any_project_missing() const;
-	void erase_missing_projects();
-	int refresh_project(const String &dir_path);
-
-private:
-	static void _bind_methods();
-	void _notification(int p_what);
-
-	void _panel_draw(Node *p_hb);
-	void _panel_input(const Ref<InputEvent> &p_ev, Node *p_hb);
-	void _favorite_pressed(Node *p_hb);
-	void _show_project(const String &p_path);
-
-	void select_range(int p_begin, int p_end);
-	void toggle_select(int p_index);
-	void create_project_item_control(int p_index);
-	void remove_project(int p_index, bool p_update_settings);
-	void update_icons_async();
-	void load_project_icon(int p_index);
-
-	static void load_project_data(const String &p_property_key, Item &p_item, bool p_favorite);
-
-	String _search_term;
-	ProjectListFilter::FilterOption _order_option;
-	Set<String> _selected_project_keys;
-	String _last_clicked; // Project key
-	VBoxContainer *_scroll_children;
-	int _icon_load_index;
-
-	Vector<Item> _projects;
-};
-
-struct ProjectListComparator {
-	ProjectListFilter::FilterOption order_option;
-
-	// operator<
-	_FORCE_INLINE_ bool operator()(const ProjectList::Item &a, const ProjectList::Item &b) const {
-		if (a.favorite && !b.favorite) {
-			return true;
-		}
-		if (b.favorite && !a.favorite) {
-			return false;
-		}
-		switch (order_option) {
-			case ProjectListFilter::FILTER_PATH:
-				return a.project_key < b.project_key;
-			case ProjectListFilter::FILTER_MODIFIED:
-				return a.last_modified > b.last_modified;
-			default:
-				return a.project_name < b.project_name;
-		}
-	}
-};
-
-ProjectList::ProjectList() {
-	_order_option = ProjectListFilter::FILTER_MODIFIED;
-
-	_scroll_children = memnew(VBoxContainer);
-	_scroll_children->set_h_size_flags(SIZE_EXPAND_FILL);
-	add_child(_scroll_children);
-
-	_icon_load_index = 0;
-}
-
-ProjectList::~ProjectList() {
-}
-
-void ProjectList::update_icons_async() {
-	_icon_load_index = 0;
-	set_process(true);
-}
-
-void ProjectList::_notification(int p_what) {
-	if (p_what == NOTIFICATION_PROCESS) {
-		// Load icons as a coroutine to speed up launch when you have hundreds of projects
-		if (_icon_load_index < _projects.size()) {
-			Item &item = _projects.write[_icon_load_index];
-			if (item.control->icon_needs_reload) {
-				load_project_icon(_icon_load_index);
-			}
-			_icon_load_index++;
-
-		} else {
-			set_process(false);
-		}
-	}
-}
-
-void ProjectList::load_project_icon(int p_index) {
-	Item &item = _projects.write[p_index];
-
-	Ref<Texture> default_icon = get_icon("DefaultProjectIcon", "EditorIcons");
-	Ref<Texture> icon;
-	if (item.icon != "") {
-		Ref<Image> img;
-		img.instance();
-		Error err = img->load(item.icon.replace_first("res://", item.path + "/"));
-		if (err == OK) {
-			img->resize(default_icon->get_width(), default_icon->get_height(), Image::INTERPOLATE_LANCZOS);
-			Ref<ImageTexture> it = memnew(ImageTexture);
-			it->create_from_image(img);
-			icon = it;
-		}
-	}
-	if (icon.is_null()) {
-		icon = default_icon;
-	}
-
-	item.control->icon->set_texture(icon);
-	item.control->icon_needs_reload = false;
-}
-
-void ProjectList::load_project_data(const String &p_property_key, Item &p_item, bool p_favorite) {
-	String path = EditorSettings::get_singleton()->get(p_property_key);
-	String conf = path.plus_file("project.godot");
-	bool grayed = false;
-	bool missing = false;
-
-	Ref<ConfigFile> cf = memnew(ConfigFile);
-	Error cf_err = cf->load(conf);
-
-	int config_version = 0;
-	String project_name = TTR("Unnamed Project");
-	if (cf_err == OK) {
-		String cf_project_name = static_cast<String>(cf->get_value("application", "config/name", ""));
-		if (cf_project_name != "") {
-			project_name = cf_project_name.xml_unescape();
-		}
-		config_version = (int)cf->get_value("", "config_version", 0);
-	}
-
-	if (config_version > ProjectSettings::CONFIG_VERSION) {
-		// Comes from an incompatible (more recent) Godot version, grey it out
-		grayed = true;
-	}
-
-	String description = cf->get_value("application", "config/description", "");
-	String icon = cf->get_value("application", "config/icon", "");
-	String main_scene = cf->get_value("application", "run/main_scene", "");
-
-	uint64_t last_modified = 0;
-	if (FileAccess::exists(conf)) {
-		last_modified = FileAccess::get_modified_time(conf);
-
-		String fscache = path.plus_file(".fscache");
-		if (FileAccess::exists(fscache)) {
-			uint64_t cache_modified = FileAccess::get_modified_time(fscache);
-			if (cache_modified > last_modified) {
-				last_modified = cache_modified;
-			}
-		}
-	} else {
-		grayed = true;
-		missing = true;
-		print_line("Project is missing: " + conf);
-	}
-
-	String project_key = p_property_key.get_slice("/", 1);
-
-	p_item = Item(project_key, project_name, description, path, icon, main_scene, last_modified, p_favorite, grayed, missing, config_version);
-}
-
-void ProjectList::load_projects() {
-	// This is a full, hard reload of the list. Don't call this unless really required, it's expensive.
-	// If you have 150 projects, it may read through 150 files on your disk at once + load 150 icons.
-
-	// Clear whole list
-	for (int i = 0; i < _projects.size(); ++i) {
-		Item &project = _projects.write[i];
-		CRASH_COND(project.control == nullptr);
-		memdelete(project.control); // Why not queue_free()?
-	}
-	_projects.clear();
-	_last_clicked = "";
-	_selected_project_keys.clear();
-
-	// Load data
-	// TODO Would be nice to change how projects and favourites are stored... it complicates things a bit.
-	// Use a dictionary associating project path to metadata (like is_favorite).
-
-	List<PropertyInfo> properties;
-	EditorSettings::get_singleton()->get_property_list(&properties);
-
-	Set<String> favorites;
-	// Find favourites...
-	for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-		String property_key = E->get().name;
-		if (property_key.begins_with("favorite_projects/")) {
-			favorites.insert(property_key);
-		}
-	}
-
-	for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-		// This is actually something like "projects/C:::Documents::Godot::Projects::MyGame"
-		String property_key = E->get().name;
-		if (!property_key.begins_with("projects/")) {
-			continue;
-		}
-
-		String project_key = property_key.get_slice("/", 1);
-		bool favorite = favorites.has("favorite_projects/" + project_key);
-
-		Item item;
-		load_project_data(property_key, item, favorite);
-
-		_projects.push_back(item);
-	}
-
-	// Create controls
-	for (int i = 0; i < _projects.size(); ++i) {
-		create_project_item_control(i);
-	}
-
-	sort_projects();
-
-	set_v_scroll(0);
-
-	update_icons_async();
-
-	update_dock_menu();
-}
-
-void ProjectList::update_dock_menu() {
-	OS::get_singleton()->global_menu_clear("_dock");
-
-	int favs_added = 0;
-	int total_added = 0;
-	for (int i = 0; i < _projects.size(); ++i) {
-		if (!_projects[i].grayed && !_projects[i].missing) {
-			if (_projects[i].favorite) {
-				favs_added++;
-			} else {
-				if (favs_added != 0) {
-					OS::get_singleton()->global_menu_add_separator("_dock");
-				}
-				favs_added = 0;
-			}
-			OS::get_singleton()->global_menu_add_item("_dock", _projects[i].project_name + " ( " + _projects[i].path + " )", GLOBAL_OPEN_PROJECT, Variant(_projects[i].path.plus_file("project.godot")));
-			total_added++;
-		}
-	}
-	if (total_added != 0) {
-		OS::get_singleton()->global_menu_add_separator("_dock");
-	}
-	OS::get_singleton()->global_menu_add_item("_dock", TTR("New Window"), GLOBAL_NEW_WINDOW, Variant());
-}
-
-void ProjectList::create_project_item_control(int p_index) {
-	// Will be added last in the list, so make sure indexes match
-	ERR_FAIL_COND(p_index != _scroll_children->get_child_count());
-
-	Item &item = _projects.write[p_index];
-	ERR_FAIL_COND(item.control != nullptr); // Already created
-
-	Ref<Texture> favorite_icon = get_icon("Favorites", "EditorIcons");
-	Color font_color = get_color("font_color", "Tree");
-
-	ProjectListItemControl *hb = memnew(ProjectListItemControl);
-	hb->connect("draw", this, "_panel_draw", varray(hb));
-	hb->connect("gui_input", this, "_panel_input", varray(hb));
-	hb->add_constant_override("separation", 10 * EDSCALE);
-	hb->set_tooltip(item.description);
-
-	VBoxContainer *favorite_box = memnew(VBoxContainer);
-	favorite_box->set_name("FavoriteBox");
-	TextureButton *favorite = memnew(TextureButton);
-	favorite->set_name("FavoriteButton");
-	favorite->set_normal_texture(favorite_icon);
-	// This makes the project's "hover" style display correctly when hovering the favorite icon
-	favorite->set_mouse_filter(MOUSE_FILTER_PASS);
-	favorite->connect("pressed", this, "_favorite_pressed", varray(hb));
-	favorite_box->add_child(favorite);
-	favorite_box->set_alignment(BoxContainer::ALIGN_CENTER);
-	hb->add_child(favorite_box);
-	hb->favorite_button = favorite;
-	hb->set_is_favorite(item.favorite);
-
-	TextureRect *tf = memnew(TextureRect);
-	// The project icon may not be loaded by the time the control is displayed,
-	// so use a loading placeholder.
-	tf->set_texture(get_icon("ProjectIconLoading", "EditorIcons"));
-	tf->set_v_size_flags(SIZE_SHRINK_CENTER);
-	if (item.missing) {
-		tf->set_modulate(Color(1, 1, 1, 0.5));
-	}
-	hb->add_child(tf);
-	hb->icon = tf;
-
-	VBoxContainer *vb = memnew(VBoxContainer);
-	if (item.grayed) {
-		vb->set_modulate(Color(1, 1, 1, 0.5));
-	}
-	vb->set_h_size_flags(SIZE_EXPAND_FILL);
-	hb->add_child(vb);
-	Control *ec = memnew(Control);
-	ec->set_custom_minimum_size(Size2(0, 1));
-	ec->set_mouse_filter(MOUSE_FILTER_PASS);
-	vb->add_child(ec);
-	Label *title = memnew(Label(!item.missing ? item.project_name : TTR("Missing Project")));
-	title->add_font_override("font", get_font("title", "EditorFonts"));
-	title->add_color_override("font_color", font_color);
-	title->set_clip_text(true);
-	vb->add_child(title);
-
-	HBoxContainer *path_hb = memnew(HBoxContainer);
-	path_hb->set_h_size_flags(SIZE_EXPAND_FILL);
-	vb->add_child(path_hb);
-
-	Button *show = memnew(Button);
-	// Display a folder icon if the project directory can be opened, or a "broken file" icon if it can't.
-	show->set_icon(get_icon(!item.missing ? "Load" : "FileBroken", "EditorIcons"));
-	if (!item.grayed) {
-		// Don't make the icon less prominent if the parent is already grayed out.
-		show->set_modulate(Color(1, 1, 1, 0.5));
-	}
-	path_hb->add_child(show);
-
-	if (!item.missing) {
-		show->connect("pressed", this, "_show_project", varray(item.path));
-		show->set_tooltip(TTR("Show in File Manager"));
-	} else {
-		show->set_tooltip(TTR("Error: Project is missing on the filesystem."));
-	}
-
-	Label *fpath = memnew(Label(item.path));
-	path_hb->add_child(fpath);
-	fpath->set_h_size_flags(SIZE_EXPAND_FILL);
-	fpath->set_modulate(Color(1, 1, 1, 0.5));
-	fpath->add_color_override("font_color", font_color);
-	fpath->set_clip_text(true);
-
-	_scroll_children->add_child(hb);
-	item.control = hb;
-}
-
-void ProjectList::set_search_term(String p_search_term) {
-	_search_term = p_search_term;
-}
-
-void ProjectList::set_order_option(ProjectListFilter::FilterOption p_option) {
-	if (_order_option != p_option) {
-		_order_option = p_option;
-		EditorSettings::get_singleton()->set("project_manager/sorting_order", (int)_order_option);
-		EditorSettings::get_singleton()->save();
-	}
-}
-
-void ProjectList::sort_projects() {
-	SortArray<Item, ProjectListComparator> sorter;
-	sorter.compare.order_option = _order_option;
-	sorter.sort(_projects.ptrw(), _projects.size());
-
-	for (int i = 0; i < _projects.size(); ++i) {
-		Item &item = _projects.write[i];
-
-		bool visible = true;
-		if (_search_term != "") {
-			String search_path;
-			if (_search_term.find("/") != -1) {
-				// Search path will match the whole path
-				search_path = item.path;
-			} else {
-				// Search path will only match the last path component to make searching more strict
-				search_path = item.path.get_file();
-			}
-
-			// When searching, display projects whose name or path contain the search term
-			visible = item.project_name.findn(_search_term) != -1 || search_path.findn(_search_term) != -1;
-		}
-
-		item.control->set_visible(visible);
-	}
-
-	for (int i = 0; i < _projects.size(); ++i) {
-		Item &item = _projects.write[i];
-		item.control->get_parent()->move_child(item.control, i);
-	}
-
-	// Rewind the coroutine because order of projects changed
-	update_icons_async();
-
-	update_dock_menu();
-}
-
-const Set<String> &ProjectList::get_selected_project_keys() const {
-	// Faster if that's all you need
-	return _selected_project_keys;
-}
-
-Vector<ProjectList::Item> ProjectList::get_selected_projects() const {
-	Vector<Item> items;
-	if (_selected_project_keys.size() == 0) {
-		return items;
-	}
-	items.resize(_selected_project_keys.size());
-	int j = 0;
-	for (int i = 0; i < _projects.size(); ++i) {
-		const Item &item = _projects[i];
-		if (_selected_project_keys.has(item.project_key)) {
-			items.write[j++] = item;
-		}
-	}
-	ERR_FAIL_COND_V(j != items.size(), items);
-	return items;
-}
-
-void ProjectList::ensure_project_visible(int p_index) {
-	const Item &item = _projects[p_index];
-	ensure_control_visible(item.control);
-}
-
-int ProjectList::get_single_selected_index() const {
-	if (_selected_project_keys.size() == 0) {
-		// Default selection
-		return 0;
-	}
-	String key;
-	if (_selected_project_keys.size() == 1) {
-		// Only one selected
-		key = _selected_project_keys.front()->get();
-	} else {
-		// Multiple selected, consider the last clicked one as "main"
-		key = _last_clicked;
-	}
-	for (int i = 0; i < _projects.size(); ++i) {
-		if (_projects[i].project_key == key) {
-			return i;
-		}
-	}
-	return 0;
-}
-
-void ProjectList::remove_project(int p_index, bool p_update_settings) {
-	const Item item = _projects[p_index]; // Take a copy
-
-	_selected_project_keys.erase(item.project_key);
-
-	if (_last_clicked == item.project_key) {
-		_last_clicked = "";
-	}
-
-	memdelete(item.control);
-	_projects.remove(p_index);
-
-	if (p_update_settings) {
-		EditorSettings::get_singleton()->erase("projects/" + item.project_key);
-		EditorSettings::get_singleton()->erase("favorite_projects/" + item.project_key);
-		// Not actually saving the file, in case you are doing more changes to settings
-	}
-
-	update_dock_menu();
-}
-
-bool ProjectList::is_any_project_missing() const {
-	for (int i = 0; i < _projects.size(); ++i) {
-		if (_projects[i].missing) {
-			return true;
-		}
-	}
-	return false;
-}
-
-void ProjectList::erase_missing_projects() {
-	if (_projects.empty()) {
-		return;
-	}
-
-	int deleted_count = 0;
-	int remaining_count = 0;
-
-	for (int i = 0; i < _projects.size(); ++i) {
-		const Item &item = _projects[i];
-
-		if (item.missing) {
-			remove_project(i, true);
-			--i;
-			++deleted_count;
-
-		} else {
-			++remaining_count;
-		}
-	}
-
-	print_line("Removed " + itos(deleted_count) + " projects from the list, remaining " + itos(remaining_count) + " projects");
-
-	EditorSettings::get_singleton()->save();
-}
-
-int ProjectList::refresh_project(const String &dir_path) {
-	// Reads editor settings and reloads information about a specific project.
-	// If it wasn't loaded and should be in the list, it is added (i.e new project).
-	// If it isn't in the list anymore, it is removed.
-	// If it is in the list but doesn't exist anymore, it is marked as missing.
-
-	String project_key = get_project_key_from_path(dir_path);
-
-	// Read project manager settings
-	bool is_favourite = false;
-	bool should_be_in_list = false;
-	String property_key = "projects/" + project_key;
-	{
-		List<PropertyInfo> properties;
-		EditorSettings::get_singleton()->get_property_list(&properties);
-		String favorite_property_key = "favorite_projects/" + project_key;
-
-		bool found = false;
-		for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-			String prop = E->get().name;
-			if (!found && prop == property_key) {
-				found = true;
-			} else if (!is_favourite && prop == favorite_property_key) {
-				is_favourite = true;
-			}
-		}
-
-		should_be_in_list = found;
-	}
-
-	bool was_selected = _selected_project_keys.has(project_key);
-
-	// Remove item in any case
-	for (int i = 0; i < _projects.size(); ++i) {
-		const Item &existing_item = _projects[i];
-		if (existing_item.path == dir_path) {
-			remove_project(i, false);
-			break;
-		}
-	}
-
-	int index = -1;
-	if (should_be_in_list) {
-		// Recreate it with updated info
-
-		Item item;
-		load_project_data(property_key, item, is_favourite);
-
-		_projects.push_back(item);
-		create_project_item_control(_projects.size() - 1);
-
-		sort_projects();
-
-		for (int i = 0; i < _projects.size(); ++i) {
-			if (_projects[i].project_key == project_key) {
-				if (was_selected) {
-					select_project(i);
-					ensure_project_visible(i);
-				}
-				load_project_icon(i);
-
-				index = i;
-				break;
-			}
-		}
-	}
-
-	return index;
-}
-
-int ProjectList::get_project_count() const {
-	return _projects.size();
-}
-
-void ProjectList::select_project(int p_index) {
-	Vector<Item> previous_selected_items = get_selected_projects();
-	_selected_project_keys.clear();
-
-	for (int i = 0; i < previous_selected_items.size(); ++i) {
-		previous_selected_items[i].control->update();
-	}
-
-	toggle_select(p_index);
-}
-
+// TODO: is there a nicer way?
 inline void sort(int &a, int &b) {
 	if (a > b) {
 		int temp = a;
@@ -1615,146 +347,775 @@ inline void sort(int &a, int &b) {
 	}
 }
 
-void ProjectList::select_range(int p_begin, int p_end) {
-	sort(p_begin, p_end);
-	select_project(p_begin);
-	for (int i = p_begin + 1; i <= p_end; ++i) {
-		toggle_select(i);
+class ProjectListFilter : public HBoxContainer {
+	GDCLASS(ProjectListFilter, HBoxContainer);
+
+public:
+	enum FilterOption {
+		FILTER_NAME,
+		FILTER_PATH,
+		FILTER_MODIFIED,
+	};
+
+private:
+	friend class ProjectManager;
+
+	OptionButton *filter_option;
+	LineEdit *search_box;
+	bool has_search_box;
+	FilterOption _current_filter;
+
+	void _search_text_changed(const String &p_newtext) {
+		emit_signal("filter_changed");
 	}
-}
 
-void ProjectList::toggle_select(int p_index) {
-	Item &item = _projects.write[p_index];
-	if (_selected_project_keys.has(item.project_key)) {
-		_selected_project_keys.erase(item.project_key);
-	} else {
-		_selected_project_keys.insert(item.project_key);
-	}
-	item.control->update();
-}
-
-void ProjectList::erase_selected_projects() {
-	if (_selected_project_keys.size() == 0) {
-		return;
-	}
-
-	for (int i = 0; i < _projects.size(); ++i) {
-		Item &item = _projects.write[i];
-		if (_selected_project_keys.has(item.project_key) && item.control->is_visible()) {
-			EditorSettings::get_singleton()->erase("projects/" + item.project_key);
-			EditorSettings::get_singleton()->erase("favorite_projects/" + item.project_key);
-
-			memdelete(item.control);
-			_projects.remove(i);
-			--i;
+	void _filter_option_selected(int p_idx) {
+		FilterOption selected = (FilterOption)(filter_option->get_selected());
+		if (_current_filter != selected) {
+			_current_filter = selected;
+			emit_signal("filter_changed");
 		}
 	}
 
-	EditorSettings::get_singleton()->save();
-
-	_selected_project_keys.clear();
-	_last_clicked = "";
-
-	update_dock_menu();
-}
-
-// Draws selected project highlight
-void ProjectList::_panel_draw(Node *p_hb) {
-	Control *hb = Object::cast_to<Control>(p_hb);
-
-	hb->draw_line(Point2(0, hb->get_size().y + 1), Point2(hb->get_size().x - 10, hb->get_size().y + 1), get_color("guide_color", "Tree"));
-
-	String key = _projects[p_hb->get_index()].project_key;
-
-	if (_selected_project_keys.has(key)) {
-		hb->draw_style_box(get_stylebox("selected", "Tree"), Rect2(Point2(), hb->get_size() - Size2(10, 0) * EDSCALE));
+protected:
+	void _notification(int p_what) {
+		if (p_what == NOTIFICATION_ENTER_TREE && has_search_box) {
+			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
+			search_box->set_clear_button_enabled(true);
+		}
 	}
-}
 
-// Input for each item in the list
-void ProjectList::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
-	Ref<InputEventMouseButton> mb = p_ev;
-	int clicked_index = p_hb->get_index();
-	const Item &clicked_project = _projects[clicked_index];
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("_search_text_changed"), &ProjectListFilter::_search_text_changed);
+		ClassDB::bind_method(D_METHOD("_filter_option_selected"), &ProjectListFilter::_filter_option_selected);
 
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
-		if (mb->get_shift() && _selected_project_keys.size() > 0 && _last_clicked != "" && clicked_project.project_key != _last_clicked) {
-			int anchor_index = -1;
-			for (int i = 0; i < _projects.size(); ++i) {
-				const Item &p = _projects[i];
-				if (p.project_key == _last_clicked) {
-					anchor_index = p.control->get_index();
-					break;
+		ADD_SIGNAL(MethodInfo("filter_changed"));
+	}
+
+public:
+	void _setup_filters(Vector<String> options) {
+		filter_option->clear();
+		for (int i = 0; i < options.size(); i++) {
+			filter_option->add_item(options[i]);
+		}
+	}
+
+	void add_filter_option() {
+		filter_option = memnew(OptionButton);
+		filter_option->set_clip_text(true);
+		filter_option->connect("item_selected", this, "_filter_option_selected");
+		add_child(filter_option);
+	}
+
+	void add_search_box() {
+		search_box = memnew(LineEdit);
+		search_box->set_placeholder(TTR("Search"));
+		search_box->set_tooltip(
+				TTR("The search box filters projects by name and last path component.\nTo filter projects by name and full path, the query must contain at least one `/` character."));
+		search_box->connect("text_changed", this, "_search_text_changed");
+		search_box->set_h_size_flags(SIZE_EXPAND_FILL);
+		add_child(search_box);
+
+		has_search_box = true;
+	}
+
+	void set_filter_size(int h_size) {
+		filter_option->set_custom_minimum_size(Size2(h_size * EDSCALE, 10 * EDSCALE));
+	}
+
+	String get_search_term() {
+		return search_box->get_text().strip_edges();
+	}
+
+	FilterOption get_filter_option() {
+		return _current_filter;
+	}
+
+	void set_filter_option(FilterOption option) {
+		filter_option->select((int)option);
+		_filter_option_selected(0);
+	}
+
+	ProjectListFilter() {
+		_current_filter = FILTER_NAME;
+		has_search_box = false;
+	}
+
+	void clear() {
+		if (has_search_box) {
+			search_box->clear();
+		}
+	}
+};
+
+class ProjectList : public ScrollContainer {
+	GDCLASS(ProjectList, ScrollContainer)
+
+public:
+	static constexpr const char *SIGNAL_SELECTION_CHANGED = "selection_changed";
+	static constexpr const char *SIGNAL_PROJECT_ASK_OPEN = "project_ask_opened";
+
+	enum MenuOptions {
+		GLOBAL_NEW_WINDOW,
+		GLOBAL_OPEN_PROJECT
+	};
+
+	// Can often be passed by copy.
+	struct Item {
+		String project_key;
+		String project_name = TTR("Unnamed Project");
+		String description;
+		String path;
+		String icon;
+		String main_scene;
+		uint64_t last_modified = 0;
+		bool favorite;
+		bool grayed = false;
+		bool missing = false;
+		int version = 0;
+
+		ProjectListItemControl *control = nullptr;
+
+		Item(const String &p_property_key, bool p_favorite) {
+			// Load item.
+			favorite = p_favorite;
+			path = EDITOR_GET(p_property_key);
+			String conf = path.plus_file("project.godot");
+
+			Ref<ConfigFile> cf = memnew(ConfigFile);
+			Error cf_err = cf->load(conf);
+
+			if (cf_err == OK) {
+				String cf_project_name = static_cast<String>(cf->get_value("application", "config/name", ""));
+				if (cf_project_name != "") {
+					project_name = cf_project_name.xml_unescape();
+				}
+				version = (int)cf->get_value("", "config_version", 0);
+			}
+
+			if (version > ProjectSettings::CONFIG_VERSION) {
+				// Comes from an incompatible (more recent) Godot version, gray it out.
+				grayed = true;
+			}
+
+			description = cf->get_value("application", "config/description", "");
+			icon = cf->get_value("application", "config/icon", "");
+			main_scene = cf->get_value("application", "run/main_scene", "");
+
+			if (FileAccess::exists(conf)) {
+				last_modified = FileAccess::get_modified_time(conf);
+
+				String fscache = path.plus_file(".fscache");
+				if (FileAccess::exists(fscache)) {
+					uint64_t cache_modified = FileAccess::get_modified_time(fscache);
+					if (cache_modified > last_modified) {
+						last_modified = cache_modified;
+					}
+				}
+			} else {
+				grayed = true;
+				missing = true;
+				// why getting called twice?
+				print_line("Project is missing: " + conf);
+			}
+
+			project_key = p_property_key.get_slice("/", 1);
+		}
+		Item(){};
+		_FORCE_INLINE_ bool operator==(const Item &l) const {
+			return project_key == l.project_key;
+		}
+	};
+
+	ProjectList() {
+		_scroll_children_vbox = memnew(VBoxContainer);
+		_scroll_children_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+		add_child(_scroll_children_vbox);
+	}
+
+	// what do I do?
+	void update_dock_menu() {
+		OS::get_singleton()->global_menu_clear("_dock");
+
+		int favs_added = 0;
+		int total_added = 0;
+		for (int i = 0; i < _projects.size(); ++i) {
+			if (!_projects[i].grayed && !_projects[i].missing) {
+				if (_projects[i].favorite) {
+					favs_added++;
+				} else {
+					if (favs_added != 0) {
+						OS::get_singleton()->global_menu_add_separator("_dock");
+					}
+					favs_added = 0;
+				}
+				OS::get_singleton()->global_menu_add_item("_dock", _projects[i].project_name + " ( " + _projects[i].path + " )", GLOBAL_OPEN_PROJECT, Variant(_projects[i].path.plus_file("project.godot")));
+				total_added++;
+			}
+		}
+		if (total_added != 0) {
+			OS::get_singleton()->global_menu_add_separator("_dock");
+		}
+		OS::get_singleton()->global_menu_add_item("_dock", TTR("New Window"), GLOBAL_NEW_WINDOW, Variant());
+	}
+
+	// rename me
+	void load_projects() {
+		// This is a full, hard reload of the list. Don't call this unless really required, it's expensive.
+		// If you have 150 projects, it may read through 150 files on your disk at once + load 150 icons.
+
+		// Clear whole list.
+		for (int i = 0; i < _projects.size(); ++i) {
+			Item &project = _projects.write[i];
+			CRASH_COND(project.control == nullptr);
+			memdelete(project.control); // Why not queue_free()?
+		}
+		_projects.clear();
+		_last_clicked = "";
+		_selected_project_keys.clear();
+
+		// Load data.
+		// TODO Would be nice to change how projects and favourites are stored... it complicates things a bit.
+		// Use a dictionary associating project path to metadata (like is_favorite).
+
+		List<PropertyInfo> properties;
+		EditorSettings::get_singleton()->get_property_list(&properties);
+
+		Set<String> favorites;
+		// Find favorites...
+		for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
+			String property_key = E->get().name;
+			if (property_key.begins_with("favorite_projects/")) {
+				favorites.insert(property_key);
+			}
+		}
+
+		for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
+			// This is actually something like "projects/C:::Documents::Godot::Projects::MyGame".
+			String property_key = E->get().name;
+			if (!property_key.begins_with("projects/")) {
+				continue;
+			}
+
+			String project_key = property_key.get_slice("/", 1);
+			bool favorite = favorites.has("favorite_projects/" + project_key);
+
+			Item item = Item(property_key, favorite);
+			_projects.push_back(item);
+		}
+
+		// Create controls.
+		for (int i = 0; i < _projects.size(); ++i) {
+			create_project_item_control(i);
+		}
+
+		sort_projects();
+		set_v_scroll(0);
+		update_icons_async();
+		update_dock_menu();
+	}
+
+	void set_search_term(String p_search_term) {
+		_search_term = p_search_term;
+	}
+
+	void set_order_option(ProjectListFilter::FilterOption p_option) {
+		if (_order_option != p_option) {
+			_order_option = p_option;
+			EditorSettings::get_singleton()->set("project_manager/sorting_order", (int)_order_option);
+			EditorSettings::get_singleton()->save();
+		}
+	}
+
+	void sort_projects() {
+		struct ProjectListComparator {
+			ProjectListFilter::FilterOption order_option;
+
+			// operator<
+			_FORCE_INLINE_ bool operator()(const ProjectList::Item &a, const ProjectList::Item &b) const {
+				if (a.favorite && !b.favorite) {
+					return true;
+				}
+				if (b.favorite && !a.favorite) {
+					return false;
+				}
+				switch (order_option) {
+					case ProjectListFilter::FILTER_PATH:
+						return a.project_key < b.project_key;
+					case ProjectListFilter::FILTER_MODIFIED:
+						return a.last_modified > b.last_modified;
+					default:
+						return a.project_name < b.project_name;
 				}
 			}
-			CRASH_COND(anchor_index == -1);
-			select_range(anchor_index, clicked_index);
+		};
 
-		} else if (mb->get_control()) {
-			toggle_select(clicked_index);
+		SortArray<Item, ProjectListComparator> sorter;
+		sorter.compare.order_option = _order_option;
+		sorter.sort(_projects.ptrw(), _projects.size());
 
-		} else {
-			_last_clicked = clicked_project.project_key;
-			select_project(clicked_index);
-		}
-
-		emit_signal(SIGNAL_SELECTION_CHANGED);
-
-		if (!mb->get_control() && mb->is_doubleclick()) {
-			emit_signal(SIGNAL_PROJECT_ASK_OPEN);
-		}
-	}
-}
-
-void ProjectList::_favorite_pressed(Node *p_hb) {
-	ProjectListItemControl *control = Object::cast_to<ProjectListItemControl>(p_hb);
-
-	int index = control->get_index();
-	Item item = _projects.write[index]; // Take copy
-
-	item.favorite = !item.favorite;
-
-	if (item.favorite) {
-		EditorSettings::get_singleton()->set("favorite_projects/" + item.project_key, item.path);
-	} else {
-		EditorSettings::get_singleton()->erase("favorite_projects/" + item.project_key);
-	}
-	EditorSettings::get_singleton()->save();
-
-	_projects.write[index] = item;
-
-	control->set_is_favorite(item.favorite);
-
-	sort_projects();
-
-	if (item.favorite) {
 		for (int i = 0; i < _projects.size(); ++i) {
-			if (_projects[i].project_key == item.project_key) {
-				ensure_project_visible(i);
+			Item &item = _projects.write[i];
+
+			bool visible = true;
+			if (_search_term != "") {
+				String search_path;
+				if (_search_term.find("/") != -1) {
+					// Search path will match the whole path.
+					search_path = item.path;
+				} else {
+					// Search path will only match the last path component to make searching more strict.
+					search_path = item.path.get_file();
+				}
+
+				// When searching, display projects whose name or path contain the search term.
+				visible = item.project_name.findn(_search_term) != -1 || search_path.findn(_search_term) != -1;
+			}
+
+			item.control->set_visible(visible);
+		}
+
+		for (int i = 0; i < _projects.size(); ++i) {
+			Item &item = _projects.write[i];
+			item.control->get_parent()->move_child(item.control, i);
+		}
+
+		// Rewind the coroutine because order of projects changed.
+		update_icons_async();
+		update_dock_menu();
+	}
+
+	int get_project_count() const {
+		return _projects.size();
+	}
+
+	void select_project(int p_index) {
+		Vector<Item> previous_selected_items = get_selected_projects();
+		_selected_project_keys.clear();
+
+		for (int i = 0; i < previous_selected_items.size(); ++i) {
+			previous_selected_items[i].control->update();
+		}
+
+		toggle_select(p_index);
+	}
+
+	void erase_selected_projects() {
+		if (_selected_project_keys.size() == 0) {
+			return;
+		}
+
+		for (int i = 0; i < _projects.size(); ++i) {
+			Item &item = _projects.write[i];
+			if (_selected_project_keys.has(item.project_key) && item.control->is_visible()) {
+				EditorSettings::get_singleton()->erase("projects/" + item.project_key);
+				EditorSettings::get_singleton()->erase("favorite_projects/" + item.project_key);
+
+				memdelete(item.control);
+				_projects.remove(i);
+				--i;
+			}
+		}
+
+		EditorSettings::get_singleton()->save();
+
+		_selected_project_keys.clear();
+		_last_clicked = "";
+
+		update_dock_menu();
+	}
+
+	Vector<Item> get_selected_projects() {
+		Vector<Item> items;
+		if (_selected_project_keys.size() == 0) {
+			return items;
+		}
+		items.resize(_selected_project_keys.size());
+		int j = 0;
+		for (int i = 0; i < _projects.size(); ++i) {
+			const Item &item = _projects[i];
+			if (_selected_project_keys.has(item.project_key)) {
+				items.write[j++] = item;
+			}
+		}
+		ERR_FAIL_COND_V(j != items.size(), items);
+		return items;
+	}
+
+	const Set<String> &get_selected_project_keys() const {
+		// Faster if that's all you need.
+		return _selected_project_keys;
+	}
+
+	bool is_any_project_missing() const {
+		for (int i = 0; i < _projects.size(); ++i) {
+			if (_projects[i].missing) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	void erase_missing_projects() {
+		if (_projects.empty()) {
+			return;
+		}
+
+		int deleted_count = 0;
+
+		for (int i = 0; i < _projects.size(); ++i) {
+			const Item &item = _projects[i];
+
+			if (item.missing) {
+				remove_project(i, true);
+				--i;
+				++deleted_count;
+			}
+		}
+
+		print_line("Removed " + itos(deleted_count) + " projects from the list, remaining " + itos(_projects.size()) + " projects");
+
+		EditorSettings::get_singleton()->save();
+	}
+
+	int refresh_project(const String &dir_path) {
+		// Reads editor settings and reloads information about a specific project.
+		// If it wasn't loaded and should be in the list, it is added (i.e new project).
+		// If it isn't in the list anymore, it is removed.
+		// If it is in the list but doesn't exist anymore, it is marked as missing.
+
+		String project_key = get_project_key_from_path(dir_path);
+
+		// Read project manager settings.
+		bool is_favorite = false;
+		bool should_be_in_list = false;
+		String property_key = "projects/" + project_key;
+		{
+			List<PropertyInfo> properties;
+			EditorSettings::get_singleton()->get_property_list(&properties);
+			String favorite_property_key = "favorite_projects/" + project_key;
+
+			bool found = false;
+			for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
+				String prop = E->get().name;
+				if (!found && prop == property_key) {
+					found = true;
+				} else if (!is_favorite && prop == favorite_property_key) {
+					is_favorite = true;
+				}
+			}
+
+			should_be_in_list = found;
+		}
+
+		bool was_selected = _selected_project_keys.has(project_key);
+
+		// Remove item in any case.
+		for (int i = 0; i < _projects.size(); ++i) {
+			const Item &existing_item = _projects[i];
+			if (existing_item.path == dir_path) {
+				remove_project(i, false);
 				break;
 			}
 		}
+
+		int index = -1;
+		if (should_be_in_list) {
+			// Recreate it with updated info.
+			Item item = Item(property_key, is_favorite);
+
+			_projects.push_back(item);
+			create_project_item_control(_projects.size() - 1);
+
+			sort_projects();
+
+			for (int i = 0; i < _projects.size(); ++i) {
+				if (_projects[i].project_key == project_key) {
+					if (was_selected) {
+						select_project(i);
+					}
+					load_project_icon(i);
+
+					index = i;
+					break;
+				}
+			}
+		}
+
+		return index;
 	}
 
-	update_dock_menu();
-}
+private:
+	static void _bind_methods() {
+		ClassDB::bind_method("_panel_draw", &ProjectList::_panel_draw);
+		ClassDB::bind_method("_panel_input", &ProjectList::_panel_input);
+		ClassDB::bind_method("_favorite_pressed", &ProjectList::_favorite_pressed);
+		ClassDB::bind_method("_show_project", &ProjectList::_show_project);
 
-void ProjectList::_show_project(const String &p_path) {
-	OS::get_singleton()->shell_open(String("file://") + p_path);
-}
+		ADD_SIGNAL(MethodInfo(SIGNAL_SELECTION_CHANGED));
+		ADD_SIGNAL(MethodInfo(SIGNAL_PROJECT_ASK_OPEN));
+	}
 
-const char *ProjectList::SIGNAL_SELECTION_CHANGED = "selection_changed";
-const char *ProjectList::SIGNAL_PROJECT_ASK_OPEN = "project_ask_open";
+	void _notification(int p_what) {
+		if (p_what == NOTIFICATION_PROCESS) {
+			// Load icons as a coroutine to speed up launch when you have hundreds of projects.
+			if (_icon_load_index < _projects.size()) {
+				Item &item = _projects.write[_icon_load_index];
+				if (item.control->icon_needs_reload) {
+					load_project_icon(_icon_load_index);
+				}
+				_icon_load_index++;
 
-void ProjectList::_bind_methods() {
-	ClassDB::bind_method("_panel_draw", &ProjectList::_panel_draw);
-	ClassDB::bind_method("_panel_input", &ProjectList::_panel_input);
-	ClassDB::bind_method("_favorite_pressed", &ProjectList::_favorite_pressed);
-	ClassDB::bind_method("_show_project", &ProjectList::_show_project);
+			} else {
+				set_process(false);
+			}
+		}
+	}
 
-	ADD_SIGNAL(MethodInfo(SIGNAL_SELECTION_CHANGED));
-	ADD_SIGNAL(MethodInfo(SIGNAL_PROJECT_ASK_OPEN));
-}
+	// Draws selected project highlight.
+	// rename me?
+	void _panel_draw(Node *p_hb) {
+		Control *hb = Object::cast_to<Control>(p_hb);
+
+		hb->draw_line(Point2(0, hb->get_size().y + 1), Point2(hb->get_size().x - 10, hb->get_size().y + 1), get_color("guide_color", "Tree"));
+
+		String key = _projects[p_hb->get_index()].project_key;
+
+		if (_selected_project_keys.has(key)) {
+			hb->draw_style_box(get_stylebox("selected", "Tree"), Rect2(Point2(), hb->get_size() - Size2(10, 0) * EDSCALE));
+		}
+	}
+
+	// Input for each item in the list.
+	void _panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
+		Ref<InputEventMouseButton> mb = p_ev;
+		int clicked_index = p_hb->get_index();
+		const Item &clicked_project = _projects[clicked_index];
+
+		if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+			if (mb->get_shift() && _selected_project_keys.size() > 0 && _last_clicked != "" && clicked_project.project_key != _last_clicked) {
+				int anchor_index = -1;
+				for (int i = 0; i < _projects.size(); ++i) {
+					const Item &p = _projects[i];
+					if (p.project_key == _last_clicked) {
+						anchor_index = p.control->get_index();
+						break;
+					}
+				}
+				CRASH_COND(anchor_index == -1);
+				select_range(anchor_index, clicked_index);
+
+			} else if (mb->get_control()) {
+				toggle_select(clicked_index);
+
+			} else {
+				_last_clicked = clicked_project.project_key;
+				select_project(clicked_index);
+			}
+
+			emit_signal(SIGNAL_SELECTION_CHANGED);
+
+			if (!mb->get_control() && mb->is_doubleclick()) {
+				emit_signal(SIGNAL_PROJECT_ASK_OPEN);
+			}
+		}
+	}
+
+	void _favorite_pressed(Node *p_hb) {
+		ProjectListItemControl *control = Object::cast_to<ProjectListItemControl>(p_hb);
+
+		int index = control->get_index();
+		Item item = _projects.write[index]; // Take copy.
+
+		item.favorite = !item.favorite;
+
+		if (item.favorite) {
+			EditorSettings::get_singleton()->set("favorite_projects/" + item.project_key, item.path);
+		} else {
+			EditorSettings::get_singleton()->erase("favorite_projects/" + item.project_key);
+		}
+		EditorSettings::get_singleton()->save();
+
+		_projects.write[index] = item;
+
+		control->set_is_favorite(item.favorite);
+
+		sort_projects();
+
+		update_dock_menu();
+	}
+
+	void _show_project(const String &p_path) {
+		OS::get_singleton()->shell_open(String("file://") + p_path);
+	}
+
+	void select_range(int p_begin, int p_end) {
+		sort(p_begin, p_end);
+		select_project(p_begin);
+		for (int i = p_begin + 1; i <= p_end; ++i) {
+			toggle_select(i);
+		}
+	}
+
+	void toggle_select(int p_index) {
+		Item &item = _projects.write[p_index];
+		if (_selected_project_keys.has(item.project_key)) {
+			_selected_project_keys.erase(item.project_key);
+		} else {
+			_selected_project_keys.insert(item.project_key);
+		}
+		item.control->update();
+	}
+
+	// REFACTOR ME
+	void create_project_item_control(int p_index) {
+		// Will be added last in the list, so make sure indexes match.
+		ERR_FAIL_COND(p_index != _scroll_children_vbox->get_child_count());
+
+		Item &item = _projects.write[p_index];
+		ERR_FAIL_COND(item.control != nullptr); // Already created.
+
+		Ref<Texture> favorite_icon = get_icon("Favorites", "EditorIcons");
+		Color font_color = get_color("font_color", "Tree");
+
+		ProjectListItemControl *item_control = memnew(ProjectListItemControl);
+		item_control->connect("draw", this, "_panel_draw", varray(item_control));
+		item_control->connect("gui_input", this, "_panel_input", varray(item_control));
+		item_control->add_constant_override("separation", 10 * EDSCALE);
+		item_control->set_tooltip(item.description);
+
+		VBoxContainer *favorite_box = memnew(VBoxContainer);
+		favorite_box->set_name("FavoriteBox");
+		TextureButton *favorite = memnew(TextureButton);
+		favorite->set_name("FavoriteButton");
+		favorite->set_normal_texture(favorite_icon);
+		// This makes the project's "hover" style display correctly when hovering the favorite icon.
+		favorite->set_mouse_filter(MOUSE_FILTER_PASS);
+		favorite->connect("pressed", this, "_favorite_pressed", varray(item_control));
+		favorite_box->add_child(favorite);
+		favorite_box->set_alignment(BoxContainer::ALIGN_CENTER);
+		item_control->add_child(favorite_box);
+		item_control->favorite_button = favorite;
+		item_control->set_is_favorite(item.favorite);
+
+		TextureRect *icon = memnew(TextureRect);
+		// The project icon may not be loaded by the time the control is displayed,
+		// so use a loading placeholder.
+		icon->set_texture(get_icon("ProjectIconLoading", "EditorIcons"));
+		icon->set_v_size_flags(SIZE_SHRINK_CENTER);
+		if (item.missing) {
+			icon->set_modulate(Color(1, 1, 1, 0.5));
+		}
+		item_control->add_child(icon);
+		item_control->icon = icon;
+
+		VBoxContainer *vbox = memnew(VBoxContainer);
+		if (item.grayed) {
+			vbox->set_modulate(Color(1, 1, 1, 0.5));
+		}
+		vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+		item_control->add_child(vbox);
+		Control *ec = memnew(Control); // rename me
+		ec->set_custom_minimum_size(Size2(0, 1));
+		ec->set_mouse_filter(MOUSE_FILTER_PASS);
+		vbox->add_child(ec);
+		Label *title = memnew(Label(!item.missing ? item.project_name : TTR("Missing Project")));
+		title->add_font_override("font", get_font("title", "EditorFonts"));
+		title->add_color_override("font_color", font_color);
+		title->set_clip_text(true);
+		vbox->add_child(title);
+
+		HBoxContainer *path_hbox = memnew(HBoxContainer);
+		path_hbox->set_h_size_flags(SIZE_EXPAND_FILL);
+		vbox->add_child(path_hbox);
+
+		Button *show = memnew(Button);
+		// Display a folder icon if the project directory can be opened, or a "broken file" icon if it can't.
+		show->set_icon(get_icon(!item.missing ? "Load" : "FileBroken", "EditorIcons"));
+		if (!item.grayed) {
+			// Don't make the icon less prominent if the parent is already grayed out.
+			show->set_modulate(Color(1, 1, 1, 0.5));
+		}
+		path_hbox->add_child(show);
+
+		if (!item.missing) {
+			show->connect("pressed", this, "_show_project", varray(item.path));
+			show->set_tooltip(TTR("Show in File Manager"));
+		} else {
+			show->set_tooltip(TTR("Error: Project is missing on the filesystem."));
+		}
+
+		Label *fpath = memnew(Label(item.path));
+		path_hbox->add_child(fpath);
+		fpath->set_h_size_flags(SIZE_EXPAND_FILL);
+		fpath->set_modulate(Color(1, 1, 1, 0.5));
+		fpath->add_color_override("font_color", font_color);
+		fpath->set_clip_text(true);
+
+		_scroll_children_vbox->add_child(item_control);
+		item.control = item_control;
+	}
+
+	void remove_project(int p_index, bool p_update_settings) {
+		const Item item = _projects[p_index]; // Take a copy.
+
+		_selected_project_keys.erase(item.project_key);
+
+		if (_last_clicked == item.project_key) {
+			_last_clicked = "";
+		}
+
+		memdelete(item.control);
+		_projects.remove(p_index);
+
+		if (p_update_settings) {
+			EditorSettings::get_singleton()->erase("projects/" + item.project_key);
+			EditorSettings::get_singleton()->erase("favorite_projects/" + item.project_key);
+			// Not actually saving the file, in case you are doing more changes to settings.
+		}
+
+		update_dock_menu();
+	}
+
+	void update_icons_async() {
+		// Icons are loaded in `NOTIFCATION_PROCESS`.
+		_icon_load_index = 0;
+		set_process(true);
+	}
+
+	void load_project_icon(int p_index) {
+		Item &item = _projects.write[p_index];
+
+		Ref<Texture> default_icon = get_icon("DefaultProjectIcon", "EditorIcons");
+		Ref<Texture> icon;
+		if (item.icon != "") {
+			Ref<Image> img;
+			img.instance();
+			Error err = img->load(item.icon.replace_first("res://", item.path + "/"));
+			if (err == OK) {
+				img->resize(default_icon->get_width(), default_icon->get_height(), Image::INTERPOLATE_LANCZOS);
+				Ref<ImageTexture> it = memnew(ImageTexture);
+				it->create_from_image(img);
+				icon = it;
+			}
+		}
+		if (icon.is_null()) {
+			icon = default_icon;
+		}
+
+		item.control->icon->set_texture(icon);
+		item.control->icon_needs_reload = false;
+	}
+
+	String _search_term;
+	ProjectListFilter::FilterOption _order_option = ProjectListFilter::FILTER_MODIFIED;
+	Set<String> _selected_project_keys;
+	String _last_clicked; // Project key.
+	VBoxContainer *_scroll_children_vbox;
+	int _icon_load_index = 0;
+
+	Vector<Item> _projects;
+};
 
 void ProjectManager::_notification(int p_what) {
 	switch (p_what) {
@@ -1773,7 +1134,7 @@ void ProjectManager::_notification(int p_what) {
 
 			if (_project_list->get_project_count() >= 1) {
 				// Focus on the search box immediately to allow the user
-				// to search without having to reach for their mouse
+				// to search without having to reach for their mouse.
 				project_filter->search_box->grab_focus();
 			}
 		} break;
@@ -1791,10 +1152,10 @@ void ProjectManager::_notification(int p_what) {
 
 void ProjectManager::_dim_window() {
 	// This method must be called before calling `get_tree()->quit()`.
-	// Otherwise, its effect won't be visible
+	// Otherwise, its effect won't be visible.
 
 	// Dim the project manager window while it's quitting to make it clearer that it's busy.
-	// No transition is applied, as the effect needs to be visible immediately
+	// No transition is applied, as the effect needs to be visible immediately.
 	float c = 0.5f;
 	Color dim_color = Color(c, c, c);
 	gui_base->set_modulate(dim_color);
@@ -1812,98 +1173,69 @@ void ProjectManager::_update_project_buttons() {
 		}
 	}
 
-	erase_btn->set_disabled(empty_selection);
-	open_btn->set_disabled(empty_selection || is_missing_project_selected);
-	rename_btn->set_disabled(empty_selection || is_missing_project_selected);
-	run_btn->set_disabled(empty_selection || is_missing_project_selected);
+	erase_button->set_disabled(empty_selection);
+	open_button->set_disabled(empty_selection || is_missing_project_selected);
+	rename_button->set_disabled(empty_selection || is_missing_project_selected);
+	run_button->set_disabled(empty_selection || is_missing_project_selected);
 
-	erase_missing_btn->set_disabled(!_project_list->is_any_project_missing());
+	remove_missing_button->set_disabled(!_project_list->is_any_project_missing());
 }
 
 void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
+	// refactor me
 	Ref<InputEventKey> k = p_ev;
+	if (!k.is_valid() || !k->is_pressed()) {
+		return;
+	}
+	if (tabs->get_current_tab() != 0) {
+		return;
+	}
 
-	if (k.is_valid()) {
-		if (!k->is_pressed()) {
-			return;
-		}
-
-		// Pressing Command + Q quits the Project Manager
-		// This is handled by the platform implementation on macOS,
-		// so only define the shortcut on other platforms
+	// Pressing Command + Q quits the Project Manager.
+	// This is handled by the platform implementation on macOS,
+	// so only define the shortcut on other platforms.
 #ifndef OSX_ENABLED
-		if (k->get_scancode_with_modifiers() == (KEY_MASK_CMD | KEY_Q)) {
-			_dim_window();
-			get_tree()->quit();
-		}
+	if (k->get_scancode_with_modifiers() == (KEY_MASK_CMD | KEY_Q)) {
+		_dim_window();
+		get_tree()->quit();
+	}
 #endif
 
-		if (tabs->get_current_tab() != 0) {
-			return;
-		}
+	bool scancode_handled = true;
 
-		bool scancode_handled = true;
-
-		switch (k->get_scancode()) {
-			case KEY_ENTER: {
-				_open_selected_projects_ask();
-			} break;
-			case KEY_HOME: {
-				if (_project_list->get_project_count() > 0) {
-					_project_list->select_project(0);
-					_update_project_buttons();
-				}
-
-			} break;
-			case KEY_END: {
-				if (_project_list->get_project_count() > 0) {
-					_project_list->select_project(_project_list->get_project_count() - 1);
-					_update_project_buttons();
-				}
-
-			} break;
-			case KEY_UP: {
-				if (k->get_shift()) {
-					break;
-				}
-
-				int index = _project_list->get_single_selected_index();
-				if (index > 0) {
-					_project_list->select_project(index - 1);
-					_project_list->ensure_project_visible(index - 1);
-					_update_project_buttons();
-				}
-
-				break;
+	switch (k->get_scancode()) {
+		case KEY_ENTER: {
+			_open_selected_projects_ask();
+		} break;
+		case KEY_DELETE: {
+			_erase_project_ask();
+		} break;
+		case KEY_HOME: {
+			if (_project_list->get_project_count() > 0) {
+				_project_list->select_project(0);
+				_update_project_buttons();
 			}
-			case KEY_DOWN: {
-				if (k->get_shift()) {
-					break;
-				}
-
-				int index = _project_list->get_single_selected_index();
-				if (index + 1 < _project_list->get_project_count()) {
-					_project_list->select_project(index + 1);
-					_project_list->ensure_project_visible(index + 1);
-					_update_project_buttons();
-				}
-
-			} break;
-			case KEY_F: {
-				if (k->get_command()) {
-					this->project_filter->search_box->grab_focus();
-				} else {
-					scancode_handled = false;
-				}
-			} break;
-			default: {
+		} break;
+		case KEY_END: {
+			if (_project_list->get_project_count() > 0) {
+				_project_list->select_project(_project_list->get_project_count() - 1);
+				_update_project_buttons();
+			}
+		} break;
+		case KEY_F: {
+			if (k->get_command()) { // refactor me
+				project_filter->search_box->grab_focus();
+			} else {
 				scancode_handled = false;
-			} break;
-		}
+			}
+		} break;
+		default: {
+			scancode_handled = false;
+		} break;
+	}
 
-		if (scancode_handled) {
-			accept_event();
-		}
+	if (scancode_handled) {
+		accept_event();
 	}
 }
 
@@ -1913,8 +1245,6 @@ void ProjectManager::_load_recent_projects() {
 	_project_list->load_projects();
 
 	_update_project_buttons();
-
-	tabs->set_current_tab(0);
 }
 
 void ProjectManager::_on_projects_updated() {
@@ -1923,18 +1253,60 @@ void ProjectManager::_on_projects_updated() {
 	for (int i = 0; i < selected_projects.size(); ++i) {
 		index = _project_list->refresh_project(selected_projects[i].path);
 	}
-	if (index != -1) {
-		_project_list->ensure_project_visible(index);
-	}
 
 	_project_list->update_dock_menu();
 }
 
-void ProjectManager::_on_project_created(const String &dir) {
-	project_filter->clear();
-	int i = _project_list->refresh_project(dir);
+void ProjectManager::_create_project(String project_name, String path, bool use_gles2) {
+	// The path to the folder the new project's folder is in/will be created if it doesn't exist.
+	String project_folder_path = path.left(path.find_last("/"));
+	String project_folder_name = path.right(path.find_last("/") + 1);
+	DirAccessRef dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+
+	ERR_FAIL_COND_MSG(!dir_access->dir_exists(project_folder_path), project_folder_path + " not found.");
+	if (!dir_access->dir_exists(path)) {
+		// Create the project's root folder if it doesn't exist.
+		// This method will only create one new folder
+		dir_access->make_dir(path);
+	}
+
+	ProjectSettings::CustomMap initial_settings;
+	if (use_gles2) {
+		initial_settings["rendering/quality/driver/driver_name"] = "GLES2";
+		initial_settings["rendering/vram_compression/import_etc2"] = false;
+		initial_settings["rendering/vram_compression/import_etc"] = true;
+	} else {
+		initial_settings["rendering/quality/driver/driver_name"] = "GLES3";
+	}
+	initial_settings["application/config/name"] = project_name;
+	initial_settings["application/config/icon"] = "res://icon.png";
+	initial_settings["rendering/environment/default_environment"] = "res://default_env.tres";
+	initial_settings["physics/common/enable_pause_aware_picking"] = true;
+
+	ERR_FAIL_COND_MSG(ProjectSettings::get_singleton()->save_custom(path.plus_file("project.godot"), initial_settings, Vector<String>(), false) != OK, "Couldn't create project.godot in project path.");
+
+	ResourceSaver::save(path.plus_file("icon.png"), create_unscaled_default_project_icon());
+
+	FileAccess *f = FileAccess::open(path.plus_file("default_env.tres"), FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(!f, "Couldn't create project.godot in project path.");
+	f->store_line("[gd_resource type=\"Environment\" load_steps=2 format=2]");
+	f->store_line("[sub_resource type=\"ProceduralSky\" id=1]");
+	f->store_line("[resource]");
+	f->store_line("background_mode = 2");
+	f->store_line("background_sky = SubResource( 1 )");
+	memdelete(f);
+
+	String project_key = get_project_key_from_path(path);
+	EditorSettings::get_singleton()->set("projects/" + project_key, path);
+	EditorSettings::get_singleton()->save();
+}
+
+// what am I for?
+void ProjectManager::_create_project_confirmed() {
+	_create_project(create_project_dialog->get_new_project_name(), create_project_dialog->get_new_project_path(), create_project_dialog->should_new_project_use_gles2());
+	//project_filter->clear();
+	int i = _project_list->refresh_project(create_project_dialog->get_new_project_path());
 	_project_list->select_project(i);
-	_project_list->ensure_project_visible(i);
 	_open_selected_projects_ask();
 
 	_project_list->update_dock_menu();
@@ -1944,6 +1316,7 @@ void ProjectManager::_confirm_update_settings() {
 	_open_selected_projects();
 }
 
+// refactor me
 void ProjectManager::_global_menu_action(const Variant &p_id, const Variant &p_meta) {
 	int id = (int)p_id;
 	if (id == ProjectList::GLOBAL_NEW_WINDOW) {
@@ -1976,7 +1349,7 @@ void ProjectManager::_open_selected_projects() {
 
 	for (const Set<String>::Element *E = selected_list.front(); E; E = E->next()) {
 		const String &selected = E->get();
-		String path = EditorSettings::get_singleton()->get("projects/" + selected);
+		String path = EDITOR_GET("projects/" + selected);
 		String conf = path.plus_file("project.godot");
 
 		if (!FileAccess::exists(conf)) {
@@ -2020,12 +1393,7 @@ void ProjectManager::_open_selected_projects() {
 void ProjectManager::_open_selected_projects_ask() {
 	const Set<String> &selected_list = _project_list->get_selected_project_keys();
 
-	if (selected_list.size() < 1) {
-		return;
-	}
-
 	if (selected_list.size() > 1) {
-		multi_open_ask->set_text(TTR("Are you sure to open more than one project?"));
 		multi_open_ask->popup_centered_minsize();
 		return;
 	}
@@ -2035,34 +1403,34 @@ void ProjectManager::_open_selected_projects_ask() {
 		return;
 	}
 
-	// Update the project settings or don't open
+	// Update the project settings or don't open.
 	String conf = project.path.plus_file("project.godot");
 	int config_version = project.version;
 
-	// Check if the config_version property was empty or 0
+	// Check if the config_version property was empty or 0.
 	if (config_version == 0) {
 		ask_update_settings->set_text(vformat(TTR("The following project settings file does not specify the version of Godot through which it was created.\n\n%s\n\nIf you proceed with opening it, it will be converted to Godot's current configuration file format.\nWarning: You won't be able to open the project with previous versions of the engine anymore."), conf));
 		ask_update_settings->popup_centered_minsize();
 		return;
 	}
-	// Check if we need to convert project settings from an earlier engine version
+	// Check if we need to convert project settings from an earlier engine version.
 	if (config_version < ProjectSettings::CONFIG_VERSION) {
 		ask_update_settings->set_text(vformat(TTR("The following project settings file was generated by an older engine version, and needs to be converted for this version:\n\n%s\n\nDo you want to convert it?\nWarning: You won't be able to open the project with previous versions of the engine anymore."), conf));
 		ask_update_settings->popup_centered_minsize();
 		return;
 	}
-	// Check if the file was generated by a newer, incompatible engine version
+	// Check if the file was generated by a newer, incompatible engine version.
 	if (config_version > ProjectSettings::CONFIG_VERSION) {
 		dialog_error->set_text(vformat(TTR("Can't open project at '%s'.") + "\n" + TTR("The project settings were created by a newer engine version, whose settings are not compatible with this version."), project.path));
 		dialog_error->popup_centered_minsize();
 		return;
 	}
 
-	// Open if the project is up-to-date
+	// Open if the project is up-to-date.
 	_open_selected_projects();
 }
 
-void ProjectManager::_run_project_confirm() {
+void ProjectManager::_run_project_confirmed() {
 	Vector<ProjectList::Item> selected_list = _project_list->get_selected_projects();
 
 	for (int i = 0; i < selected_list.size(); ++i) {
@@ -2074,7 +1442,7 @@ void ProjectManager::_run_project_confirm() {
 		}
 
 		const String &selected = selected_list[i].project_key;
-		String path = EditorSettings::get_singleton()->get("projects/" + selected);
+		String path = EDITOR_GET("projects/" + selected);
 
 		if (!DirAccess::exists(path + "/.import")) {
 			run_error_diag->set_text(TTR("Can't run project: Assets need to be imported.\nPlease edit the project to trigger the initial import."));
@@ -2101,8 +1469,8 @@ void ProjectManager::_run_project_confirm() {
 	}
 }
 
-// When you press the "Run" button
-void ProjectManager::_run_project() {
+// When you press the "Run" button.
+void ProjectManager::_run_project_ask() {
 	const Set<String> &selected_list = _project_list->get_selected_project_keys();
 
 	if (selected_list.size() < 1) {
@@ -2113,7 +1481,7 @@ void ProjectManager::_run_project() {
 		multi_run_ask->set_text(vformat(TTR("Are you sure to run %d projects at once?"), selected_list.size()));
 		multi_run_ask->popup_centered_minsize();
 	} else {
-		_run_project_confirm();
+		_run_project_confirmed();
 	}
 }
 
@@ -2144,25 +1512,17 @@ void ProjectManager::_scan_begin(const String &p_base) {
 		String proj = get_project_key_from_path(E->get());
 		EditorSettings::get_singleton()->set("projects/" + proj, E->get());
 	}
+
 	EditorSettings::get_singleton()->save();
 	_load_recent_projects();
 }
 
-void ProjectManager::_scan_projects() {
-	scan_dir->popup_centered_ratio();
-}
-
-void ProjectManager::_new_project() {
-	npdialog->set_mode(ProjectDialog::MODE_NEW);
-	npdialog->show_dialog();
-}
-
 void ProjectManager::_import_project() {
-	npdialog->set_mode(ProjectDialog::MODE_IMPORT);
-	npdialog->show_dialog();
+	/*npdialog->set_mode(ProjectDialog::MODE_IMPORT);
+	npdialog->show_dialog();*/
 }
 
-void ProjectManager::_rename_project() {
+void ProjectManager::_rename_project() { /*
 	const Set<String> &selected_list = _project_list->get_selected_project_keys();
 
 	if (selected_list.size() == 0) {
@@ -2171,29 +1531,25 @@ void ProjectManager::_rename_project() {
 
 	for (Set<String>::Element *E = selected_list.front(); E; E = E->next()) {
 		const String &selected = E->get();
-		String path = EditorSettings::get_singleton()->get("projects/" + selected);
+		String path = EDITOR_GET("projects/" + selected);
 		npdialog->set_project_path(path);
 		npdialog->set_mode(ProjectDialog::MODE_RENAME);
 		npdialog->show_dialog();
-	}
+	}*/
 }
 
-void ProjectManager::_erase_project_confirm() {
+void ProjectManager::_erase_project_confirmed() {
 	_project_list->erase_selected_projects();
 	_update_project_buttons();
 }
 
-void ProjectManager::_erase_missing_projects_confirm() {
+void ProjectManager::_erase_missing_projects_confirmed() {
 	_project_list->erase_missing_projects();
 	_update_project_buttons();
 }
 
-void ProjectManager::_erase_project() {
+void ProjectManager::_erase_project_ask() {
 	const Set<String> &selected_list = _project_list->get_selected_project_keys();
-
-	if (selected_list.size() == 0) {
-		return;
-	}
 
 	String confirm_message;
 	if (selected_list.size() >= 2) {
@@ -2216,16 +1572,15 @@ void ProjectManager::_show_about() {
 }
 
 void ProjectManager::_language_selected(int p_id) {
-	String lang = language_btn->get_item_metadata(p_id);
+	String lang = language_button->get_item_metadata(p_id);
 	EditorSettings::get_singleton()->set("interface/editor/editor_language", lang);
-	language_btn->set_text(lang);
-	language_btn->set_icon(get_icon("Environment", "EditorIcons"));
+	//language_button->set_text(lang);
 
 	language_restart_ask->set_text(TTR("Language changed.\nThe interface will update after restarting the editor or project manager."));
 	language_restart_ask->popup_centered();
 }
 
-void ProjectManager::_restart_confirm() {
+void ProjectManager::_restart_confirmed() {
 	List<String> args = OS::get_singleton()->get_cmdline_args();
 	String exec = OS::get_singleton()->get_executable_path();
 	OS::ProcessID pid = 0;
@@ -2236,17 +1591,18 @@ void ProjectManager::_restart_confirm() {
 	get_tree()->quit();
 }
 
-void ProjectManager::_install_project(const String &p_zip_path, const String &p_title) {
+void ProjectManager::_install_project_from_zip(const String &p_zip_path, const String &p_title) { /*
 	npdialog->set_mode(ProjectDialog::MODE_INSTALL);
 	npdialog->set_zip_path(p_zip_path);
 	npdialog->set_zip_title(p_title);
 	npdialog->show_dialog();
+																								  */
 }
 
 void ProjectManager::_files_dropped(PoolStringArray p_files, int p_screen) {
 	if (p_files.size() == 1 && p_files[0].ends_with(".zip")) {
 		const String file = p_files[0].get_file();
-		_install_project(p_files[0], file.substr(0, file.length() - 4).capitalize());
+		_install_project_from_zip(p_files[0], file.substr(0, file.length() - 4).capitalize());
 		return;
 	}
 	Set<String> folders_set;
@@ -2310,27 +1666,25 @@ void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_open_selected_projects_ask", &ProjectManager::_open_selected_projects_ask);
 	ClassDB::bind_method("_open_selected_projects", &ProjectManager::_open_selected_projects);
 	ClassDB::bind_method(D_METHOD("_global_menu_action"), &ProjectManager::_global_menu_action, DEFVAL(Variant()));
-	ClassDB::bind_method("_run_project", &ProjectManager::_run_project);
-	ClassDB::bind_method("_run_project_confirm", &ProjectManager::_run_project_confirm);
-	ClassDB::bind_method("_scan_projects", &ProjectManager::_scan_projects);
+	ClassDB::bind_method("_run_project_ask", &ProjectManager::_run_project_ask);
+	ClassDB::bind_method("_run_project_confirmed", &ProjectManager::_run_project_confirmed);
 	ClassDB::bind_method("_scan_begin", &ProjectManager::_scan_begin);
 	ClassDB::bind_method("_import_project", &ProjectManager::_import_project);
-	ClassDB::bind_method("_new_project", &ProjectManager::_new_project);
 	ClassDB::bind_method("_rename_project", &ProjectManager::_rename_project);
-	ClassDB::bind_method("_erase_project", &ProjectManager::_erase_project);
+	ClassDB::bind_method("_erase_project_ask", &ProjectManager::_erase_project_ask);
 	ClassDB::bind_method("_erase_missing_projects", &ProjectManager::_erase_missing_projects);
-	ClassDB::bind_method("_erase_project_confirm", &ProjectManager::_erase_project_confirm);
-	ClassDB::bind_method("_erase_missing_projects_confirm", &ProjectManager::_erase_missing_projects_confirm);
+	ClassDB::bind_method("_erase_project_confirmed", &ProjectManager::_erase_project_confirmed);
+	ClassDB::bind_method("_erase_missing_projects_confirmed", &ProjectManager::_erase_missing_projects_confirmed);
 	ClassDB::bind_method("_show_about", &ProjectManager::_show_about);
 	ClassDB::bind_method("_version_button_pressed", &ProjectManager::_version_button_pressed);
 	ClassDB::bind_method("_language_selected", &ProjectManager::_language_selected);
-	ClassDB::bind_method("_restart_confirm", &ProjectManager::_restart_confirm);
+	ClassDB::bind_method("_restart_confirmed", &ProjectManager::_restart_confirmed);
 	ClassDB::bind_method("_on_order_option_changed", &ProjectManager::_on_order_option_changed);
 	ClassDB::bind_method("_on_filter_option_changed", &ProjectManager::_on_filter_option_changed);
 	ClassDB::bind_method("_on_projects_updated", &ProjectManager::_on_projects_updated);
-	ClassDB::bind_method("_on_project_created", &ProjectManager::_on_project_created);
+	ClassDB::bind_method("_create_project_confirmed", &ProjectManager::_create_project_confirmed);
 	ClassDB::bind_method("_unhandled_input", &ProjectManager::_unhandled_input);
-	ClassDB::bind_method("_install_project", &ProjectManager::_install_project);
+	ClassDB::bind_method("_install_project_from_zip", &ProjectManager::_install_project_from_zip);
 	ClassDB::bind_method("_files_dropped", &ProjectManager::_files_dropped);
 	ClassDB::bind_method("_open_asset_library", &ProjectManager::_open_asset_library);
 	ClassDB::bind_method("_confirm_update_settings", &ProjectManager::_confirm_update_settings);
@@ -2339,108 +1693,83 @@ void ProjectManager::_bind_methods() {
 }
 
 void ProjectManager::_open_asset_library() {
+	// For if the user doesn't have any existing projects.
 	asset_library->disable_community_support();
 	tabs->set_current_tab(1);
 }
 
 void ProjectManager::_version_button_pressed() {
-	OS::get_singleton()->set_clipboard(version_btn->get_text());
+	OS::get_singleton()->set_clipboard(version_button->get_text());
 }
 
 ProjectManager::ProjectManager() {
-	// load settings
+	// Load settings.
 	if (!EditorSettings::get_singleton()) {
 		EditorSettings::create();
 	}
 
-	EditorSettings::get_singleton()->set_optimize_save(false); //just write settings as they came
+	EditorSettings::get_singleton()->set_optimize_save(false); // Just write settings as they came.
 
-	{
-		int display_scale = EditorSettings::get_singleton()->get("interface/editor/display_scale");
-		float custom_display_scale = EditorSettings::get_singleton()->get("interface/editor/custom_display_scale");
-
-		switch (display_scale) {
-			case 0:
-				// Try applying a suitable display scale automatically.
-				editor_set_scale(EditorSettings::get_singleton()->get_auto_display_scale());
-				break;
-			case 1:
-				editor_set_scale(0.75);
-				break;
-			case 2:
-				editor_set_scale(1.0);
-				break;
-			case 3:
-				editor_set_scale(1.25);
-				break;
-			case 4:
-				editor_set_scale(1.5);
-				break;
-			case 5:
-				editor_set_scale(1.75);
-				break;
-			case 6:
-				editor_set_scale(2.0);
-				break;
-			default:
-				editor_set_scale(custom_display_scale);
-				break;
-		}
-
-		// Define a minimum window size to prevent UI elements from overlapping or being cut off
-		OS::get_singleton()->set_min_window_size(Size2(750, 420) * EDSCALE);
-
-		// TODO: Resize windows on hiDPI displays on Windows and Linux and remove the line below
-		OS::get_singleton()->set_window_size(OS::get_singleton()->get_window_size() * MAX(1, EDSCALE));
+	int display_scale = EDITOR_GET("interface/editor/display_scale");
+	if (display_scale == 0) {
+		// Try applying a suitable display scale automatically.
+		editor_set_scale(EditorSettings::get_singleton()->get_auto_display_scale());
+	} else if (display_scale >= 1 && display_scale <= 6) {
+		// The display scale has been set to one of the preset options.
+		editor_set_scale(0.5 + 0.25 * display_scale);
+	} else {
+		// The user is using a custom display scale.
+		float custom_display_scale = EDITOR_GET("interface/editor/custom_display_scale");
+		editor_set_scale(custom_display_scale);
 	}
 
-	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
+	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
+	OS::get_singleton()->set_min_window_size(Size2(750, 420) * EDSCALE);
 
-	set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	// TODO: Resize windows on hiDPI displays on Windows and Linux and remove the line below.
+	OS::get_singleton()->set_window_size(OS::get_singleton()->get_window_size() * MAX(1, EDSCALE));
+
+	FileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
+
+	set_anchors_and_margins_preset(PRESET_WIDE);
 	set_theme(create_custom_theme());
 
-	gui_base = memnew(Control);
+	Panel *gui_base = memnew(Panel);
 	add_child(gui_base);
-	gui_base->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	gui_base->set_anchors_and_margins_preset(PRESET_WIDE);
+	gui_base->add_style_override("panel", gui_base->get_stylebox("Background", "EditorStyles"));
 
-	Panel *panel = memnew(Panel);
-	gui_base->add_child(panel);
-	panel->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	panel->add_style_override("panel", gui_base->get_stylebox("Background", "EditorStyles"));
+	VBoxContainer *vbox = memnew(VBoxContainer);
+	gui_base->add_child(vbox);
+	vbox->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_MINSIZE, 8 * EDSCALE);
 
-	VBoxContainer *vb = memnew(VBoxContainer);
-	panel->add_child(vb);
-	vb->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 8 * EDSCALE);
-
-	String cp;
-	cp += 0xA9;
 	// TRANSLATORS: This refers to the application where users manage their Godot projects.
 	OS::get_singleton()->set_window_title(VERSION_NAME + String(" - ") + TTR("Project Manager"));
 
 	Control *center_box = memnew(Control);
 	center_box->set_v_size_flags(SIZE_EXPAND_FILL);
-	vb->add_child(center_box);
+	vbox->add_child(center_box);
 
 	tabs = memnew(TabContainer);
 	center_box->add_child(tabs);
-	tabs->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	tabs->set_anchors_and_margins_preset(PRESET_WIDE);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
 
-	HBoxContainer *tree_hb = memnew(HBoxContainer);
-	projects_hb = tree_hb;
+	HBoxContainer *tree_hbox = memnew(HBoxContainer);
+	projects_hbox = tree_hbox;
 
-	projects_hb->set_name(TTR("Local Projects"));
+	projects_hbox->set_name(TTR("Local Projects"));
 
-	tabs->add_child(tree_hb);
+	tabs->add_child(tree_hbox);
 
-	VBoxContainer *search_tree_vb = memnew(VBoxContainer);
-	tree_hb->add_child(search_tree_vb);
-	search_tree_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+	VBoxContainer *search_buttons_vbox = memnew(VBoxContainer);
+	tree_hbox->add_child(search_buttons_vbox);
+	search_buttons_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	HBoxContainer *sort_filters = memnew(HBoxContainer);
 	loading_label = memnew(Label(TTR("Loading, please wait...")));
 	loading_label->add_font_override("font", get_font("bold", "EditorFonts"));
-	loading_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	loading_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	sort_filters->add_child(loading_label);
 	// Hide the label but make it still take up space. This prevents reflows when showing the label.
 	loading_label->set_modulate(Color(0, 0, 0, 0));
@@ -2456,148 +1785,149 @@ ProjectManager::ProjectManager() {
 	project_order_filter->add_filter_option();
 	project_order_filter->_setup_filters(sort_filter_titles);
 	project_order_filter->set_filter_size(150);
-	sort_filters->add_child(project_order_filter);
-	project_order_filter->connect("filter_changed", this, "_on_order_option_changed");
 	project_order_filter->set_custom_minimum_size(Size2(180, 10) * EDSCALE);
+	project_order_filter->connect("filter_changed", this, "_on_order_option_changed");
+	sort_filters->add_child(project_order_filter);
 
-	int projects_sorting_order = (int)EditorSettings::get_singleton()->get("project_manager/sorting_order");
+	int projects_sorting_order = (int)EDITOR_GET("project_manager/sorting_order");
 	project_order_filter->set_filter_option((ProjectListFilter::FilterOption)projects_sorting_order);
 
 	project_filter = memnew(ProjectListFilter);
 	project_filter->add_search_box();
-	project_filter->connect("filter_changed", this, "_on_filter_option_changed");
 	project_filter->set_custom_minimum_size(Size2(280, 10) * EDSCALE);
+	project_filter->connect("filter_changed", this, "_on_filter_option_changed");
 	sort_filters->add_child(project_filter);
 
-	search_tree_vb->add_child(sort_filters);
+	search_buttons_vbox->add_child(sort_filters);
 
-	PanelContainer *pc = memnew(PanelContainer);
-	pc->add_style_override("panel", gui_base->get_stylebox("bg", "Tree"));
-	search_tree_vb->add_child(pc);
-	pc->set_v_size_flags(SIZE_EXPAND_FILL);
+	PanelContainer *panel_container = memnew(PanelContainer);
+	panel_container->add_style_override("panel", get_stylebox("bg", "Tree"));
+	panel_container->set_v_size_flags(SIZE_EXPAND_FILL);
+	add_child(panel_container);
 
 	_project_list = memnew(ProjectList);
 	_project_list->connect(ProjectList::SIGNAL_SELECTION_CHANGED, this, "_update_project_buttons");
 	_project_list->connect(ProjectList::SIGNAL_PROJECT_ASK_OPEN, this, "_open_selected_projects_ask");
-	pc->add_child(_project_list);
+	search_buttons_vbox->add_child(_project_list);
 	_project_list->set_enable_h_scroll(false);
 
-	VBoxContainer *tree_vb = memnew(VBoxContainer);
-	tree_vb->set_custom_minimum_size(Size2(120, 120));
-	tree_hb->add_child(tree_vb);
+	// Contains the Edit, Run, New Project, etc. buttons.
+	VBoxContainer *buttons_vbox = memnew(VBoxContainer);
+	buttons_vbox->set_custom_minimum_size(Size2(120, 120));
+	tree_hbox->add_child(buttons_vbox);
 
-	Button *open = memnew(Button);
-	open->set_text(TTR("Edit"));
-	open->set_shortcut(ED_SHORTCUT("project_manager/edit_project", TTR("Edit Project"), KEY_MASK_CMD | KEY_E));
-	tree_vb->add_child(open);
-	open->connect("pressed", this, "_open_selected_projects_ask");
-	open_btn = open;
+	open_button = memnew(Button);
+	open_button->set_text(TTR("Edit"));
+	open_button->set_shortcut(ED_SHORTCUT("project_manager/edit_project", TTR("Edit Project"), KEY_MASK_CMD | KEY_E));
+	open_button->connect("pressed", this, "_open_selected_projects_ask");
+	buttons_vbox->add_child(open_button);
 
-	Button *run = memnew(Button);
-	run->set_text(TTR("Run"));
-	run->set_shortcut(ED_SHORTCUT("project_manager/run_project", TTR("Run Project"), KEY_MASK_CMD | KEY_R));
-	tree_vb->add_child(run);
-	run->connect("pressed", this, "_run_project");
-	run_btn = run;
+	run_button = memnew(Button);
+	run_button->set_text(TTR("Run"));
+	run_button->set_shortcut(ED_SHORTCUT("project_manager/run_project", TTR("Run Project"), KEY_MASK_CMD | KEY_R));
+	run_button->connect("pressed", this, "_run_project_ask");
+	buttons_vbox->add_child(run_button);
 
-	tree_vb->add_child(memnew(HSeparator));
+	buttons_vbox->add_child(memnew(HSeparator));
 
-	Button *scan = memnew(Button);
-	scan->set_text(TTR("Scan"));
-	scan->set_shortcut(ED_SHORTCUT("project_manager/scan_projects", TTR("Scan Projects"), KEY_MASK_CMD | KEY_S));
-	tree_vb->add_child(scan);
-	scan->connect("pressed", this, "_scan_projects");
+	create_project_dialog = memnew(CreateProjectDialog);
+	create_project_dialog->connect("confirmed", this, "_create_project_confirmed");
+	gui_base->add_child(create_project_dialog);
 
-	tree_vb->add_child(memnew(HSeparator));
+	Button *create_button = memnew(Button);
+	create_button->set_text(TTR("New Project"));
+	create_button->set_shortcut(ED_SHORTCUT("project_manager/new_project", TTR("New Project"), KEY_MASK_CMD | KEY_N));
+	create_button->connect("pressed", create_project_dialog, "create_project_popup");
+	buttons_vbox->add_child(create_button);
 
-	scan_dir = memnew(FileDialog);
-	scan_dir->set_access(FileDialog::ACCESS_FILESYSTEM);
-	scan_dir->set_mode(FileDialog::MODE_OPEN_DIR);
-	scan_dir->set_title(TTR("Select a Folder to Scan")); // must be after mode or it's overridden
-	scan_dir->set_current_dir(EditorSettings::get_singleton()->get("filesystem/directories/default_project_path"));
-	gui_base->add_child(scan_dir);
-	scan_dir->connect("dir_selected", this, "_scan_begin");
+	Button *import_button = memnew(Button);
+	import_button->set_text(TTR("Import"));
+	import_button->set_shortcut(ED_SHORTCUT("project_manager/import_project", TTR("Import Project"), KEY_MASK_CMD | KEY_I));
+	import_button->connect("pressed", this, "_import_project");
+	buttons_vbox->add_child(import_button);
 
-	Button *create = memnew(Button);
-	create->set_text(TTR("New Project"));
-	create->set_shortcut(ED_SHORTCUT("project_manager/new_project", TTR("New Project"), KEY_MASK_CMD | KEY_N));
-	tree_vb->add_child(create);
-	create->connect("pressed", this, "_new_project");
+	scan_dir_file_dialog = memnew(FileDialog);
+	scan_dir_file_dialog->set_access(FileDialog::ACCESS_FILESYSTEM);
+	scan_dir_file_dialog->set_mode(FileDialog::MODE_OPEN_DIR);
+	scan_dir_file_dialog->set_title(TTR("Select a Folder to Scan")); // Must be after `set_mode()` or it gets overridden.
+	scan_dir_file_dialog->set_current_dir(EDITOR_GET("filesystem/directories/default_project_path"));
+	scan_dir_file_dialog->connect("dir_selected", this, "_scan_begin");
+	gui_base->add_child(scan_dir_file_dialog);
 
-	Button *import = memnew(Button);
-	import->set_text(TTR("Import"));
-	import->set_shortcut(ED_SHORTCUT("project_manager/import_project", TTR("Import Project"), KEY_MASK_CMD | KEY_I));
-	tree_vb->add_child(import);
-	import->connect("pressed", this, "_import_project");
+	Button *scan_button = memnew(Button);
+	scan_button->set_text(TTR("Scan"));
+	scan_button->set_shortcut(ED_SHORTCUT("project_manager/scan_projects", TTR("Scan Projects"), KEY_MASK_CMD | KEY_S));
+	scan_button->connect("pressed", scan_dir_file_dialog, "popup_centered_ratio");
+	buttons_vbox->add_child(scan_button);
 
-	Button *rename = memnew(Button);
-	rename->set_text(TTR("Rename"));
-	rename->set_shortcut(ED_SHORTCUT("project_manager/rename_project", TTR("Rename Project"), KEY_F2));
-	tree_vb->add_child(rename);
-	rename->connect("pressed", this, "_rename_project");
-	rename_btn = rename;
+	rename_button = memnew(Button);
+	rename_button->set_text(TTR("Rename"));
+	rename_button->set_shortcut(ED_SHORTCUT("project_manager/rename_project", TTR("Rename Project"), KEY_F2));
+	rename_button->connect("pressed", this, "_rename_project");
+	buttons_vbox->add_child(rename_button);
 
-	Button *erase = memnew(Button);
-	erase->set_text(TTR("Remove"));
-	erase->set_shortcut(ED_SHORTCUT("project_manager/remove_project", TTR("Remove Project"), KEY_DELETE));
-	tree_vb->add_child(erase);
-	erase->connect("pressed", this, "_erase_project");
-	erase_btn = erase;
+	buttons_vbox->add_child(memnew(HSeparator));
 
-	Button *erase_missing = memnew(Button);
-	erase_missing->set_text(TTR("Remove Missing"));
-	tree_vb->add_child(erase_missing);
-	erase_missing->connect("pressed", this, "_erase_missing_projects");
-	erase_missing_btn = erase_missing;
+	erase_button = memnew(Button);
+	erase_button->set_text(TTR("Remove"));
+	erase_button->set_shortcut(ED_SHORTCUT("project_manager/remove_project", TTR("Remove Project"), KEY_DELETE));
+	erase_button->connect("pressed", this, "_erase_project");
+	buttons_vbox->add_child(erase_button);
 
-	tree_vb->add_spacer();
+	remove_missing_button = memnew(Button);
+	remove_missing_button->set_text(TTR("Remove Missing"));
+	remove_missing_button->connect("pressed", this, "_erase_missing_projects");
+	buttons_vbox->add_child(remove_missing_button);
 
-	about_btn = memnew(Button);
-	about_btn->set_text(TTR("About"));
-	about_btn->connect("pressed", this, "_show_about");
-	tree_vb->add_child(about_btn);
+	buttons_vbox->add_spacer();
+
+	about_button = memnew(Button);
+	about_button->set_text(TTR("About"));
+	about_button->connect("pressed", this, "_show_about");
+	buttons_vbox->add_child(about_button);
 
 	if (StreamPeerSSL::is_available()) {
 		asset_library = memnew(EditorAssetLibrary(true));
 		asset_library->set_name(TTR("Asset Library Projects"));
+		asset_library->connect("install_asset", this, "_install_project_from_zip");
 		tabs->add_child(asset_library);
-		asset_library->connect("install_asset", this, "_install_project");
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
 
-	HBoxContainer *settings_hb = memnew(HBoxContainer);
-	settings_hb->set_alignment(BoxContainer::ALIGN_END);
-	settings_hb->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
+	HBoxContainer *settings_hbox = memnew(HBoxContainer);
+	settings_hbox->set_alignment(BoxContainer::ALIGN_END);
+	settings_hbox->set_h_grow_direction(GROW_DIRECTION_BEGIN);
 
 	// A VBoxContainer that contains a dummy Control node to adjust the LinkButton's vertical position.
-	VBoxContainer *spacer_vb = memnew(VBoxContainer);
-	settings_hb->add_child(spacer_vb);
+	VBoxContainer *spacer_vbox = memnew(VBoxContainer);
+	settings_hbox->add_child(spacer_vbox);
 
 	Control *v_spacer = memnew(Control);
-	spacer_vb->add_child(v_spacer);
+	spacer_vbox->add_child(v_spacer);
 
-	version_btn = memnew(LinkButton);
+	version_button = memnew(LinkButton);
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0) {
 		hash = " " + vformat("[%s]", hash.left(9));
 	}
-	version_btn->set_text("v" VERSION_FULL_BUILD + hash);
+	version_button->set_text("v" VERSION_FULL_BUILD + hash);
 	// Fade the version label to be less prominent, but still readable.
-	version_btn->set_self_modulate(Color(1, 1, 1, 0.6));
-	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	version_btn->set_tooltip(TTR("Click to copy."));
-	version_btn->connect("pressed", this, "_version_button_pressed");
-	spacer_vb->add_child(version_btn);
+	version_button->set_self_modulate(Color(1, 1, 1, 0.6));
+	version_button->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+	version_button->set_tooltip(TTR("Click to copy."));
+	version_button->connect("pressed", this, "_version_button_pressed");
+	spacer_vbox->add_child(version_button);
 
 	// Add a small horizontal spacer between the version and language buttons
 	// to distinguish them.
 	Control *h_spacer = memnew(Control);
-	settings_hb->add_child(h_spacer);
+	settings_hbox->add_child(h_spacer);
 
-	language_btn = memnew(OptionButton);
-	language_btn->set_flat(true);
-	language_btn->set_focus_mode(Control::FOCUS_NONE);
+	language_button = memnew(OptionButton);
+	language_button->set_flat(true);
+	language_button->set_icon(get_icon("Environment", "EditorIcons"));
+	language_button->set_focus_mode(FOCUS_NONE);
 
 	Vector<String> editor_languages;
 	List<PropertyInfo> editor_settings_properties;
@@ -2608,51 +1938,49 @@ ProjectManager::ProjectManager() {
 			editor_languages = pi.hint_string.split(",");
 		}
 	}
-	String current_lang = EditorSettings::get_singleton()->get("interface/editor/editor_language");
+	String current_lang = EDITOR_GET("interface/editor/editor_language");
 	for (int i = 0; i < editor_languages.size(); i++) {
 		String lang = editor_languages[i];
 		String lang_name = TranslationServer::get_singleton()->get_locale_name(lang);
-		language_btn->add_item(lang_name + " [" + lang + "]", i);
-		language_btn->set_item_metadata(i, lang);
+		language_button->add_item(lang_name + " [" + lang + "]", i);
+		language_button->set_item_metadata(i, lang);
 		if (current_lang == lang) {
-			language_btn->select(i);
-			language_btn->set_text(lang);
+			language_button->select(i);
+			language_button->set_text(lang);
 		}
 	}
-	language_btn->set_icon(get_icon("Environment", "EditorIcons"));
+	language_button->set_icon(get_icon("Environment", "EditorIcons"));
+	language_button->connect("item_selected", this, "_language_selected");
+	settings_hbox->add_child(language_button);
 
-	settings_hb->add_child(language_btn);
-	language_btn->connect("item_selected", this, "_language_selected");
-
-	center_box->add_child(settings_hb);
-	settings_hb->set_anchors_and_margins_preset(Control::PRESET_TOP_RIGHT);
-
-	//////////////////////////////////////////////////////////////
+	center_box->add_child(settings_hbox);
+	settings_hbox->set_anchors_and_margins_preset(PRESET_TOP_RIGHT);
 
 	language_restart_ask = memnew(ConfirmationDialog);
 	language_restart_ask->get_ok()->set_text(TTR("Restart Now"));
-	language_restart_ask->get_ok()->connect("pressed", this, "_restart_confirm");
+	language_restart_ask->get_ok()->connect("pressed", this, "_restart_confirmed");
 	language_restart_ask->get_cancel()->set_text(TTR("Continue"));
 	gui_base->add_child(language_restart_ask);
 
 	erase_missing_ask = memnew(ConfirmationDialog);
 	erase_missing_ask->get_ok()->set_text(TTR("Remove All"));
-	erase_missing_ask->get_ok()->connect("pressed", this, "_erase_missing_projects_confirm");
+	erase_missing_ask->get_ok()->connect("pressed", this, "_erase_missing_projects_confirmed");
 	gui_base->add_child(erase_missing_ask);
 
 	erase_ask = memnew(ConfirmationDialog);
 	erase_ask->get_ok()->set_text(TTR("Remove"));
-	erase_ask->get_ok()->connect("pressed", this, "_erase_project_confirm");
+	erase_ask->get_ok()->connect("pressed", this, "_erase_project_confirmed");
 	gui_base->add_child(erase_ask);
 
 	multi_open_ask = memnew(ConfirmationDialog);
+	multi_open_ask->set_text(TTR("Are you sure to open more than one project?"));
 	multi_open_ask->get_ok()->set_text(TTR("Edit"));
 	multi_open_ask->get_ok()->connect("pressed", this, "_open_selected_projects");
 	gui_base->add_child(multi_open_ask);
 
 	multi_run_ask = memnew(ConfirmationDialog);
 	multi_run_ask->get_ok()->set_text(TTR("Run"));
-	multi_run_ask->get_ok()->connect("pressed", this, "_run_project_confirm");
+	multi_run_ask->get_ok()->connect("pressed", this, "_run_project_confirmed");
 	gui_base->add_child(multi_run_ask);
 
 	multi_scan_ask = memnew(ConfirmationDialog);
@@ -2665,17 +1993,11 @@ ProjectManager::ProjectManager() {
 
 	OS::get_singleton()->set_low_processor_usage_mode(true);
 
-	npdialog = memnew(ProjectDialog);
-	gui_base->add_child(npdialog);
-
-	npdialog->connect("projects_updated", this, "_on_projects_updated");
-	npdialog->connect("project_created", this, "_on_project_created");
-
 	_load_recent_projects();
 
 	DirAccessRef dir_access = DirAccess::create(DirAccess::AccessType::ACCESS_FILESYSTEM);
 
-	String default_project_path = EditorSettings::get_singleton()->get("filesystem/directories/default_project_path");
+	String default_project_path = EDITOR_GET("filesystem/directories/default_project_path");
 	if (!dir_access->dir_exists(default_project_path)) {
 		Error error = dir_access->make_dir_recursive(default_project_path);
 		if (error != OK) {
@@ -2683,15 +2005,10 @@ ProjectManager::ProjectManager() {
 		}
 	}
 
-	String autoscan_path = EditorSettings::get_singleton()->get("filesystem/directories/autoscan_project_path");
+	String autoscan_path = EDITOR_GET("filesystem/directories/autoscan_project_path");
 	if (autoscan_path != "") {
 		if (dir_access->dir_exists(autoscan_path)) {
 			_scan_begin(autoscan_path);
-		} else {
-			Error error = dir_access->make_dir_recursive(autoscan_path);
-			if (error != OK) {
-				ERR_PRINT("Could not create project autoscan directory at: " + autoscan_path);
-			}
 		}
 	}
 
@@ -2718,85 +2035,5 @@ ProjectManager::ProjectManager() {
 ProjectManager::~ProjectManager() {
 	if (EditorSettings::get_singleton()) {
 		EditorSettings::destroy();
-	}
-}
-
-void ProjectListFilter::_setup_filters(Vector<String> options) {
-	filter_option->clear();
-	for (int i = 0; i < options.size(); i++) {
-		filter_option->add_item(options[i]);
-	}
-}
-
-void ProjectListFilter::_search_text_changed(const String &p_newtext) {
-	emit_signal("filter_changed");
-}
-
-String ProjectListFilter::get_search_term() {
-	return search_box->get_text().strip_edges();
-}
-
-ProjectListFilter::FilterOption ProjectListFilter::get_filter_option() {
-	return _current_filter;
-}
-
-void ProjectListFilter::set_filter_option(FilterOption option) {
-	filter_option->select((int)option);
-	_filter_option_selected(0);
-}
-
-void ProjectListFilter::_filter_option_selected(int p_idx) {
-	FilterOption selected = (FilterOption)(filter_option->get_selected());
-	if (_current_filter != selected) {
-		_current_filter = selected;
-		emit_signal("filter_changed");
-	}
-}
-
-void ProjectListFilter::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE && has_search_box) {
-		search_box->set_right_icon(get_icon("Search", "EditorIcons"));
-		search_box->set_clear_button_enabled(true);
-	}
-}
-
-void ProjectListFilter::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_search_text_changed"), &ProjectListFilter::_search_text_changed);
-	ClassDB::bind_method(D_METHOD("_filter_option_selected"), &ProjectListFilter::_filter_option_selected);
-
-	ADD_SIGNAL(MethodInfo("filter_changed"));
-}
-
-void ProjectListFilter::add_filter_option() {
-	filter_option = memnew(OptionButton);
-	filter_option->set_clip_text(true);
-	filter_option->connect("item_selected", this, "_filter_option_selected");
-	add_child(filter_option);
-}
-
-void ProjectListFilter::add_search_box() {
-	search_box = memnew(LineEdit);
-	search_box->set_placeholder(TTR("Search"));
-	search_box->set_tooltip(
-			TTR("The search box filters projects by name and last path component.\nTo filter projects by name and full path, the query must contain at least one `/` character."));
-	search_box->connect("text_changed", this, "_search_text_changed");
-	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	add_child(search_box);
-
-	has_search_box = true;
-}
-
-void ProjectListFilter::set_filter_size(int h_size) {
-	filter_option->set_custom_minimum_size(Size2(h_size * EDSCALE, 10 * EDSCALE));
-}
-
-ProjectListFilter::ProjectListFilter() {
-	_current_filter = FILTER_NAME;
-	has_search_box = false;
-}
-
-void ProjectListFilter::clear() {
-	if (has_search_box) {
-		search_box->clear();
 	}
 }

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -39,19 +39,19 @@
 #include "scene/gui/tool_button.h"
 #include "scene/gui/tree.h"
 
-class ProjectDialog;
-class ProjectList;
 class ProjectListFilter;
+class ProjectList;
+class CreateProjectDialog;
 
 class ProjectManager : public Control {
 	GDCLASS(ProjectManager, Control);
 
-	Button *erase_btn;
-	Button *erase_missing_btn;
-	Button *open_btn;
-	Button *rename_btn;
-	Button *run_btn;
-	Button *about_btn;
+	Button *erase_button;
+	Button *remove_missing_button;
+	Button *open_button;
+	Button *rename_button;
+	Button *run_button;
+	Button *about_button;
 
 	EditorAssetLibrary *asset_library;
 
@@ -59,7 +59,7 @@ class ProjectManager : public Control {
 	ProjectListFilter *project_order_filter;
 	Label *loading_label;
 
-	FileDialog *scan_dir;
+	FileDialog *scan_dir_file_dialog;
 	ConfirmationDialog *language_restart_ask;
 	ConfirmationDialog *erase_ask;
 	ConfirmationDialog *erase_missing_ask;
@@ -71,35 +71,34 @@ class ProjectManager : public Control {
 	EditorAbout *about;
 	AcceptDialog *run_error_diag;
 	AcceptDialog *dialog_error;
-	ProjectDialog *npdialog;
+	//ProjectDialog *npdialog;
+	CreateProjectDialog *create_project_dialog;
 
-	HBoxContainer *projects_hb;
+	HBoxContainer *projects_hbox;
 	TabContainer *tabs;
 	ProjectList *_project_list;
 
-	LinkButton *version_btn;
-	OptionButton *language_btn;
+	LinkButton *version_button;
+	OptionButton *language_button;
 	Control *gui_base;
-
-	bool importing;
 
 	void _open_asset_library();
 	void _scan_projects();
-	void _run_project();
-	void _run_project_confirm();
+	void _run_project_ask();
+	void _run_project_confirmed();
 	void _open_selected_projects();
 	void _open_selected_projects_ask();
 	void _import_project();
-	void _new_project();
+	void _create_project(String project_name, String path, bool use_gles2);
 	void _rename_project();
-	void _erase_project();
+	void _erase_project_ask();
 	void _erase_missing_projects();
-	void _erase_project_confirm();
-	void _erase_missing_projects_confirm();
+	void _erase_project_confirmed();
+	void _erase_missing_projects_confirmed();
 	void _show_about();
 	void _update_project_buttons();
 	void _language_selected(int p_id);
-	void _restart_confirm();
+	void _restart_confirmed();
 	void _exit_dialog();
 	void _scan_begin(const String &p_base);
 	void _global_menu_action(const Variant &p_id, const Variant &p_meta);
@@ -107,12 +106,12 @@ class ProjectManager : public Control {
 	void _confirm_update_settings();
 
 	void _load_recent_projects();
-	void _on_project_created(const String &dir);
+	void _create_project_confirmed();
 	void _on_projects_updated();
 	void _update_scroll_position(const String &dir);
 	void _scan_dir(const String &path, List<String> *r_projects);
 
-	void _install_project(const String &p_zip_path, const String &p_title);
+	void _install_project_from_zip(const String &p_zip_path, const String &p_title);
 
 	void _dim_window();
 	void _unhandled_input(const Ref<InputEvent> &p_ev);
@@ -130,43 +129,6 @@ protected:
 public:
 	ProjectManager();
 	~ProjectManager();
-};
-
-class ProjectListFilter : public HBoxContainer {
-	GDCLASS(ProjectListFilter, HBoxContainer);
-
-public:
-	enum FilterOption {
-		FILTER_NAME,
-		FILTER_PATH,
-		FILTER_MODIFIED,
-	};
-
-private:
-	friend class ProjectManager;
-
-	OptionButton *filter_option;
-	LineEdit *search_box;
-	bool has_search_box;
-	FilterOption _current_filter;
-
-	void _search_text_changed(const String &p_newtext);
-	void _filter_option_selected(int p_idx);
-
-protected:
-	void _notification(int p_what);
-	static void _bind_methods();
-
-public:
-	void _setup_filters(Vector<String> options);
-	void add_filter_option();
-	void add_search_box();
-	void set_filter_size(int h_size);
-	String get_search_term();
-	FilterOption get_filter_option();
-	void set_filter_option(FilterOption);
-	ProjectListFilter();
-	void clear();
 };
 
 #endif // PROJECT_MANAGER_H


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
The goal of this PR **isn't** to change much of the functionality of the project manager, just to tidy up the code and make it more understandable.

[This was approved on rocket chat a couple of weeks ago.](https://chat.godotengine.org/channel/devel?msg=76depzs3oiDaHJdfm)

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/50304111/124525369-5257ad80-ddbc-11eb-8d35-d38b6c60400f.png)
</details>

The PR mostly consists of:
- Remove the massive and cluttered `ProjectDialog` and break it into smaller parts ([To each problem, its own solution](https://docs.godotengine.org/en/stable/community/contributing/best_practices_for_engine_contributors.html#to-each-problem-its-own-solution))
- Combine project manager's class's declarations and definitions when possible (less duplicated code) (only the project manager's declaration is in its header)
- Other minor readability improvements

Closes https://github.com/godotengine/godot-proposals/issues/2483

I'm opening this against 3.x since my computer doesn't support vulkan so I can't test these changes against 4.0. Once this PR is  ready and approved I can do my best to forward port it.