### PR TITLE
Importer collision fix

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -629,11 +629,11 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 							} break;
 							case MESH_PHYSICS_RIGID_BODY_AND_MESH: {
 								RigidBody3D *rigid_body = memnew(RigidBody3D);
+								rigid_body->set_transform(mi->get_transform());
 								rigid_body->set_name(p_node->get_name());
 								p_node->replace_by(rigid_body);
 								p_node->queue_delete();
 								p_node = rigid_body;
-								rigid_body->set_transform(mi->get_transform());
 								mi->set_transform(Transform3D());
 								rigid_body->add_child(mi);
 								mi->set_owner(rigid_body->get_owner());

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -425,7 +425,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<E
 			if (collision_map.has(mesh)) {
 				shapes = collision_map[mesh];
 			} else {
-				_gen_shape_list(mesh, shapes, true);
+				_pre_gen_shape_list(mesh, shapes, true);
 			}
 
 			RigidBody3D *rigid_body = memnew(RigidBody3D);
@@ -451,10 +451,10 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<E
 			if (collision_map.has(mesh)) {
 				shapes = collision_map[mesh];
 			} else if (_teststr(name, "col")) {
-				_gen_shape_list(mesh, shapes, false);
+				_pre_gen_shape_list(mesh, shapes, false);
 				collision_map[mesh] = shapes;
 			} else if (_teststr(name, "convcol")) {
-				_gen_shape_list(mesh, shapes, true);
+				_pre_gen_shape_list(mesh, shapes, true);
 				collision_map[mesh] = shapes;
 			}
 
@@ -624,6 +624,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 							case MESH_PHYSICS_MESH_AND_STATIC_COLLIDER: {
 								StaticBody3D *col = memnew(StaticBody3D);
 								p_node->add_child(col);
+								col->set_owner(mi->get_owner());
 								base = col;
 							} break;
 							case MESH_PHYSICS_RIGID_BODY_AND_MESH: {

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -631,8 +631,9 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 								RigidBody3D *rigid_body = memnew(RigidBody3D);
 								rigid_body->set_name(p_node->get_name());
 								p_node->replace_by(rigid_body);
-								rigid_body->set_transform(mi->get_transform());
+								p_node->queue_delete();
 								p_node = rigid_body;
+								rigid_body->set_transform(mi->get_transform());
 								mi->set_transform(Transform3D());
 								rigid_body->add_child(mi);
 								mi->set_owner(rigid_body->get_owner());
@@ -643,7 +644,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 								col->set_transform(mi->get_transform());
 								col->set_name(p_node->get_name());
 								p_node->replace_by(col);
-								memdelete(p_node);
+								p_node->queue_delete();
 								p_node = col;
 								base = col;
 							} break;
@@ -652,7 +653,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 								area->set_transform(mi->get_transform());
 								area->set_name(p_node->get_name());
 								p_node->replace_by(area);
-								memdelete(p_node);
+								p_node->queue_delete();
 								p_node = area;
 								base = area;
 


### PR DESCRIPTION
This is an alternative fix for the collision import options, and colliders not showing up when selecting 'Mesh + Static Collider' mentioned in #49752 (it does not however fix the rigid body scaling issue since that seems to be a limitation of the physics engine itself, not the importer). It also fixes the -col and -rigid suffixes mentioned #48945. Although it's mentioned that this might be deprecated, as it stands, the functionality is still intact (it works with -colonly for example), it was simply broken due to using _gen_shape_list rather than _pre_gen_shape_list. Even if it's to be deprecated, it may at least be worth fixing for now since, as pointed out, the usability of setting up collision with the new import menu is still lacking somewhat.

*Bugsquad edit:* Fixes #49752. Fixes #48945.