### PR TITLE
Fix indexing of multiple reflection probes

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -709,6 +709,10 @@ bool RendererSceneRenderRD::reflection_probe_instance_begin_render(RID p_instanc
 		}
 	}
 
+	if (rpi->atlas_index != -1) { // should we fail if this is still -1 ?
+		atlas->reflections.write[rpi->atlas_index].owner = p_instance;
+	}
+
 	rpi->atlas = p_reflection_atlas;
 	rpi->rendering = true;
 	rpi->dirty = false;


### PR DESCRIPTION
The code that found a free slot in the reflection probe atlas for an active probe wasn't marking the slot as owned resulting in every reflection probe using the same entry and the last one "winning". 
