### PR TITLE
LineEdit: Respect `max_length` by truncating text to append

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -196,6 +196,28 @@
 		</member>
 		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length" default="0">
 			Maximum amount of characters that can be entered inside the [LineEdit]. If [code]0[/code], there is no limit.
+			When a limit is defined, characters that would exceed [member max_length] are truncated. This happens both for existing [member text] contents when setting the max length, or for new text inserted in the [LineEdit], including pasting. If any input text is truncated, the [signal text_change_rejected] signal is emitted with the truncated substring as parameter.
+			[b]Example:[/b]
+			[codeblocks]
+			[gdscript]
+			text = "Hello world"
+			max_length = 5
+			# `text` becomes "Hello".
+			max_length = 10
+			text += " goodbye"
+			# `text` becomes "Hello good".
+			# `text_change_rejected` is emitted with "bye" as parameter.
+			[/gdscript]
+			[csharp]
+			Text = "Hello world";
+			MaxLength = 5;
+			// `Text` becomes "Hello".
+			MaxLength = 10;
+			Text += " goodbye";
+			// `Text` becomes "Hello good".
+			// `text_change_rejected` is emitted with "bye" as parameter.
+			[/csharp]
+			[/codeblocks]
 		</member>
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
 		<member name="placeholder_alpha" type="float" setter="set_placeholder_alpha" getter="get_placeholder_alpha" default="0.6">
@@ -238,8 +260,10 @@
 	</members>
 	<signals>
 		<signal name="text_change_rejected">
+			<argument index="0" name="rejected_substring" type="String">
+			</argument>
 			<description>
-				Emitted when trying to append text that would overflow the [member max_length].
+				Emitted when appending text that overflows the [member max_length]. The appended text is truncated to fit [member max_length], and the part that couldn't fit is passed as the [code]rejected_substring[/code] argument.
 			</description>
 		</signal>
 		<signal name="text_changed">

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4008,14 +4008,6 @@ bool TextEdit::is_wrap_enabled() const {
 	return wrap_enabled;
 }
 
-void TextEdit::set_max_chars(int p_max_chars) {
-	max_chars = p_max_chars;
-}
-
-int TextEdit::get_max_chars() const {
-	return max_chars;
-}
-
 void TextEdit::_reset_caret_blink_timer() {
 	if (caret_blink_enabled) {
 		draw_caret = true;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -258,7 +258,6 @@ private:
 	uint32_t version = 0;
 	uint32_t saved_version = 0;
 
-	int max_chars = 0;
 	bool readonly = true; // Initialise to opposite first, so we get past the early-out in set_readonly.
 
 	Timer *caret_blink_timer;
@@ -677,9 +676,6 @@ public:
 
 	void set_readonly(bool p_readonly);
 	bool is_readonly() const;
-
-	void set_max_chars(int p_max_chars);
-	int get_max_chars() const;
 
 	void set_wrap_enabled(bool p_wrap_enabled);
 	bool is_wrap_enabled() const;


### PR DESCRIPTION
When appending text (either via `set_text()` or by pasting from clipboard),
if the input would make the `LineEdit` exceed its configured `max_length`,
the input text is truncated to fit. The discard part is passed as a parameter
in the `text_change_rejected` signal.

Fixes #33321.
Fixes #41278.
Supersedes #41744.

Also cleaned up unimplemented `max_chars` property in `TextEdit`.

Co-authored-by: @Tony-Goat

---

Draft as there are a few questions and issues to address:

- Editing a LineEdit's `text` in the Inspector is broken with `max_length` defined, once you reach the max length the cursor jumps to start on each new keystroke.
- For the `text_change_rejected` signal, I hesitated between removing it, emitting and adding the rejected text as argument (this PR), or emitting and adding both the original append string + the rejected substring as arguments. Feedback welcome.