### PR TITLE
Add AcceptDialog::remove_button method

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -21,6 +21,7 @@
 			<description>
 				Adds a button with label [code]text[/code] and a custom [code]action[/code] to the dialog and returns the created button. [code]action[/code] will be passed to the [signal custom_action] signal when pressed.
 				If [code]true[/code], [code]right[/code] will place the button to the right of any sibling buttons.
+				You can use [method remove_button] method to remove a button created with this method from the dialog.
 			</description>
 		</method>
 		<method name="add_cancel_button">
@@ -30,6 +31,7 @@
 			</argument>
 			<description>
 				Adds a button with label [code]name[/code] and a cancel action to the dialog and returns the created button.
+				You can use [method remove_button] method to remove a button created with this method from the dialog.
 			</description>
 		</method>
 		<method name="get_label">
@@ -53,6 +55,15 @@
 			</argument>
 			<description>
 				Registers a [LineEdit] in the dialog. When the enter key is pressed, the dialog will be accepted.
+			</description>
+		</method>
+		<method name="remove_button">
+			<return type="void">
+			</return>
+			<argument index="0" name="button" type="Control">
+			</argument>
+			<description>
+				Removes the [code]button[/code] from the dialog. Does NOT free the [code]button[/code]. The [code]button[/code] must be a [Button] added with [method add_button] or [method add_cancel_button] method. After removal, pressing the [code]button[/code] will no longer emit this dialog's [signal custom_action] or [signal cancelled] signals.
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -263,6 +263,28 @@ Button *AcceptDialog::add_cancel_button(const String &p_cancel) {
 	return b;
 }
 
+void AcceptDialog::remove_button(Control *p_button) {
+	Button *button = Object::cast_to<Button>(p_button);
+	ERR_FAIL_NULL(button);
+	ERR_FAIL_COND_MSG(button->get_parent() != hbc, vformat("Cannot remove button %s as it does not belong to this dialog.", button->get_name()));
+	ERR_FAIL_COND_MSG(button == ok, "Cannot remove dialog's OK button.");
+
+	Node *right_spacer = hbc->get_child(button->get_index() + 1);
+	// Should always be valid but let's avoid crashing
+	if (right_spacer) {
+		hbc->remove_child(right_spacer);
+		memdelete(right_spacer);
+	}
+	hbc->remove_child(button);
+
+	if (button->is_connected("pressed", callable_mp(this, &AcceptDialog::_custom_action))) {
+		button->disconnect("pressed", callable_mp(this, &AcceptDialog::_custom_action));
+	}
+	if (button->is_connected("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed))) {
+		button->disconnect("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed));
+	}
+}
+
 void AcceptDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_ok_button"), &AcceptDialog::get_ok_button);
 	ClassDB::bind_method(D_METHOD("get_label"), &AcceptDialog::get_label);
@@ -270,6 +292,7 @@ void AcceptDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_hide_on_ok"), &AcceptDialog::get_hide_on_ok);
 	ClassDB::bind_method(D_METHOD("add_button", "text", "right", "action"), &AcceptDialog::add_button, DEFVAL(false), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("add_cancel_button", "name"), &AcceptDialog::add_cancel_button);
+	ClassDB::bind_method(D_METHOD("remove_button", "button"), &AcceptDialog::remove_button);
 	ClassDB::bind_method(D_METHOD("register_text_enter", "line_edit"), &AcceptDialog::register_text_enter);
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &AcceptDialog::set_text);
 	ClassDB::bind_method(D_METHOD("get_text"), &AcceptDialog::get_text);

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -82,6 +82,7 @@ public:
 	Button *get_ok_button() { return ok; }
 	Button *add_button(const String &p_text, bool p_right = false, const String &p_action = "");
 	Button *add_cancel_button(const String &p_cancel = "");
+	void remove_button(Control *p_button);
 
 	void set_hide_on_ok(bool p_hide);
 	bool get_hide_on_ok() const;


### PR DESCRIPTION
Add `AcceptDialog::remove_button` method which allows to remove a `Button` added with `AcceptDialog::add_button` or `AcceptDialog::add_cancel_button` method.
Doesn't allow to remove `OK` button.
Doesn't prevent removing `Cancel` button not added by the user, e.g. from the `ConfirmationDialog` (which derives from `AcceptDialog`) which could break things up. However, currently user can manually remove such button anyway so it shouldn't be an issue.

Fixes #50192.