### PR TITLE
Format node configuration warnings as a bullet point list

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2493,7 +2493,9 @@ String Node::get_configuration_warnings_as_string() const {
 		if (i > 0) {
 			all_warnings += "\n\n";
 		}
-		all_warnings += String(warnings[i]);
+		// Format as a bullet point list to make multiple warnings easier to distinguish
+		// from each other.
+		all_warnings += String::utf8("•  ") + String(warnings[i]);
 	}
 	return all_warnings;
 }


### PR DESCRIPTION
This makes multiple warnings easier to distinguish from each other, which helps a lot in cases like https://github.com/godotengine/godot/pull/50214.

It would be nice to figure out a way to add spacing to subsequent lines for multiline warnings, but I'm not sure how to go about it.

## Preview

### Dialog

![image](https://user-images.githubusercontent.com/180032/124643717-b0a29000-de91-11eb-818e-c8c11efebaee.png)

### Tooltip

![image](https://user-images.githubusercontent.com/180032/124643579-894bc300-de91-11eb-8914-b0c9af3c64bc.png)
