### PR TITLE
Queue the calls to GodotLib.key when Android virtual done is pressed

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
@@ -144,9 +144,10 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 
 		if (pActionID == EditorInfo.IME_ACTION_DONE) {
 			// Enter key has been pressed
-			GodotLib.key(KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_ENTER, 0, true);
-			GodotLib.key(KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_ENTER, 0, false);
-
+			mRenderView.queueOnRenderThread(() -> {
+				GodotLib.key(KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_ENTER, 0, true);
+				GodotLib.key(KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_ENTER, 0, false);
+			});
 			mRenderView.getView().requestFocus();
 			return true;
 		}


### PR DESCRIPTION
Currently, when the Android virtual keyboard done (or enter) key is pressed, the action is not queued for sending back to Godot. Not only does this run the risk of hanging the thread, but it also results in enter events being sent to Godot before all the other key events have been processed.

This PR properly queues the done events the same way all the other events are queued. This ensures:
1. They run on the correct thread
2. Godot events are processed in the correct order.

Closes #50125. Specifically, it fixes the issue of the entire word not been retyped before the `text_entered` signal is sent. It does not fix the issue of the entire word being retyped, because this is an Android issue, not a Godot issue.
