### PR TITLE
Use the Unicode multiplication symbol for the viewport size display

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2511,15 +2511,15 @@ void Node3DEditorViewport::_notification(int p_what) {
 		}
 
 		if (show_info) {
+			const String viewport_size = vformat(String::utf8("%d × %d"), viewport->get_size().x, viewport->get_size().y);
 			String text;
 			text += vformat(TTR("X: %s\n"), rtos(current_camera->get_position().x).pad_decimals(1));
 			text += vformat(TTR("Y: %s\n"), rtos(current_camera->get_position().y).pad_decimals(1));
 			text += vformat(TTR("Z: %s\n"), rtos(current_camera->get_position().z).pad_decimals(1));
 			text += "\n";
 			text += vformat(
-					TTR("Size: %dx%d (%.1fMP)\n"),
-					viewport->get_size().x,
-					viewport->get_size().y,
+					TTR("Size: %s (%.1fMP)\n"),
+					viewport_size,
 					viewport->get_size().x * viewport->get_size().y * 0.000001);
 
 			text += "\n";


### PR DESCRIPTION
I didn't add this to https://github.com/godotengine/godot/pull/45596 because I forgot about `String::utf8()` back then.

## Preview

![image](https://user-images.githubusercontent.com/180032/124658898-a1790d80-dea4-11eb-9309-aabd2b4f1907.png)