### PR TITLE
Use the Unicode multiplication symbol for the viewport size display (3.x)

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2456,6 +2456,7 @@ void SpatialEditorViewport::_notification(int p_what) {
 		}
 
 		if (show_info) {
+			const String viewport_size = vformat(String::utf8("%d × %d"), viewport->get_size().x, viewport->get_size().y);
 			String text;
 			text += "X: " + rtos(current_camera->get_translation().x).pad_decimals(1) + "\n";
 			text += "Y: " + rtos(current_camera->get_translation().y).pad_decimals(1) + "\n";
@@ -2465,9 +2466,8 @@ void SpatialEditorViewport::_notification(int p_what) {
 
 			text += TTR("Size") +
 					vformat(
-							": %dx%d (%.1fMP)\n",
-							viewport->get_size().x,
-							viewport->get_size().y,
+							": %s (%.1fMP)\n",
+							viewport_size,
 							viewport->get_size().x * viewport->get_size().y * 0.000'001);
 			text += TTR("Objects Drawn") + ": " + itos(viewport->get_render_info(Viewport::RENDER_INFO_OBJECTS_IN_FRAME)) + "\n";
 			text += TTR("Material Changes") + ": " + itos(viewport->get_render_info(Viewport::RENDER_INFO_MATERIAL_CHANGES_IN_FRAME)) + "\n";


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50222.

## Preview

![image](https://user-images.githubusercontent.com/180032/124659647-7a6f0b80-dea5-11eb-8ca2-1bf6757d8a07.png)
