### PR TITLE
Fix warning message spam when a VoxelGI node is selected in the editor

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1430,8 +1430,6 @@
 		</member>
 		<member name="rendering/global_illumination/sdfgi/probe_ray_count" type="int" setter="" getter="" default="1">
 		</member>
-		<member name="rendering/global_illumination/voxel_gi/anisotropic" type="bool" setter="" getter="" default="false">
-		</member>
 		<member name="rendering/global_illumination/voxel_gi/quality" type="int" setter="" getter="" default="1">
 		</member>
 		<member name="rendering/lightmapping/bake_performance/max_rays_per_pass" type="int" setter="" getter="" default="32">

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -69,10 +69,7 @@ void VoxelGIEditorPlugin::_notification(int p_what) {
 
 		const Vector3i size = voxel_gi->get_estimated_cell_size();
 		String text = vformat(String::utf8("%d × %d × %d"), size.x, size.y, size.z);
-		int data_size = 4;
-		if (GLOBAL_GET("rendering/quality/voxel_gi/anisotropic")) {
-			data_size += 4;
-		}
+		const int data_size = 4;
 		const double size_mb = size.x * size.y * size.z * data_size / (1024.0 * 1024.0);
 		text += " - " + vformat(TTR("VRAM Size: %s MB"), String::num(size_mb, 2));
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2772,7 +2772,6 @@ RenderingServer::RenderingServer() {
 
 	GLOBAL_DEF("rendering/global_illumination/gi/use_half_resolution", false);
 
-	GLOBAL_DEF("rendering/global_illumination/voxel_gi/anisotropic", false);
 	GLOBAL_DEF("rendering/global_illumination/voxel_gi/quality", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/global_illumination/voxel_gi/quality", PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/quality", PROPERTY_HINT_ENUM, "Low (4 Cones - Fast),High (6 Cones - Slow)"));
 


### PR DESCRIPTION
The following message was printed to the console every frame when a VoxelGI node was selected in the editor:

```
WARNING: Property not found: rendering/quality/voxel_gi/anisotropic
```

Support for anisotropy in VoxelGI was removed during its development in `master` due to the high rendering cost. This project setting was a leftover from anisotropy support.