### PR TITLE
Android: Fix truncated `application` attributes after #50028 cherry-pick

### DIFF
--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -264,11 +264,11 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_
 	String manifest_application_text = vformat(
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
 			"        android:allowBackup=\"%s\"\n"
-			"        android:icon=\"@mipmap/icon\"\n"
 			"        android:isGame=\"%s\"\n"
 			"        android:requestLegacyExternalStorage=\"%s\"\n"
 			"        tools:replace=\"android:allowBackup,android:isGame,android:requestLegacyExternalStorage\"\n"
-			"        tools:ignore=\"GoogleAppIndexingWarning\">\n\n"
+			"        tools:ignore=\"GoogleAppIndexingWarning\"\n"
+			"        android:icon=\"@mipmap/icon\" >\n\n"
 			"        <meta-data tools:node=\"remove\" android:name=\"xr_mode_metadata_name\" />\n",
 			bool_to_string(p_preset->get("user_data_backup/allow")),
 			bool_to_string(p_preset->get("package/classify_as_game")),

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -28,7 +28,7 @@
     <!-- If you want to add tags manually, do before it. -->
     <!-- WARNING: This should stay on a single line until the parsing code is improved. See GH-32414. -->
     <!-- TODO: Remove the 'requestLegacyExternalStorage' attribute when https://github.com/godotengine/godot/issues/38913 is resolved -->
-    <application android:label="@string/godot_project_name_string" android:allowBackup="false" android:icon="@mipmap/icon" android:isGame="true" android:requestLegacyExternalStorage="false" tools:ignore="GoogleAppIndexingWarning" >
+    <application android:label="@string/godot_project_name_string" android:allowBackup="false" android:isGame="true" android:requestLegacyExternalStorage="false" tools:ignore="GoogleAppIndexingWarning" android:icon="@mipmap/icon" >
 
         <!-- Records the version of the Godot editor used for building -->
         <meta-data


### PR DESCRIPTION
The `android:icon` attribute is expected to be the last one in the application
definition, as documented by the comment. cd64bcd missed that and caused some
arguments to be truncated.

Fixes #50224.