### PR TITLE
Fix concave collision with backface collision disabled

### DIFF
--- a/servers/physics_3d/collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/collision_solver_3d_sat.cpp
@@ -1024,7 +1024,7 @@ static void _collision_sphere_face(const Shape3DSW *p_a, const Transform3D &p_tr
 			n1 *= -1.0;
 		}
 
-		if (!separator.test_axis(n1.normalized(), !face_B->backface_collision)) {
+		if (!separator.test_axis(n1.normalized())) {
 			return;
 		}
 
@@ -1035,7 +1035,7 @@ static void _collision_sphere_face(const Shape3DSW *p_a, const Transform3D &p_tr
 			axis *= -1.0;
 		}
 
-		if (!separator.test_axis(axis, !face_B->backface_collision)) {
+		if (!separator.test_axis(axis)) {
 			return;
 		}
 	}
@@ -1493,7 +1493,7 @@ static void _collision_box_face(const Shape3DSW *p_a, const Transform3D &p_trans
 			axis *= -1.0;
 		}
 
-		if (!separator.test_axis(axis, !face_B->backface_collision)) {
+		if (!separator.test_axis(axis)) {
 			return;
 		}
 	}
@@ -1509,7 +1509,7 @@ static void _collision_box_face(const Shape3DSW *p_a, const Transform3D &p_trans
 				axis *= -1.0;
 			}
 
-			if (!separator.test_axis(axis, !face_B->backface_collision)) {
+			if (!separator.test_axis(axis)) {
 				return;
 			}
 		}
@@ -1533,7 +1533,7 @@ static void _collision_box_face(const Shape3DSW *p_a, const Transform3D &p_trans
 				axis_ab *= -1.0;
 			}
 
-			if (!separator.test_axis(axis_ab.normalized(), !face_B->backface_collision)) {
+			if (!separator.test_axis(axis_ab.normalized())) {
 				return;
 			}
 
@@ -1548,7 +1548,7 @@ static void _collision_box_face(const Shape3DSW *p_a, const Transform3D &p_trans
 					axis *= -1.0;
 				}
 
-				if (!separator.test_axis(axis, !face_B->backface_collision)) {
+				if (!separator.test_axis(axis)) {
 					return;
 				}
 			}
@@ -1578,7 +1578,7 @@ static void _collision_box_face(const Shape3DSW *p_a, const Transform3D &p_trans
 							axis *= -1.0;
 						}
 
-						if (!separator.test_axis(axis, !face_B->backface_collision)) {
+						if (!separator.test_axis(axis)) {
 							return;
 						}
 					}
@@ -1812,7 +1812,7 @@ static void _collision_capsule_face(const Shape3DSW *p_a, const Transform3D &p_t
 			axis *= -1.0;
 		}
 
-		if (!separator.test_axis(axis, !face_B->backface_collision)) {
+		if (!separator.test_axis(axis)) {
 			return;
 		}
 
@@ -1821,7 +1821,7 @@ static void _collision_capsule_face(const Shape3DSW *p_a, const Transform3D &p_t
 			dir_axis *= -1.0;
 		}
 
-		if (!separator.test_axis(dir_axis, !face_B->backface_collision)) {
+		if (!separator.test_axis(dir_axis)) {
 			return;
 		}
 
@@ -1834,7 +1834,7 @@ static void _collision_capsule_face(const Shape3DSW *p_a, const Transform3D &p_t
 				n1 *= -1.0;
 			}
 
-			if (!separator.test_axis(n1.normalized(), !face_B->backface_collision)) {
+			if (!separator.test_axis(n1.normalized())) {
 				return;
 			}
 
@@ -1845,7 +1845,7 @@ static void _collision_capsule_face(const Shape3DSW *p_a, const Transform3D &p_t
 				axis *= -1.0;
 			}
 
-			if (!separator.test_axis(axis.normalized(), !face_B->backface_collision)) {
+			if (!separator.test_axis(axis.normalized())) {
 				return;
 			}
 		}
@@ -1955,7 +1955,7 @@ static void _collision_cylinder_face(const Shape3DSW *p_a, const Transform3D &p_
 	}
 
 	// Cylinder end caps.
-	if (!separator.test_axis(cyl_axis, !face_B->backface_collision)) {
+	if (!separator.test_axis(cyl_axis)) {
 		return;
 	}
 
@@ -1971,7 +1971,7 @@ static void _collision_cylinder_face(const Shape3DSW *p_a, const Transform3D &p_
 			axis *= -1.0;
 		}
 
-		if (!separator.test_axis(axis.normalized(), !face_B->backface_collision)) {
+		if (!separator.test_axis(axis.normalized())) {
 			return;
 		}
 	}
@@ -1984,7 +1984,7 @@ static void _collision_cylinder_face(const Shape3DSW *p_a, const Transform3D &p_
 			axis *= -1.0;
 		}
 
-		if (!separator.test_axis(axis, !face_B->backface_collision)) {
+		if (!separator.test_axis(axis)) {
 			return;
 		}
 	}
@@ -2021,7 +2021,7 @@ static void _collision_cylinder_face(const Shape3DSW *p_a, const Transform3D &p_
 				axis *= -1.0;
 			}
 
-			if (!separator.test_axis(axis.normalized(), !face_B->backface_collision)) {
+			if (!separator.test_axis(axis.normalized())) {
 				return;
 			}
 		}
@@ -2175,7 +2175,7 @@ static void _collision_convex_polygon_face(const Shape3DSW *p_a, const Transform
 			axis *= -1.0;
 		}
 
-		if (!separator.test_axis(axis, !face_B->backface_collision)) {
+		if (!separator.test_axis(axis)) {
 			return;
 		}
 	}
@@ -2192,7 +2192,7 @@ static void _collision_convex_polygon_face(const Shape3DSW *p_a, const Transform
 				axis *= -1.0;
 			}
 
-			if (!separator.test_axis(axis, !face_B->backface_collision)) {
+			if (!separator.test_axis(axis)) {
 				return;
 			}
 		}
@@ -2209,7 +2209,7 @@ static void _collision_convex_polygon_face(const Shape3DSW *p_a, const Transform
 					axis *= -1.0;
 				}
 
-				if (!separator.test_axis(axis, !face_B->backface_collision)) {
+				if (!separator.test_axis(axis)) {
 					return;
 				}
 			}
@@ -2229,7 +2229,7 @@ static void _collision_convex_polygon_face(const Shape3DSW *p_a, const Transform
 					axis *= -1.0;
 				}
 
-				if (!separator.test_axis(axis, !face_B->backface_collision)) {
+				if (!separator.test_axis(axis)) {
 					return;
 				}
 			}
@@ -2248,7 +2248,7 @@ static void _collision_convex_polygon_face(const Shape3DSW *p_a, const Transform
 					axis *= -1.0;
 				}
 
-				if (!separator.test_axis(axis, !face_B->backface_collision)) {
+				if (!separator.test_axis(axis)) {
 					return;
 				}
 			}


### PR DESCRIPTION
Disabled backface collision is only applied on face separation axes, because applying it also on edges and vertices was causing some contacts to be wrongly disabled and contact points to be off.

Fixes #50218 (regression from #47139)
