### PR TITLE
[HTML5] Fix JavaScript string parsing with new interface.

### DIFF
--- a/platform/javascript/javascript_singleton.cpp
+++ b/platform/javascript/javascript_singleton.cpp
@@ -183,7 +183,7 @@ Variant JavaScriptObjectImpl::_js2variant(int p_type, godot_js_wrapper_ex *p_val
 		case Variant::FLOAT:
 			return p_val->r;
 		case Variant::STRING: {
-			String out((const char *)p_val->p);
+			String out = String::utf8((const char *)p_val->p);
 			free(p_val->p);
 			return out;
 		}


### PR DESCRIPTION
Strings are UTF-8 encoded and should be parsed as such, while it was being parsed as a C string before.

Thanks to @uuuuuup for the fix.
Fixes #50238