### PR TITLE
SCons: Show elapsed time after build or cleaning process

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4,10 +4,12 @@ EnsureSConsVersion(3, 0, 0)
 EnsurePythonVersion(3, 5)
 
 # System
+import atexit
 import glob
 import os
 import pickle
 import sys
+import time
 from collections import OrderedDict
 
 # Local
@@ -24,6 +26,8 @@ active_platforms = []
 active_platform_ids = []
 platform_exporters = []
 platform_apis = []
+
+time_at_start = time.time()
 
 for x in sorted(glob.glob("platform/*")):
     if not os.path.isdir(x) or not os.path.exists(x + "/detect.py"):
@@ -748,3 +752,12 @@ if "env" in locals():
     # TODO: replace this with `env.Dump(format="json")`
     # once we start requiring SCons 4.0 as min version.
     methods.dump(env)
+
+
+def print_elapsed_time():
+    elapsed_time_sec = round(time.time() - time_at_start, 3)
+    time_ms = round((elapsed_time_sec % 1) * 1000)
+    print(f"[Time elapsed: {time.strftime('%H:%M:%S', time.gmtime(elapsed_time_sec))}.{time_ms:03}]")
+
+
+atexit.register(print_elapsed_time)


### PR DESCRIPTION
This PR adds the following little build system enhancement:
- Info print after scons finishes to give some information about how long the build process took, which may be useful for contributors working with IDEs or editors which do not show such info/parsing build time
(format: `HH:MM:SS.mmm`)

![grafik](https://user-images.githubusercontent.com/50084500/124912737-98945300-dfee-11eb-9832-a6524230e1e2.png)
