### PR TITLE
Add a method to set the number of physics solver iterations in 3D

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -1024,7 +1024,7 @@
 			<argument index="0" name="iterations" type="int">
 			</argument>
 			<description>
-				Sets the amount of iterations for calculating velocities of colliding bodies. The greater the amount, the more accurate the collisions, but with a performance loss.
+				Sets the amount of iterations for calculating velocities of colliding bodies. The greater the amount of iterations, the more accurate the collisions will be. However, a greater amount of iterations requires more CPU power, which can decrease performance. The default value is [code]8[/code].
 			</description>
 		</method>
 		<method name="shape_get_data" qualifiers="const">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1187,6 +1187,16 @@
 				Activates or deactivates the 3D physics engine.
 			</description>
 		</method>
+		<method name="set_collision_iterations">
+			<return type="void">
+			</return>
+			<argument index="0" name="iterations" type="int">
+			</argument>
+			<description>
+				Sets the amount of iterations for calculating velocities of colliding bodies. The greater the amount of iterations, the more accurate the collisions will be. However, a greater amount of iterations requires more CPU power, which can decrease performance. The default value is [code]8[/code].
+				[b]Note:[/b] Only has an effect when using the default GodotPhysics engine, not the Bullet physics engine.
+			</description>
+		</method>
 		<method name="shape_get_data" qualifiers="const">
 			<return type="Variant">
 			</return>

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -1584,6 +1584,10 @@ void PhysicsServer3DSW::set_active(bool p_active) {
 	active = p_active;
 };
 
+void PhysicsServer3DSW::set_collision_iterations(int p_iterations) {
+	iterations = p_iterations;
+};
+
 void PhysicsServer3DSW::init() {
 	last_step = 0.001;
 	iterations = 8; // 8?

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -367,6 +367,8 @@ public:
 	virtual void end_sync() override;
 	virtual void finish() override;
 
+	virtual void set_collision_iterations(int p_iterations) override;
+
 	virtual bool is_flushing_queries() const override { return flushing_queries; }
 
 	int get_process_info(ProcessInfo p_info) override;

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -377,6 +377,7 @@ public:
 
 	FUNC1(free, RID);
 	FUNC1(set_active, bool);
+	FUNC1(set_collision_iterations, int);
 
 	virtual void init() override;
 	virtual void step(real_t p_step) override;

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -564,7 +564,7 @@ public:
 
 	virtual bool is_flushing_queries() const = 0;
 
-	virtual void set_collision_iterations(int iterations) = 0;
+	virtual void set_collision_iterations(int p_iterations) = 0;
 
 	enum ProcessInfo {
 		INFO_ACTIVE_OBJECTS,

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -740,6 +740,8 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &PhysicsServer3D::set_active);
 
+	ClassDB::bind_method(D_METHOD("set_collision_iterations", "iterations"), &PhysicsServer3D::set_collision_iterations);
+
 	ClassDB::bind_method(D_METHOD("get_process_info", "process_info"), &PhysicsServer3D::get_process_info);
 
 	BIND_ENUM_CONSTANT(SHAPE_PLANE);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -740,6 +740,8 @@ public:
 
 	virtual bool is_flushing_queries() const = 0;
 
+	virtual void set_collision_iterations(int p_iterations) = 0;
+
 	enum ProcessInfo {
 		INFO_ACTIVE_OBJECTS,
 		INFO_COLLISION_PAIRS,


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/50257.

This is only for GodotPhysics, and adds a 3D counterpart to the [2D method that was recently added](https://github.com/godotengine/godot/pull/48827).

I can't see much difference (if any) when setting the number of iterations to 64 – can anyone confirm that it's working as intended? In the testing project, neither tunneling nor visible depenetration is prevented by increasing the number of iterations from 8 to 64.

This closes https://github.com/godotengine/godot-proposals/issues/204.

**Testing project:** [3d_physics_iteration.zip](https://github.com/godotengine/godot/files/6778958/3d_physics_iteration.zip) (`master` only)