### PR TITLE
Add a method to set the number of physics solver iterations in 3D (3.x)

### DIFF
--- a/doc/classes/Physics2DServer.xml
+++ b/doc/classes/Physics2DServer.xml
@@ -1009,7 +1009,7 @@
 			<argument index="0" name="iterations" type="int">
 			</argument>
 			<description>
-				Sets the amount of iterations for calculating velocities of colliding bodies. The greater the amount, the more accurate the collisions, but with a performance loss.
+				Sets the amount of iterations for calculating velocities of colliding bodies. The greater the amount of iterations, the more accurate the collisions will be. However, a greater amount of iterations requires more CPU power, which can decrease performance. The default value is [code]8[/code].
 			</description>
 		</method>
 		<method name="shape_get_data" qualifiers="const">

--- a/doc/classes/PhysicsServer.xml
+++ b/doc/classes/PhysicsServer.xml
@@ -1155,6 +1155,16 @@
 				Activates or deactivates the 3D physics engine.
 			</description>
 		</method>
+		<method name="set_collision_iterations">
+			<return type="void">
+			</return>
+			<argument index="0" name="iterations" type="int">
+			</argument>
+			<description>
+				Sets the amount of iterations for calculating velocities of colliding bodies. The greater the amount of iterations, the more accurate the collisions will be. However, a greater amount of iterations requires more CPU power, which can decrease performance. The default value is [code]8[/code].
+				[b]Note:[/b] Only has an effect when using the GodotPhysics engine, not the default Bullet physics engine.
+			</description>
+		</method>
 		<method name="shape_create">
 			<return type="RID">
 			</return>

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -1546,6 +1546,10 @@ void BulletPhysicsServer::finish() {
 	BulletPhysicsDirectBodyState::destroySingleton();
 }
 
+void BulletPhysicsServer::set_collision_iterations(int p_iterations) {
+	WARN_PRINT("Changing the number of 3D physics collision iterations is only supported when using GodotPhysics, not Bullet.");
+}
+
 int BulletPhysicsServer::get_process_info(ProcessInfo p_info) {
 	return 0;
 }

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -398,6 +398,8 @@ public:
 
 	virtual bool is_flushing_queries() const { return false; }
 
+	virtual void set_collision_iterations(int p_iterations);
+
 	virtual int get_process_info(ProcessInfo p_info);
 
 	CollisionObjectBullet *get_collisin_object(RID p_object) const;

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -1274,6 +1274,10 @@ void PhysicsServerSW::set_active(bool p_active) {
 	active = p_active;
 };
 
+void PhysicsServerSW::set_collision_iterations(int p_iterations) {
+	iterations = p_iterations;
+};
+
 void PhysicsServerSW::init() {
 	last_step = 0.001;
 	iterations = 8; // 8?

--- a/servers/physics/physics_server_sw.h
+++ b/servers/physics/physics_server_sw.h
@@ -363,6 +363,8 @@ public:
 	virtual void flush_queries();
 	virtual void finish();
 
+	virtual void set_collision_iterations(int p_iterations);
+
 	virtual bool is_flushing_queries() const { return flushing_queries; }
 
 	int get_process_info(ProcessInfo p_info);

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -555,7 +555,7 @@ public:
 
 	virtual bool is_flushing_queries() const = 0;
 
-	virtual void set_collision_iterations(int iterations) = 0;
+	virtual void set_collision_iterations(int p_iterations) = 0;
 
 	enum ProcessInfo {
 

--- a/servers/physics_server.cpp
+++ b/servers/physics_server.cpp
@@ -671,6 +671,8 @@ void PhysicsServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &PhysicsServer::set_active);
 
+	ClassDB::bind_method(D_METHOD("set_collision_iterations", "iterations"), &PhysicsServer::set_collision_iterations);
+
 	ClassDB::bind_method(D_METHOD("get_process_info", "process_info"), &PhysicsServer::get_process_info);
 
 	BIND_ENUM_CONSTANT(SHAPE_PLANE);

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -726,6 +726,8 @@ public:
 
 	virtual bool is_flushing_queries() const = 0;
 
+	virtual void set_collision_iterations(int p_iterations) = 0;
+
 	enum ProcessInfo {
 
 		INFO_ACTIVE_OBJECTS,


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50255.

This is only for GodotPhysics, and adds a 3D counterpart to the 2D method that was recently added.

This PR doesn't change the `physics_server_wrap_mt.h` file because there is no such file in `3.x`.