### PR TITLE
Add cache to ColorPicker for color presets

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -40,6 +40,8 @@
 #endif
 #include "scene/main/window.h"
 
+List<Color> ColorPicker::preset_cache;
+
 void ColorPicker::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
@@ -57,11 +59,17 @@ void ColorPicker::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 			if (Engine::get_singleton()->is_editor_hint()) {
-				PackedColorArray saved_presets = EditorSettings::get_singleton()->get_project_metadata("color_picker", "presets", PackedColorArray());
-
-				for (int i = 0; i < saved_presets.size(); i++) {
-					add_preset(saved_presets[i]);
+				if (preset_cache.is_empty()) {
+					PackedColorArray saved_presets = EditorSettings::get_singleton()->get_project_metadata("color_picker", "presets", PackedColorArray());
+					for (int i = 0; i < saved_presets.size(); i++) {
+						preset_cache.push_back(saved_presets[i]);
+					}
 				}
+
+				for (int i = 0; i < preset_cache.size(); i++) {
+					presets.push_back(preset_cache[i]);
+				}
+				preset->update();
 			}
 #endif
 		} break;
@@ -413,6 +421,7 @@ void ColorPicker::add_preset(const Color &p_color) {
 		presets.move_to_back(presets.find(p_color));
 	} else {
 		presets.push_back(p_color);
+		preset_cache.push_back(p_color);
 	}
 	preset->update();
 
@@ -427,6 +436,7 @@ void ColorPicker::add_preset(const Color &p_color) {
 void ColorPicker::erase_preset(const Color &p_color) {
 	if (presets.find(p_color)) {
 		presets.erase(presets.find(p_color));
+		preset_cache.erase(preset_cache.find(p_color));
 		preset->update();
 
 #ifdef TOOLS_ENABLED

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -58,6 +58,7 @@ public:
 private:
 	static Ref<Shader> wheel_shader;
 	static Ref<Shader> circle_shader;
+	static List<Color> preset_cache;
 
 	Control *screen = nullptr;
 	Control *uv_edit = memnew(Control);


### PR DESCRIPTION
This adds a static cache to the ColorPicker to prevent loading from metadata more than once per opening a project. Currently, metadata is loaded every time a node that has a ColorPicker is opened in the editor.

Can make a 3.x version if this gets approved (which would use `PoolColorArray`, but that'd be the only change required.)

Fixes #50258 