### PR TITLE
Fix node list with Add Node Here

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -359,7 +359,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			if (reset_create_dialog) {
+			if (reset_create_dialog && !p_confirm_override) {
 				create_dialog->set_base_type("Node");
 				reset_create_dialog = false;
 			}


### PR DESCRIPTION
This fixes a bug I spotted when backporting #41437

The bug is that when you use the "Add Node Here" option twice, it will show full node list instead of only CanvasItems.