### PR TITLE
FileDialog: Fix capitalization for overwrite prompt

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -450,7 +450,7 @@ void EditorFileDialog::_action_pressed() {
 		}
 
 		if (dir_access->file_exists(f) && !disable_overwrite_warning) {
-			confirm_save->set_text(TTR("File Exists, Overwrite?"));
+			confirm_save->set_text(TTR("File exists, overwrite?"));
 			confirm_save->popup_centered(Size2(200, 80));
 		} else {
 			_save_to_recent();

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -265,7 +265,7 @@ void FileDialog::_action_pressed() {
 		}
 
 		if (dir_access->file_exists(f)) {
-			confirm_save->set_text(RTR("File Exists, Overwrite?"));
+			confirm_save->set_text(RTR("File exists, overwrite?"));
 			confirm_save->popup_centered(Size2(200, 80));
 		} else {
 			emit_signal("file_selected", f);


### PR DESCRIPTION
Sorry I can't take it anymore, I wince every time I see it.
Already fixed in master :)