### PR TITLE
Add method description to `get_current_index` in `PopupMenu`

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -260,6 +260,7 @@
 			<return type="int">
 			</return>
 			<description>
+				Returns the index of the currently focused item. Returns [code]-1[/code] if no item is focused.
 			</description>
 		</method>
 		<method name="get_item_accelerator" qualifiers="const">


### PR DESCRIPTION
This pull request adds a missing method description to `PopupMenu`.

This completes the documentation for `PopupMenu` and enhances usability by doing so.