### PR TITLE
fix 3D scene not rendered on GLES3 HTML5 export

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -157,9 +157,10 @@ public:
 			uint32_t view_index;
 
 			// make sure this struct is padded to be a multiple of 16 bytes for webgl
-			float pad[1];
+			float pad[3];
 
 		} ubo_data;
+		static_assert(sizeof(SceneDataUBO) % 16 == 0, "SceneDataUBO size must be a multiple of 16 bytes");
 
 		GLuint scene_ubo;
 


### PR DESCRIPTION
The pad size in SceneDataUBO should be multiple of 16 bytes.

Fixes [50239](https://github.com/godotengine/godot/issues/50239)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
