### PR TITLE
Implement didClose notification in LSP

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -40,6 +40,7 @@
 
 void GDScriptTextDocument::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("didOpen"), &GDScriptTextDocument::didOpen);
+	ClassDB::bind_method(D_METHOD("didClose"), &GDScriptTextDocument::didClose);
 	ClassDB::bind_method(D_METHOD("didChange"), &GDScriptTextDocument::didChange);
 	ClassDB::bind_method(D_METHOD("nativeSymbol"), &GDScriptTextDocument::nativeSymbol);
 	ClassDB::bind_method(D_METHOD("documentSymbol"), &GDScriptTextDocument::documentSymbol);
@@ -59,6 +60,11 @@ void GDScriptTextDocument::_bind_methods() {
 void GDScriptTextDocument::didOpen(const Variant &p_param) {
 	lsp::TextDocumentItem doc = load_document_item(p_param);
 	sync_script_content(doc.uri, doc.text);
+}
+
+void GDScriptTextDocument::didClose(const Variant &p_param) {
+	// Left empty on purpose. Godot does nothing special on closing a document,
+	// but it satisfies LSP clients that require didClose be implemented.
 }
 
 void GDScriptTextDocument::didChange(const Variant &p_param) {

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -43,6 +43,7 @@ protected:
 	FileAccess *file_checker;
 
 	void didOpen(const Variant &p_param);
+	void didClose(const Variant &p_param);
 	void didChange(const Variant &p_param);
 
 	void sync_script_content(const String &p_path, const String &p_content);


### PR DESCRIPTION
Implements the didClose notification to satisfy clients that require it or complain when it is not implemented. Fixes #50272 .