### PR TITLE
Fix winding of new convex hull implementation.

### DIFF
--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -2278,9 +2278,18 @@ Error ConvexHullComputer::convex_hull(const Vector<Vector3> &p_points, Geometry3
 			e = e->get_next_edge_of_face();
 		} while (e != e_start);
 
+		// reverse indices: Godot wants clockwise, but this is counter-clockwise
+		if (face.indices.size() > 2) {
+			// reverse all but the first index.
+			int *indices = face.indices.ptrw();
+			for (int c = 0; c < (face.indices.size() - 1) / 2; c++) {
+				SWAP(indices[c + 1], indices[face.indices.size() - 1 - c]);
+			}
+		}
+
 		// compute normal
 		if (face.indices.size() >= 3) {
-			face.plane = Plane(r_mesh.vertices[face.indices[0]], r_mesh.vertices[face.indices[2]], r_mesh.vertices[face.indices[1]]);
+			face.plane = Plane(r_mesh.vertices[face.indices[0]], r_mesh.vertices[face.indices[1]], r_mesh.vertices[face.indices[2]]);
 		} else {
 			WARN_PRINT("Too few vertices per face.");
 		}


### PR DESCRIPTION
Supersedes #50256.

Should be backported to 3.x.