### PR TITLE
Redo how instance bindings work

### DIFF
--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -520,6 +520,11 @@ static GDNativeObjectPtr gdnative_global_get_singleton(const char *p_name) {
 	return (GDNativeObjectPtr)Engine::get_singleton()->get_singleton_object(String(p_name));
 }
 
+static void *gdnative_object_get_instance_binding(GDNativeObjectPtr p_instance, void *p_token, GDNativeInstanceBindingCallbacks *p_callbacks) {
+	Object *o = (Object *)p_instance;
+	return o->get_instance_binding(p_token, p_callbacks);
+}
+
 static GDNativeObjectPtr gdnative_object_get_instance_from_id(GDObjectInstanceID p_instance_id) {
 	return (GDNativeObjectPtr)ObjectDB::get_instance(ObjectID(p_instance_id));
 }
@@ -665,6 +670,7 @@ void gdnative_setup_interface(GDNativeInterface *p_interface) {
 	gdni.object_method_bind_ptrcall = gdnative_object_method_bind_ptrcall;
 	gdni.object_destroy = gdnative_object_destroy;
 	gdni.global_get_singleton = gdnative_global_get_singleton;
+	gdni.object_get_instance_binding = gdnative_object_get_instance_binding;
 
 	gdni.object_cast_to = gdnative_object_cast_to;
 	gdni.object_get_instance_from_id = gdnative_object_get_instance_from_id;

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -171,6 +171,16 @@ typedef void (*GDNativePtrUtilityFunction)(GDNativeTypePtr r_return, const GDNat
 
 typedef GDNativeObjectPtr (*GDNativeClassConstructor)();
 
+typedef void *(*GDNativeInstanceBindingCreateCallback)(void *p_token, void *p_instance);
+typedef void (*GDNativeInstanceBindingFreeCallback)(void *p_token, void *p_instance, void *p_binding);
+typedef GDNativeBool (*GDNativeInstanceBindingReferenceCallback)(void *p_token, void *p_instance, GDNativeBool p_reference);
+
+struct GDNativeInstanceBindingCallbacks {
+	GDNativeInstanceBindingCreateCallback create_callback;
+	GDNativeInstanceBindingFreeCallback free_callback;
+	GDNativeInstanceBindingReferenceCallback reference_callback;
+};
+
 /* EXTENSION CLASSES */
 
 typedef void *GDExtensionClassInstancePtr;
@@ -373,6 +383,7 @@ typedef struct {
 	void (*object_method_bind_ptrcall)(GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_ret);
 	void (*object_destroy)(GDNativeObjectPtr p_o);
 	GDNativeObjectPtr (*global_get_singleton)(const char *p_name);
+	void *(*object_get_instance_binding)(GDNativeObjectPtr p_o, void *p_token, GDNativeInstanceBindingCallbacks *p_callbacks);
 
 	GDNativeObjectPtr (*object_cast_to)(const GDNativeObjectPtr p_object, void *p_class_tag);
 	GDNativeObjectPtr (*object_get_instance_from_id)(GDObjectInstanceID p_instance_id);

--- a/core/object/ref_counted.cpp
+++ b/core/object/ref_counted.cpp
@@ -65,13 +65,8 @@ bool RefCounted::reference() {
 		if (_get_extension() && _get_extension()->reference) {
 			_get_extension()->reference(_get_extension_instance());
 		}
-		if (instance_binding_count.get() > 0 && !ScriptServer::are_languages_finished()) {
-			for (int i = 0; i < MAX_SCRIPT_INSTANCE_BINDINGS; i++) {
-				if (_script_instance_bindings[i]) {
-					ScriptServer::get_language(i)->refcount_incremented_instance_binding(this);
-				}
-			}
-		}
+
+		_instance_binding_reference(true);
 	}
 
 	return success;
@@ -89,14 +84,8 @@ bool RefCounted::unreference() {
 		if (_get_extension() && _get_extension()->unreference) {
 			_get_extension()->unreference(_get_extension_instance());
 		}
-		if (instance_binding_count.get() > 0 && !ScriptServer::are_languages_finished()) {
-			for (int i = 0; i < MAX_SCRIPT_INSTANCE_BINDINGS; i++) {
-				if (_script_instance_bindings[i]) {
-					bool script_ret = ScriptServer::get_language(i)->refcount_decremented_instance_binding(this);
-					die = die && script_ret;
-				}
-			}
-		}
+
+		die = die && _instance_binding_reference(false);
 	}
 
 	return die;

--- a/modules/gdnative/nativescript/godot_nativescript.cpp
+++ b/modules/gdnative/nativescript/godot_nativescript.cpp
@@ -332,7 +332,7 @@ void GDAPI godot_nativescript_unregister_instance_binding_data_functions(int p_i
 }
 
 void GDAPI *godot_nativescript_get_instance_binding_data(int p_idx, godot_object *p_object) {
-	return NativeScriptLanguage::get_singleton()->get_instance_binding_data(p_idx, (Object *)p_object);
+	return nullptr;
 }
 
 void GDAPI godot_nativescript_profiling_add_data(const char *p_signature, uint64_t p_time) {

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1258,6 +1258,8 @@ void NativeScriptLanguage::unregister_binding_functions(int p_idx) {
 }
 
 void *NativeScriptLanguage::get_instance_binding_data(int p_idx, Object *p_object) {
+	return nullptr;
+#if 0
 	ERR_FAIL_INDEX_V(p_idx, binding_functions.size(), nullptr);
 
 	ERR_FAIL_COND_V_MSG(!binding_functions[p_idx].first, nullptr, "Tried to get binding data for a nativescript binding that does not exist.");
@@ -1287,9 +1289,12 @@ void *NativeScriptLanguage::get_instance_binding_data(int p_idx, Object *p_objec
 	}
 
 	return (*binding_data)[p_idx];
+#endif
 }
 
 void *NativeScriptLanguage::alloc_instance_binding_data(Object *p_object) {
+	return nullptr;
+#if 0
 	Vector<void *> *binding_data = new Vector<void *>;
 
 	binding_data->resize(binding_functions.size());
@@ -1301,9 +1306,11 @@ void *NativeScriptLanguage::alloc_instance_binding_data(Object *p_object) {
 	binding_instances.insert(binding_data);
 
 	return (void *)binding_data;
+#endif
 }
 
 void NativeScriptLanguage::free_instance_binding_data(void *p_data) {
+#if 0
 	if (!p_data) {
 		return;
 	}
@@ -1323,9 +1330,11 @@ void NativeScriptLanguage::free_instance_binding_data(void *p_data) {
 	binding_instances.erase(&binding_data);
 
 	delete &binding_data;
+#endif
 }
 
 void NativeScriptLanguage::refcount_incremented_instance_binding(Object *p_object) {
+#if 0
 	void *data = p_object->get_script_instance_binding(lang_idx);
 
 	if (!data) {
@@ -1347,9 +1356,11 @@ void NativeScriptLanguage::refcount_incremented_instance_binding(Object *p_objec
 			binding_functions[i].second.refcount_incremented_instance_binding(binding_data[i], p_object);
 		}
 	}
+#endif
 }
 
 bool NativeScriptLanguage::refcount_decremented_instance_binding(Object *p_object) {
+#if 0
 	void *data = p_object->get_script_instance_binding(lang_idx);
 
 	if (!data) {
@@ -1375,6 +1386,8 @@ bool NativeScriptLanguage::refcount_decremented_instance_binding(Object *p_objec
 	}
 
 	return can_die;
+#endif
+	return false;
 }
 
 void NativeScriptLanguage::set_global_type_tag(int p_idx, StringName p_class_name, const void *p_type_tag) {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1510,6 +1510,7 @@ void CSharpLanguage::free_instance_binding_data(void *p_data) {
 }
 
 void CSharpLanguage::refcount_incremented_instance_binding(Object *p_object) {
+#if 0
 	RefCounted *rc_owner = Object::cast_to<RefCounted>(p_object);
 
 #ifdef DEBUG_ENABLED
@@ -1544,9 +1545,11 @@ void CSharpLanguage::refcount_incremented_instance_binding(Object *p_object) {
 		gchandle.release();
 		gchandle = strong_gchandle;
 	}
+#endif
 }
 
 bool CSharpLanguage::refcount_decremented_instance_binding(Object *p_object) {
+#if 0
 	RefCounted *rc_owner = Object::cast_to<RefCounted>(p_object);
 
 #ifdef DEBUG_ENABLED
@@ -1586,6 +1589,8 @@ bool CSharpLanguage::refcount_decremented_instance_binding(Object *p_object) {
 	}
 
 	return refcount == 0;
+#endif
+	return false;
 }
 
 CSharpInstance *CSharpInstance::create_for_managed_type(Object *p_owner, CSharpScript *p_script, const MonoGCHandleData &p_gchandle) {
@@ -2264,8 +2269,10 @@ CSharpInstance::~CSharpInstance() {
 		// Otherwise, the unsafe reference debug checks will incorrectly detect a bug.
 		bool die = _unreference_owner_unsafe();
 		CRASH_COND(die); // `owner_keep_alive` holds a reference, so it can't die
-
+#if 0
 		void *data = owner->get_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index());
+
+
 		CRASH_COND(data == nullptr);
 
 		CSharpScriptBinding &script_binding = ((Map<Object *, CSharpScriptBinding>::Element *)data)->get();
@@ -2283,6 +2290,7 @@ CSharpInstance::~CSharpInstance() {
 #ifdef DEBUG_ENABLED
 		// The "instance binding" holds a reference so the refcount should be at least 2 before `scope_keep_owner_alive` goes out of scope
 		CRASH_COND(rc_owner->reference_get_count() <= 1);
+#endif
 #endif
 	}
 
@@ -3101,7 +3109,7 @@ CSharpInstance *CSharpScript::_create_instance(const Variant **p_args, int p_arg
 		// Hold it alive. Important if we have to dispose a script instance binding before creating the CSharpInstance.
 		ref = Ref<RefCounted>(static_cast<RefCounted *>(p_owner));
 	}
-
+#if 0
 	// If the object had a script instance binding, dispose it before adding the CSharpInstance
 	if (p_owner->has_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index())) {
 		void *data = p_owner->get_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index());
@@ -3123,7 +3131,7 @@ CSharpInstance *CSharpScript::_create_instance(const Variant **p_args, int p_arg
 			script_binding.inited = false;
 		}
 	}
-
+#endif
 	CSharpInstance *instance = memnew(CSharpInstance(Ref<CSharpScript>(this)));
 	instance->base_ref_counted = p_is_ref_counted;
 	instance->owner = p_owner;

--- a/modules/mono/glue/base_object_glue.cpp
+++ b/modules/mono/glue/base_object_glue.cpp
@@ -64,7 +64,7 @@ void godot_icall_Object_Disposed(MonoObject *p_obj, Object *p_ptr) {
 			return;
 		}
 	}
-
+#if 0
 	void *data = p_ptr->get_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index());
 
 	if (data) {
@@ -76,6 +76,7 @@ void godot_icall_Object_Disposed(MonoObject *p_obj, Object *p_ptr) {
 			}
 		}
 	}
+#endif
 }
 
 void godot_icall_RefCounted_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoolean p_is_finalizer) {
@@ -84,7 +85,7 @@ void godot_icall_RefCounted_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoole
 	// This is only called with RefCounted derived classes
 	CRASH_COND(!Object::cast_to<RefCounted>(p_ptr));
 #endif
-
+#if 0
 	RefCounted *rc = static_cast<RefCounted *>(p_ptr);
 
 	if (rc->get_script_instance()) {
@@ -124,6 +125,7 @@ void godot_icall_RefCounted_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoole
 			}
 		}
 	}
+#endif
 }
 
 void godot_icall_Object_ConnectEventSignals(Object *p_ptr) {

--- a/modules/mono/mono_gd/gd_mono_internals.cpp
+++ b/modules/mono/mono_gd/gd_mono_internals.cpp
@@ -45,7 +45,7 @@
 namespace GDMonoInternals {
 void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 	// This method should not fail
-
+#if 0
 	CRASH_COND(!unmanaged);
 
 	// All mono objects created from the managed world (e.g.: 'new Player()')
@@ -108,6 +108,7 @@ void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 	CSharpInstance *csharp_instance = CSharpInstance::create_for_managed_type(unmanaged, script.ptr(), gchandle);
 
 	unmanaged->set_script_and_instance(script, csharp_instance);
+#endif
 }
 
 void unhandled_exception(MonoException *p_exc) {

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -54,6 +54,7 @@
 namespace GDMonoUtils {
 
 MonoObject *unmanaged_get_managed(Object *unmanaged) {
+#if 0
 	if (!unmanaged) {
 		return nullptr;
 	}
@@ -120,6 +121,8 @@ MonoObject *unmanaged_get_managed(Object *unmanaged) {
 	}
 
 	return mono_object;
+#endif
+	return nullptr;
 }
 
 void set_main_thread(MonoThread *p_thread) {


### PR DESCRIPTION
* The harcoded 8 slots are no more and impose limits in the new extension system.
* New system is limitless, although it will impose small performance hit with a mutex. Given implementations end up needing to use a mutex anyway, nothing should really change.
* Uses a token to request the instance binding instead of an index.

**Warning**: Mono is broken as a result of this, will need to be modified to use the new system.