### PR TITLE
Use circular fade instead of linear fade for distance fade

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1252,15 +1252,16 @@ void BaseMaterial3D::_update_shader() {
 	}
 
 	if (distance_fade != DISTANCE_FADE_DISABLED) {
+		// Use the slightly more expensive circular fade (distance to the object) instead of linear
+		// (Z distance), so that the fade is always the same regardless of the camera angle.
 		if ((distance_fade == DISTANCE_FADE_OBJECT_DITHER || distance_fade == DISTANCE_FADE_PIXEL_DITHER)) {
 			if (!RenderingServer::get_singleton()->is_low_end()) {
 				code += "	{\n";
 
 				if (distance_fade == DISTANCE_FADE_OBJECT_DITHER) {
-					code += "		float fade_distance = abs((VIEW_MATRIX * MODEL_MATRIX[3]).z);\n";
-
+					code += "		float fade_distance = length((VIEW_MATRIX * MODEL_MATRIX[3]));\n";
 				} else {
-					code += "		float fade_distance = -VERTEX.z;\n";
+					code += "		float fade_distance = length(VERTEX);\n";
 				}
 				// Use interleaved gradient noise, which is fast but still looks good.
 				code += "		const vec3 magic = vec3(0.06711056f, 0.00583715f, 52.9829189f);";
@@ -1274,7 +1275,7 @@ void BaseMaterial3D::_update_shader() {
 			}
 
 		} else {
-			code += "	ALPHA*=clamp(smoothstep(distance_fade_min,distance_fade_max,-VERTEX.z),0.0,1.0);\n";
+			code += "	ALPHA *= clamp(smoothstep(distance_fade_min, distance_fade_max, length(VERTEX)), 0.0, 1.0);\n";
 		}
 	}
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/69959.

This makes distance fade look the same regardless of the camera angle, for all distance fade modes (Pixel Alpha, Pixel Dither, Object Dither). Distance fade now behaves like fog in this regard.

This has a minimal performance cost, but the quality increase is worth it. When viewing a plane that fully covers the screen, I get 215 FPS instead of 218 FPS with Pixel Dither in 4K, but this does not reflect the typical use case of distance fade (which is for LOD purposes). Besides, there are likely other ways to improve dithering efficiency (such as reducing branching or using [interleaved gradient noise](https://github.com/godotengine/godot/pull/50297)).

Thanks to @mrjustaguy for providing the formula here: https://github.com/godotengine/godot-proposals/issues/2963#issuecomment-876559516

This can be cherry-picked without conflicts to the `3.x` branch. I tested this PR on the `3.x` branch on both GLES3 and [GLES2](https://github.com/godotengine/godot/pull/50295), and it works as expected there too. This PR can be merged independently of https://github.com/godotengine/godot/pull/50297 as both can work together.

This closes https://github.com/godotengine/godot/issues/53853 and partially addresses https://github.com/godotengine/godot-proposals/issues/2963.

**Testing project:** [test_distance_fade_circular.zip](https://github.com/godotengine/godot/files/9407071/test_distance_fade_circular.zip)

## Preview

***Note:** These images should be viewed on a desktop device at 1:1 resolution by clicking them. Otherwise, they will not look as expected due to the nature of dithering.*

### Pixel Alpha

![Pixel Alpha](https://user-images.githubusercontent.com/180032/124992256-04081000-e043-11eb-8584-ebf0b3734f13.png)

### Pixel Dither

![Pixel Dither](https://user-images.githubusercontent.com/180032/124992249-02d6e300-e043-11eb-860c-63c31b391297.png)