### PR TITLE
Fix `Window`'s `wrap_controls` not actually doing anything

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -115,7 +115,7 @@ Size2i Window::get_max_size() const {
 
 void Window::set_min_size(const Size2i &p_min_size) {
 	min_size = p_min_size;
-	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+	if (!wrap_controls && window_id != DisplayServer::INVALID_WINDOW_ID) {
 		DisplayServer::get_singleton()->window_set_min_size(min_size, window_id);
 	}
 	_update_window_size();
@@ -541,6 +541,7 @@ void Window::_update_window_size() {
 		embedder->_sub_window_update(this);
 	} else if (window_id != DisplayServer::INVALID_WINDOW_ID) {
 		DisplayServer::get_singleton()->window_set_size(size, window_id);
+		DisplayServer::get_singleton()->window_set_min_size(size_limit, window_id);
 	}
 
 	//update the viewport


### PR DESCRIPTION
`wrap_controls` is supposed to make the window's size unable to be shrunk lower than the minimum size of its `Control` nodes. However, it wasn't doing anything, until now.