### PR TITLE
Added an editor settings for lines antialiasing/thickness in GraphEdit's

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -703,6 +703,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/animation/onion_layers_future_color", Color(0, 1, 0));
 
 	// Visual editors
+	_initial_set("editors/visual_editors/connection_lines_antialiased", true);
+	_initial_set("editors/visual_editors/connection_lines_thickness", 2.0);
+	hints["editors/visual_editors/connection_lines_thickness"] = PropertyInfo(Variant::FLOAT, "editors/visual_editors/connection_lines_thickness", PROPERTY_HINT_RANGE, "1.0,5.0,0.01", PROPERTY_USAGE_DEFAULT);
 	_initial_set("editors/visual_editors/minimap_opacity", 0.85);
 	hints["editors/visual_editors/minimap_opacity"] = PropertyInfo(Variant::FLOAT, "editors/visual_editors/minimap_opacity", PROPERTY_HINT_RANGE, "0.0,1.0,0.01", PROPERTY_USAGE_DEFAULT);
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -254,6 +254,10 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 		graph->connect_node(from, 0, to, to_idx);
 	}
 
+	bool graph_lines_antialiased = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_antialiased");
+	graph->set_connection_lines_antialiased(graph_lines_antialiased);
+	float graph_lines_thickness = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_thickness");
+	graph->set_connection_lines_thickness(graph_lines_thickness);
 	float graph_minimap_opacity = EditorSettings::get_singleton()->get("editors/visual_editors/minimap_opacity");
 	graph->set_minimap_opacity(graph_minimap_opacity);
 }
@@ -889,6 +893,10 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	graph->connect("scroll_offset_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_scroll_changed));
 	graph->connect("delete_nodes_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_delete_nodes_request));
 	graph->connect("popup_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_popup_request));
+	bool graph_lines_antialiased = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_antialiased");
+	graph->set_connection_lines_antialiased(graph_lines_antialiased);
+	float graph_lines_thickness = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_thickness");
+	graph->set_connection_lines_thickness(graph_lines_thickness);
 	float graph_minimap_opacity = EditorSettings::get_singleton()->get("editors/visual_editors/minimap_opacity");
 	graph->set_minimap_opacity(graph_minimap_opacity);
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1416,6 +1416,10 @@ void VisualShaderEditor::_update_graph() {
 		graph->connect_node(itos(from), from_idx, itos(to), to_idx);
 	}
 
+	bool graph_lines_antialiased = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_antialiased");
+	graph->set_connection_lines_antialiased(graph_lines_antialiased);
+	float graph_lines_thickness = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_thickness");
+	graph->set_connection_lines_thickness(graph_lines_thickness);
 	float graph_minimap_opacity = EditorSettings::get_singleton()->get("editors/visual_editors/minimap_opacity");
 	graph->set_minimap_opacity(graph_minimap_opacity);
 }
@@ -3738,6 +3742,10 @@ VisualShaderEditor::VisualShaderEditor() {
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_child(graph);
 	graph->set_drag_forwarding(this);
+	bool graph_lines_antialiased = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_antialiased");
+	graph->set_connection_lines_antialiased(graph_lines_antialiased);
+	float graph_lines_thickness = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_thickness");
+	graph->set_connection_lines_thickness(graph_lines_thickness);
 	float graph_minimap_opacity = EditorSettings::get_singleton()->get("editors/visual_editors/minimap_opacity");
 	graph->set_minimap_opacity(graph_minimap_opacity);
 	graph->add_valid_right_disconnect_type(VisualShaderNode::PORT_TYPE_SCALAR);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -969,6 +969,10 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 	_update_graph_connections();
 
+	bool graph_lines_antialiased = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_antialiased");
+	graph->set_connection_lines_antialiased(graph_lines_antialiased);
+	float graph_lines_thickness = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_thickness");
+	graph->set_connection_lines_thickness(graph_lines_thickness);
 	float graph_minimap_opacity = EditorSettings::get_singleton()->get("editors/visual_editors/minimap_opacity");
 	graph->set_minimap_opacity(graph_minimap_opacity);
 
@@ -4271,6 +4275,10 @@ VisualScriptEditor::VisualScriptEditor() {
 	graph->connect("duplicate_nodes_request", callable_mp(this, &VisualScriptEditor::_on_nodes_duplicate));
 	graph->connect("gui_input", callable_mp(this, &VisualScriptEditor::_graph_gui_input));
 	graph->set_drag_forwarding(this);
+	bool graph_lines_antialiased = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_antialiased");
+	graph->set_connection_lines_antialiased(graph_lines_antialiased);
+	float graph_lines_thickness = EditorSettings::get_singleton()->get("editors/visual_editors/connection_lines_thickness");
+	graph->set_connection_lines_thickness(graph_lines_thickness);
 	float graph_minimap_opacity = EditorSettings::get_singleton()->get("editors/visual_editors/minimap_opacity");
 	graph->set_minimap_opacity(graph_minimap_opacity);
 	graph->hide();


### PR DESCRIPTION
Since these properties were added in https://github.com/godotengine/godot/pull/44496 I guess it's not bad to get users a way to use them on editor's graphs like VisualScripts/VisualShaders etc:

![image](https://user-images.githubusercontent.com/3036176/125043097-45c8a300-e0a3-11eb-9db9-b5ddbced31ef.png)