### PR TITLE
Optimize NodePath update when renaming or deleting nodes in the editor

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -240,18 +240,25 @@ NodePath NodePath::rel_path_to(const NodePath &p_np) const {
 	common_parent--;
 
 	Vector<StringName> relpath;
+	relpath.resize(src_dirs.size() + dst_dirs.size() + 1);
 
-	for (int i = src_dirs.size() - 1; i > common_parent; i--) {
-		relpath.push_back("..");
+	StringName *relpath_ptr = relpath.ptrw();
+
+	int path_size = 0;
+	StringName back_str("..");
+	for (int i = common_parent + 1; i < src_dirs.size(); i++) {
+		relpath_ptr[path_size++] = back_str;
 	}
 
 	for (int i = common_parent + 1; i < dst_dirs.size(); i++) {
-		relpath.push_back(dst_dirs[i]);
+		relpath_ptr[path_size++] = dst_dirs[i];
 	}
 
-	if (relpath.size() == 0) {
-		relpath.push_back(".");
+	if (path_size == 0) {
+		relpath_ptr[path_size++] = ".";
 	}
+
+	relpath.resize(path_size);
 
 	return NodePath(relpath, p_np.get_subnames(), false);
 }

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -211,7 +211,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _selection_changed();
 	void _update_script_button();
 
-	void _fill_path_renames(Vector<StringName> base_path, Vector<StringName> new_base_path, Node *p_node, List<Pair<NodePath, NodePath>> *p_renames);
+	void _fill_path_renames(Vector<StringName> base_path, Vector<StringName> new_base_path, Node *p_node, Map<Node *, NodePath> *p_renames);
 
 	void _normalize_drop(Node *&to_node, int &to_pos, int p_type);
 
@@ -247,8 +247,8 @@ class SceneTreeDock : public VBoxContainer {
 	static SceneTreeDock *singleton;
 	static void _update_configuration_warning();
 
-	static bool _update_node_path(const NodePath &p_root_path, NodePath &r_node_path, List<Pair<NodePath, NodePath>> *p_renames);
-	static bool _check_node_path_recursive(const NodePath &p_root_path, Variant &r_variant, List<Pair<NodePath, NodePath>> *p_renames);
+	bool _update_node_path(Node *p_root_node, NodePath &r_node_path, Map<Node *, NodePath> *p_renames) const;
+	bool _check_node_path_recursive(Node *p_root_node, Variant &r_variant, Map<Node *, NodePath> *p_renames) const;
 
 protected:
 	void _notification(int p_what);
@@ -266,8 +266,8 @@ public:
 	void instantiate(const String &p_file);
 	void instantiate_scenes(const Vector<String> &p_files, Node *p_parent = nullptr);
 	void set_selected(Node *p_node, bool p_emit_selected = false);
-	void fill_path_renames(Node *p_node, Node *p_new_parent, List<Pair<NodePath, NodePath>> *p_renames);
-	void perform_node_renames(Node *p_base, List<Pair<NodePath, NodePath>> *p_renames, Map<Ref<Animation>, Set<int>> *r_rem_anims = nullptr);
+	void fill_path_renames(Node *p_node, Node *p_new_parent, Map<Node *, NodePath> *p_renames);
+	void perform_node_renames(Node *p_base, Map<Node *, NodePath> *p_renames, Map<Ref<Animation>, Set<int>> *r_rem_anims = nullptr);
 	SceneTreeEditor *get_tree_editor() { return scene_tree; }
 	EditorData *get_editor_data() { return editor_data; }
 


### PR DESCRIPTION
Fixes #50267 (regression from #49812).

Now the process uses a Map to lookup node pointers instead of iterating over all modified node paths in a list and comparing them one by one for each property to check.

The process also avoids checking properties with empty node paths and does an early exit on deleted nodes to avoid checking the node and its descendants.

Also made a minor change in NodePath::rel_path_to() to avoid resizing a Vector many times for long paths (with copy-on-write each time). Now it's down to 2 resize calls in any case.

I haven't made precise measurements of the performance difference, but with several thousands of nodes with node paths to update, it takes only a couple seconds (about the same it takes without the node path check) as opposed to freezing the editor completely (at least for several minutes).

Project used for tests on 3.x (modified MRP from #50267):
[Delete.node.test.zip](https://github.com/godotengine/godot/files/6793331/Delete.node.test.zip)