### PR TITLE
[3.x] Allow Material3D Depth in the GLES2 backend

### DIFF
--- a/doc/classes/Material3D.xml
+++ b/doc/classes/Material3D.xml
@@ -106,6 +106,7 @@
 		</member>
 		<member name="depth_deep_parallax" type="bool" setter="set_depth_deep_parallax" getter="is_depth_deep_parallax_enabled">
 			If [code]true[/code], the shader will read depth texture at multiple points along the view ray to determine occlusion and parrallax. This can be very performance demanding, but results in more realistic looking depth mapping.
+			[b]Note:[/b] When using the GLES2 backend on mobile platforms, deep parallax mapping may exhibit visible artifacts unless [ProjectSettings]' [code]rendering/gles2/compatibility/enable_high_float.Android[/code] is [code]true[/code]. However, enabling high-precision floating-point computations has a performance cost and is not compatible with all devices.
 		</member>
 		<member name="depth_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
 			If [code]true[/code], depth mapping is enabled (also called "parallax mapping" or "height mapping"). See also [member normal_enabled].
@@ -119,9 +120,11 @@
 		</member>
 		<member name="depth_max_layers" type="int" setter="set_depth_deep_parallax_max_layers" getter="get_depth_deep_parallax_max_layers">
 			Number of layers to use when using [member depth_deep_parallax] and the view direction is perpendicular to the surface of the object. A higher number will be more performance demanding while a lower number may not look as crisp.
+			[b]Note:[/b] [member depth_max_layers] is limited to 32 when using the GLES2 backend due to the shader relying on a fixed-count [code]for[/code] loop instead of a dynamic [code]while[/code] loop. This limitation is present due to GLES2 not supporting [code]while[/code] loops on all platforms.
 		</member>
 		<member name="depth_min_layers" type="int" setter="set_depth_deep_parallax_min_layers" getter="get_depth_deep_parallax_min_layers">
 			Number of layers to use when using [member depth_deep_parallax] and the view direction is parallel to the surface of the object. A higher number will be more performance demanding while a lower number may not look as crisp.
+			[b]Note:[/b] [member depth_min_layers] is limited to 32 when using the GLES2 backend due to the shader relying on a fixed-count [code]for[/code] loop instead of a dynamic [code]while[/code] loop. This limitation is present due to GLES2 not supporting [code]while[/code] loops on all platforms.
 		</member>
 		<member name="depth_scale" type="float" setter="set_depth_scale" getter="get_depth_scale">
 			Scales the depth offset effect. A higher number will create a larger depth.


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/50295.

On GLES2, the shader now uses a fixed `for` loop instead of a dynamic `while` loop as `while` loops aren't supported on all platforms in GLES2.

I've tested both simple (non-deep) parallax and deep parallax on desktop, HTML5 and Android. They all work as expected now.

Inspired by three.js: https://github.com/mrdoob/three.js/blob/bb484d616955e2bf1c3329383c3c0cc3543ccf71/examples/jsm/shaders/ParallaxShader.js#L84-L95

After merging, remember to update [Differences between GLES2 and GLES3](https://docs.godotengine.org/en/stable/tutorials/misc/gles2_gles3_differences.html) in the documentation.

**Testing project:** [tp.zip](https://github.com/godotengine/godot/files/6794440/tp.zip)

## Preview (Deep Parallax)

### Desktop

*Fedora 34 - GeForce GTX 1080 - OpenGL 2.1*

![Deep Parallax](https://user-images.githubusercontent.com/180032/125147551-6c7eec00-e12c-11eb-9a3d-811a4378e57e.png)

### HTML5

*Firefox 90 - GeForce GTX 1080 - WebGL 1.0*

![HTML5](https://user-images.githubusercontent.com/180032/125214311-babff680-e2b6-11eb-91b7-b0886efcadbe.png)

### Android (high precision not forced, resulting in artifacts)

*Android 10 - OnePlus 6*

![Android low precision](https://user-images.githubusercontent.com/180032/125214300-a7149000-e2b6-11eb-8bc9-fc97b203ead9.jpg)

### Android (high precision forced)

*Android 10 - OnePlus 6*

![Android high precision](https://user-images.githubusercontent.com/180032/125214296-9f54eb80-e2b6-11eb-9598-04f7a6b4cc47.jpg)

*Keywords for easier searching: SpatialMaterial, spatial material*