### PR TITLE
Bump the min supported sdk to version 19 (kitkat)

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,7 +1,7 @@
 ext.versions = [
-    androidGradlePlugin: '4.2.1',
+    androidGradlePlugin: '4.2.2',
     compileSdk         : 29,
-    minSdk             : 18,
+    minSdk             : 19,
     targetSdk          : 29,
     buildTools         : '30.0.3',
     supportCoreUtils   : '1.0.0',


### PR DESCRIPTION
The currently supported version (18) is [no longer supported by Google Play Services](https://android-developers.googleblog.com/2021/07/google-play-services-discontinuing-jelly-bean.html?m=1) and only add an additional `0.3%` of device coverage: `98.4%` -> `98.1%`.

![Android version distribution](https://user-images.githubusercontent.com/914968/125147757-1a18dd80-e0e2-11eb-86bd-917a6f02f303.PNG)


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
