### PR TITLE
Add description to `Viewport`

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -144,6 +144,7 @@
 			<return type="bool">
 			</return>
 			<description>
+				Returns [code]true[/code] if the viewport is currently embedding windows.
 			</description>
 		</method>
 		<method name="is_input_handled" qualifiers="const">


### PR DESCRIPTION
This pull request adds a missing method description to `Viewport` in the class docs.