### PR TITLE
Set minimum size for "Version Control" diff bottom panel

### DIFF
--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -476,6 +476,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	version_control_dock = memnew(PanelContainer);
 	version_control_dock->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	version_control_dock->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
 	version_control_dock->hide();
 
 	diff_vbc = memnew(VBoxContainer);


### PR DESCRIPTION
Allows to see working tree diffs without having to expand the bottom panel manually.

## Before

![vcs-diff-before](https://user-images.githubusercontent.com/17108460/125161785-fe1e4600-e18c-11eb-876f-3ff1050c38ab.gif)

## After

![vcs-diff](https://user-images.githubusercontent.com/17108460/125161612-fca04e00-e18b-11eb-9dbe-cd923b7dc0c7.gif)

The minimum size is the same as in shader editor plugin.

Should be cherry-pickable to 3.x.

Useful for goostengine/goost#98, but not required. Yet it would be best that this is fixed in Godot as well, since Godot provides official GDNative Git plugin.

---

**This PR is generously donated by [Goost](https://goostengine.github.io/).**


