### PR TITLE
Print the class when using Node's `print_tree()`/`print_tree_pretty()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -733,7 +733,7 @@
 		<method name="print_tree">
 			<return type="void" />
 			<description>
-				Prints the node and its children to the console, recursively. The node does not have to be inside the tree. This method outputs [NodePath]s relative to this node, and is good for copy/pasting into [method get_node]. See also [method print_tree_pretty].
+				Prints the node and its children to the console, recursively. The node does not have to be inside the tree. This method outputs [NodePath]s relative to this node, and is good for copy/pasting into [method get_node]. See also [method print_tree_pretty]. The node's string representation is always displayed on the right of each node path. By default, this displays the node type and unique instance ID. Custom representations can be created by creating a [code]_to_string()[/code] function that returns a [String]. If the custom representation contains BBCode, it is parsed as rich text following [method @GlobalScope.print_rich]'s limitations.
 				May print, for example:
 				[codeblock lang=text]
 				.
@@ -748,7 +748,7 @@
 		<method name="print_tree_pretty">
 			<return type="void" />
 			<description>
-				Prints the node and its children to the console, recursively. The node does not have to be inside the tree. Similar to [method print_tree], but the graphical representation looks like what is displayed in the editor's Scene dock. It is useful for inspecting larger trees.
+				Prints the node and its children to the console, recursively. The node does not have to be inside the tree. Similar to [method print_tree], but the graphical representation looks like what is displayed in the editor's Scene dock. It is useful for inspecting larger trees. The node's string representation is always displayed on the right of each node path. By default, this displays the node type and unique instance ID. Custom representations can be created by creating a [code]_to_string()[/code] function that returns a [String]. If the custom representation contains BBCode, it is parsed as rich text following [method @GlobalScope.print_rich]'s limitations.
 				May print, for example:
 				[codeblock lang=text]
 				 ┖╴TheGame

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2453,17 +2453,17 @@ int Node::get_persistent_group_count() const {
 }
 
 void Node::print_tree_pretty() {
-	print_line(_get_tree_string_pretty("", true));
+	print_line_rich(_get_tree_string_pretty("", true));
 }
 
 void Node::print_tree() {
-	print_line(_get_tree_string(this));
+	print_line_rich(_get_tree_string(this));
 }
 
 String Node::_get_tree_string_pretty(const String &p_prefix, bool p_last) {
 	String new_prefix = p_last ? String::utf8(" ┖╴") : String::utf8(" ┠╴");
 	_update_children_cache();
-	String return_tree = p_prefix + new_prefix + String(get_name()) + "\n";
+	String return_tree = vformat("[color=#808080]%s%s[/color][b]%s[/b]: [color=#808080]%s[/color]\n", p_prefix, new_prefix, get_name(), this->to_string());
 	for (uint32_t i = 0; i < data.children_cache.size(); i++) {
 		new_prefix = p_last ? String::utf8("   ") : String::utf8(" ┃ ");
 		return_tree += data.children_cache[i]->_get_tree_string_pretty(p_prefix + new_prefix, i == data.children_cache.size() - 1);
@@ -2477,7 +2477,7 @@ String Node::get_tree_string_pretty() {
 
 String Node::_get_tree_string(const Node *p_node) {
 	_update_children_cache();
-	String return_tree = String(p_node->get_path_to(this)) + "\n";
+	String return_tree = vformat("[b]%s[/b]: [color=#808080]%s[/color]\n", p_node->get_path_to(this), this->to_string());
 	for (uint32_t i = 0; i < data.children_cache.size(); i++) {
 		return_tree += data.children_cache[i]->_get_tree_string(p_node);
 	}


### PR DESCRIPTION
The class name may not always be obvious, especially when nodes are renamed from their default names. `_to_string()` is called if overridden in the node's script. By default, the node type and instance ID are displayed.

This also adds rich formatting, including for `_to_string()` handlers if displayed within `print_tree()` or `print_tree_pretty()`.

See https://github.com/godotengine/godot-proposals/issues/2953#issuecomment-874938164.

## Preview (outdated)

### `print_tree()`

#### Before

```
.
ThisIsNode3D
ThisIsNode3D/OccluderInstance3D
ThisIsNode3D/MeshInstance3D2
ThisIsNode3D/SomeCSGBox
ThisIsNode3D/SomeCSGBox/CSGCylinder3D
ThisIsNode3D/MeshInstance3D
ThisIsNode3D/MeshInstance3D3
ThisIsNode3D/VoxelGI
ThisIsNode3D/OmniLight3D
ThisIsNode3D/Camera3D
ThisIsNode3D/Sprite2D
ThisIsNode3D/WorldEnvironment
ThisIsNode3D/DirectionalLight3D
```

#### After

*Screenshot from the Visual Studio Code terminal.*

![image](https://user-images.githubusercontent.com/180032/181966315-7189ca5a-90d2-4f64-8dbf-fb3ac1db5a42.png)

### `print_tree_pretty()`

#### Before

```
 ┖╴root
    ┖╴ThisIsNode3D
       ┠╴OccluderInstance3D
       ┠╴MeshInstance3D2
       ┠╴SomeCSGBox
       ┃  ┖╴CSGCylinder3D
       ┠╴MeshInstance3D
       ┠╴MeshInstance3D3
       ┠╴VoxelGI
       ┠╴OmniLight3D
       ┠╴Camera3D
       ┠╴Sprite2D
       ┠╴WorldEnvironment
       ┖╴DirectionalLight3D
```

#### After

*Screenshot from the Visual Studio Code terminal.*

![image](https://user-images.githubusercontent.com/180032/181968648-be2ed95f-b605-4981-b6fa-f7fe9925a124.png)
