### PR TITLE
Rename ProjectSettings macros to follow the singleton's rename

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -510,19 +510,19 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bool p_upwards) {
 	Error err = _setup(p_path, p_main_pack, p_upwards);
 	if (err == OK) {
-		String custom_settings = GLOBAL_DEF("application/config/project_settings_override", "");
+		String custom_settings = PROJECT_DEFAULT("application/config/project_settings_override", "");
 		if (custom_settings != "") {
 			_load_settings_text(custom_settings);
 		}
 	}
-	// Using GLOBAL_GET on every block for compressing can be slow, so assigning here.
-	Compression::zstd_long_distance_matching = GLOBAL_GET("compression/formats/zstd/long_distance_matching");
-	Compression::zstd_level = GLOBAL_GET("compression/formats/zstd/compression_level");
-	Compression::zstd_window_log_size = GLOBAL_GET("compression/formats/zstd/window_log_size");
+	// Using PROJECT_GET on every block for compressing can be slow, so assigning here.
+	Compression::zstd_long_distance_matching = PROJECT_GET("compression/formats/zstd/long_distance_matching");
+	Compression::zstd_level = PROJECT_GET("compression/formats/zstd/compression_level");
+	Compression::zstd_window_log_size = PROJECT_GET("compression/formats/zstd/window_log_size");
 
-	Compression::zlib_level = GLOBAL_GET("compression/formats/zlib/compression_level");
+	Compression::zlib_level = PROJECT_GET("compression/formats/zlib/compression_level");
 
-	Compression::gzip_level = GLOBAL_GET("compression/formats/gzip/compression_level");
+	Compression::gzip_level = PROJECT_GET("compression/formats/gzip/compression_level");
 
 	return err;
 }
@@ -913,7 +913,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 	}
 }
 
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed, bool p_ignore_value_in_docs, bool p_basic) {
+Variant _PROJECT_DEFAULT(const String &p_var, const Variant &p_default, bool p_restart_if_changed, bool p_ignore_value_in_docs, bool p_basic) {
 	Variant ret;
 	if (!ProjectSettings::get_singleton()->has_setting(p_var)) {
 		ProjectSettings::get_singleton()->set(p_var, p_default);
@@ -1070,7 +1070,7 @@ void ProjectSettings::_add_builtin_input_map() {
 			action["events"] = events;
 
 			String action_name = "input/" + E.key();
-			GLOBAL_DEF(action_name, action);
+			PROJECT_DEFAULT(action_name, action);
 			input_presets.push_back(action_name);
 		}
 	}
@@ -1082,17 +1082,17 @@ ProjectSettings::ProjectSettings() {
 
 	singleton = this;
 
-	GLOBAL_DEF_BASIC("application/config/name", "");
-	GLOBAL_DEF_BASIC("application/config/description", "");
+	PROJECT_DEFAULT_BASIC("application/config/name", "");
+	PROJECT_DEFAULT_BASIC("application/config/description", "");
 	custom_prop_info["application/config/description"] = PropertyInfo(Variant::STRING, "application/config/description", PROPERTY_HINT_MULTILINE_TEXT);
-	GLOBAL_DEF_BASIC("application/run/main_scene", "");
+	PROJECT_DEFAULT_BASIC("application/run/main_scene", "");
 	custom_prop_info["application/run/main_scene"] = PropertyInfo(Variant::STRING, "application/run/main_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res");
-	GLOBAL_DEF("application/run/disable_stdout", false);
-	GLOBAL_DEF("application/run/disable_stderr", false);
-	GLOBAL_DEF("application/config/use_custom_user_dir", false);
-	GLOBAL_DEF("application/config/custom_user_dir_name", "");
-	GLOBAL_DEF("application/config/project_settings_override", "");
-	GLOBAL_DEF_BASIC("audio/buses/default_bus_layout", "res://default_bus_layout.tres");
+	PROJECT_DEFAULT("application/run/disable_stdout", false);
+	PROJECT_DEFAULT("application/run/disable_stderr", false);
+	PROJECT_DEFAULT("application/config/use_custom_user_dir", false);
+	PROJECT_DEFAULT("application/config/custom_user_dir_name", "");
+	PROJECT_DEFAULT("application/config/project_settings_override", "");
+	PROJECT_DEFAULT_BASIC("audio/buses/default_bus_layout", "res://default_bus_layout.tres");
 	custom_prop_info["audio/buses/default_bus_layout"] = PropertyInfo(Variant::STRING, "audio/buses/default_bus_layout", PROPERTY_HINT_FILE, "*.tres");
 
 	PackedStringArray extensions = PackedStringArray();
@@ -1102,12 +1102,12 @@ ProjectSettings::ProjectSettings() {
 	}
 	extensions.push_back("gdshader");
 
-	GLOBAL_DEF("editor/run/main_run_args", "");
+	PROJECT_DEFAULT("editor/run/main_run_args", "");
 
-	GLOBAL_DEF("editor/script/search_in_file_extensions", extensions);
+	PROJECT_DEFAULT("editor/script/search_in_file_extensions", extensions);
 	custom_prop_info["editor/script/search_in_file_extensions"] = PropertyInfo(Variant::PACKED_STRING_ARRAY, "editor/script/search_in_file_extensions");
 
-	GLOBAL_DEF("editor/script/templates_search_path", "res://script_templates");
+	PROJECT_DEFAULT("editor/script/templates_search_path", "res://script_templates");
 	custom_prop_info["editor/script/templates_search_path"] = PropertyInfo(Variant::STRING, "editor/script/templates_search_path", PROPERTY_HINT_DIR);
 
 	_add_builtin_input_map();
@@ -1116,23 +1116,23 @@ ProjectSettings::ProjectSettings() {
 	custom_prop_info["display/window/handheld/orientation"] = PropertyInfo(Variant::INT, "display/window/handheld/orientation", PROPERTY_HINT_ENUM, "Landscape,Portrait,Reverse Landscape,Reverse Portrait,Sensor Landscape,Sensor Portrait,Sensor");
 	custom_prop_info["display/window/vsync/vsync_mode"] = PropertyInfo(Variant::STRING, "display/window/vsync/vsync_mode", PROPERTY_HINT_ENUM, "Disabled,Enabled,Adaptive,Mailbox");
 	custom_prop_info["rendering/driver/threads/thread_model"] = PropertyInfo(Variant::INT, "rendering/driver/threads/thread_model", PROPERTY_HINT_ENUM, "Single-Unsafe,Single-Safe,Multi-Threaded");
-	GLOBAL_DEF("physics/2d/run_on_thread", false);
-	GLOBAL_DEF("physics/3d/run_on_thread", false);
+	PROJECT_DEFAULT("physics/2d/run_on_thread", false);
+	PROJECT_DEFAULT("physics/3d/run_on_thread", false);
 
-	GLOBAL_DEF("debug/settings/profiler/max_functions", 16384);
+	PROJECT_DEFAULT("debug/settings/profiler/max_functions", 16384);
 	custom_prop_info["debug/settings/profiler/max_functions"] = PropertyInfo(Variant::INT, "debug/settings/profiler/max_functions", PROPERTY_HINT_RANGE, "128,65535,1");
 
-	GLOBAL_DEF("compression/formats/zstd/long_distance_matching", Compression::zstd_long_distance_matching);
+	PROJECT_DEFAULT("compression/formats/zstd/long_distance_matching", Compression::zstd_long_distance_matching);
 	custom_prop_info["compression/formats/zstd/long_distance_matching"] = PropertyInfo(Variant::BOOL, "compression/formats/zstd/long_distance_matching");
-	GLOBAL_DEF("compression/formats/zstd/compression_level", Compression::zstd_level);
+	PROJECT_DEFAULT("compression/formats/zstd/compression_level", Compression::zstd_level);
 	custom_prop_info["compression/formats/zstd/compression_level"] = PropertyInfo(Variant::INT, "compression/formats/zstd/compression_level", PROPERTY_HINT_RANGE, "1,22,1");
-	GLOBAL_DEF("compression/formats/zstd/window_log_size", Compression::zstd_window_log_size);
+	PROJECT_DEFAULT("compression/formats/zstd/window_log_size", Compression::zstd_window_log_size);
 	custom_prop_info["compression/formats/zstd/window_log_size"] = PropertyInfo(Variant::INT, "compression/formats/zstd/window_log_size", PROPERTY_HINT_RANGE, "10,30,1");
 
-	GLOBAL_DEF("compression/formats/zlib/compression_level", Compression::zlib_level);
+	PROJECT_DEFAULT("compression/formats/zlib/compression_level", Compression::zlib_level);
 	custom_prop_info["compression/formats/zlib/compression_level"] = PropertyInfo(Variant::INT, "compression/formats/zlib/compression_level", PROPERTY_HINT_RANGE, "-1,9,1");
 
-	GLOBAL_DEF("compression/formats/gzip/compression_level", Compression::gzip_level);
+	PROJECT_DEFAULT("compression/formats/gzip/compression_level", Compression::gzip_level);
 	custom_prop_info["compression/formats/gzip/compression_level"] = PropertyInfo(Variant::INT, "compression/formats/gzip/compression_level", PROPERTY_HINT_RANGE, "-1,9,1");
 }
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -179,16 +179,54 @@ public:
 };
 
 //not a macro any longer
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false);
-#define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
-#define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
-#define GLOBAL_DEF_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true)
-#define GLOBAL_DEF_RST_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true)
-#define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get(m_var)
+Variant _PROJECT_DEFAULT(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false);
 
-#define GLOBAL_DEF_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, true)
-#define GLOBAL_DEF_RST_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, false, true)
-#define GLOBAL_DEF_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true, true)
-#define GLOBAL_DEF_RST_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true, true)
+// Returns the value of the project setting `m_var`, or `m_value` if the setting is not defined yet.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define PROJECT_DEFAULT(m_var, m_value) _PROJECT_DEFAULT(m_var, m_value)
+
+// Returns the value of the project setting `m_var`, or `m_value` if the setting is not defined yet.
+// Also requests a restart of the editor when changed using the Project Settings dialog.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define PROJECT_DEFAULT_RESTART(m_var, m_value) _PROJECT_DEFAULT(m_var, m_value, true)
+
+// Returns the value of the project setting `m_var`, or `m_value` if the setting is not defined yet.
+// Does not define a value for the class reference XML generation.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define PROJECT_DEFAULT_NO_VAL(m_var, m_value) _PROJECT_DEFAULT(m_var, m_value, false, true)
+
+// Returns the value of the project setting `m_var`, or `m_value` if the setting is not defined yet.
+// Also requests a restart of the editor when changed using the Project Settings dialog.
+// Does not define a value for the class reference XML generation.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define PROJECT_DEF_RESTART_NO_VAL(m_var, m_value) _PROJECT_DEFAULT(m_var, m_value, true, true)
+
+// Returns the value of the project setting `m_var`, or Variant `null` if the setting doesn't exist.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define PROJECT_GET(m_var) ProjectSettings::get_singleton()->get(m_var)
+
+// Returns the value of the project setting `m_var`, or `m_value` if the setting is not defined yet.
+// Marks the setting as "basic" to make it appear by default in the Project Settings dialog.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define PROJECT_DEFAULT_BASIC(m_var, m_value) _PROJECT_DEFAULT(m_var, m_value, false, false, true)
+
+// Returns the value of the project setting `m_var`, or `m_value` if the setting is not defined yet.
+// Also requests a restart of the editor when changed using the Project Settings dialog.
+// Marks the setting as "basic" to make it appear by default in the Project Settings dialog.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define PROJECT_DEFAULT_RESTART_BASIC(m_var, m_value) _PROJECT_DEFAULT(m_var, m_value, true, false, true)
+
+// Returns the value of the project setting `m_var`, or `m_value` if the setting is not defined yet.
+// Does not define a value for the class reference XML generation.
+// Marks the setting as "basic" to make it appear by default in the Project Settings dialog.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define PROJECT_DEFAULT_NO_VAL_BASIC(m_var, m_value) _PROJECT_DEFAULT(m_var, m_value, false, true, true)
+
+// Returns the value of the project setting `m_var`, or `m_value` if the setting is not defined yet.
+// Also requests a restart of the editor when changed using the Project Settings dialog.
+// Does not define a value for the class reference XML generation.
+// Marks the setting as "basic" to make it appear by default in the Project Settings dialog.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define PROJECT_DEFAULT_RESTART_NO_VAL_BASIC(m_var, m_value) _PROJECT_DEFAULT(m_var, m_value, true, true, true)
 
 #endif // PROJECT_SETTINGS_H

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -265,7 +265,7 @@ struct RemoteDebugger::ScriptsProfiler {
 	}
 
 	ScriptsProfiler() {
-		info.resize(GLOBAL_GET("debug/settings/profiler/max_functions"));
+		info.resize(PROJECT_GET("debug/settings/profiler/max_functions"));
 		ptrs.resize(info.size());
 	}
 };
@@ -921,9 +921,9 @@ Error RemoteDebugger::_profiler_capture(const String &p_cmd, const Array &p_data
 
 RemoteDebugger::RemoteDebugger(Ref<RemoteDebuggerPeer> p_peer) {
 	peer = p_peer;
-	max_chars_per_second = GLOBAL_GET("network/limits/debugger/max_chars_per_second");
-	max_errors_per_second = GLOBAL_GET("network/limits/debugger/max_errors_per_second");
-	max_warnings_per_second = GLOBAL_GET("network/limits/debugger/max_warnings_per_second");
+	max_chars_per_second = PROJECT_GET("network/limits/debugger/max_chars_per_second");
+	max_errors_per_second = PROJECT_GET("network/limits/debugger/max_errors_per_second");
+	max_warnings_per_second = PROJECT_GET("network/limits/debugger/max_warnings_per_second");
 
 	// Network Profiler
 	network_profiler = memnew(NetworkProfiler);

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -241,5 +241,5 @@ RemoteDebuggerPeer *RemoteDebuggerPeerTCP::create(const String &p_uri) {
 }
 
 RemoteDebuggerPeer::RemoteDebuggerPeer() {
-	max_queued_messages = (int)GLOBAL_GET("network/limits/debugger/max_queued_messages");
+	max_queued_messages = (int)PROJECT_GET("network/limits/debugger/max_queued_messages");
 }

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -164,7 +164,7 @@ void Input::_bind_methods() {
 void Input::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
 
-	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
+	const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
 
 	String pf = p_function;
 	if (p_idx == 0 && (pf == "is_action_pressed" || pf == "action_press" || pf == "action_release" ||

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -466,9 +466,9 @@ Error FileAccessNetwork::_set_unix_permissions(const String &p_file, uint32_t p_
 }
 
 void FileAccessNetwork::configure() {
-	GLOBAL_DEF("network/remote_fs/page_size", 65536);
+	PROJECT_DEFAULT("network/remote_fs/page_size", 65536);
 	ProjectSettings::get_singleton()->set_custom_property_info("network/remote_fs/page_size", PropertyInfo(Variant::INT, "network/remote_fs/page_size", PROPERTY_HINT_RANGE, "1,65536,1,or_greater")); //is used as denominator and can't be zero
-	GLOBAL_DEF("network/remote_fs/page_read_ahead", 4);
+	PROJECT_DEFAULT("network/remote_fs/page_read_ahead", 4);
 	ProjectSettings::get_singleton()->set_custom_property_info("network/remote_fs/page_read_ahead", PropertyInfo(Variant::INT, "network/remote_fs/page_read_ahead", PROPERTY_HINT_RANGE, "0,8,1,or_greater"));
 }
 
@@ -478,8 +478,8 @@ FileAccessNetwork::FileAccessNetwork() {
 	id = nc->last_id++;
 	nc->accesses[id] = this;
 	nc->unlock_mutex();
-	page_size = GLOBAL_GET("network/remote_fs/page_size");
-	read_ahead = GLOBAL_GET("network/remote_fs/page_read_ahead");
+	page_size = PROJECT_GET("network/remote_fs/page_size");
+	read_ahead = PROJECT_GET("network/remote_fs/page_read_ahead");
 }
 
 FileAccessNetwork::~FileAccessNetwork() {

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -290,7 +290,7 @@ int PacketPeerStream::get_output_buffer_max_size() const {
 }
 
 PacketPeerStream::PacketPeerStream() {
-	int rbsize = GLOBAL_GET("network/limits/packet_peer_stream/max_buffer_po2");
+	int rbsize = PROJECT_GET("network/limits/packet_peer_stream/max_buffer_po2");
 
 	ring_buffer.resize(rbsize);
 	input_buffer.resize(1 << rbsize);

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -60,7 +60,7 @@ void StreamPeerTCP::accept_socket(Ref<NetSocket> p_sock, IPAddress p_host, uint1
 	_sock = p_sock;
 	_sock->set_blocking_enabled(false);
 
-	timeout = OS::get_singleton()->get_ticks_msec() + (((uint64_t)GLOBAL_GET("network/limits/tcp/connect_timeout_seconds")) * 1000);
+	timeout = OS::get_singleton()->get_ticks_msec() + (((uint64_t)PROJECT_GET("network/limits/tcp/connect_timeout_seconds")) * 1000);
 	status = STATUS_CONNECTING;
 
 	peer_host = p_host;
@@ -99,7 +99,7 @@ Error StreamPeerTCP::connect_to_host(const IPAddress &p_host, int p_port) {
 		_sock->set_blocking_enabled(false);
 	}
 
-	timeout = OS::get_singleton()->get_ticks_msec() + (((uint64_t)GLOBAL_GET("network/limits/tcp/connect_timeout_seconds")) * 1000);
+	timeout = OS::get_singleton()->get_ticks_msec() + (((uint64_t)PROJECT_GET("network/limits/tcp/connect_timeout_seconds")) * 1000);
 	Error err = _sock->connect_to_host(p_host, p_port);
 
 	if (err == OK) {

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -343,7 +343,7 @@ MessageQueue::MessageQueue() {
 	ERR_FAIL_COND_MSG(singleton != nullptr, "A MessageQueue singleton already exists.");
 	singleton = this;
 
-	buffer_size = GLOBAL_DEF_RST("memory/limits/message_queue/max_size_kb", DEFAULT_QUEUE_SIZE_KB);
+	buffer_size = PROJECT_DEFAULT_RESTART("memory/limits/message_queue/max_size_kb", DEFAULT_QUEUE_SIZE_KB);
 	ProjectSettings::get_singleton()->set_custom_property_info("memory/limits/message_queue/max_size_kb", PropertyInfo(Variant::INT, "memory/limits/message_queue/max_size_kb", PROPERTY_HINT_RANGE, "1024,4096,1,or_greater"));
 	buffer_size *= 1024;
 	buffer = memnew_arr(uint8_t, buffer_size);

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -243,12 +243,12 @@ void register_core_types() {
 
 void register_core_settings() {
 	// Since in register core types, globals may not be present.
-	GLOBAL_DEF("network/limits/tcp/connect_timeout_seconds", (30));
+	PROJECT_DEFAULT("network/limits/tcp/connect_timeout_seconds", (30));
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/tcp/connect_timeout_seconds", PropertyInfo(Variant::INT, "network/limits/tcp/connect_timeout_seconds", PROPERTY_HINT_RANGE, "1,1800,1"));
-	GLOBAL_DEF_RST("network/limits/packet_peer_stream/max_buffer_po2", (16));
+	PROJECT_DEFAULT_RESTART("network/limits/packet_peer_stream/max_buffer_po2", (16));
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/packet_peer_stream/max_buffer_po2", PropertyInfo(Variant::INT, "network/limits/packet_peer_stream/max_buffer_po2", PROPERTY_HINT_RANGE, "0,64,1,or_greater"));
 
-	GLOBAL_DEF("network/ssl/certificate_bundle_override", "");
+	PROJECT_DEFAULT("network/ssl/certificate_bundle_override", "");
 	ProjectSettings::get_singleton()->set_custom_property_info("network/ssl/certificate_bundle_override", PropertyInfo(Variant::STRING, "network/ssl/certificate_bundle_override", PROPERTY_HINT_FILE, "*.crt"));
 }
 

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -1204,14 +1204,14 @@ bool TranslationServer::_load_translations(const String &p_from) {
 }
 
 void TranslationServer::setup() {
-	String test = GLOBAL_DEF("internationalization/locale/test", "");
+	String test = PROJECT_DEFAULT("internationalization/locale/test", "");
 	test = test.strip_edges();
 	if (test != "") {
 		set_locale(test);
 	} else {
 		set_locale(OS::get_singleton()->get_locale());
 	}
-	fallback = GLOBAL_DEF("internationalization/locale/fallback", "en");
+	fallback = PROJECT_DEFAULT("internationalization/locale/fallback", "en");
 #ifdef TOOLS_ENABLED
 	{
 		String options = "";

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -44,7 +44,7 @@ extern int initialize_pulse(int verbose);
 #endif
 
 Error AudioDriverALSA::init_device() {
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = PROJECT_GET("audio/driver/mix_rate");
 	speaker_mode = SPEAKER_MODE_STEREO;
 	channels = 2;
 
@@ -110,7 +110,7 @@ Error AudioDriverALSA::init_device() {
 	// In ALSA the period size seems to be the one that will determine the actual latency
 	// Ref: https://www.alsa-project.org/main/index.php/FramesPeriods
 	unsigned int periods = 2;
-	int latency = GLOBAL_GET("audio/driver/output_latency");
+	int latency = PROJECT_GET("audio/driver/output_latency");
 	buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
 	buffer_size = buffer_frames * periods;
 	period_size = buffer_frames;

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -116,7 +116,7 @@ Error AudioDriverCoreAudio::init() {
 			break;
 	}
 
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = PROJECT_GET("audio/driver/mix_rate");
 
 	memset(&strdesc, 0, sizeof(strdesc));
 	strdesc.mFormatID = kAudioFormatLinearPCM;
@@ -131,7 +131,7 @@ Error AudioDriverCoreAudio::init() {
 	result = AudioUnitSetProperty(audio_unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, kOutputBus, &strdesc, sizeof(strdesc));
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 
-	int latency = GLOBAL_GET("audio/driver/output_latency");
+	int latency = PROJECT_GET("audio/driver/output_latency");
 	// Sample rate is independent of channels (ref: https://stackoverflow.com/questions/11048825/audio-sample-frequency-rely-on-channels)
 	buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
 
@@ -157,7 +157,7 @@ Error AudioDriverCoreAudio::init() {
 	result = AudioUnitInitialize(audio_unit);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 
-	if (GLOBAL_GET("audio/driver/enable_input")) {
+	if (PROJECT_GET("audio/driver/enable_input")) {
 		return capture_init();
 	}
 	return OK;
@@ -403,7 +403,7 @@ Error AudioDriverCoreAudio::capture_init() {
 			break;
 	}
 
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = PROJECT_GET("audio/driver/mix_rate");
 
 	memset(&strdesc, 0, sizeof(strdesc));
 	strdesc.mFormatID = kAudioFormatLinearPCM;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -217,7 +217,7 @@ Error AudioDriverPulseAudio::init_device() {
 			break;
 	}
 
-	int latency = GLOBAL_GET("audio/driver/output_latency");
+	int latency = PROJECT_GET("audio/driver/output_latency");
 	buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
 	pa_buffer_size = buffer_frames * pa_map.channels;
 
@@ -288,7 +288,7 @@ Error AudioDriverPulseAudio::init() {
 	thread_exited = false;
 	exit_thread = false;
 
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = PROJECT_GET("audio/driver/mix_rate");
 
 	pa_ml = pa_mainloop_new();
 	ERR_FAIL_COND_V(pa_ml == nullptr, ERR_CANT_OPEN);

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8344,10 +8344,10 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 		}
 	}
 
-	staging_buffer_block_size = GLOBAL_DEF("rendering/vulkan/staging_buffer/block_size_kb", 256);
+	staging_buffer_block_size = PROJECT_DEFAULT("rendering/vulkan/staging_buffer/block_size_kb", 256);
 	staging_buffer_block_size = MAX(4, staging_buffer_block_size);
 	staging_buffer_block_size *= 1024; //kb -> bytes
-	staging_buffer_max_size = GLOBAL_DEF("rendering/vulkan/staging_buffer/max_size_mb", 128);
+	staging_buffer_max_size = PROJECT_DEFAULT("rendering/vulkan/staging_buffer/max_size_mb", 128);
 	staging_buffer_max_size = MAX(1, staging_buffer_max_size);
 	staging_buffer_max_size *= 1024 * 1024;
 
@@ -8355,7 +8355,7 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 		//validate enough blocks
 		staging_buffer_max_size = staging_buffer_block_size * 4;
 	}
-	texture_upload_region_size_px = GLOBAL_DEF("rendering/vulkan/staging_buffer/texture_upload_region_size_px", 64);
+	texture_upload_region_size_px = PROJECT_DEFAULT("rendering/vulkan/staging_buffer/texture_upload_region_size_px", 64);
 	texture_upload_region_size_px = nearest_power_of_2_templated(texture_upload_region_size_px);
 
 	frames_drawn = frame_count; //start from frame count, so everything else is immediately old
@@ -8370,7 +8370,7 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 		ERR_CONTINUE(err != OK);
 	}
 
-	max_descriptors_per_pool = GLOBAL_DEF("rendering/vulkan/descriptor_pools/max_descriptors_per_pool", 64);
+	max_descriptors_per_pool = PROJECT_DEFAULT("rendering/vulkan/descriptor_pools/max_descriptors_per_pool", 64);
 
 	//check to make sure DescriptorPoolKey is good
 	static_assert(sizeof(uint64_t) * 3 >= UNIFORM_TYPE_MAX * sizeof(uint16_t));

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -387,7 +387,7 @@ Error AudioDriverWASAPI::finish_capture_device() {
 }
 
 Error AudioDriverWASAPI::init() {
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = PROJECT_GET("audio/driver/mix_rate");
 
 	Error err = init_render_device();
 	if (err != OK) {

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -44,12 +44,12 @@ Error AudioDriverXAudio2::init() {
 	pcm_open = false;
 	samples_in = nullptr;
 
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = PROJECT_GET("audio/driver/mix_rate");
 	// FIXME: speaker_mode seems unused in the Xaudio2 driver so far
 	speaker_mode = SPEAKER_MODE_STEREO;
 	channels = 2;
 
-	int latency = GLOBAL_GET("audio/driver/output_latency");
+	int latency = PROJECT_GET("audio/driver/output_latency");
 	buffer_size = closest_power_of_2(latency * mix_rate / 1000);
 
 	samples_in = memnew_arr(int32_t, buffer_size * channels);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3415,7 +3415,7 @@ void AnimationTrackEditor::_query_insert(const InsertData &p_id) {
 			}
 		}
 
-		if (bool(EDITOR_DEF("editors/animation/confirm_insert_track", true))) {
+		if (bool(EDITOR_DEFAULT("editors/animation/confirm_insert_track", true))) {
 			//potential new key, does not exist
 			if (num_tracks == 1) {
 				insert_confirm_text->set_text(vformat(TTR("Create new track for %s and insert key?"), p_id.query));

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1541,7 +1541,7 @@ void CodeTextEditor::_update_text_editor_theme() {
 	text_editor->add_theme_color_override("code_folding_color", EDITOR_GET("text_editor/highlighting/code_folding_color"));
 	text_editor->add_theme_color_override("search_result_color", EDITOR_GET("text_editor/highlighting/search_result_color"));
 	text_editor->add_theme_color_override("search_result_border_color", EDITOR_GET("text_editor/highlighting/search_result_border_color"));
-	text_editor->add_theme_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 6));
+	text_editor->add_theme_constant_override("line_spacing", EDITOR_DEFAULT("text_editor/theme/line_spacing", 6));
 	emit_signal("load_theme_settings");
 	_load_theme_settings();
 }

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -68,7 +68,7 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	empty.instantiate();
 	tabs->add_theme_style_override("panel", empty);
 
-	auto_switch_remote_scene_tree = EDITOR_DEF("debugger/auto_switch_to_remote_scene_tree", false);
+	auto_switch_remote_scene_tree = EDITOR_DEFAULT("debugger/auto_switch_to_remote_scene_tree", false);
 	_add_debugger();
 
 	// Remote scene tree
@@ -78,8 +78,8 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	EditorNode::get_singleton()->get_scene_tree_dock()->add_remote_tree_editor(remote_scene_tree);
 	EditorNode::get_singleton()->get_scene_tree_dock()->connect("remote_tree_selected", callable_mp(this, &EditorDebuggerNode::request_remote_tree));
 
-	remote_scene_tree_timeout = EDITOR_DEF("debugger/remote_scene_tree_refresh_interval", 1.0);
-	inspect_edited_object_timeout = EDITOR_DEF("debugger/remote_inspect_refresh_interval", 0.2);
+	remote_scene_tree_timeout = EDITOR_DEFAULT("debugger/remote_scene_tree_refresh_interval", 1.0);
+	inspect_edited_object_timeout = EDITOR_DEFAULT("debugger/remote_inspect_refresh_interval", 0.2);
 
 	EditorNode *editor = EditorNode::get_singleton();
 	editor->get_undo_redo()->set_method_notify_callback(_method_changeds, this);

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -653,13 +653,13 @@ EditorProfiler::EditorProfiler() {
 	h_split->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
 
-	int metric_size = CLAMP(int(EDITOR_DEF("debugger/profiler_frame_history_size", 600)), 60, 1024);
+	int metric_size = CLAMP(int(EDITOR_DEFAULT("debugger/profiler_frame_history_size", 600)), 60, 1024);
 	frame_metrics.resize(metric_size);
 	total_metrics = 0;
 	last_metric = -1;
 	hover_metric = -1;
 
-	EDITOR_DEF("debugger/profiler_frame_max_functions", 64);
+	EDITOR_DEFAULT("debugger/profiler_frame_max_functions", 64);
 
 	frame_delay = memnew(Timer);
 	frame_delay->set_wait_time(0.1);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -796,7 +796,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	h_split->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
 
-	int metric_size = CLAMP(int(EDITOR_DEF("debugger/profiler_frame_history_size", 600)), 60, 1024);
+	int metric_size = CLAMP(int(EDITOR_DEFAULT("debugger/profiler_frame_history_size", 600)), 60, 1024);
 	frame_metrics.resize(metric_size);
 	last_metric = -1;
 	//cursor_metric=-1;

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1980,7 +1980,7 @@ void EditorExportTextSceneToBinaryPlugin::_export_file(const String &p_path, con
 		return;
 	}
 
-	bool convert = GLOBAL_GET("editor/export/convert_text_resources_to_binary");
+	bool convert = PROJECT_GET("editor/export/convert_text_resources_to_binary");
 	if (!convert) {
 		return;
 	}
@@ -2000,5 +2000,5 @@ void EditorExportTextSceneToBinaryPlugin::_export_file(const String &p_path, con
 }
 
 EditorExportTextSceneToBinaryPlugin::EditorExportTextSceneToBinaryPlugin() {
-	GLOBAL_DEF("editor/export/convert_text_resources_to_binary", false);
+	PROJECT_DEFAULT("editor/export/convert_text_resources_to_binary", false);
 }

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -990,7 +990,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	export_profile->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
 	set_title(TTR("Manage Editor Feature Profiles"));
-	EDITOR_DEF("_default_feature_profile", "");
+	EDITOR_DEFAULT("_default_feature_profile", "");
 
 	update_timer = memnew(Timer);
 	update_timer->set_wait_time(1); //wait a second before updating editor

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1965,7 +1965,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 
 	reimport_files.sort();
 
-	bool use_threads = GLOBAL_GET("editor/import/use_multiple_threads");
+	bool use_threads = PROJECT_GET("editor/import/use_multiple_threads");
 
 	int from = 0;
 	for (int i = 0; i < reimport_files.size(); i++) {
@@ -2144,8 +2144,8 @@ void EditorFileSystem::_update_extensions() {
 
 EditorFileSystem::EditorFileSystem() {
 	ResourceLoader::import = _resource_import;
-	reimport_on_missing_imported_files = GLOBAL_DEF("editor/import/reimport_missing_imported_files", true);
-	GLOBAL_DEF("editor/import/use_multiple_threads", true);
+	reimport_on_missing_imported_files = PROJECT_DEFAULT("editor/import/reimport_missing_imported_files", true);
+	PROJECT_DEFAULT("editor/import/use_multiple_threads", true);
 	singleton = this;
 	filesystem = memnew(EditorFileSystemDirectory); //like, empty
 	filesystem->parent = nullptr;

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1662,7 +1662,7 @@ void EditorHelp::_bind_methods() {
 EditorHelp::EditorHelp() {
 	set_custom_minimum_size(Size2(150 * EDSCALE, 0));
 
-	EDITOR_DEF("text_editor/help/sort_functions_alphabetically", true);
+	EDITOR_DEFAULT("text_editor/help/sort_functions_alphabetically", true);
 
 	class_desc = memnew(RichTextLabel);
 	add_child(class_desc);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -443,70 +443,70 @@ void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
 }
 
 void EditorNode::_update_from_settings() {
-	int current_filter = GLOBAL_GET("rendering/textures/canvas_textures/default_texture_filter");
+	int current_filter = PROJECT_GET("rendering/textures/canvas_textures/default_texture_filter");
 	if (current_filter != scene_root->get_default_canvas_item_texture_filter()) {
 		Viewport::DefaultCanvasItemTextureFilter tf = (Viewport::DefaultCanvasItemTextureFilter)current_filter;
 		scene_root->set_default_canvas_item_texture_filter(tf);
 	}
-	int current_repeat = GLOBAL_GET("rendering/textures/canvas_textures/default_texture_repeat");
+	int current_repeat = PROJECT_GET("rendering/textures/canvas_textures/default_texture_repeat");
 	if (current_repeat != scene_root->get_default_canvas_item_texture_repeat()) {
 		Viewport::DefaultCanvasItemTextureRepeat tr = (Viewport::DefaultCanvasItemTextureRepeat)current_repeat;
 		scene_root->set_default_canvas_item_texture_repeat(tr);
 	}
 
-	RS::DOFBokehShape dof_shape = RS::DOFBokehShape(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_shape")));
+	RS::DOFBokehShape dof_shape = RS::DOFBokehShape(int(PROJECT_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_shape")));
 	RS::get_singleton()->camera_effects_set_dof_blur_bokeh_shape(dof_shape);
-	RS::DOFBlurQuality dof_quality = RS::DOFBlurQuality(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_quality")));
-	bool dof_jitter = GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_use_jitter");
+	RS::DOFBlurQuality dof_quality = RS::DOFBlurQuality(int(PROJECT_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_quality")));
+	bool dof_jitter = PROJECT_GET("rendering/camera/depth_of_field/depth_of_field_use_jitter");
 	RS::get_singleton()->camera_effects_set_dof_blur_quality(dof_quality, dof_jitter);
-	RS::get_singleton()->environment_set_ssao_quality(RS::EnvironmentSSAOQuality(int(GLOBAL_GET("rendering/environment/ssao/quality"))), GLOBAL_GET("rendering/environment/ssao/half_size"), GLOBAL_GET("rendering/environment/ssao/adaptive_target"), GLOBAL_GET("rendering/environment/ssao/blur_passes"), GLOBAL_GET("rendering/environment/ssao/fadeout_from"), GLOBAL_GET("rendering/environment/ssao/fadeout_to"));
-	RS::get_singleton()->screen_space_roughness_limiter_set_active(GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/enabled"), GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/amount"), GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/limit"));
-	bool glow_bicubic = int(GLOBAL_GET("rendering/environment/glow/upscale_mode")) > 0;
+	RS::get_singleton()->environment_set_ssao_quality(RS::EnvironmentSSAOQuality(int(PROJECT_GET("rendering/environment/ssao/quality"))), PROJECT_GET("rendering/environment/ssao/half_size"), PROJECT_GET("rendering/environment/ssao/adaptive_target"), PROJECT_GET("rendering/environment/ssao/blur_passes"), PROJECT_GET("rendering/environment/ssao/fadeout_from"), PROJECT_GET("rendering/environment/ssao/fadeout_to"));
+	RS::get_singleton()->screen_space_roughness_limiter_set_active(PROJECT_GET("rendering/anti_aliasing/screen_space_roughness_limiter/enabled"), PROJECT_GET("rendering/anti_aliasing/screen_space_roughness_limiter/amount"), PROJECT_GET("rendering/anti_aliasing/screen_space_roughness_limiter/limit"));
+	bool glow_bicubic = int(PROJECT_GET("rendering/environment/glow/upscale_mode")) > 0;
 	RS::get_singleton()->environment_glow_set_use_bicubic_upscale(glow_bicubic);
-	bool glow_high_quality = GLOBAL_GET("rendering/environment/glow/use_high_quality");
+	bool glow_high_quality = PROJECT_GET("rendering/environment/glow/use_high_quality");
 	RS::get_singleton()->environment_glow_set_use_high_quality(glow_high_quality);
-	RS::EnvironmentSSRRoughnessQuality ssr_roughness_quality = RS::EnvironmentSSRRoughnessQuality(int(GLOBAL_GET("rendering/environment/screen_space_reflection/roughness_quality")));
+	RS::EnvironmentSSRRoughnessQuality ssr_roughness_quality = RS::EnvironmentSSRRoughnessQuality(int(PROJECT_GET("rendering/environment/screen_space_reflection/roughness_quality")));
 	RS::get_singleton()->environment_set_ssr_roughness_quality(ssr_roughness_quality);
-	RS::SubSurfaceScatteringQuality sss_quality = RS::SubSurfaceScatteringQuality(int(GLOBAL_GET("rendering/environment/subsurface_scattering/subsurface_scattering_quality")));
+	RS::SubSurfaceScatteringQuality sss_quality = RS::SubSurfaceScatteringQuality(int(PROJECT_GET("rendering/environment/subsurface_scattering/subsurface_scattering_quality")));
 	RS::get_singleton()->sub_surface_scattering_set_quality(sss_quality);
-	float sss_scale = GLOBAL_GET("rendering/environment/subsurface_scattering/subsurface_scattering_scale");
-	float sss_depth_scale = GLOBAL_GET("rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale");
+	float sss_scale = PROJECT_GET("rendering/environment/subsurface_scattering/subsurface_scattering_scale");
+	float sss_depth_scale = PROJECT_GET("rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale");
 	RS::get_singleton()->sub_surface_scattering_set_scale(sss_scale, sss_depth_scale);
 
-	uint32_t directional_shadow_size = GLOBAL_GET("rendering/shadows/directional_shadow/size");
-	uint32_t directional_shadow_16_bits = GLOBAL_GET("rendering/shadows/directional_shadow/16_bits");
+	uint32_t directional_shadow_size = PROJECT_GET("rendering/shadows/directional_shadow/size");
+	uint32_t directional_shadow_16_bits = PROJECT_GET("rendering/shadows/directional_shadow/16_bits");
 	RS::get_singleton()->directional_shadow_atlas_set_size(directional_shadow_size, directional_shadow_16_bits);
 
-	RS::ShadowQuality shadows_quality = RS::ShadowQuality(int(GLOBAL_GET("rendering/shadows/shadows/soft_shadow_quality")));
+	RS::ShadowQuality shadows_quality = RS::ShadowQuality(int(PROJECT_GET("rendering/shadows/shadows/soft_shadow_quality")));
 	RS::get_singleton()->shadows_quality_set(shadows_quality);
-	RS::ShadowQuality directional_shadow_quality = RS::ShadowQuality(int(GLOBAL_GET("rendering/shadows/directional_shadow/soft_shadow_quality")));
+	RS::ShadowQuality directional_shadow_quality = RS::ShadowQuality(int(PROJECT_GET("rendering/shadows/directional_shadow/soft_shadow_quality")));
 	RS::get_singleton()->directional_shadow_quality_set(directional_shadow_quality);
-	float probe_update_speed = GLOBAL_GET("rendering/lightmapping/probe_capture/update_speed");
+	float probe_update_speed = PROJECT_GET("rendering/lightmapping/probe_capture/update_speed");
 	RS::get_singleton()->lightmap_set_probe_capture_update_speed(probe_update_speed);
-	RS::EnvironmentSDFGIFramesToConverge frames_to_converge = RS::EnvironmentSDFGIFramesToConverge(int(GLOBAL_GET("rendering/global_illumination/sdfgi/frames_to_converge")));
+	RS::EnvironmentSDFGIFramesToConverge frames_to_converge = RS::EnvironmentSDFGIFramesToConverge(int(PROJECT_GET("rendering/global_illumination/sdfgi/frames_to_converge")));
 	RS::get_singleton()->environment_set_sdfgi_frames_to_converge(frames_to_converge);
-	RS::EnvironmentSDFGIRayCount ray_count = RS::EnvironmentSDFGIRayCount(int(GLOBAL_GET("rendering/global_illumination/sdfgi/probe_ray_count")));
+	RS::EnvironmentSDFGIRayCount ray_count = RS::EnvironmentSDFGIRayCount(int(PROJECT_GET("rendering/global_illumination/sdfgi/probe_ray_count")));
 	RS::get_singleton()->environment_set_sdfgi_ray_count(ray_count);
-	RS::VoxelGIQuality voxel_gi_quality = RS::VoxelGIQuality(int(GLOBAL_GET("rendering/global_illumination/voxel_gi/quality")));
+	RS::VoxelGIQuality voxel_gi_quality = RS::VoxelGIQuality(int(PROJECT_GET("rendering/global_illumination/voxel_gi/quality")));
 	RS::get_singleton()->voxel_gi_set_quality(voxel_gi_quality);
-	RS::get_singleton()->environment_set_volumetric_fog_volume_size(GLOBAL_GET("rendering/environment/volumetric_fog/volume_size"), GLOBAL_GET("rendering/environment/volumetric_fog/volume_depth"));
-	RS::get_singleton()->environment_set_volumetric_fog_filter_active(bool(GLOBAL_GET("rendering/environment/volumetric_fog/use_filter")));
-	RS::get_singleton()->canvas_set_shadow_texture_size(GLOBAL_GET("rendering/2d/shadow_atlas/size"));
+	RS::get_singleton()->environment_set_volumetric_fog_volume_size(PROJECT_GET("rendering/environment/volumetric_fog/volume_size"), PROJECT_GET("rendering/environment/volumetric_fog/volume_depth"));
+	RS::get_singleton()->environment_set_volumetric_fog_filter_active(bool(PROJECT_GET("rendering/environment/volumetric_fog/use_filter")));
+	RS::get_singleton()->canvas_set_shadow_texture_size(PROJECT_GET("rendering/2d/shadow_atlas/size"));
 
-	bool use_half_res_gi = GLOBAL_DEF("rendering/global_illumination/gi/use_half_resolution", false);
+	bool use_half_res_gi = PROJECT_DEFAULT("rendering/global_illumination/gi/use_half_resolution", false);
 	RS::get_singleton()->gi_set_use_half_resolution(use_half_res_gi);
 
-	bool snap_2d_transforms = GLOBAL_GET("rendering/2d/snap/snap_2d_transforms_to_pixel");
+	bool snap_2d_transforms = PROJECT_GET("rendering/2d/snap/snap_2d_transforms_to_pixel");
 	scene_root->set_snap_2d_transforms_to_pixel(snap_2d_transforms);
-	bool snap_2d_vertices = GLOBAL_GET("rendering/2d/snap/snap_2d_vertices_to_pixel");
+	bool snap_2d_vertices = PROJECT_GET("rendering/2d/snap/snap_2d_vertices_to_pixel");
 	scene_root->set_snap_2d_vertices_to_pixel(snap_2d_vertices);
 
-	Viewport::SDFOversize sdf_oversize = Viewport::SDFOversize(int(GLOBAL_GET("rendering/2d/sdf/oversize")));
+	Viewport::SDFOversize sdf_oversize = Viewport::SDFOversize(int(PROJECT_GET("rendering/2d/sdf/oversize")));
 	scene_root->set_sdf_oversize(sdf_oversize);
-	Viewport::SDFScale sdf_scale = Viewport::SDFScale(int(GLOBAL_GET("rendering/2d/sdf/scale")));
+	Viewport::SDFScale sdf_scale = Viewport::SDFScale(int(PROJECT_GET("rendering/2d/sdf/scale")));
 	scene_root->set_sdf_scale(sdf_scale);
 
-	float lod_threshold = GLOBAL_GET("rendering/mesh_lod/lod_change/threshold_pixels");
+	float lod_threshold = PROJECT_GET("rendering/mesh_lod/lod_change/threshold_pixels");
 	scene_root->set_lod_threshold(lod_threshold);
 }
 
@@ -4678,7 +4678,7 @@ bool EditorNode::has_scenes_in_session() {
 
 bool EditorNode::ensure_main_scene(bool p_from_native) {
 	pick_main_scene->set_meta("from_native", p_from_native); //whether from play button or native run
-	String main_scene = GLOBAL_DEF("application/run/main_scene", "");
+	String main_scene = PROJECT_DEFAULT("application/run/main_scene", "");
 
 	if (main_scene == "") {
 		current_option = -1;
@@ -4740,7 +4740,7 @@ bool EditorNode::is_run_playing() const {
 String EditorNode::get_run_playing_scene() const {
 	String run_filename = editor_run.get_running_scene();
 	if (run_filename == "" && is_run_playing()) {
-		run_filename = GLOBAL_DEF("application/run/main_scene", ""); // Must be the main scene then.
+		run_filename = PROJECT_DEFAULT("application/run/main_scene", ""); // Must be the main scene then.
 	}
 
 	return run_filename;
@@ -5865,33 +5865,33 @@ EditorNode::EditorNode() {
 	ClassDB::set_class_enabled("RootMotionView", true);
 
 	//defs here, use EDITOR_GET in logic
-	EDITOR_DEF_RST("interface/scene_tabs/always_show_close_button", false);
-	EDITOR_DEF_RST("interface/scene_tabs/resize_if_many_tabs", true);
-	EDITOR_DEF_RST("interface/scene_tabs/minimum_width", 50);
-	EDITOR_DEF("run/output/always_clear_output_on_play", true);
-	EDITOR_DEF("run/output/always_open_output_on_play", true);
-	EDITOR_DEF("run/output/always_close_output_on_stop", true);
-	EDITOR_DEF("run/auto_save/save_before_running", true);
-	EDITOR_DEF("interface/editor/save_on_focus_loss", false);
-	EDITOR_DEF_RST("interface/editor/save_each_scene_on_quit", true);
-	EDITOR_DEF("interface/editor/show_update_spinner", false);
-	EDITOR_DEF("interface/editor/update_continuously", false);
-	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", false);
-	EDITOR_DEF_RST("interface/scene_tabs/show_thumbnail_on_hover", true);
-	EDITOR_DEF_RST("interface/inspector/capitalize_properties", true);
-	EDITOR_DEF_RST("interface/inspector/default_float_step", 0.001);
+	EDITOR_DEFAULT_RESTART("interface/scene_tabs/always_show_close_button", false);
+	EDITOR_DEFAULT_RESTART("interface/scene_tabs/resize_if_many_tabs", true);
+	EDITOR_DEFAULT_RESTART("interface/scene_tabs/minimum_width", 50);
+	EDITOR_DEFAULT("run/output/always_clear_output_on_play", true);
+	EDITOR_DEFAULT("run/output/always_open_output_on_play", true);
+	EDITOR_DEFAULT("run/output/always_close_output_on_stop", true);
+	EDITOR_DEFAULT("run/auto_save/save_before_running", true);
+	EDITOR_DEFAULT("interface/editor/save_on_focus_loss", false);
+	EDITOR_DEFAULT_RESTART("interface/editor/save_each_scene_on_quit", true);
+	EDITOR_DEFAULT("interface/editor/show_update_spinner", false);
+	EDITOR_DEFAULT("interface/editor/update_continuously", false);
+	EDITOR_DEFAULT_RESTART("interface/scene_tabs/restore_scenes_on_load", false);
+	EDITOR_DEFAULT_RESTART("interface/scene_tabs/show_thumbnail_on_hover", true);
+	EDITOR_DEFAULT_RESTART("interface/inspector/capitalize_properties", true);
+	EDITOR_DEFAULT_RESTART("interface/inspector/default_float_step", 0.001);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::FLOAT, "interface/inspector/default_float_step", PROPERTY_HINT_RANGE, "0,1,0"));
-	EDITOR_DEF_RST("interface/inspector/disable_folding", false);
-	EDITOR_DEF_RST("interface/inspector/auto_unfold_foreign_scenes", true);
-	EDITOR_DEF("interface/inspector/horizontal_vector2_editing", false);
-	EDITOR_DEF("interface/inspector/horizontal_vector_types_editing", true);
-	EDITOR_DEF("interface/inspector/open_resources_in_current_inspector", true);
-	EDITOR_DEF("interface/inspector/resources_to_open_in_new_inspector", "Script,MeshLibrary");
-	EDITOR_DEF("interface/inspector/default_color_picker_mode", 0);
+	EDITOR_DEFAULT_RESTART("interface/inspector/disable_folding", false);
+	EDITOR_DEFAULT_RESTART("interface/inspector/auto_unfold_foreign_scenes", true);
+	EDITOR_DEFAULT("interface/inspector/horizontal_vector2_editing", false);
+	EDITOR_DEFAULT("interface/inspector/horizontal_vector_types_editing", true);
+	EDITOR_DEFAULT("interface/inspector/open_resources_in_current_inspector", true);
+	EDITOR_DEFAULT("interface/inspector/resources_to_open_in_new_inspector", "Script,MeshLibrary");
+	EDITOR_DEFAULT("interface/inspector/default_color_picker_mode", 0);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_color_picker_mode", PROPERTY_HINT_ENUM, "RGB,HSV,RAW", PROPERTY_USAGE_DEFAULT));
-	EDITOR_DEF("interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_VHS_CIRCLE);
+	EDITOR_DEFAULT("interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_VHS_CIRCLE);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_color_picker_shape", PROPERTY_HINT_ENUM, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle", PROPERTY_USAGE_DEFAULT));
-	EDITOR_DEF("run/auto_save/save_before_running", true);
+	EDITOR_DEFAULT("run/auto_save/save_before_running", true);
 
 	theme_base = memnew(Control);
 	add_child(theme_base);
@@ -6089,8 +6089,8 @@ EditorNode::EditorNode() {
 	scene_tabs->set_select_with_rmb(true);
 	scene_tabs->add_tab("unsaved");
 	scene_tabs->set_tab_align(Tabs::ALIGN_LEFT);
-	scene_tabs->set_tab_close_display_policy((bool(EDITOR_DEF("interface/scene_tabs/always_show_close_button", false)) ? Tabs::CLOSE_BUTTON_SHOW_ALWAYS : Tabs::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
-	scene_tabs->set_min_width(int(EDITOR_DEF("interface/scene_tabs/minimum_width", 50)) * EDSCALE);
+	scene_tabs->set_tab_close_display_policy((bool(EDITOR_DEFAULT("interface/scene_tabs/always_show_close_button", false)) ? Tabs::CLOSE_BUTTON_SHOW_ALWAYS : Tabs::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
+	scene_tabs->set_min_width(int(EDITOR_DEFAULT("interface/scene_tabs/minimum_width", 50)) * EDSCALE);
 	scene_tabs->set_drag_to_rearrange_enabled(true);
 	scene_tabs->connect("tab_changed", callable_mp(this, &EditorNode::_scene_tab_changed));
 	scene_tabs->connect("right_button_pressed", callable_mp(this, &EditorNode::_scene_tab_script_edited));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1128,7 +1128,7 @@ void EditorSettings::set_initial_value(const StringName &p_setting, const Varian
 	}
 }
 
-Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_restart_if_changed) {
+Variant _EDITOR_DEFAULT(const String &p_setting, const Variant &p_default, bool p_restart_if_changed) {
 	Variant ret = p_default;
 	if (EditorSettings::get_singleton()->has_setting(p_setting)) {
 		ret = EditorSettings::get_singleton()->get(p_setting);

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -190,15 +190,23 @@ public:
 	~EditorSettings();
 };
 
+// Returns the value of the editor setting `m_var`, or `m_value` if the setting is not defined yet.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define EDITOR_DEFAULT(m_var, m_value) _EDITOR_DEFAULT(m_var, Variant(m_value))
+
+// Returns the value of the editor setting `m_var`, or `m_value` if the setting is not defined yet.
+// Also requests a restart of the editor when changed using the Editor Settings dialog.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
+#define EDITOR_DEFAULT_RESTART(m_var, m_value) _EDITOR_DEFAULT(m_var, Variant(m_value), true)
 //not a macro any longer
+Variant _EDITOR_DEFAULT(const String &p_setting, const Variant &p_default, bool p_restart_if_changed = false);
 
-#define EDITOR_DEF(m_var, m_val) _EDITOR_DEF(m_var, Variant(m_val))
-#define EDITOR_DEF_RST(m_var, m_val) _EDITOR_DEF(m_var, Variant(m_val), true)
-Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_restart_if_changed = false);
-
+// Returns the value of the editor setting `m_var`, or Variant `null` if the setting doesn't exist.
+// Consider casting this macro's return value to a specific type to improve safety and avoid crashes.
 #define EDITOR_GET(m_var) _EDITOR_GET(m_var)
 Variant _EDITOR_GET(const String &p_setting);
 
+// Returns `true` if the InputEvent `p_ev` matches the editor shortcut with String path `p_name`, `false` otherwise.
 #define ED_IS_SHORTCUT(p_name, p_ev) (EditorSettings::get_singleton()->is_shortcut(p_name, p_ev))
 Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p_keycode = 0);
 Ref<Shortcut> ED_GET_SHORTCUT(const String &p_path);

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -298,8 +298,8 @@ void EditorFileServer::_thread_start(void *s) {
 
 void EditorFileServer::start() {
 	stop();
-	port = EDITOR_DEF("filesystem/file_server/port", 6010);
-	password = EDITOR_DEF("filesystem/file_server/password", "");
+	port = EDITOR_DEFAULT("filesystem/file_server/port", 6010);
+	password = EDITOR_DEFAULT("filesystem/file_server/password", "");
 	cmd = CMD_ACTIVATE;
 }
 
@@ -318,8 +318,8 @@ EditorFileServer::EditorFileServer() {
 	cmd = CMD_NONE;
 	thread.start(_thread_start, this);
 
-	EDITOR_DEF("filesystem/file_server/port", 6010);
-	EDITOR_DEF("filesystem/file_server/password", "");
+	EDITOR_DEFAULT("filesystem/file_server/port", 6010);
+	EDITOR_DEFAULT("filesystem/file_server/password", "");
 }
 
 EditorFileServer::~EditorFileServer() {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1307,7 +1307,7 @@ void FileSystemDock::_update_project_settings_after_move(const Map<String, Strin
 	const Map<StringName, PropertyInfo> prop_info = ProjectSettings::get_singleton()->get_custom_property_info();
 	for (const Map<StringName, PropertyInfo>::Element *E = prop_info.front(); E; E = E->next()) {
 		if (E->get().hint == PROPERTY_HINT_FILE) {
-			String old_path = GLOBAL_GET(E->key());
+			String old_path = PROJECT_GET(E->key());
 			if (p_renames.has(old_path)) {
 				ProjectSettings::get_singleton()->set_setting(E->key(), p_renames[old_path]);
 			}
@@ -1321,7 +1321,7 @@ void FileSystemDock::_update_project_settings_after_move(const Map<String, Strin
 		if (E->get().name.begins_with("autoload/")) {
 			// If the autoload resource paths has a leading "*", it indicates that it is a Singleton,
 			// so we have to handle both cases when updating.
-			String autoload = GLOBAL_GET(E->get().name);
+			String autoload = PROJECT_GET(E->get().name);
 			String autoload_singleton = autoload.substr(1, autoload.length());
 			if (p_renames.has(autoload)) {
 				ProjectSettings::get_singleton()->set_setting(E->get().name, p_renames[autoload]);

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -198,7 +198,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Node3D *p_parent) {
 						return OK; //do nothing not needed
 					}
 
-					if (!bool(GLOBAL_DEF("collada/use_ambient", false))) {
+					if (!bool(PROJECT_DEFAULT("collada/use_ambient", false))) {
 						return OK;
 					}
 					//well, it's an ambient light..

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -1048,7 +1048,7 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 //// player gizmo
 AudioStreamPlayer3DGizmoPlugin::AudioStreamPlayer3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/stream_player_3d", Color(0.4, 0.8, 1));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/stream_player_3d", Color(0.4, 0.8, 1));
 
 	create_icon_material("stream_player_3d_icon", Node3DEditor::get_singleton()->get_theme_icon("Gizmo3DSamplePlayer", "EditorIcons"));
 	create_material("stream_player_3d_material_primary", gizmo_color);
@@ -1185,7 +1185,7 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 //////
 
 Camera3DGizmoPlugin::Camera3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/camera", Color(0.8, 0.4, 0.8));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/camera", Color(0.8, 0.4, 0.8));
 
 	create_material("camera_material", gizmo_color);
 	create_handle_material("handles");
@@ -1464,7 +1464,7 @@ void MeshInstance3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 /////
 
 OccluderInstance3DGizmoPlugin::OccluderInstance3DGizmoPlugin() {
-	create_material("line_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/occluder", Color(0.8, 0.5, 1)));
+	create_material("line_material", EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/occluder", Color(0.8, 0.5, 1)));
 }
 
 bool OccluderInstance3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -1613,7 +1613,7 @@ void Position3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 /////
 
 Skeleton3DGizmoPlugin::Skeleton3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/skeleton", Color(1, 0.8, 0.4));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/skeleton", Color(1, 0.8, 0.4));
 	create_material("skeleton_material", gizmo_color);
 }
 
@@ -1767,7 +1767,7 @@ void Skeleton3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 PhysicalBone3DGizmoPlugin::PhysicalBone3DGizmoPlugin() {
-	create_material("joint_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/joint", Color(0.5, 0.8, 1)));
+	create_material("joint_material", EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/joint", Color(0.5, 0.8, 1)));
 }
 
 bool PhysicalBone3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -1900,7 +1900,7 @@ void PhysicalBone3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 /////
 
 RayCast3DGizmoPlugin::RayCast3DGizmoPlugin() {
-	const Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	const Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
 	const float gizmo_value = gizmo_color.get_v();
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
@@ -1954,7 +1954,7 @@ void SpringArm3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 }
 
 SpringArm3DGizmoPlugin::SpringArm3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
 }
 
@@ -1973,7 +1973,7 @@ int SpringArm3DGizmoPlugin::get_priority() const {
 /////
 
 VehicleWheel3DGizmoPlugin::VehicleWheel3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
 }
 
@@ -2044,7 +2044,7 @@ void VehicleWheel3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ///////////
 
 SoftBody3DGizmoPlugin::SoftBody3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
 	create_handle_material("handles");
 }
@@ -2124,7 +2124,7 @@ bool SoftBody3DGizmoPlugin::is_handle_highlighted(const EditorNode3DGizmo *p_giz
 ///////////
 
 VisibleOnScreenNotifier3DGizmoPlugin::VisibleOnScreenNotifier3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/visibility_notifier", Color(0.8, 0.5, 0.7));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/visibility_notifier", Color(0.8, 0.5, 0.7));
 	create_material("visibility_notifier_material", gizmo_color);
 	gizmo_color.a = 0.1;
 	create_material("visibility_notifier_solid_material", gizmo_color);
@@ -2311,7 +2311,7 @@ void CPUParticles3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 GPUParticles3DGizmoPlugin::GPUParticles3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/particles", Color(0.8, 0.7, 0.4));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/particles", Color(0.8, 0.7, 0.4));
 	create_material("particles_material", gizmo_color);
 	gizmo_color.a = 0.1;
 	create_material("particles_solid_material", gizmo_color);
@@ -2478,7 +2478,7 @@ void GPUParticles3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 GPUParticlesCollision3DGizmoPlugin::GPUParticlesCollision3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/particle_collision", Color(0.5, 0.7, 1));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/particle_collision", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
 	gizmo_color.a = 0.15;
 	create_material("shape_material_internal", gizmo_color);
@@ -2736,7 +2736,7 @@ void GPUParticlesCollision3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 ReflectionProbeGizmoPlugin::ReflectionProbeGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/reflection_probe", Color(0.6, 1, 0.5));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/reflection_probe", Color(0.6, 1, 0.5));
 
 	create_material("reflection_probe_material", gizmo_color);
 
@@ -2928,7 +2928,7 @@ void ReflectionProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 DecalGizmoPlugin::DecalGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/decal", Color(0.6, 0.5, 1.0));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/decal", Color(0.6, 0.5, 1.0));
 
 	create_material("decal_material", gizmo_color);
 
@@ -3061,7 +3061,7 @@ void DecalGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 ///////////////////////////////
 VoxelGIGizmoPlugin::VoxelGIGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/voxel_gi", Color(0.5, 1, 0.6));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/voxel_gi", Color(0.5, 1, 0.6));
 
 	create_material("voxel_gi_material", gizmo_color);
 
@@ -3241,7 +3241,7 @@ void VoxelGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 LightmapGIGizmoPlugin::LightmapGIGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/lightmap_lines", Color(0.5, 0.6, 1));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/lightmap_lines", Color(0.5, 0.6, 1));
 
 	gizmo_color.a = 0.1;
 	create_material("lightmap_lines", gizmo_color);
@@ -3433,7 +3433,7 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 /////////
 
 LightmapProbeGizmoPlugin::LightmapProbeGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/lightprobe_lines", Color(0.5, 0.6, 1));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/lightprobe_lines", Color(0.5, 0.6, 1));
 
 	gizmo_color.a = 0.3;
 	create_material("lightprobe_lines", gizmo_color);
@@ -3529,7 +3529,7 @@ void LightmapProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 CollisionObject3DGizmoPlugin::CollisionObject3DGizmoPlugin() {
-	const Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	const Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
 	const float gizmo_value = gizmo_color.get_v();
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
@@ -3580,7 +3580,7 @@ void CollisionObject3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 CollisionShape3DGizmoPlugin::CollisionShape3DGizmoPlugin() {
-	const Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	const Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
 	const float gizmo_value = gizmo_color.get_v();
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
@@ -4181,7 +4181,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 /////
 
 CollisionPolygon3DGizmoPlugin::CollisionPolygon3DGizmoPlugin() {
-	const Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
+	const Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/shape", Color(0.5, 0.7, 1));
 	create_material("shape_material", gizmo_color);
 	const float gizmo_value = gizmo_color.get_v();
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
@@ -4229,10 +4229,10 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 NavigationRegion3DGizmoPlugin::NavigationRegion3DGizmoPlugin() {
-	create_material("navigation_edge_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_edge", Color(0.5, 1, 1)));
-	create_material("navigation_edge_material_disabled", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_edge_disabled", Color(0.7, 0.7, 0.7)));
-	create_material("navigation_solid_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_solid", Color(0.5, 1, 1, 0.4)));
-	create_material("navigation_solid_material_disabled", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/navigation_solid_disabled", Color(0.7, 0.7, 0.7, 0.4)));
+	create_material("navigation_edge_material", EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/navigation_edge", Color(0.5, 1, 1)));
+	create_material("navigation_edge_material_disabled", EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/navigation_edge_disabled", Color(0.7, 0.7, 0.7)));
+	create_material("navigation_solid_material", EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/navigation_solid", Color(0.5, 1, 1, 0.4)));
+	create_material("navigation_solid_material_disabled", EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/navigation_solid_disabled", Color(0.7, 0.7, 0.7, 0.4)));
 }
 
 bool NavigationRegion3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -4580,9 +4580,9 @@ void JointGizmosDrawer::draw_cone(const Transform3D &p_offset, const Basis &p_ba
 ////
 
 Joint3DGizmoPlugin::Joint3DGizmoPlugin() {
-	create_material("joint_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/joint", Color(0.5, 0.8, 1)));
-	create_material("joint_body_a_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/joint_body_a", Color(0.6, 0.8, 1)));
-	create_material("joint_body_b_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/joint_body_b", Color(0.6, 0.9, 1)));
+	create_material("joint_material", EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/joint", Color(0.5, 0.8, 1)));
+	create_material("joint_body_a_material", EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/joint_body_a", Color(0.6, 0.8, 1)));
+	create_material("joint_body_b_material", EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/joint_body_b", Color(0.6, 0.9, 1)));
 
 	update_timer = memnew(Timer);
 	update_timer->set_name("JointGizmoUpdateTimer");

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1401,7 +1401,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 	// Render every past/future step with the capture shader.
 
 	RS::get_singleton()->canvas_item_set_material(onion.capture.canvas_item, onion.capture.material->get_rid());
-	onion.capture.material->set_shader_param("bkg_color", GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
+	onion.capture.material->set_shader_param("bkg_color", PROJECT_GET("rendering/environment/defaults/default_clear_color"));
 	onion.capture.material->set_shader_param("differences_only", onion.differences_only);
 	onion.capture.material->set_shader_param("present", onion.differences_only ? RS::get_singleton()->viewport_get_texture(present_rid) : RID());
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -530,7 +530,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	download = memnew(HTTPRequest);
 	add_child(download);
 	download->connect("request_completed", callable_mp(this, &EditorAssetLibraryItemDownload::_http_download_completed));
-	download->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
+	download->set_use_threads(EDITOR_DEFAULT("asset_library/use_threads", true));
 
 	download_error = memnew(AcceptDialog);
 	add_child(download_error);
@@ -601,7 +601,7 @@ void EditorAssetLibrary::_update_repository_options() {
 	Dictionary default_urls;
 	default_urls["godotengine.org"] = "https://godotengine.org/asset-library/api";
 	default_urls["localhost"] = "http://127.0.0.1/asset-library/api";
-	Dictionary available_urls = _EDITOR_DEF("asset_library/available_urls", default_urls, true);
+	Dictionary available_urls = _EDITOR_DEFAULT("asset_library/available_urls", default_urls, true);
 	repository->clear();
 	Array keys = available_urls.keys();
 	for (int i = 0; i < available_urls.size(); i++) {
@@ -866,7 +866,7 @@ void EditorAssetLibrary::_request_image(ObjectID p_for, String p_image_url, Imag
 	iq.image_index = p_image_index;
 	iq.image_type = p_type;
 	iq.request = memnew(HTTPRequest);
-	iq.request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
+	iq.request->set_use_threads(EDITOR_DEFAULT("asset_library/use_threads", true));
 
 	iq.target = p_for;
 	iq.queue_id = ++last_queue_id;
@@ -1475,7 +1475,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	request = memnew(HTTPRequest);
 	add_child(request);
-	request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
+	request->set_use_threads(EDITOR_DEFAULT("asset_library/use_threads", true));
 	request->connect("request_completed", callable_mp(this, &EditorAssetLibrary::_http_request_completed));
 
 	last_queue_id = 0;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3682,7 +3682,7 @@ void CanvasItemEditor::set_current_tool(Tool p_tool) {
 
 void CanvasItemEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_PHYSICS_PROCESS) {
-		EditorNode::get_singleton()->get_scene_root()->set_snap_controls_to_pixels(GLOBAL_GET("gui/common/snap_controls_to_pixels"));
+		EditorNode::get_singleton()->get_scene_root()->set_snap_controls_to_pixels(PROJECT_GET("gui/common/snap_controls_to_pixels"));
 
 		bool has_container_parents = false;
 		int nb_control = 0;

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -294,7 +294,7 @@ void MeshLibraryEditorPlugin::make_visible(bool p_visible) {
 }
 
 MeshLibraryEditorPlugin::MeshLibraryEditorPlugin(EditorNode *p_node) {
-	EDITOR_DEF("editors/grid_map/preview_size", 64);
+	EDITOR_DEFAULT("editors/grid_map/preview_size", 64);
 	mesh_library_editor = memnew(MeshLibraryEditor(p_node));
 
 	p_node->get_main_control()->add_child(mesh_library_editor);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2252,7 +2252,7 @@ void Node3DEditorViewport::scale_freelook_speed(real_t scale) {
 
 Point2i Node3DEditorViewport::_get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const {
 	Point2i relative;
-	if (bool(EDITOR_DEF("editors/3d/navigation/warped_mouse_panning", false))) {
+	if (bool(EDITOR_DEFAULT("editors/3d/navigation/warped_mouse_panning", false))) {
 		relative = Input::get_singleton()->warp_mouse_motion(p_ev_mouse_motion, surface->get_global_rect());
 	} else {
 		relative = p_ev_mouse_motion->get_relative();
@@ -2376,12 +2376,12 @@ void Node3DEditorViewport::_project_settings_changed() {
 
 	const int msaa_mode = ProjectSettings::get_singleton()->get("rendering/anti_aliasing/quality/msaa");
 	viewport->set_msaa(Viewport::MSAA(msaa_mode));
-	const int ssaa_mode = GLOBAL_GET("rendering/anti_aliasing/quality/screen_space_aa");
+	const int ssaa_mode = PROJECT_GET("rendering/anti_aliasing/quality/screen_space_aa");
 	viewport->set_screen_space_aa(Viewport::ScreenSpaceAA(ssaa_mode));
-	const bool use_debanding = GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding");
+	const bool use_debanding = PROJECT_GET("rendering/anti_aliasing/quality/use_debanding");
 	viewport->set_use_debanding(use_debanding);
 
-	const bool use_occlusion_culling = GLOBAL_GET("rendering/occlusion_culling/use_occlusion_culling");
+	const bool use_occlusion_culling = PROJECT_GET("rendering/occlusion_culling/use_occlusion_culling");
 	viewport->set_use_occlusion_culling(use_occlusion_culling);
 }
 
@@ -7088,11 +7088,11 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	set_process_unhandled_key_input(true);
 	add_to_group("_spatial_editor_group");
 
-	EDITOR_DEF("editors/3d/manipulator_gizmo_size", 80);
+	EDITOR_DEFAULT("editors/3d/manipulator_gizmo_size", 80);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "editors/3d/manipulator_gizmo_size", PROPERTY_HINT_RANGE, "16,160,1"));
-	EDITOR_DEF("editors/3d/manipulator_gizmo_opacity", 0.9);
+	EDITOR_DEFAULT("editors/3d/manipulator_gizmo_opacity", 0.9);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::FLOAT, "editors/3d/manipulator_gizmo_opacity", PROPERTY_HINT_RANGE, "0,1,0.01"));
-	EDITOR_DEF("editors/3d/navigation/show_viewport_rotation_gizmo", true);
+	EDITOR_DEFAULT("editors/3d/navigation/show_viewport_rotation_gizmo", true);
 
 	over_gizmo_handle = -1;
 	{
@@ -7393,7 +7393,7 @@ Node3DEditorPlugin::~Node3DEditorPlugin() {
 }
 
 void EditorNode3DGizmoPlugin::create_material(const String &p_name, const Color &p_color, bool p_billboard, bool p_on_top, bool p_use_vertex_color) {
-	Color instantiated_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/instantiated", Color(0.7, 0.7, 0.7, 0.6));
+	Color instantiated_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/instantiated", Color(0.7, 0.7, 0.7, 0.6));
 
 	Vector<Ref<StandardMaterial3D>> mats;
 
@@ -7435,7 +7435,7 @@ void EditorNode3DGizmoPlugin::create_material(const String &p_name, const Color 
 }
 
 void EditorNode3DGizmoPlugin::create_icon_material(const String &p_name, const Ref<Texture2D> &p_texture, bool p_on_top, const Color &p_albedo) {
-	Color instantiated_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/instantiated", Color(0.7, 0.7, 0.7, 0.6));
+	Color instantiated_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/instantiated", Color(0.7, 0.7, 0.7, 0.6));
 
 	Vector<Ref<StandardMaterial3D>> icons;
 

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -641,7 +641,7 @@ int Path3DGizmoPlugin::get_priority() const {
 }
 
 Path3DGizmoPlugin::Path3DGizmoPlugin() {
-	Color path_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/path", Color(0.5, 0.5, 1.0, 0.8));
+	Color path_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/path", Color(0.5, 0.5, 1.0, 0.8));
 	create_material("path_material", path_color);
 	create_material("path_thin_material", Color(0.5, 0.5, 0.5));
 	create_handle_material("handles", false, Node3DEditor::get_singleton()->get_theme_icon("EditorPathSmoothHandle", "EditorIcons"));

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1041,7 +1041,7 @@ void Polygon2DEditor::_uv_draw() {
 	for (int i = 0; i < uvs.size(); i++) {
 		int next = uv_draw_max > 0 ? (i + 1) % uv_draw_max : 0;
 
-		if (i < uv_draw_max && uv_drag && uv_move_current == UV_MODE_EDIT_POINT && EDITOR_DEF("editors/poly_editor/show_previous_outline", true)) {
+		if (i < uv_draw_max && uv_drag && uv_move_current == UV_MODE_EDIT_POINT && EDITOR_DEFAULT("editors/poly_editor/show_previous_outline", true)) {
 			uv_edit_draw->draw_line(mtx.xform(points_prev[i]), mtx.xform(points_prev[next]), prev_color, Math::round(EDSCALE));
 		}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -963,7 +963,7 @@ bool ScriptEditor::_test_script_times_on_disk(RES p_for_script) {
 
 	bool need_ask = false;
 	bool need_reload = false;
-	bool use_autoreload = bool(EDITOR_DEF("text_editor/files/auto_reload_scripts_on_external_change", false));
+	bool use_autoreload = bool(EDITOR_DEFAULT("text_editor/files/auto_reload_scripts_on_external_change", false));
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
@@ -2500,7 +2500,7 @@ void ScriptEditor::_editor_settings_changed() {
 	_update_script_colors();
 	_update_script_names();
 
-	ScriptServer::set_reload_scripts_on_save(EDITOR_DEF("text_editor/files/auto_reload_and_parse_scripts_on_save", true));
+	ScriptServer::set_reload_scripts_on_save(EDITOR_DEFAULT("text_editor/files/auto_reload_and_parse_scripts_on_save", true));
 }
 
 void ScriptEditor::_filesystem_changed() {
@@ -2829,7 +2829,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 }
 
 void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
-	if (!bool(EDITOR_DEF("text_editor/files/restore_scripts_on_load", true))) {
+	if (!bool(EDITOR_DEFAULT("text_editor/files/restore_scripts_on_load", true))) {
 		return;
 	}
 
@@ -3705,20 +3705,20 @@ ScriptEditorPlugin::ScriptEditorPlugin(EditorNode *p_node) {
 
 	script_editor->hide();
 
-	EDITOR_DEF("text_editor/files/auto_reload_scripts_on_external_change", true);
-	ScriptServer::set_reload_scripts_on_save(EDITOR_DEF("text_editor/files/auto_reload_and_parse_scripts_on_save", true));
-	EDITOR_DEF("text_editor/files/open_dominant_script_on_scene_change", true);
-	EDITOR_DEF("text_editor/external/use_external_editor", false);
-	EDITOR_DEF("text_editor/external/exec_path", "");
-	EDITOR_DEF("text_editor/script_list/script_temperature_enabled", true);
-	EDITOR_DEF("text_editor/script_list/script_temperature_history_size", 15);
-	EDITOR_DEF("text_editor/script_list/group_help_pages", true);
+	EDITOR_DEFAULT("text_editor/files/auto_reload_scripts_on_external_change", true);
+	ScriptServer::set_reload_scripts_on_save(EDITOR_DEFAULT("text_editor/files/auto_reload_and_parse_scripts_on_save", true));
+	EDITOR_DEFAULT("text_editor/files/open_dominant_script_on_scene_change", true);
+	EDITOR_DEFAULT("text_editor/external/use_external_editor", false);
+	EDITOR_DEFAULT("text_editor/external/exec_path", "");
+	EDITOR_DEFAULT("text_editor/script_list/script_temperature_enabled", true);
+	EDITOR_DEFAULT("text_editor/script_list/script_temperature_history_size", 15);
+	EDITOR_DEFAULT("text_editor/script_list/group_help_pages", true);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/script_list/sort_scripts_by", PROPERTY_HINT_ENUM, "Name,Path,None"));
-	EDITOR_DEF("text_editor/script_list/sort_scripts_by", 0);
+	EDITOR_DEFAULT("text_editor/script_list/sort_scripts_by", 0);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/script_list/list_script_names_as", PROPERTY_HINT_ENUM, "Name,Parent Directory And Name,Full Path"));
-	EDITOR_DEF("text_editor/script_list/list_script_names_as", 0);
+	EDITOR_DEFAULT("text_editor/script_list/list_script_names_as", 0);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "text_editor/external/exec_path", PROPERTY_HINT_GLOBAL_FILE));
-	EDITOR_DEF("text_editor/external/exec_flags", "{file}");
+	EDITOR_DEFAULT("text_editor/external/exec_flags", "{file}");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "text_editor/external/exec_flags", PROPERTY_HINT_PLACEHOLDER_TEXT, "Call flags with placeholders: {project}, {file}, {col}, {line}."));
 
 	ED_SHORTCUT("script_editor/reopen_closed_script", TTR("Reopen Closed Script"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_T);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -428,7 +428,7 @@ void ScriptTextEditor::_validate_script() {
 	warnings_panel->clear();
 
 	// Add missing connections.
-	if (GLOBAL_GET("debug/gdscript/warnings/enable").booleanize()) {
+	if (PROJECT_GET("debug/gdscript/warnings/enable").booleanize()) {
 		Node *base = get_tree()->get_edited_scene_root();
 		if (base && missing_connections.size() > 0) {
 			warnings_panel->push_table(1);
@@ -505,7 +505,7 @@ void ScriptTextEditor::_validate_script() {
 	}
 	errors_panel->pop(); // Table
 
-	bool highlight_safe = EDITOR_DEF("text_editor/highlighting/highlight_type_safe_lines", true);
+	bool highlight_safe = EDITOR_DEFAULT("text_editor/highlighting/highlight_type_safe_lines", true);
 	bool last_is_safe = false;
 	for (int i = 0; i < te->get_line_count(); i++) {
 		if (errors.is_empty()) {
@@ -1444,7 +1444,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	}
 
 	if (d.has("type") && (String(d["type"]) == "files" || String(d["type"]) == "files_and_dirs")) {
-		const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
+		const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
 		Array files = d["files"];
 
 		String text_to_drop;

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -435,13 +435,13 @@ void ShaderEditor::_project_settings_changed() {
 void ShaderEditor::_update_warnings(bool p_validate) {
 	bool changed = false;
 
-	bool warnings_enabled = GLOBAL_GET("debug/shader_language/warnings/enable").booleanize();
+	bool warnings_enabled = PROJECT_GET("debug/shader_language/warnings/enable").booleanize();
 	if (warnings_enabled != saved_warnings_enabled) {
 		saved_warnings_enabled = warnings_enabled;
 		changed = true;
 	}
 
-	bool treat_warning_as_errors = GLOBAL_GET("debug/shader_language/warnings/treat_warnings_as_errors").booleanize();
+	bool treat_warning_as_errors = PROJECT_GET("debug/shader_language/warnings/treat_warnings_as_errors").booleanize();
 	if (treat_warning_as_errors != saved_treat_warning_as_errors) {
 		saved_treat_warning_as_errors = treat_warning_as_errors;
 		changed = true;
@@ -451,7 +451,7 @@ void ShaderEditor::_update_warnings(bool p_validate) {
 
 	for (int i = 0; i < ShaderWarning::WARNING_MAX; i++) {
 		ShaderWarning::Code code = (ShaderWarning::Code)i;
-		bool value = GLOBAL_GET("debug/shader_language/warnings/" + ShaderWarning::get_name_from_code(code).to_lower());
+		bool value = PROJECT_GET("debug/shader_language/warnings/" + ShaderWarning::get_name_from_code(code).to_lower());
 
 		if (saved_warnings[code] != value) {
 			saved_warnings[code] = value;
@@ -479,7 +479,7 @@ void ShaderEditor::_check_for_external_edit() {
 		return;
 	}
 
-	bool use_autoreload = bool(EDITOR_DEF("text_editor/files/auto_reload_scripts_on_external_change", false));
+	bool use_autoreload = bool(EDITOR_DEFAULT("text_editor/files/auto_reload_scripts_on_external_change", false));
 	if (shader->get_last_modified_time() != FileAccess::get_modified_time(shader->get_path())) {
 		if (use_autoreload) {
 			_reload_shader_from_disk();
@@ -640,10 +640,10 @@ void ShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) {
 }
 
 ShaderEditor::ShaderEditor(EditorNode *p_node) {
-	GLOBAL_DEF("debug/shader_language/warnings/enable", true);
-	GLOBAL_DEF("debug/shader_language/warnings/treat_warnings_as_errors", false);
+	PROJECT_DEFAULT("debug/shader_language/warnings/enable", true);
+	PROJECT_DEFAULT("debug/shader_language/warnings/treat_warnings_as_errors", false);
 	for (int i = 0; i < (int)ShaderWarning::WARNING_MAX; i++) {
-		GLOBAL_DEF("debug/shader_language/warnings/" + ShaderWarning::get_name_from_code((ShaderWarning::Code)i).to_lower(), true);
+		PROJECT_DEFAULT("debug/shader_language/warnings/" + ShaderWarning::get_name_from_code((ShaderWarning::Code)i).to_lower(), true);
 	}
 	_update_warnings(false);
 

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -59,7 +59,7 @@ void ThemeEditorPreview::_propagate_redraw(Control *p_at) {
 
 void ThemeEditorPreview::_refresh_interval() {
 	// In case the project settings have changed.
-	preview_bg->set_color(GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
+	preview_bg->set_color(PROJECT_GET("rendering/environment/defaults/default_clear_color"));
 
 	_propagate_redraw(preview_bg);
 	_propagate_redraw(preview_content);
@@ -201,7 +201,7 @@ ThemeEditorPreview::ThemeEditorPreview() {
 
 	preview_bg = memnew(ColorRect);
 	preview_bg->set_anchors_and_offsets_preset(PRESET_WIDE);
-	preview_bg->set_color(GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
+	preview_bg->set_color(PROJECT_GET("rendering/environment/defaults/default_clear_color"));
 	preview_root->add_child(preview_bg);
 
 	preview_content = memnew(MarginContainer);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1540,7 +1540,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 		}
 	}
 
-	bool autorename_animation_tracks = bool(EDITOR_DEF("editors/animation/autorename_animation_tracks", true));
+	bool autorename_animation_tracks = bool(EDITOR_DEFAULT("editors/animation/autorename_animation_tracks", true));
 
 	if (autorename_animation_tracks && Object::cast_to<AnimationPlayer>(p_base)) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_base);
@@ -3285,9 +3285,9 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	profile_allow_editing = true;
 	profile_allow_script_editing = true;
 
-	EDITOR_DEF("interface/editors/show_scene_tree_root_selection", true);
-	EDITOR_DEF("interface/editors/derive_script_globals_by_name", true);
-	EDITOR_DEF("_use_favorites_root_selection", false);
+	EDITOR_DEFAULT("interface/editors/show_scene_tree_root_selection", true);
+	EDITOR_DEFAULT("interface/editors/derive_script_globals_by_name", true);
+	EDITOR_DEFAULT("_use_favorites_root_selection", false);
 
 	Resource::_update_configuration_warning = _update_configuration_warning;
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -402,7 +402,7 @@ Error Main::test_setup() {
 
 	globals = memnew(ProjectSettings);
 
-	GLOBAL_DEF("debug/settings/crash_handler/message",
+	PROJECT_DEFAULT("debug/settings/crash_handler/message",
 			String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
 
 	translation_server = memnew(TranslationServer);
@@ -554,10 +554,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	// Only flush stdout in debug builds by default, as spamming `print()` will
 	// decrease performance if this is enabled.
-	GLOBAL_DEF_RST("application/run/flush_stdout_on_print", false);
-	GLOBAL_DEF_RST("application/run/flush_stdout_on_print.debug", true);
+	PROJECT_DEFAULT_RESTART("application/run/flush_stdout_on_print", false);
+	PROJECT_DEFAULT_RESTART("application/run/flush_stdout_on_print.debug", true);
 
-	GLOBAL_DEF("debug/settings/crash_handler/message",
+	PROJECT_DEFAULT("debug/settings/crash_handler/message",
 			String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
 
 	MAIN_PRINT("Main: Parse CMDLine");
@@ -1087,31 +1087,31 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// Initialize user data dir.
 	OS::get_singleton()->ensure_user_data_dir();
 
-	GLOBAL_DEF("memory/limits/multithreaded_server/rid_pool_prealloc", 60);
+	PROJECT_DEFAULT("memory/limits/multithreaded_server/rid_pool_prealloc", 60);
 	ProjectSettings::get_singleton()->set_custom_property_info("memory/limits/multithreaded_server/rid_pool_prealloc",
 			PropertyInfo(Variant::INT,
 					"memory/limits/multithreaded_server/rid_pool_prealloc",
 					PROPERTY_HINT_RANGE,
 					"0,500,1")); // No negative and limit to 500 due to crashes
-	GLOBAL_DEF("network/limits/debugger/max_chars_per_second", 32768);
+	PROJECT_DEFAULT("network/limits/debugger/max_chars_per_second", 32768);
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_chars_per_second",
 			PropertyInfo(Variant::INT,
 					"network/limits/debugger/max_chars_per_second",
 					PROPERTY_HINT_RANGE,
 					"0, 4096, 1, or_greater"));
-	GLOBAL_DEF("network/limits/debugger/max_queued_messages", 2048);
+	PROJECT_DEFAULT("network/limits/debugger/max_queued_messages", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_queued_messages",
 			PropertyInfo(Variant::INT,
 					"network/limits/debugger/max_queued_messages",
 					PROPERTY_HINT_RANGE,
 					"0, 8192, 1, or_greater"));
-	GLOBAL_DEF("network/limits/debugger/max_errors_per_second", 400);
+	PROJECT_DEFAULT("network/limits/debugger/max_errors_per_second", 400);
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_errors_per_second",
 			PropertyInfo(Variant::INT,
 					"network/limits/debugger/max_errors_per_second",
 					PROPERTY_HINT_RANGE,
 					"0, 200, 1, or_greater"));
-	GLOBAL_DEF("network/limits/debugger/max_warnings_per_second", 400);
+	PROJECT_DEFAULT("network/limits/debugger/max_warnings_per_second", 400);
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_warnings_per_second",
 			PropertyInfo(Variant::INT,
 					"network/limits/debugger/max_warnings_per_second",
@@ -1143,29 +1143,29 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 #endif
 
-	GLOBAL_DEF("debug/file_logging/enable_file_logging", false);
+	PROJECT_DEFAULT("debug/file_logging/enable_file_logging", false);
 	// Only file logging by default on desktop platforms as logs can't be
 	// accessed easily on mobile/Web platforms (if at all).
 	// This also prevents logs from being created for the editor instance, as feature tags
 	// are disabled while in the editor (even if they should logically apply).
-	GLOBAL_DEF("debug/file_logging/enable_file_logging.pc", true);
-	GLOBAL_DEF("debug/file_logging/log_path", "user://logs/godot.log");
-	GLOBAL_DEF("debug/file_logging/max_log_files", 5);
+	PROJECT_DEFAULT("debug/file_logging/enable_file_logging.pc", true);
+	PROJECT_DEFAULT("debug/file_logging/log_path", "user://logs/godot.log");
+	PROJECT_DEFAULT("debug/file_logging/max_log_files", 5);
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/file_logging/max_log_files",
 			PropertyInfo(Variant::INT,
 					"debug/file_logging/max_log_files",
 					PROPERTY_HINT_RANGE,
 					"0,20,1,or_greater")); //no negative numbers
 	if (!project_manager && !editor && FileAccess::get_create_func(FileAccess::ACCESS_USERDATA) &&
-			GLOBAL_GET("debug/file_logging/enable_file_logging")) {
+			PROJECT_GET("debug/file_logging/enable_file_logging")) {
 		// Don't create logs for the project manager as they would be written to
 		// the current working directory, which is inconvenient.
-		String base_path = GLOBAL_GET("debug/file_logging/log_path");
-		int max_files = GLOBAL_GET("debug/file_logging/max_log_files");
+		String base_path = PROJECT_GET("debug/file_logging/log_path");
+		int max_files = PROJECT_GET("debug/file_logging/max_log_files");
 		OS::get_singleton()->add_logger(memnew(RotatedFileLogger(base_path, max_files)));
 	}
 
-	if (main_args.size() == 0 && String(GLOBAL_GET("application/run/main_scene")) == "") {
+	if (main_args.size() == 0 && String(PROJECT_GET("application/run/main_scene")) == "") {
 #ifdef TOOLS_ENABLED
 		if (!editor && !project_manager) {
 #endif
@@ -1201,36 +1201,36 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	register_core_extensions(); //before display
 
-	GLOBAL_DEF("rendering/driver/driver_name", "Vulkan");
+	PROJECT_DEFAULT("rendering/driver/driver_name", "Vulkan");
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/driver/driver_name",
 			PropertyInfo(Variant::STRING,
 					"rendering/driver/driver_name",
 					PROPERTY_HINT_ENUM, "Vulkan"));
 	if (display_driver == "") {
-		display_driver = GLOBAL_GET("rendering/driver/driver_name");
+		display_driver = PROJECT_GET("rendering/driver/driver_name");
 	}
 
-	GLOBAL_DEF_BASIC("display/window/size/width", 1024);
+	PROJECT_DEFAULT_BASIC("display/window/size/width", 1024);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/width",
 			PropertyInfo(Variant::INT, "display/window/size/width",
 					PROPERTY_HINT_RANGE,
 					"0,7680,or_greater")); // 8K resolution
-	GLOBAL_DEF_BASIC("display/window/size/height", 600);
+	PROJECT_DEFAULT_BASIC("display/window/size/height", 600);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/height",
 			PropertyInfo(Variant::INT, "display/window/size/height",
 					PROPERTY_HINT_RANGE,
 					"0,4320,or_greater")); // 8K resolution
-	GLOBAL_DEF_BASIC("display/window/size/resizable", true);
-	GLOBAL_DEF_BASIC("display/window/size/borderless", false);
-	GLOBAL_DEF_BASIC("display/window/size/fullscreen", false);
-	GLOBAL_DEF("display/window/size/always_on_top", false);
-	GLOBAL_DEF("display/window/size/test_width", 0);
+	PROJECT_DEFAULT_BASIC("display/window/size/resizable", true);
+	PROJECT_DEFAULT_BASIC("display/window/size/borderless", false);
+	PROJECT_DEFAULT_BASIC("display/window/size/fullscreen", false);
+	PROJECT_DEFAULT("display/window/size/always_on_top", false);
+	PROJECT_DEFAULT("display/window/size/test_width", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_width",
 			PropertyInfo(Variant::INT,
 					"display/window/size/test_width",
 					PROPERTY_HINT_RANGE,
 					"0,7680,or_greater")); // 8K resolution
-	GLOBAL_DEF("display/window/size/test_height", 0);
+	PROJECT_DEFAULT("display/window/size/test_height", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_height",
 			PropertyInfo(Variant::INT,
 					"display/window/size/test_height",
@@ -1239,8 +1239,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (use_custom_res) {
 		if (!force_res) {
-			window_size.width = GLOBAL_GET("display/window/size/width");
-			window_size.height = GLOBAL_GET("display/window/size/height");
+			window_size.width = PROJECT_GET("display/window/size/width");
+			window_size.height = PROJECT_GET("display/window/size/height");
 
 			if (globals->has_setting("display/window/size/test_width") &&
 					globals->has_setting("display/window/size/test_height")) {
@@ -1255,31 +1255,31 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			}
 		}
 
-		if (!bool(GLOBAL_GET("display/window/size/resizable"))) {
+		if (!bool(PROJECT_GET("display/window/size/resizable"))) {
 			window_flags |= DisplayServer::WINDOW_FLAG_RESIZE_DISABLED_BIT;
 		}
-		if (bool(GLOBAL_GET("display/window/size/borderless"))) {
+		if (bool(PROJECT_GET("display/window/size/borderless"))) {
 			window_flags |= DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
 		}
-		if (bool(GLOBAL_GET("display/window/size/fullscreen"))) {
+		if (bool(PROJECT_GET("display/window/size/fullscreen"))) {
 			window_mode = DisplayServer::WINDOW_MODE_FULLSCREEN;
 		}
 
-		if (bool(GLOBAL_GET("display/window/size/always_on_top"))) {
+		if (bool(PROJECT_GET("display/window/size/always_on_top"))) {
 			window_flags |= DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP_BIT;
 		}
 	}
 
-	GLOBAL_DEF("internationalization/rendering/force_right_to_left_layout_direction", false);
-	GLOBAL_DEF("internationalization/locale/include_text_server_data", false);
+	PROJECT_DEFAULT("internationalization/rendering/force_right_to_left_layout_direction", false);
+	PROJECT_DEFAULT("internationalization/locale/include_text_server_data", false);
 
 	if (!force_lowdpi) {
-		OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", false);
+		OS::get_singleton()->_allow_hidpi = PROJECT_DEFAULT("display/window/dpi/allow_hidpi", false);
 	}
 
 	/* todo restore
-    OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);
-    video_mode.layered = GLOBAL_DEF("display/window/per_pixel_transparency/enabled", false);
+    OS::get_singleton()->_allow_layered = PROJECT_DEFAULT("display/window/per_pixel_transparency/allowed", false);
+    video_mode.layered = PROJECT_DEFAULT("display/window/per_pixel_transparency/enabled", false);
 */
 	if (editor || project_manager) {
 		// The editor and project manager always detect and use hiDPI if needed
@@ -1287,9 +1287,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->_allow_layered = false;
 	}
 
-	OS::get_singleton()->_keep_screen_on = GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
+	OS::get_singleton()->_keep_screen_on = PROJECT_DEFAULT("display/window/energy_saving/keep_screen_on", true);
 	if (rtm == -1) {
-		rtm = GLOBAL_DEF("rendering/driver/threads/thread_model", OS::RENDER_THREAD_SAFE);
+		rtm = PROJECT_DEFAULT("rendering/driver/threads/thread_model", OS::RENDER_THREAD_SAFE);
 	}
 
 	if (rtm >= 0 && rtm < 3) {
@@ -1317,7 +1317,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (audio_driver == "") { // specified in project.godot
-		audio_driver = GLOBAL_DEF_RST_NOVAL("audio/driver/driver", AudioDriverManager::get_driver(0)->get_name());
+		audio_driver = PROJECT_DEF_RESTART_NO_VAL("audio/driver/driver", AudioDriverManager::get_driver(0)->get_name());
 	}
 
 	for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
@@ -1332,10 +1332,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	{
-		window_orientation = DisplayServer::ScreenOrientation(int(GLOBAL_DEF_BASIC("display/window/handheld/orientation", DisplayServer::ScreenOrientation::SCREEN_LANDSCAPE)));
+		window_orientation = DisplayServer::ScreenOrientation(int(PROJECT_DEFAULT_BASIC("display/window/handheld/orientation", DisplayServer::ScreenOrientation::SCREEN_LANDSCAPE)));
 	}
 	{
-		String vsync_mode = GLOBAL_DEF("display/window/vsync/vsync_mode", "Enabled");
+		String vsync_mode = PROJECT_DEFAULT("display/window/vsync/vsync_mode", "Enabled");
 
 		if (vsync_mode == "Disabled") {
 			window_vsync_mode = DisplayServer::VSYNC_DISABLED;
@@ -1350,26 +1350,26 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			window_vsync_mode = DisplayServer::VSYNC_ENABLED;
 		}
 	}
-	Engine::get_singleton()->set_iterations_per_second(GLOBAL_DEF_BASIC("physics/common/physics_fps", 60));
+	Engine::get_singleton()->set_iterations_per_second(PROJECT_DEFAULT_BASIC("physics/common/physics_fps", 60));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/common/physics_fps",
 			PropertyInfo(Variant::INT, "physics/common/physics_fps",
 					PROPERTY_HINT_RANGE, "1,1000,1"));
-	Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_DEF("physics/common/physics_jitter_fix", 0.5));
-	Engine::get_singleton()->set_target_fps(GLOBAL_DEF("debug/settings/fps/force_fps", 0));
+	Engine::get_singleton()->set_physics_jitter_fix(PROJECT_DEFAULT("physics/common/physics_jitter_fix", 0.5));
+	Engine::get_singleton()->set_target_fps(PROJECT_DEFAULT("debug/settings/fps/force_fps", 0));
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/settings/fps/force_fps",
 			PropertyInfo(Variant::INT,
 					"debug/settings/fps/force_fps",
 					PROPERTY_HINT_RANGE, "0,1000,1"));
 
-	GLOBAL_DEF("debug/settings/stdout/print_fps", false);
-	GLOBAL_DEF("debug/settings/stdout/verbose_stdout", false);
+	PROJECT_DEFAULT("debug/settings/stdout/print_fps", false);
+	PROJECT_DEFAULT("debug/settings/stdout/verbose_stdout", false);
 
 	if (!OS::get_singleton()->_verbose_stdout) { // Not manually overridden.
-		OS::get_singleton()->_verbose_stdout = GLOBAL_GET("debug/settings/stdout/verbose_stdout");
+		OS::get_singleton()->_verbose_stdout = PROJECT_GET("debug/settings/stdout/verbose_stdout");
 	}
 
 	if (frame_delay == 0) {
-		frame_delay = GLOBAL_DEF("application/run/frame_delay_msec", 0);
+		frame_delay = PROJECT_DEFAULT("application/run/frame_delay_msec", 0);
 		ProjectSettings::get_singleton()->set_custom_property_info("application/run/frame_delay_msec",
 				PropertyInfo(Variant::INT,
 						"application/run/frame_delay_msec",
@@ -1377,17 +1377,17 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 						"0,100,1,or_greater")); // No negative numbers
 	}
 
-	OS::get_singleton()->set_low_processor_usage_mode(GLOBAL_DEF("application/run/low_processor_mode", false));
+	OS::get_singleton()->set_low_processor_usage_mode(PROJECT_DEFAULT("application/run/low_processor_mode", false));
 	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(
-			GLOBAL_DEF("application/run/low_processor_mode_sleep_usec", 6900)); // Roughly 144 FPS
+			PROJECT_DEFAULT("application/run/low_processor_mode_sleep_usec", 6900)); // Roughly 144 FPS
 	ProjectSettings::get_singleton()->set_custom_property_info("application/run/low_processor_mode_sleep_usec",
 			PropertyInfo(Variant::INT,
 					"application/run/low_processor_mode_sleep_usec",
 					PROPERTY_HINT_RANGE,
 					"0,33200,1,or_greater")); // No negative numbers
 
-	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
-	GLOBAL_DEF("input_devices/pointing/ios/touch_delay", 0.150);
+	PROJECT_DEFAULT("display/window/ios/hide_home_indicator", true);
+	PROJECT_DEFAULT("input_devices/pointing/ios/touch_delay", 0.150);
 
 	Engine::get_singleton()->set_frame_delay(frame_delay);
 
@@ -1477,7 +1477,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	/* Determine text driver */
 
 	if (text_driver == "") {
-		text_driver = GLOBAL_GET("internationalization/rendering/text_driver");
+		text_driver = PROJECT_GET("internationalization/rendering/text_driver");
 	}
 
 	if (text_driver != "") {
@@ -1569,13 +1569,13 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	/* Initialize Pen Tablet Driver */
 
 	{
-		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver", "");
-		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver.Windows", "");
+		PROJECT_DEF_RESTART_NO_VAL("input_devices/pen_tablet/driver", "");
+		PROJECT_DEF_RESTART_NO_VAL("input_devices/pen_tablet/driver.Windows", "");
 		ProjectSettings::get_singleton()->set_custom_property_info("input_devices/pen_tablet/driver.Windows", PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.Windows", PROPERTY_HINT_ENUM, "wintab,winink"));
 	}
 
 	if (tablet_driver == "") { // specified in project.godot
-		tablet_driver = GLOBAL_GET("input_devices/pen_tablet/driver");
+		tablet_driver = PROJECT_GET("input_devices/pen_tablet/driver");
 		if (tablet_driver == "") {
 			tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(0);
 		}
@@ -1657,13 +1657,13 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	MAIN_PRINT("Main: Load Boot Image");
 
-	Color clear = GLOBAL_DEF("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3));
+	Color clear = PROJECT_DEFAULT("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3));
 	RenderingServer::get_singleton()->set_default_clear_color(clear);
 
 	if (show_logo) { //boot logo!
-		String boot_logo_path = GLOBAL_DEF("application/boot_splash/image", String());
-		bool boot_logo_scale = GLOBAL_DEF("application/boot_splash/fullsize", true);
-		bool boot_logo_filter = GLOBAL_DEF("application/boot_splash/use_filter", true);
+		String boot_logo_path = PROJECT_DEFAULT("application/boot_splash/image", String());
+		bool boot_logo_scale = PROJECT_DEFAULT("application/boot_splash/fullsize", true);
+		bool boot_logo_filter = PROJECT_DEFAULT("application/boot_splash/use_filter", true);
 		ProjectSettings::get_singleton()->set_custom_property_info("application/boot_splash/image",
 				PropertyInfo(Variant::STRING,
 						"application/boot_splash/image",
@@ -1683,10 +1683,10 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 #if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
 		const Color boot_bg_color =
-				GLOBAL_DEF("application/boot_splash/bg_color",
+				PROJECT_DEFAULT("application/boot_splash/bg_color",
 						(editor || project_manager) ? boot_splash_editor_bg_color : boot_splash_bg_color);
 #else
-		const Color boot_bg_color = GLOBAL_DEF("application/boot_splash/bg_color", boot_splash_bg_color);
+		const Color boot_bg_color = PROJECT_DEFAULT("application/boot_splash/bg_color", boot_splash_bg_color);
 #endif
 		if (boot_logo.is_valid()) {
 			RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color, boot_logo_scale,
@@ -1716,20 +1716,20 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	MAIN_PRINT("Main: DCC");
 	RenderingServer::get_singleton()->set_default_clear_color(
-			GLOBAL_DEF("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3)));
+			PROJECT_DEFAULT("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3)));
 
-	GLOBAL_DEF("application/config/icon", String());
+	PROJECT_DEFAULT("application/config/icon", String());
 	ProjectSettings::get_singleton()->set_custom_property_info("application/config/icon",
 			PropertyInfo(Variant::STRING, "application/config/icon",
 					PROPERTY_HINT_FILE, "*.png,*.webp,*.svg,*.svgz"));
 
-	GLOBAL_DEF("application/config/macos_native_icon", String());
+	PROJECT_DEFAULT("application/config/macos_native_icon", String());
 	ProjectSettings::get_singleton()->set_custom_property_info("application/config/macos_native_icon",
 			PropertyInfo(Variant::STRING,
 					"application/config/macos_native_icon",
 					PROPERTY_HINT_FILE, "*.icns"));
 
-	GLOBAL_DEF("application/config/windows_native_icon", String());
+	PROJECT_DEFAULT("application/config/windows_native_icon", String());
 	ProjectSettings::get_singleton()->set_custom_property_info("application/config/windows_native_icon",
 			PropertyInfo(Variant::STRING,
 					"application/config/windows_native_icon",
@@ -1737,7 +1737,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	Input *id = Input::get_singleton();
 	if (id) {
-		if (bool(GLOBAL_DEF("input_devices/pointing/emulate_touch_from_mouse", false)) &&
+		if (bool(PROJECT_DEFAULT("input_devices/pointing/emulate_touch_from_mouse", false)) &&
 				!(editor || project_manager)) {
 			bool found_touchscreen = false;
 			for (int i = 0; i < DisplayServer::get_singleton()->get_screen_count(); i++) {
@@ -1751,7 +1751,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 			}
 		}
 
-		id->set_emulate_mouse_from_touch(bool(GLOBAL_DEF("input_devices/pointing/emulate_mouse_from_touch", true)));
+		id->set_emulate_mouse_from_touch(bool(PROJECT_DEFAULT("input_devices/pointing/emulate_mouse_from_touch", true)));
 	}
 
 	MAIN_PRINT("Main: Load Translations and Remaps");
@@ -1782,9 +1782,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	register_platform_apis();
 	register_module_types();
 
-	GLOBAL_DEF("display/mouse_cursor/custom_image", String());
-	GLOBAL_DEF("display/mouse_cursor/custom_image_hotspot", Vector2());
-	GLOBAL_DEF("display/mouse_cursor/tooltip_position_offset", Point2(10, 10));
+	PROJECT_DEFAULT("display/mouse_cursor/custom_image", String());
+	PROJECT_DEFAULT("display/mouse_cursor/custom_image_hotspot", Vector2());
+	PROJECT_DEFAULT("display/mouse_cursor/tooltip_position_offset", Point2(10, 10));
 	ProjectSettings::get_singleton()->set_custom_property_info("display/mouse_cursor/custom_image",
 			PropertyInfo(Variant::STRING,
 					"display/mouse_cursor/custom_image",
@@ -1948,14 +1948,14 @@ bool Main::start() {
 		// Hack to define Mono-specific project settings even on non-Mono builds,
 		// so that we don't lose their descriptions and default values in DocData.
 		// Default values should be synced with mono_gd/gd_mono.cpp.
-		GLOBAL_DEF("mono/debugger_agent/port", 23685);
-		GLOBAL_DEF("mono/debugger_agent/wait_for_debugger", false);
-		GLOBAL_DEF("mono/debugger_agent/wait_timeout", 3000);
-		GLOBAL_DEF("mono/profiler/args", "log:calls,alloc,sample,output=output.mlpd");
-		GLOBAL_DEF("mono/profiler/enabled", false);
-		GLOBAL_DEF("mono/unhandled_exception_policy", 0);
+		PROJECT_DEFAULT("mono/debugger_agent/port", 23685);
+		PROJECT_DEFAULT("mono/debugger_agent/wait_for_debugger", false);
+		PROJECT_DEFAULT("mono/debugger_agent/wait_timeout", 3000);
+		PROJECT_DEFAULT("mono/profiler/args", "log:calls,alloc,sample,output=output.mlpd");
+		PROJECT_DEFAULT("mono/profiler/enabled", false);
+		PROJECT_DEFAULT("mono/unhandled_exception_policy", 0);
 		// From editor/csharp_project.cpp.
-		GLOBAL_DEF("mono/project/auto_update_project", true);
+		PROJECT_DEFAULT("mono/project/auto_update_project", true);
 #endif
 
 		DocTools doc;
@@ -2016,8 +2016,8 @@ bool Main::start() {
 	}
 #endif
 
-	if (script == "" && game_path == "" && String(GLOBAL_GET("application/run/main_scene")) != "") {
-		game_path = GLOBAL_GET("application/run/main_scene");
+	if (script == "" && game_path == "" && String(PROJECT_GET("application/run/main_scene")) != "") {
+		game_path = PROJECT_GET("application/run/main_scene");
 	}
 
 #ifdef TOOLS_ENABLED
@@ -2034,7 +2034,7 @@ bool Main::start() {
 	if (editor) {
 		main_loop = memnew(SceneTree);
 	}
-	String main_loop_type = GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
+	String main_loop_type = PROJECT_DEFAULT("application/run/main_loop_type", "SceneTree");
 
 	if (script != "") {
 		Ref<Script> script_res = ResourceLoader::load(script);
@@ -2116,7 +2116,7 @@ bool Main::start() {
 		}
 #endif
 
-		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", false);
+		bool embed_subwindows = PROJECT_DEFAULT("display/window/subwindows/embed_subwindows", false);
 
 		if (single_window || (!project_manager && !editor && embed_subwindows)) {
 			sml->get_root()->set_embed_subwindows_hint(true);
@@ -2202,10 +2202,10 @@ bool Main::start() {
 		if (!editor && !project_manager) {
 			//standard helpers that can be changed from main config
 
-			String stretch_mode = GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
-			String stretch_aspect = GLOBAL_DEF_BASIC("display/window/stretch/aspect", "ignore");
-			Size2i stretch_size = Size2i(GLOBAL_DEF_BASIC("display/window/size/width", 0),
-					GLOBAL_DEF_BASIC("display/window/size/height", 0));
+			String stretch_mode = PROJECT_DEFAULT_BASIC("display/window/stretch/mode", "disabled");
+			String stretch_aspect = PROJECT_DEFAULT_BASIC("display/window/stretch/aspect", "ignore");
+			Size2i stretch_size = Size2i(PROJECT_DEFAULT_BASIC("display/window/size/width", 0),
+					PROJECT_DEFAULT_BASIC("display/window/size/height", 0));
 
 			Window::ContentScaleMode cs_sm = Window::CONTENT_SCALE_MODE_DISABLED;
 			if (stretch_mode == "canvas_items") {
@@ -2229,8 +2229,8 @@ bool Main::start() {
 			sml->get_root()->set_content_scale_aspect(cs_aspect);
 			sml->get_root()->set_content_scale_size(stretch_size);
 
-			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
-			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
+			sml->set_auto_accept_quit(PROJECT_DEFAULT("application/config/auto_accept_quit", true));
+			sml->set_quit_on_go_back(PROJECT_DEFAULT("application/config/quit_on_go_back", true));
 			String appname = ProjectSettings::get_singleton()->get("application/config/name");
 			appname = TranslationServer::get_singleton()->translate(appname);
 #ifdef DEBUG_ENABLED
@@ -2242,49 +2242,49 @@ bool Main::start() {
 			DisplayServer::get_singleton()->window_set_title(appname);
 #endif
 
-			bool snap_controls = GLOBAL_DEF("gui/common/snap_controls_to_pixels", true);
+			bool snap_controls = PROJECT_DEFAULT("gui/common/snap_controls_to_pixels", true);
 			sml->get_root()->set_snap_controls_to_pixels(snap_controls);
 
-			bool font_oversampling = GLOBAL_DEF("gui/fonts/dynamic_fonts/use_oversampling", true);
+			bool font_oversampling = PROJECT_DEFAULT("gui/fonts/dynamic_fonts/use_oversampling", true);
 			sml->get_root()->set_use_font_oversampling(font_oversampling);
 
-			int texture_filter = GLOBAL_DEF("rendering/textures/canvas_textures/default_texture_filter", 1);
-			int texture_repeat = GLOBAL_DEF("rendering/textures/canvas_textures/default_texture_repeat", 0);
+			int texture_filter = PROJECT_DEFAULT("rendering/textures/canvas_textures/default_texture_filter", 1);
+			int texture_repeat = PROJECT_DEFAULT("rendering/textures/canvas_textures/default_texture_repeat", 0);
 			sml->get_root()->set_default_canvas_item_texture_filter(
 					Viewport::DefaultCanvasItemTextureFilter(texture_filter));
 			sml->get_root()->set_default_canvas_item_texture_repeat(
 					Viewport::DefaultCanvasItemTextureRepeat(texture_repeat));
 
 		} else {
-			GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
+			PROJECT_DEFAULT_BASIC("display/window/stretch/mode", "disabled");
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/mode",
 					PropertyInfo(Variant::STRING,
 							"display/window/stretch/mode",
 							PROPERTY_HINT_ENUM,
 							"disabled,canvas_items,viewport"));
-			GLOBAL_DEF_BASIC("display/window/stretch/aspect", "ignore");
+			PROJECT_DEFAULT_BASIC("display/window/stretch/aspect", "ignore");
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/aspect",
 					PropertyInfo(Variant::STRING,
 							"display/window/stretch/aspect",
 							PROPERTY_HINT_ENUM,
 							"ignore,keep,keep_width,keep_height,expand"));
-			GLOBAL_DEF_BASIC("display/window/stretch/shrink", 1.0);
+			PROJECT_DEFAULT_BASIC("display/window/stretch/shrink", 1.0);
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/shrink",
 					PropertyInfo(Variant::FLOAT,
 							"display/window/stretch/shrink",
 							PROPERTY_HINT_RANGE,
 							"1.0,8.0,0.1"));
-			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
-			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
-			GLOBAL_DEF_BASIC("gui/common/snap_controls_to_pixels", true);
-			GLOBAL_DEF_BASIC("gui/fonts/dynamic_fonts/use_oversampling", true);
+			sml->set_auto_accept_quit(PROJECT_DEFAULT("application/config/auto_accept_quit", true));
+			sml->set_quit_on_go_back(PROJECT_DEFAULT("application/config/quit_on_go_back", true));
+			PROJECT_DEFAULT_BASIC("gui/common/snap_controls_to_pixels", true);
+			PROJECT_DEFAULT_BASIC("gui/fonts/dynamic_fonts/use_oversampling", true);
 
-			GLOBAL_DEF_BASIC("rendering/textures/canvas_textures/default_texture_filter", 1);
+			PROJECT_DEFAULT_BASIC("rendering/textures/canvas_textures/default_texture_filter", 1);
 			ProjectSettings::get_singleton()->set_custom_property_info(
 					"rendering/textures/canvas_textures/default_texture_filter",
 					PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_filter", PROPERTY_HINT_ENUM,
 							"Nearest,Linear,Linear Mipmap,Nearest Mipmap"));
-			GLOBAL_DEF_BASIC("rendering/textures/canvas_textures/default_texture_repeat", 0);
+			PROJECT_DEFAULT_BASIC("rendering/textures/canvas_textures/default_texture_repeat", 0);
 			ProjectSettings::get_singleton()->set_custom_property_info(
 					"rendering/textures/canvas_textures/default_texture_repeat",
 					PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_repeat", PROPERTY_HINT_ENUM,
@@ -2337,7 +2337,7 @@ bool Main::start() {
 
 #ifdef TOOLS_ENABLED
 			if (editor) {
-				if (game_path != String(GLOBAL_GET("application/run/main_scene")) || !editor_node->has_scenes_in_session()) {
+				if (game_path != String(PROJECT_GET("application/run/main_scene")) || !editor_node->has_scenes_in_session()) {
 					Error serr = editor_node->load_scene(local_game_path);
 					if (serr != OK) {
 						ERR_PRINT("Failed to load scene");
@@ -2354,7 +2354,7 @@ bool Main::start() {
 		if (!project_manager && !editor) { // game
 
 			// Load SSL Certificates from Project Settings (or builtin).
-			Crypto::load_default_certificates(GLOBAL_DEF("network/ssl/certificate_bundle_override", ""));
+			Crypto::load_default_certificates(PROJECT_DEFAULT("network/ssl/certificate_bundle_override", ""));
 
 			if (game_path != "") {
 				Node *scene = nullptr;
@@ -2367,7 +2367,7 @@ bool Main::start() {
 				sml->add_current_scene(scene);
 
 #ifdef OSX_ENABLED
-				String mac_iconpath = GLOBAL_DEF("application/config/macos_native_icon", "Variant()");
+				String mac_iconpath = PROJECT_DEFAULT("application/config/macos_native_icon", "Variant()");
 				if (mac_iconpath != "") {
 					DisplayServer::get_singleton()->set_native_icon(mac_iconpath);
 					hasicon = true;
@@ -2375,14 +2375,14 @@ bool Main::start() {
 #endif
 
 #ifdef WINDOWS_ENABLED
-				String win_iconpath = GLOBAL_DEF("application/config/windows_native_icon", "Variant()");
+				String win_iconpath = PROJECT_DEFAULT("application/config/windows_native_icon", "Variant()");
 				if (win_iconpath != "") {
 					DisplayServer::get_singleton()->set_native_icon(win_iconpath);
 					hasicon = true;
 				}
 #endif
 
-				String iconpath = GLOBAL_DEF("application/config/icon", "Variant()");
+				String iconpath = PROJECT_DEFAULT("application/config/icon", "Variant()");
 				if ((iconpath != "") && (!hasicon)) {
 					Ref<Image> icon;
 					icon.instantiate();
@@ -2573,7 +2573,7 @@ bool Main::iteration() {
 			if (print_fps) {
 				print_line(vformat("Editor FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(1)));
 			}
-		} else if (GLOBAL_GET("debug/settings/stdout/print_fps") || print_fps) {
+		} else if (PROJECT_GET("debug/settings/stdout/print_fps") || print_fps) {
 			print_line(vformat("Project FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(1)));
 		}
 

--- a/modules/bullet/register_types.cpp
+++ b/modules/bullet/register_types.cpp
@@ -49,7 +49,7 @@ void register_bullet_types() {
 	PhysicsServer3DManager::register_server("Bullet", &_createBulletPhysicsCallback);
 	PhysicsServer3DManager::set_default_server("Bullet", 1);
 
-	GLOBAL_DEF("physics/3d/active_soft_world", true);
+	PROJECT_DEFAULT("physics/3d/active_soft_world", true);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/active_soft_world", PropertyInfo(Variant::BOOL, "physics/3d/active_soft_world"));
 #endif
 }

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -426,7 +426,7 @@ void ConcavePolygonShapeBullet::setup(Vector<Vector3> p_faces) {
 
 		meshShape = bulletnew(btBvhTriangleMeshShape(shapeInterface, useQuantizedAabbCompression));
 
-		if (GLOBAL_DEF("physics/3d/smooth_trimesh_collision", false)) {
+		if (PROJECT_DEFAULT("physics/3d/smooth_trimesh_collision", false)) {
 			btTriangleInfoMap *triangleInfoMap = new btTriangleInfoMap();
 			btGenerateInternalEdgeInfo(meshShape, triangleInfoMap);
 		}

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -342,7 +342,7 @@ Vector3 BulletPhysicsDirectSpaceState::get_closest_point_to_object_volume(RID p_
 }
 
 SpaceBullet::SpaceBullet() {
-	create_empty_world(GLOBAL_DEF("physics/3d/active_soft_world", true));
+	create_empty_world(PROJECT_DEFAULT("physics/3d/active_soft_world", true));
 	direct_access = memnew(BulletPhysicsDirectSpaceState(this));
 }
 

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -33,7 +33,7 @@
 ///////////
 
 CSGShape3DGizmoPlugin::CSGShape3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/csg", Color(0.0, 0.4, 1, 0.15));
+	Color gizmo_color = EDITOR_DEFAULT("editors/3d_gizmos/gizmo_colors/csg", Color(0.0, 0.4, 1, 0.15));
 	create_material("shape_union_material", gizmo_color);
 	create_material("shape_union_solid_material", gizmo_color);
 	gizmo_color.invert();

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -71,7 +71,7 @@ void EditorSceneImporterFBX::_register_project_setting_import(const String gener
 		List<String> *r_extensions,
 		const bool p_enabled) const {
 	const String use_generic = "use_" + generic;
-	_GLOBAL_DEF(import_setting_string + use_generic, p_enabled, true);
+	_PROJECT_DEFAULT(import_setting_string + use_generic, p_enabled, true);
 	if (ProjectSettings::get_singleton()->get(import_setting_string + use_generic)) {
 		for (int32_t i = 0; i < exts.size(); i++) {
 			r_extensions->push_back(exts[i]);

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -568,9 +568,9 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 		annotation_color = Color(0.8, 0.5, 0.25);
 	}
 
-	EDITOR_DEF("text_editor/highlighting/gdscript/function_definition_color", function_definition_color);
-	EDITOR_DEF("text_editor/highlighting/gdscript/node_path_color", node_path_color);
-	EDITOR_DEF("text_editor/highlighting/gdscript/annotation_color", annotation_color);
+	EDITOR_DEFAULT("text_editor/highlighting/gdscript/function_definition_color", function_definition_color);
+	EDITOR_DEFAULT("text_editor/highlighting/gdscript/node_path_color", node_path_color);
+	EDITOR_DEFAULT("text_editor/highlighting/gdscript/annotation_color", annotation_color);
 	if (text_edit_color_theme == "Default" || godot_2_theme) {
 		EditorSettings::get_singleton()->set_initial_value(
 				"text_editor/highlighting/gdscript/function_definition_color",

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2164,7 +2164,7 @@ GDScriptLanguage::GDScriptLanguage() {
 	script_frame_time = 0;
 
 	_debug_call_stack_pos = 0;
-	int dmcs = GLOBAL_DEF("debug/settings/gdscript/max_call_stack", 1024);
+	int dmcs = PROJECT_DEFAULT("debug/settings/gdscript/max_call_stack", 1024);
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/settings/gdscript/max_call_stack", PropertyInfo(Variant::INT, "debug/settings/gdscript/max_call_stack", PROPERTY_HINT_RANGE, "1024,4096,1,or_greater")); //minimum is 1024
 
 	if (EngineDebugger::is_active()) {
@@ -2179,14 +2179,14 @@ GDScriptLanguage::GDScriptLanguage() {
 	}
 
 #ifdef DEBUG_ENABLED
-	GLOBAL_DEF("debug/gdscript/warnings/enable", true);
-	GLOBAL_DEF("debug/gdscript/warnings/treat_warnings_as_errors", false);
-	GLOBAL_DEF("debug/gdscript/warnings/exclude_addons", true);
-	GLOBAL_DEF("debug/gdscript/completion/autocomplete_setters_and_getters", false);
+	PROJECT_DEFAULT("debug/gdscript/warnings/enable", true);
+	PROJECT_DEFAULT("debug/gdscript/warnings/treat_warnings_as_errors", false);
+	PROJECT_DEFAULT("debug/gdscript/warnings/exclude_addons", true);
+	PROJECT_DEFAULT("debug/gdscript/completion/autocomplete_setters_and_getters", false);
 	for (int i = 0; i < (int)GDScriptWarning::WARNING_MAX; i++) {
 		String warning = GDScriptWarning::get_name_from_code((GDScriptWarning::Code)i).to_lower();
 		bool default_enabled = !warning.begins_with("unsafe_");
-		GLOBAL_DEF("debug/gdscript/warnings/" + warning, default_enabled);
+		PROJECT_DEFAULT("debug/gdscript/warnings/" + warning, default_enabled);
 	}
 #endif // DEBUG_ENABLED
 }

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -59,7 +59,7 @@ String GDScriptLanguage::_get_processed_template(const String &p_template, const
 	String processed_template = p_template;
 
 #ifdef TOOLS_ENABLED
-	if (EDITOR_DEF("text_editor/completion/add_type_hints", false)) {
+	if (EDITOR_DEFAULT("text_editor/completion/add_type_hints", false)) {
 		processed_template = processed_template.replace("%INT_TYPE%", ": int");
 		processed_template = processed_template.replace("%STRING_TYPE%", ": String");
 		processed_template = processed_template.replace("%FLOAT_TYPE%", ": float");
@@ -623,7 +623,7 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 }
 
 static void _get_directory_contents(EditorFileSystemDirectory *p_dir, Map<String, ScriptCodeCompletionOption> &r_list) {
-	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
+	const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
 
 	for (int i = 0; i < p_dir->get_file_count(); i++) {
 		ScriptCodeCompletionOption option(p_dir->get_file_path(i), ScriptCodeCompletionOption::KIND_FILE_PATH);
@@ -943,7 +943,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				if (!_static || Engine::get_singleton()->has_singleton(type)) {
 					List<MethodInfo> methods;
-					bool is_autocompleting_getters = GLOBAL_GET("debug/gdscript/completion/autocomplete_setters_and_getters").booleanize();
+					bool is_autocompleting_getters = PROJECT_GET("debug/gdscript/completion/autocomplete_setters_and_getters").booleanize();
 					ClassDB::get_method_list(type, &methods, false, !is_autocompleting_getters);
 					for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
 						if (E->get().name.begins_with("_")) {
@@ -2195,7 +2195,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	Variant base = p_base.value;
 	GDScriptParser::DataType base_type = p_base.type;
 
-	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
+	const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
 
 	while (base_type.is_set() && !base_type.is_variant()) {
 		switch (base_type.kind) {
@@ -2308,7 +2308,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 }
 
 static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, const GDScriptParser::Node *p_call, int p_argidx, Map<String, ScriptCodeCompletionOption> &r_result, bool &r_forced, String &r_arghint) {
-	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
+	const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
 
 	if (p_call->type == GDScriptParser::Node::PRELOAD) {
 		if (p_argidx == 0 && bool(EditorSettings::get_singleton()->get("text_editor/completion/complete_file_paths"))) {
@@ -2385,7 +2385,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 }
 
 ::Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptCodeCompletionOption> *r_options, bool &r_forced, String &r_call_hint) {
-	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
+	const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
 
 	GDScriptParser parser;
 	GDScriptAnalyzer analyzer(&parser);
@@ -2709,10 +2709,10 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 String GDScriptLanguage::_get_indentation() const {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		bool use_space_indentation = EDITOR_DEF("text_editor/indent/type", false);
+		bool use_space_indentation = EDITOR_DEFAULT("text_editor/indent/type", false);
 
 		if (use_space_indentation) {
-			int indent_size = EDITOR_DEF("text_editor/indent/size", 4);
+			int indent_size = EDITOR_DEFAULT("text_editor/indent/size", 4);
 
 			String space_indent = "";
 			for (int i = 0; i < indent_size; i++) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -232,7 +232,7 @@ void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_
 	if (is_ignoring_warnings) {
 		return;
 	}
-	if (GLOBAL_GET("debug/gdscript/warnings/exclude_addons").booleanize() && script_path.begins_with("res://addons/")) {
+	if (PROJECT_GET("debug/gdscript/warnings/exclude_addons").booleanize() && script_path.begins_with("res://addons/")) {
 		return;
 	}
 
@@ -240,7 +240,7 @@ void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_
 	if (ignored_warnings.has(warn_name)) {
 		return;
 	}
-	if (!GLOBAL_GET("debug/gdscript/warnings/" + warn_name)) {
+	if (!PROJECT_GET("debug/gdscript/warnings/" + warn_name)) {
 		return;
 	}
 

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -36,10 +36,10 @@
 #include "editor/editor_node.h"
 
 GDScriptLanguageServer::GDScriptLanguageServer() {
-	_EDITOR_DEF("network/language_server/remote_port", port);
-	_EDITOR_DEF("network/language_server/enable_smart_resolve", true);
-	_EDITOR_DEF("network/language_server/show_native_symbols_in_editor", false);
-	_EDITOR_DEF("network/language_server/use_thread", use_thread);
+	_EDITOR_DEFAULT("network/language_server/remote_port", port);
+	_EDITOR_DEFAULT("network/language_server/enable_smart_resolve", true);
+	_EDITOR_DEFAULT("network/language_server/show_native_symbols_in_editor", false);
+	_EDITOR_DEFAULT("network/language_server/use_thread", use_thread);
 }
 
 void GDScriptLanguageServer::_notification(int p_what) {

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -268,7 +268,7 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 		}
 	} else if (item.kind == lsp::CompletionItemKind::Event) {
 		if (params.context.triggerKind == lsp::CompletionTriggerKind::TriggerCharacter && (params.context.triggerCharacter == "(")) {
-			const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
+			const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
 			item.insertText = quote_style + item.label + quote_style;
 		}
 	}

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -823,7 +823,7 @@ void GridMapEditor::_icon_size_changed(float p_value) {
 void GridMapEditor::update_palette() {
 	int selected = mesh_library_palette->get_current();
 
-	float min_size = EDITOR_DEF("editors/grid_map/preview_size", 64);
+	float min_size = EDITOR_DEFAULT("editors/grid_map/preview_size", 64);
 	min_size *= EDSCALE;
 
 	mesh_library_palette->clear();
@@ -1145,7 +1145,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	editor = p_editor;
 	undo_redo = p_editor->get_undo_redo();
 
-	int mw = EDITOR_DEF("editors/grid_map/palette_min_width", 230);
+	int mw = EDITOR_DEFAULT("editors/grid_map/palette_min_width", 230);
 	Control *ec = memnew(Control);
 	ec->set_custom_minimum_size(Size2(mw, 0) * EDSCALE);
 	add_child(ec);
@@ -1219,7 +1219,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	settings_pick_distance->set_max(10000.0f);
 	settings_pick_distance->set_min(500.0f);
 	settings_pick_distance->set_step(1.0f);
-	settings_pick_distance->set_value(EDITOR_DEF("editors/grid_map/pick_distance", 5000.0));
+	settings_pick_distance->set_value(EDITOR_DEFAULT("editors/grid_map/pick_distance", 5000.0));
 	settings_vbc->add_margin_child(TTR("Pick Distance:"), settings_pick_distance);
 
 	options->get_popup()->connect("id_pressed", callable_mp(this, &GridMapEditor::_menu_option));
@@ -1260,7 +1260,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	size_slider->connect("value_changed", callable_mp(this, &GridMapEditor::_icon_size_changed));
 	add_child(size_slider);
 
-	EDITOR_DEF("editors/grid_map/preview_size", 64);
+	EDITOR_DEFAULT("editors/grid_map/preview_size", 64);
 
 	mesh_library_palette = memnew(ItemList);
 	add_child(mesh_library_palette);
@@ -1476,7 +1476,7 @@ void GridMapEditorPlugin::make_visible(bool p_visible) {
 GridMapEditorPlugin::GridMapEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 
-	EDITOR_DEF("editors/grid_map/editor_side", 1);
+	EDITOR_DEFAULT("editors/grid_map/editor_side", 1);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "editors/grid_map/editor_side", PROPERTY_HINT_ENUM, "Left,Right"));
 
 	grid_map_editor = memnew(GridMapEditor(editor));

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -1202,23 +1202,23 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 		switch (p_quality) {
 			case BAKE_QUALITY_LOW: {
-				push_constant.ray_count = GLOBAL_GET("rendering/lightmapping/bake_quality/low_quality_ray_count");
+				push_constant.ray_count = PROJECT_GET("rendering/lightmapping/bake_quality/low_quality_ray_count");
 			} break;
 			case BAKE_QUALITY_MEDIUM: {
-				push_constant.ray_count = GLOBAL_GET("rendering/lightmapping/bake_quality/medium_quality_ray_count");
+				push_constant.ray_count = PROJECT_GET("rendering/lightmapping/bake_quality/medium_quality_ray_count");
 			} break;
 			case BAKE_QUALITY_HIGH: {
-				push_constant.ray_count = GLOBAL_GET("rendering/lightmapping/bake_quality/high_quality_ray_count");
+				push_constant.ray_count = PROJECT_GET("rendering/lightmapping/bake_quality/high_quality_ray_count");
 			} break;
 			case BAKE_QUALITY_ULTRA: {
-				push_constant.ray_count = GLOBAL_GET("rendering/lightmapping/bake_quality/ultra_quality_ray_count");
+				push_constant.ray_count = PROJECT_GET("rendering/lightmapping/bake_quality/ultra_quality_ray_count");
 			} break;
 		}
 
 		push_constant.ray_count = CLAMP(push_constant.ray_count, 16, 8192);
 
-		int max_region_size = nearest_power_of_2_templated(int(GLOBAL_GET("rendering/lightmapping/bake_performance/region_size")));
-		int max_rays = GLOBAL_GET("rendering/lightmapping/bake_performance/max_rays_per_pass");
+		int max_region_size = nearest_power_of_2_templated(int(PROJECT_GET("rendering/lightmapping/bake_performance/region_size")));
+		int max_rays = PROJECT_GET("rendering/lightmapping/bake_performance/max_rays_per_pass");
 
 		int x_regions = (atlas_size.width - 1) / max_region_size + 1;
 		int y_regions = (atlas_size.height - 1) / max_region_size + 1;
@@ -1332,23 +1332,23 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 		switch (p_quality) {
 			case BAKE_QUALITY_LOW: {
-				push_constant.ray_count = GLOBAL_GET("rendering/lightmapping/bake_quality/low_quality_probe_ray_count");
+				push_constant.ray_count = PROJECT_GET("rendering/lightmapping/bake_quality/low_quality_probe_ray_count");
 			} break;
 			case BAKE_QUALITY_MEDIUM: {
-				push_constant.ray_count = GLOBAL_GET("rendering/lightmapping/bake_quality/medium_quality_probe_ray_count");
+				push_constant.ray_count = PROJECT_GET("rendering/lightmapping/bake_quality/medium_quality_probe_ray_count");
 			} break;
 			case BAKE_QUALITY_HIGH: {
-				push_constant.ray_count = GLOBAL_GET("rendering/lightmapping/bake_quality/high_quality_probe_ray_count");
+				push_constant.ray_count = PROJECT_GET("rendering/lightmapping/bake_quality/high_quality_probe_ray_count");
 			} break;
 			case BAKE_QUALITY_ULTRA: {
-				push_constant.ray_count = GLOBAL_GET("rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count");
+				push_constant.ray_count = PROJECT_GET("rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count");
 			} break;
 		}
 
 		push_constant.atlas_size[0] = probe_positions.size();
 		push_constant.ray_count = CLAMP(push_constant.ray_count, 16, 8192);
 
-		int max_rays = GLOBAL_GET("rendering/lightmapping/bake_performance/max_rays_per_probe_pass");
+		int max_rays = PROJECT_GET("rendering/lightmapping/bake_performance/max_rays_per_probe_pass");
 		int ray_iterations = (push_constant.ray_count - 1) / max_rays + 1;
 
 		for (int i = 0; i < ray_iterations; i++) {

--- a/modules/lightmapper_rd/register_types.cpp
+++ b/modules/lightmapper_rd/register_types.cpp
@@ -41,18 +41,18 @@ static Lightmapper *create_lightmapper_rd() {
 #endif
 
 void register_lightmapper_rd_types() {
-	GLOBAL_DEF("rendering/lightmapping/bake_quality/low_quality_ray_count", 16);
-	GLOBAL_DEF("rendering/lightmapping/bake_quality/medium_quality_ray_count", 64);
-	GLOBAL_DEF("rendering/lightmapping/bake_quality/high_quality_ray_count", 256);
-	GLOBAL_DEF("rendering/lightmapping/bake_quality/ultra_quality_ray_count", 1024);
-	GLOBAL_DEF("rendering/lightmapping/bake_performance/max_rays_per_pass", 32);
-	GLOBAL_DEF("rendering/lightmapping/bake_performance/region_size", 512);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_quality/low_quality_ray_count", 16);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_quality/medium_quality_ray_count", 64);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_quality/high_quality_ray_count", 256);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_quality/ultra_quality_ray_count", 1024);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_performance/max_rays_per_pass", 32);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_performance/region_size", 512);
 
-	GLOBAL_DEF("rendering/lightmapping/bake_quality/low_quality_probe_ray_count", 64);
-	GLOBAL_DEF("rendering/lightmapping/bake_quality/medium_quality_probe_ray_count", 256);
-	GLOBAL_DEF("rendering/lightmapping/bake_quality/high_quality_probe_ray_count", 512);
-	GLOBAL_DEF("rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count", 2048);
-	GLOBAL_DEF("rendering/lightmapping/bake_performance/max_rays_per_probe_pass", 64);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_quality/low_quality_probe_ray_count", 64);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_quality/medium_quality_probe_ray_count", 256);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_quality/high_quality_probe_ray_count", 512);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count", 2048);
+	PROJECT_DEFAULT("rendering/lightmapping/bake_performance/max_rays_per_probe_pass", 64);
 #ifndef _3D_DISABLED
 	ClassDB::register_class<LightmapperRD>();
 	Lightmapper::create_gpu = create_lightmapper_rd;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -542,10 +542,10 @@ String CSharpLanguage::make_function(const String &, const String &, const Packe
 String CSharpLanguage::_get_indentation() const {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		bool use_space_indentation = EDITOR_DEF("text_editor/indent/type", 0);
+		bool use_space_indentation = EDITOR_DEFAULT("text_editor/indent/type", 0);
 
 		if (use_space_indentation) {
-			int indent_size = EDITOR_DEF("text_editor/indent/size", 4);
+			int indent_size = EDITOR_DEFAULT("text_editor/indent/size", 4);
 
 			String space_indent = "";
 			for (int i = 0; i < indent_size; i++) {

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -295,14 +295,14 @@ float godot_icall_Globals_EditorScale() {
 MonoObject *godot_icall_Globals_GlobalDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
 	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
 	Variant default_value = GDMonoMarshal::mono_object_to_variant(p_default_value);
-	Variant result = _GLOBAL_DEF(setting, default_value, (bool)p_restart_if_changed);
+	Variant result = _PROJECT_DEFAULT(setting, default_value, (bool)p_restart_if_changed);
 	return GDMonoMarshal::variant_to_mono_object(result);
 }
 
 MonoObject *godot_icall_Globals_EditorDef(MonoString *p_setting, MonoObject *p_default_value, MonoBoolean p_restart_if_changed) {
 	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
 	Variant default_value = GDMonoMarshal::mono_object_to_variant(p_default_value);
-	Variant result = _EDITOR_DEF(setting, default_value, (bool)p_restart_if_changed);
+	Variant result = _EDITOR_DEFAULT(setting, default_value, (bool)p_restart_if_changed);
 	return GDMonoMarshal::variant_to_mono_object(result);
 }
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -110,8 +110,8 @@ void gd_mono_setup_runtime_main_args() {
 }
 
 void gd_mono_profiler_init() {
-	String profiler_args = GLOBAL_DEF("mono/profiler/args", "log:calls,alloc,sample,output=output.mlpd");
-	bool profiler_enabled = GLOBAL_DEF("mono/profiler/enabled", false);
+	String profiler_args = PROJECT_DEFAULT("mono/profiler/args", "log:calls,alloc,sample,output=output.mlpd");
+	bool profiler_enabled = PROJECT_DEFAULT("mono/profiler/enabled", false);
 	if (profiler_enabled) {
 		mono_profiler_load(profiler_args.utf8());
 		return;
@@ -137,9 +137,9 @@ void gd_mono_debug_init() {
 	}
 
 #ifdef TOOLS_ENABLED
-	int da_port = GLOBAL_DEF("mono/debugger_agent/port", 23685);
-	bool da_suspend = GLOBAL_DEF("mono/debugger_agent/wait_for_debugger", false);
-	int da_timeout = GLOBAL_DEF("mono/debugger_agent/wait_timeout", 3000);
+	int da_port = PROJECT_DEFAULT("mono/debugger_agent/port", 23685);
+	bool da_suspend = PROJECT_DEFAULT("mono/debugger_agent/wait_for_debugger", false);
+	int da_timeout = PROJECT_DEFAULT("mono/debugger_agent/wait_timeout", 3000);
 
 	if (Engine::get_singleton()->is_editor_hint() ||
 			ProjectSettings::get_singleton()->get_resource_path().is_empty() ||
@@ -506,7 +506,7 @@ void GDMono::_init_godot_api_hashes() {
 void GDMono::_init_exception_policy() {
 	PropertyInfo exc_policy_prop = PropertyInfo(Variant::INT, "mono/unhandled_exception_policy", PROPERTY_HINT_ENUM,
 			vformat("Terminate Application:%s,Log Error:%s", (int)POLICY_TERMINATE_APP, (int)POLICY_LOG_ERROR));
-	unhandled_exception_policy = (UnhandledExceptionPolicy)(int)GLOBAL_DEF(exc_policy_prop.name, (int)POLICY_TERMINATE_APP);
+	unhandled_exception_policy = (UnhandledExceptionPolicy)(int)PROJECT_DEFAULT(exc_policy_prop.name, (int)POLICY_TERMINATE_APP);
 	ProjectSettings::get_singleton()->set_custom_property_info(exc_policy_prop.name, exc_policy_prop);
 
 	if (Engine::get_singleton()->is_editor_hint()) {

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -557,7 +557,7 @@ void RaycastOcclusionCull::_init_embree() {
 
 RaycastOcclusionCull::RaycastOcclusionCull() {
 	raycast_singleton = this;
-	int default_quality = GLOBAL_GET("rendering/occlusion_culling/bvh_build_quality");
+	int default_quality = PROJECT_GET("rendering/occlusion_culling/bvh_build_quality");
 	build_quality = RS::ViewportOcclusionCullingBuildQuality(default_quality);
 }
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2543,7 +2543,7 @@ void VisualScriptLanguage::get_registered_node_names(List<String> *r_names) {
 VisualScriptLanguage::VisualScriptLanguage() {
 	singleton = this;
 
-	int dmcs = GLOBAL_DEF("debug/settings/visual_script/max_call_stack", 1024);
+	int dmcs = PROJECT_DEFAULT("debug/settings/visual_script/max_call_stack", 1024);
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/settings/visual_script/max_call_stack", PropertyInfo(Variant::INT, "debug/settings/visual_script/max_call_stack", PROPERTY_HINT_RANGE, "1024,4096,1,or_greater")); //minimum is 1024
 
 	if (EngineDebugger::is_active()) {

--- a/modules/webrtc/register_types.cpp
+++ b/modules/webrtc/register_types.cpp
@@ -45,7 +45,7 @@
 
 void register_webrtc_types() {
 #define _SET_HINT(NAME, _VAL_, _MAX_) \
-	GLOBAL_DEF(NAME, _VAL_);          \
+	PROJECT_DEFAULT(NAME, _VAL_);     \
 	ProjectSettings::get_singleton()->set_custom_property_info(NAME, PropertyInfo(Variant::INT, NAME, PROPERTY_HINT_RANGE, "2," #_MAX_ ",1,or_greater"));
 
 	_SET_HINT(WRTC_IN_BUF, 64, 4096);

--- a/modules/webrtc/webrtc_data_channel.cpp
+++ b/modules/webrtc/webrtc_data_channel.cpp
@@ -59,7 +59,7 @@ void WebRTCDataChannel::_bind_methods() {
 }
 
 WebRTCDataChannel::WebRTCDataChannel() {
-	_in_buffer_shift = nearest_shift((int)GLOBAL_GET(WRTC_IN_BUF) - 1) + 10;
+	_in_buffer_shift = nearest_shift((int)PROJECT_GET(WRTC_IN_BUF) - 1) + 10;
 }
 
 WebRTCDataChannel::~WebRTCDataChannel() {

--- a/modules/websocket/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor_debugger_server_websocket.cpp
@@ -77,7 +77,7 @@ Ref<RemoteDebuggerPeer> EditorDebuggerServerWebSocket::take_connection() {
 
 EditorDebuggerServerWebSocket::EditorDebuggerServerWebSocket() {
 	server = Ref<WebSocketServer>(WebSocketServer::create());
-	int max_pkts = (int)GLOBAL_GET("network/limits/debugger/max_queued_messages");
+	int max_pkts = (int)PROJECT_GET("network/limits/debugger/max_queued_messages");
 	server->set_buffers(8192, max_pkts, 8192, max_pkts);
 	server->connect("client_connected", callable_mp(this, &EditorDebuggerServerWebSocket::_peer_connected));
 	server->connect("client_disconnected", callable_mp(this, &EditorDebuggerServerWebSocket::_peer_disconnected));

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -116,7 +116,7 @@ RemoteDebuggerPeerWebSocket::RemoteDebuggerPeerWebSocket(Ref<WebSocketPeer> p_pe
 #else
 	ws_client = Ref<WebSocketClient>(memnew(WSLClient));
 #endif
-	max_queued_messages = (int)GLOBAL_GET("network/limits/debugger/max_queued_messages");
+	max_queued_messages = (int)PROJECT_GET("network/limits/debugger/max_queued_messages");
 	ws_client->set_buffers(8192, max_queued_messages, 8192, max_queued_messages);
 	ws_peer = p_peer;
 }

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -409,7 +409,7 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 	// TODO: rendering_driver is broken, change when different drivers are supported again
 	rendering_driver = "vulkan";
 
-	keep_screen_on = GLOBAL_GET("display/window/energy_saving/keep_screen_on");
+	keep_screen_on = PROJECT_GET("display/window/energy_saving/keep_screen_on");
 
 #if defined(OPENGL_ENABLED)
 	if (rendering_driver == "opengl") {

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -882,7 +882,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		String package_name = p_preset->get("package/unique_name");
 
 		const int screen_orientation =
-				_get_android_orientation_value(DisplayServer::ScreenOrientation(int(GLOBAL_GET("display/window/handheld/orientation"))));
+				_get_android_orientation_value(DisplayServer::ScreenOrientation(int(PROJECT_GET("display/window/handheld/orientation"))));
 
 		bool screen_support_small = p_preset->get("screen/support_small");
 		bool screen_support_normal = p_preset->get("screen/support_normal");
@@ -3052,15 +3052,15 @@ void register_android_exporter() {
 		exe_ext = "*.exe";
 	}
 
-	EDITOR_DEF("export/android/android_sdk_path", "");
+	EDITOR_DEFAULT("export/android/android_sdk_path", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
-	EDITOR_DEF("export/android/debug_keystore", "");
+	EDITOR_DEFAULT("export/android/debug_keystore", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/debug_keystore", PROPERTY_HINT_GLOBAL_FILE, "*.keystore,*.jks"));
-	EDITOR_DEF("export/android/debug_keystore_user", "androiddebugkey");
-	EDITOR_DEF("export/android/debug_keystore_pass", "android");
-	EDITOR_DEF("export/android/force_system_user", false);
+	EDITOR_DEFAULT("export/android/debug_keystore_user", "androiddebugkey");
+	EDITOR_DEFAULT("export/android/debug_keystore_pass", "android");
+	EDITOR_DEFAULT("export/android/force_system_user", false);
 
-	EDITOR_DEF("export/android/shutdown_adb_on_exit", true);
+	EDITOR_DEFAULT("export/android/shutdown_adb_on_exit", true);
 
 	Ref<EditorExportPlatformAndroid> exporter = Ref<EditorExportPlatformAndroid>(memnew(EditorExportPlatformAndroid));
 	EditorExport::get_singleton()->add_export_platform(exporter);

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -236,7 +236,7 @@ String _get_instrumentation_tag(const Ref<EditorExportPreset> &p_preset) {
 
 String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 	bool uses_xr = (int)(p_preset->get("xr_features/xr_mode")) == 1;
-	String orientation = _get_android_orientation_label(DisplayServer::ScreenOrientation(int(GLOBAL_GET("display/window/handheld/orientation"))));
+	String orientation = _get_android_orientation_label(DisplayServer::ScreenOrientation(int(PROJECT_GET("display/window/handheld/orientation"))));
 	String manifest_activity_text = vformat(
 			"        <activity android:name=\"com.godot.game.GodotApp\" "
 			"tools:replace=\"android:screenOrientation\" "

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -77,7 +77,7 @@ static ViewController *mainViewController = nil;
 	};
 
 	ViewController *viewController = [[ViewController alloc] init];
-	viewController.godotView.useCADisplayLink = bool(GLOBAL_DEF("display.iOS/use_cadisplaylink", true)) ? YES : NO;
+	viewController.godotView.useCADisplayLink = bool(PROJECT_DEFAULT("display.iOS/use_cadisplaylink", true)) ? YES : NO;
 	viewController.godotView.renderingInterval = 1.0 / kRenderingFrequency;
 
 	self.window.rootViewController = viewController;

--- a/platform/iphone/display_layer.mm
+++ b/platform/iphone/display_layer.mm
@@ -89,7 +89,7 @@
 	// FIXME: Add Vulkan support via MoltenVK. Add fallback code back?
 
 	// Create GL ES 2 context
-	if (GLOBAL_GET("rendering/driver/driver_name") == "GLES2") {
+	if (PROJECT_GET("rendering/driver/driver_name") == "GLES2") {
 		context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
 		NSLog(@"Setting up an OpenGL ES 2.0 context.");
 		if (!context) {

--- a/platform/iphone/display_server_iphone.mm
+++ b/platform/iphone/display_server_iphone.mm
@@ -121,7 +121,7 @@ DisplayServerIPhone::DisplayServerIPhone(const String &p_rendering_driver, Windo
 	}
 #endif
 
-	bool keep_screen_on = bool(GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true));
+	bool keep_screen_on = bool(PROJECT_DEFAULT("display/window/energy_saving/keep_screen_on", true));
 	screen_set_keep_on(keep_screen_on);
 
 	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
@@ -222,7 +222,7 @@ void DisplayServerIPhone::_window_callback(const Callable &p_callable, const Var
 // MARK: Touches
 
 void DisplayServerIPhone::touch_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_double_click) {
-	if (!GLOBAL_DEF("debug/disable_touch", false)) {
+	if (!PROJECT_DEFAULT("debug/disable_touch", false)) {
 		Ref<InputEventScreenTouch> ev;
 		ev.instantiate();
 
@@ -234,7 +234,7 @@ void DisplayServerIPhone::touch_press(int p_idx, int p_x, int p_y, bool p_presse
 };
 
 void DisplayServerIPhone::touch_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_y) {
-	if (!GLOBAL_DEF("debug/disable_touch", false)) {
+	if (!PROJECT_DEFAULT("debug/disable_touch", false)) {
 		Ref<InputEventScreenDrag> ev;
 		ev.instantiate();
 		ev->set_index(p_idx);

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -535,7 +535,7 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].find("$interface_orientations") != -1) {
 			String orientations;
 			const DisplayServer::ScreenOrientation screen_orientation =
-					DisplayServer::ScreenOrientation(int(GLOBAL_GET("display/window/handheld/orientation")));
+					DisplayServer::ScreenOrientation(int(PROJECT_GET("display/window/handheld/orientation")));
 
 			switch (screen_orientation) {
 				case DisplayServer::SCREEN_LANDSCAPE:

--- a/platform/iphone/godot_view_gesture_recognizer.mm
+++ b/platform/iphone/godot_view_gesture_recognizer.mm
@@ -65,7 +65,7 @@ const CGFloat kGLGestureMovementDistance = 0.5;
 	self.delaysTouchesBegan = YES;
 	self.delaysTouchesEnded = YES;
 
-	self.delayTimeInterval = GLOBAL_GET("input_devices/pointing/ios/touch_delay");
+	self.delayTimeInterval = PROJECT_GET("input_devices/pointing/ios/touch_delay");
 
 	return self;
 }

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -210,7 +210,7 @@
 }
 
 - (BOOL)prefersHomeIndicatorAutoHidden {
-	if (GLOBAL_GET("display/window/ios/hide_home_indicator")) {
+	if (PROJECT_GET("display/window/ios/hide_home_indicator")) {
 		return YES;
 	} else {
 		return NO;

--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -105,8 +105,8 @@ void AudioDriverJavaScript::_audio_driver_capture(int p_from, int p_samples) {
 }
 
 Error AudioDriverJavaScript::init() {
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
-	int latency = GLOBAL_GET("audio/driver/output_latency");
+	mix_rate = PROJECT_GET("audio/driver/mix_rate");
+	int latency = PROJECT_GET("audio/driver/output_latency");
 
 	channel_count = godot_audio_init(mix_rate, latency, &_state_change_callback, &_latency_update_callback);
 	buffer_length = closest_power_of_2((latency * mix_rate / 1000));

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -733,7 +733,7 @@ DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_drive
 #if 0
 	EmscriptenWebGLContextAttributes attributes;
 	emscripten_webgl_init_context_attributes(&attributes);
-	attributes.alpha = GLOBAL_GET("display/window/per_pixel_transparency/allowed");
+	attributes.alpha = PROJECT_GET("display/window/per_pixel_transparency/allowed");
 	attributes.antialias = false;
 	ERR_FAIL_INDEX_V(p_video_driver, VIDEO_DRIVER_MAX, ERR_INVALID_PARAMETER);
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -293,7 +293,7 @@ class EditorExportPlatformJavaScript : public EditorExportPlatform {
 	Ref<Image> _get_project_icon() const {
 		Ref<Image> icon;
 		icon.instantiate();
-		const String icon_path = String(GLOBAL_GET("application/config/icon")).strip_edges();
+		const String icon_path = String(PROJECT_GET("application/config/icon")).strip_edges();
 		if (icon_path.is_empty() || ImageLoader::load_image(icon_path, icon) != OK) {
 			return EditorNode::get_singleton()->get_editor_theme()->get_icon("DefaultProjectIcon", "EditorIcons")->get_image();
 		}
@@ -303,7 +303,7 @@ class EditorExportPlatformJavaScript : public EditorExportPlatform {
 	Ref<Image> _get_project_splash() const {
 		Ref<Image> splash;
 		splash.instantiate();
-		const String splash_path = String(GLOBAL_GET("application/boot_splash/image")).strip_edges();
+		const String splash_path = String(PROJECT_GET("application/boot_splash/image")).strip_edges();
 		if (splash_path.is_empty() || ImageLoader::load_image(splash_path, splash) != OK) {
 			return Ref<Image>(memnew(Image(boot_splash_png)));
 		}
@@ -995,11 +995,11 @@ EditorExportPlatformJavaScript::~EditorExportPlatformJavaScript() {
 }
 
 void register_javascript_exporter() {
-	EDITOR_DEF("export/web/http_host", "localhost");
-	EDITOR_DEF("export/web/http_port", 8060);
-	EDITOR_DEF("export/web/use_ssl", false);
-	EDITOR_DEF("export/web/ssl_key", "");
-	EDITOR_DEF("export/web/ssl_certificate", "");
+	EDITOR_DEFAULT("export/web/http_host", "localhost");
+	EDITOR_DEFAULT("export/web/http_port", 8060);
+	EDITOR_DEFAULT("export/web/use_ssl", false);
+	EDITOR_DEFAULT("export/web/ssl_key", "");
+	EDITOR_DEFAULT("export/web/ssl_certificate", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "export/web/http_port", PROPERTY_HINT_RANGE, "1,65535,1"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/web/ssl_key", PROPERTY_HINT_GLOBAL_FILE, "*.key"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/web/ssl_certificate", PROPERTY_HINT_GLOBAL_FILE, "*.crt,*.pem"));

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3524,7 +3524,7 @@ void DisplayServerX11::_update_context(WindowData &wd) {
 
 		CharString class_str;
 		if (context == CONTEXT_ENGINE) {
-			String config_name = GLOBAL_GET("application/config/name");
+			String config_name = PROJECT_GET("application/config/name");
 			if (config_name.length() == 0) {
 				class_str = "Godot_Engine";
 			} else {
@@ -4311,7 +4311,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 #ifdef DBUS_ENABLED
 	screensaver = memnew(FreeDesktopScreenSaver);
-	screen_set_keep_on(GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true));
+	screen_set_keep_on(PROJECT_DEFAULT("display/window/energy_saving/keep_screen_on", true));
 #endif
 
 	r_error = OK;

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1436,12 +1436,12 @@ public:
 
 void register_uwp_exporter() {
 #ifdef WINDOWS_ENABLED
-	EDITOR_DEF("export/uwp/signtool", "");
+	EDITOR_DEFAULT("export/uwp/signtool", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/uwp/signtool", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
-	EDITOR_DEF("export/uwp/debug_certificate", "");
+	EDITOR_DEFAULT("export/uwp/debug_certificate", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/uwp/debug_certificate", PROPERTY_HINT_GLOBAL_FILE, "*.pfx"));
-	EDITOR_DEF("export/uwp/debug_password", "");
-	EDITOR_DEF("export/uwp/debug_algorithm", 2); // SHA256 is the default
+	EDITOR_DEFAULT("export/uwp/debug_password", "");
+	EDITOR_DEFAULT("export/uwp/debug_algorithm", 2); // SHA256 is the default
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "export/uwp/debug_algorithm", PROPERTY_HINT_ENUM, "MD5,SHA1,SHA256"));
 #endif // WINDOWS_ENABLED
 

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -278,7 +278,7 @@ Error OS_UWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	if (is_keep_screen_on())
 		display_request->RequestActive();
 
-	set_keep_screen_on(GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true));
+	set_keep_screen_on(PROJECT_DEFAULT("display/window/energy_saving/keep_screen_on", true));
 
 	return OK;
 }

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -340,16 +340,16 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 }
 
 void register_windows_exporter() {
-	EDITOR_DEF("export/windows/rcedit", "");
+	EDITOR_DEFAULT("export/windows/rcedit", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/rcedit", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
 #ifdef WINDOWS_ENABLED
-	EDITOR_DEF("export/windows/signtool", "");
+	EDITOR_DEFAULT("export/windows/signtool", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/signtool", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
 #else
-	EDITOR_DEF("export/windows/osslsigncode", "");
+	EDITOR_DEFAULT("export/windows/osslsigncode", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/osslsigncode", PROPERTY_HINT_GLOBAL_FILE));
 	// On non-Windows we need WINE to run rcedit
-	EDITOR_DEF("export/windows/wine", "");
+	EDITOR_DEFAULT("export/windows/wine", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/wine", PROPERTY_HINT_GLOBAL_FILE));
 #endif
 

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -320,7 +320,7 @@ OccluderInstance3D::BakeError OccluderInstance3D::bake(Node *p_from_node, String
 TypedArray<String> OccluderInstance3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
-	if (!bool(GLOBAL_GET("rendering/occlusion_culling/use_occlusion_culling"))) {
+	if (!bool(PROJECT_GET("rendering/occlusion_culling/use_occlusion_culling"))) {
 		warnings.push_back(TTR("Occlusion culling is disabled in the Project Settings, which means occlusion culling won't be performed in the root viewport.\nTo resolve this, open the Project Settings and enable Rendering > Occlusion Culling > Use Occlusion Culling."));
 	}
 

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -520,7 +520,7 @@ TypedArray<String> XROrigin3D::get_configuration_warnings() const {
 		}
 	}
 
-	bool xr_enabled = GLOBAL_GET("rendering/xr/enabled");
+	bool xr_enabled = PROJECT_GET("rendering/xr/enabled");
 	if (!xr_enabled) {
 		warnings.push_back(TTR("XR is not enabled in rendering project settings. Stereoscopic output is not supported unless this is enabled."));
 	}

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1486,7 +1486,7 @@ NodePath AnimationPlayer::get_root() const {
 
 void AnimationPlayer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
+	const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -445,14 +445,14 @@ bool Control::is_layout_rtl() const {
 		} else if (parent_window) {
 			return parent_window->is_layout_rtl();
 		} else {
-			if (GLOBAL_GET("internationalization/rendering/force_right_to_left_layout_direction")) {
+			if (PROJECT_GET("internationalization/rendering/force_right_to_left_layout_direction")) {
 				return true;
 			}
 			String locale = TranslationServer::get_singleton()->get_tool_locale();
 			return TS->is_locale_right_to_left(locale);
 		}
 	} else if (data.layout_dir == LAYOUT_DIRECTION_LOCALE) {
-		if (GLOBAL_GET("internationalization/rendering/force_right_to_left_layout_direction")) {
+		if (PROJECT_GET("internationalization/rendering/force_right_to_left_layout_direction")) {
 			return true;
 		}
 		String locale = TranslationServer::get_singleton()->get_tool_locale();
@@ -2529,7 +2529,7 @@ bool Control::is_visibility_clip_disabled() const {
 
 void Control::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
+	const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -784,7 +784,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 			if (k.is_valid() && k->get_unicode()) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
-				uint64_t max_interval = uint64_t(GLOBAL_DEF("gui/timers/incremental_search_max_interval_msec", 2000));
+				uint64_t max_interval = uint64_t(PROJECT_DEFAULT("gui/timers/incremental_search_max_interval_msec", 2000));
 				search_time_msec = now;
 
 				if (diff > max_interval) {
@@ -1626,7 +1626,7 @@ void ItemList::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("rmb_clicked", PropertyInfo(Variant::VECTOR2, "at_position")));
 	ADD_SIGNAL(MethodInfo("nothing_selected"));
 
-	GLOBAL_DEF("gui/timers/incremental_search_max_interval_msec", 2000);
+	PROJECT_DEFAULT("gui/timers/incremental_search_max_interval_msec", 2000);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/timers/incremental_search_max_interval_msec", PropertyInfo(Variant::INT, "gui/timers/incremental_search_max_interval_msec", PROPERTY_HINT_RANGE, "0,10000,1,or_greater")); // No negative numbers
 }
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -577,8 +577,8 @@ void LineEdit::_notification(int p_what) {
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_ENTER_TREE: {
 			if (Engine::get_singleton()->is_editor_hint() && !get_tree()->is_node_being_edited(this)) {
-				set_caret_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
-				set_caret_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
+				set_caret_blink_enabled(EDITOR_DEFAULT("text_editor/cursor/caret_blink", false));
+				set_caret_blink_speed(EDITOR_DEFAULT("text_editor/cursor/caret_blink_speed", 0.65));
 
 				if (!EditorSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed))) {
 					EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed));
@@ -1816,8 +1816,8 @@ PopupMenu *LineEdit::get_menu() const {
 
 void LineEdit::_editor_settings_changed() {
 #ifdef TOOLS_ENABLED
-	set_caret_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
-	set_caret_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
+	set_caret_blink_enabled(EDITOR_DEFAULT("text_editor/cursor/caret_blink", false));
+	set_caret_blink_speed(EDITOR_DEFAULT("text_editor/cursor/caret_blink_speed", 0.65));
 #endif
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -433,7 +433,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 	if (allow_search && k.is_valid() && k->get_unicode() && k->is_pressed()) {
 		uint64_t now = OS::get_singleton()->get_ticks_msec();
 		uint64_t diff = now - search_time_msec;
-		uint64_t max_interval = uint64_t(GLOBAL_DEF("gui/timers/incremental_search_max_interval_msec", 2000));
+		uint64_t max_interval = uint64_t(PROJECT_DEFAULT("gui/timers/incremental_search_max_interval_msec", 2000));
 		search_time_msec = now;
 
 		if (diff > max_interval) {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -613,7 +613,7 @@ void ScrollContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_vertical_visible"), "set_v_scroll_visible", "is_v_scroll_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_deadzone"), "set_deadzone", "get_deadzone");
 
-	GLOBAL_DEF("gui/common/default_scroll_deadzone", 0);
+	PROJECT_DEFAULT("gui/common/default_scroll_deadzone", 0);
 };
 
 ScrollContainer::ScrollContainer() {
@@ -627,7 +627,7 @@ ScrollContainer::ScrollContainer() {
 	add_child(v_scroll);
 	v_scroll->connect("value_changed", callable_mp(this, &ScrollContainer::_scroll_moved));
 
-	deadzone = GLOBAL_GET("gui/common/default_scroll_deadzone");
+	deadzone = PROJECT_GET("gui/common/default_scroll_deadzone");
 
 	set_clip_contents(true);
 };

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5915,9 +5915,9 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(MENU_INSERT_SHY);
 	BIND_ENUM_CONSTANT(MENU_MAX);
 
-	GLOBAL_DEF("gui/timers/text_edit_idle_detect_sec", 3);
+	PROJECT_DEFAULT("gui/timers/text_edit_idle_detect_sec", 3);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/timers/text_edit_idle_detect_sec", PropertyInfo(Variant::FLOAT, "gui/timers/text_edit_idle_detect_sec", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater")); // No negative numbers.
-	GLOBAL_DEF("gui/common/text_edit_undo_stack_max_size", 1024);
+	PROJECT_DEFAULT("gui/common/text_edit_undo_stack_max_size", 1024);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/common/text_edit_undo_stack_max_size", PropertyInfo(Variant::INT, "gui/common/text_edit_undo_stack_max_size", PROPERTY_HINT_RANGE, "0,10000,1,or_greater")); // No negative numbers.
 }
 
@@ -5950,7 +5950,7 @@ TextEdit::TextEdit() {
 	idle_detect = memnew(Timer);
 	add_child(idle_detect);
 	idle_detect->set_one_shot(true);
-	idle_detect->set_wait_time(GLOBAL_GET("gui/timers/text_edit_idle_detect_sec"));
+	idle_detect->set_wait_time(PROJECT_GET("gui/timers/text_edit_idle_detect_sec"));
 	idle_detect->connect("timeout", callable_mp(this, &TextEdit::_push_current_op));
 
 	click_select_held = memnew(Timer);
@@ -5958,7 +5958,7 @@ TextEdit::TextEdit() {
 	click_select_held->set_wait_time(0.05);
 	click_select_held->connect("timeout", callable_mp(this, &TextEdit::_click_selection_held));
 
-	undo_stack_max_size = GLOBAL_GET("gui/common/text_edit_undo_stack_max_size");
+	undo_stack_max_size = PROJECT_GET("gui/common/text_edit_undo_stack_max_size");
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4321,7 +4321,7 @@ TreeItem *Tree::get_item_with_text(const String &p_find) const {
 void Tree::_do_incr_search(const String &p_add) {
 	uint64_t time = OS::get_singleton()->get_ticks_usec() / 1000; // convert to msec
 	uint64_t diff = time - last_keypress;
-	if (diff > uint64_t(GLOBAL_DEF("gui/timers/incremental_search_max_interval_msec", 2000))) {
+	if (diff > uint64_t(PROJECT_DEFAULT("gui/timers/incremental_search_max_interval_msec", 2000))) {
 		incr_search = p_add;
 	} else if (incr_search != p_add) {
 		incr_search += p_add;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2448,7 +2448,7 @@ NodePath Node::get_import_path() const {
 
 static void _add_nodes_to_options(const Node *p_base, const Node *p_node, List<String> *r_options) {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
+	const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif
@@ -2528,9 +2528,9 @@ void Node::request_ready() {
 }
 
 void Node::_bind_methods() {
-	GLOBAL_DEF("editor/node_naming/name_num_separator", 0);
+	PROJECT_DEFAULT("editor/node_naming/name_num_separator", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("editor/node_naming/name_num_separator", PropertyInfo(Variant::INT, "editor/node_naming/name_num_separator", PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash"));
-	GLOBAL_DEF("editor/node_naming/name_casing", NAME_CASING_PASCAL_CASE);
+	PROJECT_DEFAULT("editor/node_naming/name_casing", NAME_CASING_PASCAL_CASE);
 	ProjectSettings::get_singleton()->set_custom_property_info("editor/node_naming/name_casing", PropertyInfo(Variant::INT, "editor/node_naming/name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case"));
 
 	ClassDB::bind_method(D_METHOD("add_sibling", "sibling", "legible_unique_name"), &Node::add_sibling, DEFVAL(false));

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1393,14 +1393,14 @@ SceneTree::SceneTree() {
 	if (singleton == nullptr) {
 		singleton = this;
 	}
-	debug_collisions_color = GLOBAL_DEF("debug/shapes/collision/shape_color", Color(0.0, 0.6, 0.7, 0.42));
-	debug_collision_contact_color = GLOBAL_DEF("debug/shapes/collision/contact_color", Color(1.0, 0.2, 0.1, 0.8));
-	debug_navigation_color = GLOBAL_DEF("debug/shapes/navigation/geometry_color", Color(0.1, 1.0, 0.7, 0.4));
-	debug_navigation_disabled_color = GLOBAL_DEF("debug/shapes/navigation/disabled_geometry_color", Color(1.0, 0.7, 0.1, 0.4));
-	collision_debug_contacts = GLOBAL_DEF("debug/shapes/collision/max_contacts_displayed", 10000);
+	debug_collisions_color = PROJECT_DEFAULT("debug/shapes/collision/shape_color", Color(0.0, 0.6, 0.7, 0.42));
+	debug_collision_contact_color = PROJECT_DEFAULT("debug/shapes/collision/contact_color", Color(1.0, 0.2, 0.1, 0.8));
+	debug_navigation_color = PROJECT_DEFAULT("debug/shapes/navigation/geometry_color", Color(0.1, 1.0, 0.7, 0.4));
+	debug_navigation_disabled_color = PROJECT_DEFAULT("debug/shapes/navigation/disabled_geometry_color", Color(1.0, 0.7, 0.1, 0.4));
+	collision_debug_contacts = PROJECT_DEFAULT("debug/shapes/collision/max_contacts_displayed", 10000);
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/shapes/collision/max_contacts_displayed", PropertyInfo(Variant::INT, "debug/shapes/collision/max_contacts_displayed", PROPERTY_HINT_RANGE, "0,20000,1")); // No negative
 
-	GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
+	PROJECT_DEFAULT("debug/shapes/collision/draw_2d_outlines", true);
 
 	Math::randomize();
 
@@ -1420,38 +1420,38 @@ SceneTree::SceneTree() {
 	root->set_as_audio_listener_2d(true);
 	current_scene = nullptr;
 
-	const int msaa_mode = GLOBAL_DEF("rendering/anti_aliasing/quality/msaa", 0);
+	const int msaa_mode = PROJECT_DEFAULT("rendering/anti_aliasing/quality/msaa", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/anti_aliasing/quality/msaa", PropertyInfo(Variant::INT, "rendering/anti_aliasing/quality/msaa", PROPERTY_HINT_ENUM, "Disabled (Fastest),2x (Fast),4x (Average),8x (Slow),16x (Slower)"));
 	root->set_msaa(Viewport::MSAA(msaa_mode));
 
-	const int ssaa_mode = GLOBAL_DEF("rendering/anti_aliasing/quality/screen_space_aa", 0);
+	const int ssaa_mode = PROJECT_DEFAULT("rendering/anti_aliasing/quality/screen_space_aa", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/anti_aliasing/quality/screen_space_aa", PropertyInfo(Variant::INT, "rendering/anti_aliasing/quality/screen_space_aa", PROPERTY_HINT_ENUM, "Disabled (Fastest),FXAA (Fast)"));
 	root->set_screen_space_aa(Viewport::ScreenSpaceAA(ssaa_mode));
 
-	const bool use_debanding = GLOBAL_DEF("rendering/anti_aliasing/quality/use_debanding", false);
+	const bool use_debanding = PROJECT_DEFAULT("rendering/anti_aliasing/quality/use_debanding", false);
 	root->set_use_debanding(use_debanding);
 
-	const bool use_occlusion_culling = GLOBAL_DEF("rendering/occlusion_culling/use_occlusion_culling", false);
+	const bool use_occlusion_culling = PROJECT_DEFAULT("rendering/occlusion_culling/use_occlusion_culling", false);
 	root->set_use_occlusion_culling(use_occlusion_culling);
 
-	float lod_threshold = GLOBAL_DEF("rendering/mesh_lod/lod_change/threshold_pixels", 1.0);
+	float lod_threshold = PROJECT_DEFAULT("rendering/mesh_lod/lod_change/threshold_pixels", 1.0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/mesh_lod/lod_change/threshold_pixels", PropertyInfo(Variant::FLOAT, "rendering/mesh_lod/lod_change/threshold_pixels", PROPERTY_HINT_RANGE, "0,1024,0.1"));
 	root->set_lod_threshold(lod_threshold);
 
-	bool snap_2d_transforms = GLOBAL_DEF("rendering/2d/snap/snap_2d_transforms_to_pixel", false);
+	bool snap_2d_transforms = PROJECT_DEFAULT("rendering/2d/snap/snap_2d_transforms_to_pixel", false);
 	root->set_snap_2d_transforms_to_pixel(snap_2d_transforms);
 
-	bool snap_2d_vertices = GLOBAL_DEF("rendering/2d/snap/snap_2d_vertices_to_pixel", false);
+	bool snap_2d_vertices = PROJECT_DEFAULT("rendering/2d/snap/snap_2d_vertices_to_pixel", false);
 	root->set_snap_2d_vertices_to_pixel(snap_2d_vertices);
 
-	int shadowmap_size = GLOBAL_DEF("rendering/shadows/shadow_atlas/size", 4096);
+	int shadowmap_size = PROJECT_DEFAULT("rendering/shadows/shadow_atlas/size", 4096);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/shadows/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384"));
-	GLOBAL_DEF("rendering/shadows/shadow_atlas/size.mobile", 2048);
-	bool shadowmap_16_bits = GLOBAL_DEF("rendering/shadows/shadow_atlas/16_bits", true);
-	int atlas_q0 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_0_subdiv", 2);
-	int atlas_q1 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_1_subdiv", 2);
-	int atlas_q2 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_2_subdiv", 3);
-	int atlas_q3 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_3_subdiv", 4);
+	PROJECT_DEFAULT("rendering/shadows/shadow_atlas/size.mobile", 2048);
+	bool shadowmap_16_bits = PROJECT_DEFAULT("rendering/shadows/shadow_atlas/16_bits", true);
+	int atlas_q0 = PROJECT_DEFAULT("rendering/shadows/shadow_atlas/quadrant_0_subdiv", 2);
+	int atlas_q1 = PROJECT_DEFAULT("rendering/shadows/shadow_atlas/quadrant_1_subdiv", 2);
+	int atlas_q2 = PROJECT_DEFAULT("rendering/shadows/shadow_atlas/quadrant_2_subdiv", 3);
+	int atlas_q3 = PROJECT_DEFAULT("rendering/shadows/shadow_atlas/quadrant_3_subdiv", 4);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadow_atlas/quadrant_0_subdiv", PropertyInfo(Variant::INT, "rendering/shadows/shadow_atlas/quadrant_0_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadow_atlas/quadrant_1_subdiv", PropertyInfo(Variant::INT, "rendering/shadows/shadow_atlas/quadrant_1_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadow_atlas/quadrant_2_subdiv", PropertyInfo(Variant::INT, "rendering/shadows/shadow_atlas/quadrant_2_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
@@ -1464,9 +1464,9 @@ SceneTree::SceneTree() {
 	root->set_shadow_atlas_quadrant_subdiv(2, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q2));
 	root->set_shadow_atlas_quadrant_subdiv(3, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q3));
 
-	Viewport::SDFOversize sdf_oversize = Viewport::SDFOversize(int(GLOBAL_DEF("rendering/2d/sdf/oversize", 1)));
+	Viewport::SDFOversize sdf_oversize = Viewport::SDFOversize(int(PROJECT_DEFAULT("rendering/2d/sdf/oversize", 1)));
 	root->set_sdf_oversize(sdf_oversize);
-	Viewport::SDFScale sdf_scale = Viewport::SDFScale(int(GLOBAL_DEF("rendering/2d/sdf/scale", 1)));
+	Viewport::SDFScale sdf_scale = Viewport::SDFScale(int(PROJECT_DEFAULT("rendering/2d/sdf/scale", 1)));
 	root->set_sdf_scale(sdf_scale);
 
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/sdf/oversize", PropertyInfo(Variant::INT, "rendering/2d/sdf/oversize", PROPERTY_HINT_ENUM, "100%,120%,150%,200%"));
@@ -1484,7 +1484,7 @@ SceneTree::SceneTree() {
 			ext_hint += "*." + E->get();
 		}
 		// Get path.
-		String env_path = GLOBAL_DEF("rendering/environment/defaults/default_environment", "");
+		String env_path = PROJECT_DEFAULT("rendering/environment/defaults/default_environment", "");
 		// Setup property.
 		ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/defaults/default_environment", PropertyInfo(Variant::STRING, "rendering/viewport/default_environment", PROPERTY_HINT_FILE, ext_hint));
 		env_path = env_path.strip_edges();
@@ -1504,7 +1504,7 @@ SceneTree::SceneTree() {
 		}
 	}
 
-	root->set_physics_object_picking(GLOBAL_DEF("physics/common/enable_object_picking", true));
+	root->set_physics_object_picking(PROJECT_DEFAULT("physics/common/enable_object_picking", true));
 
 	root->connect("close_requested", callable_mp(this, &SceneTree::_main_window_close));
 	root->connect("go_back_requested", callable_mp(this, &SceneTree::_main_window_go_back));

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3740,7 +3740,7 @@ Viewport::Viewport() {
 	unhandled_key_input_group = "_vp_unhandled_key_input" + id;
 
 	// Window tooltip.
-	gui.tooltip_delay = GLOBAL_DEF("gui/timers/tooltip_delay_sec", 0.5);
+	gui.tooltip_delay = PROJECT_DEFAULT("gui/timers/tooltip_delay_sec", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/timers/tooltip_delay_sec", PropertyInfo(Variant::FLOAT, "gui/timers/tooltip_delay_sec", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater")); // No negative numbers
 
 	set_sdf_oversize(sdf_oversize); //set to server

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1323,14 +1323,14 @@ bool Window::is_layout_rtl() const {
 		if (parent) {
 			return parent->is_layout_rtl();
 		} else {
-			if (GLOBAL_GET("internationalization/rendering/force_right_to_left_layout_direction")) {
+			if (PROJECT_GET("internationalization/rendering/force_right_to_left_layout_direction")) {
 				return true;
 			}
 			String locale = TranslationServer::get_singleton()->get_tool_locale();
 			return TS->is_locale_right_to_left(locale);
 		}
 	} else if (layout_dir == LAYOUT_DIRECTION_LOCALE) {
-		if (GLOBAL_GET("internationalization/rendering/force_right_to_left_layout_direction")) {
+		if (PROJECT_GET("internationalization/rendering/force_right_to_left_layout_direction")) {
 			return true;
 		}
 		String locale = TranslationServer::get_singleton()->get_tool_locale();

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -399,7 +399,7 @@ void register_scene_types() {
 
 	bool swap_cancel_ok = false;
 	if (DisplayServer::get_singleton()) {
-		swap_cancel_ok = GLOBAL_DEF_NOVAL("gui/common/swap_cancel_ok", bool(DisplayServer::get_singleton()->get_swap_cancel_ok()));
+		swap_cancel_ok = PROJECT_DEFAULT_NO_VAL("gui/common/swap_cancel_ok", bool(DisplayServer::get_singleton()->get_swap_cancel_ok()));
 	}
 	AcceptDialog::set_swap_cancel_ok(swap_cancel_ok);
 #endif
@@ -999,19 +999,19 @@ void register_scene_types() {
 	OS::get_singleton()->yield(); //may take time to init
 
 	for (int i = 0; i < 20; i++) {
-		GLOBAL_DEF_BASIC(vformat("layer_names/2d_render/layer_%d", i), "");
-		GLOBAL_DEF_BASIC(vformat("layer_names/2d_physics/layer_%d", i), "");
-		GLOBAL_DEF_BASIC(vformat("layer_names/2d_navigation/layer_%d", i), "");
-		GLOBAL_DEF_BASIC(vformat("layer_names/3d_render/layer_%d", i), "");
-		GLOBAL_DEF_BASIC(vformat("layer_names/3d_physics/layer_%d", i), "");
-		GLOBAL_DEF_BASIC(vformat("layer_names/3d_navigation/layer_%d", i), "");
+		PROJECT_DEFAULT_BASIC(vformat("layer_names/2d_render/layer_%d", i), "");
+		PROJECT_DEFAULT_BASIC(vformat("layer_names/2d_physics/layer_%d", i), "");
+		PROJECT_DEFAULT_BASIC(vformat("layer_names/2d_navigation/layer_%d", i), "");
+		PROJECT_DEFAULT_BASIC(vformat("layer_names/3d_render/layer_%d", i), "");
+		PROJECT_DEFAULT_BASIC(vformat("layer_names/3d_physics/layer_%d", i), "");
+		PROJECT_DEFAULT_BASIC(vformat("layer_names/3d_navigation/layer_%d", i), "");
 	}
 
-	bool default_theme_hidpi = GLOBAL_DEF("gui/theme/use_hidpi", false);
+	bool default_theme_hidpi = PROJECT_DEFAULT("gui/theme/use_hidpi", false);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/use_hidpi", PropertyInfo(Variant::BOOL, "gui/theme/use_hidpi", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
-	String theme_path = GLOBAL_DEF_RST("gui/theme/custom", "");
+	String theme_path = PROJECT_DEFAULT_RESTART("gui/theme/custom", "");
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/custom", PropertyInfo(Variant::STRING, "gui/theme/custom", PROPERTY_HINT_FILE, "*.tres,*.res,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
-	String font_path = GLOBAL_DEF_RST("gui/theme/custom_font", "");
+	String font_path = PROJECT_DEFAULT_RESTART("gui/theme/custom_font", "");
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/custom_font", PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.font", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
 
 	Ref<Font> font;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -268,7 +268,7 @@ void ShaderMaterial::_bind_methods() {
 
 void ShaderMaterial::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
+	const String quote_style = EDITOR_DEFAULT("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif

--- a/scene/resources/shape_2d.cpp
+++ b/scene/resources/shape_2d.cpp
@@ -115,7 +115,7 @@ bool Shape2D::is_collision_outline_enabled() {
 		return true;
 	}
 #endif
-	return GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
+	return PROJECT_DEFAULT("debug/shapes/collision/draw_2d_outlines", true);
 }
 
 Shape2D::Shape2D(const RID &p_rid) {

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -73,18 +73,18 @@ World2D::World2D() {
 	// Create and configure space2D to be more friendly with pixels than meters
 	space = PhysicsServer2D::get_singleton()->space_create();
 	PhysicsServer2D::get_singleton()->space_set_active(space, true);
-	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, GLOBAL_DEF("physics/2d/default_gravity", 980.0));
-	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY_VECTOR, GLOBAL_DEF("physics/2d/default_gravity_vector", Vector2(0, 1)));
-	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_LINEAR_DAMP, GLOBAL_DEF("physics/2d/default_linear_damp", 0.1));
+	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, PROJECT_DEFAULT("physics/2d/default_gravity", 980.0));
+	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY_VECTOR, PROJECT_DEFAULT("physics/2d/default_gravity_vector", Vector2(0, 1)));
+	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_LINEAR_DAMP, PROJECT_DEFAULT("physics/2d/default_linear_damp", 0.1));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/default_linear_damp", PropertyInfo(Variant::FLOAT, "physics/2d/default_linear_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"));
-	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_ANGULAR_DAMP, GLOBAL_DEF("physics/2d/default_angular_damp", 1.0));
+	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_ANGULAR_DAMP, PROJECT_DEFAULT("physics/2d/default_angular_damp", 1.0));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/default_angular_damp", PropertyInfo(Variant::FLOAT, "physics/2d/default_angular_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"));
 
 	// Create and configure the navigation_map to be more friendly with pixels than meters.
 	navigation_map = NavigationServer2D::get_singleton()->map_create();
 	NavigationServer2D::get_singleton()->map_set_active(navigation_map, true);
-	NavigationServer2D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_DEF("navigation/2d/default_cell_size", 10));
-	NavigationServer2D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_DEF("navigation/2d/default_edge_connection_margin", 5));
+	NavigationServer2D::get_singleton()->map_set_cell_size(navigation_map, PROJECT_DEFAULT("navigation/2d/default_cell_size", 10));
+	NavigationServer2D::get_singleton()->map_set_edge_connection_margin(navigation_map, PROJECT_DEFAULT("navigation/2d/default_edge_connection_margin", 5));
 }
 
 World2D::~World2D() {

--- a/scene/resources/world_3d.cpp
+++ b/scene/resources/world_3d.cpp
@@ -141,17 +141,17 @@ World3D::World3D() {
 	scenario = RenderingServer::get_singleton()->scenario_create();
 
 	PhysicsServer3D::get_singleton()->space_set_active(space, true);
-	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_GRAVITY, GLOBAL_DEF("physics/3d/default_gravity", 9.8));
-	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR, GLOBAL_DEF("physics/3d/default_gravity_vector", Vector3(0, -1, 0)));
-	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_LINEAR_DAMP, GLOBAL_DEF("physics/3d/default_linear_damp", 0.1));
+	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_GRAVITY, PROJECT_DEFAULT("physics/3d/default_gravity", 9.8));
+	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR, PROJECT_DEFAULT("physics/3d/default_gravity_vector", Vector3(0, -1, 0)));
+	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_LINEAR_DAMP, PROJECT_DEFAULT("physics/3d/default_linear_damp", 0.1));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/default_linear_damp", PropertyInfo(Variant::FLOAT, "physics/3d/default_linear_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"));
-	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP, GLOBAL_DEF("physics/3d/default_angular_damp", 0.1));
+	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP, PROJECT_DEFAULT("physics/3d/default_angular_damp", 0.1));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/default_angular_damp", PropertyInfo(Variant::FLOAT, "physics/3d/default_angular_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"));
 
 	navigation_map = NavigationServer3D::get_singleton()->map_create();
 	NavigationServer3D::get_singleton()->map_set_active(navigation_map, true);
-	NavigationServer3D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_DEF("navigation/3d/default_cell_size", 0.3));
-	NavigationServer3D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_DEF("navigation/3d/default_edge_connection_margin", 0.3));
+	NavigationServer3D::get_singleton()->map_set_cell_size(navigation_map, PROJECT_DEFAULT("navigation/3d/default_cell_size", 0.3));
+	NavigationServer3D::get_singleton()->map_set_edge_connection_margin(navigation_map, PROJECT_DEFAULT("navigation/3d/default_edge_connection_margin", 0.3));
 }
 
 World3D::~World3D() {

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -39,11 +39,11 @@ Error AudioDriverDummy::init() {
 	exit_thread = false;
 	samples_in = nullptr;
 
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = PROJECT_GET("audio/driver/mix_rate");
 	speaker_mode = SPEAKER_MODE_STEREO;
 	channels = 2;
 
-	int latency = GLOBAL_GET("audio/driver/output_latency");
+	int latency = PROJECT_GET("audio/driver/output_latency");
 	buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
 
 	samples_in = memnew_arr(int32_t, buffer_frames * channels);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -184,7 +184,7 @@ void AudioStreamPlaybackMicrophone::start(float p_from_pos) {
 		return;
 	}
 
-	if (!GLOBAL_GET("audio/driver/enable_input")) {
+	if (!PROJECT_GET("audio/driver/enable_input")) {
 		WARN_PRINT("Need to enable Project settings > Audio > Enable Audio Input option to use capturing.");
 		return;
 	}

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -188,10 +188,10 @@ int AudioDriverManager::get_driver_count() {
 }
 
 void AudioDriverManager::initialize(int p_driver) {
-	GLOBAL_DEF_RST("audio/driver/enable_input", false);
-	GLOBAL_DEF_RST("audio/driver/mix_rate", DEFAULT_MIX_RATE);
-	GLOBAL_DEF_RST("audio/driver/output_latency", DEFAULT_OUTPUT_LATENCY);
-	GLOBAL_DEF_RST("audio/driver/output_latency.web", 50); // Safer default output_latency for web.
+	PROJECT_DEFAULT_RESTART("audio/driver/enable_input", false);
+	PROJECT_DEFAULT_RESTART("audio/driver/mix_rate", DEFAULT_MIX_RATE);
+	PROJECT_DEFAULT_RESTART("audio/driver/output_latency", DEFAULT_OUTPUT_LATENCY);
+	PROJECT_DEFAULT_RESTART("audio/driver/output_latency.web", 50); // Safer default output_latency for web.
 
 	int failed_driver = -1;
 
@@ -940,8 +940,8 @@ void AudioServer::init_channels_and_buffers() {
 }
 
 void AudioServer::init() {
-	channel_disable_threshold_db = GLOBAL_DEF_RST("audio/buses/channel_disable_threshold_db", -60.0);
-	channel_disable_frames = float(GLOBAL_DEF_RST("audio/buses/channel_disable_time", 2.0)) * get_mix_rate();
+	channel_disable_threshold_db = PROJECT_DEFAULT_RESTART("audio/buses/channel_disable_threshold_db", -60.0);
+	channel_disable_frames = float(PROJECT_DEFAULT_RESTART("audio/buses/channel_disable_time", 2.0)) * get_mix_rate();
 	ProjectSettings::get_singleton()->set_custom_property_info("audio/buses/channel_disable_time", PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
 	buffer_size = 1024; //hardcoded for now
 
@@ -959,7 +959,7 @@ void AudioServer::init() {
 	set_edited(false); //avoid editors from thinking this was edited
 #endif
 
-	GLOBAL_DEF_RST("audio/video/video_delay_compensation_ms", 0);
+	PROJECT_DEFAULT_RESTART("audio/video/video_delay_compensation_ms", 0);
 }
 
 void AudioServer::update() {

--- a/servers/physics_2d/physics_server_2d_wrap_mt.cpp
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.cpp
@@ -121,7 +121,7 @@ PhysicsServer2DWrapMT::PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool 
 	create_thread = p_create_thread;
 	step_pending = 0;
 
-	pool_max_size = GLOBAL_GET("memory/limits/multithreaded_server/rid_pool_prealloc");
+	pool_max_size = PROJECT_GET("memory/limits/multithreaded_server/rid_pool_prealloc");
 
 	if (!p_create_thread) {
 		server_thread = Thread::get_caller_id();

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -1368,9 +1368,9 @@ Space2DSW::Space2DSW() {
 	test_motion_min_contact_depth = 0.005;
 
 	constraint_bias = 0.2;
-	body_linear_velocity_sleep_threshold = GLOBAL_DEF("physics/2d/sleep_threshold_linear", 2.0);
-	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/2d/sleep_threshold_angular", Math::deg2rad(8.0));
-	body_time_to_sleep = GLOBAL_DEF("physics/2d/time_before_sleep", 0.5);
+	body_linear_velocity_sleep_threshold = PROJECT_DEFAULT("physics/2d/sleep_threshold_linear", 2.0);
+	body_angular_velocity_sleep_threshold = PROJECT_DEFAULT("physics/2d/sleep_threshold_angular", Math::deg2rad(8.0));
+	body_time_to_sleep = PROJECT_DEFAULT("physics/2d/time_before_sleep", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/time_before_sleep", PropertyInfo(Variant::FLOAT, "physics/2d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
 
 	broadphase = BroadPhase2DSW::create_func();

--- a/servers/physics_3d/physics_server_3d_wrap_mt.cpp
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.cpp
@@ -122,7 +122,7 @@ PhysicsServer3DWrapMT::PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool 
 	step_pending = 0;
 	step_thread_up = false;
 
-	pool_max_size = GLOBAL_GET("memory/limits/multithreaded_server/rid_pool_prealloc");
+	pool_max_size = PROJECT_GET("memory/limits/multithreaded_server/rid_pool_prealloc");
 
 	if (!p_create_thread) {
 		server_thread = Thread::get_caller_id();

--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -1287,9 +1287,9 @@ Space3DSW::Space3DSW() {
 	test_motion_min_contact_depth = 0.00001;
 
 	constraint_bias = 0.01;
-	body_linear_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_linear", 0.1);
-	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_angular", Math::deg2rad(8.0));
-	body_time_to_sleep = GLOBAL_DEF("physics/3d/time_before_sleep", 0.5);
+	body_linear_velocity_sleep_threshold = PROJECT_DEFAULT("physics/3d/sleep_threshold_linear", 0.1);
+	body_angular_velocity_sleep_threshold = PROJECT_DEFAULT("physics/3d/sleep_threshold_angular", Math::deg2rad(8.0));
+	body_time_to_sleep = PROJECT_DEFAULT("physics/3d/time_before_sleep", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/time_before_sleep", PropertyInfo(Variant::FLOAT, "physics/3d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
 	body_angular_velocity_damp_ratio = 10;
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -78,7 +78,7 @@
 ShaderTypes *shader_types = nullptr;
 
 PhysicsServer3D *_createGodotPhysics3DCallback() {
-	bool using_threads = GLOBAL_GET("physics/3d/run_on_thread");
+	bool using_threads = PROJECT_GET("physics/3d/run_on_thread");
 
 	PhysicsServer3D *physics_server = memnew(PhysicsServer3DSW(using_threads));
 
@@ -86,7 +86,7 @@ PhysicsServer3D *_createGodotPhysics3DCallback() {
 }
 
 PhysicsServer2D *_createGodotPhysics2DCallback() {
-	bool using_threads = GLOBAL_GET("physics/2d/run_on_thread");
+	bool using_threads = PROJECT_GET("physics/2d/run_on_thread");
 
 	PhysicsServer2D *physics_server = memnew(PhysicsServer2DSW(using_threads));
 
@@ -106,7 +106,7 @@ static bool has_server_feature_callback(const String &p_feature) {
 void preregister_server_types() {
 	shader_types = memnew(ShaderTypes);
 
-	GLOBAL_DEF("internationalization/rendering/text_driver", "");
+	PROJECT_DEFAULT("internationalization/rendering/text_driver", "");
 	String text_driver_options;
 	for (int i = 0; i < TextServerManager::get_interface_count(); i++) {
 		if (i > 0) {
@@ -221,14 +221,14 @@ void register_server_types() {
 	ClassDB::register_class<PhysicsTestMotionResult3D>();
 
 	// Physics 2D
-	GLOBAL_DEF(PhysicsServer2DManager::setting_property_name, "DEFAULT");
+	PROJECT_DEFAULT(PhysicsServer2DManager::setting_property_name, "DEFAULT");
 	ProjectSettings::get_singleton()->set_custom_property_info(PhysicsServer2DManager::setting_property_name, PropertyInfo(Variant::STRING, PhysicsServer2DManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"));
 
 	PhysicsServer2DManager::register_server("GodotPhysics2D", &_createGodotPhysics2DCallback);
 	PhysicsServer2DManager::set_default_server("GodotPhysics2D");
 
 	// Physics 3D
-	GLOBAL_DEF(PhysicsServer3DManager::setting_property_name, "DEFAULT");
+	PROJECT_DEFAULT(PhysicsServer3DManager::setting_property_name, "DEFAULT");
 	ProjectSettings::get_singleton()->set_custom_property_info(PhysicsServer3DManager::setting_property_name, PropertyInfo(Variant::STRING, PhysicsServer3DManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"));
 
 	PhysicsServer3DManager::register_server("GodotPhysics3D", &_createGodotPhysics3DCallback);

--- a/servers/rendering/renderer_compositor.cpp
+++ b/servers/rendering/renderer_compositor.cpp
@@ -45,7 +45,7 @@ bool RendererCompositor::is_xr_enabled() const {
 }
 
 RendererCompositor::RendererCompositor() {
-	xr_enabled = GLOBAL_GET("rendering/xr/enabled");
+	xr_enabled = PROJECT_GET("rendering/xr/enabled");
 }
 
 RendererCanvasRender *RendererCanvasRender::singleton = nullptr;

--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -1770,7 +1770,7 @@ EffectsRD::EffectsRD() {
 
 	{
 		// Initialize cubemap filter
-		filter.use_high_quality = GLOBAL_GET("rendering/reflections/sky_reflections/fast_filter_high_quality");
+		filter.use_high_quality = PROJECT_GET("rendering/reflections/sky_reflections/fast_filter_high_quality");
 
 		Vector<String> cubemap_filter_modes;
 		cubemap_filter_modes.push_back("\n#define USE_HIGH_QUALITY\n");

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2947,7 +2947,7 @@ RenderForwardClustered::RenderForwardClustered(RendererStorageRD *p_storage) :
 		scene_shader.init(p_storage, defines);
 	}
 
-	render_list_thread_threshold = GLOBAL_GET("rendering/limits/forward_renderer/threaded_render_minimum_instances");
+	render_list_thread_threshold = PROJECT_GET("rendering/limits/forward_renderer/threaded_render_minimum_instances");
 }
 
 RenderForwardClustered::~RenderForwardClustered() {

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -636,7 +636,7 @@ void SceneShaderForwardClustered::init(RendererStorageRD *p_storage, const Strin
 		actions.render_mode_defines["cull_disabled"] = "#define DO_SIDE_CHECK\n";
 		actions.render_mode_defines["particle_trails"] = "#define USE_PARTICLE_TRAILS\n";
 
-		bool force_lambert = GLOBAL_GET("rendering/shading/overrides/force_lambert_over_burley");
+		bool force_lambert = PROJECT_GET("rendering/shading/overrides/force_lambert_over_burley");
 
 		if (!force_lambert) {
 			actions.render_mode_defines["diffuse_burley"] = "#define DIFFUSE_BURLEY\n";
@@ -647,7 +647,7 @@ void SceneShaderForwardClustered::init(RendererStorageRD *p_storage, const Strin
 
 		actions.render_mode_defines["sss_mode_skin"] = "#define SSS_MODE_SKIN\n";
 
-		bool force_blinn = GLOBAL_GET("rendering/shading/overrides/force_blinn_over_ggx");
+		bool force_blinn = PROJECT_GET("rendering/shading/overrides/force_blinn_over_ggx");
 
 		if (!force_blinn) {
 			actions.render_mode_defines["specular_schlick_ggx"] = "#define SPECULAR_SCHLICK_GGX\n";

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2184,7 +2184,7 @@ RenderForwardMobile::RenderForwardMobile(RendererStorageRD *p_storage) :
 	scene_shader.init(p_storage, defines);
 
 	// !BAS! maybe we need a mobile version of this setting?
-	render_list_thread_threshold = GLOBAL_GET("rendering/limits/forward_renderer/threaded_render_minimum_instances");
+	render_list_thread_threshold = PROJECT_GET("rendering/limits/forward_renderer/threaded_render_minimum_instances");
 }
 
 RenderForwardMobile::~RenderForwardMobile() {

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -627,7 +627,7 @@ void SceneShaderForwardMobile::init(RendererStorageRD *p_storage, const String p
 		actions.render_mode_defines["cull_disabled"] = "#define DO_SIDE_CHECK\n";
 		actions.render_mode_defines["particle_trails"] = "#define USE_PARTICLE_TRAILS\n";
 
-		bool force_lambert = GLOBAL_GET("rendering/shading/overrides/force_lambert_over_burley");
+		bool force_lambert = PROJECT_GET("rendering/shading/overrides/force_lambert_over_burley");
 		if (!force_lambert) {
 			actions.render_mode_defines["diffuse_burley"] = "#define DIFFUSE_BURLEY\n";
 		}
@@ -637,7 +637,7 @@ void SceneShaderForwardMobile::init(RendererStorageRD *p_storage, const String p
 
 		actions.render_mode_defines["sss_mode_skin"] = "#define SSS_MODE_SKIN\n";
 
-		bool force_blinn = GLOBAL_GET("rendering/shading/overrides/force_blinn_over_ggx");
+		bool force_blinn = PROJECT_GET("rendering/shading/overrides/force_blinn_over_ggx");
 		if (!force_blinn) {
 			actions.render_mode_defines["specular_schlick_ggx"] = "#define SPECULAR_SCHLICK_GGX\n";
 		} else {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2558,7 +2558,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD(RendererStorageRD *p_storage) {
 	default_canvas_texture = storage->canvas_texture_allocate();
 	storage->canvas_texture_initialize(default_canvas_texture);
 
-	state.shadow_texture_size = GLOBAL_GET("rendering/2d/shadow_atlas/size");
+	state.shadow_texture_size = PROJECT_GET("rendering/2d/shadow_atlas/size");
 
 	//create functions for shader and material
 	storage->shader_set_data_request_function(RendererStorageRD::SHADER_TYPE_2D, _create_shader_funcs);

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -89,7 +89,7 @@ void RendererCompositorRD::begin_frame(double frame_step) {
 	delta = frame_step;
 	time += frame_step;
 
-	double time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
+	double time_roll_over = PROJECT_GET("rendering/limits/time/time_rollover_secs");
 	time = Math::fmod(time, time_roll_over);
 
 	canvas->set_time(time);
@@ -249,15 +249,15 @@ RendererCompositorRD::RendererCompositorRD() {
 			} else {
 				shader_cache_dir = shader_cache_dir.plus_file("shader_cache");
 
-				bool shader_cache_enabled = GLOBAL_GET("rendering/shader_compiler/shader_cache/enabled");
+				bool shader_cache_enabled = PROJECT_GET("rendering/shader_compiler/shader_cache/enabled");
 				if (!Engine::get_singleton()->is_editor_hint() && !shader_cache_enabled) {
 					shader_cache_dir = String(); //disable only if not editor
 				}
 
 				if (shader_cache_dir != String()) {
-					bool compress = GLOBAL_GET("rendering/shader_compiler/shader_cache/compress");
-					bool use_zstd = GLOBAL_GET("rendering/shader_compiler/shader_cache/use_zstd_compression");
-					bool strip_debug = GLOBAL_GET("rendering/shader_compiler/shader_cache/strip_debug");
+					bool compress = PROJECT_GET("rendering/shader_compiler/shader_cache/compress");
+					bool use_zstd = PROJECT_GET("rendering/shader_compiler/shader_cache/use_zstd_compression");
+					bool strip_debug = PROJECT_GET("rendering/shader_compiler/shader_cache/strip_debug");
 
 					ShaderRD::set_shader_cache_dir(shader_cache_dir);
 					ShaderRD::set_shader_cache_save_compressed(compress);
@@ -274,7 +274,7 @@ RendererCompositorRD::RendererCompositorRD() {
 	storage = memnew(RendererStorageRD);
 	canvas = memnew(RendererCanvasRenderRD(storage));
 
-	uint32_t back_end = GLOBAL_GET("rendering/vulkan/rendering/back_end");
+	uint32_t back_end = PROJECT_GET("rendering/vulkan/rendering/back_end");
 	uint32_t textures_per_stage = RD::get_singleton()->limit_get(RD::LIMIT_MAX_TEXTURES_PER_SHADER_STAGE);
 
 	if (back_end == 1 || textures_per_stage < 48) {

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
@@ -2796,9 +2796,9 @@ void RendererSceneGIRD::VoxelGIInstance::debug(RD::DrawListID p_draw_list, RID p
 // GIRD
 
 RendererSceneGIRD::RendererSceneGIRD() {
-	sdfgi_ray_count = RS::EnvironmentSDFGIRayCount(CLAMP(int32_t(GLOBAL_GET("rendering/global_illumination/sdfgi/probe_ray_count")), 0, int32_t(RS::ENV_SDFGI_RAY_COUNT_MAX - 1)));
-	sdfgi_frames_to_converge = RS::EnvironmentSDFGIFramesToConverge(CLAMP(int32_t(GLOBAL_GET("rendering/global_illumination/sdfgi/frames_to_converge")), 0, int32_t(RS::ENV_SDFGI_CONVERGE_MAX - 1)));
-	sdfgi_frames_to_update_light = RS::EnvironmentSDFGIFramesToUpdateLight(CLAMP(int32_t(GLOBAL_GET("rendering/global_illumination/sdfgi/frames_to_update_lights")), 0, int32_t(RS::ENV_SDFGI_UPDATE_LIGHT_MAX - 1)));
+	sdfgi_ray_count = RS::EnvironmentSDFGIRayCount(CLAMP(int32_t(PROJECT_GET("rendering/global_illumination/sdfgi/probe_ray_count")), 0, int32_t(RS::ENV_SDFGI_RAY_COUNT_MAX - 1)));
+	sdfgi_frames_to_converge = RS::EnvironmentSDFGIFramesToConverge(CLAMP(int32_t(PROJECT_GET("rendering/global_illumination/sdfgi/frames_to_converge")), 0, int32_t(RS::ENV_SDFGI_CONVERGE_MAX - 1)));
+	sdfgi_frames_to_update_light = RS::EnvironmentSDFGIFramesToUpdateLight(CLAMP(int32_t(PROJECT_GET("rendering/global_illumination/sdfgi/frames_to_update_lights")), 0, int32_t(RS::ENV_SDFGI_UPDATE_LIGHT_MAX - 1)));
 }
 
 RendererSceneGIRD::~RendererSceneGIRD() {
@@ -2816,7 +2816,7 @@ void RendererSceneGIRD::init(RendererStorageRD *p_storage, RendererSceneSkyRD *p
 
 		voxel_gi_lights = memnew_arr(VoxelGILight, voxel_gi_max_lights);
 		voxel_gi_lights_uniform = RD::get_singleton()->uniform_buffer_create(voxel_gi_max_lights * sizeof(VoxelGILight));
-		voxel_gi_quality = RS::VoxelGIQuality(CLAMP(int(GLOBAL_GET("rendering/global_illumination/voxel_gi/quality")), 0, 1));
+		voxel_gi_quality = RS::VoxelGIQuality(CLAMP(int(PROJECT_GET("rendering/global_illumination/voxel_gi/quality")), 0, 1));
 
 		String defines = "\n#define MAX_LIGHTS " + itos(voxel_gi_max_lights) + "\n";
 
@@ -2992,7 +2992,7 @@ void RendererSceneGIRD::init(RendererStorageRD *p_storage, RendererSceneSkyRD *p
 		}
 	}
 	default_voxel_gi_buffer = RD::get_singleton()->uniform_buffer_create(sizeof(VoxelGIData) * MAX_VOXEL_GI_INSTANCES);
-	half_resolution = GLOBAL_GET("rendering/global_illumination/gi/use_half_resolution");
+	half_resolution = PROJECT_GET("rendering/global_illumination/gi/use_half_resolution");
 }
 
 void RendererSceneGIRD::free() {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -507,8 +507,8 @@ Ref<Image> RendererSceneRenderRD::environment_bake_panorama(RID p_env, bool p_ba
 
 RID RendererSceneRenderRD::reflection_atlas_create() {
 	ReflectionAtlas ra;
-	ra.count = GLOBAL_GET("rendering/reflections/reflection_atlas/reflection_count");
-	ra.size = GLOBAL_GET("rendering/reflections/reflection_atlas/reflection_size");
+	ra.count = PROJECT_GET("rendering/reflections/reflection_atlas/reflection_count");
+	ra.size = PROJECT_GET("rendering/reflections/reflection_atlas/reflection_size");
 
 	if (is_clustered_enabled()) {
 		ra.cluster_builder = memnew(ClusterBuilderRD);
@@ -4255,7 +4255,7 @@ bool RendererSceneRenderRD::is_volumetric_supported() const {
 }
 
 uint32_t RendererSceneRenderRD::get_max_elements() const {
-	return GLOBAL_GET("rendering/limits/cluster_builder/max_clustered_elements");
+	return PROJECT_GET("rendering/limits/cluster_builder/max_clustered_elements");
 }
 
 RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
@@ -4264,8 +4264,8 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 	storage = p_storage;
 	singleton = this;
 
-	directional_shadow.size = GLOBAL_GET("rendering/shadows/directional_shadow/size");
-	directional_shadow.use_16_bits = GLOBAL_GET("rendering/shadows/directional_shadow/16_bits");
+	directional_shadow.size = PROJECT_GET("rendering/shadows/directional_shadow/size");
+	directional_shadow.use_16_bits = PROJECT_GET("rendering/shadows/directional_shadow/16_bits");
 
 	/* SKY SHADER */
 
@@ -4335,27 +4335,27 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 		shadow_sampler = RD::get_singleton()->sampler_create(sampler);
 	}
 
-	camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_shape"))));
-	camera_effects_set_dof_blur_quality(RS::DOFBlurQuality(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_quality"))), GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_use_jitter"));
-	environment_set_ssao_quality(RS::EnvironmentSSAOQuality(int(GLOBAL_GET("rendering/environment/ssao/quality"))), GLOBAL_GET("rendering/environment/ssao/half_size"), GLOBAL_GET("rendering/environment/ssao/adaptive_target"), GLOBAL_GET("rendering/environment/ssao/blur_passes"), GLOBAL_GET("rendering/environment/ssao/fadeout_from"), GLOBAL_GET("rendering/environment/ssao/fadeout_to"));
-	screen_space_roughness_limiter = GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/enabled");
-	screen_space_roughness_limiter_amount = GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/amount");
-	screen_space_roughness_limiter_limit = GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/limit");
-	glow_bicubic_upscale = int(GLOBAL_GET("rendering/environment/glow/upscale_mode")) > 0;
-	glow_high_quality = GLOBAL_GET("rendering/environment/glow/use_high_quality");
-	ssr_roughness_quality = RS::EnvironmentSSRRoughnessQuality(int(GLOBAL_GET("rendering/environment/screen_space_reflection/roughness_quality")));
-	sss_quality = RS::SubSurfaceScatteringQuality(int(GLOBAL_GET("rendering/environment/subsurface_scattering/subsurface_scattering_quality")));
-	sss_scale = GLOBAL_GET("rendering/environment/subsurface_scattering/subsurface_scattering_scale");
-	sss_depth_scale = GLOBAL_GET("rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale");
+	camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape(int(PROJECT_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_shape"))));
+	camera_effects_set_dof_blur_quality(RS::DOFBlurQuality(int(PROJECT_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_quality"))), PROJECT_GET("rendering/camera/depth_of_field/depth_of_field_use_jitter"));
+	environment_set_ssao_quality(RS::EnvironmentSSAOQuality(int(PROJECT_GET("rendering/environment/ssao/quality"))), PROJECT_GET("rendering/environment/ssao/half_size"), PROJECT_GET("rendering/environment/ssao/adaptive_target"), PROJECT_GET("rendering/environment/ssao/blur_passes"), PROJECT_GET("rendering/environment/ssao/fadeout_from"), PROJECT_GET("rendering/environment/ssao/fadeout_to"));
+	screen_space_roughness_limiter = PROJECT_GET("rendering/anti_aliasing/screen_space_roughness_limiter/enabled");
+	screen_space_roughness_limiter_amount = PROJECT_GET("rendering/anti_aliasing/screen_space_roughness_limiter/amount");
+	screen_space_roughness_limiter_limit = PROJECT_GET("rendering/anti_aliasing/screen_space_roughness_limiter/limit");
+	glow_bicubic_upscale = int(PROJECT_GET("rendering/environment/glow/upscale_mode")) > 0;
+	glow_high_quality = PROJECT_GET("rendering/environment/glow/use_high_quality");
+	ssr_roughness_quality = RS::EnvironmentSSRRoughnessQuality(int(PROJECT_GET("rendering/environment/screen_space_reflection/roughness_quality")));
+	sss_quality = RS::SubSurfaceScatteringQuality(int(PROJECT_GET("rendering/environment/subsurface_scattering/subsurface_scattering_quality")));
+	sss_scale = PROJECT_GET("rendering/environment/subsurface_scattering/subsurface_scattering_scale");
+	sss_depth_scale = PROJECT_GET("rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale");
 	directional_penumbra_shadow_kernel = memnew_arr(float, 128);
 	directional_soft_shadow_kernel = memnew_arr(float, 128);
 	penumbra_shadow_kernel = memnew_arr(float, 128);
 	soft_shadow_kernel = memnew_arr(float, 128);
-	shadows_quality_set(RS::ShadowQuality(int(GLOBAL_GET("rendering/shadows/shadows/soft_shadow_quality"))));
-	directional_shadow_quality_set(RS::ShadowQuality(int(GLOBAL_GET("rendering/shadows/directional_shadow/soft_shadow_quality"))));
+	shadows_quality_set(RS::ShadowQuality(int(PROJECT_GET("rendering/shadows/shadows/soft_shadow_quality"))));
+	directional_shadow_quality_set(RS::ShadowQuality(int(PROJECT_GET("rendering/shadows/directional_shadow/soft_shadow_quality"))));
 
-	environment_set_volumetric_fog_volume_size(GLOBAL_GET("rendering/environment/volumetric_fog/volume_size"), GLOBAL_GET("rendering/environment/volumetric_fog/volume_depth"));
-	environment_set_volumetric_fog_filter_active(GLOBAL_GET("rendering/environment/volumetric_fog/use_filter"));
+	environment_set_volumetric_fog_volume_size(PROJECT_GET("rendering/environment/volumetric_fog/volume_size"), PROJECT_GET("rendering/environment/volumetric_fog/volume_depth"));
+	environment_set_volumetric_fog_filter_active(PROJECT_GET("rendering/environment/volumetric_fog/use_filter"));
 
 	cull_argument.set_page_pool(&cull_argument_pool);
 }

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -649,9 +649,9 @@ RendererStorageRD::MaterialData *RendererSceneSkyRD::_create_sky_material_funcs(
 };
 
 RendererSceneSkyRD::RendererSceneSkyRD() {
-	roughness_layers = GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers");
-	sky_ggx_samples_quality = GLOBAL_GET("rendering/reflections/sky_reflections/ggx_samples");
-	sky_use_cubemap_array = GLOBAL_GET("rendering/reflections/sky_reflections/texture_array_reflections");
+	roughness_layers = PROJECT_GET("rendering/reflections/sky_reflections/roughness_layers");
+	sky_ggx_samples_quality = PROJECT_GET("rendering/reflections/sky_reflections/ggx_samples");
+	sky_use_cubemap_array = PROJECT_GET("rendering/reflections/sky_reflections/texture_array_reflections");
 }
 
 void RendererSceneSkyRD::init(RendererStorageRD *p_storage) {

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -8858,7 +8858,7 @@ RendererStorageRD::RendererStorageRD() {
 
 	static_assert(sizeof(GlobalVariables::Value) == 16);
 
-	global_variables.buffer_size = GLOBAL_GET("rendering/limits/global_shader_variables/buffer_size");
+	global_variables.buffer_size = PROJECT_GET("rendering/limits/global_shader_variables/buffer_size");
 	global_variables.buffer_size = MAX(4096, global_variables.buffer_size);
 	global_variables.buffer_values = memnew_arr(GlobalVariables::Value, global_variables.buffer_size);
 	memset(global_variables.buffer_values, 0, sizeof(GlobalVariables::Value) * global_variables.buffer_size);
@@ -9125,14 +9125,14 @@ RendererStorageRD::RendererStorageRD() {
 					sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
 					sampler_state.mip_filter = RD::SAMPLER_FILTER_LINEAR;
 					sampler_state.use_anisotropy = true;
-					sampler_state.anisotropy_max = 1 << int(GLOBAL_GET("rendering/textures/default_filters/anisotropic_filtering_level"));
+					sampler_state.anisotropy_max = 1 << int(PROJECT_GET("rendering/textures/default_filters/anisotropic_filtering_level"));
 				} break;
 				case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
 					sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
 					sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
 					sampler_state.mip_filter = RD::SAMPLER_FILTER_LINEAR;
 					sampler_state.use_anisotropy = true;
-					sampler_state.anisotropy_max = 1 << int(GLOBAL_GET("rendering/textures/default_filters/anisotropic_filtering_level"));
+					sampler_state.anisotropy_max = 1 << int(PROJECT_GET("rendering/textures/default_filters/anisotropic_filtering_level"));
 
 				} break;
 				default: {
@@ -9301,7 +9301,7 @@ RendererStorageRD::RendererStorageRD() {
 		}
 	}
 
-	lightmap_probe_capture_update_speed = GLOBAL_GET("rendering/lightmapping/probe_capture/update_speed");
+	lightmap_probe_capture_update_speed = PROJECT_GET("rendering/lightmapping/probe_capture/update_speed");
 
 	/* Particles */
 

--- a/servers/rendering/renderer_rd/shader_compiler_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_compiler_rd.cpp
@@ -1498,7 +1498,7 @@ ShaderCompilerRD::ShaderCompilerRD() {
 	actions[RS::SHADER_SPATIAL].render_mode_defines["cull_front"] = "#define DO_SIDE_CHECK\n";
 	actions[RS::SHADER_SPATIAL].render_mode_defines["cull_disabled"] = "#define DO_SIDE_CHECK\n";
 
-	bool force_lambert = GLOBAL_GET("rendering/shading/overrides/force_lambert_over_burley");
+	bool force_lambert = PROJECT_GET("rendering/shading/overrides/force_lambert_over_burley");
 
 	if (!force_lambert) {
 		actions[RS::SHADER_SPATIAL].render_mode_defines["diffuse_burley"] = "#define DIFFUSE_BURLEY\n";
@@ -1507,7 +1507,7 @@ ShaderCompilerRD::ShaderCompilerRD() {
 	actions[RS::SHADER_SPATIAL].render_mode_defines["diffuse_lambert_wrap"] = "#define DIFFUSE_LAMBERT_WRAP\n";
 	actions[RS::SHADER_SPATIAL].render_mode_defines["diffuse_toon"] = "#define DIFFUSE_TOON\n";
 
-	bool force_blinn = GLOBAL_GET("rendering/shading/overrides/force_blinn_over_ggx");
+	bool force_blinn = PROJECT_GET("rendering/shading/overrides/force_blinn_over_ggx");
 
 	if (!force_blinn) {
 		actions[RS::SHADER_SPATIAL].render_mode_defines["specular_schlick_ggx"] = "#define SPECULAR_SCHLICK_GGX\n";

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3873,8 +3873,8 @@ RendererSceneCull::RendererSceneCull() {
 		scene_cull_result_threads[i].init(&rid_cull_page_pool, &geometry_instance_cull_page_pool, &instance_cull_page_pool);
 	}
 
-	indexer_update_iterations = GLOBAL_GET("rendering/limits/spatial_indexer/update_iterations_per_frame");
-	thread_cull_threshold = GLOBAL_GET("rendering/limits/spatial_indexer/threaded_cull_minimum_instances");
+	indexer_update_iterations = PROJECT_GET("rendering/limits/spatial_indexer/update_iterations_per_frame");
+	thread_cull_threshold = PROJECT_GET("rendering/limits/spatial_indexer/threaded_cull_minimum_instances");
 	thread_cull_threshold = MAX(thread_cull_threshold, (uint32_t)RendererThreadPool::singleton->thread_work_pool.get_thread_count()); //make sure there is at least one thread per CPU
 
 	dummy_occlusion_culling = memnew(RendererSceneOcclusionCull);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -478,7 +478,7 @@ void RendererViewport::draw_viewports() {
 	}
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		set_default_clear_color(GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
+		set_default_clear_color(PROJECT_GET("rendering/environment/defaults/default_clear_color"));
 	}
 
 	//sort viewports
@@ -1132,5 +1132,5 @@ int RendererViewport::get_total_draw_calls_used() const {
 }
 
 RendererViewport::RendererViewport() {
-	occlusion_rays_per_thread = GLOBAL_GET("rendering/occlusion_culling/occlusion_rays_per_thread");
+	occlusion_rays_per_thread = PROJECT_GET("rendering/occlusion_culling/occlusion_rays_per_thread");
 }

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2720,149 +2720,149 @@ RenderingServer::RenderingServer() {
 	thread_pool = memnew(RendererThreadPool);
 	singleton = this;
 
-	GLOBAL_DEF_RST("rendering/textures/vram_compression/import_bptc", false);
-	GLOBAL_DEF_RST("rendering/textures/vram_compression/import_s3tc", true);
-	GLOBAL_DEF_RST("rendering/textures/vram_compression/import_etc", false);
-	GLOBAL_DEF_RST("rendering/textures/vram_compression/import_etc2", true);
-	GLOBAL_DEF_RST("rendering/textures/vram_compression/import_pvrtc", false);
+	PROJECT_DEFAULT_RESTART("rendering/textures/vram_compression/import_bptc", false);
+	PROJECT_DEFAULT_RESTART("rendering/textures/vram_compression/import_s3tc", true);
+	PROJECT_DEFAULT_RESTART("rendering/textures/vram_compression/import_etc", false);
+	PROJECT_DEFAULT_RESTART("rendering/textures/vram_compression/import_etc2", true);
+	PROJECT_DEFAULT_RESTART("rendering/textures/vram_compression/import_pvrtc", false);
 
-	GLOBAL_DEF("rendering/textures/lossless_compression/force_png", false);
-	GLOBAL_DEF("rendering/textures/lossless_compression/webp_compression_level", 2);
+	PROJECT_DEFAULT("rendering/textures/lossless_compression/force_png", false);
+	PROJECT_DEFAULT("rendering/textures/lossless_compression/webp_compression_level", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/textures/lossless_compression/webp_compression_level", PropertyInfo(Variant::INT, "rendering/textures/lossless_compression/webp_compression_level", PROPERTY_HINT_RANGE, "0,9,1"));
 
-	GLOBAL_DEF("rendering/limits/time/time_rollover_secs", 3600);
+	PROJECT_DEFAULT("rendering/limits/time/time_rollover_secs", 3600);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/time/time_rollover_secs", PropertyInfo(Variant::FLOAT, "rendering/limits/time/time_rollover_secs", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"));
 
-	GLOBAL_DEF("rendering/shadows/directional_shadow/size", 4096);
-	GLOBAL_DEF("rendering/shadows/directional_shadow/size.mobile", 2048);
+	PROJECT_DEFAULT("rendering/shadows/directional_shadow/size", 4096);
+	PROJECT_DEFAULT("rendering/shadows/directional_shadow/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/directional_shadow/size", PropertyInfo(Variant::INT, "rendering/shadows/directional_shadow/size", PROPERTY_HINT_RANGE, "256,16384"));
-	GLOBAL_DEF("rendering/shadows/directional_shadow/soft_shadow_quality", 2);
-	GLOBAL_DEF("rendering/shadows/directional_shadow/soft_shadow_quality.mobile", 0);
+	PROJECT_DEFAULT("rendering/shadows/directional_shadow/soft_shadow_quality", 2);
+	PROJECT_DEFAULT("rendering/shadows/directional_shadow/soft_shadow_quality.mobile", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/directional_shadow/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/shadows/directional_shadow/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"));
-	GLOBAL_DEF("rendering/shadows/directional_shadow/16_bits", true);
+	PROJECT_DEFAULT("rendering/shadows/directional_shadow/16_bits", true);
 
-	GLOBAL_DEF("rendering/shadows/shadows/soft_shadow_quality", 2);
-	GLOBAL_DEF("rendering/shadows/shadows/soft_shadow_quality.mobile", 0);
+	PROJECT_DEFAULT("rendering/shadows/shadows/soft_shadow_quality", 2);
+	PROJECT_DEFAULT("rendering/shadows/shadows/soft_shadow_quality.mobile", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadows/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/shadows/shadows/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"));
 
-	GLOBAL_DEF("rendering/2d/shadow_atlas/size", 2048);
+	PROJECT_DEFAULT("rendering/2d/shadow_atlas/size", 2048);
 
-	GLOBAL_DEF_RST("rendering/vulkan/rendering/back_end", 0);
-	GLOBAL_DEF_RST("rendering/vulkan/rendering/back_end.mobile", 1);
+	PROJECT_DEFAULT_RESTART("rendering/vulkan/rendering/back_end", 0);
+	PROJECT_DEFAULT_RESTART("rendering/vulkan/rendering/back_end.mobile", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/vulkan/rendering/back_end",
 			PropertyInfo(Variant::INT,
 					"rendering/vulkan/rendering/back_end",
 					PROPERTY_HINT_ENUM, "ForwardClustered,ForwardMobile"));
 
-	GLOBAL_DEF("rendering/shader_compiler/shader_cache/enabled", true);
-	GLOBAL_DEF("rendering/shader_compiler/shader_cache/compress", true);
-	GLOBAL_DEF("rendering/shader_compiler/shader_cache/use_zstd_compression", true);
-	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug", false);
-	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug.release", true);
+	PROJECT_DEFAULT("rendering/shader_compiler/shader_cache/enabled", true);
+	PROJECT_DEFAULT("rendering/shader_compiler/shader_cache/compress", true);
+	PROJECT_DEFAULT("rendering/shader_compiler/shader_cache/use_zstd_compression", true);
+	PROJECT_DEFAULT("rendering/shader_compiler/shader_cache/strip_debug", false);
+	PROJECT_DEFAULT("rendering/shader_compiler/shader_cache/strip_debug.release", true);
 
-	GLOBAL_DEF("rendering/reflections/sky_reflections/roughness_layers", 8);
-	GLOBAL_DEF("rendering/reflections/sky_reflections/texture_array_reflections", true);
-	GLOBAL_DEF("rendering/reflections/sky_reflections/texture_array_reflections.mobile", false);
-	GLOBAL_DEF("rendering/reflections/sky_reflections/ggx_samples", 1024);
-	GLOBAL_DEF("rendering/reflections/sky_reflections/ggx_samples.mobile", 128);
-	GLOBAL_DEF("rendering/reflections/sky_reflections/fast_filter_high_quality", false);
-	GLOBAL_DEF("rendering/reflections/reflection_atlas/reflection_size", 256);
-	GLOBAL_DEF("rendering/reflections/reflection_atlas/reflection_size.mobile", 128);
-	GLOBAL_DEF("rendering/reflections/reflection_atlas/reflection_count", 64);
+	PROJECT_DEFAULT("rendering/reflections/sky_reflections/roughness_layers", 8);
+	PROJECT_DEFAULT("rendering/reflections/sky_reflections/texture_array_reflections", true);
+	PROJECT_DEFAULT("rendering/reflections/sky_reflections/texture_array_reflections.mobile", false);
+	PROJECT_DEFAULT("rendering/reflections/sky_reflections/ggx_samples", 1024);
+	PROJECT_DEFAULT("rendering/reflections/sky_reflections/ggx_samples.mobile", 128);
+	PROJECT_DEFAULT("rendering/reflections/sky_reflections/fast_filter_high_quality", false);
+	PROJECT_DEFAULT("rendering/reflections/reflection_atlas/reflection_size", 256);
+	PROJECT_DEFAULT("rendering/reflections/reflection_atlas/reflection_size.mobile", 128);
+	PROJECT_DEFAULT("rendering/reflections/reflection_atlas/reflection_count", 64);
 
-	GLOBAL_DEF("rendering/global_illumination/gi/use_half_resolution", false);
+	PROJECT_DEFAULT("rendering/global_illumination/gi/use_half_resolution", false);
 
-	GLOBAL_DEF("rendering/global_illumination/voxel_gi/quality", 1);
+	PROJECT_DEFAULT("rendering/global_illumination/voxel_gi/quality", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/global_illumination/voxel_gi/quality", PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/quality", PROPERTY_HINT_ENUM, "Low (4 Cones - Fast),High (6 Cones - Slow)"));
 
-	GLOBAL_DEF("rendering/shading/overrides/force_vertex_shading", false);
-	GLOBAL_DEF("rendering/shading/overrides/force_vertex_shading.mobile", true);
-	GLOBAL_DEF("rendering/shading/overrides/force_lambert_over_burley", false);
-	GLOBAL_DEF("rendering/shading/overrides/force_lambert_over_burley.mobile", true);
-	GLOBAL_DEF("rendering/shading/overrides/force_blinn_over_ggx", false);
-	GLOBAL_DEF("rendering/shading/overrides/force_blinn_over_ggx.mobile", true);
+	PROJECT_DEFAULT("rendering/shading/overrides/force_vertex_shading", false);
+	PROJECT_DEFAULT("rendering/shading/overrides/force_vertex_shading.mobile", true);
+	PROJECT_DEFAULT("rendering/shading/overrides/force_lambert_over_burley", false);
+	PROJECT_DEFAULT("rendering/shading/overrides/force_lambert_over_burley.mobile", true);
+	PROJECT_DEFAULT("rendering/shading/overrides/force_blinn_over_ggx", false);
+	PROJECT_DEFAULT("rendering/shading/overrides/force_blinn_over_ggx.mobile", true);
 
-	GLOBAL_DEF("rendering/driver/depth_prepass/enable", true);
-	GLOBAL_DEF("rendering/driver/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
+	PROJECT_DEFAULT("rendering/driver/depth_prepass/enable", true);
+	PROJECT_DEFAULT("rendering/driver/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
 
-	GLOBAL_DEF("rendering/textures/default_filters/use_nearest_mipmap_filter", false);
-	GLOBAL_DEF("rendering/textures/default_filters/anisotropic_filtering_level", 2);
+	PROJECT_DEFAULT("rendering/textures/default_filters/use_nearest_mipmap_filter", false);
+	PROJECT_DEFAULT("rendering/textures/default_filters/anisotropic_filtering_level", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/textures/default_filters/anisotropic_filtering_level", PropertyInfo(Variant::INT, "rendering/textures/default_filters/anisotropic_filtering_level", PROPERTY_HINT_ENUM, "Disabled (Fastest),2x (Faster),4x (Fast),8x (Average),16x (Slow)"));
 
-	GLOBAL_DEF("rendering/camera/depth_of_field/depth_of_field_bokeh_shape", 1);
+	PROJECT_DEFAULT("rendering/camera/depth_of_field/depth_of_field_bokeh_shape", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/camera/depth_of_field/depth_of_field_bokeh_shape", PropertyInfo(Variant::INT, "rendering/camera/depth_of_field/depth_of_field_bokeh_shape", PROPERTY_HINT_ENUM, "Box (Fast),Hexagon (Average),Circle (Slow)"));
-	GLOBAL_DEF("rendering/camera/depth_of_field/depth_of_field_bokeh_quality", 2);
+	PROJECT_DEFAULT("rendering/camera/depth_of_field/depth_of_field_bokeh_quality", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/camera/depth_of_field/depth_of_field_bokeh_quality", PropertyInfo(Variant::INT, "rendering/camera/depth_of_field/depth_of_field_bokeh_quality", PROPERTY_HINT_ENUM, "Very Low (Fastest),Low (Fast),Medium (Average),High (Slow)"));
-	GLOBAL_DEF("rendering/camera/depth_of_field/depth_of_field_use_jitter", false);
+	PROJECT_DEFAULT("rendering/camera/depth_of_field/depth_of_field_use_jitter", false);
 
-	GLOBAL_DEF("rendering/environment/ssao/quality", 2);
+	PROJECT_DEFAULT("rendering/environment/ssao/quality", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/ssao/quality", PropertyInfo(Variant::INT, "rendering/environment/ssao/quality", PROPERTY_HINT_ENUM, "Very Low (Fast),Low (Fast),Medium (Average),High (Slow),Ultra (Custom)"));
-	GLOBAL_DEF("rendering/environment/ssao/half_size", false);
-	GLOBAL_DEF("rendering/environment/ssao/half_size.mobile", true);
-	GLOBAL_DEF("rendering/environment/ssao/adaptive_target", 0.5);
+	PROJECT_DEFAULT("rendering/environment/ssao/half_size", false);
+	PROJECT_DEFAULT("rendering/environment/ssao/half_size.mobile", true);
+	PROJECT_DEFAULT("rendering/environment/ssao/adaptive_target", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/ssao/adaptive_target", PropertyInfo(Variant::FLOAT, "rendering/environment/ssao/adaptive_target", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"));
-	GLOBAL_DEF("rendering/environment/ssao/blur_passes", 2);
+	PROJECT_DEFAULT("rendering/environment/ssao/blur_passes", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/ssao/blur_passes", PropertyInfo(Variant::INT, "rendering/environment/ssao/blur_passes", PROPERTY_HINT_RANGE, "0,6"));
-	GLOBAL_DEF("rendering/environment/ssao/fadeout_from", 50.0);
+	PROJECT_DEFAULT("rendering/environment/ssao/fadeout_from", 50.0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/ssao/fadeout_from", PropertyInfo(Variant::FLOAT, "rendering/environment/ssao/fadeout_from", PROPERTY_HINT_RANGE, "0.0,512,0.1,or_greater"));
-	GLOBAL_DEF("rendering/environment/ssao/fadeout_to", 300.0);
+	PROJECT_DEFAULT("rendering/environment/ssao/fadeout_to", 300.0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/ssao/fadeout_to", PropertyInfo(Variant::FLOAT, "rendering/environment/ssao/fadeout_to", PROPERTY_HINT_RANGE, "64,65536,0.1,or_greater"));
 
-	GLOBAL_DEF("rendering/anti_aliasing/screen_space_roughness_limiter/enabled", true);
-	GLOBAL_DEF("rendering/anti_aliasing/screen_space_roughness_limiter/amount", 0.25);
-	GLOBAL_DEF("rendering/anti_aliasing/screen_space_roughness_limiter/limit", 0.18);
+	PROJECT_DEFAULT("rendering/anti_aliasing/screen_space_roughness_limiter/enabled", true);
+	PROJECT_DEFAULT("rendering/anti_aliasing/screen_space_roughness_limiter/amount", 0.25);
+	PROJECT_DEFAULT("rendering/anti_aliasing/screen_space_roughness_limiter/limit", 0.18);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/anti_aliasing/screen_space_roughness_limiter/amount", PropertyInfo(Variant::FLOAT, "rendering/anti_aliasing/screen_space_roughness_limiter/amount", PROPERTY_HINT_RANGE, "0.01,4.0,0.01"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/anti_aliasing/screen_space_roughness_limiter/limit", PropertyInfo(Variant::FLOAT, "rendering/anti_aliasing/screen_space_roughness_limiter/limit", PROPERTY_HINT_RANGE, "0.01,1.0,0.01"));
 
-	GLOBAL_DEF_RST("rendering/occlusion_culling/occlusion_rays_per_thread", 512);
-	GLOBAL_DEF_RST("rendering/occlusion_culling/bvh_build_quality", 2);
+	PROJECT_DEFAULT_RESTART("rendering/occlusion_culling/occlusion_rays_per_thread", 512);
+	PROJECT_DEFAULT_RESTART("rendering/occlusion_culling/bvh_build_quality", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/occlusion_culling/bvh_build_quality", PropertyInfo(Variant::INT, "rendering/occlusion_culling/bvh_build_quality", PROPERTY_HINT_ENUM, "Low,Medium,High"));
 
-	GLOBAL_DEF("rendering/environment/glow/upscale_mode", 1);
+	PROJECT_DEFAULT("rendering/environment/glow/upscale_mode", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/glow/upscale_mode", PropertyInfo(Variant::INT, "rendering/environment/glow/upscale_mode", PROPERTY_HINT_ENUM, "Linear (Fast),Bicubic (Slow)"));
-	GLOBAL_DEF("rendering/environment/glow/upscale_mode.mobile", 0);
-	GLOBAL_DEF("rendering/environment/glow/use_high_quality", false);
+	PROJECT_DEFAULT("rendering/environment/glow/upscale_mode.mobile", 0);
+	PROJECT_DEFAULT("rendering/environment/glow/use_high_quality", false);
 
-	GLOBAL_DEF("rendering/environment/screen_space_reflection/roughness_quality", 1);
+	PROJECT_DEFAULT("rendering/environment/screen_space_reflection/roughness_quality", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/screen_space_reflection/roughness_quality", PropertyInfo(Variant::INT, "rendering/environment/screen_space_reflection/roughness_quality", PROPERTY_HINT_ENUM, "Disabled (Fastest),Low (Fast),Medium (Average),High (Slow)"));
 
-	GLOBAL_DEF("rendering/environment/subsurface_scattering/subsurface_scattering_quality", 1);
+	PROJECT_DEFAULT("rendering/environment/subsurface_scattering/subsurface_scattering_quality", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/subsurface_scattering/subsurface_scattering_quality", PropertyInfo(Variant::INT, "rendering/environment/subsurface_scattering/subsurface_scattering_quality", PROPERTY_HINT_ENUM, "Disabled (Fastest),Low (Fast),Medium (Average),High (Slow)"));
-	GLOBAL_DEF("rendering/environment/subsurface_scattering/subsurface_scattering_scale", 0.05);
+	PROJECT_DEFAULT("rendering/environment/subsurface_scattering/subsurface_scattering_scale", 0.05);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/subsurface_scattering/subsurface_scattering_scale", PropertyInfo(Variant::FLOAT, "rendering/environment/subsurface_scattering/subsurface_scattering_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001"));
-	GLOBAL_DEF("rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale", 0.01);
+	PROJECT_DEFAULT("rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale", 0.01);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale", PropertyInfo(Variant::FLOAT, "rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001"));
 
-	GLOBAL_DEF("rendering/limits/global_shader_variables/buffer_size", 65536);
+	PROJECT_DEFAULT("rendering/limits/global_shader_variables/buffer_size", 65536);
 
-	GLOBAL_DEF("rendering/lightmapping/probe_capture/update_speed", 15);
+	PROJECT_DEFAULT("rendering/lightmapping/probe_capture/update_speed", 15);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/lightmapping/probe_capture/update_speed", PropertyInfo(Variant::FLOAT, "rendering/lightmapping/probe_capture/update_speed", PROPERTY_HINT_RANGE, "0.001,256,0.001"));
 
-	GLOBAL_DEF("rendering/global_illumination/sdfgi/probe_ray_count", 1);
+	PROJECT_DEFAULT("rendering/global_illumination/sdfgi/probe_ray_count", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/global_illumination/sdfgi/probe_ray_count", PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/probe_ray_count", PROPERTY_HINT_ENUM, "8 (Fastest),16,32,64,96,128 (Slowest)"));
-	GLOBAL_DEF("rendering/global_illumination/sdfgi/frames_to_converge", 4);
+	PROJECT_DEFAULT("rendering/global_illumination/sdfgi/frames_to_converge", 4);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/global_illumination/sdfgi/frames_to_converge", PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/frames_to_converge", PROPERTY_HINT_ENUM, "5 (Less Latency but Lower Quality),10,15,20,25,30 (More Latency but Higher Quality)"));
-	GLOBAL_DEF("rendering/global_illumination/sdfgi/frames_to_update_lights", 2);
+	PROJECT_DEFAULT("rendering/global_illumination/sdfgi/frames_to_update_lights", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/global_illumination/sdfgi/frames_to_update_lights", PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/frames_to_update_lights", PROPERTY_HINT_ENUM, "1 (Slower),2,4,8,16 (Faster)"));
 
-	GLOBAL_DEF("rendering/environment/volumetric_fog/volume_size", 64);
+	PROJECT_DEFAULT("rendering/environment/volumetric_fog/volume_size", 64);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/volumetric_fog/volume_size", PropertyInfo(Variant::INT, "rendering/environment/volumetric_fog/volume_size", PROPERTY_HINT_RANGE, "16,512,1"));
-	GLOBAL_DEF("rendering/environment/volumetric_fog/volume_depth", 128);
+	PROJECT_DEFAULT("rendering/environment/volumetric_fog/volume_depth", 128);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/volumetric_fog/volume_depth", PropertyInfo(Variant::INT, "rendering/environment/volumetric_fog/volume_depth", PROPERTY_HINT_RANGE, "16,512,1"));
-	GLOBAL_DEF("rendering/environment/volumetric_fog/use_filter", 1);
+	PROJECT_DEFAULT("rendering/environment/volumetric_fog/use_filter", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/volumetric_fog/use_filter", PropertyInfo(Variant::INT, "rendering/environment/volumetric_fog/use_filter", PROPERTY_HINT_ENUM, "No (Faster),Yes (Higher Quality)"));
 
-	GLOBAL_DEF("rendering/limits/spatial_indexer/update_iterations_per_frame", 10);
+	PROJECT_DEFAULT("rendering/limits/spatial_indexer/update_iterations_per_frame", 10);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/spatial_indexer/update_iterations_per_frame", PropertyInfo(Variant::INT, "rendering/limits/spatial_indexer/update_iterations_per_frame", PROPERTY_HINT_RANGE, "0,1024,1"));
-	GLOBAL_DEF("rendering/limits/spatial_indexer/threaded_cull_minimum_instances", 1000);
+	PROJECT_DEFAULT("rendering/limits/spatial_indexer/threaded_cull_minimum_instances", 1000);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/spatial_indexer/threaded_cull_minimum_instances", PropertyInfo(Variant::INT, "rendering/limits/spatial_indexer/threaded_cull_minimum_instances", PROPERTY_HINT_RANGE, "32,65536,1"));
-	GLOBAL_DEF("rendering/limits/forward_renderer/threaded_render_minimum_instances", 500);
+	PROJECT_DEFAULT("rendering/limits/forward_renderer/threaded_render_minimum_instances", 500);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/forward_renderer/threaded_render_minimum_instances", PropertyInfo(Variant::INT, "rendering/limits/forward_renderer/threaded_render_minimum_instances", PROPERTY_HINT_RANGE, "32,65536,1"));
 
-	GLOBAL_DEF("rendering/limits/cluster_builder/max_clustered_elements", 512);
+	PROJECT_DEFAULT("rendering/limits/cluster_builder/max_clustered_elements", 512);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/cluster_builder/max_clustered_elements", PropertyInfo(Variant::FLOAT, "rendering/limits/cluster_builder/max_clustered_elements", PROPERTY_HINT_RANGE, "32,8192,1"));
 
-	GLOBAL_DEF_RST("rendering/xr/enabled", false);
+	PROJECT_DEFAULT_RESTART("rendering/xr/enabled", false);
 }
 
 RenderingServer::~RenderingServer() {


### PR DESCRIPTION
The Globals singleton was renamed to ProjectSettings in 3.0. Additionally, this renames some of the macros to be more explicit (including for EditorSettings).

`_DEF` was renamed to `_DEFAULT` to avoid having the same length as `_GET` (which can look confusing at a glance).

This also adds comments above each macro, which will appear in many IDEs when hovering the macro names.

See https://github.com/godotengine/godot/issues/16863#issuecomment-871572390.