### PR TITLE
[3.x] Limit scale of `Node2D` to EPSILON (0.00001) to prevent det==0 error

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -174,10 +174,10 @@ void Node2D::set_scale(const Size2 &p_scale) {
 	}
 	_scale = p_scale;
 	// Avoid having 0 scale values, can lead to errors in physics and rendering.
-	if (_scale.x == 0) {
+	if (Math::is_zero_approx(_scale.x)) {
 		_scale.x = CMP_EPSILON;
 	}
-	if (_scale.y == 0) {
+	if (Math::is_zero_approx(_scale.y)) {
 		_scale.y = CMP_EPSILON;
 	}
 	_update_transform();


### PR DESCRIPTION
[3.x] version of #50363.

It seems that due to floating point errors value of scale never reached exactly 0 so this "safety trigger" failed.

Replaced with `Math::is_zero_approx()` instead. It should also fix this issue for any `Node2D`

Attached test file. There is no error anymore and minimum value for scale is 0.00001
[25986_issue_MRP_scene.zip](https://github.com/godotengine/godot/files/6795768/25986_issue_MRP_scene.zip)

<i>Bugsquad edit</i>: Fix #25986