### PR TITLE
Add is_built_in() method to Resource

### DIFF
--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -103,6 +103,7 @@ public:
 
 	virtual void set_path(const String &p_path, bool p_take_over = false);
 	String get_path() const;
+	_FORCE_INLINE_ bool is_built_in() const { return path_cache.is_empty() || path_cache.find("::") != -1 || path_cache.begins_with("local://"); }
 
 	static String generate_scene_unique_id();
 	void set_scene_unique_id(const String &p_id);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1572,7 +1572,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(FileAccess *f, const Varia
 				return; // don't save it
 			}
 
-			if (res->get_path().length() && res->get_path().find("::") == -1) {
+			if (!res->is_built_in()) {
 				f->store_32(OBJECT_EXTERNAL_RESOURCE_INDEX);
 				f->store_32(external_resources[res]);
 			} else {
@@ -1743,7 +1743,7 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 				return;
 			}
 
-			if (!p_main && (!bundle_resources) && res->get_path().length() && res->get_path().find("::") == -1) {
+			if (!p_main && (!bundle_resources) && !res->is_built_in()) {
 				if (res->get_path() == path) {
 					ERR_PRINT("Circular reference to resource being saved found: '" + local_path + "' will be null next time it's loaded.");
 					return;
@@ -1978,7 +1978,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	Set<String> used_unique_ids;
 
 	for (RES &r : saved_resources) {
-		if (r->get_path() == "" || r->get_path().find("::") != -1) {
+		if (r->is_built_in()) {
 			if (r->get_scene_unique_id() != "") {
 				if (used_unique_ids.has(r->get_scene_unique_id())) {
 					r->set_scene_unique_id("");
@@ -1992,7 +1992,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	Map<RES, int> resource_map;
 	int res_index = 0;
 	for (RES &r : saved_resources) {
-		if (r->get_path() == "" || r->get_path().find("::") != -1) {
+		if (r->is_built_in()) {
 			if (r->get_scene_unique_id() == "") {
 				String new_id;
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1475,7 +1475,7 @@ void Object::_clear_internal_resource_paths(const Variant &p_var) {
 				return;
 			}
 
-			if (!r->get_path().begins_with("res://") || r->get_path().find("::") == -1) {
+			if (!r->is_built_in()) {
 				return; //not an internal resource
 			}
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3490,7 +3490,7 @@ void EditorInspector::_update_script_class_properties(const Object &p_object, Li
 		String path = s->get_path();
 		String name = EditorNode::get_editor_data().script_class_get_name(path);
 		if (name.is_empty()) {
-			if (!path.is_empty() && path.find("::") == -1) {
+			if (!s->is_built_in()) {
 				name = path.get_file();
 			} else {
 				name = TTR("Built-in script");

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -375,7 +375,7 @@ void ScriptTextEditor::ensure_focus() {
 String ScriptTextEditor::get_name() {
 	String name;
 
-	if (script->get_path().find("local://") == -1 && script->get_path().find("::") == -1) {
+	if (!script->is_built_in()) {
 		name = script->get_path().get_file();
 		if (is_unsaved()) {
 			if (script->get_path().is_empty()) {
@@ -658,7 +658,7 @@ void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_fo
 			continue;
 		}
 
-		if (script->get_path() == "" || script->get_path().find("local://") != -1 || script->get_path().find("::") != -1) {
+		if (script->is_built_in()) {
 			continue; //internal script, who cares, though weird
 		}
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -482,8 +482,7 @@ void ShaderEditor::_check_for_external_edit() {
 		return;
 	}
 
-	// internal shader.
-	if (shader->get_path() == "" || shader->get_path().find("local://") != -1 || shader->get_path().find("::") != -1) {
+	if (shader->is_built_in()) {
 		return;
 	}
 
@@ -530,7 +529,7 @@ void ShaderEditor::save_external_data(const String &p_str) {
 	}
 
 	apply_shaders();
-	if (shader->get_path() != "" && shader->get_path().find("local://") == -1 && shader->get_path().find("::") == -1) {
+	if (!shader->is_built_in()) {
 		//external shader, save it
 		ResourceSaver::save(shader->get_path(), shader);
 	}

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -65,7 +65,7 @@ void TextEditor::_load_theme_settings() {
 String TextEditor::get_name() {
 	String name;
 
-	if (text_file->get_path().find("local://") == -1 && text_file->get_path().find("::") == -1) {
+	if (!text_file->is_built_in()) {
 		name = text_file->get_path().get_file();
 		if (is_unsaved()) {
 			if (text_file->get_path().is_empty()) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3152,7 +3152,7 @@ void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap)
 					}
 				}
 
-				if ((res->get_path() == "" || res->get_path().find("::") > -1) && !r_remap.has(res)) {
+				if (res->is_built_in() && !r_remap.has(res)) {
 					_create_remap_for_resource(res, r_remap);
 				}
 			}
@@ -3179,7 +3179,7 @@ void SceneTreeDock::_create_remap_for_resource(RES p_resource, Map<RES, RES> &r_
 		if (v.is_ref()) {
 			RES res = v;
 			if (res.is_valid()) {
-				if ((res->get_path() == "" || res->get_path().find("::") > -1) && !r_remap.has(res)) {
+				if (res->is_built_in() && !r_remap.has(res)) {
 					_create_remap_for_resource(res, r_remap);
 				}
 			}

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2582,7 +2582,7 @@ void VisualScriptEditor::reload_text() {
 String VisualScriptEditor::get_name() {
 	String name;
 
-	if (script->get_path().find("local://") == -1 && script->get_path().find("::") == -1) {
+	if (!script->is_built_in()) {
 		name = script->get_path().get_file();
 		if (is_unsaved()) {
 			if (script->get_path().is_empty()) {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1651,7 +1651,7 @@ Node *PackedScene::instantiate(GenEditState p_edit_state) const {
 		s->set_scene_instance_state(state);
 	}
 
-	if (get_path() != "" && get_path().find("::") == -1) {
+	if (!is_built_in()) {
 		s->set_scene_file_path(get_path());
 	}
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1492,7 +1492,7 @@ String ResourceFormatSaverTextInstance::_write_resource(const RES &res) {
 	} else {
 		if (internal_resources.has(res)) {
 			return "SubResource( \"" + internal_resources[res] + "\" )";
-		} else if (res->get_path().length() && res->get_path().find("::") == -1) {
+		} else if (!res->is_built_in()) {
 			if (res->get_path() == local_path) { //circular reference attempt
 				return "null";
 			}
@@ -1515,7 +1515,7 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 				return;
 			}
 
-			if (!p_main && (!bundle_resources) && res->get_path().length() && res->get_path().find("::") == -1) {
+			if (!p_main && (!bundle_resources) && !res->is_built_in()) {
 				if (res->get_path() == local_path) {
 					ERR_PRINT("Circular reference to resource being saved found: '" + local_path + "' will be null next time it's loaded.");
 					return;
@@ -1728,7 +1728,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 
 	for (List<RES>::Element *E = saved_resources.front(); E; E = E->next()) {
 		RES res = E->get();
-		if (E->next() && (res->get_path() == "" || res->get_path().find("::") != -1)) {
+		if (E->next() && res->is_built_in()) {
 			if (res->get_scene_unique_id() != "") {
 				if (used_unique_ids.has(res->get_scene_unique_id())) {
 					res->set_scene_unique_id(""); // Repeated.


### PR DESCRIPTION
A built-in Resource can be recognized by its path, which may be:
- empty
- containing `::`
- starting with `local://`? idk, I've seen it in few places

There were such checks all over the codebase, but they were inconsistent, which led to some bugs, e.g. #45950 or partially #49086 (`_is_built_in_script()` is not checking for empty paths, so the issue isn't fully fixed).

To fix inconsistencies I added `is_built_in()` to resources. I replaced equivalent conditions with this method.