### PR TITLE
Add an editor icon for the ImmediateMesh resource

### DIFF
--- a/editor/icons/ImmediateMesh.svg
+++ b/editor/icons/ImmediateMesh.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 14.999999 14.999999" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m2 2v2h5v-2zm5 2v3h2v-3zm2-2v2h5v-2zm-2 7v3h2v-3zm-5 3v2h5v-2zm7 0v2h5v-2z" fill="#ffca5f" transform="scale(.93749994)"/></svg>


### PR DESCRIPTION
It's mainly meant as a placeholder (it looks like an "I" for "immediate"). I made it dashed as this is generally not a mesh resource you want to instance from the editor (it'll be invisible).

I could have used the [ImmediateGeometry3D "paintbrush" icon](https://raw.githubusercontent.com/godotengine/godot/374ffbe2d2a7294dd9ea1429a3dec1eedfa34b60/editor/icons/ImmediateGeometry3D.svg) in orange, but it kind of looks like a line from a distance. However, immediate drawing is not limited to lines.

Feel free to chime in if you have better ideas :slightly_smiling_face:

## Preview

![Mesh dropdown](https://user-images.githubusercontent.com/180032/125206535-22128200-e288-11eb-9454-0c703fa72ef3.png)

<details>
<summary>Old version</summary>

![Mesh dropdown](https://user-images.githubusercontent.com/180032/125177994-c6d98480-e1e0-11eb-8f1b-79964ddde104.png)
</details>