### PR TITLE
Handle Z_BUF_ERROR in decompress_dynamic

### DIFF
--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -238,7 +238,10 @@ int Compression::decompress_dynamic(Vector<uint8_t> *p_dst_vect, int p_max_dst_s
 				case Z_DATA_ERROR:
 				case Z_MEM_ERROR:
 				case Z_STREAM_ERROR:
-					WARN_PRINT(strm.msg);
+				case Z_BUF_ERROR:
+					if (strm.msg) {
+						WARN_PRINT(strm.msg);
+					}
 					(void)inflateEnd(&strm);
 					p_dst_vect->resize(0);
 					return ret;


### PR DESCRIPTION
Fixes #50353, also applies to 3.x.

`Z_BUF_ERROR` means no inflate progress can be made with data in the input buffer. The error code was not handled, the same as an successful inflate, so the output buffer would grow indefinitely (negative `max_output_size` means no output size limit), and eventually overflows into an negative number.

I also added a null check before printing warning to avoid the confusing message:

```
WARNING: (null)
     at: decompress_dynamic (core/io/compression.cpp:242)
```