### PR TITLE
Fix unicode invalid skip error in AssetLib

### DIFF
--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -590,6 +590,7 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 				}
 			}
 			if (err != OK) {
+				ret.resize(_offset);
 				break;
 			}
 		}


### PR DESCRIPTION
To reproduce the error:

1. Run `python -m SimpleHTTPServer 80`
2. Open Godot, switch to AssetLib, and change "Site" to "localhost"
3. AssetLib will report 404 which is expected, but there is also an unicode parsing error in the console:
    ```
    Unicode parsing error: invalid skip at 195. Is the string valid UTF-8?
    ```

This is because there are cases where `_get_http_data` both receives some data and returns `ERR_FILE_EOF`:

https://github.com/godotengine/godot/blob/374ffbe2d2a7294dd9ea1429a3dec1eedfa34b60/core/io/http_client_tcp.cpp#L637-L639

and `read_response_body_chunk` only shrinks the buffer if nothing is received:

https://github.com/godotengine/godot/blob/374ffbe2d2a7294dd9ea1429a3dec1eedfa34b60/core/io/http_client_tcp.cpp#L582-L594

so the response body returned contains trailing uninitialized bytes, and it errors when trying to decode as UTF-8.

This also applies to 3.x, change `core/io/http_client_tcp.cpp` to `core/io/http_client.cpp`.