### PR TITLE
Limit scale of `Node2D` to EPSILON (0.00001) to prevent `det==0` error

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -170,10 +170,10 @@ void Node2D::set_scale(const Size2 &p_scale) {
 	}
 	_scale = p_scale;
 	// Avoid having 0 scale values, can lead to errors in physics and rendering.
-	if (_scale.x == 0) {
+	if (Math::is_zero_approx(_scale.x)) {
 		_scale.x = CMP_EPSILON;
 	}
-	if (_scale.y == 0) {
+	if (Math::is_zero_approx(_scale.y)) {
 		_scale.y = CMP_EPSILON;
 	}
 	_update_transform();


### PR DESCRIPTION
Fix for issue #25986 for `master` since it was still reproducible.

It seems that due to floating point errors value of `scale` reach almost `0`, but not exactly `0` and this "safety trigger" failed.
This issue is more severe in `3.x` since there scale NEVER reach 0, but in `master` it does eventually.

Replaced with `Math::is_zero_approx()` instead. It should also fix this issue for any Node2D

Attached test file. There is no error anymore and minimum value for scale is 0.00001
[25986_issue_godot4_MRP.zip](https://github.com/godotengine/godot/files/6796428/25986_issue_godot4_MRP.zip)

<i>Bugsquad edit</i>: Fix #25986