### PR TITLE
Try other resolved IPs if one fails to connect

### DIFF
--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -37,6 +37,7 @@ class HTTPClientTCP : public HTTPClient {
 private:
 	Status status = STATUS_DISCONNECTED;
 	IP::ResolverID resolving = IP::RESOLVER_INVALID_ID;
+	Array ip_candidates;
 	int conn_port = -1;
 	String conn_host;
 	bool ssl = false;

--- a/modules/websocket/wsl_client.h
+++ b/modules/websocket/wsl_client.h
@@ -63,6 +63,8 @@ private:
 
 	String _key;
 	String _host;
+	int _port;
+	Array ip_candidates;
 	Vector<String> _protocols;
 	bool _use_ssl = false;
 


### PR DESCRIPTION
When `HTTPClient` and `WebSocketClient` are connecting to server, save all resolved IPs, and try other candidates if one failed to connect. Not [Happy Eyeballs](https://tools.ietf.org/html/rfc8305), but at least it's happy I think :)

Fixes #46972, and hopefully fixes #36418, I don't have IPv6 connection to the AssetLib, so I only tested on my `localhost` which resolved to IPv6 first.

It's the same for 3.x, but `core/io/http_client_tcp.{h,cpp}` → `core/io/http_client.{h,cpp}` and `container.is_empty()` → `container.empty()`.