### PR TITLE
Ring emitter for 4.0

### DIFF
--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -177,8 +177,20 @@
 		<member name="emission_normals" type="PackedVector3Array" setter="set_emission_normals" getter="get_emission_normals">
 			Sets the direction the particles will be emitted in when using [constant EMISSION_SHAPE_DIRECTED_POINTS].
 		</member>
-		<member name="emission_points" type="PackedVector3Array" setter="set_emission_points" getter="get_emission_points" default="PackedVector3Array()">
+		<member name="emission_points" type="PackedVector3Array" setter="set_emission_points" getter="get_emission_points">
 			Sets the initial positions to spawn particles when using [constant EMISSION_SHAPE_POINTS] or [constant EMISSION_SHAPE_DIRECTED_POINTS].
+		</member>
+		<member name="emission_ring_axis" type="Vector3" setter="set_emission_ring_axis" getter="get_emission_ring_axis">
+			The axis of the ring when using the emitter [constant EMISSION_SHAPE_RING].
+		</member>
+		<member name="emission_ring_height" type="float" setter="set_emission_ring_height" getter="get_emission_ring_height">
+			The height of the ring when using the emitter [constant EMISSION_SHAPE_RING].
+		</member>
+		<member name="emission_ring_inner_radius" type="float" setter="set_emission_ring_inner_radius" getter="get_emission_ring_inner_radius">
+			The inner radius of the ring when using the emitter [constant EMISSION_SHAPE_RING].
+		</member>
+		<member name="emission_ring_radius" type="float" setter="set_emission_ring_radius" getter="get_emission_ring_radius">
+			The radius of the ring when using the emitter [constant EMISSION_SHAPE_RING].
 		</member>
 		<member name="emission_shape" type="int" setter="set_emission_shape" getter="get_emission_shape" enum="CPUParticles3D.EmissionShape" default="0">
 			Particles will be emitted inside this region. See [enum EmissionShape] for possible values.
@@ -378,7 +390,10 @@
 		<constant name="EMISSION_SHAPE_DIRECTED_POINTS" value="4" enum="EmissionShape">
 			Particles will be emitted at a position chosen randomly among [member emission_points]. Particle velocity and rotation will be set based on [member emission_normals]. Particle color will be modulated by [member emission_colors].
 		</constant>
-		<constant name="EMISSION_SHAPE_MAX" value="5" enum="EmissionShape">
+		<constant name="EMISSION_SHAPE_RING" value="5" enum="EmissionShape">
+			Particles will be emitted in a ring or cylinder.
+		</constant>
+		<constant name="EMISSION_SHAPE_MAX" value="6" enum="EmissionShape">
 			Represents the size of the [enum EmissionShape] enum.
 		</constant>
 	</constants>

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -174,6 +174,18 @@
 		<member name="emission_point_texture" type="Texture2D" setter="set_emission_point_texture" getter="get_emission_point_texture">
 			Particles will be emitted at positions determined by sampling this texture at a random position. Used with [constant EMISSION_SHAPE_POINTS] and [constant EMISSION_SHAPE_DIRECTED_POINTS]. Can be created automatically from mesh or node by selecting "Create Emission Points from Mesh/Node" under the "Particles" tool in the toolbar.
 		</member>
+		<member name="emission_ring_axis" type="Vector3" setter="set_emission_ring_axis" getter="get_emission_ring_axis">
+			The axis of the ring when using the emitter [constant EMISSION_SHAPE_RING].
+		</member>
+		<member name="emission_ring_height" type="float" setter="set_emission_ring_height" getter="get_emission_ring_height">
+			The height of the ring when using the emitter [constant EMISSION_SHAPE_RING].
+		</member>
+		<member name="emission_ring_inner_radius" type="float" setter="set_emission_ring_inner_radius" getter="get_emission_ring_inner_radius">
+			The inner radius of the ring when using the emitter [constant EMISSION_SHAPE_RING].
+		</member>
+		<member name="emission_ring_radius" type="float" setter="set_emission_ring_radius" getter="get_emission_ring_radius">
+			The radius of the ring when using the emitter [constant EMISSION_SHAPE_RING].
+		</member>
 		<member name="emission_shape" type="int" setter="set_emission_shape" getter="get_emission_shape" enum="ParticlesMaterial.EmissionShape" default="0">
 			Particles will be emitted inside this region. Use [enum EmissionShape] constants for values.
 		</member>
@@ -338,7 +350,10 @@
 		<constant name="EMISSION_SHAPE_DIRECTED_POINTS" value="4" enum="EmissionShape">
 			Particles will be emitted at a position determined by sampling a random point on the [member emission_point_texture]. Particle velocity and rotation will be set based on [member emission_normal_texture]. Particle color will be modulated by [member emission_color_texture].
 		</constant>
-		<constant name="EMISSION_SHAPE_MAX" value="5" enum="EmissionShape">
+		<constant name="EMISSION_SHAPE_RING" value="5" enum="EmissionShape">
+			Particles will be emitted in a ring or cylinder.
+		</constant>
+		<constant name="EMISSION_SHAPE_MAX" value="6" enum="EmissionShape">
 			Represents the size of the [enum EmissionShape] enum.
 		</constant>
 		<constant name="SUB_EMITTER_DISABLED" value="0" enum="SubEmitterMode">

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -76,6 +76,7 @@ public:
 		EMISSION_SHAPE_BOX,
 		EMISSION_SHAPE_POINTS,
 		EMISSION_SHAPE_DIRECTED_POINTS,
+		EMISSION_SHAPE_RING,
 		EMISSION_SHAPE_MAX
 	};
 
@@ -171,6 +172,10 @@ private:
 	Vector<Vector3> emission_normals;
 	Vector<Color> emission_colors;
 	int emission_point_count = 0;
+	Vector3 emission_ring_axis;
+	float emission_ring_height;
+	float emission_ring_radius;
+	float emission_ring_inner_radius;
 
 	Vector3 gravity = Vector3(0, -9.8, 0);
 
@@ -268,6 +273,10 @@ public:
 	void set_emission_normals(const Vector<Vector3> &p_normals);
 	void set_emission_colors(const Vector<Color> &p_colors);
 	void set_emission_point_count(int p_count);
+	void set_emission_ring_axis(Vector3 p_axis);
+	void set_emission_ring_height(float p_height);
+	void set_emission_ring_radius(float p_radius);
+	void set_emission_ring_inner_radius(float p_radius);
 
 	EmissionShape get_emission_shape() const;
 	float get_emission_sphere_radius() const;
@@ -276,6 +285,10 @@ public:
 	Vector<Vector3> get_emission_normals() const;
 	Vector<Color> get_emission_colors() const;
 	int get_emission_point_count() const;
+	Vector3 get_emission_ring_axis() const;
+	float get_emission_ring_height() const;
+	float get_emission_ring_radius() const;
+	float get_emission_ring_inner_radius() const;
 
 	void set_gravity(const Vector3 &p_gravity);
 	Vector3 get_gravity() const;

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -74,6 +74,7 @@ public:
 		EMISSION_SHAPE_BOX,
 		EMISSION_SHAPE_POINTS,
 		EMISSION_SHAPE_DIRECTED_POINTS,
+		EMISSION_SHAPE_RING,
 		EMISSION_SHAPE_MAX
 	};
 
@@ -195,6 +196,10 @@ private:
 		StringName emission_texture_points;
 		StringName emission_texture_normal;
 		StringName emission_texture_color;
+		StringName emission_ring_axis;
+		StringName emission_ring_height;
+		StringName emission_ring_radius;
+		StringName emission_ring_inner_radius;
 
 		StringName gravity;
 
@@ -235,6 +240,10 @@ private:
 	Ref<Texture2D> emission_point_texture;
 	Ref<Texture2D> emission_normal_texture;
 	Ref<Texture2D> emission_color_texture;
+	Vector3 emission_ring_axis;
+	float emission_ring_height;
+	float emission_ring_radius;
+	float emission_ring_inner_radius;
 	int emission_point_count = 1;
 
 	bool anim_loop;
@@ -293,6 +302,10 @@ public:
 	void set_emission_point_texture(const Ref<Texture2D> &p_points);
 	void set_emission_normal_texture(const Ref<Texture2D> &p_normals);
 	void set_emission_color_texture(const Ref<Texture2D> &p_colors);
+	void set_emission_ring_axis(Vector3 p_axis);
+	void set_emission_ring_height(float p_height);
+	void set_emission_ring_radius(float p_radius);
+	void set_emission_ring_inner_radius(float p_radius);
 	void set_emission_point_count(int p_count);
 
 	EmissionShape get_emission_shape() const;
@@ -301,6 +314,10 @@ public:
 	Ref<Texture2D> get_emission_point_texture() const;
 	Ref<Texture2D> get_emission_normal_texture() const;
 	Ref<Texture2D> get_emission_color_texture() const;
+	Vector3 get_emission_ring_axis() const;
+	float get_emission_ring_height() const;
+	float get_emission_ring_radius() const;
+	float get_emission_ring_inner_radius() const;
 	int get_emission_point_count() const;
 
 	void set_gravity(const Vector3 &p_gravity);


### PR DESCRIPTION
and 3D CPU particles. The new emitter is called "ring"
and it can emit either in a ring or cylinder fashion.
This adds the following properties for the emitter:
1. emission_ring_axis: the axis along which the ring/cylinder
    will be constructed
2. emission_ring_radius: outer radius of the ring/cylinder
3. emission_ring_inner_radius: inner radius of the cylinder.
    when set to zero, particles will emit in the full volume.
4. emission_ring_height: height of the ring/cylinder emitter.

This has already been implemented for 3.x, took me a while to get to 4.0. Apologies >.<

3.0 PR:https://github.com/godotengine/godot/pull/47801
