### PR TITLE
TextEdit cleanup and refactoring

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -645,7 +645,7 @@
 			The tint of text outline of the [CodeEdit].
 		</theme_item>
 		<theme_item name="font_readonly_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
-			Sets the font [Color] when [member TextEdit.readonly] is enabled.
+			Sets the font [Color] when [member TextEdit.editable] is disabled.
 		</theme_item>
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			Sets the [Color] of the selected text. [member TextEdit.override_selected_font_color] has to be enabled.
@@ -669,7 +669,7 @@
 			The size of the text outline.
 		</theme_item>
 		<theme_item name="read_only" data_type="style" type="StyleBox">
-			Sets the [StyleBox] when [member TextEdit.readonly] is enabled.
+			Sets the [StyleBox] when [member TextEdit.editable] is disabled.
 		</theme_item>
 		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 			Sets the highlight [Color] of text selections.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -13,13 +13,35 @@
 		<method name="_backspace" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				A virtual method that is called whenever backspace is triggered.
+				Overide this method to define what happens when the user presses the backspace key.
+			</description>
+		</method>
+		<method name="_copy" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<description>
+				Overide this method to define what happens when the user performs a copy.
+			</description>
+		</method>
+		<method name="_cut" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<description>
+				Overide this method to define what happens when the user perfroms a cut.
 			</description>
 		</method>
 		<method name="_handle_unicode_input" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="unicode" type="int" />
 			<description>
+				Overide this method to define what happens when the types in the provided key [code]unicode[/code].
+			</description>
+		</method>
+		<method name="_paste" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<description>
+				Overide this method to define what happens when the user perfroms a paste.
 			</description>
 		</method>
 		<method name="add_gutter">
@@ -31,7 +53,7 @@
 		<method name="backspace">
 			<return type="void" />
 			<description>
-				Causes the [TextEdit] to perform a backspace.
+				Called when the user presses the backspace key. Can be overriden with [method _backspace].
 			</description>
 		</method>
 		<method name="center_viewport_to_cursor">
@@ -55,7 +77,7 @@
 		<method name="copy">
 			<return type="void" />
 			<description>
-				Copy's the current text selection.
+				Copy's the current text selection. Can be overriden with [method _copy].
 			</description>
 		</method>
 		<method name="cursor_get_column" qualifiers="const">
@@ -94,7 +116,7 @@
 		<method name="cut">
 			<return type="void" />
 			<description>
-				Cut's the current selection.
+				Cut's the current selection. Can be overriden with [method _cut].
 			</description>
 		</method>
 		<method name="delete_selection">
@@ -351,7 +373,7 @@
 		<method name="paste">
 			<return type="void" />
 			<description>
-				Paste the current selection.
+				Paste the current selection. Can be overriden with [method _paste].
 			</description>
 		</method>
 		<method name="redo">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -688,6 +688,9 @@
 		<member name="draw_tabs" type="bool" setter="set_draw_tabs" getter="is_drawing_tabs" default="false">
 			If [code]true[/code], the "tab" character will have a visible representation.
 		</member>
+		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
+			If [code]false[/code], existing text cannot be modified and new text cannot be added.
+		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="highlight_all_occurrences" type="bool" setter="set_highlight_all_occurrences" getter="is_highlight_all_occurrences_enabled" default="false">
 			If [code]true[/code], all occurrences of the selected text will be highlighted.
@@ -707,9 +710,6 @@
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
 		<member name="override_selected_font_color" type="bool" setter="set_override_selected_font_color" getter="is_overriding_selected_font_color" default="false">
 			If [code]true[/code], custom [code]font_selected_color[/code] will be used for selected text.
-		</member>
-		<member name="readonly" type="bool" setter="set_readonly" getter="is_readonly" default="false">
-			If [code]true[/code], read-only mode is enabled. Existing text cannot be modified and new text cannot be added.
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			If there is a horizontal scrollbar, this determines the current horizontal scroll value in pixels.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -13,46 +13,43 @@
 		<method name="_backspace" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				Overide this method to define what happens when the user presses the backspace key.
+				Override this method to define what happens when the user presses the backspace key.
 			</description>
 		</method>
 		<method name="_copy" qualifiers="virtual">
-			<return type="void">
-			</return>
+			<return type="void" />
 			<description>
-				Overide this method to define what happens when the user performs a copy.
+				Override this method to define what happens when the user performs a copy operation.
 			</description>
 		</method>
 		<method name="_cut" qualifiers="virtual">
-			<return type="void">
-			</return>
+			<return type="void" />
 			<description>
-				Overide this method to define what happens when the user perfroms a cut.
+				Override this method to define what happens when the user performs a cut operation.
 			</description>
 		</method>
 		<method name="_handle_unicode_input" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="unicode" type="int" />
 			<description>
-				Overide this method to define what happens when the types in the provided key [code]unicode[/code].
+				Override this method to define what happens when the types in the provided key [code]unicode[/code].
 			</description>
 		</method>
 		<method name="_paste" qualifiers="virtual">
-			<return type="void">
-			</return>
+			<return type="void" />
 			<description>
-				Overide this method to define what happens when the user perfroms a paste.
+				Override this method to define what happens when the user performs a paste operation.
 			</description>
 		</method>
 		<method name="add_gutter">
 			<return type="void" />
 			<argument index="0" name="at" type="int" default="-1" />
 			<description>
+				Register a new gutter to this [TextEdit]. Use [code]at[/code] to have a specific gutter order. A value of [code]-1[/code] appends the gutter to the right.
 			</description>
 		</method>
 		<method name="adjust_viewport_to_caret">
-			<return type="void">
-			</return>
+			<return type="void" />
 			<description>
 				Adjust the viewport so the caret is visible.
 			</description>
@@ -60,14 +57,25 @@
 		<method name="backspace">
 			<return type="void" />
 			<description>
-				Called when the user presses the backspace key. Can be overriden with [method _backspace].
+				Called when the user presses the backspace key. Can be overridden with [method _backspace].
+			</description>
+		</method>
+		<method name="begin_complex_operation">
+			<return type="void" />
+			<description>
+				Starts a multipart edit. All edits will be treated as one action until [method end_complex_operation] is called.
 			</description>
 		</method>
 		<method name="center_viewport_to_caret">
-			<return type="void">
-			</return>
+			<return type="void" />
 			<description>
-				Centers the viewport on the line the editing cursor is at. This also resets the [member scroll_horizontal] value to [code]0[/code].
+				Centers the viewport on the line the editing caret is at. This also resets the [member scroll_horizontal] value to [code]0[/code].
+			</description>
+		</method>
+		<method name="clear">
+			<return type="void" />
+			<description>
+				Performs a full reset of [TextEdit], including undo history.
 			</description>
 		</method>
 		<method name="clear_opentype_features">
@@ -85,53 +93,53 @@
 		<method name="copy">
 			<return type="void" />
 			<description>
-				Copy's the current text selection. Can be overriden with [method _copy].
+				Copies the current text selection. Can be overridden with [method _copy].
 			</description>
 		</method>
 		<method name="cut">
-			<return type="void">
-			</return>
+			<return type="void" />
 			<description>
-				Cut's the current selection. Can be overriden with [method _cut].
+				Cut's the current selection. Can be overridden with [method _cut].
 			</description>
 		</method>
 		<method name="delete_selection">
-			<return type="void">
-			</return>
+			<return type="void" />
 			<description>
+				Deletes the selected text.
 			</description>
 		</method>
 		<method name="deselect">
-			<return type="void">
-			</return>
+			<return type="void" />
 			<description>
 				Deselects the current selection.
 			</description>
 		</method>
+		<method name="end_complex_operation">
+			<return type="void" />
+			<description>
+				Ends a multipart edit, started with [method begin_complex_operation]. If called outside a complex operation, the current operation is pushed onto the undo/redo stack.
+			</description>
+		</method>
 		<method name="get_caret_column" qualifiers="const">
-			<return type="int">
-			</return>
+			<return type="int" />
 			<description>
 				Returns the column the editing caret is at.
 			</description>
 		</method>
 		<method name="get_caret_draw_pos" qualifiers="const">
-			<return type="Vector2">
-			</return>
+			<return type="Vector2" />
 			<description>
-				Gets the caret pixel draw poistion.
+				Returns the caret pixel draw position.
 			</description>
 		</method>
 		<method name="get_caret_line" qualifiers="const">
-			<return type="int">
-			</return>
+			<return type="int" />
 			<description>
 				Returns the line the editing caret is on.
 			</description>
 		</method>
 		<method name="get_caret_wrap_index" qualifiers="const">
-			<return type="int">
-			</return>
+			<return type="int" />
 			<description>
 				Returns the wrap index the editing caret is on.
 			</description>
@@ -140,11 +148,11 @@
 			<return type="int" />
 			<argument index="0" name="line" type="int" />
 			<description>
+				Returns the first column containing a non-whitespace character.
 			</description>
 		</method>
 		<method name="get_first_visible_line" qualifiers="const">
-			<return type="int">
-			</return>
+			<return type="int" />
 			<description>
 				Returns the first visible line.
 			</description>
@@ -152,45 +160,53 @@
 		<method name="get_gutter_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the total amount of gutters registered.
 			</description>
 		</method>
 		<method name="get_gutter_name" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="gutter" type="int" />
 			<description>
+				Returns the name of the gutter at the given index.
 			</description>
 		</method>
 		<method name="get_gutter_type" qualifiers="const">
 			<return type="int" enum="TextEdit.GutterType" />
 			<argument index="0" name="gutter" type="int" />
 			<description>
+				Returns the type of the gutter at the given index.
 			</description>
 		</method>
 		<method name="get_gutter_width" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="gutter" type="int" />
 			<description>
+				Returns the width of the gutter at the given index.
 			</description>
 		</method>
 		<method name="get_indent_level" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="line" type="int" />
 			<description>
-				Returns the indent level of a specific line.
+				Returns the amount of spaces and [code]tab * tab_size[/code] before the first char.
 			</description>
 		</method>
 		<method name="get_last_full_visible_line" qualifiers="const">
-			<return type="int">
-			</return>
+			<return type="int" />
 			<description>
 				Return the last visible line. Use [method get_last_full_visible_line_wrap_index] for the wrap index.
 			</description>
 		</method>
 		<method name="get_last_full_visible_line_wrap_index" qualifiers="const">
-			<return type="int">
-			</return>
+			<return type="int" />
 			<description>
 				Returns the last visible wrap index of the last visible line.
+			</description>
+		</method>
+		<method name="get_last_unhidden_line" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the last unhidden line in the entire [TextEdit].
 			</description>
 		</method>
 		<method name="get_line" qualifiers="const">
@@ -200,11 +216,18 @@
 				Returns the text of a specific line.
 			</description>
 		</method>
-		<method name="get_line_background_color">
+		<method name="get_line_background_color" qualifiers="const">
 			<return type="Color" />
 			<argument index="0" name="line" type="int" />
 			<description>
 				Returns the current background color of the line. [code]Color(0, 0, 0, 0)[/code] is returned if no color is set.
+			</description>
+		</method>
+		<method name="get_line_column_at_pos" qualifiers="const">
+			<return type="Vector2i" />
+			<argument index="0" name="position" type="Vector2i" />
+			<description>
+				Returns the line and column at the given position. In the returned vector, [code]x[/code] is the column, [code]y[/code] is the line.
 			</description>
 		</method>
 		<method name="get_line_count" qualifiers="const">
@@ -218,13 +241,15 @@
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="gutter" type="int" />
 			<description>
+				Returns the icon currently in [code]gutter[/code] at [code]line[/code].
 			</description>
 		</method>
-		<method name="get_line_gutter_item_color">
+		<method name="get_line_gutter_item_color" qualifiers="const">
 			<return type="Color" />
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="gutter" type="int" />
 			<description>
+				Returns the color currently in [code]gutter[/code] at [code]line[/code].
 			</description>
 		</method>
 		<method name="get_line_gutter_metadata" qualifiers="const">
@@ -232,6 +257,7 @@
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="gutter" type="int" />
 			<description>
+				Returns the metadata currently in [code]gutter[/code] at [code]line[/code].
 			</description>
 		</method>
 		<method name="get_line_gutter_text" qualifiers="const">
@@ -239,35 +265,49 @@
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="gutter" type="int" />
 			<description>
+				Returns the text currently in [code]gutter[/code] at [code]line[/code].
+			</description>
+		</method>
+		<method name="get_line_height" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the height of a largest line.
+			</description>
+		</method>
+		<method name="get_line_width" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="wrap_index" type="int" default="-1" />
+			<description>
+				Returns the width in pixels of the [code]wrap_index[/code] on [code]line[/code].
 			</description>
 		</method>
 		<method name="get_line_wrap_count" qualifiers="const">
-			<return type="int">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
+			<return type="int" />
+			<argument index="0" name="line" type="int" />
 			<description>
-				Returns the number of the time given line is wrapped.
+				Returns the number of times the given line is wrapped.
 			</description>
 		</method>
 		<method name="get_line_wrap_index_at_column" qualifiers="const">
-			<return type="int">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
-			<argument index="1" name="column" type="int">
-			</argument>
+			<return type="int" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="column" type="int" />
 			<description>
 				Returns the wrap index of the given line column.
 			</description>
 		</method>
 		<method name="get_line_wrapped_text" qualifiers="const">
-			<return type="PackedStringArray">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
+			<return type="PackedStringArray" />
+			<argument index="0" name="line" type="int" />
 			<description>
-				Returns an array of [String] repersenting each wrapped index.
+				Returns an array of [String]s representing each wrapped index.
+			</description>
+		</method>
+		<method name="get_local_mouse_pos" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the local mouse position adjusted for the text direction.
 			</description>
 		</method>
 		<method name="get_menu" qualifiers="const">
@@ -276,11 +316,34 @@
 				Returns the [PopupMenu] of this [TextEdit]. By default, this menu is displayed when right-clicking on the [TextEdit].
 			</description>
 		</method>
-		<method name="get_minimap_visible_lines" qualifiers="const">
-			<return type="int">
-			</return>
+		<method name="get_minimap_line_at_pos" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="position" type="Vector2i" />
 			<description>
-				Gets the total amount of lines that can be draw on the minimap.
+				Returns the equivalent minimap line at [code]position[/code]
+			</description>
+		</method>
+		<method name="get_minimap_visible_lines" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total amount of lines that can be draw on the minimap.
+			</description>
+		</method>
+		<method name="get_next_visible_line_index_offset_from" qualifiers="const">
+			<return type="Vector2i" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="wrap_index" type="int" />
+			<argument index="2" name="visible_amount" type="int" />
+			<description>
+				Similar to [method get_next_visible_line_offset_from], but takes into account the line wrap indexes. In the returned vector, [code]x[/code] is the line, [code]y[/code] is the wrap index.
+			</description>
+		</method>
+		<method name="get_next_visible_line_offset_from" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="visible_amount" type="int" />
+			<description>
+				Returns the count to the next visible line from [code]line[/code] to [code]line + visible_amount[/code]. Can also count backwards. For example if a [TextEdit] has 5 lines with lines 2 and 3 hidden, calling this with [code]line = 1, visible_amount = 1[/code] would return 3.
 			</description>
 		</method>
 		<method name="get_opentype_feature" qualifiers="const">
@@ -290,27 +353,30 @@
 				Returns OpenType feature [code]tag[/code].
 			</description>
 		</method>
-		<method name="get_scroll_pos_for_line" qualifiers="const">
-			<return type="float">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
-			<argument index="1" name="wrap_index" type="int" default="0">
-			</argument>
+		<method name="get_saved_version" qualifiers="const">
+			<return type="int" />
 			<description>
-				Gets the scroll position for [code]wrap_index[/code] of [code]line[/code].
+				Returns the last tagged saved version from [method tag_saved_version]
+			</description>
+		</method>
+		<method name="get_scroll_pos_for_line" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="wrap_index" type="int" default="0" />
+			<description>
+				Returns the scroll position for [code]wrap_index[/code] of [code]line[/code].
 			</description>
 		</method>
 		<method name="get_selected_text" qualifiers="const">
-			<return type="String">
-			</return>
+			<return type="String" />
 			<description>
-				 Returns the text inside the selection.
+				Returns the text inside the selection.
 			</description>
 		</method>
 		<method name="get_selection_column" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the original start column of the selection.
 			</description>
 		</method>
 		<method name="get_selection_from_column" qualifiers="const">
@@ -328,11 +394,13 @@
 		<method name="get_selection_line" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the original start line of the selection.
 			</description>
 		</method>
 		<method name="get_selection_mode" qualifiers="const">
 			<return type="int" enum="TextEdit.SelectionMode" />
 			<description>
+				Returns the current selection mode.
 			</description>
 		</method>
 		<method name="get_selection_to_column" qualifiers="const">
@@ -356,13 +424,19 @@
 		<method name="get_total_gutter_width" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the total width of all gutters and internal padding.
 			</description>
 		</method>
 		<method name="get_total_visible_line_count" qualifiers="const">
-			<return type="int">
-			</return>
+			<return type="int" />
 			<description>
-				Gets the total amount of lines that could be draw.
+				Returns the total amount of lines that could be draw.
+			</description>
+		</method>
+		<method name="get_version" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the current version of the [TextEdit]. The version is a count of recorded operations by the undo/redo history.
 			</description>
 		</method>
 		<method name="get_visible_line_count" qualifiers="const">
@@ -371,25 +445,42 @@
 				Returns the number of visible lines, including wrapped text.
 			</description>
 		</method>
-		<method name="get_word_under_caret" qualifiers="const">
-			<return type="String">
-			</return>
+		<method name="get_word_at_pos" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="position" type="Vector2" />
 			<description>
-				Returns a [String] text with the word under the caret location.
+				Returns the word at [code]position[/code].
+			</description>
+		</method>
+		<method name="get_word_under_caret" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns a [String] text with the word under the caret's location.
+			</description>
+		</method>
+		<method name="has_ime_text" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns if the user has IME text.
 			</description>
 		</method>
 		<method name="has_selection" qualifiers="const">
-			<return type="bool">
-			</return>
+			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the user is has a selection.
+				Returns [code]true[/code] if the user has selected text.
+			</description>
+		</method>
+		<method name="insert_line_at">
+			<return type="void" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="text" type="String" />
+			<description>
+				Inserts a new line with [code]text[/code] at [code]line[/code].
 			</description>
 		</method>
 		<method name="insert_text_at_caret">
-			<return type="void">
-			</return>
-			<argument index="0" name="text" type="String">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="text" type="String" />
 			<description>
 				Insert the specified text at the caret position.
 			</description>
@@ -403,24 +494,28 @@
 		<method name="is_dragging_cursor" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Returns [code]true[/code] if the user is dragging their mouse for scrolling or selecting.
 			</description>
 		</method>
 		<method name="is_gutter_clickable" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="gutter" type="int" />
 			<description>
+				Returns whether the gutter is clickable.
 			</description>
 		</method>
 		<method name="is_gutter_drawn" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="gutter" type="int" />
 			<description>
+				Returns whether the gutter is currently drawn.
 			</description>
 		</method>
 		<method name="is_gutter_overwritable" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="gutter" type="int" />
 			<description>
+				Returns whether the gutter is overwritable.
 			</description>
 		</method>
 		<method name="is_line_gutter_clickable" qualifiers="const">
@@ -428,6 +523,14 @@
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="gutter" type="int" />
 			<description>
+				Returns whether the gutter on the given line is clickable.
+			</description>
+		</method>
+		<method name="is_line_wrapped" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="line" type="int" />
+			<description>
+				Returns if the given line is wrapped.
 			</description>
 		</method>
 		<method name="is_menu_visible" qualifiers="const">
@@ -436,20 +539,10 @@
 				Returns whether the menu is visible. Use this instead of [code]get_menu().visible[/code] to improve performance (so the creation of the menu is avoided).
 			</description>
 		</method>
-		<method name="is_line_wrapped" qualifiers="const">
-			<return type="bool">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
-			<description>
-				Returns if the given line is wrapped.
-			</description>
-		</method>
 		<method name="is_overtype_mode_enabled" qualifiers="const">
-			<return type="bool">
-			</return>
+			<return type="bool" />
 			<description>
-				Gets if the user is in overtype mode.
+				Returns whether the user is in overtype mode.
 			</description>
 		</method>
 		<method name="menu_option">
@@ -464,12 +557,13 @@
 			<argument index="0" name="from_line" type="int" />
 			<argument index="1" name="to_line" type="int" />
 			<description>
+				Merge the gutters from [code]from_line[/code] into [code]to_line[/code]. Only overwritable gutters will be copied.
 			</description>
 		</method>
 		<method name="paste">
 			<return type="void" />
 			<description>
-				Paste the current selection. Can be overriden with [method _paste].
+				Paste at the current location. Can be overridden with [method _paste].
 			</description>
 		</method>
 		<method name="redo">
@@ -482,32 +576,44 @@
 			<return type="void" />
 			<argument index="0" name="gutter" type="int" />
 			<description>
+				Removes the gutter from this [TextEdit].
+			</description>
+		</method>
+		<method name="remove_text">
+			<return type="void" />
+			<argument index="0" name="from_line" type="int" />
+			<argument index="1" name="from_column" type="int" />
+			<argument index="2" name="to_line" type="int" />
+			<argument index="3" name="to_column" type="int" />
+			<description>
+				Removes text between the given positions.
+				[b]Note:[/b]This does not adjust the caret or selection, which as a result it can end up in an invalid position.
 			</description>
 		</method>
 		<method name="search" qualifiers="const">
-			<return type="Dictionary" />
-			<argument index="0" name="key" type="String" />
+			<return type="Vector2i" />
+			<argument index="0" name="text" type="String" />
 			<argument index="1" name="flags" type="int" />
 			<argument index="2" name="from_line" type="int" />
-			<argument index="3" name="from_column" type="int" />
+			<argument index="3" name="from_colum" type="int" />
 			<description>
 				Perform a search inside the text. Search flags can be specified in the [enum SearchFlags] enum.
-				Returns an empty [code]Dictionary[/code] if no result was found. Otherwise, returns a [code]Dictionary[/code] containing [code]line[/code] and [code]column[/code] entries, e.g:
+				In the returned vector, [code]x[/code] is the column, [code]y[/code] is the line. If no results are found, both are equal to [code]-1[/code].
 				[codeblocks]
 				[gdscript]
 				var result = search("print", SEARCH_WHOLE_WORDS, 0, 0)
-				if !result.empty():
+				if  result.x != -1:
 				    # Result found.
-				    var line_number = result.line
-				    var column_number = result.column
+				    var line_number = result.y
+				    var column_number = result.x
 				[/gdscript]
 				[csharp]
-				int[] result = Search("print", (uint)TextEdit.SearchFlags.WholeWords, 0, 0);
+				Vector2i result = Search("print", (uint)TextEdit.SearchFlags.WholeWords, 0, 0);
 				if (result.Length &gt; 0)
 				{
 				    // Result found.
-				    int lineNumber = result[(int)TextEdit.SearchResult.Line];
-				    int columnNumber = result[(int)TextEdit.SearchResult.Column];
+				    int lineNumber = result.y;
+				    int columnNumber = result.x;
 				}
 				[/csharp]
 				[/codeblocks]
@@ -532,39 +638,30 @@
 			</description>
 		</method>
 		<method name="select_word_under_caret">
-			<return type="void">
-			</return>
+			<return type="void" />
 			<description>
 				Selects the word under the caret.
 			</description>
 		</method>
 		<method name="set_caret_column">
-			<return type="void">
-			</return>
-			<argument index="0" name="column" type="int">
-			</argument>
-			<argument index="1" name="adjust_viewport" type="bool" default="true">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="column" type="int" />
+			<argument index="1" name="adjust_viewport" type="bool" default="true" />
 			<description>
 				Moves the caret to the specified [code]column[/code] index.
-				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the caret position after the move occurs.
+				If [code]adjust_viewport[/code] is [code]true[/code], the viewport will center at the caret position after the move occurs.
 			</description>
 		</method>
 		<method name="set_caret_line">
-			<return type="void">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
-			<argument index="1" name="adjust_viewport" type="bool" default="true">
-			</argument>
-			<argument index="2" name="can_be_hidden" type="bool" default="true">
-			</argument>
-			<argument index="3" name="wrap_index" type="int" default="0">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="adjust_viewport" type="bool" default="true" />
+			<argument index="2" name="can_be_hidden" type="bool" default="true" />
+			<argument index="3" name="wrap_index" type="int" default="0" />
 			<description>
 				Moves the caret to the specified [code]line[/code] index.
-				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the caret position after the move occurs.
-				If [code]can_be_hidden[/code] is set to [code]true[/code], the specified [code]line[/code] can be hidden.
+				If [code]adjust_viewport[/code] is [code]true[/code], the viewport will center at the caret position after the move occurs.
+				If [code]can_be_hidden[/code] is [code]true[/code], the specified [code]line[/code] can be hidden.
 			</description>
 		</method>
 		<method name="set_gutter_clickable">
@@ -572,6 +669,7 @@
 			<argument index="0" name="gutter" type="int" />
 			<argument index="1" name="clickable" type="bool" />
 			<description>
+				Sets the gutter as clickable. This will change the mouse cursor to a pointing hand when hovering over the gutter.
 			</description>
 		</method>
 		<method name="set_gutter_custom_draw">
@@ -580,6 +678,7 @@
 			<argument index="1" name="object" type="Object" />
 			<argument index="2" name="callback" type="StringName" />
 			<description>
+				Set a custom draw method for the gutter. The callback method must take the following args: [code]line: int, gutter: int, Area: Rect2[/code].
 			</description>
 		</method>
 		<method name="set_gutter_draw">
@@ -587,6 +686,7 @@
 			<argument index="0" name="gutter" type="int" />
 			<argument index="1" name="draw" type="bool" />
 			<description>
+				Sets whether the gutter should be drawn.
 			</description>
 		</method>
 		<method name="set_gutter_name">
@@ -594,6 +694,7 @@
 			<argument index="0" name="gutter" type="int" />
 			<argument index="1" name="name" type="String" />
 			<description>
+				Sets the name of the gutter.
 			</description>
 		</method>
 		<method name="set_gutter_overwritable">
@@ -601,6 +702,7 @@
 			<argument index="0" name="gutter" type="int" />
 			<argument index="1" name="overwritable" type="bool" />
 			<description>
+				Sets the gutter to overwritable. See [method merge_gutters].
 			</description>
 		</method>
 		<method name="set_gutter_type">
@@ -608,6 +710,7 @@
 			<argument index="0" name="gutter" type="int" />
 			<argument index="1" name="type" type="int" enum="TextEdit.GutterType" />
 			<description>
+				Sets the type of gutter.
 			</description>
 		</method>
 		<method name="set_gutter_width">
@@ -615,6 +718,7 @@
 			<argument index="0" name="gutter" type="int" />
 			<argument index="1" name="width" type="int" />
 			<description>
+				Set the width of the gutter.
 			</description>
 		</method>
 		<method name="set_line">
@@ -626,34 +730,25 @@
 			</description>
 		</method>
 		<method name="set_line_as_center_visible">
-			<return type="void">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
-			<argument index="1" name="wrap_index" type="int" default="0">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="wrap_index" type="int" default="0" />
 			<description>
 				Positions the [code]wrap_index[/code] of [code]line[/code] at the center of the viewport.
 			</description>
 		</method>
 		<method name="set_line_as_first_visible">
-			<return type="void">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
-			<argument index="1" name="wrap_index" type="int" default="0">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="wrap_index" type="int" default="0" />
 			<description>
 				Positions the [code]wrap_index[/code] of [code]line[/code] at the top of the viewport.
 			</description>
 		</method>
 		<method name="set_line_as_last_visible">
-			<return type="void">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
-			<argument index="1" name="wrap_index" type="int" default="0">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="wrap_index" type="int" default="0" />
 			<description>
 				Positions the [code]wrap_index[/code] of [code]line[/code] at the bottom of the viewport.
 			</description>
@@ -672,6 +767,7 @@
 			<argument index="1" name="gutter" type="int" />
 			<argument index="2" name="clickable" type="bool" />
 			<description>
+				Sets the [code]gutter[/code] on [code]line[/code] as clickable.
 			</description>
 		</method>
 		<method name="set_line_gutter_icon">
@@ -680,6 +776,7 @@
 			<argument index="1" name="gutter" type="int" />
 			<argument index="2" name="icon" type="Texture2D" />
 			<description>
+				Sets the icon for [code]gutter[/code] on [code]line[/code].
 			</description>
 		</method>
 		<method name="set_line_gutter_item_color">
@@ -688,6 +785,7 @@
 			<argument index="1" name="gutter" type="int" />
 			<argument index="2" name="color" type="Color" />
 			<description>
+				Sets the color for [code]gutter[/code] on [code]line[/code].
 			</description>
 		</method>
 		<method name="set_line_gutter_metadata">
@@ -696,6 +794,7 @@
 			<argument index="1" name="gutter" type="int" />
 			<argument index="2" name="metadata" type="Variant" />
 			<description>
+				Sets the metadata for [code]gutter[/code] on [code]line[/code].
 			</description>
 		</method>
 		<method name="set_line_gutter_text">
@@ -704,6 +803,7 @@
 			<argument index="1" name="gutter" type="int" />
 			<argument index="2" name="text" type="String" />
 			<description>
+				Sets the text for [code]gutter[/code] on [code]line[/code].
 			</description>
 		</method>
 		<method name="set_opentype_feature">
@@ -715,12 +815,24 @@
 			</description>
 		</method>
 		<method name="set_overtype_mode_enabled">
-			<return type="void">
-			</return>
-			<argument index="0" name="enabled" type="bool">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="enabled" type="bool" />
 			<description>
-				If [code]True[/code] set the user into overtype mode. When the user types it will override existing text.
+				If [code]true[/code], sets the user into overtype mode. When the user types in this mode, it will override existing text.
+			</description>
+		</method>
+		<method name="set_search_flags">
+			<return type="void" />
+			<argument index="0" name="flags" type="int" />
+			<description>
+				Sets the search flags. This is used with [method set_search_text] to highlight occurrences of the searched text. Search flags can be specified from the [enum SearchFlags] enum.
+			</description>
+		</method>
+		<method name="set_search_text">
+			<return type="void" />
+			<argument index="0" name="search_text" type="String" />
+			<description>
+				Sets the search text. See [method set_search_flags].
 			</description>
 		</method>
 		<method name="set_selection_mode">
@@ -729,6 +841,7 @@
 			<argument index="1" name="line" type="int" default="-1" />
 			<argument index="2" name="column" type="int" default="-1" />
 			<description>
+				Sets the current selection mode.
 			</description>
 		</method>
 		<method name="set_tab_size">
@@ -736,6 +849,29 @@
 			<argument index="0" name="size" type="int" />
 			<description>
 				Sets the tab size for the [TextEdit] to use.
+			</description>
+		</method>
+		<method name="set_tooltip_request_func">
+			<return type="void" />
+			<argument index="0" name="object" type="Object" />
+			<argument index="1" name="callback" type="StringName" />
+			<argument index="2" name="data" type="Variant" />
+			<description>
+				Provide custom tooltip text. The callback method must take the following args: [code]hovered_word: String, data: Variant[/code]
+			</description>
+		</method>
+		<method name="swap_lines">
+			<return type="void" />
+			<argument index="0" name="from_line" type="int" />
+			<argument index="1" name="to_line" type="int" />
+			<description>
+				Swaps the two lines.
+			</description>
+		</method>
+		<method name="tag_saved_version">
+			<return type="void" />
+			<description>
+				Tag the current version as saved.
 			</description>
 		</method>
 		<method name="undo">
@@ -804,6 +940,12 @@
 		<member name="scroll_past_end_of_file" type="bool" setter="set_scroll_past_end_of_file_enabled" getter="is_scroll_past_end_of_file_enabled" default="false">
 			Allow scrolling past the last line into "virtual" space.
 		</member>
+		<member name="scroll_smooth" type="bool" setter="set_smooth_scroll_enable" getter="is_smooth_scroll_enabled" default="false">
+			Scroll smoothly over the text rather then jumping to the next location.
+		</member>
+		<member name="scroll_v_scroll_speed" type="float" setter="set_v_scroll_speed" getter="get_v_scroll_speed" default="80.0">
+			Sets the scroll speed with the minimap or when [member scroll_smooth] is enabled.
+		</member>
 		<member name="scroll_vertical" type="float" setter="set_v_scroll" getter="get_v_scroll" default="0.0">
 			If there is a vertical scrollbar, this determines the current vertical scroll value in line numbers, starting at 0 for the top line.
 		</member>
@@ -813,9 +955,6 @@
 		</member>
 		<member name="shortcut_keys_enabled" type="bool" setter="set_shortcut_keys_enabled" getter="is_shortcut_keys_enabled" default="true">
 			If [code]true[/code], shortcut keys for context menu items are enabled, even if the context menu is disabled.
-		</member>
-		<member name="smooth_scrolling" type="bool" setter="set_smooth_scroll_enable" getter="is_smooth_scroll_enabled" default="false">
-			If [code]true[/code], sets the [code]step[/code] of the scrollbars to [code]0.25[/code] which results in smoother scrolling.
 		</member>
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="Control.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
@@ -832,9 +971,6 @@
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="Control.TextDirection" default="0">
 			Base text writing direction.
 		</member>
-		<member name="v_scroll_speed" type="float" setter="set_v_scroll_speed" getter="get_v_scroll_speed" default="80.0">
-			Vertical scroll sensitivity.
-		</member>
 		<member name="virtual_keyboard_enabled" type="bool" setter="set_virtual_keyboard_enabled" getter="is_virtual_keyboard_enabled" default="true">
 			If [code]true[/code], the native virtual keyboard is shown when focused on platforms that support it.
 		</member>
@@ -850,22 +986,27 @@
 		</signal>
 		<signal name="gutter_added">
 			<description>
+				Emitted when a gutter is added.
 			</description>
 		</signal>
 		<signal name="gutter_clicked">
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="gutter" type="int" />
 			<description>
+				Emitted when a gutter is clicked.
 			</description>
 		</signal>
 		<signal name="gutter_removed">
 			<description>
+				Emitted when a gutter is removed.
 			</description>
 		</signal>
 		<signal name="lines_edited_from">
 			<argument index="0" name="from_line" type="int" />
 			<argument index="1" name="to_line" type="int" />
 			<description>
+				Emitted immediately when the text changes.
+				When text is added [code]from_line[/code] will be less then [code]to_line[/code]. On a remove [code]to_line[/code] will be less then [code]from_line[/code].
 			</description>
 		</signal>
 		<signal name="text_changed">
@@ -875,43 +1016,6 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="SEARCH_MATCH_CASE" value="1" enum="SearchFlags">
-			Match case when searching.
-		</constant>
-		<constant name="SEARCH_WHOLE_WORDS" value="2" enum="SearchFlags">
-			Match whole words when searching.
-		</constant>
-		<constant name="SEARCH_BACKWARDS" value="4" enum="SearchFlags">
-			Search from end to beginning.
-		</constant>
-		<constant name="CARET_TYPE_LINE" value="0" enum="CaretType">
-			Vertical line caret.
-		</constant>
-		<constant name="CARET_TYPE_BLOCK" value="1" enum="CaretType">
-			Block caret.
-		</constant>
-		<constant name="SELECTION_MODE_NONE" value="0" enum="SelectionMode">
-		</constant>
-		<constant name="SELECTION_MODE_SHIFT" value="1" enum="SelectionMode">
-		</constant>
-		<constant name="SELECTION_MODE_POINTER" value="2" enum="SelectionMode">
-		</constant>
-		<constant name="SELECTION_MODE_WORD" value="3" enum="SelectionMode">
-		</constant>
-		<constant name="SELECTION_MODE_LINE" value="4" enum="SelectionMode">
-		</constant>
-		<constant name="LINE_WRAPPING_NONE" value="0" enum="LineWrappingMode">
-			Line wrapping is disabled.
-		</constant>
-		<constant name="LINE_WRAPPING_BOUNDARY" value="1" enum="LineWrappingMode">
-			Line wrapping occurs at the control boundary, beyond what would normally be visible.
-		</constant>
-		<constant name="GUTTER_TYPE_STRING" value="0" enum="GutterType">
-		</constant>
-		<constant name="GUTTER_TYPE_ICON" value="1" enum="GutterType">
-		</constant>
-		<constant name="GUTTER_TYPE_CUSTOM" value="2" enum="GutterType">
-		</constant>
 		<constant name="MENU_CUT" value="0" enum="MenuItems">
 			Cuts (copies and clears) the selected text.
 		</constant>
@@ -999,13 +1103,58 @@
 		<constant name="MENU_MAX" value="28" enum="MenuItems">
 			Represents the size of the [enum MenuItems] enum.
 		</constant>
+		<constant name="SEARCH_MATCH_CASE" value="1" enum="SearchFlags">
+			Match case when searching.
+		</constant>
+		<constant name="SEARCH_WHOLE_WORDS" value="2" enum="SearchFlags">
+			Match whole words when searching.
+		</constant>
+		<constant name="SEARCH_BACKWARDS" value="4" enum="SearchFlags">
+			Search from end to beginning.
+		</constant>
+		<constant name="CARET_TYPE_LINE" value="0" enum="CaretType">
+			Vertical line caret.
+		</constant>
+		<constant name="CARET_TYPE_BLOCK" value="1" enum="CaretType">
+			Block caret.
+		</constant>
+		<constant name="SELECTION_MODE_NONE" value="0" enum="SelectionMode">
+			Not selecting.
+		</constant>
+		<constant name="SELECTION_MODE_SHIFT" value="1" enum="SelectionMode">
+			Select as if [code]shift[/code] is pressed.
+		</constant>
+		<constant name="SELECTION_MODE_POINTER" value="2" enum="SelectionMode">
+			Select single characters as if the user single clicked.
+		</constant>
+		<constant name="SELECTION_MODE_WORD" value="3" enum="SelectionMode">
+			Select whole words as if the user double clicked.
+		</constant>
+		<constant name="SELECTION_MODE_LINE" value="4" enum="SelectionMode">
+			Select whole lines as if the user tripped clicked.
+		</constant>
+		<constant name="LINE_WRAPPING_NONE" value="0" enum="LineWrappingMode">
+			Line wrapping is disabled.
+		</constant>
+		<constant name="LINE_WRAPPING_BOUNDARY" value="1" enum="LineWrappingMode">
+			Line wrapping occurs at the control boundary, beyond what would normally be visible.
+		</constant>
+		<constant name="GUTTER_TYPE_STRING" value="0" enum="GutterType">
+			Draw a string.
+		</constant>
+		<constant name="GUTTER_TYPE_ICON" value="1" enum="GutterType">
+			Draw an icon.
+		</constant>
+		<constant name="GUTTER_TYPE_CUSTOM" value="2" enum="GutterType">
+			Custom draw.
+		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="background_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			Sets the background [Color] of this [TextEdit].
 		</theme_item>
 		<theme_item name="caret_background_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
-			[Color] of the text behind the caret when block caret is enabled.
+			[Color] of the text behind the caret when using a block caret.
 		</theme_item>
 		<theme_item name="caret_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			[Color] of the caret.
@@ -1026,7 +1175,7 @@
 			The tint of text outline of the [TextEdit].
 		</theme_item>
 		<theme_item name="font_readonly_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
-			Sets the font [Color] when [member readonly] is enabled.
+			Sets the font [Color] when [member editable] is disabled.
 		</theme_item>
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			Sets the [Color] of the selected text. [member override_selected_font_color] has to be enabled.
@@ -1044,7 +1193,7 @@
 			The size of the text outline.
 		</theme_item>
 		<theme_item name="read_only" data_type="style" type="StyleBox">
-			Sets the [StyleBox] of this [TextEdit] when [member readonly] is enabled.
+			Sets the [StyleBox] of this [TextEdit] when [member editable] is disabled.
 		</theme_item>
 		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 			Sets the highlight [Color] of text selections.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -56,8 +56,9 @@
 				Called when the user presses the backspace key. Can be overriden with [method _backspace].
 			</description>
 		</method>
-		<method name="center_viewport_to_cursor">
-			<return type="void" />
+		<method name="center_viewport_to_caret">
+			<return type="void">
+			</return>
 			<description>
 				Centers the viewport on the line the editing cursor is at. This also resets the [member scroll_horizontal] value to [code]0[/code].
 			</description>
@@ -80,60 +81,52 @@
 				Copy's the current text selection. Can be overriden with [method _copy].
 			</description>
 		</method>
-		<method name="cursor_get_column" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the column the editing cursor is at.
-			</description>
-		</method>
-		<method name="cursor_get_line" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the line the editing cursor is at.
-			</description>
-		</method>
-		<method name="cursor_set_column">
-			<return type="void" />
-			<argument index="0" name="column" type="int" />
-			<argument index="1" name="adjust_viewport" type="bool" default="true" />
-			<description>
-				Moves the cursor at the specified [code]column[/code] index.
-				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the cursor position after the move occurs.
-			</description>
-		</method>
-		<method name="cursor_set_line">
-			<return type="void" />
-			<argument index="0" name="line" type="int" />
-			<argument index="1" name="adjust_viewport" type="bool" default="true" />
-			<argument index="2" name="can_be_hidden" type="bool" default="true" />
-			<argument index="3" name="wrap_index" type="int" default="0" />
-			<description>
-				Moves the cursor at the specified [code]line[/code] index.
-				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the cursor position after the move occurs.
-				If [code]can_be_hidden[/code] is set to [code]true[/code], the specified [code]line[/code] can be hidden.
-			</description>
-		</method>
 		<method name="cut">
-			<return type="void" />
+			<return type="void">
+			</return>
 			<description>
 				Cut's the current selection. Can be overriden with [method _cut].
 			</description>
 		</method>
 		<method name="delete_selection">
-			<return type="void" />
+			<return type="void">
+			</return>
 			<description>
 			</description>
 		</method>
 		<method name="deselect">
-			<return type="void" />
+			<return type="void">
+			</return>
 			<description>
 				Deselects the current selection.
 			</description>
 		</method>
-		<method name="get_caret_draw_pos" qualifiers="const">
-			<return type="Vector2" />
+		<method name="get_caret_column" qualifiers="const">
+			<return type="int">
+			</return>
 			<description>
-				Gets the caret pixel draw position.
+				Returns the column the editing caret is at.
+			</description>
+		</method>
+		<method name="get_caret_draw_pos" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<description>
+				Gets the caret pixel draw poistion.
+			</description>
+		</method>
+		<method name="get_caret_line" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the line the editing caret is on.
+			</description>
+		</method>
+		<method name="get_caret_wrap_index" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the wrap index the editing caret is on.
 			</description>
 		</method>
 		<method name="get_first_non_whitespace_column" qualifiers="const">
@@ -295,17 +288,20 @@
 				Returns the number of visible lines, including wrapped text.
 			</description>
 		</method>
-		<method name="get_word_under_cursor" qualifiers="const">
-			<return type="String" />
+		<method name="get_word_under_caret" qualifiers="const">
+			<return type="String">
+			</return>
 			<description>
-				Returns a [String] text with the word under the caret (text cursor) location.
+				Returns a [String] text with the word under the caret location.
 			</description>
 		</method>
-		<method name="insert_text_at_cursor">
-			<return type="void" />
-			<argument index="0" name="text" type="String" />
+		<method name="insert_text_at_caret">
+			<return type="void">
+			</return>
+			<argument index="0" name="text" type="String">
+			</argument>
 			<description>
-				Insert the specified text at the cursor position.
+				Insert the specified text at the caret position.
 			</description>
 		</method>
 		<method name="is_caret_visible" qualifiers="const">
@@ -433,6 +429,35 @@
 			<description>
 				Select all the text.
 				If [member selecting_enabled] is [code]false[/code], no selection will occur.
+			</description>
+		</method>
+		<method name="set_caret_column">
+			<return type="void">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<argument index="1" name="adjust_viewport" type="bool" default="true">
+			</argument>
+			<description>
+				Moves the caret to the specified [code]column[/code] index.
+				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the caret position after the move occurs.
+			</description>
+		</method>
+		<method name="set_caret_line">
+			<return type="void">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="adjust_viewport" type="bool" default="true">
+			</argument>
+			<argument index="2" name="can_be_hidden" type="bool" default="true">
+			</argument>
+			<argument index="3" name="wrap_index" type="int" default="0">
+			</argument>
+			<description>
+				Moves the caret to the specified [code]line[/code] index.
+				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the caret position after the move occurs.
+				If [code]can_be_hidden[/code] is set to [code]true[/code], the specified [code]line[/code] can be hidden.
 			</description>
 		</method>
 		<method name="set_gutter_clickable">
@@ -572,23 +597,22 @@
 		</method>
 	</methods>
 	<members>
-		<member name="caret_blink" type="bool" setter="cursor_set_blink_enabled" getter="cursor_get_blink_enabled" default="false">
-			If [code]true[/code], the caret (visual cursor) blinks.
+		<member name="caret_blink" type="bool" setter="set_caret_blink_enabled" getter="is_caret_blink_enabled" default="false">
+			Sets if the caret should blink.
 		</member>
-		<member name="caret_blink_speed" type="float" setter="cursor_set_blink_speed" getter="cursor_get_blink_speed" default="0.65">
+		<member name="caret_blink_speed" type="float" setter="set_caret_blink_speed" getter="get_caret_blink_speed" default="0.65">
 			Duration (in seconds) of a caret's blinking cycle.
 		</member>
-		<member name="caret_block_mode" type="bool" setter="cursor_set_block_mode" getter="cursor_is_block_mode" default="false">
-			If [code]true[/code], the caret displays as a rectangle.
-			If [code]false[/code], the caret displays as a bar.
-		</member>
-		<member name="caret_mid_grapheme" type="bool" setter="set_mid_grapheme_caret_enabled" getter="get_mid_grapheme_caret_enabled" default="false">
+		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="false">
 			Allow moving caret, selecting and removing the individual composite character components.
 			Note: [kbd]Backspace[/kbd] is always removing individual composite character components.
 		</member>
-		<member name="caret_moving_by_right_click" type="bool" setter="set_right_click_moves_caret" getter="is_right_click_moving_caret" default="true">
-			If [code]true[/code], a right-click moves the cursor at the mouse position before displaying the context menu.
+		<member name="caret_move_on_right_click" type="bool" setter="set_move_caret_on_right_click_enabled" getter="is_move_caret_on_right_click_enabled" default="true">
+			If [code]true[/code], a right-click moves the caret at the mouse position before displaying the context menu.
 			If [code]false[/code], the context menu disregards mouse location.
+		</member>
+		<member name="caret_type" type="int" setter="set_caret_type" getter="get_caret_type" enum="TextEdit.CaretType" default="0">
+			Set the type of caret to draw.
 		</member>
 		<member name="context_menu_enabled" type="bool" setter="set_context_menu_enabled" getter="is_context_menu_enabled" default="true">
 			If [code]true[/code], a right-click displays the context menu.
@@ -667,9 +691,9 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="cursor_changed">
+		<signal name="caret_changed">
 			<description>
-				Emitted when the cursor changes.
+				Emitted when the caret changes position.
 			</description>
 		</signal>
 		<signal name="gutter_added">
@@ -707,6 +731,12 @@
 		</constant>
 		<constant name="SEARCH_BACKWARDS" value="4" enum="SearchFlags">
 			Search from end to beginning.
+		</constant>
+		<constant name="CARET_TYPE_LINE" value="0" enum="CaretType">
+			Vertical line caret.
+		</constant>
+		<constant name="CARET_TYPE_BLOCK" value="1" enum="CaretType">
+			Block caret.
 		</constant>
 		<constant name="SELECTION_MODE_NONE" value="0" enum="SelectionMode">
 		</constant>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -213,6 +213,35 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_line_wrap_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<description>
+				Returns the number of the time given line is wrapped.
+			</description>
+		</method>
+		<method name="get_line_wrap_index_at_column" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="column" type="int">
+			</argument>
+			<description>
+				Returns the wrap index of the given line column.
+			</description>
+		</method>
+		<method name="get_line_wrapped_text" qualifiers="const">
+			<return type="PackedStringArray">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<description>
+				Returns an array of [String] repersenting each wrapped index.
+			</description>
+		</method>
 		<method name="get_menu" qualifiers="const">
 			<return type="PopupMenu" />
 			<description>
@@ -344,6 +373,15 @@
 			<return type="bool" />
 			<description>
 				Returns whether the menu is visible. Use this instead of [code]get_menu().visible[/code] to improve performance (so the creation of the menu is avoided).
+			</description>
+		</method>
+		<method name="is_line_wrapped" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<description>
+				Returns if the given line is wrapped.
 			</description>
 		</method>
 		<method name="is_selection_active" qualifiers="const">
@@ -686,8 +724,8 @@
 		<member name="virtual_keyboard_enabled" type="bool" setter="set_virtual_keyboard_enabled" getter="is_virtual_keyboard_enabled" default="true">
 			If [code]true[/code], the native virtual keyboard is shown when focused on platforms that support it.
 		</member>
-		<member name="wrap_enabled" type="bool" setter="set_wrap_enabled" getter="is_wrap_enabled" default="false">
-			If [code]true[/code], enables text wrapping when it goes beyond the edge of what is visible.
+		<member name="wrap_mode" type="int" setter="set_line_wrapping_mode" getter="get_line_wrapping_mode" enum="TextEdit.LineWrappingMode" default="0">
+			Sets the line wrapping mode to use.
 		</member>
 	</members>
 	<signals>
@@ -747,6 +785,12 @@
 		<constant name="SELECTION_MODE_WORD" value="3" enum="SelectionMode">
 		</constant>
 		<constant name="SELECTION_MODE_LINE" value="4" enum="SelectionMode">
+		</constant>
+		<constant name="LINE_WRAPPING_NONE" value="0" enum="LineWrappingMode">
+			Line wrapping is disabled.
+		</constant>
+		<constant name="LINE_WRAPPING_BOUNDARY" value="1" enum="LineWrappingMode">
+			Line wrapping occurs at the control boundary, beyond what would normally be visible.
 		</constant>
 		<constant name="GUTTER_TYPE_STRING" value="0" enum="GutterType">
 		</constant>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -391,6 +391,13 @@
 				Returns if the given line is wrapped.
 			</description>
 		</method>
+		<method name="is_overtype_mode_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Gets if the user is in overtype mode.
+			</description>
+		</method>
 		<method name="menu_option">
 			<return type="void" />
 			<argument index="0" name="option" type="int" />
@@ -618,6 +625,15 @@
 			<argument index="1" name="value" type="int" />
 			<description>
 				Sets OpenType feature [code]tag[/code]. More info: [url=https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags]OpenType feature tags[/url].
+			</description>
+		</method>
+		<method name="set_overtype_mode_enabled">
+			<return type="void">
+			</return>
+			<argument index="0" name="enabled" type="bool">
+			</argument>
+			<description>
+				If [code]True[/code] set the user into overtype mode. When the user types it will override existing text.
 			</description>
 		</method>
 		<method name="set_selection_mode">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -324,6 +324,13 @@
 				Returns a [String] text with the word under the caret location.
 			</description>
 		</method>
+		<method name="has_selection" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the user is has a selection.
+			</description>
+		</method>
 		<method name="insert_text_at_caret">
 			<return type="void">
 			</return>
@@ -382,12 +389,6 @@
 			</argument>
 			<description>
 				Returns if the given line is wrapped.
-			</description>
-		</method>
-		<method name="is_selection_active" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if the selection is active.
 			</description>
 		</method>
 		<method name="menu_option">
@@ -467,6 +468,13 @@
 			<description>
 				Select all the text.
 				If [member selecting_enabled] is [code]false[/code], no selection will occur.
+			</description>
+		</method>
+		<method name="select_word_under_caret">
+			<return type="void">
+			</return>
+			<description>
+				Selects the word under the caret.
 			</description>
 		</method>
 		<method name="set_caret_column">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -50,6 +50,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="adjust_viewport_to_caret">
+			<return type="void">
+			</return>
+			<description>
+				Adjust the viewport so the caret is visible.
+			</description>
+		</method>
 		<method name="backspace">
 			<return type="void" />
 			<description>
@@ -135,6 +142,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_first_visible_line" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the first visible line.
+			</description>
+		</method>
 		<method name="get_gutter_count" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -163,6 +177,20 @@
 			<argument index="0" name="line" type="int" />
 			<description>
 				Returns the indent level of a specific line.
+			</description>
+		</method>
+		<method name="get_last_full_visible_line" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the last visible line. Use [method get_last_full_visible_line_wrap_index] for the wrap index.
+			</description>
+		</method>
+		<method name="get_last_full_visible_line_wrap_index" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the last visible wrap index of the last visible line.
 			</description>
 		</method>
 		<method name="get_line" qualifiers="const">
@@ -248,11 +276,36 @@
 				Returns the [PopupMenu] of this [TextEdit]. By default, this menu is displayed when right-clicking on the [TextEdit].
 			</description>
 		</method>
+		<method name="get_minimap_visible_lines" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Gets the total amount of lines that can be draw on the minimap.
+			</description>
+		</method>
 		<method name="get_opentype_feature" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="tag" type="String" />
 			<description>
 				Returns OpenType feature [code]tag[/code].
+			</description>
+		</method>
+		<method name="get_scroll_pos_for_line" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="wrap_index" type="int" default="0">
+			</argument>
+			<description>
+				Gets the scroll position for [code]wrap_index[/code] of [code]line[/code].
+			</description>
+		</method>
+		<method name="get_selected_text" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				 Returns the text inside the selection.
 			</description>
 		</method>
 		<method name="get_selection_column" qualifiers="const">
@@ -282,12 +335,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_selection_text" qualifiers="const">
-			<return type="String" />
-			<description>
-				Returns the text inside the selection.
-			</description>
-		</method>
 		<method name="get_selection_to_column" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -309,6 +356,13 @@
 		<method name="get_total_gutter_width" qualifiers="const">
 			<return type="int" />
 			<description>
+			</description>
+		</method>
+		<method name="get_total_visible_line_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Gets the total amount of lines that could be draw.
 			</description>
 		</method>
 		<method name="get_visible_line_count" qualifiers="const">
@@ -571,6 +625,39 @@
 				Sets the text for a specific line.
 			</description>
 		</method>
+		<method name="set_line_as_center_visible">
+			<return type="void">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="wrap_index" type="int" default="0">
+			</argument>
+			<description>
+				Positions the [code]wrap_index[/code] of [code]line[/code] at the center of the viewport.
+			</description>
+		</method>
+		<method name="set_line_as_first_visible">
+			<return type="void">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="wrap_index" type="int" default="0">
+			</argument>
+			<description>
+				Positions the [code]wrap_index[/code] of [code]line[/code] at the top of the viewport.
+			</description>
+		</method>
+		<method name="set_line_as_last_visible">
+			<return type="void">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="wrap_index" type="int" default="0">
+			</argument>
+			<description>
+				Positions the [code]wrap_index[/code] of [code]line[/code] at the bottom of the viewport.
+			</description>
+		</method>
 		<method name="set_line_background_color">
 			<return type="void" />
 			<argument index="0" name="line" type="int" />
@@ -713,6 +800,9 @@
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			If there is a horizontal scrollbar, this determines the current horizontal scroll value in pixels.
+		</member>
+		<member name="scroll_past_end_of_file" type="bool" setter="set_scroll_past_end_of_file_enabled" getter="is_scroll_past_end_of_file_enabled" default="false">
+			Allow scrolling past the last line into "virtual" space.
 		</member>
 		<member name="scroll_vertical" type="float" setter="set_v_scroll" getter="get_v_scroll" default="0.0">
 			If there is a vertical scrollbar, this determines the current vertical scroll value in line numbers, starting at 0 for the top line.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -950,7 +950,7 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_draw_bookmarks_gutter(EditorSettings::get_singleton()->get("text_editor/appearance/show_bookmark_gutter"));
 	text_editor->set_line_folding_enabled(EditorSettings::get_singleton()->get("text_editor/appearance/code_folding"));
 	text_editor->set_draw_fold_gutter(EditorSettings::get_singleton()->get("text_editor/appearance/code_folding"));
-	text_editor->set_wrap_enabled(EditorSettings::get_singleton()->get("text_editor/appearance/word_wrap"));
+	text_editor->set_line_wrapping_mode((TextEdit::LineWrappingMode)EditorSettings::get_singleton()->get("text_editor/appearance/word_wrap").operator int());
 	text_editor->set_scroll_pass_end_of_file(EditorSettings::get_singleton()->get("text_editor/cursor/scroll_past_end_of_file"));
 	text_editor->set_caret_type((TextEdit::CaretType)EditorSettings::get_singleton()->get("text_editor/cursor/type").operator int());
 	text_editor->set_caret_blink_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink"));

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -44,7 +44,7 @@
 void GotoLineDialog::popup_find_line(CodeEdit *p_edit) {
 	text_editor = p_edit;
 
-	line->set_text(itos(text_editor->cursor_get_line()));
+	line->set_text(itos(text_editor->get_caret_line()));
 	line->select_all();
 	popup_centered(Size2(180, 80) * EDSCALE);
 	line->grab_focus();
@@ -59,7 +59,7 @@ void GotoLineDialog::ok_pressed() {
 		return;
 	}
 	text_editor->unfold_line(get_line() - 1);
-	text_editor->cursor_set_line(get_line() - 1);
+	text_editor->set_caret_line(get_line() - 1);
 	hide();
 }
 
@@ -150,9 +150,9 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 	if (found) {
 		if (!preserve_cursor && !is_selection_only()) {
 			text_editor->unfold_line(line);
-			text_editor->cursor_set_line(line, false);
-			text_editor->cursor_set_column(col + text.length(), false);
-			text_editor->center_viewport_to_cursor();
+			text_editor->set_caret_line(line, false);
+			text_editor->set_caret_column(col + text.length(), false);
+			text_editor->center_viewport_to_caret();
 			text_editor->select(line, col, line, col + text.length());
 		}
 
@@ -191,8 +191,8 @@ void FindReplaceBar::_replace() {
 
 	text_editor->begin_complex_operation();
 	if (selection_enabled && is_selection_only()) { // To restrict search_current() to selected region
-		text_editor->cursor_set_line(selection_begin.width);
-		text_editor->cursor_set_column(selection_begin.height);
+		text_editor->set_caret_line(selection_begin.width);
+		text_editor->set_caret_column(selection_begin.height);
 	}
 
 	if (search_current()) {
@@ -203,13 +203,13 @@ void FindReplaceBar::_replace() {
 			Point2i match_from(result_line, result_col);
 			Point2i match_to(result_line, result_col + search_text_len);
 			if (!(match_from < selection_begin || match_to > selection_end)) {
-				text_editor->insert_text_at_cursor(replace_text);
+				text_editor->insert_text_at_caret(replace_text);
 				if (match_to.x == selection_end.x) { // Adjust selection bounds if necessary
 					selection_end.y += replace_text.length() - search_text_len;
 				}
 			}
 		} else {
-			text_editor->insert_text_at_cursor(replace_text);
+			text_editor->insert_text_at_caret(replace_text);
 		}
 	}
 	text_editor->end_complex_operation();
@@ -226,7 +226,7 @@ void FindReplaceBar::_replace() {
 void FindReplaceBar::_replace_all() {
 	text_editor->disconnect("text_changed", callable_mp(this, &FindReplaceBar::_editor_text_changed));
 	// Line as x so it gets priority in comparison, column as y.
-	Point2i orig_cursor(text_editor->cursor_get_line(), text_editor->cursor_get_column());
+	Point2i orig_cursor(text_editor->get_caret_line(), text_editor->get_caret_column());
 	Point2i prev_match = Point2(-1, -1);
 
 	bool selection_enabled = text_editor->is_selection_active();
@@ -238,8 +238,8 @@ void FindReplaceBar::_replace_all() {
 
 	int vsval = text_editor->get_v_scroll();
 
-	text_editor->cursor_set_line(0);
-	text_editor->cursor_set_column(0);
+	text_editor->set_caret_line(0);
+	text_editor->set_caret_column(0);
 
 	String replace_text = get_replace_text();
 	int search_text_len = get_search_text().length();
@@ -251,8 +251,8 @@ void FindReplaceBar::_replace_all() {
 	text_editor->begin_complex_operation();
 
 	if (selection_enabled && is_selection_only()) {
-		text_editor->cursor_set_line(selection_begin.width);
-		text_editor->cursor_set_column(selection_begin.height);
+		text_editor->set_caret_line(selection_begin.width);
+		text_editor->set_caret_column(selection_begin.height);
 	}
 	if (search_current()) {
 		do {
@@ -275,14 +275,14 @@ void FindReplaceBar::_replace_all() {
 				}
 
 				// Replace but adjust selection bounds.
-				text_editor->insert_text_at_cursor(replace_text);
+				text_editor->insert_text_at_caret(replace_text);
 				if (match_to.x == selection_end.x) {
 					selection_end.y += replace_text.length() - search_text_len;
 				}
 
 			} else {
 				// Just replace.
-				text_editor->insert_text_at_cursor(replace_text);
+				text_editor->insert_text_at_caret(replace_text);
 			}
 
 			rc++;
@@ -294,8 +294,8 @@ void FindReplaceBar::_replace_all() {
 	replace_all_mode = false;
 
 	// Restore editor state (selection, cursor, scroll).
-	text_editor->cursor_set_line(orig_cursor.x);
-	text_editor->cursor_set_column(orig_cursor.y);
+	text_editor->set_caret_line(orig_cursor.x);
+	text_editor->set_caret_column(orig_cursor.y);
 
 	if (selection_enabled && is_selection_only()) {
 		// Reselect.
@@ -313,8 +313,8 @@ void FindReplaceBar::_replace_all() {
 }
 
 void FindReplaceBar::_get_search_from(int &r_line, int &r_col) {
-	r_line = text_editor->cursor_get_line();
-	r_col = text_editor->cursor_get_column();
+	r_line = text_editor->get_caret_line();
+	r_col = text_editor->get_caret_column();
 
 	if (text_editor->is_selection_active() && is_selection_only()) {
 		return;
@@ -807,10 +807,10 @@ void CodeTextEditor::_reset_zoom() {
 }
 
 void CodeTextEditor::_line_col_changed() {
-	String line = text_editor->get_line(text_editor->cursor_get_line());
+	String line = text_editor->get_line(text_editor->get_caret_line());
 
 	int positional_column = 0;
-	for (int i = 0; i < text_editor->cursor_get_column(); i++) {
+	for (int i = 0; i < text_editor->get_caret_column(); i++) {
 		if (line[i] == '\t') {
 			positional_column += text_editor->get_indent_size(); //tab size
 		} else {
@@ -820,7 +820,7 @@ void CodeTextEditor::_line_col_changed() {
 
 	StringBuilder sb;
 	sb.append("(");
-	sb.append(itos(text_editor->cursor_get_line() + 1).lpad(3));
+	sb.append(itos(text_editor->get_caret_line() + 1).lpad(3));
 	sb.append(",");
 	sb.append(itos(positional_column + 1).lpad(3));
 	sb.append(")");
@@ -952,9 +952,9 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_draw_fold_gutter(EditorSettings::get_singleton()->get("text_editor/appearance/code_folding"));
 	text_editor->set_wrap_enabled(EditorSettings::get_singleton()->get("text_editor/appearance/word_wrap"));
 	text_editor->set_scroll_pass_end_of_file(EditorSettings::get_singleton()->get("text_editor/cursor/scroll_past_end_of_file"));
-	text_editor->cursor_set_block_mode(EditorSettings::get_singleton()->get("text_editor/cursor/block_caret"));
-	text_editor->cursor_set_blink_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink"));
-	text_editor->cursor_set_blink_speed(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink_speed"));
+	text_editor->set_caret_type((TextEdit::CaretType)EditorSettings::get_singleton()->get("text_editor/cursor/type").operator int());
+	text_editor->set_caret_blink_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink"));
+	text_editor->set_caret_blink_speed(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink_speed"));
 	text_editor->set_auto_brace_completion_enabled(EditorSettings::get_singleton()->get("text_editor/completion/auto_brace_complete"));
 
 	if (EditorSettings::get_singleton()->get("text_editor/appearance/show_line_length_guidelines")) {
@@ -1039,8 +1039,8 @@ void CodeTextEditor::convert_indent_to_spaces() {
 		indent += " ";
 	}
 
-	int cursor_line = text_editor->cursor_get_line();
-	int cursor_column = text_editor->cursor_get_column();
+	int cursor_line = text_editor->get_caret_line();
+	int cursor_column = text_editor->get_caret_column();
 
 	bool changed_indentation = false;
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
@@ -1069,7 +1069,7 @@ void CodeTextEditor::convert_indent_to_spaces() {
 		}
 	}
 	if (changed_indentation) {
-		text_editor->cursor_set_column(cursor_column);
+		text_editor->set_caret_column(cursor_column);
 		text_editor->end_complex_operation();
 		text_editor->update();
 	}
@@ -1079,8 +1079,8 @@ void CodeTextEditor::convert_indent_to_tabs() {
 	int indent_size = EditorSettings::get_singleton()->get("text_editor/indent/size");
 	indent_size -= 1;
 
-	int cursor_line = text_editor->cursor_get_line();
-	int cursor_column = text_editor->cursor_get_column();
+	int cursor_line = text_editor->get_caret_line();
+	int cursor_column = text_editor->get_caret_column();
 
 	bool changed_indentation = false;
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
@@ -1118,7 +1118,7 @@ void CodeTextEditor::convert_indent_to_tabs() {
 		}
 	}
 	if (changed_indentation) {
-		text_editor->cursor_set_column(cursor_column);
+		text_editor->set_caret_column(cursor_column);
 		text_editor->end_complex_operation();
 		text_editor->update();
 	}
@@ -1176,7 +1176,7 @@ void CodeTextEditor::move_lines_up() {
 		int from_col = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
 		int to_column = text_editor->get_selection_to_column();
-		int cursor_line = text_editor->cursor_get_line();
+		int cursor_line = text_editor->get_caret_line();
 
 		for (int i = from_line; i <= to_line; i++) {
 			int line_id = i;
@@ -1190,15 +1190,15 @@ void CodeTextEditor::move_lines_up() {
 			text_editor->unfold_line(next_id);
 
 			text_editor->swap_lines(line_id, next_id);
-			text_editor->cursor_set_line(next_id);
+			text_editor->set_caret_line(next_id);
 		}
 		int from_line_up = from_line > 0 ? from_line - 1 : from_line;
 		int to_line_up = to_line > 0 ? to_line - 1 : to_line;
 		int cursor_line_up = cursor_line > 0 ? cursor_line - 1 : cursor_line;
 		text_editor->select(from_line_up, from_col, to_line_up, to_column);
-		text_editor->cursor_set_line(cursor_line_up);
+		text_editor->set_caret_line(cursor_line_up);
 	} else {
-		int line_id = text_editor->cursor_get_line();
+		int line_id = text_editor->get_caret_line();
 		int next_id = line_id - 1;
 
 		if (line_id == 0 || next_id < 0) {
@@ -1209,7 +1209,7 @@ void CodeTextEditor::move_lines_up() {
 		text_editor->unfold_line(next_id);
 
 		text_editor->swap_lines(line_id, next_id);
-		text_editor->cursor_set_line(next_id);
+		text_editor->set_caret_line(next_id);
 	}
 	text_editor->end_complex_operation();
 	text_editor->update();
@@ -1222,7 +1222,7 @@ void CodeTextEditor::move_lines_down() {
 		int from_col = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
 		int to_column = text_editor->get_selection_to_column();
-		int cursor_line = text_editor->cursor_get_line();
+		int cursor_line = text_editor->get_caret_line();
 
 		for (int i = to_line; i >= from_line; i--) {
 			int line_id = i;
@@ -1236,15 +1236,15 @@ void CodeTextEditor::move_lines_down() {
 			text_editor->unfold_line(next_id);
 
 			text_editor->swap_lines(line_id, next_id);
-			text_editor->cursor_set_line(next_id);
+			text_editor->set_caret_line(next_id);
 		}
 		int from_line_down = from_line < text_editor->get_line_count() ? from_line + 1 : from_line;
 		int to_line_down = to_line < text_editor->get_line_count() ? to_line + 1 : to_line;
 		int cursor_line_down = cursor_line < text_editor->get_line_count() ? cursor_line + 1 : cursor_line;
 		text_editor->select(from_line_down, from_col, to_line_down, to_column);
-		text_editor->cursor_set_line(cursor_line_down);
+		text_editor->set_caret_line(cursor_line_down);
 	} else {
-		int line_id = text_editor->cursor_get_line();
+		int line_id = text_editor->get_caret_line();
 		int next_id = line_id + 1;
 
 		if (line_id == text_editor->get_line_count() - 1 || next_id > text_editor->get_line_count()) {
@@ -1255,7 +1255,7 @@ void CodeTextEditor::move_lines_down() {
 		text_editor->unfold_line(next_id);
 
 		text_editor->swap_lines(line_id, next_id);
-		text_editor->cursor_set_line(next_id);
+		text_editor->set_caret_line(next_id);
 	}
 	text_editor->end_complex_operation();
 	text_editor->update();
@@ -1266,12 +1266,12 @@ void CodeTextEditor::_delete_line(int p_line) {
 	// so `begin_complex_operation` is omitted here
 	text_editor->set_line(p_line, "");
 	if (p_line == 0 && text_editor->get_line_count() > 1) {
-		text_editor->cursor_set_line(1);
-		text_editor->cursor_set_column(0);
+		text_editor->set_caret_line(1);
+		text_editor->set_caret_column(0);
 	}
 	text_editor->backspace();
 	text_editor->unfold_line(p_line);
-	text_editor->cursor_set_line(p_line);
+	text_editor->set_caret_line(p_line);
 }
 
 void CodeTextEditor::delete_lines() {
@@ -1281,42 +1281,42 @@ void CodeTextEditor::delete_lines() {
 		int from_line = text_editor->get_selection_from_line();
 		int count = Math::abs(to_line - from_line) + 1;
 
-		text_editor->cursor_set_line(from_line, false);
+		text_editor->set_caret_line(from_line, false);
 		for (int i = 0; i < count; i++) {
 			_delete_line(from_line);
 		}
 		text_editor->deselect();
 	} else {
-		_delete_line(text_editor->cursor_get_line());
+		_delete_line(text_editor->get_caret_line());
 	}
 	text_editor->end_complex_operation();
 }
 
 void CodeTextEditor::duplicate_selection() {
-	const int cursor_column = text_editor->cursor_get_column();
-	int from_line = text_editor->cursor_get_line();
-	int to_line = text_editor->cursor_get_line();
+	const int cursor_column = text_editor->get_caret_column();
+	int from_line = text_editor->get_caret_line();
+	int to_line = text_editor->get_caret_line();
 	int from_column = 0;
 	int to_column = 0;
 	int cursor_new_line = to_line + 1;
-	int cursor_new_column = text_editor->cursor_get_column();
+	int cursor_new_column = text_editor->get_caret_column();
 	String new_text = "\n" + text_editor->get_line(from_line);
 	bool selection_active = false;
 
-	text_editor->cursor_set_column(text_editor->get_line(from_line).length());
+	text_editor->set_caret_column(text_editor->get_line(from_line).length());
 	if (text_editor->is_selection_active()) {
 		from_column = text_editor->get_selection_from_column();
 		to_column = text_editor->get_selection_to_column();
 
 		from_line = text_editor->get_selection_from_line();
 		to_line = text_editor->get_selection_to_line();
-		cursor_new_line = to_line + text_editor->cursor_get_line() - from_line;
+		cursor_new_line = to_line + text_editor->get_caret_line() - from_line;
 		cursor_new_column = to_column == cursor_column ? 2 * to_column - from_column : to_column;
 		new_text = text_editor->get_selection_text();
 		selection_active = true;
 
-		text_editor->cursor_set_line(to_line);
-		text_editor->cursor_set_column(to_column);
+		text_editor->set_caret_line(to_line);
+		text_editor->set_caret_column(to_column);
 	}
 
 	text_editor->begin_complex_operation();
@@ -1325,9 +1325,9 @@ void CodeTextEditor::duplicate_selection() {
 		text_editor->unfold_line(i);
 	}
 	text_editor->deselect();
-	text_editor->insert_text_at_cursor(new_text);
-	text_editor->cursor_set_line(cursor_new_line);
-	text_editor->cursor_set_column(cursor_new_column);
+	text_editor->insert_text_at_caret(new_text);
+	text_editor->set_caret_line(cursor_new_line);
+	text_editor->set_caret_column(cursor_new_column);
 	if (selection_active) {
 		text_editor->select(to_line, to_column, 2 * to_line - from_line, to_line == from_line ? 2 * to_column - from_column : to_column);
 	}
@@ -1348,7 +1348,7 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		}
 
 		int col_to = text_editor->get_selection_to_column();
-		int cursor_pos = text_editor->cursor_get_column();
+		int cursor_pos = text_editor->get_caret_column();
 
 		// Check if all lines in the selected block are commented.
 		bool is_commented = true;
@@ -1377,7 +1377,7 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		int offset = (is_commented ? -1 : 1) * delimiter.length();
 		int col_from = text_editor->get_selection_from_column() > 0 ? text_editor->get_selection_from_column() + offset : 0;
 
-		if (is_commented && text_editor->cursor_get_column() == text_editor->get_line(text_editor->cursor_get_line()).length() + 1) {
+		if (is_commented && text_editor->get_caret_column() == text_editor->get_line(text_editor->get_caret_line()).length() + 1) {
 			cursor_pos += 1;
 		}
 
@@ -1385,19 +1385,19 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 			col_to += offset;
 		}
 
-		if (text_editor->cursor_get_column() != 0) {
+		if (text_editor->get_caret_column() != 0) {
 			cursor_pos += offset;
 		}
 
 		text_editor->select(begin, col_from, text_editor->get_selection_to_line(), col_to);
-		text_editor->cursor_set_column(cursor_pos);
+		text_editor->set_caret_column(cursor_pos);
 
 	} else {
-		int begin = text_editor->cursor_get_line();
+		int begin = text_editor->get_caret_line();
 		String line_text = text_editor->get_line(begin);
 		int delimiter_length = delimiter.length();
 
-		int col = text_editor->cursor_get_column();
+		int col = text_editor->get_caret_column();
 		if (line_text.begins_with(delimiter)) {
 			line_text = line_text.substr(delimiter_length, line_text.length());
 			col -= delimiter_length;
@@ -1407,7 +1407,7 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		}
 
 		text_editor->set_line(begin, line_text);
-		text_editor->cursor_set_column(col);
+		text_editor->set_caret_column(col);
 	}
 	text_editor->end_complex_operation();
 	text_editor->update();
@@ -1428,7 +1428,7 @@ void CodeTextEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
 
 void CodeTextEditor::goto_line_centered(int p_line) {
 	goto_line(p_line);
-	text_editor->call_deferred(SNAME("center_viewport_to_cursor"));
+	text_editor->call_deferred(SNAME("center_viewport_to_caret"));
 }
 
 void CodeTextEditor::set_executing_line(int p_line) {
@@ -1444,8 +1444,8 @@ Variant CodeTextEditor::get_edit_state() {
 
 	state["scroll_position"] = text_editor->get_v_scroll();
 	state["h_scroll_position"] = text_editor->get_h_scroll();
-	state["column"] = text_editor->cursor_get_column();
-	state["row"] = text_editor->cursor_get_line();
+	state["column"] = text_editor->get_caret_column();
+	state["row"] = text_editor->get_caret_line();
 
 	state["selection"] = get_text_editor()->is_selection_active();
 	if (get_text_editor()->is_selection_active()) {
@@ -1469,8 +1469,8 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 	Dictionary state = p_state;
 
 	/* update the row first as it sets the column to 0 */
-	text_editor->cursor_set_line(state["row"]);
-	text_editor->cursor_set_column(state["column"]);
+	text_editor->set_caret_line(state["row"]);
+	text_editor->set_caret_column(state["column"]);
 	text_editor->set_v_scroll(state["scroll_position"]);
 	text_editor->set_h_scroll(state["h_scroll_position"]);
 
@@ -1517,9 +1517,9 @@ void CodeTextEditor::set_error_pos(int p_line, int p_column) {
 void CodeTextEditor::goto_error() {
 	if (error->get_text() != "") {
 		text_editor->unfold_line(error_line);
-		text_editor->cursor_set_line(error_line);
-		text_editor->cursor_set_column(error_column);
-		text_editor->center_viewport_to_cursor();
+		text_editor->set_caret_line(error_line);
+		text_editor->set_caret_column(error_column);
+		text_editor->center_viewport_to_caret();
 	}
 }
 
@@ -1712,7 +1712,7 @@ void CodeTextEditor::set_warning_count(int p_warning_count) {
 }
 
 void CodeTextEditor::toggle_bookmark() {
-	int line = text_editor->cursor_get_line();
+	int line = text_editor->get_caret_line();
 	text_editor->set_line_as_bookmarked(line, !text_editor->is_line_bookmarked(line));
 }
 
@@ -1722,18 +1722,18 @@ void CodeTextEditor::goto_next_bookmark() {
 		return;
 	}
 
-	int line = text_editor->cursor_get_line();
+	int line = text_editor->get_caret_line();
 	if (line >= (int)bmarks[bmarks.size() - 1]) {
 		text_editor->unfold_line(bmarks[0]);
-		text_editor->cursor_set_line(bmarks[0]);
-		text_editor->center_viewport_to_cursor();
+		text_editor->set_caret_line(bmarks[0]);
+		text_editor->center_viewport_to_caret();
 	} else {
 		for (int i = 0; i < bmarks.size(); i++) {
 			int bmark_line = bmarks[i];
 			if (bmark_line > line) {
 				text_editor->unfold_line(bmark_line);
-				text_editor->cursor_set_line(bmark_line);
-				text_editor->center_viewport_to_cursor();
+				text_editor->set_caret_line(bmark_line);
+				text_editor->center_viewport_to_caret();
 				return;
 			}
 		}
@@ -1746,18 +1746,18 @@ void CodeTextEditor::goto_prev_bookmark() {
 		return;
 	}
 
-	int line = text_editor->cursor_get_line();
+	int line = text_editor->get_caret_line();
 	if (line <= (int)bmarks[0]) {
 		text_editor->unfold_line(bmarks[bmarks.size() - 1]);
-		text_editor->cursor_set_line(bmarks[bmarks.size() - 1]);
-		text_editor->center_viewport_to_cursor();
+		text_editor->set_caret_line(bmarks[bmarks.size() - 1]);
+		text_editor->center_viewport_to_caret();
 	} else {
 		for (int i = bmarks.size(); i >= 0; i--) {
 			int bmark_line = bmarks[i];
 			if (bmark_line < line) {
 				text_editor->unfold_line(bmark_line);
-				text_editor->cursor_set_line(bmark_line);
-				text_editor->center_viewport_to_cursor();
+				text_editor->set_caret_line(bmark_line);
+				text_editor->center_viewport_to_caret();
 				return;
 			}
 		}
@@ -1913,7 +1913,7 @@ CodeTextEditor::CodeTextEditor() {
 	line_and_col_txt->set_mouse_filter(MOUSE_FILTER_STOP);
 
 	text_editor->connect("gui_input", callable_mp(this, &CodeTextEditor::_text_editor_gui_input));
-	text_editor->connect("cursor_changed", callable_mp(this, &CodeTextEditor::_line_col_changed));
+	text_editor->connect("caret_changed", callable_mp(this, &CodeTextEditor::_line_col_changed));
 	text_editor->connect("text_changed", callable_mp(this, &CodeTextEditor::_text_changed));
 	text_editor->connect("request_code_completion", callable_mp(this, &CodeTextEditor::_complete_request));
 	TypedArray<String> cs;

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -142,26 +142,23 @@ void FindReplaceBar::_unhandled_input(const Ref<InputEvent> &p_event) {
 }
 
 bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) {
-	int line, col;
 	String text = get_search_text();
+	Point2i pos = text_editor->search(text, p_flags, p_from_line, p_from_col);
 
-	bool found = text_editor->search(text, p_flags, p_from_line, p_from_col, line, col);
-
-	if (found) {
+	if (pos.x != -1) {
 		if (!preserve_cursor && !is_selection_only()) {
-			text_editor->unfold_line(line);
-			text_editor->set_caret_line(line, false);
-			text_editor->set_caret_column(col + text.length(), false);
+			text_editor->unfold_line(pos.y);
+			text_editor->set_caret_line(pos.y, false);
+			text_editor->set_caret_column(pos.x + text.length(), false);
 			text_editor->center_viewport_to_caret();
-			text_editor->select(line, col, line, col + text.length());
+			text_editor->select(pos.y, pos.x, pos.y, pos.x + text.length());
 		}
 
 		text_editor->set_search_text(text);
 		text_editor->set_search_flags(p_flags);
-		text_editor->set_current_search_result(line, col);
 
-		result_line = line;
-		result_col = col;
+		result_line = pos.y;
+		result_col = pos.x;
 
 		_update_results_count();
 	} else {
@@ -170,12 +167,11 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 		result_col = -1;
 		text_editor->set_search_text("");
 		text_editor->set_search_flags(p_flags);
-		text_editor->set_current_search_result(line, col);
 	}
 
 	_update_matches_label();
 
-	return found;
+	return pos.x != -1;
 }
 
 void FindReplaceBar::_replace() {

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -951,7 +951,7 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_line_folding_enabled(EditorSettings::get_singleton()->get("text_editor/appearance/code_folding"));
 	text_editor->set_draw_fold_gutter(EditorSettings::get_singleton()->get("text_editor/appearance/code_folding"));
 	text_editor->set_line_wrapping_mode((TextEdit::LineWrappingMode)EditorSettings::get_singleton()->get("text_editor/appearance/word_wrap").operator int());
-	text_editor->set_scroll_pass_end_of_file(EditorSettings::get_singleton()->get("text_editor/cursor/scroll_past_end_of_file"));
+	text_editor->set_scroll_past_end_of_file_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/scroll_past_end_of_file"));
 	text_editor->set_caret_type((TextEdit::CaretType)EditorSettings::get_singleton()->get("text_editor/cursor/type").operator int());
 	text_editor->set_caret_blink_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink"));
 	text_editor->set_caret_blink_speed(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink_speed"));

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -179,7 +179,7 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 }
 
 void FindReplaceBar::_replace() {
-	bool selection_enabled = text_editor->is_selection_active();
+	bool selection_enabled = text_editor->has_selection();
 	Point2i selection_begin, selection_end;
 	if (selection_enabled) {
 		selection_begin = Point2i(text_editor->get_selection_from_line(), text_editor->get_selection_from_column());
@@ -229,7 +229,7 @@ void FindReplaceBar::_replace_all() {
 	Point2i orig_cursor(text_editor->get_caret_line(), text_editor->get_caret_column());
 	Point2i prev_match = Point2(-1, -1);
 
-	bool selection_enabled = text_editor->is_selection_active();
+	bool selection_enabled = text_editor->has_selection();
 	Point2i selection_begin, selection_end;
 	if (selection_enabled) {
 		selection_begin = Point2i(text_editor->get_selection_from_line(), text_editor->get_selection_from_column());
@@ -316,7 +316,7 @@ void FindReplaceBar::_get_search_from(int &r_line, int &r_col) {
 	r_line = text_editor->get_caret_line();
 	r_col = text_editor->get_caret_column();
 
-	if (text_editor->is_selection_active() && is_selection_only()) {
+	if (text_editor->has_selection() && is_selection_only()) {
 		return;
 	}
 
@@ -409,7 +409,7 @@ bool FindReplaceBar::search_prev() {
 
 	int line, col;
 	_get_search_from(line, col);
-	if (text_editor->is_selection_active()) {
+	if (text_editor->has_selection()) {
 		col--; // Skip currently selected word.
 	}
 
@@ -487,8 +487,8 @@ void FindReplaceBar::_show_search(bool p_focus_replace, bool p_show_only) {
 		search_text->call_deferred(SNAME("grab_focus"));
 	}
 
-	if (text_editor->is_selection_active() && !selection_only->is_pressed()) {
-		search_text->set_text(text_editor->get_selection_text());
+	if (text_editor->has_selection() && !selection_only->is_pressed()) {
+		search_text->set_text(text_editor->get_selected_text());
 	}
 
 	if (!get_search_text().is_empty()) {
@@ -521,9 +521,9 @@ void FindReplaceBar::popup_replace() {
 		hbc_option_replace->show();
 	}
 
-	selection_only->set_pressed((text_editor->is_selection_active() && text_editor->get_selection_from_line() < text_editor->get_selection_to_line()));
+	selection_only->set_pressed((text_editor->has_selection() && text_editor->get_selection_from_line() < text_editor->get_selection_to_line()));
 
-	_show_search(is_visible() || text_editor->is_selection_active());
+	_show_search(is_visible() || text_editor->has_selection());
 }
 
 void FindReplaceBar::_search_options_changed(bool p_pressed) {
@@ -554,7 +554,7 @@ void FindReplaceBar::_search_text_submitted(const String &p_text) {
 }
 
 void FindReplaceBar::_replace_text_submitted(const String &p_text) {
-	if (selection_only->is_pressed() && text_editor->is_selection_active()) {
+	if (selection_only->is_pressed() && text_editor->has_selection()) {
 		_replace_all();
 		_hide_bar();
 	} else if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
@@ -1125,7 +1125,7 @@ void CodeTextEditor::convert_indent_to_tabs() {
 }
 
 void CodeTextEditor::convert_case(CaseStyle p_case) {
-	if (!text_editor->is_selection_active()) {
+	if (!text_editor->has_selection()) {
 		return;
 	}
 
@@ -1171,7 +1171,7 @@ void CodeTextEditor::convert_case(CaseStyle p_case) {
 
 void CodeTextEditor::move_lines_up() {
 	text_editor->begin_complex_operation();
-	if (text_editor->is_selection_active()) {
+	if (text_editor->has_selection()) {
 		int from_line = text_editor->get_selection_from_line();
 		int from_col = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
@@ -1217,7 +1217,7 @@ void CodeTextEditor::move_lines_up() {
 
 void CodeTextEditor::move_lines_down() {
 	text_editor->begin_complex_operation();
-	if (text_editor->is_selection_active()) {
+	if (text_editor->has_selection()) {
 		int from_line = text_editor->get_selection_from_line();
 		int from_col = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
@@ -1276,7 +1276,7 @@ void CodeTextEditor::_delete_line(int p_line) {
 
 void CodeTextEditor::delete_lines() {
 	text_editor->begin_complex_operation();
-	if (text_editor->is_selection_active()) {
+	if (text_editor->has_selection()) {
 		int to_line = text_editor->get_selection_to_line();
 		int from_line = text_editor->get_selection_from_line();
 		int count = Math::abs(to_line - from_line) + 1;
@@ -1304,7 +1304,7 @@ void CodeTextEditor::duplicate_selection() {
 	bool selection_active = false;
 
 	text_editor->set_caret_column(text_editor->get_line(from_line).length());
-	if (text_editor->is_selection_active()) {
+	if (text_editor->has_selection()) {
 		from_column = text_editor->get_selection_from_column();
 		to_column = text_editor->get_selection_to_column();
 
@@ -1312,7 +1312,7 @@ void CodeTextEditor::duplicate_selection() {
 		to_line = text_editor->get_selection_to_line();
 		cursor_new_line = to_line + text_editor->get_caret_line() - from_line;
 		cursor_new_column = to_column == cursor_column ? 2 * to_column - from_column : to_column;
-		new_text = text_editor->get_selection_text();
+		new_text = text_editor->get_selected_text();
 		selection_active = true;
 
 		text_editor->set_caret_line(to_line);
@@ -1338,7 +1338,7 @@ void CodeTextEditor::duplicate_selection() {
 
 void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 	text_editor->begin_complex_operation();
-	if (text_editor->is_selection_active()) {
+	if (text_editor->has_selection()) {
 		int begin = text_editor->get_selection_from_line();
 		int end = text_editor->get_selection_to_line();
 
@@ -1447,8 +1447,8 @@ Variant CodeTextEditor::get_edit_state() {
 	state["column"] = text_editor->get_caret_column();
 	state["row"] = text_editor->get_caret_line();
 
-	state["selection"] = get_text_editor()->is_selection_active();
-	if (get_text_editor()->is_selection_active()) {
+	state["selection"] = get_text_editor()->has_selection();
+	if (get_text_editor()->has_selection()) {
 		state["selection_from_line"] = text_editor->get_selection_from_line();
 		state["selection_from_column"] = text_editor->get_selection_from_column();
 		state["selection_to_line"] = text_editor->get_selection_to_line();

--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -51,7 +51,7 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 		versions->add_child(vtab);
 		for (int j = 0; j < nsc.versions[i].stages.size(); j++) {
 			TextEdit *vtext = memnew(TextEdit);
-			vtext->set_readonly(true);
+			vtext->set_editable(false);
 			vtext->set_name(nsc.versions[i].stages[j].name);
 			vtext->set_text(nsc.versions[i].stages[j].code);
 			vtext->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -121,7 +121,7 @@ void EditorPropertyMultilineText::_open_big_text() {
 	if (!big_text_dialog) {
 		big_text = memnew(TextEdit);
 		big_text->connect("text_changed", callable_mp(this, &EditorPropertyMultilineText::_big_text_changed));
-		big_text->set_wrap_enabled(true);
+		big_text->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 		big_text_dialog = memnew(AcceptDialog);
 		big_text_dialog->add_child(big_text);
 		big_text_dialog->set_title(TTR("Edit Text:"));
@@ -166,7 +166,7 @@ EditorPropertyMultilineText::EditorPropertyMultilineText() {
 	set_bottom_editor(hb);
 	text = memnew(TextEdit);
 	text->connect("text_changed", callable_mp(this, &EditorPropertyMultilineText::_text_changed));
-	text->set_wrap_enabled(true);
+	text->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 	add_focusable(text);
 	hb->add_child(text);
 	text->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -525,7 +525,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/appearance/show_bookmark_gutter", true);
 	_initial_set("text_editor/appearance/show_info_gutter", true);
 	_initial_set("text_editor/appearance/code_folding", true);
-	_initial_set("text_editor/appearance/word_wrap", false);
+	_initial_set("text_editor/appearance/word_wrap", 0);
+	hints["text_editor/appearance/word_wrap"] = PropertyInfo(Variant::INT, "text_editor/appearance/word_wrap", PROPERTY_HINT_ENUM, "None,Boundary");
+
 	_initial_set("text_editor/appearance/show_line_length_guidelines", true);
 	_initial_set("text_editor/appearance/line_length_guideline_soft_column", 80);
 	hints["text_editor/appearance/line_length_guideline_soft_column"] = PropertyInfo(Variant::INT, "text_editor/appearance/line_length_guideline_soft_column", PROPERTY_HINT_RANGE, "20, 160, 1");

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -546,7 +546,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Cursor
 	_initial_set("text_editor/cursor/scroll_past_end_of_file", false);
-	_initial_set("text_editor/cursor/block_caret", false);
+	_initial_set("text_editor/cursor/type", 0);
+	hints["text_editor/cursor/type"] = PropertyInfo(Variant::INT, "text_editor/cursor/type", PROPERTY_HINT_ENUM, "Line,Block");
 	_initial_set("text_editor/cursor/caret_blink", true);
 	_initial_set("text_editor/cursor/caret_blink_speed", 0.5);
 	hints["text_editor/cursor/caret_blink_speed"] = PropertyInfo(Variant::FLOAT, "text_editor/cursor/caret_blink_speed", PROPERTY_HINT_RANGE, "0.1, 10, 0.01");

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1048,6 +1048,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_readonly_color", "LineEdit", font_readonly_color);
 	theme->set_color("caret_color", "TextEdit", font_color);
 	theme->set_color("selection_color", "TextEdit", selection_color);
+	theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
 
 	// CodeEdit
 	theme->set_stylebox("normal", "CodeEdit", style_widget);
@@ -1062,6 +1063,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_color", "CodeEdit", font_color);
 	theme->set_color("caret_color", "CodeEdit", font_color);
 	theme->set_color("selection_color", "CodeEdit", selection_color);
+	theme->set_constant("line_spacing", "CodeEdit", 4 * EDSCALE);
 
 	// H/VSplitContainer
 	theme->set_stylebox("bg", "VSplitContainer", make_stylebox(theme->get_icon("GuiVsplitBg", "EditorIcons"), 1, 1, 1, 1));

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -282,7 +282,7 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	desc_edit = memnew(TextEdit);
 	desc_edit->set_custom_minimum_size(Size2(400, 80) * EDSCALE);
-	desc_edit->set_wrap_enabled(true);
+	desc_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 	grid->add_child(desc_edit);
 
 	// Author

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -248,7 +248,7 @@ void ScriptTextEditor::_warning_clicked(Variant p_line) {
 
 void ScriptTextEditor::_error_clicked(Variant p_line) {
 	if (p_line.get_type() == Variant::INT) {
-		code_editor->get_text_editor()->cursor_set_line(p_line.operator int64_t());
+		code_editor->get_text_editor()->set_caret_line(p_line.operator int64_t());
 	}
 }
 
@@ -256,14 +256,14 @@ void ScriptTextEditor::reload_text() {
 	ERR_FAIL_COND(script.is_null());
 
 	CodeEdit *te = code_editor->get_text_editor();
-	int column = te->cursor_get_column();
-	int row = te->cursor_get_line();
+	int column = te->get_caret_column();
+	int row = te->get_caret_line();
 	int h = te->get_h_scroll();
 	int v = te->get_v_scroll();
 
 	te->set_text(script->get_source_code());
-	te->cursor_set_line(row);
-	te->cursor_set_column(column);
+	te->set_caret_line(row);
+	te->set_caret_column(column);
 	te->set_h_scroll(h);
 	te->set_v_scroll(v);
 
@@ -281,12 +281,12 @@ void ScriptTextEditor::add_callback(const String &p_function, PackedStringArray 
 		pos = code_editor->get_text_editor()->get_line_count() + 2;
 		String func = script->get_language()->make_function("", p_function, p_args);
 		//code=code+func;
-		code_editor->get_text_editor()->cursor_set_line(pos + 1);
-		code_editor->get_text_editor()->cursor_set_column(1000000); //none shall be that big
-		code_editor->get_text_editor()->insert_text_at_cursor("\n\n" + func);
+		code_editor->get_text_editor()->set_caret_line(pos + 1);
+		code_editor->get_text_editor()->set_caret_column(1000000); //none shall be that big
+		code_editor->get_text_editor()->insert_text_at_caret("\n\n" + func);
 	}
-	code_editor->get_text_editor()->cursor_set_line(pos);
-	code_editor->get_text_editor()->cursor_set_column(1);
+	code_editor->get_text_editor()->set_caret_line(pos);
+	code_editor->get_text_editor()->set_caret_column(1);
 }
 
 bool ScriptTextEditor::show_members_overview() {
@@ -726,7 +726,7 @@ void ScriptTextEditor::_breakpoint_item_pressed(int p_idx) {
 		_edit_option(breakpoints_menu->get_item_id(p_idx));
 	} else {
 		code_editor->goto_line(breakpoints_menu->get_item_metadata(p_idx));
-		code_editor->get_text_editor()->call_deferred(SNAME("center_viewport_to_cursor")); //Need to be deferred, because goto uses call_deferred().
+		code_editor->get_text_editor()->call_deferred(SNAME("center_viewport_to_caret")); //Need to be deferred, because goto uses call_deferred().
 	}
 }
 
@@ -1054,7 +1054,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			code_editor->duplicate_selection();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
-			tx->toggle_foldable_line(tx->cursor_get_line());
+			tx->toggle_foldable_line(tx->get_caret_line());
 			tx->update();
 		} break;
 		case EDIT_FOLD_ALL_LINES: {
@@ -1142,7 +1142,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			}
 
 			code_editor->get_text_editor()->begin_complex_operation(); //prevents creating a two-step undo
-			code_editor->get_text_editor()->insert_text_at_cursor(String("\n").join(results));
+			code_editor->get_text_editor()->insert_text_at_caret(String("\n").join(results));
 			code_editor->get_text_editor()->end_complex_operation();
 		} break;
 		case SEARCH_FIND: {
@@ -1189,7 +1189,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			code_editor->remove_all_bookmarks();
 		} break;
 		case DEBUG_TOGGLE_BREAKPOINT: {
-			int line = tx->cursor_get_line();
+			int line = tx->get_caret_line();
 			bool dobreak = !tx->is_line_breakpointed(line);
 			tx->set_line_as_breakpoint(line, dobreak);
 			EditorDebuggerNode::get_singleton()->set_breakpoint(script->get_path(), line + 1, dobreak);
@@ -1210,20 +1210,20 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
-			int line = tx->cursor_get_line();
+			int line = tx->get_caret_line();
 
 			// wrap around
 			if (line >= (int)bpoints[bpoints.size() - 1]) {
 				tx->unfold_line(bpoints[0]);
-				tx->cursor_set_line(bpoints[0]);
-				tx->center_viewport_to_cursor();
+				tx->set_caret_line(bpoints[0]);
+				tx->center_viewport_to_caret();
 			} else {
 				for (int i = 0; i < bpoints.size(); i++) {
 					int bline = bpoints[i];
 					if (bline > line) {
 						tx->unfold_line(bline);
-						tx->cursor_set_line(bline);
-						tx->center_viewport_to_cursor();
+						tx->set_caret_line(bline);
+						tx->center_viewport_to_caret();
 						return;
 					}
 				}
@@ -1236,19 +1236,19 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
-			int line = tx->cursor_get_line();
+			int line = tx->get_caret_line();
 			// wrap around
 			if (line <= (int)bpoints[0]) {
 				tx->unfold_line(bpoints[bpoints.size() - 1]);
-				tx->cursor_set_line(bpoints[bpoints.size() - 1]);
-				tx->center_viewport_to_cursor();
+				tx->set_caret_line(bpoints[bpoints.size() - 1]);
+				tx->center_viewport_to_caret();
 			} else {
 				for (int i = bpoints.size(); i >= 0; i--) {
 					int bline = bpoints[i];
 					if (bline < line) {
 						tx->unfold_line(bline);
-						tx->cursor_set_line(bline);
-						tx->center_viewport_to_cursor();
+						tx->set_caret_line(bline);
+						tx->center_viewport_to_caret();
 						return;
 					}
 				}
@@ -1258,19 +1258,19 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		case HELP_CONTEXTUAL: {
 			String text = tx->get_selection_text();
 			if (text == "") {
-				text = tx->get_word_under_cursor();
+				text = tx->get_word_under_caret();
 			}
 			if (text != "") {
 				emit_signal(SNAME("request_help"), text);
 			}
 		} break;
 		case LOOKUP_SYMBOL: {
-			String text = tx->get_word_under_cursor();
+			String text = tx->get_word_under_caret();
 			if (text == "") {
 				text = tx->get_selection_text();
 			}
 			if (text != "") {
-				_lookup_symbol(text, tx->cursor_get_line(), tx->cursor_get_column());
+				_lookup_symbol(text, tx->get_caret_line(), tx->get_caret_column());
 			}
 		} break;
 	}
@@ -1436,9 +1436,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			return;
 		}
 
-		te->cursor_set_line(row);
-		te->cursor_set_column(col);
-		te->insert_text_at_cursor(res->get_path());
+		te->set_caret_line(row);
+		te->set_caret_column(col);
+		te->insert_text_at_caret(res->get_path());
 	}
 
 	if (d.has("type") && (String(d["type"]) == "files" || String(d["type"]) == "files_and_dirs")) {
@@ -1459,9 +1459,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			}
 		}
 
-		te->cursor_set_line(row);
-		te->cursor_set_column(col);
-		te->insert_text_at_cursor(text_to_drop);
+		te->set_caret_line(row);
+		te->set_caret_column(col);
+		te->insert_text_at_caret(text_to_drop);
 	}
 
 	if (d.has("type") && String(d["type"]) == "nodes") {
@@ -1489,9 +1489,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			text_to_drop += "\"" + path.c_escape() + "\"";
 		}
 
-		te->cursor_set_line(row);
-		te->cursor_set_column(col);
-		te->insert_text_at_cursor(text_to_drop);
+		te->set_caret_line(row);
+		te->set_caret_column(col);
+		te->insert_text_at_caret(text_to_drop);
 	}
 }
 
@@ -1505,8 +1505,9 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	if (mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_RIGHT && mb->is_pressed()) {
 		local_pos = mb->get_global_position() - tx->get_global_position();
 		create_menu = true;
-	} else if (k.is_valid() && k->get_keycode() == KEY_MENU) {
-		local_pos = tx->_get_cursor_pixel_pos();
+	} else if (k.is_valid() && k->is_action("ui_menu", true)) {
+		tx->adjust_viewport_to_caret();
+		local_pos = tx->get_caret_draw_pos();
 		create_menu = true;
 	}
 
@@ -1514,8 +1515,8 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		int col, row;
 		tx->_get_mouse_pos(local_pos, row, col);
 
-		tx->set_right_click_moves_caret(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
-		if (tx->is_right_click_moving_caret()) {
+		tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
+		if (tx->is_move_caret_on_right_click_enabled()) {
 			if (tx->is_selection_active()) {
 				int from_line = tx->get_selection_from_line();
 				int to_line = tx->get_selection_to_line();
@@ -1528,14 +1529,14 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 				}
 			}
 			if (!tx->is_selection_active()) {
-				tx->cursor_set_line(row, true, false);
-				tx->cursor_set_column(col);
+				tx->set_caret_line(row, false, false);
+				tx->set_caret_column(col);
 			}
 		}
 
 		String word_at_pos = tx->get_word_at_pos(local_pos);
 		if (word_at_pos == "") {
-			word_at_pos = tx->get_word_under_cursor();
+			word_at_pos = tx->get_word_under_caret();
 		}
 		if (word_at_pos == "") {
 			word_at_pos = tx->get_selection_text();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1080,7 +1080,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 
 			tx->begin_complex_operation();
 			int begin, end;
-			if (tx->is_selection_active()) {
+			if (tx->has_selection()) {
 				begin = tx->get_selection_from_line();
 				end = tx->get_selection_to_line();
 				// ignore if the cursor is not past the first column
@@ -1122,7 +1122,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		} break;
 		case EDIT_EVALUATE: {
 			Expression expression;
-			Vector<String> lines = code_editor->get_text_editor()->get_selection_text().split("\n");
+			Vector<String> lines = code_editor->get_text_editor()->get_selected_text().split("\n");
 			PackedStringArray results;
 
 			for (int i = 0; i < lines.size(); i++) {
@@ -1158,14 +1158,14 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			code_editor->get_find_replace_bar()->popup_replace();
 		} break;
 		case SEARCH_IN_FILES: {
-			String selected_text = code_editor->get_text_editor()->get_selection_text();
+			String selected_text = code_editor->get_text_editor()->get_selected_text();
 
 			// Yep, because it doesn't make sense to instance this dialog for every single script open...
 			// So this will be delegated to the ScriptEditor.
 			emit_signal(SNAME("search_in_files_requested"), selected_text);
 		} break;
 		case REPLACE_IN_FILES: {
-			String selected_text = code_editor->get_text_editor()->get_selection_text();
+			String selected_text = code_editor->get_text_editor()->get_selected_text();
 
 			emit_signal(SNAME("replace_in_files_requested"), selected_text);
 		} break;
@@ -1256,7 +1256,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 
 		} break;
 		case HELP_CONTEXTUAL: {
-			String text = tx->get_selection_text();
+			String text = tx->get_selected_text();
 			if (text == "") {
 				text = tx->get_word_under_caret();
 			}
@@ -1267,7 +1267,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		case LOOKUP_SYMBOL: {
 			String text = tx->get_word_under_caret();
 			if (text == "") {
-				text = tx->get_selection_text();
+				text = tx->get_selected_text();
 			}
 			if (text != "") {
 				_lookup_symbol(text, tx->get_caret_line(), tx->get_caret_column());
@@ -1517,7 +1517,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 
 		tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
 		if (tx->is_move_caret_on_right_click_enabled()) {
-			if (tx->is_selection_active()) {
+			if (tx->has_selection()) {
 				int from_line = tx->get_selection_from_line();
 				int to_line = tx->get_selection_to_line();
 				int from_column = tx->get_selection_from_column();
@@ -1528,7 +1528,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					tx->deselect();
 				}
 			}
-			if (!tx->is_selection_active()) {
+			if (!tx->has_selection()) {
 				tx->set_caret_line(row, false, false);
 				tx->set_caret_column(col);
 			}
@@ -1539,7 +1539,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			word_at_pos = tx->get_word_under_caret();
 		}
 		if (word_at_pos == "") {
-			word_at_pos = tx->get_selection_text();
+			word_at_pos = tx->get_selected_text();
 		}
 
 		bool has_color = (word_at_pos == "Color");
@@ -1591,7 +1591,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 				has_color = false;
 			}
 		}
-		_make_context_menu(tx->is_selection_active(), has_color, foldable, open_docs, goto_definition, local_pos);
+		_make_context_menu(tx->has_selection(), has_color, foldable, open_docs, goto_definition, local_pos);
 	}
 }
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1062,7 +1062,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			tx->update();
 		} break;
 		case EDIT_UNFOLD_ALL_LINES: {
-			tx->unhide_all_lines();
+			tx->unfold_all_lines();
 			tx->update();
 		} break;
 		case EDIT_TOGGLE_COMMENT: {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -241,7 +241,7 @@ void ScriptTextEditor::_warning_clicked(Variant p_line) {
 		goto_line_centered(p_line.operator int64_t());
 	} else if (p_line.get_type() == Variant::DICTIONARY) {
 		Dictionary meta = p_line.operator Dictionary();
-		code_editor->get_text_editor()->insert_at("# warning-ignore:" + meta["code"].operator String(), meta["line"].operator int64_t() - 1);
+		code_editor->get_text_editor()->insert_line_at(meta["line"].operator int64_t() - 1, "# warning-ignore:" + meta["code"].operator String());
 		_validate_script();
 	}
 }
@@ -884,7 +884,7 @@ void ScriptTextEditor::update_toggle_scripts_button() {
 
 void ScriptTextEditor::_update_connected_methods() {
 	CodeEdit *text_edit = code_editor->get_text_editor();
-	text_edit->set_gutter_width(connection_gutter, text_edit->get_row_height());
+	text_edit->set_gutter_width(connection_gutter, text_edit->get_line_height());
 	for (int i = 0; i < text_edit->get_line_count(); i++) {
 		if (text_edit->get_line_gutter_metadata(i, connection_gutter) == "") {
 			continue;
@@ -1325,7 +1325,7 @@ void ScriptTextEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
-			code_editor->get_text_editor()->set_gutter_width(connection_gutter, code_editor->get_text_editor()->get_row_height());
+			code_editor->get_text_editor()->set_gutter_width(connection_gutter, code_editor->get_text_editor()->get_line_height());
 		} break;
 		default:
 			break;
@@ -1422,8 +1422,10 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	Dictionary d = p_data;
 
 	CodeEdit *te = code_editor->get_text_editor();
-	int row, col;
-	te->_get_mouse_pos(p_point, row, col);
+
+	Point2i pos = te->get_line_column_at_pos(p_point);
+	int row = pos.y;
+	int col = pos.x;
 
 	if (d.has("type") && String(d["type"]) == "resource") {
 		Ref<Resource> res = d["resource"];
@@ -1512,8 +1514,9 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	}
 
 	if (create_menu) {
-		int col, row;
-		tx->_get_mouse_pos(local_pos, row, col);
+		Point2i pos = tx->get_line_column_at_pos(local_pos);
+		int row = pos.y;
+		int col = pos.x;
 
 		tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
 		if (tx->is_move_caret_on_right_click_enabled()) {

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -556,7 +556,7 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
 
 			if (tx->is_move_caret_on_right_click_enabled()) {
-				if (tx->is_selection_active()) {
+				if (tx->has_selection()) {
 					int from_line = tx->get_selection_from_line();
 					int to_line = tx->get_selection_to_line();
 					int from_column = tx->get_selection_from_column();
@@ -567,12 +567,12 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 						tx->deselect();
 					}
 				}
-				if (!tx->is_selection_active()) {
+				if (!tx->has_selection()) {
 					tx->set_caret_line(row, true, false);
 					tx->set_caret_column(col);
 				}
 			}
-			_make_context_menu(tx->is_selection_active(), get_local_mouse_position());
+			_make_context_menu(tx->has_selection(), get_local_mouse_position());
 		}
 	}
 
@@ -580,7 +580,7 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	if (k.is_valid() && k->is_pressed() && k->is_action("ui_menu", true)) {
 		CodeEdit *tx = shader_editor->get_text_editor();
 		tx->adjust_viewport_to_caret();
-		_make_context_menu(tx->is_selection_active(), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->get_caret_draw_pos()));
+		_make_context_menu(tx->has_selection(), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->get_caret_draw_pos()));
 		context_menu->grab_focus();
 	}
 }

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -74,14 +74,14 @@ void ShaderTextEditor::reload_text() {
 	ERR_FAIL_COND(shader.is_null());
 
 	CodeEdit *te = get_text_editor();
-	int column = te->cursor_get_column();
-	int row = te->cursor_get_line();
+	int column = te->get_caret_column();
+	int row = te->get_caret_line();
 	int h = te->get_h_scroll();
 	int v = te->get_v_scroll();
 
 	te->set_text(shader->get_code());
-	te->cursor_set_line(row);
-	te->cursor_set_column(column);
+	te->set_caret_line(row);
+	te->set_caret_column(column);
 	te->set_h_scroll(h);
 	te->set_v_scroll(v);
 
@@ -408,7 +408,7 @@ void ShaderEditor::_show_warnings_panel(bool p_show) {
 
 void ShaderEditor::_warning_clicked(Variant p_line) {
 	if (p_line.get_type() == Variant::INT) {
-		shader_editor->get_text_editor()->cursor_set_line(p_line.operator int64_t());
+		shader_editor->get_text_editor()->set_caret_line(p_line.operator int64_t());
 	}
 }
 
@@ -553,9 +553,9 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			int col, row;
 			CodeEdit *tx = shader_editor->get_text_editor();
 			tx->_get_mouse_pos(mb->get_global_position() - tx->get_global_position(), row, col);
-			tx->set_right_click_moves_caret(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
+			tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
 
-			if (tx->is_right_click_moving_caret()) {
+			if (tx->is_move_caret_on_right_click_enabled()) {
 				if (tx->is_selection_active()) {
 					int from_line = tx->get_selection_from_line();
 					int to_line = tx->get_selection_to_line();
@@ -568,8 +568,8 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					}
 				}
 				if (!tx->is_selection_active()) {
-					tx->cursor_set_line(row, true, false);
-					tx->cursor_set_column(col);
+					tx->set_caret_line(row, true, false);
+					tx->set_caret_column(col);
 				}
 			}
 			_make_context_menu(tx->is_selection_active(), get_local_mouse_position());
@@ -577,9 +577,10 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	}
 
 	Ref<InputEventKey> k = ev;
-	if (k.is_valid() && k->is_pressed() && k->get_keycode() == KEY_MENU) {
+	if (k.is_valid() && k->is_pressed() && k->is_action("ui_menu", true)) {
 		CodeEdit *tx = shader_editor->get_text_editor();
-		_make_context_menu(tx->is_selection_active(), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->_get_cursor_pixel_pos()));
+		tx->adjust_viewport_to_caret();
+		_make_context_menu(tx->is_selection_active(), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->get_caret_draw_pos()));
 		context_menu->grab_focus();
 	}
 }

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -550,9 +550,11 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 
 	if (mb.is_valid()) {
 		if (mb->get_button_index() == MOUSE_BUTTON_RIGHT && mb->is_pressed()) {
-			int col, row;
 			CodeEdit *tx = shader_editor->get_text_editor();
-			tx->_get_mouse_pos(mb->get_global_position() - tx->get_global_position(), row, col);
+
+			Point2i pos = tx->get_line_column_at_pos(mb->get_global_position() - tx->get_global_position());
+			int row = pos.y;
+			int col = pos.x;
 			tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
 
 			if (tx->is_move_caret_on_right_click_enabled()) {

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -427,9 +427,11 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 
 	if (mb.is_valid()) {
 		if (mb->get_button_index() == MOUSE_BUTTON_RIGHT) {
-			int col, row;
 			CodeEdit *tx = code_editor->get_text_editor();
-			tx->_get_mouse_pos(mb->get_global_position() - tx->get_global_position(), row, col);
+
+			Point2i pos = tx->get_line_column_at_pos(mb->get_global_position() - tx->get_global_position());
+			int row = pos.y;
+			int col = pos.x;
 
 			tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
 			bool can_fold = tx->can_fold_line(row);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -374,14 +374,14 @@ void TextEditor::_edit_option(int p_op) {
 			code_editor->get_find_replace_bar()->popup_replace();
 		} break;
 		case SEARCH_IN_FILES: {
-			String selected_text = code_editor->get_text_editor()->get_selection_text();
+			String selected_text = code_editor->get_text_editor()->get_selected_text();
 
 			// Yep, because it doesn't make sense to instance this dialog for every single script open...
 			// So this will be delegated to the ScriptEditor.
 			emit_signal(SNAME("search_in_files_requested"), selected_text);
 		} break;
 		case REPLACE_IN_FILES: {
-			String selected_text = code_editor->get_text_editor()->get_selection_text();
+			String selected_text = code_editor->get_text_editor()->get_selected_text();
 
 			emit_signal(SNAME("replace_in_files_requested"), selected_text);
 		} break;
@@ -436,7 +436,7 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			bool is_folded = tx->is_line_folded(row);
 
 			if (tx->is_move_caret_on_right_click_enabled()) {
-				if (tx->is_selection_active()) {
+				if (tx->has_selection()) {
 					int from_line = tx->get_selection_from_line();
 					int to_line = tx->get_selection_to_line();
 					int from_column = tx->get_selection_from_column();
@@ -447,14 +447,14 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 						tx->deselect();
 					}
 				}
-				if (!tx->is_selection_active()) {
+				if (!tx->has_selection()) {
 					tx->set_caret_line(row, true, false);
 					tx->set_caret_column(col);
 				}
 			}
 
 			if (!mb->is_pressed()) {
-				_make_context_menu(tx->is_selection_active(), can_fold, is_folded, get_local_mouse_position());
+				_make_context_menu(tx->has_selection(), can_fold, is_folded, get_local_mouse_position());
 			}
 		}
 	}
@@ -464,7 +464,7 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		CodeEdit *tx = code_editor->get_text_editor();
 		int line = tx->get_caret_line();
 		tx->adjust_viewport_to_caret();
-		_make_context_menu(tx->is_selection_active(), tx->can_fold_line(line), tx->is_line_folded(line), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->get_caret_draw_pos()));
+		_make_context_menu(tx->has_selection(), tx->can_fold_line(line), tx->is_line_folded(line), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->get_caret_draw_pos()));
 		context_menu->grab_focus();
 	}
 }

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -132,14 +132,14 @@ void TextEditor::reload_text() {
 	ERR_FAIL_COND(text_file.is_null());
 
 	CodeEdit *te = code_editor->get_text_editor();
-	int column = te->cursor_get_column();
-	int row = te->cursor_get_line();
+	int column = te->get_caret_column();
+	int row = te->get_caret_line();
 	int h = te->get_h_scroll();
 	int v = te->get_v_scroll();
 
 	te->set_text(text_file->get_text());
-	te->cursor_set_line(row);
-	te->cursor_set_column(column);
+	te->set_caret_line(row);
+	te->set_caret_column(column);
 	te->set_h_scroll(h);
 	te->set_v_scroll(v);
 
@@ -332,7 +332,7 @@ void TextEditor::_edit_option(int p_op) {
 			code_editor->duplicate_selection();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
-			tx->toggle_foldable_line(tx->cursor_get_line());
+			tx->toggle_foldable_line(tx->get_caret_line());
 			tx->update();
 		} break;
 		case EDIT_FOLD_ALL_LINES: {
@@ -431,11 +431,11 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			CodeEdit *tx = code_editor->get_text_editor();
 			tx->_get_mouse_pos(mb->get_global_position() - tx->get_global_position(), row, col);
 
-			tx->set_right_click_moves_caret(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
+			tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
 			bool can_fold = tx->can_fold_line(row);
 			bool is_folded = tx->is_line_folded(row);
 
-			if (tx->is_right_click_moving_caret()) {
+			if (tx->is_move_caret_on_right_click_enabled()) {
 				if (tx->is_selection_active()) {
 					int from_line = tx->get_selection_from_line();
 					int to_line = tx->get_selection_to_line();
@@ -448,8 +448,8 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					}
 				}
 				if (!tx->is_selection_active()) {
-					tx->cursor_set_line(row, true, false);
-					tx->cursor_set_column(col);
+					tx->set_caret_line(row, true, false);
+					tx->set_caret_column(col);
 				}
 			}
 
@@ -460,10 +460,11 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	}
 
 	Ref<InputEventKey> k = ev;
-	if (k.is_valid() && k->is_pressed() && k->get_keycode() == KEY_MENU) {
+	if (k.is_valid() && k->is_pressed() && k->is_action("ui_menu", true)) {
 		CodeEdit *tx = code_editor->get_text_editor();
-		int line = tx->cursor_get_line();
-		_make_context_menu(tx->is_selection_active(), tx->can_fold_line(line), tx->is_line_folded(line), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->_get_cursor_pixel_pos()));
+		int line = tx->get_caret_line();
+		tx->adjust_viewport_to_caret();
+		_make_context_menu(tx->is_selection_active(), tx->can_fold_line(line), tx->is_line_folded(line), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->get_caret_draw_pos()));
 		context_menu->grab_focus();
 	}
 }

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -340,7 +340,7 @@ void TextEditor::_edit_option(int p_op) {
 			tx->update();
 		} break;
 		case EDIT_UNFOLD_ALL_LINES: {
-			tx->unhide_all_lines();
+			tx->unfold_all_lines();
 			tx->update();
 		} break;
 		case EDIT_TRIM_TRAILING_WHITESAPCE: {

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -484,7 +484,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	commit_message->set_h_grow_direction(Control::GrowDirection::GROW_DIRECTION_BEGIN);
 	commit_message->set_v_grow_direction(Control::GrowDirection::GROW_DIRECTION_END);
 	commit_message->set_custom_minimum_size(Size2(200, 100));
-	commit_message->set_wrap_enabled(true);
+	commit_message->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 	commit_message->connect("text_changed", callable_mp(this, &VersionControlEditorPlugin::_update_commit_button));
 	commit_message->connect("gui_input", callable_mp(this, &VersionControlEditorPlugin::_commit_message_gui_input));
 	commit_box_vbc->add_child(commit_message);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3968,7 +3968,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	preview_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	preview_text->set_syntax_highlighter(syntax_highlighter);
 	preview_text->set_draw_line_numbers(true);
-	preview_text->set_readonly(true);
+	preview_text->set_editable(false);
 
 	error_panel = memnew(PanelContainer);
 	preview_vbox->add_child(error_panel);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -295,8 +295,8 @@ void CodeEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 			if (mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 				if (is_line_folded(line)) {
-					int wrap_index = get_line_wrap_index_at_col(line, col);
-					if (wrap_index == times_line_wraps(line)) {
+					int wrap_index = get_line_wrap_index_at_column(line, col);
+					if (wrap_index == get_line_wrap_count(line)) {
 						int eol_icon_width = cache.folded_eol_icon->get_width();
 						int left_margin = get_total_gutter_width() + eol_icon_width + get_line_width(line, wrap_index) - get_h_scroll();
 						if (mpos.x > left_margin && mpos.x <= left_margin + eol_icon_width + 3) {
@@ -531,8 +531,8 @@ Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
 	_get_mouse_pos(p_pos, line, col);
 
 	if (is_line_folded(line)) {
-		int wrap_index = get_line_wrap_index_at_col(line, col);
-		if (wrap_index == times_line_wraps(line)) {
+		int wrap_index = get_line_wrap_index_at_column(line, col);
+		if (wrap_index == get_line_wrap_count(line)) {
 			int eol_icon_width = cache.folded_eol_icon->get_width();
 			int left_margin = get_total_gutter_width() + eol_icon_width + get_line_width(line, wrap_index) - get_h_scroll();
 			if (p_pos.x > left_margin && p_pos.x <= left_margin + eol_icon_width + 3) {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -564,7 +564,7 @@ void CodeEdit::_handle_unicode_input(const uint32_t p_unicode) {
 		delete_selection();
 	}
 
-	/* Remove the old character if in insert mode and no selection. */
+	// Remove the old character if in overtype mode and no selection.
 	if (is_overtype_mode_enabled() && !had_selection) {
 		begin_complex_operation();
 
@@ -651,8 +651,8 @@ void CodeEdit::_backspace() {
 		}
 	}
 
-	/* For space indentation we need to do a simple unindent if there are no chars to the left, acting in the */
-	/* same way as tabs.                                                                                      */
+	// For space indentation we need to do a simple unindent if there are no chars to the left, acting in the
+	// same way as tabs.
 	if (indent_using_spaces && cc != 0) {
 		if (get_first_non_whitespace_column(cl) > cc) {
 			prev_column = cc - _calculate_spaces_till_next_left_indent(cc);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -548,7 +548,7 @@ Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
 
 // Overridable actions
 void CodeEdit::_handle_unicode_input(const uint32_t p_unicode) {
-	bool had_selection = is_selection_active();
+	bool had_selection = has_selection();
 	if (had_selection) {
 		begin_complex_operation();
 		delete_selection();
@@ -611,7 +611,7 @@ void CodeEdit::_backspace() {
 		return;
 	}
 
-	if (is_selection_active()) {
+	if (has_selection()) {
 		delete_selection();
 		return;
 	}
@@ -718,7 +718,7 @@ void CodeEdit::do_indent() {
 		return;
 	}
 
-	if (is_selection_active()) {
+	if (has_selection()) {
 		indent_lines();
 		return;
 	}
@@ -747,7 +747,7 @@ void CodeEdit::indent_lines() {
 
 	int start_line = get_caret_line();
 	int end_line = start_line;
-	if (is_selection_active()) {
+	if (has_selection()) {
 		start_line = get_selection_from_line();
 		end_line = get_selection_to_line();
 
@@ -760,7 +760,7 @@ void CodeEdit::indent_lines() {
 
 	for (int i = start_line; i <= end_line; i++) {
 		const String line_text = get_line(i);
-		if (line_text.size() == 0 && is_selection_active()) {
+		if (line_text.size() == 0 && has_selection()) {
 			continue;
 		}
 
@@ -777,7 +777,7 @@ void CodeEdit::indent_lines() {
 	}
 
 	/* Fix selection and caret being off after shifting selection right.*/
-	if (is_selection_active()) {
+	if (has_selection()) {
 		select(start_line, get_selection_from_column() + selection_offset, get_selection_to_line(), get_selection_to_column() + selection_offset);
 	}
 	set_caret_column(get_caret_column() + selection_offset, false);
@@ -792,7 +792,7 @@ void CodeEdit::do_unindent() {
 
 	int cc = get_caret_column();
 
-	if (is_selection_active() || cc <= 0) {
+	if (has_selection() || cc <= 0) {
 		unindent_lines();
 		return;
 	}
@@ -839,7 +839,7 @@ void CodeEdit::unindent_lines() {
 
 	int start_line = get_caret_line();
 	int end_line = start_line;
-	if (is_selection_active()) {
+	if (has_selection()) {
 		start_line = get_selection_from_line();
 		end_line = get_selection_to_line();
 
@@ -882,7 +882,7 @@ void CodeEdit::unindent_lines() {
 		}
 	}
 
-	if (is_selection_active()) {
+	if (has_selection()) {
 		/* Fix selection being off by one on the first line. */
 		if (first_line_edited) {
 			select(get_selection_from_line(), get_selection_from_column() - removed_characters, get_selection_to_line(), initial_selection_end_column);
@@ -1423,7 +1423,7 @@ void CodeEdit::fold_line(int p_line) {
 	}
 
 	/* Fix selection. */
-	if (is_selection_active()) {
+	if (has_selection()) {
 		if (is_line_hidden(get_selection_from_line()) && is_line_hidden(get_selection_to_line())) {
 			deselect();
 		} else if (is_line_hidden(get_selection_from_line())) {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -555,7 +555,7 @@ void CodeEdit::_handle_unicode_input(const uint32_t p_unicode) {
 	}
 
 	/* Remove the old character if in insert mode and no selection. */
-	if (is_insert_mode() && !had_selection) {
+	if (is_overtype_mode_enabled() && !had_selection) {
 		begin_complex_operation();
 
 		/* Make sure we don't try and remove empty space. */
@@ -594,7 +594,7 @@ void CodeEdit::_handle_unicode_input(const uint32_t p_unicode) {
 		insert_text_at_caret(chr);
 	}
 
-	if ((is_insert_mode() && !had_selection) || (had_selection)) {
+	if ((is_overtype_mode_enabled() && !had_selection) || (had_selection)) {
 		end_complex_operation();
 	}
 }

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -523,7 +523,7 @@ Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
 		return CURSOR_POINTING_HAND;
 	}
 
-	if ((code_completion_active && code_completion_rect.has_point(p_pos)) || (is_readonly() && (!is_selecting_enabled() || get_line_count() == 0))) {
+	if ((code_completion_active && code_completion_rect.has_point(p_pos)) || (!is_editable() && (!is_selecting_enabled() || get_line_count() == 0))) {
 		return CURSOR_ARROW;
 	}
 
@@ -600,7 +600,7 @@ void CodeEdit::_handle_unicode_input(const uint32_t p_unicode) {
 }
 
 void CodeEdit::_backspace() {
-	if (is_readonly()) {
+	if (!is_editable()) {
 		return;
 	}
 
@@ -714,7 +714,7 @@ TypedArray<String> CodeEdit::get_auto_indent_prefixes() const {
 }
 
 void CodeEdit::do_indent() {
-	if (is_readonly()) {
+	if (!is_editable()) {
 		return;
 	}
 
@@ -735,7 +735,7 @@ void CodeEdit::do_indent() {
 }
 
 void CodeEdit::indent_lines() {
-	if (is_readonly()) {
+	if (!is_editable()) {
 		return;
 	}
 
@@ -786,7 +786,7 @@ void CodeEdit::indent_lines() {
 }
 
 void CodeEdit::do_unindent() {
-	if (is_readonly()) {
+	if (!is_editable()) {
 		return;
 	}
 
@@ -824,7 +824,7 @@ void CodeEdit::do_unindent() {
 }
 
 void CodeEdit::unindent_lines() {
-	if (is_readonly()) {
+	if (!is_editable()) {
 		return;
 	}
 
@@ -911,7 +911,7 @@ int CodeEdit::_calculate_spaces_till_next_right_indent(int p_column) const {
 }
 
 void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
-	if (is_readonly()) {
+	if (!is_editable()) {
 		return;
 	}
 
@@ -1839,7 +1839,7 @@ void CodeEdit::set_code_completion_selected_index(int p_index) {
 }
 
 void CodeEdit::confirm_code_completion(bool p_replace) {
-	if (is_readonly() || !code_completion_active) {
+	if (!is_editable() || !code_completion_active) {
 		return;
 	}
 

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -239,10 +239,15 @@ protected:
 
 	static void _bind_methods();
 
+	/* Text manipulation */
+
+	// Overridable actions
+	virtual void _handle_unicode_input(const uint32_t p_unicode) override;
+	virtual void _backspace() override;
+
 public:
 	/* General overrides */
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
-	virtual void handle_unicode_input(uint32_t p_unicode) override;
 
 	/* Indent management */
 	void set_indent_size(const int p_size);
@@ -262,8 +267,6 @@ public:
 
 	void indent_lines();
 	void unindent_lines();
-
-	virtual void backspace() override;
 
 	/* Auto brace completion */
 	void set_auto_brace_completion_enabled(bool p_enabled);

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -233,6 +233,14 @@ private:
 	String symbol_lookup_new_word = "";
 	String symbol_lookup_word = "";
 
+	/* Visual */
+	Ref<StyleBox> style_normal;
+
+	Ref<Font> font;
+	int font_size = 16;
+
+	int line_spacing = 1;
+
 protected:
 	void _gui_input(const Ref<InputEvent> &p_gui_input) override;
 	void _notification(int p_what);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1222,12 +1222,12 @@ void TextEdit::_notification(int p_what) {
 							if (caret.draw_pos.x >= xmargin_beg && caret.draw_pos.x < xmargin_end) {
 								caret.visible = true;
 								if (draw_caret) {
-									if (caret_type == CaretType::CARET_TYPE_BLOCK || insert_mode) {
+									if (caret_type == CaretType::CARET_TYPE_BLOCK || overtype_mode) {
 										//Block or underline caret, draw trailing carets at full height.
 										int h = cache.font->get_height(cache.font_size);
 
 										if (t_caret != Rect2()) {
-											if (insert_mode) {
+											if (overtype_mode) {
 												t_caret.position.y = TS->shaped_text_get_descent(rid);
 												t_caret.size.y = caret_width;
 											} else {
@@ -1238,7 +1238,7 @@ void TextEdit::_notification(int p_what) {
 
 											draw_rect(t_caret, caret_color, false);
 										} else { // End of the line.
-											if (insert_mode) {
+											if (overtype_mode) {
 												l_caret.position.y = TS->shaped_text_get_descent(rid);
 												l_caret.size.y = caret_width;
 											} else {
@@ -2287,7 +2287,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			return;
 		}
 		if (k->is_action("ui_text_toggle_insert_mode", true)) {
-			set_insert_mode(!insert_mode);
+			set_overtype_mode_enabled(!overtype_mode);
 			accept_event();
 			return;
 		}
@@ -3254,6 +3254,14 @@ void TextEdit::_update_caches() {
 }
 
 /* Text manipulation */
+void TextEdit::set_overtype_mode_enabled(const bool p_enabled) {
+	overtype_mode = p_enabled;
+	update();
+}
+
+bool TextEdit::is_overtype_mode_enabled() const {
+	return overtype_mode;
+}
 
 // Overridable actions
 void TextEdit::handle_unicode_input(const uint32_t p_unicode) {
@@ -4516,15 +4524,6 @@ bool TextEdit::is_drawing_spaces() const {
 	return draw_spaces;
 }
 
-void TextEdit::set_insert_mode(bool p_enabled) {
-	insert_mode = p_enabled;
-	update();
-}
-
-bool TextEdit::is_insert_mode() const {
-	return insert_mode;
-}
-
 bool TextEdit::is_insert_text_operation() {
 	return (current_op.type == TextOperation::TYPE_INSERT);
 }
@@ -5068,6 +5067,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_overriding_selected_font_color"), &TextEdit::is_overriding_selected_font_color);
 
 	/* Text manipulation */
+	ClassDB::bind_method(D_METHOD("set_overtype_mode_enabled", "enabled"), &TextEdit::set_overtype_mode_enabled);
+	ClassDB::bind_method(D_METHOD("is_overtype_mode_enabled"), &TextEdit::is_overtype_mode_enabled);
 
 	// Overridable actions
 	ClassDB::bind_method(D_METHOD("backspace"), &TextEdit::backspace);
@@ -5441,7 +5442,7 @@ void TextEdit::_handle_unicode_input(const uint32_t p_unicode) {
 	}
 
 	/* Remove the old character if in insert mode and no selection. */
-	if (insert_mode && !had_selection) {
+	if (overtype_mode && !had_selection) {
 		begin_complex_operation();
 
 		/* Make sure we don't try and remove empty space. */
@@ -5455,7 +5456,7 @@ void TextEdit::_handle_unicode_input(const uint32_t p_unicode) {
 	const char32_t chr[2] = { (char32_t)p_unicode, 0 };
 	insert_text_at_caret(chr);
 
-	if ((insert_mode && !had_selection) || (had_selection)) {
+	if ((overtype_mode && !had_selection) || (had_selection)) {
 		end_complex_operation();
 	}
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -746,8 +746,6 @@ void TextEdit::_notification(int p_what) {
 
 			int cursor_wrap_index = get_cursor_wrap_index();
 
-			//FontDrawer drawer(cache.font, Color(1, 1, 1));
-
 			int first_visible_line = get_first_visible_line() - 1;
 			int draw_amount = visible_rows + (smooth_scroll_enabled ? 1 : 0);
 			draw_amount += times_line_wraps(first_visible_line + 1);
@@ -2823,7 +2821,6 @@ void TextEdit::_base_remove_text(int p_from_line, int p_from_column, int p_to_li
 	}
 	text.set(p_from_line, pre_text + post_text, structured_text_parser(st_parser, st_args, pre_text + post_text));
 
-	//text.set_line_wrap_amount(p_from_line, -1);
 	text.invalidate_cache(p_from_line);
 
 	if (!text_changed_dirty && !setting_text) {
@@ -2940,19 +2937,6 @@ void TextEdit::_remove_text(int p_from_line, int p_from_column, int p_to_line, i
 	op.prev_version = get_version();
 	_push_current_op();
 	current_op = op;
-}
-
-int TextEdit::get_char_count() {
-	int totalsize = 0;
-
-	for (int i = 0; i < text.size(); i++) {
-		if (i > 0) {
-			totalsize++; // Include \n.
-		}
-		totalsize += text[i].length();
-	}
-
-	return totalsize; // Omit last \n.
 }
 
 Size2 TextEdit::get_minimum_size() const {
@@ -5370,11 +5354,6 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(SELECTION_MODE_POINTER);
 	BIND_ENUM_CONSTANT(SELECTION_MODE_WORD);
 	BIND_ENUM_CONSTANT(SELECTION_MODE_LINE);
-
-	/*
-	ClassDB::bind_method(D_METHOD("delete_char"),&TextEdit::delete_char);
-	ClassDB::bind_method(D_METHOD("delete_line"),&TextEdit::delete_line);
-*/
 
 	ClassDB::bind_method(D_METHOD("get_draw_control_chars"), &TextEdit::get_draw_control_chars);
 	ClassDB::bind_method(D_METHOD("set_draw_control_chars", "enable"), &TextEdit::set_draw_control_chars);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4318,6 +4318,7 @@ bool TextEdit::is_drawing_spaces() const {
 }
 
 void TextEdit::_bind_methods() {
+	/*Internal. */
 	ClassDB::bind_method(D_METHOD("_gui_input"), &TextEdit::_gui_input);
 	ClassDB::bind_method(D_METHOD("_text_changed_emit"), &TextEdit::_text_changed_emit);
 
@@ -4384,7 +4385,7 @@ void TextEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_last_unhidden_line"), &TextEdit::get_last_unhidden_line);
 	ClassDB::bind_method(D_METHOD("get_next_visible_line_offset_from", "line", "visible_amount"), &TextEdit::get_next_visible_line_offset_from);
-	ClassDB::bind_method(D_METHOD("num_lines_from_rows", "line", "wrap_index", "visible_amount"), &TextEdit::get_next_visible_line_index_offset_from);
+	ClassDB::bind_method(D_METHOD("get_next_visible_line_index_offset_from", "line", "wrap_index", "visible_amount"), &TextEdit::get_next_visible_line_index_offset_from);
 
 	// Overridable actions
 	ClassDB::bind_method(D_METHOD("backspace"), &TextEdit::backspace);
@@ -4662,28 +4663,34 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_menu_visible"), &TextEdit::is_menu_visible);
 	ClassDB::bind_method(D_METHOD("menu_option", "option"), &TextEdit::menu_option);
 
+	/* Inspector */
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "language"), "set_language", "get_language");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_control_chars"), "set_draw_control_chars", "get_draw_control_chars");
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "highlight_current_line"), "set_highlight_current_line", "is_highlight_current_line_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_tabs"), "set_draw_tabs", "is_drawing_tabs");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_spaces"), "set_draw_spaces", "is_drawing_spaces");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "highlight_all_occurrences"), "set_highlight_all_occurrences", "is_highlight_all_occurrences_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_selected_font_color"), "set_override_selected_font_color", "is_overriding_selected_font_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "context_menu_enabled"), "set_context_menu_enabled", "is_context_menu_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_keys_enabled"), "set_shortcut_keys_enabled", "is_shortcut_keys_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "virtual_keyboard_enabled"), "set_virtual_keyboard_enabled", "is_virtual_keyboard_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selecting_enabled"), "set_selecting_enabled", "is_selecting_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "smooth_scrolling"), "set_smooth_scroll_enable", "is_smooth_scroll_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_past_end_of_file"), "set_scroll_past_end_of_file_enabled", "is_scroll_past_end_of_file_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "v_scroll_speed"), "set_v_scroll_speed", "get_v_scroll_speed");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "virtual_keyboard_enabled"), "set_virtual_keyboard_enabled", "is_virtual_keyboard_enabled");
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "wrap_mode", PROPERTY_HINT_ENUM, "None,Boundary"), "set_line_wrapping_mode", "get_line_wrapping_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_vertical"), "set_v_scroll", "get_v_scroll");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_horizontal"), "set_h_scroll", "get_h_scroll");
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_selected_font_color"), "set_override_selected_font_color", "is_overriding_selected_font_color");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "highlight_all_occurrences"), "set_highlight_all_occurrences", "is_highlight_all_occurrences_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "highlight_current_line"), "set_highlight_current_line", "is_highlight_current_line_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_control_chars"), "set_draw_control_chars", "get_draw_control_chars");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_tabs"), "set_draw_tabs", "is_drawing_tabs");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_spaces"), "set_draw_spaces", "is_drawing_spaces");
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "syntax_highlighter", PROPERTY_HINT_RESOURCE_TYPE, "SyntaxHighlighter", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE), "set_syntax_highlighter", "get_syntax_highlighter");
+
+	ADD_GROUP("Scroll", "scroll_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_smooth"), "set_smooth_scroll_enable", "is_smooth_scroll_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_v_scroll_speed"), "set_v_scroll_speed", "get_v_scroll_speed");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_past_end_of_file"), "set_scroll_past_end_of_file_enabled", "is_scroll_past_end_of_file_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_vertical"), "set_v_scroll", "get_v_scroll");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_horizontal"), "set_h_scroll", "get_h_scroll");
 
 	ADD_GROUP("Minimap", "minimap_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "minimap_draw"), "draw_minimap", "is_drawing_minimap");
@@ -4701,15 +4708,19 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "structured_text_bidi_override_options"), "set_structured_text_bidi_override_options", "get_structured_text_bidi_override_options");
 
 	/* Signals */
+	/* Core. */
+	ADD_SIGNAL(MethodInfo("text_changed"));
+	ADD_SIGNAL(MethodInfo("lines_edited_from", PropertyInfo(Variant::INT, "from_line"), PropertyInfo(Variant::INT, "to_line")));
+
 	/* Caret. */
 	ADD_SIGNAL(MethodInfo("caret_changed"));
 
-	ADD_SIGNAL(MethodInfo("text_changed"));
-	ADD_SIGNAL(MethodInfo("lines_edited_from", PropertyInfo(Variant::INT, "from_line"), PropertyInfo(Variant::INT, "to_line")));
+	/* Gutters. */
 	ADD_SIGNAL(MethodInfo("gutter_clicked", PropertyInfo(Variant::INT, "line"), PropertyInfo(Variant::INT, "gutter")));
 	ADD_SIGNAL(MethodInfo("gutter_added"));
 	ADD_SIGNAL(MethodInfo("gutter_removed"));
 
+	/* Settings. */
 	GLOBAL_DEF("gui/timers/text_edit_idle_detect_sec", 3);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/timers/text_edit_idle_detect_sec", PropertyInfo(Variant::FLOAT, "gui/timers/text_edit_idle_detect_sec", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater")); // No negative numbers.
 	GLOBAL_DEF("gui/common/text_edit_undo_stack_max_size", 1024);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -188,6 +188,10 @@ private:
 	};
 
 	/* Text manipulation */
+	// User control.
+	/* Initialise to opposite first, so we get past the early-out in set_editable. */
+	bool editable = false;
+
 	bool overtype_mode = false;
 
 	String cut_copy_line = "";
@@ -331,8 +335,6 @@ private:
 
 	uint32_t version = 0;
 	uint32_t saved_version = 0;
-
-	bool readonly = true; // Initialise to opposite first, so we get past the early-out in set_readonly.
 
 	bool window_has_focus = true;
 
@@ -525,6 +527,10 @@ protected:
 
 public:
 	/* Text manipulation */
+	// User control
+	void set_editable(const bool p_editable);
+	bool is_editable() const;
+
 	void set_overtype_mode_enabled(const bool p_enabled);
 	bool is_overtype_mode_enabled() const;
 
@@ -750,9 +756,6 @@ public:
 
 	void adjust_viewport_to_caret();
 	void center_viewport_to_caret();
-
-	void set_readonly(bool p_readonly);
-	bool is_readonly() const;
 
 	void clear();
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -339,7 +339,6 @@ private:
 	bool draw_spaces = false;
 	bool text_changed_dirty = false;
 	bool undo_enabled = true;
-	bool hiding_enabled = false;
 	bool draw_minimap = false;
 	int minimap_width = 80;
 	Point2 minimap_char_size = Point2(1, 2);
@@ -360,8 +359,6 @@ private:
 	double minimap_scroll_click_pos = 0.0;
 	float target_v_scroll = 0.0;
 	float v_scroll_speed = 80.0;
-
-	String lookup_symbol_word;
 
 	Timer *idle_detect;
 	HScrollBar *h_scroll;
@@ -464,7 +461,6 @@ protected:
 	struct Cache {
 		Ref<Texture2D> tab_icon;
 		Ref<Texture2D> space_icon;
-		Ref<Texture2D> folded_eol_icon;
 		Ref<StyleBox> style_normal;
 		Ref<StyleBox> style_focus;
 		Ref<StyleBox> style_readonly;
@@ -474,7 +470,6 @@ protected:
 		Color outline_color;
 		Color font_color;
 		Color font_readonly_color;
-		Color code_folding_color;
 		Color current_line_color;
 		Color brace_mismatch_color;
 		Color word_highlighted_color;
@@ -499,6 +494,23 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+	/* Internal API for CodeEdit, pending public API. */
+	// Line hiding.
+	Color code_folding_color = Color(1, 1, 1);
+	Ref<Texture2D> folded_eol_icon;
+
+	bool hiding_enabled = false;
+
+	void _set_hiding_enabled(bool p_enabled);
+	bool _is_hiding_enabled() const;
+
+	void _set_line_as_hidden(int p_line, bool p_hidden);
+	bool _is_line_hidden(int p_line) const;
+
+	void _unhide_all_lines();
+
+	// Symbol lookup.
+	String lookup_symbol_word;
 	void _set_symbol_lookup_word(const String &p_symbol);
 
 	/* Text manipulation */
@@ -716,9 +728,6 @@ public:
 	int get_line_count() const;
 	int get_line_width(int p_line, int p_wrap_offset = -1) const;
 
-	void set_line_as_hidden(int p_line, bool p_hidden);
-	bool is_line_hidden(int p_line) const;
-	void unhide_all_lines();
 	int num_lines_from(int p_line_from, int visible_amount) const;
 	int num_lines_from_rows(int p_line_from, int p_wrap_index_from, int visible_amount, int &wrap_index) const;
 	int get_last_unhidden_line() const;
@@ -799,9 +808,6 @@ public:
 
 	void set_minimap_width(int p_minimap_width);
 	int get_minimap_width() const;
-
-	void set_hiding_enabled(bool p_enabled);
-	bool is_hiding_enabled() const;
 
 	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -173,6 +173,9 @@ private:
 		const Color get_line_background_color(int p_line) const { return text[p_line].background_color; }
 	};
 
+	/* Text manipulation */
+	String cut_copy_line = "";
+
 	struct Cursor {
 		Point2 draw_pos;
 		bool visible = false;
@@ -290,7 +293,6 @@ private:
 	bool scroll_past_end_of_file_enabled = false;
 	bool highlight_current_line = false;
 
-	String cut_copy_line;
 	bool insert_mode = false;
 	bool select_identifiers_enabled = false;
 
@@ -473,7 +475,27 @@ protected:
 
 	void _set_symbol_lookup_word(const String &p_symbol);
 
+	/* Text manipulation */
+
+	// Overridable actions
+	virtual void _handle_unicode_input(const uint32_t p_unicode);
+	virtual void _backspace();
+
+	virtual void _cut();
+	virtual void _copy();
+	virtual void _paste();
+
 public:
+	/* Text manipulation */
+
+	// Overridable actions
+	void handle_unicode_input(const uint32_t p_unicode);
+	void backspace();
+
+	void cut();
+	void copy();
+	void paste();
+
 	/* Syntax Highlighting. */
 	Ref<SyntaxHighlighter> get_syntax_highlighter();
 	void set_syntax_highlighter(Ref<SyntaxHighlighter> p_syntax_highlighter);
@@ -667,11 +689,6 @@ public:
 
 	void delete_selection();
 
-	virtual void handle_unicode_input(uint32_t p_unicode);
-	virtual void backspace();
-	void cut();
-	void copy();
-	void paste();
 	void select_all();
 	void select_word_under_caret();
 	void select(int p_from_line, int p_from_column, int p_to_line, int p_to_column);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -188,6 +188,8 @@ private:
 	};
 
 	/* Text manipulation */
+	bool overtype_mode = false;
+
 	String cut_copy_line = "";
 
 	/* Caret. */
@@ -347,8 +349,6 @@ private:
 	bool highlight_all_occurrences = false;
 	bool scroll_past_end_of_file_enabled = false;
 	bool highlight_current_line = false;
-
-	bool insert_mode = false;
 
 	bool smooth_scroll_enabled = false;
 	bool scrolling = false;
@@ -525,6 +525,8 @@ protected:
 
 public:
 	/* Text manipulation */
+	void set_overtype_mode_enabled(const bool p_enabled);
+	bool is_overtype_mode_enabled() const;
 
 	// Overridable actions
 	void handle_unicode_input(const uint32_t p_unicode);
@@ -778,9 +780,6 @@ public:
 	bool is_drawing_tabs() const;
 	void set_draw_spaces(bool p_draw);
 	bool is_drawing_spaces() const;
-
-	void set_insert_mode(bool p_enabled);
-	bool is_insert_mode() const;
 
 	double get_v_scroll() const;
 	void set_v_scroll(double p_scroll);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -280,6 +280,53 @@ private:
 
 	void _update_caret_wrap_offset();
 
+	/* Viewport. */
+	HScrollBar *h_scroll;
+	VScrollBar *v_scroll;
+
+	bool scroll_past_end_of_file_enabled = false;
+
+	// Smooth scrolling.
+	bool smooth_scroll_enabled = false;
+	float target_v_scroll = 0.0;
+	float v_scroll_speed = 80.0;
+
+	// Scrolling.
+	bool scrolling = false;
+	bool updating_scrolls = false;
+
+	void _update_scrollbars();
+
+	void _v_scroll_input();
+	void _scroll_moved(double p_to_val);
+
+	double _get_visible_lines_offset() const;
+	double _get_v_scroll_offset() const;
+
+	void _scroll_up(real_t p_delta);
+	void _scroll_down(real_t p_delta);
+
+	void _scroll_lines_up();
+	void _scroll_lines_down();
+
+	// Minimap
+	bool draw_minimap = false;
+
+	int minimap_width = 80;
+	Point2 minimap_char_size = Point2(1, 2);
+	int minimap_line_spacing = 1;
+
+	// minimap scroll
+	bool minimap_clicked = false;
+	bool dragging_minimap = false;
+	bool can_drag_minimap = false;
+
+	double minimap_scroll_ratio = 0.0;
+	double minimap_scroll_click_pos = 0.0;
+
+	void _update_minimap_click();
+	void _update_minimap_drag();
+
 	/* Syntax highlighting. */
 	Map<int, Dictionary> syntax_highlighting_cache;
 
@@ -343,29 +390,11 @@ private:
 	bool draw_spaces = false;
 	bool text_changed_dirty = false;
 	bool undo_enabled = true;
-	bool draw_minimap = false;
-	int minimap_width = 80;
-	Point2 minimap_char_size = Point2(1, 2);
-	int minimap_line_spacing = 1;
 
 	bool highlight_all_occurrences = false;
-	bool scroll_past_end_of_file_enabled = false;
 	bool highlight_current_line = false;
 
-	bool smooth_scroll_enabled = false;
-	bool scrolling = false;
-	bool dragging_minimap = false;
-	bool can_drag_minimap = false;
-	bool minimap_clicked = false;
-	double minimap_scroll_ratio = 0.0;
-	double minimap_scroll_click_pos = 0.0;
-	float target_v_scroll = 0.0;
-	float v_scroll_speed = 80.0;
-
 	Timer *idle_detect;
-	HScrollBar *h_scroll;
-	VScrollBar *v_scroll;
-	bool updating_scrolls = false;
 
 	Object *tooltip_obj = nullptr;
 	StringName tooltip_func;
@@ -382,36 +411,8 @@ private:
 	bool shortcut_keys_enabled = true;
 	bool virtual_keyboard_enabled = true;
 
-	int get_visible_rows() const;
-	int get_total_visible_rows() const;
-
-	int _get_minimap_visible_rows() const;
-
-	double get_scroll_pos_for_line(int p_line, int p_wrap_index = 0) const;
-	void set_line_as_first_visible(int p_line, int p_wrap_index = 0);
-	void set_line_as_center_visible(int p_line, int p_wrap_index = 0);
-	void set_line_as_last_visible(int p_line, int p_wrap_index = 0);
-	int get_first_visible_line() const;
-	int get_last_full_visible_line() const;
-	int get_last_full_visible_line_wrap_index() const;
-	double get_visible_rows_offset() const;
-	double get_v_scroll_offset() const;
-
 	int get_char_pos_for_line(int p_px, int p_line, int p_wrap_index = 0) const;
 	int get_column_x_offset_for_line(int p_char, int p_line) const;
-
-	double get_scroll_line_diff() const;
-	void _scroll_moved(double);
-	void _update_scrollbars();
-	void _v_scroll_input();
-
-	void _update_minimap_click();
-	void _update_minimap_drag();
-	void _scroll_up(real_t p_delta);
-	void _scroll_down(real_t p_delta);
-
-	void _scroll_lines_up();
-	void _scroll_lines_down();
 
 	Size2 get_minimum_size() const override;
 	int _get_control_height() const;
@@ -480,7 +481,6 @@ protected:
 		Color background_color;
 
 		int line_spacing = 1;
-		int minimap_width = 0;
 	} cache;
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
@@ -607,6 +607,51 @@ public:
 	int get_line_wrap_index_at_column(int p_line, int p_column) const;
 
 	Vector<String> get_line_wrapped_text(int p_line) const;
+
+	/* Viewport. */
+	//Scrolling.
+	void set_smooth_scroll_enabled(const bool p_enable);
+	bool is_smooth_scroll_enabled() const;
+
+	void set_scroll_past_end_of_file_enabled(const bool p_enabled);
+	bool is_scroll_past_end_of_file_enabled() const;
+
+	void set_v_scroll(double p_scroll);
+	double get_v_scroll() const;
+
+	void set_h_scroll(int p_scroll);
+	int get_h_scroll() const;
+
+	void set_v_scroll_speed(float p_speed);
+	float get_v_scroll_speed() const;
+
+	double get_scroll_pos_for_line(int p_line, int p_wrap_index = 0) const;
+
+	// Visible lines.
+	void set_line_as_first_visible(int p_line, int p_wrap_index = 0);
+	int get_first_visible_line() const;
+
+	void set_line_as_center_visible(int p_line, int p_wrap_index = 0);
+
+	void set_line_as_last_visible(int p_line, int p_wrap_index = 0);
+	int get_last_full_visible_line() const;
+	int get_last_full_visible_line_wrap_index() const;
+
+	int get_visible_line_count() const;
+	int get_total_visible_line_count() const;
+
+	// Auto Adjust
+	void adjust_viewport_to_caret();
+	void center_viewport_to_caret();
+
+	// Minimap
+	void set_draw_minimap(bool p_draw);
+	bool is_drawing_minimap() const;
+
+	void set_minimap_width(int p_minimap_width);
+	int get_minimap_width() const;
+
+	int get_minimap_visible_lines() const;
 
 	/* Syntax Highlighting. */
 	Ref<SyntaxHighlighter> get_syntax_highlighter();
@@ -749,14 +794,6 @@ public:
 	int get_indent_level(int p_line) const;
 	int get_first_non_whitespace_column(int p_line) const;
 
-	inline void set_scroll_pass_end_of_file(bool p_enabled) {
-		scroll_past_end_of_file_enabled = p_enabled;
-		update();
-	}
-
-	void adjust_viewport_to_caret();
-	void center_viewport_to_caret();
-
 	void clear();
 
 	void swap_lines(int line1, int line2);
@@ -784,18 +821,6 @@ public:
 	void set_draw_spaces(bool p_draw);
 	bool is_drawing_spaces() const;
 
-	double get_v_scroll() const;
-	void set_v_scroll(double p_scroll);
-
-	int get_h_scroll() const;
-	void set_h_scroll(int p_scroll);
-
-	void set_smooth_scroll_enabled(bool p_enable);
-	bool is_smooth_scroll_enabled() const;
-
-	void set_v_scroll_speed(float p_speed);
-	float get_v_scroll_speed() const;
-
 	uint32_t get_version() const;
 	uint32_t get_saved_version() const;
 	void tag_saved_version();
@@ -804,12 +829,6 @@ public:
 
 	void set_highlight_current_line(bool p_enabled);
 	bool is_highlight_current_line_enabled() const;
-
-	void set_draw_minimap(bool p_draw);
-	bool is_drawing_minimap() const;
-
-	void set_minimap_width(int p_minimap_width);
-	int get_minimap_width() const;
 
 	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -342,7 +342,6 @@ private:
 	void _update_wrap_at(bool p_force = false);
 	Vector<String> get_wrap_rows_text(int p_line) const;
 	int get_cursor_wrap_index() const;
-	int get_char_count();
 
 	double get_scroll_pos_for_line(int p_line, int p_wrap_index = 0) const;
 	void set_line_as_first_visible(int p_line, int p_wrap_index = 0);
@@ -379,7 +378,6 @@ private:
 	void _scroll_lines_up();
 	void _scroll_lines_down();
 
-	//void mouse_motion(const Point& p_pos, const Point& p_rel, int p_button_mask);
 	Size2 get_minimum_size() const override;
 	int _get_control_height() const;
 
@@ -573,9 +571,6 @@ public:
 	void _get_mouse_pos(const Point2i &p_mouse, int &r_row, int &r_col) const;
 	void _get_minimap_mouse_row(const Point2i &p_mouse, int &r_row) const;
 	bool is_dragging_cursor() const;
-
-	//void delete_char();
-	//void delete_line();
 
 	void begin_complex_operation();
 	void end_complex_operation();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -48,12 +48,6 @@ public:
 		CARET_TYPE_BLOCK
 	};
 
-	enum GutterType {
-		GUTTER_TYPE_STRING,
-		GUTTER_TYPE_ICON,
-		GUTTER_TYPE_CUSTOM
-	};
-
 	/* Selection */
 	enum SelectionMode {
 		SELECTION_MODE_NONE,
@@ -61,6 +55,19 @@ public:
 		SELECTION_MODE_POINTER,
 		SELECTION_MODE_WORD,
 		SELECTION_MODE_LINE
+	};
+
+	/* Line Wrapping.*/
+	enum LineWrappingMode {
+		LINE_WRAPPING_NONE,
+		LINE_WRAPPING_BOUNDARY
+	};
+
+	/* Gutters. */
+	enum GutterType {
+		GUTTER_TYPE_STRING,
+		GUTTER_TYPE_ICON,
+		GUTTER_TYPE_CUSTOM
 	};
 
 private:
@@ -183,7 +190,7 @@ private:
 	/* Text manipulation */
 	String cut_copy_line = "";
 
-	/* Caret */
+	/* Caret. */
 	struct Caret {
 		Point2 draw_pos;
 		bool visible = false;
@@ -217,6 +224,7 @@ private:
 	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();
 
+	/* Selection. */
 	struct Selection {
 		SelectionMode selecting_mode = SelectionMode::SELECTION_MODE_NONE;
 		int selecting_line = 0;
@@ -236,6 +244,17 @@ private:
 		bool shiftclick_left = false;
 	} selection;
 
+	/* line wrapping. */
+	LineWrappingMode line_wrapping_mode = LineWrappingMode::LINE_WRAPPING_NONE;
+
+	int wrap_at_column = 0;
+	int wrap_right_offset = 10;
+
+	void _update_wrap_at_column(bool p_force = false);
+
+	void _update_caret_wrap_offset();
+
+	/* Syntax highlighting. */
 	Map<int, Dictionary> syntax_highlighting_cache;
 
 	struct TextOperation {
@@ -294,10 +313,6 @@ private:
 	bool readonly = true; // Initialise to opposite first, so we get past the early-out in set_readonly.
 
 	bool window_has_focus = true;
-
-	bool wrap_enabled = false;
-	int wrap_at = 0;
-	int wrap_right_offset = 10;
 
 	bool first_draw = true;
 	bool draw_tabs = false;
@@ -361,10 +376,6 @@ private:
 	int get_total_visible_rows() const;
 
 	int _get_minimap_visible_rows() const;
-
-	void _update_caret_wrap_offset();
-	void _update_wrap_at(bool p_force = false);
-	Vector<String> get_wrap_rows_text(int p_line) const;
 
 	double get_scroll_pos_for_line(int p_line, int p_wrap_index = 0) const;
 	void set_line_as_first_visible(int p_line, int p_wrap_index = 0);
@@ -537,6 +548,16 @@ public:
 
 	int get_caret_wrap_index() const;
 
+	/* line wrapping. */
+	void set_line_wrapping_mode(LineWrappingMode p_wrapping_mode);
+	LineWrappingMode get_line_wrapping_mode() const;
+
+	bool is_line_wrapped(int p_line) const;
+	int get_line_wrap_count(int p_line) const;
+	int get_line_wrap_index_at_column(int p_line, int p_column) const;
+
+	Vector<String> get_line_wrapped_text(int p_line) const;
+
 	/* Syntax Highlighting. */
 	Ref<SyntaxHighlighter> get_syntax_highlighter();
 	void set_syntax_highlighter(Ref<SyntaxHighlighter> p_syntax_highlighter);
@@ -664,7 +685,6 @@ public:
 	void insert_at(const String &p_text, int at);
 	int get_line_count() const;
 	int get_line_width(int p_line, int p_wrap_offset = -1) const;
-	int get_line_wrap_index_at_col(int p_line, int p_column) const;
 
 	void set_line_as_hidden(int p_line, bool p_hidden);
 	bool is_line_hidden(int p_line) const;
@@ -697,11 +717,6 @@ public:
 
 	void set_readonly(bool p_readonly);
 	bool is_readonly() const;
-
-	void set_wrap_enabled(bool p_wrap_enabled);
-	bool is_wrap_enabled() const;
-	bool line_wraps(int line) const;
-	int times_line_wraps(int line) const;
 
 	void clear();
 
@@ -799,8 +814,8 @@ public:
 	~TextEdit();
 };
 
-
 VARIANT_ENUM_CAST(TextEdit::CaretType);
+VARIANT_ENUM_CAST(TextEdit::LineWrappingMode);
 VARIANT_ENUM_CAST(TextEdit::SelectionMode);
 VARIANT_ENUM_CAST(TextEdit::GutterType);
 VARIANT_ENUM_CAST(TextEdit::MenuItems);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -244,6 +244,26 @@ private:
 		bool shiftclick_left = false;
 	} selection;
 
+	bool selecting_enabled = true;
+
+	Color font_selected_color = Color(1, 1, 1);
+	Color selection_color = Color(1, 1, 1);
+	bool override_selected_font_color = false;
+
+	bool dragging_selection = false;
+
+	Timer *click_select_held;
+	uint64_t last_dblclk = 0;
+	Vector2 last_dblclk_pos;
+	void _click_selection_held();
+
+	void _update_selection_mode_pointer();
+	void _update_selection_mode_word();
+	void _update_selection_mode_line();
+
+	void _pre_shift_selection();
+	void _post_shift_selection();
+
 	/* line wrapping. */
 	LineWrappingMode line_wrapping_mode = LineWrappingMode::LINE_WRAPPING_NONE;
 
@@ -317,7 +337,6 @@ private:
 	bool first_draw = true;
 	bool draw_tabs = false;
 	bool draw_spaces = false;
-	bool override_selected_font_color = false;
 	bool text_changed_dirty = false;
 	bool undo_enabled = true;
 	bool hiding_enabled = false;
@@ -331,11 +350,9 @@ private:
 	bool highlight_current_line = false;
 
 	bool insert_mode = false;
-	bool select_identifiers_enabled = false;
 
 	bool smooth_scroll_enabled = false;
 	bool scrolling = false;
-	bool dragging_selection = false;
 	bool dragging_minimap = false;
 	bool can_drag_minimap = false;
 	bool minimap_clicked = false;
@@ -346,11 +363,7 @@ private:
 
 	String lookup_symbol_word;
 
-	uint64_t last_dblclk = 0;
-	Vector2 last_dblclk_pos;
-
 	Timer *idle_detect;
-	Timer *click_select_held;
 	HScrollBar *h_scroll;
 	VScrollBar *v_scroll;
 	bool updating_scrolls = false;
@@ -365,8 +378,6 @@ private:
 	uint32_t search_flags = 0;
 	int search_result_line = 0;
 	int search_result_col = 0;
-
-	bool selecting_enabled = true;
 
 	bool context_menu_enabled = true;
 	bool shortcut_keys_enabled = true;
@@ -394,19 +405,11 @@ private:
 	void _scroll_moved(double);
 	void _update_scrollbars();
 	void _v_scroll_input();
-	void _click_selection_held();
-
-	void _update_selection_mode_pointer();
-	void _update_selection_mode_word();
-	void _update_selection_mode_line();
 
 	void _update_minimap_click();
 	void _update_minimap_drag();
 	void _scroll_up(real_t p_delta);
 	void _scroll_down(real_t p_delta);
-
-	void _pre_shift_selection();
-	void _post_shift_selection();
 
 	void _scroll_lines_up();
 	void _scroll_lines_down();
@@ -470,9 +473,7 @@ protected:
 		int outline_size = 0;
 		Color outline_color;
 		Color font_color;
-		Color font_selected_color;
 		Color font_readonly_color;
-		Color selection_color;
 		Color code_folding_color;
 		Color current_line_color;
 		Color brace_mismatch_color;
@@ -547,6 +548,35 @@ public:
 	int get_caret_column() const;
 
 	int get_caret_wrap_index() const;
+
+	/* Selection. */
+	void set_selecting_enabled(const bool p_enabled);
+	bool is_selecting_enabled() const;
+
+	void set_override_selected_font_color(bool p_override_selected_font_color);
+	bool is_overriding_selected_font_color() const;
+
+	void set_selection_mode(SelectionMode p_mode, int p_line = -1, int p_column = -1);
+	SelectionMode get_selection_mode() const;
+
+	void select_all();
+	void select_word_under_caret();
+	void select(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
+
+	bool has_selection() const;
+
+	String get_selected_text() const;
+
+	int get_selection_line() const;
+	int get_selection_column() const;
+
+	int get_selection_from_line() const;
+	int get_selection_from_column() const;
+	int get_selection_to_line() const;
+	int get_selection_to_column() const;
+
+	void deselect();
+	void delete_selection();
 
 	/* line wrapping. */
 	void set_line_wrapping_mode(LineWrappingMode p_wrapping_mode);
@@ -710,22 +740,11 @@ public:
 	void adjust_viewport_to_caret();
 	void center_viewport_to_caret();
 
-	SelectionMode get_selection_mode() const;
-	void set_selection_mode(SelectionMode p_mode, int p_line = -1, int p_column = -1);
-	int get_selection_line() const;
-	int get_selection_column() const;
-
 	void set_readonly(bool p_readonly);
 	bool is_readonly() const;
 
 	void clear();
 
-	void delete_selection();
-
-	void select_all();
-	void select_word_under_caret();
-	void select(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
-	void deselect();
 	void swap_lines(int line1, int line2);
 
 	void set_search_text(const String &p_search_text);
@@ -734,12 +753,6 @@ public:
 
 	void set_highlight_all_occurrences(const bool p_enabled);
 	bool is_highlight_all_occurrences_enabled() const;
-	bool is_selection_active() const;
-	int get_selection_from_line() const;
-	int get_selection_from_column() const;
-	int get_selection_to_line() const;
-	int get_selection_to_column() const;
-	String get_selection_text() const;
 
 	String get_word_under_caret() const;
 	String get_word_at_pos(const Vector2 &p_pos) const;
@@ -756,8 +769,6 @@ public:
 	bool is_drawing_tabs() const;
 	void set_draw_spaces(bool p_draw);
 	bool is_drawing_spaces() const;
-	void set_override_selected_font_color(bool p_override_selected_font_color);
-	bool is_overriding_selected_font_color() const;
 
 	void set_insert_mode(bool p_enabled);
 	bool is_insert_mode() const;
@@ -796,9 +807,6 @@ public:
 
 	void set_context_menu_enabled(bool p_enable);
 	bool is_context_menu_enabled();
-
-	void set_selecting_enabled(bool p_enabled);
-	bool is_selecting_enabled() const;
 
 	void set_shortcut_keys_enabled(bool p_enabled);
 	bool is_shortcut_keys_enabled() const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -70,6 +70,47 @@ public:
 		GUTTER_TYPE_CUSTOM
 	};
 
+	/* Contex Menu. */
+	enum MenuItems {
+		MENU_CUT,
+		MENU_COPY,
+		MENU_PASTE,
+		MENU_CLEAR,
+		MENU_SELECT_ALL,
+		MENU_UNDO,
+		MENU_REDO,
+		MENU_DIR_INHERITED,
+		MENU_DIR_AUTO,
+		MENU_DIR_LTR,
+		MENU_DIR_RTL,
+		MENU_DISPLAY_UCC,
+		MENU_INSERT_LRM,
+		MENU_INSERT_RLM,
+		MENU_INSERT_LRE,
+		MENU_INSERT_RLE,
+		MENU_INSERT_LRO,
+		MENU_INSERT_RLO,
+		MENU_INSERT_PDF,
+		MENU_INSERT_ALM,
+		MENU_INSERT_LRI,
+		MENU_INSERT_RLI,
+		MENU_INSERT_FSI,
+		MENU_INSERT_PDI,
+		MENU_INSERT_ZWJ,
+		MENU_INSERT_ZWNJ,
+		MENU_INSERT_WJ,
+		MENU_INSERT_SHY,
+		MENU_MAX
+
+	};
+
+	/* Search. */
+	enum SearchFlags {
+		SEARCH_MATCH_CASE = 1,
+		SEARCH_WHOLE_WORDS = 2,
+		SEARCH_BACKWARDS = 4
+	};
+
 private:
 	struct GutterInfo {
 		GutterType type = GutterType::GUTTER_TYPE_STRING;
@@ -82,11 +123,6 @@ private:
 		ObjectID custom_draw_obj = ObjectID();
 		StringName custom_draw_callback;
 	};
-	Vector<GutterInfo> gutters;
-	int gutters_width = 0;
-	int gutter_padding = 0;
-
-	void _update_gutter_width();
 
 	class Text {
 	public:
@@ -135,7 +171,7 @@ private:
 		void set_font(const Ref<Font> &p_font);
 		void set_font_size(int p_font_size);
 		void set_font_features(const Dictionary &p_features);
-		void set_direction_and_language(TextServer::Direction p_direction, String p_language);
+		void set_direction_and_language(TextServer::Direction p_direction, const String &p_language);
 		void set_draw_control_chars(bool p_draw_control_chars);
 
 		int get_line_height(int p_line, int p_wrap_index) const;
@@ -173,7 +209,7 @@ private:
 		void set_line_gutter_text(int p_line, int p_gutter, const String &p_text) { text.write[p_line].gutters.write[p_gutter].text = p_text; }
 		const String &get_line_gutter_text(int p_line, int p_gutter) const { return text[p_line].gutters[p_gutter].text; }
 
-		void set_line_gutter_icon(int p_line, int p_gutter, Ref<Texture2D> p_icon) { text.write[p_line].gutters.write[p_gutter].icon = p_icon; }
+		void set_line_gutter_icon(int p_line, int p_gutter, const Ref<Texture2D> &p_icon) { text.write[p_line].gutters.write[p_gutter].icon = p_icon; }
 		const Ref<Texture2D> &get_line_gutter_icon(int p_line, int p_gutter) const { return text[p_line].gutters[p_gutter].icon; }
 
 		void set_line_gutter_item_color(int p_line, int p_gutter, const Color &p_color) { text.write[p_line].gutters.write[p_gutter].color = p_color; }
@@ -187,14 +223,101 @@ private:
 		const Color get_line_background_color(int p_line) const { return text[p_line].background_color; }
 	};
 
-	/* Text manipulation */
-	// User control.
+	/* Text */
+	Text text;
+
+	bool setting_text = false;
+
+	// Text properties.
+	String ime_text = "";
+	Point2 ime_selection;
+
 	/* Initialise to opposite first, so we get past the early-out in set_editable. */
 	bool editable = false;
 
-	bool overtype_mode = false;
+	TextDirection text_direction = TEXT_DIRECTION_AUTO;
+	TextDirection input_direction = TEXT_DIRECTION_LTR;
 
+	Dictionary opentype_features;
+	String language = "";
+
+	Control::StructuredTextParser st_parser = STRUCTURED_TEXT_DEFAULT;
+	Array st_args;
+
+	void _clear();
+	void _update_caches();
+
+	// User control.
+	bool overtype_mode = false;
+	bool context_menu_enabled = true;
+	bool shortcut_keys_enabled = true;
+	bool virtual_keyboard_enabled = true;
+
+	// Overridable actions
 	String cut_copy_line = "";
+
+	// Context menu.
+	PopupMenu *menu = nullptr;
+	PopupMenu *menu_dir = nullptr;
+	PopupMenu *menu_ctl = nullptr;
+
+	void _generate_context_menu();
+	int _get_menu_action_accelerator(const String &p_action);
+
+	/* Versioning */
+	struct TextOperation {
+		enum Type {
+			TYPE_NONE,
+			TYPE_INSERT,
+			TYPE_REMOVE
+		};
+
+		Type type = TYPE_NONE;
+		int from_line = 0;
+		int from_column = 0;
+		int to_line = 0;
+		int to_column = 0;
+		String text;
+		uint32_t prev_version = 0;
+		uint32_t version = 0;
+		bool chain_forward = false;
+		bool chain_backward = false;
+	};
+
+	bool undo_enabled = true;
+	int undo_stack_max_size = 50;
+
+	bool next_operation_is_complex = false;
+
+	TextOperation current_op;
+	List<TextOperation> undo_stack;
+	List<TextOperation>::Element *undo_stack_pos = nullptr;
+
+	Timer *idle_detect;
+
+	uint32_t version = 0;
+	uint32_t saved_version = 0;
+
+	void _push_current_op();
+	void _do_text_op(const TextOperation &p_op, bool p_reverse);
+	void _clear_redo();
+
+	/* Search */
+	Color search_result_color = Color(1, 1, 1);
+	Color search_result_border_color = Color(1, 1, 1);
+
+	String search_text = "";
+	uint32_t search_flags = 0;
+
+	int _get_column_pos_of_word(const String &p_key, const String &p_search, uint32_t p_search_flags, int p_from_column) const;
+
+	/* Tooltip. */
+	Object *tooltip_obj = nullptr;
+	StringName tooltip_func;
+	Variant tooltip_ud;
+
+	/* Mouse */
+	int _get_char_pos_for_line(int p_px, int p_line, int p_wrap_index = 0) const;
 
 	/* Caret. */
 	struct Caret {
@@ -229,6 +352,8 @@ private:
 
 	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();
+
+	int _get_column_x_offset_for_line(int p_char, int p_line) const;
 
 	/* Selection. */
 	struct Selection {
@@ -296,6 +421,7 @@ private:
 	bool updating_scrolls = false;
 
 	void _update_scrollbars();
+	int _get_control_height() const;
 
 	void _v_scroll_input();
 	void _scroll_moved(double p_to_val);
@@ -327,122 +453,62 @@ private:
 	void _update_minimap_click();
 	void _update_minimap_drag();
 
+	/* Gutters. */
+	Vector<GutterInfo> gutters;
+	int gutters_width = 0;
+	int gutter_padding = 0;
+
+	void _update_gutter_width();
+
 	/* Syntax highlighting. */
-	Map<int, Dictionary> syntax_highlighting_cache;
-
-	struct TextOperation {
-		enum Type {
-			TYPE_NONE,
-			TYPE_INSERT,
-			TYPE_REMOVE
-		};
-
-		Type type = TYPE_NONE;
-		int from_line = 0;
-		int from_column = 0;
-		int to_line = 0;
-		int to_column = 0;
-		String text;
-		uint32_t prev_version = 0;
-		uint32_t version = 0;
-		bool chain_forward = false;
-		bool chain_backward = false;
-	};
-
-	String ime_text;
-	Point2 ime_selection;
-
-	TextOperation current_op;
-
-	List<TextOperation> undo_stack;
-	List<TextOperation>::Element *undo_stack_pos = nullptr;
-	int undo_stack_max_size;
-
-	void _clear_redo();
-	void _do_text_op(const TextOperation &p_op, bool p_reverse);
-
-	//syntax coloring
 	Ref<SyntaxHighlighter> syntax_highlighter;
-	Set<String> keywords;
+	Map<int, Dictionary> syntax_highlighting_cache;
 
 	Dictionary _get_line_syntax_highlighting(int p_line);
 
-	bool setting_text = false;
+	/* Visual. */
+	Ref<StyleBox> style_normal;
+	Ref<StyleBox> style_focus;
+	Ref<StyleBox> style_readonly;
 
-	// data
-	Text text;
+	Ref<Texture2D> tab_icon;
+	Ref<Texture2D> space_icon;
 
-	Dictionary opentype_features;
-	String language;
-	TextDirection text_direction = TEXT_DIRECTION_AUTO;
-	TextDirection input_direction = TEXT_DIRECTION_LTR;
-	Control::StructuredTextParser st_parser = STRUCTURED_TEXT_DEFAULT;
-	Array st_args;
-	bool draw_control_chars = false;
+	Ref<Font> font;
+	int font_size = 16;
+	Color font_color = Color(1, 1, 1);
+	Color font_readonly_color = Color(1, 1, 1);
 
-	uint32_t version = 0;
-	uint32_t saved_version = 0;
+	int outline_size = 0;
+	Color outline_color = Color(1, 1, 1);
+
+	int line_spacing = 1;
+
+	Color background_color = Color(1, 1, 1);
+	Color current_line_color = Color(1, 1, 1);
+	Color word_highlighted_color = Color(1, 1, 1);
 
 	bool window_has_focus = true;
-
 	bool first_draw = true;
+
+	bool highlight_current_line = false;
+	bool highlight_all_occurrences = false;
+	bool draw_control_chars = false;
 	bool draw_tabs = false;
 	bool draw_spaces = false;
+
+	/*** Super internal Core API. Everything builds on it. ***/
 	bool text_changed_dirty = false;
-	bool undo_enabled = true;
-
-	bool highlight_all_occurrences = false;
-	bool highlight_current_line = false;
-
-	Timer *idle_detect;
-
-	Object *tooltip_obj = nullptr;
-	StringName tooltip_func;
-	Variant tooltip_ud;
-
-	bool next_operation_is_complex = false;
-
-	String search_text;
-	uint32_t search_flags = 0;
-	int search_result_line = 0;
-	int search_result_col = 0;
-
-	bool context_menu_enabled = true;
-	bool shortcut_keys_enabled = true;
-	bool virtual_keyboard_enabled = true;
-
-	int get_char_pos_for_line(int p_px, int p_line, int p_wrap_index = 0) const;
-	int get_column_x_offset_for_line(int p_char, int p_line) const;
-
-	Size2 get_minimum_size() const override;
-	int _get_control_height() const;
-
-	int _get_menu_action_accelerator(const String &p_action);
-
-	void _update_caches();
 	void _text_changed_emit();
 
-	void _push_current_op();
-
-	/* super internal api, undo/redo builds on it */
+	void _insert_text(int p_line, int p_char, const String &p_text, int *r_end_line = nullptr, int *r_end_char = nullptr);
+	void _remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
 
 	void _base_insert_text(int p_line, int p_char, const String &p_text, int &r_end_line, int &r_end_column);
 	String _base_get_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column) const;
 	void _base_remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
 
-	int _get_column_pos_of_word(const String &p_key, const String &p_search, uint32_t p_search_flags, int p_from_column);
-
-	Dictionary _search_bind(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column) const;
-
-	PopupMenu *menu = nullptr;
-	PopupMenu *menu_dir = nullptr;
-	PopupMenu *menu_ctl = nullptr;
-
-	void _ensure_menu();
-
-	void _clear();
-
-	// Methods used in shortcuts
+	/* Input actions. */
 	void _swap_current_input_direction();
 	void _new_line(bool p_split_current = true, bool p_above = false);
 	void _move_caret_left(bool p_select, bool p_move_by_word = false);
@@ -459,36 +525,8 @@ private:
 	void _move_caret_document_end(bool p_select);
 
 protected:
-	bool highlight_matching_braces_enabled = false;
-
-	struct Cache {
-		Ref<Texture2D> tab_icon;
-		Ref<Texture2D> space_icon;
-		Ref<StyleBox> style_normal;
-		Ref<StyleBox> style_focus;
-		Ref<StyleBox> style_readonly;
-		Ref<Font> font;
-		int font_size = 16;
-		int outline_size = 0;
-		Color outline_color;
-		Color font_color;
-		Color font_readonly_color;
-		Color current_line_color;
-		Color brace_mismatch_color;
-		Color word_highlighted_color;
-		Color search_result_color;
-		Color search_result_border_color;
-		Color background_color;
-
-		int line_spacing = 1;
-	} cache;
-
-	virtual String get_tooltip(const Point2 &p_pos) const override;
-
-	void _insert_text(int p_line, int p_char, const String &p_text, int *r_end_line = nullptr, int *r_end_char = nullptr);
-	void _remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
-	virtual void _gui_input(const Ref<InputEvent> &p_gui_input);
 	void _notification(int p_what);
+	virtual void _gui_input(const Ref<InputEvent> &p_gui_input);
 
 	static void _bind_methods();
 
@@ -497,6 +535,10 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 	/* Internal API for CodeEdit, pending public API. */
+	// brace matching
+	bool highlight_matching_braces_enabled = false;
+	Color brace_mismatch_color;
+
 	// Line hiding.
 	Color code_folding_color = Color(1, 1, 1);
 	Ref<Texture2D> folded_eol_icon;
@@ -526,13 +568,77 @@ protected:
 	virtual void _paste();
 
 public:
-	/* Text manipulation */
-	// User control
+	/* General overrides. */
+	virtual Size2 get_minimum_size() const override;
+	virtual bool is_text_field() const override;
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
+	virtual String get_tooltip(const Point2 &p_pos) const override;
+	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
+
+	/* Text */
+	// Text properties.
+	bool has_ime_text() const;
+
 	void set_editable(const bool p_editable);
 	bool is_editable() const;
 
+	void set_text_direction(TextDirection p_text_direction);
+	TextDirection get_text_direction() const;
+
+	void set_opentype_feature(const String &p_name, int p_value);
+	int get_opentype_feature(const String &p_name) const;
+	void clear_opentype_features();
+
+	void set_language(const String &p_language);
+	String get_language() const;
+
+	void set_structured_text_bidi_override(Control::StructuredTextParser p_parser);
+	Control::StructuredTextParser get_structured_text_bidi_override() const;
+	void set_structured_text_bidi_override_options(Array p_args);
+	Array get_structured_text_bidi_override_options() const;
+
+	void set_tab_size(const int p_size);
+	int get_tab_size() const;
+
+	// User controls
 	void set_overtype_mode_enabled(const bool p_enabled);
 	bool is_overtype_mode_enabled() const;
+
+	void set_context_menu_enabled(bool p_enable);
+	bool is_context_menu_enabled() const;
+
+	void set_shortcut_keys_enabled(bool p_enabled);
+	bool is_shortcut_keys_enabled() const;
+
+	void set_virtual_keyboard_enabled(bool p_enable);
+	bool is_virtual_keyboard_enabled() const;
+
+	// Text manipulation
+	void clear();
+
+	void set_text(const String &p_text);
+	String get_text() const;
+	int get_line_count() const;
+
+	void set_line(int p_line, const String &p_new_text);
+	String get_line(int p_line) const;
+
+	int get_line_width(int p_line, int p_wrap_index = -1) const;
+	int get_line_height() const;
+
+	int get_indent_level(int p_line) const;
+	int get_first_non_whitespace_column(int p_line) const;
+
+	void swap_lines(int p_from_line, int p_to_line);
+
+	void insert_line_at(int p_at, const String &p_text);
+	void insert_text_at_caret(const String &p_text);
+
+	void remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
+
+	int get_last_unhidden_line() const;
+	int get_next_visible_line_offset_from(int p_line_from, int p_visible_amount) const;
+	Point2i get_next_visible_line_index_offset_from(int p_line_from, int p_wrap_index_from, int p_visible_amount) const;
 
 	// Overridable actions
 	void handle_unicode_input(const uint32_t p_unicode);
@@ -541,6 +647,42 @@ public:
 	void cut();
 	void copy();
 	void paste();
+
+	// Context menu.
+	PopupMenu *get_menu() const;
+	bool is_menu_visible() const;
+	void menu_option(int p_option);
+
+	/* Versioning */
+	void begin_complex_operation();
+	void end_complex_operation();
+
+	void undo();
+	void redo();
+	void clear_undo_history();
+
+	bool is_insert_text_operation() const;
+
+	void tag_saved_version();
+
+	uint32_t get_version() const;
+	uint32_t get_saved_version() const;
+
+	/* Search */
+	void set_search_text(const String &p_search_text);
+	void set_search_flags(uint32_t p_flags);
+
+	Point2i search(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column) const;
+
+	/* Mouse */
+	Point2 get_local_mouse_pos() const;
+
+	String get_word_at_pos(const Vector2 &p_pos) const;
+
+	Point2i get_line_column_at_pos(const Point2i &p_pos) const;
+	int get_minimap_line_at_pos(const Point2i &p_pos) const;
+
+	bool is_dragging_cursor() const;
 
 	/* Caret */
 	void set_caret_type(CaretType p_type);
@@ -568,6 +710,8 @@ public:
 	int get_caret_column() const;
 
 	int get_caret_wrap_index() const;
+
+	String get_word_under_caret() const;
 
 	/* Selection. */
 	void set_selecting_enabled(const bool p_enabled);
@@ -609,7 +753,7 @@ public:
 	Vector<String> get_line_wrapped_text(int p_line) const;
 
 	/* Viewport. */
-	//Scrolling.
+	// Scrolling.
 	void set_smooth_scroll_enabled(const bool p_enable);
 	bool is_smooth_scroll_enabled() const;
 
@@ -653,10 +797,6 @@ public:
 
 	int get_minimap_visible_lines() const;
 
-	/* Syntax Highlighting. */
-	Ref<SyntaxHighlighter> get_syntax_highlighter();
-	void set_syntax_highlighter(Ref<SyntaxHighlighter> p_syntax_highlighter);
-
 	/* Gutters. */
 	void add_gutter(int p_at = -1);
 	void remove_gutter(int p_gutter);
@@ -692,161 +832,40 @@ public:
 	void set_line_gutter_text(int p_line, int p_gutter, const String &p_text);
 	String get_line_gutter_text(int p_line, int p_gutter) const;
 
-	void set_line_gutter_icon(int p_line, int p_gutter, Ref<Texture2D> p_icon);
+	void set_line_gutter_icon(int p_line, int p_gutter, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_line_gutter_icon(int p_line, int p_gutter) const;
 
 	void set_line_gutter_item_color(int p_line, int p_gutter, const Color &p_color);
-	Color get_line_gutter_item_color(int p_line, int p_gutter);
+	Color get_line_gutter_item_color(int p_line, int p_gutter) const;
 
 	void set_line_gutter_clickable(int p_line, int p_gutter, bool p_clickable);
 	bool is_line_gutter_clickable(int p_line, int p_gutter) const;
 
 	// Line style
 	void set_line_background_color(int p_line, const Color &p_color);
-	Color get_line_background_color(int p_line);
+	Color get_line_background_color(int p_line) const;
 
-	enum MenuItems {
-		MENU_CUT,
-		MENU_COPY,
-		MENU_PASTE,
-		MENU_CLEAR,
-		MENU_SELECT_ALL,
-		MENU_UNDO,
-		MENU_REDO,
-		MENU_DIR_INHERITED,
-		MENU_DIR_AUTO,
-		MENU_DIR_LTR,
-		MENU_DIR_RTL,
-		MENU_DISPLAY_UCC,
-		MENU_INSERT_LRM,
-		MENU_INSERT_RLM,
-		MENU_INSERT_LRE,
-		MENU_INSERT_RLE,
-		MENU_INSERT_LRO,
-		MENU_INSERT_RLO,
-		MENU_INSERT_PDF,
-		MENU_INSERT_ALM,
-		MENU_INSERT_LRI,
-		MENU_INSERT_RLI,
-		MENU_INSERT_FSI,
-		MENU_INSERT_PDI,
-		MENU_INSERT_ZWJ,
-		MENU_INSERT_ZWNJ,
-		MENU_INSERT_WJ,
-		MENU_INSERT_SHY,
-		MENU_MAX
+	/* Syntax Highlighting. */
+	void set_syntax_highlighter(Ref<SyntaxHighlighter> p_syntax_highlighter);
+	Ref<SyntaxHighlighter> get_syntax_highlighter() const;
 
-	};
-
-	enum SearchFlags {
-		SEARCH_MATCH_CASE = 1,
-		SEARCH_WHOLE_WORDS = 2,
-		SEARCH_BACKWARDS = 4
-	};
-
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
-
-	Point2 _get_local_mouse_pos() const;
-	void _get_mouse_pos(const Point2i &p_mouse, int &r_row, int &r_col) const;
-	void _get_minimap_mouse_row(const Point2i &p_mouse, int &r_row) const;
-	bool is_dragging_cursor() const;
-
-	void begin_complex_operation();
-	void end_complex_operation();
-
-	bool is_insert_text_operation();
-
-	void set_text_direction(TextDirection p_text_direction);
-	TextDirection get_text_direction() const;
-
-	void set_opentype_feature(const String &p_name, int p_value);
-	int get_opentype_feature(const String &p_name) const;
-	void clear_opentype_features();
-
-	void set_language(const String &p_language);
-	String get_language() const;
-
-	void set_draw_control_chars(bool p_draw_control_chars);
-	bool get_draw_control_chars() const;
-
-	void set_structured_text_bidi_override(Control::StructuredTextParser p_parser);
-	Control::StructuredTextParser get_structured_text_bidi_override() const;
-
-	void set_structured_text_bidi_override_options(Array p_args);
-	Array get_structured_text_bidi_override_options() const;
-
-	void set_text(String p_text);
-	void insert_text_at_caret(const String &p_text);
-	void insert_at(const String &p_text, int at);
-	int get_line_count() const;
-	int get_line_width(int p_line, int p_wrap_offset = -1) const;
-
-	int num_lines_from(int p_line_from, int visible_amount) const;
-	int num_lines_from_rows(int p_line_from, int p_wrap_index_from, int visible_amount, int &wrap_index) const;
-	int get_last_unhidden_line() const;
-
-	String get_text();
-	String get_line(int line) const;
-	bool has_ime_text() const;
-	void set_line(int line, String new_text);
-	int get_row_height() const;
-
-	int get_indent_level(int p_line) const;
-	int get_first_non_whitespace_column(int p_line) const;
-
-	void clear();
-
-	void swap_lines(int line1, int line2);
-
-	void set_search_text(const String &p_search_text);
-	void set_search_flags(uint32_t p_flags);
-	void set_current_search_result(int line, int col);
+	/* Visual. */
+	void set_highlight_current_line(bool p_enabled);
+	bool is_highlight_current_line_enabled() const;
 
 	void set_highlight_all_occurrences(const bool p_enabled);
 	bool is_highlight_all_occurrences_enabled() const;
 
-	String get_word_under_caret() const;
-	String get_word_at_pos(const Vector2 &p_pos) const;
+	void set_draw_control_chars(bool p_draw_control_chars);
+	bool get_draw_control_chars() const;
 
-	bool search(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column, int &r_line, int &r_column) const;
-
-	void undo();
-	void redo();
-	void clear_undo_history();
-
-	void set_tab_size(const int p_size);
-	int get_tab_size() const;
 	void set_draw_tabs(bool p_draw);
 	bool is_drawing_tabs() const;
+
 	void set_draw_spaces(bool p_draw);
 	bool is_drawing_spaces() const;
 
-	uint32_t get_version() const;
-	uint32_t get_saved_version() const;
-	void tag_saved_version();
-
-	void menu_option(int p_option);
-
-	void set_highlight_current_line(bool p_enabled);
-	bool is_highlight_current_line_enabled() const;
-
-	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
-
-	void set_context_menu_enabled(bool p_enable);
-	bool is_context_menu_enabled();
-
-	void set_shortcut_keys_enabled(bool p_enabled);
-	bool is_shortcut_keys_enabled() const;
-
-	void set_virtual_keyboard_enabled(bool p_enable);
-	bool is_virtual_keyboard_enabled() const;
-
-	bool is_menu_visible() const;
-	PopupMenu *get_menu() const;
-
-	virtual bool is_text_field() const override;
 	TextEdit();
-	~TextEdit();
 };
 
 VARIANT_ENUM_CAST(TextEdit::CaretType);


### PR DESCRIPTION
Continuation of #31739

Builds on #50122

---

This PR seems larger then it is, mainly moving around code and renames, rather then any changes.

The main aim of this PR is to cleanup after extracting features into `CodeEdit` and to prepare the API going forward.  Will do `EditorSettings` as a separate PR.

Given `TextEdit` has organically grown rather large it became a bit of mess, so I took the time here to reorganise the methods; hopefully will made it easier to browse.

With that said, the three main API changes are:

- Block caret no longer exists and is now an `enum CaretType`, currently with `Line` and `Block` as the options. The methods have been renamed appropriately:
    - `cursor_set_block_mode` --> `set_caret_type`
    - `cursor_is_block_mode` --> `get_caret_type`
- Line wrapping has now been changed from enable / disable to  an `enum LineWrappingMode`, with `None` and `Boundary` meaning the control boundary as it currently works. Similarly the methods have been renamed:
    - `set_wrap_enabled` --> `set_line_wrapping_mode`
    - `is_wrap_enabled`  --> `get_line_wrapping_mode`
- Cut, copy and paste are now overrideable with:
    - `_cut`
    - `_copy`
    - `_paste  `

Otherwise bedsides exposing many new methods, the following renames have taken place:

Caret:
- `cursor_get_blink_enabled` --> `set_caret_blink_enabled`
- `cursor_set_blink_enabled` --> `is_caret_blink_enabled`
- `cursor_set_blink_speed` --> `set_caret_blink_speed`
- `cursor_get_blink_speed` --> `get_caret_blink_speed`
- `set_right_click_moves_caret` --> `set_move_caret_on_right_click_enabled`
- `is_right_click_moving_caret` --> `is_move_caret_on_right_click_enabled`
- `set_mid_grapheme_caret_enabled` --> `set_caret_mid_grapheme_enabled`
- `get_mid_grapheme_caret_enabled` --> `is_caret_mid_grapheme_enabled`
- `cursor_set_line` --> `set_caret_line`
- `cursor_get_line` --> `get_caret_line`
- `cursor_set_column` --> `set_caret_column`
- `cursor_get_column` --> `get_caret_column`
- `adjust_viewport_to_cursor` --> `adjust_viewport_to_caret`
- `insert_text_at_cursor` --> `insert_text_at_caret`
- `get_word_under_cursor` --> `get_word_under_caret`

Selection:
- `is_selection_active` --> `has_selection`
- `get_selection_text` --> `get_selected_text`

Insert Mode:
- `set_insert_mode` --> `set_overtype_mode_enabled`
- `is_insert_mode` --> `is_overtype_mode_enabled`

Read only:
- `set_readonly` --> `set_editable`
- `is_readonly` --> `is_editable`

Signals:
- `cursor_changed` --> `caret_changed`

Properties:
- `caret_block_mode` --> `caret_type`
- `caret_enabled` --> `wrap_mode`
- `caret_moving_by_right_click` --> `caret_move_on_right_click`

---

Supersedes #47548

Apart from the couple features that need a little more work, after this I'm happy to close #31739