### PR TITLE
Fix breakpoint toggle signal not firing when expected

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1014,6 +1014,11 @@
 				Emitted when the text changes.
 			</description>
 		</signal>
+		<signal name="text_set">
+			<description>
+				Emitted when [method clear] is called or [member text] is set.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="MENU_CUT" value="0" enum="MenuItems">

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -221,8 +221,6 @@ private:
 
 	void _filter_code_completion_candidates();
 
-	void _lines_edited_from(int p_from_line, int p_to_line);
-
 	/* Line length guidelines */
 	TypedArray<int> line_length_guideline_columns;
 	Color line_length_guideline_color;
@@ -240,6 +238,14 @@ private:
 	int font_size = 16;
 
 	int line_spacing = 1;
+
+	/* Callbacks */
+	int lines_edited_from = -1;
+	int lines_edited_to = -1;
+
+	void _lines_edited_from(int p_from_line, int p_to_line);
+	void _text_set();
+	void _text_changed();
 
 protected:
 	void _gui_input(const Ref<InputEvent> &p_gui_input) override;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2449,6 +2449,7 @@ void TextEdit::clear() {
 	setting_text = true;
 	_clear();
 	setting_text = false;
+	emit_signal(SNAME("text_set"));
 }
 
 void TextEdit::_clear() {
@@ -2486,6 +2487,7 @@ void TextEdit::set_text(const String &p_text) {
 
 	update();
 	setting_text = false;
+	emit_signal(SNAME("text_set"));
 }
 
 String TextEdit::get_text() const {
@@ -4709,6 +4711,7 @@ void TextEdit::_bind_methods() {
 
 	/* Signals */
 	/* Core. */
+	ADD_SIGNAL(MethodInfo("text_set"));
 	ADD_SIGNAL(MethodInfo("text_changed"));
 	ADD_SIGNAL(MethodInfo("lines_edited_from", PropertyInfo(Variant::INT, "from_line"), PropertyInfo(Variant::INT, "to_line")));
 
@@ -4875,7 +4878,7 @@ void TextEdit::_backspace() {
 	int prev_line = cc ? cl : cl - 1;
 	int prev_column = cc ? (cc - 1) : (text[cl - 1].length());
 
-	merge_gutters(cl, prev_line);
+	merge_gutters(prev_line, cl);
 
 	if (_is_line_hidden(cl)) {
 		_set_line_as_hidden(prev_line, true);


### PR DESCRIPTION
Builds on #50371

---
Fix breakpoint toggle signal not firing when expected.

Due to `lines_edited_from` emitting after every edit, `CodeEdit` was getting lost with the breakpoints state. This is now connected to the `text_changed` signal.

The `text_changed` signal does not emit on a call of `set_text` or `clear`, I've added a new signal `text_set` to handle this.

`set_line_as_breakpoint` was not doing any size check so was emitting for out of bound lines.

Finally, backspacing onto a line removed the breakpoint rather then moving it.