### PR TITLE
Improve the appearance of Deep Parallax in StandardMaterial3D

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -924,7 +924,9 @@ void BaseMaterial3D::_update_shader() {
 			code += "		float layer_depth = 1.0 / num_layers;\n";
 			code += "		float current_layer_depth = 0.0;\n";
 			code += "		vec2 P = view_dir.xy * heightmap_scale;\n";
-			code += "		vec2 delta = P / num_layers;\n";
+			// Improve the depth impression when viewed at oblique angles by dividing with `dot(VIEW, NORMAL)`.
+			// This may require more samples than usual to avoid artifacts, but generally looks better in most real world use cases.
+			code += "		vec2 delta = P / num_layers / dot(VIEW, NORMAL);\n";
 			code += "		vec2 ofs = base_uv;\n";
 			if (flags[FLAG_INVERT_HEIGHTMAP]) {
 				code += "		float depth = texture(texture_heightmap, ofs).r;\n";


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51712. See also https://github.com/godotengine/godot/pull/50383.

This better preserves depth when viewed at oblique angles. Artifacts due to the amount of layers being low may be more noticeable as a result, but it's generally better to decrease the heightmap scale instead to get a more consistent effect regardless of view angle.

This is done by dividing the delta by the dot product of the view vector and normal vector.

Thanks @Arnklit for suggesting the idea :slightly_smiling_face: 

**Testing project:** https://github.com/Calinou/godot-parallax-test-4.0

## Preview

***Note:** From my testing, performance is about the same overall. The FPS counter on the last screenshot fluctuates a fair bit at higher values, so it's not meant to be used to compare performance here.*

| Before | After |
|-------:|:------|
| ![old_parallax_1](https://user-images.githubusercontent.com/180032/125207617-87b53d00-e28d-11eb-9d53-4a91cdf6f2f0.png) | ![new_parallax_1](https://user-images.githubusercontent.com/180032/125207607-8421b600-e28d-11eb-8113-5813bc27e505.png) |
| ![old_parallax_2](https://user-images.githubusercontent.com/180032/125207618-884dd380-e28d-11eb-83aa-5d6a632a3c75.png) | ![new_parallax_2](https://user-images.githubusercontent.com/180032/125207610-8552e300-e28d-11eb-895f-db1183945711.png) |
| ![old_parallax_3](https://user-images.githubusercontent.com/180032/125207619-88e66a00-e28d-11eb-9103-39c06911842c.png) | ![new_parallax_3](https://user-images.githubusercontent.com/180032/125207611-85eb7980-e28d-11eb-9dad-c1d3f176b80f.png) |
| ![old_parallax_4](https://user-images.githubusercontent.com/180032/125207620-897f0080-e28d-11eb-96f0-11eb77be9411.png) | ![new_parallax_4](https://user-images.githubusercontent.com/180032/125207613-86841000-e28d-11eb-8798-ed3583d80be6.png) |
| ![old_parallax_5](https://user-images.githubusercontent.com/180032/125207622-8a179700-e28d-11eb-9b45-97c46e5de5a3.png) | ![new_parallax_5](https://user-images.githubusercontent.com/180032/125207614-86841000-e28d-11eb-9e8a-32bae5819f9b.png) |
| ![old_parallax_6](https://user-images.githubusercontent.com/180032/125207623-8ab02d80-e28d-11eb-9837-4fb705033336.png) | ![new_parallax_6](https://user-images.githubusercontent.com/180032/125207615-871ca680-e28d-11eb-95b4-781b764d754f.png) |







