### PR TITLE
Implement applyEdit in LSP for signal connecting

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -284,6 +284,23 @@ void GDScriptLanguageProtocol::notify_client(const String &p_method, const Varia
 	peer->res_queue.push_back(msg.utf8());
 }
 
+void GDScriptLanguageProtocol::request_client(const String &p_method, const Variant &p_params, int p_client_id) {
+	if (p_client_id == -1) {
+		ERR_FAIL_COND_MSG(latest_client_id == -1,
+				"GDScript LSP: Can't notify client as none was connected.");
+		p_client_id = latest_client_id;
+	}
+	ERR_FAIL_COND(!clients.has(p_client_id));
+	Ref<LSPeer> peer = clients.get(p_client_id);
+	ERR_FAIL_COND(peer == nullptr);
+
+	Dictionary message = make_request(p_method, p_params, next_server_id);
+	next_server_id++;
+	String msg = Variant(message).to_json_string();
+	msg = format_output(msg);
+	peer->res_queue.push_back(msg.utf8());
+}
+
 bool GDScriptLanguageProtocol::is_smart_resolve_enabled() const {
 	return bool(_EDITOR_GET("network/language_server/enable_smart_resolve"));
 }

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -73,6 +73,8 @@ private:
 	int latest_client_id = 0;
 	int next_client_id = 0;
 
+	int next_server_id = 0;
+
 	Ref<GDScriptTextDocument> text_document;
 	Ref<GDScriptWorkspace> workspace;
 
@@ -101,6 +103,7 @@ public:
 	void stop();
 
 	void notify_client(const String &p_method, const Variant &p_params = Variant(), int p_client_id = -1);
+	void request_client(const String &p_method, const Variant &p_params = Variant(), int p_client_id = -1);
 
 	bool is_smart_resolve_enabled() const;
 	bool is_goto_native_symbols_enabled() const;

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -60,6 +60,8 @@ protected:
 
 	void list_script_files(const String &p_root_dir, List<String> &r_files);
 
+	void apply_new_signal(Object *obj, String function, PackedStringArray args);
+
 public:
 	String root;
 	String root_uri;

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -1266,6 +1266,58 @@ struct DocumentSymbol {
 	}
 };
 
+struct WorkspaceEdit {
+	HashMap<String, List<TextEdit>> changes;
+
+	void add_edit(String uri, TextEdit edit) {
+		if (changes.has(uri)) {
+			changes[uri].push_back(edit);
+		} else {
+			List<TextEdit> edits;
+			edits.push_back(edit);
+			changes[uri] = edits;
+		}
+	}
+
+	Dictionary to_json() {
+		Dictionary dict;
+
+		Dictionary changes_dict;
+
+		List<String> key_list;
+		changes.get_key_list(&key_list);
+		for (int i = 0; i < key_list.size(); ++i) {
+			String uri = key_list[i];
+
+			List<TextEdit> edits = changes[key_list[i]];
+			Array changes_arr;
+			for (int l = 0; l < edits.size(); ++l) {
+				Dictionary change_dict;
+				change_dict["newText"] = edits[l].newText;
+				change_dict["range"] = edits[l].range.to_json();
+				changes_arr.push_back(change_dict);
+			}
+			changes_dict[uri] = changes_arr;
+		}
+
+		dict["changes"] = changes_dict;
+
+		return dict;
+	}
+};
+
+struct ApplyWorkspaceEditParams {
+	WorkspaceEdit edit;
+
+	Dictionary to_json() {
+		Dictionary dict;
+
+		dict["edit"] = edit.to_json();
+
+		return dict;
+	}
+};
+
 struct NativeSymbolInspectParams {
 	String native_class;
 	String symbol_name;


### PR DESCRIPTION
As per the discussion in #42416, when an external text editor is set, the Connect Dialog fails to actually enact any change into the script. The workaround currently is to disable external editor, connect your signals, then re-enable it (or work in an external editor even with it turned off.)

This PR implements the workspace/applyEdit server request, which can cause a connected client to insert or replace text - in this case, a blank method stub. By connecting to the EditorNode, we can detect the "script_add_function_request" signal and pass the new function along to the client.

~~## Known Issues~~

~~Currently, once the script has been saved, its changes are not detected by Godot, so the "Go to method" menu item fails, and it will try to add duplicate functions if it already exists. This is fixed by the as yet unmerged #48615, which forces a resync by the server whenever a script is saved.~~

That PR has been merged in, so it's no longer an issue - so long as you save your script.