### PR TITLE
Improve the appearance of simple parallax in StandardMaterial3D

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -957,7 +957,9 @@ void BaseMaterial3D::_update_shader() {
 			} else {
 				code += "		float depth = 1.0 - texture(texture_heightmap, base_uv).r;\n";
 			}
-			code += "		vec2 ofs = base_uv - view_dir.xy / view_dir.z * (depth * heightmap_scale);\n";
+			// Use offset limiting to improve the appearance of non-deep parallax.
+			// This reduces the impression of depth, but avoids visible warping in the distance.
+			code += "		vec2 ofs = base_uv - view_dir.xy * depth * heightmap_scale;\n";
 		}
 
 		code += "		base_uv=ofs;\n";


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51433. Follow-up to https://github.com/godotengine/godot/pull/50377.

This uses offset limiting to avoid distortion in the distance, and makes simple (non-deep) parallax more usable overall. While this reduces the overall impression of depth, it results in much less texture warping in motion.

Inspired by the Three.js parallax mapping demo: https://github.com/mrdoob/three.js/blob/bb484d616955e2bf1c3329383c3c0cc3543ccf71/examples/jsm/shaders/ParallaxShader.js#L62-L64

**Testing project:** https://github.com/Calinou/godot-parallax-test-4.0

## Preview

| Before | After |
|--------|-------|
| ![old_simple_parallax_1](https://user-images.githubusercontent.com/180032/125212174-eb4e6300-e2ab-11eb-9a45-69f6d1574c7a.png) | ![new_simple_parallax_1](https://user-images.githubusercontent.com/180032/125212168-e7badc00-e2ab-11eb-8a64-647991ad3ddc.png) |
| ![old_simple_parallax_2](https://user-images.githubusercontent.com/180032/125212175-ebe6f980-e2ab-11eb-8d8b-6ed3ef1df94e.png) | ![new_simple_parallax_2](https://user-images.githubusercontent.com/180032/125212169-e8ec0900-e2ab-11eb-9239-4fb7651a4b94.png) |
| ![old_simple_parallax_3](https://user-images.githubusercontent.com/180032/125212176-ec7f9000-e2ab-11eb-8680-b25e5a3d1947.png) | ![new_simple_parallax_3](https://user-images.githubusercontent.com/180032/125212170-e9849f80-e2ab-11eb-9c6a-5dc0ad25e5a6.png) |
| ![old_simple_parallax_4](https://user-images.githubusercontent.com/180032/125212178-ec7f9000-e2ab-11eb-8821-ce87ca5d062f.png) | ![new_simple_parallax_4](https://user-images.githubusercontent.com/180032/125212171-ea1d3600-e2ab-11eb-93be-06b91547a77e.png) |
| ![old_simple_parallax_5](https://user-images.githubusercontent.com/180032/125212179-ed182680-e2ab-11eb-87aa-2d20f492a8f1.png) | ![new_simple_parallax_5](https://user-images.githubusercontent.com/180032/125212172-ea1d3600-e2ab-11eb-9f32-63ff5af1108e.png) |
| ![old_simple_parallax_6](https://user-images.githubusercontent.com/180032/125212180-edb0bd00-e2ab-11eb-9bc5-37605c6f8bc6.png) | ![new_simple_parallax_6](https://user-images.githubusercontent.com/180032/125212173-eab5cc80-e2ab-11eb-8a8d-75efc528a7a6.png) |