### PR TITLE
Change VSync mode project setting enum type from string to integer

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1114,7 +1114,8 @@ ProjectSettings::ProjectSettings() {
 
 	// Keep the enum values in sync with the `DisplayServer::ScreenOrientation` enum.
 	custom_prop_info["display/window/handheld/orientation"] = PropertyInfo(Variant::INT, "display/window/handheld/orientation", PROPERTY_HINT_ENUM, "Landscape,Portrait,Reverse Landscape,Reverse Portrait,Sensor Landscape,Sensor Portrait,Sensor");
-	custom_prop_info["display/window/vsync/vsync_mode"] = PropertyInfo(Variant::STRING, "display/window/vsync/vsync_mode", PROPERTY_HINT_ENUM, "Disabled,Enabled,Adaptive,Mailbox");
+	// Keep the enum values in sync with the `DisplayServer::VSyncMode` enum.
+	custom_prop_info["display/window/vsync/vsync_mode"] = PropertyInfo(Variant::INT, "display/window/vsync/vsync_mode", PROPERTY_HINT_ENUM, "Disabled,Enabled,Adaptive,Mailbox");
 	custom_prop_info["rendering/driver/threads/thread_model"] = PropertyInfo(Variant::INT, "rendering/driver/threads/thread_model", PROPERTY_HINT_ENUM, "Single-Unsafe,Single-Safe,Multi-Threaded");
 	GLOBAL_DEF("physics/2d/run_on_thread", false);
 	GLOBAL_DEF("physics/3d/run_on_thread", false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -532,7 +532,7 @@
 		<member name="display/window/size/width" type="int" setter="" getter="" default="1024">
 			Sets the game's main viewport width. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
 		</member>
-		<member name="display/window/vsync/vsync_mode" type="String" setter="" getter="" default="&quot;Enabled&quot;">
+		<member name="display/window/vsync/vsync_mode" type="int" setter="" getter="" default="1">
 			Sets the VSync mode for the main game window.
 			See [enum DisplayServer.VSyncMode] for possible values and how they affect the behavior of your application.
 			Depending on the platform and used renderer, the engine will fall back to [code]Enabled[/code], if the desired mode is not supported.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1335,20 +1335,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		window_orientation = DisplayServer::ScreenOrientation(int(GLOBAL_DEF_BASIC("display/window/handheld/orientation", DisplayServer::ScreenOrientation::SCREEN_LANDSCAPE)));
 	}
 	{
-		String vsync_mode = GLOBAL_DEF("display/window/vsync/vsync_mode", "Enabled");
-
-		if (vsync_mode == "Disabled") {
-			window_vsync_mode = DisplayServer::VSYNC_DISABLED;
-		} else if (vsync_mode == "Enabled") {
-			window_vsync_mode = DisplayServer::VSYNC_ENABLED;
-		} else if (vsync_mode == "Adaptive") {
-			window_vsync_mode = DisplayServer::VSYNC_ADAPTIVE;
-		} else if (vsync_mode == "Mailbox") {
-			window_vsync_mode = DisplayServer::VSYNC_MAILBOX;
-		} else {
-			WARN_PRINT("VSync mode unknown.");
-			window_vsync_mode = DisplayServer::VSYNC_ENABLED;
-		}
+		window_vsync_mode = DisplayServer::VSyncMode(int(GLOBAL_DEF("display/window/vsync/vsync_mode", DisplayServer::VSyncMode::VSYNC_ENABLED)));
 	}
 	Engine::get_singleton()->set_iterations_per_second(GLOBAL_DEF_BASIC("physics/common/physics_fps", 60));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/common/physics_fps",

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -56,6 +56,8 @@ public:
 		WINDOW_MODE_FULLSCREEN
 	};
 
+	// Keep the VSyncMode enum values in sync with the `display/window/vsync/vsync_mode`
+	// project setting hint.
 	enum VSyncMode {
 		VSYNC_DISABLED,
 		VSYNC_ENABLED,


### PR DESCRIPTION
This PR just changes the VSync mode project setting to be a integer enum for consistency/to clean up the code. 
I added comments in project_setting.cpp as well as display_server.h as a reminder that the setting should be synced with the DisplayServer enum (like it was done with ScreenOrientation).
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

*Bugsquad edit: Follow-up to https://github.com/godotengine/godot/pull/48622.*