### PR TITLE
Auto-set a first compatible uniform on dragging to create a UniformRef (VisualShaders)

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2708,6 +2708,28 @@ VisualShaderNodeUniformRef::UniformType VisualShaderNodeUniformRef::get_uniform_
 	return UniformType::UNIFORM_TYPE_FLOAT;
 }
 
+VisualShaderNodeUniformRef::PortType VisualShaderNodeUniformRef::get_port_type_by_index(int p_idx) const {
+	if (p_idx >= 0 && p_idx < uniforms.size()) {
+		switch (uniforms[p_idx].type) {
+			case UniformType::UNIFORM_TYPE_FLOAT:
+				return PORT_TYPE_SCALAR;
+			case UniformType::UNIFORM_TYPE_INT:
+				return PORT_TYPE_SCALAR_INT;
+			case UniformType::UNIFORM_TYPE_SAMPLER:
+				return PORT_TYPE_SAMPLER;
+			case UniformType::UNIFORM_TYPE_VECTOR:
+				return PORT_TYPE_VECTOR;
+			case UniformType::UNIFORM_TYPE_TRANSFORM:
+				return PORT_TYPE_TRANSFORM;
+			case UniformType::UNIFORM_TYPE_COLOR:
+				return PORT_TYPE_VECTOR;
+			default:
+				break;
+		}
+	}
+	return PORT_TYPE_SCALAR;
+}
+
 String VisualShaderNodeUniformRef::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	switch (uniform_type) {
 		case UniformType::UNIFORM_TYPE_FLOAT:

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -517,6 +517,7 @@ public:
 	String get_uniform_name_by_index(int p_idx) const;
 	UniformType get_uniform_type_by_name(const String &p_name) const;
 	UniformType get_uniform_type_by_index(int p_idx) const;
+	PortType get_port_type_by_index(int p_idx) const;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 


### PR DESCRIPTION
Small QoL-change to auto-connect to most compatible type when dragging from input port on creating a `UniformRef`:
![vs_uniform_ref](https://user-images.githubusercontent.com/3036176/125254051-c1745b00-e302-11eb-9b86-5d30740838af.gif)
