### PR TITLE
Makerst: Remove redundant GDScript from code blocks

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -842,7 +842,7 @@ def rstize_text(text, state):  # type: (str, State) -> str
                 inside_code = True
             elif cmd == "gdscript":
                 tag_depth += 1
-                tag_text = "\n .. code-tab:: gdscript GDScript\n"
+                tag_text = "\n .. code-tab:: gdscript\n"
                 inside_code = True
             elif cmd == "csharp":
                 tag_depth += 1


### PR DESCRIPTION
I did a test build and the code blocks work fine