### PR TITLE
[Net] Remove most multiplayer hooks from SceneTree.

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -660,7 +660,7 @@
 			</argument>
 			<description>
 				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. Returns an empty [Variant].
-				[b]Note:[/b] You can only safely use RPCs on clients after you received the [code]connected_to_server[/code] signal from the [SceneTree]. You also need to keep track of the connection state, either by the [SceneTree] signals like [code]server_disconnected[/code] or by checking [code]SceneTree.network_peer.get_connection_status() == CONNECTION_CONNECTED[/code].
+				[b]Note:[/b] You can only safely use RPCs on clients after you received the [code]connected_to_server[/code] signal from the [MultiplayerAPI]. You also need to keep track of the connection state, either by the [MultiplayerAPI] signals like [code]server_disconnected[/code] or by checking [code]get_multiplayer().network_peer.get_connection_status() == CONNECTION_CONNECTED[/code].
 			</description>
 		</method>
 		<method name="rpc_config">

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -112,20 +112,6 @@
 				Returns the current frame number, i.e. the total frame count since the application started.
 			</description>
 		</method>
-		<method name="get_network_connected_peers" qualifiers="const">
-			<return type="PackedInt32Array">
-			</return>
-			<description>
-				Returns the peer IDs of all connected peers of this [SceneTree]'s [member network_peer].
-			</description>
-		</method>
-		<method name="get_network_unique_id" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-				Returns the unique peer ID of this [SceneTree]'s [member network_peer].
-			</description>
-		</method>
 		<method name="get_node_count" qualifiers="const">
 			<return type="int">
 			</return>
@@ -149,13 +135,6 @@
 				Returns an array of currently exising [Tween]s in the [SceneTree] (both running and paused).
 			</description>
 		</method>
-		<method name="get_rpc_sender_id" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-				Returns the sender's peer ID for the most recently received RPC call.
-			</description>
-		</method>
 		<method name="has_group" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -163,20 +142,6 @@
 			</argument>
 			<description>
 				Returns [code]true[/code] if the given group exists.
-			</description>
-		</method>
-		<method name="has_network_peer" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-				Returns [code]true[/code] if there is a [member network_peer] set.
-			</description>
-		</method>
-		<method name="is_network_server" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-				Returns [code]true[/code] if this [SceneTree]'s [member network_peer] is in server mode (listening for connections).
 			</description>
 		</method>
 		<method name="notify_group">
@@ -301,32 +266,16 @@
 			If [code]true[/code] (default value), enables automatic polling of the [MultiplayerAPI] for this SceneTree during [signal process_frame].
 			If [code]false[/code], you need to manually call [method MultiplayerAPI.poll] to process network packets and deliver RPCs/RSETs. This allows running RPCs/RSETs in a different loop (e.g. physics, thread, specific time step) and for manual [Mutex] protection when accessing the [MultiplayerAPI] from threads.
 		</member>
-		<member name="network_peer" type="NetworkedMultiplayerPeer" setter="set_network_peer" getter="get_network_peer">
-			The peer object to handle the RPC system (effectively enabling networking when set). Depending on the peer itself, the [SceneTree] will become a network server (check with [method is_network_server]) and will set the root node's network mode to master, or it will become a regular peer with the root node set to puppet. All child nodes are set to inherit the network mode by default. Handling of networking-related events (connection, disconnection, new clients) is done by connecting to [SceneTree]'s signals.
-		</member>
 		<member name="paused" type="bool" setter="set_pause" getter="is_paused" default="false">
 			If [code]true[/code], the [SceneTree] is paused. Doing so will have the following behavior:
 			- 2D and 3D physics will be stopped.
 			- [method Node._process], [method Node._physics_process] and [method Node._input] will not be called anymore in nodes.
-		</member>
-		<member name="refuse_new_network_connections" type="bool" setter="set_refuse_new_network_connections" getter="is_refusing_new_network_connections" default="false">
-			If [code]true[/code], the [SceneTree]'s [member network_peer] refuses new incoming connections.
 		</member>
 		<member name="root" type="Window" setter="" getter="get_root">
 			The [SceneTree]'s root [Window].
 		</member>
 	</members>
 	<signals>
-		<signal name="connected_to_server">
-			<description>
-				Emitted whenever this [SceneTree]'s [member network_peer] successfully connected to a server. Only emitted on clients.
-			</description>
-		</signal>
-		<signal name="connection_failed">
-			<description>
-				Emitted whenever this [SceneTree]'s [member network_peer] fails to establish a connection to a server. Only emitted on clients.
-			</description>
-		</signal>
 		<signal name="files_dropped">
 			<argument index="0" name="files" type="PackedStringArray">
 			</argument>
@@ -334,20 +283,6 @@
 			</argument>
 			<description>
 				Emitted when files are dragged from the OS file manager and dropped in the game window. The arguments are a list of file paths and the identifier of the screen where the drag originated.
-			</description>
-		</signal>
-		<signal name="network_peer_connected">
-			<argument index="0" name="id" type="int">
-			</argument>
-			<description>
-				Emitted whenever this [SceneTree]'s [member network_peer] connects with a new peer. ID is the peer ID of the new peer. Clients get notified when other clients connect to the same server. Upon connecting to a server, a client also receives this signal for the server (with ID being 1).
-			</description>
-		</signal>
-		<signal name="network_peer_disconnected">
-			<argument index="0" name="id" type="int">
-			</argument>
-			<description>
-				Emitted whenever this [SceneTree]'s [member network_peer] disconnects from a peer. Clients get notified when other clients disconnect from the same server.
 			</description>
 		</signal>
 		<signal name="node_added">
@@ -386,11 +321,6 @@
 		<signal name="process_frame">
 			<description>
 				Emitted immediately before [method Node._process] is called on every node in the [SceneTree].
-			</description>
-		</signal>
-		<signal name="server_disconnected">
-			<description>
-				Emitted whenever this [SceneTree]'s [member network_peer] disconnected from server. Only emitted on clients.
 			</description>
 		</signal>
 		<signal name="tree_changed">

--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -4,7 +4,7 @@
 		PacketPeer implementation using the [url=http://enet.bespin.org/index.html]ENet[/url] library.
 	</brief_description>
 	<description>
-		A PacketPeer implementation that should be passed to [member SceneTree.network_peer] after being initialized as either a client or server. Events can then be handled by connecting to [SceneTree] signals.
+		A PacketPeer implementation that should be passed to [member MultiplayerAPI.network_peer] after being initialized as either a client or server. Events can then be handled by connecting to [SceneTree] signals.
 		ENet's purpose is to provide a relatively thin, simple and robust network communication layer on top of UDP (User Datagram Protocol).
 		[b]Note:[/b] ENet only uses UDP, not TCP. When forwarding the server port to make your server accessible on the public Internet, you only need to forward the server port in UDP. You can use the [UPNP] class to try to forward the server port automatically when starting the server.
 	</description>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1142,26 +1142,6 @@ Array SceneTree::get_processed_tweens() {
 	return ret;
 }
 
-void SceneTree::_network_peer_connected(int p_id) {
-	emit_signal("network_peer_connected", p_id);
-}
-
-void SceneTree::_network_peer_disconnected(int p_id) {
-	emit_signal("network_peer_disconnected", p_id);
-}
-
-void SceneTree::_connected_to_server() {
-	emit_signal("connected_to_server");
-}
-
-void SceneTree::_connection_failed() {
-	emit_signal("connection_failed");
-}
-
-void SceneTree::_server_disconnected() {
-	emit_signal("server_disconnected");
-}
-
 Ref<MultiplayerAPI> SceneTree::get_multiplayer() const {
 	return multiplayer;
 }
@@ -1177,58 +1157,8 @@ bool SceneTree::is_multiplayer_poll_enabled() const {
 void SceneTree::set_multiplayer(Ref<MultiplayerAPI> p_multiplayer) {
 	ERR_FAIL_COND(!p_multiplayer.is_valid());
 
-	if (multiplayer.is_valid()) {
-		multiplayer->disconnect("network_peer_connected", callable_mp(this, &SceneTree::_network_peer_connected));
-		multiplayer->disconnect("network_peer_disconnected", callable_mp(this, &SceneTree::_network_peer_disconnected));
-		multiplayer->disconnect("connected_to_server", callable_mp(this, &SceneTree::_connected_to_server));
-		multiplayer->disconnect("connection_failed", callable_mp(this, &SceneTree::_connection_failed));
-		multiplayer->disconnect("server_disconnected", callable_mp(this, &SceneTree::_server_disconnected));
-	}
-
 	multiplayer = p_multiplayer;
 	multiplayer->set_root_node(root);
-
-	multiplayer->connect("network_peer_connected", callable_mp(this, &SceneTree::_network_peer_connected));
-	multiplayer->connect("network_peer_disconnected", callable_mp(this, &SceneTree::_network_peer_disconnected));
-	multiplayer->connect("connected_to_server", callable_mp(this, &SceneTree::_connected_to_server));
-	multiplayer->connect("connection_failed", callable_mp(this, &SceneTree::_connection_failed));
-	multiplayer->connect("server_disconnected", callable_mp(this, &SceneTree::_server_disconnected));
-}
-
-void SceneTree::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_network_peer) {
-	multiplayer->set_network_peer(p_network_peer);
-}
-
-Ref<NetworkedMultiplayerPeer> SceneTree::get_network_peer() const {
-	return multiplayer->get_network_peer();
-}
-
-bool SceneTree::is_network_server() const {
-	return multiplayer->is_network_server();
-}
-
-bool SceneTree::has_network_peer() const {
-	return multiplayer->has_network_peer();
-}
-
-int SceneTree::get_network_unique_id() const {
-	return multiplayer->get_network_unique_id();
-}
-
-Vector<int> SceneTree::get_network_connected_peers() const {
-	return multiplayer->get_network_connected_peers();
-}
-
-int SceneTree::get_rpc_sender_id() const {
-	return multiplayer->get_rpc_sender_id();
-}
-
-void SceneTree::set_refuse_new_network_connections(bool p_refuse) {
-	multiplayer->set_refuse_new_network_connections(p_refuse);
-}
-
-bool SceneTree::is_refusing_new_network_connections() const {
-	return multiplayer->is_refusing_new_network_connections();
 }
 
 void SceneTree::_bind_methods() {
@@ -1297,24 +1227,12 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_multiplayer"), &SceneTree::get_multiplayer);
 	ClassDB::bind_method(D_METHOD("set_multiplayer_poll_enabled", "enabled"), &SceneTree::set_multiplayer_poll_enabled);
 	ClassDB::bind_method(D_METHOD("is_multiplayer_poll_enabled"), &SceneTree::is_multiplayer_poll_enabled);
-	ClassDB::bind_method(D_METHOD("set_network_peer", "peer"), &SceneTree::set_network_peer);
-	ClassDB::bind_method(D_METHOD("get_network_peer"), &SceneTree::get_network_peer);
-	ClassDB::bind_method(D_METHOD("is_network_server"), &SceneTree::is_network_server);
-	ClassDB::bind_method(D_METHOD("has_network_peer"), &SceneTree::has_network_peer);
-	ClassDB::bind_method(D_METHOD("get_network_connected_peers"), &SceneTree::get_network_connected_peers);
-	ClassDB::bind_method(D_METHOD("get_network_unique_id"), &SceneTree::get_network_unique_id);
-	ClassDB::bind_method(D_METHOD("get_rpc_sender_id"), &SceneTree::get_rpc_sender_id);
-	ClassDB::bind_method(D_METHOD("set_refuse_new_network_connections", "refuse"), &SceneTree::set_refuse_new_network_connections);
-	ClassDB::bind_method(D_METHOD("is_refusing_new_network_connections"), &SceneTree::is_refusing_new_network_connections);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_collisions_hint"), "set_debug_collisions_hint", "is_debugging_collisions_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_navigation_hint"), "set_debug_navigation_hint", "is_debugging_navigation_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused"), "set_pause", "is_paused");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_network_connections"), "set_refuse_new_network_connections", "is_refusing_new_network_connections");
-	ADD_PROPERTY_DEFAULT("refuse_new_network_connections", false);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "edited_scene_root", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_edited_scene_root", "get_edited_scene_root");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "current_scene", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_current_scene", "get_current_scene");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "network_peer", PROPERTY_HINT_RESOURCE_TYPE, "NetworkedMultiplayerPeer", PROPERTY_USAGE_NONE), "set_network_peer", "get_network_peer");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "root", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "", "get_root");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multiplayer", PROPERTY_HINT_RESOURCE_TYPE, "MultiplayerAPI", PROPERTY_USAGE_NONE), "set_multiplayer", "get_multiplayer");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "multiplayer_poll"), "set_multiplayer_poll_enabled", "is_multiplayer_poll_enabled");
@@ -1330,11 +1248,6 @@ void SceneTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("physics_frame"));
 
 	ADD_SIGNAL(MethodInfo("files_dropped", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files"), PropertyInfo(Variant::INT, "screen")));
-	ADD_SIGNAL(MethodInfo("network_peer_connected", PropertyInfo(Variant::INT, "id")));
-	ADD_SIGNAL(MethodInfo("network_peer_disconnected", PropertyInfo(Variant::INT, "id")));
-	ADD_SIGNAL(MethodInfo("connected_to_server"));
-	ADD_SIGNAL(MethodInfo("connection_failed"));
-	ADD_SIGNAL(MethodInfo("server_disconnected"));
 
 	BIND_ENUM_CONSTANT(GROUP_CALL_DEFAULT);
 	BIND_ENUM_CONSTANT(GROUP_CALL_REVERSE);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -159,13 +159,6 @@ private:
 	Ref<MultiplayerAPI> multiplayer;
 	bool multiplayer_poll = true;
 
-	void _network_peer_connected(int p_id);
-	void _network_peer_disconnected(int p_id);
-
-	void _connected_to_server();
-	void _connection_failed();
-	void _server_disconnected();
-
 	static SceneTree *singleton;
 	friend class Node;
 
@@ -337,16 +330,6 @@ public:
 	void set_multiplayer_poll_enabled(bool p_enabled);
 	bool is_multiplayer_poll_enabled() const;
 	void set_multiplayer(Ref<MultiplayerAPI> p_multiplayer);
-	void set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_network_peer);
-	Ref<NetworkedMultiplayerPeer> get_network_peer() const;
-	bool is_network_server() const;
-	bool has_network_peer() const;
-	int get_network_unique_id() const;
-	Vector<int> get_network_connected_peers() const;
-	int get_rpc_sender_id() const;
-
-	void set_refuse_new_network_connections(bool p_refuse);
-	bool is_refusing_new_network_connections() const;
 
 	static void add_idle_callback(IdleCallback p_callback);
 


### PR DESCRIPTION
Use `multiplayer` or `get_multiplayer()` instead of `get_tree()`.

An old planned change finally coming into reality.