### PR TITLE
[3.x] Skip rendering of `Light2D` with zero size texture

### DIFF
--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -131,6 +131,10 @@ void VisualServerViewport::_draw_viewport(Viewport *p_viewport, ARVRInterface::E
 				if (cl->enabled && cl->texture.is_valid()) {
 					//not super efficient..
 					Size2 tsize = VSG::storage->texture_size_with_proxy(cl->texture);
+					// Skip using lights with texture of 0 size
+					if (!tsize.x || !tsize.y) {
+						continue;
+					}
 					tsize *= cl->scale;
 
 					Vector2 offset = tsize / 2.0;


### PR DESCRIPTION


Fix  #41756 

Using light with not yet set texture cause spam of `det==0` error to the console both in editor and in the game. (See issue #41756).
Error is coming from no yet set texture which seems to have size of (0,0) by default.
See explanation here: https://github.com/godotengine/godot/issues/41756#issuecomment-695756032

I tried to find best solution to this and this is the simplest one. I check if `Light2D` texture have 0 size and if it does then skip rendering this light.

Attached MRP provided by original author of the issue. Issue exist in 3.3.2 and this PR fixed it.
[41756_issue_MRP.zip](https://github.com/godotengine/godot/files/6801806/41756_issue_MRP.zip)
I didn't noticed any regressions.

This issue doesn't exist in [master]