### PR TITLE
Add node configuration warnings for the Decal node

### DIFF
--- a/scene/3d/decal.h
+++ b/scene/3d/decal.h
@@ -67,6 +67,8 @@ protected:
 	void _validate_property(PropertyInfo &property) const override;
 
 public:
+	virtual TypedArray<String> get_configuration_warnings() const override;
+
 	void set_extents(const Vector3 &p_extents);
 	Vector3 get_extents() const;
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/50214.

The `normal_fade` property hint is now capped to 0.999, as setting it to 1.0 makes the decal invisible even if it's fully perpendicular to a surface.