### PR TITLE
Take CPU time into account when calculating FPS in the editor Frame Time

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2620,7 +2620,10 @@ void Node3DEditorViewport::_notification(int p_what) {
 						frame_time_gradient->get_color_at_offset(
 								Math::range_lerp(gpu_time, 0, 30, 0, 1)));
 
-				const double fps = 1000.0 / gpu_time;
+				// Tasks may run in parallel on both the CPU and GPU. Estimating the FPS
+				// is best done by using the highest measure of both,
+				// rather than summing both values (which assumes that nothing runs in parallel).
+				const double fps = 1000.0 / MAX(cpu_time, gpu_time);
 				fps_label->set_text(vformat(TTR("FPS: %d"), fps));
 				// Middle point is at 60 FPS.
 				fps_label->add_theme_color_override(


### PR DESCRIPTION
This is required to display accurate FPS measurements when the CPU is the bottleneck.

**Note:** Not cherry-pickable to the `3.x` branch, as the View Frame Time panel is new in `master` (and relies on Vulkan-only functionality).