### PR TITLE
Implement simplification of generated occluders in OccluderInstance3D

### DIFF
--- a/doc/classes/OccluderInstance3D.xml
+++ b/doc/classes/OccluderInstance3D.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OccluderInstance3D" inherits="Node3D" version="4.0">
 	<brief_description>
+		Provides occlusion culling for 3D nodes, which improves performance in closed areas.
 	</brief_description>
 	<description>
+		Occlusion culling can improve rendering performance in closed/semi-open areas by hiding geometry that is occluded by other objects.
+		The occlusion culling system is mostly static. [OccluderInstance3D]s can be moved at run-time, but doing so will trigger a background recomputation that can take several frames. It is recommended to only move [OccluderInstance3D]s sporadically (e.g. for procedural generation purposes), rather than doing so every frame.
+		The occlusion culling system works by rendering the occluders on the CPU in parallel using [url=https://www.embree.org/]Embree[/url], drawing the result to a 160×90 buffer then using this to cull 3D nodes individually. In the 3D editor, you can preview the occlusion culling buffer by choosing [b]Perspective &gt; Debug Advanced... &gt; Occlusion Culling Buffer[/b] in the top-left corner of the 3D viewport.
+		[b]Baking:[/b] Select an [OccluderInstance3D] node, then use the [b]Bake Occluders[/b] button at the top of the 3D editor. Only opaque materials will be taken into account; transparent materials (alpha-blended or alpha-tested) will be ignored by the occluder generation.
+		[b]Note:[/b] Occlusion culling is only effective if [member ProjectSettings.rendering/occlusion_culling/use_occlusion_culling] is [code]true[/code]. Enabling occlusion culling has a cost on the CPU. Only enable occlusion culling if you actually plan to use it. Large, open scenes with few or no objects blocking the view will generally not benefit much from occlusion culling.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -25,8 +31,17 @@
 	</methods>
 	<members>
 		<member name="bake_mask" type="int" setter="set_bake_mask" getter="get_bake_mask" default="4294967295">
+			The visual layers to account for when baking for occluders. Only [MeshInstance3D]s whose [member VisualInstance3D.layers] match with this [member bake_mask] will be included in the generated occluder mesh. By default, all objects are taken into account for the occluder baking.
+			To improve performance and avoid artifacts, it is recommended to exclude dynamic objects, small objects and fixtures from the baking process by moving them to a separate visual layer and excluding the layer here.
+		</member>
+		<member name="bake_simplify" type="float" setter="set_bake_simplify" getter="get_bake_simplify" default="0.02">
+			The simplification to apply to the generated occluder resource. Higher values result in a less detailed occluder mesh, which improves performance but reduces culling accuracy.
+			The geometry is rendered on the CPU, so it is important to keep its geometry as simple as possible. Since the buffer is rendered at a low resolution, less detailed occluder meshes generally still work well. The default value is fairly aggressive, so you may have to decrase it if you run into false negatives (objects being occluded even though they are visible by the camera). A value of [code]0.0001[/code] will act conservatively, and will keep geometry [i]perceptually[/i] unaffected in the occlusion culling buffer. Depending on the scene, a value of [code]0.0001[/code] may still simplify the mesh noticeably compared to disabling simplification entirely.
+			Setting this to [code]0.0[/code] disables simplification entirely and will use the original meshes' vertices as-is.
+			[b]Note:[/b] This uses the [url=https://meshoptimizer.org/]meshoptimizer[/url] library under the hood, similar to LOD generation.
 		</member>
 		<member name="occluder" type="Occluder3D" setter="set_occluder" getter="get_occluder">
+			The occluder resource for this [OccluderInstance3D]. You can generate an occluder resource by selecting an [OccluderInstance3D] node then using the [b]Bake Occluders[/b] button at the top of the editor.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1619,6 +1619,8 @@
 		<member name="rendering/occlusion_culling/occlusion_rays_per_thread" type="int" setter="" getter="" default="512">
 		</member>
 		<member name="rendering/occlusion_culling/use_occlusion_culling" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], [OccluderInstance3D] nodes will be usable for occlusion culling in 3D in the root viewport. In custom viewports, [member Viewport.use_occlusion_culling] must be set to [code]true[/code] instead.
+			[b]Note:[/b] Enabling occlusion culling has a cost on the CPU. Only enable occlusion culling if you actually plan to use it. Large, open scenes with few or no objects blocking the view will generally not benefit much from occlusion culling.
 		</member>
 		<member name="rendering/reflections/reflection_atlas/reflection_count" type="int" setter="" getter="" default="64">
 			Number of cubemaps to store in the reflection atlas. The number of [ReflectionProbe]s in a scene will be limited by this amount. A higher number requires more VRAM.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -246,6 +246,8 @@
 		<member name="use_debanding" type="bool" setter="set_use_debanding" getter="is_using_debanding" default="false">
 		</member>
 		<member name="use_occlusion_culling" type="bool" setter="set_use_occlusion_culling" getter="is_using_occlusion_culling" default="false">
+			If [code]true[/code], [OccluderInstance3D] nodes will be usable for occlusion culling in 3D for this viewport. For the root viewport, [member ProjectSettings.rendering/occlusion_culling/use_occlusion_culling] must be set to [code]true[/code] instead.
+			[b]Note:[/b] Enabling occlusion culling has a cost on the CPU. Only enable occlusion culling if you actually plan to use it, and think whether your scene can actually benefit from occlusion culling. Large, open scenes with few or no objects blocking the view will generally not benefit much from occlusion culling.
 		</member>
 		<member name="use_xr" type="bool" setter="set_use_xr" getter="is_using_xr" default="false">
 			If [code]true[/code], the viewport will use the primary XR interface to render XR output. When applicable this can result in a stereoscopic image and the resulting render being output to a headset.

--- a/scene/3d/occluder_instance_3d.h
+++ b/scene/3d/occluder_instance_3d.h
@@ -72,6 +72,7 @@ class OccluderInstance3D : public VisualInstance3D {
 private:
 	Ref<Occluder3D> occluder;
 	uint32_t bake_mask = 0xFFFFFFFF;
+	float simplify = 0.02;
 
 	void _occluder_changed();
 
@@ -101,6 +102,9 @@ public:
 
 	void set_bake_mask_value(int p_layer_number, bool p_enable);
 	bool get_bake_mask_value(int p_layer_number) const;
+
+	void set_bake_simplify(float p_threshold);
+	float get_bake_simplify() const;
 
 	BakeError bake(Node *p_from_node, String p_occluder_path = "");
 


### PR DESCRIPTION
The meshoptimizer library is used if the `bake_simplify` property is set to a value greater than 0.

The default simplifcation threshold (0.02) is fairly aggressive, but occluders don't need to be very detailed to work well.

This also adds documentation for occlusion culling in the class reference XML.

**Testing project:** [test_occlusion_culling.zip](https://github.com/godotengine/godot/files/6805329/test_occlusion_culling.zip)

## Preview

*In this particular scene, even the most aggressive simplification still provides good culling capabilities. However, this may not be true in more complex scenes.*

*Remember to tweak the Bake Mask to exclude dynamic objects, small objects and fixtures from your occluder mesh.*

### No simplification (0.0)

*Lots of stuttering.*

![No simplification](https://user-images.githubusercontent.com/180032/125376756-faa4dd80-e38b-11eb-80e8-6062715b3060.png)

### Most conservative simplification (0.0001)

*Still a fair bit of stuttering.*

![Most conservative simplification](https://user-images.githubusercontent.com/180032/125376761-fd9fce00-e38b-11eb-90fb-012eb814d830.png)

### Balanced simplification (0.01)

*No more stuttering.*
**Note:** The default simplification value is now 0.02, which is more aggressive but still works quite well.*

![Balanced simplification](https://user-images.githubusercontent.com/180032/125376768-009abe80-e38c-11eb-8589-d1a5428cead3.png)

### Aggressive simplification (0.1)

*No more stuttering.*

![Aggressive simplification](https://user-images.githubusercontent.com/180032/125376774-0395af00-e38c-11eb-9e90-d48d104f067b.png)