### PR TITLE
Fixes ambiguous variant error for build on Debian 10 (Buster) using clang v7

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -425,7 +425,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	// Generates the .trashinfo file
 	OS::Date date = OS::get_singleton()->get_date(false);
 	OS::Time time = OS::get_singleton()->get_time(false);
-	String timestamp = vformat("%04d-%02d-%02dT%02d:%02d:", date.year, date.month, date.day, time.hour, time.minute);
+	String timestamp = vformat("%04d-%02d-%02dT%02d:%02d:", date.year, (int)date.month, date.day, time.hour, time.minute);
 	timestamp = vformat("%s%02d", timestamp, time.second); // vformat only supports up to 6 arguments.
 	String trash_info = "[Trash Info]\nPath=" + p_path.uri_encode() + "\nDeletionDate=" + timestamp + "\n";
 	{


### PR DESCRIPTION
**some context**
I have a clean install of Debian 10 (Buster) which i intend to use for experimenting with Godot engine projects.

after following the detailed instructions from godot docs (which are excellent btw)

Debian 10 (stable) build-essentials package has gcc v8.3.0 and scons complains:
> Detected GCC 8 version < 8.4, which is not supported due to a regression in its C++17 guaranteed copy elision support.

so _for now at least_ i have to use clang to compile.
`sudo apt-get install clang lld`

which installs clang v7.. which should be fine.
`clang --version
clang version 7.0.1-8+deb10u2 (tags/RELEASE_701/final)`

**onto the error**
when building with scons the script ends due to an error:

> platform/linuxbsd/os_linuxbsd.cpp:428:74: error: conversion from 'OS::Month' to
>      'const Variant' is ambiguous
>  ...= vformat("%04d-%02d-%02dT%02d:%02d:", date.year, date.month, date.day, ...

to resolve this i have _explicitly cast_ the `date.month` parameter to an `int` which should be fine since it is being formatted with `%d`.

i am now able to complete the compilation and produce the binary:
`scons -j4 platform=x11 target=release_debug use_llvm=yes use_lld=yes`

which works fine.. _on my platform at least_

i hope this will help others trying to build godot on Debian 10.

kind regards
joe




