### PR TITLE
Merge similar editor strings

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4450,7 +4450,7 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 			}
 
 			if (node == AnimationPlayerEditor::singleton->get_player()) {
-				EditorNode::get_singleton()->show_warning(TTR("An animation player can't animate itself, only other players."));
+				EditorNode::get_singleton()->show_warning(TTR("AnimationPlayer can't animate itself, only other players."));
 				return;
 			}
 
@@ -5334,7 +5334,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 		} break;
 		case EDIT_PASTE_TRACKS: {
 			if (track_clipboard.size() == 0) {
-				EditorNode::get_singleton()->show_warning(TTR("Clipboard is empty"));
+				EditorNode::get_singleton()->show_warning(TTR("Clipboard is empty!"));
 				break;
 			}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2713,7 +2713,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 						}
 
 						save_confirmation->get_ok_button()->set_text(TTR("Save & Quit"));
-						save_confirmation->set_text((p_option == FILE_QUIT ? TTR("Save changes to the following scene(s) before quitting?") : TTR("Save changes the following scene(s) before opening Project Manager?")) + unsaved_scenes);
+						save_confirmation->set_text((p_option == FILE_QUIT ? TTR("Save changes to the following scene(s) before quitting?") : TTR("Save changes to the following scene(s) before opening Project Manager?")) + unsaved_scenes);
 						save_confirmation->popup_centered();
 					}
 				}


### PR DESCRIPTION
Found a pair of similar strings when translating on Weblate, so I went through the translatable strings roughly.

* Parameter of `EditorNode::get_singleton()->show_warning()`
    * The same meaning, emitted at the same scenario
        > An animation player can't animate itself, only other players.
        > AnimationPlayer can't animate itself, only other players.

    * With/without exclamation mark
        > Clipboard is empty
        > Clipboard is empty!

* The part before "before" should be the same, the second message is missing a "to"
    > Save changes to the following scene(s) before quitting?
    > Save changes the following scene(s) before opening Project Manager?

It's the same on 3.x.
