### PR TITLE
Fix decompression with FastLZ when buffer size is less than 16 bytes

### DIFF
--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -134,8 +134,9 @@ int Compression::decompress(uint8_t *p_dst, int p_dst_max_size, const uint8_t *p
 
 			if (p_dst_max_size < 16) {
 				uint8_t dst[16];
-				ret_size = fastlz_decompress(p_src, p_src_size, dst, 16);
+				fastlz_decompress(p_src, p_src_size, dst, 16);
 				memcpy(p_dst, dst, p_dst_max_size);
+				ret_size = p_dst_max_size;
 			} else {
 				ret_size = fastlz_decompress(p_src, p_src_size, p_dst, p_dst_max_size);
 			}


### PR DESCRIPTION
Fixes #49104, also applies to 3.x.

The random trailing bytes are due to only `p_dst_max_size` bytes are `memcpy`ed to `p_dst` and other bytes are left uninitialized. It's fine as it's just a buffer. The caller will then shrink the buffer to the return value of this function.

The return value of `fastlz_decompress()` does not matter because:

* It's capped by the fourth parameter to 16.
* It seems that FastLZ has a limit of minimum 16 bytes to uncompressed data. When compressing data less than 16 bytes with `Compression::compress()`, the input is first padded to 16 bytes with trailing zeros.