### PR TITLE
Prevents some warnings from appearing in visual scripts

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2836,6 +2836,20 @@ void VisualScriptEditor::_graph_connected(const String &p_from, int p_from_slot,
 
 	ERR_FAIL_COND(from_seq != to_seq);
 
+	// Checking to prevent warnings.
+	if (from_seq) {
+		if (script->has_sequence_connection(p_from.to_int(), from_port, p_to.to_int())) {
+			return;
+		}
+	} else if (script->has_data_connection(p_from.to_int(), from_port, p_to.to_int(), to_port)) {
+		return;
+	}
+
+	// Preventing connection to itself.
+	if (p_from.to_int() == p_to.to_int()) {
+		return;
+	}
+
 	// Do all the checks here.
 	StringName func; // This the func where we store the one the nodes at the end of the resolution on having multiple nodes.
 
@@ -2989,7 +3003,7 @@ VisualScriptNode::TypeGuess VisualScriptEditor::_guess_output_type(int p_port_ac
 
 	Ref<VisualScriptNode> node = script->get_node(p_port_action_node);
 
-	if (!node.is_valid()) {
+	if (!node.is_valid() || node->get_output_value_port_count() <= p_port_action_output) {
 		return tg;
 	}
 

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -191,7 +191,10 @@ PropertyInfo VisualScriptFunction::get_input_value_port_info(int p_idx) const {
 }
 
 PropertyInfo VisualScriptFunction::get_output_value_port_info(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, arguments.size(), PropertyInfo());
+	// Need to check it without ERR_FAIL_COND, to prevent warnings from appearing on node creation via dragging.
+	if (p_idx < 0 || p_idx >= arguments.size()) {
+		return PropertyInfo();
+	}
 	PropertyInfo out;
 	out.type = arguments[p_idx].type;
 	out.name = arguments[p_idx].name;


### PR DESCRIPTION
Fixed warning 1:

![vs_warning](https://user-images.githubusercontent.com/3036176/125418119-43d1d40e-643b-48c6-8eb9-f4d2358c0a16.gif)

Fixed warning 2:

![vs_warning2](https://user-images.githubusercontent.com/3036176/125418179-45c2a410-787c-44ce-b99d-f901475b846b.gif)

Fixed warning 3:

![vs_warning3](https://user-images.githubusercontent.com/3036176/125425949-9ffbd865-4684-4bfc-a3e1-82909368a7ed.gif)

Also added a check to prevent a node from connecting to itself:

![image](https://user-images.githubusercontent.com/3036176/125418009-a4519b7c-4091-46f1-9f53-af54e19e39c2.png)
