### PR TITLE
Fix casing of the "to" stop word in editor strings

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1119,7 +1119,7 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	add_child(slot_menu);
 	slot_menu->connect("id_pressed", this, "_handle_slot_menu_option");
 	slot_menu->add_item(TTR("Edit..."), EDIT);
-	slot_menu->add_item(TTR("Go To Method"), GO_TO_SCRIPT);
+	slot_menu->add_item(TTR("Go to Method"), GO_TO_SCRIPT);
 	slot_menu->add_item(TTR("Disconnect"), DISCONNECT);
 
 	connect_dialog->connect("connected", this, "_make_or_edit_connection");

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -207,7 +207,7 @@ void EditorResourcePicker::_update_menu_items() {
 				icon = get_icon(what, "Resource");
 			}
 
-			edit_menu->add_icon_item(icon, vformat(TTR("Convert To %s"), what), CONVERT_BASE_ID + i);
+			edit_menu->add_icon_item(icon, vformat(TTR("Convert to %s"), what), CONVERT_BASE_ID + i);
 		}
 	}
 }

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5873,7 +5873,7 @@ void SpatialEditor::snap_selected_nodes_to_floor() {
 		}
 
 		if (snapped_to_floor) {
-			undo_redo->create_action(TTR("Snap Nodes To Floor"));
+			undo_redo->create_action(TTR("Snap Nodes to Floor"));
 
 			// Perform snapping if at least one node can be snapped
 			for (int i = 0; i < keys.size(); i++) {

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -977,7 +977,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 						icon = get_icon(what, "Resource");
 					}
 
-					menu->add_icon_item(icon, vformat(TTR("Convert To %s"), what), CONVERT_BASE_ID + i);
+					menu->add_icon_item(icon, vformat(TTR("Convert to %s"), what), CONVERT_BASE_ID + i);
 				}
 			}
 

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -417,7 +417,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "optional_icons/spotlight_80x80", PROPERTY_HINT_FILE, "*.png"), "")); // Spotlight on devices with retina display
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "storyboard/use_launch_screen_storyboard"), false));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "storyboard/image_scale_mode", PROPERTY_HINT_ENUM, "Same as Logo,Center,Scale To Fit,Scale To Fill,Scale"), 0));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "storyboard/image_scale_mode", PROPERTY_HINT_ENUM, "Same as Logo,Center,Scale to Fit,Scale to Fill,Scale"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "storyboard/custom_image@2x", PROPERTY_HINT_FILE, "*.png"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "storyboard/custom_image@3x", PROPERTY_HINT_FILE, "*.png"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "storyboard/use_custom_bg_color"), false));


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50418.

Unlike the `master` PR, this does not include the documentation change because the `3.x` class reference doesn't have C# code examples.