### PR TITLE
[iOS] Fix plugin configuration loading

### DIFF
--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -368,6 +368,8 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "plugins/" + found_plugins[i].name), false));
 	}
 
+	Set<String> plist_keys;
+
 	for (int i = 0; i < found_plugins.size(); i++) {
 		// Editable plugin plist values
 		PluginConfigIOS plugin = found_plugins[i];
@@ -379,7 +381,10 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 			switch (item.type) {
 				case PluginConfigIOS::PlistItemType::STRING_INPUT: {
 					String preset_name = "plugins_plist/" + key;
-					r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, preset_name), item.value));
+					if (!plist_keys.has(preset_name)) {
+						r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, preset_name), item.value));
+						plist_keys.insert(preset_name);
+					}
 				} break;
 				default:
 					continue;

--- a/platform/iphone/plugin/godot_plugin_config.h
+++ b/platform/iphone/plugin/godot_plugin_config.h
@@ -252,6 +252,8 @@ static inline PluginConfigIOS load_plugin_config(Ref<ConfigFile> config_file, co
 		return plugin_config;
 	}
 
+	config_file->clear();
+
 	Error err = config_file->load(path);
 
 	if (err != OK) {


### PR DESCRIPTION
Can be cherry-picked for `3.x`.

Fixes cases when config file had previous plugin data - plist keys and values.
Also removes duplicate plist keys in export window.