### PR TITLE
Particle params are expressed as min-max rather than value+range AND separate axes scaling

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -683,7 +683,7 @@
 		</constant>
 		<constant name="BILLBOARD_PARTICLES" value="3" enum="BillboardMode">
 			Used for particle systems when assigned to [GPUParticles3D] and [CPUParticles3D] nodes. Enables [code]particles_anim_*[/code] properties.
-			The [member ParticlesMaterial.anim_speed] or [member CPUParticles3D.anim_speed] should also be set to a positive value for the animation to play.
+			The [member ParticlesMaterial.anim_speed_min] or [member CPUParticles3D.anim_speed_min] should also be set to a value bigger than zero for the animation to play.
 		</constant>
 		<constant name="TEXTURE_CHANNEL_RED" value="0" enum="TextureChannel">
 			Used to read from the red channel of a texture.

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -18,13 +18,6 @@
 				Sets this node's properties to match a given [GPUParticles2D] node with an assigned [ParticlesMaterial].
 			</description>
 		</method>
-		<method name="get_param" qualifiers="const">
-			<return type="float" />
-			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter" />
-			<description>
-				Returns the base value of the parameter specified by [enum Parameter].
-			</description>
-		</method>
 		<method name="get_param_curve" qualifiers="const">
 			<return type="Curve" />
 			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter" />
@@ -32,11 +25,16 @@
 				Returns the [Curve] of the parameter specified by [enum Parameter].
 			</description>
 		</method>
-		<method name="get_param_randomness" qualifiers="const">
+		<method name="get_param_max" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter" />
 			<description>
-				Returns the randomness factor of the parameter specified by [enum Parameter].
+			</description>
+		</method>
+		<method name="get_param_min" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter" />
+			<description>
 			</description>
 		</method>
 		<method name="get_particle_flag" qualifiers="const">
@@ -52,14 +50,6 @@
 				Restarts the particle emitter.
 			</description>
 		</method>
-		<method name="set_param">
-			<return type="void" />
-			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter" />
-			<argument index="1" name="value" type="float" />
-			<description>
-				Sets the base value of the parameter specified by [enum Parameter].
-			</description>
-		</method>
 		<method name="set_param_curve">
 			<return type="void" />
 			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter" />
@@ -68,12 +58,18 @@
 				Sets the [Curve] of the parameter specified by [enum Parameter].
 			</description>
 		</method>
-		<method name="set_param_randomness">
+		<method name="set_param_max">
 			<return type="void" />
 			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter" />
-			<argument index="1" name="randomness" type="float" />
+			<argument index="1" name="value" type="float" />
 			<description>
-				Sets the randomness factor of the parameter specified by [enum Parameter].
+			</description>
+		</method>
+		<method name="set_param_min">
+			<return type="void" />
+			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter" />
+			<argument index="1" name="value" type="float" />
+			<description>
 			</description>
 		</method>
 		<method name="set_particle_flag">
@@ -89,41 +85,33 @@
 		<member name="amount" type="int" setter="set_amount" getter="get_amount" default="8">
 			Number of particles emitted in one emission cycle.
 		</member>
-		<member name="angle" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial rotation applied to each particle, in degrees.
-		</member>
 		<member name="angle_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's rotation will be animated along this [Curve].
 		</member>
-		<member name="angle_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Rotation randomness ratio.
+		<member name="angle_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 		</member>
-		<member name="angular_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
+		<member name="angle_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="angular_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's angular velocity will vary along this [Curve].
 		</member>
-		<member name="angular_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Angular velocity randomness ratio.
+		<member name="angular_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 		</member>
-		<member name="anim_offset" type="float" setter="set_param" getter="get_param" default="0.0">
-			Particle animation offset.
+		<member name="angular_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="anim_offset_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's animation offset will vary along this [Curve].
 		</member>
-		<member name="anim_offset_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Animation offset randomness ratio.
+		<member name="anim_offset_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 		</member>
-		<member name="anim_speed" type="float" setter="set_param" getter="get_param" default="0.0">
-			Particle animation speed.
+		<member name="anim_offset_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="anim_speed_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's animation speed will vary along this [Curve].
 		</member>
-		<member name="anim_speed_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Animation speed randomness ratio.
+		<member name="anim_speed_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+		</member>
+		<member name="anim_speed_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			Each particle's initial color. If [member texture] is defined, it will be multiplied by this color.
@@ -131,14 +119,12 @@
 		<member name="color_ramp" type="Gradient" setter="set_color_ramp" getter="get_color_ramp">
 			Each particle's color will vary along this [Gradient] (multiplied with [member color]).
 		</member>
-		<member name="damping" type="float" setter="set_param" getter="get_param" default="0.0">
-			The rate at which particles lose velocity.
-		</member>
 		<member name="damping_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Damping will vary along this [Curve].
 		</member>
-		<member name="damping_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Damping randomness ratio.
+		<member name="damping_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+		</member>
+		<member name="damping_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="direction" type="Vector2" setter="set_direction" getter="get_direction" default="Vector2(1, 0)">
 			Unit vector specifying the particles' emission direction.
@@ -179,20 +165,16 @@
 		<member name="gravity" type="Vector2" setter="set_gravity" getter="get_gravity" default="Vector2(0, 980)">
 			Gravity applied to every particle.
 		</member>
-		<member name="hue_variation" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial hue variation applied to each particle.
-		</member>
 		<member name="hue_variation_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's hue will vary along this [Curve].
 		</member>
-		<member name="hue_variation_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Hue variation randomness ratio.
+		<member name="hue_variation_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 		</member>
-		<member name="initial_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial velocity magnitude for each particle. Direction comes from [member spread] and the node's orientation.
+		<member name="hue_variation_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
-		<member name="initial_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Initial velocity randomness ratio.
+		<member name="initial_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+		</member>
+		<member name="initial_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="lifetime" type="float" setter="set_lifetime" getter="get_lifetime" default="1.0">
 			Amount of time each particle will exist.
@@ -200,14 +182,12 @@
 		<member name="lifetime_randomness" type="float" setter="set_lifetime_randomness" getter="get_lifetime_randomness" default="0.0">
 			Particle lifetime randomness ratio.
 		</member>
-		<member name="linear_accel" type="float" setter="set_param" getter="get_param" default="0.0">
-			Linear acceleration applied to each particle in the direction of motion.
-		</member>
 		<member name="linear_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's linear acceleration will vary along this [Curve].
 		</member>
-		<member name="linear_accel_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Linear acceleration randomness ratio.
+		<member name="linear_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+		</member>
+		<member name="linear_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="local_coords" type="bool" setter="set_use_local_coordinates" getter="get_use_local_coordinates" default="true">
 			If [code]true[/code], particles use the parent node's coordinate space. If [code]false[/code], they use global coordinates.
@@ -215,14 +195,12 @@
 		<member name="one_shot" type="bool" setter="set_one_shot" getter="get_one_shot" default="false">
 			If [code]true[/code], only one emission cycle occurs. If set [code]true[/code] during a cycle, emission will stop at the cycle's end.
 		</member>
-		<member name="orbit_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Orbital velocity applied to each particle. Makes the particles circle around origin. Specified in number of full rotations around origin per second.
-		</member>
 		<member name="orbit_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's orbital velocity will vary along this [Curve].
 		</member>
-		<member name="orbit_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Orbital velocity randomness ratio.
+		<member name="orbit_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+		</member>
+		<member name="orbit_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="particle_flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
 			Align Y axis of particle with the direction of its velocity.
@@ -230,41 +208,41 @@
 		<member name="preprocess" type="float" setter="set_pre_process_time" getter="get_pre_process_time" default="0.0">
 			Particle system starts as if it had already run for this many seconds.
 		</member>
-		<member name="radial_accel" type="float" setter="set_param" getter="get_param" default="0.0">
-			Radial acceleration applied to each particle. Makes particle accelerate away from origin.
-		</member>
 		<member name="radial_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's radial acceleration will vary along this [Curve].
 		</member>
-		<member name="radial_accel_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Radial acceleration randomness ratio.
+		<member name="radial_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+		</member>
+		<member name="radial_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="randomness" type="float" setter="set_randomness_ratio" getter="get_randomness_ratio" default="0.0">
 			Emission lifetime randomness ratio.
 		</member>
-		<member name="scale_amount" type="float" setter="set_param" getter="get_param" default="1.0">
-			Initial scale applied to each particle.
-		</member>
 		<member name="scale_amount_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's scale will vary along this [Curve].
 		</member>
-		<member name="scale_amount_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Scale randomness ratio.
+		<member name="scale_amount_max" type="float" setter="set_param_max" getter="get_param_max" default="1.0">
+		</member>
+		<member name="scale_amount_min" type="float" setter="set_param_min" getter="get_param_min" default="1.0">
+		</member>
+		<member name="scale_curve_x" type="Curve" setter="set_scale_curve_x" getter="get_scale_curve_x">
+		</member>
+		<member name="scale_curve_y" type="Curve" setter="set_scale_curve_y" getter="get_scale_curve_y">
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			Particle system's running speed scaling ratio. A value of [code]0[/code] can be used to pause the particles.
 		</member>
+		<member name="split_scale" type="bool" setter="set_split_scale" getter="get_split_scale" default="false">
+		</member>
 		<member name="spread" type="float" setter="set_spread" getter="get_spread" default="45.0">
 			Each particle's initial direction range from [code]+spread[/code] to [code]-spread[/code] degrees.
-		</member>
-		<member name="tangential_accel" type="float" setter="set_param" getter="get_param" default="0.0">
-			Tangential acceleration applied to each particle. Tangential acceleration is perpendicular to the particle's velocity giving the particles a swirling motion.
 		</member>
 		<member name="tangential_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's tangential acceleration will vary along this [Curve].
 		</member>
-		<member name="tangential_accel_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Tangential acceleration randomness ratio.
+		<member name="tangential_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+		</member>
+		<member name="tangential_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			Particle texture. If [code]null[/code], particles will be squares.
@@ -278,40 +256,40 @@
 			Particles are drawn in order of remaining lifetime.
 		</constant>
 		<constant name="PARAM_INITIAL_LINEAR_VELOCITY" value="0" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set initial velocity properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set initial velocity properties.
 		</constant>
 		<constant name="PARAM_ANGULAR_VELOCITY" value="1" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set angular velocity properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set angular velocity properties.
 		</constant>
 		<constant name="PARAM_ORBIT_VELOCITY" value="2" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set orbital velocity properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set orbital velocity properties.
 		</constant>
 		<constant name="PARAM_LINEAR_ACCEL" value="3" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set linear acceleration properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set linear acceleration properties.
 		</constant>
 		<constant name="PARAM_RADIAL_ACCEL" value="4" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set radial acceleration properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set radial acceleration properties.
 		</constant>
 		<constant name="PARAM_TANGENTIAL_ACCEL" value="5" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set tangential acceleration properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set tangential acceleration properties.
 		</constant>
 		<constant name="PARAM_DAMPING" value="6" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set damping properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set damping properties.
 		</constant>
 		<constant name="PARAM_ANGLE" value="7" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set angle properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set angle properties.
 		</constant>
 		<constant name="PARAM_SCALE" value="8" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set scale properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set scale properties.
 		</constant>
 		<constant name="PARAM_HUE_VARIATION" value="9" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set hue variation properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set hue variation properties.
 		</constant>
 		<constant name="PARAM_ANIM_SPEED" value="10" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set animation speed properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set animation speed properties.
 		</constant>
 		<constant name="PARAM_ANIM_OFFSET" value="11" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set animation offset properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set animation offset properties.
 		</constant>
 		<constant name="PARAM_MAX" value="12" enum="Parameter">
 			Represents the size of the [enum Parameter] enum.

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -17,13 +17,6 @@
 				Sets this node's properties to match a given [GPUParticles3D] node with an assigned [ParticlesMaterial].
 			</description>
 		</method>
-		<method name="get_param" qualifiers="const">
-			<return type="float" />
-			<argument index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
-			<description>
-				Returns the base value of the parameter specified by [enum Parameter].
-			</description>
-		</method>
 		<method name="get_param_curve" qualifiers="const">
 			<return type="Curve" />
 			<argument index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
@@ -31,11 +24,16 @@
 				Returns the [Curve] of the parameter specified by [enum Parameter].
 			</description>
 		</method>
-		<method name="get_param_randomness" qualifiers="const">
+		<method name="get_param_max" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
 			<description>
-				Returns the randomness factor of the parameter specified by [enum Parameter].
+			</description>
+		</method>
+		<method name="get_param_min" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
+			<description>
 			</description>
 		</method>
 		<method name="get_particle_flag" qualifiers="const">
@@ -51,14 +49,6 @@
 				Restarts the particle emitter.
 			</description>
 		</method>
-		<method name="set_param">
-			<return type="void" />
-			<argument index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
-			<argument index="1" name="value" type="float" />
-			<description>
-				Sets the base value of the parameter specified by [enum Parameter].
-			</description>
-		</method>
 		<method name="set_param_curve">
 			<return type="void" />
 			<argument index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
@@ -67,12 +57,20 @@
 				Sets the [Curve] of the parameter specified by [enum Parameter].
 			</description>
 		</method>
-		<method name="set_param_randomness">
+		<method name="set_param_max">
 			<return type="void" />
 			<argument index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
-			<argument index="1" name="randomness" type="float" />
+			<argument index="1" name="value" type="float" />
 			<description>
-				Sets the randomness factor of the parameter specified by [enum Parameter].
+				Sets the maximum value for the given parameter
+			</description>
+		</method>
+		<method name="set_param_min">
+			<return type="void" />
+			<argument index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
+			<argument index="1" name="value" type="float" />
+			<description>
+				Sets the minimum value for the given parameter
 			</description>
 		</method>
 		<method name="set_particle_flag">
@@ -88,41 +86,41 @@
 		<member name="amount" type="int" setter="set_amount" getter="get_amount" default="8">
 			Number of particles emitted in one emission cycle.
 		</member>
-		<member name="angle" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial rotation applied to each particle, in degrees.
-		</member>
 		<member name="angle_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's rotation will be animated along this [Curve].
 		</member>
-		<member name="angle_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Rotation randomness ratio.
+		<member name="angle_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum angle.
 		</member>
-		<member name="angular_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
+		<member name="angle_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum angle.
 		</member>
 		<member name="angular_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's angular velocity will vary along this [Curve].
 		</member>
-		<member name="angular_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Angular velocity randomness ratio.
+		<member name="angular_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum angular velocity.
 		</member>
-		<member name="anim_offset" type="float" setter="set_param" getter="get_param" default="0.0">
-			Particle animation offset.
+		<member name="angular_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum angular velocity.
 		</member>
 		<member name="anim_offset_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's animation offset will vary along this [Curve].
 		</member>
-		<member name="anim_offset_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Animation offset randomness ratio.
+		<member name="anim_offset_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum animation offset.
 		</member>
-		<member name="anim_speed" type="float" setter="set_param" getter="get_param" default="0.0">
-			Particle animation speed.
+		<member name="anim_offset_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum animation offset.
 		</member>
 		<member name="anim_speed_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's animation speed will vary along this [Curve].
 		</member>
-		<member name="anim_speed_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Animation speed randomness ratio.
+		<member name="anim_speed_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum particle animation speed.
+		</member>
+		<member name="anim_speed_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum particle animation speed.
 		</member>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			Each particle's initial color. To have particle display color in a [BaseMaterial3D] make sure to set [member BaseMaterial3D.vertex_color_use_as_albedo] to [code]true[/code].
@@ -130,14 +128,14 @@
 		<member name="color_ramp" type="Gradient" setter="set_color_ramp" getter="get_color_ramp">
 			Each particle's color will vary along this [GradientTexture] over its lifetime (multiplied with [member color]).
 		</member>
-		<member name="damping" type="float" setter="set_param" getter="get_param" default="0.0">
-			The rate at which particles lose velocity.
-		</member>
 		<member name="damping_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Damping will vary along this [Curve].
 		</member>
-		<member name="damping_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Damping randomness ratio.
+		<member name="damping_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum damping.
+		</member>
+		<member name="damping_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum damping
 		</member>
 		<member name="direction" type="Vector3" setter="set_direction" getter="get_direction" default="Vector3(1, 0, 0)">
 			Unit vector specifying the particles' emission direction.
@@ -193,20 +191,20 @@
 		<member name="gravity" type="Vector3" setter="set_gravity" getter="get_gravity" default="Vector3(0, -9.8, 0)">
 			Gravity applied to every particle.
 		</member>
-		<member name="hue_variation" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial hue variation applied to each particle.
-		</member>
 		<member name="hue_variation_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's hue will vary along this [Curve].
 		</member>
-		<member name="hue_variation_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Hue variation randomness ratio.
+		<member name="hue_variation_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum hue variation.
 		</member>
-		<member name="initial_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial velocity magnitude for each particle. Direction comes from [member spread] and the node's orientation.
+		<member name="hue_variation_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum hue variation.
 		</member>
-		<member name="initial_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Initial velocity randomness ratio.
+		<member name="initial_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum value of the initial velocity.
+		</member>
+		<member name="initial_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum value of the initial velocity.
 		</member>
 		<member name="lifetime" type="float" setter="set_lifetime" getter="get_lifetime" default="1.0">
 			Amount of time each particle will exist.
@@ -214,14 +212,14 @@
 		<member name="lifetime_randomness" type="float" setter="set_lifetime_randomness" getter="get_lifetime_randomness" default="0.0">
 			Particle lifetime randomness ratio.
 		</member>
-		<member name="linear_accel" type="float" setter="set_param" getter="get_param" default="0.0">
-			Linear acceleration applied to each particle in the direction of motion.
-		</member>
 		<member name="linear_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's linear acceleration will vary along this [Curve].
 		</member>
-		<member name="linear_accel_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Linear acceleration randomness ratio.
+		<member name="linear_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum linear acceleration.
+		</member>
+		<member name="linear_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum linear acceleration.
 		</member>
 		<member name="local_coords" type="bool" setter="set_use_local_coordinates" getter="get_use_local_coordinates" default="true">
 			If [code]true[/code], particles use the parent node's coordinate space. If [code]false[/code], they use global coordinates.
@@ -232,15 +230,14 @@
 		<member name="one_shot" type="bool" setter="set_one_shot" getter="get_one_shot" default="false">
 			If [code]true[/code], only one emission cycle occurs. If set [code]true[/code] during a cycle, emission will stop at the cycle's end.
 		</member>
-		<member name="orbit_velocity" type="float" setter="set_param" getter="get_param">
-			Orbital velocity applied to each particle. Makes the particles circle around origin in the local XY plane. Specified in number of full rotations around origin per second.
-			This property is only available when [member particle_flag_disable_z] is [code]true[/code].
-		</member>
 		<member name="orbit_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's orbital velocity will vary along this [Curve].
 		</member>
-		<member name="orbit_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness">
-			Orbital velocity randomness ratio.
+		<member name="orbit_velocity_max" type="float" setter="set_param_max" getter="get_param_max">
+			Maximum orbit velocity.
+		</member>
+		<member name="orbit_velocity_min" type="float" setter="set_param_min" getter="get_param_min">
+			Minimum orbit velocity.
 		</member>
 		<member name="particle_flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
 			Align Y axis of particle with the direction of its velocity.
@@ -249,46 +246,58 @@
 			If [code]true[/code], particles will not move on the Z axis.
 		</member>
 		<member name="particle_flag_rotate_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
-			If [code]true[/code], particles rotate around Y axis by [member angle].
+			If [code]true[/code], particles rotate around Y axis by [member angle_min].
 		</member>
 		<member name="preprocess" type="float" setter="set_pre_process_time" getter="get_pre_process_time" default="0.0">
 			Particle system starts as if it had already run for this many seconds.
 		</member>
-		<member name="radial_accel" type="float" setter="set_param" getter="get_param" default="0.0">
-			Radial acceleration applied to each particle. Makes particle accelerate away from origin.
-		</member>
 		<member name="radial_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's radial acceleration will vary along this [Curve].
 		</member>
-		<member name="radial_accel_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Radial acceleration randomness ratio.
+		<member name="radial_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum radial acceleration.
+		</member>
+		<member name="radial_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum radial acceleration.
 		</member>
 		<member name="randomness" type="float" setter="set_randomness_ratio" getter="get_randomness_ratio" default="0.0">
 			Emission lifetime randomness ratio.
 		</member>
-		<member name="scale_amount" type="float" setter="set_param" getter="get_param" default="1.0">
-			Initial scale applied to each particle.
-		</member>
 		<member name="scale_amount_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's scale will vary along this [Curve].
 		</member>
-		<member name="scale_amount_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Scale randomness ratio.
+		<member name="scale_amount_max" type="float" setter="set_param_max" getter="get_param_max" default="1.0">
+			Maximum scale.
+		</member>
+		<member name="scale_amount_min" type="float" setter="set_param_min" getter="get_param_min" default="1.0">
+			Minimum scale.
+		</member>
+		<member name="scale_curve_x" type="Curve" setter="set_scale_curve_x" getter="get_scale_curve_x">
+			Curve for the scale over life, along the x axis.
+		</member>
+		<member name="scale_curve_y" type="Curve" setter="set_scale_curve_y" getter="get_scale_curve_y">
+			Curve for the scale over life, along the y axis.
+		</member>
+		<member name="scale_curve_z" type="Curve" setter="set_scale_curve_z" getter="get_scale_curve_z">
+			Curve for the scale over life, along the z axis.
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			Particle system's running speed scaling ratio. A value of [code]0[/code] can be used to pause the particles.
 		</member>
+		<member name="split_scale" type="bool" setter="set_split_scale" getter="get_split_scale" default="false">
+			If set to true, three different scale curves can be specified, one per scale axis.
+		</member>
 		<member name="spread" type="float" setter="set_spread" getter="get_spread" default="45.0">
 			Each particle's initial direction range from [code]+spread[/code] to [code]-spread[/code] degrees. Applied to X/Z plane and Y/Z planes.
-		</member>
-		<member name="tangential_accel" type="float" setter="set_param" getter="get_param" default="0.0">
-			Tangential acceleration applied to each particle. Tangential acceleration is perpendicular to the particle's velocity giving the particles a swirling motion.
 		</member>
 		<member name="tangential_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's tangential acceleration will vary along this [Curve].
 		</member>
-		<member name="tangential_accel_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Tangential acceleration randomness ratio.
+		<member name="tangential_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum tangent acceleration.
+		</member>
+		<member name="tangential_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum tangent acceleration.
 		</member>
 	</members>
 	<constants>
@@ -302,40 +311,40 @@
 			Particles are drawn in order of depth.
 		</constant>
 		<constant name="PARAM_INITIAL_LINEAR_VELOCITY" value="0" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set initial velocity properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set initial velocity properties.
 		</constant>
 		<constant name="PARAM_ANGULAR_VELOCITY" value="1" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set angular velocity properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set angular velocity properties.
 		</constant>
 		<constant name="PARAM_ORBIT_VELOCITY" value="2" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set orbital velocity properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set orbital velocity properties.
 		</constant>
 		<constant name="PARAM_LINEAR_ACCEL" value="3" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set linear acceleration properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set linear acceleration properties.
 		</constant>
 		<constant name="PARAM_RADIAL_ACCEL" value="4" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set radial acceleration properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set radial acceleration properties.
 		</constant>
 		<constant name="PARAM_TANGENTIAL_ACCEL" value="5" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set tangential acceleration properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set tangential acceleration properties.
 		</constant>
 		<constant name="PARAM_DAMPING" value="6" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set damping properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set damping properties.
 		</constant>
 		<constant name="PARAM_ANGLE" value="7" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set angle properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set angle properties.
 		</constant>
 		<constant name="PARAM_SCALE" value="8" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set scale properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set scale properties.
 		</constant>
 		<constant name="PARAM_HUE_VARIATION" value="9" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set hue variation properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set hue variation properties.
 		</constant>
 		<constant name="PARAM_ANIM_SPEED" value="10" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set animation speed properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set animation speed properties.
 		</constant>
 		<constant name="PARAM_ANIM_OFFSET" value="11" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_curve] to set animation offset properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_curve] to set animation offset properties.
 		</constant>
 		<constant name="PARAM_MAX" value="12" enum="Parameter">
 			Represents the size of the [enum Parameter] enum.

--- a/doc/classes/CanvasItemMaterial.xml
+++ b/doc/classes/CanvasItemMaterial.xml
@@ -30,7 +30,7 @@
 			[b]Note:[/b] This property is only used and visible in the editor if [member particles_animation] is [code]true[/code].
 		</member>
 		<member name="particles_animation" type="bool" setter="set_particles_animation" getter="get_particles_animation" default="false">
-			If [code]true[/code], enable spritesheet-based animation features when assigned to [GPUParticles2D] and [CPUParticles2D] nodes. The [member ParticlesMaterial.anim_speed] or [member CPUParticles2D.anim_speed] should also be set to a positive value for the animation to play.
+			If [code]true[/code], enable spritesheet-based animation features when assigned to [GPUParticles2D] and [CPUParticles2D] nodes. The [member ParticlesMaterial.anim_speed_max] or [member CPUParticles2D.anim_speed_max] should also be set to a positive value for the animation to play.
 			This property (and other [code]particles_anim_*[/code] properties that depend on it) has no effect on other types of nodes.
 		</member>
 	</members>

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -11,18 +11,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_param" qualifiers="const">
+		<method name="get_param_max" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter" />
 			<description>
-				Returns the value of the specified parameter.
+				Return the maximum value range for the given prameter.
 			</description>
 		</method>
-		<method name="get_param_randomness" qualifiers="const">
+		<method name="get_param_min" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter" />
 			<description>
-				Returns the randomness ratio associated with the specified parameter.
+				Return the minimum value range for the given parameter.
 			</description>
 		</method>
 		<method name="get_param_texture" qualifiers="const">
@@ -39,20 +39,20 @@
 				Returns [code]true[/code] if the specified particle flag is enabled. See [enum ParticleFlags] for options.
 			</description>
 		</method>
-		<method name="set_param">
+		<method name="set_param_max">
 			<return type="void" />
 			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter" />
 			<argument index="1" name="value" type="float" />
 			<description>
-				Sets the specified [enum Parameter].
+				Sets the maximum value range for the given parameter.
 			</description>
 		</method>
-		<method name="set_param_randomness">
+		<method name="set_param_min">
 			<return type="void" />
 			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter" />
-			<argument index="1" name="randomness" type="float" />
+			<argument index="1" name="value" type="float" />
 			<description>
-				Sets the randomness ratio for the specified [enum Parameter].
+				Sets the minimum value range for the given parameter.
 			</description>
 		</method>
 		<method name="set_param_texture">
@@ -73,53 +73,56 @@
 		</method>
 	</methods>
 	<members>
-		<member name="angle" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial rotation applied to each particle, in degrees.
-			Only applied when [member particle_flag_disable_z] or [member particle_flag_rotate_y] are [code]true[/code] or the [BaseMaterial3D] being used to draw the particle is using [constant BaseMaterial3D.BILLBOARD_PARTICLES].
-		</member>
 		<member name="angle_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's rotation will be animated along this [CurveTexture].
 		</member>
-		<member name="angle_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Rotation randomness ratio.
+		<member name="angle_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum angle.
 		</member>
-		<member name="angular_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
-			Only applied when [member particle_flag_disable_z] or [member particle_flag_rotate_y] are [code]true[/code] or the [BaseMaterial3D] being used to draw the particle is using [constant BaseMaterial3D.BILLBOARD_PARTICLES].
+		<member name="angle_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum angle.
 		</member>
 		<member name="angular_velocity_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's angular velocity will vary along this [CurveTexture].
 		</member>
-		<member name="angular_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Angular velocity randomness ratio.
+		<member name="angular_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum angular velocity.
 		</member>
-		<member name="anim_offset" type="float" setter="set_param" getter="get_param" default="0.0">
-			Particle animation offset.
+		<member name="angular_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum angular velocity.
 		</member>
 		<member name="anim_offset_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's animation offset will vary along this [CurveTexture].
 		</member>
-		<member name="anim_offset_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Animation offset randomness ratio.
+		<member name="anim_offset_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum animation offset.
 		</member>
-		<member name="anim_speed" type="float" setter="set_param" getter="get_param" default="0.0">
-			Particle animation speed.
+		<member name="anim_offset_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum animation offset.
 		</member>
 		<member name="anim_speed_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's animation speed will vary along this [CurveTexture].
 		</member>
-		<member name="anim_speed_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Animation speed randomness ratio.
+		<member name="anim_speed_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum particle animation speed.
+		</member>
+		<member name="anim_speed_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum particle animation speed.
 		</member>
 		<member name="attractor_interaction_enabled" type="bool" setter="set_attractor_interaction_enabled" getter="is_attractor_interaction_enabled" default="true">
+			True if the interaction with particle attractors is enabled.
 		</member>
 		<member name="collision_bounce" type="float" setter="set_collision_bounce" getter="get_collision_bounce" default="0.0">
+			Collision bouncyness.
 		</member>
 		<member name="collision_enabled" type="bool" setter="set_collision_enabled" getter="is_collision_enabled" default="false">
+			True if collisions are enabled for this particle system.
 		</member>
 		<member name="collision_friction" type="float" setter="set_collision_friction" getter="get_collision_friction" default="0.0">
+			Collision friction.
 		</member>
 		<member name="collision_use_scale" type="bool" setter="set_collision_use_scale" getter="is_collision_using_scale" default="false">
+			Should collision take scale into account.
 		</member>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			Each particle's initial color. If the [GPUParticles2D]'s [code]texture[/code] is defined, it will be multiplied by this color. To have particle display color in a [BaseMaterial3D] make sure to set [member BaseMaterial3D.vertex_color_use_as_albedo] to [code]true[/code].
@@ -127,14 +130,12 @@
 		<member name="color_ramp" type="Texture2D" setter="set_color_ramp" getter="get_color_ramp">
 			Each particle's color will vary along this [GradientTexture] over its lifetime (multiplied with [member color]).
 		</member>
-		<member name="damping" type="float" setter="set_param" getter="get_param" default="0.0">
-			The rate at which particles lose velocity.
-		</member>
 		<member name="damping_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Damping will vary along this [CurveTexture].
 		</member>
-		<member name="damping_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Damping randomness ratio.
+		<member name="damping_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+		</member>
+		<member name="damping_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 		</member>
 		<member name="direction" type="Vector3" setter="set_direction" getter="get_direction" default="Vector3(1, 0, 0)">
 			Unit vector specifying the particles' emission direction.
@@ -178,42 +179,41 @@
 		<member name="gravity" type="Vector3" setter="set_gravity" getter="get_gravity" default="Vector3(0, -9.8, 0)">
 			Gravity applied to every particle.
 		</member>
-		<member name="hue_variation" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial hue variation applied to each particle.
-		</member>
 		<member name="hue_variation_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's hue will vary along this [CurveTexture].
 		</member>
-		<member name="hue_variation_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Hue variation randomness ratio.
+		<member name="hue_variation_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum hue variation.
 		</member>
-		<member name="initial_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial velocity magnitude for each particle. Direction comes from [member spread] and the node's orientation.
+		<member name="hue_variation_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum hue variation.
 		</member>
-		<member name="initial_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Initial velocity randomness ratio.
+		<member name="initial_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum initial velocity.
+		</member>
+		<member name="initial_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum initial velocity.
 		</member>
 		<member name="lifetime_randomness" type="float" setter="set_lifetime_randomness" getter="get_lifetime_randomness" default="0.0">
 			Particle lifetime randomness ratio.
 		</member>
-		<member name="linear_accel" type="float" setter="set_param" getter="get_param" default="0.0">
-			Linear acceleration applied to each particle in the direction of motion.
-		</member>
 		<member name="linear_accel_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's linear acceleration will vary along this [CurveTexture].
 		</member>
-		<member name="linear_accel_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Linear acceleration randomness ratio.
+		<member name="linear_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum linear acceleration.
 		</member>
-		<member name="orbit_velocity" type="float" setter="set_param" getter="get_param">
-			Orbital velocity applied to each particle. Makes the particles circle around origin. Specified in number of full rotations around origin per second.
-			Only available when [member particle_flag_disable_z] is [code]true[/code].
+		<member name="linear_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum linear acceleration.
 		</member>
 		<member name="orbit_velocity_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's orbital velocity will vary along this [CurveTexture].
 		</member>
-		<member name="orbit_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness">
-			Orbital velocity randomness ratio.
+		<member name="orbit_velocity_max" type="float" setter="set_param_max" getter="get_param_max">
+			Maximum orbit velocity.
+		</member>
+		<member name="orbit_velocity_min" type="float" setter="set_param_min" getter="get_param_min">
+			Minimum orbit velocity.
 		</member>
 		<member name="particle_flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
 			Align Y axis of particle with the direction of its velocity.
@@ -222,25 +222,25 @@
 			If [code]true[/code], particles will not move on the z axis.
 		</member>
 		<member name="particle_flag_rotate_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
-			If [code]true[/code], particles rotate around Y axis by [member angle].
-		</member>
-		<member name="radial_accel" type="float" setter="set_param" getter="get_param" default="0.0">
-			Radial acceleration applied to each particle. Makes particle accelerate away from origin.
+			If [code]true[/code], particles rotate around Y axis by [member angle_min].
 		</member>
 		<member name="radial_accel_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's radial acceleration will vary along this [CurveTexture].
 		</member>
-		<member name="radial_accel_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Radial acceleration randomness ratio.
+		<member name="radial_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum radial acceleration.
 		</member>
-		<member name="scale" type="float" setter="set_param" getter="get_param" default="1.0">
-			Initial scale applied to each particle.
+		<member name="radial_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum radial acceleration.
 		</member>
 		<member name="scale_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
-			Each particle's scale will vary along this [CurveTexture].
+			Each particle's scale will vary along this [CurveTexture]. If a [CurveXYZTexture] is supplied instead, the scale will be separated per-axis.
 		</member>
-		<member name="scale_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Scale randomness ratio.
+		<member name="scale_max" type="float" setter="set_param_max" getter="get_param_max" default="1.0">
+			Maximum scale.
+		</member>
+		<member name="scale_min" type="float" setter="set_param_min" getter="get_param_min" default="1.0">
+			Minimum scale.
 		</member>
 		<member name="spread" type="float" setter="set_spread" getter="get_spread" default="45.0">
 			Each particle's initial direction range from [code]+spread[/code] to [code]-spread[/code] degrees.
@@ -253,52 +253,52 @@
 		</member>
 		<member name="sub_emitter_mode" type="int" setter="set_sub_emitter_mode" getter="get_sub_emitter_mode" enum="ParticlesMaterial.SubEmitterMode" default="0">
 		</member>
-		<member name="tangential_accel" type="float" setter="set_param" getter="get_param" default="0.0">
-			Tangential acceleration applied to each particle. Tangential acceleration is perpendicular to the particle's velocity giving the particles a swirling motion.
-		</member>
 		<member name="tangential_accel_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's tangential acceleration will vary along this [CurveTexture].
 		</member>
-		<member name="tangential_accel_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
-			Tangential acceleration randomness ratio.
+		<member name="tangential_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum tangential acceleration.
+		</member>
+		<member name="tangential_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum tangential acceleration.
 		</member>
 	</members>
 	<constants>
 		<constant name="PARAM_INITIAL_LINEAR_VELOCITY" value="0" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set initial velocity properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set initial velocity properties.
 		</constant>
 		<constant name="PARAM_ANGULAR_VELOCITY" value="1" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set angular velocity properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set angular velocity properties.
 		</constant>
 		<constant name="PARAM_ORBIT_VELOCITY" value="2" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set orbital velocity properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set orbital velocity properties.
 		</constant>
 		<constant name="PARAM_LINEAR_ACCEL" value="3" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set linear acceleration properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set linear acceleration properties.
 		</constant>
 		<constant name="PARAM_RADIAL_ACCEL" value="4" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set radial acceleration properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set radial acceleration properties.
 		</constant>
 		<constant name="PARAM_TANGENTIAL_ACCEL" value="5" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set tangential acceleration properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set tangential acceleration properties.
 		</constant>
 		<constant name="PARAM_DAMPING" value="6" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set damping properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set damping properties.
 		</constant>
 		<constant name="PARAM_ANGLE" value="7" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set angle properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set angle properties.
 		</constant>
 		<constant name="PARAM_SCALE" value="8" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set scale properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set scale properties.
 		</constant>
 		<constant name="PARAM_HUE_VARIATION" value="9" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set hue variation properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set hue variation properties.
 		</constant>
 		<constant name="PARAM_ANIM_SPEED" value="10" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set animation speed properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set animation speed properties.
 		</constant>
 		<constant name="PARAM_ANIM_OFFSET" value="11" enum="Parameter">
-			Use with [method set_param], [method set_param_randomness], and [method set_param_texture] to set animation offset properties.
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set animation offset properties.
 		</constant>
 		<constant name="PARAM_MAX" value="12" enum="Parameter">
 			Represents the size of the [enum Parameter] enum.

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -248,7 +248,7 @@ TypedArray<String> CPUParticles2D::get_configuration_warnings() const {
 	CanvasItemMaterial *mat = Object::cast_to<CanvasItemMaterial>(get_material().ptr());
 
 	if (get_material().is_null() || (mat && !mat->get_particles_animation())) {
-		if (get_param(PARAM_ANIM_SPEED) != 0.0 || get_param(PARAM_ANIM_OFFSET) != 0.0 ||
+		if (get_param_max(PARAM_ANIM_SPEED) != 0.0 || get_param_max(PARAM_ANIM_OFFSET) != 0.0 ||
 				get_param_curve(PARAM_ANIM_SPEED).is_valid() || get_param_curve(PARAM_ANIM_OFFSET).is_valid()) {
 			warnings.push_back(TTR("CPUParticles2D animation requires the usage of a CanvasItemMaterial with \"Particles Animation\" enabled."));
 		}
@@ -292,28 +292,34 @@ real_t CPUParticles2D::get_spread() const {
 	return spread;
 }
 
-void CPUParticles2D::set_param(Parameter p_param, real_t p_value) {
+void CPUParticles2D::set_param_min(Parameter p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 
-	parameters[p_param] = p_value;
+	parameters_min[p_param] = p_value;
+	if (parameters_min[p_param] > parameters_max[p_param]) {
+		set_param_max(p_param, p_value);
+	}
 }
 
-real_t CPUParticles2D::get_param(Parameter p_param) const {
+real_t CPUParticles2D::get_param_min(Parameter p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 
-	return parameters[p_param];
+	return parameters_min[p_param];
 }
 
-void CPUParticles2D::set_param_randomness(Parameter p_param, real_t p_value) {
+void CPUParticles2D::set_param_max(Parameter p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 
-	randomness[p_param] = p_value;
+	parameters_max[p_param] = p_value;
+	if (parameters_min[p_param] > parameters_max[p_param]) {
+		set_param_min(p_param, p_value);
+	}
 }
 
-real_t CPUParticles2D::get_param_randomness(Parameter p_param) const {
+real_t CPUParticles2D::get_param_max(Parameter p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 
-	return randomness[p_param];
+	return parameters_max[p_param];
 }
 
 static void _adjust_curve_range(const Ref<Curve> &p_curve, real_t p_min, real_t p_max) {
@@ -460,6 +466,31 @@ Vector2 CPUParticles2D::get_gravity() const {
 	return gravity;
 }
 
+void CPUParticles2D::set_scale_curve_x(Ref<Curve> p_scale_curve) {
+	scale_curve_x = p_scale_curve;
+}
+
+void CPUParticles2D::set_scale_curve_y(Ref<Curve> p_scale_curve) {
+	scale_curve_y = p_scale_curve;
+}
+
+void CPUParticles2D::set_split_scale(bool p_split_scale) {
+	split_scale = p_split_scale;
+	notify_property_list_changed();
+}
+
+Ref<Curve> CPUParticles2D::get_scale_curve_x() const {
+	return scale_curve_x;
+}
+
+Ref<Curve> CPUParticles2D::get_scale_curve_y() const {
+	return scale_curve_y;
+}
+
+bool CPUParticles2D::get_split_scale() {
+	return split_scale;
+}
+
 void CPUParticles2D::_validate_property(PropertyInfo &property) const {
 	if (property.name == "emission_sphere_radius" && emission_shape != EMISSION_SHAPE_SPHERE) {
 		property.usage = PROPERTY_USAGE_NONE;
@@ -482,6 +513,9 @@ void CPUParticles2D::_validate_property(PropertyInfo &property) const {
 	}
 
 	if (property.name == "emission_colors" && emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
+		property.usage = PROPERTY_USAGE_NONE;
+	}
+	if (property.name.begins_with("scale_curve_") && !split_scale) {
 		property.usage = PROPERTY_USAGE_NONE;
 	}
 }
@@ -695,14 +729,14 @@ void CPUParticles2D::_particles_process(double p_delta) {
 
 			real_t angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
 			Vector2 rot = Vector2(Math::cos(angle1_rad), Math::sin(angle1_rad));
-			p.velocity = rot * parameters[PARAM_INITIAL_LINEAR_VELOCITY] * Math::lerp((real_t)1.0, real_t(Math::randf()), randomness[PARAM_INITIAL_LINEAR_VELOCITY]);
+			p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], Math::randf());
 
-			real_t base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp((real_t)1.0, p.angle_rand, randomness[PARAM_ANGLE]);
+			real_t base_angle = tex_angle * Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);
 			p.rotation = Math::deg2rad(base_angle);
 
 			p.custom[0] = 0.0; // unused
 			p.custom[1] = 0.0; // phase [0..1]
-			p.custom[2] = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp((real_t)1.0, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]); //animation phase [0..1]
+			p.custom[2] = tex_anim_offset * Math::lerp(parameters_min[PARAM_ANIM_OFFSET], parameters_max[PARAM_ANIM_OFFSET], p.anim_offset_rand);
 			p.custom[3] = 0.0;
 			p.transform = Transform2D();
 			p.time = 0;
@@ -766,51 +800,51 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			p.custom[1] = p.time / lifetime;
 			tv = p.time / p.lifetime;
 
-			real_t tex_linear_velocity = 0.0;
+			real_t tex_linear_velocity = 1.0;
 			if (curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
 				tex_linear_velocity = curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY]->interpolate(tv);
 			}
 
-			real_t tex_orbit_velocity = 0.0;
+			real_t tex_orbit_velocity = 1.0;
 			if (curve_parameters[PARAM_ORBIT_VELOCITY].is_valid()) {
 				tex_orbit_velocity = curve_parameters[PARAM_ORBIT_VELOCITY]->interpolate(tv);
 			}
 
-			real_t tex_angular_velocity = 0.0;
+			real_t tex_angular_velocity = 1.0;
 			if (curve_parameters[PARAM_ANGULAR_VELOCITY].is_valid()) {
 				tex_angular_velocity = curve_parameters[PARAM_ANGULAR_VELOCITY]->interpolate(tv);
 			}
 
-			real_t tex_linear_accel = 0.0;
+			real_t tex_linear_accel = 1.0;
 			if (curve_parameters[PARAM_LINEAR_ACCEL].is_valid()) {
 				tex_linear_accel = curve_parameters[PARAM_LINEAR_ACCEL]->interpolate(tv);
 			}
 
-			real_t tex_tangential_accel = 0.0;
+			real_t tex_tangential_accel = 1.0;
 			if (curve_parameters[PARAM_TANGENTIAL_ACCEL].is_valid()) {
 				tex_tangential_accel = curve_parameters[PARAM_TANGENTIAL_ACCEL]->interpolate(tv);
 			}
 
-			real_t tex_radial_accel = 0.0;
+			real_t tex_radial_accel = 1.0;
 			if (curve_parameters[PARAM_RADIAL_ACCEL].is_valid()) {
 				tex_radial_accel = curve_parameters[PARAM_RADIAL_ACCEL]->interpolate(tv);
 			}
 
-			real_t tex_damping = 0.0;
+			real_t tex_damping = 1.0;
 			if (curve_parameters[PARAM_DAMPING].is_valid()) {
 				tex_damping = curve_parameters[PARAM_DAMPING]->interpolate(tv);
 			}
 
-			real_t tex_angle = 0.0;
+			real_t tex_angle = 1.0;
 			if (curve_parameters[PARAM_ANGLE].is_valid()) {
 				tex_angle = curve_parameters[PARAM_ANGLE]->interpolate(tv);
 			}
-			real_t tex_anim_speed = 0.0;
+			real_t tex_anim_speed = 1.0;
 			if (curve_parameters[PARAM_ANIM_SPEED].is_valid()) {
 				tex_anim_speed = curve_parameters[PARAM_ANIM_SPEED]->interpolate(tv);
 			}
 
-			real_t tex_anim_offset = 0.0;
+			real_t tex_anim_offset = 1.0;
 			if (curve_parameters[PARAM_ANIM_OFFSET].is_valid()) {
 				tex_anim_offset = curve_parameters[PARAM_ANIM_OFFSET]->interpolate(tv);
 			}
@@ -819,18 +853,18 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			Vector2 pos = p.transform[2];
 
 			//apply linear acceleration
-			force += p.velocity.length() > 0.0 ? p.velocity.normalized() * (parameters[PARAM_LINEAR_ACCEL] + tex_linear_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_LINEAR_ACCEL]) : Vector2();
+			force += p.velocity.length() > 0.0 ? p.velocity.normalized() * tex_linear_accel * Math::lerp(parameters_min[PARAM_LINEAR_ACCEL], parameters_max[PARAM_LINEAR_ACCEL], rand_from_seed(alt_seed)) : Vector2();
 			//apply radial acceleration
 			Vector2 org = emission_xform[2];
 			Vector2 diff = pos - org;
-			force += diff.length() > 0.0 ? diff.normalized() * (parameters[PARAM_RADIAL_ACCEL] + tex_radial_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_RADIAL_ACCEL]) : Vector2();
+			force += diff.length() > 0.0 ? diff.normalized() * (tex_radial_accel)*Math::lerp(parameters_min[PARAM_RADIAL_ACCEL], parameters_max[PARAM_RADIAL_ACCEL], rand_from_seed(alt_seed)) : Vector2();
 			//apply tangential acceleration;
 			Vector2 yx = Vector2(diff.y, diff.x);
-			force += yx.length() > 0.0 ? (yx * Vector2(-1.0, 1.0)).normalized() * ((parameters[PARAM_TANGENTIAL_ACCEL] + tex_tangential_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_TANGENTIAL_ACCEL])) : Vector2();
+			force += yx.length() > 0.0 ? yx.normalized() * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(alt_seed))) : Vector2();
 			//apply attractor forces
 			p.velocity += force * local_delta;
 			//orbit velocity
-			real_t orbit_amount = (parameters[PARAM_ORBIT_VELOCITY] + tex_orbit_velocity) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_ORBIT_VELOCITY]);
+			real_t orbit_amount = tex_orbit_velocity * Math::lerp(parameters_min[PARAM_ORBIT_VELOCITY], parameters_max[PARAM_ORBIT_VELOCITY], rand_from_seed(alt_seed));
 			if (orbit_amount != 0.0) {
 				real_t ang = orbit_amount * local_delta * Math_TAU;
 				// Not sure why the ParticlesMaterial code uses a clockwise rotation matrix,
@@ -843,9 +877,9 @@ void CPUParticles2D::_particles_process(double p_delta) {
 				p.velocity = p.velocity.normalized() * tex_linear_velocity;
 			}
 
-			if (parameters[PARAM_DAMPING] + tex_damping > 0.0) {
+			if (parameters_max[PARAM_DAMPING] + tex_damping > 0.0) {
 				real_t v = p.velocity.length();
-				real_t damp = (parameters[PARAM_DAMPING] + tex_damping) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_DAMPING]);
+				real_t damp = tex_damping * Math::lerp(parameters_min[PARAM_DAMPING], parameters_max[PARAM_DAMPING], rand_from_seed(alt_seed));
 				v -= damp * local_delta;
 				if (v < 0.0) {
 					p.velocity = Vector2();
@@ -853,18 +887,32 @@ void CPUParticles2D::_particles_process(double p_delta) {
 					p.velocity = p.velocity.normalized() * v;
 				}
 			}
-			real_t base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp((real_t)1.0, p.angle_rand, randomness[PARAM_ANGLE]);
-			base_angle += p.custom[1] * lifetime * (parameters[PARAM_ANGULAR_VELOCITY] + tex_angular_velocity) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed) * 2.0f - 1.0f, randomness[PARAM_ANGULAR_VELOCITY]);
+			real_t base_angle = (tex_angle)*Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);
+			base_angle += p.custom[1] * lifetime * tex_angular_velocity * Math::lerp(parameters_min[PARAM_ANGULAR_VELOCITY], parameters_max[PARAM_ANGULAR_VELOCITY], rand_from_seed(alt_seed));
 			p.rotation = Math::deg2rad(base_angle); //angle
-			real_t animation_phase = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp((real_t)1.0, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]) + p.custom[1] * (parameters[PARAM_ANIM_SPEED] + tex_anim_speed) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_ANIM_SPEED]);
-			p.custom[2] = animation_phase;
+			p.custom[2] = tex_anim_offset * Math::lerp(parameters_min[PARAM_ANIM_OFFSET], parameters_max[PARAM_ANIM_OFFSET], p.anim_offset_rand) + p.custom[1] * tex_anim_speed * Math::lerp(parameters_min[PARAM_ANIM_SPEED], parameters_max[PARAM_ANIM_SPEED], rand_from_seed(alt_seed));
 		}
 		//apply color
 		//apply hue rotation
 
-		real_t tex_scale = 1.0;
-		if (curve_parameters[PARAM_SCALE].is_valid()) {
-			tex_scale = curve_parameters[PARAM_SCALE]->interpolate(tv);
+		Vector2 tex_scale = Vector2(1.0, 1.0);
+		if (split_scale) {
+			if (scale_curve_x.is_valid()) {
+				tex_scale.x = scale_curve_x->interpolate(tv);
+			} else {
+				tex_scale.x = 1.0;
+			}
+			if (scale_curve_y.is_valid()) {
+				tex_scale.y = scale_curve_y->interpolate(tv);
+			} else {
+				tex_scale.y = 1.0;
+			}
+		} else {
+			if (curve_parameters[PARAM_SCALE].is_valid()) {
+				real_t tmp_scale = curve_parameters[PARAM_SCALE]->interpolate(tv);
+				tex_scale.x = tmp_scale;
+				tex_scale.y = tmp_scale;
+			}
 		}
 
 		real_t tex_hue_variation = 0.0;
@@ -872,7 +920,7 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->interpolate(tv);
 		}
 
-		real_t hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
+		real_t hue_rot_angle = (tex_hue_variation)*Math_TAU * Math::lerp(parameters_min[PARAM_HUE_VARIATION], parameters_max[PARAM_HUE_VARIATION], p.hue_rot_rand);
 		real_t hue_rot_c = Math::cos(hue_rot_angle);
 		real_t hue_rot_s = Math::sin(hue_rot_angle);
 
@@ -912,13 +960,15 @@ void CPUParticles2D::_particles_process(double p_delta) {
 		}
 
 		//scale by scale
-		real_t base_scale = tex_scale * Math::lerp(parameters[PARAM_SCALE], (real_t)1.0, p.scale_rand * randomness[PARAM_SCALE]);
-		if (base_scale < 0.000001) {
-			base_scale = 0.000001;
+		Vector2 base_scale = tex_scale * Math::lerp(parameters_min[PARAM_SCALE], parameters_max[PARAM_SCALE], p.scale_rand);
+		if (base_scale.x < 0.00001) {
+			base_scale.x = 0.00001;
 		}
-
-		p.transform.elements[0] *= base_scale;
-		p.transform.elements[1] *= base_scale;
+		if (base_scale.y < 0.00001) {
+			base_scale.y = 0.00001;
+		}
+		p.transform.elements[0] *= base_scale.x;
+		p.transform.elements[1] *= base_scale.y;
 
 		p.transform[2] += p.velocity * local_delta;
 	}
@@ -1130,18 +1180,24 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 	Vector2 rect_extents = Vector2(material->get_emission_box_extents().x, material->get_emission_box_extents().y);
 	set_emission_rect_extents(rect_extents);
 
+	Ref<CurveXYZTexture> scale3D = material->get_param_texture(ParticlesMaterial::PARAM_SCALE);
+	if (scale3D.is_valid()) {
+		split_scale = true;
+		scale_curve_x = scale3D->get_curve_x();
+		scale_curve_y = scale3D->get_curve_y();
+	}
 	Vector2 gravity = Vector2(material->get_gravity().x, material->get_gravity().y);
 	set_gravity(gravity);
 	set_lifetime_randomness(material->get_lifetime_randomness());
 
 #define CONVERT_PARAM(m_param)                                                            \
-	set_param(m_param, material->get_param(ParticlesMaterial::m_param));                  \
+	set_param_min(m_param, material->get_param_min(ParticlesMaterial::m_param));          \
 	{                                                                                     \
 		Ref<CurveTexture> ctex = material->get_param_texture(ParticlesMaterial::m_param); \
 		if (ctex.is_valid())                                                              \
 			set_param_curve(m_param, ctex->get_curve());                                  \
 	}                                                                                     \
-	set_param_randomness(m_param, material->get_param_randomness(ParticlesMaterial::m_param));
+	set_param_max(m_param, material->get_param_max(ParticlesMaterial::m_param));
 
 	CONVERT_PARAM(PARAM_INITIAL_LINEAR_VELOCITY);
 	CONVERT_PARAM(PARAM_ANGULAR_VELOCITY);
@@ -1224,11 +1280,11 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_spread", "degrees"), &CPUParticles2D::set_spread);
 	ClassDB::bind_method(D_METHOD("get_spread"), &CPUParticles2D::get_spread);
 
-	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &CPUParticles2D::set_param);
-	ClassDB::bind_method(D_METHOD("get_param", "param"), &CPUParticles2D::get_param);
+	ClassDB::bind_method(D_METHOD("set_param_min", "param", "value"), &CPUParticles2D::set_param_min);
+	ClassDB::bind_method(D_METHOD("get_param_min", "param"), &CPUParticles2D::get_param_min);
 
-	ClassDB::bind_method(D_METHOD("set_param_randomness", "param", "randomness"), &CPUParticles2D::set_param_randomness);
-	ClassDB::bind_method(D_METHOD("get_param_randomness", "param"), &CPUParticles2D::get_param_randomness);
+	ClassDB::bind_method(D_METHOD("set_param_max", "param", "value"), &CPUParticles2D::set_param_max);
+	ClassDB::bind_method(D_METHOD("get_param_max", "param"), &CPUParticles2D::get_param_max);
 
 	ClassDB::bind_method(D_METHOD("set_param_curve", "param", "curve"), &CPUParticles2D::set_param_curve);
 	ClassDB::bind_method(D_METHOD("get_param_curve", "param"), &CPUParticles2D::get_param_curve);
@@ -1263,6 +1319,15 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_gravity"), &CPUParticles2D::get_gravity);
 	ClassDB::bind_method(D_METHOD("set_gravity", "accel_vec"), &CPUParticles2D::set_gravity);
 
+	ClassDB::bind_method(D_METHOD("get_split_scale"), &CPUParticles2D::get_split_scale);
+	ClassDB::bind_method(D_METHOD("set_split_scale", "split_scale"), &CPUParticles2D::set_split_scale);
+
+	ClassDB::bind_method(D_METHOD("get_scale_curve_x"), &CPUParticles2D::get_scale_curve_x);
+	ClassDB::bind_method(D_METHOD("set_scale_curve_x", "scale_curve"), &CPUParticles2D::set_scale_curve_x);
+
+	ClassDB::bind_method(D_METHOD("get_scale_curve_y"), &CPUParticles2D::get_scale_curve_y);
+	ClassDB::bind_method(D_METHOD("set_scale_curve_y", "scale_curve"), &CPUParticles2D::set_scale_curve_y);
+
 	ClassDB::bind_method(D_METHOD("convert_from_particles", "particles"), &CPUParticles2D::convert_from_particles);
 
 	ADD_GROUP("Emission Shape", "emission_");
@@ -1280,54 +1345,58 @@ void CPUParticles2D::_bind_methods() {
 	ADD_GROUP("Gravity", "");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "gravity"), "set_gravity", "get_gravity");
 	ADD_GROUP("Initial Velocity", "initial_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param", "get_param", PARAM_INITIAL_LINEAR_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_INITIAL_LINEAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_min", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_min", "get_param_min", PARAM_INITIAL_LINEAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_max", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_max", "get_param_max", PARAM_INITIAL_LINEAR_VELOCITY);
 	ADD_GROUP("Angular Velocity", "angular_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity", PROPERTY_HINT_RANGE, "-720,720,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_ANGULAR_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ANGULAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_min", PROPERTY_HINT_RANGE, "-720,720,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_ANGULAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_max", PROPERTY_HINT_RANGE, "-720,720,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_ANGULAR_VELOCITY);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "angular_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_ANGULAR_VELOCITY);
 	ADD_GROUP("Orbit Velocity", "orbit_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_ORBIT_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ORBIT_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_min", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_ORBIT_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_max", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_ORBIT_VELOCITY);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "orbit_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_ORBIT_VELOCITY);
 	ADD_GROUP("Linear Accel", "linear_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_LINEAR_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_LINEAR_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_LINEAR_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_LINEAR_ACCEL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "linear_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_LINEAR_ACCEL);
 	ADD_GROUP("Radial Accel", "radial_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_RADIAL_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_RADIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_RADIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_RADIAL_ACCEL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "radial_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_RADIAL_ACCEL);
 	ADD_GROUP("Tangential Accel", "tangential_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_TANGENTIAL_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_TANGENTIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_TANGENTIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_TANGENTIAL_ACCEL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "tangential_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_TANGENTIAL_ACCEL);
 	ADD_GROUP("Damping", "");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_param", "get_param", PARAM_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_min", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_param_min", "get_param_min", PARAM_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_max", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_param_max", "get_param_max", PARAM_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "damping_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_DAMPING);
 	ADD_GROUP("Angle", "");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle", PROPERTY_HINT_RANGE, "-720,720,0.1,or_lesser,or_greater,degrees"), "set_param", "get_param", PARAM_ANGLE);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ANGLE);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle_min", PROPERTY_HINT_RANGE, "-720,720,0.1,or_lesser,or_greater,degrees"), "set_param_min", "get_param_min", PARAM_ANGLE);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle_max", PROPERTY_HINT_RANGE, "-720,720,0.1,or_lesser,or_greater,degrees"), "set_param_max", "get_param_max", PARAM_ANGLE);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "angle_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_ANGLE);
 	ADD_GROUP("Scale", "");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_amount", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param", "get_param", PARAM_SCALE);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_amount_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_SCALE);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_amount_min", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_min", "get_param_min", PARAM_SCALE);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_amount_max", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_max", "get_param_max", PARAM_SCALE);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "scale_amount_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_SCALE);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "split_scale"), "set_split_scale", "get_split_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "scale_curve_x", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_scale_curve_x", "get_scale_curve_x");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "scale_curve_y", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_scale_curve_y", "get_scale_curve_y");
+
 	ADD_GROUP("Color", "");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "color_ramp", PROPERTY_HINT_RESOURCE_TYPE, "Gradient"), "set_color_ramp", "get_color_ramp");
 
 	ADD_GROUP("Hue Variation", "hue_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_param", "get_param", PARAM_HUE_VARIATION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_HUE_VARIATION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation_min", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_param_min", "get_param_min", PARAM_HUE_VARIATION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation_max", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_param_max", "get_param_max", PARAM_HUE_VARIATION);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "hue_variation_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_HUE_VARIATION);
 	ADD_GROUP("Animation", "anim_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed", PROPERTY_HINT_RANGE, "0,128,0.01,or_greater"), "set_param", "get_param", PARAM_ANIM_SPEED);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ANIM_SPEED);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_min", PROPERTY_HINT_RANGE, "0,128,0.01,or_greater,or_lesser"), "set_param_min", "get_param_min", PARAM_ANIM_SPEED);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_max", PROPERTY_HINT_RANGE, "0,128,0.01,or_greater,or_lesser"), "set_param_max", "get_param_max", PARAM_ANIM_SPEED);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "anim_speed_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_ANIM_SPEED);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param", "get_param", PARAM_ANIM_OFFSET);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ANIM_OFFSET);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_min", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_min", "get_param_min", PARAM_ANIM_OFFSET);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_max", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_max", "get_param_max", PARAM_ANIM_OFFSET);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "anim_offset_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_param_curve", "get_param_curve", PARAM_ANIM_OFFSET);
 
 	BIND_ENUM_CONSTANT(PARAM_INITIAL_LINEAR_VELOCITY);
@@ -1366,22 +1435,31 @@ CPUParticles2D::CPUParticles2D() {
 	set_amount(8);
 	set_use_local_coordinates(true);
 
-	set_param(PARAM_INITIAL_LINEAR_VELOCITY, 0);
-	set_param(PARAM_ANGULAR_VELOCITY, 0);
-	set_param(PARAM_ORBIT_VELOCITY, 0);
-	set_param(PARAM_LINEAR_ACCEL, 0);
-	set_param(PARAM_RADIAL_ACCEL, 0);
-	set_param(PARAM_TANGENTIAL_ACCEL, 0);
-	set_param(PARAM_DAMPING, 0);
-	set_param(PARAM_ANGLE, 0);
-	set_param(PARAM_SCALE, 1);
-	set_param(PARAM_HUE_VARIATION, 0);
-	set_param(PARAM_ANIM_SPEED, 0);
-	set_param(PARAM_ANIM_OFFSET, 0);
+	set_param_min(PARAM_INITIAL_LINEAR_VELOCITY, 0);
+	set_param_min(PARAM_ANGULAR_VELOCITY, 0);
+	set_param_min(PARAM_ORBIT_VELOCITY, 0);
+	set_param_min(PARAM_LINEAR_ACCEL, 0);
+	set_param_min(PARAM_RADIAL_ACCEL, 0);
+	set_param_min(PARAM_TANGENTIAL_ACCEL, 0);
+	set_param_min(PARAM_DAMPING, 0);
+	set_param_min(PARAM_ANGLE, 0);
+	set_param_min(PARAM_SCALE, 1);
+	set_param_min(PARAM_HUE_VARIATION, 0);
+	set_param_min(PARAM_ANIM_SPEED, 0);
+	set_param_min(PARAM_ANIM_OFFSET, 0);
 
-	for (int i = 0; i < PARAM_MAX; i++) {
-		set_param_randomness(Parameter(i), 0);
-	}
+	set_param_max(PARAM_INITIAL_LINEAR_VELOCITY, 0);
+	set_param_max(PARAM_ANGULAR_VELOCITY, 0);
+	set_param_max(PARAM_ORBIT_VELOCITY, 0);
+	set_param_max(PARAM_LINEAR_ACCEL, 0);
+	set_param_max(PARAM_RADIAL_ACCEL, 0);
+	set_param_max(PARAM_TANGENTIAL_ACCEL, 0);
+	set_param_max(PARAM_DAMPING, 0);
+	set_param_max(PARAM_ANGLE, 0);
+	set_param_max(PARAM_SCALE, 1);
+	set_param_max(PARAM_HUE_VARIATION, 0);
+	set_param_max(PARAM_ANIM_SPEED, 0);
+	set_param_max(PARAM_ANIM_OFFSET, 0);
 
 	for (int i = 0; i < PARTICLE_FLAG_MAX; i++) {
 		particle_flags[i] = false;

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -150,8 +150,8 @@ private:
 	Vector2 direction = Vector2(1, 0);
 	real_t spread = 45.0;
 
-	real_t parameters[PARAM_MAX];
-	real_t randomness[PARAM_MAX];
+	real_t parameters_min[PARAM_MAX];
+	real_t parameters_max[PARAM_MAX];
 
 	Ref<Curve> curve_parameters[PARAM_MAX];
 	Color color;
@@ -166,6 +166,10 @@ private:
 	Vector<Vector2> emission_normals;
 	Vector<Color> emission_colors;
 	int emission_point_count = 0;
+
+	Ref<Curve> scale_curve_x;
+	Ref<Curve> scale_curve_y;
+	bool split_scale = false;
 
 	Vector2 gravity = Vector2(0, 980);
 
@@ -236,11 +240,11 @@ public:
 	void set_spread(real_t p_spread);
 	real_t get_spread() const;
 
-	void set_param(Parameter p_param, real_t p_value);
-	real_t get_param(Parameter p_param) const;
+	void set_param_min(Parameter p_param, real_t p_value);
+	real_t get_param_min(Parameter p_param) const;
 
-	void set_param_randomness(Parameter p_param, real_t p_value);
-	real_t get_param_randomness(Parameter p_param) const;
+	void set_param_max(Parameter p_param, real_t p_value);
+	real_t get_param_max(Parameter p_param) const;
 
 	void set_param_curve(Parameter p_param, const Ref<Curve> &p_curve);
 	Ref<Curve> get_param_curve(Parameter p_param) const;
@@ -261,6 +265,9 @@ public:
 	void set_emission_normals(const Vector<Vector2> &p_normals);
 	void set_emission_colors(const Vector<Color> &p_colors);
 	void set_emission_point_count(int p_count);
+	void set_scale_curve_x(Ref<Curve> p_scale_curve);
+	void set_scale_curve_y(Ref<Curve> p_scale_curve);
+	void set_split_scale(bool p_split_scale);
 
 	EmissionShape get_emission_shape() const;
 	real_t get_emission_sphere_radius() const;
@@ -269,6 +276,9 @@ public:
 	Vector<Vector2> get_emission_normals() const;
 	Vector<Color> get_emission_colors() const;
 	int get_emission_point_count() const;
+	Ref<Curve> get_scale_curve_x() const;
+	Ref<Curve> get_scale_curve_y() const;
+	bool get_split_scale();
 
 	void set_gravity(const Vector2 &p_gravity);
 	Vector2 get_gravity() const;

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -295,7 +295,7 @@ TypedArray<String> GPUParticles2D::get_configuration_warnings() const {
 		if (get_material().is_null() || (mat && !mat->get_particles_animation())) {
 			const ParticlesMaterial *process = Object::cast_to<ParticlesMaterial>(process_material.ptr());
 			if (process &&
-					(process->get_param(ParticlesMaterial::PARAM_ANIM_SPEED) != 0.0 || process->get_param(ParticlesMaterial::PARAM_ANIM_OFFSET) != 0.0 ||
+					(process->get_param_max(ParticlesMaterial::PARAM_ANIM_SPEED) != 0.0 || process->get_param_max(ParticlesMaterial::PARAM_ANIM_OFFSET) != 0.0 ||
 							process->get_param_texture(ParticlesMaterial::PARAM_ANIM_SPEED).is_valid() || process->get_param_texture(ParticlesMaterial::PARAM_ANIM_OFFSET).is_valid())) {
 				warnings.push_back(TTR("Particles2D animation requires the usage of a CanvasItemMaterial with \"Particles Animation\" enabled."));
 			}

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -154,8 +154,8 @@ private:
 	real_t spread = 45.0;
 	real_t flatness = 0.0;
 
-	real_t parameters[PARAM_MAX];
-	real_t randomness[PARAM_MAX] = {};
+	real_t parameters_min[PARAM_MAX];
+	real_t parameters_max[PARAM_MAX] = {};
 
 	Ref<Curve> curve_parameters[PARAM_MAX];
 	Color color = Color(1, 1, 1, 1);
@@ -174,6 +174,11 @@ private:
 	real_t emission_ring_height;
 	real_t emission_ring_radius;
 	real_t emission_ring_inner_radius;
+
+	Ref<Curve> scale_curve_x;
+	Ref<Curve> scale_curve_y;
+	Ref<Curve> scale_curve_z;
+	bool split_scale = false;
 
 	Vector3 gravity = Vector3(0, -9.8, 0);
 
@@ -246,11 +251,11 @@ public:
 	void set_flatness(real_t p_flatness);
 	real_t get_flatness() const;
 
-	void set_param(Parameter p_param, real_t p_value);
-	real_t get_param(Parameter p_param) const;
+	void set_param_min(Parameter p_param, real_t p_value);
+	real_t get_param_min(Parameter p_param) const;
 
-	void set_param_randomness(Parameter p_param, real_t p_value);
-	real_t get_param_randomness(Parameter p_param) const;
+	void set_param_max(Parameter p_param, real_t p_value);
+	real_t get_param_max(Parameter p_param) const;
 
 	void set_param_curve(Parameter p_param, const Ref<Curve> &p_curve);
 	Ref<Curve> get_param_curve(Parameter p_param) const;
@@ -275,6 +280,10 @@ public:
 	void set_emission_ring_height(real_t p_height);
 	void set_emission_ring_radius(real_t p_radius);
 	void set_emission_ring_inner_radius(real_t p_radius);
+	void set_scale_curve_x(Ref<Curve> p_scale_curve);
+	void set_scale_curve_y(Ref<Curve> p_scale_curve);
+	void set_scale_curve_z(Ref<Curve> p_scale_curve);
+	void set_split_scale(bool p_split_scale);
 
 	EmissionShape get_emission_shape() const;
 	real_t get_emission_sphere_radius() const;
@@ -287,6 +296,10 @@ public:
 	real_t get_emission_ring_height() const;
 	real_t get_emission_ring_radius() const;
 	real_t get_emission_ring_inner_radius() const;
+	Ref<Curve> get_scale_curve_x() const;
+	Ref<Curve> get_scale_curve_y() const;
+	Ref<Curve> get_scale_curve_z() const;
+	bool get_split_scale();
 
 	void set_gravity(const Vector3 &p_gravity);
 	Vector3 get_gravity() const;

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -312,7 +312,7 @@ TypedArray<String> GPUParticles3D::get_configuration_warnings() const {
 	} else {
 		const ParticlesMaterial *process = Object::cast_to<ParticlesMaterial>(process_material.ptr());
 		if (!anim_material_found && process &&
-				(process->get_param(ParticlesMaterial::PARAM_ANIM_SPEED) != 0.0 || process->get_param(ParticlesMaterial::PARAM_ANIM_OFFSET) != 0.0 ||
+				(process->get_param_max(ParticlesMaterial::PARAM_ANIM_SPEED) != 0.0 || process->get_param_max(ParticlesMaterial::PARAM_ANIM_OFFSET) != 0.0 ||
 						process->get_param_texture(ParticlesMaterial::PARAM_ANIM_SPEED).is_valid() || process->get_param_texture(ParticlesMaterial::PARAM_ANIM_OFFSET).is_valid())) {
 			warnings.push_back(TTR("Particles animation requires the usage of a BaseMaterial3D whose Billboard Mode is set to \"Particle Billboard\"."));
 		}

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -45,31 +45,31 @@ void ParticlesMaterial::init_shaders() {
 	shader_names->direction = "direction";
 	shader_names->spread = "spread";
 	shader_names->flatness = "flatness";
-	shader_names->initial_linear_velocity = "initial_linear_velocity";
-	shader_names->initial_angle = "initial_angle";
-	shader_names->angular_velocity = "angular_velocity";
-	shader_names->orbit_velocity = "orbit_velocity";
-	shader_names->linear_accel = "linear_accel";
-	shader_names->radial_accel = "radial_accel";
-	shader_names->tangent_accel = "tangent_accel";
-	shader_names->damping = "damping";
-	shader_names->scale = "scale";
-	shader_names->hue_variation = "hue_variation";
-	shader_names->anim_speed = "anim_speed";
-	shader_names->anim_offset = "anim_offset";
+	shader_names->initial_linear_velocity_min = "initial_linear_velocity_min";
+	shader_names->initial_angle_min = "initial_angle_min";
+	shader_names->angular_velocity_min = "angular_velocity_min";
+	shader_names->orbit_velocity_min = "orbit_velocity_min";
+	shader_names->linear_accel_min = "linear_accel_min";
+	shader_names->radial_accel_min = "radial_accel_min";
+	shader_names->tangent_accel_min = "tangent_accel_min";
+	shader_names->damping_min = "damping_min";
+	shader_names->scale_min = "scale_min";
+	shader_names->hue_variation_min = "hue_variation_min";
+	shader_names->anim_speed_min = "anim_speed_min";
+	shader_names->anim_offset_min = "anim_offset_min";
 
-	shader_names->initial_linear_velocity_random = "initial_linear_velocity_random";
-	shader_names->initial_angle_random = "initial_angle_random";
-	shader_names->angular_velocity_random = "angular_velocity_random";
-	shader_names->orbit_velocity_random = "orbit_velocity_random";
-	shader_names->linear_accel_random = "linear_accel_random";
-	shader_names->radial_accel_random = "radial_accel_random";
-	shader_names->tangent_accel_random = "tangent_accel_random";
-	shader_names->damping_random = "damping_random";
-	shader_names->scale_random = "scale_random";
-	shader_names->hue_variation_random = "hue_variation_random";
-	shader_names->anim_speed_random = "anim_speed_random";
-	shader_names->anim_offset_random = "anim_offset_random";
+	shader_names->initial_linear_velocity_max = "initial_linear_velocity_max";
+	shader_names->initial_angle_max = "initial_angle_max";
+	shader_names->angular_velocity_max = "angular_velocity_max";
+	shader_names->orbit_velocity_max = "orbit_velocity_max";
+	shader_names->linear_accel_max = "linear_accel_max";
+	shader_names->radial_accel_max = "radial_accel_max";
+	shader_names->tangent_accel_max = "tangent_accel_max";
+	shader_names->damping_max = "damping_max";
+	shader_names->scale_max = "scale_max";
+	shader_names->hue_variation_max = "hue_variation_max";
+	shader_names->anim_speed_max = "anim_speed_max";
+	shader_names->anim_offset_max = "anim_offset_max";
 
 	shader_names->angle_texture = "angle_texture";
 	shader_names->angular_velocity_texture = "angular_velocity_texture";
@@ -155,31 +155,31 @@ void ParticlesMaterial::_update_shader() {
 	code += "uniform vec3 direction;\n";
 	code += "uniform float spread;\n";
 	code += "uniform float flatness;\n";
-	code += "uniform float initial_linear_velocity;\n";
-	code += "uniform float initial_angle;\n";
-	code += "uniform float angular_velocity;\n";
-	code += "uniform float orbit_velocity;\n";
-	code += "uniform float linear_accel;\n";
-	code += "uniform float radial_accel;\n";
-	code += "uniform float tangent_accel;\n";
-	code += "uniform float damping;\n";
-	code += "uniform float scale;\n";
-	code += "uniform float hue_variation;\n";
-	code += "uniform float anim_speed;\n";
-	code += "uniform float anim_offset;\n";
+	code += "uniform float initial_linear_velocity_min;\n";
+	code += "uniform float initial_angle_min;\n";
+	code += "uniform float angular_velocity_min;\n";
+	code += "uniform float orbit_velocity_min;\n";
+	code += "uniform float linear_accel_min;\n";
+	code += "uniform float radial_accel_min;\n";
+	code += "uniform float tangent_accel_min;\n";
+	code += "uniform float damping_min;\n";
+	code += "uniform float scale_min;\n";
+	code += "uniform float hue_variation_min;\n";
+	code += "uniform float anim_speed_min;\n";
+	code += "uniform float anim_offset_min;\n";
 
-	code += "uniform float initial_linear_velocity_random;\n";
-	code += "uniform float initial_angle_random;\n";
-	code += "uniform float angular_velocity_random;\n";
-	code += "uniform float orbit_velocity_random;\n";
-	code += "uniform float linear_accel_random;\n";
-	code += "uniform float radial_accel_random;\n";
-	code += "uniform float tangent_accel_random;\n";
-	code += "uniform float damping_random;\n";
-	code += "uniform float scale_random;\n";
-	code += "uniform float hue_variation_random;\n";
-	code += "uniform float anim_speed_random;\n";
-	code += "uniform float anim_offset_random;\n";
+	code += "uniform float initial_linear_velocity_max;\n";
+	code += "uniform float initial_angle_max;\n";
+	code += "uniform float angular_velocity_max;\n";
+	code += "uniform float orbit_velocity_max;\n";
+	code += "uniform float linear_accel_max;\n";
+	code += "uniform float radial_accel_max;\n";
+	code += "uniform float tangent_accel_max;\n";
+	code += "uniform float damping_max;\n";
+	code += "uniform float scale_max;\n";
+	code += "uniform float hue_variation_max;\n";
+	code += "uniform float anim_speed_max;\n";
+	code += "uniform float anim_offset_max;\n";
 	code += "uniform float lifetime_randomness;\n";
 
 	switch (emission_shape) {
@@ -329,7 +329,7 @@ void ParticlesMaterial::_update_shader() {
 	if (tex_parameters[PARAM_ANIM_OFFSET].is_valid()) {
 		code += "	float tex_anim_offset = textureLod(anim_offset_texture, vec2(0.0, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_anim_offset = 0.0;\n";
+		code += "	float tex_anim_offset = 1.0;\n";
 	}
 
 	code += "	float spread_rad = spread * degree_to_rad;\n";
@@ -339,7 +339,7 @@ void ParticlesMaterial::_update_shader() {
 	if (tex_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
 		code += "		float tex_linear_velocity = textureLod(linear_velocity_texture, vec2(0.0, 0.0), 0.0).r;\n";
 	} else {
-		code += "		float tex_linear_velocity = 0.0;\n";
+		code += "		float tex_linear_velocity = 1.0;\n";
 	}
 
 	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
@@ -347,7 +347,7 @@ void ParticlesMaterial::_update_shader() {
 		code += "			float angle1_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad;\n";
 		code += "			angle1_rad += direction.x != 0.0 ? atan(direction.y, direction.x) : sign(direction.y) * (pi / 2.0);\n";
 		code += "			vec3 rot = vec3(cos(angle1_rad), sin(angle1_rad), 0.0);\n";
-		code += "			VELOCITY = rot * initial_linear_velocity * mix(1.0, rand_from_seed(alt_seed), initial_linear_velocity_random);\n";
+		code += "			VELOCITY = rot * mix(initial_linear_velocity_min,initial_linear_velocity_max, rand_from_seed(alt_seed));\n";
 		code += "		}\n";
 
 	} else {
@@ -369,16 +369,16 @@ void ParticlesMaterial::_update_shader() {
 		code += "			binormal = normalize(binormal);\n";
 		code += "			vec3 normal = cross(binormal, direction_nrm);\n";
 		code += "			spread_direction = binormal * spread_direction.x + normal * spread_direction.y + direction_nrm * spread_direction.z;\n";
-		code += "			VELOCITY = spread_direction * initial_linear_velocity * mix(1.0, rand_from_seed(alt_seed), initial_linear_velocity_random);\n";
+		code += "			VELOCITY = spread_direction * mix(initial_linear_velocity_min, initial_linear_velocity_max,rand_from_seed(alt_seed));\n";
 		code += "		}\n";
 	}
 	code += "	}\n";
 
-	code += "	float base_angle = (initial_angle + tex_angle) * mix(1.0, angle_rand, initial_angle_random);\n";
+	code += "	float base_angle = (tex_angle) * mix(initial_angle_min, initial_angle_max, angle_rand);\n";
 	code += "	CUSTOM.x = base_angle * degree_to_rad;\n"; // angle
 	code += "	CUSTOM.y = 0.0;\n"; // phase
 	code += "	CUSTOM.w = (1.0 - lifetime_randomness * rand_from_seed(alt_seed));\n";
-	code += "	CUSTOM.z = (anim_offset + tex_anim_offset) * mix(1.0, anim_offset_rand, anim_offset_random);\n"; // animation offset (0-1)
+	code += "	CUSTOM.z = (tex_anim_offset) * mix(anim_offset_min, anim_offset_max, anim_offset_rand);\n"; // animation offset (0-1)
 
 	code += "	if (RESTART_POSITION) {\n";
 
@@ -471,63 +471,63 @@ void ParticlesMaterial::_update_shader() {
 	if (tex_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
 		code += "	float tex_linear_velocity = textureLod(linear_velocity_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_linear_velocity = 0.0;\n";
+		code += "	float tex_linear_velocity = 1.0;\n";
 	}
 
 	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		if (tex_parameters[PARAM_ORBIT_VELOCITY].is_valid()) {
 			code += "	float tex_orbit_velocity = textureLod(orbit_velocity_texture, vec2(tv, 0.0), 0.0).r;\n";
 		} else {
-			code += "	float tex_orbit_velocity = 0.0;\n";
+			code += "	float tex_orbit_velocity = 1.0;\n";
 		}
 	}
 
 	if (tex_parameters[PARAM_ANGULAR_VELOCITY].is_valid()) {
 		code += "	float tex_angular_velocity = textureLod(angular_velocity_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_angular_velocity = 0.0;\n";
+		code += "	float tex_angular_velocity = 1.0;\n";
 	}
 
 	if (tex_parameters[PARAM_LINEAR_ACCEL].is_valid()) {
 		code += "	float tex_linear_accel = textureLod(linear_accel_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_linear_accel = 0.0;\n";
+		code += "	float tex_linear_accel = 1.0;\n";
 	}
 
 	if (tex_parameters[PARAM_RADIAL_ACCEL].is_valid()) {
 		code += "	float tex_radial_accel = textureLod(radial_accel_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_radial_accel = 0.0;\n";
+		code += "	float tex_radial_accel = 1.0;\n";
 	}
 
 	if (tex_parameters[PARAM_TANGENTIAL_ACCEL].is_valid()) {
 		code += "	float tex_tangent_accel = textureLod(tangent_accel_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_tangent_accel = 0.0;\n";
+		code += "	float tex_tangent_accel = 1.0;\n";
 	}
 
 	if (tex_parameters[PARAM_DAMPING].is_valid()) {
 		code += "	float tex_damping = textureLod(damping_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_damping = 0.0;\n";
+		code += "	float tex_damping = 1.0;\n";
 	}
 
 	if (tex_parameters[PARAM_ANGLE].is_valid()) {
 		code += "	float tex_angle = textureLod(angle_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_angle = 0.0;\n";
+		code += "	float tex_angle = 1.0;\n";
 	}
 
 	if (tex_parameters[PARAM_ANIM_SPEED].is_valid()) {
 		code += "	float tex_anim_speed = textureLod(anim_speed_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_anim_speed = 0.0;\n";
+		code += "	float tex_anim_speed = 1.0;\n";
 	}
 
 	if (tex_parameters[PARAM_ANIM_OFFSET].is_valid()) {
 		code += "	float tex_anim_offset = textureLod(anim_offset_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_anim_offset = 0.0;\n";
+		code += "	float tex_anim_offset = 1.0;\n";
 	}
 
 	code += "	vec3 force = gravity;\n";
@@ -536,18 +536,19 @@ void ParticlesMaterial::_update_shader() {
 		code += "	pos.z = 0.0;\n";
 	}
 	code += "	// apply linear acceleration\n";
-	code += "	force += length(VELOCITY) > 0.0 ? normalize(VELOCITY) * (linear_accel + tex_linear_accel) * mix(1.0, rand_from_seed(alt_seed), linear_accel_random) : vec3(0.0);\n";
+	code += "	force += length(VELOCITY) > 0.0 ? normalize(VELOCITY) * tex_linear_accel * mix(linear_accel_min, linear_accel_max, rand_from_seed(alt_seed)) : vec3(0.0);\n";
 	code += "	// apply radial acceleration\n";
 	code += "	vec3 org = EMISSION_TRANSFORM[3].xyz;\n";
 	code += "	vec3 diff = pos - org;\n";
-	code += "	force += length(diff) > 0.0 ? normalize(diff) * (radial_accel + tex_radial_accel) * mix(1.0, rand_from_seed(alt_seed), radial_accel_random) : vec3(0.0);\n";
+	code += "	force += length(diff) > 0.0 ? normalize(diff) * tex_radial_accel * mix(radial_accel_min, radial_accel_max, rand_from_seed(alt_seed)) : vec3(0.0);\n";
 	code += "	// apply tangential acceleration;\n";
+	code += "	float tangent_accel_val = tex_tangent_accel * mix(tangent_accel_min, tangent_accel_max, rand_from_seed(alt_seed))\n;";
 	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		code += "	force += length(diff.yx) > 0.0 ? vec3(normalize(diff.yx * vec2(-1.0, 1.0)), 0.0) * ((tangent_accel + tex_tangent_accel) * mix(1.0, rand_from_seed(alt_seed), tangent_accel_random)) : vec3(0.0);\n";
+		code += "	force += length(diff.yx) > 0.0 ? vec3(normalize(diff.yx * vec2(-1.0, 1.0)), 0.0) * tangent_accel_val : vec3(0.0);\n";
 
 	} else {
 		code += "	vec3 crossDiff = cross(normalize(diff), normalize(gravity));\n";
-		code += "	force += length(crossDiff) > 0.0 ? normalize(crossDiff) * ((tangent_accel + tex_tangent_accel) * mix(1.0, rand_from_seed(alt_seed), tangent_accel_random)) : vec3(0.0);\n";
+		code += "	force += length(crossDiff) > 0.0 ? normalize(crossDiff) * tangent_accel_val : vec3(0.0);\n";
 	}
 	if (attractor_interaction_enabled) {
 		code += "	force += ATTRACTOR_FORCE;\n\n";
@@ -557,7 +558,7 @@ void ParticlesMaterial::_update_shader() {
 	code += "	VELOCITY += force * DELTA;\n";
 	code += "	// orbit velocity\n";
 	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		code += "	float orbit_amount = (orbit_velocity + tex_orbit_velocity) * mix(1.0, rand_from_seed(alt_seed), orbit_velocity_random);\n";
+		code += "	float orbit_amount = tex_orbit_velocity * mix(orbit_velocity_min, orbit_velocity_max, rand_from_seed(alt_seed));\n";
 		code += "	if (orbit_amount != 0.0) {\n";
 		code += "	     float ang = orbit_amount * DELTA * pi * 2.0;\n";
 		code += "	     mat2 rot = mat2(vec2(cos(ang), -sin(ang)), vec2(sin(ang), cos(ang)));\n";
@@ -569,9 +570,10 @@ void ParticlesMaterial::_update_shader() {
 	if (tex_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
 		code += "	VELOCITY = normalize(VELOCITY) * tex_linear_velocity;\n";
 	}
-	code += "	if (damping + tex_damping > 0.0) {\n";
+	code += "	float dmp = mix(damping_min, damping_max, rand_from_seed(alt_seed));\n";
+	code += "	if (dmp * tex_damping > 0.0) {\n";
 	code += "		float v = length(VELOCITY);\n";
-	code += "		float damp = (damping + tex_damping) * mix(1.0, rand_from_seed(alt_seed), damping_random);\n";
+	code += "		float damp = tex_damping * dmp;\n";
 	code += "		v -= damp * DELTA;\n";
 	code += "		if (v < 0.0) {\n";
 	code += "			VELOCITY = vec3(0.0);\n";
@@ -579,26 +581,26 @@ void ParticlesMaterial::_update_shader() {
 	code += "			VELOCITY = normalize(VELOCITY) * v;\n";
 	code += "		}\n";
 	code += "	}\n";
-	code += "	float base_angle = (initial_angle + tex_angle) * mix(1.0, angle_rand, initial_angle_random);\n";
-	code += "	base_angle += CUSTOM.y * LIFETIME * (angular_velocity + tex_angular_velocity) * mix(1.0, rand_from_seed(alt_seed) * 2.0 - 1.0, angular_velocity_random);\n";
+	code += "	float base_angle = (tex_angle) * mix(initial_angle_min, initial_angle_max, rand_from_seed(alt_seed));\n";
+	code += "	base_angle += CUSTOM.y * LIFETIME * (tex_angular_velocity) * mix(angular_velocity_min,angular_velocity_max, rand_from_seed(alt_seed));\n";
 	code += "	CUSTOM.x = base_angle * degree_to_rad;\n"; // angle
-	code += "	CUSTOM.z = (anim_offset + tex_anim_offset) * mix(1.0, anim_offset_rand, anim_offset_random) + CUSTOM.y * (anim_speed + tex_anim_speed) * mix(1.0, rand_from_seed(alt_seed), anim_speed_random);\n"; // angle
+	code += "	CUSTOM.z = (tex_anim_offset) * mix(anim_offset_min, anim_offset_max, rand_from_seed(alt_seed)) + CUSTOM.y * tex_anim_speed * mix(anim_speed_min, anim_speed_max, rand_from_seed(alt_seed));\n"; // angle
 
 	// apply color
 	// apply hue rotation
 	if (tex_parameters[PARAM_SCALE].is_valid()) {
-		code += "	float tex_scale = textureLod(scale_texture, vec2(tv, 0.0), 0.0).r;\n";
+		code += "	vec3 tex_scale = textureLod(scale_texture, vec2(tv, 0.0), 0.0).rgb;\n";
 	} else {
-		code += "	float tex_scale = 1.0;\n";
+		code += "	vec3 tex_scale = vec3(1.0);\n";
 	}
 
 	if (tex_parameters[PARAM_HUE_VARIATION].is_valid()) {
 		code += "	float tex_hue_variation = textureLod(hue_variation_texture, vec2(tv, 0.0), 0.0).r;\n";
 	} else {
-		code += "	float tex_hue_variation = 0.0;\n";
+		code += "	float tex_hue_variation = 1.0;\n";
 	}
 
-	code += "	float hue_rot_angle = (hue_variation + tex_hue_variation) * pi * 2.0 * mix(1.0, hue_rot_rand * 2.0 - 1.0, hue_variation_random);\n";
+	code += "	float hue_rot_angle = (tex_hue_variation) * pi * 2.0 * mix(hue_variation_min, hue_variation_max, rand_from_seed(alt_seed));\n";
 	code += "	float hue_rot_c = cos(hue_rot_angle);\n";
 	code += "	float hue_rot_s = sin(hue_rot_angle);\n";
 	code += "	mat4 hue_rot_mat = mat4(vec4(0.299, 0.587, 0.114, 0.0),\n";
@@ -660,18 +662,18 @@ void ParticlesMaterial::_update_shader() {
 		}
 		// turn particle by rotation in Y
 		if (particle_flags[PARTICLE_FLAG_ROTATE_Y]) {
+			code += "	vec4 origin = TRANSFORM[3];\n";
 			code += "	TRANSFORM = mat4(vec4(cos(CUSTOM.x), 0.0, -sin(CUSTOM.x), 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(sin(CUSTOM.x), 0.0, cos(CUSTOM.x), 0.0), vec4(0.0, 0.0, 0.0, 1.0));\n";
+			code += "	TRANSFORM[3] = origin;\n";
 		}
 	}
 	//scale by scale
-	code += "	float base_scale = tex_scale * mix(scale, 1.0, scale_random * scale_rand);\n";
-	code += "	if (base_scale < 0.000001) {\n";
-	code += "		base_scale = 0.000001;\n";
-	code += "	}\n";
+	code += "	float base_scale = mix(scale_min, scale_max, scale_rand);\n";
+	code += "	base_scale = sign(base_scale) * max(abs(base_scale), 0.001);\n";
 
-	code += "	TRANSFORM[0].xyz *= base_scale;\n";
-	code += "	TRANSFORM[1].xyz *= base_scale;\n";
-	code += "	TRANSFORM[2].xyz *= base_scale;\n";
+	code += "	TRANSFORM[0].xyz *= base_scale * sign(tex_scale.r) * max(abs(tex_scale.r), 0.001);\n";
+	code += "	TRANSFORM[1].xyz *= base_scale * sign(tex_scale.g) * max(abs(tex_scale.g), 0.001);\n";
+	code += "	TRANSFORM[2].xyz *= base_scale * sign(tex_scale.b) * max(abs(tex_scale.b), 0.001);\n";
 	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		code += "	VELOCITY.z = 0.0;\n";
 		code += "	TRANSFORM[3].z = 0.0;\n";
@@ -777,110 +779,116 @@ float ParticlesMaterial::get_flatness() const {
 	return flatness;
 }
 
-void ParticlesMaterial::set_param(Parameter p_param, float p_value) {
+void ParticlesMaterial::set_param_min(Parameter p_param, float p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 
-	parameters[p_param] = p_value;
+	params_min[p_param] = p_value;
+	if (params_min[p_param] > params_max[p_param]) {
+		set_param_max(p_param, p_value);
+	}
 
 	switch (p_param) {
 		case PARAM_INITIAL_LINEAR_VELOCITY: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->initial_linear_velocity, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->initial_linear_velocity_min, p_value);
 		} break;
 		case PARAM_ANGULAR_VELOCITY: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->angular_velocity, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->angular_velocity_min, p_value);
 		} break;
 		case PARAM_ORBIT_VELOCITY: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->orbit_velocity, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->orbit_velocity_min, p_value);
 		} break;
 		case PARAM_LINEAR_ACCEL: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->linear_accel, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->linear_accel_min, p_value);
 		} break;
 		case PARAM_RADIAL_ACCEL: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->radial_accel, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->radial_accel_min, p_value);
 		} break;
 		case PARAM_TANGENTIAL_ACCEL: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->tangent_accel, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->tangent_accel_min, p_value);
 		} break;
 		case PARAM_DAMPING: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->damping, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->damping_min, p_value);
 		} break;
 		case PARAM_ANGLE: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->initial_angle, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->initial_angle_min, p_value);
 		} break;
 		case PARAM_SCALE: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->scale, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->scale_min, p_value);
 		} break;
 		case PARAM_HUE_VARIATION: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->hue_variation, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->hue_variation_min, p_value);
 		} break;
 		case PARAM_ANIM_SPEED: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_speed, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_speed_min, p_value);
 		} break;
 		case PARAM_ANIM_OFFSET: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_offset, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_offset_min, p_value);
 		} break;
 		case PARAM_MAX:
 			break; // Can't happen, but silences warning
 	}
 }
 
-float ParticlesMaterial::get_param(Parameter p_param) const {
+float ParticlesMaterial::get_param_min(Parameter p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 
-	return parameters[p_param];
+	return params_min[p_param];
 }
 
-void ParticlesMaterial::set_param_randomness(Parameter p_param, float p_value) {
+void ParticlesMaterial::set_param_max(Parameter p_param, float p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 
-	randomness[p_param] = p_value;
+	params_max[p_param] = p_value;
+	if (params_min[p_param] > params_max[p_param]) {
+		set_param_min(p_param, p_value);
+	}
 
 	switch (p_param) {
 		case PARAM_INITIAL_LINEAR_VELOCITY: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->initial_linear_velocity_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->initial_linear_velocity_max, p_value);
 		} break;
 		case PARAM_ANGULAR_VELOCITY: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->angular_velocity_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->angular_velocity_max, p_value);
 		} break;
 		case PARAM_ORBIT_VELOCITY: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->orbit_velocity_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->orbit_velocity_max, p_value);
 		} break;
 		case PARAM_LINEAR_ACCEL: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->linear_accel_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->linear_accel_max, p_value);
 		} break;
 		case PARAM_RADIAL_ACCEL: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->radial_accel_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->radial_accel_max, p_value);
 		} break;
 		case PARAM_TANGENTIAL_ACCEL: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->tangent_accel_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->tangent_accel_max, p_value);
 		} break;
 		case PARAM_DAMPING: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->damping_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->damping_max, p_value);
 		} break;
 		case PARAM_ANGLE: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->initial_angle_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->initial_angle_max, p_value);
 		} break;
 		case PARAM_SCALE: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->scale_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->scale_max, p_value);
 		} break;
 		case PARAM_HUE_VARIATION: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->hue_variation_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->hue_variation_max, p_value);
 		} break;
 		case PARAM_ANIM_SPEED: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_speed_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_speed_max, p_value);
 		} break;
 		case PARAM_ANIM_OFFSET: {
-			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_offset_random, p_value);
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->anim_offset_max, p_value);
 		} break;
 		case PARAM_MAX:
 			break; // Can't happen, but silences warning
 	}
 }
 
-float ParticlesMaterial::get_param_randomness(Parameter p_param) const {
+float ParticlesMaterial::get_param_max(Parameter p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 
-	return randomness[p_param];
+	return params_max[p_param];
 }
 
 static void _adjust_curve_range(const Ref<Texture2D> &p_texture, float p_min, float p_max) {
@@ -1259,11 +1267,11 @@ void ParticlesMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flatness", "amount"), &ParticlesMaterial::set_flatness);
 	ClassDB::bind_method(D_METHOD("get_flatness"), &ParticlesMaterial::get_flatness);
 
-	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &ParticlesMaterial::set_param);
-	ClassDB::bind_method(D_METHOD("get_param", "param"), &ParticlesMaterial::get_param);
+	ClassDB::bind_method(D_METHOD("set_param_min", "param", "value"), &ParticlesMaterial::set_param_min);
+	ClassDB::bind_method(D_METHOD("get_param_min", "param"), &ParticlesMaterial::get_param_min);
 
-	ClassDB::bind_method(D_METHOD("set_param_randomness", "param", "randomness"), &ParticlesMaterial::set_param_randomness);
-	ClassDB::bind_method(D_METHOD("get_param_randomness", "param"), &ParticlesMaterial::get_param_randomness);
+	ClassDB::bind_method(D_METHOD("set_param_max", "param", "value"), &ParticlesMaterial::set_param_max);
+	ClassDB::bind_method(D_METHOD("get_param_max", "param"), &ParticlesMaterial::get_param_max);
 
 	ClassDB::bind_method(D_METHOD("set_param_texture", "param", "texture"), &ParticlesMaterial::set_param_texture);
 	ClassDB::bind_method(D_METHOD("get_param_texture", "param"), &ParticlesMaterial::get_param_texture);
@@ -1369,54 +1377,54 @@ void ParticlesMaterial::_bind_methods() {
 	ADD_GROUP("Gravity", "");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "gravity"), "set_gravity", "get_gravity");
 	ADD_GROUP("Initial Velocity", "initial_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity", PROPERTY_HINT_RANGE, "0,1000,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_INITIAL_LINEAR_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_INITIAL_LINEAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_min", PROPERTY_HINT_RANGE, "0,1000,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_INITIAL_LINEAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_max", PROPERTY_HINT_RANGE, "0,1000,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_INITIAL_LINEAR_VELOCITY);
 	ADD_GROUP("Angular Velocity", "angular_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity", PROPERTY_HINT_RANGE, "-720,720,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_ANGULAR_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ANGULAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_min", PROPERTY_HINT_RANGE, "-720,720,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_ANGULAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_max", PROPERTY_HINT_RANGE, "-720,720,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_ANGULAR_VELOCITY);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "angular_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANGULAR_VELOCITY);
 	ADD_GROUP("Orbit Velocity", "orbit_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_ORBIT_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ORBIT_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_min", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_ORBIT_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_max", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_ORBIT_VELOCITY);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "orbit_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ORBIT_VELOCITY);
 	ADD_GROUP("Linear Accel", "linear_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_LINEAR_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_LINEAR_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_LINEAR_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_LINEAR_ACCEL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "linear_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_LINEAR_ACCEL);
 	ADD_GROUP("Radial Accel", "radial_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_RADIAL_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_RADIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_RADIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_RADIAL_ACCEL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "radial_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_RADIAL_ACCEL);
 	ADD_GROUP("Tangential Accel", "tangential_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param", "get_param", PARAM_TANGENTIAL_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_TANGENTIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_TANGENTIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_TANGENTIAL_ACCEL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "tangential_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_TANGENTIAL_ACCEL);
 	ADD_GROUP("Damping", "");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping", PROPERTY_HINT_RANGE, "0,100,0.01,or_greater"), "set_param", "get_param", PARAM_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_min", PROPERTY_HINT_RANGE, "0,100,0.01,or_greater"), "set_param_min", "get_param_min", PARAM_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_max", PROPERTY_HINT_RANGE, "0,100,0.01,or_greater"), "set_param_max", "get_param_max", PARAM_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "damping_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_DAMPING);
 	ADD_GROUP("Angle", "");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle", PROPERTY_HINT_RANGE, "-720,720,0.1,or_lesser,or_greater,degrees"), "set_param", "get_param", PARAM_ANGLE);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ANGLE);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle_min", PROPERTY_HINT_RANGE, "-720,720,0.1,or_lesser,or_greater,degrees"), "set_param_min", "get_param_min", PARAM_ANGLE);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle_max", PROPERTY_HINT_RANGE, "-720,720,0.1,or_lesser,or_greater,degrees"), "set_param_max", "get_param_max", PARAM_ANGLE);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "angle_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANGLE);
 	ADD_GROUP("Scale", "");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param", "get_param", PARAM_SCALE);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_SCALE);
-	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "scale_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_SCALE);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_min", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_min", "get_param_min", PARAM_SCALE);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_max", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_max", "get_param_max", PARAM_SCALE);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "scale_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture,CurveXYZTexture"), "set_param_texture", "get_param_texture", PARAM_SCALE);
 	ADD_GROUP("Color", "");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "color_ramp", PROPERTY_HINT_RESOURCE_TYPE, "GradientTexture"), "set_color_ramp", "get_color_ramp");
 
 	ADD_GROUP("Hue Variation", "hue_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_param", "get_param", PARAM_HUE_VARIATION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_HUE_VARIATION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation_min", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_param_min", "get_param_min", PARAM_HUE_VARIATION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation_max", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_param_max", "get_param_max", PARAM_HUE_VARIATION);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "hue_variation_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_HUE_VARIATION);
 	ADD_GROUP("Animation", "anim_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed", PROPERTY_HINT_RANGE, "0,128,0.01,or_greater"), "set_param", "get_param", PARAM_ANIM_SPEED);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ANIM_SPEED);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_min", PROPERTY_HINT_RANGE, "0,16,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_ANIM_SPEED);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_max", PROPERTY_HINT_RANGE, "0,16,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_ANIM_SPEED);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "anim_speed_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANIM_SPEED);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param", "get_param", PARAM_ANIM_OFFSET);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_random", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_randomness", "get_param_randomness", PARAM_ANIM_OFFSET);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_min", PROPERTY_HINT_RANGE, "0,16,0.01,or_lesser,or_greater"), "set_param_min", "get_param_min", PARAM_ANIM_OFFSET);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_max", PROPERTY_HINT_RANGE, "0,16,0.01,or_lesser,or_greater"), "set_param_max", "get_param_max", PARAM_ANIM_OFFSET);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "anim_offset_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANIM_OFFSET);
 
 	ADD_GROUP("Sub Emitter", "sub_emitter_");
@@ -1472,18 +1480,30 @@ ParticlesMaterial::ParticlesMaterial() :
 	set_direction(Vector3(1, 0, 0));
 	set_spread(45);
 	set_flatness(0);
-	set_param(PARAM_INITIAL_LINEAR_VELOCITY, 0);
-	set_param(PARAM_ANGULAR_VELOCITY, 0);
-	set_param(PARAM_ORBIT_VELOCITY, 0);
-	set_param(PARAM_LINEAR_ACCEL, 0);
-	set_param(PARAM_RADIAL_ACCEL, 0);
-	set_param(PARAM_TANGENTIAL_ACCEL, 0);
-	set_param(PARAM_DAMPING, 0);
-	set_param(PARAM_ANGLE, 0);
-	set_param(PARAM_SCALE, 1);
-	set_param(PARAM_HUE_VARIATION, 0);
-	set_param(PARAM_ANIM_SPEED, 0);
-	set_param(PARAM_ANIM_OFFSET, 0);
+	set_param_min(PARAM_INITIAL_LINEAR_VELOCITY, 0);
+	set_param_min(PARAM_ANGULAR_VELOCITY, 0);
+	set_param_min(PARAM_ORBIT_VELOCITY, 0);
+	set_param_min(PARAM_LINEAR_ACCEL, 0);
+	set_param_min(PARAM_RADIAL_ACCEL, 0);
+	set_param_min(PARAM_TANGENTIAL_ACCEL, 0);
+	set_param_min(PARAM_DAMPING, 0);
+	set_param_min(PARAM_ANGLE, 0);
+	set_param_min(PARAM_SCALE, 1);
+	set_param_min(PARAM_HUE_VARIATION, 0);
+	set_param_min(PARAM_ANIM_SPEED, 0);
+	set_param_min(PARAM_ANIM_OFFSET, 0);
+	set_param_max(PARAM_INITIAL_LINEAR_VELOCITY, 0);
+	set_param_max(PARAM_ANGULAR_VELOCITY, 0);
+	set_param_max(PARAM_ORBIT_VELOCITY, 0);
+	set_param_max(PARAM_LINEAR_ACCEL, 0);
+	set_param_max(PARAM_RADIAL_ACCEL, 0);
+	set_param_max(PARAM_TANGENTIAL_ACCEL, 0);
+	set_param_max(PARAM_DAMPING, 0);
+	set_param_max(PARAM_ANGLE, 0);
+	set_param_max(PARAM_SCALE, 1);
+	set_param_max(PARAM_HUE_VARIATION, 0);
+	set_param_max(PARAM_ANIM_SPEED, 0);
+	set_param_max(PARAM_ANIM_OFFSET, 0);
 	set_emission_shape(EMISSION_SHAPE_POINT);
 	set_emission_sphere_radius(1);
 	set_emission_box_extents(Vector3(1, 1, 1));
@@ -1504,10 +1524,6 @@ ParticlesMaterial::ParticlesMaterial() :
 	set_collision_bounce(0.0);
 	set_collision_friction(0.0);
 	set_collision_use_scale(false);
-
-	for (int i = 0; i < PARAM_MAX; i++) {
-		set_param_randomness(Parameter(i), 0);
-	}
 
 	for (int i = 0; i < PARTICLE_FLAG_MAX; i++) {
 		particle_flags[i] = false;

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -154,31 +154,31 @@ private:
 		StringName direction;
 		StringName spread;
 		StringName flatness;
-		StringName initial_linear_velocity;
-		StringName initial_angle;
-		StringName angular_velocity;
-		StringName orbit_velocity;
-		StringName linear_accel;
-		StringName radial_accel;
-		StringName tangent_accel;
-		StringName damping;
-		StringName scale;
-		StringName hue_variation;
-		StringName anim_speed;
-		StringName anim_offset;
+		StringName initial_linear_velocity_min;
+		StringName initial_angle_min;
+		StringName angular_velocity_min;
+		StringName orbit_velocity_min;
+		StringName linear_accel_min;
+		StringName radial_accel_min;
+		StringName tangent_accel_min;
+		StringName damping_min;
+		StringName scale_min;
+		StringName hue_variation_min;
+		StringName anim_speed_min;
+		StringName anim_offset_min;
 
-		StringName initial_linear_velocity_random;
-		StringName initial_angle_random;
-		StringName angular_velocity_random;
-		StringName orbit_velocity_random;
-		StringName linear_accel_random;
-		StringName radial_accel_random;
-		StringName tangent_accel_random;
-		StringName damping_random;
-		StringName scale_random;
-		StringName hue_variation_random;
-		StringName anim_speed_random;
-		StringName anim_offset_random;
+		StringName initial_linear_velocity_max;
+		StringName initial_angle_max;
+		StringName angular_velocity_max;
+		StringName orbit_velocity_max;
+		StringName linear_accel_max;
+		StringName radial_accel_max;
+		StringName tangent_accel_max;
+		StringName damping_max;
+		StringName scale_max;
+		StringName hue_variation_max;
+		StringName anim_speed_max;
+		StringName anim_offset_max;
 
 		StringName angle_texture;
 		StringName angular_velocity_texture;
@@ -230,8 +230,8 @@ private:
 	float spread;
 	float flatness;
 
-	float parameters[PARAM_MAX];
-	float randomness[PARAM_MAX];
+	float params_min[PARAM_MAX];
+	float params_max[PARAM_MAX];
 
 	Ref<Texture2D> tex_parameters[PARAM_MAX];
 	Color color;
@@ -283,11 +283,11 @@ public:
 	void set_flatness(float p_flatness);
 	float get_flatness() const;
 
-	void set_param(Parameter p_param, float p_value);
-	float get_param(Parameter p_param) const;
+	void set_param_min(Parameter p_param, float p_value);
+	float get_param_min(Parameter p_param) const;
 
-	void set_param_randomness(Parameter p_param, float p_value);
-	float get_param_randomness(Parameter p_param) const;
+	void set_param_max(Parameter p_param, float p_value);
+	float get_param_max(Parameter p_param) const;
 
 	void set_param_texture(Parameter p_param, const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_param_texture(Parameter p_param) const;


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/46912

I got a bit carried away and implemented separate axes scale as well.. sorry!

CPUParticle2D conversion will come next week. Since this is a relatively big change to ParticleMaterial, i wanted to get it in asap so whoever else needs to work on it, can.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/2405.*
And also closes https://github.com/godotengine/godot-proposals/issues/2404