### PR TITLE
Check if there are new docs missing on CI

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -85,7 +85,7 @@ jobs:
           echo "Running --doctool to see if this changes the public API without updating the documentation."
           echo -e "If a diff is shown, it means that your code/doc changes are incomplete and you should update the class reference with --doctool.\n\n"
           VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run bin/godot.linuxbsd.opt.tools.64 --doctool . 2>&1 > /dev/null || true
-          git diff --color --exit-code
+          git diff --color --exit-code && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
 
       - uses: actions/upload-artifact@v2
         with:

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -458,7 +458,7 @@ class RDPipelineSpecializationConstant : public RefCounted {
 	friend class RenderingDevice;
 
 	Variant value = false;
-	uint32_t constant_id;
+	uint32_t constant_id = 0;
 
 public:
 	void set_value(const Variant &p_value) {


### PR DESCRIPTION
This PR should fail to build because we currently have a documentation XML missing. After it fails just that one check, but passes all the others, the missing file can be pushed to make this PR pass the CI.