### PR TITLE
Rename Curve3Texture to CurveXYZTexture

### DIFF
--- a/doc/classes/CurveXYZTexture.xml
+++ b/doc/classes/CurveXYZTexture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Curve3Texture" inherits="Texture2D" version="4.0">
+<class name="CurveXYZTexture" inherits="Texture2D" version="4.0">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VisualShaderNodeCurveXYZTexture.xml
+++ b/doc/classes/VisualShaderNodeCurveXYZTexture.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeCurve3Texture" inherits="VisualShaderNodeResizableBase" version="4.0">
+<class name="VisualShaderNodeCurveXYZTexture" inherits="VisualShaderNodeResizableBase" version="4.0">
 	<brief_description>
-		Performs a [Curve3Texture] lookup within the visual shader graph.
+		Performs a [CurveXYZTexture] lookup within the visual shader graph.
 	</brief_description>
 	<description>
 		Comes with a built-in editor for texture's curves.
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="texture" type="Curve3Texture" setter="set_texture" getter="get_texture">
+		<member name="texture" type="CurveXYZTexture" setter="set_texture" getter="get_texture">
 			The source texture.
 		</member>
 	</members>

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -110,7 +110,7 @@ void VisualShaderGraphPlugin::_bind_methods() {
 	ClassDB::bind_method("set_uniform_name", &VisualShaderGraphPlugin::set_uniform_name);
 	ClassDB::bind_method("set_expression", &VisualShaderGraphPlugin::set_expression);
 	ClassDB::bind_method("update_curve", &VisualShaderGraphPlugin::update_curve);
-	ClassDB::bind_method("update_curve3", &VisualShaderGraphPlugin::update_curve3);
+	ClassDB::bind_method("update_curve_xyz", &VisualShaderGraphPlugin::update_curve_xyz);
 	ClassDB::bind_method("update_constant", &VisualShaderGraphPlugin::update_constant);
 }
 
@@ -219,12 +219,12 @@ void VisualShaderGraphPlugin::update_curve(int p_node_id) {
 	}
 }
 
-void VisualShaderGraphPlugin::update_curve3(int p_node_id) {
+void VisualShaderGraphPlugin::update_curve_xyz(int p_node_id) {
 	if (links.has(p_node_id) && links[p_node_id].curve_editors[0] && links[p_node_id].curve_editors[1] && links[p_node_id].curve_editors[2]) {
-		if (((VisualShaderNodeCurve3Texture *)links[p_node_id].visual_node)->get_texture().is_valid()) {
-			links[p_node_id].curve_editors[0]->set_curve(((VisualShaderNodeCurve3Texture *)links[p_node_id].visual_node)->get_texture()->get_curve_x());
-			links[p_node_id].curve_editors[1]->set_curve(((VisualShaderNodeCurve3Texture *)links[p_node_id].visual_node)->get_texture()->get_curve_y());
-			links[p_node_id].curve_editors[2]->set_curve(((VisualShaderNodeCurve3Texture *)links[p_node_id].visual_node)->get_texture()->get_curve_z());
+		if (((VisualShaderNodeCurveXYZTexture *)links[p_node_id].visual_node)->get_texture().is_valid()) {
+			links[p_node_id].curve_editors[0]->set_curve(((VisualShaderNodeCurveXYZTexture *)links[p_node_id].visual_node)->get_texture()->get_curve_x());
+			links[p_node_id].curve_editors[1]->set_curve(((VisualShaderNodeCurveXYZTexture *)links[p_node_id].visual_node)->get_texture()->get_curve_y());
+			links[p_node_id].curve_editors[2]->set_curve(((VisualShaderNodeCurveXYZTexture *)links[p_node_id].visual_node)->get_texture()->get_curve_z());
 		}
 	}
 }
@@ -483,10 +483,10 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		custom_editor = hbox;
 	}
 
-	Ref<VisualShaderNodeCurve3Texture> curve3 = vsnode;
-	if (curve3.is_valid()) {
-		if (curve3->get_texture().is_valid() && !curve3->get_texture()->is_connected("changed", callable_mp(VisualShaderEditor::get_singleton()->get_graph_plugin(), &VisualShaderGraphPlugin::update_curve3))) {
-			curve3->get_texture()->connect("changed", callable_mp(VisualShaderEditor::get_singleton()->get_graph_plugin(), &VisualShaderGraphPlugin::update_curve3), varray(p_id));
+	Ref<VisualShaderNodeCurveXYZTexture> curve_xyz = vsnode;
+	if (curve_xyz.is_valid()) {
+		if (curve_xyz->get_texture().is_valid() && !curve_xyz->get_texture()->is_connected("changed", callable_mp(VisualShaderEditor::get_singleton()->get_graph_plugin(), &VisualShaderGraphPlugin::update_curve_xyz))) {
+			curve_xyz->get_texture()->connect("changed", callable_mp(VisualShaderEditor::get_singleton()->get_graph_plugin(), &VisualShaderGraphPlugin::update_curve_xyz), varray(p_id));
 		}
 
 		HBoxContainer *hbox = memnew(HBoxContainer);
@@ -518,7 +518,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		port_offset++;
 		node->add_child(custom_editor);
 
-		bool is_curve = curve.is_valid() || curve3.is_valid();
+		bool is_curve = curve.is_valid() || curve_xyz.is_valid();
 
 		if (is_curve) {
 			VisualShaderEditor::get_singleton()->graph->add_child(node);
@@ -551,14 +551,14 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			}
 		}
 
-		if (curve3.is_valid()) {
+		if (curve_xyz.is_valid()) {
 			CurveEditor *curve_editor_x = memnew(CurveEditor);
 			node->add_child(curve_editor_x);
 			register_curve_editor(p_id, 0, curve_editor_x);
 			curve_editor_x->set_custom_minimum_size(Size2(300, 0));
 			curve_editor_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-			if (curve3->get_texture().is_valid()) {
-				curve_editor_x->set_curve(curve3->get_texture()->get_curve_x());
+			if (curve_xyz->get_texture().is_valid()) {
+				curve_editor_x->set_curve(curve_xyz->get_texture()->get_curve_x());
 			}
 
 			CurveEditor *curve_editor_y = memnew(CurveEditor);
@@ -566,8 +566,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			register_curve_editor(p_id, 1, curve_editor_y);
 			curve_editor_y->set_custom_minimum_size(Size2(300, 0));
 			curve_editor_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-			if (curve3->get_texture().is_valid()) {
-				curve_editor_y->set_curve(curve3->get_texture()->get_curve_y());
+			if (curve_xyz->get_texture().is_valid()) {
+				curve_editor_y->set_curve(curve_xyz->get_texture()->get_curve_y());
 			}
 
 			CurveEditor *curve_editor_z = memnew(CurveEditor);
@@ -575,8 +575,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			register_curve_editor(p_id, 2, curve_editor_z);
 			curve_editor_z->set_custom_minimum_size(Size2(300, 0));
 			curve_editor_z->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-			if (curve3->get_texture().is_valid()) {
-				curve_editor_z->set_curve(curve3->get_texture()->get_curve_z());
+			if (curve_xyz->get_texture().is_valid()) {
+				curve_editor_z->set_curve(curve_xyz->get_texture()->get_curve_z());
 			}
 		}
 
@@ -2473,9 +2473,9 @@ void VisualShaderEditor::_add_node(int p_idx, int p_op_idx, String p_resource_pa
 		graph_plugin->call_deferred("update_curve", id_to_use);
 	}
 
-	VisualShaderNodeCurve3Texture *curve3 = Object::cast_to<VisualShaderNodeCurve3Texture>(vsnode.ptr());
-	if (curve3) {
-		graph_plugin->call_deferred("update_curve3", id_to_use);
+	VisualShaderNodeCurveXYZTexture *curve_xyz = Object::cast_to<VisualShaderNodeCurveXYZTexture>(vsnode.ptr());
+	if (curve_xyz) {
+		graph_plugin->call_deferred("update_curve_xyz", id_to_use);
 	}
 
 	if (p_resource_path.is_empty()) {
@@ -2486,7 +2486,7 @@ void VisualShaderEditor::_add_node(int p_idx, int p_op_idx, String p_resource_pa
 		VisualShaderNodeTexture *texture2d = Object::cast_to<VisualShaderNodeTexture>(vsnode.ptr());
 		VisualShaderNodeTexture3D *texture3d = Object::cast_to<VisualShaderNodeTexture3D>(vsnode.ptr());
 
-		if (texture2d || texture3d || curve || curve3) {
+		if (texture2d || texture3d || curve || curve_xyz) {
 			undo_redo->add_do_method(vsnode.ptr(), "set_texture", ResourceLoader::load(p_resource_path));
 			return;
 		}
@@ -3681,10 +3681,10 @@ void VisualShaderEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 						saved_node_pos = p_point + Vector2(0, i * 250 * EDSCALE);
 						saved_node_pos_dirty = true;
 						_add_node(curve_node_option_idx, -1, arr[i], i);
-					} else if (type == "Curve3Texture") {
+					} else if (type == "CurveXYZTexture") {
 						saved_node_pos = p_point + Vector2(0, i * 250 * EDSCALE);
 						saved_node_pos_dirty = true;
-						_add_node(curve3_node_option_idx, -1, arr[i], i);
+						_add_node(curve_xyz_node_option_idx, -1, arr[i], i);
 					} else if (ClassDB::get_parent_class(type) == "Texture2D") {
 						saved_node_pos = p_point + Vector2(0, i * 250 * EDSCALE);
 						saved_node_pos_dirty = true;
@@ -4406,8 +4406,8 @@ VisualShaderEditor::VisualShaderEditor() {
 	add_options.push_back(AddOption("CubeMap", "Textures", "Functions", "VisualShaderNodeCubemap", TTR("Perform the cubic texture lookup."), -1, -1));
 	curve_node_option_idx = add_options.size();
 	add_options.push_back(AddOption("CurveTexture", "Textures", "Functions", "VisualShaderNodeCurveTexture", TTR("Perform the curve texture lookup."), -1, -1));
-	curve3_node_option_idx = add_options.size();
-	add_options.push_back(AddOption("CurveTexture3", "Textures", "Functions", "VisualShaderNodeCurve3Texture", TTR("Perform the ternary curve texture lookup."), -1, -1));
+	curve_xyz_node_option_idx = add_options.size();
+	add_options.push_back(AddOption("CurveXYZTexture", "Textures", "Functions", "VisualShaderNodeCurveXYZTexture", TTR("Perform the three components curve texture lookup."), -1, -1));
 	texture2d_node_option_idx = add_options.size();
 	add_options.push_back(AddOption("Texture2D", "Textures", "Functions", "VisualShaderNodeTexture", TTR("Perform the 2D texture lookup."), -1, -1));
 	texture2d_array_node_option_idx = add_options.size();

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -117,7 +117,7 @@ public:
 	void update_uniform_refs();
 	void set_uniform_name(VisualShader::Type p_type, int p_node_id, const String &p_name);
 	void update_curve(int p_node_id);
-	void update_curve3(int p_node_id);
+	void update_curve_xyz(int p_node_id);
 	void update_constant(VisualShader::Type p_type, int p_node_id);
 	void set_expression(VisualShader::Type p_type, int p_node_id, const String &p_expression);
 	int get_constant_index(float p_constant) const;
@@ -290,7 +290,7 @@ class VisualShaderEditor : public VBoxContainer {
 	int texture3d_node_option_idx;
 	int custom_node_option_idx;
 	int curve_node_option_idx;
-	int curve3_node_option_idx;
+	int curve_xyz_node_option_idx;
 	List<String> keyword_list;
 
 	List<VisualShaderNodeUniformRef> uniform_refs;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -586,7 +586,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(VisualShaderNodeTransformDecompose);
 	GDREGISTER_CLASS(VisualShaderNodeTexture);
 	GDREGISTER_CLASS(VisualShaderNodeCurveTexture);
-	GDREGISTER_CLASS(VisualShaderNodeCurve3Texture);
+	GDREGISTER_CLASS(VisualShaderNodeCurveXYZTexture);
 	GDREGISTER_VIRTUAL_CLASS(VisualShaderNodeSample3D);
 	GDREGISTER_CLASS(VisualShaderNodeTexture2DArray);
 	GDREGISTER_CLASS(VisualShaderNodeTexture3D);
@@ -775,7 +775,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AtlasTexture);
 	GDREGISTER_CLASS(MeshTexture);
 	GDREGISTER_CLASS(CurveTexture);
-	GDREGISTER_CLASS(Curve3Texture);
+	GDREGISTER_CLASS(CurveXYZTexture);
 	GDREGISTER_CLASS(GradientTexture);
 	GDREGISTER_CLASS(ProxyTexture);
 	GDREGISTER_CLASS(AnimatedTexture);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1545,19 +1545,19 @@ CurveTexture::~CurveTexture() {
 
 //////////////////
 
-void Curve3Texture::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_width", "width"), &Curve3Texture::set_width);
+void CurveXYZTexture::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_width", "width"), &CurveXYZTexture::set_width);
 
-	ClassDB::bind_method(D_METHOD("set_curve_x", "curve"), &Curve3Texture::set_curve_x);
-	ClassDB::bind_method(D_METHOD("get_curve_x"), &Curve3Texture::get_curve_x);
+	ClassDB::bind_method(D_METHOD("set_curve_x", "curve"), &CurveXYZTexture::set_curve_x);
+	ClassDB::bind_method(D_METHOD("get_curve_x"), &CurveXYZTexture::get_curve_x);
 
-	ClassDB::bind_method(D_METHOD("set_curve_y", "curve"), &Curve3Texture::set_curve_y);
-	ClassDB::bind_method(D_METHOD("get_curve_y"), &Curve3Texture::get_curve_y);
+	ClassDB::bind_method(D_METHOD("set_curve_y", "curve"), &CurveXYZTexture::set_curve_y);
+	ClassDB::bind_method(D_METHOD("get_curve_y"), &CurveXYZTexture::get_curve_y);
 
-	ClassDB::bind_method(D_METHOD("set_curve_z", "curve"), &Curve3Texture::set_curve_z);
-	ClassDB::bind_method(D_METHOD("get_curve_z"), &Curve3Texture::get_curve_z);
+	ClassDB::bind_method(D_METHOD("set_curve_z", "curve"), &CurveXYZTexture::set_curve_z);
+	ClassDB::bind_method(D_METHOD("get_curve_z"), &CurveXYZTexture::get_curve_z);
 
-	ClassDB::bind_method(D_METHOD("_update"), &Curve3Texture::_update);
+	ClassDB::bind_method(D_METHOD("_update"), &CurveXYZTexture::_update);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "width", PROPERTY_HINT_RANGE, "1,4096"), "set_width", "get_width");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "curve_x", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_curve_x", "get_curve_x");
@@ -1565,7 +1565,7 @@ void Curve3Texture::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "curve_z", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_curve_z", "get_curve_z");
 }
 
-void Curve3Texture::set_width(int p_width) {
+void CurveXYZTexture::set_width(int p_width) {
 	ERR_FAIL_COND(p_width < 32 || p_width > 4096);
 
 	if (_width == p_width) {
@@ -1576,11 +1576,11 @@ void Curve3Texture::set_width(int p_width) {
 	_update();
 }
 
-int Curve3Texture::get_width() const {
+int CurveXYZTexture::get_width() const {
 	return _width;
 }
 
-void Curve3Texture::ensure_default_setup(float p_min, float p_max) {
+void CurveXYZTexture::ensure_default_setup(float p_min, float p_max) {
 	if (_curve_x.is_null()) {
 		Ref<Curve> curve = Ref<Curve>(memnew(Curve));
 		curve->add_point(Vector2(0, 1));
@@ -1609,46 +1609,46 @@ void Curve3Texture::ensure_default_setup(float p_min, float p_max) {
 	}
 }
 
-void Curve3Texture::set_curve_x(Ref<Curve> p_curve) {
+void CurveXYZTexture::set_curve_x(Ref<Curve> p_curve) {
 	if (_curve_x != p_curve) {
 		if (_curve_x.is_valid()) {
-			_curve_x->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Curve3Texture::_update));
+			_curve_x->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update));
 		}
 		_curve_x = p_curve;
 		if (_curve_x.is_valid()) {
-			_curve_x->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Curve3Texture::_update), varray(), CONNECT_REFERENCE_COUNTED);
+			_curve_x->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update), varray(), CONNECT_REFERENCE_COUNTED);
 		}
 		_update();
 	}
 }
 
-void Curve3Texture::set_curve_y(Ref<Curve> p_curve) {
+void CurveXYZTexture::set_curve_y(Ref<Curve> p_curve) {
 	if (_curve_y != p_curve) {
 		if (_curve_y.is_valid()) {
-			_curve_y->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Curve3Texture::_update));
+			_curve_y->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update));
 		}
 		_curve_y = p_curve;
 		if (_curve_y.is_valid()) {
-			_curve_y->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Curve3Texture::_update), varray(), CONNECT_REFERENCE_COUNTED);
+			_curve_y->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update), varray(), CONNECT_REFERENCE_COUNTED);
 		}
 		_update();
 	}
 }
 
-void Curve3Texture::set_curve_z(Ref<Curve> p_curve) {
+void CurveXYZTexture::set_curve_z(Ref<Curve> p_curve) {
 	if (_curve_z != p_curve) {
 		if (_curve_z.is_valid()) {
-			_curve_z->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Curve3Texture::_update));
+			_curve_z->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update));
 		}
 		_curve_z = p_curve;
 		if (_curve_z.is_valid()) {
-			_curve_z->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Curve3Texture::_update), varray(), CONNECT_REFERENCE_COUNTED);
+			_curve_z->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update), varray(), CONNECT_REFERENCE_COUNTED);
 		}
 		_update();
 	}
 }
 
-void Curve3Texture::_update() {
+void CurveXYZTexture::_update() {
 	Vector<uint8_t> data;
 	data.resize(_width * sizeof(float) * 3);
 
@@ -1714,28 +1714,28 @@ void Curve3Texture::_update() {
 	emit_changed();
 }
 
-Ref<Curve> Curve3Texture::get_curve_x() const {
+Ref<Curve> CurveXYZTexture::get_curve_x() const {
 	return _curve_x;
 }
 
-Ref<Curve> Curve3Texture::get_curve_y() const {
+Ref<Curve> CurveXYZTexture::get_curve_y() const {
 	return _curve_y;
 }
 
-Ref<Curve> Curve3Texture::get_curve_z() const {
+Ref<Curve> CurveXYZTexture::get_curve_z() const {
 	return _curve_z;
 }
 
-RID Curve3Texture::get_rid() const {
+RID CurveXYZTexture::get_rid() const {
 	if (!_texture.is_valid()) {
 		_texture = RS::get_singleton()->texture_2d_placeholder_create();
 	}
 	return _texture;
 }
 
-Curve3Texture::Curve3Texture() {}
+CurveXYZTexture::CurveXYZTexture() {}
 
-Curve3Texture::~Curve3Texture() {
+CurveXYZTexture::~CurveXYZTexture() {
 	if (_texture.is_valid()) {
 		RS::get_singleton()->free(_texture);
 	}

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -628,8 +628,8 @@ public:
 
 VARIANT_ENUM_CAST(CurveTexture::TextureMode)
 
-class Curve3Texture : public Texture2D {
-	GDCLASS(Curve3Texture, Texture2D);
+class CurveXYZTexture : public Texture2D {
+	GDCLASS(CurveXYZTexture, Texture2D);
 	RES_BASE_EXTENSION("curvetex")
 
 private:
@@ -665,8 +665,8 @@ public:
 	virtual int get_height() const override { return 1; }
 	virtual bool has_alpha() const override { return false; }
 
-	Curve3Texture();
-	~Curve3Texture();
+	CurveXYZTexture();
+	~CurveXYZTexture();
 };
 
 class GradientTexture : public Texture2D {

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -889,56 +889,56 @@ VisualShaderNodeCurveTexture::VisualShaderNodeCurveTexture() {
 	allow_v_resize = false;
 }
 
-////////////// Curve3Texture
+////////////// CurveXYZTexture
 
-String VisualShaderNodeCurve3Texture::get_caption() const {
-	return "Curve3Texture";
+String VisualShaderNodeCurveXYZTexture::get_caption() const {
+	return "CurveXYZTexture";
 }
 
-int VisualShaderNodeCurve3Texture::get_input_port_count() const {
+int VisualShaderNodeCurveXYZTexture::get_input_port_count() const {
 	return 1;
 }
 
-VisualShaderNodeCurve3Texture::PortType VisualShaderNodeCurve3Texture::get_input_port_type(int p_port) const {
+VisualShaderNodeCurveXYZTexture::PortType VisualShaderNodeCurveXYZTexture::get_input_port_type(int p_port) const {
 	return PORT_TYPE_SCALAR;
 }
 
-String VisualShaderNodeCurve3Texture::get_input_port_name(int p_port) const {
+String VisualShaderNodeCurveXYZTexture::get_input_port_name(int p_port) const {
 	return String();
 }
 
-int VisualShaderNodeCurve3Texture::get_output_port_count() const {
+int VisualShaderNodeCurveXYZTexture::get_output_port_count() const {
 	return 1;
 }
 
-VisualShaderNodeCurve3Texture::PortType VisualShaderNodeCurve3Texture::get_output_port_type(int p_port) const {
+VisualShaderNodeCurveXYZTexture::PortType VisualShaderNodeCurveXYZTexture::get_output_port_type(int p_port) const {
 	return PORT_TYPE_VECTOR;
 }
 
-String VisualShaderNodeCurve3Texture::get_output_port_name(int p_port) const {
+String VisualShaderNodeCurveXYZTexture::get_output_port_name(int p_port) const {
 	return String();
 }
 
-void VisualShaderNodeCurve3Texture::set_texture(Ref<Curve3Texture> p_texture) {
+void VisualShaderNodeCurveXYZTexture::set_texture(Ref<CurveXYZTexture> p_texture) {
 	texture = p_texture;
 	emit_changed();
 }
 
-Ref<Curve3Texture> VisualShaderNodeCurve3Texture::get_texture() const {
+Ref<CurveXYZTexture> VisualShaderNodeCurveXYZTexture::get_texture() const {
 	return texture;
 }
 
-Vector<StringName> VisualShaderNodeCurve3Texture::get_editable_properties() const {
+Vector<StringName> VisualShaderNodeCurveXYZTexture::get_editable_properties() const {
 	Vector<StringName> props;
 	props.push_back("texture");
 	return props;
 }
 
-String VisualShaderNodeCurve3Texture::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
+String VisualShaderNodeCurveXYZTexture::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
 	return "uniform sampler2D " + make_unique_id(p_type, p_id, "curve3d") + ";\n";
 }
 
-String VisualShaderNodeCurve3Texture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
+String VisualShaderNodeCurveXYZTexture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	if (p_input_vars[0] == String()) {
 		return "\t" + p_output_vars[0] + " = vec3(0.0);\n";
 	}
@@ -948,7 +948,7 @@ String VisualShaderNodeCurve3Texture::generate_code(Shader::Mode p_mode, VisualS
 	return code;
 }
 
-Vector<VisualShader::DefaultTextureParam> VisualShaderNodeCurve3Texture::get_default_texture_parameters(VisualShader::Type p_type, int p_id) const {
+Vector<VisualShader::DefaultTextureParam> VisualShaderNodeCurveXYZTexture::get_default_texture_parameters(VisualShader::Type p_type, int p_id) const {
 	VisualShader::DefaultTextureParam dtp;
 	dtp.name = make_unique_id(p_type, p_id, "curve3d");
 	dtp.param = texture;
@@ -957,18 +957,18 @@ Vector<VisualShader::DefaultTextureParam> VisualShaderNodeCurve3Texture::get_def
 	return ret;
 }
 
-void VisualShaderNodeCurve3Texture::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &VisualShaderNodeCurve3Texture::set_texture);
-	ClassDB::bind_method(D_METHOD("get_texture"), &VisualShaderNodeCurve3Texture::get_texture);
+void VisualShaderNodeCurveXYZTexture::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &VisualShaderNodeCurveXYZTexture::set_texture);
+	ClassDB::bind_method(D_METHOD("get_texture"), &VisualShaderNodeCurveXYZTexture::get_texture);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Curve3Texture"), "set_texture", "get_texture");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "CurveXYZTexture"), "set_texture", "get_texture");
 }
 
-bool VisualShaderNodeCurve3Texture::is_use_prop_slots() const {
+bool VisualShaderNodeCurveXYZTexture::is_use_prop_slots() const {
 	return true;
 }
 
-VisualShaderNodeCurve3Texture::VisualShaderNodeCurve3Texture() {
+VisualShaderNodeCurveXYZTexture::VisualShaderNodeCurveXYZTexture() {
 	simple_decl = true;
 	allow_v_resize = false;
 }

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -338,9 +338,9 @@ public:
 
 ///////////////////////////////////////
 
-class VisualShaderNodeCurve3Texture : public VisualShaderNodeResizableBase {
-	GDCLASS(VisualShaderNodeCurve3Texture, VisualShaderNodeResizableBase);
-	Ref<Curve3Texture> texture;
+class VisualShaderNodeCurveXYZTexture : public VisualShaderNodeResizableBase {
+	GDCLASS(VisualShaderNodeCurveXYZTexture, VisualShaderNodeResizableBase);
+	Ref<CurveXYZTexture> texture;
 
 protected:
 	static void _bind_methods();
@@ -360,13 +360,13 @@ public:
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
-	void set_texture(Ref<Curve3Texture> p_value);
-	Ref<Curve3Texture> get_texture() const;
+	void set_texture(Ref<CurveXYZTexture> p_value);
+	Ref<CurveXYZTexture> get_texture() const;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 	virtual bool is_use_prop_slots() const override;
 
-	VisualShaderNodeCurve3Texture();
+	VisualShaderNodeCurveXYZTexture();
 };
 
 ///////////////////////////////////////


### PR DESCRIPTION
Neither name is a perfect match but `Curve3Texture` looked too similar to
`CurveTexture` and `Curve3D`, which made things confusing when picking a
texture type or browsing the API reference.

Follow-up to #50054.