### PR TITLE
Implement blending in particle flipbook animation

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -270,6 +270,9 @@
 		</member>
 		<member name="orm_texture" type="Texture2D" setter="set_texture" getter="get_texture">
 		</member>
+		<member name="particles_anim_blend" type="bool" setter="set_particles_anim_blend" getter="get_particles_anim_blend">
+			If [code]true[/code], enables blending between frames in the particle flipbook animation. This results in a smoother animation appearance, especially for fire or smoke effects. Only enabled when using [constant BILLBOARD_PARTICLES]. See [member billboard_mode].
+		</member>
 		<member name="particles_anim_h_frames" type="int" setter="set_particles_anim_h_frames" getter="get_particles_anim_h_frames">
 			The number of horizontal frames in the particle sprite sheet. Only enabled when using [constant BILLBOARD_PARTICLES]. See [member billboard_mode].
 		</member>

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -403,6 +403,7 @@ private:
 		StringName particles_anim_h_frames;
 		StringName particles_anim_v_frames;
 		StringName particles_anim_loop;
+		StringName particles_anim_blend;
 		StringName heightmap_min_layers;
 		StringName heightmap_max_layers;
 		StringName heightmap_flip;
@@ -473,6 +474,7 @@ private:
 	int particles_anim_h_frames;
 	int particles_anim_v_frames;
 	bool particles_anim_loop;
+	bool particles_anim_blend;
 	Transparency transparency = TRANSPARENCY_DISABLED;
 	ShadingMode shading_mode = SHADING_MODE_PER_PIXEL;
 
@@ -689,6 +691,9 @@ public:
 
 	void set_particles_anim_loop(bool p_loop);
 	bool get_particles_anim_loop() const;
+
+	void set_particles_anim_blend(bool p_blend);
+	bool get_particles_anim_blend() const;
 
 	void set_grow_enabled(bool p_enable);
 	bool is_grow_enabled() const;


### PR DESCRIPTION
This makes changes between frames look smoother, making flipbook particle animation more viable for realistic particle effects such as fire.

This works with both GPUParticles3D and CPUParticles3D.

This closes https://github.com/godotengine/godot-proposals/issues/1636.

**Testing project:** [test_particle_animation.zip](https://github.com/godotengine/godot/files/6812878/test_particle_animation.zip) (`master` only, won't work in `3.x`)

## Preview

https://user-images.githubusercontent.com/180032/125545579-b652fea8-0db1-4c67-b0e3-0b09d2129239.mp4

## TODO

- [ ] Implement this feature in CanvasItemMaterial for 2D particles.
- [x] See if we can keep UV2 free for other purposes when this feature is active, and ideally not require UV2 in meshes in the first place.
- [ ] Investigate whether it's better to use a different shader version rather than a conditional. From my testing, the conditional doesn't affect performance in a meaningful way – I get 342 FPS instead of 343 FPS in my test project. However, this is a material feature that won't be used often, so perhaps it's still worth moving it to separate shader version (which requires compiling another shader when this feature is used).