### PR TITLE
Fix extends with relative path to parent script

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -242,6 +242,9 @@ Error GDScriptAnalyzer::resolve_inheritance(GDScriptParser::ClassNode *p_class, 
 		int extends_index = 0;
 
 		if (!p_class->extends_path.is_empty()) {
+			if (p_class->extends_path.is_relative_path()) {
+				p_class->extends_path = class_type.script_path.get_base_dir().plus_file(p_class->extends_path).simplify_path();
+			}
 			Ref<GDScriptParserRef> parser = get_parser_for(p_class->extends_path);
 			if (parser.is_null()) {
 				push_error(vformat(R"(Could not resolve super class path "%s".)", p_class->extends_path), p_class);


### PR DESCRIPTION
Closes #49938

In gdscript, when extending to a parent script using a relative path, the parent file cannot be found as it does not manage relative paths.
This PR makes the following change: in the GDScript analyser, when analyzing the extends, the relative path is transformed to an absolute path, which helps the next code to find the parent script file.