### PR TITLE
Fixes 50428, added missing checks for image lock

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1237,7 +1237,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 
 void Image::crop_from_point(int p_x, int p_y, int p_width, int p_height) {
 	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot crop in compressed or custom image formats.");
-
+	ERR_FAIL_COND_MSG(write_lock.ptr(), "Cannot modify image when it is locked.");
 	ERR_FAIL_COND_MSG(p_x < 0, "Start x position cannot be smaller than 0.");
 	ERR_FAIL_COND_MSG(p_y < 0, "Start y position cannot be smaller than 0.");
 	ERR_FAIL_COND_MSG(p_width <= 0, "Width of image must be greater than 0.");
@@ -1476,6 +1476,8 @@ void Image::expand_x2_hq2x() {
 }
 
 void Image::shrink_x2() {
+	ERR_FAIL_COND(!_can_modify(format));
+	ERR_FAIL_COND_MSG(write_lock.ptr(), "Cannot modify image when it is locked.");
 	ERR_FAIL_COND(data.size() == 0);
 
 	if (mipmaps) {
@@ -1599,6 +1601,8 @@ void Image::normalize() {
 
 Error Image::generate_mipmaps(bool p_renormalize) {
 	ERR_FAIL_COND_V_MSG(!_can_modify(format), ERR_UNAVAILABLE, "Cannot generate mipmaps in compressed or custom image formats.");
+
+	ERR_FAIL_COND_V_MSG(write_lock.ptr(), ERR_UNAVAILABLE, "Cannot modify image when it is locked.");
 
 	ERR_FAIL_COND_V_MSG(format == FORMAT_RGBA4444 || format == FORMAT_RGBA5551, ERR_UNAVAILABLE, "Cannot generate mipmaps in custom image formats.");
 
@@ -3148,6 +3152,9 @@ void Image::premultiply_alpha() {
 }
 
 void Image::fix_alpha_edges() {
+	ERR_FAIL_COND(!_can_modify(format));
+	ERR_FAIL_COND_MSG(write_lock.ptr(), "Cannot modify image when it is locked.");
+
 	if (data.size() == 0) {
 		return;
 	}


### PR DESCRIPTION
Fixed #50428

Added check in following functions to return if image is locked.

 - shrink_x2
 - fix_alpha_edges
 - crop_from_point
 - generate_mipmaps

Unit tested using debugger,  Debugger screenshot is attached. However, couldn't get to reproduce the AddressSanitizer errors, will appreciate if someone can help me with that.

![image](https://user-images.githubusercontent.com/52410428/125657779-9af6d12c-9a32-4206-8d6b-71bb78e86da1.png)
