### PR TITLE
[3.x] SCons: Refactor module defines into a generated header, cleanup

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -125,7 +125,6 @@ opts.Add(BoolVariable("use_lto", "Use link-time optimization", False))
 
 # Components
 opts.Add(BoolVariable("deprecated", "Enable deprecated features", True))
-opts.Add(BoolVariable("gdscript", "Enable GDScript support", True))
 opts.Add(BoolVariable("minizip", "Enable ZIP archive support using minizip", True))
 opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
 opts.Add("custom_modules", "A list of comma-separated directory paths containing custom modules to build.", "")
@@ -575,8 +574,6 @@ if selected_platform in platform_list:
             sys.exit(255)
         else:
             env.Append(CPPDEFINES=["_3D_DISABLED"])
-    if env["gdscript"]:
-        env.Append(CPPDEFINES=["GDSCRIPT_ENABLED"])
     if env["disable_advanced_gui"]:
         if env["tools"]:
             print(

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -1,8 +1,8 @@
 """Functions used to generate source files during build time
 
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
-
 """
+
 from platform_methods import subprocess_main
 from compat import iteritems, itervalues, open_utf8, escape_string, byte_to_str
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -36,7 +36,8 @@
 #include "editor_scale.h"
 #include "editor_settings.h"
 
-#ifdef SVG_ENABLED
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
 #endif
 
@@ -104,7 +105,7 @@ static Ref<Texture> flip_icon(Ref<Texture> p_texture, bool p_flip_y = false, boo
 	return texture;
 }
 
-#ifdef SVG_ENABLED
+#ifdef MODULE_SVG_ENABLED
 static Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color, float p_scale = EDSCALE, bool p_force_filter = false) {
 	Ref<ImageTexture> icon = memnew(ImageTexture);
 	Ref<Image> img = memnew(Image);
@@ -133,7 +134,7 @@ static Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color,
 #endif
 
 void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = true, int p_thumb_size = 32, bool p_only_thumbs = false) {
-#ifdef SVG_ENABLED
+#ifdef MODULE_SVG_ENABLED
 	// The default icon theme is designed to be used for a dark theme.
 	// This dictionary stores color codes to convert to other colors
 	// for better readability on a light theme.
@@ -1383,7 +1384,7 @@ Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 }
 
 Ref<ImageTexture> create_unscaled_default_project_icon() {
-#ifdef SVG_ENABLED
+#ifdef MODULE_SVG_ENABLED
 	for (int i = 0; i < editor_icons_count; i++) {
 		// ESCALE should never affect size of the icon
 		if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0) {

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -37,7 +37,8 @@
 #include "editor/project_settings_editor.h"
 #include "scene/gui/grid_container.h"
 
-#ifdef GDSCRIPT_ENABLED
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_GDSCRIPT_ENABLED
 #include "modules/gdscript/gdscript.h"
 #endif
 
@@ -78,7 +79,9 @@ void PluginConfigDialog::_on_confirmed() {
 		// TODO Use script templates. Right now, this code won't add the 'tool' annotation to other languages.
 		// TODO Better support script languages with named classes (has_named_classes).
 
-#ifdef GDSCRIPT_ENABLED
+		// FIXME: It's hacky to have hardcoded access to the GDScript module here.
+		// The editor code should not have to know what languages are enabled.
+#ifdef MODULE_GDSCRIPT_ENABLED
 		if (lang_name == GDScriptLanguage::get_singleton()->get_name()) {
 			// Hard-coded GDScript template to keep usability until we use script templates.
 			Ref<Script> gdscript = memnew(GDScript);
@@ -105,7 +108,7 @@ void PluginConfigDialog::_on_confirmed() {
 			script = ScriptServer::get_language(lang_idx)->get_template(class_name, "EditorPlugin");
 			script->set_path(script_path);
 			ResourceSaver::save(script_path, script);
-#ifdef GDSCRIPT_ENABLED
+#ifdef MODULE_GDSCRIPT_ENABLED
 		}
 #endif
 
@@ -237,7 +240,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		ScriptLanguage *lang = ScriptServer::get_language(i);
 		script_option_edit->add_item(lang->get_name());
-#ifdef GDSCRIPT_ENABLED
+#ifdef MODULE_GDSCRIPT_ENABLED
 		if (lang == GDScriptLanguage::get_singleton()) {
 			default_lang = i;
 		}

--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -34,7 +34,8 @@
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 
-#ifdef GDSCRIPT_ENABLED
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_GDSCRIPT_ENABLED
 
 #include "modules/gdscript/gdscript.h"
 #include "modules/gdscript/gdscript_compiler.h"
@@ -1024,6 +1025,7 @@ MainLoop *test(TestType p_type) {
 namespace TestGDScript {
 
 MainLoop *test(TestType p_type) {
+	ERR_PRINT("The GDScript module is disabled, therefore GDScript tests cannot be used.");
 	return NULL;
 }
 } // namespace TestGDScript

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -28,15 +28,19 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "core/ustring.h"
-#include <wchar.h>
-//#include "core/math/math_funcs.h"
+#include "test_string.h"
+
 #include "core/io/ip_address.h"
 #include "core/os/os.h"
-#include "modules/regex/regex.h"
-#include <stdio.h>
+#include "core/ustring.h"
 
-#include "test_string.h"
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_REGEX_ENABLED
+#include "modules/regex/regex.h"
+#endif
+
+#include <stdio.h>
+#include <wchar.h>
 
 namespace TestString {
 

--- a/methods.py
+++ b/methods.py
@@ -238,27 +238,25 @@ def write_modules(modules):
         except IOError:
             pass
 
-    modules_cpp = (
-        """
-// modules.cpp - THIS FILE IS GENERATED, DO NOT EDIT!!!!!!!
+    modules_cpp = """// register_module_types.gen.cpp
+/* THIS FILE IS GENERATED DO NOT EDIT */
 #include "register_module_types.h"
 
-"""
-        + includes_cpp
-        + """
+#include "modules/modules_enabled.gen.h"
+
+%s
 
 void register_module_types() {
-"""
-        + register_cpp
-        + """
+%s
 }
 
 void unregister_module_types() {
-"""
-        + unregister_cpp
-        + """
+%s
 }
-"""
+""" % (
+        includes_cpp,
+        register_cpp,
+        unregister_cpp,
     )
 
     # NOTE: It is safe to generate this file here, since this is still executed serially

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -4,19 +4,18 @@ Import("env")
 
 import os
 
+import modules_builders
+
 env_modules = env.Clone()
 
 Export("env_modules")
 
-env.modules_sources = []
+env.CommandNoCache("modules_enabled.gen.h", Value(env.module_list), modules_builders.generate_modules_enabled)
 
+env.modules_sources = []
 env_modules.add_source_files(env.modules_sources, "register_module_types.gen.cpp")
 
 for name, path in env.module_list.items():
-    if name in env.disabled_modules:
-        continue
-
-    env_modules.Append(CPPDEFINES=["MODULE_" + name.upper() + "_ENABLED"])
     if not os.path.isabs(path):
         SConscript(name + "/SCsub")  # Built-in.
     else:

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -10,6 +10,7 @@ env_modules = env.Clone()
 
 Export("env_modules")
 
+env.Depends("modules_enabled.gen.h", Value(env.module_list))
 env.CommandNoCache("modules_enabled.gen.h", Value(env.module_list), modules_builders.generate_modules_enabled)
 
 env.modules_sources = []

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -112,8 +112,5 @@ module_obj = []
 env_freetype.add_source_files(module_obj, "*.cpp")
 env.modules_sources += module_obj
 
-# Used in scene/, needs to be in main env
-env.Append(CPPDEFINES=["FREETYPE_ENABLED"])
-
 # Needed to force rebuilding the module files when the thirdparty library is updated.
 env.Depends(module_obj, thirdparty_obj)

--- a/modules/modules_builders.py
+++ b/modules/modules_builders.py
@@ -1,0 +1,16 @@
+"""Functions used to generate source files during build time
+
+All such functions are invoked in a subprocess on Windows to prevent build flakiness.
+"""
+
+from platform_methods import subprocess_main
+
+
+def generate_modules_enabled(target, source, env):
+    with open(target[0].path, "w") as f:
+        for module in env.module_list:
+            f.write("#define %s\n" % ("MODULE_" + module.upper() + "_ENABLED"))
+
+
+if __name__ == "__main__":
+    subprocess_main(globals())

--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "navigation_mesh_generator.h"
+
 #include "core/math/convex_hull.h"
 #include "core/os/thread.h"
 #include "editor/editor_settings.h"
@@ -45,10 +46,10 @@
 #include "scene/resources/shape.h"
 #include "scene/resources/sphere_shape.h"
 
+#include "modules/modules_enabled.gen.h"
 #ifdef MODULE_CSG_ENABLED
 #include "modules/csg/csg_shape.h"
 #endif
-
 #ifdef MODULE_GRIDMAP_ENABLED
 #include "modules/gridmap/grid_map.h"
 #endif

--- a/modules/register_module_types.h
+++ b/modules/register_module_types.h
@@ -31,9 +31,7 @@
 #ifndef REGISTER_MODULE_TYPES_H
 #define REGISTER_MODULE_TYPES_H
 
-//
-
 void register_module_types();
 void unregister_module_types();
 
-#endif
+#endif // REGISTER_MODULE_TYPES_H

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -14,10 +14,6 @@ thirdparty_sources = ["nanosvg.cc"]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
 env_svg.Prepend(CPPPATH=[thirdparty_dir])
-# FIXME: Needed in editor/editor_themes.cpp for now, but ideally there
-# shouldn't be a dependency on modules/ and its own 3rd party deps.
-env.Prepend(CPPPATH=[thirdparty_dir])
-env.Append(CPPDEFINES=["SVG_ENABLED"])
 
 env_thirdparty = env_svg.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -30,9 +30,8 @@
 
 #include "image_loader_svg.h"
 
-#include "core/os/os.h"
-#include "core/print_string.h"
-#include "core/ustring.h"
+#include <nanosvg.h>
+#include <nanosvgrast.h>
 
 void SVGRasterizer::rasterize(NSVGimage *p_image, float p_tx, float p_ty, float p_scale, unsigned char *p_dst, int p_w, int p_h, int p_stride) {
 	nsvgRasterize(rasterizer, p_image, p_tx, p_ty, p_scale, p_dst, p_w, p_h, p_stride);

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -34,12 +34,13 @@
 #include "core/io/image_loader.h"
 #include "core/ustring.h"
 
-#include <nanosvg.h>
-#include <nanosvgrast.h>
-
 /**
 	@author Daniel Ramirez <djrmuv@gmail.com>
 */
+
+// Forward declare and include thirdparty headers in .cpp.
+struct NSVGrasterizer;
+struct NSVGimage;
 
 class SVGRasterizer {
 	NSVGrasterizer *rasterizer;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -33,8 +33,13 @@
 #include "core/math/math_defs.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
-#include "modules/regex/regex.h"
 #include "scene/scene_string_names.h"
+
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_REGEX_ENABLED
+#include "modules/regex/regex.h"
+#endif
+
 #ifdef TOOLS_ENABLED
 #include "editor/editor_scale.h"
 #endif
@@ -2900,6 +2905,7 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 
 		Vector<String> values = parts[1].split(",", false);
 
+#ifdef MODULE_REGEX_ENABLED
 		RegEx color;
 		color.compile("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$");
 		RegEx nodepath;
@@ -2933,6 +2939,7 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 				a.append(values[j]);
 			}
 		}
+#endif
 
 		if (values.size() > 1) {
 			d[key] = a;

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -28,8 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef FREETYPE_ENABLED
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_FREETYPE_ENABLED
+
 #include "dynamic_font.h"
+
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -31,7 +31,9 @@
 #ifndef DYNAMIC_FONT_H
 #define DYNAMIC_FONT_H
 
-#ifdef FREETYPE_ENABLED
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_FREETYPE_ENABLED
+
 #include "core/io/resource_loader.h"
 #include "core/os/mutex.h"
 #include "core/os/thread_safe.h"


### PR DESCRIPTION
Backport of #35963 for 3.4+. Initially I hadn't planned to backport this but since the `3.2` branch turned into a long-lived `3.x` development branch, it becomes relevant to backport.