### PR TITLE
Portals - fix autolink sprawling, refine logs

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -4546,7 +4546,7 @@ void PortalGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 
 	if (portal) {
 		// warnings
-		if (portal->_warning_outside_room_aabb || portal->_warning_facing_wrong_way) {
+		if (portal->_warning_outside_room_aabb || portal->_warning_facing_wrong_way || portal->_warning_autolink_failed) {
 			Ref<Material> icon = get_material("portal_icon", p_gizmo);
 			p_gizmo->add_unscaled_billboard(icon, 0.05);
 		}

--- a/scene/3d/portal.h
+++ b/scene/3d/portal.h
@@ -158,6 +158,7 @@ private:
 	// warnings
 	bool _warning_outside_room_aabb = false;
 	bool _warning_facing_wrong_way = false;
+	bool _warning_autolink_failed = false;
 #endif
 
 	// this is read from the gizmo

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -157,7 +157,7 @@ private:
 
 	bool _convert_manual_bound(Room *p_room, Spatial *p_node, const LocalVector<Portal *> &p_portals);
 	void _check_portal_for_warnings(Portal *p_portal, const AABB &p_room_aabb_without_portals);
-	void _find_statics_recursive(Room *p_room, Spatial *p_node, Vector<Vector3> &r_room_pts);
+	void _find_statics_recursive(Room *p_room, Spatial *p_node, Vector<Vector3> &r_room_pts, bool p_add_to_portal_renderer);
 	bool _convert_room_hull_preliminary(Room *p_room, const Vector<Vector3> &p_room_pts, const LocalVector<Portal *> &p_portals);
 
 	bool _bound_findpoints_mesh_instance(MeshInstance *p_mi, Vector<Vector3> &r_room_pts, AABB &r_aabb);
@@ -201,7 +201,7 @@ private:
 	Error _build_convex_hull(const Vector<Vector3> &p_points, Geometry::MeshData &r_mesh, real_t p_epsilon = 3.0 * UNIT_EPSILON);
 
 	// output strings during conversion process
-	void convert_log(String p_string, int p_priority = 0) { debug_print_line(p_string, p_priority); }
+	void convert_log(String p_string, int p_priority = 0) { debug_print_line(p_string, 1); }
 
 	// only prints when user has set 'debug' in the room manager inspector
 	// also does not show in non editor builds

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -221,9 +221,9 @@ private:
 		return _rooms_lookup_bsp.find_room_within(*this, p_pos, p_previous_room_id);
 	}
 
-	void sprawl_static(int p_static_id, const VSStatic &p_static, int p_room_id);
-	void sprawl_static_geometry(int p_static_id, const VSStatic &p_static, int p_room_id, const Vector<Vector3> &p_object_pts);
-	void sprawl_static_ghost(int p_ghost_id, const AABB &p_aabb, int p_room_id);
+	bool sprawl_static(int p_static_id, const VSStatic &p_static, int p_room_id);
+	bool sprawl_static_geometry(int p_static_id, const VSStatic &p_static, int p_room_id, const Vector<Vector3> &p_object_pts);
+	bool sprawl_static_ghost(int p_ghost_id, const AABB &p_aabb, int p_room_id);
 
 	void _load_finalize_roaming();
 	void sprawl_roaming(uint32_t p_mover_pool_id, MovingBase &r_moving, int p_room_id, bool p_moving_or_ghost);


### PR DESCRIPTION
It turned out the new autolinking feature was linking portals AFTER the static meshes had been added to rooms in the PortalRenderer. This meant that large meshes weren't being sprawled across these portals. The fix involves doing the autolinking BEFORE adding the static meshes.

Fixes a bug in the warning for portals being in the wrong direction, they should have only been checkout for outgoing portals. This was resulting in erroneous warnings.

Also the room conversion logs are refined to be more compact and informative.

A warning icon is also added in the gizmo for portals where autolink fails.

## Notes
* Very probably no one had noticed this bug yet. Autolinking was put in quite late as a convenience so I hadn't noticed this potential problem. It only would affect large objects that should have sprawled into adjacent rooms through autolinked portals.
* Conversion logs are a bit more sensible now and show more information. They are controlled almost fully by the `show_debug` setting in the `RoomManager` (these are not shown at final exports, because `show_debug` is forced to false when TOOLS_ENABLED is not set. This means you don't have to worry about turning it off for final exports.
* The portal gizmo billboard icon now shows for portals where autolinking fails. This should make fixing these more user friendly.

_Example log_
![conversion_log](https://user-images.githubusercontent.com/21999379/125779166-0545dbca-f5e9-4f75-bfaa-723a9a6d8a15.png)

## Portal Gizmo Icon
I'm actually using the original portal icon to indicate when there is a portal error (as I didn't decide to use it in all cases as it is rather distracting). But as there are now 3 separate warning conditions on the portals, we can potentially have 3 separate svg billboard icons, if anyone is interested to make them.

The warnings are now:
* portal is a long way from room aabb (likely placed in the wrong room)
* portal is facing the wrong way (it should be facing out from the source room)
* portal autolinking failed (could not find an adjacent room to link to)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
