### PR TITLE
Portals - Autoplacing static objects and further work

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6820,6 +6820,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(BakedLightmapEditorPlugin(this)));
 	add_editor_plugin(memnew(RoomManagerEditorPlugin(this)));
 	add_editor_plugin(memnew(RoomEditorPlugin(this)));
+	add_editor_plugin(memnew(PortalEditorPlugin(this)));
 	add_editor_plugin(memnew(Path2DEditorPlugin(this)));
 	add_editor_plugin(memnew(PathEditorPlugin(this)));
 	add_editor_plugin(memnew(Line2DEditorPlugin(this)));

--- a/editor/plugins/room_manager_editor_plugin.cpp
+++ b/editor/plugins/room_manager_editor_plugin.cpp
@@ -170,3 +170,53 @@ RoomEditorPlugin::RoomEditorPlugin(EditorNode *p_node) {
 
 RoomEditorPlugin::~RoomEditorPlugin() {
 }
+
+///////////////////////
+
+void PortalEditorPlugin::_flip_portal() {
+	if (_portal) {
+		_portal->flip();
+		_portal->_changed();
+	}
+}
+
+void PortalEditorPlugin::edit(Object *p_object) {
+	Portal *p = Object::cast_to<Portal>(p_object);
+	if (!p) {
+		return;
+	}
+
+	_portal = p;
+}
+
+bool PortalEditorPlugin::handles(Object *p_object) const {
+	return p_object->is_class("Portal");
+}
+
+void PortalEditorPlugin::make_visible(bool p_visible) {
+	if (p_visible) {
+		button_flip->show();
+	} else {
+		button_flip->hide();
+	}
+}
+
+void PortalEditorPlugin::_bind_methods() {
+	ClassDB::bind_method("_flip_portal", &PortalEditorPlugin::_flip_portal);
+}
+
+PortalEditorPlugin::PortalEditorPlugin(EditorNode *p_node) {
+	editor = p_node;
+
+	button_flip = memnew(ToolButton);
+	button_flip->set_icon(editor->get_gui_base()->get_icon("Portal", "EditorIcons"));
+	button_flip->set_text(TTR("Flip Portal"));
+	button_flip->hide();
+	button_flip->connect("pressed", this, "_flip_portal");
+	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, button_flip);
+
+	_portal = nullptr;
+}
+
+PortalEditorPlugin::~PortalEditorPlugin() {
+}

--- a/editor/plugins/room_manager_editor_plugin.h
+++ b/editor/plugins/room_manager_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "editor/editor_node.h"
 #include "editor/editor_plugin.h"
+#include "scene/3d/portal.h"
 #include "scene/3d/room.h"
 #include "scene/3d/room_manager.h"
 #include "scene/resources/material.h"
@@ -87,6 +88,31 @@ public:
 
 	RoomEditorPlugin(EditorNode *p_node);
 	~RoomEditorPlugin();
+};
+
+///////////////////////
+
+class PortalEditorPlugin : public EditorPlugin {
+	GDCLASS(PortalEditorPlugin, EditorPlugin);
+
+	Portal *_portal;
+	ToolButton *button_flip;
+	EditorNode *editor;
+
+	void _flip_portal();
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual String get_name() const { return "Portal"; }
+	bool has_main_screen() const { return false; }
+	virtual void edit(Object *p_object);
+	virtual bool handles(Object *p_object) const;
+	virtual void make_visible(bool p_visible);
+
+	PortalEditorPlugin(EditorNode *p_node);
+	~PortalEditorPlugin();
 };
 
 #endif

--- a/scene/3d/portal.h
+++ b/scene/3d/portal.h
@@ -31,11 +31,13 @@
 #ifndef PORTAL_H
 #define PORTAL_H
 
+#include "core/local_vector.h"
 #include "core/rid.h"
 #include "spatial.h"
 
 class RoomManager;
 class MeshInstance;
+class Room;
 
 class Portal : public Spatial {
 	GDCLASS(Portal, Spatial);
@@ -44,6 +46,7 @@ class Portal : public Spatial {
 
 	friend class RoomManager;
 	friend class PortalGizmoPlugin;
+	friend class PortalEditorPlugin;
 
 public:
 	// ui interface .. will have no effect after room conversion
@@ -61,6 +64,7 @@ public:
 	}
 	bool is_two_way() const { return _settings_two_way; }
 
+	// call during each conversion
 	void clear();
 
 	// whether to use the room manager default
@@ -104,7 +108,7 @@ private:
 	Vector3 _vec2to3(const Vector2 &p_pt) const { return Vector3(p_pt.x, p_pt.y, 0.0); }
 	void _sort_verts_clockwise(bool portal_plane_convention, Vector<Vector3> &r_verts);
 	Plane _plane_from_points_newell(const Vector<Vector3> &p_pts);
-	void resolve_links(const RID &p_from_room_rid);
+	void resolve_links(const LocalVector<Room *, int32_t> &p_rooms, const RID &p_from_room_rid);
 	void _changed();
 
 	// nodepath to the room this outgoing portal leads to

--- a/scene/3d/room.cpp
+++ b/scene/3d/room.cpp
@@ -108,6 +108,20 @@ Room::~Room() {
 	}
 }
 
+bool Room::contains_point(const Vector3 &p_pt) const {
+	if (!_aabb.has_point(p_pt)) {
+		return false;
+	}
+
+	for (int n = 0; n < _planes.size(); n++) {
+		if (_planes[n].is_point_over(p_pt)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 void Room::set_room_simplify(real_t p_value) {
 	_simplify_info.set_simplify(p_value, _aabb.get_longest_axis_size());
 }

--- a/scene/3d/room.h
+++ b/scene/3d/room.h
@@ -84,6 +84,9 @@ private:
 	template <typename T>
 	static bool detect_nodes_using_lambda(const Node *p_node, T p_lambda, bool p_ignore_first_node = true);
 
+	// note this is client side, and does not use the final planes stored in the PortalRenderer
+	bool contains_point(const Vector3 &p_pt) const;
+
 	// planes forming convex hull of room
 	LocalVector<Plane, int32_t> _planes;
 

--- a/scene/3d/room.h
+++ b/scene/3d/room.h
@@ -77,7 +77,9 @@ public:
 	String get_configuration_warning() const;
 
 private:
+	// call during each conversion
 	void clear();
+
 	void _changed(bool p_regenerate_bounds = false);
 	template <class T>
 	static bool detect_nodes_of_type(const Node *p_node, bool p_ignore_first_node = true);

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -39,6 +39,7 @@ class Portal;
 class RoomGroup;
 class MeshInstance;
 class GeometryInstance;
+class VisualInstance;
 
 #define GODOT_PORTAL_DELINEATOR String("_")
 #define GODOT_PORTAL_WILDCARD String("*")
@@ -157,6 +158,7 @@ private:
 
 	bool _convert_manual_bound(Room *p_room, Spatial *p_node, const LocalVector<Portal *> &p_portals);
 	void _check_portal_for_warnings(Portal *p_portal, const AABB &p_room_aabb_without_portals);
+	void _process_static(Room *p_room, Spatial *p_node, Vector<Vector3> &r_room_pts, bool p_add_to_portal_renderer);
 	void _find_statics_recursive(Room *p_room, Spatial *p_node, Vector<Vector3> &r_room_pts, bool p_add_to_portal_renderer);
 	bool _convert_room_hull_preliminary(Room *p_room, const Vector<Vector3> &p_room_pts, const LocalVector<Portal *> &p_portals);
 
@@ -164,16 +166,21 @@ private:
 	bool _bound_findpoints_geom_instance(GeometryInstance *p_gi, Vector<Vector3> &r_room_pts, AABB &r_aabb);
 
 	// THIRD PASS
-	void _third_pass_portals(Spatial *p_roomlist, LocalVector<Portal *> &r_portals);
+	void _autolink_portals(Spatial *p_roomlist, LocalVector<Portal *> &r_portals);
 	void _third_pass_rooms(const LocalVector<Portal *> &p_portals);
 
 	bool _convert_room_hull_final(Room *p_room, const LocalVector<Portal *> &p_portals);
 	void _build_simplified_bound(const Room *p_room, Geometry::MeshData &r_md, LocalVector<Plane, int32_t> &r_planes, int p_num_portal_planes);
 
+	// AUTOPLACE - automatically place STATIC and DYNAMICs that are not within a room
+	// into the most appropriate room, and sprawl
+	void _autoplace_recursive(Spatial *p_node);
+	bool _autoplace_object(VisualInstance *p_vi);
+
 	// misc
 	bool _add_plane_if_unique(const Room *p_room, LocalVector<Plane, int32_t> &r_planes, const Plane &p);
 	void _update_portal_margins(Spatial *p_node, real_t p_margin);
-	Node *_check_roomlist_validity_recursive(Node *p_node);
+	bool _check_roomlist_validity(Node *p_node);
 	void _cleanup_after_conversion();
 	Error _build_room_convex_hull(const Room *p_room, const Vector<Vector3> &p_points, Geometry::MeshData &r_mesh);
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
In order to make level building easier, the system can now support STATIC and DYNAMIC objects in the roomlist that are not placed in rooms. The system will automatically place them in the appropriate room.

* Lifts restrictions now allowing the `RoomManager` to be the roomlist.
* Fixes a couple of bugs which could occur if the user attempted to link Portals to Rooms that were outside the roomlist.
* Adds a PortalEditorPlugin allowing you to flip individual portals.
* Add support for MultiMeshInstance in calculating room bound.

## Notes
* This should prove a lot easier to use for users. Instead of placing all objects within each room, they only need to make sure the Room bound is defined (either by placing walls and floor in the room, or manual bound), and that Portals are placed in the Room. Other objects can be placed freely within the roomlist (not in rooms) and they will be autoplaced during conversion.
* Autoplacing does not change their position in the scene tree, it just changes how they are structured in the portal renderer.
* Autoplaced nodes cannot affect the room bounds (hence why you need to place walls etc explicitly in the room if you are deriving the bound from the geometry)
* It should work in most cases and uses the AABB centre to determine which room to put in
* It is not guaranteed to work with internal rooms. It will attempt to choose the highest priority internal rooms and will work in 95% of cases, but there are some special cases for large objects that sprawl outside internal rooms (see the portal instructions) and these should be placed manually in the rooms in the scene tree rather than relying on autoplace.
* At the moment autoplaced objects will not be merged (static batching) if you have that option selected. I may be able to get this to work in a later PR.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
