### PR TITLE
CI: Upgrade Emscripten to 2.0.25

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -6,7 +6,7 @@ env:
   GODOT_BASE_BRANCH: 3.x
   SCONSFLAGS: platform=javascript verbose=yes warnings=all werror=yes debug_symbols=no --jobs=2
   SCONS_CACHE_LIMIT: 4096
-  EM_VERSION: 2.0.15
+  EM_VERSION: 2.0.25
   EM_CACHE_FOLDER: 'emsdk-cache'
 
 jobs:
@@ -62,7 +62,7 @@ jobs:
           scons --version
 
       - name: Set up Emscripten latest
-        uses: mymindstorm/setup-emsdk@v7
+        uses: mymindstorm/setup-emsdk@v10
         with:
           version: ${{env.EM_VERSION}}
           actions-cache-folder: ${{env.EM_CACHE_FOLDER}}

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2700,21 +2700,19 @@ void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p
 	}
 	use_post_process = use_post_process || storage->frame.current_rt->use_fxaa;
 
-	GLuint next_buffer;
-
-	if (use_post_process) {
-		next_buffer = storage->frame.current_rt->mip_maps[0].sizes[0].fbo;
-	} else if (storage->frame.current_rt->external.fbo != 0) {
-		next_buffer = storage->frame.current_rt->external.fbo;
-	} else {
-		// set next_buffer to front buffer so multisample blit can happen if needed
-		next_buffer = storage->frame.current_rt->fbo;
-	}
-
 	// If using multisample buffer, resolve to post_process_effect buffer or to front buffer
 	if (storage->frame.current_rt && storage->frame.current_rt->multisample_active) {
-#ifdef GLES_OVER_GL
+		GLuint next_buffer;
+		if (use_post_process) {
+			next_buffer = storage->frame.current_rt->mip_maps[0].sizes[0].fbo;
+		} else if (storage->frame.current_rt->external.fbo != 0) {
+			next_buffer = storage->frame.current_rt->external.fbo;
+		} else {
+			// set next_buffer to front buffer so multisample blit can happen if needed
+			next_buffer = storage->frame.current_rt->fbo;
+		}
 
+#ifdef GLES_OVER_GL
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->multisample_fbo);
 		glReadBuffer(GL_COLOR_ATTACHMENT0);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, next_buffer);
@@ -2736,6 +2734,7 @@ void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p
 		_copy_texture_to_buffer(storage->frame.current_rt->multisample_color, next_buffer);
 #else
 		// TODO: any other platform not supported? this will fail.. maybe we should just call _copy_texture_to_buffer here as well?
+		(void)next_buffer; // Silence warning as it's unused.
 #endif
 	} else if (use_post_process) {
 		if (storage->frame.current_rt->external.fbo != 0) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -7073,9 +7073,11 @@ GDScriptParser::DataType GDScriptParser::_reduce_function_call_type(const Operat
 	DataType return_type;
 	List<DataType> arg_types;
 	int default_args_count = 0;
-	int arg_count = p_call->arguments.size();
 	String callee_name;
 	bool is_vararg = false;
+#ifdef DEBUG_ENABLED
+	int arg_count = p_call->arguments.size();
+#endif
 
 	switch (p_call->arguments[0]->type) {
 		case GDScriptParser::Node::TYPE_TYPE: {
@@ -7186,7 +7188,9 @@ GDScriptParser::DataType GDScriptParser::_reduce_function_call_type(const Operat
 
 			default_args_count = mi.default_arguments.size();
 			callee_name = mi.name;
+#ifdef DEBUG_ENABLED
 			arg_count -= 1;
+#endif
 
 			// Check each argument type
 			for (List<PropertyInfo>::Element *E = mi.arguments.front(); E; E = E->next()) {
@@ -7213,7 +7217,9 @@ GDScriptParser::DataType GDScriptParser::_reduce_function_call_type(const Operat
 
 			IdentifierNode *func_id = static_cast<IdentifierNode *>(p_call->arguments[arg_id]);
 			callee_name = func_id->name;
+#ifdef DEBUG_ENABLED
 			arg_count -= 1 + arg_id;
+#endif
 
 			DataType base_type;
 			if (p_call->op == OperatorNode::OP_PARENT_CALL) {
@@ -7392,7 +7398,6 @@ GDScriptParser::DataType GDScriptParser::_reduce_function_call_type(const Operat
 			}
 		}
 	}
-
 #endif // DEBUG_ENABLED
 
 	return return_type;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -180,7 +180,6 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 	}
 
 	int wofs = margin;
-	int spaces_size = 0;
 	int align_ofs = 0;
 
 	if (p_mode != PROCESS_CACHE && align != ALIGN_FILL) {
@@ -248,7 +247,6 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 		line_ascent = 0;                                                                                                                                        \
 		line_descent = 0;                                                                                                                                       \
 		spaces = 0;                                                                                                                                             \
-		spaces_size = 0;                                                                                                                                        \
 		wofs = begin;                                                                                                                                           \
 		align_ofs = 0;                                                                                                                                          \
 		if (p_mode != PROCESS_CACHE) {                                                                                                                          \
@@ -449,9 +447,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 					fh = line_ascent + line_descent;
 
 					if (end && c[end - 1] == ' ') {
-						if (p_mode == PROCESS_CACHE) {
-							spaces_size += font->get_char_size(' ').width;
-						} else if (align == ALIGN_FILL) {
+						if (align == ALIGN_FILL) {
 							int ln = MIN(l.offset_caches.size() - 1, line);
 							if (l.space_caches[ln]) {
 								align_ofs = spaces * l.offset_caches[ln] / l.space_caches[ln];


### PR DESCRIPTION
That's the version used by current containers for Godot 3.4.

Not a candidate for cherry-picking to `3.3` as we will stick to version 2.0.15 to avoid surprises.