### PR TITLE
AudioServer: Silence Clang -Wordered-compare-function-pointers warning

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=javascript verbose=yes warnings=extra debug_symbols=no module_webxr_enabled=no --jobs=2
+  SCONSFLAGS: platform=javascript verbose=yes warnings=extra werror=yes debug_symbols=no module_webxr_enabled=no --jobs=2
   SCONS_CACHE_LIMIT: 4096
   EM_VERSION: 2.0.25
   EM_CACHE_FOLDER: 'emsdk-cache'

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -236,7 +236,10 @@ private:
 		void *userdata;
 
 		bool operator<(const CallbackItem &p_item) const {
-			return (callback == p_item.callback ? userdata < p_item.userdata : callback < p_item.callback);
+			// Only implemented because it's a requirement to use in Set, but we don't
+			// actually care about the ordering being consistent.
+			// Casting to ints to silence -Wordered-compare-function-pointers warning.
+			return (callback == p_item.callback ? (uint64_t)userdata < (uint64_t)p_item.userdata : (uint64_t)callback < (uint64_t)p_item.callback);
 		}
 	};
 


### PR DESCRIPTION
We need to implement this comparator for Set but we don't mind if the ordering
is not reliable.

Re-enable `werror=yes` for JavaScript builds now that this is fixed.