### PR TITLE
SCons: Disable Clang -Wordered-compare-function-pointers warning, fix Emscripten warnings setup

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=javascript verbose=yes warnings=extra debug_symbols=no --jobs=2
+  SCONSFLAGS: platform=javascript verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2
   SCONS_CACHE_LIMIT: 4096
   EM_VERSION: 2.0.25
   EM_CACHE_FOLDER: 'emsdk-cache'

--- a/SConstruct
+++ b/SConstruct
@@ -506,13 +506,17 @@ if selected_platform in platform_list:
         if env["werror"]:
             env.Append(CCFLAGS=["/WX"])
     else:  # GCC, Clang
-        gcc_common_warnings = []
+        common_warnings = []
 
         if methods.using_gcc(env):
-            gcc_common_warnings += ["-Wshadow-local", "-Wno-misleading-indentation"]
+            common_warnings += ["-Wshadow-local", "-Wno-misleading-indentation"]
+        elif methods.using_clang(env):
+            # We often implement `operator<` for structs of pointers as a requirement
+            # for putting them in `Set` or `Map`. We don't mind about unreliable ordering.
+            common_warnings += ["-Wno-ordered-compare-function-pointers"]
 
         if env["warnings"] == "extra":
-            env.Append(CCFLAGS=["-Wall", "-Wextra", "-Wwrite-strings", "-Wno-unused-parameter"] + gcc_common_warnings)
+            env.Append(CCFLAGS=["-Wall", "-Wextra", "-Wwrite-strings", "-Wno-unused-parameter"] + common_warnings)
             env.Append(CXXFLAGS=["-Wctor-dtor-privacy", "-Wnon-virtual-dtor"])
             if methods.using_gcc(env):
                 env.Append(
@@ -531,9 +535,9 @@ if selected_platform in platform_list:
             elif methods.using_clang(env):
                 env.Append(CCFLAGS=["-Wimplicit-fallthrough"])
         elif env["warnings"] == "all":
-            env.Append(CCFLAGS=["-Wall"] + gcc_common_warnings)
+            env.Append(CCFLAGS=["-Wall"] + common_warnings)
         elif env["warnings"] == "moderate":
-            env.Append(CCFLAGS=["-Wall", "-Wno-unused"] + gcc_common_warnings)
+            env.Append(CCFLAGS=["-Wall", "-Wno-unused"] + common_warnings)
         else:  # 'no'
             env.Append(CCFLAGS=["-w"])
 
@@ -544,7 +548,7 @@ if selected_platform in platform_list:
                 env.Append(CXXFLAGS=["-Wno-error=cpp"])
                 if cc_version_major == 7:  # Bogus warning fixed in 8+.
                     env.Append(CCFLAGS=["-Wno-error=strict-overflow"])
-            else:
+            elif methods.using_clang(env):
                 env.Append(CXXFLAGS=["-Wno-error=#warnings"])
         else:  # always enable those errors
             env.Append(CCFLAGS=["-Werror=return-type"])

--- a/SConstruct
+++ b/SConstruct
@@ -510,7 +510,7 @@ if selected_platform in platform_list:
 
         if methods.using_gcc(env):
             common_warnings += ["-Wshadow-local", "-Wno-misleading-indentation"]
-        elif methods.using_clang(env):
+        elif methods.using_clang(env) or methods.using_emcc(env):
             # We often implement `operator<` for structs of pointers as a requirement
             # for putting them in `Set` or `Map`. We don't mind about unreliable ordering.
             common_warnings += ["-Wno-ordered-compare-function-pointers"]
@@ -532,7 +532,7 @@ if selected_platform in platform_list:
                 env.Append(CXXFLAGS=["-Wplacement-new=1"])
                 if cc_version_major >= 9:
                     env.Append(CCFLAGS=["-Wattribute-alias=2"])
-            elif methods.using_clang(env):
+            elif methods.using_clang(env) or methods.using_emcc(env):
                 env.Append(CCFLAGS=["-Wimplicit-fallthrough"])
         elif env["warnings"] == "all":
             env.Append(CCFLAGS=["-Wall"] + common_warnings)
@@ -548,7 +548,7 @@ if selected_platform in platform_list:
                 env.Append(CXXFLAGS=["-Wno-error=cpp"])
                 if cc_version_major == 7:  # Bogus warning fixed in 8+.
                     env.Append(CCFLAGS=["-Wno-error=strict-overflow"])
-            elif methods.using_clang(env):
+            elif methods.using_clang(env) or methods.using_emcc(env):
                 env.Append(CXXFLAGS=["-Wno-error=#warnings"])
         else:  # always enable those errors
             env.Append(CCFLAGS=["-Werror=return-type"])

--- a/methods.py
+++ b/methods.py
@@ -828,6 +828,10 @@ def using_clang(env):
     return "clang" in os.path.basename(env["CC"])
 
 
+def using_emcc(env):
+    return "emcc" in os.path.basename(env["CC"])
+
+
 def show_progress(env):
     import sys
     from SCons.Script import Progress, Command, AlwaysBuild

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -80,6 +80,7 @@ if env["builtin_freetype"]:
         # Forcibly undefine this macro so SIMD is not used in this file,
         # since currently unsupported in WASM
         tmp_env = env_freetype.Clone()
+        tmp_env.disable_warnings()
         tmp_env.Append(CPPFLAGS=["-U__OPTIMIZE__"])
         sfnt = tmp_env.Object(sfnt)
     thirdparty_sources += [sfnt]

--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -54,7 +54,7 @@ Error EMWSPeer::read_msg(const uint8_t *p_data, uint32_t p_size, bool p_is_strin
 }
 
 Error EMWSPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
-	ERR_FAIL_COND_V(_out_buf_size && (godot_js_websocket_buffered_amount(peer_sock) >= (1ULL << _out_buf_size)), ERR_OUT_OF_MEMORY);
+	ERR_FAIL_COND_V(_out_buf_size && ((uint64_t)godot_js_websocket_buffered_amount(peer_sock) >= (1ULL << _out_buf_size)), ERR_OUT_OF_MEMORY);
 
 	int is_bin = write_mode == WebSocketPeer::WRITE_MODE_BINARY ? 1 : 0;
 


### PR DESCRIPTION
It's raised for us on many comparators implemented to be able to store a struct
in `Set` or `Map` (who rely on `operator<` internally). In the cases I reviewed
we don't actually care about the ordering and we use the struct's function
pointers as that's the only distinctive data available.

SCons: Add method to detect Emscripten and use it for warnings config

Emscripten is LLVM-based so we want to follow the same logic. But we can't just
put it as a match in `methods.using_clang()` as that would mess with the
compiler version detection logic used to restrict old GCC and Clang releases.

HTML5: Fix warnings and re-enable `werror=yes` on CI
    
Add a missing call to disable warnings on a forked env for freetype's
`sfnt.c`.

Supersedes #50485.