### PR TITLE
Improve 2D editor zoom logic (3.x)

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -539,12 +539,13 @@ private:
 
 	VBoxContainer *controls_vb;
 	HBoxContainer *zoom_hb;
-	float _get_next_zoom_value(int p_increment_count) const;
+	float _get_next_zoom_value(int p_increment_count, bool p_integer_only = false) const;
 	void _zoom_on_position(float p_zoom, Point2 p_position = Point2());
 	void _update_zoom_label();
 	void _button_zoom_minus();
 	void _button_zoom_reset();
 	void _button_zoom_plus();
+	void _shortcut_zoom_set(float p_zoom);
 	void _button_toggle_smart_snap(bool p_status);
 	void _button_toggle_grid_snap(bool p_status);
 	void _button_override_camera(bool p_pressed);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/48252.

- Add <kbd>1</kbd>-<kbd>5</kbd> shortcuts to zoom between 100% and 1600% quickly (similar to GIMP).
- When holding down <kbd>Alt</kbd>, go through integer zoom values if above 100% or fractional zoom values with integer denominators if below 100% (50%, ~33.3%, 25%, …).

I tested this PR on `3.x` and everything works as expected with the editor scale set to 150%.