### PR TITLE
Add list initialization support for Vector & LocalVector

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -36,6 +36,8 @@
 #include "core/templates/sort_array.h"
 #include "core/templates/vector.h"
 
+#include <initializer_list>
+
 template <class T, class U = uint32_t, bool force_trivial = false>
 class LocalVector {
 private:
@@ -228,6 +230,12 @@ public:
 	}
 
 	_FORCE_INLINE_ LocalVector() {}
+	_FORCE_INLINE_ LocalVector(std::initializer_list<T> p_init) {
+		reserve(p_init.size());
+		for (const T &element : p_init) {
+			push_back(element);
+		}
+	}
 	_FORCE_INLINE_ LocalVector(const LocalVector &p_from) {
 		resize(p_from.size());
 		for (U i = 0; i < p_from.count; i++) {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -43,6 +43,8 @@
 #include "core/templates/search_array.h"
 #include "core/templates/sort_array.h"
 
+#include <initializer_list>
+
 template <class T>
 class VectorWriteProxy {
 public:
@@ -258,6 +260,15 @@ public:
 	}
 
 	_FORCE_INLINE_ Vector() {}
+	_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) {
+		Error err = _cowdata.resize(p_init.size());
+		ERR_FAIL_COND(err);
+
+		int i = 0;
+		for (const T &element : p_init) {
+			_cowdata.set(i++, element);
+		}
+	}
 	_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
 
 	_FORCE_INLINE_ ~Vector() {}

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/string/ustring.h"
+#include "core/templates/local_vector.h"
 #include "core/version.h"
 #include "servers/rendering/rendering_device.h"
 
@@ -41,7 +42,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <vector>
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 #define APP_SHORT_NAME "GodotEngine"
@@ -212,7 +212,7 @@ VkBool32 VulkanContext::_check_layers(uint32_t check_count, const char *const *c
 }
 
 Error VulkanContext::_get_preferred_validation_layers(uint32_t *count, const char *const **names) {
-	static const std::vector<std::vector<const char *>> instance_validation_layers_alt{
+	static const LocalVector<LocalVector<const char *>> instance_validation_layers_alt{
 		// Preferred set of validation layers
 		{ "VK_LAYER_KHRONOS_validation" },
 
@@ -249,10 +249,10 @@ Error VulkanContext::_get_preferred_validation_layers(uint32_t *count, const cha
 	}
 
 	for (uint32_t i = 0; i < instance_validation_layers_alt.size(); i++) {
-		if (_check_layers(instance_validation_layers_alt[i].size(), instance_validation_layers_alt[i].data(), instance_layer_count, instance_layers)) {
+		if (_check_layers(instance_validation_layers_alt[i].size(), instance_validation_layers_alt[i].ptr(), instance_layer_count, instance_layers)) {
 			*count = instance_validation_layers_alt[i].size();
 			if (names != nullptr) {
-				*names = instance_validation_layers_alt[i].data();
+				*names = instance_validation_layers_alt[i].ptr();
 			}
 			break;
 		}

--- a/tests/core/templates/test_local_vector.h
+++ b/tests/core/templates/test_local_vector.h
@@ -37,6 +37,17 @@
 
 namespace TestLocalVector {
 
+TEST_CASE("[LocalVector] List Initialization.") {
+	LocalVector<int> vector{ 0, 1, 2, 3, 4 };
+
+	CHECK(vector.size() == 5);
+	CHECK(vector[0] == 0);
+	CHECK(vector[1] == 1);
+	CHECK(vector[2] == 2);
+	CHECK(vector[3] == 3);
+	CHECK(vector[4] == 4);
+}
+
 TEST_CASE("[LocalVector] Push Back.") {
 	LocalVector<int> vector;
 	vector.push_back(0);

--- a/tests/core/templates/test_vector.h
+++ b/tests/core/templates/test_vector.h
@@ -37,6 +37,17 @@
 
 namespace TestVector {
 
+TEST_CASE("[Vector] List initialization") {
+	Vector<int> vector{ 0, 1, 2, 3, 4 };
+
+	CHECK(vector.size() == 5);
+	CHECK(vector[0] == 0);
+	CHECK(vector[1] == 1);
+	CHECK(vector[2] == 2);
+	CHECK(vector[3] == 3);
+	CHECK(vector[4] == 4);
+}
+
 TEST_CASE("[Vector] Push back and append") {
 	Vector<int> vector;
 	vector.push_back(0);


### PR DESCRIPTION
Adds list initialzation support for `LocalVector` in order to get rid of `std::vector` in `VulkanContext`.

* `std::initializer_list` is used because it's the required parameter type when doing list initialization.
* ranged-for loop is used because I think it's allowed since #50284 was merged and simplifies code.

Also added list initialzation support for `Vector`. No code were harmed during production, only added a unit test.