### PR TITLE
Automatically focus the Search field when displaying asset library (3.x)

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -569,8 +569,15 @@ void EditorAssetLibrary::_notification(int p_what) {
 			error_label->raise();
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (is_visible() && initial_loading) {
-				_repository_changed(0); // Update when shown for the first time.
+			if (is_visible()) {
+				// Focus the search box automatically when switching to the Templates tab (in the Project Manager)
+				// or switching to the AssetLib tab (in the editor).
+				// The Project Manager's project filter box is automatically focused in the project manager code.
+				filter->grab_focus();
+
+				if (initial_loading) {
+					_repository_changed(0); // Update when shown for the first time.
+				}
 			}
 		} break;
 		case NOTIFICATION_PROCESS: {
@@ -1338,6 +1345,11 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	library_main->add_constant_override("separation", 10 * EDSCALE);
 
 	filter = memnew(LineEdit);
+	if (templates_only) {
+		filter->set_placeholder(TTR("Search templates, projects, and demos"));
+	} else {
+		filter->set_placeholder(TTR("Search assets (excluding templates, projects, and demos)"));
+	}
 	search_hb->add_child(filter);
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->connect("text_changed", this, "_search_text_changed");

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2306,6 +2306,20 @@ void ProjectManager::_on_filter_option_changed() {
 	_project_list->sort_projects();
 }
 
+void ProjectManager::_on_tab_changed(int p_tab) {
+	if (p_tab == 0) { // Projects
+		// Automatically grab focus when the user moves from the Templates tab
+		// back to the Projects tab.
+		LineEdit *search_box = project_filter->get_search_box();
+		if (search_box) {
+			search_box->grab_focus();
+		}
+	}
+
+	// The Templates tab's search field is focused on display in the asset
+	// library editor plugin code.
+}
+
 void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_open_selected_projects_ask", &ProjectManager::_open_selected_projects_ask);
 	ClassDB::bind_method("_open_selected_projects", &ProjectManager::_open_selected_projects);
@@ -2327,6 +2341,7 @@ void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_restart_confirm", &ProjectManager::_restart_confirm);
 	ClassDB::bind_method("_on_order_option_changed", &ProjectManager::_on_order_option_changed);
 	ClassDB::bind_method("_on_filter_option_changed", &ProjectManager::_on_filter_option_changed);
+	ClassDB::bind_method("_on_tab_changed", &ProjectManager::_on_tab_changed);
 	ClassDB::bind_method("_on_projects_updated", &ProjectManager::_on_projects_updated);
 	ClassDB::bind_method("_on_project_created", &ProjectManager::_on_project_created);
 	ClassDB::bind_method("_unhandled_input", &ProjectManager::_unhandled_input);
@@ -2425,6 +2440,7 @@ ProjectManager::ProjectManager() {
 	center_box->add_child(tabs);
 	tabs->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
+	tabs->connect("tab_changed", this, "_on_tab_changed");
 
 	HBoxContainer *tree_hb = memnew(HBoxContainer);
 	projects_hb = tree_hb;
@@ -2776,14 +2792,17 @@ void ProjectListFilter::add_filter_option() {
 
 void ProjectListFilter::add_search_box() {
 	search_box = memnew(LineEdit);
-	search_box->set_placeholder(TTR("Search"));
-	search_box->set_tooltip(
-			TTR("The search box filters projects by name and last path component.\nTo filter projects by name and full path, the query must contain at least one `/` character."));
+	search_box->set_placeholder(TTR("Filter projects"));
+	search_box->set_tooltip(TTR("This field filters projects by name and last path component.\nTo filter projects by name and full path, the query must contain at least one `/` character."));
 	search_box->connect("text_changed", this, "_search_text_changed");
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_child(search_box);
 
 	has_search_box = true;
+}
+
+LineEdit *ProjectListFilter::get_search_box() const {
+	return search_box;
 }
 
 void ProjectListFilter::set_filter_size(int h_size) {

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -122,6 +122,7 @@ class ProjectManager : public Control {
 	void _version_button_pressed();
 	void _on_order_option_changed();
 	void _on_filter_option_changed();
+	void _on_tab_changed(int p_tab);
 
 protected:
 	void _notification(int p_what);
@@ -160,7 +161,12 @@ protected:
 public:
 	void _setup_filters(Vector<String> options);
 	void add_filter_option();
+
 	void add_search_box();
+	// May return `nullptr` if the search box wasn't created yet, so check for validity
+	// before using the returned value.
+	LineEdit *get_search_box() const;
+
 	void set_filter_size(int h_size);
 	String get_search_term();
 	FilterOption get_filter_option();


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/47632.

- Focus the project search box when switching from the Templates tab back to the Projects tab in the project manager.
- Add a context-specific placeholder for the asset library search box.
- Rename "Search" project filter box placeholder to the more descriptive "Filter projects". [When performing a search on an existing selection, "Filter" is more accurate than "Search".](https://ux.stackexchange.com/questions/4752/search-vs-filter-what-is-the-difference#4756)