### PR TITLE
Remove unnecessary `get_editor_theme()` in `SubViewportPreview`

### DIFF
--- a/editor/plugins/sub_viewport_preview_editor_plugin.cpp
+++ b/editor/plugins/sub_viewport_preview_editor_plugin.cpp
@@ -38,6 +38,7 @@ void EditorInspectorPluginSubViewportPreview::parse_begin(Object *p_object) {
 	SubViewport *sub_viewport = Object::cast_to<SubViewport>(p_object);
 
 	TexturePreview *sub_viewport_preview = memnew(TexturePreview(sub_viewport->get_texture(), false));
+	// Otherwise `sub_viewport_preview`'s `texture_display` doesn't update properly when `sub_viewport`'s size changes.
 	sub_viewport->connect("size_changed", callable_mp((CanvasItem *)sub_viewport_preview->get_texture_display(), &CanvasItem::update));
 	add_custom_control(sub_viewport_preview);
 }

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -37,10 +37,8 @@ TextureRect *TexturePreview::get_texture_display() {
 }
 
 TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
-	Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
-
 	TextureRect *checkerboard = memnew(TextureRect);
-	checkerboard->set_texture(theme->get_icon("Checkerboard", "EditorIcons"));
+	checkerboard->set_texture(get_theme_icon("Checkerboard", "EditorIcons"));
 	checkerboard->set_stretch_mode(TextureRect::STRETCH_TILE);
 	checkerboard->set_texture_repeat(CanvasItem::TEXTURE_REPEAT_ENABLED);
 	checkerboard->set_custom_minimum_size(Size2(0.0, 256.0) * EDSCALE);
@@ -70,10 +68,10 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 		metadata_label->add_theme_font_size_override("font_size", 16 * EDSCALE);
 		metadata_label->add_theme_color_override("font_outline_color", Color::named("black"));
 		metadata_label->add_theme_constant_override("outline_size", 2 * EDSCALE);
-		Ref<Font> metadata_label_font = theme->get_font("expression", "EditorFonts");
+		Ref<Font> metadata_label_font = get_theme_font("expression", "EditorFonts");
 		metadata_label->add_theme_font_override("font", metadata_label_font);
 
-		// it's okay that these colors are static since the grid color is static too
+		// It's okay that these colors are static since the grid color is static too.
 		metadata_label->add_theme_color_override("font_color", Color::named("white"));
 		metadata_label->add_theme_color_override("font_color_shadow", Color::named("black"));
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
I wasn't as familiar with the codebase when I made https://github.com/godotengine/godot/pull/47245, looking back I realized the `EditorNode::get_singleton()->get_editor_theme()` was unnecessary and that I could just use the `get_theme_x()` methods.