### PR TITLE
[3.x] Implement constructors and operator= for std::initializer_list<T> in …

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -34,6 +34,8 @@
 #include "core/object.h"
 #include "core/variant.h"
 #include "core/vector.h"
+#include <initializer_list>
+#include <utility>
 
 class ArrayPrivate {
 public:
@@ -102,6 +104,9 @@ uint32_t Array::hash() const {
 }
 void Array::operator=(const Array &p_array) {
 	_ref(p_array);
+}
+void Array::operator=(std::initializer_list<Variant> l) {
+	_ref(Array(std::move(l)));
 }
 void Array::push_back(const Variant &p_value) {
 	_p->array.push_back(p_value);
@@ -431,6 +436,12 @@ const void *Array::id() const {
 Array::Array(const Array &p_from) {
 	_p = nullptr;
 	_ref(p_from);
+}
+
+Array::Array(std::initializer_list<Variant> l) {
+	_p = memnew(ArrayPrivate);
+	_p->refcount.init();
+	_p->array = Vector<Variant>(l);
 }
 
 Array::Array() {

--- a/core/array.h
+++ b/core/array.h
@@ -37,6 +37,10 @@ class Variant;
 class ArrayPrivate;
 class Object;
 class StringName;
+namespace std {
+template <class _E>
+class initializer_list;
+}
 
 class Array {
 	mutable ArrayPrivate *_p;
@@ -60,6 +64,7 @@ public:
 
 	uint32_t hash() const;
 	void operator=(const Array &p_array);
+	void operator=(std::initializer_list<Variant> l);
 
 	void push_back(const Variant &p_value);
 	_FORCE_INLINE_ void append(const Variant &p_value) { push_back(p_value); } //for python compatibility
@@ -101,6 +106,7 @@ public:
 	const void *id() const;
 
 	Array(const Array &p_from);
+	Array(std::initializer_list<Variant> l);
 	Array();
 	~Array();
 };

--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -233,6 +233,14 @@ public:
 			data[i] = p_from.data[i];
 		}
 	}
+	_FORCE_INLINE_ LocalVector(std::initializer_list<T> l) {
+		resize(l.size());
+		U i = 0;
+		for (const T &v : l) {
+			data[i] = v;
+			++i;
+		}
+	}
 	inline LocalVector &operator=(const LocalVector &p_from) {
 		resize(p_from.size());
 		for (U i = 0; i < p_from.count; i++) {
@@ -244,6 +252,13 @@ public:
 		resize(p_from.size());
 		for (U i = 0; i < count; i++) {
 			data[i] = p_from[i];
+		}
+		return *this;
+	}
+	inline LocalVector &operator=(std::initializer_list<T> l) {
+		resize(l.size());
+		for (U i = 0; i < l.size(); ++i) {
+			data[i] = std::move(l[i]);
 		}
 		return *this;
 	}

--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -451,10 +451,22 @@ public:
 	void invert();
 
 	void operator=(const PoolVector &p_pool_vector) { _reference(p_pool_vector); }
+	void operator=(std::initializer_list<T> l) {
+		alloc = nullptr;
+		resize(l.size());
+		Write w = write();
+		int p_index = -1;
+		for (const T &p_val : l) {
+			w[++p_index] = p_val;
+		}
+	}
 	PoolVector() { alloc = nullptr; }
 	PoolVector(const PoolVector &p_pool_vector) {
 		alloc = nullptr;
 		_reference(p_pool_vector);
+	}
+	PoolVector(std::initializer_list<T> l) {
+		*this = l;
 	}
 	~PoolVector() { _unreference(); }
 };

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2527,6 +2527,10 @@ Variant::Variant(const IP_Address &p_address) {
 	memnew_placement(_data._mem, String(p_address));
 }
 
+Variant::Variant(std::initializer_list<Variant> l) {
+	*this = Array(l);
+}
+
 Variant::Variant(const Variant &p_variant) {
 	type = NIL;
 	reference(p_variant);

--- a/core/variant.h
+++ b/core/variant.h
@@ -317,6 +317,7 @@ public:
 	Variant(const PoolVector<Vector2> &p_vector2_array); // helper
 
 	Variant(const IP_Address &p_address);
+	Variant(std::initializer_list<Variant> l);
 
 	// If this changes the table in variant_op must be updated
 	enum Operator {

--- a/core/vector.h
+++ b/core/vector.h
@@ -41,6 +41,8 @@
 #include "core/error_macros.h"
 #include "core/os/memory.h"
 #include "core/sort_array.h"
+#include <initializer_list>
+#include <utility>
 
 template <class T>
 class VectorWriteProxy {
@@ -118,8 +120,17 @@ public:
 
 	_FORCE_INLINE_ Vector() {}
 	_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
+	_FORCE_INLINE_ Vector(std::initializer_list<T> l) { *this = std::move(l); }
 	inline Vector &operator=(const Vector &p_from) {
 		_cowdata._ref(p_from._cowdata);
+		return *this;
+	}
+	Vector &operator=(std::initializer_list<T> l) {
+		_cowdata.resize(l.size());
+		int i = -1;
+		for (const T &v : l) {
+			_cowdata.set(++i, v);
+		}
 		return *this;
 	}
 


### PR DESCRIPTION
…one dimensional data containers. As a side effect append_array() also works with initializer_list

**TODO:** reimplement for master branch

**Test case:**
Paste the following snippet on any runnable piece of code and put a breakpoint to follow the execution
```
	Array test = {1, 2, "String"};
	Vector<int> v1 = {1, 2, 3, 4, 5};
	Vector<int> v2({1, 2, 3, 4, 5});
	v1.append_array({6,7,8});
	LocalVector<int, uint32_t, true> v3 = {7,8,9,10,11};
	LocalVector<int, uint32_t, true> v4({12,13,14,15});
	LocalVector<int, uint32_t, false> v5 = {7,8,9,10,11};
	LocalVector<int, uint32_t, false> v6({12,13,14,15});
	PoolStringArray v7 = {"AB", "CD", "EF"};
	PoolStringArray v8({"AB", "CD", "EF"});
	v8.append_array({"GH", "IJ"});
	PoolVector2Array v9 = {Vector2(0, 1), Vector2(2, 3)};
	v9.append_array({Vector2(0, 1), Vector2(2, 3)});
	Variant varArray = {1, 2, "String", false, this, {1, 2}};
```
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
