### PR TITLE
Use C++ range iterators for Lists in many situations

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -214,8 +214,8 @@ bool Engine::has_singleton(const String &p_name) const {
 }
 
 void Engine::get_singletons(List<Singleton> *p_singletons) {
-	for (List<Singleton>::Element *E = singletons.front(); E; E = E->next()) {
-		p_singletons->push_back(E->get());
+	for (Singleton &E : singletons) {
+		p_singletons->push_back(E);
 	}
 }
 

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -700,9 +700,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 	int count = 0;
 
 	for (Map<String, List<String>>::Element *E = props.front(); E; E = E->next()) {
-		for (List<String>::Element *F = E->get().front(); F; F = F->next()) {
-			count++;
-		}
+		count += E->get().size();
 	}
 
 	if (p_custom_features != String()) {
@@ -734,8 +732,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 	}
 
 	for (Map<String, List<String>>::Element *E = props.front(); E; E = E->next()) {
-		for (List<String>::Element *F = E->get().front(); F; F = F->next()) {
-			String key = F->get();
+		for (String &key : E->get()) {
 			if (E->key() != "") {
 				key = E->key() + "/" + key;
 			}
@@ -803,8 +800,8 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 		if (E->key() != "") {
 			file->store_string("[" + E->key() + "]\n\n");
 		}
-		for (List<String>::Element *F = E->get().front(); F; F = F->next()) {
-			String key = F->get();
+		for (String &F : E->get()) {
+			String key = F;
 			if (E->key() != "") {
 				key = E->key() + "/" + key;
 			}
@@ -817,7 +814,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 
 			String vstr;
 			VariantWriter::write_to_string(value, vstr);
-			file->store_string(F->get().property_name_encode() + "=" + vstr + "\n");
+			file->store_string(F.property_name_encode() + "=" + vstr + "\n");
 		}
 	}
 
@@ -931,11 +928,11 @@ Vector<String> ProjectSettings::get_optimizer_presets() const {
 	ProjectSettings::get_singleton()->get_property_list(&pi);
 	Vector<String> names;
 
-	for (List<PropertyInfo>::Element *E = pi.front(); E; E = E->next()) {
-		if (!E->get().name.begins_with("optimizer_presets/")) {
+	for (PropertyInfo &E : pi) {
+		if (!E.name.begins_with("optimizer_presets/")) {
 			continue;
 		}
-		names.push_back(E->get().name.get_slicec('/', 1));
+		names.push_back(E.name.get_slicec('/', 1));
 	}
 
 	names.sort();

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -75,8 +75,8 @@ Vector<String> _ResourceLoader::get_recognized_extensions_for_type(const String 
 	List<String> exts;
 	ResourceLoader::get_recognized_extensions_for_type(p_type, &exts);
 	Vector<String> ret;
-	for (List<String>::Element *E = exts.front(); E; E = E->next()) {
-		ret.push_back(E->get());
+	for (String &E : exts) {
+		ret.push_back(E);
 	}
 
 	return ret;
@@ -91,8 +91,8 @@ PackedStringArray _ResourceLoader::get_dependencies(const String &p_path) {
 	ResourceLoader::get_dependencies(p_path, &deps);
 
 	PackedStringArray ret;
-	for (List<String>::Element *E = deps.front(); E; E = E->next()) {
-		ret.push_back(E->get());
+	for (String &E : deps) {
+		ret.push_back(E);
 	}
 
 	return ret;
@@ -141,8 +141,8 @@ Vector<String> _ResourceSaver::get_recognized_extensions(const RES &p_resource) 
 	List<String> exts;
 	ResourceSaver::get_recognized_extensions(p_resource, &exts);
 	Vector<String> ret;
-	for (List<String>::Element *E = exts.front(); E; E = E->next()) {
-		ret.push_back(E->get());
+	for (String &E : exts) {
+		ret.push_back(E);
 	}
 	return ret;
 }
@@ -268,8 +268,8 @@ String _OS::get_name() const {
 Vector<String> _OS::get_cmdline_args() {
 	List<String> cmdline = OS::get_singleton()->get_cmdline_args();
 	Vector<String> cmdlinev;
-	for (List<String>::Element *E = cmdline.front(); E; E = E->next()) {
-		cmdlinev.push_back(E->get());
+	for (String &E : cmdline) {
+		cmdlinev.push_back(E);
 	}
 
 	return cmdlinev;
@@ -355,20 +355,20 @@ void _OS::print_all_textures_by_size() {
 		List<Ref<Resource>> rsrc;
 		ResourceCache::get_cached_resources(&rsrc);
 
-		for (List<Ref<Resource>>::Element *E = rsrc.front(); E; E = E->next()) {
-			if (!E->get()->is_class("ImageTexture")) {
+		for (Ref<Resource> E : rsrc) {
+			if (!E->is_class("ImageTexture")) {
 				continue;
 			}
 
-			Size2 size = E->get()->call("get_size");
-			int fmt = E->get()->call("get_format");
+			Size2 size = E->call("get_size");
+			int fmt = E->call("get_format");
 
 			_OSCoreBindImg img;
 			img.size = size;
 			img.fmt = fmt;
-			img.path = E->get()->get_path();
+			img.path = E->get_path();
 			img.vram = Image::get_image_data_size(img.size.width, img.size.height, Image::Format(img.fmt));
-			img.id = E->get()->get_instance_id();
+			img.id = E->get_instance_id();
 			total += img.vram;
 			imgs.push_back(img);
 		}
@@ -376,8 +376,8 @@ void _OS::print_all_textures_by_size() {
 
 	imgs.sort();
 
-	for (List<_OSCoreBindImg>::Element *E = imgs.front(); E; E = E->next()) {
-		total -= E->get().vram;
+	for (_OSCoreBindImg &E : imgs) {
+		total -= E.vram;
 	}
 }
 
@@ -387,9 +387,7 @@ void _OS::print_resources_by_type(const Vector<String> &p_types) {
 	List<Ref<Resource>> resources;
 	ResourceCache::get_cached_resources(&resources);
 
-	for (List<Ref<Resource>>::Element *E = resources.front(); E; E = E->next()) {
-		Ref<Resource> r = E->get();
-
+	for (Ref<Resource> r : resources) {
 		bool found = false;
 
 		for (int i = 0; i < p_types.size(); i++) {
@@ -1824,8 +1822,8 @@ PackedStringArray _ClassDB::get_class_list() const {
 	PackedStringArray ret;
 	ret.resize(classes.size());
 	int idx = 0;
-	for (List<StringName>::Element *E = classes.front(); E; E = E->next()) {
-		ret.set(idx++, E->get());
+	for (StringName &E : classes) {
+		ret.set(idx++, E);
 	}
 
 	return ret;
@@ -1838,8 +1836,8 @@ PackedStringArray _ClassDB::get_inheriters_from_class(const StringName &p_class)
 	PackedStringArray ret;
 	ret.resize(classes.size());
 	int idx = 0;
-	for (List<StringName>::Element *E = classes.front(); E; E = E->next()) {
-		ret.set(idx++, E->get());
+	for (StringName &E : classes) {
+		ret.set(idx++, E);
 	}
 
 	return ret;
@@ -1893,8 +1891,8 @@ Array _ClassDB::get_signal_list(StringName p_class, bool p_no_inheritance) const
 	ClassDB::get_signal_list(p_class, &signals, p_no_inheritance);
 	Array ret;
 
-	for (List<MethodInfo>::Element *E = signals.front(); E; E = E->next()) {
-		ret.push_back(E->get().operator Dictionary());
+	for (MethodInfo &E : signals) {
+		ret.push_back(E.operator Dictionary());
 	}
 
 	return ret;
@@ -1904,8 +1902,8 @@ Array _ClassDB::get_property_list(StringName p_class, bool p_no_inheritance) con
 	List<PropertyInfo> plist;
 	ClassDB::get_property_list(p_class, &plist, p_no_inheritance);
 	Array ret;
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		ret.push_back(E->get().operator Dictionary());
+	for (PropertyInfo &E : plist) {
+		ret.push_back(E.operator Dictionary());
 	}
 
 	return ret;
@@ -1937,12 +1935,12 @@ Array _ClassDB::get_method_list(StringName p_class, bool p_no_inheritance) const
 	ClassDB::get_method_list(p_class, &methods, p_no_inheritance);
 	Array ret;
 
-	for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
+	for (MethodInfo &E : methods) {
 #ifdef DEBUG_METHODS_ENABLED
-		ret.push_back(E->get().operator Dictionary());
+		ret.push_back(E.operator Dictionary());
 #else
 		Dictionary dict;
-		dict["name"] = E->get().name;
+		dict["name"] = E.name;
 		ret.push_back(dict);
 #endif
 	}
@@ -1957,8 +1955,8 @@ PackedStringArray _ClassDB::get_integer_constant_list(const StringName &p_class,
 	PackedStringArray ret;
 	ret.resize(constants.size());
 	int idx = 0;
-	for (List<String>::Element *E = constants.front(); E; E = E->next()) {
-		ret.set(idx++, E->get());
+	for (String &E : constants) {
+		ret.set(idx++, E);
 	}
 
 	return ret;

--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -40,11 +40,11 @@ Array DebuggerMarshalls::ResourceUsage::serialize() {
 
 	Array arr;
 	arr.push_back(infos.size() * 4);
-	for (List<ResourceInfo>::Element *E = infos.front(); E; E = E->next()) {
-		arr.push_back(E->get().path);
-		arr.push_back(E->get().format);
-		arr.push_back(E->get().type);
-		arr.push_back(E->get().vram);
+	for (ResourceInfo &E : infos) {
+		arr.push_back(E.path);
+		arr.push_back(E.format);
+		arr.push_back(E.type);
+		arr.push_back(E.vram);
 	}
 	return arr;
 }

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -320,13 +320,13 @@ void LocalDebugger::print_variables(const List<String> &names, const List<Varian
 	String value;
 	Vector<String> value_lines;
 	const List<Variant>::Element *V = values.front();
-	for (const List<String>::Element *E = names.front(); E; E = E->next()) {
+	for (const String &E : names) {
 		value = String(V->get());
 
 		if (variable_prefix.is_empty()) {
-			print_line(E->get() + ": " + String(V->get()));
+			print_line(E + ": " + String(V->get()));
 		} else {
-			print_line(E->get() + ":");
+			print_line(E + ":");
 			value_lines = value.split("\n");
 			for (int i = 0; i < value_lines.size(); ++i) {
 				print_line(variable_prefix + value_lines[i]);

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -427,16 +427,16 @@ void RemoteDebugger::_send_resource_usage() {
 	List<RS::TextureInfo> tinfo;
 	RS::get_singleton()->texture_debug_usage(&tinfo);
 
-	for (List<RS::TextureInfo>::Element *E = tinfo.front(); E; E = E->next()) {
+	for (RS::TextureInfo &E : tinfo) {
 		DebuggerMarshalls::ResourceInfo info;
-		info.path = E->get().path;
-		info.vram = E->get().bytes;
-		info.id = E->get().texture;
+		info.path = E.path;
+		info.vram = E.bytes;
+		info.id = E.texture;
 		info.type = "Texture";
-		if (E->get().depth == 0) {
-			info.format = itos(E->get().width) + "x" + itos(E->get().height) + " " + Image::get_format_name(E->get().format);
+		if (E.depth == 0) {
+			info.format = itos(E.width) + "x" + itos(E.height) + " " + Image::get_format_name(E.format);
 		} else {
-			info.format = itos(E->get().width) + "x" + itos(E->get().height) + "x" + itos(E->get().depth) + " " + Image::get_format_name(E->get().format);
+			info.format = itos(E.width) + "x" + itos(E.height) + "x" + itos(E.depth) + " " + Image::get_format_name(E.format);
 		}
 		usage.infos.push_back(info);
 	}

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -276,10 +276,10 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 			Dictionary d1;
 			d1["name"] = E->key();
 			Array values;
-			for (List<Pair<String, int>>::Element *F = E->get().front(); F; F = F->next()) {
+			for (Pair<String, int> &F : E->get()) {
 				Dictionary d2;
-				d2["name"] = F->get().first;
-				d2["value"] = F->get().second;
+				d2["name"] = F.first;
+				d2["value"] = F.second;
 				values.push_back(d2);
 			}
 			d1["values"] = values;
@@ -294,8 +294,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 		List<StringName> utility_func_names;
 		Variant::get_utility_function_list(&utility_func_names);
 
-		for (List<StringName>::Element *E = utility_func_names.front(); E; E = E->next()) {
-			StringName name = E->get();
+		for (StringName &name : utility_func_names) {
 			Dictionary func;
 			func["name"] = String(name);
 			if (Variant::has_utility_function_return_value(name)) {
@@ -363,8 +362,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 
 				List<StringName> member_names;
 				Variant::get_member_list(type, &member_names);
-				for (List<StringName>::Element *E = member_names.front(); E; E = E->next()) {
-					StringName member_name = E->get();
+				for (StringName &member_name : member_names) {
 					Dictionary d2;
 					d2["name"] = String(member_name);
 					d2["type"] = Variant::get_type_name(Variant::get_member_type(type, member_name));
@@ -380,8 +378,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 
 				List<StringName> constant_names;
 				Variant::get_constants_for_type(type, &constant_names);
-				for (List<StringName>::Element *E = constant_names.front(); E; E = E->next()) {
-					StringName constant_name = E->get();
+				for (StringName &constant_name : constant_names) {
 					Dictionary d2;
 					d2["name"] = String(constant_name);
 					Variant constant = Variant::get_constant_value(type, constant_name);
@@ -420,8 +417,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 
 				List<StringName> method_names;
 				Variant::get_builtin_method_list(type, &method_names);
-				for (List<StringName>::Element *E = method_names.front(); E; E = E->next()) {
-					StringName method_name = E->get();
+				for (StringName &method_name : method_names) {
 					Dictionary d2;
 					d2["name"] = String(method_name);
 					if (Variant::has_builtin_method_return_value(type, method_name)) {
@@ -503,9 +499,8 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 
 		class_list.sort_custom<StringName::AlphCompare>();
 
-		for (List<StringName>::Element *E = class_list.front(); E; E = E->next()) {
+		for (StringName &class_name : class_list) {
 			Dictionary d;
-			StringName class_name = E->get();
 			d["name"] = String(class_name);
 			d["is_refcounted"] = ClassDB::is_parent_class(class_name, "RefCounted");
 			d["is_instantiable"] = ClassDB::can_instantiate(class_name);
@@ -525,15 +520,15 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 				Array constants;
 				List<String> constant_list;
 				ClassDB::get_integer_constant_list(class_name, &constant_list, true);
-				for (List<String>::Element *F = constant_list.front(); F; F = F->next()) {
-					StringName enum_name = ClassDB::get_integer_constant_enum(class_name, F->get());
+				for (String &F : constant_list) {
+					StringName enum_name = ClassDB::get_integer_constant_enum(class_name, F);
 					if (enum_name != StringName()) {
 						continue; //enums will be handled on their own
 					}
 
 					Dictionary d2;
-					d2["name"] = String(F->get());
-					d2["value"] = ClassDB::get_integer_constant(class_name, F->get());
+					d2["name"] = String(F);
+					d2["value"] = ClassDB::get_integer_constant(class_name, F);
 
 					constants.push_back(d2);
 				}
@@ -547,13 +542,13 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 				Array enums;
 				List<StringName> enum_list;
 				ClassDB::get_enum_list(class_name, &enum_list, true);
-				for (List<StringName>::Element *F = enum_list.front(); F; F = F->next()) {
+				for (StringName &F : enum_list) {
 					Dictionary d2;
-					d2["name"] = String(F->get());
+					d2["name"] = String(F);
 
 					Array values;
 					List<StringName> enum_constant_list;
-					ClassDB::get_enum_constants(class_name, F->get(), &enum_constant_list, true);
+					ClassDB::get_enum_constants(class_name, F, &enum_constant_list, true);
 					for (List<StringName>::Element *G = enum_constant_list.front(); G; G = G->next()) {
 						Dictionary d3;
 						d3["name"] = String(G->get());
@@ -575,14 +570,14 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 				Array methods;
 				List<MethodInfo> method_list;
 				ClassDB::get_method_list(class_name, &method_list, true);
-				for (List<MethodInfo>::Element *F = method_list.front(); F; F = F->next()) {
-					StringName method_name = F->get().name;
-					if (F->get().flags & METHOD_FLAG_VIRTUAL) {
+				for (MethodInfo &F : method_list) {
+					StringName method_name = F.name;
+					if (F.flags & METHOD_FLAG_VIRTUAL) {
 						//virtual method
-						const MethodInfo &mi = F->get();
+						const MethodInfo &mi = F;
 						Dictionary d2;
 						d2["name"] = String(method_name);
-						d2["is_const"] = (F->get().flags & METHOD_FLAG_CONST) ? true : false;
+						d2["is_const"] = (F.flags & METHOD_FLAG_CONST) ? true : false;
 						d2["is_vararg"] = false;
 						d2["is_virtual"] = true;
 						// virtual functions have no hash since no MethodBind is involved
@@ -619,7 +614,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 
 						methods.push_back(d2);
 
-					} else if (F->get().name.begins_with("_")) {
+					} else if (F.name.begins_with("_")) {
 						//hidden method, ignore
 
 					} else {
@@ -692,19 +687,19 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 				Array signals;
 				List<MethodInfo> signal_list;
 				ClassDB::get_signal_list(class_name, &signal_list, true);
-				for (List<MethodInfo>::Element *F = signal_list.front(); F; F = F->next()) {
-					StringName signal_name = F->get().name;
+				for (MethodInfo &F : signal_list) {
+					StringName signal_name = F.name;
 					Dictionary d2;
 					d2["name"] = String(signal_name);
 
 					Array arguments;
 
-					for (int i = 0; i < F->get().arguments.size(); i++) {
+					for (int i = 0; i < F.arguments.size(); i++) {
 						Dictionary d3;
-						d3["name"] = F->get().arguments[i].name;
-						Variant::Type type = F->get().arguments[i].type;
-						if (F->get().arguments[i].class_name != StringName()) {
-							d3["type"] = String(F->get().arguments[i].class_name);
+						d3["name"] = F.arguments[i].name;
+						Variant::Type type = F.arguments[i].type;
+						if (F.arguments[i].class_name != StringName()) {
+							d3["type"] = String(F.arguments[i].class_name);
 						} else if (type == Variant::NIL) {
 							d3["type"] = "Variant";
 						} else {
@@ -728,28 +723,28 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 				Array properties;
 				List<PropertyInfo> property_list;
 				ClassDB::get_property_list(class_name, &property_list, true);
-				for (List<PropertyInfo>::Element *F = property_list.front(); F; F = F->next()) {
-					if (F->get().usage & PROPERTY_USAGE_CATEGORY || F->get().usage & PROPERTY_USAGE_GROUP || F->get().usage & PROPERTY_USAGE_SUBGROUP) {
+				for (PropertyInfo &F : property_list) {
+					if (F.usage & PROPERTY_USAGE_CATEGORY || F.usage & PROPERTY_USAGE_GROUP || F.usage & PROPERTY_USAGE_SUBGROUP) {
 						continue; //not real properties
 					}
-					if (F->get().name.begins_with("_")) {
+					if (F.name.begins_with("_")) {
 						continue; //hidden property
 					}
-					StringName property_name = F->get().name;
+					StringName property_name = F.name;
 					Dictionary d2;
 					d2["name"] = String(property_name);
 
-					if (F->get().class_name != StringName()) {
-						d2["type"] = String(F->get().class_name);
-					} else if (F->get().type == Variant::NIL && F->get().usage & PROPERTY_USAGE_NIL_IS_VARIANT) {
+					if (F.class_name != StringName()) {
+						d2["type"] = String(F.class_name);
+					} else if (F.type == Variant::NIL && F.usage & PROPERTY_USAGE_NIL_IS_VARIANT) {
 						d2["type"] = "Variant";
 					} else {
-						d2["type"] = Variant::get_type_name(F->get().type);
+						d2["type"] = Variant::get_type_name(F.type);
 					}
 
-					d2["setter"] = ClassDB::get_property_setter(class_name, F->get().name);
-					d2["getter"] = ClassDB::get_property_getter(class_name, F->get().name);
-					d2["index"] = ClassDB::get_property_index(class_name, F->get().name);
+					d2["setter"] = ClassDB::get_property_setter(class_name, F.name);
+					d2["getter"] = ClassDB::get_property_getter(class_name, F.name);
+					d2["index"] = ClassDB::get_property_index(class_name, F.name);
 					properties.push_back(d2);
 				}
 
@@ -771,8 +766,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 		List<Engine::Singleton> singleton_list;
 		Engine::get_singleton()->get_singletons(&singleton_list);
 
-		for (List<Engine::Singleton>::Element *E = singleton_list.front(); E; E = E->next()) {
-			const Engine::Singleton &s = E->get();
+		for (Engine::Singleton &s : singleton_list) {
 			Dictionary d;
 			d["name"] = s.name;
 			if (s.class_name != StringName()) {

--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -351,8 +351,8 @@ RES NativeExtensionResourceLoader::load(const String &p_path, const String &p_or
 
 	String library_path;
 
-	for (List<String>::Element *E = libraries.front(); E; E = E->next()) {
-		Vector<String> tags = E->get().split(".");
+	for (String &E : libraries) {
+		Vector<String> tags = E.split(".");
 		bool all_tags_met = true;
 		for (int i = 0; i < tags.size(); i++) {
 			String tag = tags[i].strip_edges();
@@ -363,7 +363,7 @@ RES NativeExtensionResourceLoader::load(const String &p_path, const String &p_or
 		}
 
 		if (all_tags_met) {
-			library_path = config->get_value("libraries", E->get());
+			library_path = config->get_value("libraries", E);
 			break;
 		}
 	}

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -174,9 +174,7 @@ void Input::get_argument_options(const StringName &p_function, int p_idx, List<S
 		List<PropertyInfo> pinfo;
 		ProjectSettings::get_singleton()->get_property_list(&pinfo);
 
-		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-			const PropertyInfo &pi = E->get();
-
+		for (PropertyInfo &pi : pinfo) {
 			if (!pi.name.begins_with("input/")) {
 				continue;
 			}

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -65,11 +65,11 @@ String InputMap::_suggest_actions(const StringName &p_action) const {
 	float closest_similarity = 0.0;
 
 	// Find the most action with the most similar name.
-	for (List<StringName>::Element *E = actions.front(); E; E = E->next()) {
-		const float similarity = String(E->get()).similarity(p_action);
+	for (StringName &action : actions) {
+		const float similarity = String(action).similarity(p_action);
 
 		if (similarity > closest_similarity) {
-			closest_action = E->get();
+			closest_action = action;
 			closest_similarity = similarity;
 		}
 	}
@@ -105,8 +105,8 @@ Array InputMap::_get_actions() {
 		return ret;
 	}
 
-	for (const List<StringName>::Element *E = actions.front(); E; E = E->next()) {
-		ret.push_back(E->get());
+	for (const StringName &E : actions) {
+		ret.push_back(E);
 	}
 
 	return ret;
@@ -129,13 +129,11 @@ List<Ref<InputEvent>>::Element *InputMap::_find_event(Action &p_action, const Re
 	ERR_FAIL_COND_V(!p_event.is_valid(), nullptr);
 
 	for (List<Ref<InputEvent>>::Element *E = p_action.inputs.front(); E; E = E->next()) {
-		const Ref<InputEvent> e = E->get();
-
-		int device = e->get_device();
+		int device = E->get()->get_device();
 		if (device == ALL_DEVICES || device == p_event->get_device()) {
-			if (p_exact_match && e->is_match(p_event, true)) {
+			if (p_exact_match && E->get()->is_match(p_event, true)) {
 				return E;
-			} else if (!p_exact_match && e->action_match(p_event, p_pressed, p_strength, p_raw_strength, p_action.deadzone)) {
+			} else if (!p_exact_match && E->get()->action_match(p_event, p_pressed, p_strength, p_raw_strength, p_action.deadzone)) {
 				return E;
 			}
 		}
@@ -198,7 +196,7 @@ Array InputMap::_action_get_events(const StringName &p_action) {
 	const List<Ref<InputEvent>> *al = action_get_events(p_action);
 	if (al) {
 		for (const List<Ref<InputEvent>>::Element *E = al->front(); E; E = E->next()) {
-			ret.push_back(E->get());
+			ret.push_back(E);
 		}
 	}
 
@@ -263,9 +261,7 @@ void InputMap::load_from_project_settings() {
 	List<PropertyInfo> pinfo;
 	ProjectSettings::get_singleton()->get_property_list(&pinfo);
 
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		const PropertyInfo &pi = E->get();
-
+	for (PropertyInfo &pi : pinfo) {
 		if (!pi.name.begins_with("input/")) {
 			continue;
 		}

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -40,8 +40,8 @@ PackedStringArray ConfigFile::_get_sections() const {
 	PackedStringArray arr;
 	arr.resize(s.size());
 	int idx = 0;
-	for (const List<String>::Element *E = s.front(); E; E = E->next()) {
-		arr.set(idx++, E->get());
+	for (const String &E : s) {
+		arr.set(idx++, E);
 	}
 
 	return arr;
@@ -53,8 +53,8 @@ PackedStringArray ConfigFile::_get_section_keys(const String &p_section) const {
 	PackedStringArray arr;
 	arr.resize(s.size());
 	int idx = 0;
-	for (const List<String>::Element *E = s.front(); E; E = E->next()) {
-		arr.set(idx++, E->get());
+	for (const String &E : s) {
+		arr.set(idx++, E);
 	}
 
 	return arr;

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -93,8 +93,8 @@ static Error _erase_recursive(DirAccess *da) {
 
 	da->list_dir_end();
 
-	for (List<String>::Element *E = dirs.front(); E; E = E->next()) {
-		Error err = da->change_dir(E->get());
+	for (String &E : dirs) {
+		Error err = da->change_dir(E);
 		if (err == OK) {
 			err = _erase_recursive(da);
 			if (err) {
@@ -105,7 +105,7 @@ static Error _erase_recursive(DirAccess *da) {
 			if (err) {
 				return err;
 			}
-			err = da->remove(da->get_current_dir().plus_file(E->get()));
+			err = da->remove(da->get_current_dir().plus_file(E));
 			if (err) {
 				return err;
 			}
@@ -114,8 +114,8 @@ static Error _erase_recursive(DirAccess *da) {
 		}
 	}
 
-	for (List<String>::Element *E = files.front(); E; E = E->next()) {
-		Error err = da->remove(da->get_current_dir().plus_file(E->get()));
+	for (String &E : files) {
+		Error err = da->remove(da->get_current_dir().plus_file(E));
 		if (err) {
 			return err;
 		}
@@ -362,16 +362,15 @@ Error DirAccess::_copy_dir(DirAccess *p_target_da, String p_to, int p_chmod_flag
 
 	list_dir_end();
 
-	for (List<String>::Element *E = dirs.front(); E; E = E->next()) {
-		String rel_path = E->get();
+	for (String &rel_path : dirs) {
 		String target_dir = p_to + rel_path;
 		if (!p_target_da->dir_exists(target_dir)) {
 			Error err = p_target_da->make_dir(target_dir);
 			ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot create directory '" + target_dir + "'.");
 		}
 
-		Error err = change_dir(E->get());
-		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot change current directory to '" + E->get() + "'.");
+		Error err = change_dir(rel_path);
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot change current directory to '" + rel_path + "'.");
 
 		err = _copy_dir(p_target_da, p_to + rel_path + "/", p_chmod_flags, p_copy_links);
 		if (err) {

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -93,8 +93,7 @@ Dictionary HTTPClient::_get_response_headers_as_dictionary() {
 	List<String> rh;
 	get_response_headers(&rh);
 	Dictionary ret;
-	for (const List<String>::Element *E = rh.front(); E; E = E->next()) {
-		const String &s = E->get();
+	for (const String &s : rh) {
 		int sp = s.find(":");
 		if (sp == -1) {
 			continue;
@@ -113,8 +112,8 @@ PackedStringArray HTTPClient::_get_response_headers() {
 	PackedStringArray ret;
 	ret.resize(rh.size());
 	int idx = 0;
-	for (const List<String>::Element *E = rh.front(); E; E = E->next()) {
-		ret.set(idx++, E->get());
+	for (const String &E : rh) {
+		ret.set(idx++, E);
 	}
 
 	return ret;

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -35,8 +35,8 @@
 bool ImageFormatLoader::recognize(const String &p_extension) const {
 	List<String> extensions;
 	get_recognized_extensions(&extensions);
-	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-		if (E->get().nocasecmp_to(p_extension) == 0) {
+	for (String &E : extensions) {
+		if (E.nocasecmp_to(p_extension) == 0) {
 			return true;
 		}
 	}

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -252,8 +252,8 @@ Array IP::_get_local_addresses() const {
 	Array addresses;
 	List<IPAddress> ip_addresses;
 	get_local_addresses(&ip_addresses);
-	for (List<IPAddress>::Element *E = ip_addresses.front(); E; E = E->next()) {
-		addresses.push_back(E->get());
+	for (IPAddress &E : ip_addresses) {
+		addresses.push_back(E);
 	}
 
 	return addresses;
@@ -271,8 +271,8 @@ Array IP::_get_local_interfaces() const {
 		rc["index"] = c.index;
 
 		Array ips;
-		for (const List<IPAddress>::Element *F = c.ip_addresses.front(); F; F = F->next()) {
-			ips.push_front(F->get());
+		for (const IPAddress &F : c.ip_addresses) {
+			ips.push_front(F);
 		}
 		rc["addresses"] = ips;
 
@@ -286,8 +286,8 @@ void IP::get_local_addresses(List<IPAddress> *r_addresses) const {
 	Map<String, Interface_Info> interfaces;
 	get_local_interfaces(&interfaces);
 	for (Map<String, Interface_Info>::Element *E = interfaces.front(); E; E = E->next()) {
-		for (const List<IPAddress>::Element *F = E->get().ip_addresses.front(); F; F = F->next()) {
-			r_addresses->push_front(F->get());
+		for (const IPAddress &F : E->get().ip_addresses) {
+			r_addresses->push_front(F);
 		}
 	}
 }

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -121,14 +121,14 @@ String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_
 				keys.sort();
 			}
 
-			for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
+			for (Variant &E : keys) {
 				if (E != keys.front()) {
 					s += ",";
 					s += end_statement;
 				}
-				s += _make_indent(p_indent, p_cur_indent + 1) + _stringify(String(E->get()), p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
+				s += _make_indent(p_indent, p_cur_indent + 1) + _stringify(String(E), p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
 				s += colon;
-				s += _stringify(d[E->get()], p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
+				s += _stringify(d[E], p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
 			}
 
 			s += end_statement + _make_indent(p_indent, p_cur_indent) + "}";

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1358,8 +1358,8 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 					obj->get_property_list(&props);
 
 					int pc = 0;
-					for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-						if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+					for (PropertyInfo &E : props) {
+						if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 							continue;
 						}
 						pc++;
@@ -1372,15 +1372,15 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 
 					r_len += 4;
 
-					for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-						if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+					for (PropertyInfo &E : props) {
+						if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 							continue;
 						}
 
-						_encode_string(E->get().name, buf, r_len);
+						_encode_string(E.name, buf, r_len);
 
 						int len;
-						Error err = encode_variant(obj->get(E->get().name), buf, len, p_full_objects);
+						Error err = encode_variant(obj->get(E.name), buf, len, p_full_objects);
 						if (err) {
 							return err;
 						}
@@ -1418,7 +1418,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			List<Variant> keys;
 			d.get_key_list(&keys);
 
-			for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
+			for (Variant &E : keys) {
 				/*
 				CharString utf8 = E->->utf8();
 
@@ -1433,13 +1433,13 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 					r_len++; //pad
 				*/
 				int len;
-				encode_variant(E->get(), buf, len, p_full_objects);
+				encode_variant(E, buf, len, p_full_objects);
 				ERR_FAIL_COND_V(len % 4, ERR_BUG);
 				r_len += len;
 				if (buf) {
 					buf += len;
 				}
-				Variant *v = d.getptr(E->get());
+				Variant *v = d.getptr(E);
 				ERR_FAIL_COND_V(!v, ERR_BUG);
 				encode_variant(*v, buf, len, p_full_objects);
 				ERR_FAIL_COND_V(len % 4, ERR_BUG);

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -555,12 +555,12 @@ bool MultiplayerAPI::_send_confirm_path(Node *p_node, NodePath p_path, PathSentC
 
 		ofs += encode_cstring(path.get_data(), &packet.write[ofs]);
 
-		for (List<int>::Element *E = peers_to_add.front(); E; E = E->next()) {
-			network_peer->set_target_peer(E->get()); // To all of you.
+		for (int &E : peers_to_add) {
+			network_peer->set_target_peer(E); // To all of you.
 			network_peer->set_transfer_mode(MultiplayerPeer::TRANSFER_MODE_RELIABLE);
 			network_peer->put_packet(packet.ptr(), packet.size());
 
-			psc->confirmed_peers.insert(E->get(), false); // Insert into confirmed, but as false since it was not confirmed.
+			psc->confirmed_peers.insert(E, false); // Insert into confirmed, but as false since it was not confirmed.
 		}
 	}
 
@@ -917,8 +917,8 @@ void MultiplayerAPI::_del_peer(int p_id) {
 	// Some refactoring is needed to make this faster and do paths GC.
 	List<NodePath> keys;
 	path_send_cache.get_key_list(&keys);
-	for (List<NodePath>::Element *E = keys.front(); E; E = E->next()) {
-		PathSentCache *psc = path_send_cache.getptr(E->get());
+	for (NodePath &E : keys) {
+		PathSentCache *psc = path_send_cache.getptr(E);
 		psc->confirmed_peers.erase(p_id);
 	}
 	emit_signal(SNAME("network_peer_disconnected"), p_id);

--- a/core/io/packed_data_container.cpp
+++ b/core/io/packed_data_container.cpp
@@ -268,21 +268,21 @@ uint32_t PackedDataContainer::_pack(const Variant &p_data, Vector<uint8_t> &tmpd
 			d.get_key_list(&keys);
 			List<DictKey> sortk;
 
-			for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
+			for (Variant &key : keys) {
 				DictKey dk;
-				dk.hash = E->get().hash();
-				dk.key = E->get();
+				dk.hash = key.hash();
+				dk.key = key;
 				sortk.push_back(dk);
 			}
 
 			sortk.sort();
 
 			int idx = 0;
-			for (List<DictKey>::Element *E = sortk.front(); E; E = E->next()) {
-				encode_uint32(E->get().hash, &tmpdata.write[pos + 8 + idx * 12 + 0]);
-				uint32_t ofs = _pack(E->get().key, tmpdata, string_cache);
+			for (DictKey &E : sortk) {
+				encode_uint32(E.hash, &tmpdata.write[pos + 8 + idx * 12 + 0]);
+				uint32_t ofs = _pack(E.key, tmpdata, string_cache);
 				encode_uint32(ofs, &tmpdata.write[pos + 8 + idx * 12 + 4]);
-				ofs = _pack(d[E->get().key], tmpdata, string_cache);
+				ofs = _pack(d[E.key], tmpdata, string_cache);
 				encode_uint32(ofs, &tmpdata.write[pos + 8 + idx * 12 + 8]);
 				idx++;
 			}

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -165,15 +165,15 @@ Error Resource::copy_from(const Ref<Resource> &p_resource) {
 	List<PropertyInfo> pi;
 	p_resource->get_property_list(&pi);
 
-	for (List<PropertyInfo>::Element *E = pi.front(); E; E = E->next()) {
-		if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+	for (PropertyInfo &E : pi) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 			continue;
 		}
-		if (E->get().name == "resource_path") {
+		if (E.name == "resource_path") {
 			continue; //do not change path
 		}
 
-		set(E->get().name, p_resource->get(E->get().name));
+		set(E.name, p_resource->get(E.name));
 	}
 	return OK;
 }
@@ -201,11 +201,11 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Res
 
 	r->local_scene = p_for_scene;
 
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+	for (PropertyInfo &E : plist) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 			continue;
 		}
-		Variant p = get(E->get().name);
+		Variant p = get(E.name);
 		if (p.get_type() == Variant::OBJECT) {
 			RES sr = p;
 			if (sr.is_valid()) {
@@ -221,7 +221,7 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Res
 			}
 		}
 
-		r->set(E->get().name, p);
+		r->set(E.name, p);
 	}
 
 	return r;
@@ -233,11 +233,11 @@ void Resource::configure_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, R
 
 	local_scene = p_for_scene;
 
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+	for (PropertyInfo &E : plist) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 			continue;
 		}
-		Variant p = get(E->get().name);
+		Variant p = get(E.name);
 		if (p.get_type() == Variant::OBJECT) {
 			RES sr = p;
 			if (sr.is_valid()) {
@@ -259,21 +259,21 @@ Ref<Resource> Resource::duplicate(bool p_subresources) const {
 	Ref<Resource> r = (Resource *)ClassDB::instantiate(get_class());
 	ERR_FAIL_COND_V(r.is_null(), Ref<Resource>());
 
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+	for (PropertyInfo &E : plist) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 			continue;
 		}
-		Variant p = get(E->get().name);
+		Variant p = get(E.name);
 
 		if ((p.get_type() == Variant::DICTIONARY || p.get_type() == Variant::ARRAY)) {
-			r->set(E->get().name, p.duplicate(p_subresources));
-		} else if (p.get_type() == Variant::OBJECT && (p_subresources || (E->get().usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE))) {
+			r->set(E.name, p.duplicate(p_subresources));
+		} else if (p.get_type() == Variant::OBJECT && (p_subresources || (E.usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE))) {
 			RES sr = p;
 			if (sr.is_valid()) {
-				r->set(E->get().name, sr->duplicate(p_subresources));
+				r->set(E.name, sr->duplicate(p_subresources));
 			}
 		} else {
-			r->set(E->get().name, p);
+			r->set(E.name, p);
 		}
 	}
 
@@ -317,9 +317,9 @@ uint32_t Resource::hash_edited_version() const {
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		if (E->get().usage & PROPERTY_USAGE_STORAGE && E->get().type == Variant::OBJECT && E->get().hint == PROPERTY_HINT_RESOURCE_TYPE) {
-			RES res = get(E->get().name);
+	for (PropertyInfo &E : plist) {
+		if (E.usage & PROPERTY_USAGE_STORAGE && E.type == Variant::OBJECT && E.hint == PROPERTY_HINT_RESOURCE_TYPE) {
+			RES res = get(E.name);
 			if (res.is_valid()) {
 				hash = hash_djb2_one_32(res->hash_edited_version(), hash);
 			}

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1025,8 +1025,8 @@ void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String
 
 	extensions.sort();
 
-	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-		String ext = E->get().to_lower();
+	for (String &E : extensions) {
+		String ext = E.to_lower();
 		p_extensions->push_back(ext);
 	}
 }
@@ -1036,8 +1036,8 @@ void ResourceFormatLoaderBinary::get_recognized_extensions(List<String> *p_exten
 	ClassDB::get_resource_base_extensions(&extensions);
 	extensions.sort();
 
-	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-		String ext = E->get().to_lower();
+	for (String &E : extensions) {
+		String ext = E.to_lower();
 		p_extensions->push_back(ext);
 	}
 }
@@ -1528,14 +1528,14 @@ void ResourceFormatSaverBinaryInstance::write_variant(FileAccess *f, const Varia
 			List<Variant> keys;
 			d.get_key_list(&keys);
 
-			for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
+			for (Variant &E : keys) {
 				/*
-				if (!_check_type(dict[E->get()]))
+				if (!_check_type(dict[E]))
 					continue;
 				*/
 
-				write_variant(f, E->get(), resource_map, external_resources, string_map);
-				write_variant(f, d[E->get()], resource_map, external_resources, string_map);
+				write_variant(f, E, resource_map, external_resources, string_map);
+				write_variant(f, d[E], resource_map, external_resources, string_map);
 			}
 
 		} break;
@@ -1685,15 +1685,15 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 
 			res->get_property_list(&property_list);
 
-			for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
-				if (E->get().usage & PROPERTY_USAGE_STORAGE) {
-					Variant value = res->get(E->get().name);
-					if (E->get().usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
+			for (PropertyInfo &E : property_list) {
+				if (E.usage & PROPERTY_USAGE_STORAGE) {
+					Variant value = res->get(E.name);
+					if (E.usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
 						RES sres = value;
 						if (sres.is_valid()) {
 							NonPersistentKey npk;
 							npk.base = res;
-							npk.property = E->get().name;
+							npk.property = E.name;
 							non_persistent_map[npk] = sres;
 							resource_set.insert(sres);
 							saved_resources.push_back(sres);
@@ -1723,9 +1723,9 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 			Dictionary d = p_variant;
 			List<Variant> keys;
 			d.get_key_list(&keys);
-			for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-				_find_resources(E->get());
-				Variant v = d[E->get()];
+			for (Variant &E : keys) {
+				_find_resources(E);
+				Variant v = d[E];
 				_find_resources(v);
 			}
 		} break;
@@ -1832,39 +1832,39 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	List<ResourceData> resources;
 
 	{
-		for (List<RES>::Element *E = saved_resources.front(); E; E = E->next()) {
+		for (RES &E : saved_resources) {
 			ResourceData &rd = resources.push_back(ResourceData())->get();
-			rd.type = E->get()->get_class();
+			rd.type = E->get_class();
 
 			List<PropertyInfo> property_list;
-			E->get()->get_property_list(&property_list);
+			E->get_property_list(&property_list);
 
-			for (List<PropertyInfo>::Element *F = property_list.front(); F; F = F->next()) {
-				if (skip_editor && F->get().name.begins_with("__editor")) {
+			for (PropertyInfo &F : property_list) {
+				if (skip_editor && F.name.begins_with("__editor")) {
 					continue;
 				}
-				if ((F->get().usage & PROPERTY_USAGE_STORAGE)) {
+				if ((F.usage & PROPERTY_USAGE_STORAGE)) {
 					Property p;
-					p.name_idx = get_string_index(F->get().name);
+					p.name_idx = get_string_index(F.name);
 
-					if (F->get().usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
+					if (F.usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
 						NonPersistentKey npk;
-						npk.base = E->get();
-						npk.property = F->get().name;
+						npk.base = E;
+						npk.property = F.name;
 						if (non_persistent_map.has(npk)) {
 							p.value = non_persistent_map[npk];
 						}
 					} else {
-						p.value = E->get()->get(F->get().name);
+						p.value = E->get(F.name);
 					}
 
-					Variant default_value = ClassDB::class_get_default_property_value(E->get()->get_class(), F->get().name);
+					Variant default_value = ClassDB::class_get_default_property_value(E->get_class(), F.name);
 
 					if (default_value.get_type() != Variant::NIL && bool(Variant::evaluate(Variant::OP_EQUAL, p.value, default_value))) {
 						continue;
 					}
 
-					p.pi = F->get();
+					p.pi = F;
 
 					rd.properties.push_back(p);
 				}
@@ -1897,8 +1897,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	Vector<uint64_t> ofs_pos;
 	Set<String> used_unique_ids;
 
-	for (List<RES>::Element *E = saved_resources.front(); E; E = E->next()) {
-		RES r = E->get();
+	for (RES &r : saved_resources) {
 		if (r->get_path() == "" || r->get_path().find("::") != -1) {
 			if (r->get_scene_unique_id() != "") {
 				if (used_unique_ids.has(r->get_scene_unique_id())) {
@@ -1912,8 +1911,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 
 	Map<RES, int> resource_map;
 	int res_index = 0;
-	for (List<RES>::Element *E = saved_resources.front(); E; E = E->next()) {
-		RES r = E->get();
+	for (RES &r : saved_resources) {
 		if (r->get_path() == "" || r->get_path().find("::") != -1) {
 			if (r->get_scene_unique_id() == "") {
 				String new_id;
@@ -1947,17 +1945,15 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	Vector<uint64_t> ofs_table;
 
 	//now actually save the resources
-	for (List<ResourceData>::Element *E = resources.front(); E; E = E->next()) {
-		ResourceData &rd = E->get();
-
+	for (ResourceData &rd : resources) {
 		ofs_table.push_back(f->get_position());
 		save_unicode_string(f, rd.type);
 		f->store_32(rd.properties.size());
 
-		for (List<Property>::Element *F = rd.properties.front(); F; F = F->next()) {
-			Property &p = F->get();
+		for (Property &F : rd.properties) {
+			Property &p = F;
 			f->store_32(p.name_idx);
-			write_variant(f, p.value, resource_map, external_resources, string_map, F->get().pi);
+			write_variant(f, p.value, resource_map, external_resources, string_map, F.pi);
 		}
 	}
 

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -146,10 +146,10 @@ void ResourceFormatImporter::get_recognized_extensions(List<String> *p_extension
 	for (int i = 0; i < importers.size(); i++) {
 		List<String> local_exts;
 		importers[i]->get_recognized_extensions(&local_exts);
-		for (List<String>::Element *F = local_exts.front(); F; F = F->next()) {
-			if (!found.has(F->get())) {
-				p_extensions->push_back(F->get());
-				found.insert(F->get());
+		for (String &F : local_exts) {
+			if (!found.has(F)) {
+				p_extensions->push_back(F);
+				found.insert(F);
 			}
 		}
 	}
@@ -175,10 +175,10 @@ void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_
 
 		List<String> local_exts;
 		importers[i]->get_recognized_extensions(&local_exts);
-		for (List<String>::Element *F = local_exts.front(); F; F = F->next()) {
-			if (!found.has(F->get())) {
-				p_extensions->push_back(F->get());
-				found.insert(F->get());
+		for (String &F : local_exts) {
+			if (!found.has(F)) {
+				p_extensions->push_back(F);
+				found.insert(F);
 			}
 		}
 	}
@@ -372,8 +372,8 @@ void ResourceFormatImporter::get_importers_for_extension(const String &p_extensi
 	for (int i = 0; i < importers.size(); i++) {
 		List<String> local_exts;
 		importers[i]->get_recognized_extensions(&local_exts);
-		for (List<String>::Element *F = local_exts.front(); F; F = F->next()) {
-			if (p_extension.to_lower() == F->get()) {
+		for (String &F : local_exts) {
+			if (p_extension.to_lower() == F) {
 				r_importers->push_back(importers[i]);
 			}
 		}
@@ -393,8 +393,8 @@ Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_extension(const St
 	for (int i = 0; i < importers.size(); i++) {
 		List<String> local_exts;
 		importers[i]->get_recognized_extensions(&local_exts);
-		for (List<String>::Element *F = local_exts.front(); F; F = F->next()) {
-			if (p_extension.to_lower() == F->get() && importers[i]->get_priority() > priority) {
+		for (String &F : local_exts) {
+			if (p_extension.to_lower() == F && importers[i]->get_priority() > priority) {
 				importer = importers[i];
 				priority = importers[i]->get_priority();
 			}

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -58,8 +58,8 @@ bool ResourceFormatLoader::recognize_path(const String &p_path, const String &p_
 		get_recognized_extensions_for_type(p_for_type, &extensions);
 	}
 
-	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-		if (E->get().nocasecmp_to(extension) == 0) {
+	for (String &E : extensions) {
+		if (E.nocasecmp_to(extension) == 0) {
 			return true;
 		}
 	}
@@ -978,15 +978,15 @@ void ResourceLoader::load_translation_remaps() {
 	Dictionary remaps = ProjectSettings::get_singleton()->get("internationalization/locale/translation_remaps");
 	List<Variant> keys;
 	remaps.get_key_list(&keys);
-	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-		Array langs = remaps[E->get()];
+	for (Variant &E : keys) {
+		Array langs = remaps[E];
 		Vector<String> lang_remaps;
 		lang_remaps.resize(langs.size());
 		for (int i = 0; i < langs.size(); i++) {
 			lang_remaps.write[i] = langs[i];
 		}
 
-		translation_remaps[String(E->get())] = lang_remaps;
+		translation_remaps[String(E)] = lang_remaps;
 	}
 }
 
@@ -1071,8 +1071,7 @@ void ResourceLoader::add_custom_loaders() {
 	List<StringName> global_classes;
 	ScriptServer::get_global_class_list(&global_classes);
 
-	for (List<StringName>::Element *E = global_classes.front(); E; E = E->next()) {
-		StringName class_name = E->get();
+	for (StringName &class_name : global_classes) {
 		StringName base_class = ScriptServer::get_global_class_native_base(class_name);
 
 		if (base_class == custom_loader_base_class) {

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -94,8 +94,8 @@ Error ResourceSaver::save(const String &p_path, const RES &p_resource, uint32_t 
 		bool recognized = false;
 		saver[i]->get_recognized_extensions(p_resource, &extensions);
 
-		for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-			if (E->get().nocasecmp_to(extension) == 0) {
+		for (String &E : extensions) {
+			if (E.nocasecmp_to(extension) == 0) {
 				recognized = true;
 			}
 		}
@@ -236,8 +236,7 @@ void ResourceSaver::add_custom_savers() {
 	List<StringName> global_classes;
 	ScriptServer::get_global_class_list(&global_classes);
 
-	for (List<StringName>::Element *E = global_classes.front(); E; E = E->next()) {
-		StringName class_name = E->get();
+	for (StringName &class_name : global_classes) {
 		StringName base_class = ScriptServer::get_global_class_native_base(class_name);
 
 		if (base_class == custom_saver_base_class) {

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -375,8 +375,7 @@ public:
 		OutputSimplex *ret_simplicesw = ret_simplices.ptrw();
 		uint32_t simplices_written = 0;
 
-		for (List<Simplex *>::Element *E = simplex_list.front(); E; E = E->next()) {
-			Simplex *simplex = E->get();
+		for (Simplex *simplex : simplex_list) {
 			bool invalid = false;
 			for (int j = 0; j < 4; j++) {
 				if (simplex->points[j] >= point_count) {

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -192,9 +192,9 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 			continue;
 		}
 
-		for (List<Face>::Element *E = faces.front(); E; E = E->next()) {
-			if (E->get().plane.distance_to(p_points[i]) > over_tolerance) {
-				E->get().points_over.push_back(i);
+		for (Face &E : faces) {
+			if (E.plane.distance_to(p_points[i]) > over_tolerance) {
+				E.points_over.push_back(i);
 				break;
 			}
 		}
@@ -292,8 +292,8 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 		//distribute points into new faces
 
-		for (List<List<Face>::Element *>::Element *F = lit_faces.front(); F; F = F->next()) {
-			Face &lf = F->get()->get();
+		for (List<Face>::Element *&F : lit_faces) {
+			Face &lf = F->get();
 
 			for (int i = 0; i < lf.points_over.size(); i++) {
 				if (lf.points_over[i] == f.points_over[next]) { //do not add current one
@@ -301,8 +301,8 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 				}
 
 				Vector3 p = p_points[lf.points_over[i]];
-				for (List<List<Face>::Element *>::Element *E = new_faces.front(); E; E = E->next()) {
-					Face &f2 = E->get()->get();
+				for (List<Face>::Element *&E : new_faces) {
+					Face &f2 = E->get();
 					if (f2.plane.distance_to(p) > over_tolerance) {
 						f2.points_over.push_back(lf.points_over[i]);
 						break;
@@ -320,10 +320,10 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 		//put faces that contain no points on the front
 
-		for (List<List<Face>::Element *>::Element *E = new_faces.front(); E; E = E->next()) {
-			Face &f2 = E->get()->get();
+		for (List<Face>::Element *&E : new_faces) {
+			Face &f2 = E->get();
 			if (f2.points_over.size() == 0) {
-				faces.move_to_front(E->get());
+				faces.move_to_front(E);
 			}
 		}
 
@@ -336,19 +336,19 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 	Map<Edge, RetFaceConnect> ret_edges;
 	List<Geometry3D::MeshData::Face> ret_faces;
 
-	for (List<Face>::Element *E = faces.front(); E; E = E->next()) {
+	for (Face &E : faces) {
 		Geometry3D::MeshData::Face f;
-		f.plane = E->get().plane;
+		f.plane = E.plane;
 
 		for (int i = 0; i < 3; i++) {
-			f.indices.push_back(E->get().vertices[i]);
+			f.indices.push_back(E.vertices[i]);
 		}
 
 		List<Geometry3D::MeshData::Face>::Element *F = ret_faces.push_back(f);
 
 		for (int i = 0; i < 3; i++) {
-			uint32_t a = E->get().vertices[i];
-			uint32_t b = E->get().vertices[(i + 1) % 3];
+			uint32_t a = E.vertices[i];
+			uint32_t b = E.vertices[(i + 1) % 3];
 			Edge e(a, b);
 
 			Map<Edge, RetFaceConnect>::Element *G = ret_edges.find(e);
@@ -439,8 +439,8 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 	r_mesh.faces.resize(ret_faces.size());
 
 	int idx = 0;
-	for (List<Geometry3D::MeshData::Face>::Element *E = ret_faces.front(); E; E = E->next()) {
-		r_mesh.faces.write[idx++] = E->get();
+	for (Geometry3D::MeshData::Face &E : ret_faces) {
+		r_mesh.faces.write[idx++] = E;
 	}
 	r_mesh.edges.resize(ret_edges.size());
 	idx = 0;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -969,8 +969,8 @@ Vector<StringName> Object::_get_meta_list_bind() const {
 
 	List<Variant> keys;
 	metadata.get_key_list(&keys);
-	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-		_metaret.push_back(E->get());
+	for (Variant &E : keys) {
+		_metaret.push_back(E);
 	}
 
 	return _metaret;
@@ -979,8 +979,8 @@ Vector<StringName> Object::_get_meta_list_bind() const {
 void Object::get_meta_list(List<StringName> *p_list) const {
 	List<Variant> keys;
 	metadata.get_key_list(&keys);
-	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-		p_list->push_back(E->get());
+	for (Variant &E : keys) {
+		p_list->push_back(E);
 	}
 }
 
@@ -1184,8 +1184,8 @@ Array Object::_get_signal_list() const {
 	get_signal_list(&signal_list);
 
 	Array ret;
-	for (List<MethodInfo>::Element *E = signal_list.front(); E; E = E->next()) {
-		ret.push_back(Dictionary(E->get()));
+	for (MethodInfo &E : signal_list) {
+		ret.push_back(Dictionary(E));
 	}
 
 	return ret;
@@ -1197,8 +1197,7 @@ Array Object::_get_signal_connection_list(const String &p_signal) const {
 
 	Array ret;
 
-	for (List<Connection>::Element *E = conns.front(); E; E = E->next()) {
-		Connection &c = E->get();
+	for (Connection &c : conns) {
 		if (c.signal.get_name() == p_signal) {
 			ret.push_back(c);
 		}
@@ -1297,8 +1296,8 @@ int Object::get_persistent_signal_connection_count() const {
 }
 
 void Object::get_signals_connected_to_this(List<Connection> *p_connections) const {
-	for (const List<Connection>::Element *E = connections.front(); E; E = E->next()) {
-		p_connections->push_back(E->get());
+	for (const Connection &E : connections) {
+		p_connections->push_back(E);
 	}
 }
 
@@ -1500,9 +1499,9 @@ void Object::_clear_internal_resource_paths(const Variant &p_var) {
 			List<Variant> keys;
 			d.get_key_list(&keys);
 
-			for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-				_clear_internal_resource_paths(E->get());
-				_clear_internal_resource_paths(d[E->get()]);
+			for (Variant &E : keys) {
+				_clear_internal_resource_paths(E);
+				_clear_internal_resource_paths(d[E]);
 			}
 		} break;
 		default: {
@@ -1531,8 +1530,8 @@ void Object::clear_internal_resource_paths() {
 
 	get_property_list(&pinfo);
 
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		_clear_internal_resource_paths(get(E->get().name));
+	for (PropertyInfo &E : pinfo) {
+		_clear_internal_resource_paths(get(E.name));
 	}
 }
 
@@ -1666,12 +1665,12 @@ void Object::get_translatable_strings(List<String> *p_strings) const {
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		if (!(E->get().usage & PROPERTY_USAGE_INTERNATIONALIZED)) {
+	for (PropertyInfo &E : plist) {
+		if (!(E.usage & PROPERTY_USAGE_INTERNATIONALIZED)) {
 			continue;
 		}
 
-		String text = get(E->get().name);
+		String text = get(E.name);
 
 		if (text == "") {
 			continue;

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -63,8 +63,8 @@ Array Script::_get_script_property_list() {
 	Array ret;
 	List<PropertyInfo> list;
 	get_script_property_list(&list);
-	for (List<PropertyInfo>::Element *E = list.front(); E; E = E->next()) {
-		ret.append(E->get().operator Dictionary());
+	for (PropertyInfo &E : list) {
+		ret.append(E.operator Dictionary());
 	}
 	return ret;
 }
@@ -73,8 +73,8 @@ Array Script::_get_script_method_list() {
 	Array ret;
 	List<MethodInfo> list;
 	get_script_method_list(&list);
-	for (List<MethodInfo>::Element *E = list.front(); E; E = E->next()) {
-		ret.append(E->get().operator Dictionary());
+	for (MethodInfo &E : list) {
+		ret.append(E.operator Dictionary());
 	}
 	return ret;
 }
@@ -83,8 +83,8 @@ Array Script::_get_script_signal_list() {
 	Array ret;
 	List<MethodInfo> list;
 	get_script_signal_list(&list);
-	for (List<MethodInfo>::Element *E = list.front(); E; E = E->next()) {
-		ret.append(E->get().operator Dictionary());
+	for (MethodInfo &E : list) {
+		ret.append(E.operator Dictionary());
 	}
 	return ret;
 }
@@ -257,8 +257,8 @@ void ScriptServer::get_global_class_list(List<StringName> *r_global_classes) {
 		classes.push_back(*K);
 	}
 	classes.sort_custom<StringName::AlphCompare>();
-	for (List<StringName>::Element *E = classes.front(); E; E = E->next()) {
-		r_global_classes->push_back(E->get());
+	for (StringName &E : classes) {
+		r_global_classes->push_back(E);
 	}
 }
 
@@ -266,12 +266,12 @@ void ScriptServer::save_global_classes() {
 	List<StringName> gc;
 	get_global_class_list(&gc);
 	Array gcarr;
-	for (List<StringName>::Element *E = gc.front(); E; E = E->next()) {
+	for (StringName &E : gc) {
 		Dictionary d;
-		d["class"] = E->get();
-		d["language"] = global_classes[E->get()].language;
-		d["path"] = global_classes[E->get()].path;
-		d["base"] = global_classes[E->get()].base;
+		d["class"] = E;
+		d["language"] = global_classes[E].language;
+		d["path"] = global_classes[E].path;
+		d["base"] = global_classes[E].base;
 		gcarr.push_back(d);
 	}
 
@@ -297,10 +297,10 @@ void ScriptServer::save_global_classes() {
 void ScriptInstance::get_property_state(List<Pair<StringName, Variant>> &state) {
 	List<PropertyInfo> pinfo;
 	get_property_list(&pinfo);
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		if (E->get().usage & PROPERTY_USAGE_STORAGE) {
+	for (PropertyInfo &E : pinfo) {
+		if (E.usage & PROPERTY_USAGE_STORAGE) {
 			Pair<StringName, Variant> p;
-			p.first = E->get().name;
+			p.first = E.name;
 			if (get(p.first, p.second)) {
 				state.push_back(p);
 			}
@@ -430,16 +430,16 @@ bool PlaceHolderScriptInstance::get(const StringName &p_name, Variant &r_ret) co
 
 void PlaceHolderScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 	if (script->is_placeholder_fallback_enabled()) {
-		for (const List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-			p_properties->push_back(E->get());
+		for (const PropertyInfo &E : properties) {
+			p_properties->push_back(E);
 		}
 	} else {
-		for (const List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-			PropertyInfo pinfo = E->get();
+		for (const PropertyInfo &E : properties) {
+			PropertyInfo pinfo = E;
 			if (!values.has(pinfo.name)) {
 				pinfo.usage |= PROPERTY_USAGE_SCRIPT_DEFAULT_VALUE;
 			}
-			p_properties->push_back(E->get());
+			p_properties->push_back(E);
 		}
 	}
 }
@@ -489,11 +489,11 @@ bool PlaceHolderScriptInstance::has_method(const StringName &p_method) const {
 
 void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, const Map<StringName, Variant> &p_values) {
 	Set<StringName> new_values;
-	for (const List<PropertyInfo>::Element *E = p_properties.front(); E; E = E->next()) {
-		StringName n = E->get().name;
+	for (const PropertyInfo &E : p_properties) {
+		StringName n = E.name;
 		new_values.insert(n);
 
-		if (!values.has(n) || values[n].get_type() != E->get().type) {
+		if (!values.has(n) || values[n].get_type() != E.type) {
 			if (p_values.has(n)) {
 				values[n] = p_values[n];
 			}
@@ -511,7 +511,7 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 		Variant defval;
 		if (script->get_property_default_value(E->key(), defval)) {
 			//remove because it's the same as the default value
-			if (defval == E->get()) {
+			if (defval == E) {
 				to_remove.push_back(E->key());
 			}
 		}
@@ -542,8 +542,8 @@ void PlaceHolderScriptInstance::property_set_fallback(const StringName &p_name, 
 		}
 
 		bool found = false;
-		for (const List<PropertyInfo>::Element *F = properties.front(); F; F = F->next()) {
-			if (F->get().name == p_name) {
+		for (const PropertyInfo &F : properties) {
+			if (F.name == p_name) {
 				found = true;
 				break;
 			}

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -39,12 +39,12 @@ void UndoRedo::_discard_redo() {
 	}
 
 	for (int i = current_action + 1; i < actions.size(); i++) {
-		for (List<Operation>::Element *E = actions.write[i].do_ops.front(); E; E = E->next()) {
-			if (E->get().type == Operation::TYPE_REFERENCE) {
-				if (E->get().ref.is_valid()) {
-					E->get().ref.unref();
+		for (Operation &E : actions.write[i].do_ops) {
+			if (E.type == Operation::TYPE_REFERENCE) {
+				if (E.ref.is_valid()) {
+					E.ref.unref();
 				} else {
-					Object *obj = ObjectDB::get_instance(E->get().object);
+					Object *obj = ObjectDB::get_instance(E.object);
 					if (obj) {
 						memdelete(obj);
 					}
@@ -244,12 +244,12 @@ void UndoRedo::_pop_history_tail() {
 		return;
 	}
 
-	for (List<Operation>::Element *E = actions.write[0].undo_ops.front(); E; E = E->next()) {
-		if (E->get().type == Operation::TYPE_REFERENCE) {
-			if (E->get().ref.is_valid()) {
-				E->get().ref.unref();
+	for (Operation &E : actions.write[0].undo_ops) {
+		if (E.type == Operation::TYPE_REFERENCE) {
+			if (E.ref.is_valid()) {
+				E.ref.unref();
 			} else {
-				Object *obj = ObjectDB::get_instance(E->get().object);
+				Object *obj = ObjectDB::get_instance(E.object);
 				if (obj) {
 					memdelete(obj);
 				}

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -66,9 +66,9 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 	int total_compression_size = 0;
 	int total_string_size = 0;
 
-	for (List<StringName>::Element *E = keys.front(); E; E = E->next()) {
+	for (StringName &E : keys) {
 		//hash string
-		CharString cs = E->get().operator String().utf8();
+		CharString cs = E.operator String().utf8();
 		uint32_t h = hash(0, cs.get_data());
 		Pair<int, CharString> p;
 		p.first = idx;
@@ -76,7 +76,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		buckets.write[h % size].push_back(p);
 
 		//compress string
-		CharString src_s = p_from->get_message(E->get()).operator String().utf8();
+		CharString src_s = p_from->get_message(E).operator String().utf8();
 		CompressedString ps;
 		ps.orig_len = src_s.size();
 		ps.offset = total_compression_size;

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -841,8 +841,8 @@ Vector<String> Translation::_get_message_list() const {
 void Translation::_set_messages(const Dictionary &p_messages) {
 	List<Variant> keys;
 	p_messages.get_key_list(&keys);
-	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-		translation_map[E->get()] = p_messages[E->get()];
+	for (Variant &E : keys) {
+		translation_map[E] = p_messages[E];
 	}
 }
 

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -47,8 +47,7 @@ void TranslationPO::print_translation_map() {
 
 	List<StringName> context_l;
 	translation_map.get_key_list(&context_l);
-	for (List<StringName>::Element *E = context_l.front(); E; E = E->next()) {
-		StringName ctx = E->get();
+	for (StringName &ctx : context_l) {
 		file->store_line(" ===== Context: " + String::utf8(String(ctx).utf8()) + " ===== ");
 		const HashMap<StringName, Vector<StringName>> &inner_map = translation_map[ctx];
 
@@ -74,8 +73,7 @@ Dictionary TranslationPO::_get_messages() const {
 
 	List<StringName> context_l;
 	translation_map.get_key_list(&context_l);
-	for (List<StringName>::Element *E = context_l.front(); E; E = E->next()) {
-		StringName ctx = E->get();
+	for (StringName &ctx : context_l) {
 		const HashMap<StringName, Vector<StringName>> &id_str_map = translation_map[ctx];
 
 		Dictionary d2;
@@ -98,8 +96,7 @@ void TranslationPO::_set_messages(const Dictionary &p_messages) {
 
 	List<Variant> context_l;
 	p_messages.get_key_list(&context_l);
-	for (List<Variant>::Element *E = context_l.front(); E; E = E->next()) {
-		StringName ctx = E->get();
+	for (Variant &ctx : context_l) {
 		const Dictionary &id_str_map = p_messages[ctx];
 
 		HashMap<StringName, Vector<StringName>> temp_map;
@@ -121,8 +118,8 @@ Vector<String> TranslationPO::_get_message_list() const {
 	get_message_list(&msgs);
 
 	Vector<String> v;
-	for (List<StringName>::Element *E = msgs.front(); E; E = E->next()) {
-		v.push_back(E->get());
+	for (StringName &E : msgs) {
+		v.push_back(E);
 	}
 
 	return v;
@@ -281,13 +278,13 @@ void TranslationPO::get_message_list(List<StringName> *r_messages) const {
 	List<StringName> context_l;
 	translation_map.get_key_list(&context_l);
 
-	for (List<StringName>::Element *E = context_l.front(); E; E = E->next()) {
-		if (String(E->get()) != "") {
+	for (StringName &E : context_l) {
+		if (String(E) != "") {
 			continue;
 		}
 
 		List<StringName> msgid_l;
-		translation_map[E->get()].get_key_list(&msgid_l);
+		translation_map[E].get_key_list(&msgid_l);
 
 		for (List<StringName>::Element *E2 = msgid_l.front(); E2; E2 = E2->next()) {
 			r_messages->push_back(E2->get());
@@ -300,8 +297,8 @@ int TranslationPO::get_message_count() const {
 	translation_map.get_key_list(&context_l);
 
 	int count = 0;
-	for (List<StringName>::Element *E = context_l.front(); E; E = E->next()) {
-		count += translation_map[E->get()].size();
+	for (StringName &E : context_l) {
+		count += translation_map[E].size();
 	}
 	return count;
 }

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3421,11 +3421,8 @@ String String::format(const Variant &values, String placeholder) const {
 		List<Variant> keys;
 		d.get_key_list(&keys);
 
-		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-			String key = E->get();
-			String val = d[E->get()];
-
-			new_string = new_string.replace(placeholder.replace("_", key), val);
+		for (Variant &key : keys) {
+			new_string = new_string.replace(placeholder.replace("_", key), d[key]);
 		}
 	} else {
 		ERR_PRINT(String("Invalid type: use Array or Dictionary.").ascii().get_data());

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -407,8 +407,8 @@ Array Signal::get_connections() const {
 	object->get_signal_connection_list(name, &connections);
 
 	Array arr;
-	for (List<Object::Connection>::Element *E = connections.front(); E; E = E->next()) {
-		arr.push_back(E->get());
+	for (Object::Connection &E : connections) {
+		arr.push_back(E);
 	}
 	return arr;
 }

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1681,10 +1681,10 @@ String Variant::stringify(List<const void *> &stack) const {
 
 			Vector<_VariantStrPair> pairs;
 
-			for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
+			for (Variant &E : keys) {
 				_VariantStrPair sp;
-				sp.key = E->get().stringify(stack);
-				sp.value = d[E->get()].stringify(stack);
+				sp.key = E.stringify(stack);
+				sp.value = d[E].stringify(stack);
 
 				pairs.push_back(sp);
 			}

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1088,8 +1088,8 @@ bool Variant::has_builtin_method_return_value(Variant::Type p_type, const String
 
 void Variant::get_builtin_method_list(Variant::Type p_type, List<StringName> *p_list) {
 	ERR_FAIL_INDEX(p_type, Variant::VARIANT_MAX);
-	for (List<StringName>::Element *E = builtin_method_names[p_type].front(); E; E = E->next()) {
-		p_list->push_back(E->get());
+	for (StringName &E : builtin_method_names[p_type]) {
+		p_list->push_back(E);
 	}
 }
 
@@ -1152,12 +1152,12 @@ void Variant::get_method_list(List<MethodInfo> *p_list) const {
 			obj->get_method_list(p_list);
 		}
 	} else {
-		for (List<StringName>::Element *E = builtin_method_names[type].front(); E; E = E->next()) {
-			const VariantBuiltInMethodInfo *method = builtin_method_info[type].lookup_ptr(E->get());
+		for (StringName &E : builtin_method_names[type]) {
+			const VariantBuiltInMethodInfo *method = builtin_method_info[type].lookup_ptr(E);
 			ERR_CONTINUE(!method);
 
 			MethodInfo mi;
-			mi.name = E->get();
+			mi.name = E;
 
 			//return type
 			if (method->has_return_type) {

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1586,8 +1586,8 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 			List<PropertyInfo> props;
 			obj->get_property_list(&props);
 			bool first = true;
-			for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-				if (E->get().usage & PROPERTY_USAGE_STORAGE || E->get().usage & PROPERTY_USAGE_SCRIPT_VARIABLE) {
+			for (PropertyInfo &E : props) {
+				if (E.usage & PROPERTY_USAGE_STORAGE || E.usage & PROPERTY_USAGE_SCRIPT_VARIABLE) {
 					//must be serialized
 
 					if (first) {
@@ -1596,8 +1596,8 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 						p_store_string_func(p_store_string_ud, ",");
 					}
 
-					p_store_string_func(p_store_string_ud, "\"" + E->get().name + "\":");
-					write(obj->get(E->get().name), p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud);
+					p_store_string_func(p_store_string_ud, "\"" + E.name + "\":");
+					write(obj->get(E.name), p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud);
 				}
 			}
 
@@ -1615,7 +1615,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 			p_store_string_func(p_store_string_ud, "{\n");
 			for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
 				/*
-				if (!_check_type(dict[E->get()]))
+				if (!_check_type(dict[E]))
 					continue;
 				*/
 				write(E->get(), p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud);

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1093,9 +1093,9 @@ void Variant::get_property_list(List<PropertyInfo> *p_list) const {
 		const Dictionary *dic = reinterpret_cast<const Dictionary *>(_data._mem);
 		List<Variant> keys;
 		dic->get_key_list(&keys);
-		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-			if (E->get().get_type() == Variant::STRING) {
-				p_list->push_back(PropertyInfo(Variant::STRING, E->get()));
+		for (Variant &E : keys) {
+			if (E.get_type() == Variant::STRING) {
+				p_list->push_back(PropertyInfo(Variant::STRING, E));
 			}
 		}
 	} else if (type == OBJECT) {
@@ -1106,10 +1106,10 @@ void Variant::get_property_list(List<PropertyInfo> *p_list) const {
 	} else {
 		List<StringName> members;
 		get_member_list(type, &members);
-		for (List<StringName>::Element *E = members.front(); E; E = E->next()) {
+		for (StringName &E : members) {
 			PropertyInfo pi;
-			pi.name = E->get();
-			pi.type = get_member_type(type, E->get());
+			pi.name = E;
+			pi.type = get_member_type(type, E);
 			p_list->push_back(pi);
 		}
 	}

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1397,8 +1397,8 @@ uint32_t Variant::get_utility_function_hash(const StringName &p_name) {
 }
 
 void Variant::get_utility_function_list(List<StringName> *r_functions) {
-	for (List<StringName>::Element *E = utility_function_name_table.front(); E; E = E->next()) {
-		r_functions->push_back(E->get());
+	for (StringName &E : utility_function_name_table) {
+		r_functions->push_back(E);
 	}
 }
 

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -269,11 +269,11 @@ _FORCE_INLINE_ Error NetSocketPosix::_change_multicast_group(IPAddress p_ip, Str
 			break; // IPv6 uses index.
 		}
 
-		for (List<IPAddress>::Element *F = c.ip_addresses.front(); F; F = F->next()) {
-			if (!F->get().is_ipv4()) {
+		for (IPAddress &F : c.ip_addresses) {
+			if (!F.is_ipv4()) {
 				continue; // Wrong IP type
 			}
-			if_ip = F->get();
+			if_ip = F;
 			break;
 		}
 		break;

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8542,8 +8542,8 @@ void RenderingDeviceVulkan::_free_rids(T &p_owner, const char *p_type) {
 		} else {
 			WARN_PRINT(vformat("%d RIDs of type \"%s\" were leaked.", owned.size(), p_type));
 		}
-		for (List<RID>::Element *E = owned.front(); E; E = E->next()) {
-			free(E->get());
+		for (RID E : owned) {
+			free(E);
 		}
 	}
 }
@@ -8764,13 +8764,13 @@ void RenderingDeviceVulkan::finalize() {
 				List<RID>::Element *N = E->next();
 				if (texture_is_shared(E->get())) {
 					free(E->get());
-					owned.erase(E->get());
+					owned.erase(E);
 				}
 				E = N;
 			}
 			//free non shared second, this will avoid an error trying to free unexisting textures due to dependencies.
-			for (List<RID>::Element *E = owned.front(); E; E = E->next()) {
-				free(E->get());
+			for (RID E : owned) {
+				free(E);
 			}
 		}
 	}

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -898,8 +898,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			// 6-(undo) reinsert overlapped keys
-			for (List<AnimMoveRestore>::Element *E = to_restore.front(); E; E = E->next()) {
-				AnimMoveRestore &amr = E->get();
+			for (AnimMoveRestore &amr : to_restore) {
 				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, 1);
 			}
 
@@ -1091,9 +1090,9 @@ void AnimationBezierTrackEdit::duplicate_selection() {
 	//reselect duplicated
 
 	selection.clear();
-	for (List<Pair<int, float>>::Element *E = new_selection_values.front(); E; E = E->next()) {
-		int track = E->get().first;
-		float time = E->get().second;
+	for (Pair<int, float> &E : new_selection_values) {
+		int track = E.first;
+		float time = E.second;
 
 		int existing_idx = animation->track_find_key(track, time, true);
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -598,12 +598,12 @@ public:
 					if (ap) {
 						List<StringName> anims;
 						ap->get_animation_list(&anims);
-						for (List<StringName>::Element *E = anims.front(); E; E = E->next()) {
+						for (StringName &E : anims) {
 							if (animations != String()) {
 								animations += ",";
 							}
 
-							animations += String(E->get());
+							animations += String(E);
 						}
 					}
 				}
@@ -702,8 +702,8 @@ public:
 
 		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 			int key = 0;
-			for (List<float>::Element *F = E->value().front(); F; F = F->next()) {
-				float key_ofs = F->get();
+			for (float &F : E->value()) {
+				float key_ofs = F;
 				if (from != key_ofs) {
 					key++;
 					continue;
@@ -728,8 +728,8 @@ public:
 		bool change_notify_deserved = false;
 		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 			int track = E->key();
-			for (List<float>::Element *F = E->value().front(); F; F = F->next()) {
-				float key_ofs = F->get();
+			for (float &F : E->value()) {
+				float key_ofs = F;
 				int key = animation->track_find_key(track, key_ofs, true);
 				ERR_FAIL_COND_V(key == -1, false);
 
@@ -986,8 +986,8 @@ public:
 	bool _get(const StringName &p_name, Variant &r_ret) const {
 		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 			int track = E->key();
-			for (List<float>::Element *F = E->value().front(); F; F = F->next()) {
-				float key_ofs = F->get();
+			for (float &F : E->value()) {
+				float key_ofs = F;
 				int key = animation->track_find_key(track, key_ofs, true);
 				ERR_CONTINUE(key == -1);
 
@@ -1137,8 +1137,8 @@ public:
 					same_key_type = false;
 				}
 
-				for (List<float>::Element *F = E->value().front(); F; F = F->next()) {
-					int key = animation->track_find_key(track, F->get(), true);
+				for (float &F : E->value()) {
+					int key = animation->track_find_key(track, F, true);
 					ERR_FAIL_COND(key == -1);
 					if (first_key < 0) {
 						first_key = key;
@@ -3356,9 +3356,9 @@ void AnimationTrackEditor::_query_insert(const InsertData &p_id) {
 	}
 	insert_frame = Engine::get_singleton()->get_frames_drawn();
 
-	for (List<InsertData>::Element *E = insert_data.front(); E; E = E->next()) {
+	for (InsertData &E : insert_data) {
 		//prevent insertion of multiple tracks
-		if (E->get().path == p_id.path) {
+		if (E.path == p_id.path) {
 			return; //already inserted a track for this on this frame
 		}
 	}
@@ -3843,9 +3843,9 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 	List<PropertyInfo> pinfo;
 	property_info_base.get_property_list(&pinfo);
 
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		if (E->get().name == leftover_path[leftover_path.size() - 1]) {
-			return E->get();
+	for (PropertyInfo &E : pinfo) {
+		if (E.name == leftover_path[leftover_path.size() - 1]) {
+			return E;
 		}
 	}
 
@@ -4675,21 +4675,21 @@ void AnimationTrackEditor::_add_method_key(const String &p_method) {
 	List<MethodInfo> minfo;
 	base->get_method_list(&minfo);
 
-	for (List<MethodInfo>::Element *E = minfo.front(); E; E = E->next()) {
-		if (E->get().name == p_method) {
+	for (MethodInfo &E : minfo) {
+		if (E.name == p_method) {
 			Dictionary d;
 			d["method"] = p_method;
 			Array params;
-			int first_defarg = E->get().arguments.size() - E->get().default_arguments.size();
+			int first_defarg = E.arguments.size() - E.default_arguments.size();
 
-			for (int i = 0; i < E->get().arguments.size(); i++) {
+			for (int i = 0; i < E.arguments.size(); i++) {
 				if (i >= first_defarg) {
-					Variant arg = E->get().default_arguments[i - first_defarg];
+					Variant arg = E.default_arguments[i - first_defarg];
 					params.push_back(arg);
 				} else {
 					Callable::CallError ce;
 					Variant arg;
-					Variant::construct(E->get().arguments[i].type, arg, nullptr, 0, ce);
+					Variant::construct(E.arguments[i].type, arg, nullptr, 0, ce);
 					params.push_back(arg);
 				}
 			}
@@ -4936,8 +4936,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 	}
 
 	// 6 - (undo) reinsert overlapped keys
-	for (List<_AnimMoveRestore>::Element *E = to_restore.front(); E; E = E->next()) {
-		_AnimMoveRestore &amr = E->get();
+	for (_AnimMoveRestore &amr : to_restore) {
 		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
 	}
 
@@ -5151,9 +5150,9 @@ void AnimationTrackEditor::_anim_duplicate_keys(bool transpose) {
 		//reselect duplicated
 
 		Map<SelectedKey, KeyInfo> new_selection;
-		for (List<Pair<int, float>>::Element *E = new_selection_values.front(); E; E = E->next()) {
-			int track = E->get().first;
-			float time = E->get().second;
+		for (Pair<int, float> &E : new_selection_values) {
+			int track = E.first;
+			float time = E.second;
 
 			int existing_idx = animation->track_find_key(track, time, true);
 
@@ -5462,8 +5461,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			}
 
 			// 6-(undo) reinsert overlapped keys
-			for (List<_AnimMoveRestore>::Element *E = to_restore.front(); E; E = E->next()) {
-				_AnimMoveRestore &amr = E->get();
+			for (_AnimMoveRestore &amr : to_restore) {
 				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
 			}
 
@@ -5543,8 +5541,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			if (cleanup_all->is_pressed()) {
 				List<StringName> names;
 				AnimationPlayerEditor::singleton->get_player()->get_animation_list(&names);
-				for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-					_cleanup_animation(AnimationPlayerEditor::singleton->get_player()->get_animation(E->get()));
+				for (StringName &E : names) {
+					_cleanup_animation(AnimationPlayerEditor::singleton->get_player()->get_animation(E));
 				}
 			} else {
 				_cleanup_animation(animation);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -854,9 +854,7 @@ void CodeTextEditor::_complete_request() {
 		return;
 	}
 
-	for (List<ScriptCodeCompletionOption>::Element *E = entries.front(); E; E = E->next()) {
-		ScriptCodeCompletionOption &e = E->get();
-
+	for (ScriptCodeCompletionOption &e : entries) {
 		Color font_color = completion_font_color;
 		if (e.insert_text.begins_with("\"") || e.insert_text.begins_with("\'")) {
 			font_color = completion_string_color;

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -944,9 +944,7 @@ void ConnectionsDock::update_tree() {
 			node_signals2.sort();
 		}
 
-		for (List<MethodInfo>::Element *E = node_signals2.front(); E; E = E->next()) {
-			MethodInfo &mi = E->get();
-
+		for (MethodInfo &mi : node_signals2) {
 			StringName signal_name = mi.name;
 			String signaldesc = "(";
 			PackedStringArray argnames;
@@ -1025,8 +1023,8 @@ void ConnectionsDock::update_tree() {
 			List<Object::Connection> connections;
 			selectedNode->get_signal_connection_list(signal_name, &connections);
 
-			for (List<Object::Connection>::Element *F = connections.front(); F; F = F->next()) {
-				Connection cn = F->get();
+			for (Object::Connection &F : connections) {
+				Connection cn = F;
 				if (!(cn.flags & CONNECT_PERSIST)) {
 					continue;
 				}

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -447,8 +447,7 @@ Variant CreateDialog::instance_selected() {
 	List<PropertyInfo> pinfo;
 	((Object *)obj)->get_property_list(&pinfo);
 
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		PropertyInfo pi = E->get();
+	for (PropertyInfo &pi : pinfo) {
 		if (pi.type == Variant::OBJECT && pi.usage & PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT) {
 			Object *prop = ClassDB::instantiate(pi.class_name);
 			((Object *)obj)->set(pi.name, prop);

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -56,8 +56,8 @@ bool EditorDebuggerRemoteObject::_get(const StringName &p_name, Variant &r_ret) 
 
 void EditorDebuggerRemoteObject::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->clear(); //sorry, no want category
-	for (const List<PropertyInfo>::Element *E = prop_list.front(); E; E = E->next()) {
-		p_list->push_back(E->get());
+	for (const PropertyInfo &E : prop_list) {
+		p_list->push_back(E);
 	}
 }
 

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -365,13 +365,13 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 		}
 		TreeItem *category = variables->create_item(parent);
 
-		for (List<TreeItem *>::Element *E = stack.front(); E; E = E->next()) {
-			float total_cpu = E->get()->get_metadata(1);
-			float total_gpu = E->get()->get_metadata(2);
+		for (TreeItem *E : stack) {
+			float total_cpu = E->get_metadata(1);
+			float total_gpu = E->get_metadata(2);
 			total_cpu += cpu_time;
 			total_gpu += gpu_time;
-			E->get()->set_metadata(1, cpu_time);
-			E->get()->set_metadata(2, gpu_time);
+			E->set_metadata(1, cpu_time);
+			E->set_metadata(2, gpu_time);
 		}
 
 		category->set_icon(0, track_icon);
@@ -392,11 +392,11 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 		}
 	}
 
-	for (List<TreeItem *>::Element *E = categories.front(); E; E = E->next()) {
-		float total_cpu = E->get()->get_metadata(1);
-		float total_gpu = E->get()->get_metadata(2);
-		E->get()->set_text(1, _get_time_as_text(total_cpu));
-		E->get()->set_text(2, _get_time_as_text(total_gpu));
+	for (TreeItem *E : categories) {
+		float total_cpu = E->get_metadata(1);
+		float total_gpu = E->get_metadata(2);
+		E->set_text(1, _get_time_as_text(total_cpu));
+		E->set_text(2, _get_time_as_text(total_gpu));
 	}
 
 	if (ensure_selected) {

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -347,13 +347,13 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 		uint64_t total = 0;
 
-		for (List<DebuggerMarshalls::ResourceInfo>::Element *E = usage.infos.front(); E; E = E->next()) {
+		for (DebuggerMarshalls::ResourceInfo &E : usage.infos) {
 			TreeItem *it = vmem_tree->create_item(root);
-			String type = E->get().type;
-			int bytes = E->get().vram;
-			it->set_text(0, E->get().path);
+			String type = E.type;
+			int bytes = E.vram;
+			it->set_text(0, E.path);
 			it->set_text(1, type);
-			it->set_text(2, E->get().format);
+			it->set_text(2, E.format);
 			it->set_text(3, String::humanize_size(bytes));
 			total += bytes;
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -55,8 +55,8 @@ void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button) {
 	search->clear_filters();
 	List<String> ext;
 	ResourceLoader::get_recognized_extensions_for_type(ti->get_metadata(0), &ext);
-	for (List<String>::Element *E = ext.front(); E; E = E->next()) {
-		search->add_filter("*" + E->get());
+	for (String &E : ext) {
+		search->add_filter("*" + E);
 	}
 	search->popup_file_dialog();
 }
@@ -120,13 +120,13 @@ void DependencyEditor::_fix_all() {
 
 	Map<String, Map<String, String>> candidates;
 
-	for (List<String>::Element *E = missing.front(); E; E = E->next()) {
-		String base = E->get().get_file();
+	for (String &E : missing) {
+		String base = E.get_file();
 		if (!candidates.has(base)) {
 			candidates[base] = Map<String, String>();
 		}
 
-		candidates[base][E->get()] = "";
+		candidates[base][E] = "";
 	}
 
 	_fix_and_find(EditorFileSystem::get_singleton()->get_filesystem(), candidates);
@@ -166,10 +166,8 @@ void DependencyEditor::_update_list() {
 
 	bool broken = false;
 
-	for (List<String>::Element *E = deps.front(); E; E = E->next()) {
+	for (String &n : deps) {
 		TreeItem *item = tree->create_item(root);
-
-		String n = E->get();
 		String path;
 		String type;
 
@@ -741,9 +739,9 @@ void OrphanResourcesDialog::_find_to_delete(TreeItem *p_item, List<String> &path
 
 void OrphanResourcesDialog::_delete_confirm() {
 	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	for (List<String>::Element *E = paths.front(); E; E = E->next()) {
-		da->remove(E->get());
-		EditorFileSystem::get_singleton()->update_file(E->get());
+	for (String &E : paths) {
+		da->remove(E);
+		EditorFileSystem::get_singleton()->update_file(E);
 	}
 	memdelete(da);
 	refresh();

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -920,15 +920,15 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	List<StringName> effects;
 	ClassDB::get_inheriters_from_class("AudioEffect", &effects);
 	effects.sort_custom<StringName::AlphCompare>();
-	for (List<StringName>::Element *E = effects.front(); E; E = E->next()) {
-		if (!ClassDB::can_instantiate(E->get())) {
+	for (StringName &E : effects) {
+		if (!ClassDB::can_instantiate(E)) {
 			continue;
 		}
 
-		Ref<Texture2D> icon = EditorNode::get_singleton()->get_class_icon(E->get());
-		String name = E->get().operator String().replace("AudioEffect", "");
+		Ref<Texture2D> icon = EditorNode::get_singleton()->get_class_icon(E);
+		String name = E.operator String().replace("AudioEffect", "");
 		effect_options->add_item(name);
-		effect_options->set_item_metadata(effect_options->get_item_count() - 1, E->get());
+		effect_options->set_item_metadata(effect_options->get_item_count() - 1, E);
 		effect_options->set_item_icon(effect_options->get_item_count() - 1, icon);
 	}
 
@@ -1331,8 +1331,8 @@ EditorAudioBuses::EditorAudioBuses() {
 	file_dialog = memnew(EditorFileDialog);
 	List<String> ext;
 	ResourceLoader::get_recognized_extensions_for_type("AudioBusLayout", &ext);
-	for (List<String>::Element *E = ext.front(); E; E = E->next()) {
-		file_dialog->add_filter("*." + E->get() + "; Audio Bus Layout");
+	for (String &E : ext) {
+		file_dialog->add_filter("*." + E + "; Audio Bus Layout");
 	}
 	add_child(file_dialog);
 	file_dialog->connect("file_selected", callable_mp(this, &EditorAudioBuses::_file_dialog_callback));

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -46,12 +46,11 @@ void EditorAutoloadSettings::_notification(int p_what) {
 		ResourceLoader::get_recognized_extensions_for_type("Script", &afn);
 		ResourceLoader::get_recognized_extensions_for_type("PackedScene", &afn);
 
-		for (List<String>::Element *E = afn.front(); E; E = E->next()) {
-			file_dialog->add_filter("*." + E->get());
+		for (String &E : afn) {
+			file_dialog->add_filter("*." + E);
 		}
 
-		for (List<AutoLoadInfo>::Element *E = autoload_cache.front(); E; E = E->next()) {
-			AutoLoadInfo &info = E->get();
+		for (AutoLoadInfo &info : autoload_cache) {
 			if (info.node && info.in_editor) {
 				get_tree()->get_root()->call_deferred(SNAME("add_child"), info.node);
 			}
@@ -102,8 +101,8 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		List<String> keywords;
 		ScriptServer::get_language(i)->get_reserved_words(&keywords);
-		for (List<String>::Element *E = keywords.front(); E; E = E->next()) {
-			if (E->get() == p_name) {
+		for (String &E : keywords) {
+			if (E == p_name) {
 				if (r_error) {
 					*r_error = TTR("Invalid name.") + "\n" + TTR("Keyword cannot be used as an autoload name.");
 				}
@@ -379,8 +378,7 @@ void EditorAutoloadSettings::update_autoload() {
 	Map<String, AutoLoadInfo> to_remove;
 	List<AutoLoadInfo *> to_add;
 
-	for (List<AutoLoadInfo>::Element *E = autoload_cache.front(); E; E = E->next()) {
-		AutoLoadInfo &info = E->get();
+	for (AutoLoadInfo &info : autoload_cache) {
 		to_remove.insert(info.name, info);
 	}
 
@@ -392,9 +390,7 @@ void EditorAutoloadSettings::update_autoload() {
 	List<PropertyInfo> props;
 	ProjectSettings::get_singleton()->get_property_list(&props);
 
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		const PropertyInfo &pi = E->get();
-
+	for (PropertyInfo &pi : props) {
 		if (!pi.name.begins_with("autoload/")) {
 			continue;
 		}
@@ -483,9 +479,7 @@ void EditorAutoloadSettings::update_autoload() {
 
 	// Load new/changed autoloads
 	List<Node *> nodes_to_add;
-	for (List<AutoLoadInfo *>::Element *E = to_add.front(); E; E = E->next()) {
-		AutoLoadInfo *info = E->get();
-
+	for (AutoLoadInfo *info : to_add) {
 		info->node = _create_autoload(info->path);
 
 		ERR_CONTINUE(!info->node);
@@ -518,8 +512,8 @@ void EditorAutoloadSettings::update_autoload() {
 		}
 	}
 
-	for (List<Node *>::Element *E = nodes_to_add.front(); E; E = E->next()) {
-		get_tree()->get_root()->add_child(E->get());
+	for (Node *E : nodes_to_add) {
+		get_tree()->get_root()->add_child(E);
 	}
 
 	updating_autoload = false;
@@ -649,8 +643,8 @@ void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &
 
 	int i = 0;
 
-	for (List<AutoLoadInfo>::Element *F = autoload_cache.front(); F; F = F->next()) {
-		orders.write[i++] = F->get().order;
+	for (AutoLoadInfo &F : autoload_cache) {
+		orders.write[i++] = F.order;
 	}
 
 	orders.sort();
@@ -661,9 +655,9 @@ void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &
 
 	i = 0;
 
-	for (List<AutoLoadInfo>::Element *F = autoload_cache.front(); F; F = F->next()) {
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", "autoload/" + F->get().name, orders[i++]);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", "autoload/" + F->get().name, F->get().order);
+	for (AutoLoadInfo &F : autoload_cache) {
+		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", "autoload/" + F.name, orders[i++]);
+		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", "autoload/" + F.name, F.order);
 	}
 
 	orders.clear();
@@ -764,9 +758,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	// Make first cache
 	List<PropertyInfo> props;
 	ProjectSettings::get_singleton()->get_property_list(&props);
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		const PropertyInfo &pi = E->get();
-
+	for (PropertyInfo &pi : props) {
 		if (!pi.name.begins_with("autoload/")) {
 			continue;
 		}
@@ -799,9 +791,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 		autoload_cache.push_back(info);
 	}
 
-	for (List<AutoLoadInfo>::Element *E = autoload_cache.front(); E; E = E->next()) {
-		AutoLoadInfo &info = E->get();
-
+	for (AutoLoadInfo &info : autoload_cache) {
 		info.node = _create_autoload(info.path);
 
 		if (info.node) {
@@ -904,8 +894,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 }
 
 EditorAutoloadSettings::~EditorAutoloadSettings() {
-	for (List<AutoLoadInfo>::Element *E = autoload_cache.front(); E; E = E->next()) {
-		AutoLoadInfo &info = E->get();
+	for (AutoLoadInfo &info : autoload_cache) {
 		if (info.node && !info.in_editor) {
 			memdelete(info.node);
 		}

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -299,13 +299,13 @@ void EditorData::copy_object_params(Object *p_object) {
 	List<PropertyInfo> pinfo;
 	p_object->get_property_list(&pinfo);
 
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		if (!(E->get().usage & PROPERTY_USAGE_EDITOR) || E->get().name == "script" || E->get().name == "scripts") {
+	for (PropertyInfo &E : pinfo) {
+		if (!(E.usage & PROPERTY_USAGE_EDITOR) || E.name == "script" || E.name == "scripts") {
 			continue;
 		}
 
 		PropertyData pd;
-		pd.name = E->get().name;
+		pd.name = E.name;
 		pd.value = p_object->get(pd.name);
 		clipboard.push_back(pd);
 	}
@@ -404,9 +404,9 @@ void EditorData::restore_editor_global_states() {
 void EditorData::paste_object_params(Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	undo_redo.create_action(TTR("Paste Params"));
-	for (List<PropertyData>::Element *E = clipboard.front(); E; E = E->next()) {
-		String name = E->get().name;
-		undo_redo.add_do_property(p_object, name, E->get().value);
+	for (PropertyData &E : clipboard) {
+		String name = E.name;
+		undo_redo.add_do_property(p_object, name, E.value);
 		undo_redo.add_undo_property(p_object, name, p_object->get(name));
 	}
 	undo_redo.commit_action();
@@ -616,8 +616,8 @@ bool EditorData::check_and_update_scene(int p_idx) {
 
 		//transfer selection
 		List<Node *> new_selection;
-		for (List<Node *>::Element *E = edited_scene.write[p_idx].selection.front(); E; E = E->next()) {
-			NodePath p = edited_scene[p_idx].root->get_path_to(E->get());
+		for (Node *E : edited_scene.write[p_idx].selection) {
+			NodePath p = edited_scene[p_idx].root->get_path_to(E);
 			Node *new_node = new_scene->get_node(p);
 			if (new_node) {
 				new_selection.push_back(new_node);
@@ -841,8 +841,8 @@ Dictionary EditorData::restore_edited_scene_state(EditorSelection *p_selection, 
 	p_history->history = es.history_stored;
 
 	p_selection->clear();
-	for (List<Node *>::Element *E = es.selection.front(); E; E = E->next()) {
-		p_selection->add_node(E->get());
+	for (Node *E : es.selection) {
+		p_selection->add_node(E);
 	}
 	set_editor_states(es.editor_states);
 
@@ -964,9 +964,9 @@ void EditorData::script_class_save_icon_paths() {
 	_script_class_icon_paths.get_key_list(&keys);
 
 	Dictionary d;
-	for (List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-		if (ScriptServer::is_global_class(E->get())) {
-			d[E->get()] = _script_class_icon_paths[E->get()];
+	for (StringName &E : keys) {
+		if (ScriptServer::is_global_class(E)) {
+			d[E] = _script_class_icon_paths[E];
 		}
 	}
 
@@ -996,8 +996,8 @@ void EditorData::script_class_load_icon_paths() {
 		List<Variant> keys;
 		d.get_key_list(&keys);
 
-		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-			String name = E->get().operator String();
+		for (Variant &E : keys) {
+			String name = E.operator String();
 			_script_class_icon_paths[name] = d[name];
 
 			String path = ScriptServer::get_global_class_path(name);
@@ -1038,8 +1038,8 @@ void EditorSelection::add_node(Node *p_node) {
 	changed = true;
 	nl_changed = true;
 	Object *meta = nullptr;
-	for (List<Object *>::Element *E = editor_plugins.front(); E; E = E->next()) {
-		meta = E->get()->call("_get_editor_data", p_node);
+	for (Object *E : editor_plugins) {
+		meta = E->call("_get_editor_data", p_node);
 		if (meta) {
 			break;
 		}
@@ -1076,8 +1076,8 @@ bool EditorSelection::is_selected(Node *p_node) const {
 Array EditorSelection::_get_transformable_selected_nodes() {
 	Array ret;
 
-	for (List<Node *>::Element *E = selected_node_list.front(); E; E = E->next()) {
-		ret.push_back(E->get());
+	for (Node *E : selected_node_list) {
+		ret.push_back(E);
 	}
 
 	return ret;

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -80,9 +80,9 @@ bool EditorExportPreset::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void EditorExportPreset::_get_property_list(List<PropertyInfo> *p_list) const {
-	for (const List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-		if (platform->get_option_visibility(E->get().name, values)) {
-			p_list->push_back(E->get());
+	for (const PropertyInfo &E : properties) {
+		if (platform->get_option_visibility(E.name, values)) {
+			p_list->push_back(E);
 		}
 	}
 }
@@ -436,9 +436,9 @@ Ref<EditorExportPreset> EditorExportPlatform::create_preset() {
 	List<ExportOption> options;
 	get_export_options(&options);
 
-	for (List<ExportOption>::Element *E = options.front(); E; E = E->next()) {
-		preset->properties.push_back(E->get().option);
-		preset->values[E->get().option.name] = E->get().default_value;
+	for (ExportOption &E : options) {
+		preset->properties.push_back(E.option);
+		preset->values[E.option.name] = E.default_value;
 	}
 
 	return preset;
@@ -679,9 +679,9 @@ EditorExportPlatform::FeatureContainers EditorExportPlatform::get_feature_contai
 	platform->get_preset_features(p_preset, &feature_list);
 
 	FeatureContainers result;
-	for (List<String>::Element *E = feature_list.front(); E; E = E->next()) {
-		result.features.insert(E->get());
-		result.features_pv.push_back(E->get());
+	for (String &E : feature_list) {
+		result.features.insert(E);
+		result.features_pv.push_back(E);
 	}
 
 	if (p_preset->get_custom_features() != String()) {
@@ -752,9 +752,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		List<PropertyInfo> props;
 		ProjectSettings::get_singleton()->get_property_list(&props);
 
-		for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-			const PropertyInfo &pi = E->get();
-
+		for (PropertyInfo &pi : props) {
 			if (!pi.name.begins_with("autoload/")) {
 				continue;
 			}
@@ -899,8 +897,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 			Set<String> remap_features;
 
-			for (List<String>::Element *F = remaps.front(); F; F = F->next()) {
-				String remap = F->get();
+			for (String &F : remaps) {
+				String remap = F;
 				String feature = remap.get_slice(".", 1);
 				if (features.has(feature)) {
 					remap_features.insert(feature);
@@ -913,8 +911,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 			err = OK;
 
-			for (List<String>::Element *F = remaps.front(); F; F = F->next()) {
-				String remap = F->get();
+			for (String &F : remaps) {
+				String remap = F;
 				if (remap == "path") {
 					String remapped_path = config->get_value("remap", remap);
 					Vector<uint8_t> array = FileAccess::get_file_as_array(remapped_path);
@@ -1362,7 +1360,7 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 		if (breakpoints.size()) {
 			r_flags.push_back("--breakpoints");
 			String bpoints;
-			for (const List<String>::Element *E = breakpoints.front(); E; E = E->next()) {
+			for (List<String>::Element *E = breakpoints.front(); E; E = E->next()) {
 				bpoints += E->get().replace(" ", "%20");
 				if (E->next()) {
 					bpoints += ",";
@@ -1436,8 +1434,8 @@ void EditorExport::_save() {
 
 		String option_section = "preset." + itos(i) + ".options";
 
-		for (const List<PropertyInfo>::Element *E = preset->get_properties().front(); E; E = E->next()) {
-			config->set_value(option_section, E->get().name, preset->get(E->get().name));
+		for (const PropertyInfo &E : preset->get_properties()) {
+			config->set_value(option_section, E.name, preset->get(E.name));
 		}
 	}
 
@@ -1642,10 +1640,10 @@ void EditorExport::load_config() {
 
 		config->get_section_keys(option_section, &options);
 
-		for (List<String>::Element *E = options.front(); E; E = E->next()) {
-			Variant value = config->get_value(option_section, E->get());
+		for (String &E : options) {
+			Variant value = config->get_value(option_section, E);
 
-			preset->set(E->get(), value);
+			preset->set(E, value);
 		}
 
 		add_export_preset(preset);
@@ -1684,11 +1682,11 @@ void EditorExport::update_export_presets() {
 			preset->properties.clear();
 			preset->values.clear();
 
-			for (List<EditorExportPlatform::ExportOption>::Element *E = options.front(); E; E = E->next()) {
-				preset->properties.push_back(E->get().option);
+			for (EditorExportPlatform::ExportOption &E : options) {
+				preset->properties.push_back(E.option);
 
-				StringName option_name = E->get().option.name;
-				preset->values[option_name] = previous_values.has(option_name) ? previous_values[option_name] : E->get().default_value;
+				StringName option_name = E.option.name;
+				preset->values[option_name] = previous_values.has(option_name) ? previous_values[option_name] : E.default_value;
 			}
 		}
 	}

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -527,9 +527,8 @@ void EditorFeatureProfileManager::_fill_classes_from(TreeItem *p_parent, const S
 	ClassDB::get_direct_inheriters_from_class(p_class, &child_classes);
 	child_classes.sort_custom<StringName::AlphCompare>();
 
-	for (List<StringName>::Element *E = child_classes.front(); E; E = E->next()) {
-		String name = E->get();
-		if (name.begins_with("Editor") || ClassDB::get_api_type(name) != ClassDB::API_CORE) {
+	for (StringName &name : child_classes) {
+		if (String(name).begins_with("Editor") || ClassDB::get_api_type(name) != ClassDB::API_CORE) {
 			continue;
 		}
 		_fill_classes_from(class_item, name, p_selected);
@@ -597,9 +596,9 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 		TreeItem *properties = property_list->create_item(root);
 		properties->set_text(0, TTR("Class Properties:"));
 
-		for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-			String name = E->get().name;
-			if (!(E->get().usage & PROPERTY_USAGE_EDITOR)) {
+		for (PropertyInfo &E : props) {
+			String name = E.name;
+			if (!(E.usage & PROPERTY_USAGE_EDITOR)) {
 				continue;
 			}
 			TreeItem *property = property_list->create_item(properties);
@@ -609,7 +608,7 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 			property->set_checked(0, !edited->is_class_property_disabled(class_name, name));
 			property->set_text(0, name.capitalize());
 			property->set_metadata(0, name);
-			String icon_type = Variant::get_type_name(E->get().type);
+			String icon_type = Variant::get_type_name(E.type);
 			property->set_icon(0, EditorNode::get_singleton()->get_class_icon(icon_type));
 		}
 	}

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -830,8 +830,8 @@ void EditorFileDialog::update_file_list() {
 	while (!files.is_empty()) {
 		bool match = patterns.is_empty();
 
-		for (List<String>::Element *E = patterns.front(); E; E = E->next()) {
-			if (files.front()->get().matchn(E->get())) {
+		for (String &E : patterns) {
+			if (files.front()->get().matchn(E)) {
 				match = true;
 				break;
 			}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -457,8 +457,8 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 	memdelete(md5s);
 
 	//imported files are gone, reimport
-	for (List<String>::Element *E = to_check.front(); E; E = E->next()) {
-		if (!FileAccess::exists(E->get())) {
+	for (String &E : to_check) {
+		if (!FileAccess::exists(E)) {
 			return true;
 		}
 	}
@@ -497,9 +497,7 @@ bool EditorFileSystem::_update_scan_actions() {
 	Vector<String> reimports;
 	Vector<String> reloads;
 
-	for (List<ItemAction>::Element *E = scan_actions.front(); E; E = E->next()) {
-		ItemAction &ia = E->get();
-
+	for (ItemAction &ia : scan_actions) {
 		switch (ia.action) {
 			case ItemAction::ACTION_NONE: {
 			} break;
@@ -1027,8 +1025,8 @@ void EditorFileSystem::_delete_internal_files(String p_file) {
 		List<String> paths;
 		ResourceFormatImporter::get_singleton()->get_internal_resource_path_list(p_file, &paths);
 		DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-		for (List<String>::Element *E = paths.front(); E; E = E->next()) {
-			da->remove(E->get());
+		for (String &E : paths) {
+			da->remove(E);
 		}
 		da->remove(p_file + ".import");
 		memdelete(da);
@@ -1368,8 +1366,8 @@ Vector<String> EditorFileSystem::_get_dependencies(const String &p_path) {
 	ResourceLoader::get_dependencies(p_path, &deps);
 
 	Vector<String> ret;
-	for (List<String>::Element *E = deps.front(); E; E = E->next()) {
-		ret.push_back(E->get());
+	for (String &E : deps) {
+		ret.push_back(E);
 	}
 
 	return ret;
@@ -1549,15 +1547,14 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		List<ResourceImporter::ImportOption> options;
 		importer->get_import_options(&options);
 		//set default values
-		for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
-			source_file_options[p_files[i]][E->get().option.name] = E->get().default_value;
+		for (ResourceImporter::ImportOption &E : options) {
+			source_file_options[p_files[i]][E.option.name] = E.default_value;
 		}
 
 		if (config->has_section("params")) {
 			List<String> sk;
 			config->get_section_keys("params", &sk);
-			for (List<String>::Element *E = sk.front(); E; E = E->next()) {
-				String param = E->get();
+			for (String &param : sk) {
 				Variant value = config->get_value("params", param);
 				//override with whathever is in file
 				source_file_options[p_files[i]][param] = value;
@@ -1631,9 +1628,9 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		List<ResourceImporter::ImportOption> options;
 		importer->get_import_options(&options);
 		//set default values
-		for (List<ResourceImporter::ImportOption>::Element *F = options.front(); F; F = F->next()) {
-			String base = F->get().option.name;
-			Variant v = F->get().default_value;
+		for (ResourceImporter::ImportOption &F : options) {
+			String base = F.option.name;
+			Variant v = F.default_value;
 			if (source_file_options[file].has(base)) {
 				v = source_file_options[file][base];
 			}
@@ -1712,8 +1709,8 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 				if (cf->has_section("params")) {
 					List<String> sk;
 					cf->get_section_keys("params", &sk);
-					for (List<String>::Element *E = sk.front(); E; E = E->next()) {
-						params[E->get()] = cf->get_value("params", E->get());
+					for (String &E : sk) {
+						params[E] = cf->get_value("params", E);
 					}
 				}
 				if (p_custom_importer == String() && cf->has_section("remap")) {
@@ -1754,9 +1751,9 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 
 	List<ResourceImporter::ImportOption> opts;
 	importer->get_import_options(&opts);
-	for (List<ResourceImporter::ImportOption>::Element *E = opts.front(); E; E = E->next()) {
-		if (!params.has(E->get().option.name)) { //this one is not present
-			params[E->get().option.name] = E->get().default_value;
+	for (ResourceImporter::ImportOption &E : opts) {
+		if (!params.has(E.option.name)) { //this one is not present
+			params[E.option.name] = E.default_value;
 		}
 	}
 
@@ -1766,8 +1763,8 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 		List<Variant> v;
 		d.get_key_list(&v);
 
-		for (List<Variant>::Element *E = v.front(); E; E = E->next()) {
-			params[E->get()] = d[E->get()];
+		for (Variant &E : v) {
+			params[E] = d[E];
 		}
 	}
 
@@ -1807,10 +1804,10 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 			//no path
 		} else if (import_variants.size()) {
 			//import with variants
-			for (List<String>::Element *E = import_variants.front(); E; E = E->next()) {
-				String path = base_path.c_escape() + "." + E->get() + "." + importer->get_save_extension();
+			for (String &E : import_variants) {
+				String path = base_path.c_escape() + "." + E + "." + importer->get_save_extension();
 
-				f->store_line("path." + E->get() + "=\"" + path + "\"");
+				f->store_line("path." + E + "=\"" + path + "\"");
 				dest_paths.push_back(path);
 			}
 		} else {
@@ -1833,9 +1830,9 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 
 	if (gen_files.size()) {
 		Array genf;
-		for (List<String>::Element *E = gen_files.front(); E; E = E->next()) {
-			genf.push_back(E->get());
-			dest_paths.push_back(E->get());
+		for (String &E : gen_files) {
+			genf.push_back(E);
+			dest_paths.push_back(E);
 		}
 
 		String value;
@@ -1859,8 +1856,8 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 
 	//store options in provided order, to avoid file changing. Order is also important because first match is accepted first.
 
-	for (List<ResourceImporter::ImportOption>::Element *E = opts.front(); E; E = E->next()) {
-		String base = E->get().option.name;
+	for (ResourceImporter::ImportOption &E : opts) {
+		String base = E.option.name;
 		String value;
 		VariantWriter::write_to_string(params[base], value);
 		f->store_line(base + "=" + value);
@@ -2080,9 +2077,8 @@ void EditorFileSystem::_move_group_files(EditorFileSystemDirectory *efd, const S
 
 			List<String> sk;
 			config->get_section_keys("params", &sk);
-			for (List<String>::Element *E = sk.front(); E; E = E->next()) {
+			for (String &param : sk) {
 				//not very clean, but should work
-				String param = E->get();
 				String value = config->get_value("params", param);
 				if (value == p_group_file) {
 					config->set_value("params", param, p_new_location);
@@ -2131,14 +2127,14 @@ void EditorFileSystem::_update_extensions() {
 
 	List<String> extensionsl;
 	ResourceLoader::get_recognized_extensions_for_type("", &extensionsl);
-	for (List<String>::Element *E = extensionsl.front(); E; E = E->next()) {
-		valid_extensions.insert(E->get());
+	for (String &E : extensionsl) {
+		valid_extensions.insert(E);
 	}
 
 	extensionsl.clear();
 	ResourceFormatImporter::get_singleton()->get_recognized_extensions(&extensionsl);
-	for (List<String>::Element *E = extensionsl.front(); E; E = E->next()) {
-		import_extensions.insert(E->get());
+	for (String &E : extensionsl) {
+		import_extensions.insert(E);
 	}
 }
 

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -109,10 +109,10 @@ void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p
 
 	List<PropertyInfo> plist;
 	p_node->get_property_list(&plist);
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		if (E->get().usage & PROPERTY_USAGE_EDITOR) {
-			if (E->get().type == Variant::OBJECT) {
-				RES res = p_node->get(E->get().name);
+	for (PropertyInfo &E : plist) {
+		if (E.usage & PROPERTY_USAGE_EDITOR) {
+			if (E.type == Variant::OBJECT) {
+				RES res = p_node->get(E.name);
 				if (res.is_valid() && !resources.has(res) && res->get_path() != String() && !res->get_path().is_resource_file()) {
 					Vector<String> res_unfolds = _get_unfolds(res.ptr());
 					resource_folds.push_back(res->get_path());
@@ -228,41 +228,41 @@ void EditorFolding::_do_object_unfolds(Object *p_object, Set<RES> &resources) {
 
 	Set<String> unfold_group;
 
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		if (E->get().usage & PROPERTY_USAGE_CATEGORY) {
+	for (PropertyInfo &E : plist) {
+		if (E.usage & PROPERTY_USAGE_CATEGORY) {
 			group = "";
 			group_base = "";
 		}
-		if (E->get().usage & PROPERTY_USAGE_GROUP) {
-			group = E->get().name;
-			group_base = E->get().hint_string;
+		if (E.usage & PROPERTY_USAGE_GROUP) {
+			group = E.name;
+			group_base = E.hint_string;
 			if (group_base.ends_with("_")) {
 				group_base = group_base.substr(0, group_base.length() - 1);
 			}
 		}
 
 		//can unfold
-		if (E->get().usage & PROPERTY_USAGE_EDITOR) {
+		if (E.usage & PROPERTY_USAGE_EDITOR) {
 			if (group != "") { //group
-				if (group_base == String() || E->get().name.begins_with(group_base)) {
-					bool can_revert = EditorPropertyRevert::can_property_revert(p_object, E->get().name);
+				if (group_base == String() || E.name.begins_with(group_base)) {
+					bool can_revert = EditorPropertyRevert::can_property_revert(p_object, E.name);
 					if (can_revert) {
 						unfold_group.insert(group);
 					}
 				}
 			} else { //path
-				int last = E->get().name.rfind("/");
+				int last = E.name.rfind("/");
 				if (last != -1) {
-					bool can_revert = EditorPropertyRevert::can_property_revert(p_object, E->get().name);
+					bool can_revert = EditorPropertyRevert::can_property_revert(p_object, E.name);
 					if (can_revert) {
-						unfold_group.insert(E->get().name.substr(0, last));
+						unfold_group.insert(E.name.substr(0, last));
 					}
 				}
 			}
 
-			if (E->get().type == Variant::OBJECT) {
-				RES res = p_object->get(E->get().name);
-				print_line("res: " + String(E->get().name) + " valid " + itos(res.is_valid()));
+			if (E.type == Variant::OBJECT) {
+				RES res = p_object->get(E.name);
+				print_line("res: " + String(E.name) + " valid " + itos(res.is_valid()));
 				if (res.is_valid()) {
 					print_line("path " + res->get_path());
 				}

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1508,9 +1508,9 @@ String EditorInspector::get_selected_path() const {
 }
 
 void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, Ref<EditorInspectorPlugin> ped) {
-	for (List<EditorInspectorPlugin::AddedEditor>::Element *F = ped->added_editors.front(); F; F = F->next()) {
-		EditorProperty *ep = Object::cast_to<EditorProperty>(F->get().property_editor);
-		current_vbox->add_child(F->get().property_editor);
+	for (EditorInspectorPlugin::AddedEditor &F : ped->added_editors) {
+		EditorProperty *ep = Object::cast_to<EditorProperty>(F.property_editor);
+		current_vbox->add_child(F.property_editor);
 
 		if (ep) {
 			ep->object = object;
@@ -1524,19 +1524,19 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, Ref<Edit
 			ep->connect("resource_selected", callable_mp(this, &EditorInspector::_resource_selected), varray(), CONNECT_DEFERRED);
 			ep->connect("object_id_selected", callable_mp(this, &EditorInspector::_object_id_selected), varray(), CONNECT_DEFERRED);
 
-			if (F->get().properties.size()) {
-				if (F->get().properties.size() == 1) {
+			if (F.properties.size()) {
+				if (F.properties.size() == 1) {
 					//since it's one, associate:
-					ep->property = F->get().properties[0];
+					ep->property = F.properties[0];
 					ep->property_usage = 0;
 				}
 
-				if (F->get().label != String()) {
-					ep->set_label(F->get().label);
+				if (F.label != String()) {
+					ep->set_label(F.label);
 				}
 
-				for (int i = 0; i < F->get().properties.size(); i++) {
-					String prop = F->get().properties[i];
+				for (int i = 0; i < F.properties.size(); i++) {
+					String prop = F.properties[i];
 
 					if (!editor_property_map.has(prop)) {
 						editor_property_map[prop] = List<EditorProperty *>();
@@ -1648,8 +1648,7 @@ void EditorInspector::update_tree() {
 
 	Color sscolor = get_theme_color(SNAME("prop_subsection"), SNAME("Editor"));
 
-	for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
-		Ref<EditorInspectorPlugin> ped = E->get();
+	for (Ref<EditorInspectorPlugin> ped : valid_plugins) {
 		ped->parse_begin(object);
 		_parse_added_editors(main_vbox, ped);
 	}
@@ -1746,8 +1745,7 @@ void EditorInspector::update_tree() {
 				category->set_tooltip(p.name + "::" + (class_descr_cache[type2] == "" ? "" : class_descr_cache[type2]));
 			}
 
-			for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
-				Ref<EditorInspectorPlugin> ped = E->get();
+			for (Ref<EditorInspectorPlugin> ped : valid_plugins) {
 				ped->parse_category(object, p.name);
 				_parse_added_editors(main_vbox, ped);
 			}
@@ -1948,36 +1946,35 @@ void EditorInspector::update_tree() {
 			doc_hint = descr;
 		}
 
-		for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
-			Ref<EditorInspectorPlugin> ped = E->get();
+		for (Ref<EditorInspectorPlugin> ped : valid_plugins) {
 			bool exclusive = ped->parse_property(object, p.type, p.name, p.hint, p.hint_string, p.usage, wide_editors);
 
 			List<EditorInspectorPlugin::AddedEditor> editors = ped->added_editors; //make a copy, since plugins may be used again in a sub-inspector
 			ped->added_editors.clear();
 
-			for (List<EditorInspectorPlugin::AddedEditor>::Element *F = editors.front(); F; F = F->next()) {
-				EditorProperty *ep = Object::cast_to<EditorProperty>(F->get().property_editor);
+			for (EditorInspectorPlugin::AddedEditor &F : editors) {
+				EditorProperty *ep = Object::cast_to<EditorProperty>(F.property_editor);
 
 				if (ep) {
 					//set all this before the control gets the ENTER_TREE notification
 					ep->object = object;
 
-					if (F->get().properties.size()) {
-						if (F->get().properties.size() == 1) {
+					if (F.properties.size()) {
+						if (F.properties.size() == 1) {
 							//since it's one, associate:
-							ep->property = F->get().properties[0];
+							ep->property = F.properties[0];
 							ep->property_usage = p.usage;
 							//and set label?
 						}
 
-						if (F->get().label != String()) {
-							ep->set_label(F->get().label);
+						if (F.label != String()) {
+							ep->set_label(F.label);
 						} else {
 							//use existin one
 							ep->set_label(name);
 						}
-						for (int i = 0; i < F->get().properties.size(); i++) {
-							String prop = F->get().properties[i];
+						for (int i = 0; i < F.properties.size(); i++) {
+							String prop = F.properties[i];
 
 							if (!editor_property_map.has(prop)) {
 								editor_property_map[prop] = List<EditorProperty *>();
@@ -1995,7 +1992,7 @@ void EditorInspector::update_tree() {
 					ep->set_deletable(deletable_properties);
 				}
 
-				current_vbox->add_child(F->get().property_editor);
+				current_vbox->add_child(F.property_editor);
 
 				if (ep) {
 					ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed));
@@ -2031,8 +2028,7 @@ void EditorInspector::update_tree() {
 		}
 	}
 
-	for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
-		Ref<EditorInspectorPlugin> ped = E->get();
+	for (Ref<EditorInspectorPlugin> ped : valid_plugins) {
 		ped->parse_end();
 		_parse_added_editors(main_vbox, ped);
 	}
@@ -2045,10 +2041,10 @@ void EditorInspector::update_property(const String &p_prop) {
 		return;
 	}
 
-	for (List<EditorProperty *>::Element *E = editor_property_map[p_prop].front(); E; E = E->next()) {
-		E->get()->update_property();
-		E->get()->update_reload_status();
-		E->get()->update_cache();
+	for (EditorProperty *E : editor_property_map[p_prop]) {
+		E->update_property();
+		E->update_reload_status();
+		E->update_cache();
 	}
 }
 
@@ -2157,24 +2153,24 @@ bool EditorInspector::is_using_folding() {
 }
 
 void EditorInspector::collapse_all_folding() {
-	for (List<EditorInspectorSection *>::Element *E = sections.front(); E; E = E->next()) {
-		E->get()->fold();
+	for (EditorInspectorSection *E : sections) {
+		E->fold();
 	}
 
 	for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
-		for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
-			E->get()->collapse_all_folding();
+		for (EditorProperty *E : F->get()) {
+			E->collapse_all_folding();
 		}
 	}
 }
 
 void EditorInspector::expand_all_folding() {
-	for (List<EditorInspectorSection *>::Element *E = sections.front(); E; E = E->next()) {
-		E->get()->unfold();
+	for (EditorInspectorSection *E : sections) {
+		E->unfold();
 	}
 	for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
-		for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
-			E->get()->expand_all_folding();
+		for (EditorProperty *E : F->get()) {
+			E->expand_all_folding();
 		}
 	}
 }
@@ -2239,9 +2235,9 @@ void EditorInspector::_edit_request_change(Object *p_object, const String &p_pro
 
 void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field) {
 	if (autoclear && editor_property_map.has(p_name)) {
-		for (List<EditorProperty *>::Element *E = editor_property_map[p_name].front(); E; E = E->next()) {
-			if (E->get()->is_checkable()) {
-				E->get()->set_checked(true);
+		for (EditorProperty *E : editor_property_map[p_name]) {
+			if (E->is_checkable()) {
+				E->set_checked(true);
 			}
 		}
 	}
@@ -2308,8 +2304,8 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 	}
 
 	if (editor_property_map.has(p_name)) {
-		for (List<EditorProperty *>::Element *E = editor_property_map[p_name].front(); E; E = E->next()) {
-			E->get()->update_reload_status();
+		for (EditorProperty *E : editor_property_map[p_name]) {
+			E->update_reload_status();
 		}
 	}
 }
@@ -2395,10 +2391,10 @@ void EditorInspector::_property_checked(const String &p_path, bool p_checked) {
 			Variant to_create;
 			List<PropertyInfo> pinfo;
 			object->get_property_list(&pinfo);
-			for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-				if (E->get().name == p_path) {
+			for (PropertyInfo &E : pinfo) {
+				if (E.name == p_path) {
 					Callable::CallError ce;
-					Variant::construct(E->get().type, to_create, nullptr, 0, ce);
+					Variant::construct(E.type, to_create, nullptr, 0, ce);
 					break;
 				}
 			}
@@ -2406,10 +2402,10 @@ void EditorInspector::_property_checked(const String &p_path, bool p_checked) {
 		}
 
 		if (editor_property_map.has(p_path)) {
-			for (List<EditorProperty *>::Element *E = editor_property_map[p_path].front(); E; E = E->next()) {
-				E->get()->update_property();
-				E->get()->update_reload_status();
-				E->get()->update_cache();
+			for (EditorProperty *E : editor_property_map[p_path]) {
+				E->update_property();
+				E->update_reload_status();
+				E->update_cache();
 			}
 		}
 
@@ -2426,9 +2422,9 @@ void EditorInspector::_property_selected(const String &p_path, int p_focusable) 
 		if (F->key() == property_selected) {
 			continue;
 		}
-		for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
-			if (E->get()->is_selected()) {
-				E->get()->deselect();
+		for (EditorProperty *E : F->get()) {
+			if (E->is_selected()) {
+				E->deselect();
 			}
 		}
 	}
@@ -2485,11 +2481,11 @@ void EditorInspector::_notification(int p_what) {
 			refresh_countdown -= get_process_delta_time();
 			if (refresh_countdown <= 0) {
 				for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
-					for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
-						if (!E->get()->is_cache_valid()) {
-							E->get()->update_property();
-							E->get()->update_reload_status();
-							E->get()->update_cache();
+					for (EditorProperty *E : F->get()) {
+						if (!E->is_cache_valid()) {
+							E->update_property();
+							E->update_reload_status();
+							E->update_cache();
 						}
 					}
 				}
@@ -2508,10 +2504,10 @@ void EditorInspector::_notification(int p_what) {
 			while (pending.size()) {
 				StringName prop = pending.front()->get();
 				if (editor_property_map.has(prop)) {
-					for (List<EditorProperty *>::Element *E = editor_property_map[prop].front(); E; E = E->next()) {
-						E->get()->update_property();
-						E->get()->update_reload_status();
-						E->get()->update_cache();
+					for (EditorProperty *E : editor_property_map[prop]) {
+						E->update_property();
+						E->update_reload_status();
+						E->update_cache();
 					}
 				}
 				pending.erase(pending.front());
@@ -2599,8 +2595,7 @@ void EditorInspector::_update_script_class_properties(const Object &p_object, Li
 	}
 
 	Set<StringName> added;
-	for (List<Ref<Script>>::Element *E = classes.front(); E; E = E->next()) {
-		Ref<Script> s = E->get();
+	for (Ref<Script> s : classes) {
 		String path = s->get_path();
 		String name = EditorNode::get_editor_data().script_class_get_name(path);
 		if (name.is_empty()) {

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -92,8 +92,8 @@ void EditorLayoutsDialog::_post_popup() {
 	List<String> layouts;
 	config.ptr()->get_sections(&layouts);
 
-	for (List<String>::Element *E = layouts.front(); E; E = E->next()) {
-		layout_names->add_item(**E);
+	for (String &E : layouts) {
+		layout_names->add_item(E);
 	}
 }
 

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -40,15 +40,15 @@ void EditorPath::_add_children_to_popup(Object *p_obj, int p_depth) {
 
 	List<PropertyInfo> pinfo;
 	p_obj->get_property_list(&pinfo);
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		if (!(E->get().usage & PROPERTY_USAGE_EDITOR)) {
+	for (PropertyInfo &E : pinfo) {
+		if (!(E.usage & PROPERTY_USAGE_EDITOR)) {
 			continue;
 		}
-		if (E->get().hint != PROPERTY_HINT_RESOURCE_TYPE) {
+		if (E.hint != PROPERTY_HINT_RESOURCE_TYPE) {
 			continue;
 		}
 
-		Variant value = p_obj->get(E->get().name);
+		Variant value = p_obj->get(E.name);
 		if (value.get_type() != Variant::OBJECT) {
 			continue;
 		}
@@ -60,7 +60,7 @@ void EditorPath::_add_children_to_popup(Object *p_obj, int p_depth) {
 		Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(obj);
 
 		String proper_name = "";
-		Vector<String> name_parts = E->get().name.split("/");
+		Vector<String> name_parts = E.name.split("/");
 
 		for (int i = 0; i < name_parts.size(); i++) {
 			if (i > 0) {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -221,8 +221,8 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			}
 
 			Set<String> valid_extensions;
-			for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-				valid_extensions.insert(E->get());
+			for (String &E : extensions) {
+				valid_extensions.insert(E);
 			}
 
 			if (!file_dialog) {
@@ -260,9 +260,8 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			List<PropertyInfo> property_list;
 			edited_resource->get_property_list(&property_list);
 			List<Pair<String, Variant>> propvalues;
-			for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
+			for (PropertyInfo &pi : property_list) {
 				Pair<String, Variant> p;
-				PropertyInfo &pi = E->get();
 				if (pi.usage & PROPERTY_USAGE_STORAGE) {
 					p.first = pi.name;
 					p.second = edited_resource->get(pi.name);
@@ -276,8 +275,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			Ref<Resource> unique_resource = Ref<Resource>(Object::cast_to<Resource>(inst));
 			ERR_FAIL_COND(unique_resource.is_null());
 
-			for (List<Pair<String, Variant>>::Element *E = propvalues.front(); E; E = E->next()) {
-				Pair<String, Variant> &p = E->get();
+			for (Pair<String, Variant> &p : propvalues) {
 				unique_resource->set(p.first, p.second);
 			}
 
@@ -467,13 +465,13 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, Set<String> *
 		List<StringName> inheriters;
 
 		ClassDB::get_inheriters_from_class(base, &inheriters);
-		for (List<StringName>::Element *E = inheriters.front(); E; E = E->next()) {
-			p_vector->insert(E->get());
+		for (StringName &E : inheriters) {
+			p_vector->insert(E);
 		}
 
-		for (List<StringName>::Element *E = global_classes.front(); E; E = E->next()) {
-			if (EditorNode::get_editor_data().script_class_is_parent(E->get(), base)) {
-				p_vector->insert(E->get());
+		for (StringName &E : global_classes) {
+			if (EditorNode::get_editor_data().script_class_is_parent(E, base)) {
+				p_vector->insert(E);
 			}
 		}
 

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -228,8 +228,8 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 	}
 
 	printf("Running: %s", exec.utf8().get_data());
-	for (List<String>::Element *E = args.front(); E; E = E->next()) {
-		printf(" %s", E->get().utf8().get_data());
+	for (String &E : args) {
+		printf(" %s", E.utf8().get_data());
 	};
 	printf("\n");
 
@@ -250,8 +250,8 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 }
 
 bool EditorRun::has_child_process(OS::ProcessID p_pid) const {
-	for (const List<OS::ProcessID>::Element *E = pids.front(); E; E = E->next()) {
-		if (E->get() == p_pid) {
+	for (const OS::ProcessID &E : pids) {
+		if (E == p_pid) {
 			return true;
 		}
 	}
@@ -267,8 +267,8 @@ void EditorRun::stop_child_process(OS::ProcessID p_pid) {
 
 void EditorRun::stop() {
 	if (status != STATUS_STOP && pids.size() > 0) {
-		for (List<OS::ProcessID>::Element *E = pids.front(); E; E = E->next()) {
-			OS::get_singleton()->kill(E->get());
+		for (OS::ProcessID &E : pids) {
+			OS::get_singleton()->kill(E);
 		}
 	}
 

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -76,8 +76,7 @@ class SectionedInspectorFilter : public Object {
 
 		List<PropertyInfo> pinfo;
 		edited->get_property_list(&pinfo);
-		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-			PropertyInfo pi = E->get();
+		for (PropertyInfo &pi : pinfo) {
 			int sp = pi.name.find("/");
 
 			if (pi.name == "resource_path" || pi.name == "resource_name" || pi.name == "resource_local_to_scene" || pi.name.begins_with("script/") || pi.name.begins_with("_global_script")) { //skip resource stuff
@@ -221,9 +220,7 @@ void SectionedInspector::update_category_list() {
 		filter = search_box->get_text();
 	}
 
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		PropertyInfo pi = E->get();
-
+	for (PropertyInfo &pi : pinfo) {
 		if (pi.usage & PROPERTY_USAGE_CATEGORY) {
 			continue;
 		} else if (!(pi.usage & PROPERTY_USAGE_EDITOR) || (restrict_to_basic && !(pi.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -759,8 +759,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 			List<String> keys;
 			p_extra_config->get_section_keys("presets", &keys);
 
-			for (List<String>::Element *E = keys.front(); E; E = E->next()) {
-				String key = E->get();
+			for (String &key : keys) {
 				Variant val = p_extra_config->get_value("presets", key);
 				set(key, val);
 			}
@@ -815,8 +814,7 @@ bool EditorSettings::_save_text_editor_theme(String p_file) {
 	props.get_key_list(&keys);
 	keys.sort();
 
-	for (const List<String>::Element *E = keys.front(); E; E = E->next()) {
-		const String &key = E->get();
+	for (const String &key : keys) {
 		if (key.begins_with("text_editor/highlighting/") && key.find("color") >= 0) {
 			cf->set_value(theme_section, key.replace("text_editor/highlighting/", ""), ((Color)props[key].variant).to_html());
 		}
@@ -1015,15 +1013,13 @@ void EditorSettings::setup_network() {
 	String selected = "127.0.0.1";
 
 	// Check that current remote_host is a valid interface address and populate hints.
-	for (List<IPAddress>::Element *E = local_ip.front(); E; E = E->next()) {
-		String ip = E->get();
-
+	for (IPAddress &ip : local_ip) {
 		// link-local IPv6 addresses don't work, skipping them
-		if (ip.begins_with("fe80:0:0:0:")) { // fe80::/64
+		if (String(ip).begins_with("fe80:0:0:0:")) { // fe80::/64
 			continue;
 		}
 		// Same goes for IPv4 link-local (APIPA) addresses.
-		if (ip.begins_with("169.254.")) { // 169.254.0.0/16
+		if (String(ip).begins_with("169.254.")) { // 169.254.0.0/16
 			continue;
 		}
 		// Select current IP (found)
@@ -1303,8 +1299,8 @@ void EditorSettings::list_text_editor_themes() {
 		memdelete(d);
 
 		custom_themes.sort();
-		for (List<String>::Element *E = custom_themes.front(); E; E = E->next()) {
-			themes += "," + E->get();
+		for (String &E : custom_themes) {
+			themes += "," + E;
 		}
 	}
 	add_property_hint(PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, themes));
@@ -1332,8 +1328,7 @@ void EditorSettings::load_text_editor_theme() {
 	List<String> keys;
 	cf->get_section_keys("color_theme", &keys);
 
-	for (List<String>::Element *E = keys.front(); E; E = E->next()) {
-		String key = E->get();
+	for (String &key : keys) {
 		String val = cf->get_value("color_theme", key);
 
 		// don't load if it's not already there!
@@ -1585,8 +1580,8 @@ void EditorSettings::set_builtin_action_override(const String &p_name, const Arr
 			int event_idx = 0;
 
 			// Check equality of each event.
-			for (List<Ref<InputEvent>>::Element *E = builtin_events.front(); E; E = E->next()) {
-				if (!E->get()->is_match(p_events[event_idx])) {
+			for (Ref<InputEvent> E : builtin_events) {
+				if (!E->is_match(p_events[event_idx])) {
 					same_as_builtin = false;
 					break;
 				}
@@ -1615,8 +1610,8 @@ const Array EditorSettings::get_builtin_action_overrides(const String &p_name) c
 		Array event_array;
 
 		List<Ref<InputEvent>> events_list = AO->get();
-		for (List<Ref<InputEvent>>::Element *E = events_list.front(); E; E = E->next()) {
-			event_array.push_back(E->get());
+		for (Ref<InputEvent> E : events_list) {
+			event_array.push_back(E);
 		}
 		return event_array;
 	}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -135,9 +135,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 		_sort_file_info_list(file_list);
 
 		// Build the tree.
-		for (List<FileInfo>::Element *E = file_list.front(); E; E = E->next()) {
-			FileInfo fi = E->get();
-
+		for (FileInfo &fi : file_list) {
 			TreeItem *file_item = tree->create_item(subdirectory_item);
 			file_item->set_text(0, fi.name);
 			file_item->set_structured_text_bidi_override(0, STRUCTURED_TEXT_FILE);
@@ -869,8 +867,8 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	// Fills the ItemList control node from the FileInfos.
 	String main_scene = ProjectSettings::get_singleton()->get("application/run/main_scene");
 	String oi = "Object";
-	for (List<FileInfo>::Element *E = file_list.front(); E; E = E->next()) {
-		FileInfo *finfo = &(E->get());
+	for (FileInfo &E : file_list) {
+		FileInfo *finfo = &(E);
 		String fname = finfo->name;
 		String fpath = finfo->path;
 		String ftype = finfo->type;
@@ -966,8 +964,8 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 				List<String> importer_exts;
 				ResourceImporterScene::get_singleton()->get_recognized_extensions(&importer_exts);
 				String extension = fpath.get_extension();
-				for (List<String>::Element *E = importer_exts.front(); E; E = E->next()) {
-					if (extension.nocasecmp_to(E->get()) == 0) {
+				for (String &E : importer_exts) {
+					if (extension.nocasecmp_to(E) == 0) {
 						is_imported = true;
 						break;
 					}
@@ -1239,9 +1237,7 @@ void FileSystemDock::_update_resource_paths_after_move(const Map<String, String>
 	List<Ref<Resource>> cached;
 	ResourceCache::get_cached_resources(&cached);
 
-	for (List<Ref<Resource>>::Element *E = cached.front(); E; E = E->next()) {
-		Ref<Resource> r = E->get();
-
+	for (Ref<Resource> r : cached) {
 		String base_path = r->get_path();
 		String extra_path;
 		int sep_pos = r->get_path().find("::");
@@ -1317,16 +1313,16 @@ void FileSystemDock::_update_project_settings_after_move(const Map<String, Strin
 	// Also search for the file in autoload, as they are stored differently from normal files.
 	List<PropertyInfo> property_list;
 	ProjectSettings::get_singleton()->get_property_list(&property_list);
-	for (const List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
-		if (E->get().name.begins_with("autoload/")) {
+	for (const PropertyInfo &E : property_list) {
+		if (E.name.begins_with("autoload/")) {
 			// If the autoload resource paths has a leading "*", it indicates that it is a Singleton,
 			// so we have to handle both cases when updating.
-			String autoload = GLOBAL_GET(E->get().name);
+			String autoload = GLOBAL_GET(E.name);
 			String autoload_singleton = autoload.substr(1, autoload.length());
 			if (p_renames.has(autoload)) {
-				ProjectSettings::get_singleton()->set_setting(E->get().name, p_renames[autoload]);
+				ProjectSettings::get_singleton()->set_setting(E.name, p_renames[autoload]);
 			} else if (autoload.begins_with("*") && p_renames.has(autoload_singleton)) {
-				ProjectSettings::get_singleton()->set_setting(E->get().name, "*" + p_renames[autoload_singleton]);
+				ProjectSettings::get_singleton()->set_setting(E.name, "*" + p_renames[autoload_singleton]);
 			}
 		}
 	}
@@ -1417,8 +1413,8 @@ void FileSystemDock::_make_scene_confirm() {
 	ResourceSaver::get_recognized_extensions(sd, &extensions);
 
 	bool extension_correct = false;
-	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-		if (E->get() == extension) {
+	for (String &E : extensions) {
+		if (E == extension) {
 			extension_correct = true;
 			break;
 		}

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -240,8 +240,7 @@ void GroupDialog::_group_renamed() {
 	List<Node *> nodes;
 	scene_tree->get_nodes_in_group(selected_group, &nodes);
 	bool removed_all = true;
-	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
-		Node *node = E->get();
+	for (Node *node : nodes) {
 		if (_can_edit(node, selected_group)) {
 			undo_redo->add_do_method(node, "remove_from_group", selected_group);
 			undo_redo->add_undo_method(node, "remove_from_group", name);
@@ -286,11 +285,11 @@ void GroupDialog::_load_groups(Node *p_current) {
 	List<Node::GroupInfo> gi;
 	p_current->get_groups(&gi);
 
-	for (List<Node::GroupInfo>::Element *E = gi.front(); E; E = E->next()) {
-		if (!E->get().persistent) {
+	for (Node::GroupInfo &E : gi) {
+		if (!E.persistent) {
 			continue;
 		}
-		_add_group(E->get().name);
+		_add_group(E.name);
 	}
 
 	for (int i = 0; i < p_current->get_child_count(); i++) {
@@ -311,10 +310,10 @@ void GroupDialog::_delete_group_pressed(Object *p_item, int p_column, int p_id) 
 	List<Node *> nodes;
 	scene_tree->get_nodes_in_group(name, &nodes);
 	bool removed_all = true;
-	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
-		if (_can_edit(E->get(), name)) {
-			undo_redo->add_do_method(E->get(), "remove_from_group", name);
-			undo_redo->add_undo_method(E->get(), "add_to_group", name, true);
+	for (Node *E : nodes) {
+		if (_can_edit(E, name)) {
+			undo_redo->add_do_method(E, "remove_from_group", name);
+			undo_redo->add_undo_method(E, "add_to_group", name, true);
 		} else {
 			removed_all = false;
 		}
@@ -628,8 +627,7 @@ void GroupsEditor::update_tree() {
 
 	TreeItem *root = tree->create_item();
 
-	for (List<GroupInfo>::Element *E = groups.front(); E; E = E->next()) {
-		Node::GroupInfo gi = E->get();
+	for (GroupInfo &gi : groups) {
 		if (!gi.persistent) {
 			continue;
 		}

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -894,8 +894,8 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<EditorSceneImpor
 				surftool->add_vertex(vertex_array[k].vertex);
 			}
 
-			for (List<int>::Element *E = indices_list.front(); E; E = E->next()) {
-				surftool->add_index(E->get());
+			for (int &E : indices_list) {
+				surftool->add_index(E);
 			}
 
 			if (!normal_src) {

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -438,17 +438,16 @@ Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, in
 
 	Node3D *scene = memnew(Node3D);
 
-	for (List<Ref<Mesh>>::Element *E = meshes.front(); E; E = E->next()) {
+	for (Ref<Mesh> m : meshes) {
 		Ref<EditorSceneImporterMesh> mesh;
 		mesh.instantiate();
-		Ref<Mesh> m = E->get();
 		for (int i = 0; i < m->get_surface_count(); i++) {
 			mesh->add_surface(m->surface_get_primitive_type(i), m->surface_get_arrays(i), Array(), Dictionary(), m->surface_get_material(i));
 		}
 
 		EditorSceneImporterMeshNode3D *mi = memnew(EditorSceneImporterMeshNode3D);
 		mi->set_mesh(mesh);
-		mi->set_name(E->get()->get_name());
+		mi->set_name(m->get_name());
 		scene->add_child(mi);
 		mi->set_owner(scene);
 	}

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -312,8 +312,8 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<E
 
 		List<StringName> anims;
 		ap->get_animation_list(&anims);
-		for (List<StringName>::Element *E = anims.front(); E; E = E->next()) {
-			Ref<Animation> anim = ap->get_animation(E->get());
+		for (StringName &E : anims) {
+			Ref<Animation> anim = ap->get_animation(E);
 			ERR_CONTINUE(anim.is_null());
 			for (int i = 0; i < anim->get_track_count(); i++) {
 				NodePath path = anim->track_get_path(i);
@@ -328,14 +328,14 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<E
 				}
 			}
 
-			String animname = E->get();
+			String animname = E;
 			const int loop_string_count = 3;
 			static const char *loop_strings[loop_string_count] = { "loops", "loop", "cycle" };
 			for (int i = 0; i < loop_string_count; i++) {
 				if (_teststr(animname, loop_strings[i])) {
 					anim->set_loop(true);
 					animname = _fixstr(animname, loop_strings[i]);
-					ap->rename_animation(E->get(), animname);
+					ap->rename_animation(E, animname);
 				}
 			}
 		}
@@ -659,9 +659,9 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 						}
 
 						int idx = 0;
-						for (List<Ref<Shape3D>>::Element *E = shapes.front(); E; E = E->next()) {
+						for (Ref<Shape3D> &E : shapes) {
 							CollisionShape3D *cshape = memnew(CollisionShape3D);
-							cshape->set_shape(E->get());
+							cshape->set_shape(E);
 							base->add_child(cshape);
 
 							cshape->set_owner(base->get_owner());
@@ -712,9 +712,9 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 			//fill node settings for this node with default values
 			List<ImportOption> iopts;
 			get_internal_import_options(INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE, &iopts);
-			for (List<ImportOption>::Element *E = iopts.front(); E; E = E->next()) {
-				if (!node_settings.has(E->get().option.name)) {
-					node_settings[E->get().option.name] = E->get().default_value;
+			for (ImportOption &E : iopts) {
+				if (!node_settings.has(E.option.name)) {
+					node_settings[E.option.name] = E.default_value;
 				}
 			}
 		}
@@ -756,8 +756,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 		} else {
 			List<StringName> anims;
 			ap->get_animation_list(&anims);
-			for (List<StringName>::Element *E = anims.front(); E; E = E->next()) {
-				String name = E->get();
+			for (StringName &name : anims) {
 				Ref<Animation> anim = ap->get_animation(name);
 				if (p_animation_data.has(name)) {
 					Dictionary anim_settings = p_animation_data[name];
@@ -765,9 +764,9 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 						//fill with default values
 						List<ImportOption> iopts;
 						get_internal_import_options(INTERNAL_IMPORT_CATEGORY_ANIMATION, &iopts);
-						for (List<ImportOption>::Element *F = iopts.front(); F; F = F->next()) {
-							if (!anim_settings.has(F->get().option.name)) {
-								anim_settings[F->get().option.name] = F->get().default_value;
+						for (ImportOption &F : iopts) {
+							if (!anim_settings.has(F.option.name)) {
+								anim_settings[F.option.name] = F.default_value;
 							}
 						}
 					}
@@ -936,8 +935,8 @@ void ResourceImporterScene::_create_clips(AnimationPlayer *anim, const Array &p_
 void ResourceImporterScene::_optimize_animations(AnimationPlayer *anim, float p_max_lin_error, float p_max_ang_error, float p_max_angle) {
 	List<StringName> anim_names;
 	anim->get_animation_list(&anim_names);
-	for (List<StringName>::Element *E = anim_names.front(); E; E = E->next()) {
-		Ref<Animation> a = anim->get_animation(E->get());
+	for (StringName &E : anim_names) {
+		Ref<Animation> a = anim->get_animation(E);
 		a->optimize(p_max_lin_error, p_max_ang_error, Math::deg2rad(p_max_angle));
 	}
 }
@@ -1046,11 +1045,11 @@ void ResourceImporterScene::get_import_options(List<ImportOption> *r_options, in
 
 	String script_ext_hint;
 
-	for (List<String>::Element *E = script_extentions.front(); E; E = E->next()) {
+	for (String &E : script_extentions) {
 		if (script_ext_hint != "") {
 			script_ext_hint += ",";
 		}
-		script_ext_hint += "*." + E->get();
+		script_ext_hint += "*." + E;
 	}
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "nodes/root_scale", PROPERTY_HINT_RANGE, "0.001,1000,0.001"), 1.0));
@@ -1089,9 +1088,9 @@ Node *ResourceImporterScene::import_scene_from_other_importer(EditorSceneImporte
 		List<String> extensions;
 		E->get()->get_extensions(&extensions);
 
-		for (List<String>::Element *F = extensions.front(); F; F = F->next()) {
-			if (F->get().to_lower() == ext) {
-				importer = E->get();
+		for (String &F : extensions) {
+			if (F.to_lower() == ext) {
+				importer = E;
 				break;
 			}
 		}
@@ -1119,9 +1118,9 @@ Ref<Animation> ResourceImporterScene::import_animation_from_other_importer(Edito
 		List<String> extensions;
 		E->get()->get_extensions(&extensions);
 
-		for (List<String>::Element *F = extensions.front(); F; F = F->next()) {
-			if (F->get().to_lower() == ext) {
-				importer = E->get();
+		for (String &F : extensions) {
+			if (F.to_lower() == ext) {
+				importer = E;
 				break;
 			}
 		}
@@ -1291,9 +1290,9 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 }
 
 void ResourceImporterScene::_add_shapes(Node *p_node, const List<Ref<Shape3D>> &p_shapes) {
-	for (const List<Ref<Shape3D>>::Element *E = p_shapes.front(); E; E = E->next()) {
+	for (const Ref<Shape3D> &E : p_shapes) {
 		CollisionShape3D *cshape = memnew(CollisionShape3D);
-		cshape->set_shape(E->get());
+		cshape->set_shape(E);
 		p_node->add_child(cshape);
 
 		cshape->set_owner(p_node->get_owner());
@@ -1311,9 +1310,9 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file) {
 		List<String> extensions;
 		E->get()->get_extensions(&extensions);
 
-		for (List<String>::Element *F = extensions.front(); F; F = F->next()) {
-			if (F->get().to_lower() == ext) {
-				importer = E->get();
+		for (String &F : extensions) {
+			if (F.to_lower() == ext) {
+				importer = E;
 				break;
 			}
 		}
@@ -1351,9 +1350,9 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		List<String> extensions;
 		E->get()->get_extensions(&extensions);
 
-		for (List<String>::Element *F = extensions.front(); F; F = F->next()) {
-			if (F->get().to_lower() == ext) {
-				importer = E->get();
+		for (String &F : extensions) {
+			if (F.to_lower() == ext) {
+				importer = E;
 				break;
 			}
 		}

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -71,9 +71,9 @@ class SceneImportSettingsData : public Object {
 		return false;
 	}
 	void _get_property_list(List<PropertyInfo> *p_list) const {
-		for (const List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
-			if (ResourceImporterScene::get_singleton()->get_internal_option_visibility(category, E->get().option.name, current)) {
-				p_list->push_back(E->get().option);
+		for (const ResourceImporter::ImportOption &E : options) {
+			if (ResourceImporterScene::get_singleton()->get_internal_option_visibility(category, E.option.name, current)) {
+				p_list->push_back(E.option);
 			}
 		}
 	}
@@ -305,8 +305,8 @@ void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
 	if (anim_node) {
 		List<StringName> animations;
 		anim_node->get_animation_list(&animations);
-		for (List<StringName>::Element *E = animations.front(); E; E = E->next()) {
-			_fill_animation(scene_tree, anim_node->get_animation(E->get()), E->get(), item);
+		for (StringName &E : animations) {
+			_fill_animation(scene_tree, anim_node->get_animation(E), E, item);
 		}
 	}
 
@@ -394,8 +394,8 @@ void SceneImportSettings::_load_default_subresource_settings(Map<StringName, Var
 			d = d[p_import_id];
 			List<ResourceImporterScene::ImportOption> options;
 			ResourceImporterScene::get_singleton()->get_internal_import_options(p_category, &options);
-			for (List<ResourceImporterScene::ImportOption>::Element *E = options.front(); E; E = E->next()) {
-				String key = E->get().option.name;
+			for (ResourceImporterScene::ImportOption &E : options) {
+				String key = E.option.name;
 				if (d.has(key)) {
 					settings[key] = d[key];
 				}
@@ -440,12 +440,12 @@ void SceneImportSettings::open_settings(const String &p_path) {
 		if (err == OK) {
 			List<String> keys;
 			config->get_section_keys("params", &keys);
-			for (List<String>::Element *E = keys.front(); E; E = E->next()) {
-				Variant value = config->get_value("params", E->get());
-				if (E->get() == "_subresources") {
+			for (String &E : keys) {
+				Variant value = config->get_value("params", E);
+				if (E == "_subresources") {
 					base_subresource_settings = value;
 				} else {
-					defaults[E->get()] = value;
+					defaults[E] = value;
 				}
 			}
 		}
@@ -605,13 +605,13 @@ void SceneImportSettings::_select(Tree *p_from, String p_type, String p_id) {
 	scene_import_settings_data->defaults.clear();
 	scene_import_settings_data->current.clear();
 
-	for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
-		scene_import_settings_data->defaults[E->get().option.name] = E->get().default_value;
+	for (ResourceImporter::ImportOption &E : options) {
+		scene_import_settings_data->defaults[E.option.name] = E.default_value;
 		//needed for visibility toggling (fails if something is missing)
-		if (scene_import_settings_data->settings->has(E->get().option.name)) {
-			scene_import_settings_data->current[E->get().option.name] = (*scene_import_settings_data->settings)[E->get().option.name];
+		if (scene_import_settings_data->settings->has(E.option.name)) {
+			scene_import_settings_data->current[E.option.name] = (*scene_import_settings_data->settings)[E.option.name];
 		} else {
-			scene_import_settings_data->current[E->get().option.name] = E->get().default_value;
+			scene_import_settings_data->current[E.option.name] = E.default_value;
 		}
 	}
 	scene_import_settings_data->options = options;

--- a/editor/import/scene_importer_mesh.cpp
+++ b/editor/import/scene_importer_mesh.cpp
@@ -79,11 +79,11 @@ void EditorSceneImporterMesh::add_surface(Mesh::PrimitiveType p_primitive, const
 
 	List<Variant> lods;
 	p_lods.get_key_list(&lods);
-	for (List<Variant>::Element *E = lods.front(); E; E = E->next()) {
-		ERR_CONTINUE(!E->get().is_num());
+	for (Variant &E : lods) {
+		ERR_CONTINUE(!E.is_num());
 		Surface::LOD lod;
-		lod.distance = E->get();
-		lod.indices = p_lods[E->get()];
+		lod.distance = E;
+		lod.indices = p_lods[E];
 		ERR_CONTINUE(lod.indices.size() == 0);
 		s.lods.push_back(lod);
 	}

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -61,9 +61,9 @@ protected:
 		if (importer.is_null()) {
 			return;
 		}
-		for (const List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-			if (importer->get_option_visibility(E->get().name, values)) {
-				p_list->push_back(E->get());
+		for (const PropertyInfo &E : properties) {
+			if (importer->get_option_visibility(E.name, values)) {
+				p_list->push_back(E);
 			}
 		}
 	}
@@ -106,9 +106,9 @@ void ImportDefaultsEditor::_update_importer() {
 	List<Ref<ResourceImporter>> importer_list;
 	ResourceFormatImporter::get_singleton()->get_importers(&importer_list);
 	Ref<ResourceImporter> importer;
-	for (List<Ref<ResourceImporter>>::Element *E = importer_list.front(); E; E = E->next()) {
-		if (E->get()->get_visible_name() == importers->get_item_text(importers->get_selected())) {
-			importer = E->get();
+	for (Ref<ResourceImporter> E : importer_list) {
+		if (E->get_visible_name() == importers->get_item_text(importers->get_selected())) {
+			importer = E;
 			break;
 		}
 	}
@@ -125,14 +125,14 @@ void ImportDefaultsEditor::_update_importer() {
 			d = ProjectSettings::get_singleton()->get("importer_defaults/" + importer->get_importer_name());
 		}
 
-		for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
-			settings->properties.push_back(E->get().option);
-			if (d.has(E->get().option.name)) {
-				settings->values[E->get().option.name] = d[E->get().option.name];
+		for (ResourceImporter::ImportOption &E : options) {
+			settings->properties.push_back(E.option);
+			if (d.has(E.option.name)) {
+				settings->values[E.option.name] = d[E.option.name];
 			} else {
-				settings->values[E->get().option.name] = E->get().default_value;
+				settings->values[E.option.name] = E.default_value;
 			}
-			settings->default_values[E->get().option.name] = E->get().default_value;
+			settings->default_values[E.option.name] = E.default_value;
 		}
 
 		save_defaults->set_disabled(false);
@@ -166,8 +166,8 @@ void ImportDefaultsEditor::clear() {
 	List<Ref<ResourceImporter>> importer_list;
 	ResourceFormatImporter::get_singleton()->get_importers(&importer_list);
 	Vector<String> names;
-	for (List<Ref<ResourceImporter>>::Element *E = importer_list.front(); E; E = E->next()) {
-		String vn = E->get()->get_visible_name();
+	for (Ref<ResourceImporter> E : importer_list) {
+		String vn = E->get_visible_name();
 		names.push_back(vn);
 	}
 	names.sort();

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -65,14 +65,14 @@ public:
 		return false;
 	}
 	void _get_property_list(List<PropertyInfo> *p_list) const {
-		for (const List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-			if (!importer->get_option_visibility(E->get().name, values)) {
+		for (const PropertyInfo &E : properties) {
+			if (!importer->get_option_visibility(E.name, values)) {
 				continue;
 			}
-			PropertyInfo pi = E->get();
+			PropertyInfo pi = E;
 			if (checking) {
 				pi.usage |= PROPERTY_USAGE_CHECKABLE;
-				if (checked.has(E->get().name)) {
+				if (checked.has(E.name)) {
 					pi.usage |= PROPERTY_USAGE_CHECKED;
 				}
 			}
@@ -111,18 +111,18 @@ void ImportDock::set_edit_path(const String &p_path) {
 	ResourceFormatImporter::get_singleton()->get_importers_for_extension(p_path.get_extension(), &importers);
 	List<Pair<String, String>> importer_names;
 
-	for (List<Ref<ResourceImporter>>::Element *E = importers.front(); E; E = E->next()) {
-		importer_names.push_back(Pair<String, String>(E->get()->get_visible_name(), E->get()->get_importer_name()));
+	for (Ref<ResourceImporter> E : importers) {
+		importer_names.push_back(Pair<String, String>(E->get_visible_name(), E->get_importer_name()));
 	}
 
 	importer_names.sort_custom<PairSort<String, String>>();
 
 	import_as->clear();
 
-	for (List<Pair<String, String>>::Element *E = importer_names.front(); E; E = E->next()) {
-		import_as->add_item(E->get().first);
-		import_as->set_item_metadata(import_as->get_item_count() - 1, E->get().second);
-		if (E->get().second == importer_name) {
+	for (Pair<String, String> &E : importer_names) {
+		import_as->add_item(E.first);
+		import_as->set_item_metadata(import_as->get_item_count() - 1, E.second);
+		if (E.second == importer_name) {
 			import_as->select(import_as->get_item_count() - 1);
 		}
 	}
@@ -153,12 +153,12 @@ void ImportDock::_update_options(const Ref<ConfigFile> &p_config) {
 	params->checking = params->paths.size() > 1;
 	params->checked.clear();
 
-	for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
-		params->properties.push_back(E->get().option);
-		if (p_config.is_valid() && p_config->has_section_key("params", E->get().option.name)) {
-			params->values[E->get().option.name] = p_config->get_value("params", E->get().option.name);
+	for (ResourceImporter::ImportOption &E : options) {
+		params->properties.push_back(E.option);
+		if (p_config.is_valid() && p_config->has_section_key("params", E.option.name)) {
+			params->values[E.option.name] = p_config->get_value("params", E.option.name);
 		} else {
-			params->values[E->get().option.name] = E->get().default_value;
+			params->values[E.option.name] = E.default_value;
 		}
 	}
 
@@ -201,17 +201,17 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 		List<String> keys;
 		config->get_section_keys("params", &keys);
 
-		for (List<String>::Element *E = keys.front(); E; E = E->next()) {
-			if (!value_frequency.has(E->get())) {
-				value_frequency[E->get()] = Dictionary();
+		for (String &E : keys) {
+			if (!value_frequency.has(E)) {
+				value_frequency[E] = Dictionary();
 			}
 
-			Variant value = config->get_value("params", E->get());
+			Variant value = config->get_value("params", E);
 
-			if (value_frequency[E->get()].has(value)) {
-				value_frequency[E->get()][value] = int(value_frequency[E->get()][value]) + 1;
+			if (value_frequency[E].has(value)) {
+				value_frequency[E][value] = int(value_frequency[E][value]) + 1;
 			} else {
-				value_frequency[E->get()][value] = 1;
+				value_frequency[E][value] = 1;
 			}
 		}
 	}
@@ -226,25 +226,25 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 	params->checking = true;
 	params->checked.clear();
 
-	for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
-		params->properties.push_back(E->get().option);
+	for (ResourceImporter::ImportOption &E : options) {
+		params->properties.push_back(E.option);
 
-		if (value_frequency.has(E->get().option.name)) {
-			Dictionary d = value_frequency[E->get().option.name];
+		if (value_frequency.has(E.option.name)) {
+			Dictionary d = value_frequency[E.option.name];
 			int freq = 0;
 			List<Variant> v;
 			d.get_key_list(&v);
 			Variant value;
-			for (List<Variant>::Element *F = v.front(); F; F = F->next()) {
-				int f = d[F->get()];
+			for (Variant &F : v) {
+				int f = d[F];
 				if (f > freq) {
-					value = F->get();
+					value = F;
 				}
 			}
 
-			params->values[E->get().option.name] = value;
+			params->values[E.option.name] = value;
 		} else {
-			params->values[E->get().option.name] = E->get().default_value;
+			params->values[E.option.name] = E.default_value;
 		}
 	}
 
@@ -254,18 +254,18 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 	ResourceFormatImporter::get_singleton()->get_importers_for_extension(p_paths[0].get_extension(), &importers);
 	List<Pair<String, String>> importer_names;
 
-	for (List<Ref<ResourceImporter>>::Element *E = importers.front(); E; E = E->next()) {
-		importer_names.push_back(Pair<String, String>(E->get()->get_visible_name(), E->get()->get_importer_name()));
+	for (Ref<ResourceImporter> E : importers) {
+		importer_names.push_back(Pair<String, String>(E->get_visible_name(), E->get_importer_name()));
 	}
 
 	importer_names.sort_custom<PairSort<String, String>>();
 
 	import_as->clear();
 
-	for (List<Pair<String, String>>::Element *E = importer_names.front(); E; E = E->next()) {
-		import_as->add_item(E->get().first);
-		import_as->set_item_metadata(import_as->get_item_count() - 1, E->get().second);
-		if (E->get().second == params->importer->get_importer_name()) {
+	for (Pair<String, String> &E : importer_names) {
+		import_as->add_item(E.first);
+		import_as->set_item_metadata(import_as->get_item_count() - 1, E.second);
+		if (E.second == params->importer->get_importer_name()) {
 			import_as->select(import_as->get_item_count() - 1);
 		}
 	}
@@ -345,8 +345,8 @@ void ImportDock::_preset_selected(int p_idx) {
 		case ITEM_SET_AS_DEFAULT: {
 			Dictionary d;
 
-			for (const List<PropertyInfo>::Element *E = params->properties.front(); E; E = E->next()) {
-				d[E->get().name] = params->values[E->get().name];
+			for (const PropertyInfo &E : params->properties) {
+				d[E.name] = params->values[E.name];
 			}
 
 			ProjectSettings::get_singleton()->set("importer_defaults/" + params->importer->get_importer_name(), d);
@@ -363,10 +363,10 @@ void ImportDock::_preset_selected(int p_idx) {
 			if (params->checking) {
 				params->checked.clear();
 			}
-			for (List<Variant>::Element *E = v.front(); E; E = E->next()) {
-				params->values[E->get()] = d[E->get()];
+			for (Variant &E : v) {
+				params->values[E] = d[E];
 				if (params->checking) {
-					params->checked.insert(E->get());
+					params->checked.insert(E);
 				}
 			}
 			params->update();
@@ -384,10 +384,10 @@ void ImportDock::_preset_selected(int p_idx) {
 			if (params->checking) {
 				params->checked.clear();
 			}
-			for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
-				params->values[E->get().option.name] = E->get().default_value;
+			for (ResourceImporter::ImportOption &E : options) {
+				params->values[E.option.name] = E.default_value;
 				if (params->checking) {
-					params->checked.insert(E->get().option.name);
+					params->checked.insert(E.option.name);
 				}
 			}
 			params->update();
@@ -486,9 +486,9 @@ void ImportDock::_reimport() {
 
 			if (params->checking && config->get_value("remap", "importer") == params->importer->get_importer_name()) {
 				//update only what is edited (checkboxes) if the importer is the same
-				for (List<PropertyInfo>::Element *E = params->properties.front(); E; E = E->next()) {
-					if (params->checked.has(E->get().name)) {
-						config->set_value("params", E->get().name, params->values[E->get().name]);
+				for (PropertyInfo &E : params->properties) {
+					if (params->checked.has(E.name)) {
+						config->set_value("params", E.name, params->values[E.name]);
 					}
 				}
 			} else {
@@ -498,8 +498,8 @@ void ImportDock::_reimport() {
 					config->erase_section("params");
 				}
 
-				for (List<PropertyInfo>::Element *E = params->properties.front(); E; E = E->next()) {
-					config->set_value("params", E->get().name, params->values[E->get().name]);
+				for (PropertyInfo &E : params->properties) {
+					config->set_value("params", E.name, params->values[E.name]);
 				}
 			}
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -87,12 +87,12 @@ void InspectorDock::_menu_option(int p_option) {
 				List<PropertyInfo> props;
 				current->get_property_list(&props);
 				Map<RES, RES> duplicates;
-				for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-					if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+				for (PropertyInfo &E : props) {
+					if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 						continue;
 					}
 
-					Variant v = current->get(E->get().name);
+					Variant v = current->get(E.name);
 					if (v.is_ref()) {
 						REF ref = v;
 						if (ref.is_valid()) {
@@ -103,8 +103,8 @@ void InspectorDock::_menu_option(int p_option) {
 								}
 								res = duplicates[res];
 
-								current->set(E->get().name, res);
-								editor->get_inspector()->update_property(E->get().name);
+								current->set(E.name, res);
+								editor->get_inspector()->update_property(E.name);
 							}
 						}
 					}

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -43,15 +43,15 @@ void LocalizationEditor::_notification(int p_what) {
 
 		List<String> tfn;
 		ResourceLoader::get_recognized_extensions_for_type("Translation", &tfn);
-		for (List<String>::Element *E = tfn.front(); E; E = E->next()) {
-			translation_file_open->add_filter("*." + E->get());
+		for (String &E : tfn) {
+			translation_file_open->add_filter("*." + E);
 		}
 
 		List<String> rfn;
 		ResourceLoader::get_recognized_extensions_for_type("Resource", &rfn);
-		for (List<String>::Element *E = rfn.front(); E; E = E->next()) {
-			translation_res_file_open_dialog->add_filter("*." + E->get());
-			translation_res_option_file_open_dialog->add_filter("*." + E->get());
+		for (String &E : rfn) {
+			translation_res_file_open_dialog->add_filter("*." + E);
+			translation_res_option_file_open_dialog->add_filter("*." + E);
 		}
 
 		_update_pot_file_extensions();
@@ -430,8 +430,8 @@ void LocalizationEditor::_update_pot_file_extensions() {
 	pot_file_open_dialog->clear_filters();
 	List<String> translation_parse_file_extensions;
 	EditorTranslationParser::get_singleton()->get_recognized_extensions(&translation_parse_file_extensions);
-	for (List<String>::Element *E = translation_parse_file_extensions.front(); E; E = E->next()) {
-		pot_file_open_dialog->add_filter("*." + E->get());
+	for (String &E : translation_parse_file_extensions) {
+		pot_file_open_dialog->add_filter("*." + E);
 	}
 }
 
@@ -560,8 +560,8 @@ void LocalizationEditor::update_translations() {
 		List<Variant> rk;
 		remaps.get_key_list(&rk);
 		Vector<String> keys;
-		for (List<Variant>::Element *E = rk.front(); E; E = E->next()) {
-			keys.push_back(E->get());
+		for (Variant &E : rk) {
+			keys.push_back(E);
 		}
 		keys.sort();
 

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -52,12 +52,12 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 
 	ur->create_action(TTR("MultiNode Set") + " " + String(name), UndoRedo::MERGE_ENDS);
-	for (const List<NodePath>::Element *E = nodes.front(); E; E = E->next()) {
-		if (!es->has_node(E->get())) {
+	for (const NodePath &E : nodes) {
+		if (!es->has_node(E)) {
 			continue;
 		}
 
-		Node *n = es->get_node(E->get());
+		Node *n = es->get_node(E);
 		if (!n) {
 			continue;
 		}
@@ -98,12 +98,12 @@ bool MultiNodeEdit::_get(const StringName &p_name, Variant &r_ret) const {
 		name = "script";
 	}
 
-	for (const List<NodePath>::Element *E = nodes.front(); E; E = E->next()) {
-		if (!es->has_node(E->get())) {
+	for (const NodePath &E : nodes) {
+		if (!es->has_node(E)) {
 			continue;
 		}
 
-		const Node *n = es->get_node(E->get());
+		const Node *n = es->get_node(E);
 		if (!n) {
 			continue;
 		}
@@ -130,12 +130,12 @@ void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	List<PLData *> data_list;
 
-	for (const List<NodePath>::Element *E = nodes.front(); E; E = E->next()) {
-		if (!es->has_node(E->get())) {
+	for (const NodePath &E : nodes) {
+		if (!es->has_node(E)) {
 			continue;
 		}
 
-		Node *n = es->get_node(E->get());
+		Node *n = es->get_node(E);
 		if (!n) {
 			continue;
 		}
@@ -143,30 +143,30 @@ void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 		List<PropertyInfo> plist;
 		n->get_property_list(&plist, true);
 
-		for (List<PropertyInfo>::Element *F = plist.front(); F; F = F->next()) {
-			if (F->get().name == "script") {
+		for (PropertyInfo &F : plist) {
+			if (F.name == "script") {
 				continue; //added later manually, since this is intercepted before being set (check Variant Object::get() )
 			}
-			if (!usage.has(F->get().name)) {
+			if (!usage.has(F.name)) {
 				PLData pld;
 				pld.uses = 0;
-				pld.info = F->get();
-				usage[F->get().name] = pld;
-				data_list.push_back(usage.getptr(F->get().name));
+				pld.info = F;
+				usage[F.name] = pld;
+				data_list.push_back(usage.getptr(F.name));
 			}
 
 			// Make sure only properties with the same exact PropertyInfo data will appear
-			if (usage[F->get().name].info == F->get()) {
-				usage[F->get().name].uses++;
+			if (usage[F.name].info == F) {
+				usage[F.name].uses++;
 			}
 		}
 
 		nc++;
 	}
 
-	for (List<PLData *>::Element *E = data_list.front(); E; E = E->next()) {
-		if (nc == E->get()->uses) {
-			p_list->push_back(E->get()->info);
+	for (PLData *E : data_list) {
+		if (nc == E->uses) {
+			p_list->push_back(E->info);
 		}
 	}
 

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -72,22 +72,22 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 				List<StringName> names;
 				ap->get_animation_list(&names);
 
-				for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E->get());
-					animations_to_add.push_back(E->get());
+				for (StringName &E : names) {
+					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E);
+					animations_to_add.push_back(E);
 				}
 			}
 		}
 
-		for (List<StringName>::Element *E = classes.front(); E; E = E->next()) {
-			String name = String(E->get()).replace_first("AnimationNode", "");
+		for (StringName &E : classes) {
+			String name = String(E).replace_first("AnimationNode", "");
 			if (name == "Animation") {
 				continue;
 			}
 
 			int idx = menu->get_item_count();
 			menu->add_item(vformat("Add %s", name), idx);
-			menu->set_item_metadata(idx, E->get());
+			menu->set_item_metadata(idx, E);
 		}
 
 		Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
@@ -373,8 +373,8 @@ void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 		open_file->clear_filters();
 		List<String> filters;
 		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", &filters);
-		for (List<String>::Element *E = filters.front(); E; E = E->next()) {
-			open_file->add_filter("*." + E->get());
+		for (String &E : filters) {
+			open_file->add_filter("*." + E);
 		}
 		open_file->popup_file_dialog();
 		return;

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -96,21 +96,21 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			if (ap) {
 				List<StringName> names;
 				ap->get_animation_list(&names);
-				for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E->get());
-					animations_to_add.push_back(E->get());
+				for (StringName &E : names) {
+					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E);
+					animations_to_add.push_back(E);
 				}
 			}
 		}
 
-		for (List<StringName>::Element *E = classes.front(); E; E = E->next()) {
-			String name = String(E->get()).replace_first("AnimationNode", "");
+		for (StringName &E : classes) {
+			String name = String(E).replace_first("AnimationNode", "");
 			if (name == "Animation") {
 				continue; // nope
 			}
 			int idx = menu->get_item_count();
 			menu->add_item(vformat("Add %s", name), idx);
-			menu->set_item_metadata(idx, E->get());
+			menu->set_item_metadata(idx, E);
 		}
 
 		Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
@@ -295,8 +295,8 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 		open_file->clear_filters();
 		List<String> filters;
 		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", &filters);
-		for (List<String>::Element *E = filters.front(); E; E = E->next()) {
-			open_file->add_filter("*." + E->get());
+		for (String &E : filters) {
+			open_file->add_filter("*." + E);
 		}
 		open_file->popup_file_dialog();
 		return;

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -121,21 +121,21 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 	List<StringName> nodes;
 	blend_tree->get_node_list(&nodes);
 
-	for (List<StringName>::Element *E = nodes.front(); E; E = E->next()) {
+	for (StringName &E : nodes) {
 		GraphNode *node = memnew(GraphNode);
 		graph->add_child(node);
 
-		Ref<AnimationNode> agnode = blend_tree->get_node(E->get());
+		Ref<AnimationNode> agnode = blend_tree->get_node(E);
 
-		node->set_position_offset(blend_tree->get_node_position(E->get()) * EDSCALE);
+		node->set_position_offset(blend_tree->get_node_position(E) * EDSCALE);
 
 		node->set_title(agnode->get_caption());
-		node->set_name(E->get());
+		node->set_name(E);
 
 		int base = 0;
-		if (String(E->get()) != "output") {
+		if (String(E) != "output") {
 			LineEdit *name = memnew(LineEdit);
-			name->set_text(E->get());
+			name->set_text(E);
 			name->set_expand_to_text_length_enabled(true);
 			node->add_child(name);
 			node->set_slot(0, false, 0, Color(), true, 0, get_theme_color(SNAME("font_color"), SNAME("Label")));
@@ -143,7 +143,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			name->connect("focus_exited", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed_focus_out), varray(name, agnode), CONNECT_DEFERRED);
 			base = 1;
 			node->set_show_close_button(true);
-			node->connect("close_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_delete_request), varray(E->get()), CONNECT_DEFERRED);
+			node->connect("close_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_delete_request), varray(E), CONNECT_DEFERRED);
 		}
 
 		for (int i = 0; i < agnode->get_input_count(); i++) {
@@ -155,12 +155,12 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 
 		List<PropertyInfo> pinfo;
 		agnode->get_parameter_list(&pinfo);
-		for (List<PropertyInfo>::Element *F = pinfo.front(); F; F = F->next()) {
-			if (!(F->get().usage & PROPERTY_USAGE_EDITOR)) {
+		for (PropertyInfo &F : pinfo) {
+			if (!(F.usage & PROPERTY_USAGE_EDITOR)) {
 				continue;
 			}
-			String base_path = AnimationTreeEditor::get_singleton()->get_base_path() + String(E->get()) + "/" + F->get().name;
-			EditorProperty *prop = EditorInspector::instantiate_property_editor(AnimationTreeEditor::get_singleton()->get_tree(), F->get().type, base_path, F->get().hint, F->get().hint_string, F->get().usage);
+			String base_path = AnimationTreeEditor::get_singleton()->get_base_path() + String(E) + "/" + F.name;
+			EditorProperty *prop = EditorInspector::instantiate_property_editor(AnimationTreeEditor::get_singleton()->get_tree(), F.type, base_path, F.hint, F.hint_string, F.usage);
 			if (prop) {
 				prop->set_object_and_property(AnimationTreeEditor::get_singleton()->get_tree(), base_path);
 				prop->update_property();
@@ -171,7 +171,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			}
 		}
 
-		node->connect("dragged", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_dragged), varray(E->get()));
+		node->connect("dragged", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_dragged), varray(E));
 
 		if (AnimationTreeEditor::get_singleton()->can_edit(agnode)) {
 			node->add_child(memnew(HSeparator));
@@ -179,7 +179,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			open_in_editor->set_text(TTR("Open Editor"));
 			open_in_editor->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 			node->add_child(open_in_editor);
-			open_in_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_open_in_editor), varray(E->get()), CONNECT_DEFERRED);
+			open_in_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_open_in_editor), varray(E), CONNECT_DEFERRED);
 			open_in_editor->set_h_size_flags(SIZE_SHRINK_CENTER);
 		}
 
@@ -189,7 +189,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			edit_filters->set_text(TTR("Edit Filters"));
 			edit_filters->set_icon(get_theme_icon(SNAME("AnimationFilter"), SNAME("EditorIcons")));
 			node->add_child(edit_filters);
-			edit_filters->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_edit_filters), varray(E->get()), CONNECT_DEFERRED);
+			edit_filters->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_edit_filters), varray(E), CONNECT_DEFERRED);
 			edit_filters->set_h_size_flags(SIZE_SHRINK_CENTER);
 		}
 
@@ -212,9 +212,9 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 					List<StringName> anims;
 					ap->get_animation_list(&anims);
 
-					for (List<StringName>::Element *F = anims.front(); F; F = F->next()) {
-						mb->get_popup()->add_item(F->get());
-						options.push_back(F->get());
+					for (StringName &F : anims) {
+						mb->get_popup()->add_item(F);
+						options.push_back(F);
 					}
 
 					if (ap->has_animation(anim->get_animation())) {
@@ -225,10 +225,10 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 
 			pb->set_percent_visible(false);
 			pb->set_custom_minimum_size(Vector2(0, 14) * EDSCALE);
-			animations[E->get()] = pb;
+			animations[E] = pb;
 			node->add_child(pb);
 
-			mb->get_popup()->connect("index_pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_anim_selected), varray(options, E->get()), CONNECT_DEFERRED);
+			mb->get_popup()->connect("index_pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_anim_selected), varray(options, E), CONNECT_DEFERRED);
 		}
 
 		Ref<StyleBoxFlat> sb = node->get_theme_stylebox(SNAME("frame"), SNAME("GraphNode"));
@@ -246,10 +246,10 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 	List<AnimationNodeBlendTree::NodeConnection> connections;
 	blend_tree->get_node_connections(&connections);
 
-	for (List<AnimationNodeBlendTree::NodeConnection>::Element *E = connections.front(); E; E = E->next()) {
-		StringName from = E->get().output_node;
-		StringName to = E->get().input_node;
-		int to_idx = E->get().input_index;
+	for (AnimationNodeBlendTree::NodeConnection &E : connections) {
+		StringName from = E.output_node;
+		StringName to = E.input_node;
+		int to_idx = E.input_index;
 
 		graph->connect_node(from, 0, to, to_idx);
 	}
@@ -274,8 +274,8 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		open_file->clear_filters();
 		List<String> filters;
 		ResourceLoader::get_recognized_extensions_for_type("AnimationNode", &filters);
-		for (List<String>::Element *E = filters.front(); E; E = E->next()) {
-			open_file->add_filter("*." + E->get());
+		for (String &E : filters) {
+			open_file->add_filter("*." + E);
 		}
 		open_file->popup_file_dialog();
 		return;
@@ -394,9 +394,9 @@ void AnimationNodeBlendTreeEditor::_delete_request(const String &p_which) {
 	List<AnimationNodeBlendTree::NodeConnection> conns;
 	blend_tree->get_node_connections(&conns);
 
-	for (List<AnimationNodeBlendTree::NodeConnection>::Element *E = conns.front(); E; E = E->next()) {
-		if (E->get().output_node == p_which || E->get().input_node == p_which) {
-			undo_redo->add_undo_method(blend_tree.ptr(), "connect_node", E->get().input_node, E->get().input_index, E->get().output_node);
+	for (AnimationNodeBlendTree::NodeConnection &E : conns) {
+		if (E.output_node == p_which || E.input_node == p_which) {
+			undo_redo->add_undo_method(blend_tree.ptr(), "connect_node", E.input_node, E.input_index, E.output_node);
 		}
 	}
 
@@ -423,8 +423,8 @@ void AnimationNodeBlendTreeEditor::_delete_nodes_request() {
 
 	undo_redo->create_action(TTR("Delete Node(s)"));
 
-	for (List<StringName>::Element *F = to_erase.front(); F; F = F->next()) {
-		_delete_request(F->get());
+	for (StringName &F : to_erase) {
+		_delete_request(F);
 	}
 
 	undo_redo->commit_action();
@@ -517,8 +517,8 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 		List<StringName> animations;
 		player->get_animation_list(&animations);
 
-		for (List<StringName>::Element *E = animations.front(); E; E = E->next()) {
-			Ref<Animation> anim = player->get_animation(E->get());
+		for (StringName &E : animations) {
+			Ref<Animation> anim = player->get_animation(E);
 			for (int i = 0; i < anim->get_track_count(); i++) {
 				String track_path = anim->track_get_path(i);
 				paths.insert(track_path);
@@ -718,13 +718,13 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 
 		List<AnimationNodeBlendTree::NodeConnection> conns;
 		blend_tree->get_node_connections(&conns);
-		for (List<AnimationNodeBlendTree::NodeConnection>::Element *E = conns.front(); E; E = E->next()) {
+		for (AnimationNodeBlendTree::NodeConnection &E : conns) {
 			float activity = 0;
-			StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + E->get().input_node;
+			StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + E.input_node;
 			if (AnimationTreeEditor::get_singleton()->get_tree() && !AnimationTreeEditor::get_singleton()->get_tree()->is_state_invalid()) {
-				activity = AnimationTreeEditor::get_singleton()->get_tree()->get_connection_activity(path, E->get().input_index);
+				activity = AnimationTreeEditor::get_singleton()->get_tree()->get_connection_activity(path, E.input_index);
 			}
-			graph->set_connection_activity(E->get().output_node, 0, E->get().input_node, E->get().input_index, activity);
+			graph->set_connection_activity(E.output_node, 0, E.input_node, E.input_index, activity);
 		}
 
 		AnimationTree *graph_player = AnimationTreeEditor::get_singleton()->get_tree();
@@ -741,7 +741,7 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 						Ref<Animation> anim = player->get_animation(an->get_animation());
 						if (anim.is_valid()) {
 							E->get()->set_max(anim->get_length());
-							//StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + E->get().input_node;
+							//StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + E.input_node;
 							StringName time_path = AnimationTreeEditor::get_singleton()->get_base_path() + String(E->key()) + "/time";
 							E->get()->set_value(AnimationTreeEditor::get_singleton()->get_tree()->get(time_path));
 						}
@@ -828,10 +828,10 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 	List<AnimationNodeBlendTree::NodeConnection> connections;
 	blend_tree->get_node_connections(&connections);
 
-	for (List<AnimationNodeBlendTree::NodeConnection>::Element *E = connections.front(); E; E = E->next()) {
-		StringName from = E->get().output_node;
-		StringName to = E->get().input_node;
-		int to_idx = E->get().input_index;
+	for (AnimationNodeBlendTree::NodeConnection &E : connections) {
+		StringName from = E.output_node;
+		StringName to = E.input_node;
+		int to_idx = E.input_index;
 
 		graph->connect_node(from, 0, to, to_idx);
 	}

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -350,8 +350,8 @@ void AnimationPlayerEditor::_animation_load() {
 	List<String> extensions;
 
 	ResourceLoader::get_recognized_extensions_for_type("Animation", &extensions);
-	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-		file->add_filter("*." + E->get() + " ; " + E->get().to_upper());
+	for (String &E : extensions) {
+		file->add_filter("*." + E + " ; " + E.to_upper());
 	}
 
 	file->popup_file_dialog();
@@ -584,8 +584,7 @@ void AnimationPlayerEditor::_animation_blend() {
 	blend_editor.next->clear();
 	blend_editor.next->add_item("", i);
 
-	for (List<StringName>::Element *E = anims.front(); E; E = E->next()) {
-		String to = E->get();
+	for (StringName &to : anims) {
 		TreeItem *blend = blend_editor.tree->create_item(root);
 		blend->set_editable(0, false);
 		blend->set_editable(1, true);
@@ -830,20 +829,20 @@ void AnimationPlayerEditor::_update_player() {
 	}
 
 	int active_idx = -1;
-	for (List<StringName>::Element *E = animlist.front(); E; E = E->next()) {
+	for (StringName &E : animlist) {
 		Ref<Texture2D> icon;
-		if (E->get() == player->get_autoplay()) {
-			if (E->get() == "RESET") {
+		if (E == player->get_autoplay()) {
+			if (E == "RESET") {
 				icon = autoplay_reset_icon;
 			} else {
 				icon = autoplay_icon;
 			}
-		} else if (E->get() == "RESET") {
+		} else if (E == "RESET") {
 			icon = reset_icon;
 		}
-		animation->add_icon_item(icon, E->get());
+		animation->add_icon_item(icon, E);
 
-		if (player->get_assigned_animation() == E->get()) {
+		if (player->get_assigned_animation() == E) {
 			active_idx = animation->get_item_count() - 1;
 		}
 	}
@@ -966,9 +965,9 @@ void AnimationPlayerEditor::_animation_duplicate() {
 	Ref<Animation> new_anim = memnew(Animation);
 	List<PropertyInfo> plist;
 	anim->get_property_list(&plist);
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		if (E->get().usage & PROPERTY_USAGE_STORAGE) {
-			new_anim->set(E->get().name, anim->get(E->get().name));
+	for (PropertyInfo &E : plist) {
+		if (E.usage & PROPERTY_USAGE_STORAGE) {
+			new_anim->set(E.name, anim->get(E.name));
 		}
 	}
 	new_anim->set_path("");

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -93,21 +93,21 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			if (ap) {
 				List<StringName> names;
 				ap->get_animation_list(&names);
-				for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E->get());
-					animations_to_add.push_back(E->get());
+				for (StringName &E : names) {
+					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E);
+					animations_to_add.push_back(E);
 				}
 			}
 		}
 
-		for (List<StringName>::Element *E = classes.front(); E; E = E->next()) {
-			String name = String(E->get()).replace_first("AnimationNode", "");
+		for (StringName &E : classes) {
+			String name = String(E).replace_first("AnimationNode", "");
 			if (name == "Animation") {
 				continue; // nope
 			}
 			int idx = menu->get_item_count();
 			menu->add_item(vformat("Add %s", name), idx);
-			menu->set_item_metadata(idx, E->get());
+			menu->set_item_metadata(idx, E);
 		}
 		Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
 
@@ -318,24 +318,24 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			float best_d_x = 1e20;
 			float best_d_y = 1e20;
 
-			for (List<StringName>::Element *E = nodes.front(); E; E = E->next()) {
-				if (E->get() == selected_node) {
+			for (StringName &E : nodes) {
+				if (E == selected_node) {
 					continue;
 				}
-				Vector2 npos = state_machine->get_node_position(E->get());
+				Vector2 npos = state_machine->get_node_position(E);
 
 				float d_x = ABS(npos.x - cpos.x);
 				if (d_x < MIN(5, best_d_x)) {
 					drag_ofs.x -= cpos.x - npos.x;
 					best_d_x = d_x;
-					snap_x = E->get();
+					snap_x = E;
 				}
 
 				float d_y = ABS(npos.y - cpos.y);
 				if (d_y < MIN(5, best_d_y)) {
 					drag_ofs.y -= cpos.y - npos.y;
 					best_d_y = d_y;
-					snap_y = E->get();
+					snap_y = E;
 				}
 			}
 		}
@@ -409,8 +409,8 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 		open_file->clear_filters();
 		List<String> filters;
 		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", &filters);
-		for (List<String>::Element *E = filters.front(); E; E = E->next()) {
-			open_file->add_filter("*." + E->get());
+		for (String &E : filters) {
+			open_file->add_filter("*." + E);
 		}
 		open_file->popup_file_dialog();
 		return;
@@ -606,11 +606,11 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	}
 
 	//pre pass nodes so we know the rectangles
-	for (List<StringName>::Element *E = nodes.front(); E; E = E->next()) {
-		Ref<AnimationNode> anode = state_machine->get_node(E->get());
-		String name = E->get();
+	for (StringName &E : nodes) {
+		Ref<AnimationNode> anode = state_machine->get_node(E);
+		String name = E;
 		bool needs_editor = EditorNode::get_singleton()->item_has_editor(anode.ptr());
-		Ref<StyleBox> sb = E->get() == selected_node ? style_selected : style;
+		Ref<StyleBox> sb = E == selected_node ? style_selected : style;
 
 		Size2 s = sb->get_minimum_size();
 		int strsize = font->get_string_size(name, font_size).width;
@@ -622,8 +622,8 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		}
 
 		Vector2 offset;
-		offset += state_machine->get_node_position(E->get()) * EDSCALE;
-		if (selected_node == E->get() && dragging_selected) {
+		offset += state_machine->get_node_position(E) * EDSCALE;
+		if (selected_node == E && dragging_selected) {
 			offset += drag_ofs;
 		}
 		offset -= s / 2;
@@ -633,7 +633,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 
 		NodeRect nr;
 		nr.node = Rect2(offset, s);
-		nr.node_name = E->get();
+		nr.node_name = E;
 
 		scroll_range = scroll_range.merge(nr.node); //merge with range
 

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -215,8 +215,8 @@ Vector<String> AnimationTreeEditor::get_animation_list() {
 	List<StringName> anims;
 	ap->get_animation_list(&anims);
 	Vector<String> ret;
-	for (List<StringName>::Element *E = anims.front(); E; E = E->next()) {
-		ret.push_back(E->get());
+	for (StringName &E : anims) {
+		ret.push_back(E);
 	}
 
 	return ret;

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -607,7 +607,7 @@ void EditorAssetLibrary::_update_repository_options() {
 	Dictionary available_urls = _EDITOR_DEF("asset_library/available_urls", default_urls, true);
 	repository->clear();
 	Array keys = available_urls.keys();
-	for (int i = 0; i < available_urls.size(); i++) {
+	for (int i = 0; i < keys.size(); i++) {
 		String key = keys[i];
 		repository->add_item(key);
 		repository->set_item_metadata(i, available_urls[key]);

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -253,8 +253,8 @@ CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin(EditorNode *p_node) {
 	file = memnew(EditorFileDialog);
 	List<String> ext;
 	ImageLoader::get_recognized_extensions(&ext);
-	for (List<String>::Element *E = ext.front(); E; E = E->next()) {
-		file->add_filter("*." + E->get() + "; " + E->get().to_upper());
+	for (String &E : ext) {
+		file->add_filter("*." + E + "; " + E.to_upper());
 	}
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	toolbar->add_child(file);

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -490,11 +490,11 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 	Set<String> control_flow_keywords;
 	Set<String> keywords;
 
-	for (List<String>::Element *E = kwors.front(); E; E = E->next()) {
-		if (scr->get_language()->is_control_flow_keyword(E->get())) {
-			control_flow_keywords.insert(E->get());
+	for (String &E : kwors) {
+		if (scr->get_language()->is_control_flow_keyword(E)) {
+			control_flow_keywords.insert(E);
 		} else {
-			keywords.insert(E->get());
+			keywords.insert(E);
 		}
 	}
 

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -361,8 +361,8 @@ GPUParticles2DEditorPlugin::GPUParticles2DEditorPlugin(EditorNode *p_node) {
 	file = memnew(EditorFileDialog);
 	List<String> ext;
 	ImageLoader::get_recognized_extensions(&ext);
-	for (List<String>::Element *E = ext.front(); E; E = E->next()) {
-		file->add_filter("*." + E->get() + "; " + E->get().to_upper());
+	for (String &E : ext) {
+		file->add_filter("*." + E + "; " + E.to_upper());
 	}
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	toolbar->add_child(file);

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -265,15 +265,15 @@ Ref<Resource> StandardMaterial3DConversionPlugin::convert(const Ref<Resource> &p
 	List<PropertyInfo> params;
 	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
 
-	for (List<PropertyInfo>::Element *E = params.front(); E; E = E->next()) {
+	for (PropertyInfo &E : params) {
 		// Texture parameter has to be treated specially since StandardMaterial3D saved it
 		// as RID but ShaderMaterial needs Texture itself
-		Ref<Texture2D> texture = mat->get_texture_by_name(E->get().name);
+		Ref<Texture2D> texture = mat->get_texture_by_name(E.name);
 		if (texture.is_valid()) {
-			smat->set_shader_param(E->get().name, texture);
+			smat->set_shader_param(E.name, texture);
 		} else {
-			Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E->get().name);
-			smat->set_shader_param(E->get().name, value);
+			Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
+			smat->set_shader_param(E.name, value);
 		}
 	}
 
@@ -309,9 +309,9 @@ Ref<Resource> ParticlesMaterialConversionPlugin::convert(const Ref<Resource> &p_
 	List<PropertyInfo> params;
 	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
 
-	for (List<PropertyInfo>::Element *E = params.front(); E; E = E->next()) {
-		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E->get().name);
-		smat->set_shader_param(E->get().name, value);
+	for (PropertyInfo &E : params) {
+		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
+		smat->set_shader_param(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());
@@ -346,9 +346,9 @@ Ref<Resource> CanvasItemMaterialConversionPlugin::convert(const Ref<Resource> &p
 	List<PropertyInfo> params;
 	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
 
-	for (List<PropertyInfo>::Element *E = params.front(); E; E = E->next()) {
-		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E->get().name);
-		smat->set_shader_param(E->get().name, value);
+	for (PropertyInfo &E : params) {
+		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
+		smat->set_shader_param(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());
@@ -383,9 +383,9 @@ Ref<Resource> ProceduralSkyMaterialConversionPlugin::convert(const Ref<Resource>
 	List<PropertyInfo> params;
 	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
 
-	for (List<PropertyInfo>::Element *E = params.front(); E; E = E->next()) {
-		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E->get().name);
-		smat->set_shader_param(E->get().name, value);
+	for (PropertyInfo &E : params) {
+		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
+		smat->set_shader_param(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());
@@ -420,9 +420,9 @@ Ref<Resource> PanoramaSkyMaterialConversionPlugin::convert(const Ref<Resource> &
 	List<PropertyInfo> params;
 	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
 
-	for (List<PropertyInfo>::Element *E = params.front(); E; E = E->next()) {
-		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E->get().name);
-		smat->set_shader_param(E->get().name, value);
+	for (PropertyInfo &E : params) {
+		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
+		smat->set_shader_param(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());
@@ -457,9 +457,9 @@ Ref<Resource> PhysicalSkyMaterialConversionPlugin::convert(const Ref<Resource> &
 	List<PropertyInfo> params;
 	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
 
-	for (List<PropertyInfo>::Element *E = params.front(); E; E = E->next()) {
-		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E->get().name);
-		smat->set_shader_param(E->get().name, value);
+	for (PropertyInfo &E : params) {
+		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
+		smat->set_shader_param(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -90,8 +90,8 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			ur->create_action(TTR("Create Static Trimesh Body"));
 
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				MeshInstance3D *instance = Object::cast_to<MeshInstance3D>(E->get());
+			for (Node *E : selection) {
+				MeshInstance3D *instance = Object::cast_to<MeshInstance3D>(E);
 				if (!instance) {
 					continue;
 				}

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -122,23 +122,23 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 			List<uint32_t> shapes;
 			sb->get_shape_owners(&shapes);
 
-			for (List<uint32_t>::Element *E = shapes.front(); E; E = E->next()) {
-				if (sb->is_shape_owner_disabled(E->get())) {
+			for (uint32_t &E : shapes) {
+				if (sb->is_shape_owner_disabled(E)) {
 					continue;
 				}
 
-				//Transform3D shape_transform = sb->shape_owner_get_transform(E->get());
+				//Transform3D shape_transform = sb->shape_owner_get_transform(E);
 
 				//shape_transform.set_origin(shape_transform.get_origin() - phys_offset);
 
-				for (int k = 0; k < sb->shape_owner_get_shape_count(E->get()); k++) {
-					Ref<Shape3D> collision = sb->shape_owner_get_shape(E->get(), k);
+				for (int k = 0; k < sb->shape_owner_get_shape_count(E); k++) {
+					Ref<Shape3D> collision = sb->shape_owner_get_shape(E, k);
 					if (!collision.is_valid()) {
 						continue;
 					}
 					MeshLibrary::ShapeData shape_data;
 					shape_data.shape = collision;
-					shape_data.local_transform = sb->get_transform() * sb->shape_owner_get_transform(E->get());
+					shape_data.local_transform = sb->get_transform() * sb->shape_owner_get_transform(E);
 					collisions.push_back(shape_data);
 				}
 			}

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -4013,8 +4013,7 @@ void CollisionObject3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	List<uint32_t> owners;
 	co->get_shape_owners(&owners);
-	for (List<uint32_t>::Element *E = owners.front(); E; E = E->next()) {
-		uint32_t owner_id = E->get();
+	for (uint32_t &owner_id : owners) {
 		Transform3D xform = co->shape_owner_get_transform(owner_id);
 		Object *owner = co->shape_owner_get_owner(owner_id);
 		// Exclude CollisionShape3D and CollisionPolygon3D as they have their gizmo.
@@ -4747,9 +4746,7 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector3 *tw = tmeshfaces.ptrw();
 		int tidx = 0;
 
-		for (List<Face3>::Element *E = faces.front(); E; E = E->next()) {
-			const Face3 &f = E->get();
-
+		for (Face3 &f : faces) {
 			for (int j = 0; j < 3; j++) {
 				tw[tidx++] = f.vertex[j];
 				_EdgeKey ek;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1327,8 +1327,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 					List<Node *> &selection = editor_selection->get_selected_node_list();
 
-					for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-						Node3D *sp = Object::cast_to<Node3D>(E->get());
+					for (Node *E : selection) {
+						Node3D *sp = Object::cast_to<Node3D>(E);
 						if (!sp) {
 							continue;
 						}
@@ -1771,8 +1771,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 									String::num(motion_snapped.y, snap_step_decimals) + ", " + String::num(motion_snapped.z, snap_step_decimals) + ")");
 
 						List<Node *> &selection = editor_selection->get_selected_node_list();
-						for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-							Node3D *sp = Object::cast_to<Node3D>(E->get());
+						for (Node *E : selection) {
+							Node3D *sp = Object::cast_to<Node3D>(E);
 							if (!sp) {
 								continue;
 							}
@@ -1870,8 +1870,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 									String::num(motion_snapped.y, snap_step_decimals) + ", " + String::num(motion_snapped.z, snap_step_decimals) + ")");
 
 						List<Node *> &selection = editor_selection->get_selected_node_list();
-						for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-							Node3D *sp = Object::cast_to<Node3D>(E->get());
+						for (Node *E : selection) {
+							Node3D *sp = Object::cast_to<Node3D>(E);
 							if (!sp) {
 								continue;
 							}
@@ -1955,8 +1955,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						bool local_coords = (spatial_editor->are_local_coords_enabled() && _edit.plane != TRANSFORM_VIEW); // Disable local transformation for TRANSFORM_VIEW
 
 						List<Node *> &selection = editor_selection->get_selected_node_list();
-						for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-							Node3D *sp = Object::cast_to<Node3D>(E->get());
+						for (Node *E : selection) {
+							Node3D *sp = Object::cast_to<Node3D>(E);
 							if (!sp) {
 								continue;
 							}
@@ -2186,8 +2186,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *sp = Object::cast_to<Node3D>(E->get());
+			for (Node *E : selection) {
+				Node3D *sp = Object::cast_to<Node3D>(E);
 				if (!sp) {
 					continue;
 				}
@@ -3052,8 +3052,8 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 
 			undo_redo->create_action(TTR("Align Transform with View"));
 
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *sp = Object::cast_to<Node3D>(E->get());
+			for (Node *E : selection) {
+				Node3D *sp = Object::cast_to<Node3D>(E);
 				if (!sp) {
 					continue;
 				}
@@ -3088,8 +3088,8 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
 			undo_redo->create_action(TTR("Align Rotation with View"));
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *sp = Object::cast_to<Node3D>(E->get());
+			for (Node *E : selection) {
+				Node3D *sp = Object::cast_to<Node3D>(E);
 				if (!sp) {
 					continue;
 				}
@@ -3741,8 +3741,8 @@ void Node3DEditorViewport::focus_selection() {
 
 	List<Node *> &selection = editor_selection->get_selected_node_list();
 
-	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-		Node3D *sp = Object::cast_to<Node3D>(E->get());
+	for (Node *E : selection) {
+		Node3D *sp = Object::cast_to<Node3D>(E);
 		if (!sp) {
 			continue;
 		}
@@ -5176,8 +5176,8 @@ void Node3DEditor::_xform_dialog_action() {
 
 	List<Node *> &selection = editor_selection->get_selected_node_list();
 
-	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-		Node3D *sp = Object::cast_to<Node3D>(E->get());
+	for (Node *E : selection) {
+		Node3D *sp = Object::cast_to<Node3D>(E);
 		if (!sp) {
 			continue;
 		}
@@ -5413,8 +5413,8 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *spatial = Object::cast_to<Node3D>(E->get());
+			for (Node *E : selection) {
+				Node3D *spatial = Object::cast_to<Node3D>(E);
 				if (!spatial || !spatial->is_inside_tree()) {
 					continue;
 				}
@@ -5438,8 +5438,8 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *spatial = Object::cast_to<Node3D>(E->get());
+			for (Node *E : selection) {
+				Node3D *spatial = Object::cast_to<Node3D>(E);
 				if (!spatial || !spatial->is_inside_tree()) {
 					continue;
 				}
@@ -5463,8 +5463,8 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *spatial = Object::cast_to<Node3D>(E->get());
+			for (Node *E : selection) {
+				Node3D *spatial = Object::cast_to<Node3D>(E);
 				if (!spatial || !spatial->is_inside_tree()) {
 					continue;
 				}
@@ -5487,8 +5487,8 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			undo_redo->create_action(TTR("Ungroup Selected"));
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *spatial = Object::cast_to<Node3D>(E->get());
+			for (Node *E : selection) {
+				Node3D *spatial = Object::cast_to<Node3D>(E);
 				if (!spatial || !spatial->is_inside_tree()) {
 					continue;
 				}
@@ -6243,14 +6243,14 @@ void Node3DEditor::_refresh_menu_icons() {
 		all_locked = false;
 		all_grouped = false;
 	} else {
-		for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-			if (Object::cast_to<Node3D>(E->get()) && !Object::cast_to<Node3D>(E->get())->has_meta("_edit_lock_")) {
+		for (Node *E : selection) {
+			if (Object::cast_to<Node3D>(E) && !Object::cast_to<Node3D>(E)->has_meta("_edit_lock_")) {
 				all_locked = false;
 				break;
 			}
 		}
-		for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-			if (Object::cast_to<Node3D>(E->get()) && !Object::cast_to<Node3D>(E->get())->has_meta("_edit_group_")) {
+		for (Node *E : selection) {
+			if (Object::cast_to<Node3D>(E) && !Object::cast_to<Node3D>(E)->has_meta("_edit_group_")) {
 				all_grouped = false;
 				break;
 			}
@@ -6303,8 +6303,8 @@ void Node3DEditor::snap_selected_nodes_to_floor() {
 	List<Node *> &selection = editor_selection->get_selected_node_list();
 	Dictionary snap_data;
 
-	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-		Node3D *sp = Object::cast_to<Node3D>(E->get());
+	for (Node *E : selection) {
+		Node3D *sp = Object::cast_to<Node3D>(E);
 		if (sp) {
 			Vector3 from = Vector3();
 			Vector3 position_offset = Vector3();

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -181,21 +181,21 @@ void ResourcePreloaderEditor::_update_library() {
 	preloader->get_resource_list(&rnames);
 
 	List<String> names;
-	for (List<StringName>::Element *E = rnames.front(); E; E = E->next()) {
-		names.push_back(E->get());
+	for (StringName &E : rnames) {
+		names.push_back(E);
 	}
 
 	names.sort();
 
-	for (List<String>::Element *E = names.front(); E; E = E->next()) {
+	for (String &E : names) {
 		TreeItem *ti = tree->create_item(root);
 		ti->set_cell_mode(0, TreeItem::CELL_MODE_STRING);
 		ti->set_editable(0, true);
 		ti->set_selectable(0, true);
-		ti->set_text(0, E->get());
-		ti->set_metadata(0, E->get());
+		ti->set_text(0, E);
+		ti->set_metadata(0, E);
 
-		RES r = preloader->get_resource(E->get());
+		RES r = preloader->get_resource(E);
 
 		ERR_CONTINUE(r.is_null());
 

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -70,8 +70,8 @@ void EditorPropertyRootMotion::_node_assign() {
 		List<StringName> animations;
 		player->get_animation_list(&animations);
 
-		for (List<StringName>::Element *E = animations.front(); E; E = E->next()) {
-			Ref<Animation> anim = player->get_animation(E->get());
+		for (StringName &E : animations) {
+			Ref<Animation> anim = player->get_animation(E);
 			for (int i = 0; i < anim->get_track_count(); i++) {
 				paths.insert(anim->track_get_path(i));
 			}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -103,8 +103,8 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 	const Color type_color = EDITOR_GET("text_editor/highlighting/engine_type_color");
 	List<StringName> types;
 	ClassDB::get_class_list(&types);
-	for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
-		String n = E->get();
+	for (StringName &E : types) {
+		String n = E;
 		if (n.begins_with("_")) {
 			n = n.substr(1, n.length());
 		}
@@ -115,8 +115,8 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 	const Color usertype_color = EDITOR_GET("text_editor/highlighting/user_type_color");
 	List<StringName> global_classes;
 	ScriptServer::get_global_class_list(&global_classes);
-	for (List<StringName>::Element *E = global_classes.front(); E; E = E->next()) {
-		highlighter->add_keyword_color(E->get(), usertype_color);
+	for (StringName &E : global_classes) {
+		highlighter->add_keyword_color(E, usertype_color);
 	}
 
 	/* Autoloads. */
@@ -134,8 +134,8 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		const Color basetype_color = EDITOR_GET("text_editor/highlighting/base_type_color");
 		List<String> core_types;
 		script->get_language()->get_core_type_words(&core_types);
-		for (List<String>::Element *E = core_types.front(); E; E = E->next()) {
-			highlighter->add_keyword_color(E->get(), basetype_color);
+		for (String &E : core_types) {
+			highlighter->add_keyword_color(E, basetype_color);
 		}
 
 		/* Reserved words. */
@@ -143,11 +143,11 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		const Color control_flow_keyword_color = EDITOR_GET("text_editor/highlighting/control_flow_keyword_color");
 		List<String> keywords;
 		script->get_language()->get_reserved_words(&keywords);
-		for (List<String>::Element *E = keywords.front(); E; E = E->next()) {
-			if (script->get_language()->is_control_flow_keyword(E->get())) {
-				highlighter->add_keyword_color(E->get(), control_flow_keyword_color);
+		for (String &E : keywords) {
+			if (script->get_language()->is_control_flow_keyword(E)) {
+				highlighter->add_keyword_color(E, control_flow_keyword_color);
 			} else {
-				highlighter->add_keyword_color(E->get(), keyword_color);
+				highlighter->add_keyword_color(E, keyword_color);
 			}
 		}
 
@@ -157,9 +157,9 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		if (instance_base != StringName()) {
 			List<PropertyInfo> plist;
 			ClassDB::get_property_list(instance_base, &plist);
-			for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-				String name = E->get().name;
-				if (E->get().usage & PROPERTY_USAGE_CATEGORY || E->get().usage & PROPERTY_USAGE_GROUP || E->get().usage & PROPERTY_USAGE_SUBGROUP) {
+			for (PropertyInfo &E : plist) {
+				String name = E.name;
+				if (E.usage & PROPERTY_USAGE_CATEGORY || E.usage & PROPERTY_USAGE_GROUP || E.usage & PROPERTY_USAGE_SUBGROUP) {
 					continue;
 				}
 				if (name.find("/") != -1) {
@@ -170,8 +170,8 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 
 			List<String> clist;
 			ClassDB::get_integer_constant_list(instance_base, &clist);
-			for (List<String>::Element *E = clist.front(); E; E = E->next()) {
-				highlighter->add_member_keyword_color(E->get(), member_variable_color);
+			for (String &E : clist) {
+				highlighter->add_member_keyword_color(E, member_variable_color);
 			}
 		}
 
@@ -179,8 +179,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		const Color comment_color = EDITOR_GET("text_editor/highlighting/comment_color");
 		List<String> comments;
 		script->get_language()->get_comment_delimiters(&comments);
-		for (List<String>::Element *E = comments.front(); E; E = E->next()) {
-			String comment = E->get();
+		for (String &comment : comments) {
 			String beg = comment.get_slice(" ", 0);
 			String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
 			highlighter->add_color_region(beg, end, comment_color, end == "");
@@ -190,8 +189,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		const Color string_color = EDITOR_GET("text_editor/highlighting/string_color");
 		List<String> strings;
 		script->get_language()->get_string_delimiters(&strings);
-		for (List<String>::Element *E = strings.front(); E; E = E->next()) {
-			String string = E->get();
+		for (String &string : strings) {
 			String beg = string.get_slice(" ", 0);
 			String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
 			highlighter->add_color_region(beg, end, string_color, end == "");

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -50,9 +50,7 @@ void ConnectionInfoDialog::popup_connections(String p_method, Vector<Node *> p_n
 		List<Connection> all_connections;
 		p_nodes[i]->get_signals_connected_to_this(&all_connections);
 
-		for (List<Connection>::Element *E = all_connections.front(); E; E = E->next()) {
-			Connection connection = E->get();
-
+		for (Connection &connection : all_connections) {
 			if (connection.callable.get_method() != p_method) {
 				continue;
 			}
@@ -116,8 +114,8 @@ Vector<String> ScriptTextEditor::get_functions() {
 	if (script->get_language()->validate(text, script->get_path(), &fnc)) {
 		//if valid rewrite functions to latest
 		functions.clear();
-		for (List<String>::Element *E = fnc.front(); E; E = E->next()) {
-			functions.push_back(E->get());
+		for (String &E : fnc) {
+			functions.push_back(E);
 		}
 	}
 
@@ -203,8 +201,7 @@ void ScriptTextEditor::_set_theme_for_script() {
 	List<String> strings;
 	script->get_language()->get_string_delimiters(&strings);
 	text_edit->clear_string_delimiters();
-	for (List<String>::Element *E = strings.front(); E; E = E->next()) {
-		String string = E->get();
+	for (String &string : strings) {
 		String beg = string.get_slice(" ", 0);
 		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
 		text_edit->add_string_delimiter(beg, end, end == "");
@@ -213,8 +210,7 @@ void ScriptTextEditor::_set_theme_for_script() {
 	List<String> comments;
 	script->get_language()->get_comment_delimiters(&comments);
 	text_edit->clear_comment_delimiters();
-	for (List<String>::Element *E = comments.front(); E; E = E->next()) {
-		String comment = E->get();
+	for (String &comment : comments) {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
 		text_edit->add_comment_delimiter(beg, end, end == "");
@@ -417,8 +413,8 @@ void ScriptTextEditor::_validate_script() {
 		}
 
 		functions.clear();
-		for (List<String>::Element *E = fnc.front(); E; E = E->next()) {
-			functions.push_back(E->get());
+		for (String &E : fnc) {
+			functions.push_back(E);
 		}
 		script_is_valid = true;
 	}
@@ -432,9 +428,7 @@ void ScriptTextEditor::_validate_script() {
 		Node *base = get_tree()->get_edited_scene_root();
 		if (base && missing_connections.size() > 0) {
 			warnings_panel->push_table(1);
-			for (List<Connection>::Element *E = missing_connections.front(); E; E = E->next()) {
-				Connection connection = E->get();
-
+			for (Connection &connection : missing_connections) {
 				String base_path = base->get_name();
 				String source_path = base == connection.signal.get_object() ? base_path : base_path + "/" + base->get_path_to(Object::cast_to<Node>(connection.signal.get_object()));
 				String target_path = base == connection.callable.get_object() ? base_path : base_path + "/" + base->get_path_to(Object::cast_to<Node>(connection.callable.get_object()));
@@ -456,9 +450,7 @@ void ScriptTextEditor::_validate_script() {
 
 	// Add script warnings.
 	warnings_panel->push_table(3);
-	for (List<ScriptLanguage::Warning>::Element *E = warnings.front(); E; E = E->next()) {
-		ScriptLanguage::Warning w = E->get();
-
+	for (ScriptLanguage::Warning &w : warnings) {
 		Dictionary ignore_meta;
 		ignore_meta["line"] = w.start_line;
 		ignore_meta["code"] = w.string_code.to_lower();
@@ -488,9 +480,7 @@ void ScriptTextEditor::_validate_script() {
 
 	errors_panel->clear();
 	errors_panel->push_table(2);
-	for (List<ScriptLanguage::ScriptError>::Element *E = errors.front(); E; E = E->next()) {
-		ScriptLanguage::ScriptError err = E->get();
-
+	for (ScriptLanguage::ScriptError &err : errors) {
 		errors_panel->push_cell();
 		errors_panel->push_meta(err.line - 1);
 		errors_panel->push_color(warnings_panel->get_theme_color(SNAME("error_color"), SNAME("Editor")));
@@ -511,8 +501,8 @@ void ScriptTextEditor::_validate_script() {
 		if (errors.is_empty()) {
 			te->set_line_background_color(i, Color(0, 0, 0, 0));
 		} else {
-			for (List<ScriptLanguage::ScriptError>::Element *E = errors.front(); E; E = E->next()) {
-				bool error_line = i == E->get().line - 1;
+			for (ScriptLanguage::ScriptError &E : errors) {
+				bool error_line = i == E.line - 1;
 				te->set_line_background_color(i, error_line ? marked_line_color : Color(0, 0, 0, 0));
 				if (error_line) {
 					break;
@@ -910,8 +900,7 @@ void ScriptTextEditor::_update_connected_methods() {
 		List<Connection> connections;
 		nodes[i]->get_signals_connected_to_this(&connections);
 
-		for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
-			Connection connection = E->get();
+		for (Connection &connection : connections) {
 			if (!(connection.flags & CONNECT_PERSIST)) {
 				continue;
 			}
@@ -1286,8 +1275,7 @@ void ScriptTextEditor::_edit_option_toggle_inline_comment() {
 	List<String> comment_delimiters;
 	script->get_language()->get_comment_delimiters(&comment_delimiters);
 
-	for (List<String>::Element *E = comment_delimiters.front(); E; E = E->next()) {
-		String script_delimiter = E->get();
+	for (String &script_delimiter : comment_delimiters) {
 		if (script_delimiter.find(" ") == -1) {
 			delimiter = script_delimiter;
 			break;

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -118,11 +118,11 @@ void ShaderTextEditor::_load_theme_settings() {
 	const Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
 	const Color control_flow_keyword_color = EDITOR_GET("text_editor/highlighting/control_flow_keyword_color");
 
-	for (List<String>::Element *E = keywords.front(); E; E = E->next()) {
-		if (ShaderLanguage::is_control_flow_keyword(E->get())) {
-			syntax_highlighter->add_keyword_color(E->get(), control_flow_keyword_color);
+	for (String &E : keywords) {
+		if (ShaderLanguage::is_control_flow_keyword(E)) {
+			syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
 		} else {
-			syntax_highlighter->add_keyword_color(E->get(), keyword_color);
+			syntax_highlighter->add_keyword_color(E, keyword_color);
 		}
 	}
 
@@ -144,8 +144,8 @@ void ShaderTextEditor::_load_theme_settings() {
 
 	const Color member_variable_color = EDITOR_GET("text_editor/highlighting/member_variable_color");
 
-	for (List<String>::Element *E = built_ins.front(); E; E = E->next()) {
-		syntax_highlighter->add_keyword_color(E->get(), member_variable_color);
+	for (String &E : built_ins) {
+		syntax_highlighter->add_keyword_color(E, member_variable_color);
 	}
 
 	// Colorize comments.

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -365,8 +365,8 @@ void SpriteFramesEditor::_file_load_request(const Vector<String> &p_path, int p_
 
 	int count = 0;
 
-	for (List<Ref<Texture2D>>::Element *E = resources.front(); E; E = E->next()) {
-		undo_redo->add_do_method(frames, "add_frame", edited_anim, E->get(), p_at_pos == -1 ? -1 : p_at_pos + count);
+	for (Ref<Texture2D> &E : resources) {
+		undo_redo->add_do_method(frames, "add_frame", edited_anim, E, p_at_pos == -1 ? -1 : p_at_pos + count);
 		undo_redo->add_undo_method(frames, "remove_frame", edited_anim, p_at_pos == -1 ? fc : p_at_pos);
 		count++;
 	}
@@ -624,10 +624,10 @@ void SpriteFramesEditor::_animation_name_edited() {
 	undo_redo->add_do_method(frames, "rename_animation", edited_anim, name);
 	undo_redo->add_undo_method(frames, "rename_animation", name, edited_anim);
 
-	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
-		String current = E->get()->call("get_animation");
-		undo_redo->add_do_method(E->get(), "set_animation", name);
-		undo_redo->add_undo_method(E->get(), "set_animation", edited_anim);
+	for (Node *E : nodes) {
+		String current = E->call("get_animation");
+		undo_redo->add_do_method(E, "set_animation", name);
+		undo_redo->add_undo_method(E, "set_animation", edited_anim);
 	}
 
 	undo_redo->add_do_method(this, "_update_library");
@@ -655,10 +655,10 @@ void SpriteFramesEditor::_animation_add() {
 	undo_redo->add_do_method(this, "_update_library");
 	undo_redo->add_undo_method(this, "_update_library");
 
-	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
-		String current = E->get()->call("get_animation");
-		undo_redo->add_do_method(E->get(), "set_animation", name);
-		undo_redo->add_undo_method(E->get(), "set_animation", current);
+	for (Node *E : nodes) {
+		String current = E->call("get_animation");
+		undo_redo->add_do_method(E, "set_animation", name);
+		undo_redo->add_undo_method(E, "set_animation", current);
 	}
 
 	edited_anim = name;
@@ -788,8 +788,8 @@ void SpriteFramesEditor::_update_library(bool p_skip_selector) {
 
 		anim_names.sort_custom<StringName::AlphCompare>();
 
-		for (List<StringName>::Element *E = anim_names.front(); E; E = E->next()) {
-			String name = E->get();
+		for (StringName &E : anim_names) {
+			String name = E;
 
 			TreeItem *it = animations->create_item(anim_root);
 
@@ -798,7 +798,7 @@ void SpriteFramesEditor::_update_library(bool p_skip_selector) {
 			it->set_text(0, name);
 			it->set_editable(0, true);
 
-			if (E->get() == edited_anim) {
+			if (E == edited_anim) {
 				it->select(0);
 			}
 		}

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -144,8 +144,7 @@ void TextureRegionEditor::_region_draw() {
 			}
 		}
 	} else if (snap_mode == SNAP_AUTOSLICE) {
-		for (List<Rect2>::Element *E = autoslice_cache.front(); E; E = E->next()) {
-			Rect2 r = E->get();
+		for (Rect2 &r : autoslice_cache) {
 			Vector2 endpoints[4] = {
 				mtx.basis_xform(r.position),
 				mtx.basis_xform(r.position + Vector2(r.size.x, 0)),
@@ -328,9 +327,9 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 				}
 				if (edited_margin < 0 && snap_mode == SNAP_AUTOSLICE) {
 					Vector2 point = mtx.affine_inverse().xform(Vector2(mb->get_position().x, mb->get_position().y));
-					for (List<Rect2>::Element *E = autoslice_cache.front(); E; E = E->next()) {
-						if (E->get().has_point(point)) {
-							rect = E->get();
+					for (Rect2 &E : autoslice_cache) {
+						if (E.has_point(point)) {
+							rect = E;
 							if (Input::get_singleton()->is_key_pressed(KEY_CTRL) && !(Input::get_singleton()->is_key_pressed(KEY_SHIFT | KEY_ALT))) {
 								Rect2 r;
 								if (node_sprite) {
@@ -749,12 +748,12 @@ void TextureRegionEditor::_update_autoslice() {
 		for (int x = 0; x < texture->get_width(); x++) {
 			if (texture->is_pixel_opaque(x, y)) {
 				bool found = false;
-				for (List<Rect2>::Element *E = autoslice_cache.front(); E; E = E->next()) {
-					Rect2 grown = E->get().grow(1.5);
+				for (Rect2 &E : autoslice_cache) {
+					Rect2 grown = E.grow(1.5);
 					if (grown.has_point(Point2(x, y))) {
-						E->get().expand_to(Point2(x, y));
-						E->get().expand_to(Point2(x + 1, y + 1));
-						x = E->get().position.x + E->get().size.x - 1;
+						E.expand_to(Point2(x, y));
+						E.expand_to(Point2(x + 1, y + 1));
+						x = E.position.x + E.size.x - 1;
 						bool merged = true;
 						while (merged) {
 							merged = false;
@@ -764,12 +763,12 @@ void TextureRegionEditor::_update_autoslice() {
 									autoslice_cache.erase(F->prev());
 									queue_erase = false;
 								}
-								if (F == E) {
+								if (F->get() == E) {
 									continue;
 								}
-								if (E->get().grow(1).intersects(F->get())) {
-									E->get().expand_to(F->get().position);
-									E->get().expand_to(F->get().position + F->get().size);
+								if (E.grow(1).intersects(F->get())) {
+									E.expand_to(F->get().position);
+									E.expand_to(F->get().position + F->get().size);
 									if (F->prev()) {
 										F = F->prev();
 										autoslice_cache.erase(F->next());

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -65,8 +65,8 @@ void ThemeItemImportTree::_update_items_tree() {
 	tree_icon_items.clear();
 	tree_stylebox_items.clear();
 
-	for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
-		String type_name = (String)E->get();
+	for (StringName &E : types) {
+		String type_name = (String)E;
 
 		TreeItem *type_node = import_items_tree->create_item(root);
 		type_node->set_meta("_can_be_imported", false);
@@ -89,12 +89,12 @@ void ThemeItemImportTree::_update_items_tree() {
 
 			names.clear();
 			filtered_names.clear();
-			base_theme->get_theme_item_list(dt, E->get(), &names);
+			base_theme->get_theme_item_list(dt, E, &names);
 
 			bool data_type_has_filtered_items = false;
 
-			for (List<StringName>::Element *F = names.front(); F; F = F->next()) {
-				String item_name = (String)F->get();
+			for (StringName &F : names) {
+				String item_name = (String)F;
 				bool is_item_matching_filter = (item_name.findn(filter_text) > -1);
 				if (!filter_text.is_empty() && !is_matching_filter && !is_item_matching_filter) {
 					continue;
@@ -105,7 +105,7 @@ void ThemeItemImportTree::_update_items_tree() {
 					has_filtered_items = true;
 					data_type_has_filtered_items = true;
 				}
-				filtered_names.push_back(F->get());
+				filtered_names.push_back(F);
 			}
 
 			if (filtered_names.size() == 0) {
@@ -182,10 +182,10 @@ void ThemeItemImportTree::_update_items_tree() {
 			bool data_type_any_checked_with_data = false;
 
 			filtered_names.sort_custom<StringName::AlphCompare>();
-			for (List<StringName>::Element *F = filtered_names.front(); F; F = F->next()) {
+			for (StringName &F : filtered_names) {
 				TreeItem *item_node = import_items_tree->create_item(data_type_node);
 				item_node->set_meta("_can_be_imported", true);
-				item_node->set_text(0, F->get());
+				item_node->set_text(0, F);
 				item_node->set_cell_mode(IMPORT_ITEM, TreeItem::CELL_MODE_CHECK);
 				item_node->set_checked(IMPORT_ITEM, false);
 				item_node->set_editable(IMPORT_ITEM, true);
@@ -1236,16 +1236,16 @@ void ThemeItemEditorDialog::_update_edit_types() {
 	bool item_reselected = false;
 	edit_type_list->clear();
 	int e_idx = 0;
-	for (List<StringName>::Element *E = theme_types.front(); E; E = E->next()) {
+	for (StringName &E : theme_types) {
 		Ref<Texture2D> item_icon;
-		if (E->get() == "") {
+		if (E == "") {
 			item_icon = get_theme_icon(SNAME("NodeDisabled"), SNAME("EditorIcons"));
 		} else {
-			item_icon = EditorNode::get_singleton()->get_class_icon(E->get(), "NodeDisabled");
+			item_icon = EditorNode::get_singleton()->get_class_icon(E, "NodeDisabled");
 		}
-		edit_type_list->add_item(E->get(), item_icon);
+		edit_type_list->add_item(E, item_icon);
 
-		if (E->get() == edited_item_type) {
+		if (E == edited_item_type) {
 			edit_type_list->select(e_idx);
 			item_reselected = true;
 		}
@@ -1318,9 +1318,9 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 			color_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Color Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
-			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+			for (StringName &E : names) {
 				TreeItem *item = edit_items_tree->create_item(color_root);
-				item->set_text(0, E->get());
+				item->set_text(0, E);
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
@@ -1339,9 +1339,9 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 			constant_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Constant Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
-			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+			for (StringName &E : names) {
 				TreeItem *item = edit_items_tree->create_item(constant_root);
-				item->set_text(0, E->get());
+				item->set_text(0, E);
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
@@ -1360,9 +1360,9 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 			font_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Font Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
-			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+			for (StringName &E : names) {
 				TreeItem *item = edit_items_tree->create_item(font_root);
-				item->set_text(0, E->get());
+				item->set_text(0, E);
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
@@ -1381,9 +1381,9 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 			font_size_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Font Size Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
-			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+			for (StringName &E : names) {
 				TreeItem *item = edit_items_tree->create_item(font_size_root);
-				item->set_text(0, E->get());
+				item->set_text(0, E);
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
@@ -1402,9 +1402,9 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 			icon_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Icon Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
-			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+			for (StringName &E : names) {
 				TreeItem *item = edit_items_tree->create_item(icon_root);
-				item->set_text(0, E->get());
+				item->set_text(0, E);
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
@@ -1423,9 +1423,9 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 			stylebox_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All StyleBox Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
-			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+			for (StringName &E : names) {
 				TreeItem *item = edit_items_tree->create_item(stylebox_root);
-				item->set_text(0, E->get());
+				item->set_text(0, E);
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
@@ -1507,8 +1507,8 @@ void ThemeItemEditorDialog::_remove_data_type_items(Theme::DataType p_data_type,
 	edited_theme->_freeze_change_propagation();
 
 	edited_theme->get_theme_item_list(p_data_type, p_item_type, &names);
-	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-		edited_theme->clear_theme_item(p_data_type, E->get(), p_item_type);
+	for (StringName &E : names) {
+		edited_theme->clear_theme_item(p_data_type, E, p_item_type);
 	}
 
 	// Allow changes to be reported now that the operation is finished.
@@ -1526,9 +1526,9 @@ void ThemeItemEditorDialog::_remove_class_items() {
 
 		names.clear();
 		Theme::get_default()->get_theme_item_list(data_type, edited_item_type, &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (edited_theme->has_theme_item_nocheck(data_type, E->get(), edited_item_type)) {
-				edited_theme->clear_theme_item(data_type, E->get(), edited_item_type);
+		for (StringName &E : names) {
+			if (edited_theme->has_theme_item_nocheck(data_type, E, edited_item_type)) {
+				edited_theme->clear_theme_item(data_type, E, edited_item_type);
 			}
 		}
 	}
@@ -1550,9 +1550,9 @@ void ThemeItemEditorDialog::_remove_custom_items() {
 
 		names.clear();
 		edited_theme->get_theme_item_list(data_type, edited_item_type, &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (!Theme::get_default()->has_theme_item_nocheck(data_type, E->get(), edited_item_type)) {
-				edited_theme->clear_theme_item(data_type, E->get(), edited_item_type);
+		for (StringName &E : names) {
+			if (!Theme::get_default()->has_theme_item_nocheck(data_type, E, edited_item_type)) {
+				edited_theme->clear_theme_item(data_type, E, edited_item_type);
 			}
 		}
 	}
@@ -1574,8 +1574,8 @@ void ThemeItemEditorDialog::_remove_all_items() {
 
 		names.clear();
 		edited_theme->get_theme_item_list(data_type, edited_item_type, &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			edited_theme->clear_theme_item(data_type, E->get(), edited_item_type);
+		for (StringName &E : names) {
+			edited_theme->clear_theme_item(data_type, E, edited_item_type);
 		}
 	}
 
@@ -1927,8 +1927,8 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	import_another_theme_dialog->set_title(TTR("Select Another Theme Resource:"));
 	List<String> ext;
 	ResourceLoader::get_recognized_extensions_for_type("Theme", &ext);
-	for (List<String>::Element *E = ext.front(); E; E = E->next()) {
-		import_another_theme_dialog->add_filter("*." + E->get() + "; Theme Resource");
+	for (String &E : ext) {
+		import_another_theme_dialog->add_filter("*." + E + "; Theme Resource");
 	}
 	import_another_file_hb->add_child(import_another_theme_dialog);
 	import_another_theme_dialog->connect("file_selected", callable_mp(this, &ThemeItemEditorDialog::_select_another_theme_cbk));
@@ -1969,26 +1969,26 @@ void ThemeTypeDialog::_update_add_type_options(const String &p_filter) {
 	names.sort_custom<StringName::AlphCompare>();
 
 	Vector<StringName> unique_names;
-	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+	for (StringName &E : names) {
 		// Filter out undesired values.
-		if (!p_filter.is_subsequence_ofi(String(E->get()))) {
+		if (!p_filter.is_subsequence_ofi(String(E))) {
 			continue;
 		}
 
 		// Skip duplicate values.
-		if (unique_names.has(E->get())) {
+		if (unique_names.has(E)) {
 			continue;
 		}
-		unique_names.append(E->get());
+		unique_names.append(E);
 
 		Ref<Texture2D> item_icon;
-		if (E->get() == "") {
+		if (E == "") {
 			item_icon = get_theme_icon(SNAME("NodeDisabled"), SNAME("EditorIcons"));
 		} else {
-			item_icon = EditorNode::get_singleton()->get_class_icon(E->get(), "NodeDisabled");
+			item_icon = EditorNode::get_singleton()->get_class_icon(E, "NodeDisabled");
 		}
 
-		add_type_options->add_item(E->get(), item_icon);
+		add_type_options->add_item(E, item_icon);
 	}
 }
 
@@ -2132,16 +2132,16 @@ void ThemeTypeEditor::_update_type_list() {
 
 		bool item_reselected = false;
 		int e_idx = 0;
-		for (List<StringName>::Element *E = theme_types.front(); E; E = E->next()) {
+		for (StringName &E : theme_types) {
 			Ref<Texture2D> item_icon;
-			if (E->get() == "") {
+			if (E == "") {
 				item_icon = get_theme_icon(SNAME("NodeDisabled"), SNAME("EditorIcons"));
 			} else {
-				item_icon = EditorNode::get_singleton()->get_class_icon(E->get(), "NodeDisabled");
+				item_icon = EditorNode::get_singleton()->get_class_icon(E, "NodeDisabled");
 			}
-			theme_type_list->add_icon_item(item_icon, E->get());
+			theme_type_list->add_icon_item(item_icon, E);
 
-			if (E->get() == edited_type) {
+			if (E == edited_type) {
 				theme_type_list->select(e_idx);
 				item_reselected = true;
 			}
@@ -2182,8 +2182,8 @@ OrderedHashMap<StringName, bool> ThemeTypeEditor::_get_type_items(String p_type_
 
 		(Theme::get_default().operator->()->*get_list_func)(default_type, &names);
 		names.sort_custom<StringName::AlphCompare>();
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			items[E->get()] = false;
+		for (StringName &E : names) {
+			items[E] = false;
 		}
 	}
 
@@ -2191,8 +2191,8 @@ OrderedHashMap<StringName, bool> ThemeTypeEditor::_get_type_items(String p_type_
 		names.clear();
 		(edited_theme.operator->()->*get_list_func)(p_type_name, &names);
 		names.sort_custom<StringName::AlphCompare>();
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			items[E->get()] = true;
+		for (StringName &E : names) {
+			items[E] = true;
 		}
 	}
 
@@ -2203,8 +2203,8 @@ OrderedHashMap<StringName, bool> ThemeTypeEditor::_get_type_items(String p_type_
 	keys.sort_custom<StringName::AlphCompare>();
 
 	OrderedHashMap<StringName, bool> ordered_items;
-	for (List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-		ordered_items[E->get()] = items[E->get()];
+	for (StringName &E : keys) {
+		ordered_items[E] = items[E];
 	}
 
 	return ordered_items;
@@ -2580,54 +2580,54 @@ void ThemeTypeEditor::_add_default_type_items() {
 	{
 		names.clear();
 		Theme::get_default()->get_icon_list(default_type, &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (!edited_theme->has_icon(E->get(), edited_type)) {
-				edited_theme->set_icon(E->get(), edited_type, Ref<Texture2D>());
+		for (StringName &E : names) {
+			if (!edited_theme->has_icon(E, edited_type)) {
+				edited_theme->set_icon(E, edited_type, Ref<Texture2D>());
 			}
 		}
 	}
 	{
 		names.clear();
 		Theme::get_default()->get_stylebox_list(default_type, &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (!edited_theme->has_stylebox(E->get(), edited_type)) {
-				edited_theme->set_stylebox(E->get(), edited_type, Ref<StyleBox>());
+		for (StringName &E : names) {
+			if (!edited_theme->has_stylebox(E, edited_type)) {
+				edited_theme->set_stylebox(E, edited_type, Ref<StyleBox>());
 			}
 		}
 	}
 	{
 		names.clear();
 		Theme::get_default()->get_font_list(default_type, &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (!edited_theme->has_font(E->get(), edited_type)) {
-				edited_theme->set_font(E->get(), edited_type, Ref<Font>());
+		for (StringName &E : names) {
+			if (!edited_theme->has_font(E, edited_type)) {
+				edited_theme->set_font(E, edited_type, Ref<Font>());
 			}
 		}
 	}
 	{
 		names.clear();
 		Theme::get_default()->get_font_size_list(default_type, &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (!edited_theme->has_font_size(E->get(), edited_type)) {
-				edited_theme->set_font_size(E->get(), edited_type, Theme::get_default()->get_font_size(E->get(), default_type));
+		for (StringName &E : names) {
+			if (!edited_theme->has_font_size(E, edited_type)) {
+				edited_theme->set_font_size(E, edited_type, Theme::get_default()->get_font_size(E, default_type));
 			}
 		}
 	}
 	{
 		names.clear();
 		Theme::get_default()->get_color_list(default_type, &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (!edited_theme->has_color(E->get(), edited_type)) {
-				edited_theme->set_color(E->get(), edited_type, Theme::get_default()->get_color(E->get(), default_type));
+		for (StringName &E : names) {
+			if (!edited_theme->has_color(E, edited_type)) {
+				edited_theme->set_color(E, edited_type, Theme::get_default()->get_color(E, default_type));
 			}
 		}
 	}
 	{
 		names.clear();
 		Theme::get_default()->get_constant_list(default_type, &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (!edited_theme->has_constant(E->get(), edited_type)) {
-				edited_theme->set_constant(E->get(), edited_type, Theme::get_default()->get_constant(E->get(), default_type));
+		for (StringName &E : names) {
+			if (!edited_theme->has_constant(E, edited_type)) {
+				edited_theme->set_constant(E, edited_type, Theme::get_default()->get_constant(E, default_type));
 			}
 		}
 	}
@@ -2882,12 +2882,12 @@ void ThemeTypeEditor::_update_stylebox_from_leading() {
 	List<StringName> names;
 	edited_theme->get_stylebox_list(edited_type, &names);
 	List<Ref<StyleBox>> styleboxes;
-	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-		if (E->get() == leading_stylebox.item_name) {
+	for (StringName &E : names) {
+		if (E == leading_stylebox.item_name) {
 			continue;
 		}
 
-		Ref<StyleBox> sb = edited_theme->get_stylebox(E->get(), edited_type);
+		Ref<StyleBox> sb = edited_theme->get_stylebox(E, edited_type);
 		if (sb->get_class() == leading_stylebox.stylebox->get_class()) {
 			styleboxes.push_back(sb);
 		}
@@ -2895,20 +2895,20 @@ void ThemeTypeEditor::_update_stylebox_from_leading() {
 
 	List<PropertyInfo> props;
 	leading_stylebox.stylebox->get_property_list(&props);
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+	for (PropertyInfo &E : props) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 			continue;
 		}
 
-		Variant value = leading_stylebox.stylebox->get(E->get().name);
-		Variant ref_value = leading_stylebox.ref_stylebox->get(E->get().name);
+		Variant value = leading_stylebox.stylebox->get(E.name);
+		Variant ref_value = leading_stylebox.ref_stylebox->get(E.name);
 		if (value == ref_value) {
 			continue;
 		}
 
-		for (List<Ref<StyleBox>>::Element *F = styleboxes.front(); F; F = F->next()) {
-			Ref<StyleBox> sb = F->get();
-			sb->set(E->get().name, value);
+		for (Ref<StyleBox> F : styleboxes) {
+			Ref<StyleBox> sb = F;
+			sb->set(E.name, value);
 		}
 	}
 
@@ -3301,8 +3301,8 @@ ThemeEditor::ThemeEditor() {
 	preview_scene_dialog->set_title(TTR("Select UI Scene:"));
 	List<String> ext;
 	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &ext);
-	for (List<String>::Element *E = ext.front(); E; E = E->next()) {
-		preview_scene_dialog->add_filter("*." + E->get() + "; Scene");
+	for (String &E : ext) {
+		preview_scene_dialog->add_filter("*." + E + "; Scene");
 	}
 	main_hs->add_child(preview_scene_dialog);
 	preview_scene_dialog->connect("file_selected", callable_mp(this, &ThemeEditor::_preview_scene_dialog_cbk));
@@ -3343,12 +3343,12 @@ bool ThemeEditorPlugin::handles(Object *p_node) const {
 		List<StringName> names;
 
 		edited_theme->get_font_type_list(&types);
-		for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
+		for (StringName &E : types) {
 			names.clear();
-			edited_theme->get_font_list(E->get(), &names);
+			edited_theme->get_font_list(E, &names);
 
-			for (List<StringName>::Element *F = names.front(); F; F = F->next()) {
-				if (font_item == edited_theme->get_font(F->get(), E->get())) {
+			for (StringName &F : names) {
+				if (font_item == edited_theme->get_font(F, E)) {
 					belongs_to_theme = true;
 					break;
 				}
@@ -3360,12 +3360,12 @@ bool ThemeEditorPlugin::handles(Object *p_node) const {
 		List<StringName> names;
 
 		edited_theme->get_stylebox_type_list(&types);
-		for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
+		for (StringName &E : types) {
 			names.clear();
-			edited_theme->get_stylebox_list(E->get(), &names);
+			edited_theme->get_stylebox_list(E, &names);
 
-			for (List<StringName>::Element *F = names.front(); F; F = F->next()) {
-				if (stylebox_item == edited_theme->get_stylebox(F->get(), E->get())) {
+			for (StringName &F : names) {
+				if (stylebox_item == edited_theme->get_stylebox(F, E)) {
 					belongs_to_theme = true;
 					break;
 				}
@@ -3377,12 +3377,12 @@ bool ThemeEditorPlugin::handles(Object *p_node) const {
 		List<StringName> names;
 
 		edited_theme->get_icon_type_list(&types);
-		for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
+		for (StringName &E : types) {
 			names.clear();
-			edited_theme->get_icon_list(E->get(), &names);
+			edited_theme->get_icon_list(E, &names);
 
-			for (List<StringName>::Element *F = names.front(); F; F = F->next()) {
-				if (icon_item == edited_theme->get_icon(F->get(), E->get())) {
+			for (StringName &F : names) {
+				if (icon_item == edited_theme->get_icon(F, E)) {
 					belongs_to_theme = true;
 					break;
 				}

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -303,9 +303,9 @@ void TileSetAtlasSourceEditor::AtlasTileProxyObject::_get_property_list(List<Pro
 	}
 
 	// Add only properties that are common to all tiles.
-	for (List<PLData *>::Element *E = data_list.front(); E; E = E->next()) {
-		if (E->get()->uses == tiles.size()) {
-			p_list->push_back(E->get()->property_info);
+	for (PLData *E : data_list) {
+		if (E->uses == tiles.size()) {
+			p_list->push_back(E->property_info);
 		}
 	}
 }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -666,8 +666,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		if (valid_left) {
 			name_left = vsnode->get_input_port_name(i);
 			port_left = vsnode->get_input_port_type(i);
-			for (List<VisualShader::Connection>::Element *E = connections.front(); E; E = E->next()) {
-				if (E->get().to_node == p_id && E->get().to_port == j) {
+			for (VisualShader::Connection &E : connections) {
+				if (E.to_node == p_id && E.to_port == j) {
 					port_left_used = true;
 				}
 			}
@@ -899,11 +899,11 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		expression_box->set_syntax_highlighter(expression_syntax_highlighter);
 		expression_box->add_theme_color_override("background_color", background_color);
 
-		for (List<String>::Element *E = VisualShaderEditor::get_singleton()->keyword_list.front(); E; E = E->next()) {
-			if (ShaderLanguage::is_control_flow_keyword(E->get())) {
-				expression_syntax_highlighter->add_keyword_color(E->get(), control_flow_keyword_color);
+		for (String &E : VisualShaderEditor::get_singleton()->keyword_list) {
+			if (ShaderLanguage::is_control_flow_keyword(E)) {
+				expression_syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
 			} else {
-				expression_syntax_highlighter->add_keyword_color(E->get(), keyword_color);
+				expression_syntax_highlighter->add_keyword_color(E, keyword_color);
 			}
 		}
 
@@ -961,7 +961,7 @@ void VisualShaderGraphPlugin::connect_nodes(VisualShader::Type p_type, int p_fro
 void VisualShaderGraphPlugin::disconnect_nodes(VisualShader::Type p_type, int p_from_node, int p_from_port, int p_to_node, int p_to_port) {
 	if (visual_shader->get_shader_type() == p_type) {
 		VisualShaderEditor::get_singleton()->graph->disconnect_node(itos(p_from_node), p_from_port, itos(p_to_node), p_to_port);
-		for (List<VisualShader::Connection>::Element *E = connections.front(); E; E = E->next()) {
+		for (const List<VisualShader::Connection>::Element *E = connections.front(); E; E = E->next()) {
 			if (E->get().from_node == p_from_node && E->get().from_port == p_from_port && E->get().to_node == p_to_node && E->get().to_port == p_to_port) {
 				connections.erase(E);
 				break;
@@ -1470,11 +1470,11 @@ void VisualShaderEditor::_update_graph() {
 
 	graph_plugin->make_dirty(false);
 
-	for (List<VisualShader::Connection>::Element *E = connections.front(); E; E = E->next()) {
-		int from = E->get().from_node;
-		int from_idx = E->get().from_port;
-		int to = E->get().to_node;
-		int to_idx = E->get().to_port;
+	for (VisualShader::Connection &E : connections) {
+		int from = E.from_node;
+		int from_idx = E.from_port;
+		int to = E.to_node;
+		int to_idx = E.to_port;
 
 		graph->connect_node(itos(from), from_idx, itos(to), to_idx);
 	}
@@ -1634,11 +1634,11 @@ void VisualShaderEditor::_expand_output_port(int p_node, int p_port, bool p_expa
 	List<VisualShader::Connection> conns;
 	visual_shader->get_node_connections(type, &conns);
 
-	for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-		int from_node = E->get().from_node;
-		int from_port = E->get().from_port;
-		int to_node = E->get().to_node;
-		int to_port = E->get().to_port;
+	for (VisualShader::Connection &E : conns) {
+		int from_node = E.from_node;
+		int from_port = E.from_port;
+		int to_node = E.to_node;
+		int to_port = E.to_port;
 
 		if (from_node == p_node) {
 			if (p_expand) {
@@ -1708,11 +1708,11 @@ void VisualShaderEditor::_remove_input_port(int p_node, int p_port) {
 
 	List<VisualShader::Connection> conns;
 	visual_shader->get_node_connections(type, &conns);
-	for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-		int from_node = E->get().from_node;
-		int from_port = E->get().from_port;
-		int to_node = E->get().to_node;
-		int to_port = E->get().to_port;
+	for (VisualShader::Connection &E : conns) {
+		int from_node = E.from_node;
+		int from_port = E.from_port;
+		int to_node = E.to_node;
+		int to_port = E.to_port;
 
 		if (to_node == p_node) {
 			if (to_port == p_port) {
@@ -1757,11 +1757,11 @@ void VisualShaderEditor::_remove_output_port(int p_node, int p_port) {
 
 	List<VisualShader::Connection> conns;
 	visual_shader->get_node_connections(type, &conns);
-	for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-		int from_node = E->get().from_node;
-		int from_port = E->get().from_port;
-		int to_node = E->get().to_node;
-		int to_port = E->get().to_port;
+	for (VisualShader::Connection &E : conns) {
+		int from_node = E.from_node;
+		int from_port = E.from_port;
+		int to_node = E.to_node;
+		int to_port = E.to_port;
 
 		if (from_node == p_node) {
 			if (from_port == p_port) {
@@ -2518,11 +2518,11 @@ void VisualShaderEditor::_nodes_dragged() {
 
 	undo_redo->create_action(TTR("Node(s) Moved"));
 
-	for (List<DragOp>::Element *E = drag_buffer.front(); E; E = E->next()) {
-		undo_redo->add_do_method(visual_shader.ptr(), "set_node_position", E->get().type, E->get().node, E->get().to);
-		undo_redo->add_undo_method(visual_shader.ptr(), "set_node_position", E->get().type, E->get().node, E->get().from);
-		undo_redo->add_do_method(graph_plugin.ptr(), "set_node_position", E->get().type, E->get().node, E->get().to);
-		undo_redo->add_undo_method(graph_plugin.ptr(), "set_node_position", E->get().type, E->get().node, E->get().from);
+	for (DragOp &E : drag_buffer) {
+		undo_redo->add_do_method(visual_shader.ptr(), "set_node_position", E.type, E.node, E.to);
+		undo_redo->add_undo_method(visual_shader.ptr(), "set_node_position", E.type, E.node, E.from);
+		undo_redo->add_do_method(graph_plugin.ptr(), "set_node_position", E.type, E.node, E.to);
+		undo_redo->add_undo_method(graph_plugin.ptr(), "set_node_position", E.type, E.node, E.from);
 	}
 
 	drag_buffer.clear();
@@ -2544,12 +2544,12 @@ void VisualShaderEditor::_connection_request(const String &p_from, int p_from_in
 	List<VisualShader::Connection> conns;
 	visual_shader->get_node_connections(type, &conns);
 
-	for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-		if (E->get().to_node == to && E->get().to_port == p_to_index) {
-			undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-			undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-			undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-			undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+	for (VisualShader::Connection &E : conns) {
+		if (E.to_node == to && E.to_port == p_to_index) {
+			undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+			undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+			undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+			undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
 		}
 	}
 
@@ -2597,22 +2597,22 @@ void VisualShaderEditor::_delete_nodes(int p_type, const List<int> &p_nodes) {
 	List<VisualShader::Connection> conns;
 	visual_shader->get_node_connections(type, &conns);
 
-	for (const List<int>::Element *F = p_nodes.front(); F; F = F->next()) {
-		for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-			if (E->get().from_node == F->get() || E->get().to_node == F->get()) {
-				undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+	for (const int &F : p_nodes) {
+		for (VisualShader::Connection &E : conns) {
+			if (E.from_node == F || E.to_node == F) {
+				undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
 			}
 		}
 	}
 
 	Set<String> uniform_names;
 
-	for (const List<int>::Element *F = p_nodes.front(); F; F = F->next()) {
-		Ref<VisualShaderNode> node = visual_shader->get_node(type, F->get());
+	for (const int &F : p_nodes) {
+		Ref<VisualShaderNode> node = visual_shader->get_node(type, F);
 
-		undo_redo->add_do_method(visual_shader.ptr(), "remove_node", type, F->get());
-		undo_redo->add_undo_method(visual_shader.ptr(), "add_node", type, node, visual_shader->get_node_position(type, F->get()), F->get());
-		undo_redo->add_undo_method(graph_plugin.ptr(), "add_node", type, F->get());
+		undo_redo->add_do_method(visual_shader.ptr(), "remove_node", type, F);
+		undo_redo->add_undo_method(visual_shader.ptr(), "add_node", type, node, visual_shader->get_node_position(type, F), F);
+		undo_redo->add_undo_method(graph_plugin.ptr(), "add_node", type, F);
 
 		undo_redo->add_do_method(this, "_clear_buffer");
 		undo_redo->add_undo_method(this, "_clear_buffer");
@@ -2638,28 +2638,28 @@ void VisualShaderEditor::_delete_nodes(int p_type, const List<int> &p_nodes) {
 	}
 
 	List<VisualShader::Connection> used_conns;
-	for (const List<int>::Element *F = p_nodes.front(); F; F = F->next()) {
-		for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-			if (E->get().from_node == F->get() || E->get().to_node == F->get()) {
+	for (const int &F : p_nodes) {
+		for (VisualShader::Connection &E : conns) {
+			if (E.from_node == F || E.to_node == F) {
 				bool cancel = false;
 				for (List<VisualShader::Connection>::Element *R = used_conns.front(); R; R = R->next()) {
-					if (R->get().from_node == E->get().from_node && R->get().from_port == E->get().from_port && R->get().to_node == E->get().to_node && R->get().to_port == E->get().to_port) {
+					if (R->get().from_node == E.from_node && R->get().from_port == E.from_port && R->get().to_node == E.to_node && R->get().to_port == E.to_port) {
 						cancel = true; // to avoid ERR_ALREADY_EXISTS warning
 						break;
 					}
 				}
 				if (!cancel) {
-					undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-					undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-					used_conns.push_back(E->get());
+					undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+					undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+					used_conns.push_back(E);
 				}
 			}
 		}
 	}
 
 	// delete nodes from the graph
-	for (const List<int>::Element *F = p_nodes.front(); F; F = F->next()) {
-		undo_redo->add_do_method(graph_plugin.ptr(), "remove_node", type, F->get());
+	for (const int &F : p_nodes) {
+		undo_redo->add_do_method(graph_plugin.ptr(), "remove_node", type, F);
 	}
 
 	// update uniform refs if any uniform has been deleted
@@ -3094,11 +3094,11 @@ void VisualShaderEditor::_notification(int p_what) {
 
 			preview_text->add_theme_color_override("background_color", background_color);
 
-			for (List<String>::Element *E = keyword_list.front(); E; E = E->next()) {
-				if (ShaderLanguage::is_control_flow_keyword(E->get())) {
-					syntax_highlighter->add_keyword_color(E->get(), control_flow_keyword_color);
+			for (String &E : keyword_list) {
+				if (ShaderLanguage::is_control_flow_keyword(E)) {
+					syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
 				} else {
-					syntax_highlighter->add_keyword_color(E->get(), keyword_color);
+					syntax_highlighter->add_keyword_color(E, keyword_color);
 				}
 			}
 
@@ -3206,9 +3206,9 @@ void VisualShaderEditor::_dup_paste_nodes(int p_type, int p_pasted_type, List<in
 	Map<int, int> connection_remap;
 	Set<int> unsupported_set;
 
-	for (List<int>::Element *E = r_nodes.front(); E; E = E->next()) {
-		connection_remap[E->get()] = id_from;
-		Ref<VisualShaderNode> node = visual_shader->get_node(pasted_type, E->get());
+	for (int &E : r_nodes) {
+		connection_remap[E] = id_from;
+		Ref<VisualShaderNode> node = visual_shader->get_node(pasted_type, E);
 
 		bool unsupported = false;
 		for (int i = 0; i < add_options.size(); i++) {
@@ -3220,13 +3220,13 @@ void VisualShaderEditor::_dup_paste_nodes(int p_type, int p_pasted_type, List<in
 			}
 		}
 		if (unsupported) {
-			unsupported_set.insert(E->get());
+			unsupported_set.insert(E);
 			continue;
 		}
 
 		Ref<VisualShaderNode> dupli = node->duplicate();
 
-		undo_redo->add_do_method(visual_shader.ptr(), "add_node", type, dupli, visual_shader->get_node_position(pasted_type, E->get()) + p_offset, id_from);
+		undo_redo->add_do_method(visual_shader.ptr(), "add_node", type, dupli, visual_shader->get_node_position(pasted_type, E) + p_offset, id_from);
 		undo_redo->add_do_method(graph_plugin.ptr(), "add_node", type, id_from);
 
 		// duplicate size, inputs and outputs if node is group
@@ -3249,19 +3249,19 @@ void VisualShaderEditor::_dup_paste_nodes(int p_type, int p_pasted_type, List<in
 	List<VisualShader::Connection> conns;
 	visual_shader->get_node_connections(pasted_type, &conns);
 
-	for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-		if (unsupported_set.has(E->get().from_node) || unsupported_set.has(E->get().to_node)) {
+	for (VisualShader::Connection &E : conns) {
+		if (unsupported_set.has(E.from_node) || unsupported_set.has(E.to_node)) {
 			continue;
 		}
-		if (connection_remap.has(E->get().from_node) && connection_remap.has(E->get().to_node)) {
-			undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes", type, connection_remap[E->get().from_node], E->get().from_port, connection_remap[E->get().to_node], E->get().to_port);
-			undo_redo->add_do_method(graph_plugin.ptr(), "connect_nodes", type, connection_remap[E->get().from_node], E->get().from_port, connection_remap[E->get().to_node], E->get().to_port);
-			undo_redo->add_undo_method(graph_plugin.ptr(), "disconnect_nodes", type, connection_remap[E->get().from_node], E->get().from_port, connection_remap[E->get().to_node], E->get().to_port);
+		if (connection_remap.has(E.from_node) && connection_remap.has(E.to_node)) {
+			undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes", type, connection_remap[E.from_node], E.from_port, connection_remap[E.to_node], E.to_port);
+			undo_redo->add_do_method(graph_plugin.ptr(), "connect_nodes", type, connection_remap[E.from_node], E.from_port, connection_remap[E.to_node], E.to_port);
+			undo_redo->add_undo_method(graph_plugin.ptr(), "disconnect_nodes", type, connection_remap[E.from_node], E.from_port, connection_remap[E.to_node], E.to_port);
 		}
 	}
 
 	id_from = base_id;
-	for (List<int>::Element *E = r_nodes.front(); E; E = E->next()) {
+	for (int i = 0; i < r_nodes.size(); i++) {
 		undo_redo->add_undo_method(visual_shader.ptr(), "remove_node", type, id_from);
 		undo_redo->add_undo_method(graph_plugin.ptr(), "remove_node", type, id_from);
 		id_from++;
@@ -3399,17 +3399,17 @@ void VisualShaderEditor::_input_select_item(Ref<VisualShaderNodeInput> p_input, 
 			if (type_changed) {
 				List<VisualShader::Connection> conns;
 				visual_shader->get_node_connections(type, &conns);
-				for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-					if (E->get().from_node == id) {
-						if (visual_shader->is_port_types_compatible(p_input->get_input_type_by_name(p_name), visual_shader->get_node(type, E->get().to_node)->get_input_port_type(E->get().to_port))) {
-							undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-							undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+				for (VisualShader::Connection &E : conns) {
+					if (E.from_node == id) {
+						if (visual_shader->is_port_types_compatible(p_input->get_input_type_by_name(p_name), visual_shader->get_node(type, E.to_node)->get_input_port_type(E.to_port))) {
+							undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+							undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
 							continue;
 						}
-						undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+						undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+						undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+						undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
 					}
 				}
 			}
@@ -3445,15 +3445,15 @@ void VisualShaderEditor::_uniform_select_item(Ref<VisualShaderNodeUniformRef> p_
 			if (type_changed) {
 				List<VisualShader::Connection> conns;
 				visual_shader->get_node_connections(type, &conns);
-				for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-					if (E->get().from_node == id) {
-						if (visual_shader->is_port_types_compatible(p_uniform_ref->get_uniform_type_by_name(p_name), visual_shader->get_node(type, E->get().to_node)->get_input_port_type(E->get().to_port))) {
+				for (VisualShader::Connection &E : conns) {
+					if (E.from_node == id) {
+						if (visual_shader->is_port_types_compatible(p_uniform_ref->get_uniform_type_by_name(p_name), visual_shader->get_node(type, E.to_node)->get_input_port_type(E.to_port))) {
 							continue;
 						}
-						undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+						undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+						undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
+						undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
 					}
 				}
 			}
@@ -4825,10 +4825,10 @@ Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_par
 
 	Vector<PropertyInfo> pinfo;
 
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
+	for (PropertyInfo &E : props) {
 		for (int i = 0; i < properties.size(); i++) {
-			if (E->get().name == String(properties[i])) {
-				pinfo.push_back(E->get());
+			if (E.name == String(properties[i])) {
+				pinfo.push_back(E);
 			}
 		}
 	}
@@ -4894,9 +4894,9 @@ void EditorPropertyShaderMode::_option_selected(int p_which) {
 		VisualShader::Type type = VisualShader::Type(i);
 		List<VisualShader::Connection> conns;
 		visual_shader->get_node_connections(type, &conns);
-		for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
-			if (E->get().to_node == VisualShader::NODE_ID_OUTPUT) {
-				undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+		for (VisualShader::Connection &E : conns) {
+			if (E.to_node == VisualShader::NODE_ID_OUTPUT) {
+				undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E.from_node, E.from_port, E.to_node, E.to_port);
 			}
 		}
 	}
@@ -4918,9 +4918,9 @@ void EditorPropertyShaderMode::_option_selected(int p_which) {
 	List<PropertyInfo> props;
 	visual_shader->get_property_list(&props);
 
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		if (E->get().name.begins_with("flags/") || E->get().name.begins_with("modes/")) {
-			undo_redo->add_undo_property(visual_shader.ptr(), E->get().name, visual_shader->get(E->get().name));
+	for (PropertyInfo &E : props) {
+		if (E.name.begins_with("flags/") || E.name.begins_with("modes/")) {
+			undo_redo->add_undo_property(visual_shader.ptr(), E.name, visual_shader->get(E.name));
 		}
 	}
 
@@ -5024,8 +5024,8 @@ void VisualShaderNodePortPreview::_shader_changed() {
 		if (src_mat && src_mat->get_shader().is_valid()) {
 			List<PropertyInfo> params;
 			src_mat->get_shader()->get_param_list(&params);
-			for (List<PropertyInfo>::Element *E = params.front(); E; E = E->next()) {
-				material->set(E->get().name, src_mat->get(E->get().name));
+			for (PropertyInfo &E : params) {
+				material->set(E.name, src_mat->get(E.name));
 			}
 		}
 	}

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -340,8 +340,8 @@ void ProjectExportDialog::_update_feature_list() {
 		}
 	}
 
-	for (List<String>::Element *E = features.front(); E; E = E->next()) {
-		fset.insert(E->get());
+	for (String &E : features) {
+		fset.insert(E);
 	}
 
 	custom_feature_display->clear();
@@ -567,8 +567,8 @@ void ProjectExportDialog::_duplicate_preset() {
 	preset->set_exclude_filter(current->get_exclude_filter());
 	preset->set_custom_features(current->get_custom_features());
 
-	for (const List<PropertyInfo>::Element *E = current->get_properties().front(); E; E = E->next()) {
-		preset->set(E->get().name, current->get(E->get().name));
+	for (const PropertyInfo &E : current->get_properties()) {
+		preset->set(E.name, current->get(E.name));
 	}
 
 	EditorExport::get_singleton()->add_export_preset(preset);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1238,16 +1238,16 @@ void ProjectList::load_projects() {
 
 	Set<String> favorites;
 	// Find favourites...
-	for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-		String property_key = E->get().name;
+	for (PropertyInfo &E : properties) {
+		String property_key = E.name;
 		if (property_key.begins_with("favorite_projects/")) {
 			favorites.insert(property_key);
 		}
 	}
 
-	for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
+	for (PropertyInfo &E : properties) {
 		// This is actually something like "projects/C:::Documents::Godot::Projects::MyGame"
-		String property_key = E->get().name;
+		String property_key = E.name;
 		if (!property_key.begins_with("projects/")) {
 			continue;
 		}
@@ -1582,8 +1582,8 @@ int ProjectList::refresh_project(const String &dir_path) {
 		String favorite_property_key = "favorite_projects/" + project_key;
 
 		bool found = false;
-		for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-			String prop = E->get().name;
+		for (PropertyInfo &E : properties) {
+			String prop = E.name;
 			if (!found && prop == property_key) {
 				found = true;
 			} else if (!is_favourite && prop == favorite_property_key) {
@@ -2188,9 +2188,9 @@ void ProjectManager::_scan_begin(const String &p_base) {
 	_scan_dir(p_base, &projects);
 	print_line("Found " + itos(projects.size()) + " projects.");
 
-	for (List<String>::Element *E = projects.front(); E; E = E->next()) {
-		String proj = get_project_key_from_path(E->get());
-		EditorSettings::get_singleton()->set("projects/" + proj, E->get());
+	for (String &E : projects) {
+		String proj = get_project_key_from_path(E);
+		EditorSettings::get_singleton()->set("projects/" + proj, E);
 	}
 	EditorSettings::get_singleton()->save();
 	_load_recent_projects();
@@ -2625,8 +2625,7 @@ ProjectManager::ProjectManager() {
 		Vector<String> editor_languages;
 		List<PropertyInfo> editor_settings_properties;
 		EditorSettings::get_singleton()->get_property_list(&editor_settings_properties);
-		for (List<PropertyInfo>::Element *E = editor_settings_properties.front(); E; E = E->next()) {
-			PropertyInfo &pi = E->get();
+		for (PropertyInfo &pi : editor_settings_properties) {
 			if (pi.name == "interface/editor/editor_language") {
 				editor_languages = pi.hint_string.split(",");
 				break;

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -229,16 +229,16 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 	for (int i = 0; i < ee->get_export_platform_count(); i++) {
 		List<String> p;
 		ee->get_export_platform(i)->get_platform_features(&p);
-		for (List<String>::Element *E = p.front(); E; E = E->next()) {
-			presets.insert(E->get());
+		for (String &E : p) {
+			presets.insert(E);
 		}
 	}
 
 	for (int i = 0; i < ee->get_export_preset_count(); i++) {
 		List<String> p;
 		ee->get_export_preset(i)->get_platform()->get_preset_features(ee->get_export_preset(i), &p);
-		for (List<String>::Element *E = p.front(); E; E = E->next()) {
-			presets.insert(E->get());
+		for (String &E : p) {
+			presets.insert(E);
 		}
 
 		String custom = ee->get_export_preset(i)->get_custom_features();
@@ -391,8 +391,7 @@ void ProjectSettingsEditor::_action_reordered(const String &p_action_name, const
 
 	undo_redo->create_action(TTR("Update Input Action Order"));
 
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		PropertyInfo prop = E->get();
+	for (PropertyInfo &prop : props) {
 		// Skip builtins and non-inputs
 		if (ProjectSettings::get_singleton()->is_builtin_setting(prop.name) || !prop.name.begins_with("input/")) {
 			continue;
@@ -445,8 +444,8 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 	ProjectSettings::get_singleton()->get_property_list(&props);
 
 	const Ref<Texture2D> builtin_icon = get_theme_icon(SNAME("PinPressed"), SNAME("EditorIcons"));
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		const String property_name = E->get().name;
+	for (PropertyInfo &E : props) {
+		const String property_name = E.name;
 
 		if (!property_name.begins_with("input/")) {
 			continue;

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -143,8 +143,8 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 					}
 
 					Set<String> valid_extensions;
-					for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-						valid_extensions.insert(E->get());
+					for (String &E : extensions) {
+						valid_extensions.insert(E);
 					}
 
 					file->clear_filters();
@@ -179,9 +179,8 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 					res_orig->get_property_list(&property_list);
 					List<Pair<String, Variant>> propvalues;
 
-					for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
+					for (PropertyInfo &pi : property_list) {
 						Pair<String, Variant> p;
-						PropertyInfo &pi = E->get();
 						if (pi.usage & PROPERTY_USAGE_STORAGE) {
 							p.first = pi.name;
 							p.second = res_orig->get(pi.name);
@@ -198,8 +197,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					ERR_FAIL_COND(res.is_null());
 
-					for (List<Pair<String, Variant>>::Element *E = propvalues.front(); E; E = E->next()) {
-						Pair<String, Variant> &p = E->get();
+					for (Pair<String, Variant> &p : propvalues) {
 						res->set(p.first, p.second);
 					}
 
@@ -1293,8 +1291,8 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 				ResourceLoader::get_recognized_extensions_for_type(type, &extensions);
 				file->clear_filters();
-				for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-					file->add_filter("*." + E->get() + " ; " + E->get().to_upper());
+				for (String &E : extensions) {
+					file->add_filter("*." + E + " ; " + E.to_upper());
 				}
 
 				file->popup_file_dialog();
@@ -1321,9 +1319,8 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 				res_orig->get_property_list(&property_list);
 				List<Pair<String, Variant>> propvalues;
 
-				for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
+				for (PropertyInfo &pi : property_list) {
 					Pair<String, Variant> p;
-					PropertyInfo &pi = E->get();
 					if (pi.usage & PROPERTY_USAGE_STORAGE) {
 						p.first = pi.name;
 						p.second = res_orig->get(pi.name);
@@ -1336,8 +1333,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 				ERR_FAIL_COND(res.is_null());
 
-				for (List<Pair<String, Variant>>::Element *E = propvalues.front(); E; E = E->next()) {
-					Pair<String, Variant> &p = E->get();
+				for (Pair<String, Variant> &p : propvalues) {
 					res->set(p.first, p.second);
 				}
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -156,43 +156,43 @@ void PropertySelector::_update_search() {
 			search_options->get_theme_icon(SNAME("PackedColorArray"), SNAME("EditorIcons"))
 		};
 
-		for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-			if (E->get().usage == PROPERTY_USAGE_CATEGORY) {
+		for (PropertyInfo &E : props) {
+			if (E.usage == PROPERTY_USAGE_CATEGORY) {
 				if (category && category->get_first_child() == nullptr) {
 					memdelete(category); //old category was unused
 				}
 				category = search_options->create_item(root);
-				category->set_text(0, E->get().name);
+				category->set_text(0, E.name);
 				category->set_selectable(0, false);
 
 				Ref<Texture2D> icon;
-				if (E->get().name == "Script Variables") {
+				if (E.name == "Script Variables") {
 					icon = search_options->get_theme_icon(SNAME("Script"), SNAME("EditorIcons"));
 				} else {
-					icon = EditorNode::get_singleton()->get_class_icon(E->get().name);
+					icon = EditorNode::get_singleton()->get_class_icon(E.name);
 				}
 				category->set_icon(0, icon);
 				continue;
 			}
 
-			if (!(E->get().usage & PROPERTY_USAGE_EDITOR) && !(E->get().usage & PROPERTY_USAGE_SCRIPT_VARIABLE)) {
+			if (!(E.usage & PROPERTY_USAGE_EDITOR) && !(E.usage & PROPERTY_USAGE_SCRIPT_VARIABLE)) {
 				continue;
 			}
 
-			if (search_box->get_text() != String() && E->get().name.findn(search_text) == -1) {
+			if (search_box->get_text() != String() && E.name.findn(search_text) == -1) {
 				continue;
 			}
 
-			if (type_filter.size() && type_filter.find(E->get().type) == -1) {
+			if (type_filter.size() && type_filter.find(E.type) == -1) {
 				continue;
 			}
 
 			TreeItem *item = search_options->create_item(category ? category : root);
-			item->set_text(0, E->get().name);
-			item->set_metadata(0, E->get().name);
-			item->set_icon(0, type_icons[E->get().type]);
+			item->set_text(0, E.name);
+			item->set_metadata(0, E.name);
+			item->set_icon(0, type_icons[E.type]);
 
-			if (!found && search_box->get_text() != String() && E->get().name.findn(search_text) != -1) {
+			if (!found && search_box->get_text() != String() && E.name.findn(search_text) != -1) {
 				item->select(0);
 				found = true;
 			}
@@ -231,19 +231,19 @@ void PropertySelector::_update_search() {
 		bool found = false;
 		bool script_methods = false;
 
-		for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
-			if (E->get().name.begins_with("*")) {
+		for (MethodInfo &mi : methods) {
+			if (mi.name.begins_with("*")) {
 				if (category && category->get_first_child() == nullptr) {
 					memdelete(category); //old category was unused
 				}
 				category = search_options->create_item(root);
-				category->set_text(0, E->get().name.replace_first("*", ""));
+				category->set_text(0, mi.name.replace_first("*", ""));
 				category->set_selectable(0, false);
 
 				Ref<Texture2D> icon;
 				script_methods = false;
-				String rep = E->get().name.replace("*", "");
-				if (E->get().name == "*Script Methods") {
+				String rep = mi.name.replace("*", "");
+				if (mi.name == "*Script Methods") {
 					icon = search_options->get_theme_icon(SNAME("Script"), SNAME("EditorIcons"));
 					script_methods = true;
 				} else {
@@ -254,16 +254,16 @@ void PropertySelector::_update_search() {
 				continue;
 			}
 
-			String name = E->get().name.get_slice(":", 0);
-			if (!script_methods && name.begins_with("_") && !(E->get().flags & METHOD_FLAG_VIRTUAL)) {
+			String name = mi.name.get_slice(":", 0);
+			if (!script_methods && name.begins_with("_") && !(mi.flags & METHOD_FLAG_VIRTUAL)) {
 				continue;
 			}
 
-			if (virtuals_only && !(E->get().flags & METHOD_FLAG_VIRTUAL)) {
+			if (virtuals_only && !(mi.flags & METHOD_FLAG_VIRTUAL)) {
 				continue;
 			}
 
-			if (!virtuals_only && (E->get().flags & METHOD_FLAG_VIRTUAL)) {
+			if (!virtuals_only && (mi.flags & METHOD_FLAG_VIRTUAL)) {
 				continue;
 			}
 
@@ -272,8 +272,6 @@ void PropertySelector::_update_search() {
 			}
 
 			TreeItem *item = search_options->create_item(category ? category : root);
-
-			MethodInfo mi = E->get();
 
 			String desc;
 			if (mi.name.find(":") != -1) {
@@ -306,11 +304,11 @@ void PropertySelector::_update_search() {
 
 			desc += ")";
 
-			if (E->get().flags & METHOD_FLAG_CONST) {
+			if (mi.flags & METHOD_FLAG_CONST) {
 				desc += " const";
 			}
 
-			if (E->get().flags & METHOD_FLAG_VIRTUAL) {
+			if (mi.flags & METHOD_FLAG_VIRTUAL) {
 				desc += " virtual";
 			}
 

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -79,8 +79,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		_toggle_visible(n);
 		List<Node *> selection = editor_selection->get_selected_node_list();
 		if (selection.size() > 1 && selection.find(n) != nullptr) {
-			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node *nv = E->get();
+			for (Node *nv : selection) {
 				ERR_FAIL_COND(!nv);
 				if (nv == n) {
 					continue;

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -205,12 +205,12 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	bool found = false;
 	bool match = false;
 	int index = 0;
-	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-		if (E->get().nocasecmp_to(extension) == 0) {
+	for (String &E : extensions) {
+		if (E.nocasecmp_to(extension) == 0) {
 			//FIXME (?) - changing language this way doesn't update controls, needs rework
 			//language_menu->select(index); // change Language option by extension
 			found = true;
-			if (E->get() == ScriptServer::get_language(language_menu->get_selected())->get_extension()) {
+			if (E == ScriptServer::get_language(language_menu->get_selected())->get_extension()) {
 				match = true;
 			}
 			break;
@@ -373,8 +373,8 @@ void ScriptCreateDialog::_lang_changed(int l) {
 				ScriptServer::get_language(m)->get_recognized_extensions(&extensions);
 			}
 
-			for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-				if (E->get().nocasecmp_to(extension) == 0) {
+			for (String &E : extensions) {
+				if (E.nocasecmp_to(extension) == 0) {
 					path = path.get_basename() + selected_ext;
 					_path_changed(path);
 					break;
@@ -534,8 +534,8 @@ void ScriptCreateDialog::_browse_path(bool browse_parent, bool p_save) {
 	int lang = language_menu->get_selected();
 	ScriptServer::get_language(lang)->get_recognized_extensions(&extensions);
 
-	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-		file_browse->add_filter("*." + E->get());
+	for (String &E : extensions) {
+		file_browse->add_filter("*." + E);
 	}
 
 	file_browse->set_current_path(file_path->get_text());

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -324,15 +324,15 @@ void EditorSettingsDialog::_update_shortcuts() {
 	List<String> slist;
 	EditorSettings::get_singleton()->get_shortcut_list(&slist);
 
-	for (List<String>::Element *E = slist.front(); E; E = E->next()) {
-		Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(E->get());
+	for (String &E : slist) {
+		Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(E);
 		if (!sc->has_meta("original")) {
 			continue;
 		}
 
 		Ref<InputEvent> original = sc->get_meta("original");
 
-		String section_name = E->get().get_slice("/", 0);
+		String section_name = E.get_slice("/", 0);
 
 		TreeItem *section;
 
@@ -372,8 +372,8 @@ void EditorSettingsDialog::_update_shortcuts() {
 
 			item->add_button(1, shortcuts->get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), 0);
 			item->add_button(1, shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")), 1);
-			item->set_tooltip(0, E->get());
-			item->set_metadata(0, E->get());
+			item->set_tooltip(0, E);
+			item->set_metadata(0, E);
 		}
 	}
 
@@ -403,10 +403,9 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 				List<Ref<InputEvent>> defaults = InputMap::get_singleton()->get_builtins()[current_action];
 
 				// Convert the list to an array, and only keep key events as this is for the editor.
-				for (List<Ref<InputEvent>>::Element *E = defaults.front(); E; E = E->next()) {
-					Ref<InputEventKey> k = E->get();
+				for (Ref<InputEvent> k : defaults) {
 					if (k.is_valid()) {
-						events.append(E->get());
+						events.append(k);
 					}
 				}
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2169,8 +2169,8 @@ bool Main::start() {
 					}
 				}
 
-				for (List<Node *>::Element *E = to_add.front(); E; E = E->next()) {
-					sml->get_root()->add_child(E->get());
+				for (Node *E : to_add) {
+					sml->get_root()->add_child(E);
 				}
 			}
 		}

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -530,8 +530,8 @@ void CSGBrushOperation::MeshMerge::_add_distance(List<real_t> &r_intersectionsA,
 	List<real_t> &intersections = p_from_B ? r_intersectionsB : r_intersectionsA;
 
 	// Check if distance exists.
-	for (const List<real_t>::Element *E = intersections.front(); E; E = E->next()) {
-		if (Math::is_equal_approx(**E, p_distance)) {
+	for (const real_t E : intersections) {
+		if (Math::is_equal_approx(E, p_distance)) {
 			return;
 		}
 	}

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -129,9 +129,7 @@ void GDNativeLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 		config_file->get_section_keys("entry", &entry_key_list);
 	}
 
-	for (List<String>::Element *E = entry_key_list.front(); E; E = E->next()) {
-		String key = E->get();
-
+	for (String &key : entry_key_list) {
 		PropertyInfo prop;
 
 		prop.type = Variant::STRING;
@@ -147,9 +145,7 @@ void GDNativeLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 		config_file->get_section_keys("dependencies", &dependency_key_list);
 	}
 
-	for (List<String>::Element *E = dependency_key_list.front(); E; E = E->next()) {
-		String key = E->get();
-
+	for (String &key : dependency_key_list) {
 		PropertyInfo prop;
 
 		prop.type = Variant::STRING;
@@ -175,9 +171,7 @@ void GDNativeLibrary::set_config_file(Ref<ConfigFile> p_config_file) {
 			p_config_file->get_section_keys("entry", &entry_keys);
 		}
 
-		for (List<String>::Element *E = entry_keys.front(); E; E = E->next()) {
-			String key = E->get();
-
+		for (String &key : entry_keys) {
 			Vector<String> tags = key.split(".");
 
 			bool skip = false;
@@ -207,9 +201,7 @@ void GDNativeLibrary::set_config_file(Ref<ConfigFile> p_config_file) {
 			p_config_file->get_section_keys("dependencies", &dependency_keys);
 		}
 
-		for (List<String>::Element *E = dependency_keys.front(); E; E = E->next()) {
-			String key = E->get();
-
+		for (String &key : dependency_keys) {
 			Vector<String> tags = key.split(".");
 
 			bool skip = false;

--- a/modules/gdnative/gdnative/variant.cpp
+++ b/modules/gdnative/gdnative/variant.cpp
@@ -915,8 +915,8 @@ void GDAPI godot_variant_get_builtin_method_list(godot_variant_type p_type, godo
 	List<StringName> list;
 	Variant::get_builtin_method_list((Variant::Type)p_type, &list);
 	int i = 0;
-	for (const List<StringName>::Element *E = list.front(); E; E = E->next()) {
-		memnew_placement_custom(&r_list[i], StringName, StringName(E->get()));
+	for (const StringName &E : list) {
+		memnew_placement_custom(&r_list[i], StringName, StringName(E));
 	}
 }
 
@@ -970,8 +970,8 @@ void GDAPI godot_variant_get_member_list(godot_variant_type p_type, godot_string
 	List<StringName> members;
 	Variant::get_member_list((Variant::Type)p_type, &members);
 	int i = 0;
-	for (const List<StringName>::Element *E = members.front(); E; E = E->next()) {
-		memnew_placement_custom(&r_list[i++], StringName, StringName(E->get()));
+	for (const StringName &E : members) {
+		memnew_placement_custom(&r_list[i++], StringName, StringName(E));
 	}
 }
 
@@ -1075,8 +1075,8 @@ void GDAPI godot_variant_get_constants_list(godot_variant_type p_type, godot_str
 	List<StringName> constants;
 	int i = 0;
 	Variant::get_constants_for_type((Variant::Type)p_type, &constants);
-	for (const List<StringName>::Element *E = constants.front(); E; E = E->next()) {
-		memnew_placement_custom(&r_list[i++], StringName, StringName(E->get()));
+	for (const StringName &E : constants) {
+		memnew_placement_custom(&r_list[i++], StringName, StringName(E));
 	}
 }
 
@@ -1227,8 +1227,8 @@ void GDAPI godot_variant_get_utility_function_list(godot_string_name *r_function
 	godot_string_name *func = r_functions;
 	Variant::get_utility_function_list(&functions);
 
-	for (const List<StringName>::Element *E = functions.front(); E; E = E->next()) {
-		memnew_placement_custom(func++, StringName, StringName(E->get()));
+	for (const StringName &E : functions) {
+		memnew_placement_custom(func++, StringName, StringName(E));
 	}
 }
 

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -425,11 +425,11 @@ List<ClassAPI> generate_c_api_classes() {
 			List<EnumAPI> enums;
 			List<StringName> enum_names;
 			ClassDB::get_enum_list(class_name, &enum_names, true);
-			for (List<StringName>::Element *E = enum_names.front(); E; E = E->next()) {
+			for (StringName &E : enum_names) {
 				List<StringName> value_names;
 				EnumAPI enum_api;
-				enum_api.name = E->get();
-				ClassDB::get_enum_constants(class_name, E->get(), &value_names, true);
+				enum_api.name = E;
+				ClassDB::get_enum_constants(class_name, E, &value_names, true);
 				for (List<StringName>::Element *val_e = value_names.front(); val_e; val_e = val_e->next()) {
 					int int_val = ClassDB::get_integer_constant(class_name, val_e->get(), nullptr);
 					enum_api.values.push_back(Pair<int, String>(int_val, val_e->get()));
@@ -459,8 +459,8 @@ List<ClassAPI> generate_c_builtin_api_types() {
 
 		List<StringName> utility_functions;
 		Variant::get_utility_function_list(&utility_functions);
-		for (const List<StringName>::Element *E = utility_functions.front(); E; E = E->next()) {
-			const StringName &function_name = E->get();
+		for (const StringName &E : utility_functions) {
+			const StringName &function_name = E;
 
 			MethodAPI function_api;
 			function_api.method_name = function_name;
@@ -521,8 +521,8 @@ List<ClassAPI> generate_c_builtin_api_types() {
 
 		List<StringName> methods;
 		Variant::get_builtin_method_list(type, &methods);
-		for (const List<StringName>::Element *E = methods.front(); E; E = E->next()) {
-			const StringName &method_name = E->get();
+		for (const StringName &E : methods) {
+			const StringName &method_name = E;
 
 			MethodAPI method_api;
 
@@ -578,8 +578,8 @@ List<ClassAPI> generate_c_builtin_api_types() {
 
 		List<StringName> constants;
 		Variant::get_constants_for_type(type, &constants);
-		for (const List<StringName>::Element *E = constants.front(); E; E = E->next()) {
-			const StringName &constant_name = E->get();
+		for (const StringName &E : constants) {
+			const StringName &constant_name = E;
 			ConstantAPI constant_api;
 
 			constant_api.constant_name = constant_name;
@@ -593,8 +593,8 @@ List<ClassAPI> generate_c_builtin_api_types() {
 
 		List<StringName> members;
 		Variant::get_member_list(type, &members);
-		for (const List<StringName>::Element *E = members.front(); E; E = E->next()) {
-			const StringName &member_name = E->get();
+		for (const StringName &E : members) {
+			const StringName &member_name = E;
 
 			PropertyAPI member_api;
 			member_api.name = member_name;

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -98,10 +98,10 @@ void NativeScript::_update_placeholder(PlaceHolderScriptInstance *p_placeholder)
 	List<PropertyInfo> info;
 	get_script_property_list(&info);
 	Map<StringName, Variant> values;
-	for (List<PropertyInfo>::Element *E = info.front(); E; E = E->next()) {
+	for (PropertyInfo &E : info) {
 		Variant value;
-		get_property_default_value(E->get().name, value);
-		values[E->get().name] = value;
+		get_property_default_value(E.name, value);
+		values[E.name] = value;
 	}
 
 	p_placeholder->update(info, values);

--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -79,9 +79,7 @@ void GDNativeExportPlugin::_export_file(const String &p_path, const String &p_ty
 		List<String> entry_keys;
 		config->get_section_keys("entry", &entry_keys);
 
-		for (List<String>::Element *E = entry_keys.front(); E; E = E->next()) {
-			String key = E->get();
-
+		for (String &key : entry_keys) {
 			Vector<String> tags = key.split(".");
 
 			bool skip = false;
@@ -112,9 +110,7 @@ void GDNativeExportPlugin::_export_file(const String &p_path, const String &p_ty
 		List<String> dependency_keys;
 		config->get_section_keys("dependencies", &dependency_keys);
 
-		for (List<String>::Element *E = dependency_keys.front(); E; E = E->next()) {
-			String key = E->get();
-
+		for (String &key : dependency_keys) {
 			Vector<String> tags = key.split(".");
 
 			bool skip = false;
@@ -149,9 +145,7 @@ void GDNativeExportPlugin::_export_file(const String &p_path, const String &p_ty
 		List<String> entry_keys;
 		config->get_section_keys("entry", &entry_keys);
 
-		for (List<String>::Element *E = entry_keys.front(); E; E = E->next()) {
-			String key = E->get();
-
+		for (String &key : entry_keys) {
 			Vector<String> tags = key.split(".");
 
 			bool skip = false;

--- a/modules/gdnative/tests/test_variant.h
+++ b/modules/gdnative/tests/test_variant.h
@@ -191,8 +191,8 @@ TEST_CASE("[GDNative Variant] Get utility function list") {
 
 	godot_string_name *cur = c_list;
 
-	for (const List<StringName>::Element *E = cpp_list.front(); E; E = E->next()) {
-		const StringName &cpp_name = E->get();
+	for (const StringName &E : cpp_list) {
+		const StringName &cpp_name = E;
 		StringName *c_name = (StringName *)cur++;
 
 		CHECK(*c_name == cpp_name);

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -458,8 +458,8 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	const Color types_color = EDITOR_GET("text_editor/highlighting/engine_type_color");
 	List<StringName> types;
 	ClassDB::get_class_list(&types);
-	for (List<StringName>::Element *E = types.front(); E; E = E->next()) {
-		String n = E->get();
+	for (StringName &E : types) {
+		String n = E;
 		if (n.begins_with("_")) {
 			n = n.substr(1, n.length());
 		}
@@ -470,8 +470,8 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	const Color usertype_color = EDITOR_GET("text_editor/highlighting/user_type_color");
 	List<StringName> global_classes;
 	ScriptServer::get_global_class_list(&global_classes);
-	for (List<StringName>::Element *E = global_classes.front(); E; E = E->next()) {
-		keywords[String(E->get())] = usertype_color;
+	for (StringName &E : global_classes) {
+		keywords[String(E)] = usertype_color;
 	}
 
 	/* Autoloads. */
@@ -489,8 +489,8 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	const Color basetype_color = EDITOR_GET("text_editor/highlighting/base_type_color");
 	List<String> core_types;
 	gdscript->get_core_type_words(&core_types);
-	for (List<String>::Element *E = core_types.front(); E; E = E->next()) {
-		keywords[E->get()] = basetype_color;
+	for (String &E : core_types) {
+		keywords[E] = basetype_color;
 	}
 
 	/* Reserved words. */
@@ -498,11 +498,11 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	const Color control_flow_keyword_color = EDITOR_GET("text_editor/highlighting/control_flow_keyword_color");
 	List<String> keyword_list;
 	gdscript->get_reserved_words(&keyword_list);
-	for (List<String>::Element *E = keyword_list.front(); E; E = E->next()) {
-		if (gdscript->is_control_flow_keyword(E->get())) {
-			keywords[E->get()] = control_flow_keyword_color;
+	for (String &E : keyword_list) {
+		if (gdscript->is_control_flow_keyword(E)) {
+			keywords[E] = control_flow_keyword_color;
 		} else {
-			keywords[E->get()] = keyword_color;
+			keywords[E] = keyword_color;
 		}
 	}
 
@@ -510,8 +510,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	const Color comment_color = EDITOR_GET("text_editor/highlighting/comment_color");
 	List<String> comments;
 	gdscript->get_comment_delimiters(&comments);
-	for (List<String>::Element *E = comments.front(); E; E = E->next()) {
-		String comment = E->get();
+	for (String &comment : comments) {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
 		add_color_region(beg, end, comment_color, end == "");
@@ -521,8 +520,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	const Color string_color = EDITOR_GET("text_editor/highlighting/string_color");
 	List<String> strings;
 	gdscript->get_string_delimiters(&strings);
-	for (List<String>::Element *E = strings.front(); E; E = E->next()) {
-		String string = E->get();
+	for (String &string : strings) {
 		String beg = string.get_slice(" ", 0);
 		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
 		add_color_region(beg, end, string_color, end == "");
@@ -536,9 +534,9 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 		if (instance_base != StringName()) {
 			List<PropertyInfo> plist;
 			ClassDB::get_property_list(instance_base, &plist);
-			for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-				String name = E->get().name;
-				if (E->get().usage & PROPERTY_USAGE_CATEGORY || E->get().usage & PROPERTY_USAGE_GROUP || E->get().usage & PROPERTY_USAGE_SUBGROUP) {
+			for (PropertyInfo &E : plist) {
+				String name = E.name;
+				if (E.usage & PROPERTY_USAGE_CATEGORY || E.usage & PROPERTY_USAGE_GROUP || E.usage & PROPERTY_USAGE_SUBGROUP) {
 					continue;
 				}
 				if (name.find("/") != -1) {
@@ -549,8 +547,8 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 
 			List<String> clist;
 			ClassDB::get_integer_constant_list(instance_base, &clist);
-			for (List<String>::Element *E = clist.front(); E; E = E->next()) {
-				member_keywords[E->get()] = member_variable_color;
+			for (String &E : clist) {
+				member_keywords[E] = member_variable_color;
 			}
 		}
 	}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -291,8 +291,8 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 		sptr = sptr->_base;
 	}
 
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		r_list->push_back(E->get());
+	for (PropertyInfo &E : props) {
+		r_list->push_back(E);
 	}
 }
 
@@ -401,8 +401,8 @@ void GDScript::_update_exports_values(Map<StringName, Variant> &values, List<Pro
 		values[E->key()] = E->get();
 	}
 
-	for (List<PropertyInfo>::Element *E = members_cache.front(); E; E = E->next()) {
-		propnames.push_back(E->get());
+	for (PropertyInfo &E : members_cache) {
+		propnames.push_back(E);
 	}
 }
 
@@ -861,8 +861,8 @@ Error GDScript::reload(bool p_keep_state) {
 		}
 	}
 #ifdef DEBUG_ENABLED
-	for (const List<GDScriptWarning>::Element *E = parser.get_warnings().front(); E; E = E->next()) {
-		const GDScriptWarning &warning = E->get();
+	for (const GDScriptWarning &E : parser.get_warnings()) {
+		const GDScriptWarning &warning = E;
 		if (EngineDebugger::is_active()) {
 			Vector<ScriptLanguage::StackInfo> si;
 			EngineDebugger::get_script_debugger()->send_error("", get_path(), warning.start_line, warning.get_name(), warning.get_message(), ERR_HANDLER_WARNING, si);
@@ -1445,8 +1445,8 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 		sptr = sptr->_base;
 	}
 
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		p_properties->push_back(E->get());
+	for (PropertyInfo &E : props) {
+		p_properties->push_back(E);
 	}
 }
 
@@ -1644,8 +1644,7 @@ void GDScriptLanguage::init() {
 
 	List<StringName> class_list;
 	ClassDB::get_class_list(&class_list);
-	for (List<StringName>::Element *E = class_list.front(); E; E = E->next()) {
-		StringName n = E->get();
+	for (StringName &n : class_list) {
 		String s = String(n);
 		if (s.begins_with("_")) {
 			n = s.substr(1, s.length());
@@ -1654,7 +1653,7 @@ void GDScriptLanguage::init() {
 		if (globals.has(n)) {
 			continue;
 		}
-		Ref<GDScriptNativeClass> nc = memnew(GDScriptNativeClass(E->get()));
+		Ref<GDScriptNativeClass> nc = memnew(GDScriptNativeClass(n));
 		_add_global(n, nc);
 	}
 
@@ -1662,8 +1661,8 @@ void GDScriptLanguage::init() {
 
 	List<Engine::Singleton> singletons;
 	Engine::get_singleton()->get_singletons(&singletons);
-	for (List<Engine::Singleton>::Element *E = singletons.front(); E; E = E->next()) {
-		_add_global(E->get().name, E->get().ptr);
+	for (Engine::Singleton &E : singletons) {
+		_add_global(E.name, E.ptr);
 	}
 
 #ifdef TESTS_ENABLED
@@ -1806,10 +1805,10 @@ void GDScriptLanguage::reload_all_scripts() {
 
 	scripts.sort_custom<GDScriptDepSort>(); //update in inheritance dependency order
 
-	for (List<Ref<GDScript>>::Element *E = scripts.front(); E; E = E->next()) {
-		print_verbose("GDScript: Reloading: " + E->get()->get_path());
-		E->get()->load_source_code(E->get()->get_path());
-		E->get()->reload(true);
+	for (Ref<GDScript> E : scripts) {
+		print_verbose("GDScript: Reloading: " + E->get_path());
+		E->load_source_code(E->get_path());
+		E->reload(true);
 	}
 #endif
 }
@@ -1838,21 +1837,21 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 
 	scripts.sort_custom<GDScriptDepSort>(); //update in inheritance dependency order
 
-	for (List<Ref<GDScript>>::Element *E = scripts.front(); E; E = E->next()) {
-		bool reload = E->get() == p_script || to_reload.has(E->get()->get_base());
+	for (Ref<GDScript> E : scripts) {
+		bool reload = E == p_script || to_reload.has(E->get_base());
 
 		if (!reload) {
 			continue;
 		}
 
-		to_reload.insert(E->get(), Map<ObjectID, List<Pair<StringName, Variant>>>());
+		to_reload.insert(E, Map<ObjectID, List<Pair<StringName, Variant>>>());
 
 		if (!p_soft_reload) {
 			//save state and remove script from instances
-			Map<ObjectID, List<Pair<StringName, Variant>>> &map = to_reload[E->get()];
+			Map<ObjectID, List<Pair<StringName, Variant>>> &map = to_reload[E];
 
-			while (E->get()->instances.front()) {
-				Object *obj = E->get()->instances.front()->get();
+			while (E->instances.front()) {
+				Object *obj = E->instances.front()->get();
 				//save instance info
 				List<Pair<StringName, Variant>> state;
 				if (obj->get_script_instance()) {
@@ -1865,8 +1864,8 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 //same thing for placeholders
 #ifdef TOOLS_ENABLED
 
-			while (E->get()->placeholders.size()) {
-				Object *obj = E->get()->placeholders.front()->get()->get_owner();
+			while (E->placeholders.size()) {
+				Object *obj = E->placeholders.front()->get()->get_owner();
 
 				//save instance info
 				if (obj->get_script_instance()) {
@@ -1876,13 +1875,13 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 					obj->set_script(Variant());
 				} else {
 					// no instance found. Let's remove it so we don't loop forever
-					E->get()->placeholders.erase(E->get()->placeholders.front()->get());
+					E->placeholders.erase(E->placeholders.front()->get());
 				}
 			}
 
 #endif
 
-			for (Map<ObjectID, List<Pair<StringName, Variant>>>::Element *F = E->get()->pending_reload_state.front(); F; F = F->next()) {
+			for (Map<ObjectID, List<Pair<StringName, Variant>>>::Element *F = E->pending_reload_state.front(); F; F = F->next()) {
 				map[F->key()] = F->get(); //pending to reload, use this one instead
 			}
 		}
@@ -2025,8 +2024,8 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 	List<StringName> functions;
 	GDScriptUtilityFunctions::get_function_list(&functions);
 
-	for (const List<StringName>::Element *E = functions.front(); E; E = E->next()) {
-		p_words->push_back(String(E->get()));
+	for (const StringName &E : functions) {
+		p_words->push_back(String(E));
 	}
 }
 
@@ -2296,8 +2295,8 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 		return;
 	}
 
-	for (const List<String>::Element *E = parser.get_dependencies().front(); E; E = E->next()) {
-		p_dependencies->push_back(E->get());
+	for (const String &E : parser.get_dependencies()) {
+		p_dependencies->push_back(E);
 	}
 }
 

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1459,8 +1459,8 @@ void GDScriptByteCodeGenerator::write_endfor() {
 	}
 
 	// Patch break statements.
-	for (const List<int>::Element *E = current_breaks_to_patch.back()->get().front(); E; E = E->next()) {
-		patch_jump(E->get());
+	for (const int &E : current_breaks_to_patch.back()->get()) {
+		patch_jump(E);
 	}
 	current_breaks_to_patch.pop_back();
 
@@ -1494,8 +1494,8 @@ void GDScriptByteCodeGenerator::write_endwhile() {
 	while_jmp_addrs.pop_back();
 
 	// Patch break statements.
-	for (const List<int>::Element *E = current_breaks_to_patch.back()->get().front(); E; E = E->next()) {
-		patch_jump(E->get());
+	for (const int &E : current_breaks_to_patch.back()->get()) {
+		patch_jump(E);
 	}
 	current_breaks_to_patch.pop_back();
 }
@@ -1506,8 +1506,8 @@ void GDScriptByteCodeGenerator::start_match() {
 
 void GDScriptByteCodeGenerator::start_match_branch() {
 	// Patch continue statements.
-	for (const List<int>::Element *E = match_continues_to_patch.back()->get().front(); E; E = E->next()) {
-		patch_jump(E->get());
+	for (const int &E : match_continues_to_patch.back()->get()) {
+		patch_jump(E);
 	}
 	match_continues_to_patch.pop_back();
 	// Start a new list for next branch.
@@ -1516,8 +1516,8 @@ void GDScriptByteCodeGenerator::start_match_branch() {
 
 void GDScriptByteCodeGenerator::end_match() {
 	// Patch continue statements.
-	for (const List<int>::Element *E = match_continues_to_patch.back()->get().front(); E; E = E->next()) {
-		patch_jump(E->get());
+	for (const int &E : match_continues_to_patch.back()->get()) {
+		patch_jump(E);
 	}
 	match_continues_to_patch.pop_back();
 }

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -981,8 +981,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				assigned = prev_base;
 
 				// Set back the values into their bases.
-				for (List<ChainInfo>::Element *E = set_chain.front(); E; E = E->next()) {
-					const ChainInfo &info = E->get();
+				for (ChainInfo &info : set_chain) {
 					if (!info.is_named) {
 						gen->write_set(info.base, info.key, assigned);
 						if (info.key.mode == GDScriptCodeGenerator::Address::TEMPORARY) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -141,8 +141,8 @@ bool GDScriptLanguage::validate(const String &p_script, const String &p_path, Li
 	}
 #ifdef DEBUG_ENABLED
 	if (r_warnings) {
-		for (const List<GDScriptWarning>::Element *E = parser.get_warnings().front(); E; E = E->next()) {
-			const GDScriptWarning &warn = E->get();
+		for (const GDScriptWarning &E : parser.get_warnings()) {
+			const GDScriptWarning &warn = E;
 			ScriptLanguage::Warning w;
 			w.start_line = warn.start_line;
 			w.end_line = warn.end_line;
@@ -157,8 +157,8 @@ bool GDScriptLanguage::validate(const String &p_script, const String &p_path, Li
 #endif
 	if (err) {
 		if (r_errors) {
-			for (const List<GDScriptParser::ParserError>::Element *E = parser.get_errors().front(); E; E = E->next()) {
-				const GDScriptParser::ParserError &pe = E->get();
+			for (const GDScriptParser::ParserError &E : parser.get_errors()) {
+				const GDScriptParser::ParserError &pe = E;
 				ScriptLanguage::ScriptError e;
 				e.line = pe.line;
 				e.column = pe.column;
@@ -319,9 +319,9 @@ void GDScriptLanguage::debug_get_stack_level_locals(int p_level, List<String> *p
 	List<Pair<StringName, int>> locals;
 
 	f->debug_get_stack_member_state(*_call_stack[l].line, &locals);
-	for (List<Pair<StringName, int>>::Element *E = locals.front(); E; E = E->next()) {
-		p_locals->push_back(E->get().first);
-		p_values->push_back(_call_stack[l].stack[E->get().second]);
+	for (Pair<StringName, int> &E : locals) {
+		p_locals->push_back(E.first);
+		p_values->push_back(_call_stack[l].stack[E.second]);
 	}
 }
 
@@ -421,8 +421,8 @@ void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const
 	List<StringName> functions;
 	GDScriptUtilityFunctions::get_function_list(&functions);
 
-	for (const List<StringName>::Element *E = functions.front(); E; E = E->next()) {
-		p_functions->push_back(GDScriptUtilityFunctions::get_function_info(E->get()));
+	for (const StringName &E : functions) {
+		p_functions->push_back(GDScriptUtilityFunctions::get_function_info(E));
 	}
 
 	// Not really "functions", but show in documentation.
@@ -548,7 +548,7 @@ static String _make_arguments_hint(const MethodInfo &p_info, int p_arg_idx, bool
 
 	int def_args = p_info.arguments.size() - p_info.default_arguments.size();
 	int i = 0;
-	for (const List<PropertyInfo>::Element *E = p_info.arguments.front(); E; E = E->next()) {
+	for (const PropertyInfo &E : p_info.arguments) {
 		if (i > 0) {
 			arghint += ", ";
 		}
@@ -556,7 +556,7 @@ static String _make_arguments_hint(const MethodInfo &p_info, int p_arg_idx, bool
 		if (i == p_arg_idx) {
 			arghint += String::chr(0xFFFF);
 		}
-		arghint += E->get().name + ": " + _get_visual_datatype(E->get(), true);
+		arghint += E.name + ": " + _get_visual_datatype(E, true);
 
 		if (i - def_args >= 0) {
 			arghint += String(" = ") + p_info.default_arguments[i - def_args].get_construct_string();
@@ -662,11 +662,11 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 		r_result.insert(node.display, node);
 		List<StringName> node_types;
 		ClassDB::get_inheriters_from_class("Node", &node_types);
-		for (const List<StringName>::Element *E = node_types.front(); E != nullptr; E = E->next()) {
-			if (!ClassDB::is_class_exposed(E->get())) {
+		for (const StringName &E : node_types) {
+			if (!ClassDB::is_class_exposed(E)) {
 				continue;
 			}
-			ScriptCodeCompletionOption option(E->get(), ScriptCodeCompletionOption::KIND_CLASS);
+			ScriptCodeCompletionOption option(E, ScriptCodeCompletionOption::KIND_CLASS);
 			r_result.insert(option.display, option);
 		}
 	}
@@ -675,9 +675,9 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 static void _list_available_types(bool p_inherit_only, GDScriptParser::CompletionContext &p_context, Map<String, ScriptCodeCompletionOption> &r_result) {
 	List<StringName> native_types;
 	ClassDB::get_class_list(&native_types);
-	for (const List<StringName>::Element *E = native_types.front(); E != nullptr; E = E->next()) {
-		if (ClassDB::is_class_exposed(E->get()) && !Engine::get_singleton()->has_singleton(E->get())) {
-			ScriptCodeCompletionOption option(E->get(), ScriptCodeCompletionOption::KIND_CLASS);
+	for (const StringName &E : native_types) {
+		if (ClassDB::is_class_exposed(E) && !Engine::get_singleton()->has_singleton(E)) {
+			ScriptCodeCompletionOption option(E, ScriptCodeCompletionOption::KIND_CLASS);
 			r_result.insert(option.display, option);
 		}
 	}
@@ -687,8 +687,8 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 			// Native enums from base class
 			List<StringName> enums;
 			ClassDB::get_enum_list(p_context.current_class->base_type.native_type, &enums);
-			for (const List<StringName>::Element *E = enums.front(); E != nullptr; E = E->next()) {
-				ScriptCodeCompletionOption option(E->get(), ScriptCodeCompletionOption::KIND_ENUM);
+			for (const StringName &E : enums) {
+				ScriptCodeCompletionOption option(E, ScriptCodeCompletionOption::KIND_ENUM);
 				r_result.insert(option.display, option);
 			}
 		}
@@ -725,8 +725,8 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 	// Global scripts
 	List<StringName> global_classes;
 	ScriptServer::get_global_class_list(&global_classes);
-	for (const List<StringName>::Element *E = global_classes.front(); E != nullptr; E = E->next()) {
-		ScriptCodeCompletionOption option(E->get(), ScriptCodeCompletionOption::KIND_CLASS);
+	for (const StringName &E : global_classes) {
+		ScriptCodeCompletionOption option(E, ScriptCodeCompletionOption::KIND_CLASS);
 		r_result.insert(option.display, option);
 	}
 
@@ -865,8 +865,8 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						if (!_static) {
 							List<PropertyInfo> members;
 							scr->get_script_property_list(&members);
-							for (List<PropertyInfo>::Element *E = members.front(); E; E = E->next()) {
-								ScriptCodeCompletionOption option(E->get().name, ScriptCodeCompletionOption::KIND_MEMBER);
+							for (PropertyInfo &E : members) {
+								ScriptCodeCompletionOption option(E.name, ScriptCodeCompletionOption::KIND_MEMBER);
 								r_result.insert(option.display, option);
 							}
 						}
@@ -879,20 +879,20 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 						List<MethodInfo> signals;
 						scr->get_script_signal_list(&signals);
-						for (List<MethodInfo>::Element *E = signals.front(); E; E = E->next()) {
-							ScriptCodeCompletionOption option(E->get().name, ScriptCodeCompletionOption::KIND_SIGNAL);
+						for (MethodInfo &E : signals) {
+							ScriptCodeCompletionOption option(E.name, ScriptCodeCompletionOption::KIND_SIGNAL);
 							r_result.insert(option.display, option);
 						}
 					}
 
 					List<MethodInfo> methods;
 					scr->get_script_method_list(&methods);
-					for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
-						if (E->get().name.begins_with("@")) {
+					for (MethodInfo &E : methods) {
+						if (E.name.begins_with("@")) {
 							continue;
 						}
-						ScriptCodeCompletionOption option(E->get().name, ScriptCodeCompletionOption::KIND_FUNCTION);
-						if (E->get().arguments.size()) {
+						ScriptCodeCompletionOption option(E.name, ScriptCodeCompletionOption::KIND_FUNCTION);
+						if (E.arguments.size()) {
 							option.insert_text += "(";
 						} else {
 							option.insert_text += "()";
@@ -920,22 +920,22 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 				if (!p_only_functions) {
 					List<String> constants;
 					ClassDB::get_integer_constant_list(type, &constants);
-					for (List<String>::Element *E = constants.front(); E; E = E->next()) {
-						ScriptCodeCompletionOption option(E->get(), ScriptCodeCompletionOption::KIND_CONSTANT);
+					for (String &E : constants) {
+						ScriptCodeCompletionOption option(E, ScriptCodeCompletionOption::KIND_CONSTANT);
 						r_result.insert(option.display, option);
 					}
 
 					if (!_static || Engine::get_singleton()->has_singleton(type)) {
 						List<PropertyInfo> pinfo;
 						ClassDB::get_property_list(type, &pinfo);
-						for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-							if (E->get().usage & (PROPERTY_USAGE_GROUP | PROPERTY_USAGE_CATEGORY)) {
+						for (PropertyInfo &E : pinfo) {
+							if (E.usage & (PROPERTY_USAGE_GROUP | PROPERTY_USAGE_CATEGORY)) {
 								continue;
 							}
-							if (E->get().name.find("/") != -1) {
+							if (E.name.find("/") != -1) {
 								continue;
 							}
-							ScriptCodeCompletionOption option(E->get().name, ScriptCodeCompletionOption::KIND_MEMBER);
+							ScriptCodeCompletionOption option(E.name, ScriptCodeCompletionOption::KIND_MEMBER);
 							r_result.insert(option.display, option);
 						}
 					}
@@ -945,12 +945,12 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 					List<MethodInfo> methods;
 					bool is_autocompleting_getters = GLOBAL_GET("debug/gdscript/completion/autocomplete_setters_and_getters").booleanize();
 					ClassDB::get_method_list(type, &methods, false, !is_autocompleting_getters);
-					for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
-						if (E->get().name.begins_with("_")) {
+					for (MethodInfo &E : methods) {
+						if (E.name.begins_with("_")) {
 							continue;
 						}
-						ScriptCodeCompletionOption option(E->get().name, ScriptCodeCompletionOption::KIND_FUNCTION);
-						if (E->get().arguments.size()) {
+						ScriptCodeCompletionOption option(E.name, ScriptCodeCompletionOption::KIND_FUNCTION);
+						if (E.arguments.size()) {
 							option.insert_text += "(";
 						} else {
 							option.insert_text += "()";
@@ -977,9 +977,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						tmp.get_property_list(&members);
 					}
 
-					for (List<PropertyInfo>::Element *E = members.front(); E; E = E->next()) {
-						if (String(E->get().name).find("/") == -1) {
-							ScriptCodeCompletionOption option(E->get().name, ScriptCodeCompletionOption::KIND_MEMBER);
+					for (PropertyInfo &E : members) {
+						if (String(E.name).find("/") == -1) {
+							ScriptCodeCompletionOption option(E.name, ScriptCodeCompletionOption::KIND_MEMBER);
 							r_result.insert(option.display, option);
 						}
 					}
@@ -987,9 +987,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				List<MethodInfo> methods;
 				tmp.get_method_list(&methods);
-				for (const List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
-					ScriptCodeCompletionOption option(E->get().name, ScriptCodeCompletionOption::KIND_FUNCTION);
-					if (E->get().arguments.size()) {
+				for (const MethodInfo &E : methods) {
+					ScriptCodeCompletionOption option(E.name, ScriptCodeCompletionOption::KIND_FUNCTION);
+					if (E.arguments.size()) {
 						option.insert_text += "(";
 					} else {
 						option.insert_text += "()";
@@ -1019,9 +1019,9 @@ static void _find_identifiers(GDScriptParser::CompletionContext &p_context, bool
 	List<StringName> functions;
 	GDScriptUtilityFunctions::get_function_list(&functions);
 
-	for (const List<StringName>::Element *E = functions.front(); E; E = E->next()) {
-		MethodInfo function = GDScriptUtilityFunctions::get_function_info(E->get());
-		ScriptCodeCompletionOption option(String(E->get()), ScriptCodeCompletionOption::KIND_FUNCTION);
+	for (const StringName &E : functions) {
+		MethodInfo function = GDScriptUtilityFunctions::get_function_info(E);
+		ScriptCodeCompletionOption option(String(E), ScriptCodeCompletionOption::KIND_FUNCTION);
 		if (function.arguments.size() || (function.flags & METHOD_FLAG_VARARG)) {
 			option.insert_text += "(";
 		} else {
@@ -1768,9 +1768,9 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 					StringName real_native = GDScriptParser::get_real_class_name(base_type.native_type);
 					MethodInfo info;
 					if (ClassDB::get_method_info(real_native, p_context.current_function->identifier->name, &info)) {
-						for (const List<PropertyInfo>::Element *E = info.arguments.front(); E; E = E->next()) {
-							if (E->get().name == p_identifier) {
-								r_type = _type_from_property(E->get());
+						for (const PropertyInfo &E : info.arguments) {
+							if (E.name == p_identifier) {
+								r_type = _type_from_property(E);
 								return true;
 							}
 						}
@@ -1932,8 +1932,7 @@ static bool _guess_identifier_type_from_base(GDScriptParser::CompletionContext &
 					if (!is_static) {
 						List<PropertyInfo> members;
 						scr->get_script_property_list(&members);
-						for (const List<PropertyInfo>::Element *E = members.front(); E; E = E->next()) {
-							const PropertyInfo &prop = E->get();
+						for (const PropertyInfo &prop : members) {
 							if (prop.name == p_identifier) {
 								r_type = _type_from_property(prop);
 								return true;
@@ -2096,8 +2095,7 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 				if (scr.is_valid()) {
 					List<MethodInfo> methods;
 					scr->get_script_method_list(&methods);
-					for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
-						MethodInfo &mi = E->get();
+					for (MethodInfo &mi : methods) {
 						if (mi.name == p_method) {
 							r_type = _type_from_property(mi.return_val);
 							return true;
@@ -2137,8 +2135,7 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 				List<MethodInfo> methods;
 				tmp.get_method_list(&methods);
 
-				for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
-					MethodInfo &mi = E->get();
+				for (MethodInfo &mi : methods) {
 					if (mi.name == p_method) {
 						r_type = _type_from_property(mi.return_val);
 						return true;
@@ -2183,8 +2180,8 @@ static void _find_enumeration_candidates(GDScriptParser::CompletionContext &p_co
 
 		List<StringName> enum_constants;
 		ClassDB::get_enum_constants(class_name, enum_name, &enum_constants);
-		for (List<StringName>::Element *E = enum_constants.front(); E; E = E->next()) {
-			String candidate = class_name + "." + E->get();
+		for (StringName &E : enum_constants) {
+			String candidate = class_name + "." + E;
 			ScriptCodeCompletionOption option(candidate, ScriptCodeCompletionOption::KIND_ENUM);
 			r_result.insert(option.display, option);
 		}
@@ -2228,8 +2225,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						if (obj) {
 							List<String> options;
 							obj->get_argument_options(p_method, p_argidx, &options);
-							for (List<String>::Element *F = options.front(); F; F = F->next()) {
-								ScriptCodeCompletionOption option(F->get(), ScriptCodeCompletionOption::KIND_FUNCTION);
+							for (String &F : options) {
+								ScriptCodeCompletionOption option(F, ScriptCodeCompletionOption::KIND_FUNCTION);
 								r_result.insert(option.display, option);
 							}
 						}
@@ -2250,8 +2247,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					List<PropertyInfo> props;
 					ProjectSettings::get_singleton()->get_property_list(&props);
 
-					for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-						String s = E->get().name;
+					for (PropertyInfo &E : props) {
+						String s = E.name;
 						if (!s.begins_with("autoload/")) {
 							continue;
 						}
@@ -2266,8 +2263,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					// Get input actions
 					List<PropertyInfo> props;
 					ProjectSettings::get_singleton()->get_property_list(&props);
-					for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-						String s = E->get().name;
+					for (PropertyInfo &E : props) {
+						String s = E.name;
 						if (!s.begins_with("input/")) {
 							continue;
 						}
@@ -2291,9 +2288,9 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 				List<MethodInfo> methods;
 				base.get_method_list(&methods);
-				for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
-					if (E->get().name == p_method) {
-						r_arghint = _make_arguments_hint(E->get(), p_argidx);
+				for (MethodInfo &E : methods) {
+					if (E.name == p_method) {
+						r_arghint = _make_arguments_hint(E, p_argidx);
 						return;
 					}
 				}
@@ -2340,14 +2337,14 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 		Variant::get_constructor_list(GDScriptParser::get_builtin_type(call->function_name), &constructors);
 
 		int i = 0;
-		for (List<MethodInfo>::Element *E = constructors.front(); E; E = E->next()) {
-			if (p_argidx >= E->get().arguments.size()) {
+		for (MethodInfo &E : constructors) {
+			if (p_argidx >= E.arguments.size()) {
 				continue;
 			}
 			if (i > 0) {
 				r_arghint += "\n";
 			}
-			r_arghint += _make_arguments_hint(E->get(), p_argidx);
+			r_arghint += _make_arguments_hint(E, p_argidx);
 			i++;
 		}
 		return;
@@ -2406,9 +2403,9 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 		case GDScriptParser::COMPLETION_ANNOTATION: {
 			List<MethodInfo> annotations;
 			parser.get_annotation_list(&annotations);
-			for (const List<MethodInfo>::Element *E = annotations.front(); E != nullptr; E = E->next()) {
-				ScriptCodeCompletionOption option(E->get().name.substr(1), ScriptCodeCompletionOption::KIND_PLAIN_TEXT);
-				if (E->get().arguments.size() > 0) {
+			for (const MethodInfo &E : annotations) {
+				ScriptCodeCompletionOption option(E.name.substr(1), ScriptCodeCompletionOption::KIND_PLAIN_TEXT);
+				if (E.arguments.size() > 0) {
 					option.insert_text += "(";
 				}
 				options.insert(option.display, option);
@@ -2426,10 +2423,10 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 		case GDScriptParser::COMPLETION_BUILT_IN_TYPE_CONSTANT: {
 			List<StringName> constants;
 			Variant::get_constants_for_type(completion_context.builtin_type, &constants);
-			for (const List<StringName>::Element *E = constants.front(); E != nullptr; E = E->next()) {
-				ScriptCodeCompletionOption option(E->get(), ScriptCodeCompletionOption::KIND_CONSTANT);
+			for (const StringName &E : constants) {
+				ScriptCodeCompletionOption option(E, ScriptCodeCompletionOption::KIND_CONSTANT);
 				bool valid = false;
-				Variant default_value = Variant::get_constant_value(completion_context.builtin_type, E->get(), &valid);
+				Variant default_value = Variant::get_constant_value(completion_context.builtin_type, E, &valid);
 				if (valid) {
 					option.default_value = default_value;
 				}
@@ -2606,8 +2603,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 			List<MethodInfo> virtual_methods;
 			ClassDB::get_virtual_methods(class_name, &virtual_methods);
-			for (List<MethodInfo>::Element *E = virtual_methods.front(); E; E = E->next()) {
-				MethodInfo &mi = E->get();
+			for (MethodInfo &mi : virtual_methods) {
 				String method_hint = mi.name;
 				if (method_hint.find(":") != -1) {
 					method_hint = method_hint.get_slice(":", 0);
@@ -2656,8 +2652,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 				List<String> opts;
 				p_owner->get_argument_options("get_node", 0, &opts);
 
-				for (List<String>::Element *E = opts.front(); E; E = E->next()) {
-					String opt = E->get().strip_edges();
+				for (String &E : opts) {
+					String opt = E.strip_edges();
 					if (opt.is_quoted()) {
 						r_forced = true;
 						String idopt = opt.unquote();
@@ -2841,8 +2837,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 
 				List<MethodInfo> virtual_methods;
 				ClassDB::get_virtual_methods(class_name, &virtual_methods, true);
-				for (List<MethodInfo>::Element *E = virtual_methods.front(); E; E = E->next()) {
-					if (E->get().name == p_symbol) {
+				for (MethodInfo &E : virtual_methods) {
+					if (E.name == p_symbol) {
 						r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_METHOD;
 						r_result.class_name = base_type.native_type;
 						r_result.class_member = p_symbol;
@@ -2860,8 +2856,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 
 				List<String> constants;
 				ClassDB::get_integer_constant_list(class_name, &constants, true);
-				for (List<String>::Element *E = constants.front(); E; E = E->next()) {
-					if (E->get() == p_symbol) {
+				for (String &E : constants) {
+					if (E == p_symbol) {
 						r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_CONSTANT;
 						r_result.class_name = base_type.native_type;
 						r_result.class_member = p_symbol;

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -94,8 +94,7 @@ struct _GDFKCS {
 void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<StringName, int>> *r_stackvars) const {
 	int oc = 0;
 	Map<StringName, _GDFKC> sdmap;
-	for (const List<StackDebug>::Element *E = stack_debug.front(); E; E = E->next()) {
-		const StackDebug &sd = E->get();
+	for (const StackDebug &sd : stack_debug) {
 		if (sd.line > p_line) {
 			break;
 		}
@@ -131,10 +130,10 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 
 	stackpositions.sort();
 
-	for (List<_GDFKCS>::Element *E = stackpositions.front(); E; E = E->next()) {
+	for (_GDFKCS &E : stackpositions) {
 		Pair<StringName, int> p;
-		p.first = E->get().id;
-		p.second = E->get().pos;
+		p.first = E.id;
+		p.second = E.pos;
 		r_stackvars->push_back(p);
 	}
 }

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -136,8 +136,8 @@ void GDScriptParser::cleanup() {
 void GDScriptParser::get_annotation_list(List<MethodInfo> *r_annotations) const {
 	List<StringName> keys;
 	valid_annotations.get_key_list(&keys);
-	for (const List<StringName>::Element *E = keys.front(); E != nullptr; E = E->next()) {
-		r_annotations->push_back(valid_annotations[E->get()].info);
+	for (const StringName &E : keys) {
+		r_annotations->push_back(valid_annotations[E].info);
 	}
 }
 
@@ -248,7 +248,7 @@ void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_
 	warning.rightmost_column = p_source->rightmost_column;
 
 	List<GDScriptWarning>::Element *before = nullptr;
-	for (List<GDScriptWarning>::Element *E = warnings.front(); E != nullptr; E = E->next()) {
+	for (List<GDScriptWarning>::Element *E = warnings.front(); E; E = E->next()) {
 		if (E->get().start_line > warning.start_line) {
 			break;
 		}
@@ -1332,8 +1332,7 @@ GDScriptParser::AnnotationNode *GDScriptParser::parse_annotation(uint32_t p_vali
 }
 
 void GDScriptParser::clear_unused_annotations() {
-	for (const List<AnnotationNode *>::Element *E = annotation_stack.front(); E != nullptr; E = E->next()) {
-		AnnotationNode *annotation = E->get();
+	for (AnnotationNode *annotation : annotation_stack) {
 		push_error(vformat(R"(Annotation "%s" does not precedes a valid target, so it will have no effect.)", annotation->name), annotation);
 	}
 
@@ -1796,8 +1795,8 @@ GDScriptParser::MatchBranchNode *GDScriptParser::parse_match_branch() {
 		List<StringName> binds;
 		branch->patterns[0]->binds.get_key_list(&binds);
 
-		for (List<StringName>::Element *E = binds.front(); E != nullptr; E = E->next()) {
-			SuiteNode::Local local(branch->patterns[0]->binds[E->get()], current_function);
+		for (StringName &E : binds) {
+			SuiteNode::Local local(branch->patterns[0]->binds[E], current_function);
 			suite->add_local(local);
 		}
 	}
@@ -3993,8 +3992,8 @@ void GDScriptParser::TreePrinter::print_for(ForNode *p_for) {
 }
 
 void GDScriptParser::TreePrinter::print_function(FunctionNode *p_function, const String &p_context) {
-	for (const List<AnnotationNode *>::Element *E = p_function->annotations.front(); E != nullptr; E = E->next()) {
-		print_annotation(E->get());
+	for (AnnotationNode *E : p_function->annotations) {
+		print_annotation(E);
 	}
 	push_text(p_context);
 	push_text(" ");
@@ -4333,8 +4332,8 @@ void GDScriptParser::TreePrinter::print_unary_op(UnaryOpNode *p_unary_op) {
 }
 
 void GDScriptParser::TreePrinter::print_variable(VariableNode *p_variable) {
-	for (const List<AnnotationNode *>::Element *E = p_variable->annotations.front(); E != nullptr; E = E->next()) {
-		print_annotation(E->get());
+	for (AnnotationNode *E : p_variable->annotations) {
+		print_annotation(E);
 	}
 
 	push_text("Variable ");

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -706,8 +706,8 @@ bool GDScriptUtilityFunctions::function_exists(const StringName &p_function) {
 }
 
 void GDScriptUtilityFunctions::get_function_list(List<StringName> *r_functions) {
-	for (const List<StringName>::Element *E = utility_function_name_table.front(); E; E = E->next()) {
-		r_functions->push_back(E->get());
+	for (const StringName &E : utility_function_name_table) {
+		r_functions->push_back(E);
 	}
 }
 

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -39,8 +39,7 @@ void ExtendGDScriptParser::update_diagnostics() {
 	diagnostics.clear();
 
 	const List<ParserError> &errors = get_errors();
-	for (const List<ParserError>::Element *E = errors.front(); E != nullptr; E = E->next()) {
-		const ParserError &error = E->get();
+	for (const ParserError &error : errors) {
 		lsp::Diagnostic diagnostic;
 		diagnostic.severity = lsp::DiagnosticSeverity::Error;
 		diagnostic.message = error.message;
@@ -61,8 +60,7 @@ void ExtendGDScriptParser::update_diagnostics() {
 	}
 
 	const List<GDScriptWarning> &warnings = get_warnings();
-	for (const List<GDScriptWarning>::Element *E = warnings.front(); E; E = E->next()) {
-		const GDScriptWarning &warning = E->get();
+	for (const GDScriptWarning &warning : warnings) {
 		lsp::Diagnostic diagnostic;
 		diagnostic.severity = lsp::DiagnosticSeverity::Warning;
 		diagnostic.message = "(" + warning.get_name() + "): " + warning.get_message();
@@ -467,8 +465,8 @@ String ExtendGDScriptParser::parse_documentation(int p_line, bool p_docs_down) {
 	}
 
 	String doc;
-	for (List<String>::Element *E = doc_lines.front(); E; E = E->next()) {
-		doc += E->get() + "\n";
+	for (String &E : doc_lines) {
+		doc += E + "\n";
 	}
 	return doc;
 }

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -157,8 +157,7 @@ Array GDScriptTextDocument::completion(const Dictionary &p_params) {
 		int i = 0;
 		arr.resize(options.size());
 
-		for (const List<ScriptCodeCompletionOption>::Element *E = options.front(); E; E = E->next()) {
-			const ScriptCodeCompletionOption &option = E->get();
+		for (const ScriptCodeCompletionOption &option : options) {
 			lsp::CompletionItem item;
 			item.label = option.display;
 			item.data = request_data;
@@ -294,8 +293,8 @@ Array GDScriptTextDocument::documentLink(const Dictionary &p_params) {
 
 	List<lsp::DocumentLink> links;
 	GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_document_links(params.textDocument.uri, links);
-	for (const List<lsp::DocumentLink>::Element *E = links.front(); E; E = E->next()) {
-		ret.push_back(E->get().to_json());
+	for (const lsp::DocumentLink &E : links) {
+		ret.push_back(E.to_json());
 	}
 	return ret;
 }
@@ -322,8 +321,8 @@ Variant GDScriptTextDocument::hover(const Dictionary &p_params) {
 		Array contents;
 		List<const lsp::DocumentSymbol *> list;
 		GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_related_symbols(params, list);
-		for (List<const lsp::DocumentSymbol *>::Element *E = list.front(); E; E = E->next()) {
-			if (const lsp::DocumentSymbol *s = E->get()) {
+		for (const lsp::DocumentSymbol *&E : list) {
+			if (const lsp::DocumentSymbol *s = E) {
 				contents.push_back(s->render().value);
 			}
 		}
@@ -430,8 +429,8 @@ Array GDScriptTextDocument::find_symbols(const lsp::TextDocumentPositionParams &
 	} else if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
 		List<const lsp::DocumentSymbol *> list;
 		GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_related_symbols(p_location, list);
-		for (List<const lsp::DocumentSymbol *>::Element *E = list.front(); E; E = E->next()) {
-			if (const lsp::DocumentSymbol *s = E->get()) {
+		for (const lsp::DocumentSymbol *&E : list) {
+			if (const lsp::DocumentSymbol *s = E) {
 				if (!s->uri.is_empty()) {
 					lsp::Location location;
 					location.uri = s->uri;

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -119,8 +119,7 @@ const lsp::DocumentSymbol *GDScriptWorkspace::get_script_symbol(const String &p_
 void GDScriptWorkspace::reload_all_workspace_scripts() {
 	List<String> paths;
 	list_script_files("res://", paths);
-	for (List<String>::Element *E = paths.front(); E; E = E->next()) {
-		const String &path = E->get();
+	for (String &path : paths) {
 		Error err;
 		String content = FileAccess::get_file_as_string(path, &err);
 		ERR_CONTINUE(err != OK);
@@ -559,8 +558,8 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_native_symbol(const lsp::N
 void GDScriptWorkspace::resolve_document_links(const String &p_uri, List<lsp::DocumentLink> &r_list) {
 	if (const ExtendGDScriptParser *parser = get_parse_successed_script(get_file_path(p_uri))) {
 		const List<lsp::DocumentLink> &links = parser->get_document_links();
-		for (const List<lsp::DocumentLink>::Element *E = links.front(); E; E = E->next()) {
-			r_list.push_back(E->get());
+		for (const lsp::DocumentLink &E : links) {
+			r_list.push_back(E);
 		}
 	}
 }
@@ -587,8 +586,7 @@ Error GDScriptWorkspace::resolve_signature(const lsp::TextDocumentPositionParams
 				GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_related_symbols(text_pos, symbols);
 			}
 
-			for (List<const lsp::DocumentSymbol *>::Element *E = symbols.front(); E; E = E->next()) {
-				const lsp::DocumentSymbol *symbol = E->get();
+			for (const lsp::DocumentSymbol *symbol : symbols) {
 				if (symbol->kind == lsp::SymbolKind::Method || symbol->kind == lsp::SymbolKind::Function) {
 					lsp::SignatureInformation signature_info;
 					signature_info.label = symbol->detail;

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -295,7 +295,7 @@ void GDScriptTestRunner::handle_cmdline() {
 	String test_cmd = "--gdscript-test";
 	String gen_cmd = "--gdscript-generate-tests";
 
-	for (List<String>::Element *E = cmdline_args.front(); E != nullptr; E = E->next()) {
+	for (List<String>::Element *E = cmdline_args.front(); E; E = E->next()) {
 		String &cmd = E->get();
 		if (cmd == test_cmd || cmd == gen_cmd) {
 			if (E->next() == nullptr) {
@@ -440,8 +440,8 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		result.output = get_text_for_status(result.status) + "\n";
 
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
-		for (const List<GDScriptParser::ParserError>::Element *E = errors.front(); E; E = E->next()) {
-			result.output += E->get().message + "\n"; // TODO: line, column?
+		for (const GDScriptParser::ParserError &E : errors) {
+			result.output += E.message + "\n"; // TODO: line, column?
 			break; // Only the first error since the following might be cascading.
 		}
 		if (!p_is_generating) {
@@ -459,8 +459,8 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		result.output = get_text_for_status(result.status) + "\n";
 
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
-		for (const List<GDScriptParser::ParserError>::Element *E = errors.front(); E; E = E->next()) {
-			result.output += E->get().message + "\n"; // TODO: line, column?
+		for (const GDScriptParser::ParserError &E : errors) {
+			result.output += E.message + "\n"; // TODO: line, column?
 			break; // Only the first error since the following might be cascading.
 		}
 		if (!p_is_generating) {
@@ -470,8 +470,8 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	}
 
 	StringBuilder warning_string;
-	for (const List<GDScriptWarning>::Element *E = parser.get_warnings().front(); E != nullptr; E = E->next()) {
-		const GDScriptWarning warning = E->get();
+	for (const GDScriptWarning &E : parser.get_warnings()) {
+		const GDScriptWarning warning = E;
 		warning_string.append(">> WARNING");
 		warning_string.append("\n>> Line: ");
 		warning_string.append(itos(warning.start_line));

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -113,8 +113,7 @@ static void test_parser(const String &p_code, const String &p_script_path, const
 
 	if (err != OK) {
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
-		for (const List<GDScriptParser::ParserError>::Element *E = errors.front(); E != nullptr; E = E->next()) {
-			const GDScriptParser::ParserError &error = E->get();
+		for (const GDScriptParser::ParserError &error : errors) {
 			print_line(vformat("%02d:%02d: %s", error.line, error.column, error.message));
 		}
 	}
@@ -124,8 +123,7 @@ static void test_parser(const String &p_code, const String &p_script_path, const
 
 	if (err != OK) {
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
-		for (const List<GDScriptParser::ParserError>::Element *E = errors.front(); E != nullptr; E = E->next()) {
-			const GDScriptParser::ParserError &error = E->get();
+		for (const GDScriptParser::ParserError &error : errors) {
 			print_line(vformat("%02d:%02d: %s", error.line, error.column, error.message));
 		}
 	}
@@ -143,8 +141,7 @@ static void test_compiler(const String &p_code, const String &p_script_path, con
 	if (err != OK) {
 		print_line("Error in parser:");
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
-		for (const List<GDScriptParser::ParserError>::Element *E = errors.front(); E != nullptr; E = E->next()) {
-			const GDScriptParser::ParserError &error = E->get();
+		for (const GDScriptParser::ParserError &error : errors) {
 			print_line(vformat("%02d:%02d: %s", error.line, error.column, error.message));
 		}
 		return;
@@ -156,8 +153,7 @@ static void test_compiler(const String &p_code, const String &p_script_path, con
 	if (err != OK) {
 		print_line("Error in analyzer:");
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
-		for (const List<GDScriptParser::ParserError>::Element *E = errors.front(); E != nullptr; E = E->next()) {
-			const GDScriptParser::ParserError &error = E->get();
+		for (const GDScriptParser::ParserError &error : errors) {
 			print_line(vformat("%02d:%02d: %s", error.line, error.column, error.message));
 		}
 		return;

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -519,14 +519,14 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 			RS::get_singleton()->multimesh_set_mesh(mm, mesh_library->get_item_mesh(E->key())->get_rid());
 
 			int idx = 0;
-			for (List<Pair<Transform3D, IndexKey>>::Element *F = E->get().front(); F; F = F->next()) {
-				RS::get_singleton()->multimesh_instance_set_transform(mm, idx, F->get().first);
+			for (Pair<Transform3D, IndexKey> &F : E->get()) {
+				RS::get_singleton()->multimesh_instance_set_transform(mm, idx, F.first);
 #ifdef TOOLS_ENABLED
 
 				Octant::MultimeshInstance::Item it;
 				it.index = idx;
-				it.transform = F->get().first;
-				it.key = F->get().second;
+				it.transform = F.first;
+				it.key = F.second;
 				mmi.items.push_back(it);
 #endif
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -497,8 +497,8 @@ void GridMapEditor::_fill_selection() {
 }
 
 void GridMapEditor::_clear_clipboard_data() {
-	for (List<ClipboardItem>::Element *E = clipboard_items.front(); E; E = E->next()) {
-		RenderingServer::get_singleton()->free(E->get().instance);
+	for (ClipboardItem &E : clipboard_items) {
+		RenderingServer::get_singleton()->free(E.instance);
 	}
 
 	clipboard_items.clear();
@@ -552,9 +552,7 @@ void GridMapEditor::_update_paste_indicator() {
 
 	RenderingServer::get_singleton()->instance_set_transform(paste_instance, node->get_global_transform() * xf);
 
-	for (List<ClipboardItem>::Element *E = clipboard_items.front(); E; E = E->next()) {
-		ClipboardItem &item = E->get();
-
+	for (ClipboardItem &item : clipboard_items) {
 		xf = Transform3D();
 		xf.origin = (paste_indicator.begin + (paste_indicator.current - paste_indicator.click) + center) * node->get_cell_size();
 		xf.basis = rot * xf.basis;
@@ -578,9 +576,7 @@ void GridMapEditor::_do_paste() {
 	Vector3 ofs = paste_indicator.current - paste_indicator.click;
 	undo_redo->create_action(TTR("GridMap Paste Selection"));
 
-	for (List<ClipboardItem>::Element *E = clipboard_items.front(); E; E = E->next()) {
-		ClipboardItem &item = E->get();
-
+	for (ClipboardItem &item : clipboard_items) {
 		Vector3 position = rot.xform(item.grid_offset) + paste_indicator.begin + ofs;
 
 		Basis orm;
@@ -663,8 +659,7 @@ bool GridMapEditor::forward_spatial_input_event(Camera3D *p_camera, const Ref<In
 			if ((mb->get_button_index() == MOUSE_BUTTON_RIGHT && input_action == INPUT_ERASE) || (mb->get_button_index() == MOUSE_BUTTON_LEFT && input_action == INPUT_PAINT)) {
 				if (set_items.size()) {
 					undo_redo->create_action(TTR("GridMap Paint"));
-					for (List<SetItem>::Element *E = set_items.front(); E; E = E->next()) {
-						const SetItem &si = E->get();
+					for (SetItem &si : set_items) {
 						undo_redo->add_do_method(node, "set_cell_item", si.position, si.new_value, si.new_orientation);
 					}
 					for (List<SetItem>::Element *E = set_items.back(); E; E = E->prev()) {
@@ -869,8 +864,8 @@ void GridMapEditor::update_palette() {
 
 	int item = 0;
 
-	for (List<_CGMEItemSort>::Element *E = il.front(); E; E = E->next()) {
-		int id = E->get().id;
+	for (_CGMEItemSort &E : il) {
+		int id = E.id;
 		String name = mesh_library->get_item_name(id);
 		Ref<Texture2D> preview = mesh_library->get_item_preview(id);
 

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -50,8 +50,8 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 	//must be alphabetically sorted for hash to compute
 	names.sort_custom<StringName::AlphCompare>();
 
-	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-		ClassDB::ClassInfo *t = ClassDB::classes.getptr(E->get());
+	for (StringName &E : names) {
+		ClassDB::ClassInfo *t = ClassDB::classes.getptr(E);
 		ERR_FAIL_COND(!t);
 		if (t->api != p_api || !t->exposed) {
 			continue;
@@ -84,11 +84,11 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			Array methods;
 
-			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
+			for (StringName &F : snames) {
 				Dictionary method_dict;
 				methods.push_back(method_dict);
 
-				MethodBind *mb = t->method_map[F->get()];
+				MethodBind *mb = t->method_map[F];
 				method_dict["name"] = mb->get_name();
 				method_dict["argument_count"] = mb->get_argument_count();
 				method_dict["return_type"] = mb->get_argument_type(-1);
@@ -141,12 +141,12 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			Array constants;
 
-			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
+			for (StringName &F : snames) {
 				Dictionary constant_dict;
 				constants.push_back(constant_dict);
 
-				constant_dict["name"] = F->get();
-				constant_dict["value"] = t->constant_map[F->get()];
+				constant_dict["name"] = F;
+				constant_dict["value"] = t->constant_map[F];
 			}
 
 			if (!constants.is_empty()) {
@@ -168,12 +168,12 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			Array signals;
 
-			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
+			for (StringName &F : snames) {
 				Dictionary signal_dict;
 				signals.push_back(signal_dict);
 
-				MethodInfo &mi = t->signal_map[F->get()];
-				signal_dict["name"] = F->get();
+				MethodInfo &mi = t->signal_map[F];
+				signal_dict["name"] = F;
 
 				Array arguments;
 				signal_dict["arguments"] = arguments;
@@ -203,13 +203,13 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			Array properties;
 
-			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
+			for (StringName &F : snames) {
 				Dictionary property_dict;
 				properties.push_back(property_dict);
 
-				ClassDB::PropertySetGet *psg = t->property_setget.getptr(F->get());
+				ClassDB::PropertySetGet *psg = t->property_setget.getptr(F);
 
-				property_dict["name"] = F->get();
+				property_dict["name"] = F;
 				property_dict["setter"] = psg->setter;
 				property_dict["getter"] = psg->getter;
 			}
@@ -222,15 +222,15 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 		Array property_list;
 
 		//property list
-		for (List<PropertyInfo>::Element *F = t->property_list.front(); F; F = F->next()) {
+		for (PropertyInfo &F : t->property_list) {
 			Dictionary property_dict;
 			property_list.push_back(property_dict);
 
-			property_dict["name"] = F->get().name;
-			property_dict["type"] = F->get().type;
-			property_dict["hint"] = F->get().hint;
-			property_dict["hint_string"] = F->get().hint_string;
-			property_dict["usage"] = F->get().usage;
+			property_dict["name"] = F.name;
+			property_dict["type"] = F.type;
+			property_dict["hint"] = F.hint;
+			property_dict["hint_string"] = F.hint_string;
+			property_dict["usage"] = F.usage;
 		}
 
 		if (!property_list.is_empty()) {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -874,9 +874,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 
 	// As scripts are going to be reloaded, must proceed without locking here
 
-	for (List<Ref<CSharpScript>>::Element *E = scripts.front(); E; E = E->next()) {
-		Ref<CSharpScript> &script = E->get();
-
+	for (Ref<CSharpScript> script : scripts) {
 		to_reload.push_back(script);
 
 		if (script->get_path().is_empty()) {
@@ -936,9 +934,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 	}
 
 	// After the state of all instances is saved, clear scripts and script instances
-	for (List<Ref<CSharpScript>>::Element *E = scripts.front(); E; E = E->next()) {
-		Ref<CSharpScript> &script = E->get();
-
+	for (Ref<CSharpScript> script : scripts) {
 		while (script->instances.front()) {
 			Object *obj = script->instances.front()->get();
 			obj->set_script(REF()); // Remove script and existing script instances (placeholder are not removed before domain reload)
@@ -951,9 +947,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 	if (gdmono->reload_scripts_domain() != OK) {
 		// Failed to reload the scripts domain
 		// Make sure to add the scripts back to their owners before returning
-		for (List<Ref<CSharpScript>>::Element *E = to_reload.front(); E; E = E->next()) {
-			Ref<CSharpScript> scr = E->get();
-
+		for (Ref<CSharpScript> scr : to_reload) {
 			for (const Map<ObjectID, CSharpScript::StateBackup>::Element *F = scr->pending_reload_state.front(); F; F = F->next()) {
 				Object *obj = ObjectDB::get_instance(F->key());
 
@@ -988,9 +982,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 
 	List<Ref<CSharpScript>> to_reload_state;
 
-	for (List<Ref<CSharpScript>>::Element *E = to_reload.front(); E; E = E->next()) {
-		Ref<CSharpScript> script = E->get();
-
+	for (Ref<CSharpScript> script : to_reload) {
 #ifdef TOOLS_ENABLED
 		script->exports_invalidated = true;
 #endif
@@ -1095,9 +1087,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 		to_reload_state.push_back(script);
 	}
 
-	for (List<Ref<CSharpScript>>::Element *E = to_reload_state.front(); E; E = E->next()) {
-		Ref<CSharpScript> script = E->get();
-
+	for (Ref<CSharpScript> script : to_reload_state) {
 		for (Set<ObjectID>::Element *F = script->pending_reload_instances.front(); F; F = F->next()) {
 			ObjectID obj_id = F->get();
 			Object *obj = ObjectDB::get_instance(obj_id);
@@ -1741,9 +1731,9 @@ void CSharpInstance::get_properties_state_for_reloading(List<Pair<StringName, Va
 	List<PropertyInfo> pinfo;
 	get_property_list(&pinfo);
 
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
+	for (PropertyInfo &E : pinfo) {
 		Pair<StringName, Variant> state_pair;
-		state_pair.first = E->get().name;
+		state_pair.first = E.name;
 
 		ManagedType managedType;
 
@@ -2049,8 +2039,7 @@ void CSharpInstance::connect_event_signals() {
 }
 
 void CSharpInstance::disconnect_event_signals() {
-	for (const List<Callable>::Element *E = connected_event_signals.front(); E; E = E->next()) {
-		const Callable &callable = E->get();
+	for (const Callable &callable : connected_event_signals) {
 		const EventSignalCallable *event_signal_callable = static_cast<const EventSignalCallable *>(callable.get_custom());
 		owner->disconnect(event_signal_callable->get_signal(), callable);
 	}
@@ -2324,8 +2313,8 @@ void CSharpScript::_update_exports_values(Map<StringName, Variant> &values, List
 		values[E->key()] = E->get();
 	}
 
-	for (List<PropertyInfo>::Element *E = exported_members_cache.front(); E; E = E->next()) {
-		propnames.push_back(E->get());
+	for (PropertyInfo &E : exported_members_cache) {
+		propnames.push_back(E);
 	}
 }
 

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -416,8 +416,8 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 						// Try to find as global enum constant
 						const EnumInterface *target_ienum = nullptr;
 
-						for (const List<EnumInterface>::Element *E = global_enums.front(); E; E = E->next()) {
-							target_ienum = &E->get();
+						for (const EnumInterface &E : global_enums) {
+							target_ienum = &E;
 							target_iconst = find_constant_by_name(target_name, target_ienum->constants);
 							if (target_iconst) {
 								break;
@@ -455,8 +455,8 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 						// Try to find as enum constant in the current class
 						const EnumInterface *target_ienum = nullptr;
 
-						for (const List<EnumInterface>::Element *E = target_itype->enums.front(); E; E = E->next()) {
-							target_ienum = &E->get();
+						for (const EnumInterface &E : target_itype->enums) {
+							target_ienum = &E;
 							target_iconst = find_constant_by_name(target_name, target_ienum->constants);
 							if (target_iconst) {
 								break;
@@ -682,10 +682,10 @@ int BindingsGenerator::_determine_enum_prefix(const EnumInterface &p_ienum) {
 
 void BindingsGenerator::_apply_prefix_to_enum_constants(BindingsGenerator::EnumInterface &p_ienum, int p_prefix_length) {
 	if (p_prefix_length > 0) {
-		for (List<ConstantInterface>::Element *E = p_ienum.constants.front(); E; E = E->next()) {
+		for (ConstantInterface &E : p_ienum.constants) {
 			int curr_prefix_length = p_prefix_length;
 
-			ConstantInterface &curr_const = E->get();
+			ConstantInterface &curr_const = E;
 
 			String constant_name = curr_const.name;
 
@@ -719,9 +719,7 @@ void BindingsGenerator::_apply_prefix_to_enum_constants(BindingsGenerator::EnumI
 }
 
 void BindingsGenerator::_generate_method_icalls(const TypeInterface &p_itype) {
-	for (const List<MethodInterface>::Element *E = p_itype.methods.front(); E; E = E->next()) {
-		const MethodInterface &imethod = E->get();
-
+	for (const MethodInterface &imethod : p_itype.methods) {
 		if (imethod.is_virtual) {
 			continue;
 		}
@@ -735,8 +733,8 @@ void BindingsGenerator::_generate_method_icalls(const TypeInterface &p_itype) {
 
 		// Get arguments information
 		int i = 0;
-		for (const List<ArgumentInterface>::Element *F = imethod.arguments.front(); F; F = F->next()) {
-			const TypeInterface *arg_type = _get_type_or_placeholder(F->get().type);
+		for (const ArgumentInterface &F : imethod.arguments) {
+			const TypeInterface *arg_type = _get_type_or_placeholder(F.type);
 
 			im_sig += ", ";
 			im_sig += arg_type->im_type_in;
@@ -776,10 +774,10 @@ void BindingsGenerator::_generate_method_icalls(const TypeInterface &p_itype) {
 			if (p_itype.api_type != ClassDB::API_EDITOR) {
 				match->get().editor_only = false;
 			}
-			method_icalls_map.insert(&E->get(), &match->get());
+			method_icalls_map.insert(&E, &match->get());
 		} else {
 			List<InternalCall>::Element *added = method_icalls.push_back(im_icall);
-			method_icalls_map.insert(&E->get(), &added->get());
+			method_icalls_map.insert(&E, &added->get());
 		}
 	}
 }
@@ -859,9 +857,7 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 	p_output.append("namespace " BINDINGS_NAMESPACE "\n" OPEN_BLOCK);
 	p_output.append(INDENT1 "public static partial class " BINDINGS_GLOBAL_SCOPE_CLASS "\n" INDENT1 "{");
 
-	for (const List<ConstantInterface>::Element *E = global_constants.front(); E; E = E->next()) {
-		const ConstantInterface &iconstant = E->get();
-
+	for (const ConstantInterface &iconstant : global_constants) {
 		if (iconstant.const_doc && iconstant.const_doc->description.size()) {
 			String xml_summary = bbcode_to_xml(fix_doc_description(iconstant.const_doc->description), nullptr);
 			Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
@@ -894,9 +890,7 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 
 	// Enums
 
-	for (List<EnumInterface>::Element *E = global_enums.front(); E; E = E->next()) {
-		const EnumInterface &ienum = E->get();
-
+	for (EnumInterface &ienum : global_enums) {
 		CRASH_COND(ienum.constants.is_empty());
 
 		String enum_proxy_name = ienum.cname.operator String();
@@ -921,8 +915,8 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 		p_output.append(enum_proxy_name);
 		p_output.append("\n" INDENT1 OPEN_BLOCK);
 
-		for (const List<ConstantInterface>::Element *F = ienum.constants.front(); F; F = F->next()) {
-			const ConstantInterface &iconstant = F->get();
+		for (const ConstantInterface &F : ienum.constants) {
+			const ConstantInterface &iconstant = F;
 
 			if (iconstant.const_doc && iconstant.const_doc->description.size()) {
 				String xml_summary = bbcode_to_xml(fix_doc_description(iconstant.const_doc->description), nullptr);
@@ -1053,11 +1047,11 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		cs_icalls_content.append(m_icall.im_sig + ");\n");                                       \
 	}
 
-	for (const List<InternalCall>::Element *E = core_custom_icalls.front(); E; E = E->next()) {
-		ADD_INTERNAL_CALL(E->get());
+	for (const InternalCall &E : core_custom_icalls) {
+		ADD_INTERNAL_CALL(E);
 	}
-	for (const List<InternalCall>::Element *E = method_icalls.front(); E; E = E->next()) {
-		ADD_INTERNAL_CALL(E->get());
+	for (const InternalCall &E : method_icalls) {
+		ADD_INTERNAL_CALL(E);
 	}
 
 #undef ADD_INTERNAL_CALL
@@ -1161,11 +1155,11 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 		cs_icalls_content.append(m_icall.im_sig + ");\n");                                  \
 	}
 
-	for (const List<InternalCall>::Element *E = editor_custom_icalls.front(); E; E = E->next()) {
-		ADD_INTERNAL_CALL(E->get());
+	for (const InternalCall &E : editor_custom_icalls) {
+		ADD_INTERNAL_CALL(E);
 	}
-	for (const List<InternalCall>::Element *E = method_icalls.front(); E; E = E->next()) {
-		ADD_INTERNAL_CALL(E->get());
+	for (const InternalCall &E : method_icalls) {
+		ADD_INTERNAL_CALL(E);
 	}
 
 #undef ADD_INTERNAL_CALL
@@ -1327,9 +1321,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 	// Add constants
 
-	for (const List<ConstantInterface>::Element *E = itype.constants.front(); E; E = E->next()) {
-		const ConstantInterface &iconstant = E->get();
-
+	for (const ConstantInterface &iconstant : itype.constants) {
 		if (iconstant.const_doc && iconstant.const_doc->description.size()) {
 			String xml_summary = bbcode_to_xml(fix_doc_description(iconstant.const_doc->description), &itype);
 			Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
@@ -1360,17 +1352,15 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 	// Add enums
 
-	for (const List<EnumInterface>::Element *E = itype.enums.front(); E; E = E->next()) {
-		const EnumInterface &ienum = E->get();
-
+	for (const EnumInterface &ienum : itype.enums) {
 		ERR_FAIL_COND_V(ienum.constants.is_empty(), ERR_BUG);
 
 		output.append(MEMBER_BEGIN "public enum ");
 		output.append(ienum.cname.operator String());
 		output.append(MEMBER_BEGIN OPEN_BLOCK);
 
-		for (const List<ConstantInterface>::Element *F = ienum.constants.front(); F; F = F->next()) {
-			const ConstantInterface &iconstant = F->get();
+		for (const ConstantInterface &F : ienum.constants) {
+			const ConstantInterface &iconstant = F;
 
 			if (iconstant.const_doc && iconstant.const_doc->description.size()) {
 				String xml_summary = bbcode_to_xml(fix_doc_description(iconstant.const_doc->description), &itype);
@@ -1401,8 +1391,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 	// Add properties
 
-	for (const List<PropertyInterface>::Element *E = itype.properties.front(); E; E = E->next()) {
-		const PropertyInterface &iprop = E->get();
+	for (const PropertyInterface &iprop : itype.properties) {
 		Error prop_err = _generate_cs_property(itype, iprop, output);
 		ERR_FAIL_COND_V_MSG(prop_err != OK, prop_err,
 				"Failed to generate property '" + iprop.cname.operator String() +
@@ -1463,15 +1452,13 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 	}
 
 	int method_bind_count = 0;
-	for (const List<MethodInterface>::Element *E = itype.methods.front(); E; E = E->next()) {
-		const MethodInterface &imethod = E->get();
+	for (const MethodInterface &imethod : itype.methods) {
 		Error method_err = _generate_cs_method(itype, imethod, method_bind_count, output);
 		ERR_FAIL_COND_V_MSG(method_err != OK, method_err,
 				"Failed to generate method '" + imethod.name + "' for class '" + itype.name + "'.");
 	}
 
-	for (const List<SignalInterface>::Element *E = itype.signals_.front(); E; E = E->next()) {
-		const SignalInterface &isignal = E->get();
+	for (const SignalInterface &isignal : itype.signals_) {
 		Error method_err = _generate_cs_signal(itype, isignal, output);
 		ERR_FAIL_COND_V_MSG(method_err != OK, method_err,
 				"Failed to generate signal '" + isignal.name + "' for class '" + itype.name + "'.");
@@ -1678,8 +1665,8 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 	StringBuilder default_args_doc;
 
 	// Retrieve information from the arguments
-	for (const List<ArgumentInterface>::Element *F = p_imethod.arguments.front(); F; F = F->next()) {
-		const ArgumentInterface &iarg = F->get();
+	for (const ArgumentInterface &F : p_imethod.arguments) {
+		const ArgumentInterface &iarg = F;
 		const TypeInterface *arg_type = _get_type_or_placeholder(iarg.type);
 
 		ERR_FAIL_COND_V_MSG(arg_type->is_singleton, ERR_BUG,
@@ -1855,9 +1842,9 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 			p_output.append(p_imethod.name);
 			p_output.append("\"");
 
-			for (const List<ArgumentInterface>::Element *F = p_imethod.arguments.front(); F; F = F->next()) {
+			for (const ArgumentInterface &F : p_imethod.arguments) {
 				p_output.append(", ");
-				p_output.append(F->get().name);
+				p_output.append(F.name);
 			}
 
 			p_output.append(");\n" CLOSE_BLOCK_L2);
@@ -1899,8 +1886,8 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 	String arguments_sig;
 
 	// Retrieve information from the arguments
-	for (const List<ArgumentInterface>::Element *F = p_isignal.arguments.front(); F; F = F->next()) {
-		const ArgumentInterface &iarg = F->get();
+	for (const ArgumentInterface &F : p_isignal.arguments) {
+		const ArgumentInterface &iarg = F;
 		const TypeInterface *arg_type = _get_type_or_placeholder(iarg.type);
 
 		ERR_FAIL_COND_V_MSG(arg_type->is_singleton, ERR_BUG,
@@ -2042,8 +2029,7 @@ Error BindingsGenerator::generate_glue(const String &p_output_dir) {
 
 		String ctor_method(ICALL_PREFIX + itype.proxy_name + "_Ctor"); // Used only for derived types
 
-		for (const List<MethodInterface>::Element *E = itype.methods.front(); E; E = E->next()) {
-			const MethodInterface &imethod = E->get();
+		for (const MethodInterface &imethod : itype.methods) {
 			Error method_err = _generate_glue_method(itype, imethod, output);
 			ERR_FAIL_COND_V_MSG(method_err != OK, method_err,
 					"Failed to generate method '" + imethod.name + "' for class '" + itype.name + "'.");
@@ -2114,20 +2100,20 @@ Error BindingsGenerator::generate_glue(const String &p_output_dir) {
 	}
 
 	bool tools_sequence = false;
-	for (const List<InternalCall>::Element *E = core_custom_icalls.front(); E; E = E->next()) {
+	for (const InternalCall &E : core_custom_icalls) {
 		if (tools_sequence) {
-			if (!E->get().editor_only) {
+			if (!E.editor_only) {
 				tools_sequence = false;
 				output.append("#endif\n");
 			}
 		} else {
-			if (E->get().editor_only) {
+			if (E.editor_only) {
 				output.append("#ifdef TOOLS_ENABLED\n");
 				tools_sequence = true;
 			}
 		}
 
-		ADD_INTERNAL_CALL_REGISTRATION(E->get());
+		ADD_INTERNAL_CALL_REGISTRATION(E);
 	}
 
 	if (tools_sequence) {
@@ -2136,24 +2122,24 @@ Error BindingsGenerator::generate_glue(const String &p_output_dir) {
 	}
 
 	output.append("#ifdef TOOLS_ENABLED\n");
-	for (const List<InternalCall>::Element *E = editor_custom_icalls.front(); E; E = E->next())
-		ADD_INTERNAL_CALL_REGISTRATION(E->get());
+	for (const InternalCall &E : editor_custom_icalls)
+		ADD_INTERNAL_CALL_REGISTRATION(E);
 	output.append("#endif // TOOLS_ENABLED\n");
 
-	for (const List<InternalCall>::Element *E = method_icalls.front(); E; E = E->next()) {
+	for (const InternalCall &E : method_icalls) {
 		if (tools_sequence) {
-			if (!E->get().editor_only) {
+			if (!E.editor_only) {
 				tools_sequence = false;
 				output.append("#endif\n");
 			}
 		} else {
-			if (E->get().editor_only) {
+			if (E.editor_only) {
 				output.append("#ifdef TOOLS_ENABLED\n");
 				tools_sequence = true;
 			}
 		}
 
-		ADD_INTERNAL_CALL_REGISTRATION(E->get());
+		ADD_INTERNAL_CALL_REGISTRATION(E);
 	}
 
 	if (tools_sequence) {
@@ -2209,8 +2195,8 @@ Error BindingsGenerator::_generate_glue_method(const BindingsGenerator::TypeInte
 
 	// Get arguments information
 	int i = 0;
-	for (const List<ArgumentInterface>::Element *F = p_imethod.arguments.front(); F; F = F->next()) {
-		const ArgumentInterface &iarg = F->get();
+	for (const ArgumentInterface &F : p_imethod.arguments) {
+		const ArgumentInterface &iarg = F;
 		const TypeInterface *arg_type = _get_type_or_placeholder(iarg.type);
 
 		String c_param_name = "arg" + itos(i + 1);
@@ -2623,9 +2609,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 		Map<StringName, StringName> accessor_methods;
 
-		for (const List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
-			const PropertyInfo &property = E->get();
-
+		for (const PropertyInfo &property : property_list) {
 			if (property.usage & PROPERTY_USAGE_GROUP || property.usage & PROPERTY_USAGE_SUBGROUP || property.usage & PROPERTY_USAGE_CATEGORY) {
 				continue;
 			}
@@ -2684,8 +2668,8 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		ClassDB::get_method_list(type_cname, &method_list, true);
 		method_list.sort();
 
-		for (List<MethodInfo>::Element *E = method_list.front(); E; E = E->next()) {
-			const MethodInfo &method_info = E->get();
+		for (MethodInfo &E : method_list) {
+			const MethodInfo &method_info = E;
 
 			int argc = method_info.arguments.size();
 
@@ -2840,8 +2824,8 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 			// Classes starting with an underscore are ignored unless they're used as a property setter or getter
 			if (!imethod.is_virtual && imethod.name[0] == '_') {
-				for (const List<PropertyInterface>::Element *F = itype.properties.front(); F; F = F->next()) {
-					const PropertyInterface &iprop = F->get();
+				for (const PropertyInterface &F : itype.properties) {
+					const PropertyInterface &iprop = F;
 
 					if (iprop.setter == imethod.name || iprop.getter == imethod.name) {
 						imethod.is_internal = true;
@@ -2952,8 +2936,8 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			}
 			EnumInterface ienum(enum_proxy_cname);
 			const List<StringName> &enum_constants = enum_map.get(*k);
-			for (const List<StringName>::Element *E = enum_constants.front(); E; E = E->next()) {
-				const StringName &constant_cname = E->get();
+			for (const StringName &E : enum_constants) {
+				const StringName &constant_cname = E;
 				String constant_name = constant_cname.operator String();
 				int *value = class_info->constant_map.getptr(constant_cname);
 				ERR_FAIL_NULL_V(value, false);
@@ -2989,9 +2973,9 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			enum_types.insert(enum_itype.cname, enum_itype);
 		}
 
-		for (const List<String>::Element *E = constants.front(); E; E = E->next()) {
-			const String &constant_name = E->get();
-			int *value = class_info->constant_map.getptr(StringName(E->get()));
+		for (const String &E : constants) {
+			const String &constant_name = E;
+			int *value = class_info->constant_map.getptr(StringName(E));
 			ERR_FAIL_NULL_V(value, false);
 
 			ConstantInterface iconstant(constant_name, snake_to_pascal_case(constant_name, true), *value);
@@ -3539,9 +3523,7 @@ void BindingsGenerator::_populate_global_constants() {
 			}
 		}
 
-		for (List<EnumInterface>::Element *E = global_enums.front(); E; E = E->next()) {
-			EnumInterface &ienum = E->get();
-
+		for (EnumInterface &ienum : global_enums) {
 			TypeInterface enum_itype;
 			enum_itype.is_enum = true;
 			enum_itype.name = ienum.cname.operator String();
@@ -3571,13 +3553,13 @@ void BindingsGenerator::_populate_global_constants() {
 	hardcoded_enums.push_back("Vector2i.Axis");
 	hardcoded_enums.push_back("Vector3.Axis");
 	hardcoded_enums.push_back("Vector3i.Axis");
-	for (List<StringName>::Element *E = hardcoded_enums.front(); E; E = E->next()) {
+	for (StringName &E : hardcoded_enums) {
 		// These enums are not generated and must be written manually (e.g.: Vector3.Axis)
 		// Here, we assume core types do not begin with underscore
 		TypeInterface enum_itype;
 		enum_itype.is_enum = true;
-		enum_itype.name = E->get().operator String();
-		enum_itype.cname = E->get();
+		enum_itype.name = E.operator String();
+		enum_itype.cname = E;
 		enum_itype.proxy_name = enum_itype.name;
 		TypeInterface::postsetup_enum_type(enum_itype);
 		enum_types.insert(enum_itype.cname, enum_itype);

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -357,9 +357,9 @@ class BindingsGenerator {
 		List<SignalInterface> signals_;
 
 		const MethodInterface *find_method_by_name(const StringName &p_cname) const {
-			for (const List<MethodInterface>::Element *E = methods.front(); E; E = E->next()) {
-				if (E->get().cname == p_cname) {
-					return &E->get();
+			for (const MethodInterface &E : methods) {
+				if (E.cname == p_cname) {
+					return &E;
 				}
 			}
 
@@ -367,9 +367,9 @@ class BindingsGenerator {
 		}
 
 		const PropertyInterface *find_property_by_name(const StringName &p_cname) const {
-			for (const List<PropertyInterface>::Element *E = properties.front(); E; E = E->next()) {
-				if (E->get().cname == p_cname) {
-					return &E->get();
+			for (const PropertyInterface &E : properties) {
+				if (E.cname == p_cname) {
+					return &E;
 				}
 			}
 
@@ -377,9 +377,9 @@ class BindingsGenerator {
 		}
 
 		const PropertyInterface *find_property_by_proxy_name(const String &p_proxy_name) const {
-			for (const List<PropertyInterface>::Element *E = properties.front(); E; E = E->next()) {
-				if (E->get().proxy_name == p_proxy_name) {
-					return &E->get();
+			for (const PropertyInterface &E : properties) {
+				if (E.proxy_name == p_proxy_name) {
+					return &E;
 				}
 			}
 
@@ -387,9 +387,9 @@ class BindingsGenerator {
 		}
 
 		const MethodInterface *find_method_by_proxy_name(const String &p_proxy_name) const {
-			for (const List<MethodInterface>::Element *E = methods.front(); E; E = E->next()) {
-				if (E->get().proxy_name == p_proxy_name) {
-					return &E->get();
+			for (const MethodInterface &E : methods) {
+				if (E.proxy_name == p_proxy_name) {
+					return &E;
 				}
 			}
 
@@ -613,9 +613,9 @@ class BindingsGenerator {
 	}
 
 	const ConstantInterface *find_constant_by_name(const String &p_name, const List<ConstantInterface> &p_constants) const {
-		for (const List<ConstantInterface>::Element *E = p_constants.front(); E; E = E->next()) {
-			if (E->get().name == p_name) {
-				return &E->get();
+		for (const ConstantInterface &E : p_constants) {
+			if (E.name == p_name) {
+				return &E;
 			}
 		}
 

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -109,9 +109,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			List<PropertyInfo> project_props;
 			ProjectSettings::get_singleton()->get_property_list(&project_props);
 
-			for (List<PropertyInfo>::Element *E = project_props.front(); E; E = E->next()) {
-				const PropertyInfo &prop = E->get();
-
+			for (PropertyInfo &prop : project_props) {
 				if (!prop.name.begins_with("input/")) {
 					continue;
 				}
@@ -187,8 +185,8 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				ClassDB::get_signal_list(native, &signals, /* p_no_inheritance: */ false);
 			}
 
-			for (List<MethodInfo>::Element *E = signals.front(); E; E = E->next()) {
-				const String &signal = E->get().name;
+			for (MethodInfo &E : signals) {
+				const String &signal = E.name;
 				suggestions.push_back(quoted(signal));
 			}
 		} break;
@@ -199,8 +197,8 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				List<StringName> sn;
 				Theme::get_default()->get_color_list(base->get_class(), &sn);
 
-				for (List<StringName>::Element *E = sn.front(); E; E = E->next()) {
-					suggestions.push_back(quoted(E->get()));
+				for (StringName &E : sn) {
+					suggestions.push_back(quoted(E));
 				}
 			}
 		} break;
@@ -211,8 +209,8 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				List<StringName> sn;
 				Theme::get_default()->get_constant_list(base->get_class(), &sn);
 
-				for (List<StringName>::Element *E = sn.front(); E; E = E->next()) {
-					suggestions.push_back(quoted(E->get()));
+				for (StringName &E : sn) {
+					suggestions.push_back(quoted(E));
 				}
 			}
 		} break;
@@ -223,8 +221,8 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				List<StringName> sn;
 				Theme::get_default()->get_font_list(base->get_class(), &sn);
 
-				for (List<StringName>::Element *E = sn.front(); E; E = E->next()) {
-					suggestions.push_back(quoted(E->get()));
+				for (StringName &E : sn) {
+					suggestions.push_back(quoted(E));
 				}
 			}
 		} break;
@@ -235,8 +233,8 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				List<StringName> sn;
 				Theme::get_default()->get_font_size_list(base->get_class(), &sn);
 
-				for (List<StringName>::Element *E = sn.front(); E; E = E->next()) {
-					suggestions.push_back(quoted(E->get()));
+				for (StringName &E : sn) {
+					suggestions.push_back(quoted(E));
 				}
 			}
 		} break;
@@ -247,8 +245,8 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				List<StringName> sn;
 				Theme::get_default()->get_stylebox_list(base->get_class(), &sn);
 
-				for (List<StringName>::Element *E = sn.front(); E; E = E->next()) {
-					suggestions.push_back(quoted(E->get()));
+				for (StringName &E : sn) {
+					suggestions.push_back(quoted(E));
 				}
 			}
 		} break;

--- a/modules/mono/glue/base_object_glue.cpp
+++ b/modules/mono/glue/base_object_glue.cpp
@@ -177,8 +177,8 @@ MonoArray *godot_icall_DynamicGodotObject_SetMemberList(Object *p_ptr) {
 	MonoArray *result = mono_array_new(mono_domain_get(), CACHED_CLASS_RAW(String), property_list.size());
 
 	int i = 0;
-	for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
-		MonoString *boxed = GDMonoMarshal::mono_string_from_godot(E->get().name);
+	for (PropertyInfo &E : property_list) {
+		MonoString *boxed = GDMonoMarshal::mono_string_from_godot(E.name);
 		mono_array_setref(result, i, boxed);
 		i++;
 	}

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -100,8 +100,8 @@ void gd_mono_setup_runtime_main_args() {
 	main_args.write[0] = execpath.ptrw();
 
 	int i = 1;
-	for (List<String>::Element *E = cmdline_args.front(); E; E = E->next()) {
-		CharString &stored = cmdline_args_utf8.push_back(E->get().utf8())->get();
+	for (String &E : cmdline_args) {
+		CharString &stored = cmdline_args_utf8.push_back(E.utf8())->get();
 		main_args.write[i] = stored.ptrw();
 		i++;
 	}

--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -514,11 +514,11 @@ void NavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node)
 	}
 
 	Transform3D navmesh_xform = Object::cast_to<Node3D>(p_node)->get_transform().affine_inverse();
-	for (const List<Node *>::Element *E = parse_nodes.front(); E; E = E->next()) {
+	for (Node *E : parse_nodes) {
 		int geometry_type = p_nav_mesh->get_parsed_geometry_type();
 		uint32_t collision_mask = p_nav_mesh->get_collision_mask();
 		bool recurse_children = p_nav_mesh->get_source_geometry_mode() != NavigationMesh::SOURCE_GEOMETRY_GROUPS_EXPLICIT;
-		_parse_geometry(navmesh_xform, E->get(), vertices, indices, geometry_type, collision_mask, recurse_children);
+		_parse_geometry(navmesh_xform, E, vertices, indices, geometry_type, collision_mask, recurse_children);
 	}
 
 	if (vertices.size() > 0 && indices.size() > 0) {

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -927,14 +927,14 @@ void TextServerAdvanced::font_set_oversampling(float p_oversampling) {
 		oversampling = p_oversampling;
 		List<RID> fonts;
 		font_owner.get_owned_list(&fonts);
-		for (List<RID>::Element *E = fonts.front(); E; E = E->next()) {
-			font_owner.getornull(E->get())->clear_cache();
+		for (RID E : fonts) {
+			font_owner.getornull(E)->clear_cache();
 		}
 
 		List<RID> text_bufs;
 		shaped_owner.get_owned_list(&text_bufs);
-		for (List<RID>::Element *E = text_bufs.front(); E; E = E->next()) {
-			invalidate(shaped_owner.getornull(E->get()));
+		for (RID E : text_bufs) {
+			invalidate(shaped_owner.getornull(E));
 		}
 	}
 }

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -473,8 +473,8 @@ void TextServerFallback::font_set_oversampling(float p_oversampling) {
 		oversampling = p_oversampling;
 		List<RID> fonts;
 		font_owner.get_owned_list(&fonts);
-		for (List<RID>::Element *E = fonts.front(); E; E = E->next()) {
-			font_owner.getornull(E->get())->clear_cache();
+		for (RID E : fonts) {
+			font_owner.getornull(E)->clear_cache();
 		}
 	}
 }

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -588,14 +588,14 @@ void VisualScript::rename_variable(const StringName &p_name, const StringName &p
 	variables.erase(p_name);
 	List<int> ids;
 	get_node_list(&ids);
-	for (List<int>::Element *E = ids.front(); E; E = E->next()) {
-		Ref<VisualScriptVariableGet> nodeget = get_node(E->get());
+	for (int &E : ids) {
+		Ref<VisualScriptVariableGet> nodeget = get_node(E);
 		if (nodeget.is_valid()) {
 			if (nodeget->get_variable() == p_name) {
 				nodeget->set_variable(p_new_name);
 			}
 		} else {
-			Ref<VisualScriptVariableSet> nodeset = get_node(E->get());
+			Ref<VisualScriptVariableSet> nodeset = get_node(E);
 			if (nodeset.is_valid()) {
 				if (nodeset->get_variable() == p_name) {
 					nodeset->set_variable(p_new_name);
@@ -715,9 +715,9 @@ int VisualScript::get_available_id() const {
 	List<int> nds;
 	nodes.get_key_list(&nds);
 	int max = -1;
-	for (const List<int>::Element *E = nds.front(); E; E = E->next()) {
-		if (E->get() > max) {
-			max = E->get();
+	for (const int &E : nds) {
+		if (E > max) {
+			max = E;
 		}
 	}
 	return (max + 1);
@@ -752,15 +752,15 @@ void VisualScript::_update_placeholders() {
 	List<StringName> keys;
 	variables.get_key_list(&keys);
 
-	for (List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-		if (!variables[E->get()]._export) {
+	for (StringName &E : keys) {
+		if (!variables[E]._export) {
 			continue;
 		}
 
-		PropertyInfo p = variables[E->get()].info;
-		p.name = String(E->get());
+		PropertyInfo p = variables[E].info;
+		p.name = String(E);
 		pinfo.push_back(p);
-		values[p.name] = variables[E->get()].default_value;
+		values[p.name] = variables[E].default_value;
 	}
 
 	for (Set<PlaceHolderScriptInstance *>::Element *E = placeholders.front(); E; E = E->next()) {
@@ -783,15 +783,15 @@ ScriptInstance *VisualScript::instance_create(Object *p_this) {
 		List<StringName> keys;
 		variables.get_key_list(&keys);
 
-		for (const List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-			if (!variables[E->get()]._export) {
+		for (const StringName &E : keys) {
+			if (!variables[E]._export) {
 				continue;
 			}
 
-			PropertyInfo p = variables[E->get()].info;
-			p.name = String(E->get());
+			PropertyInfo p = variables[E].info;
+			p.name = String(E);
 			pinfo.push_back(p);
-			values[p.name] = variables[E->get()].default_value;
+			values[p.name] = variables[E].default_value;
 		}
 		sins->update(pinfo, values);
 
@@ -874,11 +874,11 @@ void VisualScript::get_script_method_list(List<MethodInfo> *p_list) const {
 	List<StringName> funcs;
 	functions.get_key_list(&funcs);
 
-	for (List<StringName>::Element *E = funcs.front(); E; E = E->next()) {
+	for (StringName &E : funcs) {
 		MethodInfo mi;
-		mi.name = E->get();
-		if (functions[E->get()].func_id >= 0) {
-			Ref<VisualScriptFunction> func = nodes[functions[E->get()].func_id].node;
+		mi.name = E;
+		if (functions[E].func_id >= 0) {
+			Ref<VisualScriptFunction> func = nodes[functions[E].func_id].node;
 			if (func.is_valid()) {
 				for (int i = 0; i < func->get_argument_count(); i++) {
 					PropertyInfo arg;
@@ -928,10 +928,10 @@ void VisualScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 	List<StringName> vars;
 	get_variable_list(&vars);
 
-	for (List<StringName>::Element *E = vars.front(); E; E = E->next()) {
-		//if (!variables[E->get()]._export)
+	for (StringName &E : vars) {
+		//if (!variables[E]._export)
 		//	continue;
-		PropertyInfo pi = variables[E->get()].info;
+		PropertyInfo pi = variables[E].info;
 		pi.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
 		p_list->push_back(pi);
 	}
@@ -945,8 +945,8 @@ int VisualScript::get_member_line(const StringName &p_member) const {
 bool VisualScript::are_subnodes_edited() const {
 	List<int> keys;
 	nodes.get_key_list(&keys);
-	for (const List<int>::Element *F = keys.front(); F; F = F->next()) {
-		if (nodes[F->get()].node->is_edited()) {
+	for (const int &F : keys) {
+		if (nodes[F].node->is_edited()) {
 			return true;
 		}
 	}
@@ -1017,13 +1017,13 @@ void VisualScript::_set_data(const Dictionary &p_data) {
 	rpc_functions.clear();
 	List<StringName> fns;
 	functions.get_key_list(&fns);
-	for (const List<StringName>::Element *E = fns.front(); E; E = E->next()) {
-		if (functions[E->get()].func_id >= 0 && nodes.has(functions[E->get()].func_id)) {
-			Ref<VisualScriptFunction> vsf = nodes[functions[E->get()].func_id].node;
+	for (const StringName &E : fns) {
+		if (functions[E].func_id >= 0 && nodes.has(functions[E].func_id)) {
+			Ref<VisualScriptFunction> vsf = nodes[functions[E].func_id].node;
 			if (vsf.is_valid()) {
 				if (vsf->get_rpc_mode() != MultiplayerAPI::RPC_MODE_DISABLED) {
 					MultiplayerAPI::RPCConfig nd;
-					nd.name = E->get();
+					nd.name = E;
 					nd.rpc_mode = vsf->get_rpc_mode();
 					nd.transfer_mode = MultiplayerPeer::TRANSFER_MODE_RELIABLE; // TODO
 					if (rpc_functions.find(nd) == -1) {
@@ -1045,11 +1045,11 @@ Dictionary VisualScript::_get_data() const {
 	Array vars;
 	List<StringName> var_names;
 	variables.get_key_list(&var_names);
-	for (const List<StringName>::Element *E = var_names.front(); E; E = E->next()) {
-		Dictionary var = _get_variable_info(E->get());
-		var["name"] = E->get(); // Make sure it's the right one.
-		var["default_value"] = variables[E->get()].default_value;
-		var["export"] = variables[E->get()]._export;
+	for (const StringName &E : var_names) {
+		Dictionary var = _get_variable_info(E);
+		var["name"] = E; // Make sure it's the right one.
+		var["default_value"] = variables[E].default_value;
+		var["export"] = variables[E]._export;
 		vars.push_back(var);
 	}
 	d["variables"] = vars;
@@ -1073,10 +1073,10 @@ Dictionary VisualScript::_get_data() const {
 	Array funcs;
 	List<StringName> func_names;
 	functions.get_key_list(&func_names);
-	for (const List<StringName>::Element *E = func_names.front(); E; E = E->next()) {
+	for (const StringName &E : func_names) {
 		Dictionary func;
-		func["name"] = E->get();
-		func["function_id"] = functions[E->get()].func_id;
+		func["name"] = E;
+		func["function_id"] = functions[E].func_id;
 		funcs.push_back(func);
 	}
 	d["functions"] = funcs;
@@ -1084,10 +1084,10 @@ Dictionary VisualScript::_get_data() const {
 	Array nds;
 	List<int> node_ids;
 	nodes.get_key_list(&node_ids);
-	for (const List<int>::Element *F = node_ids.front(); F; F = F->next()) {
-		nds.push_back(F->get());
-		nds.push_back(nodes[F->get()].pos);
-		nds.push_back(nodes[F->get()].node);
+	for (const int &F : node_ids) {
+		nds.push_back(F);
+		nds.push_back(nodes[F].pos);
+		nds.push_back(nodes[F].node);
 	}
 	d["nodes"] = nds;
 
@@ -1202,8 +1202,8 @@ VisualScript::~VisualScript() {
 	// Remove all nodes and stuff that hold data refs.
 	List<int> nds;
 	nodes.get_key_list(&nds);
-	for (const List<int>::Element *E = nds.front(); E; E = E->next()) {
-		remove_node(E->get());
+	for (const int &E : nds) {
+		remove_node(E);
 	}
 }
 
@@ -1233,12 +1233,12 @@ bool VisualScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 void VisualScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 	List<StringName> vars;
 	script->variables.get_key_list(&vars);
-	for (const List<StringName>::Element *E = vars.front(); E; E = E->next()) {
-		if (!script->variables[E->get()]._export) {
+	for (const StringName &E : vars) {
+		if (!script->variables[E]._export) {
 			continue;
 		}
-		PropertyInfo p = script->variables[E->get()].info;
-		p.name = String(E->get());
+		PropertyInfo p = script->variables[E].info;
+		p.name = String(E);
 		p.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
 		p_properties->push_back(p);
 	}
@@ -1262,11 +1262,11 @@ Variant::Type VisualScriptInstance::get_property_type(const StringName &p_name, 
 void VisualScriptInstance::get_method_list(List<MethodInfo> *p_list) const {
 	List<StringName> fns;
 	script->functions.get_key_list(&fns);
-	for (const List<StringName>::Element *E = fns.front(); E; E = E->next()) {
+	for (const StringName &E : fns) {
 		MethodInfo mi;
-		mi.name = E->get();
-		if (script->functions[E->get()].func_id >= 0 && script->nodes.has(script->functions[E->get()].func_id)) {
-			Ref<VisualScriptFunction> vsf = script->nodes[script->functions[E->get()].func_id].node;
+		mi.name = E;
+		if (script->functions[E].func_id >= 0 && script->nodes.has(script->functions[E].func_id)) {
+			Ref<VisualScriptFunction> vsf = script->nodes[script->functions[E].func_id].node;
 			if (vsf.is_valid()) {
 				for (int i = 0; i < vsf->get_argument_count(); i++) {
 					PropertyInfo arg;
@@ -1868,8 +1868,8 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 	{
 		List<StringName> keys;
 		script->variables.get_key_list(&keys);
-		for (const List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-			variables[E->get()] = script->variables[E->get()].default_value;
+		for (const StringName &E : keys) {
+			variables[E] = script->variables[E].default_value;
 		}
 	}
 
@@ -1877,8 +1877,8 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 	{
 		List<StringName> keys;
 		script->functions.get_key_list(&keys);
-		for (const List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-			const VisualScript::Function vsfn = p_script->functions[E->get()];
+		for (const StringName &E : keys) {
+			const VisualScript::Function vsfn = p_script->functions[E];
 			Function function;
 			function.node = vsfn.func_id;
 			function.max_stack = 0;
@@ -1889,7 +1889,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 			Map<StringName, int> local_var_indices;
 
 			if (function.node < 0) {
-				VisualScriptLanguage::singleton->debug_break_parse(get_script()->get_path(), 0, "No start node in function: " + String(E->get()));
+				VisualScriptLanguage::singleton->debug_break_parse(get_script()->get_path(), 0, "No start node in function: " + String(E));
 				ERR_CONTINUE(function.node < 0);
 			}
 
@@ -1897,7 +1897,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				Ref<VisualScriptFunction> func_node = script->get_node(vsfn.func_id);
 
 				if (func_node.is_null()) {
-					VisualScriptLanguage::singleton->debug_break_parse(get_script()->get_path(), 0, "No VisualScriptFunction typed start node in function: " + String(E->get()));
+					VisualScriptLanguage::singleton->debug_break_parse(get_script()->get_path(), 0, "No VisualScriptFunction typed start node in function: " + String(E));
 				}
 
 				ERR_CONTINUE(!func_node.is_valid());
@@ -1938,12 +1938,12 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				while (!nd_queue.is_empty()) {
 					int ky = nd_queue.front()->get();
 					dc_lut[ky].get_key_list(&dc_keys);
-					for (const List<int>::Element *F = dc_keys.front(); F; F = F->next()) {
+					for (const int &F : dc_keys) {
 						VisualScript::DataConnection dc;
-						dc.from_node = dc_lut[ky][F->get()].first;
-						dc.from_port = dc_lut[ky][F->get()].second;
+						dc.from_node = dc_lut[ky][F].first;
+						dc.from_port = dc_lut[ky][F].second;
 						dc.to_node = ky;
-						dc.to_port = F->get();
+						dc.to_port = F;
 						dataconns.insert(dc);
 						nd_queue.push_back(dc.from_node);
 						node_ids.insert(dc.from_node);
@@ -2093,7 +2093,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				}
 			}
 
-			functions[E->get()] = function;
+			functions[E] = function;
 		}
 	}
 }
@@ -2467,10 +2467,10 @@ void VisualScriptLanguage::debug_get_stack_level_members(int p_level, List<Strin
 
 	List<StringName> vars;
 	vs->get_variable_list(&vars);
-	for (List<StringName>::Element *E = vars.front(); E; E = E->next()) {
+	for (StringName &E : vars) {
 		Variant v;
-		if (_call_stack[l].instance->get_variable(E->get(), &v)) {
-			p_members->push_back("variables/" + E->get());
+		if (_call_stack[l].instance->get_variable(E, &v)) {
+			p_members->push_back("variables/" + E);
 			p_values->push_back(v);
 		}
 	}

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -852,11 +852,11 @@ void VisualScriptTypeCast::_bind_methods() {
 	}
 
 	String script_ext_hint;
-	for (List<String>::Element *E = script_extensions.front(); E; E = E->next()) {
+	for (String &E : script_extensions) {
 		if (script_ext_hint != String()) {
 			script_ext_hint += ",";
 		}
-		script_ext_hint += "*." + E->get();
+		script_ext_hint += "*." + E;
 	}
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "base_type", PROPERTY_HINT_TYPE_STRING, "Object"), "set_base_type", "get_base_type");

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -538,11 +538,11 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 			Engine::get_singleton()->get_singletons(&names);
 			property.hint = PROPERTY_HINT_ENUM;
 			String sl;
-			for (List<Engine::Singleton>::Element *E = names.front(); E; E = E->next()) {
+			for (Engine::Singleton &E : names) {
 				if (sl != String()) {
 					sl += ",";
 				}
-				sl += E->get().name;
+				sl += E.name;
 			}
 			property.hint_string = sl;
 		}
@@ -683,11 +683,11 @@ void VisualScriptFunctionCall::_bind_methods() {
 	}
 
 	String script_ext_hint;
-	for (List<String>::Element *E = script_extensions.front(); E; E = E->next()) {
+	for (String &E : script_extensions) {
 		if (script_ext_hint != String()) {
 			script_ext_hint += ",";
 		}
-		script_ext_hint += "*." + E->get();
+		script_ext_hint += "*." + E;
 	}
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "call_mode", PROPERTY_HINT_ENUM, "Self,Node Path,Instance,Basic Type,Singleton"), "set_call_mode", "get_call_mode");
@@ -1004,13 +1004,13 @@ PropertyInfo VisualScriptPropertySet::get_input_value_port_info(int p_idx) const
 
 	List<PropertyInfo> props;
 	ClassDB::get_property_list(_get_base_type(), &props, false);
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		if (E->get().name == property) {
+	for (PropertyInfo &E : props) {
+		if (E.name == property) {
 			String detail_prop_name = property;
 			if (index != StringName()) {
 				detail_prop_name += "." + String(index);
 			}
-			PropertyInfo pinfo = PropertyInfo(E->get().type, detail_prop_name, PROPERTY_HINT_TYPE_STRING, E->get().hint_string);
+			PropertyInfo pinfo = PropertyInfo(E.type, detail_prop_name, PROPERTY_HINT_TYPE_STRING, E.hint_string);
 			_adjust_input_index(pinfo);
 			return pinfo;
 		}
@@ -1135,9 +1135,9 @@ void VisualScriptPropertySet::_update_cache() {
 		List<PropertyInfo> pinfo;
 		v.get_property_list(&pinfo);
 
-		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-			if (E->get().name == property) {
-				type_cache = E->get();
+		for (PropertyInfo &E : pinfo) {
+			if (E.name == property) {
+				type_cache = E;
 			}
 		}
 
@@ -1186,9 +1186,9 @@ void VisualScriptPropertySet::_update_cache() {
 			script->get_script_property_list(&pinfo);
 		}
 
-		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-			if (E->get().name == property) {
-				type_cache = E->get();
+		for (PropertyInfo &E : pinfo) {
+			if (E.name == property) {
+				type_cache = E;
 				return;
 			}
 		}
@@ -1354,8 +1354,8 @@ void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
 		List<PropertyInfo> plist;
 		v.get_property_list(&plist);
 		String options = "";
-		for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-			options += "," + E->get().name;
+		for (PropertyInfo &E : plist) {
+			options += "," + E.name;
 		}
 
 		property.hint = PROPERTY_HINT_ENUM;
@@ -1410,11 +1410,11 @@ void VisualScriptPropertySet::_bind_methods() {
 	}
 
 	String script_ext_hint;
-	for (List<String>::Element *E = script_extensions.front(); E; E = E->next()) {
+	for (String &E : script_extensions) {
 		if (script_ext_hint != String()) {
 			script_ext_hint += ",";
 		}
-		script_ext_hint += "*." + E->get();
+		script_ext_hint += "*." + E;
 	}
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "set_mode", PROPERTY_HINT_ENUM, "Self,Node Path,Instance,Basic Type"), "set_call_mode", "get_call_mode");
@@ -1820,9 +1820,9 @@ void VisualScriptPropertyGet::_update_cache() {
 		List<PropertyInfo> pinfo;
 		v.get_property_list(&pinfo);
 
-		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-			if (E->get().name == property) {
-				type_cache = E->get().type;
+		for (PropertyInfo &E : pinfo) {
+			if (E.name == property) {
+				type_cache = E.type;
 				return;
 			}
 		}
@@ -2059,8 +2059,8 @@ void VisualScriptPropertyGet::_validate_property(PropertyInfo &property) const {
 		List<PropertyInfo> plist;
 		v.get_property_list(&plist);
 		String options = "";
-		for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-			options += "," + E->get().name;
+		for (PropertyInfo &E : plist) {
+			options += "," + E.name;
 		}
 
 		property.hint = PROPERTY_HINT_ENUM;
@@ -2112,11 +2112,11 @@ void VisualScriptPropertyGet::_bind_methods() {
 	}
 
 	String script_ext_hint;
-	for (List<String>::Element *E = script_extensions.front(); E; E = E->next()) {
+	for (String &E : script_extensions) {
 		if (script_ext_hint != String()) {
 			script_ext_hint += ",";
 		}
-		script_ext_hint += "." + E->get();
+		script_ext_hint += "." + E;
 	}
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "set_mode", PROPERTY_HINT_ENUM, "Self,Node Path,Instance,Basic Type"), "set_call_mode", "get_call_mode");
@@ -2323,11 +2323,11 @@ void VisualScriptEmitSignal::_validate_property(PropertyInfo &property) const {
 		}
 
 		String ml;
-		for (List<StringName>::Element *E = sigs.front(); E; E = E->next()) {
+		for (StringName &E : sigs) {
 			if (ml != String()) {
 				ml += ",";
 			}
-			ml += E->get();
+			ml += E;
 		}
 
 		property.hint_string = ml;
@@ -2418,8 +2418,8 @@ void register_visual_script_func_nodes() {
 		List<MethodInfo> ml;
 		vt.get_method_list(&ml);
 
-		for (List<MethodInfo>::Element *E = ml.front(); E; E = E->next()) {
-			VisualScriptLanguage::singleton->add_register_func("functions/by_type/" + type_name + "/" + E->get().name, create_basic_type_call_node);
+		for (MethodInfo &E : ml) {
+			VisualScriptLanguage::singleton->add_register_func("functions/by_type/" + type_name + "/" + E.name, create_basic_type_call_node);
 		}
 	}
 }

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1306,12 +1306,12 @@ void VisualScriptVariableGet::_validate_property(PropertyInfo &property) const {
 		vs->get_variable_list(&vars);
 
 		String vhint;
-		for (List<StringName>::Element *E = vars.front(); E; E = E->next()) {
+		for (StringName &E : vars) {
 			if (vhint != String()) {
 				vhint += ",";
 			}
 
-			vhint += E->get().operator String();
+			vhint += E.operator String();
 		}
 
 		property.hint = PROPERTY_HINT_ENUM;
@@ -1416,12 +1416,12 @@ void VisualScriptVariableSet::_validate_property(PropertyInfo &property) const {
 		vs->get_variable_list(&vars);
 
 		String vhint;
-		for (List<StringName>::Element *E = vars.front(); E; E = E->next()) {
+		for (StringName &E : vars) {
 			if (vhint != String()) {
 				vhint += ",";
 			}
 
-			vhint += E->get().operator String();
+			vhint += E.operator String();
 		}
 
 		property.hint = PROPERTY_HINT_ENUM;
@@ -1944,8 +1944,8 @@ void VisualScriptClassConstant::set_base_type(const StringName &p_which) {
 	ClassDB::get_integer_constant_list(base_type, &constants, true);
 	if (constants.size() > 0) {
 		bool found_name = false;
-		for (List<String>::Element *E = constants.front(); E; E = E->next()) {
-			if (E->get() == name) {
+		for (String &E : constants) {
+			if (E == name) {
 				found_name = true;
 				break;
 			}
@@ -1993,11 +1993,11 @@ void VisualScriptClassConstant::_validate_property(PropertyInfo &property) const
 		ClassDB::get_integer_constant_list(base_type, &constants, true);
 
 		property.hint_string = "";
-		for (List<String>::Element *E = constants.front(); E; E = E->next()) {
+		for (String &E : constants) {
 			if (property.hint_string != String()) {
 				property.hint_string += ",";
 			}
-			property.hint_string += E->get();
+			property.hint_string += E;
 		}
 	}
 }
@@ -2078,8 +2078,8 @@ void VisualScriptBasicTypeConstant::set_basic_type(Variant::Type p_which) {
 	Variant::get_constants_for_type(type, &constants);
 	if (constants.size() > 0) {
 		bool found_name = false;
-		for (List<StringName>::Element *E = constants.front(); E; E = E->next()) {
-			if (E->get() == name) {
+		for (StringName &E : constants) {
+			if (E == name) {
 				found_name = true;
 				break;
 			}
@@ -2131,11 +2131,11 @@ void VisualScriptBasicTypeConstant::_validate_property(PropertyInfo &property) c
 			return;
 		}
 		property.hint_string = "";
-		for (List<StringName>::Element *E = constants.front(); E; E = E->next()) {
+		for (StringName &E : constants) {
 			if (property.hint_string != String()) {
 				property.hint_string += ",";
 			}
-			property.hint_string += String(E->get());
+			property.hint_string += String(E);
 		}
 	}
 }
@@ -2358,15 +2358,15 @@ void VisualScriptEngineSingleton::_validate_property(PropertyInfo &property) con
 
 	Engine::get_singleton()->get_singletons(&singletons);
 
-	for (List<Engine::Singleton>::Element *E = singletons.front(); E; E = E->next()) {
-		if (E->get().name == "VS" || E->get().name == "PS" || E->get().name == "PS2D" || E->get().name == "AS" || E->get().name == "TS" || E->get().name == "SS" || E->get().name == "SS2D") {
+	for (Engine::Singleton &E : singletons) {
+		if (E.name == "VS" || E.name == "PS" || E.name == "PS2D" || E.name == "AS" || E.name == "TS" || E.name == "SS" || E.name == "SS2D") {
 			continue; //skip these, too simple named
 		}
 
 		if (cc != String()) {
 			cc += ",";
 		}
-		cc += E->get().name;
+		cc += E.name;
 	}
 
 	property.hint = PROPERTY_HINT_ENUM;
@@ -3749,9 +3749,7 @@ void VisualScriptInputAction::_validate_property(PropertyInfo &property) const {
 		ProjectSettings::get_singleton()->get_property_list(&pinfo);
 		Vector<String> al;
 
-		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-			const PropertyInfo &pi = E->get();
-
+		for (PropertyInfo &pi : pinfo) {
 			if (!pi.name.begins_with("input/")) {
 				continue;
 			}
@@ -3844,10 +3842,10 @@ void VisualScriptDeconstruct::_update_elements() {
 	List<PropertyInfo> pinfo;
 	v.get_property_list(&pinfo);
 
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
+	for (PropertyInfo &E : pinfo) {
 		Element e;
-		e.name = E->get().name;
-		e.type = E->get().type;
+		e.name = E.name;
+		e.type = E.type;
 		elements.push_back(e);
 	}
 }
@@ -4025,24 +4023,24 @@ void register_visual_script_nodes() {
 		List<MethodInfo> constructors;
 		Variant::get_constructor_list(Variant::Type(i), &constructors);
 
-		for (List<MethodInfo>::Element *E = constructors.front(); E; E = E->next()) {
-			if (E->get().arguments.size() > 0) {
+		for (MethodInfo &E : constructors) {
+			if (E.arguments.size() > 0) {
 				String name = "functions/constructors/" + Variant::get_type_name(Variant::Type(i)) + "(";
-				for (int j = 0; j < E->get().arguments.size(); j++) {
+				for (int j = 0; j < E.arguments.size(); j++) {
 					if (j > 0) {
 						name += ", ";
 					}
-					if (E->get().arguments.size() == 1) {
-						name += Variant::get_type_name(E->get().arguments[j].type);
+					if (E.arguments.size() == 1) {
+						name += Variant::get_type_name(E.arguments[j].type);
 					} else {
-						name += E->get().arguments[j].name;
+						name += E.arguments[j].name;
 					}
 				}
 				name += ")";
 				VisualScriptLanguage::singleton->add_register_func(name, create_constructor_node);
 				Pair<Variant::Type, MethodInfo> pair;
 				pair.first = Variant::Type(i);
-				pair.second = E->get();
+				pair.second = E;
 				constructor_map[name] = pair;
 			}
 		}

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -93,7 +93,7 @@ void VisualScriptPropertySelector::_update_search() {
 		base = ClassDB::get_parent_class_nocheck(base);
 	}
 
-	for (List<StringName>::Element *E = base_list.front(); E; E = E->next()) {
+	for (StringName &E : base_list) {
 		List<MethodInfo> methods;
 		List<PropertyInfo> props;
 		TreeItem *category = nullptr;
@@ -135,7 +135,7 @@ void VisualScriptPropertySelector::_update_search() {
 			vbc->get_theme_icon(SNAME("PackedColorArray"), SNAME("EditorIcons"))
 		};
 		{
-			String b = String(E->get());
+			String b = String(E);
 			category = search_options->create_item(root);
 			if (category) {
 				category->set_text(0, b.replace_first("*", ""));
@@ -154,30 +154,30 @@ void VisualScriptPropertySelector::_update_search() {
 				if (Object::cast_to<Script>(obj)) {
 					Object::cast_to<Script>(obj)->get_script_property_list(&props);
 				} else {
-					ClassDB::get_property_list(E->get(), &props, true);
+					ClassDB::get_property_list(E, &props, true);
 				}
 			}
-			for (List<PropertyInfo>::Element *F = props.front(); F; F = F->next()) {
-				if (!(F->get().usage & PROPERTY_USAGE_EDITOR) && !(F->get().usage & PROPERTY_USAGE_SCRIPT_VARIABLE)) {
+			for (PropertyInfo &F : props) {
+				if (!(F.usage & PROPERTY_USAGE_EDITOR) && !(F.usage & PROPERTY_USAGE_SCRIPT_VARIABLE)) {
 					continue;
 				}
 
-				if (type_filter.size() && type_filter.find(F->get().type) == -1) {
+				if (type_filter.size() && type_filter.find(F.type) == -1) {
 					continue;
 				}
 
 				// capitalize() also converts underscore to space, we'll match again both possible styles
-				String get_text_raw = String(vformat(TTR("Get %s"), F->get().name));
+				String get_text_raw = String(vformat(TTR("Get %s"), F.name));
 				String get_text = get_text_raw.capitalize();
-				String set_text_raw = String(vformat(TTR("Set %s"), F->get().name));
+				String set_text_raw = String(vformat(TTR("Set %s"), F.name));
 				String set_text = set_text_raw.capitalize();
 				String input = search_box->get_text().capitalize();
 
 				if (input == String() || get_text_raw.findn(input) != -1 || get_text.findn(input) != -1) {
 					TreeItem *item = search_options->create_item(category ? category : root);
 					item->set_text(0, get_text);
-					item->set_metadata(0, F->get().name);
-					item->set_icon(0, type_icons[F->get().type]);
+					item->set_metadata(0, F.name);
+					item->set_icon(0, type_icons[F.type]);
 					item->set_metadata(1, "get");
 					item->set_collapsed(true);
 					item->set_selectable(0, true);
@@ -189,8 +189,8 @@ void VisualScriptPropertySelector::_update_search() {
 				if (input == String() || set_text_raw.findn(input) != -1 || set_text.findn(input) != -1) {
 					TreeItem *item = search_options->create_item(category ? category : root);
 					item->set_text(0, set_text);
-					item->set_metadata(0, F->get().name);
-					item->set_icon(0, type_icons[F->get().type]);
+					item->set_metadata(0, F.name);
+					item->set_icon(0, type_icons[F.type]);
 					item->set_metadata(1, "set");
 					item->set_selectable(0, true);
 					item->set_selectable(1, false);
@@ -211,7 +211,7 @@ void VisualScriptPropertySelector::_update_search() {
 					Object::cast_to<Script>(obj)->get_script_method_list(&methods);
 				}
 
-				ClassDB::get_method_list(E->get(), &methods, true, true);
+				ClassDB::get_method_list(E, &methods, true, true);
 			}
 		}
 		for (List<MethodInfo>::Element *M = methods.front(); M; M = M->next()) {
@@ -340,11 +340,11 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 	List<String> fnodes;
 	VisualScriptLanguage::singleton->get_registered_node_names(&fnodes);
 
-	for (List<String>::Element *E = fnodes.front(); E; E = E->next()) {
-		if (!E->get().begins_with(root_filter)) {
+	for (String &E : fnodes) {
+		if (!E.begins_with(root_filter)) {
 			continue;
 		}
-		Vector<String> path = E->get().split("/");
+		Vector<String> path = E.split("/");
 
 		// check if the name has the filter
 		bool in_filter = false;
@@ -355,7 +355,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 			} else {
 				in_filter = false;
 			}
-			if (E->get().findn(tx_filters[i]) != -1) {
+			if (E.findn(tx_filters[i]) != -1) {
 				in_filter = true;
 				break;
 			}
@@ -366,7 +366,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 
 		bool in_modifier = p_modifiers.is_empty();
 		for (Set<String>::Element *F = p_modifiers.front(); F && in_modifier; F = F->next()) {
-			if (E->get().findn(F->get()) != -1) {
+			if (E.findn(F->get()) != -1) {
 				in_modifier = true;
 			}
 		}
@@ -375,7 +375,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 		}
 
 		TreeItem *item = search_options->create_item(root);
-		Ref<VisualScriptNode> vnode = VisualScriptLanguage::singleton->create_node_from_name(E->get());
+		Ref<VisualScriptNode> vnode = VisualScriptLanguage::singleton->create_node_from_name(E);
 		Ref<VisualScriptOperator> vnode_operator = vnode;
 		String type_name;
 		if (vnode_operator.is_valid()) {
@@ -409,7 +409,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 		item->set_text(0, type_name + String("").join(desc));
 		item->set_icon(0, vbc->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
 		item->set_selectable(0, true);
-		item->set_metadata(0, E->get());
+		item->set_metadata(0, E);
 		item->set_selectable(0, true);
 		item->set_metadata(1, "visualscript");
 		item->set_selectable(1, false);

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -438,21 +438,21 @@ void VisualScriptYieldSignal::_validate_property(PropertyInfo &property) const {
 		ClassDB::get_signal_list(_get_base_type(), &methods);
 
 		List<String> mstring;
-		for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
-			if (E->get().name.begins_with("_")) {
+		for (MethodInfo &E : methods) {
+			if (E.name.begins_with("_")) {
 				continue;
 			}
-			mstring.push_back(E->get().name.get_slice(":", 0));
+			mstring.push_back(E.name.get_slice(":", 0));
 		}
 
 		mstring.sort();
 
 		String ml;
-		for (List<String>::Element *E = mstring.front(); E; E = E->next()) {
+		for (String &E : mstring) {
 			if (ml != String()) {
 				ml += ",";
 			}
-			ml += E->get();
+			ml += E;
 		}
 
 		property.hint_string = ml;

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -112,22 +112,22 @@ void WebRTCMultiplayerPeer::poll() {
 		}
 	}
 	// Remove disconnected peers
-	for (List<int>::Element *E = remove.front(); E; E = E->next()) {
-		remove_peer(E->get());
-		if (next_packet_peer == E->get()) {
+	for (int &E : remove) {
+		remove_peer(E);
+		if (next_packet_peer == E) {
 			next_packet_peer = 0;
 		}
 	}
 	// Signal newly connected peers
-	for (List<int>::Element *E = add.front(); E; E = E->next()) {
+	for (int &E : add) {
 		// Already connected to server: simply notify new peer.
 		// NOTE: Mesh is always connected.
 		if (connection_status == CONNECTION_CONNECTED) {
-			emit_signal(SNAME("peer_connected"), E->get());
+			emit_signal(SNAME("peer_connected"), E);
 		}
 
 		// Server emulation mode suppresses peer_conencted until server connects.
-		if (server_compat && E->get() == TARGET_PEER_SERVER) {
+		if (server_compat && E == TARGET_PEER_SERVER) {
 			// Server connected.
 			connection_status = CONNECTION_CONNECTED;
 			emit_signal(SNAME("peer_connected"), TARGET_PEER_SERVER);
@@ -154,8 +154,8 @@ void WebRTCMultiplayerPeer::_find_next_peer() {
 	}
 	// After last.
 	while (E) {
-		for (List<Ref<WebRTCDataChannel>>::Element *F = E->get()->channels.front(); F; F = F->next()) {
-			if (F->get()->get_available_packet_count()) {
+		for (Ref<WebRTCDataChannel> F : E->get()->channels) {
+			if (F->get_available_packet_count()) {
 				next_packet_peer = E->key();
 				return;
 			}
@@ -165,8 +165,8 @@ void WebRTCMultiplayerPeer::_find_next_peer() {
 	E = peer_map.front();
 	// Before last
 	while (E) {
-		for (List<Ref<WebRTCDataChannel>>::Element *F = E->get()->channels.front(); F; F = F->next()) {
-			if (F->get()->get_available_packet_count()) {
+		for (Ref<WebRTCDataChannel> F : E->get()->channels) {
+			if (F->get_available_packet_count()) {
 				next_packet_peer = E->key();
 				return;
 			}
@@ -213,8 +213,8 @@ int WebRTCMultiplayerPeer::get_unique_id() const {
 
 void WebRTCMultiplayerPeer::_peer_to_dict(Ref<ConnectedPeer> p_connected_peer, Dictionary &r_dict) {
 	Array channels;
-	for (List<Ref<WebRTCDataChannel>>::Element *F = p_connected_peer->channels.front(); F; F = F->next()) {
-		channels.push_back(F->get());
+	for (Ref<WebRTCDataChannel> F : p_connected_peer->channels) {
+		channels.push_back(F);
 	}
 	r_dict["connection"] = p_connected_peer->connection;
 	r_dict["connected"] = p_connected_peer->connected;
@@ -297,9 +297,9 @@ Error WebRTCMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_
 		_find_next_peer();
 		ERR_FAIL_V(ERR_UNAVAILABLE);
 	}
-	for (List<Ref<WebRTCDataChannel>>::Element *E = peer_map[next_packet_peer]->channels.front(); E; E = E->next()) {
-		if (E->get()->get_available_packet_count()) {
-			Error err = E->get()->get_packet(r_buffer, r_buffer_size);
+	for (Ref<WebRTCDataChannel> E : peer_map[next_packet_peer]->channels) {
+		if (E->get_available_packet_count()) {
+			Error err = E->get_packet(r_buffer, r_buffer_size);
 			_find_next_peer();
 			return err;
 		}
@@ -357,8 +357,8 @@ int WebRTCMultiplayerPeer::get_available_packet_count() const {
 	}
 	int size = 0;
 	for (Map<int, Ref<ConnectedPeer>>::Element *E = peer_map.front(); E; E = E->next()) {
-		for (List<Ref<WebRTCDataChannel>>::Element *F = E->get()->channels.front(); F; F = F->next()) {
-			size += F->get()->get_available_packet_count();
+		for (Ref<WebRTCDataChannel> F : E->get()->channels) {
+			size += F->get_available_packet_count();
 		}
 	}
 	return size;

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -65,9 +65,9 @@ void WebSocketMultiplayerPeer::_clear() {
 		memfree(_current_packet.data);
 	}
 
-	for (List<Packet>::Element *E = _incoming_packets.front(); E; E = E->next()) {
-		memfree(E->get().data);
-		E->get().data = nullptr;
+	for (Packet &E : _incoming_packets) {
+		memfree(E.data);
+		E.data = nullptr;
 	}
 
 	_incoming_packets.clear();

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -190,15 +190,15 @@ void WSLServer::poll() {
 			remove_ids.push_back(E->key());
 		}
 	}
-	for (List<int>::Element *E = remove_ids.front(); E; E = E->next()) {
-		_peer_map.erase(E->get());
+	for (int &E : remove_ids) {
+		_peer_map.erase(E);
 	}
 	remove_ids.clear();
 
 	List<Ref<PendingPeer>> remove_peers;
-	for (List<Ref<PendingPeer>>::Element *E = _pending.front(); E; E = E->next()) {
+	for (Ref<PendingPeer> E : _pending) {
 		String resource_name;
-		Ref<PendingPeer> ppeer = E->get();
+		Ref<PendingPeer> ppeer = E;
 		Error err = ppeer->do_handshake(_protocols, handshake_timeout, resource_name);
 		if (err == ERR_BUSY) {
 			continue;
@@ -224,8 +224,8 @@ void WSLServer::poll() {
 		remove_peers.push_back(ppeer);
 		_on_connect(id, ppeer->protocol, resource_name);
 	}
-	for (List<Ref<PendingPeer>>::Element *E = remove_peers.front(); E; E = E->next()) {
-		_pending.erase(E->get());
+	for (Ref<PendingPeer> E : remove_peers) {
+		_pending.erase(E);
 	}
 	remove_peers.clear();
 

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -41,13 +41,13 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 	ERR_FAIL_COND_V(env == nullptr, false);
 
 	MethodInfo *method = nullptr;
-	for (List<MethodInfo>::Element *E = M->get().front(); E; E = E->next()) {
-		if (!p_instance && !E->get()._static) {
+	for (MethodInfo &E : M->get()) {
+		if (!p_instance && !E._static) {
 			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
 			continue;
 		}
 
-		int pc = E->get().param_types.size();
+		int pc = E.param_types.size();
 		if (pc > p_argcount) {
 			r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 			r_error.argument = pc;
@@ -58,7 +58,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 			r_error.argument = pc;
 			continue;
 		}
-		uint32_t *ptypes = E->get().param_types.ptrw();
+		uint32_t *ptypes = E.param_types.ptrw();
 		bool valid = true;
 
 		for (int i = 0; i < pc; i++) {
@@ -107,7 +107,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 							if (Object::cast_to<JavaObject>(ref.ptr())) {
 								Ref<JavaObject> jo = ref;
 								//could be faster
-								jclass c = env->FindClass(E->get().param_sigs[i].operator String().utf8().get_data());
+								jclass c = env->FindClass(E.param_sigs[i].operator String().utf8().get_data());
 								if (!c || !env->IsInstanceOf(jo->instance, c)) {
 									arg_expected = Variant::OBJECT;
 								} else {
@@ -138,7 +138,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 		if (!valid)
 			continue;
 
-		method = &E->get();
+		method = &E;
 		break;
 	}
 
@@ -474,8 +474,8 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 		} break;
 	}
 
-	for (List<jobject>::Element *E = to_free.front(); E; E = E->next()) {
-		env->DeleteLocalRef(E->get());
+	for (jobject &E : to_free) {
+		env->DeleteLocalRef(E);
 	}
 
 	return success;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -115,8 +115,8 @@ Error OS_JavaScript::execute(const String &p_path, const List<String> &p_argumen
 
 Error OS_JavaScript::create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id) {
 	Array args;
-	for (const List<String>::Element *E = p_arguments.front(); E; E = E->next()) {
-		args.push_back(E->get());
+	for (const String &E : p_arguments) {
+		args.push_back(E);
 	}
 	String json_args = Variant(args).to_json_string();
 	int failed = godot_js_os_execute(json_args.utf8().get_data());

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -411,8 +411,8 @@ String OS_Windows::_quote_command_line_argument(const String &p_text) const {
 Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments, String *r_pipe, int *r_exitcode, bool read_stderr, Mutex *p_pipe_mutex) {
 	String path = p_path.replace("/", "\\");
 	String command = _quote_command_line_argument(path);
-	for (const List<String>::Element *E = p_arguments.front(); E; E = E->next()) {
-		command += " " + _quote_command_line_argument(E->get());
+	for (const String &E : p_arguments) {
+		command += " " + _quote_command_line_argument(E);
 	}
 
 	if (r_pipe) {
@@ -467,8 +467,8 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 Error OS_Windows::create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id) {
 	String path = p_path.replace("/", "\\");
 	String command = _quote_command_line_argument(path);
-	for (const List<String>::Element *E = p_arguments.front(); E; E = E->next()) {
-		command += " " + _quote_command_line_argument(E->get());
+	for (const String &E : p_arguments) {
+		command += " " + _quote_command_line_argument(E);
 	}
 
 	ProcessInfo pi;

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -123,7 +123,7 @@ void AnimatedSprite2D::_validate_property(PropertyInfo &property) const {
 			}
 
 			property.hint_string += String(E->get());
-			if (animation == E->get()) {
+			if (animation == E) {
 				current_found = true;
 			}
 		}

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -145,8 +145,7 @@ TypedArray<PhysicsBody2D> PhysicsBody2D::get_collision_exceptions() {
 	List<RID> exceptions;
 	PhysicsServer2D::get_singleton()->body_get_collision_exceptions(get_rid(), &exceptions);
 	Array ret;
-	for (List<RID>::Element *E = exceptions.front(); E; E = E->next()) {
-		RID body = E->get();
+	for (RID body : exceptions) {
 		ObjectID instance_id = PhysicsServer2D::get_singleton()->body_get_object_instance_id(body);
 		Object *obj = ObjectDB::get_instance(instance_id);
 		PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(obj);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1596,8 +1596,8 @@ void TileMap::set_light_mask(int p_light_mask) {
 	// Occlusion: set light mask.
 	CanvasItem::set_light_mask(p_light_mask);
 	for (Map<Vector2i, TileMapQuadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
-		for (List<RID>::Element *F = E->get().canvas_items.front(); F; F = F->next()) {
-			RenderingServer::get_singleton()->canvas_item_set_light_mask(F->get(), get_light_mask());
+		for (RID F : E->get().canvas_items) {
+			RenderingServer::get_singleton()->canvas_item_set_light_mask(F, get_light_mask());
 		}
 	}
 }
@@ -1609,8 +1609,8 @@ void TileMap::set_material(const Ref<Material> &p_material) {
 	// Update material for the whole tilemap.
 	for (Map<Vector2i, TileMapQuadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
 		TileMapQuadrant &q = E->get();
-		for (List<RID>::Element *F = q.canvas_items.front(); F; F = F->next()) {
-			RS::get_singleton()->canvas_item_set_use_parent_material(F->get(), get_use_parent_material() || get_material().is_valid());
+		for (RID F : q.canvas_items) {
+			RS::get_singleton()->canvas_item_set_use_parent_material(F, get_use_parent_material() || get_material().is_valid());
 		}
 	}
 }
@@ -1622,8 +1622,8 @@ void TileMap::set_use_parent_material(bool p_use_parent_material) {
 	// Update use_parent_material for the whole tilemap.
 	for (Map<Vector2i, TileMapQuadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
 		TileMapQuadrant &q = E->get();
-		for (List<RID>::Element *F = q.canvas_items.front(); F; F = F->next()) {
-			RS::get_singleton()->canvas_item_set_use_parent_material(F->get(), get_use_parent_material() || get_material().is_valid());
+		for (RID F : q.canvas_items) {
+			RS::get_singleton()->canvas_item_set_use_parent_material(F, get_use_parent_material() || get_material().is_valid());
 		}
 	}
 }
@@ -1633,8 +1633,8 @@ void TileMap::set_texture_filter(TextureFilter p_texture_filter) {
 	CanvasItem::set_texture_filter(p_texture_filter);
 	for (Map<Vector2i, TileMapQuadrant>::Element *F = quadrant_map.front(); F; F = F->next()) {
 		TileMapQuadrant &q = F->get();
-		for (List<RID>::Element *E = q.canvas_items.front(); E; E = E->next()) {
-			RenderingServer::get_singleton()->canvas_item_set_default_texture_filter(E->get(), RS::CanvasItemTextureFilter(p_texture_filter));
+		for (RID E : q.canvas_items) {
+			RenderingServer::get_singleton()->canvas_item_set_default_texture_filter(E, RS::CanvasItemTextureFilter(p_texture_filter));
 			_make_quadrant_dirty(F);
 		}
 	}
@@ -1645,8 +1645,8 @@ void TileMap::set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) {
 	CanvasItem::set_texture_repeat(p_texture_repeat);
 	for (Map<Vector2i, TileMapQuadrant>::Element *F = quadrant_map.front(); F; F = F->next()) {
 		TileMapQuadrant &q = F->get();
-		for (List<RID>::Element *E = q.canvas_items.front(); E; E = E->next()) {
-			RenderingServer::get_singleton()->canvas_item_set_default_texture_repeat(E->get(), RS::CanvasItemTextureRepeat(p_texture_repeat));
+		for (RID E : q.canvas_items) {
+			RenderingServer::get_singleton()->canvas_item_set_default_texture_repeat(E, RS::CanvasItemTextureRepeat(p_texture_repeat));
 			_make_quadrant_dirty(F);
 		}
 	}

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -397,9 +397,7 @@ Ref<Image> GPUParticlesCollisionSDF::bake() {
 		bake_step_function(0, "Finding Meshes");
 	}
 
-	for (List<PlotMesh>::Element *E = plot_meshes.front(); E; E = E->next()) {
-		const PlotMesh &pm = E->get();
-
+	for (PlotMesh &pm : plot_meshes) {
 		for (int i = 0; i < pm.mesh->get_surface_count(); i++) {
 			if (pm.mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
 				continue; //only triangles

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -94,8 +94,8 @@ void MeshInstance3D::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	ls.sort();
 
-	for (List<String>::Element *E = ls.front(); E; E = E->next()) {
-		p_list->push_back(PropertyInfo(Variant::FLOAT, E->get(), PROPERTY_HINT_RANGE, "-1,1,0.00001"));
+	for (String &E : ls) {
+		p_list->push_back(PropertyInfo(Variant::FLOAT, E, PROPERTY_HINT_RANGE, "-1,1,0.00001"));
 	}
 
 	if (mesh.is_valid()) {

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -103,11 +103,11 @@ void Node3D::_propagate_transform_changed(Node3D *p_origin) {
 
 	data.children_lock++;
 
-	for (List<Node3D *>::Element *E = data.children.front(); E; E = E->next()) {
-		if (E->get()->data.top_level_active) {
+	for (Node3D *&E : data.children) {
+		if (E->data.top_level_active) {
 			continue; //don't propagate to a top_level
 		}
-		E->get()->_propagate_transform_changed(p_origin);
+		E->_propagate_transform_changed(p_origin);
 	}
 #ifdef TOOLS_ENABLED
 	if ((!data.gizmos.is_empty() || data.notify_transform) && !data.ignore_notification && !xform_change.in_list()) {
@@ -527,8 +527,7 @@ void Node3D::_propagate_visibility_changed() {
 	}
 #endif
 
-	for (List<Node3D *>::Element *E = data.children.front(); E; E = E->next()) {
-		Node3D *c = E->get();
+	for (Node3D *c : data.children) {
 		if (!c || !c->data.visible) {
 			continue;
 		}
@@ -753,8 +752,7 @@ void Node3D::_update_visibility_parent(bool p_update_root) {
 		RS::get_singleton()->instance_set_visibility_parent(vi->get_instance(), data.visibility_parent);
 	}
 
-	for (List<Node3D *>::Element *E = data.children.front(); E; E = E->next()) {
-		Node3D *c = E->get();
+	for (Node3D *c : data.children) {
 		c->_update_visibility_parent(false);
 	}
 }

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -78,8 +78,7 @@ TypedArray<PhysicsBody3D> PhysicsBody3D::get_collision_exceptions() {
 	List<RID> exceptions;
 	PhysicsServer3D::get_singleton()->body_get_collision_exceptions(get_rid(), &exceptions);
 	Array ret;
-	for (List<RID>::Element *E = exceptions.front(); E; E = E->next()) {
-		RID body = E->get();
+	for (RID body : exceptions) {
 		ObjectID instance_id = PhysicsServer3D::get_singleton()->body_get_object_instance_id(body);
 		Object *obj = ObjectDB::get_instance(instance_id);
 		PhysicsBody3D *physics_body = Object::cast_to<PhysicsBody3D>(obj);

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -264,8 +264,8 @@ void Skeleton3D::_notification(int p_what) {
 					b.global_pose_override_amount = 0.0;
 				}
 
-				for (List<ObjectID>::Element *E = b.nodes_bound.front(); E; E = E->next()) {
-					Object *obj = ObjectDB::get_instance(E->get());
+				for (ObjectID &E : b.nodes_bound) {
+					Object *obj = ObjectDB::get_instance(E);
 					ERR_CONTINUE(!obj);
 					Node3D *node_3d = Object::cast_to<Node3D>(obj);
 					ERR_CONTINUE(!node_3d);
@@ -524,8 +524,8 @@ void Skeleton3D::bind_child_node_to_bone(int p_bone, Node *p_node) {
 
 	ObjectID id = p_node->get_instance_id();
 
-	for (const List<ObjectID>::Element *E = bones[p_bone].nodes_bound.front(); E; E = E->next()) {
-		if (E->get() == id) {
+	for (const ObjectID &E : bones[p_bone].nodes_bound) {
+		if (E == id) {
 			return; // already here
 		}
 	}
@@ -544,8 +544,8 @@ void Skeleton3D::unbind_child_node_from_bone(int p_bone, Node *p_node) {
 void Skeleton3D::get_bound_child_nodes_to_bone(int p_bone, List<Node *> *p_bound) const {
 	ERR_FAIL_INDEX(p_bone, bones.size());
 
-	for (const List<ObjectID>::Element *E = bones[p_bone].nodes_bound.front(); E; E = E->next()) {
-		Object *obj = ObjectDB::get_instance(E->get());
+	for (const ObjectID &E : bones[p_bone].nodes_bound) {
+		Object *obj = ObjectDB::get_instance(E);
 		ERR_CONTINUE(!obj);
 		p_bound->push_back(Object::cast_to<Node>(obj));
 	}

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -592,8 +592,7 @@ Array SoftBody3D::get_collision_exceptions() {
 	List<RID> exceptions;
 	PhysicsServer3D::get_singleton()->soft_body_get_collision_exceptions(physics_rid, &exceptions);
 	Array ret;
-	for (List<RID>::Element *E = exceptions.front(); E; E = E->next()) {
-		RID body = E->get();
+	for (RID body : exceptions) {
 		ObjectID instance_id = PhysicsServer3D::get_singleton()->body_get_object_instance_id(body);
 		Object *obj = ObjectDB::get_instance(instance_id);
 		PhysicsBody3D *physics_body = Object::cast_to<PhysicsBody3D>(obj);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -60,8 +60,8 @@ void SpriteBase3D::_propagate_color_changed() {
 	color_dirty = true;
 	_queue_update();
 
-	for (List<SpriteBase3D *>::Element *E = children.front(); E; E = E->next()) {
-		E->get()->_propagate_color_changed();
+	for (SpriteBase3D *&E : children) {
+		E->_propagate_color_changed();
 	}
 }
 
@@ -996,7 +996,7 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &property) const {
 			}
 
 			property.hint_string += String(E->get());
-			if (animation == E->get()) {
+			if (animation == E) {
 				current_found = true;
 			}
 		}

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -238,8 +238,7 @@ bool GeometryInstance3D::_get(const StringName &p_name, Variant &r_ret) const {
 void GeometryInstance3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<PropertyInfo> pinfo;
 	RS::get_singleton()->instance_geometry_get_shader_parameter_list(get_instance(), &pinfo);
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		PropertyInfo pi = E->get();
+	for (PropertyInfo &pi : pinfo) {
 		bool has_def_value = false;
 		Variant def_value = RS::get_singleton()->instance_geometry_get_shader_parameter_default_value(get_instance(), pi.name);
 		if (def_value.get_type() != Variant::NIL) {

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -384,14 +384,14 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 
 	int pmc = 0;
 
-	for (List<PlotMesh>::Element *E = mesh_list.front(); E; E = E->next()) {
+	for (PlotMesh &E : mesh_list) {
 		if (bake_step_function) {
 			bake_step_function(pmc, RTR("Plotting Meshes") + " " + itos(pmc) + "/" + itos(mesh_list.size()));
 		}
 
 		pmc++;
 
-		baker.plot_mesh(E->get().local_xform, E->get().mesh, E->get().instance_materials, E->get().override_material);
+		baker.plot_mesh(E.local_xform, E.mesh, E.instance_materials, E.override_material);
 	}
 	if (bake_step_function) {
 		bake_step_function(pmc++, RTR("Finishing Plot"));

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1089,10 +1089,10 @@ bool AnimationNodeBlendTree::_get(const StringName &p_name, Variant &r_ret) cons
 		conns.resize(nc.size() * 3);
 
 		int idx = 0;
-		for (List<NodeConnection>::Element *E = nc.front(); E; E = E->next()) {
-			conns[idx * 3 + 0] = E->get().input_node;
-			conns[idx * 3 + 1] = E->get().input_index;
-			conns[idx * 3 + 2] = E->get().output_node;
+		for (NodeConnection &E : nc) {
+			conns[idx * 3 + 0] = E.input_node;
+			conns[idx * 3 + 1] = E.input_index;
+			conns[idx * 3 + 2] = E.output_node;
 			idx++;
 		}
 
@@ -1110,8 +1110,8 @@ void AnimationNodeBlendTree::_get_property_list(List<PropertyInfo> *p_list) cons
 	}
 	names.sort_custom<StringName::AlphCompare>();
 
-	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-		String name = E->get();
+	for (StringName &E : names) {
+		String name = E;
 		if (name != "output") {
 			p_list->push_back(PropertyInfo(Variant::OBJECT, "nodes/" + name + "/node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationNode", PROPERTY_USAGE_NOEDITOR));
 		}

--- a/scene/animation/animation_cache.cpp
+++ b/scene/animation/animation_cache.cpp
@@ -252,8 +252,8 @@ void AnimationCache::set_all(float p_time, float p_delta) {
 					List<int> indices;
 					animation->value_track_get_key_indices(i, p_time, p_delta, &indices);
 
-					for (List<int>::Element *E = indices.front(); E; E = E->next()) {
-						Variant v = animation->track_get_key_value(i, E->get());
+					for (int &E : indices) {
+						Variant v = animation->track_get_key_value(i, E);
 						set_track_value(i, v);
 					}
 				}
@@ -263,9 +263,9 @@ void AnimationCache::set_all(float p_time, float p_delta) {
 				List<int> indices;
 				animation->method_track_get_key_indices(i, p_time, p_delta, &indices);
 
-				for (List<int>::Element *E = indices.front(); E; E = E->next()) {
-					Vector<Variant> args = animation->method_track_get_params(i, E->get());
-					StringName name = animation->method_track_get_name(i, E->get());
+				for (int &E : indices) {
+					Vector<Variant> args = animation->method_track_get_params(i, E);
+					StringName name = animation->method_track_get_name(i, E);
 					Callable::CallError err;
 
 					if (!args.size()) {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -512,8 +512,8 @@ void AnimationNodeStateMachine::get_parameter_list(List<PropertyInfo> *r_list) c
 	}
 
 	advance_conditions.sort_custom<StringName::AlphCompare>();
-	for (List<StringName>::Element *E = advance_conditions.front(); E; E = E->next()) {
-		r_list->push_back(PropertyInfo(Variant::BOOL, E->get()));
+	for (StringName &E : advance_conditions) {
+		r_list->push_back(PropertyInfo(Variant::BOOL, E));
 	}
 }
 
@@ -679,8 +679,8 @@ void AnimationNodeStateMachine::get_node_list(List<StringName> *r_nodes) const {
 	}
 	nodes.sort_custom<StringName::AlphCompare>();
 
-	for (List<StringName>::Element *E = nodes.front(); E; E = E->next()) {
-		r_nodes->push_back(E->get());
+	for (StringName &E : nodes) {
+		r_nodes->push_back(E);
 	}
 }
 
@@ -902,8 +902,7 @@ void AnimationNodeStateMachine::_get_property_list(List<PropertyInfo> *p_list) c
 	}
 	names.sort_custom<StringName::AlphCompare>();
 
-	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-		String name = E->get();
+	for (StringName &name : names) {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "states/" + name + "/node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationNode", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, "states/" + name + "/position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	}

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -176,8 +176,8 @@ void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	anim_names.sort();
 
-	for (List<PropertyInfo>::Element *E = anim_names.front(); E; E = E->next()) {
-		p_list->push_back(E->get());
+	for (PropertyInfo &E : anim_names) {
+		p_list->push_back(E);
 	}
 
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "blend_times", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
@@ -485,8 +485,8 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 					List<int> indices;
 					a->value_track_get_key_indices(i, p_time, p_delta, &indices);
 
-					for (List<int>::Element *F = indices.front(); F; F = F->next()) {
-						Variant value = a->track_get_key_value(i, F->get());
+					for (int &F : indices) {
+						Variant value = a->track_get_key_value(i, F);
 						switch (pa->special) {
 							case SP_NONE: {
 								bool valid;
@@ -544,9 +544,9 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 
 				a->method_track_get_key_indices(i, p_time, p_delta, &indices);
 
-				for (List<int>::Element *E = indices.front(); E; E = E->next()) {
-					StringName method = a->method_track_get_name(i, E->get());
-					Vector<Variant> params = a->method_track_get_params(i, E->get());
+				for (int &E : indices) {
+					StringName method = a->method_track_get_name(i, E);
+					Vector<Variant> params = a->method_track_get_params(i, E);
 
 					int s = params.size();
 
@@ -1076,8 +1076,8 @@ void AnimationPlayer::get_animation_list(List<StringName> *p_animations) const {
 
 	anims.sort();
 
-	for (List<String>::Element *E = anims.front(); E; E = E->next()) {
-		p_animations->push_back(E->get());
+	for (String &E : anims) {
+		p_animations->push_back(E);
 	}
 }
 
@@ -1118,8 +1118,8 @@ void AnimationPlayer::queue(const StringName &p_name) {
 
 Vector<String> AnimationPlayer::get_queue() {
 	Vector<String> ret;
-	for (List<StringName>::Element *E = queued.front(); E; E = E->next()) {
-		ret.push_back(E->get());
+	for (StringName &E : queued) {
+		ret.push_back(E);
 	}
 
 	return ret;
@@ -1502,8 +1502,8 @@ void AnimationPlayer::get_argument_options(const StringName &p_function, int p_i
 	if (p_idx == 0 && (p_function == "play" || p_function == "play_backwards" || p_function == "remove_animation" || p_function == "has_animation" || p_function == "queue")) {
 		List<StringName> al;
 		get_animation_list(&al);
-		for (List<StringName>::Element *E = al.front(); E; E = E->next()) {
-			r_options->push_back(quote_style + String(E->get()) + quote_style);
+		for (StringName &E : al) {
+			r_options->push_back(quote_style + String(E) + quote_style);
 		}
 	}
 	Node::get_argument_options(p_function, p_idx, r_options);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -76,10 +76,10 @@ void AnimationNode::get_child_nodes(List<ChildNode> *r_child_nodes) {
 		Dictionary cn = get_script_instance()->call("_get_child_nodes");
 		List<Variant> keys;
 		cn.get_key_list(&keys);
-		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
+		for (Variant &E : keys) {
 			ChildNode child;
-			child.name = E->get();
-			child.node = cn[E->get()];
+			child.name = E;
+			child.node = cn[E];
 			r_child_nodes->push_back(child);
 		}
 	}
@@ -536,8 +536,8 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 	List<StringName> sname;
 	player->get_animation_list(&sname);
 
-	for (List<StringName>::Element *E = sname.front(); E; E = E->next()) {
-		Ref<Animation> anim = player->get_animation(E->get());
+	for (StringName &E : sname) {
+		Ref<Animation> anim = player->get_animation(E);
 		for (int i = 0; i < anim->get_track_count(); i++) {
 			NodePath path = anim->track_get_path(i);
 			Animation::TrackType track_type = anim->track_get_type(i);
@@ -561,7 +561,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 				Node *child = parent->get_node_and_resource(path, resource, leftover_path);
 
 				if (!child) {
-					ERR_PRINT("AnimationTree: '" + String(E->get()) + "', couldn't resolve track:  '" + String(path) + "'");
+					ERR_PRINT("AnimationTree: '" + String(E) + "', couldn't resolve track:  '" + String(path) + "'");
 					continue;
 				}
 
@@ -590,7 +590,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 						Node3D *node_3d = Object::cast_to<Node3D>(child);
 
 						if (!node_3d) {
-							ERR_PRINT("AnimationTree: '" + String(E->get()) + "', transform track does not point to Node3D:  '" + String(path) + "'");
+							ERR_PRINT("AnimationTree: '" + String(E) + "', transform track does not point to Node3D:  '" + String(path) + "'");
 							continue;
 						}
 
@@ -816,9 +816,7 @@ void AnimationTree::_process_graph(float p_delta) {
 	{
 		bool can_call = is_inside_tree() && !Engine::get_singleton()->is_editor_hint();
 
-		for (List<AnimationNode::AnimationState>::Element *E = state.animation_states.front(); E; E = E->next()) {
-			const AnimationNode::AnimationState &as = E->get();
-
+		for (AnimationNode::AnimationState &as : state.animation_states) {
 			Ref<Animation> a = as.animation;
 			float time = as.time;
 			float delta = as.delta;
@@ -962,8 +960,8 @@ void AnimationTree::_process_graph(float p_delta) {
 							List<int> indices;
 							a->value_track_get_key_indices(i, time, delta, &indices);
 
-							for (List<int>::Element *F = indices.front(); F; F = F->next()) {
-								Variant value = a->track_get_key_value(i, F->get());
+							for (int &F : indices) {
+								Variant value = a->track_get_key_value(i, F);
 								t->object->set_indexed(t->subpath, value);
 							}
 						}
@@ -979,9 +977,9 @@ void AnimationTree::_process_graph(float p_delta) {
 
 						a->method_track_get_key_indices(i, time, delta, &indices);
 
-						for (List<int>::Element *F = indices.front(); F; F = F->next()) {
-							StringName method = a->method_track_get_name(i, F->get());
-							Vector<Variant> params = a->method_track_get_params(i, F->get());
+						for (int &F : indices) {
+							StringName method = a->method_track_get_name(i, F);
+							Vector<Variant> params = a->method_track_get_params(i, F);
 
 							int s = params.size();
 
@@ -1355,9 +1353,7 @@ void AnimationTree::_update_properties_for_node(const String &p_base_path, Ref<A
 
 	List<PropertyInfo> plist;
 	node->get_parameter_list(&plist);
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		PropertyInfo pinfo = E->get();
-
+	for (PropertyInfo &pinfo : plist) {
 		StringName key = pinfo.name;
 
 		if (!property_map.has(p_base_path + key)) {
@@ -1373,8 +1369,8 @@ void AnimationTree::_update_properties_for_node(const String &p_base_path, Ref<A
 	List<AnimationNode::ChildNode> children;
 	node->get_child_nodes(&children);
 
-	for (List<AnimationNode::ChildNode>::Element *E = children.front(); E; E = E->next()) {
-		_update_properties_for_node(p_base_path + E->get().name + "/", E->get().node);
+	for (AnimationNode::ChildNode &E : children) {
+		_update_properties_for_node(p_base_path + E.name + "/", E.node);
 	}
 }
 
@@ -1428,17 +1424,17 @@ void AnimationTree::_get_property_list(List<PropertyInfo> *p_list) const {
 		const_cast<AnimationTree *>(this)->_update_properties();
 	}
 
-	for (const List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-		p_list->push_back(E->get());
+	for (const PropertyInfo &E : properties) {
+		p_list->push_back(E);
 	}
 }
 
 void AnimationTree::rename_parameter(const String &p_base, const String &p_new_base) {
 	//rename values first
-	for (const List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
-		if (E->get().name.begins_with(p_base)) {
-			String new_name = E->get().name.replace_first(p_base, p_new_base);
-			property_map[new_name] = property_map[E->get().name];
+	for (const PropertyInfo &E : properties) {
+		if (E.name.begins_with(p_base)) {
+			String new_name = E.name.replace_first(p_base, p_new_base);
+			property_map[new_name] = property_map[E.name];
 		}
 	}
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -46,8 +46,8 @@ void Tween::start_tweeners() {
 		ERR_FAIL_MSG("Tween without commands, aborting.");
 	}
 
-	for (List<Ref<Tweener>>::Element *E = tweeners.write[current_step].front(); E; E = E->next()) {
-		E->get()->start();
+	for (Ref<Tweener> E : tweeners.write[current_step]) {
+		E->start();
 	}
 }
 
@@ -253,11 +253,11 @@ bool Tween::step(float p_delta) {
 		float step_delta = rem_delta;
 		step_active = false;
 
-		for (List<Ref<Tweener>>::Element *E = tweeners.write[current_step].front(); E; E = E->next()) {
+		for (Ref<Tweener> E : tweeners.write[current_step]) {
 			// Modified inside Tweener.step().
 			float temp_delta = rem_delta;
 			// Turns to true if any Tweener returns true (i.e. is still not finished).
-			step_active = E->get()->step(temp_delta) || step_active;
+			step_active = E->step(temp_delta) || step_active;
 			step_delta = MIN(temp_delta, rem_delta);
 		}
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -292,9 +292,9 @@ SceneDebuggerObject::SceneDebuggerObject(ObjectID p_id) {
 	// Add base object properties.
 	List<PropertyInfo> pinfo;
 	obj->get_property_list(&pinfo, true);
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		if (E->get().usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CATEGORY)) {
-			properties.push_back(SceneDebuggerProperty(E->get(), obj->get(E->get().name)));
+	for (PropertyInfo &E : pinfo) {
+		if (E.usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CATEGORY)) {
+			properties.push_back(SceneDebuggerProperty(E, obj->get(E.name)));
 		}
 	}
 }
@@ -452,8 +452,7 @@ SceneDebuggerTree::SceneDebuggerTree(Node *p_root) {
 }
 
 void SceneDebuggerTree::serialize(Array &p_arr) {
-	for (List<RemoteNode>::Element *E = nodes.front(); E; E = E->next()) {
-		RemoteNode &n = E->get();
+	for (RemoteNode &n : nodes) {
 		p_arr.push_back(n.child_count);
 		p_arr.push_back(n.name);
 		p_arr.push_back(n.type_name);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2288,14 +2288,14 @@ void CodeEdit::_filter_code_completion_candidates() {
 		TypedArray<Dictionary> completion_options_sources;
 		completion_options_sources.resize(code_completion_option_sources.size());
 		int i = 0;
-		for (List<ScriptCodeCompletionOption>::Element *E = code_completion_option_sources.front(); E; E = E->next()) {
+		for (ScriptCodeCompletionOption &E : code_completion_option_sources) {
 			Dictionary option;
-			option["kind"] = E->get().kind;
-			option["display_text"] = E->get().display;
-			option["insert_text"] = E->get().insert_text;
-			option["font_color"] = E->get().font_color;
-			option["icon"] = E->get().icon;
-			option["default_value"] = E->get().default_value;
+			option["kind"] = E.kind;
+			option["display_text"] = E.display;
+			option["insert_text"] = E.insert_text;
+			option["font_color"] = E.font_color;
+			option["icon"] = E.icon;
+			option["default_value"] = E.default_value;
 			completion_options_sources[i] = option;
 			i++;
 		}
@@ -2406,9 +2406,7 @@ void CodeEdit::_filter_code_completion_candidates() {
 
 	int max_width = 0;
 	String string_to_complete_lower = string_to_complete.to_lower();
-	for (List<ScriptCodeCompletionOption>::Element *E = code_completion_option_sources.front(); E; E = E->next()) {
-		ScriptCodeCompletionOption &option = E->get();
-
+	for (ScriptCodeCompletionOption &option : code_completion_option_sources) {
 		if (single_quote && option.display.is_quoted()) {
 			option.display = option.display.unquote().quote("'");
 		}
@@ -2527,8 +2525,7 @@ void CodeEdit::_lines_edited_from(int p_from_line, int p_to_line) {
 	int line_count = (p_to_line - p_from_line);
 	List<int> breakpoints;
 	breakpointed_lines.get_key_list(&breakpoints);
-	for (const List<int>::Element *E = breakpoints.front(); E; E = E->next()) {
-		int line = E->get();
+	for (const int line : breakpoints) {
 		if (line <= from_line) {
 			continue;
 		}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -343,73 +343,73 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	{
 		List<StringName> names;
 		theme->get_icon_list(get_class_name(), &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		for (StringName &E : names) {
 			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (data.icon_override.has(E->get())) {
+			if (data.icon_override.has(E)) {
 				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_icons/" + E->get(), PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", usage));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_icons/" + E, PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", usage));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_stylebox_list(get_class_name(), &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		for (StringName &E : names) {
 			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (data.style_override.has(E->get())) {
+			if (data.style_override.has(E)) {
 				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_styles/" + E->get(), PROPERTY_HINT_RESOURCE_TYPE, "StyleBox", usage));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_styles/" + E, PROPERTY_HINT_RESOURCE_TYPE, "StyleBox", usage));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_font_list(get_class_name(), &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		for (StringName &E : names) {
 			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (data.font_override.has(E->get())) {
+			if (data.font_override.has(E)) {
 				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_fonts/" + E->get(), PROPERTY_HINT_RESOURCE_TYPE, "Font", usage));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_fonts/" + E, PROPERTY_HINT_RESOURCE_TYPE, "Font", usage));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_font_size_list(get_class_name(), &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		for (StringName &E : names) {
 			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (data.font_size_override.has(E->get())) {
+			if (data.font_size_override.has(E)) {
 				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::INT, "custom_font_sizes/" + E->get(), PROPERTY_HINT_NONE, "", usage));
+			p_list->push_back(PropertyInfo(Variant::INT, "custom_font_sizes/" + E, PROPERTY_HINT_NONE, "", usage));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_color_list(get_class_name(), &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		for (StringName &E : names) {
 			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (data.color_override.has(E->get())) {
+			if (data.color_override.has(E)) {
 				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::COLOR, "custom_colors/" + E->get(), PROPERTY_HINT_NONE, "", usage));
+			p_list->push_back(PropertyInfo(Variant::COLOR, "custom_colors/" + E, PROPERTY_HINT_NONE, "", usage));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_constant_list(get_class_name(), &names);
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		for (StringName &E : names) {
 			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (data.constant_override.has(E->get())) {
+			if (data.constant_override.has(E)) {
 				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::INT, "custom_constants/" + E->get(), PROPERTY_HINT_RANGE, "-16384,16384", usage));
+			p_list->push_back(PropertyInfo(Variant::INT, "custom_constants/" + E, PROPERTY_HINT_RANGE, "-16384,16384", usage));
 		}
 	}
 }
@@ -428,14 +428,14 @@ void Control::_validate_property(PropertyInfo &property) const {
 
 		Vector<StringName> unique_names;
 		String hint_string;
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		for (StringName &E : names) {
 			// Skip duplicate values.
-			if (unique_names.has(E->get())) {
+			if (unique_names.has(E)) {
 				continue;
 			}
 
-			hint_string += String(E->get()) + ",";
-			unique_names.append(E->get());
+			hint_string += String(E) + ",";
+			unique_names.append(E);
 		}
 
 		property.hint_string = hint_string;
@@ -793,13 +793,13 @@ T Control::get_theme_item_in_types(Control *p_theme_owner, Window *p_theme_owner
 	Window *theme_owner_window = p_theme_owner_window;
 
 	while (theme_owner || theme_owner_window) {
-		for (List<StringName>::Element *E = p_theme_types.front(); E; E = E->next()) {
-			if (theme_owner && theme_owner->data.theme->has_theme_item(p_data_type, p_name, E->get())) {
-				return theme_owner->data.theme->get_theme_item(p_data_type, p_name, E->get());
+		for (StringName &E : p_theme_types) {
+			if (theme_owner && theme_owner->data.theme->has_theme_item(p_data_type, p_name, E)) {
+				return theme_owner->data.theme->get_theme_item(p_data_type, p_name, E);
 			}
 
-			if (theme_owner_window && theme_owner_window->theme->has_theme_item(p_data_type, p_name, E->get())) {
-				return theme_owner_window->theme->get_theme_item(p_data_type, p_name, E->get());
+			if (theme_owner_window && theme_owner_window->theme->has_theme_item(p_data_type, p_name, E)) {
+				return theme_owner_window->theme->get_theme_item(p_data_type, p_name, E);
 			}
 		}
 
@@ -822,17 +822,17 @@ T Control::get_theme_item_in_types(Control *p_theme_owner, Window *p_theme_owner
 
 	// Secondly, check the project-defined Theme resource.
 	if (Theme::get_project_default().is_valid()) {
-		for (List<StringName>::Element *E = p_theme_types.front(); E; E = E->next()) {
-			if (Theme::get_project_default()->has_theme_item(p_data_type, p_name, E->get())) {
-				return Theme::get_project_default()->get_theme_item(p_data_type, p_name, E->get());
+		for (StringName &E : p_theme_types) {
+			if (Theme::get_project_default()->has_theme_item(p_data_type, p_name, E)) {
+				return Theme::get_project_default()->get_theme_item(p_data_type, p_name, E);
 			}
 		}
 	}
 
 	// Lastly, fall back on the items defined in the default Theme, if they exist.
-	for (List<StringName>::Element *E = p_theme_types.front(); E; E = E->next()) {
-		if (Theme::get_default()->has_theme_item(p_data_type, p_name, E->get())) {
-			return Theme::get_default()->get_theme_item(p_data_type, p_name, E->get());
+	for (StringName &E : p_theme_types) {
+		if (Theme::get_default()->has_theme_item(p_data_type, p_name, E)) {
+			return Theme::get_default()->get_theme_item(p_data_type, p_name, E);
 		}
 	}
 	// If they don't exist, use any type to return the default/empty value.
@@ -848,12 +848,12 @@ bool Control::has_theme_item_in_types(Control *p_theme_owner, Window *p_theme_ow
 	Window *theme_owner_window = p_theme_owner_window;
 
 	while (theme_owner || theme_owner_window) {
-		for (List<StringName>::Element *E = p_theme_types.front(); E; E = E->next()) {
-			if (theme_owner && theme_owner->data.theme->has_theme_item(p_data_type, p_name, E->get())) {
+		for (StringName &E : p_theme_types) {
+			if (theme_owner && theme_owner->data.theme->has_theme_item(p_data_type, p_name, E)) {
 				return true;
 			}
 
-			if (theme_owner_window && theme_owner_window->theme->has_theme_item(p_data_type, p_name, E->get())) {
+			if (theme_owner_window && theme_owner_window->theme->has_theme_item(p_data_type, p_name, E)) {
 				return true;
 			}
 		}
@@ -877,16 +877,16 @@ bool Control::has_theme_item_in_types(Control *p_theme_owner, Window *p_theme_ow
 
 	// Secondly, check the project-defined Theme resource.
 	if (Theme::get_project_default().is_valid()) {
-		for (List<StringName>::Element *E = p_theme_types.front(); E; E = E->next()) {
-			if (Theme::get_project_default()->has_theme_item(p_data_type, p_name, E->get())) {
+		for (StringName &E : p_theme_types) {
+			if (Theme::get_project_default()->has_theme_item(p_data_type, p_name, E)) {
 				return true;
 			}
 		}
 	}
 
 	// Lastly, fall back on the items defined in the default Theme, if they exist.
-	for (List<StringName>::Element *E = p_theme_types.front(); E; E = E->next()) {
-		if (Theme::get_default()->has_theme_item(p_data_type, p_name, E->get())) {
+	for (StringName &E : p_theme_types) {
+		if (Theme::get_default()->has_theme_item(p_data_type, p_name, E)) {
 			return true;
 		}
 	}
@@ -2580,8 +2580,8 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 		}
 
 		sn.sort_custom<StringName::AlphCompare>();
-		for (List<StringName>::Element *E = sn.front(); E; E = E->next()) {
-			r_options->push_back(quote_style + E->get() + quote_style);
+		for (StringName &E : sn) {
+			r_options->push_back(quote_style + E + quote_style);
 		}
 	}
 }

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -552,9 +552,9 @@ void FileDialog::update_file_list() {
 		bool match = patterns.is_empty();
 		String match_str;
 
-		for (List<String>::Element *E = patterns.front(); E; E = E->next()) {
-			if (files.front()->get().matchn(E->get())) {
-				match_str = E->get();
+		for (String &E : patterns) {
+			if (files.front()->get().matchn(E)) {
+				match_str = E;
 				match = true;
 				break;
 			}

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -217,8 +217,8 @@ Error GraphEdit::connect_node(const StringName &p_from, int p_from_port, const S
 }
 
 bool GraphEdit::is_node_connected(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port) {
-	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
-		if (E->get().from == p_from && E->get().from_port == p_from_port && E->get().to == p_to && E->get().to_port == p_to_port) {
+	for (Connection &E : connections) {
+		if (E.from == p_from && E.from_port == p_from_port && E.to == p_to && E.to_port == p_to_port) {
 			return true;
 		}
 	}
@@ -227,7 +227,7 @@ bool GraphEdit::is_node_connected(const StringName &p_from, int p_from_port, con
 }
 
 void GraphEdit::disconnect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port) {
-	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
+	for (const List<Connection>::Element *E = connections.front(); E; E = E->next()) {
 		if (E->get().from == p_from && E->get().from_port == p_from_port && E->get().to == p_to && E->get().to_port == p_to_port) {
 			connections.erase(E);
 			top_layer->update();
@@ -561,20 +561,20 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 				if (is_in_hot_zone(pos / zoom, click_pos)) {
 					if (valid_left_disconnect_types.has(gn->get_connection_output_type(j))) {
 						//check disconnect
-						for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
-							if (E->get().from == gn->get_name() && E->get().from_port == j) {
-								Node *to = get_node(String(E->get().to));
+						for (Connection &E : connections) {
+							if (E.from == gn->get_name() && E.from_port == j) {
+								Node *to = get_node(String(E.to));
 								if (Object::cast_to<GraphNode>(to)) {
-									connecting_from = E->get().to;
-									connecting_index = E->get().to_port;
+									connecting_from = E.to;
+									connecting_index = E.to_port;
 									connecting_out = false;
-									connecting_type = Object::cast_to<GraphNode>(to)->get_connection_input_type(E->get().to_port);
-									connecting_color = Object::cast_to<GraphNode>(to)->get_connection_input_color(E->get().to_port);
+									connecting_type = Object::cast_to<GraphNode>(to)->get_connection_input_type(E.to_port);
+									connecting_color = Object::cast_to<GraphNode>(to)->get_connection_input_color(E.to_port);
 									connecting_target = false;
 									connecting_to = pos;
 									just_disconnected = true;
 
-									emit_signal(SNAME("disconnection_request"), E->get().from, E->get().from_port, E->get().to, E->get().to_port);
+									emit_signal(SNAME("disconnection_request"), E.from, E.from_port, E.to, E.to_port);
 									to = get_node(String(connecting_from)); //maybe it was erased
 									if (Object::cast_to<GraphNode>(to)) {
 										connecting = true;
@@ -603,20 +603,20 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 				if (is_in_hot_zone(pos / zoom, click_pos)) {
 					if (right_disconnects || valid_right_disconnect_types.has(gn->get_connection_input_type(j))) {
 						//check disconnect
-						for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
-							if (E->get().to == gn->get_name() && E->get().to_port == j) {
-								Node *fr = get_node(String(E->get().from));
+						for (Connection &E : connections) {
+							if (E.to == gn->get_name() && E.to_port == j) {
+								Node *fr = get_node(String(E.from));
 								if (Object::cast_to<GraphNode>(fr)) {
-									connecting_from = E->get().from;
-									connecting_index = E->get().from_port;
+									connecting_from = E.from;
+									connecting_index = E.from_port;
 									connecting_out = true;
-									connecting_type = Object::cast_to<GraphNode>(fr)->get_connection_output_type(E->get().from_port);
-									connecting_color = Object::cast_to<GraphNode>(fr)->get_connection_output_color(E->get().from_port);
+									connecting_type = Object::cast_to<GraphNode>(fr)->get_connection_output_type(E.from_port);
+									connecting_color = Object::cast_to<GraphNode>(fr)->get_connection_output_color(E.from_port);
 									connecting_target = false;
 									connecting_to = pos;
 									just_disconnected = true;
 
-									emit_signal(SNAME("disconnection_request"), E->get().from, E->get().from_port, E->get().to, E->get().to_port);
+									emit_signal(SNAME("disconnection_request"), E.from, E.from_port, E.to, E.to_port);
 									fr = get_node(String(connecting_from)); //maybe it was erased
 									if (Object::cast_to<GraphNode>(fr)) {
 										connecting = true;
@@ -1001,8 +1001,8 @@ void GraphEdit::_minimap_draw() {
 
 	// Draw node connections.
 	Color activity_color = get_theme_color(SNAME("activity"));
-	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
-		NodePath fromnp(E->get().from);
+	for (Connection &E : connections) {
+		NodePath fromnp(E.from);
 
 		Node *from = get_node(fromnp);
 		if (!from) {
@@ -1013,7 +1013,7 @@ void GraphEdit::_minimap_draw() {
 			continue;
 		}
 
-		NodePath tonp(E->get().to);
+		NodePath tonp(E.to);
 		Node *to = get_node(tonp);
 		if (!to) {
 			continue;
@@ -1023,16 +1023,16 @@ void GraphEdit::_minimap_draw() {
 			continue;
 		}
 
-		Vector2 from_slot_position = gfrom->get_position_offset() * zoom + gfrom->get_connection_output_position(E->get().from_port);
+		Vector2 from_slot_position = gfrom->get_position_offset() * zoom + gfrom->get_connection_output_position(E.from_port);
 		Vector2 from_position = minimap->_convert_from_graph_position(from_slot_position - graph_offset) + minimap_offset;
-		Color from_color = gfrom->get_connection_output_color(E->get().from_port);
-		Vector2 to_slot_position = gto->get_position_offset() * zoom + gto->get_connection_input_position(E->get().to_port);
+		Color from_color = gfrom->get_connection_output_color(E.from_port);
+		Vector2 to_slot_position = gto->get_position_offset() * zoom + gto->get_connection_input_position(E.to_port);
 		Vector2 to_position = minimap->_convert_from_graph_position(to_slot_position - graph_offset) + minimap_offset;
-		Color to_color = gto->get_connection_input_color(E->get().to_port);
+		Color to_color = gto->get_connection_input_color(E.to_port);
 
-		if (E->get().activity > 0) {
-			from_color = from_color.lerp(activity_color, E->get().activity);
-			to_color = to_color.lerp(activity_color, E->get().activity);
+		if (E.activity > 0) {
+			from_color = from_color.lerp(activity_color, E.activity);
+			to_color = to_color.lerp(activity_color, E.activity);
 		}
 		_draw_cos_line(minimap, from_position, to_position, from_color, to_color, 1.0, 0.5);
 	}
@@ -1360,15 +1360,15 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 }
 
 void GraphEdit::set_connection_activity(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port, float p_activity) {
-	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
-		if (E->get().from == p_from && E->get().from_port == p_from_port && E->get().to == p_to && E->get().to_port == p_to_port) {
-			if (Math::is_equal_approx(E->get().activity, p_activity)) {
+	for (Connection &E : connections) {
+		if (E.from == p_from && E.from_port == p_from_port && E.to == p_to && E.to_port == p_to_port) {
+			if (Math::is_equal_approx(E.activity, p_activity)) {
 				//update only if changed
 				top_layer->update();
 				minimap->update();
 				connections_layer->update();
 			}
-			E->get().activity = p_activity;
+			E.activity = p_activity;
 			return;
 		}
 	}
@@ -1500,12 +1500,12 @@ Array GraphEdit::_get_connection_list() const {
 	List<Connection> conns;
 	get_connection_list(&conns);
 	Array arr;
-	for (List<Connection>::Element *E = conns.front(); E; E = E->next()) {
+	for (Connection &E : conns) {
 		Dictionary d;
-		d["from"] = E->get().from;
-		d["from_port"] = E->get().from_port;
-		d["to"] = E->get().to;
-		d["to_port"] = E->get().to_port;
+		d["from"] = E.from;
+		d["from_port"] = E.from_port;
+		d["to"] = E.to;
+		d["to_port"] = E.to_port;
 		arr.push_back(d);
 	}
 	return arr;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -397,8 +397,8 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseMotion> m = p_event;
 
 	if (m.is_valid()) {
-		for (List<Rect2>::Element *E = autohide_areas.front(); E; E = E->next()) {
-			if (!Rect2(Point2(), get_size()).has_point(m->get_position()) && E->get().has_point(m->get_position())) {
+		for (Rect2 &E : autohide_areas) {
+			if (!Rect2(Point2(), get_size()).has_point(m->get_position()) && E.has_point(m->get_position())) {
 				_close_pressed();
 				return;
 			}
@@ -751,8 +751,8 @@ void PopupMenu::_notification(int p_what) {
 				Point2 mouse_pos = DisplayServer::get_singleton()->mouse_get_position();
 				mouse_pos -= get_position();
 
-				for (List<Rect2>::Element *E = autohide_areas.front(); E; E = E->next()) {
-					if (!Rect2(Point2(), get_size()).has_point(mouse_pos) && E->get().has_point(mouse_pos)) {
+				for (Rect2 &E : autohide_areas) {
+					if (!Rect2(Point2(), get_size()).has_point(mouse_pos) && E.has_point(mouse_pos)) {
 						_close_pressed();
 						return;
 					}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -238,9 +238,9 @@ void RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				}
 
 				int idx = 0;
-				for (List<Item *>::Element *E = table->subitems.front(); E; E = E->next()) {
-					ERR_CONTINUE(E->get()->type != ITEM_FRAME); // Children should all be frames.
-					ItemFrame *frame = static_cast<ItemFrame *>(E->get());
+				for (Item *E : table->subitems) {
+					ERR_CONTINUE(E->type != ITEM_FRAME); // Children should all be frames.
+					ItemFrame *frame = static_cast<ItemFrame *>(E);
 					for (int i = 0; i < frame->lines.size(); i++) {
 						_resize_line(frame, i, p_base_font, p_base_font_size, 1);
 					}
@@ -316,9 +316,9 @@ void RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				Vector2 offset;
 				float row_height = 0.0;
 
-				for (List<Item *>::Element *E = table->subitems.front(); E; E = E->next()) {
-					ERR_CONTINUE(E->get()->type != ITEM_FRAME); // Children should all be frames.
-					ItemFrame *frame = static_cast<ItemFrame *>(E->get());
+				for (Item *E : table->subitems) {
+					ERR_CONTINUE(E->type != ITEM_FRAME); // Children should all be frames.
+					ItemFrame *frame = static_cast<ItemFrame *>(E);
 
 					int column = idx % col_count;
 
@@ -472,9 +472,9 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 				const int available_width = p_width - hseparation * (col_count - 1);
 
 				int idx = 0;
-				for (List<Item *>::Element *E = table->subitems.front(); E; E = E->next()) {
-					ERR_CONTINUE(E->get()->type != ITEM_FRAME); // Children should all be frames.
-					ItemFrame *frame = static_cast<ItemFrame *>(E->get());
+				for (Item *E : table->subitems) {
+					ERR_CONTINUE(E->type != ITEM_FRAME); // Children should all be frames.
+					ItemFrame *frame = static_cast<ItemFrame *>(E);
 
 					int column = idx % col_count;
 					for (int i = 0; i < frame->lines.size(); i++) {
@@ -556,7 +556,7 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 				Vector2 offset;
 				float row_height = 0.0;
 
-				for (List<Item *>::Element *E = table->subitems.front(); E; E = E->next()) {
+				for (const List<Item *>::Element *E = table->subitems.front(); E; E = E->next()) {
 					ERR_CONTINUE(E->get()->type != ITEM_FRAME); // Children should all be frames.
 					ItemFrame *frame = static_cast<ItemFrame *>(E->get());
 
@@ -783,8 +783,8 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 						int row_count = table->rows.size();
 
 						int idx = 0;
-						for (List<Item *>::Element *E = table->subitems.front(); E; E = E->next()) {
-							ItemFrame *frame = static_cast<ItemFrame *>(E->get());
+						for (Item *E : table->subitems) {
+							ItemFrame *frame = static_cast<ItemFrame *>(E);
 
 							int col = idx % col_count;
 							int row = idx / col_count;
@@ -1203,8 +1203,8 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 							int col_count = table->columns.size();
 							int row_count = table->rows.size();
 
-							for (List<Item *>::Element *E = table->subitems.front(); E; E = E->next()) {
-								ItemFrame *frame = static_cast<ItemFrame *>(E->get());
+							for (Item *E : table->subitems) {
+								ItemFrame *frame = static_cast<ItemFrame *>(E);
 
 								int col = idx % col_count;
 								int row = idx / col_count;
@@ -2080,8 +2080,8 @@ bool RichTextLabel::_find_layout_subitem(Item *from, Item *to) {
 			return true;
 		}
 
-		for (List<Item *>::Element *E = from->subitems.front(); E; E = E->next()) {
-			bool layout = _find_layout_subitem(E->get(), to);
+		for (Item *E : from->subitems) {
+			bool layout = _find_layout_subitem(E, to);
 
 			if (layout) {
 				return true;
@@ -3448,8 +3448,8 @@ Error RichTextLabel::append_bbcode(const String &p_bbcode) {
 	}
 
 	Vector<ItemFX *> fx_items;
-	for (List<Item *>::Element *E = main->subitems.front(); E; E = E->next()) {
-		Item *subitem = static_cast<Item *>(E->get());
+	for (Item *E : main->subitems) {
+		Item *subitem = static_cast<Item *>(E);
 		_fetch_item_fx_stack(subitem, fx_items);
 
 		if (fx_items.size()) {
@@ -3719,9 +3719,9 @@ String RichTextLabel::_get_line_text(ItemFrame *p_frame, int p_line, Selection p
 				ItemTable *table = static_cast<ItemTable *>(it);
 				int idx = 0;
 				int col_count = table->columns.size();
-				for (List<Item *>::Element *E = table->subitems.front(); E; E = E->next()) {
-					ERR_CONTINUE(E->get()->type != ITEM_FRAME); // Children should all be frames.
-					ItemFrame *frame = static_cast<ItemFrame *>(E->get());
+				for (Item *E : table->subitems) {
+					ERR_CONTINUE(E->type != ITEM_FRAME); // Children should all be frames.
+					ItemFrame *frame = static_cast<ItemFrame *>(E);
 					int column = idx % col_count;
 
 					for (int i = 0; i < frame->lines.size(); i++) {

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -956,8 +956,7 @@ void CanvasItem::_notify_transform(CanvasItem *p_node) {
 		}
 	}
 
-	for (List<CanvasItem *>::Element *E = p_node->children_items.front(); E; E = E->next()) {
-		CanvasItem *ci = E->get();
+	for (CanvasItem *ci : p_node->children_items) {
 		if (ci->top_level) {
 			continue;
 		}
@@ -1334,9 +1333,9 @@ void CanvasItem::_update_texture_filter_changed(bool p_propagate) {
 	update();
 
 	if (p_propagate) {
-		for (List<CanvasItem *>::Element *E = children_items.front(); E; E = E->next()) {
-			if (!E->get()->top_level && E->get()->texture_filter == TEXTURE_FILTER_PARENT_NODE) {
-				E->get()->_update_texture_filter_changed(true);
+		for (CanvasItem *E : children_items) {
+			if (!E->top_level && E->texture_filter == TEXTURE_FILTER_PARENT_NODE) {
+				E->_update_texture_filter_changed(true);
 			}
 		}
 	}
@@ -1374,9 +1373,9 @@ void CanvasItem::_update_texture_repeat_changed(bool p_propagate) {
 	RS::get_singleton()->canvas_item_set_default_texture_repeat(get_canvas_item(), texture_repeat_cache);
 	update();
 	if (p_propagate) {
-		for (List<CanvasItem *>::Element *E = children_items.front(); E; E = E->next()) {
-			if (!E->get()->top_level && E->get()->texture_repeat == TEXTURE_REPEAT_PARENT_NODE) {
-				E->get()->_update_texture_repeat_changed(true);
+		for (CanvasItem *E : children_items) {
+			if (!E->top_level && E->texture_repeat == TEXTURE_REPEAT_PARENT_NODE) {
+				E->_update_texture_repeat_changed(true);
 			}
 		}
 	}

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -220,8 +220,8 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 	client->get_response_headers(&rheaders);
 	response_headers.resize(0);
 	downloaded.set(0);
-	for (List<String>::Element *E = rheaders.front(); E; E = E->next()) {
-		response_headers.push_back(E->get());
+	for (String &E : rheaders) {
+		response_headers.push_back(E);
 	}
 
 	if (response_code == 301 || response_code == 302) {
@@ -235,9 +235,9 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 
 		String new_request;
 
-		for (List<String>::Element *E = rheaders.front(); E; E = E->next()) {
-			if (E->get().findn("Location: ") != -1) {
-				new_request = E->get().substr(9, E->get().length()).strip_edges();
+		for (String &E : rheaders) {
+			if (E.findn("Location: ") != -1) {
+				new_request = E.substr(9, E.length()).strip_edges();
 			}
 		}
 

--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -42,9 +42,9 @@ bool InstancePlaceholder::_set(const StringName &p_name, const Variant &p_value)
 }
 
 bool InstancePlaceholder::_get(const StringName &p_name, Variant &r_ret) const {
-	for (const List<PropSet>::Element *E = stored_values.front(); E; E = E->next()) {
-		if (E->get().name == p_name) {
-			r_ret = E->get().value;
+	for (const PropSet &E : stored_values) {
+		if (E.name == p_name) {
+			r_ret = E.value;
 			return true;
 		}
 	}
@@ -52,10 +52,10 @@ bool InstancePlaceholder::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void InstancePlaceholder::_get_property_list(List<PropertyInfo> *p_list) const {
-	for (const List<PropSet>::Element *E = stored_values.front(); E; E = E->next()) {
+	for (const PropSet &E : stored_values) {
 		PropertyInfo pi;
-		pi.name = E->get().name;
-		pi.type = E->get().value.get_type();
+		pi.name = E.name;
+		pi.type = E.value.get_type();
 		pi.usage = PROPERTY_USAGE_STORAGE;
 
 		p_list->push_back(pi);
@@ -95,8 +95,8 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 	scene->set_name(get_name());
 	int pos = get_index();
 
-	for (List<PropSet>::Element *E = stored_values.front(); E; E = E->next()) {
-		scene->set(E->get().name, E->get().value);
+	for (PropSet &E : stored_values) {
+		scene->set(E.name, E.value);
 	}
 
 	if (p_replace) {
@@ -114,10 +114,10 @@ Dictionary InstancePlaceholder::get_stored_values(bool p_with_order) {
 	Dictionary ret;
 	PackedStringArray order;
 
-	for (List<PropSet>::Element *E = stored_values.front(); E; E = E->next()) {
-		ret[E->get().name] = E->get().value;
+	for (PropSet &E : stored_values) {
+		ret[E.name] = E.value;
 		if (p_with_order) {
-			order.push_back(E->get().name);
+			order.push_back(E.name);
 		}
 	};
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -94,8 +94,7 @@ void SceneTreeTimer::release_connections() {
 	List<Connection> connections;
 	get_all_signal_connections(&connections);
 
-	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
-		Connection const &connection = E->get();
+	for (Connection &connection : connections) {
 		disconnect(connection.signal.get_name(), connection.callable);
 	}
 }
@@ -572,8 +571,8 @@ void SceneTree::finalize() {
 	}
 
 	// cleanup timers
-	for (List<Ref<SceneTreeTimer>>::Element *E = timers.front(); E; E = E->next()) {
-		E->get()->release_connections();
+	for (Ref<SceneTreeTimer> E : timers) {
+		E->release_connections();
 	}
 	timers.clear();
 }
@@ -1147,8 +1146,8 @@ Array SceneTree::get_processed_tweens() {
 	ret.resize(tweens.size());
 
 	int i = 0;
-	for (List<Ref<Tween>>::Element *E = tweens.front(); E; E = E->next()) {
-		ret[i] = E->get();
+	for (Ref<Tween> E : tweens) {
+		ret[i] = E;
 		i++;
 	}
 
@@ -1403,11 +1402,11 @@ SceneTree::SceneTree() {
 		List<String> exts;
 		ResourceLoader::get_recognized_extensions_for_type("Environment", &exts);
 		String ext_hint;
-		for (List<String>::Element *E = exts.front(); E; E = E->next()) {
+		for (String &E : exts) {
 			if (ext_hint != String()) {
 				ext_hint += ",";
 			}
-			ext_hint += "*." + E->get();
+			ext_hint += "*." + E;
 		}
 		// Get path.
 		String env_path = GLOBAL_DEF("rendering/environment/defaults/default_environment", "");

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -573,8 +573,7 @@ void Viewport::_process_picking() {
 		// if no mouse event exists, create a motion one. This is necessary because objects or camera may have moved.
 		// while this extra event is sent, it is checked if both camera and last object and last ID did not move. If nothing changed, the event is discarded to avoid flooding with unnecessary motion events every frame
 		bool has_mouse_event = false;
-		for (List<Ref<InputEvent>>::Element *E = physics_picking_events.front(); E; E = E->next()) {
-			Ref<InputEventMouse> m = E->get();
+		for (Ref<InputEvent> m : physics_picking_events) {
 			if (m.is_valid()) {
 				has_mouse_event = true;
 				break;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1356,14 +1356,14 @@ void Window::_validate_property(PropertyInfo &property) const {
 
 		Vector<StringName> unique_names;
 		String hint_string;
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		for (StringName &E : names) {
 			// Skip duplicate values.
-			if (unique_names.has(E->get())) {
+			if (unique_names.has(E)) {
 				continue;
 			}
 
-			hint_string += String(E->get()) + ",";
-			unique_names.append(E->get());
+			hint_string += String(E) + ",";
+			unique_names.append(E);
 		}
 
 		property.hint_string = hint_string;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -228,8 +228,8 @@ private:
 		value_track_get_key_indices(p_track, p_time, p_delta, &idxs);
 		Vector<int> idxr;
 
-		for (List<int>::Element *E = idxs.front(); E; E = E->next()) {
-			idxr.push_back(E->get());
+		for (int &E : idxs) {
+			idxr.push_back(E);
 		}
 		return idxr;
 	}
@@ -238,8 +238,8 @@ private:
 		method_track_get_key_indices(p_track, p_time, p_delta, &idxs);
 		Vector<int> idxr;
 
-		for (List<int>::Element *E = idxs.front(); E; E = E->next()) {
-			idxr.push_back(E->get());
+		for (int &E : idxs) {
+			idxr.push_back(E);
 		}
 		return idxr;
 	}

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -729,8 +729,8 @@ void Curve2D::_bake() const {
 	Vector2 *w = baked_point_cache.ptrw();
 	int idx = 0;
 
-	for (List<Vector2>::Element *E = pointlist.front(); E; E = E->next()) {
-		w[idx] = E->get();
+	for (Vector2 &E : pointlist) {
+		w[idx] = E;
 		idx++;
 	}
 }
@@ -1239,9 +1239,9 @@ void Curve3D::_bake() const {
 	Vector3 prev_up = Vector3(0, 1, 0);
 	Vector3 prev_forward = Vector3(0, 0, 1);
 
-	for (List<Plane>::Element *E = pointlist.front(); E; E = E->next()) {
-		w[idx] = E->get().normal;
-		wt[idx] = E->get().d;
+	for (Plane &E : pointlist) {
+		w[idx] = E.normal;
+		wt[idx] = E.d;
 
 		if (!up_vector_enabled) {
 			idx++;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -278,8 +278,8 @@ void ShaderMaterial::get_argument_options(const StringName &p_function, int p_id
 		if (shader.is_valid()) {
 			List<PropertyInfo> pl;
 			shader->get_param_list(&pl);
-			for (List<PropertyInfo>::Element *E = pl.front(); E; E = E->next()) {
-				r_options->push_back(quote_style + E->get().name.replace_first("shader_param/", "") + quote_style);
+			for (PropertyInfo &E : pl) {
+				r_options->push_back(quote_style + E.name.replace_first("shader_param/", "") + quote_style);
 			}
 		}
 	}

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -329,9 +329,7 @@ Ref<Mesh> NavigationMesh::get_debug_mesh() {
 		Vector3 *tw = tmeshfaces.ptrw();
 		int tidx = 0;
 
-		for (List<Face3>::Element *E = faces.front(); E; E = E->next()) {
-			const Face3 &f = E->get();
-
+		for (Face3 &f : faces) {
 			for (int j = 0; j < 3; j++) {
 				tw[tidx++] = f.vertex[j];
 				_EdgeKey ek;
@@ -366,8 +364,8 @@ Ref<Mesh> NavigationMesh::get_debug_mesh() {
 	{
 		Vector3 *w = varr.ptrw();
 		int idx = 0;
-		for (List<Vector3>::Element *E = lines.front(); E; E = E->next()) {
-			w[idx++] = E->get();
+		for (Vector3 &E : lines) {
+			w[idx++] = E;
 		}
 	}
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -206,8 +206,8 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 						node->set(snames[nprops[j].name], props[nprops[j].value], &valid);
 
 						//restore old state for new script, if exists
-						for (List<Pair<StringName, Variant>>::Element *E = old_state.front(); E; E = E->next()) {
-							node->set(E->get().first, E->get().second);
+						for (Pair<StringName, Variant> &E : old_state) {
+							node->set(E.first, E.second);
 						}
 					} else {
 						Variant value = props[nprops[j].value];
@@ -477,13 +477,13 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 		script->update_exports();
 	}
 
-	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-		if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+	for (PropertyInfo &E : plist) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 			continue;
 		}
 
-		String name = E->get().name;
-		Variant value = p_node->get(E->get().name);
+		String name = E.name;
+		Variant value = p_node->get(E.name);
 
 		bool isdefault = false;
 		Variant default_value = ClassDB::class_get_default_property_value(type, name);
@@ -497,7 +497,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 		}
 		// the version above makes more sense, because it does not rely on placeholder or usage flag
 		// in the script, just the default value function.
-		// if (E->get().usage & PROPERTY_USAGE_SCRIPT_DEFAULT_VALUE) {
+		// if (E.usage & PROPERTY_USAGE_SCRIPT_DEFAULT_VALUE) {
 		// 	isdefault = true; //is script default value
 		// }
 
@@ -507,7 +507,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 			// only save what has been changed
 			// only save changed properties in instance
 
-			if ((E->get().usage & PROPERTY_USAGE_NO_INSTANCE_STATE) || E->get().name == "__meta__") {
+			if ((E.usage & PROPERTY_USAGE_NO_INSTANCE_STATE) || E.name == "__meta__") {
 				//property has requested that no instance state is saved, sorry
 				//also, meta won't be overridden or saved
 				continue;
@@ -520,7 +520,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 				//check all levels of pack to see if the property exists somewhere
 				const PackState &ps = F->get();
 
-				original = ps.state->get_property_value(ps.node, E->get().name, exists);
+				original = ps.state->get_property_value(ps.node, E.name, exists);
 				if (exists) {
 					break;
 				}
@@ -565,9 +565,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 
 	List<Node::GroupInfo> groups;
 	p_node->get_groups(&groups);
-	for (List<Node::GroupInfo>::Element *E = groups.front(); E; E = E->next()) {
-		Node::GroupInfo &gi = E->get();
-
+	for (Node::GroupInfo &gi : groups) {
 		if (!gi.persistent) {
 			continue;
 		}
@@ -577,9 +575,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 		*/
 
 		bool skip = false;
-		for (List<PackState>::Element *F = pack_state_stack.front(); F; F = F->next()) {
+		for (PackState &F : pack_state_stack) {
 			//check all levels of pack to see if the group was added somewhere
-			const PackState &ps = F->get();
+			const PackState &ps = F;
 			if (ps.state->is_node_in_group(ps.node, gi.name)) {
 				skip = true;
 				break;
@@ -679,14 +677,14 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, Map<StringName
 	//ERR_FAIL_COND_V( !node_map.has(p_node), ERR_BUG);
 	//NodeData &nd = nodes[node_map[p_node]];
 
-	for (List<MethodInfo>::Element *E = _signals.front(); E; E = E->next()) {
+	for (MethodInfo &E : _signals) {
 		List<Node::Connection> conns;
-		p_node->get_signal_connection_list(E->get().name, &conns);
+		p_node->get_signal_connection_list(E.name, &conns);
 
 		conns.sort();
 
-		for (List<Node::Connection>::Element *F = conns.front(); F; F = F->next()) {
-			const Node::Connection &c = F->get();
+		for (Node::Connection &F : conns) {
+			const Node::Connection &c = F;
 
 			if (!(c.flags & CONNECT_PERSIST)) { //only persistent connections get saved
 				continue;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1167,12 +1167,12 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 
 		int prop_count = 0;
 
-		for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-			if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
+		for (PropertyInfo &E : props) {
+			if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
 				continue;
 			}
 
-			String name = E->get().name;
+			String name = E.name;
 			Variant value = packed_scene->get(name);
 
 			Map<StringName, int> empty_string_map; //unused
@@ -1488,8 +1488,8 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 			Dictionary d = p_variant;
 			List<Variant> keys;
 			d.get_key_list(&keys);
-			for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-				Variant v = d[E->get()];
+			for (Variant &E : keys) {
+				Variant v = d[E];
 				_find_resources(v);
 			}
 		} break;

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -72,13 +72,12 @@ void Shader::get_param_list(List<PropertyInfo> *p_params) const {
 	params_cache.clear();
 	params_cache_dirty = false;
 
-	for (List<PropertyInfo>::Element *E = local.front(); E; E = E->next()) {
-		PropertyInfo pi = E->get();
+	for (PropertyInfo &pi : local) {
 		if (default_textures.has(pi.name)) { //do not show default textures
 			continue;
 		}
 		pi.name = "shader_param/" + pi.name;
-		params_cache[pi.name] = E->get().name;
+		params_cache[pi.name] = pi.name;
 		if (p_params) {
 			//small little hack
 			if (pi.type == Variant::RID) {

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -100,8 +100,8 @@ Vector<String> SpriteFrames::_get_animation_list() const {
 	Vector<String> ret;
 	List<StringName> al;
 	get_animation_list(&al);
-	for (List<StringName>::Element *E = al.front(); E; E = E->next()) {
-		ret.push_back(E->get());
+	for (StringName &E : al) {
+		ret.push_back(E);
 	}
 
 	return ret;

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -529,8 +529,8 @@ void CodeHighlighter::set_color_regions(const Dictionary &p_color_regions) {
 	List<Variant> keys;
 	p_color_regions.get_key_list(&keys);
 
-	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-		String key = E->get();
+	for (Variant &E : keys) {
+		String key = E;
 
 		String start_key = key.get_slice(" ", 0);
 		String end_key = key.get_slice_count(" ") > 1 ? key.get_slice(" ", 1) : String();

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -447,8 +447,8 @@ void Theme::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	// Sort and store properties.
 	list.sort();
-	for (List<PropertyInfo>::Element *E = list.front(); E; E = E->next()) {
-		p_list->push_back(E->get());
+	for (PropertyInfo &E : list) {
+		p_list->push_back(E);
 	}
 }
 
@@ -1275,15 +1275,15 @@ void Theme::get_type_variation_list(const StringName &p_base_type, List<StringNa
 		return;
 	}
 
-	for (const List<StringName>::Element *E = variation_base_map[p_base_type].front(); E; E = E->next()) {
+	for (const StringName &E : variation_base_map[p_base_type]) {
 		// Prevent infinite loops if variants were set to be cross-dependent (that's still invalid usage, but handling for stability sake).
-		if (p_list->find(E->get())) {
+		if (p_list->find(E)) {
 			continue;
 		}
 
-		p_list->push_back(E->get());
+		p_list->push_back(E);
 		// Continue looking for sub-variations.
-		get_type_variation_list(E->get(), p_list);
+		get_type_variation_list(E, p_list);
 	}
 }
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -4357,14 +4357,14 @@ void TileSetPluginAtlasRendering::update_dirty_quadrants(TileMap *p_tile_map, Se
 		RenderingServer *rs = RenderingServer::get_singleton();
 
 		// Free the canvas items.
-		for (List<RID>::Element *E = q.canvas_items.front(); E; E = E->next()) {
-			rs->free(E->get());
+		for (RID E : q.canvas_items) {
+			rs->free(E);
 		}
 		q.canvas_items.clear();
 
 		// Free the occluders.
-		for (List<RID>::Element *E = q.occluders.front(); E; E = E->next()) {
-			rs->free(E->get());
+		for (RID E : q.occluders) {
+			rs->free(E);
 		}
 		q.occluders.clear();
 
@@ -4473,8 +4473,8 @@ void TileSetPluginAtlasRendering::update_dirty_quadrants(TileMap *p_tile_map, Se
 		// Sort the quadrants
 		for (Map<Vector2i, Vector2i, TileMapQuadrant::CoordsWorldComparator>::Element *E = world_to_map.front(); E; E = E->next()) {
 			TileMapQuadrant &q = quadrant_map[E->value()];
-			for (List<RID>::Element *F = q.canvas_items.front(); F; F = F->next()) {
-				RS::get_singleton()->canvas_item_set_draw_index(F->get(), index++);
+			for (RID F : q.canvas_items) {
+				RS::get_singleton()->canvas_item_set_draw_index(F, index++);
 			}
 		}
 
@@ -4491,14 +4491,14 @@ void TileSetPluginAtlasRendering::create_quadrant(TileMap *p_tile_map, TileMapQu
 
 void TileSetPluginAtlasRendering::cleanup_quadrant(TileMap *p_tile_map, TileMapQuadrant *p_quadrant) {
 	// Free the canvas items.
-	for (List<RID>::Element *E = p_quadrant->canvas_items.front(); E; E = E->next()) {
-		RenderingServer::get_singleton()->free(E->get());
+	for (RID E : p_quadrant->canvas_items) {
+		RenderingServer::get_singleton()->free(E);
 	}
 	p_quadrant->canvas_items.clear();
 
 	// Free the occluders.
-	for (List<RID>::Element *E = p_quadrant->occluders.front(); E; E = E->next()) {
-		RenderingServer::get_singleton()->free(E->get());
+	for (RID E : p_quadrant->occluders) {
+		RenderingServer::get_singleton()->free(E);
 	}
 	p_quadrant->occluders.clear();
 }

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -532,13 +532,13 @@ void Body2DSW::integrate_velocities(real_t p_step) {
 }
 
 void Body2DSW::wakeup_neighbours() {
-	for (List<Pair<Constraint2DSW *, int>>::Element *E = constraint_list.front(); E; E = E->next()) {
-		const Constraint2DSW *c = E->get().first;
+	for (Pair<Constraint2DSW *, int> &E : constraint_list) {
+		const Constraint2DSW *c = E.first;
 		Body2DSW **n = c->get_body_ptr();
 		int bc = c->get_body_count();
 
 		for (int i = 0; i < bc; i++) {
-			if (i == E->get().second) {
+			if (i == E.second) {
 				continue;
 			}
 			Body2DSW *b = n[i];

--- a/servers/physics_2d/step_2d_sw.cpp
+++ b/servers/physics_2d/step_2d_sw.cpp
@@ -46,8 +46,8 @@ void Step2DSW::_populate_island(Body2DSW *p_body, LocalVector<Body2DSW *> &p_bod
 		p_body_island.push_back(p_body);
 	}
 
-	for (const List<Pair<Constraint2DSW *, int>>::Element *E = p_body->get_constraint_list().front(); E; E = E->next()) {
-		Constraint2DSW *constraint = (Constraint2DSW *)E->get().first;
+	for (const Pair<Constraint2DSW *, int> &E : p_body->get_constraint_list()) {
+		Constraint2DSW *constraint = (Constraint2DSW *)E.first;
 		if (constraint->get_island_step() == _step) {
 			continue; // Already processed.
 		}
@@ -56,7 +56,7 @@ void Step2DSW::_populate_island(Body2DSW *p_body, LocalVector<Body2DSW *> &p_bod
 		all_constraints.push_back(constraint);
 
 		for (int i = 0; i < constraint->get_body_count(); i++) {
-			if (i == E->get().second) {
+			if (i == E.second) {
 				continue;
 			}
 			Body2DSW *other_body = constraint->get_body_ptr()[i];

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -2716,9 +2716,7 @@ void RendererStorageRD::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_su
 	mesh->surfaces[mesh->surface_count] = s;
 	mesh->surface_count++;
 
-	for (List<MeshInstance *>::Element *E = mesh->instances.front(); E; E = E->next()) {
-		//update instances
-		MeshInstance *mi = E->get();
+	for (MeshInstance *mi : mesh->instances) {
 		_mesh_instance_add_surface(mi, mesh, mesh->surface_count - 1);
 	}
 
@@ -3029,8 +3027,7 @@ void RendererStorageRD::mesh_clear(RID p_mesh) {
 	mesh->surface_count = 0;
 	mesh->material_cache.clear();
 	//clear instance data
-	for (List<MeshInstance *>::Element *E = mesh->instances.front(); E; E = E->next()) {
-		MeshInstance *mi = E->get();
+	for (MeshInstance *mi : mesh->instances) {
 		_mesh_instance_clear(mi);
 	}
 	mesh->has_bone_weights = false;
@@ -8413,10 +8410,10 @@ void RendererStorageRD::global_variables_load_settings(bool p_load_textures) {
 	List<PropertyInfo> settings;
 	ProjectSettings::get_singleton()->get_property_list(&settings);
 
-	for (List<PropertyInfo>::Element *E = settings.front(); E; E = E->next()) {
-		if (E->get().name.begins_with("shader_globals/")) {
-			StringName name = E->get().name.get_slice("/", 1);
-			Dictionary d = ProjectSettings::get_singleton()->get(E->get().name);
+	for (PropertyInfo &E : settings) {
+		if (E.name.begins_with("shader_globals/")) {
+			StringName name = E.name.get_slice("/", 1);
+			Dictionary d = ProjectSettings::get_singleton()->get(E.name);
 
 			ERR_CONTINUE(!d.has("type"));
 			ERR_CONTINUE(!d.has("value"));
@@ -8584,8 +8581,8 @@ void RendererStorageRD::_update_global_variables() {
 	if (global_variables.must_update_buffer_materials) {
 		// only happens in the case of a buffer variable added or removed,
 		// so not often.
-		for (List<RID>::Element *E = global_variables.materials_using_buffer.front(); E; E = E->next()) {
-			Material *material = material_owner.getornull(E->get());
+		for (RID E : global_variables.materials_using_buffer) {
+			Material *material = material_owner.getornull(E);
 			ERR_CONTINUE(!material); //wtf
 
 			_material_queue_update(material, true, false);
@@ -8597,8 +8594,8 @@ void RendererStorageRD::_update_global_variables() {
 	if (global_variables.must_update_texture_materials) {
 		// only happens in the case of a buffer variable added or removed,
 		// so not often.
-		for (List<RID>::Element *E = global_variables.materials_using_texture.front(); E; E = E->next()) {
-			Material *material = material_owner.getornull(E->get());
+		for (RID E : global_variables.materials_using_texture) {
+			Material *material = material_owner.getornull(E);
 			ERR_CONTINUE(!material); //wtf
 
 			_material_queue_update(material, false, true);

--- a/servers/rendering/renderer_rd/shader_compiler_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_compiler_rd.cpp
@@ -760,11 +760,11 @@ String ShaderCompilerRD::_dump_node_code(const SL::Node *p_node, int p_level, Ge
 
 			if (var_frag_to_light.size() > 0) {
 				String gcode = "\n\nstruct {\n";
-				for (List<Pair<StringName, SL::ShaderNode::Varying>>::Element *E = var_frag_to_light.front(); E; E = E->next()) {
-					gcode += "\t" + _prestr(E->get().second.precision) + _typestr(E->get().second.type) + " " + _mkid(E->get().first);
-					if (E->get().second.array_size > 0) {
+				for (Pair<StringName, SL::ShaderNode::Varying> &E : var_frag_to_light) {
+					gcode += "\t" + _prestr(E.second.precision) + _typestr(E.second.type) + " " + _mkid(E.first);
+					if (E.second.array_size > 0) {
 						gcode += "[";
-						gcode += itos(E->get().second.array_size);
+						gcode += itos(E.second.array_size);
 						gcode += "]";
 					}
 					gcode += ";\n";
@@ -1394,8 +1394,8 @@ void ShaderCompilerRD::initialize(DefaultIdentifierActions p_actions) {
 
 	ShaderLanguage::get_builtin_funcs(&func_list);
 
-	for (List<String>::Element *E = func_list.front(); E; E = E->next()) {
-		internal_functions.insert(E->get());
+	for (String &E : func_list) {
+		internal_functions.insert(E);
 	}
 	texture_functions.insert("texture");
 	texture_functions.insert("textureProj");

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2876,8 +2876,8 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 		Vector<Instance *> lights_with_shadow;
 
-		for (List<Instance *>::Element *E = scenario->directional_lights.front(); E; E = E->next()) {
-			if (!E->get()->visible) {
+		for (Instance *E : scenario->directional_lights) {
+			if (!E->visible) {
 				continue;
 			}
 
@@ -2885,13 +2885,13 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 				break;
 			}
 
-			InstanceLightData *light = static_cast<InstanceLightData *>(E->get()->base_data);
+			InstanceLightData *light = static_cast<InstanceLightData *>(E->base_data);
 
 			//check shadow..
 
 			if (light) {
-				if (p_using_shadows && p_shadow_atlas.is_valid() && RSG::storage->light_has_shadow(E->get()->base) && !(RSG::storage->light_get_type(E->get()->base) == RS::LIGHT_DIRECTIONAL && RSG::storage->light_directional_is_sky_only(E->get()->base))) {
-					lights_with_shadow.push_back(E->get());
+				if (p_using_shadows && p_shadow_atlas.is_valid() && RSG::storage->light_has_shadow(E->base) && !(RSG::storage->light_get_type(E->base) == RS::LIGHT_DIRECTIONAL && RSG::storage->light_directional_is_sky_only(E->base))) {
+					lights_with_shadow.push_back(E);
 				}
 				//add to list
 				directional_lights.push_back(light->instance);
@@ -3391,8 +3391,7 @@ void RendererSceneCull::render_probes() {
 				idx++;
 			}
 
-			for (List<Instance *>::Element *E = probe->owner->scenario->directional_lights.front(); E; E = E->next()) {
-				Instance *instance = E->get();
+			for (Instance *instance : probe->owner->scenario->directional_lights) {
 				InstanceLightData *instance_light = (InstanceLightData *)instance->base_data;
 				if (!instance->visible) {
 					continue;
@@ -3465,8 +3464,7 @@ void RendererSceneCull::render_probes() {
 
 					idx++;
 				}
-				for (List<Instance *>::Element *E = probe->owner->scenario->directional_lights.front(); E; E = E->next()) {
-					Instance *instance = E->get();
+				for (Instance *instance : probe->owner->scenario->directional_lights) {
 					InstanceLightData *instance_light = (InstanceLightData *)instance->base_data;
 					if (!instance->visible) {
 						continue;
@@ -3573,26 +3571,26 @@ void RendererSceneCull::render_particle_colliders() {
 void RendererSceneCull::_update_instance_shader_parameters_from_material(Map<StringName, Instance::InstanceShaderParameter> &isparams, const Map<StringName, Instance::InstanceShaderParameter> &existing_isparams, RID p_material) {
 	List<RendererStorage::InstanceShaderParam> plist;
 	RSG::storage->material_get_instance_shader_parameters(p_material, &plist);
-	for (List<RendererStorage::InstanceShaderParam>::Element *E = plist.front(); E; E = E->next()) {
-		StringName name = E->get().info.name;
+	for (RendererStorage::InstanceShaderParam &E : plist) {
+		StringName name = E.info.name;
 		if (isparams.has(name)) {
-			if (isparams[name].info.type != E->get().info.type) {
-				WARN_PRINT("More than one material in instance export the same instance shader uniform '" + E->get().info.name + "', but they do it with different data types. Only the first one (in order) will display correctly.");
+			if (isparams[name].info.type != E.info.type) {
+				WARN_PRINT("More than one material in instance export the same instance shader uniform '" + E.info.name + "', but they do it with different data types. Only the first one (in order) will display correctly.");
 			}
-			if (isparams[name].index != E->get().index) {
-				WARN_PRINT("More than one material in instance export the same instance shader uniform '" + E->get().info.name + "', but they do it with different indices. Only the first one (in order) will display correctly.");
+			if (isparams[name].index != E.index) {
+				WARN_PRINT("More than one material in instance export the same instance shader uniform '" + E.info.name + "', but they do it with different indices. Only the first one (in order) will display correctly.");
 			}
 			continue; //first one found always has priority
 		}
 
 		Instance::InstanceShaderParameter isp;
-		isp.index = E->get().index;
-		isp.info = E->get().info;
-		isp.default_value = E->get().default_value;
+		isp.index = E.index;
+		isp.info = E.info;
+		isp.default_value = E.default_value;
 		if (existing_isparams.has(name)) {
 			isp.value = existing_isparams[name].value;
 		} else {
-			isp.value = E->get().default_value;
+			isp.value = E.default_value;
 		}
 		isparams[name] = isp;
 	}

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -388,9 +388,9 @@ protected:
 		versions.clear();
 		List<Variant> keys;
 		p_versions.get_key_list(&keys);
-		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-			StringName name = E->get();
-			Ref<RDShaderBytecode> bc = p_versions[E->get()];
+		for (Variant &E : keys) {
+			StringName name = E;
+			Ref<RDShaderBytecode> bc = p_versions[E];
 			ERR_CONTINUE(bc.is_null());
 			versions[name] = bc;
 		}

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4448,12 +4448,12 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						String member_name = String(ident.ptr());
 						if (shader->structs.has(st)) {
 							StructNode *n = shader->structs[st].shader_struct;
-							for (List<MemberNode *>::Element *E = n->members.front(); E; E = E->next()) {
-								if (String(E->get()->name) == member_name) {
-									member_type = E->get()->datatype;
-									array_size = E->get()->array_size;
+							for (MemberNode *E : n->members) {
+								if (String(E->name) == member_name) {
+									member_type = E->datatype;
+									array_size = E->array_size;
 									if (member_type == TYPE_STRUCT) {
-										member_struct_name = E->get()->struct_name;
+										member_struct_name = E->struct_name;
 									}
 									ok = true;
 									break;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -53,15 +53,15 @@ Array RenderingServer::_texture_debug_usage_bind() {
 	List<TextureInfo> list;
 	texture_debug_usage(&list);
 	Array arr;
-	for (const List<TextureInfo>::Element *E = list.front(); E; E = E->next()) {
+	for (const TextureInfo &E : list) {
 		Dictionary dict;
-		dict["texture"] = E->get().texture;
-		dict["width"] = E->get().width;
-		dict["height"] = E->get().height;
-		dict["depth"] = E->get().depth;
-		dict["format"] = E->get().format;
-		dict["bytes"] = E->get().bytes;
-		dict["path"] = E->get().path;
+		dict["texture"] = E.texture;
+		dict["width"] = E.width;
+		dict["height"] = E.height;
+		dict["depth"] = E.depth;
+		dict["format"] = E.format;
+		dict["bytes"] = E.bytes;
+		dict["path"] = E.path;
 		arr.push_back(dict);
 	}
 	return arr;
@@ -972,10 +972,10 @@ Error RenderingServer::mesh_create_surface_data_from_arrays(SurfaceData *r_surfa
 	if (index_array_len) {
 		List<Variant> keys;
 		p_lods.get_key_list(&keys);
-		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-			float distance = E->get();
+		for (Variant &E : keys) {
+			float distance = E;
 			ERR_CONTINUE(distance <= 0.0);
-			Vector<int> indices = p_lods[E->get()];
+			Vector<int> indices = p_lods[E];
 			ERR_CONTINUE(indices.size() == 0);
 			uint32_t index_count = indices.size();
 			ERR_CONTINUE(index_count >= (uint32_t)index_array_len); //should be smaller..

--- a/tests/test_class_db.h
+++ b/tests/test_class_db.h
@@ -108,9 +108,9 @@ struct ExposedClass {
 	List<SignalData> signals_;
 
 	const PropertyData *find_property_by_name(const StringName &p_name) const {
-		for (const List<PropertyData>::Element *E = properties.front(); E; E = E->next()) {
-			if (E->get().name == p_name) {
-				return &E->get();
+		for (const PropertyData &E : properties) {
+			if (E.name == p_name) {
+				return &E;
 			}
 		}
 
@@ -118,9 +118,9 @@ struct ExposedClass {
 	}
 
 	const MethodData *find_method_by_name(const StringName &p_name) const {
-		for (const List<MethodData>::Element *E = methods.front(); E; E = E->next()) {
-			if (E->get().name == p_name) {
-				return &E->get();
+		for (const MethodData &E : methods) {
+			if (E.name == p_name) {
+				return &E;
 			}
 		}
 
@@ -395,8 +395,8 @@ void validate_method(const Context &p_context, const ExposedClass &p_class, cons
 		}
 	}
 
-	for (const List<ArgumentData>::Element *F = p_method.arguments.front(); F; F = F->next()) {
-		const ArgumentData &arg = F->get();
+	for (const ArgumentData &F : p_method.arguments) {
+		const ArgumentData &arg = F;
 
 		const ExposedClass *arg_class = p_context.find_exposed_class(arg.type);
 		if (arg_class) {
@@ -427,8 +427,8 @@ void validate_method(const Context &p_context, const ExposedClass &p_class, cons
 }
 
 void validate_signal(const Context &p_context, const ExposedClass &p_class, const SignalData &p_signal) {
-	for (const List<ArgumentData>::Element *F = p_signal.arguments.front(); F; F = F->next()) {
-		const ArgumentData &arg = F->get();
+	for (const ArgumentData &F : p_signal.arguments) {
+		const ArgumentData &arg = F;
 
 		const ExposedClass *arg_class = p_context.find_exposed_class(arg.type);
 		if (arg_class) {
@@ -469,16 +469,16 @@ void validate_class(const Context &p_context, const ExposedClass &p_exposed_clas
 	TEST_FAIL_COND((is_derived_type && !p_context.exposed_classes.has(p_exposed_class.base)),
 			"Base type '", p_exposed_class.base.operator String(), "' does not exist, for class '", p_exposed_class.name, "'.");
 
-	for (const List<PropertyData>::Element *F = p_exposed_class.properties.front(); F; F = F->next()) {
-		validate_property(p_context, p_exposed_class, F->get());
+	for (const PropertyData &F : p_exposed_class.properties) {
+		validate_property(p_context, p_exposed_class, F);
 	}
 
-	for (const List<MethodData>::Element *F = p_exposed_class.methods.front(); F; F = F->next()) {
-		validate_method(p_context, p_exposed_class, F->get());
+	for (const MethodData &F : p_exposed_class.methods) {
+		validate_method(p_context, p_exposed_class, F);
 	}
 
-	for (const List<SignalData>::Element *F = p_exposed_class.signals_.front(); F; F = F->next()) {
-		validate_signal(p_context, p_exposed_class, F->get());
+	for (const SignalData &F : p_exposed_class.signals_) {
+		validate_signal(p_context, p_exposed_class, F);
 	}
 }
 
@@ -526,9 +526,7 @@ void add_exposed_classes(Context &r_context) {
 
 		Map<StringName, StringName> accessor_methods;
 
-		for (const List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
-			const PropertyInfo &property = E->get();
-
+		for (const PropertyInfo &property : property_list) {
 			if (property.usage & PROPERTY_USAGE_GROUP || property.usage & PROPERTY_USAGE_SUBGROUP || property.usage & PROPERTY_USAGE_CATEGORY) {
 				continue;
 			}
@@ -561,8 +559,8 @@ void add_exposed_classes(Context &r_context) {
 		ClassDB::get_method_list(class_name, &method_list, true);
 		method_list.sort();
 
-		for (List<MethodInfo>::Element *E = method_list.front(); E; E = E->next()) {
-			const MethodInfo &method_info = E->get();
+		for (MethodInfo &E : method_list) {
+			const MethodInfo &method_info = E;
 
 			int argc = method_info.arguments.size();
 
@@ -667,8 +665,8 @@ void add_exposed_classes(Context &r_context) {
 
 			// Methods starting with an underscore are ignored unless they're virtual or used as a property setter or getter.
 			if (!method.is_virtual && String(method.name)[0] == '_') {
-				for (const List<PropertyData>::Element *F = exposed_class.properties.front(); F; F = F->next()) {
-					const PropertyData &prop = F->get();
+				for (const PropertyData &F : exposed_class.properties) {
+					const PropertyData &prop = F;
 
 					if (prop.setter == method.name || prop.getter == method.name) {
 						exposed_class.methods.push_back(method);
@@ -752,8 +750,8 @@ void add_exposed_classes(Context &r_context) {
 			enum_.name = *k;
 
 			const List<StringName> &enum_constants = enum_map.get(*k);
-			for (const List<StringName>::Element *E = enum_constants.front(); E; E = E->next()) {
-				const StringName &constant_name = E->get();
+			for (const StringName &E : enum_constants) {
+				const StringName &constant_name = E;
 				TEST_FAIL_COND(String(constant_name).find("::") != -1,
 						"Enum constant contains '::', check bindings to remove the scope: '",
 						String(class_name), ".", String(enum_.name), ".", String(constant_name), "'.");
@@ -774,12 +772,12 @@ void add_exposed_classes(Context &r_context) {
 			r_context.enum_types.push_back(String(class_name) + "." + String(*k));
 		}
 
-		for (const List<String>::Element *E = constants.front(); E; E = E->next()) {
-			const String &constant_name = E->get();
+		for (const String &E : constants) {
+			const String &constant_name = E;
 			TEST_FAIL_COND(constant_name.find("::") != -1,
 					"Constant contains '::', check bindings to remove the scope: '",
 					String(class_name), ".", constant_name, "'.");
-			int *value = class_info->constant_map.getptr(StringName(E->get()));
+			int *value = class_info->constant_map.getptr(StringName(E));
 			TEST_FAIL_COND(!value, "Missing constant value: '", String(class_name), ".", String(constant_name), "'.");
 
 			ConstantData constant;
@@ -829,8 +827,8 @@ void add_global_enums(Context &r_context) {
 			}
 		}
 
-		for (List<EnumData>::Element *E = r_context.global_enums.front(); E; E = E->next()) {
-			r_context.enum_types.push_back(E->get().name);
+		for (EnumData &E : r_context.global_enums) {
+			r_context.enum_types.push_back(E.name);
 		}
 	}
 
@@ -840,10 +838,10 @@ void add_global_enums(Context &r_context) {
 	hardcoded_enums.push_back("Vector2i.Axis");
 	hardcoded_enums.push_back("Vector3.Axis");
 	hardcoded_enums.push_back("Vector3i.Axis");
-	for (List<StringName>::Element *E = hardcoded_enums.front(); E; E = E->next()) {
+	for (StringName &E : hardcoded_enums) {
 		// These enums are not generated and must be written manually (e.g.: Vector3.Axis)
 		// Here, we assume core types do not begin with underscore
-		r_context.enum_types.push_back(E->get());
+		r_context.enum_types.push_back(E);
 	}
 }
 

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -549,8 +549,8 @@ MainLoop *test() {
 		List<StringName> tl;
 		ClassDB::get_class_list(&tl);
 
-		for (List<StringName>::Element *E = tl.front(); E; E = E->next()) {
-			Vector<uint8_t> m5b = E->get().operator String().md5_buffer();
+		for (StringName &E : tl) {
+			Vector<uint8_t> m5b = E.operator String().md5_buffer();
 			hashes.push_back(hashes.size());
 		}
 

--- a/tests/test_render.cpp
+++ b/tests/test_render.cpp
@@ -210,12 +210,12 @@ public:
 
 		//return quit;
 
-		for (List<InstanceInfo>::Element *E = instances.front(); E; E = E->next()) {
-			Transform3D pre(Basis(E->get().rot_axis, ofs), Vector3());
-			vs->instance_set_transform(E->get().instance, pre * E->get().base);
+		for (InstanceInfo &E : instances) {
+			Transform3D pre(Basis(E.rot_axis, ofs), Vector3());
+			vs->instance_set_transform(E.instance, pre * E.base);
 			/*
 			if( !E->next() ) {
-				vs->free( E->get().instance );
+				vs->free( E.instance );
 				instances.erase(E );
 			}*/
 		}

--- a/thirdparty/enet/godot.cpp
+++ b/thirdparty/enet/godot.cpp
@@ -353,8 +353,8 @@ public:
 		}
 
 		// Remove disconnected peers from map.
-		for (List<String>::Element *E = remove.front(); E; E = E->next()) {
-			peers.erase(E->get());
+		for (String &E : remove) {
+			peers.erase(E);
 		}
 
 		return err; // OK, ERR_BUSY, or possibly an error.


### PR DESCRIPTION
With #50284, we now have range iterators. This PR uses them throughout the codebase for `List`. This PR doesn't replace every single usage of `List<>::Element`, but it does replace many of them.

It's likely that I made some mistakes, but it would be like finding a needle in a haystack simply because this PR is so big. 99% of this should be good. This took a lot longer than I expected.
