### PR TITLE
Minor enhancements for the TileMap editor

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -575,6 +575,7 @@ TileAtlasView::TileAtlasView() {
 	button_center_view->connect("pressed", callable_mp(this, &TileAtlasView::_center_view));
 	button_center_view->set_flat(true);
 	button_center_view->set_disabled(true);
+	button_center_view->set_tooltip(TTR("Center View"));
 	add_child(button_center_view);
 
 	center_container = memnew(CenterContainer);

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -168,9 +168,9 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		if (atlas_source) {
 			texture = atlas_source->get_texture();
 			if (texture.is_valid()) {
-				item_text = vformat("%s (id:%d)", texture->get_path().get_file(), source_id);
+				item_text = vformat("%s (ID: %d)", texture->get_path().get_file(), source_id);
 			} else {
-				item_text = vformat("No Texture Atlas Source (id:%d)", source_id);
+				item_text = vformat("No Texture Atlas Source (ID: %d)", source_id);
 			}
 		}
 
@@ -178,12 +178,12 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		TileSetScenesCollectionSource *scene_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);
 		if (scene_collection_source) {
 			texture = get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
-			item_text = vformat(TTR("Scene Collection Source (id:%d)"), source_id);
+			item_text = vformat(TTR("Scene Collection Source (ID: %d)"), source_id);
 		}
 
 		// Use default if not valid.
 		if (item_text.is_empty()) {
-			item_text = vformat(TTR("Unknown Type Source (id:%d)"), source_id);
+			item_text = vformat(TTR("Unknown Type Source (ID: %d)"), source_id);
 		}
 		if (!texture.is_valid()) {
 			texture = missing_atlas_texture_icon;
@@ -302,7 +302,7 @@ void TileMapEditorTilesPlugin::_update_scenes_collection_view() {
 
 		int item_index = 0;
 		if (scene.is_valid()) {
-			item_index = scene_tiles_list->add_item(vformat("%s (path:%s id:%d)", scene->get_path().get_file().get_basename(), scene->get_path(), scene_id));
+			item_index = scene_tiles_list->add_item(vformat("%s (Path: %s, ID: %d)", scene->get_path().get_file().get_basename(), scene->get_path(), scene_id));
 			Variant udata = i;
 			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(scene, this, "_scene_thumbnail_done", udata);
 		} else {
@@ -1865,6 +1865,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	toggle_grid_button = memnew(Button);
 	toggle_grid_button->set_flat(true);
 	toggle_grid_button->set_toggle_mode(true);
+	toggle_grid_button->set_tooltip(TTR("Toggle grid visibility."));
 	toggle_grid_button->connect("toggled", callable_mp(this, &TileMapEditorTilesPlugin::_on_grid_toggled));
 	toolbar->add_child(toggle_grid_button);
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2055,7 +2055,7 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 
 			tools_settings_erase_button->set_icon(get_theme_icon(SNAME("Eraser"), SNAME("EditorIcons")));
 
-			tool_advanced_menu_buttom->set_icon(get_theme_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
+			tool_advanced_menu_buttom->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
 			resize_handle = get_theme_icon(SNAME("EditorHandle"), SNAME("EditorIcons"));
 			resize_handle_disabled = get_theme_icon(SNAME("EditorHandleDisabled"), SNAME("EditorIcons"));
@@ -2176,7 +2176,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	// -- Dialogs --
 	confirm_auto_create_tiles = memnew(AcceptDialog);
-	confirm_auto_create_tiles->set_title(TTR("Create tiles automatically in non-transparent texture regions?"));
+	confirm_auto_create_tiles->set_title(TTR("Auto Create Tiles in Non-Transparent Texture Regions?"));
 	confirm_auto_create_tiles->set_text(TTR("The atlas's texture was modified.\nWould you like to automatically create tiles in the atlas?"));
 	confirm_auto_create_tiles->get_ok_button()->set_text(TTR("Yes"));
 	confirm_auto_create_tiles->add_cancel_button()->set_text(TTR("No"));
@@ -2202,7 +2202,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tool_setup_atlas_source_button->set_toggle_mode(true);
 	tool_setup_atlas_source_button->set_pressed(true);
 	tool_setup_atlas_source_button->set_button_group(tools_button_group);
-	tool_setup_atlas_source_button->set_tooltip(TTR("Atlas Setup. Add/Remove tiles tool (use the shift key to create big tiles, control for rectangle editing)."));
+	tool_setup_atlas_source_button->set_tooltip(TTR("Atlas setup. Add/Remove tiles tool (use the shift key to create big tiles, control for rectangle editing)."));
 	toolbox->add_child(tool_setup_atlas_source_button);
 
 	tool_select_button = memnew(Button);


### PR DESCRIPTION
- Use the highlighted version of the "GuiTabMenu" icon, like the rest of the editor.
- Tweak some existing strings.
- Add tooltips to some buttons.