### PR TITLE
Assign value to property by dropping to scene tree

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2261,7 +2261,7 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		_edit_request_change(object, p_name);
 		emit_signal(_prop_edited, p_name);
 	} else {
-		undo_redo->create_action(TTR("Set") + " " + p_name, UndoRedo::MERGE_ENDS);
+		undo_redo->create_action(vformat(TTR("Set %s"), p_name), UndoRedo::MERGE_ENDS);
 		undo_redo->add_do_property(object, p_name, p_value);
 		undo_redo->add_undo_property(object, p_name, object->get(p_name));
 

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -123,7 +123,12 @@ class SceneTreeDock : public VBoxContainer {
 
 	HBoxContainer *tool_hbc;
 	void _tool_selected(int p_tool, bool p_confirm_override = false);
+	void _property_selected(int p_idx);
 	void _node_collapsed(Object *p_obj);
+
+	Node *property_drop_node = nullptr;
+	String resource_drop_path;
+	void _perform_property_drop(Node *p_node, String p_property, RES p_res);
 
 	EditorData *editor_data;
 	EditorSelection *editor_selection;
@@ -147,6 +152,7 @@ class SceneTreeDock : public VBoxContainer {
 
 	PopupMenu *menu;
 	PopupMenu *menu_subresources;
+	PopupMenu *menu_properties;
 	ConfirmationDialog *clear_inherit_confirm;
 
 	bool first_enter;

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1037,15 +1037,24 @@ bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 			return true;
 		}
 
+		bool scene_drop = true;
 		for (int i = 0; i < files.size(); i++) {
 			String file = files[i];
 			String ftype = EditorFileSystem::get_singleton()->get_file_type(file);
 			if (ftype != "PackedScene") {
-				return false;
+				scene_drop = false;
+				break;
 			}
 		}
 
-		tree->set_drop_mode_flags(Tree::DROP_MODE_INBETWEEN | Tree::DROP_MODE_ON_ITEM); //so it works..
+		if (scene_drop) {
+			tree->set_drop_mode_flags(Tree::DROP_MODE_INBETWEEN | Tree::DROP_MODE_ON_ITEM);
+		} else {
+			if (files.size() > 1) {
+				return false;
+			}
+			tree->set_drop_mode_flags(Tree::DROP_MODE_ON_ITEM);
+		}
 
 		return true;
 	}


### PR DESCRIPTION
I had this idea for a long time and gave it a shot today. Somewhat related to #16464 and #10684.
Basically, you can drop files onto scene tree nodes and they will be assigned to properties.

![eCczALT5q2](https://user-images.githubusercontent.com/2223172/125964135-e97fcaf7-ab2a-4271-92f9-d182230f19d7.gif)

~~If you hold Ctrl, a popup will appear with list of available properties. If not, the resource is assigned to the first compatible property.~~
(see my last comment)