### PR TITLE
Fix control picker in the Theme editor

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1365,6 +1365,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme_preview_picker_sb->set_border_color(accent_color);
 	theme_preview_picker_sb->set_border_width_all(1.0 * EDSCALE);
 	theme->set_stylebox("preview_picker_overlay", "ThemeEditor", theme_preview_picker_sb);
+	Color theme_preview_picker_label_bg_color = accent_color;
+	theme_preview_picker_label_bg_color.set_v(0.5);
+	Ref<StyleBoxFlat> theme_preview_picker_label_sb = make_flat_stylebox(theme_preview_picker_label_bg_color, 4.0, 1.0, 4.0, 3.0);
+	theme->set_stylebox("preview_picker_label", "ThemeEditor", theme_preview_picker_label_sb);
 
 	// adaptive script theme constants
 	// for comments and elements with lower relevance

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3299,7 +3299,7 @@ ThemeEditor::ThemeEditor() {
 
 	theme_type_editor = memnew(ThemeTypeEditor);
 	main_hs->add_child(theme_type_editor);
-	theme_type_editor->set_custom_minimum_size(Size2(360, 0) * EDSCALE);
+	theme_type_editor->set_custom_minimum_size(Size2(280, 0) * EDSCALE);
 }
 
 void ThemeEditorPlugin::edit(Object *p_node) {

--- a/editor/plugins/theme_editor_preview.h
+++ b/editor/plugins/theme_editor_preview.h
@@ -60,6 +60,13 @@ class ThemeEditorPreview : public VBoxContainer {
 	Control *picker_overlay;
 	Control *hovered_control = nullptr;
 
+	struct ThemeCache {
+		Ref<StyleBox> preview_picker_overlay;
+		Color preview_picker_overlay_color;
+		Ref<StyleBox> preview_picker_label;
+		Ref<Font> preview_picker_font;
+	} theme_cache;
+
 	double time_left = 0;
 
 	void _propagate_redraw(Control *p_at);
@@ -71,6 +78,7 @@ class ThemeEditorPreview : public VBoxContainer {
 
 	void _draw_picker_overlay();
 	void _gui_input_picker_overlay(const Ref<InputEvent> &p_event);
+	void _reset_picker_overlay();
 
 protected:
 	HBoxContainer *preview_toolbar;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/50519. This, of course, includes support for type variations:

![godot windows tools 64_2021-07-16_21-12-23](https://user-images.githubusercontent.com/11782833/125993408-6ddb2274-1590-48e9-8cdb-e066647cd6b8.png)
