### PR TITLE
Use `is_equal_approx` in more places

### DIFF
--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -562,7 +562,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 	if (selectable_icon_size > 0.0f) {
 		Transform3D t = spatial_node->get_global_transform();
 		Vector3 camera_position = p_camera->get_camera_transform().origin;
-		if (camera_position.distance_squared_to(t.origin) > 0.01) {
+		if (!camera_position.is_equal_approx(t.origin)) {
 			t.set_look_at(t.origin, camera_position);
 		}
 
@@ -578,7 +578,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 
 		Transform3D orig_camera_transform = p_camera->get_camera_transform();
 
-		if (orig_camera_transform.origin.distance_squared_to(t.origin) > 0.01 &&
+		if (!orig_camera_transform.origin.is_equal_approx(t.origin) &&
 				ABS(orig_camera_transform.basis.get_axis(Vector3::AXIS_Z).dot(Vector3(0, 1, 0))) < 0.99) {
 			p_camera->look_at(t.origin);
 		}

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3338,7 +3338,7 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 
 	Transform3D camera_xform = camera->get_transform();
 
-	if (xform.origin.distance_squared_to(camera_xform.origin) < 0.01) {
+	if (xform.origin.is_equal_approx(camera_xform.origin)) {
 		for (int i = 0; i < 3; i++) {
 			RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
 			RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -481,7 +481,7 @@ void Path2DEditor::_mode_selected(int p_mode) {
 
 		Vector2 begin = node->get_curve()->get_point_position(0);
 		Vector2 end = node->get_curve()->get_point_position(node->get_curve()->get_point_count() - 1);
-		if (begin.distance_to(end) < CMP_EPSILON) {
+		if (begin.is_equal_approx(end)) {
 			return;
 		}
 

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -42,7 +42,7 @@ inline static bool is_snapable(const Vector3 &p_point1, const Vector3 &p_point2,
 
 inline static Vector2 interpolate_segment_uv(const Vector2 p_segement_points[2], const Vector2 p_uvs[2], const Vector2 &p_interpolation_point) {
 	float segment_length = (p_segement_points[1] - p_segement_points[0]).length();
-	if (segment_length < CMP_EPSILON) {
+	if (p_segement_points[0].is_equal_approx(p_segement_points[1])) {
 		return p_uvs[0];
 	}
 
@@ -53,13 +53,13 @@ inline static Vector2 interpolate_segment_uv(const Vector2 p_segement_points[2],
 }
 
 inline static Vector2 interpolate_triangle_uv(const Vector2 p_vertices[3], const Vector2 p_uvs[3], const Vector2 &p_interpolation_point) {
-	if (p_interpolation_point.distance_squared_to(p_vertices[0]) < CMP_EPSILON2) {
+	if (p_interpolation_point.is_equal_approx(p_vertices[0])) {
 		return p_uvs[0];
 	}
-	if (p_interpolation_point.distance_squared_to(p_vertices[1]) < CMP_EPSILON2) {
+	if (p_interpolation_point.is_equal_approx(p_vertices[1])) {
 		return p_uvs[1];
 	}
-	if (p_interpolation_point.distance_squared_to(p_vertices[2]) < CMP_EPSILON2) {
+	if (p_interpolation_point.is_equal_approx(p_vertices[2])) {
 		return p_uvs[2];
 	}
 
@@ -589,7 +589,7 @@ bool CSGBrushOperation::MeshMerge::_bvh_inside(FaceBVH *facebvhptr, int p_max_de
 							Vector3 intersection_point;
 
 							// Check if faces are co-planar.
-							if ((current_normal - face_normal).length_squared() < CMP_EPSILON2 &&
+							if (current_normal.is_equal_approx(face_normal) &&
 									is_point_in_triangle(face_center, current_points)) {
 								// Only add an intersection if not a B face.
 								if (!face.from_b) {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -778,7 +778,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 					}
 				}
 
-				bool flat = normal[0].distance_to(normal[1]) < CMP_EPSILON && normal[0].distance_to(normal[2]) < CMP_EPSILON;
+				bool flat = normal[0].is_equal_approx(normal[1]) && normal[0].is_equal_approx(normal[2]);
 
 				vw[as + j + 0] = vertex[0];
 				vw[as + j + 1] = vertex[1];
@@ -820,7 +820,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 					}
 				}
 
-				bool flat = normal[0].distance_to(normal[1]) < CMP_EPSILON && normal[0].distance_to(normal[2]) < CMP_EPSILON;
+				bool flat = normal[0].is_equal_approx(normal[1]) && normal[0].is_equal_approx(normal[2]);
 
 				vw[as + j + 0] = vertex[0];
 				vw[as + j + 1] = vertex[1];

--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -525,7 +525,7 @@ void FBXMeshData::reorganize_vertices(
 				}
 
 				const Vector3 vert_poly_normal = *nrml_arr->getptr(*pid);
-				if ((this_vert_poly_normal - vert_poly_normal).length_squared() > CMP_EPSILON) {
+				if (!vert_poly_normal.is_equal_approx(this_vert_poly_normal)) {
 					// Yes this polygon need duplication.
 					need_duplication = true;
 					break;
@@ -586,7 +586,7 @@ void FBXMeshData::reorganize_vertices(
 								continue;
 							}
 							const Vector2 vert_poly_uv = *uvs->getptr(*pid);
-							if (((*this_vert_poly_uv) - vert_poly_uv).length_squared() > CMP_EPSILON) {
+							if (!vert_poly_uv.is_equal_approx(*this_vert_poly_uv)) {
 								// Yes this polygon need duplication.
 								need_duplication = true;
 								break;

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -734,7 +734,7 @@ void NavMap::dispatch_callbacks() {
 void NavMap::clip_path(const std::vector<gd::NavigationPoly> &p_navigation_polys, Vector<Vector3> &path, const gd::NavigationPoly *from_poly, const Vector3 &p_to_point, const gd::NavigationPoly *p_to_poly) const {
 	Vector3 from = path[path.size() - 1];
 
-	if (from.distance_to(p_to_point) < CMP_EPSILON) {
+	if (from.is_equal_approx(p_to_point)) {
 		return;
 	}
 	Plane cut_plane;
@@ -752,10 +752,10 @@ void NavMap::clip_path(const std::vector<gd::NavigationPoly> &p_navigation_polys
 		ERR_FAIL_COND(from_poly->back_navigation_poly_id == -1);
 		from_poly = &p_navigation_polys[from_poly->back_navigation_poly_id];
 
-		if (pathway_start.distance_to(pathway_end) > CMP_EPSILON) {
+		if (!pathway_start.is_equal_approx(pathway_end)) {
 			Vector3 inters;
 			if (cut_plane.intersects_segment(pathway_start, pathway_end, &inters)) {
-				if (inters.distance_to(p_to_point) > CMP_EPSILON && inters.distance_to(path[path.size() - 1]) > CMP_EPSILON) {
+				if (!inters.is_equal_approx(p_to_point) && !inters.is_equal_approx(path[path.size() - 1])) {
 					path.push_back(inters);
 				}
 			}

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -599,7 +599,7 @@ void LightmapGI::_gen_new_positions_from_octree(const GenProbesOctree *p_cell, f
 			const Vector3 *pp = probe_positions.ptr();
 			bool exists = false;
 			for (int j = 0; j < ppcount; j++) {
-				if (pp[j].distance_to(real_pos) < CMP_EPSILON) {
+				if (pp[j].is_equal_approx(real_pos)) {
 					exists = true;
 					break;
 				}

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -36,17 +36,17 @@
 #include <stdlib.h>
 
 static _FORCE_INLINE_ void get_uv_and_normal(const Vector3 &p_pos, const Vector3 *p_vtx, const Vector2 *p_uv, const Vector3 *p_normal, Vector2 &r_uv, Vector3 &r_normal) {
-	if (p_pos.distance_squared_to(p_vtx[0]) < CMP_EPSILON2) {
+	if (p_pos.is_equal_approx(p_vtx[0])) {
 		r_uv = p_uv[0];
 		r_normal = p_normal[0];
 		return;
 	}
-	if (p_pos.distance_squared_to(p_vtx[1]) < CMP_EPSILON2) {
+	if (p_pos.is_equal_approx(p_vtx[1])) {
 		r_uv = p_uv[1];
 		r_normal = p_normal[1];
 		return;
 	}
-	if (p_pos.distance_squared_to(p_vtx[2]) < CMP_EPSILON2) {
+	if (p_pos.is_equal_approx(p_vtx[2])) {
 		r_uv = p_uv[2];
 		r_normal = p_normal[2];
 		return;

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -387,19 +387,19 @@ Vector2 AnimationNodeBlendSpace2D::get_closest_point(const Vector2 &p_point) {
 }
 
 void AnimationNodeBlendSpace2D::_blend_triangle(const Vector2 &p_pos, const Vector2 *p_points, float *r_weights) {
-	if (p_pos.distance_squared_to(p_points[0]) < CMP_EPSILON2) {
+	if (p_pos.is_equal_approx(p_points[0])) {
 		r_weights[0] = 1;
 		r_weights[1] = 0;
 		r_weights[2] = 0;
 		return;
 	}
-	if (p_pos.distance_squared_to(p_points[1]) < CMP_EPSILON2) {
+	if (p_pos.is_equal_approx(p_points[1])) {
 		r_weights[0] = 0;
 		r_weights[1] = 1;
 		r_weights[2] = 0;
 		return;
 	}
-	if (p_pos.distance_squared_to(p_points[2]) < CMP_EPSILON2) {
+	if (p_pos.is_equal_approx(p_points[2])) {
 		r_weights[0] = 0;
 		r_weights[1] = 0;
 		r_weights[2] = 1;

--- a/servers/physics_3d/collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/collision_solver_3d_sat.cpp
@@ -629,9 +629,7 @@ public:
 	_FORCE_INLINE_ bool test_axis(const Vector3 &p_axis, bool p_directional = false) {
 		Vector3 axis = p_axis;
 
-		if (Math::abs(axis.x) < CMP_EPSILON &&
-				Math::abs(axis.y) < CMP_EPSILON &&
-				Math::abs(axis.z) < CMP_EPSILON) {
+		if (axis.is_equal_approx(Vector3())) {
 			// strange case, try an upwards separator
 			axis = Vector3(0.0, 1.0, 0.0);
 		}

--- a/servers/physics_3d/shape_3d_sw.cpp
+++ b/servers/physics_3d/shape_3d_sw.cpp
@@ -1783,7 +1783,7 @@ bool HeightMapShape3DSW::intersect_segment(const Vector3 &p_begin, const Vector3
 		int z = floor(local_begin.z);
 
 		// Workaround cases where the ray starts at an integer position.
-		if (Math::abs(cross_x) < CMP_EPSILON) {
+		if (Math::is_zero_approx(cross_x)) {
 			cross_x += delta_x;
 			// If going backwards, we should ignore the position we would get by the above flooring,
 			// because the ray is not heading in that direction.
@@ -1792,7 +1792,7 @@ bool HeightMapShape3DSW::intersect_segment(const Vector3 &p_begin, const Vector3
 			}
 		}
 
-		if (Math::abs(cross_z) < CMP_EPSILON) {
+		if (Math::is_zero_approx(cross_z)) {
 			cross_z += delta_z;
 			if (z_step == -1) {
 				z -= 1;


### PR DESCRIPTION
This PR uses `is_equal_approx` and `is_zero_approx` in more places.

As a quick reminder:

* `is_equal_approx` is similar to what's being replaced here, except that it scales the tolerance to account for the magnitude of the number, which will make the code more robust at handling large numbers.

* `is_zero_approx` is mostly a semantic change and should behave the same.
