### PR TITLE
Change in PackedByteArray decode api and docs

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -750,6 +750,42 @@ struct _VariantCall {
 		return 0;
 	}
 
+	static PackedInt32Array func_PackedByteArray_decode_s32_array(PackedByteArray *p_instance) {
+		uint64_t size = p_instance->size();
+		const uint8_t *r = p_instance->ptr();
+		PackedInt32Array dest;
+		dest.resize(size / sizeof(int32_t));
+		memcpy(dest.ptrw(), r, size);
+		return dest;
+	}
+
+	static PackedInt64Array func_PackedByteArray_decode_s64_array(PackedByteArray *p_instance) {
+		uint64_t size = p_instance->size();
+		const uint8_t *r = p_instance->ptr();
+		PackedInt64Array dest;
+		dest.resize(size / sizeof(int64_t));
+		memcpy(dest.ptrw(), r, size);
+		return dest;
+	}
+
+	static PackedFloat32Array func_PackedByteArray_decode_float_array(PackedByteArray *p_instance) {
+		uint64_t size = p_instance->size();
+		const uint8_t *r = p_instance->ptr();
+		PackedFloat32Array dest;
+		dest.resize(size / sizeof(float));
+		memcpy(dest.ptrw(), r, size);
+		return dest;
+	}
+
+	static PackedFloat64Array func_PackedByteArray_decode_double_array(PackedByteArray *p_instance) {
+		uint64_t size = p_instance->size();
+		const uint8_t *r = p_instance->ptr();
+		PackedFloat64Array dest;
+		dest.resize(size / sizeof(double));
+		memcpy(dest.ptrw(), r, size);
+		return dest;
+	}
+
 	static void func_PackedByteArray_encode_u8(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 1);
@@ -1823,6 +1859,11 @@ static void _register_variant_builtin_methods() {
 	bind_function(PackedByteArray, has_encoded_var, _VariantCall::func_PackedByteArray_has_encoded_var, sarray("byte_offset", "allow_objects"), varray(false));
 	bind_function(PackedByteArray, decode_var, _VariantCall::func_PackedByteArray_decode_var, sarray("byte_offset", "allow_objects"), varray(false));
 	bind_function(PackedByteArray, decode_var_size, _VariantCall::func_PackedByteArray_decode_var_size, sarray("byte_offset", "allow_objects"), varray(false));
+
+	bind_function(PackedByteArray, to_int32_array, _VariantCall::func_PackedByteArray_decode_s32_array, sarray(), varray());
+	bind_function(PackedByteArray, to_int64_array, _VariantCall::func_PackedByteArray_decode_s64_array, sarray(), varray());
+	bind_function(PackedByteArray, to_float32_array, _VariantCall::func_PackedByteArray_decode_float_array, sarray(), varray());
+	bind_function(PackedByteArray, to_float64_array, _VariantCall::func_PackedByteArray_decode_double_array, sarray(), varray());
 
 	bind_functionnc(PackedByteArray, encode_u8, _VariantCall::func_PackedByteArray_encode_u8, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_s8, _VariantCall::func_PackedByteArray_encode_s8, sarray("byte_offset", "value"), varray());

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -515,6 +515,42 @@
 				Returns the slice of the [PackedByteArray] between indices (inclusive) as a new [PackedByteArray]. Any negative index is considered to be from the end of the array.
 			</description>
 		</method>
+		<method name="to_float32_array" qualifiers="const">
+			<return type="PackedFloat32Array">
+			</return>
+			<description>
+				Returns a copy of the data converted to a [PackedFloat32Array], where each block of 4 bytes has been converted to a 32-bit float (C++ [code]float[/code]).
+				The size of the new array will be [code]byte_array.size() / 4[/code].
+				If the original data can't be converted to 32-bit floats, the resulting data is undefined.
+			</description>
+		</method>
+		<method name="to_float64_array" qualifiers="const">
+			<return type="PackedFloat64Array">
+			</return>
+			<description>
+				Returns a copy of the data converted to a [PackedFloat64Array], where each block of 8 bytes has been converted to a 64-bit float (C++ [code]double[/code], Godot [float]).
+				The size of the new array will be [code]byte_array.size() / 8[/code].
+				If the original data can't be converted to 64-bit floats, the resulting data is undefined.
+			</description>
+		</method>
+		<method name="to_int32_array" qualifiers="const">
+			<return type="PackedInt32Array">
+			</return>
+			<description>
+				Returns a copy of the data converted to a [PackedInt32Array], where each block of 4 bytes has been converted to a signed 32-bit integer (C++ [code]int32_t[/code]).
+				The size of the new array will be [code]byte_array.size() / 4[/code].
+				If the original data can't be converted to signed 32-bit integers, the resulting data is undefined.
+			</description>
+		</method>
+		<method name="to_int64_array" qualifiers="const">
+			<return type="PackedInt64Array">
+			</return>
+			<description>
+				Returns a copy of the data converted to a [PackedInt64Array], where each block of 4 bytes has been converted to a signed 64-bit integer (C++ [code]int64_t[/code], Godot [int]).
+				The size of the new array will be [code]byte_array.size() / 8[/code].
+				If the original data can't be converted to signed 64-bit integers, the resulting data is undefined.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -201,6 +201,8 @@
 			<return type="PackedByteArray">
 			</return>
 			<description>
+				Returns a copy of the data converted to a [PackedByteArray], where each element have been encoded as 4 bytes.
+				The size of the new array will be [code]float32_array.size() * 4[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -201,6 +201,8 @@
 			<return type="PackedByteArray">
 			</return>
 			<description>
+				Returns a copy of the data converted to a [PackedByteArray], where each element have been encoded as 8 bytes.
+				The size of the new array will be [code]float64_array.size() * 8[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -201,6 +201,8 @@
 			<return type="PackedByteArray">
 			</return>
 			<description>
+				Returns a copy of the data converted to a [PackedByteArray], where each element have been encoded as 4 bytes.
+				The size of the new array will be [code]int32_array.size() * 4[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -201,6 +201,8 @@
 			<return type="PackedByteArray">
 			</return>
 			<description>
+				Returns a copy of the data converted to a [PackedByteArray], where each element have been encoded as 8 bytes.
+				The size of the new array will be [code]int64_array.size() * 8[/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
- New methods PackedByteArray::to_***_array to decode all the byte array at once (and be easier to use) and its documentations
- Documentation for Packed***Array for the counterpart method to_byte_array

Discussed here : https://github.com/godotengine/godot-proposals/issues/2993