### PR TITLE
Improve the shader error console output (3.x)

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -987,7 +987,13 @@ Error ShaderCompilerGLES2::compile(VS::ShaderMode p_mode, const String &p_code, 
 	if (err != OK) {
 		Vector<String> shader = p_code.split("\n");
 		for (int i = 0; i < shader.size(); i++) {
-			print_line(itos(i + 1) + " " + shader[i]);
+			if (i + 1 == parser.get_error_line()) {
+				// Mark the error line to be visible without having to look at
+				// the trace at the end.
+				print_line(vformat("E%4d-> %s", i + 1, shader[i]));
+			} else {
+				print_line(vformat("%5d | %s", i + 1, shader[i]));
+			}
 		}
 
 		_err_print_error(nullptr, p_path.utf8().get_data(), parser.get_error_line(), parser.get_error_text().utf8().get_data(), ERR_HANDLER_SHADER);

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -119,7 +119,7 @@ static void _display_error_with_code(const String &p_error, const Vector<const c
 	Vector<String> lines = String(total_code).split("\n");
 
 	for (int j = 0; j < lines.size(); j++) {
-		print_line(itos(line) + ": " + lines[j]);
+		print_line(vformat("%4d | %s", line, lines[j]));
 		line++;
 	}
 

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -1031,7 +1031,13 @@ Error ShaderCompilerGLES3::compile(VS::ShaderMode p_mode, const String &p_code, 
 	if (err != OK) {
 		Vector<String> shader = p_code.split("\n");
 		for (int i = 0; i < shader.size(); i++) {
-			print_line(itos(i + 1) + " " + shader[i]);
+			if (i + 1 == parser.get_error_line()) {
+				// Mark the error line to be visible without having to look at
+				// the trace at the end.
+				print_line(vformat("E%4d-> %s", i + 1, shader[i]));
+			} else {
+				print_line(vformat("%5d | %s", i + 1, shader[i]));
+			}
 		}
 
 		_err_print_error(nullptr, p_path.utf8().get_data(), parser.get_error_line(), parser.get_error_text().utf8().get_data(), ERR_HANDLER_SHADER);

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -149,7 +149,7 @@ static void _display_error_with_code(const String &p_error, const Vector<const c
 	Vector<String> lines = String(total_code).split("\n");
 
 	for (int j = 0; j < lines.size(); j++) {
-		print_line(itos(line) + ": " + lines[j]);
+		print_line(vformat("%4d | %s", line, lines[j]));
 		line++;
 	}
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/37579 (with error marking added).

Error marking in `master` added in https://github.com/godotengine/godot/pull/50537.

This makes the line gutter look more like an actual line gutter, which makes it less confusing.

## Preview

### Before

```
1 shader_type spatial;
2 render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx;
3 uniform vec4 albedo : hint_color;
4 uniform sampler2D texture_albedo : hint_albedo;
5 uniform float specular;
6 uniform float metallic;
7 uniform float roughness : hint_range(0,1);
8 uniform float point_size : hint_range(0,128);
9 uniform vec3 uv1_scale;
10 uniform vec3 uv1_offset;
11 uniform vec3 uv2_scale;
12 uniform vec3 uv2_offset;
13
14
15 void vertex() {
16         UV=UV*uv1_scale.xy+uv1_offset.xy;
17 }
18
19
20
21
22 void fragment() {
23         vec2 base_uv = UV;
24         vec4 albedo_tex ds= texture(texture_albedo,base_uv);
25         ALBEDO = albedo.rgb * albedo_tex.rgb;
26         METALLIC = metallic;
27         ROUGHNESS = roughness;
28         SPECULAR = specular;
29 }
30
SHADER ERROR: Expected ',' or ';' after variable
          at: (null) (:24)
```

### After

```
    1 | shader_type spatial;
    2 | render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx;
    3 | uniform vec4 albedo : hint_color;
    4 | uniform sampler2D texture_albedo : hint_albedo;
    5 | uniform float specular;
    6 | uniform float metallic;
    7 | uniform float roughness : hint_range(0,1);
    8 | uniform float point_size : hint_range(0,128);
    9 | uniform vec3 uv1_scale;
   10 | uniform vec3 uv1_offset;
   11 | uniform vec3 uv2_scale;
   12 | uniform vec3 uv2_offset;
   13 |
   14 |
   15 | void vertex() {
   16 |         UV=UV*uv1_scale.xy+uv1_offset.xy;
   17 | }
   18 |
   19 |
   20 |
   21 |
   22 | void fragment() {
   23 |         vec2 base_uv = UV;
E  24->         vec4 albedo_tex ds= texture(texture_albedo,base_uv);
   25 |         ALBEDO = albedo.rgb * albedo_tex.rgb;
   26 |         METALLIC = metallic;
   27 |         ROUGHNESS = roughness;
   28 |         SPECULAR = specular;
   29 | }
   30 |
SHADER ERROR: Expected ',' or ';' after variable
          at: (null) (:24)
```