### PR TITLE
Add error marking to the shader error console output

### DIFF
--- a/servers/rendering/renderer_rd/shader_compiler_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_compiler_rd.cpp
@@ -1351,7 +1351,13 @@ Error ShaderCompilerRD::compile(RS::ShaderMode p_mode, const String &p_code, Ide
 	if (err != OK) {
 		Vector<String> shader = p_code.split("\n");
 		for (int i = 0; i < shader.size(); i++) {
-			print_line(itos(i + 1) + " " + shader[i]);
+			if (i + 1 == parser.get_error_line()) {
+				// Mark the error line to be visible without having to look at
+				// the trace at the end.
+				print_line(vformat("E%4d-> %s", i + 1, shader[i]));
+			} else {
+				print_line(vformat("%5d | %s", i + 1, shader[i]));
+			}
 		}
 
 		_err_print_error(nullptr, p_path.utf8().get_data(), parser.get_error_line(), parser.get_error_text().utf8().get_data(), ERR_HANDLER_SHADER);


### PR DESCRIPTION
`master` port of the error marking added in https://github.com/godotengine/godot/pull/50536.

This makes it possible to see where the shader error is without having to look at the trace printed below the source code. (In long shaders, the trace may be printed far away from the error location.)

## Preview

### Before

```
1 shader_type spatial;
2 render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx,unshaded;
3 uniform vec4 albedo : hint_color;
4 uniform sampler2D texture_albedo : hint_albedo,filter_linear_mipmap,repeat_enable;
5 uniform float point_size : hint_range(0,128);
6 uniform float roughness : hint_range(0,1);
7 uniform sampler2D texture_metallic : hint_white,filter_linear_mipmap,repeat_enable;
8 uniform vec4 metallic_texture_channel;
9 uniform sampler2D texture_roughness : hint_roughness_r,filter_linear_mipmap,repeat_enable;
10 uniform float specular;
11 uniform float metallic;
12 uniform int particles_anim_h_frames;
13 uniform int particles_anim_v_frames;
14 uniform bool particles_anim_loop;
15 uniform vec3 uv1_scale;
16 uniform vec3 uv1_offset;
17 uniform vec3 uv2_scale;
18 uniform vec3 uv2_offset;
19 
20 
21 void vertex() {
22      UV=UV*uv1_scale.xy+uv1_offset.xy;
23      mat4 mat_world = mat4(normalize(CAMERA_MATRIX[0])*length(WORLD_MATRIX[0]),normalize(CAMERA_MATRIX[1])*length(WORLD_MATRIX[0]),normalize(CAMERA_MATRIX[2])*length(WORLD_MATRIX[2]),WORLD_MATRIX[3]);
24      mat_world = mat_world * mat4( vec4(cos(INSTANCE_CUSTOM.x),-sin(INSTANCE_CUSTOM.x), 0.0, 0.0), vec4(sin(INSTANCE_CUSTOM.x), cos(INSTANCE_CUSTOM.x), 0.0, 0.0),vec4(0.0, 0.0, 1.0, 0.0),vec4(0.0, 0.0, 0.0, 1.0));
25      MODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat_world;
26      float h_frames = float(particles_anim_h_frames);
27      float v_frames = float(particles_anim_v_frames);
28      float particle_total_frames = float(particles_anim_h_frames * particles_anim_v_frames);
29      float particle_frame = floor(INSTANCE_CUSTOM.z * float(particle_total_frames));
30      if (!particles_anim_loop) {
31              particle_frame = clamp(particle_frame, 0.0, particle_total_frames - 1.0);
32      } else {
33              particle_frame = mod(particle_frame, particle_total_frames);
34      }       UV /= vec2(h_frames, v_frames);
35      UV += vec2(mod(particle_frame, h_frames) / h_frames, floor(particle_frame / h_frames) / v_frames);
36 }
37 
38 
39 
40 
41 void fragment() {
42      vec2 base_uv = UV;
43      vec4 albedo_tex = texture(texture_albedo,base_uv);
44      albedo_tex *= COLOR;
45      ALBEDO = albedo.rgb * albedo_tex.rgb;
46      float metallic_tex = dot(texture(texture_metallic,base_uv),metallic_texture_channel);
47      METALLIC = metallic_tex * metallic;
48      vec4 roughness_texture_channel = vec4(1.0,0.0,0.0,0.0);
49      float roughness_tex = dot(texture(texture_roughness,base_uv),roughness_texture_channel);
50      ROUGHNESS = roughness_tex * roughness;
51      SPECULAR = specular;
52      ALPHA = 32albedo.a * albedo_tex.a;
53 }
54 
SHADER ERROR: Invalid member for int expression: .a
          at: (null) (:52)
```

### After

```
    1 | shader_type spatial;
    2 | render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx,unshaded;
    3 | uniform vec4 albedo : hint_color;
    4 | uniform sampler2D texture_albedo : hint_albedo,filter_linear_mipmap,repeat_enable;
    5 | uniform float point_size : hint_range(0,128);
    6 | uniform float roughness : hint_range(0,1);
    7 | uniform sampler2D texture_metallic : hint_white,filter_linear_mipmap,repeat_enable;
    8 | uniform vec4 metallic_texture_channel;
    9 | uniform sampler2D texture_roughness : hint_roughness_r,filter_linear_mipmap,repeat_enable;
   10 | uniform float specular;
   11 | uniform float metallic;
   12 | uniform int particles_anim_h_frames;
   13 | uniform int particles_anim_v_frames;
   14 | uniform bool particles_anim_loop;
   15 | uniform vec3 uv1_scale;
   16 | uniform vec3 uv1_offset;
   17 | uniform vec3 uv2_scale;
   18 | uniform vec3 uv2_offset;
   19 |
   20 |
   21 | void vertex() {
   22 |         UV=UV*uv1_scale.xy+uv1_offset.xy;
   23 |         mat4 mat_world = mat4(normalize(CAMERA_MATRIX[0])*length(WORLD_MATRIX[0]),normalize(CAMERA_MATRIX[1])*length(WORLD_MATRIX[0]),normalize(CAMERA_MATRIX[2])*length(WORLD_MATRIX[2]),WORLD_MATRIX[3]);
   24 |         mat_world = mat_world * mat4( vec4(cos(INSTANCE_CUSTOM.x),-sin(INSTANCE_CUSTOM.x), 0.0, 0.0), vec4(sin(INSTANCE_CUSTOM.x), cos(INSTANCE_CUSTOM.x), 0.0, 0.0),vec4(0.0, 0.0, 1.0, 0.0),vec4(0.0, 0.0, 0.0, 1.0));
   25 |         MODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat_world;
   26 |         float h_frames = float(particles_anim_h_frames);
   27 |         float v_frames = float(particles_anim_v_frames);
   28 |         float particle_total_frames = float(particles_anim_h_frames * particles_anim_v_frames);
   29 |         float particle_frame = floor(INSTANCE_CUSTOM.z * float(particle_total_frames));
   30 |         if (!particles_anim_loop) {
   31 |                 particle_frame = clamp(particle_frame, 0.0, particle_total_frames - 1.0);
   32 |         } else {
   33 |                 particle_frame = mod(particle_frame, particle_total_frames);
   34 |         }       UV /= vec2(h_frames, v_frames);
   35 |         UV += vec2(mod(particle_frame, h_frames) / h_frames, floor(particle_frame / h_frames) / v_frames);
   36 | }
   37 |
   38 |
   39 |
   40 |
   41 | void fragment() {
   42 |         vec2 base_uv = UV;
   43 |         vec4 albedo_tex = texture(texture_albedo,base_uv);
   44 |         albedo_tex *= COLOR;
   45 |         ALBEDO = albedo.rgb * albedo_tex.rgb;
   46 |         float metallic_tex = dot(texture(texture_metallic,base_uv),metallic_texture_channel);
   47 |         METALLIC = metallic_tex * metallic;
   48 |         vec4 roughness_texture_channel = vec4(1.0,0.0,0.0,0.0);
   49 |         float roughness_tex = dot(texture(texture_roughness,base_uv),roughness_texture_channel);
   50 |         ROUGHNESS = roughness_tex * roughness;
   51 |         SPECULAR = specular;
E  52->         ALPHA = 32albedo.a * albedo_tex.a;
   53 | }
   54 |
SHADER ERROR: Invalid member for int expression: .a
          at: (null) (:52)
```