### PR TITLE
Hide triplanar subproperties when triplanar is disabled in BaseMaterial3D

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1793,12 +1793,21 @@ void BaseMaterial3D::set_flag(Flags p_flag, bool p_enabled) {
 	}
 
 	flags[p_flag] = p_enabled;
-	if (p_flag == FLAG_USE_SHADOW_TO_OPACITY || p_flag == FLAG_USE_TEXTURE_REPEAT || p_flag == FLAG_SUBSURFACE_MODE_SKIN || p_flag == FLAG_USE_POINT_SIZE) {
+
+	if (
+			p_flag == FLAG_USE_SHADOW_TO_OPACITY ||
+			p_flag == FLAG_USE_TEXTURE_REPEAT ||
+			p_flag == FLAG_SUBSURFACE_MODE_SKIN ||
+			p_flag == FLAG_USE_POINT_SIZE ||
+			p_flag == FLAG_UV1_USE_TRIPLANAR ||
+			p_flag == FLAG_UV2_USE_TRIPLANAR) {
 		notify_property_list_changed();
 	}
+
 	if (p_flag == FLAG_PARTICLE_TRAILS_MODE) {
 		update_configuration_warning();
 	}
+
 	_queue_shader_change();
 }
 
@@ -1921,6 +1930,14 @@ void BaseMaterial3D::_validate_property(PropertyInfo &property) const {
 	}
 
 	if ((property.name == "distance_fade_max_distance" || property.name == "distance_fade_min_distance") && distance_fade == DISTANCE_FADE_DISABLED) {
+		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+
+	if ((property.name == "uv1_triplanar_sharpness" || property.name == "uv1_world_triplanar") && !flags[FLAG_UV1_USE_TRIPLANAR]) {
+		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+
+	if ((property.name == "uv2_triplanar_sharpness" || property.name == "uv2_world_triplanar") && !flags[FLAG_UV2_USE_TRIPLANAR]) {
 		property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
@@ -2684,7 +2701,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "emission_on_uv2"), "set_flag", "get_flag", FLAG_EMISSION_ON_UV2);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "emission_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_EMISSION);
 
-	ADD_GROUP("NormalMap", "normal_");
+	ADD_GROUP("Normal Map", "normal_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "normal_enabled"), "set_feature", "get_feature", FEATURE_NORMAL_MAPPING);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "normal_scale", PROPERTY_HINT_RANGE, "-16,16,0.01"), "set_normal_scale", "get_normal_scale");
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "normal_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_NORMAL);
@@ -2724,7 +2741,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "heightmap_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_HEIGHTMAP);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "heightmap_flip_texture"), "set_flag", "get_flag", FLAG_INVERT_HEIGHTMAP);
 
-	ADD_GROUP("Subsurf Scatter", "subsurf_scatter_");
+	ADD_GROUP("Subsurface Scattering", "subsurf_scatter_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "subsurf_scatter_enabled"), "set_feature", "get_feature", FEATURE_SUBSURFACE_SCATTERING);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "subsurf_scatter_strength", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_subsurface_scattering_strength", "get_subsurface_scattering_strength");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "subsurf_scatter_skin_mode"), "set_flag", "get_flag", FLAG_SUBSURFACE_MODE_SKIN);


### PR DESCRIPTION
The Triplanar Sharpness and World Triplanar properties have no effect when their respective UV triplanar property is disabled.

This also renames some sections for consistency.


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->