### PR TITLE
Hide triplanar sharpness when triplanar is disabled in SpatialMaterial

### DIFF
--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -365,7 +365,7 @@
 		<member name="uv1_triplanar" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], instead of using [code]UV[/code] textures will use a triplanar texture lookup to determine how to apply textures. Triplanar uses the orientation of the object's surface to blend between texture coordinates. It reads from the source texture 3 times, once for each axis and then blends between the results based on how closely the pixel aligns with each axis. This is often used for natural features to get a realistic blend of materials. Because triplanar texturing requires many more texture reads per-pixel it is much slower than normal UV texturing. Additionally, because it is blending the texture between the three axes, it is unsuitable when you are trying to achieve crisp texturing.
 		</member>
-		<member name="uv1_triplanar_sharpness" type="float" setter="set_uv1_triplanar_blend_sharpness" getter="get_uv1_triplanar_blend_sharpness" default="1.0">
+		<member name="uv1_triplanar_sharpness" type="float" setter="set_uv1_triplanar_blend_sharpness" getter="get_uv1_triplanar_blend_sharpness">
 			A lower number blends the texture more softly while a higher number blends the texture more sharply.
 		</member>
 		<member name="uv2_offset" type="Vector3" setter="set_uv2_offset" getter="get_uv2_offset" default="Vector3( 0, 0, 0 )">
@@ -377,7 +377,7 @@
 		<member name="uv2_triplanar" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], instead of using [code]UV2[/code] textures will use a triplanar texture lookup to determine how to apply textures. Triplanar uses the orientation of the object's surface to blend between texture coordinates. It reads from the source texture 3 times, once for each axis and then blends between the results based on how closely the pixel aligns with each axis. This is often used for natural features to get a realistic blend of materials. Because triplanar texturing requires many more texture reads per-pixel it is much slower than normal UV texturing. Additionally, because it is blending the texture between the three axes, it is unsuitable when you are trying to achieve crisp texturing.
 		</member>
-		<member name="uv2_triplanar_sharpness" type="float" setter="set_uv2_triplanar_blend_sharpness" getter="get_uv2_triplanar_blend_sharpness" default="1.0">
+		<member name="uv2_triplanar_sharpness" type="float" setter="set_uv2_triplanar_blend_sharpness" getter="get_uv2_triplanar_blend_sharpness">
 			A lower number blends the texture more softly while a higher number blends the texture more sharply.
 		</member>
 		<member name="vertex_color_is_srgb" type="bool" setter="set_flag" getter="get_flag" default="false">

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1322,9 +1322,16 @@ void SpatialMaterial::set_flag(Flags p_flag, bool p_enabled) {
 	}
 
 	flags[p_flag] = p_enabled;
-	if ((p_flag == FLAG_USE_ALPHA_SCISSOR) || (p_flag == FLAG_UNSHADED) || (p_flag == FLAG_USE_SHADOW_TO_OPACITY)) {
+
+	if (
+			p_flag == FLAG_USE_ALPHA_SCISSOR ||
+			p_flag == FLAG_UNSHADED ||
+			p_flag == FLAG_USE_SHADOW_TO_OPACITY ||
+			p_flag == FLAG_UV1_USE_TRIPLANAR ||
+			p_flag == FLAG_UV2_USE_TRIPLANAR) {
 		_change_notify();
 	}
+
 	_queue_shader_change();
 }
 
@@ -1417,6 +1424,14 @@ void SpatialMaterial::_validate_property(PropertyInfo &property) const {
 	}
 
 	if ((property.name == "distance_fade_max_distance" || property.name == "distance_fade_min_distance") && distance_fade == DISTANCE_FADE_DISABLED) {
+		property.usage = 0;
+	}
+
+	if (property.name == "uv1_triplanar_sharpness" && !flags[FLAG_UV1_USE_TRIPLANAR]) {
+		property.usage = 0;
+	}
+
+	if (property.name == "uv2_triplanar_sharpness" && !flags[FLAG_UV2_USE_TRIPLANAR]) {
 		property.usage = 0;
 	}
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50539 (without world triplanar, as that property is a global flag for both UV1 and UV2 in `3.x`).

The Triplanar Sharpness property has no effect when Triplanar is disabled.