### PR TITLE
Fix focus behavior in the Add Item Type dialog of the Theme editor

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2015,6 +2015,12 @@ void ThemeTypeDialog::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_add_type_options();
 		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible()) {
+				add_type_filter->grab_focus();
+			}
+		} break;
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/50545. Doesn't need a cherrypick/backport to 3.x.