### PR TITLE
Fix duplicate selection in SceneTree

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -521,7 +521,7 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 
 	if (p_node == selected) {
 		selected = nullptr;
-		emit_signal("node_selected");
+		_emit_node_selected();
 	}
 }
 
@@ -615,30 +615,18 @@ void SceneTreeEditor::_tree_changed() {
 	pending_test_update = true;
 }
 
-void SceneTreeEditor::_selected_changed() {
-	TreeItem *s = tree->get_selected();
-	ERR_FAIL_COND(!s);
-	NodePath np = s->get_metadata(0);
-
-	Node *n = get_node(np);
-
-	if (n == selected) {
-		return;
-	}
-
-	selected = get_node(np);
-
-	blocked++;
-	emit_signal("node_selected");
-	blocked--;
-}
-
 void SceneTreeEditor::_deselect_items() {
 	// Clear currently selected items in scene tree dock.
 	if (editor_selection) {
 		editor_selection->clear();
 		emit_signal("node_changed");
 	}
+}
+
+void SceneTreeEditor::_emit_node_selected() {
+	blocked++;
+	emit_signal("node_selected");
+	blocked--;
 }
 
 void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_selected) {
@@ -667,7 +655,7 @@ void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_
 	// Selection changed to be single node, so emit "selected" (for single node) rather than "changed" (for multiple nodes)
 	if (editor_selection->get_selected_nodes().size() == 1) {
 		selected = editor_selection->get_selected_node_list()[0];
-		emit_signal("node_selected");
+		_emit_node_selected();
 	} else {
 		emit_signal("node_changed");
 	}
@@ -759,7 +747,7 @@ void SceneTreeEditor::set_selected(Node *p_node, bool p_emit_selected) {
 	}
 
 	if (p_emit_selected) {
-		emit_signal("node_selected");
+		_emit_node_selected();
 	}
 }
 
@@ -1200,7 +1188,6 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 		tree->connect("empty_tree_rmb_selected", callable_mp(this, &SceneTreeEditor::_rmb_select));
 	}
 
-	tree->connect("cell_selected", callable_mp(this, &SceneTreeEditor::_selected_changed));
 	tree->connect("item_edited", callable_mp(this, &SceneTreeEditor::_renamed), varray(), CONNECT_DEFERRED);
 	tree->connect("multi_selected", callable_mp(this, &SceneTreeEditor::_cell_multi_selected));
 	tree->connect("button_pressed", callable_mp(this, &SceneTreeEditor::_cell_button_pressed));

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -81,7 +81,6 @@ class SceneTreeEditor : public Control {
 
 	TreeItem *_find(TreeItem *p_node, const NodePath &p_path);
 	void _notification(int p_what);
-	void _selected_changed();
 	void _deselect_items();
 	void _rename_node(ObjectID p_node, const String &p_name);
 
@@ -132,6 +131,8 @@ class SceneTreeEditor : public Control {
 	bool _is_script_type(const StringName &p_type) const;
 
 	Vector<StringName> valid_types;
+
+	void _emit_node_selected();
 
 public:
 	void set_filter(const String &p_filter);


### PR DESCRIPTION
* It seems both _cell_selected_ and _multi_selected_ were being triggered.
* This caused inspector updating twice.
* cell_selected connection and callback were removed.

This may be a bug in Godot 3.x too, recommend checking.