### PR TITLE
Clarify that resize doesn't initialize memory

### DIFF
--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -112,6 +112,7 @@
 			<argument index="0" name="idx" type="int" />
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+				[b]Note:[/b] Added elements are not automatically initialized to 0 and will contain garbage, i.e. indeterminate values.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -65,6 +65,7 @@
 			<argument index="0" name="idx" type="int" />
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+				[b]Note:[/b] Added elements are not automatically initialized to 0 and will contain garbage, i.e. indeterminate values.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -65,6 +65,7 @@
 			<argument index="0" name="idx" type="int" />
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+				[b]Note:[/b] Added elements are not automatically initialized to 0 and will contain garbage, i.e. indeterminate values.
 			</description>
 		</method>
 		<method name="set">


### PR DESCRIPTION
Some users might expect resize() to initialize added elements to zero. This clarifies that it is not the case.

Only relevant to 3.x since 4.0 handles it differently
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
