### PR TITLE
Re-enable building WebXR in GitHub Actions

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=javascript verbose=yes warnings=extra debug_symbols=no module_webxr_enabled=no --jobs=2
+  SCONSFLAGS: platform=javascript verbose=yes warnings=extra debug_symbols=no --jobs=2
   SCONS_CACHE_LIMIT: 4096
   EM_VERSION: 2.0.25
   EM_CACHE_FOLDER: 'emsdk-cache'

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -35,6 +35,7 @@
 #include "core/os/os.h"
 #include "emscripten.h"
 #include "godot_webxr.h"
+#include "servers/rendering/renderer_compositor.h"
 #include <stdlib.h>
 
 void _emwebxr_on_session_supported(char *p_session_mode, int p_supported) {
@@ -376,6 +377,22 @@ void WebXRInterfaceJS::commit_for_eye(XRInterface::Eyes p_eye, RID p_render_targ
 		return;
 	}
 	godot_webxr_commit_for_eye(p_eye);
+}
+
+Vector<BlitToScreen> WebXRInterfaceJS::commit_views(RID p_render_target, const Rect2 &p_screen_rect) {
+	Vector<BlitToScreen> blit_to_screen;
+
+	if (!initialized) {
+		return blit_to_screen;
+	}
+
+	// @todo Refactor this to be based on "views" rather than "eyes".
+	godot_webxr_commit_for_eye(XRInterface::EYE_LEFT);
+	if (godot_webxr_get_view_count() > 1) {
+		godot_webxr_commit_for_eye(XRInterface::EYE_RIGHT);
+	}
+
+	return blit_to_screen;
 };
 
 void WebXRInterfaceJS::process() {

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -89,6 +89,7 @@ public:
 	virtual CameraMatrix get_projection_for_view(uint32_t p_view, real_t p_aspect, real_t p_z_near, real_t p_z_far) override;
 	virtual unsigned int get_external_texture_for_eye(XRInterface::Eyes p_eye) override;
 	virtual void commit_for_eye(XRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) override;
+	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) override;
 
 	virtual void process() override;
 	virtual void notification(int p_what) override;


### PR DESCRIPTION
I'm not sure if this is a valid way to implement `XRInterface::commit_views()` - I'll connect with @BastiaanOlij to figure that out.

There's a number of other things that make sense to change in WebXR to better match the new XR API. For example, internally WebXR just has N views and it's translating from `XRInterface::Eyes`, but the new XR API is also just based on N views and so all that translating junk can be removed.

But, if possible, I'd prefer to just get it building in CI and address that in another PR, ideally, when I could actually test that it's working. :-)