### PR TITLE
Backport filesystem dock sorting to 3.x

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -123,6 +123,11 @@ bool EditorFileSystemDirectory::get_file_import_is_valid(int p_idx) const {
 	return files[p_idx]->import_valid;
 }
 
+uint64_t EditorFileSystemDirectory::get_file_modified_time(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, files.size(), 0);
+	return files[p_idx]->modified_time;
+}
+
 String EditorFileSystemDirectory::get_file_script_class_name(int p_idx) const {
 	return files[p_idx]->script_class_name;
 }

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -91,6 +91,7 @@ public:
 	StringName get_file_type(int p_idx) const;
 	Vector<String> get_file_deps(int p_idx) const;
 	bool get_file_import_is_valid(int p_idx) const;
+	uint64_t get_file_modified_time(int p_idx) const;
 	String get_file_script_class_name(int p_idx) const; //used for scripts
 	String get_file_script_class_extends(int p_idx) const; //used for scripts
 	String get_file_script_class_icon_path(int p_idx) const; //used for scripts

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -70,6 +70,16 @@ public:
 		DISPLAY_MODE_SPLIT,
 	};
 
+	enum FileSortOption {
+		FILE_SORT_NAME = 0,
+		FILE_SORT_NAME_REVERSE,
+		FILE_SORT_TYPE,
+		FILE_SORT_TYPE_REVERSE,
+		FILE_SORT_MODIFIED_TIME,
+		FILE_SORT_MODIFIED_TIME_REVERSE,
+		FILE_SORT_MAX,
+	};
+
 private:
 	enum FileMenu {
 		FILE_OPEN,
@@ -96,6 +106,8 @@ private:
 		FOLDER_COLLAPSE_ALL,
 	};
 
+	FileSortOption file_sort = FILE_SORT_NAME;
+
 	VBoxContainer *scanning_vb;
 	ProgressBar *scanning_progress;
 	VSplitContainer *split_box;
@@ -110,8 +122,13 @@ private:
 	Button *button_hist_next;
 	Button *button_hist_prev;
 	LineEdit *current_path;
+
+	HBoxContainer *toolbar2_hbc;
 	LineEdit *tree_search_box;
+	MenuButton *tree_button_sort;
+
 	LineEdit *file_list_search_box;
+	MenuButton *file_list_button_sort;
 
 	String searched_string;
 	Vector<String> uncollapsed_paths_before_search;
@@ -176,7 +193,7 @@ private:
 	ItemList *files;
 	bool import_dock_needs_update;
 
-	Ref<Texture> _get_tree_item_icon(EditorFileSystemDirectory *p_dir, int p_idx);
+	Ref<Texture> _get_tree_item_icon(bool p_is_valid, String p_file_type);
 	bool _create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths, bool p_select_in_favorites, bool p_unfold_path = false);
 	Vector<String> _compute_uncollapsed_paths();
 	void _update_tree(const Vector<String> &p_uncollapsed_paths = Vector<String>(), bool p_uncollapse_root = false, bool p_select_in_favorites = false, bool p_unfold_path = false);
@@ -241,6 +258,9 @@ private:
 	void _focus_current_search_box();
 	void _search_changed(const String &p_text, const Control *p_from);
 
+	MenuButton *_create_file_menu_button();
+	void _file_sort_popup(int p_id);
+
 	void _file_and_folders_fill_popup(PopupMenu *p_popup, Vector<String> p_paths, bool p_display_path_dependent_options = true);
 	void _tree_rmb_select(const Vector2 &p_pos);
 	void _tree_rmb_empty(const Vector2 &p_pos);
@@ -254,11 +274,17 @@ private:
 		StringName type;
 		Vector<String> sources;
 		bool import_broken;
+		uint64_t modified_time;
 
 		bool operator<(const FileInfo &fi) const {
 			return NaturalNoCaseComparator()(name, fi.name);
 		}
 	};
+
+	struct FileInfoTypeComparator;
+	struct FileInfoModifiedTimeComparator;
+
+	void _sort_file_info_list(List<FileSystemDock::FileInfo> &r_file_list);
 
 	void _search(EditorFileSystemDirectory *p_path, List<FileInfo> *matches, int p_max_items);
 
@@ -301,6 +327,9 @@ public:
 
 	void set_display_mode(DisplayMode p_display_mode);
 	DisplayMode get_display_mode() { return display_mode; }
+
+	void set_file_sort(FileSortOption p_file_sort);
+	FileSortOption get_file_sort() { return file_sort; }
 
 	void set_file_list_display_mode(FileListDisplayMode p_mode);
 	FileListDisplayMode get_file_list_display_mode() { return file_list_display_mode; };


### PR DESCRIPTION

Backports https://github.com/godotengine/godot/pull/42654 and https://github.com/godotengine/godot/pull/43018 to 3.x
I often find the sort dropdown in the filesystem in 4.0 really useful. It seems worthy of being added to 3.x of Godot itself.

https://user-images.githubusercontent.com/12120644/126049639-9bfed8e9-392a-47f5-a56e-3336f1ce0c4e.mp4