### PR TITLE
Optimize StringName usage

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -438,7 +438,7 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, S
 	}
 	joy_names[p_idx] = js;
 
-	emit_signal("joy_connection_changed", p_idx, p_connected);
+	emit_signal(SNAME("joy_connection_changed"), p_idx, p_connected);
 }
 
 Vector3 Input::get_gravity() const {

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -941,7 +941,7 @@ void MultiplayerAPI::_send_rpc(Node *p_from, int p_to, uint16_t p_rpc_id, const 
 void MultiplayerAPI::_add_peer(int p_id) {
 	connected_peers.insert(p_id);
 	path_get_cache.insert(p_id, PathGetCache());
-	emit_signal("network_peer_connected", p_id);
+	emit_signal(SNAME("network_peer_connected"), p_id);
 }
 
 void MultiplayerAPI::_del_peer(int p_id) {
@@ -956,19 +956,19 @@ void MultiplayerAPI::_del_peer(int p_id) {
 		PathSentCache *psc = path_send_cache.getptr(E->get());
 		psc->confirmed_peers.erase(p_id);
 	}
-	emit_signal("network_peer_disconnected", p_id);
+	emit_signal(SNAME("network_peer_disconnected"), p_id);
 }
 
 void MultiplayerAPI::_connected_to_server() {
-	emit_signal("connected_to_server");
+	emit_signal(SNAME("connected_to_server"));
 }
 
 void MultiplayerAPI::_connection_failed() {
-	emit_signal("connection_failed");
+	emit_signal(SNAME("connection_failed"));
 }
 
 void MultiplayerAPI::_server_disconnected() {
-	emit_signal("server_disconnected");
+	emit_signal(SNAME("server_disconnected"));
 }
 
 void MultiplayerAPI::rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const StringName &p_method, const Variant **p_arg, int p_argcount) {
@@ -1059,7 +1059,7 @@ void MultiplayerAPI::_process_raw(int p_from, const uint8_t *p_packet, int p_pac
 		uint8_t *w = out.ptrw();
 		memcpy(&w[0], &p_packet[1], len);
 	}
-	emit_signal("network_peer_packet", p_from, out);
+	emit_signal(SNAME("network_peer_packet"), p_from, out);
 }
 
 int MultiplayerAPI::get_network_unique_id() const {

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -65,7 +65,7 @@ bool UndoRedo::_redo(bool p_execute) {
 		_process_operation_list(actions.write[current_action].do_ops.front());
 	}
 	version++;
-	emit_signal("version_changed");
+	emit_signal(SNAME("version_changed"));
 
 	return true;
 }
@@ -352,7 +352,7 @@ bool UndoRedo::undo() {
 	_process_operation_list(actions.write[current_action].undo_ops.front());
 	current_action--;
 	version--;
-	emit_signal("version_changed");
+	emit_signal(SNAME("version_changed"));
 
 	return true;
 }
@@ -385,7 +385,7 @@ void UndoRedo::clear_history(bool p_increase_version) {
 
 	if (p_increase_version) {
 		version++;
-		emit_signal("version_changed");
+		emit_signal(SNAME("version_changed"));
 	}
 }
 

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -200,7 +200,7 @@ void InputEventConfigurationDialog::_tab_selected(int p_tab) {
 		if (is_connected("window_input", signal_method)) {
 			disconnect("window_input", signal_method);
 		}
-		input_list_tree->call_deferred("ensure_cursor_is_visible");
+		input_list_tree->call_deferred(SNAME("ensure_cursor_is_visible"));
 		if (input_list_tree->get_selected() == nullptr) {
 			// If nothing selected, scroll to top.
 			input_list_tree->scroll_to_item(input_list_tree->get_root());
@@ -532,14 +532,14 @@ void InputEventConfigurationDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			input_list_search->set_right_icon(input_list_search->get_theme_icon("Search", "EditorIcons"));
+			input_list_search->set_right_icon(input_list_search->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
-			physical_key_checkbox->set_icon(get_theme_icon("KeyboardPhysical", "EditorIcons"));
+			physical_key_checkbox->set_icon(get_theme_icon(SNAME("KeyboardPhysical"), SNAME("EditorIcons")));
 
-			icon_cache.keyboard = get_theme_icon("Keyboard", "EditorIcons");
-			icon_cache.mouse = get_theme_icon("Mouse", "EditorIcons");
-			icon_cache.joypad_button = get_theme_icon("JoyButton", "EditorIcons");
-			icon_cache.joypad_axis = get_theme_icon("JoyAxis", "EditorIcons");
+			icon_cache.keyboard = get_theme_icon(SNAME("Keyboard"), SNAME("EditorIcons"));
+			icon_cache.mouse = get_theme_icon(SNAME("Mouse"), SNAME("EditorIcons"));
+			icon_cache.joypad_button = get_theme_icon(SNAME("JoyButton"), SNAME("EditorIcons"));
+			icon_cache.joypad_axis = get_theme_icon(SNAME("JoyAxis"), SNAME("EditorIcons"));
 
 			_update_input_list();
 		} break;
@@ -724,7 +724,7 @@ void ActionMapEditor::_event_config_confirmed() {
 	}
 
 	new_action["events"] = events;
-	emit_signal("action_edited", current_action_name, new_action);
+	emit_signal(SNAME("action_edited"), current_action_name, new_action);
 }
 
 void ActionMapEditor::_add_action_pressed() {
@@ -738,7 +738,7 @@ void ActionMapEditor::_add_action(const String &p_name) {
 	}
 
 	add_edit->clear();
-	emit_signal("action_added", p_name);
+	emit_signal(SNAME("action_added"), p_name);
 }
 
 void ActionMapEditor::_action_edited() {
@@ -762,7 +762,7 @@ void ActionMapEditor::_action_edited() {
 			return;
 		}
 
-		emit_signal("action_renamed", old_name, new_name);
+		emit_signal(SNAME("action_renamed"), old_name, new_name);
 	} else if (action_tree->get_selected_column() == 1) {
 		// Deadzone Edited
 		String name = ti->get_meta("__name");
@@ -771,7 +771,7 @@ void ActionMapEditor::_action_edited() {
 		new_action["deadzone"] = ti->get_range(1);
 
 		// Call deferred so that input can finish propagating through tree, allowing re-making of tree to occur.
-		call_deferred("emit_signal", "action_edited", name, new_action);
+		call_deferred(SNAME("emit_signal"), "action_edited", name, new_action);
 	}
 }
 
@@ -808,7 +808,7 @@ void ActionMapEditor::_tree_button_pressed(Object *p_item, int p_column, int p_i
 		case ActionMapEditor::BUTTON_REMOVE_ACTION: {
 			// Send removed action name
 			String name = item->get_meta("__name");
-			emit_signal("action_removed", name);
+			emit_signal(SNAME("action_removed"), name);
 		} break;
 		case ActionMapEditor::BUTTON_REMOVE_EVENT: {
 			// Remove event and send updated action
@@ -821,7 +821,7 @@ void ActionMapEditor::_tree_button_pressed(Object *p_item, int p_column, int p_i
 			events.remove(event_index);
 			action["events"] = events;
 
-			emit_signal("action_edited", action_name, action);
+			emit_signal(SNAME("action_edited"), action_name, action);
 		} break;
 		default:
 			break;
@@ -922,7 +922,7 @@ void ActionMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 		// Change action order.
 		String relative_to = target->get_meta("__name");
 		String action_name = selected->get_meta("__name");
-		emit_signal("action_reordered", action_name, relative_to, drop_above);
+		emit_signal(SNAME("action_reordered"), action_name, relative_to, drop_above);
 
 	} else if (d["input_type"] == "event") {
 		// Change event order
@@ -956,7 +956,7 @@ void ActionMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 		}
 
 		new_action["events"] = new_events;
-		emit_signal("action_edited", selected->get_parent()->get_meta("__name"), new_action);
+		emit_signal(SNAME("action_edited"), selected->get_parent()->get_meta("__name"), new_action);
 	}
 }
 
@@ -964,7 +964,7 @@ void ActionMapEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			action_list_search->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			action_list_search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 		} break;
 		default:
 			break;
@@ -1038,11 +1038,11 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 		action_item->set_range(1, deadzone);
 
 		// Third column - buttons
-		action_item->add_button(2, action_tree->get_theme_icon("Add", "EditorIcons"), BUTTON_ADD_EVENT, false, TTR("Add Event"));
-		action_item->add_button(2, action_tree->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_ACTION, !action_info.editable, action_info.editable ? "Remove Action" : "Cannot Remove Action");
+		action_item->add_button(2, action_tree->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), BUTTON_ADD_EVENT, false, TTR("Add Event"));
+		action_item->add_button(2, action_tree->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_ACTION, !action_info.editable, action_info.editable ? "Remove Action" : "Cannot Remove Action");
 
-		action_item->set_custom_bg_color(0, action_tree->get_theme_color("prop_subsection", "Editor"));
-		action_item->set_custom_bg_color(1, action_tree->get_theme_color("prop_subsection", "Editor"));
+		action_item->set_custom_bg_color(0, action_tree->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
+		action_item->set_custom_bg_color(1, action_tree->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 
 		for (int evnt_idx = 0; evnt_idx < events.size(); evnt_idx++) {
 			Ref<InputEvent> event = events[evnt_idx];
@@ -1058,8 +1058,8 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 			event_item->set_meta("__index", evnt_idx);
 
 			// Third Column - Buttons
-			event_item->add_button(2, action_tree->get_theme_icon("Edit", "EditorIcons"), BUTTON_EDIT_EVENT, false, TTR("Edit Event"));
-			event_item->add_button(2, action_tree->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_EVENT, false, TTR("Remove Event"));
+			event_item->add_button(2, action_tree->get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), BUTTON_EDIT_EVENT, false, TTR("Edit Event"));
+			event_item->add_button(2, action_tree->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_EVENT, false, TTR("Remove Event"));
 			event_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 			event_item->set_button_color(2, 1, Color(1, 1, 1, 0.75));
 		}

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -217,19 +217,19 @@ void AnimationBezierTrackEdit::_draw_line_clipped(const Vector2 &p_from, const V
 
 void AnimationBezierTrackEdit::_notification(int p_what) {
 	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
-		bezier_icon = get_theme_icon("KeyBezierPoint", "EditorIcons");
-		bezier_handle_icon = get_theme_icon("KeyBezierHandle", "EditorIcons");
-		selected_icon = get_theme_icon("KeyBezierSelected", "EditorIcons");
+		bezier_icon = get_theme_icon(SNAME("KeyBezierPoint"), SNAME("EditorIcons"));
+		bezier_handle_icon = get_theme_icon(SNAME("KeyBezierHandle"), SNAME("EditorIcons"));
+		selected_icon = get_theme_icon(SNAME("KeyBezierSelected"), SNAME("EditorIcons"));
 		if (handle_mode_option->get_item_count() == 0) {
-			handle_mode_option->add_icon_item(get_theme_icon("BezierHandlesFree", "EditorIcons"), TTR("Free"), HANDLE_MODE_FREE);
-			handle_mode_option->add_icon_item(get_theme_icon("BezierHandlesBalanced", "EditorIcons"), TTR("Balanced"), HANDLE_MODE_BALANCED);
-			handle_mode_option->add_icon_item(get_theme_icon("BezierHandlesMirror", "EditorIcons"), TTR("Mirror"), HANDLE_MODE_MIRROR);
+			handle_mode_option->add_icon_item(get_theme_icon(SNAME("BezierHandlesFree"), SNAME("EditorIcons")), TTR("Free"), HANDLE_MODE_FREE);
+			handle_mode_option->add_icon_item(get_theme_icon(SNAME("BezierHandlesBalanced"), SNAME("EditorIcons")), TTR("Balanced"), HANDLE_MODE_BALANCED);
+			handle_mode_option->add_icon_item(get_theme_icon(SNAME("BezierHandlesMirror"), SNAME("EditorIcons")), TTR("Mirror"), HANDLE_MODE_MIRROR);
 		}
 	}
 	if (p_what == NOTIFICATION_RESIZED) {
 		int right_limit = get_size().width - timeline->get_buttons_width();
-		int hsep = get_theme_constant("hseparation", "ItemList");
-		int vsep = get_theme_constant("vseparation", "ItemList");
+		int hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
+		int vsep = get_theme_constant(SNAME("vseparation"), SNAME("ItemList"));
 
 		handle_mode_option->set_position(Vector2(right_limit + hsep, get_size().height - handle_mode_option->get_combined_minimum_size().height - vsep));
 		handle_mode_option->set_size(Vector2(timeline->get_buttons_width() - hsep * 2, handle_mode_option->get_combined_minimum_size().height));
@@ -242,16 +242,16 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 		int limit = timeline->get_name_limit();
 
 		if (has_focus()) {
-			Color accent = get_theme_color("accent_color", "Editor");
+			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			accent.a *= 0.7;
 			draw_rect(Rect2(Point2(), get_size()), accent, false);
 		}
 
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
-		Color color = get_theme_color("font_color", "Label");
-		int hsep = get_theme_constant("hseparation", "ItemList");
-		int vsep = get_theme_constant("vseparation", "ItemList");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
+		int hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
+		int vsep = get_theme_constant(SNAME("vseparation"), SNAME("ItemList"));
 		Color linecolor = color;
 		linecolor.a = 0.2;
 
@@ -261,7 +261,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 
 		draw_line(Point2(right_limit, 0), Point2(right_limit, get_size().height), linecolor);
 
-		Ref<Texture2D> close_icon = get_theme_icon("Close", "EditorIcons");
+		Ref<Texture2D> close_icon = get_theme_icon(SNAME("Close"), SNAME("EditorIcons"));
 
 		close_icon_rect.position = Vector2(get_size().width - close_icon->get_width() - hsep, hsep);
 		close_icon_rect.size = close_icon->get_size();
@@ -349,7 +349,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 
 				subtracks[i] = rect;
 			} else {
-				Color ac = get_theme_color("accent_color", "Editor");
+				Color ac = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 				ac.a = 0.5;
 				draw_rect(rect, ac);
 			}
@@ -360,7 +360,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			vofs += text_buf.get_size().y + vsep;
 		}
 
-		Color accent = get_theme_color("accent_color", "Editor");
+		Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 
 		{ //guides
 			float min_left_scale = font->get_height(font_size) + vsep;
@@ -401,7 +401,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 		{ //draw OTHER curves
 
 			float scale = timeline->get_zoom_scale();
-			Ref<Texture2D> point = get_theme_icon("KeyValue", "EditorIcons");
+			Ref<Texture2D> point = get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons"));
 			for (Map<int, Color>::Element *E = subtrack_colors.front(); E; E = E->next()) {
 				_draw_track(E->key(), E->get());
 
@@ -418,7 +418,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			}
 
 			//draw edited curve
-			const Color highlight = get_theme_color("highlight_color", "Editor");
+			const Color highlight = get_theme_color(SNAME("highlight_color"), SNAME("Editor"));
 			_draw_track(track, highlight);
 		}
 
@@ -547,7 +547,7 @@ void AnimationBezierTrackEdit::_play_position_draw() {
 	int px = (-timeline->get_value() + play_position_pos) * scale + timeline->get_name_limit();
 
 	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
-		Color color = get_theme_color("accent_color", "Editor");
+		Color color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 	}
 }
@@ -576,7 +576,7 @@ String AnimationBezierTrackEdit::get_tooltip(const Point2 &p_pos) const {
 
 void AnimationBezierTrackEdit::_clear_selection() {
 	selection.clear();
-	emit_signal("clear_selection");
+	emit_signal(SNAME("clear_selection"));
 	update();
 }
 
@@ -597,7 +597,7 @@ void AnimationBezierTrackEdit::_select_at_anim(const Ref<Animation> &p_anim, int
 	ERR_FAIL_COND(idx < 0);
 
 	selection.insert(idx);
-	emit_signal("select_key", idx, true);
+	emit_signal(SNAME("select_key"), idx, true);
 	update();
 }
 
@@ -663,9 +663,9 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			menu->add_icon_item(bezier_icon, TTR("Insert Key Here"), MENU_KEY_INSERT);
 			if (selection.size()) {
 				menu->add_separator();
-				menu->add_icon_item(get_theme_icon("Duplicate", "EditorIcons"), TTR("Duplicate Selected Key(s)"), MENU_KEY_DUPLICATE);
+				menu->add_icon_item(get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")), TTR("Duplicate Selected Key(s)"), MENU_KEY_DUPLICATE);
 				menu->add_separator();
-				menu->add_icon_item(get_theme_icon("Remove", "EditorIcons"), TTR("Delete Selected Key(s)"), MENU_KEY_DELETE);
+				menu->add_icon_item(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Delete Selected Key(s)"), MENU_KEY_DELETE);
 			}
 
 			menu->set_as_minsize();
@@ -676,7 +676,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 		if (close_icon_rect.has_point(mb->get_position())) {
-			emit_signal("close_request");
+			emit_signal(SNAME("close_request"));
 			return;
 		}
 		for (Map<int, Rect2>::Element *E = subtracks.front(); E; E = E->next()) {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1290,7 +1290,7 @@ public:
 void AnimationTimelineEdit::_zoom_changed(double) {
 	update();
 	play_position->update();
-	emit_signal("zoom_changed");
+	emit_signal(SNAME("zoom_changed"));
 }
 
 float AnimationTimelineEdit::get_zoom_scale() const {
@@ -1321,7 +1321,7 @@ void AnimationTimelineEdit::_anim_length_changed(double p_new_len) {
 	editing = false;
 	update();
 
-	emit_signal("length_changed", p_new_len);
+	emit_signal(SNAME("length_changed"), p_new_len);
 }
 
 void AnimationTimelineEdit::_anim_loop_pressed() {
@@ -1332,11 +1332,11 @@ void AnimationTimelineEdit::_anim_loop_pressed() {
 }
 
 int AnimationTimelineEdit::get_buttons_width() const {
-	Ref<Texture2D> interp_mode = get_theme_icon("TrackContinuous", "EditorIcons");
-	Ref<Texture2D> interp_type = get_theme_icon("InterpRaw", "EditorIcons");
-	Ref<Texture2D> loop_type = get_theme_icon("InterpWrapClamp", "EditorIcons");
-	Ref<Texture2D> remove_icon = get_theme_icon("Remove", "EditorIcons");
-	Ref<Texture2D> down_icon = get_theme_icon("select_arrow", "Tree");
+	Ref<Texture2D> interp_mode = get_theme_icon(SNAME("TrackContinuous"), SNAME("EditorIcons"));
+	Ref<Texture2D> interp_type = get_theme_icon(SNAME("InterpRaw"), SNAME("EditorIcons"));
+	Ref<Texture2D> loop_type = get_theme_icon(SNAME("InterpWrapClamp"), SNAME("EditorIcons"));
+	Ref<Texture2D> remove_icon = get_theme_icon(SNAME("Remove"), SNAME("EditorIcons"));
+	Ref<Texture2D> down_icon = get_theme_icon(SNAME("select_arrow"), SNAME("Tree"));
 
 	int total_w = interp_mode->get_width() + interp_type->get_width() + loop_type->get_width() + remove_icon->get_width();
 	total_w += (down_icon->get_width() + 4 * EDSCALE) * 4;
@@ -1345,7 +1345,7 @@ int AnimationTimelineEdit::get_buttons_width() const {
 }
 
 int AnimationTimelineEdit::get_name_limit() const {
-	Ref<Texture2D> hsize_icon = get_theme_icon("Hsize", "EditorIcons");
+	Ref<Texture2D> hsize_icon = get_theme_icon(SNAME("Hsize"), SNAME("EditorIcons"));
 
 	int limit = MAX(name_limit, add_track->get_minimum_size().width + hsize_icon->get_width());
 
@@ -1356,17 +1356,17 @@ int AnimationTimelineEdit::get_name_limit() const {
 
 void AnimationTimelineEdit::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		add_track->set_icon(get_theme_icon("Add", "EditorIcons"));
-		loop->set_icon(get_theme_icon("Loop", "EditorIcons"));
-		time_icon->set_texture(get_theme_icon("Time", "EditorIcons"));
+		add_track->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		loop->set_icon(get_theme_icon(SNAME("Loop"), SNAME("EditorIcons")));
+		time_icon->set_texture(get_theme_icon(SNAME("Time"), SNAME("EditorIcons")));
 
 		add_track->get_popup()->clear();
-		add_track->get_popup()->add_icon_item(get_theme_icon("KeyValue", "EditorIcons"), TTR("Property Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon("KeyXform", "EditorIcons"), TTR("3D Transform Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon("KeyCall", "EditorIcons"), TTR("Call Method Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon("KeyBezier", "EditorIcons"), TTR("Bezier Curve Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon("KeyAudio", "EditorIcons"), TTR("Audio Playback Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon("KeyAnimation", "EditorIcons"), TTR("Animation Playback Track"));
+		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")), TTR("Property Track"));
+		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyXform"), SNAME("EditorIcons")), TTR("3D Transform Track"));
+		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")), TTR("Call Method Track"));
+		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")), TTR("Bezier Curve Track"));
+		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")), TTR("Audio Playback Track"));
+		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons")), TTR("Animation Playback Track"));
 	}
 
 	if (p_what == NOTIFICATION_RESIZED) {
@@ -1381,9 +1381,9 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			return;
 		}
 
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
-		Color color = get_theme_color("font_color", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 
 		int zoomw = key_range;
 		float scale = get_zoom_scale();
@@ -1394,7 +1394,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			l = 0.001; //avoid crashor
 		}
 
-		Ref<Texture2D> hsize_icon = get_theme_icon("Hsize", "EditorIcons");
+		Ref<Texture2D> hsize_icon = get_theme_icon(SNAME("Hsize"), SNAME("EditorIcons"));
 		hsize_rect = Rect2(get_name_limit() - hsize_icon->get_width() - 2 * EDSCALE, (get_size().height - hsize_icon->get_height()) / 2, hsize_icon->get_width(), hsize_icon->get_height());
 		draw_texture(hsize_icon, hsize_rect.position);
 
@@ -1443,7 +1443,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 
 		int end_px = (l - get_value()) * scale;
 		int begin_px = -get_value() * scale;
-		Color notimecol = get_theme_color("dark_color_2", "Editor");
+		Color notimecol = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
 		Color timecolor = color;
 		timecolor.a = 0.2;
 		Color linecolor = color;
@@ -1568,10 +1568,10 @@ void AnimationTimelineEdit::set_animation(const Ref<Animation> &p_animation) {
 
 Size2 AnimationTimelineEdit::get_minimum_size() const {
 	Size2 ms = add_track->get_minimum_size();
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	ms.height = MAX(ms.height, font->get_height(font_size));
-	ms.width = get_buttons_width() + add_track->get_minimum_size().width + get_theme_icon("Hsize", "EditorIcons")->get_width() + 2;
+	ms.width = get_buttons_width() + add_track->get_minimum_size().width + get_theme_icon(SNAME("Hsize"), SNAME("EditorIcons"))->get_width() + 2;
 	return ms;
 }
 
@@ -1633,11 +1633,11 @@ void AnimationTimelineEdit::_play_position_draw() {
 	int px = (-get_value() + play_position_pos) * scale + get_name_limit();
 
 	if (px >= get_name_limit() && px < (play_position->get_size().width - get_buttons_width())) {
-		Color color = get_theme_color("accent_color", "Editor");
+		Color color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 		play_position->draw_texture(
-				get_theme_icon("TimelineIndicator", "EditorIcons"),
-				Point2(px - get_theme_icon("TimelineIndicator", "EditorIcons")->get_width() * 0.5, 0),
+				get_theme_icon(SNAME("TimelineIndicator"), SNAME("EditorIcons")),
+				Point2(px - get_theme_icon(SNAME("TimelineIndicator"), SNAME("EditorIcons"))->get_width() * 0.5, 0),
 				color);
 	}
 }
@@ -1685,7 +1685,7 @@ void AnimationTimelineEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			int x = mb->get_position().x - get_name_limit();
 
 			float ofs = x / get_zoom_scale() + get_value();
-			emit_signal("timeline_changed", ofs, false, Input::get_singleton()->is_key_pressed(KEY_ALT));
+			emit_signal(SNAME("timeline_changed"), ofs, false, Input::get_singleton()->is_key_pressed(KEY_ALT));
 			dragging_timeline = true;
 		}
 		if (!dragging_timeline && mb->get_button_index() == MOUSE_BUTTON_MIDDLE) {
@@ -1718,13 +1718,13 @@ void AnimationTimelineEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			int ofs = mm->get_position().x - dragging_hsize_from;
 			name_limit = dragging_hsize_at + ofs;
 			update();
-			emit_signal("name_limit_changed");
+			emit_signal(SNAME("name_limit_changed"));
 			play_position->update();
 		}
 		if (dragging_timeline) {
 			int x = mm->get_position().x - get_name_limit();
 			float ofs = x / get_zoom_scale() + get_value();
-			emit_signal("timeline_changed", ofs, false, Input::get_singleton()->is_key_pressed(KEY_ALT));
+			emit_signal(SNAME("timeline_changed"), ofs, false, Input::get_singleton()->is_key_pressed(KEY_ALT));
 		}
 		if (panning_timeline) {
 			int x = mm->get_position().x - get_name_limit();
@@ -1750,7 +1750,7 @@ void AnimationTimelineEdit::set_hscroll(HScrollBar *p_hscroll) {
 }
 
 void AnimationTimelineEdit::_track_added(int p_track) {
-	emit_signal("track_added", p_track);
+	emit_signal(SNAME("track_added"), p_track);
 }
 
 void AnimationTimelineEdit::_bind_methods() {
@@ -1832,31 +1832,31 @@ void AnimationTrackEdit::_notification(int p_what) {
 		int limit = timeline->get_name_limit();
 
 		if (has_focus()) {
-			Color accent = get_theme_color("accent_color", "Editor");
+			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			accent.a *= 0.7;
 			// Offside so the horizontal sides aren't cutoff.
 			draw_rect(Rect2(Point2(1 * EDSCALE, 0), get_size() - Size2(1 * EDSCALE, 0)), accent, false);
 		}
 
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
-		Color color = get_theme_color("font_color", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 		Ref<Texture2D> type_icons[6] = {
-			get_theme_icon("KeyValue", "EditorIcons"),
-			get_theme_icon("KeyXform", "EditorIcons"),
-			get_theme_icon("KeyCall", "EditorIcons"),
-			get_theme_icon("KeyBezier", "EditorIcons"),
-			get_theme_icon("KeyAudio", "EditorIcons"),
-			get_theme_icon("KeyAnimation", "EditorIcons")
+			get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")),
+			get_theme_icon(SNAME("KeyXform"), SNAME("EditorIcons")),
+			get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")),
+			get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")),
+			get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")),
+			get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons"))
 		};
-		int hsep = get_theme_constant("hseparation", "ItemList");
+		int hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
 		Color linecolor = color;
 		linecolor.a = 0.2;
 
 		// NAMES AND ICONS //
 
 		{
-			Ref<Texture2D> check = animation->track_is_enabled(track) ? get_theme_icon("checked", "CheckBox") : get_theme_icon("unchecked", "CheckBox");
+			Ref<Texture2D> check = animation->track_is_enabled(track) ? get_theme_icon(SNAME("checked"), SNAME("CheckBox")) : get_theme_icon(SNAME("unchecked"), SNAME("CheckBox"));
 
 			int ofs = in_group ? check->get_width() : 0; //not the best reference for margin but..
 
@@ -1877,7 +1877,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			String text;
 			Color text_color = color;
 			if (node && EditorNode::get_singleton()->get_editor_selection()->is_selected(node)) {
-				text_color = get_theme_color("accent_color", "Editor");
+				text_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			}
 
 			if (in_group) {
@@ -1952,25 +1952,25 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 		{
 			Ref<Texture2D> wrap_icon[2] = {
-				get_theme_icon("InterpWrapClamp", "EditorIcons"),
-				get_theme_icon("InterpWrapLoop", "EditorIcons"),
+				get_theme_icon(SNAME("InterpWrapClamp"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("InterpWrapLoop"), SNAME("EditorIcons")),
 			};
 
 			Ref<Texture2D> interp_icon[3] = {
-				get_theme_icon("InterpRaw", "EditorIcons"),
-				get_theme_icon("InterpLinear", "EditorIcons"),
-				get_theme_icon("InterpCubic", "EditorIcons")
+				get_theme_icon(SNAME("InterpRaw"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("InterpLinear"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("InterpCubic"), SNAME("EditorIcons"))
 			};
 			Ref<Texture2D> cont_icon[4] = {
-				get_theme_icon("TrackContinuous", "EditorIcons"),
-				get_theme_icon("TrackDiscrete", "EditorIcons"),
-				get_theme_icon("TrackTrigger", "EditorIcons"),
-				get_theme_icon("TrackCapture", "EditorIcons")
+				get_theme_icon(SNAME("TrackContinuous"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("TrackDiscrete"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("TrackTrigger"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("TrackCapture"), SNAME("EditorIcons"))
 			};
 
 			int ofs = get_size().width - timeline->get_buttons_width();
 
-			Ref<Texture2D> down_icon = get_theme_icon("select_arrow", "Tree");
+			Ref<Texture2D> down_icon = get_theme_icon(SNAME("select_arrow"), SNAME("Tree"));
 
 			draw_line(Point2(ofs, 0), Point2(ofs, get_size().height), linecolor, Math::round(EDSCALE));
 
@@ -2007,7 +2007,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 					update_mode_rect.size.x += down_icon->get_width();
 					bezier_edit_rect = Rect2();
 				} else if (animation->track_get_type(track) == Animation::TYPE_BEZIER) {
-					Ref<Texture2D> bezier_icon = get_theme_icon("EditBezier", "EditorIcons");
+					Ref<Texture2D> bezier_icon = get_theme_icon(SNAME("EditBezier"), SNAME("EditorIcons"));
 					update_mode_rect.size.x += down_icon->get_width();
 					bezier_edit_rect.position = update_mode_rect.position + (update_mode_rect.size - bezier_icon->get_size()) / 2;
 					bezier_edit_rect.size = bezier_icon->get_size();
@@ -2092,7 +2092,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			{
 				//erase
 
-				Ref<Texture2D> icon = get_theme_icon("Remove", "EditorIcons");
+				Ref<Texture2D> icon = get_theme_icon(SNAME("Remove"), SNAME("EditorIcons"));
 
 				remove_rect.position.x = ofs + ((get_size().width - ofs) - icon->get_width()) / 2;
 				remove_rect.position.y = int(get_size().height - icon->get_height()) / 2;
@@ -2109,7 +2109,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 		}
 
 		if (dropping_at != 0) {
-			Color drop_color = get_theme_color("accent_color", "Editor");
+			Color drop_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			if (dropping_at < 0) {
 				draw_line(Vector2(0, 0), Vector2(get_size().width, 0), drop_color, Math::round(EDSCALE));
 			} else {
@@ -2161,7 +2161,7 @@ void AnimationTrackEdit::draw_key_link(int p_index, float p_pixels_sec, int p_x,
 		return;
 	}
 
-	Color color = get_theme_color("font_color", "Label");
+	Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	color.a = 0.5;
 
 	int from_x = MAX(p_x, p_clip_left);
@@ -2186,16 +2186,16 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 		const Variant &v = animation->track_get_key_value(track, p_index);
 		Variant::Type valid_type = Variant::NIL;
 		if (!_is_value_key_valid(v, valid_type)) {
-			icon_to_draw = get_theme_icon("KeyInvalid", "EditorIcons");
+			icon_to_draw = get_theme_icon(SNAME("KeyInvalid"), SNAME("EditorIcons"));
 		}
 	}
 
 	Vector2 ofs(p_x - icon_to_draw->get_width() / 2, int(get_size().height - icon_to_draw->get_height()) / 2);
 
 	if (animation->track_get_type(track) == Animation::TYPE_METHOD) {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
-		Color color = get_theme_color("font_color", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 		color.a = 0.5;
 
 		Dictionary d = animation->track_get_key_value(track, p_index);
@@ -2298,19 +2298,19 @@ void AnimationTrackEdit::set_animation_and_track(const Ref<Animation> &p_animati
 	update();
 
 	Ref<Texture2D> type_icons[6] = {
-		get_theme_icon("KeyValue", "EditorIcons"),
-		get_theme_icon("KeyXform", "EditorIcons"),
-		get_theme_icon("KeyCall", "EditorIcons"),
-		get_theme_icon("KeyBezier", "EditorIcons"),
-		get_theme_icon("KeyAudio", "EditorIcons"),
-		get_theme_icon("KeyAnimation", "EditorIcons")
+		get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyXform"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons"))
 	};
 
 	ERR_FAIL_INDEX(track, animation->get_track_count());
 
 	node_path = animation->track_get_path(p_track);
 	type_icon = type_icons[animation->track_get_type(track)];
-	selected_icon = get_theme_icon("KeySelected", "EditorIcons");
+	selected_icon = get_theme_icon(SNAME("KeySelected"), SNAME("EditorIcons"));
 }
 
 NodePath AnimationTrackEdit::get_path() const {
@@ -2318,10 +2318,10 @@ NodePath AnimationTrackEdit::get_path() const {
 }
 
 Size2 AnimationTrackEdit::get_minimum_size() const {
-	Ref<Texture2D> texture = get_theme_icon("Object", "EditorIcons");
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
-	int separation = get_theme_constant("vseparation", "ItemList");
+	Ref<Texture2D> texture = get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+	int separation = get_theme_constant(SNAME("vseparation"), SNAME("ItemList"));
 
 	int max_h = MAX(texture->get_height(), font->get_height(font_size));
 	max_h = MAX(max_h, get_key_height());
@@ -2355,7 +2355,7 @@ void AnimationTrackEdit::_play_position_draw() {
 	int px = (-timeline->get_value() + play_position_pos) * scale + timeline->get_name_limit();
 
 	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
-		Color color = get_theme_color("accent_color", "Editor");
+		Color color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 	}
 }
@@ -2556,17 +2556,17 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (p_event->is_pressed()) {
 		if (ED_GET_SHORTCUT("animation_editor/duplicate_selection")->is_shortcut(p_event)) {
-			emit_signal("duplicate_request");
+			emit_signal(SNAME("duplicate_request"));
 			accept_event();
 		}
 
 		if (ED_GET_SHORTCUT("animation_editor/duplicate_selection_transposed")->is_shortcut(p_event)) {
-			emit_signal("duplicate_transpose_request");
+			emit_signal(SNAME("duplicate_transpose_request"));
 			accept_event();
 		}
 
 		if (ED_GET_SHORTCUT("animation_editor/delete_selection")->is_shortcut(p_event)) {
-			emit_signal("delete_request");
+			emit_signal(SNAME("delete_request"));
 			accept_event();
 		}
 	}
@@ -2597,10 +2597,10 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				menu->connect("id_pressed", callable_mp(this, &AnimationTrackEdit::_menu_selected));
 			}
 			menu->clear();
-			menu->add_icon_item(get_theme_icon("TrackContinuous", "EditorIcons"), TTR("Continuous"), MENU_CALL_MODE_CONTINUOUS);
-			menu->add_icon_item(get_theme_icon("TrackDiscrete", "EditorIcons"), TTR("Discrete"), MENU_CALL_MODE_DISCRETE);
-			menu->add_icon_item(get_theme_icon("TrackTrigger", "EditorIcons"), TTR("Trigger"), MENU_CALL_MODE_TRIGGER);
-			menu->add_icon_item(get_theme_icon("TrackCapture", "EditorIcons"), TTR("Capture"), MENU_CALL_MODE_CAPTURE);
+			menu->add_icon_item(get_theme_icon(SNAME("TrackContinuous"), SNAME("EditorIcons")), TTR("Continuous"), MENU_CALL_MODE_CONTINUOUS);
+			menu->add_icon_item(get_theme_icon(SNAME("TrackDiscrete"), SNAME("EditorIcons")), TTR("Discrete"), MENU_CALL_MODE_DISCRETE);
+			menu->add_icon_item(get_theme_icon(SNAME("TrackTrigger"), SNAME("EditorIcons")), TTR("Trigger"), MENU_CALL_MODE_TRIGGER);
+			menu->add_icon_item(get_theme_icon(SNAME("TrackCapture"), SNAME("EditorIcons")), TTR("Capture"), MENU_CALL_MODE_CAPTURE);
 			menu->set_as_minsize();
 
 			Vector2 popup_pos = get_screen_position() + update_mode_rect.position + Vector2(0, update_mode_rect.size.height);
@@ -2616,9 +2616,9 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				menu->connect("id_pressed", callable_mp(this, &AnimationTrackEdit::_menu_selected));
 			}
 			menu->clear();
-			menu->add_icon_item(get_theme_icon("InterpRaw", "EditorIcons"), TTR("Nearest"), MENU_INTERPOLATION_NEAREST);
-			menu->add_icon_item(get_theme_icon("InterpLinear", "EditorIcons"), TTR("Linear"), MENU_INTERPOLATION_LINEAR);
-			menu->add_icon_item(get_theme_icon("InterpCubic", "EditorIcons"), TTR("Cubic"), MENU_INTERPOLATION_CUBIC);
+			menu->add_icon_item(get_theme_icon(SNAME("InterpRaw"), SNAME("EditorIcons")), TTR("Nearest"), MENU_INTERPOLATION_NEAREST);
+			menu->add_icon_item(get_theme_icon(SNAME("InterpLinear"), SNAME("EditorIcons")), TTR("Linear"), MENU_INTERPOLATION_LINEAR);
+			menu->add_icon_item(get_theme_icon(SNAME("InterpCubic"), SNAME("EditorIcons")), TTR("Cubic"), MENU_INTERPOLATION_CUBIC);
 			menu->set_as_minsize();
 
 			Vector2 popup_pos = get_screen_position() + interp_mode_rect.position + Vector2(0, interp_mode_rect.size.height);
@@ -2634,8 +2634,8 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				menu->connect("id_pressed", callable_mp(this, &AnimationTrackEdit::_menu_selected));
 			}
 			menu->clear();
-			menu->add_icon_item(get_theme_icon("InterpWrapClamp", "EditorIcons"), TTR("Clamp Loop Interp"), MENU_LOOP_CLAMP);
-			menu->add_icon_item(get_theme_icon("InterpWrapLoop", "EditorIcons"), TTR("Wrap Loop Interp"), MENU_LOOP_WRAP);
+			menu->add_icon_item(get_theme_icon(SNAME("InterpWrapClamp"), SNAME("EditorIcons")), TTR("Clamp Loop Interp"), MENU_LOOP_CLAMP);
+			menu->add_icon_item(get_theme_icon(SNAME("InterpWrapLoop"), SNAME("EditorIcons")), TTR("Wrap Loop Interp"), MENU_LOOP_WRAP);
 			menu->set_as_minsize();
 
 			Vector2 popup_pos = get_screen_position() + loop_mode_rect.position + Vector2(0, loop_mode_rect.size.height);
@@ -2645,13 +2645,13 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (remove_rect.has_point(pos)) {
-			emit_signal("remove_request", track);
+			emit_signal(SNAME("remove_request"), track);
 			accept_event();
 			return;
 		}
 
 		if (bezier_edit_rect.has_point(pos)) {
-			emit_signal("bezier_edit");
+			emit_signal(SNAME("bezier_edit"));
 			accept_event();
 		}
 
@@ -2692,16 +2692,16 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			if (key_idx != -1) {
 				if (mb->is_command_pressed() || mb->is_shift_pressed()) {
 					if (editor->is_key_selected(track, key_idx)) {
-						emit_signal("deselect_key", key_idx);
+						emit_signal(SNAME("deselect_key"), key_idx);
 					} else {
-						emit_signal("select_key", key_idx, false);
+						emit_signal(SNAME("select_key"), key_idx, false);
 						moving_selection_attempt = true;
 						select_single_attempt = -1;
 						moving_selection_from_ofs = (mb->get_position().x - limit) / timeline->get_zoom_scale();
 					}
 				} else {
 					if (!editor->is_key_selected(track, key_idx)) {
-						emit_signal("select_key", key_idx, true);
+						emit_signal(SNAME("select_key"), key_idx, true);
 						select_single_attempt = -1;
 					} else {
 						select_single_attempt = key_idx;
@@ -2727,12 +2727,12 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			menu->clear();
-			menu->add_icon_item(get_theme_icon("Key", "EditorIcons"), TTR("Insert Key"), MENU_KEY_INSERT);
+			menu->add_icon_item(get_theme_icon(SNAME("Key"), SNAME("EditorIcons")), TTR("Insert Key"), MENU_KEY_INSERT);
 			if (editor->is_selection_active()) {
 				menu->add_separator();
-				menu->add_icon_item(get_theme_icon("Duplicate", "EditorIcons"), TTR("Duplicate Key(s)"), MENU_KEY_DUPLICATE);
+				menu->add_icon_item(get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")), TTR("Duplicate Key(s)"), MENU_KEY_DUPLICATE);
 				menu->add_separator();
-				menu->add_icon_item(get_theme_icon("Remove", "EditorIcons"), TTR("Delete Key(s)"), MENU_KEY_DELETE);
+				menu->add_icon_item(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Delete Key(s)"), MENU_KEY_DELETE);
 			}
 			menu->set_as_minsize();
 
@@ -2757,7 +2757,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		path->set_text(animation->track_get_path(track));
-		Vector2 theme_ofs = path->get_theme_stylebox("normal", "LineEdit")->get_offset();
+		Vector2 theme_ofs = path->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit"))->get_offset();
 		path_popup->set_position(get_screen_position() + path_rect.position - theme_ofs);
 		path_popup->set_size(path_rect.size);
 		path_popup->popup();
@@ -2770,9 +2770,9 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		if (!mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 			moving_selection_attempt = false;
 			if (moving_selection) {
-				emit_signal("move_selection_commit");
+				emit_signal(SNAME("move_selection_commit"));
 			} else if (select_single_attempt != -1) {
-				emit_signal("select_key", select_single_attempt, true);
+				emit_signal(SNAME("select_key"), select_single_attempt, true);
 			}
 			moving_selection = false;
 			select_single_attempt = -1;
@@ -2781,7 +2781,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		if (moving_selection && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_RIGHT) {
 			moving_selection_attempt = false;
 			moving_selection = false;
-			emit_signal("move_selection_cancel");
+			emit_signal(SNAME("move_selection_cancel"));
 		}
 	}
 
@@ -2789,11 +2789,11 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 	if (mm.is_valid() && mm->get_button_mask() & MOUSE_BUTTON_MASK_LEFT && moving_selection_attempt) {
 		if (!moving_selection) {
 			moving_selection = true;
-			emit_signal("move_selection_begin");
+			emit_signal(SNAME("move_selection_begin"));
 		}
 
 		float new_ofs = (mm->get_position().x - timeline->get_name_limit()) / timeline->get_zoom_scale();
-		emit_signal("move_selection", new_ofs - moving_selection_from_ofs);
+		emit_signal(SNAME("move_selection"), new_ofs - moving_selection_from_ofs);
 	}
 }
 
@@ -2847,7 +2847,7 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 	}
 
 	const_cast<AnimationTrackEdit *>(this)->update();
-	const_cast<AnimationTrackEdit *>(this)->emit_signal("drop_attempted", track);
+	const_cast<AnimationTrackEdit *>(this)->emit_signal(SNAME("drop_attempted"), track);
 
 	return true;
 }
@@ -2875,9 +2875,9 @@ void AnimationTrackEdit::drop_data(const Point2 &p_point, const Variant &p_data)
 	int from_track = d["index"];
 
 	if (dropping_at < 0) {
-		emit_signal("dropped", from_track, track);
+		emit_signal(SNAME("dropped"), from_track, track);
 	} else {
-		emit_signal("dropped", from_track, track + 1);
+		emit_signal(SNAME("dropped"), from_track, track + 1);
 	}
 }
 
@@ -2916,14 +2916,14 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 
 		} break;
 		case MENU_KEY_INSERT: {
-			emit_signal("insert_key", insert_at_pos);
+			emit_signal(SNAME("insert_key"), insert_at_pos);
 		} break;
 		case MENU_KEY_DUPLICATE: {
-			emit_signal("duplicate_request");
+			emit_signal(SNAME("duplicate_request"));
 
 		} break;
 		case MENU_KEY_DELETE: {
-			emit_signal("delete_request");
+			emit_signal(SNAME("delete_request"));
 
 		} break;
 	}
@@ -2956,9 +2956,9 @@ void AnimationTrackEdit::append_to_selection(const Rect2 &p_box, bool p_deselect
 
 		if (select_rect.intersects(rect)) {
 			if (p_deselection) {
-				emit_signal("deselect_key", i);
+				emit_signal(SNAME("deselect_key"), i);
 			} else {
-				emit_signal("select_key", i, false);
+				emit_signal(SNAME("select_key"), i, false);
 			}
 		}
 	}
@@ -3057,19 +3057,19 @@ AnimationTrackEdit *AnimationTrackEditPlugin::create_animation_track_edit(Object
 
 void AnimationTrackEditGroup::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
-		int separation = get_theme_constant("hseparation", "ItemList");
-		Color color = get_theme_color("font_color", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+		int separation = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 
 		if (root && root->has_node(node)) {
 			Node *n = root->get_node(node);
 			if (n && EditorNode::get_singleton()->get_editor_selection()->is_selected(n)) {
-				color = get_theme_color("accent_color", "Editor");
+				color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			}
 		}
 
-		Color bgcol = get_theme_color("dark_color_2", "Editor");
+		Color bgcol = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
 		bgcol.a *= 0.6;
 		draw_rect(Rect2(Point2(), get_size()), bgcol);
 		Color linecolor = color;
@@ -3087,7 +3087,7 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 		int px = (-timeline->get_value() + timeline->get_play_position()) * timeline->get_zoom_scale() + timeline->get_name_limit();
 
 		if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
-			Color accent = get_theme_color("accent_color", "Editor");
+			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			draw_line(Point2(px, 0), Point2(px, get_size().height), accent, Math::round(2 * EDSCALE));
 		}
 	}
@@ -3102,9 +3102,9 @@ void AnimationTrackEditGroup::set_type_and_name(const Ref<Texture2D> &p_type, co
 }
 
 Size2 AnimationTrackEditGroup::get_minimum_size() const {
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
-	int separation = get_theme_constant("vseparation", "ItemList");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+	int separation = get_theme_constant(SNAME("vseparation"), SNAME("ItemList"));
 
 	return Vector2(0, MAX(font->get_height(font_size), icon->get_height()) + separation);
 }
@@ -3226,7 +3226,7 @@ void AnimationTrackEditor::update_keying() {
 
 	keying = keying_enabled;
 
-	emit_signal("keying_changed");
+	emit_signal(SNAME("keying_changed"));
 }
 
 bool AnimationTrackEditor::has_keying() const {
@@ -3283,7 +3283,7 @@ void AnimationTrackEditor::_name_limit_changed() {
 }
 
 void AnimationTrackEditor::_timeline_changed(float p_new_pos, bool p_drag, bool p_timeline_only) {
-	emit_signal("timeline_changed", p_new_pos, p_drag, p_timeline_only);
+	emit_signal(SNAME("timeline_changed"), p_new_pos, p_drag, p_timeline_only);
 }
 
 void AnimationTrackEditor::_track_remove_request(int p_track) {
@@ -3430,14 +3430,14 @@ void AnimationTrackEditor::_query_insert(const InsertData &p_id) {
 			insert_confirm->popup_centered();
 			insert_query = true;
 		} else {
-			call_deferred("_insert_delay", reset_allowed && EDITOR_GET("editors/animation/default_create_reset_tracks"), all_bezier && EDITOR_GET("editors/animation/default_create_bezier_tracks"));
+			call_deferred(SNAME("_insert_delay"), reset_allowed && EDITOR_GET("editors/animation/default_create_reset_tracks"), all_bezier && EDITOR_GET("editors/animation/default_create_bezier_tracks"));
 			insert_queue = true;
 		}
 
 	} else {
 		if (!insert_query && !insert_queue) {
 			// Create Beziers wouldn't make sense in this case, where no tracks are being created
-			call_deferred("_insert_delay", reset_allowed && EDITOR_GET("editors/animation/default_create_reset_tracks"), false);
+			call_deferred(SNAME("_insert_delay"), reset_allowed && EDITOR_GET("editors/animation/default_create_reset_tracks"), false);
 			insert_queue = true;
 		}
 	}
@@ -3482,7 +3482,7 @@ void AnimationTrackEditor::_insert_delay(bool p_create_reset, bool p_create_bezi
 			pos = animation->get_length();
 		}
 		set_anim_pos(pos);
-		emit_signal("timeline_changed", pos, true);
+		emit_signal(SNAME("timeline_changed"), pos, true);
 	}
 	insert_queue = false;
 }
@@ -4166,7 +4166,7 @@ void AnimationTrackEditor::_update_tracks() {
 
 			if (!group_sort.has(base_path)) {
 				AnimationTrackEditGroup *g = memnew(AnimationTrackEditGroup);
-				Ref<Texture2D> icon = get_theme_icon("Node", "EditorIcons");
+				Ref<Texture2D> icon = get_theme_icon(SNAME("Node"), SNAME("EditorIcons"));
 				String name = base_path;
 				String tooltip;
 				if (root && root->has_node(base_path)) {
@@ -4245,7 +4245,7 @@ void AnimationTrackEditor::_animation_changed() {
 	}
 
 	animation_changing_awaiting_update = true;
-	call_deferred("_animation_update");
+	call_deferred(SNAME("_animation_update"));
 }
 
 void AnimationTrackEditor::_snap_mode_changed(int p_mode) {
@@ -4313,8 +4313,8 @@ void AnimationTrackEditor::_animation_update() {
 	bezier_edit->update();
 
 	_update_step_spinbox();
-	emit_signal("animation_step_changed", animation->get_step());
-	emit_signal("animation_len_changed", animation->get_length());
+	emit_signal(SNAME("animation_step_changed"), animation->get_step());
+	emit_signal(SNAME("animation_len_changed"), animation->get_length());
 
 	animation_changing_awaiting_update = false;
 }
@@ -4325,13 +4325,13 @@ MenuButton *AnimationTrackEditor::get_edit_menu() {
 
 void AnimationTrackEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
-		zoom_icon->set_texture(get_theme_icon("Zoom", "EditorIcons"));
-		snap->set_icon(get_theme_icon("Snap", "EditorIcons"));
+		zoom_icon->set_texture(get_theme_icon(SNAME("Zoom"), SNAME("EditorIcons")));
+		snap->set_icon(get_theme_icon(SNAME("Snap"), SNAME("EditorIcons")));
 		view_group->set_icon(get_theme_icon(view_group->is_pressed() ? "AnimationTrackList" : "AnimationTrackGroup", "EditorIcons"));
-		selected_filter->set_icon(get_theme_icon("AnimationFilter", "EditorIcons"));
-		imported_anim_warning->set_icon(get_theme_icon("NodeWarning", "EditorIcons"));
-		main_panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-		edit->get_popup()->set_item_icon(edit->get_popup()->get_item_index(EDIT_APPLY_RESET), get_theme_icon("Reload", "EditorIcons"));
+		selected_filter->set_icon(get_theme_icon(SNAME("AnimationFilter"), SNAME("EditorIcons")));
+		imported_anim_warning->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
+		main_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		edit->get_popup()->set_item_icon(edit->get_popup()->get_item_index(EDIT_APPLY_RESET), get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 	}
 
 	if (p_what == NOTIFICATION_READY) {
@@ -4341,7 +4341,7 @@ void AnimationTrackEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 		update_keying();
 		EditorNode::get_singleton()->update_keying();
-		emit_signal("keying_changed");
+		emit_signal(SNAME("keying_changed"));
 	}
 }
 
@@ -4367,11 +4367,11 @@ void AnimationTrackEditor::_update_step(double p_new_step) {
 	step->set_block_signals(true);
 	undo_redo->commit_action();
 	step->set_block_signals(false);
-	emit_signal("animation_step_changed", step_value);
+	emit_signal(SNAME("animation_step_changed"), step_value);
 }
 
 void AnimationTrackEditor::_update_length(double p_new_len) {
-	emit_signal("animation_len_changed", p_new_len);
+	emit_signal(SNAME("animation_len_changed"), p_new_len);
 }
 
 void AnimationTrackEditor::_dropped_track(int p_from_track, int p_to_track) {
@@ -4980,8 +4980,8 @@ float AnimationTrackEditor::get_moving_selection_offset() const {
 
 void AnimationTrackEditor::_box_selection_draw() {
 	const Rect2 selection_rect = Rect2(Point2(), box_selection->get_size());
-	box_selection->draw_rect(selection_rect, get_theme_color("box_selection_fill_color", "Editor"));
-	box_selection->draw_rect(selection_rect, get_theme_color("box_selection_stroke_color", "Editor"), false, Math::round(EDSCALE));
+	box_selection->draw_rect(selection_rect, get_theme_color(SNAME("box_selection_fill_color"), SNAME("Editor")));
+	box_selection->draw_rect(selection_rect, get_theme_color(SNAME("box_selection_stroke_color"), SNAME("Editor")), false, Math::round(EDSCALE));
 }
 
 void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
@@ -5201,7 +5201,7 @@ void AnimationTrackEditor::goto_prev_step(bool p_from_mouse_event) {
 		pos = 0;
 	}
 	set_anim_pos(pos);
-	emit_signal("timeline_changed", pos, true);
+	emit_signal(SNAME("timeline_changed"), pos, true);
 }
 
 void AnimationTrackEditor::goto_next_step(bool p_from_mouse_event) {
@@ -5228,7 +5228,7 @@ void AnimationTrackEditor::goto_next_step(bool p_from_mouse_event) {
 	}
 	set_anim_pos(pos);
 
-	emit_signal("timeline_changed", pos, true);
+	emit_signal(SNAME("timeline_changed"), pos, true);
 }
 
 void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
@@ -5247,7 +5247,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				}
 
 				String text;
-				Ref<Texture2D> icon = get_theme_icon("Node", "EditorIcons");
+				Ref<Texture2D> icon = get_theme_icon(SNAME("Node"), SNAME("EditorIcons"));
 				if (node) {
 					if (has_theme_icon(node->get_class(), "EditorIcons")) {
 						icon = get_theme_icon(node->get_class(), "EditorIcons");

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -42,12 +42,12 @@
 
 /// BOOL ///
 int AnimationTrackEditBool::get_key_height() const {
-	Ref<Texture2D> checked = get_theme_icon("checked", "CheckBox");
+	Ref<Texture2D> checked = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return checked->get_height();
 }
 
 Rect2 AnimationTrackEditBool::get_key_rect(int p_index, float p_pixels_sec) {
-	Ref<Texture2D> checked = get_theme_icon("checked", "CheckBox");
+	Ref<Texture2D> checked = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return Rect2(-checked->get_width() / 2, 0, checked->get_width(), get_size().height);
 }
 
@@ -72,7 +72,7 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 	draw_texture(icon, ofs);
 
 	if (p_selected) {
-		Color color = get_theme_color("accent_color", "Editor");
+		Color color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		draw_rect_clipped(Rect2(ofs, icon->get_size()), color, false);
 	}
 }
@@ -80,14 +80,14 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 /// COLOR ///
 
 int AnimationTrackEditColor::get_key_height() const {
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	return font->get_height(font_size) * 0.8;
 }
 
 Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	int fh = font->get_height(font_size) * 0.8;
 	return Rect2(-fh / 2, 0, fh, get_size().height);
 }
@@ -97,8 +97,8 @@ bool AnimationTrackEditColor::is_key_selectable_by_distance() const {
 }
 
 void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	int fh = (font->get_height(font_size) * 0.8);
 
 	fh /= 3;
@@ -167,8 +167,8 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	Color color = get_animation()->track_get_key_value(get_track(), p_index);
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	int fh = font->get_height(font_size) * 0.8;
 
 	Rect2 rect(Vector2(p_x - fh / 2, int(get_size().height - fh) / 2), Size2(fh, fh));
@@ -180,7 +180,7 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 	draw_rect_clipped(rect, color);
 
 	if (p_selected) {
-		Color accent = get_theme_color("accent_color", "Editor");
+		Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		draw_rect_clipped(rect, accent, false);
 	}
 }
@@ -206,8 +206,8 @@ int AnimationTrackEditAudio::get_key_height() const {
 		return AnimationTrackEdit::get_key_height();
 	}
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	return int(font->get_height(font_size) * 1.5);
 }
 
@@ -239,8 +239,8 @@ Rect2 AnimationTrackEditAudio::get_key_rect(int p_index, float p_pixels_sec) {
 
 		return Rect2(0, 0, len * p_pixels_sec, get_size().height);
 	} else {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		int fh = font->get_height(font_size) * 0.8;
 		return Rect2(0, 0, fh, get_size().height);
 	}
@@ -303,8 +303,8 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 			return;
 		}
 
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		float fh = int(font->get_height(font_size) * 1.5);
 		Rect2 rect = Rect2(from_x, (get_size().height - fh) / 2, to_x - from_x, fh);
 		draw_rect(rect, Color(0.25, 0.25, 0.25));
@@ -330,20 +330,20 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 		RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), lines, color);
 
 		if (p_selected) {
-			Color accent = get_theme_color("accent_color", "Editor");
+			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			draw_rect(rect, accent, false);
 		}
 	} else {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		int fh = font->get_height(font_size) * 0.8;
 		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
 
-		Color color = get_theme_color("font_color", "Label");
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 		draw_rect(rect, color);
 
 		if (p_selected) {
-			Color accent = get_theme_color("accent_color", "Editor");
+			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			draw_rect(rect, accent, false);
 		}
 	}
@@ -367,8 +367,8 @@ int AnimationTrackEditSpriteFrame::get_key_height() const {
 		return AnimationTrackEdit::get_key_height();
 	}
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	return int(font->get_height(font_size) * 2);
 }
 
@@ -435,8 +435,8 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 
 	size = size.floor();
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	int height = int(font->get_height(font_size) * 2);
 	int width = height * size.width / size.height;
 
@@ -526,8 +526,8 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 		region.size = texture->get_size();
 	}
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	int height = int(font->get_height(font_size) * 2);
 
 	int width = height * region.size.width / region.size.height;
@@ -542,7 +542,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 		return;
 	}
 
-	Color accent = get_theme_color("accent_color", "Editor");
+	Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 	Color bg = accent;
 	bg.a = 0.15;
 
@@ -570,8 +570,8 @@ int AnimationTrackEditSubAnim::get_key_height() const {
 		return AnimationTrackEdit::get_key_height();
 	}
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	return int(font->get_height(font_size) * 1.5);
 }
 
@@ -599,8 +599,8 @@ Rect2 AnimationTrackEditSubAnim::get_key_rect(int p_index, float p_pixels_sec) {
 
 		return Rect2(0, 0, len * p_pixels_sec, get_size().height);
 	} else {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		int fh = font->get_height(font_size) * 0.8;
 		return Rect2(0, 0, fh, get_size().height);
 	}
@@ -654,13 +654,13 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 			return;
 		}
 
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		int fh = font->get_height(font_size) * 1.5;
 
 		Rect2 rect(from_x, int(get_size().height - fh) / 2, to_x - from_x, fh);
 
-		Color color = get_theme_color("font_color", "Label");
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 		Color bg = color;
 		bg.r = 1 - color.r;
 		bg.g = 1 - color.g;
@@ -703,20 +703,20 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 		}
 
 		if (p_selected) {
-			Color accent = get_theme_color("accent_color", "Editor");
+			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			draw_rect(rect, accent, false);
 		}
 	} else {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		int fh = font->get_height(font_size) * 0.8;
 		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
 
-		Color color = get_theme_color("font_color", "Label");
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 		draw_rect(rect, color);
 
 		if (p_selected) {
-			Color accent = get_theme_color("accent_color", "Editor");
+			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			draw_rect(rect, accent, false);
 		}
 	}
@@ -729,12 +729,12 @@ void AnimationTrackEditSubAnim::set_node(Object *p_object) {
 //// VOLUME DB ////
 
 int AnimationTrackEditVolumeDB::get_key_height() const {
-	Ref<Texture2D> volume_texture = get_theme_icon("ColorTrackVu", "EditorIcons");
+	Ref<Texture2D> volume_texture = get_theme_icon(SNAME("ColorTrackVu"), SNAME("EditorIcons"));
 	return volume_texture->get_height() * 1.2;
 }
 
 void AnimationTrackEditVolumeDB::draw_bg(int p_clip_left, int p_clip_right) {
-	Ref<Texture2D> volume_texture = get_theme_icon("ColorTrackVu", "EditorIcons");
+	Ref<Texture2D> volume_texture = get_theme_icon(SNAME("ColorTrackVu"), SNAME("EditorIcons"));
 	int tex_h = volume_texture->get_height();
 
 	int y_from = (get_size().height - tex_h) / 2;
@@ -745,7 +745,7 @@ void AnimationTrackEditVolumeDB::draw_bg(int p_clip_left, int p_clip_right) {
 }
 
 void AnimationTrackEditVolumeDB::draw_fg(int p_clip_left, int p_clip_right) {
-	Ref<Texture2D> volume_texture = get_theme_icon("ColorTrackVu", "EditorIcons");
+	Ref<Texture2D> volume_texture = get_theme_icon(SNAME("ColorTrackVu"), SNAME("EditorIcons"));
 	int tex_h = volume_texture->get_height();
 	int y_from = (get_size().height - tex_h) / 2;
 	int db0 = y_from + (24 / 80.0) * tex_h;
@@ -780,12 +780,12 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 		to_x = p_clip_right;
 	}
 
-	Ref<Texture2D> volume_texture = get_theme_icon("ColorTrackVu", "EditorIcons");
+	Ref<Texture2D> volume_texture = get_theme_icon(SNAME("ColorTrackVu"), SNAME("EditorIcons"));
 	int tex_h = volume_texture->get_height();
 
 	int y_from = (get_size().height - tex_h) / 2;
 
-	Color color = get_theme_color("font_color", "Label");
+	Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	color.a *= 0.7;
 
 	draw_line(Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2);
@@ -806,8 +806,8 @@ void AnimationTrackEditTypeAudio::_preview_changed(ObjectID p_which) {
 }
 
 int AnimationTrackEditTypeAudio::get_key_height() const {
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	return int(font->get_height(font_size) * 1.5);
 }
 
@@ -871,8 +871,8 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 		}
 	}
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	float fh = int(font->get_height(font_size) * 1.5);
 
 	float len = stream->get_length();
@@ -947,7 +947,7 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 
 	RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), lines, color);
 
-	Color cut_color = get_theme_color("accent_color", "Editor");
+	Color cut_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 	cut_color.a = 0.7;
 	if (start_ofs > 0 && pixel_begin > p_clip_left) {
 		draw_rect(Rect2(pixel_begin, rect.position.y, 1, rect.size.y), cut_color);
@@ -957,7 +957,7 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 	}
 
 	if (p_selected) {
-		Color accent = get_theme_color("accent_color", "Editor");
+		Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		draw_rect(rect, accent, false);
 	}
 }
@@ -1143,8 +1143,8 @@ int AnimationTrackEditTypeAnimation::get_key_height() const {
 		return AnimationTrackEdit::get_key_height();
 	}
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	return int(font->get_height(font_size) * 1.5);
 }
 
@@ -1172,8 +1172,8 @@ Rect2 AnimationTrackEditTypeAnimation::get_key_rect(int p_index, float p_pixels_
 
 		return Rect2(0, 0, len * p_pixels_sec, get_size().height);
 	} else {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		int fh = font->get_height(font_size) * 0.8;
 		return Rect2(0, 0, fh, get_size().height);
 	}
@@ -1227,13 +1227,13 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 			return;
 		}
 
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		int fh = font->get_height(font_size) * 1.5;
 
 		Rect2 rect(from_x, int(get_size().height - fh) / 2, to_x - from_x, fh);
 
-		Color color = get_theme_color("font_color", "Label");
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 		Color bg = color;
 		bg.r = 1 - color.r;
 		bg.g = 1 - color.g;
@@ -1276,20 +1276,20 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 		}
 
 		if (p_selected) {
-			Color accent = get_theme_color("accent_color", "Editor");
+			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			draw_rect(rect, accent, false);
 		}
 	} else {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		int fh = font->get_height(font_size) * 0.8;
 		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
 
-		Color color = get_theme_color("font_color", "Label");
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 		draw_rect(rect, color);
 
 		if (p_selected) {
-			Color accent = get_theme_color("accent_color", "Editor");
+			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			draw_rect(rect, accent, false);
 		}
 	}

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -97,7 +97,7 @@ AudioStreamPreview::AudioStreamPreview() {
 ////
 
 void AudioStreamPreviewGenerator::_update_emit(ObjectID p_id) {
-	emit_signal("preview_updated", p_id);
+	emit_signal(SNAME("preview_updated"), p_id);
 }
 
 void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
@@ -150,7 +150,7 @@ void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
 		}
 
 		frames_todo -= to_read;
-		singleton->call_deferred("_update_emit", preview->id);
+		singleton->call_deferred(SNAME("_update_emit"), preview->id);
 	}
 
 	preview->playback->stop();

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -88,23 +88,23 @@ GotoLineDialog::GotoLineDialog() {
 
 void FindReplaceBar::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
-		find_prev->set_icon(get_theme_icon("MoveUp", "EditorIcons"));
-		find_next->set_icon(get_theme_icon("MoveDown", "EditorIcons"));
-		hide_button->set_normal_texture(get_theme_icon("Close", "EditorIcons"));
-		hide_button->set_hover_texture(get_theme_icon("Close", "EditorIcons"));
-		hide_button->set_pressed_texture(get_theme_icon("Close", "EditorIcons"));
+		find_prev->set_icon(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
+		find_next->set_icon(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
+		hide_button->set_normal_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+		hide_button->set_hover_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+		hide_button->set_pressed_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 		hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 		set_process_unhandled_input(is_visible_in_tree());
 	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		find_prev->set_icon(get_theme_icon("MoveUp", "EditorIcons"));
-		find_next->set_icon(get_theme_icon("MoveDown", "EditorIcons"));
-		hide_button->set_normal_texture(get_theme_icon("Close", "EditorIcons"));
-		hide_button->set_hover_texture(get_theme_icon("Close", "EditorIcons"));
-		hide_button->set_pressed_texture(get_theme_icon("Close", "EditorIcons"));
+		find_prev->set_icon(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
+		find_next->set_icon(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
+		hide_button->set_normal_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+		hide_button->set_hover_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+		hide_button->set_pressed_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 		hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color("font_color", "Label") : get_theme_color("error_color", "Editor"));
+		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	} else if (p_what == NOTIFICATION_PREDELETE) {
 		if (base_text_editor) {
 			base_text_editor->remove_find_replace_bar();
@@ -304,10 +304,10 @@ void FindReplaceBar::_replace_all() {
 	}
 
 	text_editor->set_v_scroll(vsval);
-	matches_label->add_theme_color_override("font_color", rc > 0 ? get_theme_color("font_color", "Label") : get_theme_color("error_color", "Editor"));
+	matches_label->add_theme_color_override("font_color", rc > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	matches_label->set_text(vformat(TTR("%d replaced."), rc));
 
-	text_editor->call_deferred("connect", "text_changed", callable_mp(this, &FindReplaceBar::_editor_text_changed));
+	text_editor->call_deferred(SNAME("connect"), "text_changed", callable_mp(this, &FindReplaceBar::_editor_text_changed));
 	results_count = -1;
 }
 
@@ -368,7 +368,7 @@ void FindReplaceBar::_update_matches_label() {
 	} else {
 		matches_label->show();
 
-		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color("font_color", "Label") : get_theme_color("error_color", "Editor"));
+		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		matches_label->set_text(vformat(results_count == 1 ? TTR("%d match.") : TTR("%d matches."), results_count));
 	}
 }
@@ -480,10 +480,10 @@ void FindReplaceBar::_show_search(bool p_focus_replace, bool p_show_only) {
 
 	if (p_focus_replace) {
 		search_text->deselect();
-		replace_text->call_deferred("grab_focus");
+		replace_text->call_deferred(SNAME("grab_focus"));
 	} else {
 		replace_text->deselect();
-		search_text->call_deferred("grab_focus");
+		search_text->call_deferred(SNAME("grab_focus"));
 	}
 
 	if (text_editor->is_selection_active() && !selection_only->is_pressed()) {
@@ -585,7 +585,7 @@ bool FindReplaceBar::is_selection_only() const {
 }
 
 void FindReplaceBar::set_error(const String &p_label) {
-	emit_signal("error", p_label);
+	emit_signal(SNAME("error"), p_label);
 }
 
 void FindReplaceBar::set_text_edit(CodeTextEditor *p_text_editor) {
@@ -760,10 +760,10 @@ void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMagnifyGesture> magnify_gesture = p_event;
 	if (magnify_gesture.is_valid()) {
-		font_size = text_editor->get_theme_font_size("font_size");
+		font_size = text_editor->get_theme_font_size(SNAME("font_size"));
 		font_size *= powf(magnify_gesture->get_factor(), 0.25);
 
-		_add_font_size((int)font_size - text_editor->get_theme_font_size("font_size"));
+		_add_font_size((int)font_size - text_editor->get_theme_font_size(SNAME("font_size")));
 		return;
 	}
 
@@ -875,38 +875,38 @@ Ref<Texture2D> CodeTextEditor::_get_completion_icon(const ScriptCodeCompletionOp
 			if (has_theme_icon(p_option.display, "EditorIcons")) {
 				tex = get_theme_icon(p_option.display, "EditorIcons");
 			} else {
-				tex = get_theme_icon("Object", "EditorIcons");
+				tex = get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
 			}
 		} break;
 		case ScriptCodeCompletionOption::KIND_ENUM:
-			tex = get_theme_icon("Enum", "EditorIcons");
+			tex = get_theme_icon(SNAME("Enum"), SNAME("EditorIcons"));
 			break;
 		case ScriptCodeCompletionOption::KIND_FILE_PATH:
-			tex = get_theme_icon("File", "EditorIcons");
+			tex = get_theme_icon(SNAME("File"), SNAME("EditorIcons"));
 			break;
 		case ScriptCodeCompletionOption::KIND_NODE_PATH:
-			tex = get_theme_icon("NodePath", "EditorIcons");
+			tex = get_theme_icon(SNAME("NodePath"), SNAME("EditorIcons"));
 			break;
 		case ScriptCodeCompletionOption::KIND_VARIABLE:
-			tex = get_theme_icon("Variant", "EditorIcons");
+			tex = get_theme_icon(SNAME("Variant"), SNAME("EditorIcons"));
 			break;
 		case ScriptCodeCompletionOption::KIND_CONSTANT:
-			tex = get_theme_icon("MemberConstant", "EditorIcons");
+			tex = get_theme_icon(SNAME("MemberConstant"), SNAME("EditorIcons"));
 			break;
 		case ScriptCodeCompletionOption::KIND_MEMBER:
-			tex = get_theme_icon("MemberProperty", "EditorIcons");
+			tex = get_theme_icon(SNAME("MemberProperty"), SNAME("EditorIcons"));
 			break;
 		case ScriptCodeCompletionOption::KIND_SIGNAL:
-			tex = get_theme_icon("MemberSignal", "EditorIcons");
+			tex = get_theme_icon(SNAME("MemberSignal"), SNAME("EditorIcons"));
 			break;
 		case ScriptCodeCompletionOption::KIND_FUNCTION:
-			tex = get_theme_icon("MemberMethod", "EditorIcons");
+			tex = get_theme_icon(SNAME("MemberMethod"), SNAME("EditorIcons"));
 			break;
 		case ScriptCodeCompletionOption::KIND_PLAIN_TEXT:
-			tex = get_theme_icon("BoxMesh", "EditorIcons");
+			tex = get_theme_icon(SNAME("BoxMesh"), SNAME("EditorIcons"));
 			break;
 		default:
-			tex = get_theme_icon("String", "EditorIcons");
+			tex = get_theme_icon(SNAME("String"), SNAME("EditorIcons"));
 			break;
 	}
 	return tex;
@@ -919,7 +919,7 @@ void CodeTextEditor::_font_resize_timeout() {
 }
 
 bool CodeTextEditor::_add_font_size(int p_delta) {
-	int old_size = text_editor->get_theme_font_size("font_size");
+	int old_size = text_editor->get_theme_font_size(SNAME("font_size"));
 	int new_size = CLAMP(old_size + p_delta, 8 * EDSCALE, 96 * EDSCALE);
 
 	if (new_size != old_size) {
@@ -1411,19 +1411,19 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 void CodeTextEditor::goto_line(int p_line) {
 	text_editor->deselect();
 	text_editor->unfold_line(p_line);
-	text_editor->call_deferred("cursor_set_line", p_line);
+	text_editor->call_deferred(SNAME("cursor_set_line"), p_line);
 }
 
 void CodeTextEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
 	text_editor->unfold_line(p_line);
-	text_editor->call_deferred("cursor_set_line", p_line);
-	text_editor->call_deferred("cursor_set_column", p_begin);
+	text_editor->call_deferred(SNAME("cursor_set_line"), p_line);
+	text_editor->call_deferred(SNAME("cursor_set_column"), p_begin);
 	text_editor->select(p_line, p_begin, p_line, p_end);
 }
 
 void CodeTextEditor::goto_line_centered(int p_line) {
 	goto_line(p_line);
-	text_editor->call_deferred("center_viewport_to_cursor");
+	text_editor->call_deferred(SNAME("center_viewport_to_cursor"));
 }
 
 void CodeTextEditor::set_executing_line(int p_line) {
@@ -1542,20 +1542,20 @@ void CodeTextEditor::_update_text_editor_theme() {
 	text_editor->add_theme_color_override("search_result_color", EDITOR_GET("text_editor/highlighting/search_result_color"));
 	text_editor->add_theme_color_override("search_result_border_color", EDITOR_GET("text_editor/highlighting/search_result_border_color"));
 	text_editor->add_theme_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 6));
-	emit_signal("load_theme_settings");
+	emit_signal(SNAME("load_theme_settings"));
 	_load_theme_settings();
 }
 
 void CodeTextEditor::_update_font() {
-	text_editor->add_theme_font_override("font", get_theme_font("source", "EditorFonts"));
-	text_editor->add_theme_font_size_override("font_size", get_theme_font_size("source_size", "EditorFonts"));
+	text_editor->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+	text_editor->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts")));
 
-	error->add_theme_font_override("font", get_theme_font("status_source", "EditorFonts"));
-	error->add_theme_font_size_override("font_size", get_theme_font_size("status_source_size", "EditorFonts"));
-	error->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
+	error->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	error->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+	error->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
-	Ref<Font> status_bar_font = get_theme_font("status_source", "EditorFonts");
-	int status_bar_font_size = get_theme_font_size("status_source_size", "EditorFonts");
+	Ref<Font> status_bar_font = get_theme_font(SNAME("status_source"), SNAME("EditorFonts"));
+	int status_bar_font_size = get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts"));
 	error->add_theme_font_override("font", status_bar_font);
 	error->add_theme_font_size_override("font_size", status_bar_font_size);
 	int count = status_bar->get_child_count();
@@ -1614,7 +1614,7 @@ void CodeTextEditor::_on_settings_change() {
 
 void CodeTextEditor::_text_changed_idle_timeout() {
 	_validate_script();
-	emit_signal("validate_script");
+	emit_signal(SNAME("validate_script"));
 }
 
 void CodeTextEditor::validate_script() {
@@ -1633,19 +1633,19 @@ void CodeTextEditor::_warning_button_pressed() {
 
 void CodeTextEditor::_set_show_errors_panel(bool p_show) {
 	is_errors_panel_opened = p_show;
-	emit_signal("show_errors_panel", p_show);
+	emit_signal(SNAME("show_errors_panel"), p_show);
 }
 
 void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
 	is_warnings_panel_opened = p_show;
-	emit_signal("show_warnings_panel", p_show);
+	emit_signal(SNAME("show_warnings_panel"), p_show);
 }
 
 void CodeTextEditor::_toggle_scripts_pressed() {
 	if (is_layout_rtl()) {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon("Forward", "EditorIcons") : get_theme_icon("Back", "EditorIcons"));
+		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")) : get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 	} else {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon("Back", "EditorIcons") : get_theme_icon("Forward", "EditorIcons"));
+		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon(SNAME("Back"), SNAME("EditorIcons")) : get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 	}
 }
 
@@ -1666,8 +1666,8 @@ void CodeTextEditor::_notification(int p_what) {
 			_update_font();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
-			error_button->set_icon(get_theme_icon("StatusError", "EditorIcons"));
-			warning_button->set_icon(get_theme_icon("NodeWarning", "EditorIcons"));
+			error_button->set_icon(get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
+			warning_button->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
 			add_theme_constant_override("separation", 4 * EDSCALE);
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -1779,9 +1779,9 @@ void CodeTextEditor::show_toggle_scripts_button() {
 
 void CodeTextEditor::update_toggle_scripts_button() {
 	if (is_layout_rtl()) {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon("Forward", "EditorIcons") : get_theme_icon("Back", "EditorIcons"));
+		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")) : get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 	} else {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon("Back", "EditorIcons") : get_theme_icon("Forward", "EditorIcons"));
+		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon(SNAME("Back"), SNAME("EditorIcons")) : get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 	}
 	toggle_scripts_button->set_tooltip(TTR("Toggle Scripts Panel") + " (" + ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text() + ")");
 }
@@ -1871,9 +1871,9 @@ CodeTextEditor::CodeTextEditor() {
 	error_button->connect("pressed", callable_mp(this, &CodeTextEditor::_error_button_pressed));
 	error_button->set_tooltip(TTR("Errors"));
 
-	error_button->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("error_color", "Editor"));
-	error_button->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
-	error_button->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
+	error_button->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	error_button->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	error_button->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 
 	is_errors_panel_opened = false;
 	set_error_count(0);
@@ -1887,9 +1887,9 @@ CodeTextEditor::CodeTextEditor() {
 	warning_button->connect("pressed", callable_mp(this, &CodeTextEditor::_warning_button_pressed));
 	warning_button->set_tooltip(TTR("Warnings"));
 
-	warning_button->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("warning_color", "Editor"));
-	warning_button->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
-	warning_button->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
+	warning_button->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+	warning_button->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	warning_button->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 
 	is_warnings_panel_opened = false;
 	set_warning_count(0);
@@ -1898,8 +1898,8 @@ CodeTextEditor::CodeTextEditor() {
 	line_and_col_txt = memnew(Label);
 	status_bar->add_child(line_and_col_txt);
 	line_and_col_txt->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
-	line_and_col_txt->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
-	line_and_col_txt->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
+	line_and_col_txt->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	line_and_col_txt->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 	line_and_col_txt->set_tooltip(TTR("Line and column numbers."));
 	line_and_col_txt->set_mouse_filter(MOUSE_FILTER_STOP);
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -134,7 +134,7 @@ void ConnectDialog::ok_pressed() {
 			return;
 		}
 	}
-	emit_signal("connected");
+	emit_signal(SNAME("connected"));
 	hide();
 }
 
@@ -360,7 +360,7 @@ void ConnectDialog::init(ConnectionData c, bool bEdit) {
 
 void ConnectDialog::popup_dialog(const String &p_for_signal) {
 	from_signal->set_text(p_for_signal);
-	error_label->add_theme_color_override("font_color", error_label->get_theme_color("error_color", "Editor"));
+	error_label->add_theme_color_override("font_color", error_label->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	if (!advanced->is_pressed()) {
 		error_label->set_visible(!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root()));
 	}
@@ -509,13 +509,13 @@ ConnectDialog::~ConnectDialog() {
 // Originally copied and adapted from EditorProperty, try to keep style in sync.
 Control *ConnectionsDockTree::make_custom_tooltip(const String &p_text) const {
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	help_bit->add_theme_style_override("panel", get_theme_stylebox("panel", "TooltipPanel"));
+	help_bit->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
 	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
 
 	String text = TTR("Signal:") + " [u][b]" + p_text.get_slice("::", 0) + "[/b][/u]";
 	text += p_text.get_slice("::", 1).strip_edges() + "\n";
 	text += p_text.get_slice("::", 2).strip_edges();
-	help_bit->call_deferred("set_text", text); //hack so it uses proper theme once inside scene
+	help_bit->call_deferred(SNAME("set_text"), text); //hack so it uses proper theme once inside scene
 	return help_bit;
 }
 
@@ -591,7 +591,7 @@ void ConnectionsDock::_make_or_edit_connection() {
 	it = nullptr;
 
 	if (add_script_function) {
-		editor->emit_signal("script_add_function_request", target, cToMake.method, script_function_args);
+		editor->emit_signal(SNAME("script_add_function_request"), target, cToMake.method, script_function_args);
 		hide();
 	}
 
@@ -921,14 +921,14 @@ void ConnectionsDock::update_tree() {
 			}
 		} else {
 			ClassDB::get_signal_list(base, &node_signals2, true);
-			if (has_theme_icon(base, "EditorIcons")) {
-				icon = get_theme_icon(base, "EditorIcons");
+			if (has_theme_icon(base, SNAME("EditorIcons"))) {
+				icon = get_theme_icon(base, SNAME("EditorIcons"));
 			}
 			name = base;
 		}
 
 		if (!icon.is_valid()) {
-			icon = get_theme_icon("Object", "EditorIcons");
+			icon = get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
 		}
 
 		TreeItem *section_item = nullptr;
@@ -940,7 +940,7 @@ void ConnectionsDock::update_tree() {
 			section_item->set_icon(0, icon);
 			section_item->set_selectable(0, false);
 			section_item->set_editable(0, false);
-			section_item->set_custom_bg_color(0, get_theme_color("prop_subsection", "Editor"));
+			section_item->set_custom_bg_color(0, get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 			node_signals2.sort();
 		}
 
@@ -982,7 +982,7 @@ void ConnectionsDock::update_tree() {
 			sinfo["name"] = signal_name;
 			sinfo["args"] = argnames;
 			signal_item->set_metadata(0, sinfo);
-			signal_item->set_icon(0, get_theme_icon("Signal", "EditorIcons"));
+			signal_item->set_icon(0, get_theme_icon(SNAME("Signal"), SNAME("EditorIcons")));
 
 			// Set tooltip with the signal's documentation.
 			{
@@ -1059,7 +1059,7 @@ void ConnectionsDock::update_tree() {
 				connection_item->set_text(0, path);
 				Connection cd = c;
 				connection_item->set_metadata(0, cd);
-				connection_item->set_icon(0, get_theme_icon("Slot", "EditorIcons"));
+				connection_item->set_icon(0, get_theme_icon(SNAME("Slot"), SNAME("EditorIcons")));
 			}
 		}
 
@@ -1083,7 +1083,7 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	search_box = memnew(LineEdit);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search_box->set_placeholder(TTR("Filter signals"));
-	search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+	search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	search_box->set_clear_button_enabled(true);
 	search_box->connect("text_changed", callable_mp(this, &ConnectionsDock::_filter_changed));
 	vbc->add_child(search_box);

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -40,7 +40,7 @@
 void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_select_type) {
 	_fill_type_list();
 
-	icon_fallback = search_options->has_theme_icon(base_type, "EditorIcons") ? base_type : "Object";
+	icon_fallback = search_options->has_theme_icon(base_type, SNAME("EditorIcons")) ? base_type : "Object";
 
 	if (p_dont_clear) {
 		search_box->select_all();
@@ -168,7 +168,7 @@ void CreateDialog::_update_search() {
 
 	TreeItem *root = search_options->create_item();
 	root->set_text(0, base_type);
-	root->set_icon(0, search_options->get_theme_icon(icon_fallback, "EditorIcons"));
+	root->set_icon(0, search_options->get_theme_icon(icon_fallback, SNAME("EditorIcons")));
 	search_options_types[base_type] = root;
 	_configure_search_option_item(root, base_type, ClassDB::class_exists(base_type));
 
@@ -236,7 +236,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 
 	bool can_instantiate = (p_cpp_type && ClassDB::can_instantiate(p_type)) || !p_cpp_type;
 	if (!can_instantiate) {
-		r_item->set_custom_color(0, search_options->get_theme_color("disabled_font_color", "Editor"));
+		r_item->set_custom_color(0, search_options->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, "NodeDisabled"));
 		r_item->set_selectable(0, false);
 	} else {
@@ -338,7 +338,7 @@ void CreateDialog::_confirmed() {
 		memdelete(f);
 	}
 
-	emit_signal("create");
+	emit_signal(SNAME("create"));
 	hide();
 	_cleanup();
 }
@@ -366,16 +366,16 @@ void CreateDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			connect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
-			search_box->set_right_icon(search_options->get_theme_icon("Search", "EditorIcons"));
+			search_box->set_right_icon(search_options->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			search_box->set_clear_button_enabled(true);
-			favorite->set_icon(search_options->get_theme_icon("Favorites", "EditorIcons"));
+			favorite->set_icon(search_options->get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible()) {
-				search_box->call_deferred("grab_focus"); // still not visible
+				search_box->call_deferred(SNAME("grab_focus")); // still not visible
 				search_box->select_all();
 			} else {
 				EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "create_new_node", Rect2(get_position(), get_size()));
@@ -607,7 +607,7 @@ void CreateDialog::_save_and_update_favorite_list() {
 		memdelete(f);
 	}
 
-	emit_signal("favorites_updated");
+	emit_signal(SNAME("favorites_updated"));
 }
 
 void CreateDialog::_load_favorites_and_history() {

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -41,7 +41,7 @@ bool EditorDebuggerRemoteObject::_set(const StringName &p_name, const Variant &p
 	}
 
 	prop_values[p_name] = p_value;
-	emit_signal("value_edited", remote_object_id, p_name, p_value);
+	emit_signal(SNAME("value_edited"), remote_object_id, p_name, p_value);
 	return true;
 }
 
@@ -114,11 +114,11 @@ void EditorDebuggerInspector::_notification(int p_what) {
 }
 
 void EditorDebuggerInspector::_object_edited(ObjectID p_id, const String &p_prop, const Variant &p_value) {
-	emit_signal("object_edited", p_id, p_prop, p_value);
+	emit_signal(SNAME("object_edited"), p_id, p_prop, p_value);
 }
 
 void EditorDebuggerInspector::_object_selected(ObjectID p_object) {
-	emit_signal("object_selected", p_object);
+	emit_signal(SNAME("object_selected"), p_object);
 }
 
 ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
@@ -190,7 +190,7 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 	if (old_prop_size == debugObj->prop_list.size() && new_props_added == 0) {
 		//only some may have changed, if so, then update those, if exist
 		for (Set<String>::Element *E = changed.front(); E; E = E->next()) {
-			emit_signal("object_property_updated", debugObj->remote_object_id, E->get());
+			emit_signal(SNAME("object_property_updated"), debugObj->remote_object_id, E->get());
 		}
 	} else {
 		//full update, because props were added or removed

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -55,8 +55,8 @@ EditorDebuggerNode::EditorDebuggerNode() {
 		singleton = this;
 	}
 
-	add_theme_constant_override("margin_left", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(SIDE_LEFT));
-	add_theme_constant_override("margin_right", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(SIDE_RIGHT));
+	add_theme_constant_override("margin_left", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_LEFT));
+	add_theme_constant_override("margin_right", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_RIGHT));
 
 	tabs = memnew(TabContainer);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
@@ -112,7 +112,7 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	if (tabs->get_tab_count() > 1) {
 		node->clear_style();
 		tabs->set_tabs_visible(true);
-		tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("DebuggerPanel", "EditorStyles"));
+		tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 	}
 
 	if (!debugger_plugins.is_empty()) {
@@ -135,7 +135,7 @@ void EditorDebuggerNode::_stack_frame_selected(int p_debugger) {
 
 void EditorDebuggerNode::_error_selected(const String &p_file, int p_line, int p_debugger) {
 	Ref<Script> s = ResourceLoader::load(p_file);
-	emit_signal("goto_script_line", s, p_line - 1);
+	emit_signal(SNAME("goto_script_line"), s, p_line - 1);
 }
 
 void EditorDebuggerNode::_text_editor_stack_goto(const ScriptEditorDebugger *p_debugger) {
@@ -145,8 +145,8 @@ void EditorDebuggerNode::_text_editor_stack_goto(const ScriptEditorDebugger *p_d
 	}
 	stack_script = ResourceLoader::load(file);
 	const int line = p_debugger->get_stack_script_line() - 1;
-	emit_signal("goto_script_line", stack_script, line);
-	emit_signal("set_execution", stack_script, line);
+	emit_signal(SNAME("goto_script_line"), stack_script, line);
+	emit_signal(SNAME("set_execution"), stack_script, line);
 	stack_script.unref(); // Why?!?
 }
 
@@ -226,10 +226,10 @@ void EditorDebuggerNode::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (tabs->get_tab_count() > 1) {
-				add_theme_constant_override("margin_left", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(SIDE_LEFT));
-				add_theme_constant_override("margin_right", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(SIDE_RIGHT));
+				add_theme_constant_override("margin_left", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_LEFT));
+				add_theme_constant_override("margin_right", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_RIGHT));
 
-				tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("DebuggerPanel", "EditorStyles"));
+				tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 			}
 		} break;
 		case NOTIFICATION_READY: {
@@ -268,11 +268,11 @@ void EditorDebuggerNode::_notification(int p_what) {
 		} else {
 			debugger_button->set_text(TTR("Debugger") + " (" + itos(error_count + warning_count) + ")");
 			if (error_count >= 1 && warning_count >= 1) {
-				debugger_button->set_icon(get_theme_icon("ErrorWarning", "EditorIcons"));
+				debugger_button->set_icon(get_theme_icon(SNAME("ErrorWarning"), SNAME("EditorIcons")));
 			} else if (error_count >= 1) {
-				debugger_button->set_icon(get_theme_icon("Error", "EditorIcons"));
+				debugger_button->set_icon(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 			} else {
-				debugger_button->set_icon(get_theme_icon("Warning", "EditorIcons"));
+				debugger_button->set_icon(get_theme_icon(SNAME("Warning"), SNAME("EditorIcons")));
 			}
 		}
 		last_error_count = error_count;
@@ -359,7 +359,7 @@ void EditorDebuggerNode::_debugger_wants_stop(int p_id) {
 	// Ask editor to kill PID.
 	int pid = get_debugger(p_id)->get_remote_pid();
 	if (pid) {
-		EditorNode::get_singleton()->call_deferred("stop_child_process", pid);
+		EditorNode::get_singleton()->call_deferred(SNAME("stop_child_process"), pid);
 	}
 }
 
@@ -475,7 +475,7 @@ void EditorDebuggerNode::_breaked(bool p_breaked, bool p_can_debug, int p_debugg
 	}
 	_break_state_changed();
 	EditorNode::get_singleton()->get_pause_button()->set_pressed(p_breaked);
-	emit_signal("breaked", p_breaked, p_can_debug);
+	emit_signal(SNAME("breaked"), p_breaked, p_can_debug);
 }
 
 bool EditorDebuggerNode::is_skip_breakpoints() const {

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -123,7 +123,7 @@ protected:
 	void _save_node_requested(ObjectID p_id, const String &p_file, int p_debugger);
 
 	void _clear_execution(REF p_script) {
-		emit_signal("clear_execution", p_script);
+		emit_signal(SNAME("clear_execution"), p_script);
 	}
 
 	void _text_editor_stack_goto(const ScriptEditorDebugger *p_debugger);

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -75,7 +75,7 @@ void EditorDebuggerTree::_scene_tree_selected() {
 
 	inspected_object_id = uint64_t(item->get_metadata(0));
 
-	emit_signal("object_selected", inspected_object_id, debugger_id);
+	emit_signal(SNAME("object_selected"), inspected_object_id, debugger_id);
 }
 
 void EditorDebuggerTree::_scene_tree_folded(Object *p_obj) {
@@ -105,8 +105,8 @@ void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position) {
 	item->select(0);
 
 	item_menu->clear();
-	item_menu->add_icon_item(get_theme_icon("CreateNewSceneFrom", "EditorIcons"), TTR("Save Branch as Scene"), ITEM_MENU_SAVE_REMOTE_NODE);
-	item_menu->add_icon_item(get_theme_icon("CopyNodePath", "EditorIcons"), TTR("Copy Node Path"), ITEM_MENU_COPY_NODE_PATH);
+	item_menu->add_icon_item(get_theme_icon(SNAME("CreateNewSceneFrom"), SNAME("EditorIcons")), TTR("Save Branch as Scene"), ITEM_MENU_SAVE_REMOTE_NODE);
+	item_menu->add_icon_item(get_theme_icon(SNAME("CopyNodePath"), SNAME("EditorIcons")), TTR("Copy Node Path"), ITEM_MENU_COPY_NODE_PATH);
 	item_menu->set_position(get_screen_transform().xform(get_local_mouse_position()));
 	item_menu->popup();
 }
@@ -211,7 +211,7 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 	}
 	debugger_id = p_debugger; // Needed by hook, could be avoided if every debugger had its own tree
 	if (scroll_item) {
-		call_deferred("scroll_to_item", scroll_item);
+		call_deferred(SNAME("scroll_to_item"), scroll_item);
 	}
 	last_filter = filter;
 	updating_scene_tree = false;
@@ -279,5 +279,5 @@ void EditorDebuggerTree::_file_selected(const String &p_file) {
 	if (inspected_object_id.is_null()) {
 		return;
 	}
-	emit_signal("save_node", inspected_object_id, p_file, debugger_id);
+	emit_signal(SNAME("save_node"), inspected_object_id, p_file, debugger_id);
 }

--- a/editor/debugger/editor_network_profiler.cpp
+++ b/editor/debugger/editor_network_profiler.cpp
@@ -40,14 +40,14 @@ void EditorNetworkProfiler::_bind_methods() {
 
 void EditorNetworkProfiler::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		activate->set_icon(get_theme_icon("Play", "EditorIcons"));
-		clear_button->set_icon(get_theme_icon("Clear", "EditorIcons"));
-		incoming_bandwidth_text->set_right_icon(get_theme_icon("ArrowDown", "EditorIcons"));
-		outgoing_bandwidth_text->set_right_icon(get_theme_icon("ArrowUp", "EditorIcons"));
+		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+		clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
+		incoming_bandwidth_text->set_right_icon(get_theme_icon(SNAME("ArrowDown"), SNAME("EditorIcons")));
+		outgoing_bandwidth_text->set_right_icon(get_theme_icon(SNAME("ArrowUp"), SNAME("EditorIcons")));
 
 		// This needs to be done here to set the faded color when the profiler is first opened
-		incoming_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color("font_color", "Editor") * Color(1, 1, 1, 0.5));
-		outgoing_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color("font_color", "Editor") * Color(1, 1, 1, 0.5));
+		incoming_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
+		outgoing_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
 	}
 }
 
@@ -73,13 +73,13 @@ void EditorNetworkProfiler::_update_frame() {
 
 void EditorNetworkProfiler::_activate_pressed() {
 	if (activate->is_pressed()) {
-		activate->set_icon(get_theme_icon("Stop", "EditorIcons"));
+		activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Stop"));
 	} else {
-		activate->set_icon(get_theme_icon("Play", "EditorIcons"));
+		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Start"));
 	}
-	emit_signal("enable_profiling", activate->is_pressed());
+	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
 
 void EditorNetworkProfiler::_clear_pressed() {
@@ -114,10 +114,10 @@ void EditorNetworkProfiler::set_bandwidth(int p_incoming, int p_outgoing) {
 	// Make labels more prominent when the bandwidth is greater than 0 to attract user attention
 	incoming_bandwidth_text->add_theme_color_override(
 			"font_uneditable_color",
-			get_theme_color("font_color", "Editor") * Color(1, 1, 1, p_incoming > 0 ? 1 : 0.5));
+			get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, p_incoming > 0 ? 1 : 0.5));
 	outgoing_bandwidth_text->add_theme_color_override(
 			"font_uneditable_color",
-			get_theme_color("font_color", "Editor") * Color(1, 1, 1, p_outgoing > 0 ? 1 : 0.5));
+			get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, p_outgoing > 0 ? 1 : 0.5));
 }
 
 bool EditorNetworkProfiler::is_profiling() {

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -109,9 +109,9 @@ void EditorPerformanceProfiler::_monitor_draw() {
 
 	info_message->hide();
 
-	Ref<StyleBox> graph_style_box = get_theme_stylebox("normal", "TextEdit");
-	Ref<Font> graph_font = get_theme_font("font", "TextEdit");
-	int font_size = get_theme_font_size("font_size", "TextEdit");
+	Ref<StyleBox> graph_style_box = get_theme_stylebox(SNAME("normal"), SNAME("TextEdit"));
+	Ref<Font> graph_font = get_theme_font(SNAME("font"), SNAME("TextEdit"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("TextEdit"));
 
 	int columns = int(Math::ceil(Math::sqrt(float(active.size()))));
 	int rows = int(Math::ceil(float(active.size()) / float(columns)));
@@ -130,7 +130,7 @@ void EditorPerformanceProfiler::_monitor_draw() {
 
 		rect.position += graph_style_box->get_offset();
 		rect.size -= graph_style_box->get_minimum_size();
-		Color draw_color = get_theme_color("accent_color", "Editor");
+		Color draw_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		draw_color.set_hsv(Math::fmod(hue_shift * float(current.frame_index), 0.9f), draw_color.get_s() * 0.9f, draw_color.get_v() * value_multiplier, 0.6f);
 		monitor_draw->draw_string(graph_font, rect.position + Point2(0, graph_font->get_ascent(font_size)), current.item->get_text(0), HALIGN_LEFT, rect.size.x, font_size, draw_color);
 
@@ -271,7 +271,7 @@ void EditorPerformanceProfiler::_marker_input(const Ref<InputEvent> &p_event) {
 				} else {
 					marker_key = "";
 				}
-				Ref<StyleBox> graph_style_box = get_theme_stylebox("normal", "TextEdit");
+				Ref<StyleBox> graph_style_box = get_theme_stylebox(SNAME("normal"), SNAME("TextEdit"));
 				rect.position += graph_style_box->get_offset();
 				rect.size -= graph_style_box->get_minimum_size();
 				Vector2 point = mb->get_position() - rect.position;

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -135,11 +135,11 @@ String EditorProfiler::_get_time_as_text(const Metric &m, float p_time, int p_ca
 }
 
 Color EditorProfiler::_get_color_from_signature(const StringName &p_signature) const {
-	Color bc = get_theme_color("error_color", "Editor");
+	Color bc = get_theme_color(SNAME("error_color"), SNAME("Editor"));
 	double rot = ABS(double(p_signature.hash()) / double(0x7FFFFFFF));
 	Color c;
 	c.set_hsv(rot, bc.get_s(), bc.get_v());
-	return c.lerp(get_theme_color("base_color", "Editor"), 0.07);
+	return c.lerp(get_theme_color(SNAME("base_color"), SNAME("Editor")), 0.07);
 }
 
 void EditorProfiler::_item_edited() {
@@ -180,7 +180,7 @@ void EditorProfiler::_update_plot() {
 	}
 
 	uint8_t *wr = graph_image.ptrw();
-	const Color background_color = get_theme_color("dark_color_2", "Editor");
+	const Color background_color = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
 
 	// Clear the previous frame and set the background color.
 	for (int i = 0; i < desired_len; i += 4) {
@@ -376,14 +376,14 @@ void EditorProfiler::_update_frame() {
 
 void EditorProfiler::_activate_pressed() {
 	if (activate->is_pressed()) {
-		activate->set_icon(get_theme_icon("Stop", "EditorIcons"));
+		activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Stop"));
 		_clear_pressed();
 	} else {
-		activate->set_icon(get_theme_icon("Play", "EditorIcons"));
+		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Start"));
 	}
-	emit_signal("enable_profiling", activate->is_pressed());
+	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
 
 void EditorProfiler::_clear_pressed() {
@@ -394,8 +394,8 @@ void EditorProfiler::_clear_pressed() {
 
 void EditorProfiler::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		activate->set_icon(get_theme_icon("Play", "EditorIcons"));
-		clear_button->set_icon(get_theme_icon("Clear", "EditorIcons"));
+		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+		clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
 	}
 }
 
@@ -462,7 +462,7 @@ void EditorProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 
 			if (activate->is_pressed()) {
 				if (!seeking) {
-					emit_signal("break_request");
+					emit_signal(SNAME("break_request"));
 				}
 			}
 

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -123,11 +123,11 @@ String EditorVisualProfiler::_get_time_as_text(float p_time) {
 }
 
 Color EditorVisualProfiler::_get_color_from_signature(const StringName &p_signature) const {
-	Color bc = get_theme_color("error_color", "Editor");
+	Color bc = get_theme_color(SNAME("error_color"), SNAME("Editor"));
 	double rot = ABS(double(p_signature.hash()) / double(0x7FFFFFFF));
 	Color c;
 	c.set_hsv(rot, bc.get_s(), bc.get_v());
-	return c.lerp(get_theme_color("base_color", "Editor"), 0.07);
+	return c.lerp(get_theme_color(SNAME("base_color"), SNAME("Editor")), 0.07);
 }
 
 void EditorVisualProfiler::_item_selected() {
@@ -318,7 +318,7 @@ void EditorVisualProfiler::_update_plot() {
 void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 	int cursor_metric = _get_cursor_index();
 
-	Ref<Texture> track_icon = get_theme_icon("TrackColor", "EditorIcons");
+	Ref<Texture> track_icon = get_theme_icon(SNAME("TrackColor"), SNAME("EditorIcons"));
 
 	ERR_FAIL_INDEX(cursor_metric, frame_metrics.size());
 
@@ -407,14 +407,14 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 
 void EditorVisualProfiler::_activate_pressed() {
 	if (activate->is_pressed()) {
-		activate->set_icon(get_theme_icon("Stop", "EditorIcons"));
+		activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Stop"));
 		_clear_pressed(); //always clear on start
 	} else {
-		activate->set_icon(get_theme_icon("Play", "EditorIcons"));
+		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Start"));
 	}
-	emit_signal("enable_profiling", activate->is_pressed());
+	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
 
 void EditorVisualProfiler::_clear_pressed() {
@@ -425,11 +425,11 @@ void EditorVisualProfiler::_clear_pressed() {
 void EditorVisualProfiler::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 		if (is_layout_rtl()) {
-			activate->set_icon(get_theme_icon("PlayBackwards", "EditorIcons"));
+			activate->set_icon(get_theme_icon(SNAME("PlayBackwards"), SNAME("EditorIcons")));
 		} else {
-			activate->set_icon(get_theme_icon("Play", "EditorIcons"));
+			activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 		}
-		clear_button->set_icon(get_theme_icon("Clear", "EditorIcons"));
+		clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
 	}
 }
 
@@ -437,8 +437,8 @@ void EditorVisualProfiler::_graph_tex_draw() {
 	if (last_metric < 0) {
 		return;
 	}
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	if (seeking) {
 		int max_frames = frame_metrics.size();
 		int frame = cursor_metric_edit->get_value() - (frame_metrics[last_metric].frame_number - max_frames + 1);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -87,9 +87,9 @@ void ScriptEditorDebugger::debug_copy() {
 void ScriptEditorDebugger::debug_skip_breakpoints() {
 	skip_breakpoints_value = !skip_breakpoints_value;
 	if (skip_breakpoints_value) {
-		skip_breakpoints->set_icon(get_theme_icon("DebugSkipBreakpointsOn", "EditorIcons"));
+		skip_breakpoints->set_icon(get_theme_icon(SNAME("DebugSkipBreakpointsOn"), SNAME("EditorIcons")));
 	} else {
-		skip_breakpoints->set_icon(get_theme_icon("DebugSkipBreakpointsOff", "EditorIcons"));
+		skip_breakpoints->set_icon(get_theme_icon(SNAME("DebugSkipBreakpointsOff"), SNAME("EditorIcons")));
 	}
 
 	Array msg;
@@ -136,11 +136,11 @@ void ScriptEditorDebugger::update_tabs() {
 	} else {
 		errors_tab->set_name(TTR("Errors") + " (" + itos(error_count + warning_count) + ")");
 		if (error_count >= 1 && warning_count >= 1) {
-			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon("ErrorWarning", "EditorIcons"));
+			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon(SNAME("ErrorWarning"), SNAME("EditorIcons")));
 		} else if (error_count >= 1) {
-			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon("Error", "EditorIcons"));
+			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 		} else {
-			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon("Warning", "EditorIcons"));
+			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon(SNAME("Warning"), SNAME("EditorIcons")));
 		}
 	}
 }
@@ -264,7 +264,7 @@ Object *ScriptEditorDebugger::get_remote_object(ObjectID p_id) {
 }
 
 void ScriptEditorDebugger::_remote_object_selected(ObjectID p_id) {
-	emit_signal("remote_object_requested", p_id);
+	emit_signal(SNAME("remote_object_requested"), p_id);
 }
 
 void ScriptEditorDebugger::_remote_object_edited(ObjectID p_id, const String &p_prop, const Variant &p_value) {
@@ -273,7 +273,7 @@ void ScriptEditorDebugger::_remote_object_edited(ObjectID p_id, const String &p_
 }
 
 void ScriptEditorDebugger::_remote_object_property_updated(ObjectID p_id, const String &p_property) {
-	emit_signal("remote_object_property_updated", p_id, p_property);
+	emit_signal(SNAME("remote_object_property_updated"), p_id, p_property);
 }
 
 void ScriptEditorDebugger::_video_mem_request() {
@@ -305,7 +305,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		can_debug = can_continue;
 		_update_buttons_state();
 		_set_reason_text(error, MESSAGE_ERROR);
-		emit_signal("breaked", true, can_continue);
+		emit_signal(SNAME("breaked"), true, can_continue);
 		DisplayServer::get_singleton()->window_move_to_foreground();
 		if (error != "") {
 			tabs->set_current_tab(0);
@@ -319,7 +319,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		_clear_execution();
 		_update_buttons_state();
 		_set_reason_text(TTR("Execution resumed."), MESSAGE_SUCCESS);
-		emit_signal("breaked", false, false);
+		emit_signal(SNAME("breaked"), false, false);
 		profiler->set_enabled(true);
 		profiler->disable_seeking();
 	} else if (p_msg == "set_pid") {
@@ -332,12 +332,12 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 	} else if (p_msg == "scene:scene_tree") {
 		scene_tree->nodes.clear();
 		scene_tree->deserialize(p_data);
-		emit_signal("remote_tree_updated");
+		emit_signal(SNAME("remote_tree_updated"));
 		_update_buttons_state();
 	} else if (p_msg == "scene:inspect_object") {
 		ObjectID id = inspector->add_object(p_data);
 		if (id.is_valid()) {
-			emit_signal("remote_object_updated", id);
+			emit_signal(SNAME("remote_object_updated"), id);
 		}
 	} else if (p_msg == "memory:usage") {
 		vmem_tree->clear();
@@ -357,8 +357,8 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			it->set_text(3, String::humanize_size(bytes));
 			total += bytes;
 
-			if (has_theme_icon(type, "EditorIcons")) {
-				it->set_icon(0, get_theme_icon(type, "EditorIcons"));
+			if (has_theme_icon(type, SNAME("EditorIcons"))) {
+				it->set_icon(0, get_theme_icon(type, SNAME("EditorIcons")));
 			}
 		}
 
@@ -698,7 +698,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		network_profiler->set_bandwidth(p_data[0], p_data[1]);
 
 	} else if (p_msg == "request_quit") {
-		emit_signal("stop_requested");
+		emit_signal(SNAME("stop_requested"));
 		_stop_and_notify();
 
 	} else if (p_msg == "performance:profile_names") {
@@ -739,13 +739,13 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType p_type) {
 	switch (p_type) {
 		case MESSAGE_ERROR:
-			reason->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
+			reason->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 			break;
 		case MESSAGE_WARNING:
-			reason->add_theme_color_override("font_color", get_theme_color("warning_color", "Editor"));
+			reason->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 			break;
 		default:
-			reason->add_theme_color_override("font_color", get_theme_color("success_color", "Editor"));
+			reason->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	}
 	reason->set_text(p_reason);
 	reason->set_tooltip(p_reason.word_wrap(80));
@@ -754,21 +754,21 @@ void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType 
 void ScriptEditorDebugger::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			skip_breakpoints->set_icon(get_theme_icon("DebugSkipBreakpointsOff", "EditorIcons"));
-			copy->set_icon(get_theme_icon("ActionCopy", "EditorIcons"));
+			skip_breakpoints->set_icon(get_theme_icon(SNAME("DebugSkipBreakpointsOff"), SNAME("EditorIcons")));
+			copy->set_icon(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")));
 
-			step->set_icon(get_theme_icon("DebugStep", "EditorIcons"));
-			next->set_icon(get_theme_icon("DebugNext", "EditorIcons"));
-			dobreak->set_icon(get_theme_icon("Pause", "EditorIcons"));
-			docontinue->set_icon(get_theme_icon("DebugContinue", "EditorIcons"));
+			step->set_icon(get_theme_icon(SNAME("DebugStep"), SNAME("EditorIcons")));
+			next->set_icon(get_theme_icon(SNAME("DebugNext"), SNAME("EditorIcons")));
+			dobreak->set_icon(get_theme_icon(SNAME("Pause"), SNAME("EditorIcons")));
+			docontinue->set_icon(get_theme_icon(SNAME("DebugContinue"), SNAME("EditorIcons")));
 			le_set->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_live_edit_set));
 			le_clear->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_live_edit_clear));
 			error_tree->connect("item_selected", callable_mp(this, &ScriptEditorDebugger::_error_selected));
 			error_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_error_activated));
-			vmem_refresh->set_icon(get_theme_icon("Reload", "EditorIcons"));
-			vmem_export->set_icon(get_theme_icon("Save", "EditorIcons"));
+			vmem_refresh->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
+			vmem_export->set_icon(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")));
 
-			reason->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
+			reason->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
 		} break;
 		case NOTIFICATION_PROCESS: {
@@ -831,16 +831,16 @@ void ScriptEditorDebugger::_notification(int p_what) {
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (tabs->has_theme_stylebox_override("panel")) {
-				tabs->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox("DebuggerPanel", "EditorStyles"));
+				tabs->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 			}
 
-			copy->set_icon(get_theme_icon("ActionCopy", "EditorIcons"));
-			step->set_icon(get_theme_icon("DebugStep", "EditorIcons"));
-			next->set_icon(get_theme_icon("DebugNext", "EditorIcons"));
-			dobreak->set_icon(get_theme_icon("Pause", "EditorIcons"));
-			docontinue->set_icon(get_theme_icon("DebugContinue", "EditorIcons"));
-			vmem_refresh->set_icon(get_theme_icon("Reload", "EditorIcons"));
-			vmem_export->set_icon(get_theme_icon("Save", "EditorIcons"));
+			copy->set_icon(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")));
+			step->set_icon(get_theme_icon(SNAME("DebugStep"), SNAME("EditorIcons")));
+			next->set_icon(get_theme_icon(SNAME("DebugNext"), SNAME("EditorIcons")));
+			dobreak->set_icon(get_theme_icon(SNAME("Pause"), SNAME("EditorIcons")));
+			docontinue->set_icon(get_theme_icon(SNAME("DebugContinue"), SNAME("EditorIcons")));
+			vmem_refresh->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
+			vmem_export->set_icon(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")));
 		} break;
 	}
 }
@@ -854,7 +854,7 @@ void ScriptEditorDebugger::_clear_execution() {
 	Dictionary d = ti->get_metadata(0);
 
 	stack_script = ResourceLoader::load(d["file"]);
-	emit_signal("clear_execution", stack_script);
+	emit_signal(SNAME("clear_execution"), stack_script);
 	stack_script.unref();
 	stack_dump->clear();
 	inspector->clear_stack_variables();
@@ -878,7 +878,7 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	tabs->set_current_tab(0);
 	_set_reason_text(TTR("Debug session started."), MESSAGE_SUCCESS);
 	_update_buttons_state();
-	emit_signal("started");
+	emit_signal(SNAME("started"));
 }
 
 void ScriptEditorDebugger::_update_buttons_state() {
@@ -896,7 +896,7 @@ void ScriptEditorDebugger::_update_buttons_state() {
 
 void ScriptEditorDebugger::_stop_and_notify() {
 	stop();
-	emit_signal("stopped");
+	emit_signal(SNAME("stopped"));
 	_set_reason_text(TTR("Debug session closed."), MESSAGE_WARNING);
 }
 
@@ -959,7 +959,7 @@ void ScriptEditorDebugger::_profiler_seeked() {
 }
 
 void ScriptEditorDebugger::_stack_dump_frame_selected() {
-	emit_signal("stack_frame_selected");
+	emit_signal(SNAME("stack_frame_selected"));
 
 	int frame = get_stack_script_frame();
 
@@ -1332,7 +1332,7 @@ void ScriptEditorDebugger::_error_selected() {
 		return;
 	}
 
-	emit_signal("error_selected", String(meta[0]), int(meta[1]));
+	emit_signal(SNAME("error_selected"), String(meta[0]), int(meta[1]));
 }
 
 void ScriptEditorDebugger::_expand_errors_list() {
@@ -1373,8 +1373,8 @@ void ScriptEditorDebugger::_error_tree_item_rmb_selected(const Vector2 &p_pos) {
 	item_menu->set_size(Size2(1, 1));
 
 	if (error_tree->is_anything_selected()) {
-		item_menu->add_icon_item(get_theme_icon("ActionCopy", "EditorIcons"), TTR("Copy Error"), ACTION_COPY_ERROR);
-		item_menu->add_icon_item(get_theme_icon("Instance", "EditorIcons"), TTR("Open C++ Source on GitHub"), ACTION_OPEN_SOURCE);
+		item_menu->add_icon_item(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")), TTR("Copy Error"), ACTION_COPY_ERROR);
+		item_menu->add_icon_item(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Open C++ Source on GitHub"), ACTION_OPEN_SOURCE);
 	}
 
 	if (item_menu->get_item_count() > 0) {
@@ -1393,9 +1393,9 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 
 			String type;
 
-			if (ti->get_icon(0) == get_theme_icon("Warning", "EditorIcons")) {
+			if (ti->get_icon(0) == get_theme_icon(SNAME("Warning"), SNAME("EditorIcons"))) {
 				type = "W ";
-			} else if (ti->get_icon(0) == get_theme_icon("Error", "EditorIcons")) {
+			} else if (ti->get_icon(0) == get_theme_icon(SNAME("Error"), SNAME("EditorIcons"))) {
 				type = "E ";
 			}
 
@@ -1518,7 +1518,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 	tabs = memnew(TabContainer);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
-	tabs->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox("DebuggerPanel", "EditorStyles"));
+	tabs->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 	tabs->connect("tab_changed", callable_mp(this, &ScriptEditorDebugger::_tab_changed));
 
 	add_child(tabs);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -162,7 +162,7 @@ void DependencyEditor::_update_list() {
 
 	TreeItem *root = tree->create_item();
 
-	Ref<Texture2D> folder = tree->get_theme_icon("folder", "FileDialog");
+	Ref<Texture2D> folder = tree->get_theme_icon(SNAME("folder"), SNAME("FileDialog"));
 
 	bool broken = false;
 
@@ -278,7 +278,7 @@ void DependencyEditorOwners::_select_file(int p_idx) {
 	if (ResourceLoader::get_resource_type(fpath) == "PackedScene") {
 		editor->open_request(fpath);
 		hide();
-		emit_signal("confirmed");
+		emit_signal(SNAME("confirmed"));
 	}
 }
 
@@ -412,17 +412,17 @@ void DependencyRemoveDialog::_build_removed_dependency_tree(const Vector<Removed
 				if (!tree_items.has(rd.dependency_folder)) {
 					TreeItem *folder_item = owners->create_item(owners->get_root());
 					folder_item->set_text(0, rd.dependency_folder);
-					folder_item->set_icon(0, owners->get_theme_icon("Folder", "EditorIcons"));
+					folder_item->set_icon(0, owners->get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 					tree_items[rd.dependency_folder] = folder_item;
 				}
 				TreeItem *dependency_item = owners->create_item(tree_items[rd.dependency_folder]);
 				dependency_item->set_text(0, rd.dependency);
-				dependency_item->set_icon(0, owners->get_theme_icon("Warning", "EditorIcons"));
+				dependency_item->set_icon(0, owners->get_theme_icon(SNAME("Warning"), SNAME("EditorIcons")));
 				tree_items[rd.dependency] = dependency_item;
 			} else {
 				TreeItem *dependency_item = owners->create_item(owners->get_root());
 				dependency_item->set_text(0, rd.dependency);
-				dependency_item->set_icon(0, owners->get_theme_icon("Warning", "EditorIcons"));
+				dependency_item->set_icon(0, owners->get_theme_icon(SNAME("Warning"), SNAME("EditorIcons")));
 				tree_items[rd.dependency] = dependency_item;
 			}
 		}
@@ -508,7 +508,7 @@ void DependencyRemoveDialog::ok_pressed() {
 		if (err != OK) {
 			EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:") + "\n" + files_to_delete[i] + "\n");
 		} else {
-			emit_signal("file_removed", files_to_delete[i]);
+			emit_signal(SNAME("file_removed"), files_to_delete[i]);
 		}
 	}
 
@@ -525,7 +525,7 @@ void DependencyRemoveDialog::ok_pressed() {
 			if (err != OK) {
 				EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:") + "\n" + dirs_to_delete[i] + "\n");
 			} else {
-				emit_signal("folder_removed", dirs_to_delete[i]);
+				emit_signal(SNAME("folder_removed"), dirs_to_delete[i]);
 			}
 		}
 
@@ -665,7 +665,7 @@ bool OrphanResourcesDialog::_fill_owners(EditorFileSystemDirectory *efsd, HashMa
 		if (p_parent) {
 			dir_item = files->create_item(p_parent);
 			dir_item->set_text(0, efsd->get_subdir(i)->get_name());
-			dir_item->set_icon(0, files->get_theme_icon("folder", "FileDialog"));
+			dir_item->set_icon(0, files->get_theme_icon(SNAME("folder"), SNAME("FileDialog")));
 		}
 		bool children = _fill_owners(efsd->get_subdir(i), refs, dir_item);
 
@@ -701,7 +701,7 @@ bool OrphanResourcesDialog::_fill_owners(EditorFileSystemDirectory *efsd, HashMa
 				int ds = efsd->get_file_deps(i).size();
 				ti->set_text(1, itos(ds));
 				if (ds) {
-					ti->add_button(1, files->get_theme_icon("GuiVisibilityVisible", "EditorIcons"), -1, false, TTR("Show Dependencies"));
+					ti->add_button(1, files->get_theme_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")), -1, false, TTR("Show Dependencies"));
 				}
 				ti->set_metadata(0, path);
 				has_children = true;

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -41,15 +41,15 @@
 static const String META_TEXT_TO_COPY = "text_to_copy";
 
 void EditorAbout::_theme_changed() {
-	const Ref<Font> font = get_theme_font("source", "EditorFonts");
-	const int font_size = get_theme_font_size("source_size", "EditorFonts");
+	const Ref<Font> font = get_theme_font(SNAME("source"), SNAME("EditorFonts"));
+	const int font_size = get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts"));
 	_tpl_text->add_theme_font_override("normal_font", font);
 	_tpl_text->add_theme_font_size_override("normal_font_size", font_size);
 	_tpl_text->add_theme_constant_override("line_separation", 6 * EDSCALE);
 	_license_text->add_theme_font_override("normal_font", font);
 	_license_text->add_theme_font_size_override("normal_font_size", font_size);
 	_license_text->add_theme_constant_override("line_separation", 6 * EDSCALE);
-	_logo->set_texture(get_theme_icon("Logo", "EditorIcons"));
+	_logo->set_texture(get_theme_icon(SNAME("Logo"), SNAME("EditorIcons")));
 }
 
 void EditorAbout::_notification(int p_what) {

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -132,57 +132,57 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 
 	Map<String, Ref<Texture2D>> extension_guess;
 	{
-		extension_guess["bmp"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["dds"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["exr"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["hdr"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["jpg"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["jpeg"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["png"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["svg"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["svgz"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["tga"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
-		extension_guess["webp"] = tree->get_theme_icon("ImageTexture", "EditorIcons");
+		extension_guess["bmp"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["dds"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["exr"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["hdr"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["jpg"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["jpeg"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["png"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["svg"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["svgz"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["tga"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
+		extension_guess["webp"] = tree->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons"));
 
-		extension_guess["wav"] = tree->get_theme_icon("AudioStreamSample", "EditorIcons");
-		extension_guess["ogg"] = tree->get_theme_icon("AudioStreamOGGVorbis", "EditorIcons");
-		extension_guess["mp3"] = tree->get_theme_icon("AudioStreamMP3", "EditorIcons");
+		extension_guess["wav"] = tree->get_theme_icon(SNAME("AudioStreamSample"), SNAME("EditorIcons"));
+		extension_guess["ogg"] = tree->get_theme_icon(SNAME("AudioStreamOGGVorbis"), SNAME("EditorIcons"));
+		extension_guess["mp3"] = tree->get_theme_icon(SNAME("AudioStreamMP3"), SNAME("EditorIcons"));
 
-		extension_guess["scn"] = tree->get_theme_icon("PackedScene", "EditorIcons");
-		extension_guess["tscn"] = tree->get_theme_icon("PackedScene", "EditorIcons");
-		extension_guess["escn"] = tree->get_theme_icon("PackedScene", "EditorIcons");
-		extension_guess["dae"] = tree->get_theme_icon("PackedScene", "EditorIcons");
-		extension_guess["gltf"] = tree->get_theme_icon("PackedScene", "EditorIcons");
-		extension_guess["glb"] = tree->get_theme_icon("PackedScene", "EditorIcons");
+		extension_guess["scn"] = tree->get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
+		extension_guess["tscn"] = tree->get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
+		extension_guess["escn"] = tree->get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
+		extension_guess["dae"] = tree->get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
+		extension_guess["gltf"] = tree->get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
+		extension_guess["glb"] = tree->get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
 
-		extension_guess["gdshader"] = tree->get_theme_icon("Shader", "EditorIcons");
-		extension_guess["gd"] = tree->get_theme_icon("GDScript", "EditorIcons");
+		extension_guess["gdshader"] = tree->get_theme_icon(SNAME("Shader"), SNAME("EditorIcons"));
+		extension_guess["gd"] = tree->get_theme_icon(SNAME("GDScript"), SNAME("EditorIcons"));
 		if (Engine::get_singleton()->has_singleton("GodotSharp")) {
-			extension_guess["cs"] = tree->get_theme_icon("CSharpScript", "EditorIcons");
+			extension_guess["cs"] = tree->get_theme_icon(SNAME("CSharpScript"), SNAME("EditorIcons"));
 		} else {
 			// Mark C# support as unavailable.
-			extension_guess["cs"] = tree->get_theme_icon("ImportFail", "EditorIcons");
+			extension_guess["cs"] = tree->get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons"));
 		}
-		extension_guess["vs"] = tree->get_theme_icon("VisualScript", "EditorIcons");
+		extension_guess["vs"] = tree->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons"));
 
-		extension_guess["res"] = tree->get_theme_icon("Resource", "EditorIcons");
-		extension_guess["tres"] = tree->get_theme_icon("Resource", "EditorIcons");
-		extension_guess["atlastex"] = tree->get_theme_icon("AtlasTexture", "EditorIcons");
+		extension_guess["res"] = tree->get_theme_icon(SNAME("Resource"), SNAME("EditorIcons"));
+		extension_guess["tres"] = tree->get_theme_icon(SNAME("Resource"), SNAME("EditorIcons"));
+		extension_guess["atlastex"] = tree->get_theme_icon(SNAME("AtlasTexture"), SNAME("EditorIcons"));
 		// By default, OBJ files are imported as Mesh resources rather than PackedScenes.
-		extension_guess["obj"] = tree->get_theme_icon("Mesh", "EditorIcons");
+		extension_guess["obj"] = tree->get_theme_icon(SNAME("Mesh"), SNAME("EditorIcons"));
 
-		extension_guess["txt"] = tree->get_theme_icon("TextFile", "EditorIcons");
-		extension_guess["md"] = tree->get_theme_icon("TextFile", "EditorIcons");
-		extension_guess["rst"] = tree->get_theme_icon("TextFile", "EditorIcons");
-		extension_guess["json"] = tree->get_theme_icon("TextFile", "EditorIcons");
-		extension_guess["yml"] = tree->get_theme_icon("TextFile", "EditorIcons");
-		extension_guess["yaml"] = tree->get_theme_icon("TextFile", "EditorIcons");
-		extension_guess["toml"] = tree->get_theme_icon("TextFile", "EditorIcons");
-		extension_guess["cfg"] = tree->get_theme_icon("TextFile", "EditorIcons");
-		extension_guess["ini"] = tree->get_theme_icon("TextFile", "EditorIcons");
+		extension_guess["txt"] = tree->get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons"));
+		extension_guess["md"] = tree->get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons"));
+		extension_guess["rst"] = tree->get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons"));
+		extension_guess["json"] = tree->get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons"));
+		extension_guess["yml"] = tree->get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons"));
+		extension_guess["yaml"] = tree->get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons"));
+		extension_guess["toml"] = tree->get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons"));
+		extension_guess["cfg"] = tree->get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons"));
+		extension_guess["ini"] = tree->get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons"));
 	}
 
-	Ref<Texture2D> generic_extension = tree->get_theme_icon("Object", "EditorIcons");
+	Ref<Texture2D> generic_extension = tree->get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
 
 	unzClose(pkg);
 
@@ -191,7 +191,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 	TreeItem *root = tree->create_item();
 	root->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 	root->set_checked(0, true);
-	root->set_icon(0, tree->get_theme_icon("folder", "FileDialog"));
+	root->set_icon(0, tree->get_theme_icon(SNAME("folder"), SNAME("FileDialog")));
 	root->set_text(0, "res://");
 	root->set_editable(0, true);
 	Map<String, TreeItem *> dir_map;
@@ -242,7 +242,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 		if (isdir) {
 			dir_map[path] = ti;
 			ti->set_text(0, path.get_file() + "/");
-			ti->set_icon(0, tree->get_theme_icon("folder", "FileDialog"));
+			ti->set_icon(0, tree->get_theme_icon(SNAME("folder"), SNAME("FileDialog")));
 			ti->set_metadata(0, String());
 		} else {
 			String file = path.get_file();
@@ -257,7 +257,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 			String res_path = "res://" + path;
 			if (FileAccess::exists(res_path)) {
 				num_file_conflicts += 1;
-				ti->set_custom_color(0, tree->get_theme_color("error_color", "Editor"));
+				ti->set_custom_color(0, tree->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 				ti->set_tooltip(0, vformat(TTR("%s (already exists)"), res_path));
 				ti->set_checked(0, false);
 			} else {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -64,42 +64,42 @@ void EditorAudioBus::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			for (int i = 0; i < CHANNELS_MAX; i++) {
-				channel[i].vu_l->set_under_texture(get_theme_icon("BusVuEmpty", "EditorIcons"));
-				channel[i].vu_l->set_progress_texture(get_theme_icon("BusVuFull", "EditorIcons"));
-				channel[i].vu_r->set_under_texture(get_theme_icon("BusVuEmpty", "EditorIcons"));
-				channel[i].vu_r->set_progress_texture(get_theme_icon("BusVuFull", "EditorIcons"));
+				channel[i].vu_l->set_under_texture(get_theme_icon(SNAME("BusVuEmpty"), SNAME("EditorIcons")));
+				channel[i].vu_l->set_progress_texture(get_theme_icon(SNAME("BusVuFull"), SNAME("EditorIcons")));
+				channel[i].vu_r->set_under_texture(get_theme_icon(SNAME("BusVuEmpty"), SNAME("EditorIcons")));
+				channel[i].vu_r->set_progress_texture(get_theme_icon(SNAME("BusVuFull"), SNAME("EditorIcons")));
 				channel[i].prev_active = true;
 			}
 
-			disabled_vu = get_theme_icon("BusVuFrozen", "EditorIcons");
+			disabled_vu = get_theme_icon(SNAME("BusVuFrozen"), SNAME("EditorIcons"));
 
 			Color solo_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1.0, 0.89, 0.22) : Color(1.0, 0.92, 0.44);
 			Color mute_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1.0, 0.16, 0.16) : Color(1.0, 0.44, 0.44);
 			Color bypass_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(0.13, 0.8, 1.0) : Color(0.44, 0.87, 1.0);
 
-			solo->set_icon(get_theme_icon("AudioBusSolo", "EditorIcons"));
+			solo->set_icon(get_theme_icon(SNAME("AudioBusSolo"), SNAME("EditorIcons")));
 			solo->add_theme_color_override("icon_pressed_color", solo_color);
-			mute->set_icon(get_theme_icon("AudioBusMute", "EditorIcons"));
+			mute->set_icon(get_theme_icon(SNAME("AudioBusMute"), SNAME("EditorIcons")));
 			mute->add_theme_color_override("icon_pressed_color", mute_color);
-			bypass->set_icon(get_theme_icon("AudioBusBypass", "EditorIcons"));
+			bypass->set_icon(get_theme_icon(SNAME("AudioBusBypass"), SNAME("EditorIcons")));
 			bypass->add_theme_color_override("icon_pressed_color", bypass_color);
 
-			bus_options->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
+			bus_options->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
 			update_bus();
 			set_process(true);
 		} break;
 		case NOTIFICATION_DRAW: {
 			if (is_master) {
-				draw_style_box(get_theme_stylebox("disabled", "Button"), Rect2(Vector2(), get_size()));
+				draw_style_box(get_theme_stylebox(SNAME("disabled"), SNAME("Button")), Rect2(Vector2(), get_size()));
 			} else if (has_focus()) {
-				draw_style_box(get_theme_stylebox("focus", "Button"), Rect2(Vector2(), get_size()));
+				draw_style_box(get_theme_stylebox(SNAME("focus"), SNAME("Button")), Rect2(Vector2(), get_size()));
 			} else {
-				draw_style_box(get_theme_stylebox("panel", "TabContainer"), Rect2(Vector2(), get_size()));
+				draw_style_box(get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")), Rect2(Vector2(), get_size()));
 			}
 
 			if (get_index() != 0 && hovering_drop) {
-				Color accent = get_theme_color("accent_color", "Editor");
+				Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 				accent.a *= 0.7;
 				draw_rect(Rect2(Point2(), get_size()), accent, false);
 			}
@@ -159,23 +159,23 @@ void EditorAudioBus::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			for (int i = 0; i < CHANNELS_MAX; i++) {
-				channel[i].vu_l->set_under_texture(get_theme_icon("BusVuEmpty", "EditorIcons"));
-				channel[i].vu_l->set_progress_texture(get_theme_icon("BusVuFull", "EditorIcons"));
-				channel[i].vu_r->set_under_texture(get_theme_icon("BusVuEmpty", "EditorIcons"));
-				channel[i].vu_r->set_progress_texture(get_theme_icon("BusVuFull", "EditorIcons"));
+				channel[i].vu_l->set_under_texture(get_theme_icon(SNAME("BusVuEmpty"), SNAME("EditorIcons")));
+				channel[i].vu_l->set_progress_texture(get_theme_icon(SNAME("BusVuFull"), SNAME("EditorIcons")));
+				channel[i].vu_r->set_under_texture(get_theme_icon(SNAME("BusVuEmpty"), SNAME("EditorIcons")));
+				channel[i].vu_r->set_progress_texture(get_theme_icon(SNAME("BusVuFull"), SNAME("EditorIcons")));
 				channel[i].prev_active = true;
 			}
 
-			disabled_vu = get_theme_icon("BusVuFrozen", "EditorIcons");
+			disabled_vu = get_theme_icon(SNAME("BusVuFrozen"), SNAME("EditorIcons"));
 
-			solo->set_icon(get_theme_icon("AudioBusSolo", "EditorIcons"));
-			mute->set_icon(get_theme_icon("AudioBusMute", "EditorIcons"));
-			bypass->set_icon(get_theme_icon("AudioBusBypass", "EditorIcons"));
+			solo->set_icon(get_theme_icon(SNAME("AudioBusSolo"), SNAME("EditorIcons")));
+			mute->set_icon(get_theme_icon(SNAME("AudioBusMute"), SNAME("EditorIcons")));
+			bypass->set_icon(get_theme_icon(SNAME("AudioBusBypass"), SNAME("EditorIcons")));
 
-			bus_options->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
+			bus_options->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
-			audio_value_preview_box->add_theme_color_override("font_color", get_theme_color("font_color", "TooltipLabel"));
-			audio_value_preview_box->add_theme_style_override("panel", get_theme_stylebox("panel", "TooltipPanel"));
+			audio_value_preview_box->add_theme_color_override("font_color", get_theme_color(SNAME("font_color"), SNAME("TooltipLabel")));
+			audio_value_preview_box->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
 		} break;
 		case NOTIFICATION_MOUSE_EXIT:
 		case NOTIFICATION_DRAG_END: {
@@ -567,12 +567,12 @@ void EditorAudioBus::_effects_gui_input(Ref<InputEvent> p_event) {
 void EditorAudioBus::_bus_popup_pressed(int p_option) {
 	if (p_option == 2) {
 		// Reset volume
-		emit_signal("vol_reset_request");
+		emit_signal(SNAME("vol_reset_request"));
 	} else if (p_option == 1) {
-		emit_signal("delete_request");
+		emit_signal(SNAME("delete_request"));
 	} else if (p_option == 0) {
 		//duplicate
-		emit_signal("duplicate_request", get_index());
+		emit_signal(SNAME("duplicate_request"), get_index());
 	}
 }
 
@@ -585,7 +585,7 @@ Variant EditorAudioBus::get_drag_data(const Point2 &p_point) {
 	Panel *p = memnew(Panel);
 	c->add_child(p);
 	p->set_modulate(Color(1, 1, 1, 0.7));
-	p->add_theme_style_override("panel", get_theme_stylebox("focus", "Button"));
+	p->add_theme_style_override("panel", get_theme_stylebox(SNAME("focus"), SNAME("Button")));
 	p->set_size(get_size());
 	p->set_position(-p_point);
 	set_drag_preview(c);
@@ -594,7 +594,7 @@ Variant EditorAudioBus::get_drag_data(const Point2 &p_point) {
 	d["index"] = get_index();
 
 	if (get_index() < AudioServer::get_singleton()->get_bus_count() - 1) {
-		emit_signal("drop_end_request");
+		emit_signal(SNAME("drop_end_request"));
 	}
 
 	return d;
@@ -616,7 +616,7 @@ bool EditorAudioBus::can_drop_data(const Point2 &p_point, const Variant &p_data)
 
 void EditorAudioBus::drop_data(const Point2 &p_point, const Variant &p_data) {
 	Dictionary d = p_data;
-	emit_signal("dropped", d["index"], get_index());
+	emit_signal(SNAME("dropped"), d["index"], get_index());
 }
 
 Variant EditorAudioBus::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
@@ -842,13 +842,13 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	audio_value_preview_label->set_v_size_flags(SIZE_EXPAND_FILL);
 	audio_value_preview_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	audio_value_preview_label->set_mouse_filter(MOUSE_FILTER_PASS);
-	audio_value_preview_box->add_theme_color_override("font_color", get_theme_color("font_color", "TooltipLabel"));
+	audio_value_preview_box->add_theme_color_override("font_color", get_theme_color(SNAME("font_color"), SNAME("TooltipLabel")));
 
 	audioprev_hbc->add_child(audio_value_preview_label);
 
 	slider->add_child(audio_value_preview_box);
 	audio_value_preview_box->set_as_top_level(true);
-	audio_value_preview_box->add_theme_style_override("panel", get_theme_stylebox("panel", "TooltipPanel"));
+	audio_value_preview_box->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
 	audio_value_preview_box->set_mouse_filter(MOUSE_FILTER_PASS);
 	audio_value_preview_box->hide();
 
@@ -955,10 +955,10 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 void EditorAudioBusDrop::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			draw_style_box(get_theme_stylebox("normal", "Button"), Rect2(Vector2(), get_size()));
+			draw_style_box(get_theme_stylebox(SNAME("normal"), SNAME("Button")), Rect2(Vector2(), get_size()));
 
 			if (hovering_drop) {
-				Color accent = get_theme_color("accent_color", "Editor");
+				Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 				accent.a *= 0.7;
 				draw_rect(Rect2(Point2(), get_size()), accent, false);
 			}
@@ -986,7 +986,7 @@ bool EditorAudioBusDrop::can_drop_data(const Point2 &p_point, const Variant &p_d
 
 void EditorAudioBusDrop::drop_data(const Point2 &p_point, const Variant &p_data) {
 	Dictionary d = p_data;
-	emit_signal("dropped", d["index"], AudioServer::get_singleton()->get_bus_count());
+	emit_signal(SNAME("dropped"), d["index"], AudioServer::get_singleton()->get_bus_count());
 }
 
 void EditorAudioBusDrop::_bind_methods() {
@@ -1026,7 +1026,7 @@ void EditorAudioBuses::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			bus_scroll->add_theme_style_override("bg", get_theme_stylebox("bg", "Tree"));
+			bus_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 		case NOTIFICATION_READY: {
 			_update_buses();
@@ -1217,7 +1217,7 @@ void EditorAudioBuses::_load_default_layout() {
 	AudioServer::get_singleton()->set_bus_layout(state);
 	_update_buses();
 	EditorNode::get_singleton()->get_undo_redo()->clear_history();
-	call_deferred("_select_layout");
+	call_deferred(SNAME("_select_layout"));
 }
 
 void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
@@ -1233,7 +1233,7 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 		AudioServer::get_singleton()->set_bus_layout(state);
 		_update_buses();
 		EditorNode::get_singleton()->get_undo_redo()->clear_history();
-		call_deferred("_select_layout");
+		call_deferred(SNAME("_select_layout"));
 
 	} else if (file_dialog->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
 		if (new_layout) {
@@ -1253,7 +1253,7 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 		file->set_text(String(TTR("Layout")) + ": " + p_string.get_file());
 		_update_buses();
 		EditorNode::get_singleton()->get_undo_redo()->clear_history();
-		call_deferred("_select_layout");
+		call_deferred(SNAME("_select_layout"));
 	}
 }
 
@@ -1354,7 +1354,7 @@ void EditorAudioBuses::open_layout(const String &p_path) {
 	AudioServer::get_singleton()->set_bus_layout(state);
 	_update_buses();
 	EditorNode::get_singleton()->get_undo_redo()->clear_history();
-	call_deferred("_select_layout");
+	call_deferred(SNAME("_select_layout"));
 }
 
 void AudioBusesEditorPlugin::edit(Object *p_node) {
@@ -1385,8 +1385,8 @@ void EditorAudioMeterNotches::add_notch(float p_normalized_offset, float p_db_va
 }
 
 Size2 EditorAudioMeterNotches::get_minimum_size() const {
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	float font_height = font->get_height(font_size);
 
 	float width = 0;
@@ -1411,7 +1411,7 @@ void EditorAudioMeterNotches::_bind_methods() {
 void EditorAudioMeterNotches::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			notch_color = get_theme_color("font_color", "Editor");
+			notch_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 		} break;
 		case NOTIFICATION_DRAW: {
 			_draw_audio_notches();
@@ -1420,8 +1420,8 @@ void EditorAudioMeterNotches::_notification(int p_what) {
 }
 
 void EditorAudioMeterNotches::_draw_audio_notches() {
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	float font_height = font->get_height(font_size);
 
 	for (int i = 0; i < notches.size(); i++) {
@@ -1443,5 +1443,5 @@ void EditorAudioMeterNotches::_draw_audio_notches() {
 }
 
 EditorAudioMeterNotches::EditorAudioMeterNotches() {
-	notch_color = get_theme_color("font_color", "Editor");
+	notch_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 }

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -53,12 +53,12 @@ void EditorAutoloadSettings::_notification(int p_what) {
 		for (List<AutoLoadInfo>::Element *E = autoload_cache.front(); E; E = E->next()) {
 			AutoLoadInfo &info = E->get();
 			if (info.node && info.in_editor) {
-				get_tree()->get_root()->call_deferred("add_child", info.node);
+				get_tree()->get_root()->call_deferred(SNAME("add_child"), info.node);
 			}
 		}
-		browse_button->set_icon(get_theme_icon("Folder", "EditorIcons"));
+		browse_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		browse_button->set_icon(get_theme_icon("Folder", "EditorIcons"));
+		browse_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 	}
 }
 
@@ -453,10 +453,10 @@ void EditorAutoloadSettings::update_autoload() {
 		item->set_editable(2, true);
 		item->set_text(2, TTR("Enable"));
 		item->set_checked(2, info.is_singleton);
-		item->add_button(3, get_theme_icon("Load", "EditorIcons"), BUTTON_OPEN);
-		item->add_button(3, get_theme_icon("MoveUp", "EditorIcons"), BUTTON_MOVE_UP);
-		item->add_button(3, get_theme_icon("MoveDown", "EditorIcons"), BUTTON_MOVE_DOWN);
-		item->add_button(3, get_theme_icon("Remove", "EditorIcons"), BUTTON_DELETE);
+		item->add_button(3, get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), BUTTON_OPEN);
+		item->add_button(3, get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")), BUTTON_MOVE_UP);
+		item->add_button(3, get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")), BUTTON_MOVE_DOWN);
+		item->add_button(3, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_DELETE);
 		item->set_selectable(3, false);
 	}
 
@@ -470,7 +470,7 @@ void EditorAutoloadSettings::update_autoload() {
 		}
 		if (info.in_editor) {
 			ERR_CONTINUE(!info.node);
-			get_tree()->get_root()->call_deferred("remove_child", info.node);
+			get_tree()->get_root()->call_deferred(SNAME("remove_child"), info.node);
 		}
 
 		if (info.node) {
@@ -914,7 +914,7 @@ EditorAutoloadSettings::~EditorAutoloadSettings() {
 
 void EditorAutoloadSettings::_set_autoload_add_path(const String &p_text) {
 	autoload_add_path->set_text(p_text);
-	autoload_add_path->emit_signal("text_submitted", p_text);
+	autoload_add_path->emit_signal(SNAME("text_submitted"), p_text);
 }
 
 void EditorAutoloadSettings::_browse_autoload_add_path() {

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1048,7 +1048,7 @@ void EditorSelection::add_node(Node *p_node) {
 
 	p_node->connect("tree_exiting", callable_mp(this, &EditorSelection::_node_removed), varray(p_node), CONNECT_ONESHOT);
 
-	//emit_signal("selection_changed");
+	//emit_signal(SNAME("selection_changed"));
 }
 
 void EditorSelection::remove_node(Node *p_node) {
@@ -1066,7 +1066,7 @@ void EditorSelection::remove_node(Node *p_node) {
 	}
 	selection.erase(p_node);
 	p_node->disconnect("tree_exiting", callable_mp(this, &EditorSelection::_node_removed));
-	//emit_signal("selection_changed");
+	//emit_signal(SNAME("selection_changed"));
 }
 
 bool EditorSelection::is_selected(Node *p_node) const {
@@ -1144,12 +1144,12 @@ void EditorSelection::update() {
 	changed = false;
 	if (!emitted) {
 		emitted = true;
-		call_deferred("_emit_change");
+		call_deferred(SNAME("_emit_change"));
 	}
 }
 
 void EditorSelection::_emit_change() {
-	emit_signal("selection_changed");
+	emit_signal(SNAME("selection_changed"));
 	emitted = false;
 }
 

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -43,7 +43,7 @@ void EditorDirDialog::_update_dir(TreeItem *p_item, EditorFileSystemDirectory *p
 	String path = p_dir->get_path();
 
 	p_item->set_metadata(0, p_dir->get_path());
-	p_item->set_icon(0, tree->get_theme_icon("Folder", "EditorIcons"));
+	p_item->set_icon(0, tree->get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 
 	if (!p_item->get_parent()) {
 		p_item->set_text(0, "res://");
@@ -129,7 +129,7 @@ void EditorDirDialog::ok_pressed() {
 	}
 
 	String dir = ti->get_metadata(0);
-	emit_signal("dir_selected", dir);
+	emit_signal(SNAME("dir_selected"), dir);
 	hide();
 }
 

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -497,7 +497,7 @@ void EditorFeatureProfileManager::_fill_classes_from(TreeItem *p_parent, const S
 	bool disabled_editor = edited->is_class_editor_disabled(p_class);
 	bool disabled_properties = edited->has_class_properties_disabled(p_class);
 	if (disabled) {
-		class_item->set_custom_color(0, class_list->get_theme_color("disabled_font_color", "Editor"));
+		class_item->set_custom_color(0, class_list->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 	} else if (disabled_editor && disabled_properties) {
 		text += " " + TTR("(Editor Disabled, Properties Disabled)");
 	} else if (disabled_properties) {
@@ -834,7 +834,7 @@ void EditorFeatureProfileManager::_save_and_update() {
 }
 
 void EditorFeatureProfileManager::_emit_current_profile_changed() {
-	emit_signal("current_feature_profile_changed");
+	emit_signal(SNAME("current_feature_profile_changed"));
 }
 
 void EditorFeatureProfileManager::notify_changed() {

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -61,22 +61,22 @@ VBoxContainer *EditorFileDialog::get_vbox() {
 void EditorFileDialog::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY || p_what == NOTIFICATION_THEME_CHANGED || p_what == Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 		// Update icons.
-		mode_thumbnails->set_icon(item_list->get_theme_icon("FileThumbnail", "EditorIcons"));
-		mode_list->set_icon(item_list->get_theme_icon("FileList", "EditorIcons"));
+		mode_thumbnails->set_icon(item_list->get_theme_icon(SNAME("FileThumbnail"), SNAME("EditorIcons")));
+		mode_list->set_icon(item_list->get_theme_icon(SNAME("FileList"), SNAME("EditorIcons")));
 		if (is_layout_rtl()) {
-			dir_prev->set_icon(item_list->get_theme_icon("Forward", "EditorIcons"));
-			dir_next->set_icon(item_list->get_theme_icon("Back", "EditorIcons"));
+			dir_prev->set_icon(item_list->get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
+			dir_next->set_icon(item_list->get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 		} else {
-			dir_prev->set_icon(item_list->get_theme_icon("Back", "EditorIcons"));
-			dir_next->set_icon(item_list->get_theme_icon("Forward", "EditorIcons"));
+			dir_prev->set_icon(item_list->get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
+			dir_next->set_icon(item_list->get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 		}
-		dir_up->set_icon(item_list->get_theme_icon("ArrowUp", "EditorIcons"));
-		refresh->set_icon(item_list->get_theme_icon("Reload", "EditorIcons"));
-		favorite->set_icon(item_list->get_theme_icon("Favorites", "EditorIcons"));
-		show_hidden->set_icon(item_list->get_theme_icon("GuiVisibilityVisible", "EditorIcons"));
+		dir_up->set_icon(item_list->get_theme_icon(SNAME("ArrowUp"), SNAME("EditorIcons")));
+		refresh->set_icon(item_list->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
+		favorite->set_icon(item_list->get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")));
+		show_hidden->set_icon(item_list->get_theme_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
 
-		fav_up->set_icon(item_list->get_theme_icon("MoveUp", "EditorIcons"));
-		fav_down->set_icon(item_list->get_theme_icon("MoveDown", "EditorIcons"));
+		fav_up->set_icon(item_list->get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
+		fav_down->set_icon(item_list->get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
 
 	} else if (p_what == NOTIFICATION_PROCESS) {
 		if (preview_waiting) {
@@ -100,21 +100,21 @@ void EditorFileDialog::_notification(int p_what) {
 		set_display_mode((DisplayMode)EditorSettings::get_singleton()->get("filesystem/file_dialog/display_mode").operator int());
 
 		// Update icons.
-		mode_thumbnails->set_icon(item_list->get_theme_icon("FileThumbnail", "EditorIcons"));
-		mode_list->set_icon(item_list->get_theme_icon("FileList", "EditorIcons"));
+		mode_thumbnails->set_icon(item_list->get_theme_icon(SNAME("FileThumbnail"), SNAME("EditorIcons")));
+		mode_list->set_icon(item_list->get_theme_icon(SNAME("FileList"), SNAME("EditorIcons")));
 		if (is_layout_rtl()) {
-			dir_prev->set_icon(item_list->get_theme_icon("Forward", "EditorIcons"));
-			dir_next->set_icon(item_list->get_theme_icon("Back", "EditorIcons"));
+			dir_prev->set_icon(item_list->get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
+			dir_next->set_icon(item_list->get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 		} else {
-			dir_prev->set_icon(item_list->get_theme_icon("Back", "EditorIcons"));
-			dir_next->set_icon(item_list->get_theme_icon("Forward", "EditorIcons"));
+			dir_prev->set_icon(item_list->get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
+			dir_next->set_icon(item_list->get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 		}
-		dir_up->set_icon(item_list->get_theme_icon("ArrowUp", "EditorIcons"));
-		refresh->set_icon(item_list->get_theme_icon("Reload", "EditorIcons"));
-		favorite->set_icon(item_list->get_theme_icon("Favorites", "EditorIcons"));
+		dir_up->set_icon(item_list->get_theme_icon(SNAME("ArrowUp"), SNAME("EditorIcons")));
+		refresh->set_icon(item_list->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
+		favorite->set_icon(item_list->get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")));
 
-		fav_up->set_icon(item_list->get_theme_icon("MoveUp", "EditorIcons"));
-		fav_down->set_icon(item_list->get_theme_icon("MoveDown", "EditorIcons"));
+		fav_up->set_icon(item_list->get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
+		fav_down->set_icon(item_list->get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
 		// DO NOT CALL UPDATE FILE LIST HERE, ALL HUNDREDS OF HIDDEN DIALOGS WILL RESPOND, CALL INVALIDATE INSTEAD
 		invalidate();
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
@@ -245,7 +245,7 @@ void EditorFileDialog::_save_confirm_pressed() {
 	String f = dir_access->get_current_dir().plus_file(file->get_text());
 	_save_to_recent();
 	hide();
-	emit_signal("file_selected", f);
+	emit_signal(SNAME("file_selected"), f);
 }
 
 void EditorFileDialog::_post_popup() {
@@ -279,8 +279,8 @@ void EditorFileDialog::_post_popup() {
 	}
 
 	if (is_visible()) {
-		Ref<Texture2D> folder = item_list->get_theme_icon("folder", "FileDialog");
-		const Color folder_color = item_list->get_theme_color("folder_icon_modulate", "FileDialog");
+		Ref<Texture2D> folder = item_list->get_theme_icon(SNAME("folder"), SNAME("FileDialog"));
+		const Color folder_color = item_list->get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"));
 		recent->clear();
 
 		bool res = access == ACCESS_RESOURCES;
@@ -379,7 +379,7 @@ void EditorFileDialog::_action_pressed() {
 		if (files.size()) {
 			_save_to_recent();
 			hide();
-			emit_signal("files_selected", files);
+			emit_signal(SNAME("files_selected"), files);
 		}
 
 		return;
@@ -390,7 +390,7 @@ void EditorFileDialog::_action_pressed() {
 	if ((mode == FILE_MODE_OPEN_ANY || mode == FILE_MODE_OPEN_FILE) && dir_access->file_exists(f)) {
 		_save_to_recent();
 		hide();
-		emit_signal("file_selected", f);
+		emit_signal(SNAME("file_selected"), f);
 	} else if (mode == FILE_MODE_OPEN_ANY || mode == FILE_MODE_OPEN_DIR) {
 		String path = dir_access->get_current_dir();
 
@@ -409,7 +409,7 @@ void EditorFileDialog::_action_pressed() {
 
 		_save_to_recent();
 		hide();
-		emit_signal("dir_selected", path);
+		emit_signal(SNAME("dir_selected"), path);
 	}
 
 	if (mode == FILE_MODE_SAVE_FILE) {
@@ -474,7 +474,7 @@ void EditorFileDialog::_action_pressed() {
 		} else {
 			_save_to_recent();
 			hide();
-			emit_signal("file_selected", f);
+			emit_signal(SNAME("file_selected"), f);
 		}
 	}
 }
@@ -563,8 +563,8 @@ void EditorFileDialog::_item_dc_selected(int p_item) {
 
 	if (d["dir"]) {
 		dir_access->change_dir(d["name"]);
-		call_deferred("_update_file_list");
-		call_deferred("_update_dir");
+		call_deferred(SNAME("_update_file_list"));
+		call_deferred(SNAME("_update_dir"));
 
 		_push_history();
 
@@ -595,16 +595,16 @@ void EditorFileDialog::_item_list_item_rmb_selected(int p_item, const Vector2 &p
 	}
 
 	if (single_item_selected) {
-		item_menu->add_icon_item(item_list->get_theme_icon("ActionCopy", "EditorIcons"), TTR("Copy Path"), ITEM_MENU_COPY_PATH);
+		item_menu->add_icon_item(item_list->get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")), TTR("Copy Path"), ITEM_MENU_COPY_PATH);
 	}
 	if (allow_delete) {
-		item_menu->add_icon_item(item_list->get_theme_icon("Remove", "EditorIcons"), TTR("Delete"), ITEM_MENU_DELETE, KEY_DELETE);
+		item_menu->add_icon_item(item_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Delete"), ITEM_MENU_DELETE, KEY_DELETE);
 	}
 	if (single_item_selected) {
 		item_menu->add_separator();
 		Dictionary item_meta = item_list->get_item_metadata(p_item);
 		String item_text = item_meta["dir"] ? TTR("Open in File Manager") : TTR("Show in File Manager");
-		item_menu->add_icon_item(item_list->get_theme_icon("Filesystem", "EditorIcons"), item_text, ITEM_MENU_SHOW_IN_EXPLORER);
+		item_menu->add_icon_item(item_list->get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")), item_text, ITEM_MENU_SHOW_IN_EXPLORER);
 	}
 
 	if (item_menu->get_item_count() > 0) {
@@ -623,11 +623,11 @@ void EditorFileDialog::_item_list_rmb_clicked(const Vector2 &p_pos) {
 	item_menu->set_size(Size2(1, 1));
 
 	if (can_create_dir) {
-		item_menu->add_icon_item(item_list->get_theme_icon("folder", "FileDialog"), TTR("New Folder..."), ITEM_MENU_NEW_FOLDER, KEY_MASK_CMD | KEY_N);
+		item_menu->add_icon_item(item_list->get_theme_icon(SNAME("folder"), SNAME("FileDialog")), TTR("New Folder..."), ITEM_MENU_NEW_FOLDER, KEY_MASK_CMD | KEY_N);
 	}
-	item_menu->add_icon_item(item_list->get_theme_icon("Reload", "EditorIcons"), TTR("Refresh"), ITEM_MENU_REFRESH, KEY_F5);
+	item_menu->add_icon_item(item_list->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")), TTR("Refresh"), ITEM_MENU_REFRESH, KEY_F5);
 	item_menu->add_separator();
-	item_menu->add_icon_item(item_list->get_theme_icon("Filesystem", "EditorIcons"), TTR("Open in File Manager"), ITEM_MENU_SHOW_IN_EXPLORER);
+	item_menu->add_icon_item(item_list->get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")), TTR("Open in File Manager"), ITEM_MENU_SHOW_IN_EXPLORER);
 
 	item_menu->set_position(item_list->get_global_position() + p_pos);
 	item_menu->popup();
@@ -731,11 +731,11 @@ void EditorFileDialog::update_file_list() {
 		item_list->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
 
 		if (thumbnail_size < 64) {
-			folder_thumbnail = item_list->get_theme_icon("FolderMediumThumb", "EditorIcons");
-			file_thumbnail = item_list->get_theme_icon("FileMediumThumb", "EditorIcons");
+			folder_thumbnail = item_list->get_theme_icon(SNAME("FolderMediumThumb"), SNAME("EditorIcons"));
+			file_thumbnail = item_list->get_theme_icon(SNAME("FileMediumThumb"), SNAME("EditorIcons"));
 		} else {
-			folder_thumbnail = item_list->get_theme_icon("FolderBigThumb", "EditorIcons");
-			file_thumbnail = item_list->get_theme_icon("FileBigThumb", "EditorIcons");
+			folder_thumbnail = item_list->get_theme_icon(SNAME("FolderBigThumb"), SNAME("EditorIcons"));
+			file_thumbnail = item_list->get_theme_icon(SNAME("FileBigThumb"), SNAME("EditorIcons"));
 		}
 
 		preview_vb->hide();
@@ -755,8 +755,8 @@ void EditorFileDialog::update_file_list() {
 
 	dir_access->list_dir_begin();
 
-	Ref<Texture2D> folder = item_list->get_theme_icon("folder", "FileDialog");
-	const Color folder_color = item_list->get_theme_color("folder_icon_modulate", "FileDialog");
+	Ref<Texture2D> folder = item_list->get_theme_icon(SNAME("folder"), SNAME("FileDialog"));
+	const Color folder_color = item_list->get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"));
 	List<String> files;
 	List<String> dirs;
 
@@ -1206,8 +1206,8 @@ void EditorFileDialog::_update_favorites() {
 	bool res = access == ACCESS_RESOURCES;
 
 	String current = get_current_dir();
-	Ref<Texture2D> folder_icon = item_list->get_theme_icon("Folder", "EditorIcons");
-	const Color folder_color = item_list->get_theme_color("folder_icon_modulate", "FileDialog");
+	Ref<Texture2D> folder_icon = item_list->get_theme_icon(SNAME("Folder"), SNAME("EditorIcons"));
+	const Color folder_color = item_list->get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"));
 	favorites->clear();
 
 	favorite->set_pressed(false);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -592,7 +592,7 @@ bool EditorFileSystem::_update_scan_actions() {
 	}
 
 	if (reloads.size()) {
-		emit_signal("resources_reload", reloads);
+		emit_signal(SNAME("resources_reload"), reloads);
 	}
 	scan_actions.clear();
 
@@ -623,8 +623,8 @@ void EditorFileSystem::scan() {
 		new_filesystem = nullptr;
 		_update_scan_actions();
 		scanning = false;
-		emit_signal("filesystem_changed");
-		emit_signal("sources_changed", sources_changed.size() > 0);
+		emit_signal(SNAME("filesystem_changed"));
+		emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
 		_queue_update_script_classes();
 		first_scan = false;
 	} else {
@@ -1073,12 +1073,12 @@ void EditorFileSystem::scan_changes() {
 			scan_total = 0;
 			_scan_fs_changes(filesystem, sp);
 			if (_update_scan_actions()) {
-				emit_signal("filesystem_changed");
+				emit_signal(SNAME("filesystem_changed"));
 			}
 		}
 		scanning_changes = false;
 		scanning_changes_done = true;
-		emit_signal("sources_changed", sources_changed.size() > 0);
+		emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
 	} else {
 		ERR_FAIL_COND(thread_sources.is_started());
 		set_process(true);
@@ -1092,7 +1092,7 @@ void EditorFileSystem::scan_changes() {
 void EditorFileSystem::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			call_deferred("scan"); //this should happen after every editor node entered the tree
+			call_deferred(SNAME("scan")); //this should happen after every editor node entered the tree
 
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
@@ -1128,9 +1128,9 @@ void EditorFileSystem::_notification(int p_what) {
 
 						thread_sources.wait_to_finish();
 						if (_update_scan_actions()) {
-							emit_signal("filesystem_changed");
+							emit_signal(SNAME("filesystem_changed"));
 						}
-						emit_signal("sources_changed", sources_changed.size() > 0);
+						emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
 						_queue_update_script_classes();
 						first_scan = false;
 					}
@@ -1144,8 +1144,8 @@ void EditorFileSystem::_notification(int p_what) {
 					new_filesystem = nullptr;
 					thread.wait_to_finish();
 					_update_scan_actions();
-					emit_signal("filesystem_changed");
-					emit_signal("sources_changed", sources_changed.size() > 0);
+					emit_signal(SNAME("filesystem_changed"));
+					emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
 					_queue_update_script_classes();
 					first_scan = false;
 				}
@@ -1445,7 +1445,7 @@ void EditorFileSystem::_queue_update_script_classes() {
 	}
 
 	update_script_classes_queued.set();
-	call_deferred("update_script_classes");
+	call_deferred(SNAME("update_script_classes"));
 }
 
 void EditorFileSystem::update_file(const String &p_file) {
@@ -1466,7 +1466,7 @@ void EditorFileSystem::update_file(const String &p_file) {
 			fs->files.remove(cpos);
 		}
 
-		call_deferred("emit_signal", "filesystem_changed"); //update later
+		call_deferred(SNAME("emit_signal"), "filesystem_changed"); //update later
 		_queue_update_script_classes();
 		return;
 	}
@@ -1513,7 +1513,7 @@ void EditorFileSystem::update_file(const String &p_file) {
 	// Update preview
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
 
-	call_deferred("emit_signal", "filesystem_changed"); //update later
+	call_deferred(SNAME("emit_signal"), "filesystem_changed"); //update later
 	_queue_update_script_classes();
 }
 
@@ -2026,10 +2026,10 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 	_save_filesystem_cache();
 	importing = false;
 	if (!is_scanning()) {
-		emit_signal("filesystem_changed");
+		emit_signal(SNAME("filesystem_changed"));
 	}
 
-	emit_signal("resources_reimported", p_files);
+	emit_signal(SNAME("resources_reimported"), p_files);
 }
 
 Error EditorFileSystem::_resource_import(const String &p_path) {

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -43,16 +43,16 @@
 DocTools *EditorHelp::doc = nullptr;
 
 void EditorHelp::_init_colors() {
-	title_color = get_theme_color("accent_color", "Editor");
-	text_color = get_theme_color("default_color", "RichTextLabel");
-	headline_color = get_theme_color("headline_color", "EditorHelp");
+	title_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+	text_color = get_theme_color(SNAME("default_color"), SNAME("RichTextLabel"));
+	headline_color = get_theme_color(SNAME("headline_color"), SNAME("EditorHelp"));
 	base_type_color = title_color.lerp(text_color, 0.5);
 	comment_color = text_color * Color(1, 1, 1, 0.6);
 	symbol_color = comment_color;
 	value_color = text_color * Color(1, 1, 1, 0.6);
 	qualifier_color = text_color * Color(1, 1, 1, 0.8);
-	type_color = get_theme_color("accent_color", "Editor").lerp(text_color, 0.5);
-	class_desc->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
+	type_color = get_theme_color(SNAME("accent_color"), SNAME("Editor")).lerp(text_color, 0.5);
+	class_desc->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 	class_desc->add_theme_constant_override("line_separation", Math::round(5 * EDSCALE));
 }
 
@@ -78,10 +78,10 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		} else {
 			class_name = "@GlobalScope";
 		}
-		emit_signal("go_to_help", "class_enum:" + class_name + ":" + select);
+		emit_signal(SNAME("go_to_help"), "class_enum:" + class_name + ":" + select);
 		return;
 	} else if (p_select.begins_with("#")) {
-		emit_signal("go_to_help", "class_name:" + p_select.substr(1, p_select.length()));
+		emit_signal(SNAME("go_to_help"), "class_name:" + p_select.substr(1, p_select.length()));
 		return;
 	} else if (p_select.begins_with("@")) {
 		int tag_end = p_select.find(" ");
@@ -112,7 +112,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		}
 
 		if (link.find(".") != -1) {
-			emit_signal("go_to_help", topic + ":" + link.get_slice(".", 0) + ":" + link.get_slice(".", 1));
+			emit_signal(SNAME("go_to_help"), topic + ":" + link.get_slice(".", 0) + ":" + link.get_slice(".", 1));
 		} else {
 			if (table->has(link)) {
 				// Found in the current page
@@ -125,7 +125,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 					for (int i = 0; i < cd.constants.size(); i++) {
 						if (cd.constants[i].enumeration == link) {
 							// Found in @GlobalScope
-							emit_signal("go_to_help", topic + ":@GlobalScope:" + link);
+							emit_signal(SNAME("go_to_help"), topic + ":@GlobalScope:" + link);
 							break;
 						}
 					}
@@ -136,7 +136,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 					for (int i = 0; i < cd.constants.size(); i++) {
 						if (cd.constants[i].name == link) {
 							// Found in @GlobalScope
-							emit_signal("go_to_help", topic + ":@GlobalScope:" + link);
+							emit_signal(SNAME("go_to_help"), topic + ":@GlobalScope:" + link);
 							break;
 						}
 					}
@@ -154,12 +154,12 @@ void EditorHelp::_class_desc_input(const Ref<InputEvent> &p_input) {
 void EditorHelp::_class_desc_resized() {
 	// Add extra horizontal margins for better readability.
 	// The margins increase as the width of the editor help container increases.
-	Ref<Font> doc_code_font = get_theme_font("doc_source", "EditorFonts");
-	int font_size = get_theme_font_size("doc_source_size", "EditorFonts");
+	Ref<Font> doc_code_font = get_theme_font(SNAME("doc_source"), SNAME("EditorFonts"));
+	int font_size = get_theme_font_size(SNAME("doc_source_size"), SNAME("EditorFonts"));
 	real_t char_width = doc_code_font->get_char_size('x', 0, font_size).width;
 	const int display_margin = MAX(30 * EDSCALE, get_parent_anchorable_rect().size.width - char_width * 120 * EDSCALE) * 0.5;
 
-	Ref<StyleBox> class_desc_stylebox = EditorNode::get_singleton()->get_theme_base()->get_theme_stylebox("normal", "RichTextLabel")->duplicate();
+	Ref<StyleBox> class_desc_stylebox = EditorNode::get_singleton()->get_theme_base()->get_theme_stylebox(SNAME("normal"), SNAME("RichTextLabel"))->duplicate();
 	class_desc_stylebox->set_default_margin(SIDE_LEFT, display_margin);
 	class_desc_stylebox->set_default_margin(SIDE_RIGHT, display_margin);
 	class_desc->add_theme_style_override("normal", class_desc_stylebox);
@@ -179,8 +179,8 @@ void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 			t = p_enum.get_slice(".", 0);
 		}
 	}
-	const Color text_color = get_theme_color("default_color", "RichTextLabel");
-	const Color type_color = get_theme_color("accent_color", "Editor").lerp(text_color, 0.5);
+	const Color text_color = get_theme_color(SNAME("default_color"), SNAME("RichTextLabel"));
+	const Color type_color = get_theme_color(SNAME("accent_color"), SNAME("Editor")).lerp(text_color, 0.5);
 	class_desc->push_color(type_color);
 	bool add_array = false;
 	if (can_ref) {
@@ -344,10 +344,10 @@ void EditorHelp::_update_doc() {
 
 	DocData::ClassDoc cd = doc->class_list[edited_class]; //make a copy, so we can sort without worrying
 
-	Ref<Font> doc_font = get_theme_font("doc", "EditorFonts");
-	Ref<Font> doc_bold_font = get_theme_font("doc_bold", "EditorFonts");
-	Ref<Font> doc_title_font = get_theme_font("doc_title", "EditorFonts");
-	Ref<Font> doc_code_font = get_theme_font("doc_source", "EditorFonts");
+	Ref<Font> doc_font = get_theme_font(SNAME("doc"), SNAME("EditorFonts"));
+	Ref<Font> doc_bold_font = get_theme_font(SNAME("doc_bold"), SNAME("EditorFonts"));
+	Ref<Font> doc_title_font = get_theme_font(SNAME("doc_title"), SNAME("EditorFonts"));
+	Ref<Font> doc_code_font = get_theme_font(SNAME("doc_source"), SNAME("EditorFonts"));
 	String link_color_text = title_color.to_html(false);
 
 	// Class name
@@ -1177,7 +1177,7 @@ void EditorHelp::_update_doc() {
 			if (!cd.properties[i].description.strip_edges().is_empty()) {
 				_add_text(DTR(cd.properties[i].description));
 			} else {
-				class_desc->add_image(get_theme_icon("Error", "EditorIcons"));
+				class_desc->add_image(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 				class_desc->add_text(" ");
 				class_desc->push_color(comment_color);
 				if (cd.is_script_doc) {
@@ -1232,7 +1232,7 @@ void EditorHelp::_update_doc() {
 				if (!methods_filtered[i].description.strip_edges().is_empty()) {
 					_add_text(DTR(methods_filtered[i].description));
 				} else {
-					class_desc->add_image(get_theme_icon("Error", "EditorIcons"));
+					class_desc->add_image(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 					class_desc->add_text(" ");
 					class_desc->push_color(comment_color);
 					if (cd.is_script_doc) {
@@ -1319,21 +1319,21 @@ void EditorHelp::_help_callback(const String &p_topic) {
 		}
 	}
 
-	class_desc->call_deferred("scroll_to_line", line);
+	class_desc->call_deferred(SNAME("scroll_to_line"), line);
 }
 
 static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 	DocTools *doc = EditorHelp::get_doc_data();
 	String base_path;
 
-	Ref<Font> doc_font = p_rt->get_theme_font("doc", "EditorFonts");
-	Ref<Font> doc_bold_font = p_rt->get_theme_font("doc_bold", "EditorFonts");
-	Ref<Font> doc_code_font = p_rt->get_theme_font("doc_source", "EditorFonts");
-	Ref<Font> doc_kbd_font = p_rt->get_theme_font("doc_keyboard", "EditorFonts");
+	Ref<Font> doc_font = p_rt->get_theme_font(SNAME("doc"), SNAME("EditorFonts"));
+	Ref<Font> doc_bold_font = p_rt->get_theme_font(SNAME("doc_bold"), SNAME("EditorFonts"));
+	Ref<Font> doc_code_font = p_rt->get_theme_font(SNAME("doc_source"), SNAME("EditorFonts"));
+	Ref<Font> doc_kbd_font = p_rt->get_theme_font(SNAME("doc_keyboard"), SNAME("EditorFonts"));
 
-	Color headline_color = p_rt->get_theme_color("headline_color", "EditorHelp");
-	Color accent_color = p_rt->get_theme_color("accent_color", "Editor");
-	Color property_color = p_rt->get_theme_color("property_color", "Editor");
+	Color headline_color = p_rt->get_theme_color(SNAME("headline_color"), SNAME("EditorHelp"));
+	Color accent_color = p_rt->get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+	Color property_color = p_rt->get_theme_color(SNAME("property_color"), SNAME("Editor"));
 	Color link_color = accent_color.lerp(headline_color, 0.8);
 	Color code_color = accent_color.lerp(headline_color, 0.6);
 	Color kbd_color = accent_color.lerp(property_color, 0.6);
@@ -1667,7 +1667,7 @@ EditorHelp::EditorHelp() {
 	class_desc = memnew(RichTextLabel);
 	add_child(class_desc);
 	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
-	class_desc->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
+	class_desc->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 
 	class_desc->connect("meta_clicked", callable_mp(this, &EditorHelp::_class_desc_select));
 	class_desc->connect("gui_input", callable_mp(this, &EditorHelp::_class_desc_input));
@@ -1693,7 +1693,7 @@ EditorHelp::~EditorHelp() {
 void EditorHelpBit::_go_to_help(String p_what) {
 	EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
 	ScriptEditor::get_singleton()->goto_help(p_what);
-	emit_signal("request_hide");
+	emit_signal(SNAME("request_hide"));
 }
 
 void EditorHelpBit::_meta_clicked(String p_select) {
@@ -1733,7 +1733,7 @@ void EditorHelpBit::_notification(int p_what) {
 
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			rich_text->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
+			rich_text->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 		} break;
 		default:
 			break;
@@ -1750,7 +1750,7 @@ EditorHelpBit::EditorHelpBit() {
 	rich_text = memnew(RichTextLabel);
 	add_child(rich_text);
 	rich_text->connect("meta_clicked", callable_mp(this, &EditorHelpBit::_meta_clicked));
-	rich_text->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
+	rich_text->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 	rich_text->set_override_selected_font_color(false);
 	set_custom_minimum_size(Size2(0, 70 * EDSCALE));
 }
@@ -1812,13 +1812,13 @@ void FindBar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			find_prev->set_icon(get_theme_icon("MoveUp", "EditorIcons"));
-			find_next->set_icon(get_theme_icon("MoveDown", "EditorIcons"));
-			hide_button->set_normal_texture(get_theme_icon("Close", "EditorIcons"));
-			hide_button->set_hover_texture(get_theme_icon("Close", "EditorIcons"));
-			hide_button->set_pressed_texture(get_theme_icon("Close", "EditorIcons"));
+			find_prev->set_icon(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
+			find_next->set_icon(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
+			hide_button->set_normal_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+			hide_button->set_hover_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+			hide_button->set_pressed_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 			hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
-			matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color("font_color", "Label") : get_theme_color("error_color", "Editor"));
+			matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			set_process_unhandled_input(is_visible_in_tree());
@@ -1891,7 +1891,7 @@ void FindBar::_update_matches_label() {
 	} else {
 		matches_label->show();
 
-		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color("font_color", "Label") : get_theme_color("error_color", "Editor"));
+		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		matches_label->set_text(vformat(results_count == 1 ? TTR("%d match.") : TTR("%d matches."), results_count));
 	}
 }

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -36,11 +36,11 @@
 #include "editor_scale.h"
 
 void EditorHelpSearch::_update_icons() {
-	search_box->set_right_icon(results_tree->get_theme_icon("Search", "EditorIcons"));
+	search_box->set_right_icon(results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	search_box->set_clear_button_enabled(true);
-	search_box->add_theme_icon_override("right_icon", results_tree->get_theme_icon("Search", "EditorIcons"));
-	case_sensitive_button->set_icon(results_tree->get_theme_icon("MatchCase", "EditorIcons"));
-	hierarchy_button->set_icon(results_tree->get_theme_icon("ClassList", "EditorIcons"));
+	search_box->add_theme_icon_override("right_icon", results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+	case_sensitive_button->set_icon(results_tree->get_theme_icon(SNAME("MatchCase"), SNAME("EditorIcons")));
+	hierarchy_button->set_icon(results_tree->get_theme_icon(SNAME("ClassList"), SNAME("EditorIcons")));
 
 	if (is_visible()) {
 		_update_results();
@@ -95,7 +95,7 @@ void EditorHelpSearch::_confirmed() {
 	// Activate the script editor and emit the signal with the documentation link to display.
 	EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
 
-	emit_signal("go_to_help", item->get_metadata(0));
+	emit_signal(SNAME("go_to_help"), item->get_metadata(0));
 
 	hide();
 }
@@ -104,7 +104,7 @@ void EditorHelpSearch::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible()) {
-				results_tree->call_deferred("clear"); // Wait for the Tree's mouse event propagation.
+				results_tree->call_deferred(SNAME("clear")); // Wait for the Tree's mouse event propagation.
 				get_ok_button()->set_disabled(true);
 				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "search_help", Rect2(get_position(), get_size()));
 			}
@@ -506,7 +506,7 @@ TreeItem *EditorHelpSearch::Runner::_create_class_item(TreeItem *p_parent, const
 	if (ui_service->has_theme_icon(p_doc->name, "EditorIcons")) {
 		icon = ui_service->get_theme_icon(p_doc->name, "EditorIcons");
 	} else if (ClassDB::class_exists(p_doc->name) && ClassDB::is_parent_class(p_doc->name, "Object")) {
-		icon = ui_service->get_theme_icon("Object", "EditorIcons");
+		icon = ui_service->get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
 	}
 	String tooltip = p_doc->brief_description.strip_edges();
 
@@ -580,10 +580,10 @@ TreeItem *EditorHelpSearch::Runner::_create_member_item(TreeItem *p_parent, cons
 	Ref<Texture2D> icon;
 	String text;
 	if (search_flags & SEARCH_SHOW_HIERARCHY) {
-		icon = ui_service->get_theme_icon(p_icon, "EditorIcons");
+		icon = ui_service->get_theme_icon(p_icon, SNAME("EditorIcons"));
 		text = p_text;
 	} else {
-		icon = ui_service->get_theme_icon(p_icon, "EditorIcons");
+		icon = ui_service->get_theme_icon(p_icon, SNAME("EditorIcons"));
 		/*// In flat mode, show the class icon.
 if (ui_service->has_icon(p_class_name, "EditorIcons"))
 icon = ui_service->get_icon(p_class_name, "EditorIcons");
@@ -621,6 +621,6 @@ EditorHelpSearch::Runner::Runner(Control *p_icon_service, Tree *p_results_tree, 
 		results_tree(p_results_tree),
 		term((p_search_flags & SEARCH_CASE_SENSITIVE) == 0 ? p_term.strip_edges().to_lower() : p_term.strip_edges()),
 		search_flags(p_search_flags),
-		empty_icon(ui_service->get_theme_icon("ArrowRight", "EditorIcons")),
-		disabled_color(ui_service->get_theme_color("disabled_font_color", "Editor")) {
+		empty_icon(ui_service->get_theme_icon(SNAME("ArrowRight"), SNAME("EditorIcons"))),
+		disabled_color(ui_service->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor"))) {
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -41,8 +41,8 @@
 
 Size2 EditorProperty::get_minimum_size() const {
 	Size2 ms;
-	Ref<Font> font = get_theme_font("font", "Tree");
-	int font_size = get_theme_font_size("font_size", "Tree");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Tree"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Tree"));
 	ms.height = font->get_height(font_size);
 
 	for (int i = 0; i < get_child_count(); i++) {
@@ -66,22 +66,22 @@ Size2 EditorProperty::get_minimum_size() const {
 	}
 
 	if (keying) {
-		Ref<Texture2D> key = get_theme_icon("Key", "EditorIcons");
-		ms.width += key->get_width() + get_theme_constant("hseparator", "Tree");
+		Ref<Texture2D> key = get_theme_icon(SNAME("Key"), SNAME("EditorIcons"));
+		ms.width += key->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 	}
 
 	if (deletable) {
-		Ref<Texture2D> key = get_theme_icon("Close", "EditorIcons");
-		ms.width += key->get_width() + get_theme_constant("hseparator", "Tree");
+		Ref<Texture2D> key = get_theme_icon(SNAME("Close"), SNAME("EditorIcons"));
+		ms.width += key->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 	}
 
 	if (checkable) {
-		Ref<Texture2D> check = get_theme_icon("checked", "CheckBox");
-		ms.width += check->get_width() + get_theme_constant("hseparation", "CheckBox") + get_theme_constant("hseparator", "Tree");
+		Ref<Texture2D> check = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
+		ms.width += check->get_width() + get_theme_constant(SNAME("hseparation"), SNAME("CheckBox")) + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 	}
 
 	if (bottom_editor != nullptr && bottom_editor->is_visible()) {
-		ms.height += get_theme_constant("vseparation");
+		ms.height += get_theme_constant(SNAME("vseparation"));
 		Size2 bems = bottom_editor->get_combined_minimum_size();
 		//bems.width += get_constant("item_margin", "Tree");
 		ms.height += bems.height;
@@ -96,7 +96,7 @@ void EditorProperty::emit_changed(const StringName &p_property, const Variant &p
 	const Variant *argptrs[4] = { &args[0], &args[1], &args[2], &args[3] };
 
 	cache[p_property] = p_value;
-	emit_signal("property_changed", (const Variant **)argptrs, 4);
+	emit_signal(SNAME("property_changed"), (const Variant **)argptrs, 4);
 }
 
 void EditorProperty::_notification(int p_what) {
@@ -110,8 +110,8 @@ void EditorProperty::_notification(int p_what) {
 
 		{
 			int child_room = size.width * (1.0 - split_ratio);
-			Ref<Font> font = get_theme_font("font", "Tree");
-			int font_size = get_theme_font_size("font_size", "Tree");
+			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Tree"));
+			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Tree"));
 			int height = font->get_height(font_size);
 			bool no_children = true;
 
@@ -149,21 +149,21 @@ void EditorProperty::_notification(int p_what) {
 			if (bottom_editor) {
 				int m = 0; //get_constant("item_margin", "Tree");
 
-				bottom_rect = Rect2(m, rect.size.height + get_theme_constant("vseparation"), size.width - m, bottom_editor->get_combined_minimum_size().height);
+				bottom_rect = Rect2(m, rect.size.height + get_theme_constant(SNAME("vseparation")), size.width - m, bottom_editor->get_combined_minimum_size().height);
 			}
 
 			if (keying) {
 				Ref<Texture2D> key;
 
 				if (use_keying_next()) {
-					key = get_theme_icon("KeyNext", "EditorIcons");
+					key = get_theme_icon(SNAME("KeyNext"), SNAME("EditorIcons"));
 				} else {
-					key = get_theme_icon("Key", "EditorIcons");
+					key = get_theme_icon(SNAME("Key"), SNAME("EditorIcons"));
 				}
 
-				rect.size.x -= key->get_width() + get_theme_constant("hseparator", "Tree");
+				rect.size.x -= key->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 				if (is_layout_rtl()) {
-					rect.position.x += key->get_width() + get_theme_constant("hseparator", "Tree");
+					rect.position.x += key->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 				}
 
 				if (no_children) {
@@ -174,12 +174,12 @@ void EditorProperty::_notification(int p_what) {
 			if (deletable) {
 				Ref<Texture2D> close;
 
-				close = get_theme_icon("Close", "EditorIcons");
+				close = get_theme_icon(SNAME("Close"), SNAME("EditorIcons"));
 
-				rect.size.x -= close->get_width() + get_theme_constant("hseparator", "Tree");
+				rect.size.x -= close->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 
 				if (is_layout_rtl()) {
-					rect.position.x += close->get_width() + get_theme_constant("hseparator", "Tree");
+					rect.position.x += close->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 				}
 
 				if (no_children) {
@@ -214,9 +214,9 @@ void EditorProperty::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Font> font = get_theme_font("font", "Tree");
-		int font_size = get_theme_font_size("font_size", "Tree");
-		Color dark_color = get_theme_color("dark_color_2", "Editor");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Tree"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Tree"));
+		Color dark_color = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
 		bool rtl = is_layout_rtl();
 
 		Size2 size = get_size();
@@ -228,9 +228,9 @@ void EditorProperty::_notification(int p_what) {
 
 		Ref<StyleBox> sb;
 		if (selected) {
-			sb = get_theme_stylebox("bg_selected");
+			sb = get_theme_stylebox(SNAME("bg_selected"));
 		} else {
-			sb = get_theme_stylebox("bg");
+			sb = get_theme_stylebox(SNAME("bg"));
 		}
 
 		draw_style_box(sb, Rect2(Vector2(), size));
@@ -244,23 +244,23 @@ void EditorProperty::_notification(int p_what) {
 
 		Color color;
 		if (draw_red) {
-			color = get_theme_color("error_color");
+			color = get_theme_color(SNAME("error_color"));
 		} else {
-			color = get_theme_color("property_color");
+			color = get_theme_color(SNAME("property_color"));
 		}
 		if (label.find(".") != -1) {
 			color.a = 0.5; //this should be un-hacked honestly, as it's used for editor overrides
 		}
 
-		int ofs = get_theme_constant("font_offset");
+		int ofs = get_theme_constant(SNAME("font_offset"));
 		int text_limit = text_size;
 
 		if (checkable) {
 			Ref<Texture2D> checkbox;
 			if (checked) {
-				checkbox = get_theme_icon("GuiChecked", "EditorIcons");
+				checkbox = get_theme_icon(SNAME("GuiChecked"), SNAME("EditorIcons"));
 			} else {
-				checkbox = get_theme_icon("GuiUnchecked", "EditorIcons");
+				checkbox = get_theme_icon(SNAME("GuiUnchecked"), SNAME("EditorIcons"));
 			}
 
 			Color color2(1, 1, 1);
@@ -275,16 +275,16 @@ void EditorProperty::_notification(int p_what) {
 			} else {
 				draw_texture(checkbox, check_rect.position, color2);
 			}
-			ofs += get_theme_constant("hseparator", "Tree") + checkbox->get_width() + get_theme_constant("hseparation", "CheckBox");
+			ofs += get_theme_constant(SNAME("hseparator"), SNAME("Tree")) + checkbox->get_width() + get_theme_constant(SNAME("hseparation"), SNAME("CheckBox"));
 			text_limit -= ofs;
 		} else {
 			check_rect = Rect2();
 		}
 
 		if (can_revert) {
-			Ref<Texture2D> reload_icon = get_theme_icon("ReloadSmall", "EditorIcons");
-			text_limit -= reload_icon->get_width() + get_theme_constant("hseparator", "Tree") * 2;
-			revert_rect = Rect2(text_limit + get_theme_constant("hseparator", "Tree"), (size.height - reload_icon->get_height()) / 2, reload_icon->get_width(), reload_icon->get_height());
+			Ref<Texture2D> reload_icon = get_theme_icon(SNAME("ReloadSmall"), SNAME("EditorIcons"));
+			text_limit -= reload_icon->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree")) * 2;
+			revert_rect = Rect2(text_limit + get_theme_constant(SNAME("hseparator"), SNAME("Tree")), (size.height - reload_icon->get_height()) / 2, reload_icon->get_width(), reload_icon->get_height());
 
 			Color color2(1, 1, 1);
 			if (revert_hover) {
@@ -312,12 +312,12 @@ void EditorProperty::_notification(int p_what) {
 			Ref<Texture2D> key;
 
 			if (use_keying_next()) {
-				key = get_theme_icon("KeyNext", "EditorIcons");
+				key = get_theme_icon(SNAME("KeyNext"), SNAME("EditorIcons"));
 			} else {
-				key = get_theme_icon("Key", "EditorIcons");
+				key = get_theme_icon(SNAME("Key"), SNAME("EditorIcons"));
 			}
 
-			ofs = size.width - key->get_width() - get_theme_constant("hseparator", "Tree");
+			ofs = size.width - key->get_width() - get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 
 			Color color2(1, 1, 1);
 			if (keying_hover) {
@@ -339,9 +339,9 @@ void EditorProperty::_notification(int p_what) {
 		if (deletable) {
 			Ref<Texture2D> close;
 
-			close = get_theme_icon("Close", "EditorIcons");
+			close = get_theme_icon(SNAME("Close"), SNAME("EditorIcons"));
 
-			ofs = size.width - close->get_width() - get_theme_constant("hseparator", "Tree");
+			ofs = size.width - close->get_width() - get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 
 			Color color2(1, 1, 1);
 			if (delete_hover) {
@@ -646,7 +646,7 @@ void EditorProperty::_focusable_focused(int p_index) {
 	selected_focusable = p_index;
 	update();
 	if (!already_selected && selected) {
-		emit_signal("selected", property, selected_focusable);
+		emit_signal(SNAME("selected"), property, selected_focusable);
 	}
 }
 
@@ -667,7 +667,7 @@ void EditorProperty::select(int p_focusable) {
 	}
 
 	if (!already_selected && selected) {
-		emit_signal("selected", property, selected_focusable);
+		emit_signal(SNAME("selected"), property, selected_focusable);
 	}
 }
 
@@ -732,12 +732,12 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 
 		if (!selected && selectable) {
 			selected = true;
-			emit_signal("selected", property, -1);
+			emit_signal(SNAME("selected"), property, -1);
 			update();
 		}
 
 		if (keying_rect.has_point(mpos)) {
-			emit_signal("property_keyed", property, use_keying_next());
+			emit_signal(SNAME("property_keyed"), property, use_keying_next());
 
 			if (use_keying_next()) {
 				if (property == "frame_coords" && (object->is_class("Sprite2D") || object->is_class("Sprite3D"))) {
@@ -748,16 +748,16 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 						new_coords.y++;
 					}
 
-					call_deferred("emit_changed", property, new_coords, "", false);
+					call_deferred(SNAME("emit_changed"), property, new_coords, "", false);
 				} else {
-					call_deferred("emit_changed", property, object->get(property).operator int64_t() + 1, "", false);
+					call_deferred(SNAME("emit_changed"), property, object->get(property).operator int64_t() + 1, "", false);
 				}
 
-				call_deferred("_update_property");
+				call_deferred(SNAME("_update_property"));
 			}
 		}
 		if (delete_rect.has_point(mpos)) {
-			emit_signal("property_deleted", property);
+			emit_signal(SNAME("property_deleted"), property);
 		}
 
 		if (revert_rect.has_point(mpos)) {
@@ -799,7 +799,7 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 		if (check_rect.has_point(mpos)) {
 			checked = !checked;
 			update();
-			emit_signal("property_checked", property, checked);
+			emit_signal(SNAME("property_checked"), property, checked);
 		}
 	}
 }
@@ -889,7 +889,7 @@ void EditorProperty::set_object_and_property(Object *p_object, const StringName 
 Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 	tooltip_text = p_text;
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	//help_bit->add_theme_style_override("panel", get_theme_stylebox("panel", "TooltipPanel"));
+	//help_bit->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
 	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
 
 	String text;
@@ -1076,14 +1076,14 @@ void EditorInspectorPlugin::_bind_methods() {
 
 void EditorInspectorCategory::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<StyleBox> sb = get_theme_stylebox("prop_category_style", "Editor");
+		Ref<StyleBox> sb = get_theme_stylebox(SNAME("prop_category_style"), SNAME("Editor"));
 
 		draw_style_box(sb, Rect2(Vector2(), get_size()));
 
-		Ref<Font> font = get_theme_font("bold", "EditorFonts");
-		int font_size = get_theme_font_size("bold_size", "EditorFonts");
+		Ref<Font> font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
+		int font_size = get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts"));
 
-		int hs = get_theme_constant("hseparation", "Tree");
+		int hs = get_theme_constant(SNAME("hseparation"), SNAME("Tree"));
 
 		int w = font->get_string_size(label, font_size).width;
 		if (icon.is_valid()) {
@@ -1097,7 +1097,7 @@ void EditorInspectorCategory::_notification(int p_what) {
 			ofs += hs + icon->get_width();
 		}
 
-		Color color = get_theme_color("font_color", "Tree");
+		Color color = get_theme_color(SNAME("font_color"), SNAME("Tree"));
 		draw_string(font, Point2(ofs, font->get_ascent(font_size) + (get_size().height - font->get_height(font_size)) / 2).floor(), label, HALIGN_LEFT, get_size().width, font_size, color);
 	}
 }
@@ -1105,7 +1105,7 @@ void EditorInspectorCategory::_notification(int p_what) {
 Control *EditorInspectorCategory::make_custom_tooltip(const String &p_text) const {
 	tooltip_text = p_text;
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	help_bit->add_theme_style_override("panel", get_theme_stylebox("panel", "TooltipPanel"));
+	help_bit->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
 	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
 
 	PackedStringArray slices = p_text.split("::", false);
@@ -1126,8 +1126,8 @@ Control *EditorInspectorCategory::make_custom_tooltip(const String &p_text) cons
 }
 
 Size2 EditorInspectorCategory::get_minimum_size() const {
-	Ref<Font> font = get_theme_font("font", "Tree");
-	int font_size = get_theme_font_size("font_size", "Tree");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Tree"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Tree"));
 
 	Size2 ms;
 	ms.width = 1;
@@ -1135,7 +1135,7 @@ Size2 EditorInspectorCategory::get_minimum_size() const {
 	if (icon.is_valid()) {
 		ms.height = MAX(icon->get_height(), ms.height);
 	}
-	ms.height += get_theme_constant("vseparation", "Tree");
+	ms.height += get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
 
 	return ms;
 }
@@ -1163,19 +1163,19 @@ void EditorInspectorSection::_test_unfold() {
 
 void EditorInspectorSection::_notification(int p_what) {
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
-		Ref<Font> font = get_theme_font("bold", "EditorFonts");
-		int font_size = get_theme_font_size("bold_size", "EditorFonts");
+		Ref<Font> font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
+		int font_size = get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts"));
 
 		Ref<Texture2D> arrow;
 
 		if (foldable) {
 			if (object->editor_is_section_unfolded(section)) {
-				arrow = get_theme_icon("arrow", "Tree");
+				arrow = get_theme_icon(SNAME("arrow"), SNAME("Tree"));
 			} else {
 				if (is_layout_rtl()) {
-					arrow = get_theme_icon("arrow_collapsed_mirrored", "Tree");
+					arrow = get_theme_icon(SNAME("arrow_collapsed_mirrored"), SNAME("Tree"));
 				} else {
-					arrow = get_theme_icon("arrow_collapsed", "Tree");
+					arrow = get_theme_icon(SNAME("arrow_collapsed"), SNAME("Tree"));
 				}
 			}
 		}
@@ -1188,11 +1188,11 @@ void EditorInspectorSection::_notification(int p_what) {
 			offset.y = MAX(offset.y, arrow->get_height());
 		}
 
-		offset.y += get_theme_constant("vseparation", "Tree");
+		offset.y += get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
 		if (is_layout_rtl()) {
-			rect = Rect2(offset, size - offset - Vector2(get_theme_constant("inspector_margin", "Editor"), 0));
+			rect = Rect2(offset, size - offset - Vector2(get_theme_constant(SNAME("inspector_margin"), SNAME("Editor")), 0));
 		} else {
-			offset.x += get_theme_constant("inspector_margin", "Editor");
+			offset.x += get_theme_constant(SNAME("inspector_margin"), SNAME("Editor"));
 			rect = Rect2(offset, size - offset);
 		}
 
@@ -1221,24 +1221,24 @@ void EditorInspectorSection::_notification(int p_what) {
 
 		if (foldable) {
 			if (object->editor_is_section_unfolded(section)) {
-				arrow = get_theme_icon("arrow", "Tree");
+				arrow = get_theme_icon(SNAME("arrow"), SNAME("Tree"));
 			} else {
 				if (is_layout_rtl()) {
-					arrow = get_theme_icon("arrow_collapsed_mirrored", "Tree");
+					arrow = get_theme_icon(SNAME("arrow_collapsed_mirrored"), SNAME("Tree"));
 				} else {
-					arrow = get_theme_icon("arrow_collapsed", "Tree");
+					arrow = get_theme_icon(SNAME("arrow_collapsed"), SNAME("Tree"));
 				}
 			}
 		}
 
-		Ref<Font> font = get_theme_font("bold", "EditorFonts");
-		int font_size = get_theme_font_size("bold_size", "EditorFonts");
+		Ref<Font> font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
+		int font_size = get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts"));
 
 		int h = font->get_height(font_size);
 		if (arrow.is_valid()) {
 			h = MAX(h, arrow->get_height());
 		}
-		h += get_theme_constant("vseparation", "Tree");
+		h += get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
 
 		Color c = bg_color;
 		c.a *= 0.4;
@@ -1246,7 +1246,7 @@ void EditorInspectorSection::_notification(int p_what) {
 
 		const int arrow_margin = 2;
 		const int arrow_width = arrow.is_valid() ? arrow->get_width() : 0;
-		Color color = get_theme_color("font_color");
+		Color color = get_theme_color(SNAME("font_color"));
 		float text_width = get_size().width - Math::round(arrow_width + arrow_margin * EDSCALE);
 		draw_string(font, Point2(rtl ? 0 : Math::round(arrow_width + arrow_margin * EDSCALE), font->get_ascent(font_size) + (h - font->get_height(font_size)) / 2).floor(), label, rtl ? HALIGN_RIGHT : HALIGN_LEFT, text_width, font_size, color);
 
@@ -1259,7 +1259,7 @@ void EditorInspectorSection::_notification(int p_what) {
 		}
 
 		if (dropping && !vbox->is_visible_in_tree()) {
-			Color accent_color = get_theme_color("accent_color", "Editor");
+			Color accent_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			draw_rect(Rect2(Point2(), get_size()), accent_color, false);
 		}
 	}
@@ -1319,10 +1319,10 @@ Size2 EditorInspectorSection::get_minimum_size() const {
 		ms.height = MAX(ms.height, minsize.height);
 	}
 
-	Ref<Font> font = get_theme_font("font", "Tree");
-	int font_size = get_theme_font_size("font_size", "Tree");
-	ms.height += font->get_height(font_size) + get_theme_constant("vseparation", "Tree");
-	ms.width += get_theme_constant("inspector_margin", "Editor");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Tree"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Tree"));
+	ms.height += font->get_height(font_size) + get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
+	ms.width += get_theme_constant(SNAME("inspector_margin"), SNAME("Editor"));
 
 	return ms;
 }
@@ -1358,8 +1358,8 @@ void EditorInspectorSection::_gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
-		Ref<Font> font = get_theme_font("font", "Tree");
-		int font_size = get_theme_font_size("font_size", "Tree");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Tree"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Tree"));
 		if (mb->get_position().y > font->get_height(font_size)) { //clicked outside
 			return;
 		}
@@ -1646,7 +1646,7 @@ void EditorInspector::update_tree() {
 
 	item_path[""] = main_vbox;
 
-	Color sscolor = get_theme_color("prop_subsection", "Editor");
+	Color sscolor = get_theme_color(SNAME("prop_subsection"), SNAME("Editor"));
 
 	for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
 		Ref<EditorInspectorPlugin> ped = E->get();
@@ -1720,8 +1720,8 @@ void EditorInspector::update_tree() {
 					}
 					s = s->get_base_script();
 				}
-				if (category->icon.is_null() && has_theme_icon(base_type, "EditorIcons")) {
-					category->icon = get_theme_icon(base_type, "EditorIcons");
+				if (category->icon.is_null() && has_theme_icon(base_type, SNAME("EditorIcons"))) {
+					category->icon = get_theme_icon(base_type, SNAME("EditorIcons"));
 				}
 			}
 			if (category->icon.is_null()) {
@@ -2205,7 +2205,7 @@ void EditorInspector::_update_inspector_bg() {
 		count_subinspectors = MIN(15, count_subinspectors);
 		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_bg" + itos(count_subinspectors), "Editor"));
 	} else {
-		add_theme_style_override("bg", get_theme_stylebox("bg", "Tree"));
+		add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 	}
 }
 void EditorInspector::set_sub_inspector(bool p_enable) {
@@ -2328,7 +2328,7 @@ void EditorInspector::_property_changed(const String &p_path, const Variant &p_v
 	}
 
 	if (restart_request_props.has(p_path)) {
-		emit_signal("restart_requested");
+		emit_signal(SNAME("restart_requested"));
 	}
 }
 
@@ -2350,7 +2350,7 @@ void EditorInspector::_multiple_properties_changed(Vector<String> p_paths, Array
 	for (int i = 0; i < p_paths.size(); i++) {
 		_edit_set(p_paths[i], p_values[i], false, "");
 		if (restart_request_props.has(p_paths[i])) {
-			emit_signal("restart_requested");
+			emit_signal(SNAME("restart_requested"));
 		}
 	}
 	changing++;
@@ -2363,7 +2363,7 @@ void EditorInspector::_property_keyed(const String &p_path, bool p_advance) {
 		return;
 	}
 
-	emit_signal("property_keyed", p_path, object->get(p_path), p_advance); //second param is deprecated
+	emit_signal(SNAME("property_keyed"), p_path, object->get(p_path), p_advance); //second param is deprecated
 }
 
 void EditorInspector::_property_deleted(const String &p_path) {
@@ -2372,7 +2372,7 @@ void EditorInspector::_property_deleted(const String &p_path) {
 		return;
 	}
 
-	emit_signal("property_deleted", p_path); //second param is deprecated
+	emit_signal(SNAME("property_deleted"), p_path); //second param is deprecated
 }
 
 void EditorInspector::_property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance) {
@@ -2380,7 +2380,7 @@ void EditorInspector::_property_keyed_with_value(const String &p_path, const Var
 		return;
 	}
 
-	emit_signal("property_keyed", p_path, p_value, p_advance); //second param is deprecated
+	emit_signal(SNAME("property_keyed"), p_path, p_value, p_advance); //second param is deprecated
 }
 
 void EditorInspector::_property_checked(const String &p_path, bool p_checked) {
@@ -2415,7 +2415,7 @@ void EditorInspector::_property_checked(const String &p_path, bool p_checked) {
 		}
 
 	} else {
-		emit_signal("property_toggled", p_path, p_checked);
+		emit_signal(SNAME("property_toggled"), p_path, p_checked);
 	}
 }
 
@@ -2434,15 +2434,15 @@ void EditorInspector::_property_selected(const String &p_path, int p_focusable) 
 		}
 	}
 
-	emit_signal("property_selected", p_path);
+	emit_signal(SNAME("property_selected"), p_path);
 }
 
 void EditorInspector::_object_id_selected(const String &p_path, ObjectID p_id) {
-	emit_signal("object_id_selected", p_id);
+	emit_signal(SNAME("object_id_selected"), p_id);
 }
 
 void EditorInspector::_resource_selected(const String &p_path, RES p_resource) {
-	emit_signal("resource_selected", p_resource, p_path);
+	emit_signal(SNAME("resource_selected"), p_resource, p_path);
 }
 
 void EditorInspector::_node_removed(Node *p_node) {
@@ -2479,7 +2479,7 @@ void EditorInspector::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_PROCESS) {
 		if (update_scroll_request >= 0) {
-			get_v_scrollbar()->call_deferred("set_value", update_scroll_request);
+			get_v_scrollbar()->call_deferred(SNAME("set_value"), update_scroll_request);
 			update_scroll_request = -1;
 		}
 		if (refresh_countdown > 0) {

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -70,10 +70,10 @@ void EditorLayoutsDialog::ok_pressed() {
 	if (layout_names->is_anything_selected()) {
 		Vector<int> const selected_items = layout_names->get_selected_items();
 		for (int i = 0; i < selected_items.size(); ++i) {
-			emit_signal("name_confirmed", layout_names->get_item_text(selected_items[i]));
+			emit_signal(SNAME("name_confirmed"), layout_names->get_item_text(selected_items[i]));
 		}
 	} else if (name->is_visible() && name->get_text() != "") {
-		emit_signal("name_confirmed", name->get_text());
+		emit_signal(SNAME("name_confirmed"), name->get_text());
 	}
 }
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -60,30 +60,30 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 void EditorLog::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		//button->set_icon(get_icon("Console","EditorIcons"));
-		log->add_theme_font_override("normal_font", get_theme_font("output_source", "EditorFonts"));
-		log->add_theme_font_size_override("normal_font_size", get_theme_font_size("output_source_size", "EditorFonts"));
-		log->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
-		log->add_theme_font_override("bold_font", get_theme_font("bold", "EditorFonts"));
+		log->add_theme_font_override("normal_font", get_theme_font(SNAME("output_source"), SNAME("EditorFonts")));
+		log->add_theme_font_size_override("normal_font_size", get_theme_font_size(SNAME("output_source_size"), SNAME("EditorFonts")));
+		log->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
+		log->add_theme_font_override("bold_font", get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
 
-		type_filter_map[MSG_TYPE_STD]->toggle_button->set_icon(get_theme_icon("Popup", "EditorIcons"));
-		type_filter_map[MSG_TYPE_ERROR]->toggle_button->set_icon(get_theme_icon("StatusError", "EditorIcons"));
-		type_filter_map[MSG_TYPE_WARNING]->toggle_button->set_icon(get_theme_icon("StatusWarning", "EditorIcons"));
-		type_filter_map[MSG_TYPE_EDITOR]->toggle_button->set_icon(get_theme_icon("Edit", "EditorIcons"));
+		type_filter_map[MSG_TYPE_STD]->toggle_button->set_icon(get_theme_icon(SNAME("Popup"), SNAME("EditorIcons")));
+		type_filter_map[MSG_TYPE_ERROR]->toggle_button->set_icon(get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
+		type_filter_map[MSG_TYPE_WARNING]->toggle_button->set_icon(get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
+		type_filter_map[MSG_TYPE_EDITOR]->toggle_button->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 
-		clear_button->set_icon(get_theme_icon("Clear", "EditorIcons"));
-		copy_button->set_icon(get_theme_icon("ActionCopy", "EditorIcons"));
-		collapse_button->set_icon(get_theme_icon("CombineLines", "EditorIcons"));
-		show_search_button->set_icon(get_theme_icon("Search", "EditorIcons"));
+		clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
+		copy_button->set_icon(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")));
+		collapse_button->set_icon(get_theme_icon(SNAME("CombineLines"), SNAME("EditorIcons")));
+		show_search_button->set_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
 		_load_state();
 
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		Ref<Font> df_output_code = get_theme_font("output_source", "EditorFonts");
+		Ref<Font> df_output_code = get_theme_font(SNAME("output_source"), SNAME("EditorFonts"));
 		if (df_output_code.is_valid()) {
 			if (log != nullptr) {
-				log->add_theme_font_override("normal_font", get_theme_font("output_source", "EditorFonts"));
-				log->add_theme_font_size_override("normal_font_size", get_theme_font_size("output_source_size", "EditorFonts"));
-				log->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
+				log->add_theme_font_override("normal_font", get_theme_font(SNAME("output_source"), SNAME("EditorFonts")));
+				log->add_theme_font_size_override("normal_font_size", get_theme_font_size(SNAME("output_source_size"), SNAME("EditorFonts")));
+				log->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 			}
 		}
 	}
@@ -242,22 +242,22 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		case MSG_TYPE_STD: {
 		} break;
 		case MSG_TYPE_ERROR: {
-			log->push_color(get_theme_color("error_color", "Editor"));
-			Ref<Texture2D> icon = get_theme_icon("Error", "EditorIcons");
+			log->push_color(get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			Ref<Texture2D> icon = get_theme_icon(SNAME("Error"), SNAME("EditorIcons"));
 			log->add_image(icon);
 			log->add_text(" ");
 			tool_button->set_icon(icon);
 		} break;
 		case MSG_TYPE_WARNING: {
-			log->push_color(get_theme_color("warning_color", "Editor"));
-			Ref<Texture2D> icon = get_theme_icon("Warning", "EditorIcons");
+			log->push_color(get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			Ref<Texture2D> icon = get_theme_icon(SNAME("Warning"), SNAME("EditorIcons"));
 			log->add_image(icon);
 			log->add_text(" ");
 			tool_button->set_icon(icon);
 		} break;
 		case MSG_TYPE_EDITOR: {
 			// Distinguish editor messages from messages printed by the project
-			log->push_color(get_theme_color("font_color", "Editor") * Color(1, 1, 1, 0.6));
+			log->push_color(get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.6));
 		} break;
 	}
 
@@ -336,7 +336,7 @@ EditorLog::EditorLog() {
 	search_box = memnew(LineEdit);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search_box->set_placeholder(TTR("Filter messages"));
-	search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+	search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	search_box->set_clear_button_enabled(true);
 	search_box->set_visible(true);
 	search_box->connect("text_changed", callable_mp(this, &EditorLog::_search_changed));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -316,7 +316,7 @@ void EditorNode::_update_scene_tabs() {
 	disambiguate_filenames(full_path_names, disambiguated_scene_names);
 
 	scene_tabs->clear_tabs();
-	Ref<Texture2D> script_icon = gui_base->get_theme_icon("Script", "EditorIcons");
+	Ref<Texture2D> script_icon = gui_base->get_theme_icon(SNAME("Script"), SNAME("EditorIcons"));
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		Node *type_node = editor_data.get_edited_scene_root(i);
 		Ref<Texture2D> icon;
@@ -427,7 +427,7 @@ void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
 		} else if (ED_IS_SHORTCUT("editor/editor_script", p_event)) {
 			_editor_select(EDITOR_SCRIPT);
 		} else if (ED_IS_SHORTCUT("editor/editor_help", p_event)) {
-			emit_signal("request_help_search", "");
+			emit_signal(SNAME("request_help_search"), "");
 		} else if (ED_IS_SHORTCUT("editor/editor_assetlib", p_event) && StreamPeerSSL::is_available()) {
 			_editor_select(EDITOR_ASSETLIB);
 		} else if (ED_IS_SHORTCUT("editor/editor_next", p_event)) {
@@ -553,7 +553,7 @@ void EditorNode::_notification(int p_what) {
 			if (settings_changed) {
 				_update_from_settings();
 				settings_changed = false;
-				emit_signal("project_settings_changed");
+				emit_signal(SNAME("project_settings_changed"));
 			}
 		} break;
 
@@ -642,17 +642,17 @@ void EditorNode::_notification(int p_what) {
 			theme_base->set_theme(theme);
 			gui_base->set_theme(theme);
 
-			gui_base->add_theme_style_override("panel", gui_base->get_theme_stylebox("Background", "EditorStyles"));
-			scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox("Content", "EditorStyles"));
-			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox("panel", "TabContainer"));
-			scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox("SceneTabFG", "EditorStyles"));
-			scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox("SceneTabBG", "EditorStyles"));
+			gui_base->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
+			scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Content"), SNAME("EditorStyles")));
+			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
+			scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox(SNAME("SceneTabFG"), SNAME("EditorStyles")));
+			scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox(SNAME("SceneTabBG"), SNAME("EditorStyles")));
 
-			file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
-			project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
-			debug_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
-			settings_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
-			help_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
+			file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			debug_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			settings_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			help_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 
 			if (EDITOR_GET("interface/scene_tabs/resize_if_many_tabs")) {
 				scene_tabs->set_min_width(int(EDITOR_GET("interface/scene_tabs/minimum_width")) * EDSCALE);
@@ -665,7 +665,7 @@ void EditorNode::_notification(int p_what) {
 
 			// debugger area
 			if (EditorDebuggerNode::get_singleton()->is_visible()) {
-				bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox("BottomPanelDebuggerOverride", "EditorStyles"));
+				bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles")));
 			}
 
 			// update_icons
@@ -683,17 +683,17 @@ void EditorNode::_notification(int p_what) {
 
 			_build_icon_type_cache();
 
-			play_button->set_icon(gui_base->get_theme_icon("MainPlay", "EditorIcons"));
-			play_scene_button->set_icon(gui_base->get_theme_icon("PlayScene", "EditorIcons"));
-			play_custom_scene_button->set_icon(gui_base->get_theme_icon("PlayCustom", "EditorIcons"));
-			pause_button->set_icon(gui_base->get_theme_icon("Pause", "EditorIcons"));
-			stop_button->set_icon(gui_base->get_theme_icon("Stop", "EditorIcons"));
+			play_button->set_icon(gui_base->get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
+			play_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayScene"), SNAME("EditorIcons")));
+			play_custom_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayCustom"), SNAME("EditorIcons")));
+			pause_button->set_icon(gui_base->get_theme_icon(SNAME("Pause"), SNAME("EditorIcons")));
+			stop_button->set_icon(gui_base->get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 
-			prev_scene->set_icon(gui_base->get_theme_icon("PrevScene", "EditorIcons"));
-			distraction_free->set_icon(gui_base->get_theme_icon("DistractionFree", "EditorIcons"));
-			scene_tab_add->set_icon(gui_base->get_theme_icon("Add", "EditorIcons"));
+			prev_scene->set_icon(gui_base->get_theme_icon(SNAME("PrevScene"), SNAME("EditorIcons")));
+			distraction_free->set_icon(gui_base->get_theme_icon(SNAME("DistractionFree"), SNAME("EditorIcons")));
+			scene_tab_add->set_icon(gui_base->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 
-			bottom_panel_raise->set_icon(gui_base->get_theme_icon("ExpandBottomDock", "EditorIcons"));
+			bottom_panel_raise->set_icon(gui_base->get_theme_icon(SNAME("ExpandBottomDock"), SNAME("EditorIcons")));
 
 			// clear_button->set_icon(gui_base->get_icon("Close", "EditorIcons")); don't have access to that node. needs to become a class property
 			if (gui_base->is_layout_rtl()) {
@@ -705,19 +705,19 @@ void EditorNode::_notification(int p_what) {
 			}
 
 			PopupMenu *p = help_menu->get_popup();
-			p->set_item_icon(p->get_item_index(HELP_SEARCH), gui_base->get_theme_icon("HelpSearch", "EditorIcons"));
-			p->set_item_icon(p->get_item_index(HELP_DOCS), gui_base->get_theme_icon("Instance", "EditorIcons"));
-			p->set_item_icon(p->get_item_index(HELP_QA), gui_base->get_theme_icon("Instance", "EditorIcons"));
-			p->set_item_icon(p->get_item_index(HELP_REPORT_A_BUG), gui_base->get_theme_icon("Instance", "EditorIcons"));
-			p->set_item_icon(p->get_item_index(HELP_SUGGEST_A_FEATURE), gui_base->get_theme_icon("Instance", "EditorIcons"));
-			p->set_item_icon(p->get_item_index(HELP_SEND_DOCS_FEEDBACK), gui_base->get_theme_icon("Instance", "EditorIcons"));
-			p->set_item_icon(p->get_item_index(HELP_COMMUNITY), gui_base->get_theme_icon("Instance", "EditorIcons"));
-			p->set_item_icon(p->get_item_index(HELP_ABOUT), gui_base->get_theme_icon("Godot", "EditorIcons"));
-			p->set_item_icon(p->get_item_index(HELP_SUPPORT_GODOT_DEVELOPMENT), gui_base->get_theme_icon("Heart", "EditorIcons"));
+			p->set_item_icon(p->get_item_index(HELP_SEARCH), gui_base->get_theme_icon(SNAME("HelpSearch"), SNAME("EditorIcons")));
+			p->set_item_icon(p->get_item_index(HELP_DOCS), gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
+			p->set_item_icon(p->get_item_index(HELP_QA), gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
+			p->set_item_icon(p->get_item_index(HELP_REPORT_A_BUG), gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
+			p->set_item_icon(p->get_item_index(HELP_SUGGEST_A_FEATURE), gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
+			p->set_item_icon(p->get_item_index(HELP_SEND_DOCS_FEEDBACK), gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
+			p->set_item_icon(p->get_item_index(HELP_COMMUNITY), gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
+			p->set_item_icon(p->get_item_index(HELP_ABOUT), gui_base->get_theme_icon(SNAME("Godot"), SNAME("EditorIcons")));
+			p->set_item_icon(p->get_item_index(HELP_SUPPORT_GODOT_DEVELOPMENT), gui_base->get_theme_icon(SNAME("Heart"), SNAME("EditorIcons")));
 
 			for (int i = 0; i < main_editor_buttons.size(); i++) {
-				main_editor_buttons.write[i]->add_theme_font_override("font", gui_base->get_theme_font("main_button_font", "EditorFonts"));
-				main_editor_buttons.write[i]->add_theme_font_size_override("font_size", gui_base->get_theme_font_size("main_button_font_size", "EditorFonts"));
+				main_editor_buttons.write[i]->add_theme_font_override("font", gui_base->get_theme_font(SNAME("main_button_font"), SNAME("EditorFonts")));
+				main_editor_buttons.write[i]->add_theme_font_size_override("font_size", gui_base->get_theme_font_size(SNAME("main_button_font_size"), SNAME("EditorFonts")));
 			}
 
 			_update_update_spinner();
@@ -972,7 +972,7 @@ void EditorNode::_scan_external_changes() {
 	}
 
 	if (need_reload) {
-		disk_changed->call_deferred("popup_centered_ratio", 0.5);
+		disk_changed->call_deferred(SNAME("popup_centered_ratio"), 0.5);
 	}
 }
 
@@ -1105,7 +1105,7 @@ void EditorNode::save_resource_in_path(const Ref<Resource> &p_resource, const St
 	}
 
 	((Resource *)p_resource.ptr())->set_path(path);
-	emit_signal("resource_saved", p_resource);
+	emit_signal(SNAME("resource_saved"), p_resource);
 	editor_data.notify_resource_saved(p_resource);
 }
 
@@ -2217,11 +2217,11 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	}
 
 	play_button->set_pressed(false);
-	play_button->set_icon(gui_base->get_theme_icon("MainPlay", "EditorIcons"));
+	play_button->set_icon(gui_base->get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
 	play_scene_button->set_pressed(false);
-	play_scene_button->set_icon(gui_base->get_theme_icon("PlayScene", "EditorIcons"));
+	play_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayScene"), SNAME("EditorIcons")));
 	play_custom_scene_button->set_pressed(false);
-	play_custom_scene_button->set_icon(gui_base->get_theme_icon("PlayCustom", "EditorIcons"));
+	play_custom_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayCustom"), SNAME("EditorIcons")));
 
 	String run_filename;
 	String args;
@@ -2294,17 +2294,17 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 		return;
 	}
 
-	emit_signal("play_pressed");
+	emit_signal(SNAME("play_pressed"));
 	if (p_current) {
 		play_scene_button->set_pressed(true);
-		play_scene_button->set_icon(gui_base->get_theme_icon("Reload", "EditorIcons"));
+		play_scene_button->set_icon(gui_base->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 	} else if (p_custom != "") {
 		run_custom_filename = p_custom;
 		play_custom_scene_button->set_pressed(true);
-		play_custom_scene_button->set_icon(gui_base->get_theme_icon("Reload", "EditorIcons"));
+		play_custom_scene_button->set_icon(gui_base->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 	} else {
 		play_button->set_pressed(true);
-		play_button->set_icon(gui_base->get_theme_icon("Reload", "EditorIcons"));
+		play_button->set_icon(gui_base->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 	}
 	stop_button->set_disabled(false);
 
@@ -2324,7 +2324,7 @@ void EditorNode::_run_native(const Ref<EditorExportPreset> &p_preset) {
 		}
 
 		EditorDebuggerNode::get_singleton()->start(p_preset->get_platform()->get_debug_protocol());
-		emit_signal("play_pressed");
+		emit_signal(SNAME("play_pressed"));
 		editor_run.run_native_notify();
 	}
 }
@@ -2639,11 +2639,11 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			editor_run.stop();
 			run_custom_filename.clear();
 			play_button->set_pressed(false);
-			play_button->set_icon(gui_base->get_theme_icon("MainPlay", "EditorIcons"));
+			play_button->set_icon(gui_base->get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
 			play_scene_button->set_pressed(false);
-			play_scene_button->set_icon(gui_base->get_theme_icon("PlayScene", "EditorIcons"));
+			play_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayScene"), SNAME("EditorIcons")));
 			play_custom_scene_button->set_pressed(false);
-			play_custom_scene_button->set_icon(gui_base->get_theme_icon("PlayCustom", "EditorIcons"));
+			play_custom_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayCustom"), SNAME("EditorIcons")));
 			stop_button->set_disabled(true);
 
 			if (bool(EDITOR_GET("run/output/always_close_output_on_stop"))) {
@@ -2655,7 +2655,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				}
 			}
 			EditorDebuggerNode::get_singleton()->stop();
-			emit_signal("stop_pressed");
+			emit_signal(SNAME("stop_pressed"));
 
 		} break;
 
@@ -2793,7 +2793,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		} break;
 		case HELP_SEARCH: {
-			emit_signal("request_help_search", "");
+			emit_signal(SNAME("request_help_search"), "");
 		} break;
 		case HELP_DOCS: {
 			OS::get_singleton()->shell_open("https://docs.godotengine.org/");
@@ -3067,8 +3067,8 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 			tb->set_icon(singleton->gui_base->get_theme_icon(p_editor->get_name(), "EditorIcons"));
 		}
 
-		tb->add_theme_font_override("font", singleton->gui_base->get_theme_font("main_button_font", "EditorFonts"));
-		tb->add_theme_font_size_override("font_size", singleton->gui_base->get_theme_font_size("main_button_font_size", "EditorFonts"));
+		tb->add_theme_font_override("font", singleton->gui_base->get_theme_font(SNAME("main_button_font"), SNAME("EditorFonts")));
+		tb->add_theme_font_size_override("font_size", singleton->gui_base->get_theme_font_size(SNAME("main_button_font_size"), SNAME("EditorFonts")));
 
 		tb->set_name(p_editor->get_name());
 		singleton->main_editor_buttons.push_back(tb);
@@ -3366,7 +3366,7 @@ void EditorNode::set_current_scene(int p_idx) {
 			editor_folding.load_scene_folding(editor_data.get_edited_scene_root(p_idx), editor_data.get_scene_path(p_idx));
 		}
 
-		call_deferred("_clear_undo_history");
+		call_deferred(SNAME("_clear_undo_history"));
 	}
 
 	changing_scene = true;
@@ -3403,7 +3403,7 @@ void EditorNode::set_current_scene(int p_idx) {
 
 	_update_title();
 
-	call_deferred("_set_main_scene_state", state, get_edited_scene()); //do after everything else is done setting up
+	call_deferred(SNAME("_set_main_scene_state"), state, get_edited_scene()); //do after everything else is done setting up
 }
 
 bool EditorNode::is_scene_open(const String &p_path) {
@@ -3650,7 +3650,7 @@ void EditorNode::_add_to_recent_scenes(const String &p_scene) {
 void EditorNode::_open_recent_scene(int p_idx) {
 	if (p_idx == recent_scenes->get_item_count() - 1) {
 		EditorSettings::get_singleton()->set_project_metadata("recent_files", "scenes", Array());
-		call_deferred("_update_recent_scenes");
+		call_deferred(SNAME("_update_recent_scenes"));
 	} else {
 		Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scenes", Array());
 		ERR_FAIL_INDEX(p_idx, rc.size());
@@ -3712,7 +3712,7 @@ void EditorNode::add_io_error(const String &p_error) {
 
 void EditorNode::_load_error_notify(void *p_ud, const String &p_text) {
 	EditorNode *en = (EditorNode *)p_ud;
-	en->load_errors->add_image(en->gui_base->get_theme_icon("Error", "EditorIcons"));
+	en->load_errors->add_image(en->gui_base->get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 	en->load_errors->add_text(p_text + "\n");
 	en->load_error_dialog->popup_centered_ratio(0.5);
 }
@@ -3939,7 +3939,7 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 	}
 
 	if (p_fallback.length()) {
-		return gui_base->get_theme_icon(p_fallback, "EditorIcons");
+		return gui_base->get_theme_icon(p_fallback, SNAME("EditorIcons"));
 	}
 
 	return nullptr;
@@ -3980,12 +3980,12 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 		}
 	}
 
-	if (gui_base->has_theme_icon(p_class, "EditorIcons")) {
-		return gui_base->get_theme_icon(p_class, "EditorIcons");
+	if (gui_base->has_theme_icon(p_class, SNAME("EditorIcons"))) {
+		return gui_base->get_theme_icon(p_class, SNAME("EditorIcons"));
 	}
 
-	if (p_fallback.length() && gui_base->has_theme_icon(p_fallback, "EditorIcons")) {
-		return gui_base->get_theme_icon(p_fallback, "EditorIcons");
+	if (p_fallback.length() && gui_base->has_theme_icon(p_fallback, SNAME("EditorIcons"))) {
+		return gui_base->get_theme_icon(p_fallback, SNAME("EditorIcons"));
 	}
 
 	return nullptr;
@@ -4289,7 +4289,7 @@ void EditorNode::_dock_select_draw() {
 
 	Color used = Color(0.6, 0.6, 0.6, 0.8);
 	Color used_selected = Color(0.8, 0.8, 0.8, 0.8);
-	Color tab_selected = theme_base->get_theme_color("mono_color", "Editor");
+	Color tab_selected = theme_base->get_theme_color(SNAME("mono_color"), SNAME("Editor"));
 	Color unused = used;
 	unused.a = 0.4;
 	Color unusable = unused;
@@ -5052,9 +5052,9 @@ void EditorNode::_bottom_panel_switch(bool p_enable, int p_idx) {
 			bottom_panel_items[i].control->set_visible(i == p_idx);
 		}
 		if (EditorDebuggerNode::get_singleton() == bottom_panel_items[p_idx].control) { // this is the debug panel which uses tabs, so the top section should be smaller
-			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox("BottomPanelDebuggerOverride", "EditorStyles"));
+			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles")));
 		} else {
-			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox("panel", "TabContainer"));
+			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
 		}
 		center_split->set_dragger_visibility(SplitContainer::DRAGGER_VISIBLE);
 		center_split->set_collapsed(false);
@@ -5064,7 +5064,7 @@ void EditorNode::_bottom_panel_switch(bool p_enable, int p_idx) {
 		bottom_panel_raise->show();
 
 	} else {
-		bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox("panel", "TabContainer"));
+		bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
 		bottom_panel_items[p_idx].button->set_pressed(false);
 		bottom_panel_items[p_idx].control->set_visible(false);
 		center_split->set_dragger_visibility(SplitContainer::DRAGGER_HIDDEN);
@@ -5153,7 +5153,7 @@ Variant EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from) {
 
 	{
 		//todo make proper previews
-		Ref<ImageTexture> texture = gui_base->get_theme_icon("FileBigThumb", "EditorIcons");
+		Ref<ImageTexture> texture = gui_base->get_theme_icon(SNAME("FileBigThumb"), SNAME("EditorIcons"));
 		Ref<Image> img = texture->get_image();
 		img = img->duplicate();
 		img->resize(48, 48); //meh
@@ -5205,10 +5205,10 @@ Variant EditorNode::drag_files_and_dirs(const Vector<String> &p_paths, Control *
 
 		if (p_paths[i].ends_with("/")) {
 			label->set_text(p_paths[i].substr(0, p_paths[i].length() - 1).get_file());
-			icon->set_texture(gui_base->get_theme_icon("Folder", "EditorIcons"));
+			icon->set_texture(gui_base->get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 		} else {
 			label->set_text(p_paths[i].get_file());
-			icon->set_texture(gui_base->get_theme_icon("File", "EditorIcons"));
+			icon->set_texture(gui_base->get_theme_icon(SNAME("File"), SNAME("EditorIcons")));
 		}
 		icon->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
 		icon->set_size(Size2(16, 16));
@@ -5480,7 +5480,7 @@ void EditorNode::_update_video_driver_color() {
 	if (video_driver->get_text() == "GLES2") {
 		video_driver->add_theme_color_override("font_color", Color::hex(0x5586a4ff));
 	} else if (video_driver->get_text() == "Vulkan") {
-		video_driver->add_theme_color_override("font_color", theme_base->get_theme_color("vulkan_color", "Editor"));
+		video_driver->add_theme_color_override("font_color", theme_base->get_theme_color(SNAME("vulkan_color"), SNAME("Editor")));
 	}
 }
 
@@ -5910,7 +5910,7 @@ EditorNode::EditorNode() {
 
 	theme_base->set_theme(theme);
 	gui_base->set_theme(theme);
-	gui_base->add_theme_style_override("panel", gui_base->get_theme_stylebox("Background", "EditorStyles"));
+	gui_base->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
 
 	resource_preview = memnew(EditorResourcePreview);
 	add_child(resource_preview);
@@ -6091,8 +6091,8 @@ EditorNode::EditorNode() {
 	tab_preview_panel->add_child(tab_preview);
 
 	scene_tabs = memnew(Tabs);
-	scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox("SceneTabFG", "EditorStyles"));
-	scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox("SceneTabBG", "EditorStyles"));
+	scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox(SNAME("SceneTabFG"), SNAME("EditorStyles")));
+	scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox(SNAME("SceneTabBG"), SNAME("EditorStyles")));
 	scene_tabs->set_select_with_rmb(true);
 	scene_tabs->add_tab("unsaved");
 	scene_tabs->set_tab_align(Tabs::ALIGN_LEFT);
@@ -6126,7 +6126,7 @@ EditorNode::EditorNode() {
 #endif
 	distraction_free->set_tooltip(TTR("Toggle distraction-free mode."));
 	distraction_free->connect("pressed", callable_mp(this, &EditorNode::_toggle_distraction_free_mode));
-	distraction_free->set_icon(gui_base->get_theme_icon("DistractionFree", "EditorIcons"));
+	distraction_free->set_icon(gui_base->get_theme_icon(SNAME("DistractionFree"), SNAME("EditorIcons")));
 	distraction_free->set_toggle_mode(true);
 
 	scene_tab_add = memnew(Button);
@@ -6134,13 +6134,13 @@ EditorNode::EditorNode() {
 	tabbar_container->add_child(scene_tab_add);
 	tabbar_container->add_child(distraction_free);
 	scene_tab_add->set_tooltip(TTR("Add a new scene."));
-	scene_tab_add->set_icon(gui_base->get_theme_icon("Add", "EditorIcons"));
+	scene_tab_add->set_icon(gui_base->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 	scene_tab_add->add_theme_color_override("icon_normal_color", Color(0.6f, 0.6f, 0.6f, 0.8f));
 	scene_tab_add->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_NEW_SCENE));
 
 	scene_root_parent = memnew(PanelContainer);
 	scene_root_parent->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
-	scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox("Content", "EditorStyles"));
+	scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Content"), SNAME("EditorStyles")));
 	scene_root_parent->set_draw_behind_parent(true);
 	srt->add_child(scene_root_parent);
 	scene_root_parent->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -6164,12 +6164,12 @@ EditorNode::EditorNode() {
 	file_menu->set_flat(false);
 	file_menu->set_switch_on_hover(true);
 	file_menu->set_text(TTR("Scene"));
-	file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
+	file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(file_menu);
 
 	prev_scene = memnew(Button);
 	prev_scene->set_flat(true);
-	prev_scene->set_icon(gui_base->get_theme_icon("PrevScene", "EditorIcons"));
+	prev_scene->set_icon(gui_base->get_theme_icon(SNAME("PrevScene"), SNAME("EditorIcons")));
 	prev_scene->set_tooltip(TTR("Go to previously opened scene."));
 	prev_scene->set_disabled(true);
 	prev_scene->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_OPEN_PREV));
@@ -6268,7 +6268,7 @@ EditorNode::EditorNode() {
 	project_menu->set_switch_on_hover(true);
 	project_menu->set_tooltip(TTR("Miscellaneous project or scene-wide tools."));
 	project_menu->set_text(TTR("Project"));
-	project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
+	project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(project_menu);
 
 	p = project_menu->get_popup();
@@ -6319,7 +6319,7 @@ EditorNode::EditorNode() {
 	debug_menu->set_flat(false);
 	debug_menu->set_switch_on_hover(true);
 	debug_menu->set_text(TTR("Debug"));
-	debug_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
+	debug_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(debug_menu);
 
 	menu_hb->add_spacer();
@@ -6328,7 +6328,7 @@ EditorNode::EditorNode() {
 	settings_menu->set_flat(false);
 	settings_menu->set_switch_on_hover(true);
 	settings_menu->set_text(TTR("Editor"));
-	settings_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
+	settings_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(settings_menu);
 
 	p = settings_menu->get_popup();
@@ -6381,26 +6381,26 @@ EditorNode::EditorNode() {
 	help_menu->set_flat(false);
 	help_menu->set_switch_on_hover(true);
 	help_menu->set_text(TTR("Help"));
-	help_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
+	help_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(help_menu);
 
 	p = help_menu->get_popup();
 	p->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 #ifdef OSX_ENABLED
-	p->add_icon_shortcut(gui_base->get_theme_icon("HelpSearch", "EditorIcons"), ED_SHORTCUT("editor/editor_help", TTR("Search Help"), KEY_MASK_ALT | KEY_SPACE), HELP_SEARCH);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("HelpSearch"), SNAME("EditorIcons")), ED_SHORTCUT("editor/editor_help", TTR("Search Help"), KEY_MASK_ALT | KEY_SPACE), HELP_SEARCH);
 #else
-	p->add_icon_shortcut(gui_base->get_theme_icon("HelpSearch", "EditorIcons"), ED_SHORTCUT("editor/editor_help", TTR("Search Help"), KEY_F1), HELP_SEARCH);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("HelpSearch"), SNAME("EditorIcons")), ED_SHORTCUT("editor/editor_help", TTR("Search Help"), KEY_F1), HELP_SEARCH);
 #endif
 	p->add_separator();
-	p->add_icon_shortcut(gui_base->get_theme_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/online_docs", TTR("Online Documentation")), HELP_DOCS);
-	p->add_icon_shortcut(gui_base->get_theme_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/q&a", TTR("Questions & Answers")), HELP_QA);
-	p->add_icon_shortcut(gui_base->get_theme_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/report_a_bug", TTR("Report a Bug")), HELP_REPORT_A_BUG);
-	p->add_icon_shortcut(gui_base->get_theme_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/suggest_a_feature", TTR("Suggest a Feature")), HELP_SUGGEST_A_FEATURE);
-	p->add_icon_shortcut(gui_base->get_theme_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/send_docs_feedback", TTR("Send Docs Feedback")), HELP_SEND_DOCS_FEEDBACK);
-	p->add_icon_shortcut(gui_base->get_theme_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/community", TTR("Community")), HELP_COMMUNITY);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_SHORTCUT("editor/online_docs", TTR("Online Documentation")), HELP_DOCS);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_SHORTCUT("editor/q&a", TTR("Questions & Answers")), HELP_QA);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_SHORTCUT("editor/report_a_bug", TTR("Report a Bug")), HELP_REPORT_A_BUG);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_SHORTCUT("editor/suggest_a_feature", TTR("Suggest a Feature")), HELP_SUGGEST_A_FEATURE);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_SHORTCUT("editor/send_docs_feedback", TTR("Send Docs Feedback")), HELP_SEND_DOCS_FEEDBACK);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_SHORTCUT("editor/community", TTR("Community")), HELP_COMMUNITY);
 	p->add_separator();
-	p->add_icon_shortcut(gui_base->get_theme_icon("Godot", "EditorIcons"), ED_SHORTCUT("editor/about", TTR("About Godot")), HELP_ABOUT);
-	p->add_icon_shortcut(gui_base->get_theme_icon("Heart", "EditorIcons"), ED_SHORTCUT("editor/support_development", TTR("Support Godot Development")), HELP_SUPPORT_GODOT_DEVELOPMENT);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("Godot"), SNAME("EditorIcons")), ED_SHORTCUT("editor/about", TTR("About Godot")), HELP_ABOUT);
+	p->add_icon_shortcut(gui_base->get_theme_icon(SNAME("Heart"), SNAME("EditorIcons")), ED_SHORTCUT("editor/support_development", TTR("Support Godot Development")), HELP_SUPPORT_GODOT_DEVELOPMENT);
 
 	HBoxContainer *play_hb = memnew(HBoxContainer);
 	menu_hb->add_child(play_hb);
@@ -6409,7 +6409,7 @@ EditorNode::EditorNode() {
 	play_button->set_flat(true);
 	play_hb->add_child(play_button);
 	play_button->set_toggle_mode(true);
-	play_button->set_icon(gui_base->get_theme_icon("MainPlay", "EditorIcons"));
+	play_button->set_icon(gui_base->get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
 	play_button->set_focus_mode(Control::FOCUS_NONE);
 	play_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY));
 	play_button->set_tooltip(TTR("Play the project."));
@@ -6422,7 +6422,7 @@ EditorNode::EditorNode() {
 	pause_button = memnew(Button);
 	pause_button->set_flat(true);
 	pause_button->set_toggle_mode(true);
-	pause_button->set_icon(gui_base->get_theme_icon("Pause", "EditorIcons"));
+	pause_button->set_icon(gui_base->get_theme_icon(SNAME("Pause"), SNAME("EditorIcons")));
 	pause_button->set_focus_mode(Control::FOCUS_NONE);
 	pause_button->set_tooltip(TTR("Pause the scene execution for debugging."));
 	pause_button->set_disabled(true);
@@ -6437,7 +6437,7 @@ EditorNode::EditorNode() {
 	stop_button->set_flat(true);
 	play_hb->add_child(stop_button);
 	stop_button->set_focus_mode(Control::FOCUS_NONE);
-	stop_button->set_icon(gui_base->get_theme_icon("Stop", "EditorIcons"));
+	stop_button->set_icon(gui_base->get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 	stop_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_STOP));
 	stop_button->set_tooltip(TTR("Stop the scene."));
 	stop_button->set_disabled(true);
@@ -6456,7 +6456,7 @@ EditorNode::EditorNode() {
 	play_hb->add_child(play_scene_button);
 	play_scene_button->set_toggle_mode(true);
 	play_scene_button->set_focus_mode(Control::FOCUS_NONE);
-	play_scene_button->set_icon(gui_base->get_theme_icon("PlayScene", "EditorIcons"));
+	play_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayScene"), SNAME("EditorIcons")));
 	play_scene_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY_SCENE));
 	play_scene_button->set_tooltip(TTR("Play the edited scene."));
 #ifdef OSX_ENABLED
@@ -6470,7 +6470,7 @@ EditorNode::EditorNode() {
 	play_hb->add_child(play_custom_scene_button);
 	play_custom_scene_button->set_toggle_mode(true);
 	play_custom_scene_button->set_focus_mode(Control::FOCUS_NONE);
-	play_custom_scene_button->set_icon(gui_base->get_theme_icon("PlayCustom", "EditorIcons"));
+	play_custom_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayCustom"), SNAME("EditorIcons")));
 	play_custom_scene_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY_CUSTOM_SCENE));
 	play_custom_scene_button->set_tooltip(TTR("Play custom scene"));
 #ifdef OSX_ENABLED
@@ -6486,8 +6486,8 @@ EditorNode::EditorNode() {
 	video_driver = memnew(OptionButton);
 	video_driver->set_focus_mode(Control::FOCUS_NONE);
 	video_driver->connect("item_selected", callable_mp(this, &EditorNode::_video_driver_selected));
-	video_driver->add_theme_font_override("font", gui_base->get_theme_font("bold", "EditorFonts"));
-	video_driver->add_theme_font_size_override("font_size", gui_base->get_theme_font_size("bold_size", "EditorFonts"));
+	video_driver->add_theme_font_override("font", gui_base->get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
+	video_driver->add_theme_font_size_override("font_size", gui_base->get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts")));
 	// TODO: Show again when OpenGL is ported.
 	video_driver->set_visible(false);
 	right_menu_hb->add_child(video_driver);
@@ -6529,7 +6529,7 @@ EditorNode::EditorNode() {
 	update_spinner = memnew(MenuButton);
 	update_spinner->set_tooltip(TTR("Spins when the editor window redraws."));
 	right_menu_hb->add_child(update_spinner);
-	update_spinner->set_icon(gui_base->get_theme_icon("Progress1", "EditorIcons"));
+	update_spinner->set_icon(gui_base->get_theme_icon(SNAME("Progress1"), SNAME("EditorIcons")));
 	update_spinner->get_popup()->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 	p = update_spinner->get_popup();
 	p->add_radio_check_item(TTR("Update Continuously"), SETTINGS_UPDATE_CONTINUOUSLY);
@@ -6606,7 +6606,7 @@ EditorNode::EditorNode() {
 	// Bottom panels
 
 	bottom_panel = memnew(PanelContainer);
-	bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox("panel", "TabContainer"));
+	bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
 	center_split->add_child(bottom_panel);
 	center_split->set_dragger_visibility(SplitContainer::DRAGGER_HIDDEN);
 
@@ -6649,7 +6649,7 @@ EditorNode::EditorNode() {
 
 	bottom_panel_raise = memnew(Button);
 	bottom_panel_raise->set_flat(true);
-	bottom_panel_raise->set_icon(gui_base->get_theme_icon("ExpandBottomDock", "EditorIcons"));
+	bottom_panel_raise->set_icon(gui_base->get_theme_icon(SNAME("ExpandBottomDock"), SNAME("EditorIcons")));
 
 	bottom_panel_raise->set_shortcut(ED_SHORTCUT("editor/bottom_panel_expand", TTR("Expand Bottom Panel"), KEY_MASK_SHIFT | KEY_F12));
 

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -180,8 +180,8 @@ void EditorPath::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			update_path();
 
-			sub_objects_icon->set_texture(get_theme_icon("select_arrow", "Tree"));
-			current_object_label->add_theme_font_override("font", get_theme_font("main", "EditorFonts"));
+			sub_objects_icon->set_texture(get_theme_icon(SNAME("select_arrow"), SNAME("Tree")));
+			current_object_label->add_theme_font_override("font", get_theme_font(SNAME("main"), SNAME("EditorFonts")));
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -532,7 +532,7 @@ void EditorPlugin::set_force_draw_over_forwarding_enabled() {
 }
 
 void EditorPlugin::notify_scene_changed(const Node *scn_root) {
-	emit_signal("scene_changed", scn_root);
+	emit_signal(SNAME("scene_changed"), scn_root);
 }
 
 void EditorPlugin::notify_main_screen_changed(const String &screen_name) {
@@ -540,16 +540,16 @@ void EditorPlugin::notify_main_screen_changed(const String &screen_name) {
 		return;
 	}
 
-	emit_signal("main_screen_changed", screen_name);
+	emit_signal(SNAME("main_screen_changed"), screen_name);
 	last_main_screen_name = screen_name;
 }
 
 void EditorPlugin::notify_scene_closed(const String &scene_filepath) {
-	emit_signal("scene_closed", scene_filepath);
+	emit_signal(SNAME("scene_closed"), scene_filepath);
 }
 
 void EditorPlugin::notify_resource_saved(const Ref<Resource> &p_resource) {
-	emit_signal("resource_saved", p_resource);
+	emit_signal(SNAME("resource_saved"), p_resource);
 }
 
 bool EditorPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
@@ -729,13 +729,13 @@ void EditorPlugin::remove_translation_parser_plugin(const Ref<EditorTranslationP
 void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
 	ERR_FAIL_COND(!p_importer.is_valid());
 	ResourceFormatImporter::get_singleton()->add_importer(p_importer);
-	EditorFileSystem::get_singleton()->call_deferred("scan");
+	EditorFileSystem::get_singleton()->call_deferred(SNAME("scan"));
 }
 
 void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
 	ERR_FAIL_COND(!p_importer.is_valid());
 	ResourceFormatImporter::get_singleton()->remove_importer(p_importer);
-	EditorFileSystem::get_singleton()->call_deferred("scan");
+	EditorFileSystem::get_singleton()->call_deferred(SNAME("scan"));
 }
 
 void EditorPlugin::add_export_plugin(const Ref<EditorExportPlugin> &p_exporter) {
@@ -854,7 +854,7 @@ void EditorPlugin::remove_debugger_plugin(const Ref<Script> &p_script) {
 }
 
 void EditorPlugin::_editor_project_settings_changed() {
-	emit_signal("project_settings_changed");
+	emit_signal(SNAME("project_settings_changed"));
 }
 void EditorPlugin::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -108,7 +108,7 @@ void EditorPluginSettings::update_plugins() {
 				bool is_active = EditorNode::get_singleton()->is_addon_plugin_enabled(path);
 				item->set_checked(3, is_active);
 				item->set_editable(3, true);
-				item->add_button(4, get_theme_icon("Edit", "EditorIcons"), BUTTON_PLUGIN_EDIT, false, TTR("Edit Plugin"));
+				item->add_button(4, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), BUTTON_PLUGIN_EDIT, false, TTR("Edit Plugin"));
 			}
 		}
 	}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -147,10 +147,10 @@ void EditorPropertyMultilineText::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
-			Ref<Texture2D> df = get_theme_icon("DistractionFree", "EditorIcons");
+			Ref<Texture2D> df = get_theme_icon(SNAME("DistractionFree"), SNAME("EditorIcons"));
 			open_big_text->set_icon(df);
-			Ref<Font> font = get_theme_font("font", "Label");
-			int font_size = get_theme_font_size("font_size", "Label");
+			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 			text->set_custom_minimum_size(Vector2(0, font->get_height(font_size) * 6));
 
 		} break;
@@ -276,9 +276,9 @@ void EditorPropertyTextEnum::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			edit_button->set_icon(get_theme_icon("Edit", "EditorIcons"));
-			accept_button->set_icon(get_theme_icon("ImportCheck", "EditorIcons"));
-			cancel_button->set_icon(get_theme_icon("ImportFail", "EditorIcons"));
+			edit_button->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+			accept_button->set_icon(get_theme_icon(SNAME("ImportCheck"), SNAME("EditorIcons")));
+			cancel_button->set_icon(get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons")));
 			break;
 	}
 }
@@ -386,7 +386,7 @@ void EditorPropertyPath::set_save_mode() {
 
 void EditorPropertyPath::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		path_edit->set_icon(get_theme_icon("Folder", "EditorIcons"));
+		path_edit->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 	}
 }
 
@@ -699,8 +699,8 @@ public:
 	int hovered_index;
 
 	virtual Size2 get_minimum_size() const override {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		return Vector2(0, font->get_height(font_size) * 2);
 	}
 
@@ -737,7 +737,7 @@ public:
 				value |= (1 << hovered_index);
 			}
 
-			emit_signal("flag_changed", value);
+			emit_signal(SNAME("flag_changed"), value);
 			update();
 		}
 	}
@@ -753,7 +753,7 @@ public:
 				const int h = bsize * 2 + 1;
 				const int vofs = (rect.size.height - h) / 2;
 
-				Color color = get_theme_color("highlight_color", "Editor");
+				Color color = get_theme_color(SNAME("highlight_color"), SNAME("Editor"));
 				for (int i = 0; i < 2; i++) {
 					Point2 ofs(4, vofs);
 					if (i == 1) {
@@ -957,7 +957,7 @@ EditorPropertyInteger::EditorPropertyInteger() {
 ///////////////////// OBJECT ID /////////////////////////
 
 void EditorPropertyObjectID::_edit_pressed() {
-	emit_signal("object_id_selected", get_edited_property(), get_edited_object()->get(get_edited_property()));
+	emit_signal(SNAME("object_id_selected"), get_edited_property(), get_edited_object()->get(get_edited_property()));
 }
 
 void EditorPropertyObjectID::update_property() {
@@ -1112,14 +1112,14 @@ void EditorPropertyEasing::_draw_easing() {
 
 	const float exp = get_edited_object()->get(get_edited_property());
 
-	const Ref<Font> f = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
-	const Color font_color = get_theme_color("font_color", "Label");
+	const Ref<Font> f = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+	const Color font_color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	Color line_color;
 	if (dragging) {
-		line_color = get_theme_color("accent_color", "Editor");
+		line_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 	} else {
-		line_color = get_theme_color("font_color", "Label") * Color(1, 1, 1, 0.9);
+		line_color = get_theme_color(SNAME("font_color"), SNAME("Label")) * Color(1, 1, 1, 0.9);
 	}
 
 	Vector<Point2> points;
@@ -1205,15 +1205,15 @@ void EditorPropertyEasing::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
 			preset->clear();
-			preset->add_icon_item(get_theme_icon("CurveConstant", "EditorIcons"), "Zero", EASING_ZERO);
-			preset->add_icon_item(get_theme_icon("CurveLinear", "EditorIcons"), "Linear", EASING_LINEAR);
-			preset->add_icon_item(get_theme_icon("CurveIn", "EditorIcons"), "In", EASING_IN);
-			preset->add_icon_item(get_theme_icon("CurveOut", "EditorIcons"), "Out", EASING_OUT);
+			preset->add_icon_item(get_theme_icon(SNAME("CurveConstant"), SNAME("EditorIcons")), "Zero", EASING_ZERO);
+			preset->add_icon_item(get_theme_icon(SNAME("CurveLinear"), SNAME("EditorIcons")), "Linear", EASING_LINEAR);
+			preset->add_icon_item(get_theme_icon(SNAME("CurveIn"), SNAME("EditorIcons")), "In", EASING_IN);
+			preset->add_icon_item(get_theme_icon(SNAME("CurveOut"), SNAME("EditorIcons")), "Out", EASING_OUT);
 			if (full) {
-				preset->add_icon_item(get_theme_icon("CurveInOut", "EditorIcons"), "In-Out", EASING_IN_OUT);
-				preset->add_icon_item(get_theme_icon("CurveOutIn", "EditorIcons"), "Out-In", EASING_OUT_IN);
+				preset->add_icon_item(get_theme_icon(SNAME("CurveInOut"), SNAME("EditorIcons")), "In-Out", EASING_IN_OUT);
+				preset->add_icon_item(get_theme_icon(SNAME("CurveOutIn"), SNAME("EditorIcons")), "Out-In", EASING_OUT_IN);
 			}
-			easing_draw->set_custom_minimum_size(Size2(0, get_theme_font("font", "Label")->get_height(get_theme_font_size("font_size", "Label")) * 2));
+			easing_draw->set_custom_minimum_size(Size2(0, get_theme_font(SNAME("font"), SNAME("Label"))->get_height(get_theme_font_size(SNAME("font_size"), SNAME("Label"))) * 2));
 		} break;
 	}
 }
@@ -1273,7 +1273,7 @@ void EditorPropertyVector2::update_property() {
 
 void EditorPropertyVector2::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 2; i++) {
 			Color c = base;
 			c.set_hsv(float(i) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -1360,7 +1360,7 @@ void EditorPropertyRect2::update_property() {
 
 void EditorPropertyRect2::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 4; i++) {
 			Color c = base;
 			c.set_hsv(float(i % 2) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -1482,7 +1482,7 @@ Vector3 EditorPropertyVector3::get_vector() {
 
 void EditorPropertyVector3::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 3; i++) {
 			Color c = base;
 			c.set_hsv(float(i) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -1565,7 +1565,7 @@ void EditorPropertyVector2i::update_property() {
 
 void EditorPropertyVector2i::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 2; i++) {
 			Color c = base;
 			c.set_hsv(float(i) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -1652,7 +1652,7 @@ void EditorPropertyRect2i::update_property() {
 
 void EditorPropertyRect2i::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 4; i++) {
 			Color c = base;
 			c.set_hsv(float(i % 2) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -1747,7 +1747,7 @@ void EditorPropertyVector3i::update_property() {
 
 void EditorPropertyVector3i::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 3; i++) {
 			Color c = base;
 			c.set_hsv(float(i) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -1833,7 +1833,7 @@ void EditorPropertyPlane::update_property() {
 
 void EditorPropertyPlane::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 3; i++) {
 			Color c = base;
 			c.set_hsv(float(i) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -1920,7 +1920,7 @@ void EditorPropertyQuaternion::update_property() {
 
 void EditorPropertyQuaternion::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 3; i++) {
 			Color c = base;
 			c.set_hsv(float(i) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -2010,7 +2010,7 @@ void EditorPropertyAABB::update_property() {
 
 void EditorPropertyAABB::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 6; i++) {
 			Color c = base;
 			c.set_hsv(float(i % 3) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -2087,7 +2087,7 @@ void EditorPropertyTransform2D::update_property() {
 
 void EditorPropertyTransform2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 6; i++) {
 			Color c = base;
 			c.set_hsv(float(i % 2) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -2169,7 +2169,7 @@ void EditorPropertyBasis::update_property() {
 
 void EditorPropertyBasis::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 9; i++) {
 			Color c = base;
 			c.set_hsv(float(i % 3) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -2259,7 +2259,7 @@ void EditorPropertyTransform3D::update_using_transform(Transform3D p_transform) 
 
 void EditorPropertyTransform3D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		for (int i = 0; i < 12; i++) {
 			Color c = base;
 			c.set_hsv(float(i % 3) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
@@ -2475,7 +2475,7 @@ void EditorPropertyNodePath::setup(const NodePath &p_base_hint, Vector<StringNam
 
 void EditorPropertyNodePath::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Ref<Texture2D> t = get_theme_icon("Clear", "EditorIcons");
+		Ref<Texture2D> t = get_theme_icon(SNAME("Clear"), SNAME("EditorIcons"));
 		clear->set_icon(t);
 	}
 }
@@ -2527,7 +2527,7 @@ void EditorPropertyResource::_resource_selected(const RES &p_resource) {
 		get_edited_object()->editor_set_section_unfold(get_edited_property(), unfold);
 		update_property();
 	} else {
-		emit_signal("resource_selected", get_edited_property(), p_resource);
+		emit_signal(SNAME("resource_selected"), get_edited_property(), p_resource);
 	}
 }
 
@@ -2580,22 +2580,22 @@ void EditorPropertyResource::_resource_changed(const RES &p_resource) {
 }
 
 void EditorPropertyResource::_sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool) {
-	emit_signal("property_keyed_with_value", String(get_edited_property()) + ":" + p_property, p_value, false);
+	emit_signal(SNAME("property_keyed_with_value"), String(get_edited_property()) + ":" + p_property, p_value, false);
 }
 
 void EditorPropertyResource::_sub_inspector_resource_selected(const RES &p_resource, const String &p_property) {
-	emit_signal("resource_selected", String(get_edited_property()) + ":" + p_property, p_resource);
+	emit_signal(SNAME("resource_selected"), String(get_edited_property()) + ":" + p_property, p_resource);
 }
 
 void EditorPropertyResource::_sub_inspector_object_id_selected(int p_id) {
-	emit_signal("object_id_selected", get_edited_property(), p_id);
+	emit_signal(SNAME("object_id_selected"), get_edited_property(), p_id);
 }
 
 void EditorPropertyResource::_open_editor_pressed() {
 	RES res = get_edited_object()->get(get_edited_property());
 	if (res.is_valid()) {
 		// May clear the editor so do it deferred.
-		EditorNode::get_singleton()->call_deferred("edit_item_resource", res);
+		EditorNode::get_singleton()->call_deferred(SNAME("edit_item_resource"), res);
 	}
 }
 
@@ -2651,18 +2651,18 @@ void EditorPropertyResource::_update_property_bg() {
 		}
 		count_subinspectors = MIN(15, count_subinspectors);
 
-		add_theme_color_override("property_color", get_theme_color("sub_inspector_property_color", "Editor"));
+		add_theme_color_override("property_color", get_theme_color(SNAME("sub_inspector_property_color"), SNAME("Editor")));
 		add_theme_style_override("bg_selected", get_theme_stylebox("sub_inspector_property_bg_selected" + itos(count_subinspectors), "Editor"));
 		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_property_bg" + itos(count_subinspectors), "Editor"));
 
-		add_theme_constant_override("font_offset", get_theme_constant("sub_inspector_font_offset", "Editor"));
+		add_theme_constant_override("font_offset", get_theme_constant(SNAME("sub_inspector_font_offset"), SNAME("Editor")));
 		add_theme_constant_override("vseparation", 0);
 	} else {
-		add_theme_color_override("property_color", get_theme_color("property_color", "EditorProperty"));
-		add_theme_style_override("bg_selected", get_theme_stylebox("bg_selected", "EditorProperty"));
-		add_theme_style_override("bg", get_theme_stylebox("bg", "EditorProperty"));
-		add_theme_constant_override("vseparation", get_theme_constant("vseparation", "EditorProperty"));
-		add_theme_constant_override("font_offset", get_theme_constant("font_offset", "EditorProperty"));
+		add_theme_color_override("property_color", get_theme_color(SNAME("property_color"), SNAME("EditorProperty")));
+		add_theme_style_override("bg_selected", get_theme_stylebox(SNAME("bg_selected"), SNAME("EditorProperty")));
+		add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("EditorProperty")));
+		add_theme_constant_override("vseparation", get_theme_constant(SNAME("vseparation"), SNAME("EditorProperty")));
+		add_theme_constant_override("font_offset", get_theme_constant(SNAME("font_offset"), SNAME("EditorProperty")));
 	}
 
 	updating_theme = false;
@@ -2760,7 +2760,7 @@ void EditorPropertyResource::update_property() {
 					// Open editor directly and hide other such editors which are currently open.
 					_open_editor_pressed();
 					if (is_inside_tree()) {
-						get_tree()->call_deferred("call_group", "_editor_resource_properties", "_fold_other_editors", this);
+						get_tree()->call_deferred(SNAME("call_group"), "_editor_resource_properties", "_fold_other_editors", this);
 					}
 					opened_editor = true;
 				}

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -203,7 +203,7 @@ void EditorPropertyArray::_change_type_menu(int p_index) {
 }
 
 void EditorPropertyArray::_object_id_selected(const StringName &p_property, ObjectID p_id) {
-	emit_signal("object_id_selected", p_property, p_id);
+	emit_signal(SNAME("object_id_selected"), p_property, p_id);
 }
 
 void EditorPropertyArray::update_property() {
@@ -346,7 +346,7 @@ void EditorPropertyArray::update_property() {
 			vbox->add_child(hbox);
 
 			Button *reorder_button = memnew(Button);
-			reorder_button->set_icon(get_theme_icon("TripleBar", "EditorIcons"));
+			reorder_button->set_icon(get_theme_icon(SNAME("TripleBar"), SNAME("EditorIcons")));
 			reorder_button->set_default_cursor_shape(Control::CURSOR_MOVE);
 			reorder_button->connect("gui_input", callable_mp(this, &EditorPropertyArray::_reorder_button_gui_input));
 			reorder_button->connect("button_down", callable_mp(this, &EditorPropertyArray::_reorder_button_down), varray(i + offset));
@@ -383,12 +383,12 @@ void EditorPropertyArray::update_property() {
 
 			if (is_untyped_array) {
 				Button *edit = memnew(Button);
-				edit->set_icon(get_theme_icon("Edit", "EditorIcons"));
+				edit->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 				hbox->add_child(edit);
 				edit->connect("pressed", callable_mp(this, &EditorPropertyArray::_change_type), varray(edit, i + offset));
 			} else {
 				Button *remove = memnew(Button);
-				remove->set_icon(get_theme_icon("Remove", "EditorIcons"));
+				remove->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 				remove->connect("pressed", callable_mp(this, &EditorPropertyArray::_remove_pressed), varray(i + offset));
 				hbox->add_child(remove);
 			}
@@ -421,7 +421,7 @@ void EditorPropertyArray::_remove_pressed(int p_index) {
 
 void EditorPropertyArray::_button_draw() {
 	if (dropping) {
-		Color color = get_theme_color("accent_color", "Editor");
+		Color color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		edit->draw_rect(Rect2(Point2(), edit->get_size()), color, false);
 	}
 }
@@ -1070,7 +1070,7 @@ void EditorPropertyDictionary::update_property() {
 				for (int j = 0; j < 4; j++) {
 					flat->set_default_margin(Side(j), 2 * EDSCALE);
 				}
-				flat->set_bg_color(get_theme_color("prop_subsection", "Editor"));
+				flat->set_bg_color(get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 
 				pc->add_theme_style_override("panel", flat);
 				add_vbox = memnew(VBoxContainer);
@@ -1105,7 +1105,7 @@ void EditorPropertyDictionary::update_property() {
 			hbox->add_child(prop);
 			prop->set_h_size_flags(SIZE_EXPAND_FILL);
 			Button *edit = memnew(Button);
-			edit->set_icon(get_theme_icon("Edit", "EditorIcons"));
+			edit->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 			hbox->add_child(edit);
 			edit->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_change_type), varray(edit, change_index));
 
@@ -1131,7 +1131,7 @@ void EditorPropertyDictionary::update_property() {
 }
 
 void EditorPropertyDictionary::_object_id_selected(const StringName &p_property, ObjectID p_id) {
-	emit_signal("object_id_selected", p_property, p_id);
+	emit_signal(SNAME("object_id_selected"), p_property, p_id);
 }
 
 void EditorPropertyDictionary::_notification(int p_what) {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -76,7 +76,7 @@ void EditorResourcePicker::_update_resource_preview(const String &p_path, const 
 	}
 
 	if (p_preview.is_valid()) {
-		preview_rect->set_offset(SIDE_LEFT, assign_button->get_icon()->get_width() + assign_button->get_theme_stylebox("normal")->get_default_margin(SIDE_LEFT) + get_theme_constant("hseparation", "Button"));
+		preview_rect->set_offset(SIDE_LEFT, assign_button->get_icon()->get_width() + assign_button->get_theme_stylebox(SNAME("normal"))->get_default_margin(SIDE_LEFT) + get_theme_constant(SNAME("hseparation"), SNAME("Button")));
 
 		if (type == "GradientTexture") {
 			preview_rect->set_stretch_mode(TextureRect::STRETCH_SCALE);
@@ -100,7 +100,7 @@ void EditorResourcePicker::_resource_selected() {
 		return;
 	}
 
-	emit_signal("resource_selected", edited_resource);
+	emit_signal(SNAME("resource_selected"), edited_resource);
 }
 
 void EditorResourcePicker::_file_selected(const String &p_path) {
@@ -125,7 +125,7 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 	}
 
 	edited_resource = loaded_resource;
-	emit_signal("resource_changed", edited_resource);
+	emit_signal(SNAME("resource_changed"), edited_resource);
 	_update_resource();
 }
 
@@ -148,14 +148,14 @@ void EditorResourcePicker::_update_menu_items() {
 	set_create_options(edit_menu);
 
 	// Add an option to load a resource from a file.
-	edit_menu->add_icon_item(get_theme_icon("Load", "EditorIcons"), TTR("Load"), OBJ_MENU_LOAD);
+	edit_menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Load"), OBJ_MENU_LOAD);
 
 	// Add options for changing existing value of the resource.
 	if (edited_resource.is_valid()) {
-		edit_menu->add_icon_item(get_theme_icon("Edit", "EditorIcons"), TTR("Edit"), OBJ_MENU_EDIT);
-		edit_menu->add_icon_item(get_theme_icon("Clear", "EditorIcons"), TTR("Clear"), OBJ_MENU_CLEAR);
-		edit_menu->add_icon_item(get_theme_icon("Duplicate", "EditorIcons"), TTR("Make Unique"), OBJ_MENU_MAKE_UNIQUE);
-		edit_menu->add_icon_item(get_theme_icon("Save", "EditorIcons"), TTR("Save"), OBJ_MENU_SAVE);
+		edit_menu->add_icon_item(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), TTR("Edit"), OBJ_MENU_EDIT);
+		edit_menu->add_icon_item(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), TTR("Clear"), OBJ_MENU_CLEAR);
+		edit_menu->add_icon_item(get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")), TTR("Make Unique"), OBJ_MENU_MAKE_UNIQUE);
+		edit_menu->add_icon_item(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")), TTR("Save"), OBJ_MENU_SAVE);
 
 		if (edited_resource->get_path().is_resource_file()) {
 			edit_menu->add_separator();
@@ -200,10 +200,10 @@ void EditorResourcePicker::_update_menu_items() {
 		for (int i = 0; i < conversions.size(); i++) {
 			String what = conversions[i]->converts_to();
 			Ref<Texture2D> icon;
-			if (has_theme_icon(what, "EditorIcons")) {
-				icon = get_theme_icon(what, "EditorIcons");
+			if (has_theme_icon(what, SNAME("EditorIcons"))) {
+				icon = get_theme_icon(what, SNAME("EditorIcons"));
 			} else {
-				icon = get_theme_icon(what, "Resource");
+				icon = get_theme_icon(what, SNAME("Resource"));
 			}
 
 			edit_menu->add_icon_item(icon, vformat(TTR("Convert to %s"), what), CONVERT_BASE_ID + i);
@@ -242,13 +242,13 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 
 		case OBJ_MENU_EDIT: {
 			if (edited_resource.is_valid()) {
-				emit_signal("resource_selected", edited_resource);
+				emit_signal(SNAME("resource_selected"), edited_resource);
 			}
 		} break;
 
 		case OBJ_MENU_CLEAR: {
 			edited_resource = RES();
-			emit_signal("resource_changed", edited_resource);
+			emit_signal(SNAME("resource_changed"), edited_resource);
 			_update_resource();
 		} break;
 
@@ -282,7 +282,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			}
 
 			edited_resource = unique_resource;
-			emit_signal("resource_changed", edited_resource);
+			emit_signal(SNAME("resource_changed"), edited_resource);
 			_update_resource();
 		} break;
 
@@ -299,7 +299,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 
 		case OBJ_MENU_PASTE: {
 			edited_resource = EditorSettings::get_singleton()->get_resource_clipboard();
-			emit_signal("resource_changed", edited_resource);
+			emit_signal(SNAME("resource_changed"), edited_resource);
 			_update_resource();
 		} break;
 
@@ -324,7 +324,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 				ERR_FAIL_INDEX(to_type, conversions.size());
 
 				edited_resource = conversions[to_type]->convert(edited_resource);
-				emit_signal("resource_changed", edited_resource);
+				emit_signal(SNAME("resource_changed"), edited_resource);
 				_update_resource();
 				break;
 			}
@@ -354,7 +354,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			ERR_BREAK(!resp);
 
 			edited_resource = RES(resp);
-			emit_signal("resource_changed", edited_resource);
+			emit_signal(SNAME("resource_changed"), edited_resource);
 			_update_resource();
 		} break;
 	}
@@ -404,7 +404,7 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 			inheritors_array.push_back(t);
 
 			if (!icon.is_valid()) {
-				icon = get_theme_icon(has_theme_icon(t, "EditorIcons") ? t : "Object", "EditorIcons");
+				icon = get_theme_icon(has_theme_icon(t, SNAME("EditorIcons")) ? t : String("Object"), SNAME("EditorIcons"));
 			}
 
 			int id = TYPE_BASE_ID + idx;
@@ -429,7 +429,7 @@ bool EditorResourcePicker::handle_menu_selected(int p_which) {
 
 void EditorResourcePicker::_button_draw() {
 	if (dropping) {
-		Color color = get_theme_color("accent_color", "Editor");
+		Color color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		assign_button->draw_rect(Rect2(Point2(), assign_button->get_size()), color, false);
 	}
 }
@@ -620,7 +620,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 		}
 
 		edited_resource = dropped_resource;
-		emit_signal("resource_changed", edited_resource);
+		emit_signal(SNAME("resource_changed"), edited_resource);
 		_update_resource();
 	}
 }
@@ -661,11 +661,11 @@ void EditorResourcePicker::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
-			edit_button->set_icon(get_theme_icon("select_arrow", "Tree"));
+			edit_button->set_icon(get_theme_icon(SNAME("select_arrow"), SNAME("Tree")));
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			draw_style_box(get_theme_stylebox("bg", "Tree"), Rect2(Point2(), get_size()));
+			draw_style_box(get_theme_stylebox(SNAME("bg"), SNAME("Tree")), Rect2(Point2(), get_size()));
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN: {
@@ -827,8 +827,8 @@ void EditorScriptPicker::set_create_options(Object *p_menu_node) {
 		return;
 	}
 
-	menu_node->add_icon_item(get_theme_icon("ScriptCreate", "EditorIcons"), TTR("New Script"), OBJ_MENU_NEW_SCRIPT);
-	menu_node->add_icon_item(get_theme_icon("ScriptExtend", "EditorIcons"), TTR("Extend Script"), OBJ_MENU_EXTEND_SCRIPT);
+	menu_node->add_icon_item(get_theme_icon(SNAME("ScriptCreate"), SNAME("EditorIcons")), TTR("New Script"), OBJ_MENU_NEW_SCRIPT);
+	menu_node->add_icon_item(get_theme_icon(SNAME("ScriptExtend"), SNAME("EditorIcons")), TTR("Extend Script"), OBJ_MENU_EXTEND_SCRIPT);
 	menu_node->add_separator();
 }
 

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -161,7 +161,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 		}
 		r_texture = generated;
 
-		int small_thumbnail_size = EditorNode::get_singleton()->get_theme_base()->get_theme_icon("Object", "EditorIcons")->get_width(); // Kind of a workaround to retrieve the default icon size
+		int small_thumbnail_size = EditorNode::get_singleton()->get_theme_base()->get_theme_icon(SNAME("Object"), SNAME("EditorIcons"))->get_width(); // Kind of a workaround to retrieve the default icon size
 
 		if (preview_generators[i]->can_generate_small_preview()) {
 			Ref<Texture2D> generated_small;
@@ -419,7 +419,7 @@ void EditorResourcePreview::check_for_invalidation(const String &p_path) {
 	}
 
 	if (call_invalidated) { //do outside mutex
-		call_deferred("emit_signal", "preview_invalidated", p_path);
+		call_deferred(SNAME("emit_signal"), "preview_invalidated", p_path);
 	}
 }
 

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -127,7 +127,7 @@ void EditorRunNative::_run_native(int p_idx, int p_platform) {
 		return;
 	}
 
-	emit_signal("native_run", preset);
+	emit_signal(SNAME("native_run"), preset);
 
 	int flags = 0;
 

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -250,8 +250,8 @@ void SectionedInspector::update_category_list() {
 
 		for (int i = 0; i < sc; i++) {
 			TreeItem *parent = section_map[metasection];
-			//parent->set_custom_bg_color(0, get_theme_color("prop_subsection", "Editor"));
-			parent->set_custom_font(0, get_theme_font("bold", "EditorFonts"));
+			//parent->set_custom_bg_color(0, get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
+			parent->set_custom_font(0, get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
 
 			if (i > 0) {
 				metasection += "/" + sectionarr[i];

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -63,7 +63,7 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 
 	bool changed = _set_only(p_name, p_value);
 	if (changed) {
-		emit_signal("settings_changed");
+		emit_signal(SNAME("settings_changed"));
 	}
 	return true;
 }
@@ -1344,7 +1344,7 @@ void EditorSettings::load_text_editor_theme() {
 			}
 		}
 	}
-	emit_signal("settings_changed");
+	emit_signal(SNAME("settings_changed"));
 	// if it doesn't load just use what is currently loaded
 }
 

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -88,7 +88,7 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 		} else if (mb->get_button_index() == MOUSE_BUTTON_WHEEL_UP || mb->get_button_index() == MOUSE_BUTTON_WHEEL_DOWN) {
 			if (grabber->is_visible()) {
-				call_deferred("update");
+				call_deferred(SNAME("update"));
 			}
 		}
 	}
@@ -193,7 +193,7 @@ void EditorSpinSlider::_update_value_input_stylebox() {
 	// when it's edited. The LineEdit "focus" stylebox uses the "normal" stylebox's
 	// default margins.
 	Ref<StyleBoxFlat> stylebox =
-			EditorNode::get_singleton()->get_theme_base()->get_theme_stylebox("normal", "LineEdit")->duplicate();
+			EditorNode::get_singleton()->get_theme_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit"))->duplicate();
 	// EditorSpinSliders with a label have more space on the left, so add an
 	// higher margin to match the location where the text begins.
 	// The margin values below were determined by empirical testing.
@@ -229,19 +229,19 @@ void EditorSpinSlider::_notification(int p_what) {
 		bool rtl = is_layout_rtl();
 		Vector2 size = get_size();
 
-		Ref<StyleBox> sb = get_theme_stylebox("normal", "LineEdit");
+		Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"), SNAME("LineEdit"));
 		if (!flat) {
 			draw_style_box(sb, Rect2(Vector2(), size));
 		}
-		Ref<Font> font = get_theme_font("font", "LineEdit");
-		int font_size = get_theme_font_size("font_size", "LineEdit");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("LineEdit"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("LineEdit"));
 		int sep_base = 4 * EDSCALE;
 		int sep = sep_base + sb->get_offset().x; //make it have the same margin on both sides, looks better
 
 		int label_width = font->get_string_size(label, font_size).width;
 		int number_width = size.width - sb->get_minimum_size().width - label_width - sep;
 
-		Ref<Texture2D> updown = get_theme_icon("updown", "SpinBox");
+		Ref<Texture2D> updown = get_theme_icon(SNAME("updown"), SNAME("SpinBox"));
 
 		if (get_step() == 1) {
 			number_width -= updown->get_width();
@@ -251,7 +251,7 @@ void EditorSpinSlider::_notification(int p_what) {
 
 		int vofs = (size.height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
 
-		Color fc = get_theme_color("font_color", "LineEdit");
+		Color fc = get_theme_color(SNAME("font_color"), SNAME("LineEdit"));
 		Color lc;
 		if (use_custom_label_color) {
 			lc = custom_label_color;
@@ -260,7 +260,7 @@ void EditorSpinSlider::_notification(int p_what) {
 		}
 
 		if (flat && label != String()) {
-			Color label_bg_color = get_theme_color("dark_color_3", "Editor");
+			Color label_bg_color = get_theme_color(SNAME("dark_color_3"), SNAME("Editor"));
 			if (rtl) {
 				draw_rect(Rect2(Vector2(size.width - (sb->get_offset().x * 2 + label_width), 0), Vector2(sb->get_offset().x * 2 + label_width, size.height)), label_bg_color);
 			} else {
@@ -269,7 +269,7 @@ void EditorSpinSlider::_notification(int p_what) {
 		}
 
 		if (has_focus()) {
-			Ref<StyleBox> focus = get_theme_stylebox("focus", "LineEdit");
+			Ref<StyleBox> focus = get_theme_stylebox(SNAME("focus"), SNAME("LineEdit"));
 			draw_style_box(focus, Rect2(Vector2(), size));
 		}
 
@@ -307,7 +307,7 @@ void EditorSpinSlider::_notification(int p_what) {
 		TS->free(num_rid);
 
 		if (get_step() == 1) {
-			Ref<Texture2D> updown2 = get_theme_icon("updown", "SpinBox");
+			Ref<Texture2D> updown2 = get_theme_icon(SNAME("updown"), SNAME("SpinBox"));
 			int updown_vofs = (size.height - updown2->get_height()) / 2;
 			if (rtl) {
 				updown_offset = sb->get_margin(SIDE_LEFT);
@@ -350,9 +350,9 @@ void EditorSpinSlider::_notification(int p_what) {
 			if (display_grabber) {
 				Ref<Texture2D> grabber_tex;
 				if (mouse_over_grabber) {
-					grabber_tex = get_theme_icon("grabber_highlight", "HSlider");
+					grabber_tex = get_theme_icon(SNAME("grabber_highlight"), SNAME("HSlider"));
 				} else {
-					grabber_tex = get_theme_icon("grabber", "HSlider");
+					grabber_tex = get_theme_icon(SNAME("grabber"), SNAME("HSlider"));
 				}
 
 				if (grabber->get_texture() != grabber_tex) {
@@ -395,9 +395,9 @@ LineEdit *EditorSpinSlider::get_line_edit() {
 }
 
 Size2 EditorSpinSlider::get_minimum_size() const {
-	Ref<StyleBox> sb = get_theme_stylebox("normal", "LineEdit");
-	Ref<Font> font = get_theme_font("font", "LineEdit");
-	int font_size = get_theme_font_size("font_size", "LineEdit");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"), SNAME("LineEdit"));
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("LineEdit"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("LineEdit"));
 
 	Size2 ms = sb->get_minimum_size();
 	ms.height += font->get_height(font_size);
@@ -529,9 +529,9 @@ void EditorSpinSlider::_focus_entered() {
 	value_input->set_text(get_text_value());
 	value_input_popup->set_position(gr.position);
 	value_input_popup->set_size(gr.size);
-	value_input_popup->call_deferred("popup");
-	value_input->call_deferred("grab_focus");
-	value_input->call_deferred("select_all");
+	value_input_popup->call_deferred(SNAME("popup"));
+	value_input->call_deferred(SNAME("grab_focus"));
+	value_input->call_deferred(SNAME("select_all"));
 	value_input->set_focus_next(find_next_valid_focus()->get_path());
 	value_input->set_focus_previous(find_prev_valid_focus()->get_path());
 }

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -996,7 +996,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("DebuggerPanel", "EditorStyles", style_panel_debugger);
 
 	Ref<StyleBoxFlat> style_panel_invisible_top = style_content_panel->duplicate();
-	int stylebox_offset = theme->get_font("tab_selected", "TabContainer")->get_height(theme->get_font_size("tab_selected", "TabContainer")) + theme->get_stylebox("tab_selected", "TabContainer")->get_minimum_size().height + theme->get_stylebox("panel", "TabContainer")->get_default_margin(SIDE_TOP);
+	int stylebox_offset = theme->get_font("tab_selected", "TabContainer")->get_height(theme->get_font_size("tab_selected", "TabContainer")) + theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->get_minimum_size().height + theme->get_stylebox(SNAME("panel"), SNAME("TabContainer"))->get_default_margin(SIDE_TOP);
 	style_panel_invisible_top->set_expand_margin_size(SIDE_TOP, -stylebox_offset);
 	style_panel_invisible_top->set_default_margin(SIDE_TOP, 0);
 	theme->set_stylebox("BottomPanelDebuggerOverride", "EditorStyles", style_panel_invisible_top);

--- a/editor/editor_zoom_widget.cpp
+++ b/editor/editor_zoom_widget.cpp
@@ -52,17 +52,17 @@ void EditorZoomWidget::_update_zoom_label() {
 
 void EditorZoomWidget::_button_zoom_minus() {
 	set_zoom_by_increments(-6, Input::get_singleton()->is_key_pressed(KEY_ALT));
-	emit_signal("zoom_changed", zoom);
+	emit_signal(SNAME("zoom_changed"), zoom);
 }
 
 void EditorZoomWidget::_button_zoom_reset() {
 	set_zoom(1.0 * MAX(1, EDSCALE));
-	emit_signal("zoom_changed", zoom);
+	emit_signal(SNAME("zoom_changed"), zoom);
 }
 
 void EditorZoomWidget::_button_zoom_plus() {
 	set_zoom_by_increments(6, Input::get_singleton()->is_key_pressed(KEY_ALT));
-	emit_signal("zoom_changed", zoom);
+	emit_signal(SNAME("zoom_changed"), zoom);
 }
 
 float EditorZoomWidget::get_zoom() {
@@ -145,8 +145,8 @@ void EditorZoomWidget::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			zoom_minus->set_icon(get_theme_icon("ZoomLess", "EditorIcons"));
-			zoom_plus->set_icon(get_theme_icon("ZoomMore", "EditorIcons"));
+			zoom_minus->set_icon(get_theme_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));
+			zoom_plus->set_icon(get_theme_icon(SNAME("ZoomMore"), SNAME("EditorIcons")));
 			break;
 		default:
 			break;

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -106,8 +106,8 @@ void ExportTemplateManager::_update_template_status() {
 		TreeItem *ti = installed_table->create_item(installed_root);
 		ti->set_text(0, version_string);
 
-		ti->add_button(0, get_theme_icon("Folder", "EditorIcons"), OPEN_TEMPLATE_FOLDER, false, TTR("Open the folder containing these templates."));
-		ti->add_button(0, get_theme_icon("Remove", "EditorIcons"), UNINSTALL_TEMPLATE, false, TTR("Uninstall these templates."));
+		ti->add_button(0, get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), OPEN_TEMPLATE_FOLDER, false, TTR("Open the folder containing these templates."));
+		ti->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), UNINSTALL_TEMPLATE, false, TTR("Uninstall these templates."));
 	}
 }
 
@@ -352,9 +352,9 @@ void ExportTemplateManager::_set_current_progress_status(const String &p_status,
 	download_progress_label->set_text(p_status);
 
 	if (p_error) {
-		download_progress_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
+		download_progress_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	} else {
-		download_progress_label->add_theme_color_override("font_color", get_theme_color("font_color", "Label"));
+		download_progress_label->add_theme_color_override("font_color", get_theme_color(SNAME("font_color"), SNAME("Label")));
 	}
 }
 
@@ -739,11 +739,11 @@ void ExportTemplateManager::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			current_value->add_theme_font_override("font", get_theme_font("main", "EditorFonts"));
-			current_missing_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
-			current_installed_label->add_theme_color_override("font_color", get_theme_color("disabled_font_color", "Editor"));
+			current_value->add_theme_font_override("font", get_theme_font(SNAME("main"), SNAME("EditorFonts")));
+			current_missing_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			current_installed_label->add_theme_color_override("font_color", get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 
-			mirror_options_button->set_icon(get_theme_icon("GuiTabMenu", "EditorIcons"));
+			mirror_options_button->set_icon(get_theme_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -50,9 +50,9 @@
 Ref<Texture2D> FileSystemDock::_get_tree_item_icon(bool p_is_valid, String p_file_type) {
 	Ref<Texture2D> file_icon;
 	if (!p_is_valid) {
-		file_icon = get_theme_icon("ImportFail", "EditorIcons");
+		file_icon = get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons"));
 	} else {
-		file_icon = (has_theme_icon(p_file_type, "EditorIcons")) ? get_theme_icon(p_file_type, "EditorIcons") : get_theme_icon("File", "EditorIcons");
+		file_icon = (has_theme_icon(p_file_type, SNAME("EditorIcons"))) ? get_theme_icon(p_file_type, SNAME("EditorIcons")) : get_theme_icon(SNAME("File"), SNAME("EditorIcons"));
 	}
 	return file_icon;
 }
@@ -69,8 +69,8 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 
 	subdirectory_item->set_text(0, dname);
 	subdirectory_item->set_structured_text_bidi_override(0, STRUCTURED_TEXT_FILE);
-	subdirectory_item->set_icon(0, get_theme_icon("Folder", "EditorIcons"));
-	subdirectory_item->set_icon_modulate(0, get_theme_color("folder_icon_modulate", "FileDialog"));
+	subdirectory_item->set_icon(0, get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
+	subdirectory_item->set_icon_modulate(0, get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog")));
 	subdirectory_item->set_selectable(0, true);
 	String lpath = p_dir->get_path();
 	subdirectory_item->set_metadata(0, lpath);
@@ -149,7 +149,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 				file_item->set_as_cursor(0);
 			}
 			if (main_scene == file_metadata) {
-				file_item->set_custom_color(0, get_theme_color("accent_color", "Editor"));
+				file_item->set_custom_color(0, get_theme_color(SNAME("accent_color"), SNAME("Editor")));
 			}
 			Array udata;
 			udata.push_back(tree_update_id);
@@ -215,7 +215,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 
 	// Handles the favorites.
 	TreeItem *favorites = tree->create_item(root);
-	favorites->set_icon(0, get_theme_icon("Favorites", "EditorIcons"));
+	favorites->set_icon(0, get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")));
 	favorites->set_text(0, TTR("Favorites:"));
 	favorites->set_metadata(0, "Favorites");
 	favorites->set_collapsed(p_uncollapsed_paths.find("Favorites") < 0);
@@ -227,8 +227,8 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 			continue;
 		}
 
-		Ref<Texture2D> folder_icon = get_theme_icon("Folder", "EditorIcons");
-		const Color folder_color = get_theme_color("folder_icon_modulate", "FileDialog");
+		Ref<Texture2D> folder_icon = get_theme_icon(SNAME("Folder"), SNAME("EditorIcons"));
+		const Color folder_color = get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"));
 
 		String text;
 		Ref<Texture2D> icon;
@@ -248,7 +248,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 			if (dir) {
 				icon = _get_tree_item_icon(dir->get_file_import_is_valid(index), dir->get_file_type(index));
 			} else {
-				icon = get_theme_icon("File", "EditorIcons");
+				icon = get_theme_icon(SNAME("File"), SNAME("EditorIcons"));
 			}
 			color = Color(1, 1, 1);
 		}
@@ -339,28 +339,28 @@ void FileSystemDock::_notification(int p_what) {
 
 			String ei = "EditorIcons";
 
-			button_reload->set_icon(get_theme_icon("Reload", ei));
-			button_toggle_display_mode->set_icon(get_theme_icon("Panels2", ei));
+			button_reload->set_icon(get_theme_icon(SNAME("Reload"), ei));
+			button_toggle_display_mode->set_icon(get_theme_icon(SNAME("Panels2"), ei));
 			button_file_list_display_mode->connect("pressed", callable_mp(this, &FileSystemDock::_toggle_file_display));
 
 			files->connect("item_activated", callable_mp(this, &FileSystemDock::_file_list_activate_file));
 			button_hist_next->connect("pressed", callable_mp(this, &FileSystemDock::_fw_history));
 			button_hist_prev->connect("pressed", callable_mp(this, &FileSystemDock::_bw_history));
 
-			tree_search_box->set_right_icon(get_theme_icon("Search", ei));
+			tree_search_box->set_right_icon(get_theme_icon(SNAME("Search"), ei));
 			tree_search_box->set_clear_button_enabled(true);
-			tree_button_sort->set_icon(get_theme_icon("Sort", ei));
+			tree_button_sort->set_icon(get_theme_icon(SNAME("Sort"), ei));
 
-			file_list_search_box->set_right_icon(get_theme_icon("Search", ei));
+			file_list_search_box->set_right_icon(get_theme_icon(SNAME("Search"), ei));
 			file_list_search_box->set_clear_button_enabled(true);
-			file_list_button_sort->set_icon(get_theme_icon("Sort", ei));
+			file_list_button_sort->set_icon(get_theme_icon(SNAME("Sort"), ei));
 
 			if (is_layout_rtl()) {
-				button_hist_next->set_icon(get_theme_icon("Back", ei));
-				button_hist_prev->set_icon(get_theme_icon("Forward", ei));
+				button_hist_next->set_icon(get_theme_icon(SNAME("Back"), ei));
+				button_hist_prev->set_icon(get_theme_icon(SNAME("Forward"), ei));
 			} else {
-				button_hist_next->set_icon(get_theme_icon("Forward", ei));
-				button_hist_prev->set_icon(get_theme_icon("Back", ei));
+				button_hist_next->set_icon(get_theme_icon(SNAME("Forward"), ei));
+				button_hist_prev->set_icon(get_theme_icon(SNAME("Back"), ei));
 			}
 			file_list_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_file_list_rmb_option));
 			tree_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_tree_rmb_option));
@@ -412,28 +412,28 @@ void FileSystemDock::_notification(int p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			// Update icons.
 			String ei = "EditorIcons";
-			button_reload->set_icon(get_theme_icon("Reload", ei));
-			button_toggle_display_mode->set_icon(get_theme_icon("Panels2", ei));
+			button_reload->set_icon(get_theme_icon(SNAME("Reload"), ei));
+			button_toggle_display_mode->set_icon(get_theme_icon(SNAME("Panels2"), ei));
 			if (is_layout_rtl()) {
-				button_hist_next->set_icon(get_theme_icon("Back", ei));
-				button_hist_prev->set_icon(get_theme_icon("Forward", ei));
+				button_hist_next->set_icon(get_theme_icon(SNAME("Back"), ei));
+				button_hist_prev->set_icon(get_theme_icon(SNAME("Forward"), ei));
 			} else {
-				button_hist_next->set_icon(get_theme_icon("Forward", ei));
-				button_hist_prev->set_icon(get_theme_icon("Back", ei));
+				button_hist_next->set_icon(get_theme_icon(SNAME("Forward"), ei));
+				button_hist_prev->set_icon(get_theme_icon(SNAME("Back"), ei));
 			}
 			if (file_list_display_mode == FILE_LIST_DISPLAY_LIST) {
-				button_file_list_display_mode->set_icon(get_theme_icon("FileThumbnail", "EditorIcons"));
+				button_file_list_display_mode->set_icon(get_theme_icon(SNAME("FileThumbnail"), SNAME("EditorIcons")));
 			} else {
-				button_file_list_display_mode->set_icon(get_theme_icon("FileList", "EditorIcons"));
+				button_file_list_display_mode->set_icon(get_theme_icon(SNAME("FileList"), SNAME("EditorIcons")));
 			}
 
-			tree_search_box->set_right_icon(get_theme_icon("Search", ei));
+			tree_search_box->set_right_icon(get_theme_icon(SNAME("Search"), ei));
 			tree_search_box->set_clear_button_enabled(true);
-			tree_button_sort->set_icon(get_theme_icon("Sort", ei));
+			tree_button_sort->set_icon(get_theme_icon(SNAME("Sort"), ei));
 
-			file_list_search_box->set_right_icon(get_theme_icon("Search", ei));
+			file_list_search_box->set_right_icon(get_theme_icon(SNAME("Search"), ei));
 			file_list_search_box->set_clear_button_enabled(true);
-			file_list_button_sort->set_icon(get_theme_icon("Sort", ei));
+			file_list_button_sort->set_icon(get_theme_icon(SNAME("Sort"), ei));
 
 			// Update always show folders.
 			bool new_always_show_folders = bool(EditorSettings::get_singleton()->get("docks/filesystem/always_show_folders"));
@@ -451,7 +451,7 @@ void FileSystemDock::_notification(int p_what) {
 void FileSystemDock::_tree_multi_selected(Object *p_item, int p_column, bool p_selected) {
 	// Update the import dock.
 	import_dock_needs_update = true;
-	call_deferred("_update_import_dock");
+	call_deferred(SNAME("_update_import_dock"));
 
 	// Return if we don't select something new.
 	if (!p_selected) {
@@ -581,17 +581,17 @@ void FileSystemDock::_tree_thumbnail_done(const String &p_path, const Ref<Textur
 
 void FileSystemDock::_toggle_file_display() {
 	_set_file_display(file_list_display_mode != FILE_LIST_DISPLAY_LIST);
-	emit_signal("display_mode_changed");
+	emit_signal(SNAME("display_mode_changed"));
 }
 
 void FileSystemDock::_set_file_display(bool p_active) {
 	if (p_active) {
 		file_list_display_mode = FILE_LIST_DISPLAY_LIST;
-		button_file_list_display_mode->set_icon(get_theme_icon("FileThumbnail", "EditorIcons"));
+		button_file_list_display_mode->set_icon(get_theme_icon(SNAME("FileThumbnail"), SNAME("EditorIcons")));
 		button_file_list_display_mode->set_tooltip(TTR("View items as a grid of thumbnails."));
 	} else {
 		file_list_display_mode = FILE_LIST_DISPLAY_THUMBNAILS;
-		button_file_list_display_mode->set_icon(get_theme_icon("FileList", "EditorIcons"));
+		button_file_list_display_mode->set_icon(get_theme_icon(SNAME("FileList"), SNAME("EditorIcons")));
 		button_file_list_display_mode->set_tooltip(TTR("View items as a list."));
 	}
 
@@ -733,13 +733,13 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
 
 		if (thumbnail_size < 64) {
-			folder_thumbnail = get_theme_icon("FolderMediumThumb", ei);
-			file_thumbnail = get_theme_icon("FileMediumThumb", ei);
-			file_thumbnail_broken = get_theme_icon("FileDeadMediumThumb", ei);
+			folder_thumbnail = get_theme_icon(SNAME("FolderMediumThumb"), ei);
+			file_thumbnail = get_theme_icon(SNAME("FileMediumThumb"), ei);
+			file_thumbnail_broken = get_theme_icon(SNAME("FileDeadMediumThumb"), ei);
 		} else {
-			folder_thumbnail = get_theme_icon("FolderBigThumb", ei);
-			file_thumbnail = get_theme_icon("FileBigThumb", ei);
-			file_thumbnail_broken = get_theme_icon("FileDeadBigThumb", ei);
+			folder_thumbnail = get_theme_icon(SNAME("FolderBigThumb"), ei);
+			file_thumbnail = get_theme_icon(SNAME("FileBigThumb"), ei);
+			file_thumbnail_broken = get_theme_icon(SNAME("FileDeadBigThumb"), ei);
 		}
 	} else {
 		// No thumbnails.
@@ -750,8 +750,8 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_fixed_icon_size(Size2());
 	}
 
-	Ref<Texture2D> folder_icon = (use_thumbnails) ? folder_thumbnail : get_theme_icon("folder", "FileDialog");
-	const Color folder_color = get_theme_color("folder_icon_modulate", "FileDialog");
+	Ref<Texture2D> folder_icon = (use_thumbnails) ? folder_thumbnail : get_theme_icon(SNAME("folder"), SNAME("FileDialog"));
+	const Color folder_color = get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"));
 
 	// Build the FileInfo list.
 	List<FileInfo> file_list;
@@ -885,7 +885,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			type_icon = (has_theme_icon(ftype, ei)) ? get_theme_icon(ftype, ei) : get_theme_icon(oi, ei);
 			big_icon = file_thumbnail;
 		} else {
-			type_icon = get_theme_icon("ImportFail", ei);
+			type_icon = get_theme_icon(SNAME("ImportFail"), ei);
 			big_icon = file_thumbnail_broken;
 			tooltip += "\n" + TTR("Status: Import of file failed. Please fix file and reimport manually.");
 		}
@@ -905,7 +905,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		}
 
 		if (fpath == main_scene) {
-			files->set_item_custom_fg_color(item_index, get_theme_color("accent_color", "Editor"));
+			files->set_item_custom_fg_color(item_index, get_theme_color(SNAME("accent_color"), SNAME("Editor")));
 		}
 
 		// Generate the preview.
@@ -1189,11 +1189,11 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			p_file_renames[file_changed_paths[i]] = file_changed_paths[i].replace_first(old_path, new_path);
 			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
-			emit_signal("files_moved", file_changed_paths[i], p_file_renames[file_changed_paths[i]]);
+			emit_signal(SNAME("files_moved"), file_changed_paths[i], p_file_renames[file_changed_paths[i]]);
 		}
 		for (int i = 0; i < folder_changed_paths.size(); ++i) {
 			p_folder_renames[folder_changed_paths[i]] = folder_changed_paths[i].replace_first(old_path, new_path);
-			emit_signal("folder_moved", folder_changed_paths[i], p_folder_renames[folder_changed_paths[i]].substr(0, p_folder_renames[folder_changed_paths[i]].length() - 1));
+			emit_signal(SNAME("folder_moved"), folder_changed_paths[i], p_folder_renames[folder_changed_paths[i]].substr(0, p_folder_renames[folder_changed_paths[i]].length() - 1));
 		}
 	} else {
 		EditorNode::get_singleton()->add_io_error(TTR("Error moving:") + "\n" + old_path + "\n");
@@ -1442,7 +1442,7 @@ void FileSystemDock::_make_scene_confirm() {
 }
 
 void FileSystemDock::_file_removed(String p_file) {
-	emit_signal("file_removed", p_file);
+	emit_signal(SNAME("file_removed"), p_file);
 
 	// Find the closest parent directory available, in case multiple items were deleted along the same path.
 	path = p_file.get_base_dir();
@@ -1455,7 +1455,7 @@ void FileSystemDock::_file_removed(String p_file) {
 }
 
 void FileSystemDock::_folder_removed(String p_folder) {
-	emit_signal("folder_removed", p_folder);
+	emit_signal(SNAME("folder_removed"), p_folder);
 
 	// Find the closest parent directory available, in case multiple items were deleted along the same path.
 	path = p_folder.get_base_dir();
@@ -1762,7 +1762,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		case FILE_INHERIT: {
 			// Create a new scene inherited from the selected one.
 			if (p_selected.size() == 1) {
-				emit_signal("inherit", p_selected[0]);
+				emit_signal(SNAME("inherit"), p_selected[0]);
 			}
 		} break;
 
@@ -1786,7 +1786,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				}
 			}
 			if (!paths.is_empty()) {
-				emit_signal("instance", paths);
+				emit_signal(SNAME("instance"), paths);
 			}
 		} break;
 
@@ -2019,7 +2019,7 @@ void FileSystemDock::_rescan() {
 
 void FileSystemDock::_toggle_split_mode(bool p_active) {
 	set_display_mode(p_active ? DISPLAY_MODE_SPLIT : DISPLAY_MODE_TREE_ONLY);
-	emit_signal("display_mode_changed");
+	emit_signal(SNAME("display_mode_changed"));
 }
 
 void FileSystemDock::fix_dependencies(const String &p_for_file) {
@@ -2404,28 +2404,28 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 	if (all_files) {
 		if (all_files_scenes) {
 			if (filenames.size() == 1) {
-				p_popup->add_icon_item(get_theme_icon("Load", "EditorIcons"), TTR("Open Scene"), FILE_OPEN);
-				p_popup->add_icon_item(get_theme_icon("CreateNewSceneFrom", "EditorIcons"), TTR("New Inherited Scene"), FILE_INHERIT);
+				p_popup->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open Scene"), FILE_OPEN);
+				p_popup->add_icon_item(get_theme_icon(SNAME("CreateNewSceneFrom"), SNAME("EditorIcons")), TTR("New Inherited Scene"), FILE_INHERIT);
 				if (ProjectSettings::get_singleton()->get("application/run/main_scene") != filenames[0]) {
-					p_popup->add_icon_item(get_theme_icon("PlayScene", "EditorIcons"), TTR("Set As Main Scene"), FILE_MAIN_SCENE);
+					p_popup->add_icon_item(get_theme_icon(SNAME("PlayScene"), SNAME("EditorIcons")), TTR("Set As Main Scene"), FILE_MAIN_SCENE);
 				}
 			} else {
-				p_popup->add_icon_item(get_theme_icon("Load", "EditorIcons"), TTR("Open Scenes"), FILE_OPEN);
+				p_popup->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open Scenes"), FILE_OPEN);
 			}
-			p_popup->add_icon_item(get_theme_icon("Instance", "EditorIcons"), TTR("Instance"), FILE_INSTANCE);
+			p_popup->add_icon_item(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Instance"), FILE_INSTANCE);
 			p_popup->add_separator();
 		} else if (filenames.size() == 1) {
-			p_popup->add_icon_item(get_theme_icon("Load", "EditorIcons"), TTR("Open"), FILE_OPEN);
+			p_popup->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open"), FILE_OPEN);
 			p_popup->add_separator();
 		}
 	}
 
 	if (p_paths.size() >= 1) {
 		if (!all_favorites) {
-			p_popup->add_icon_item(get_theme_icon("Favorites", "EditorIcons"), TTR("Add to Favorites"), FILE_ADD_FAVORITE);
+			p_popup->add_icon_item(get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")), TTR("Add to Favorites"), FILE_ADD_FAVORITE);
 		}
 		if (!all_not_favorites) {
-			p_popup->add_icon_item(get_theme_icon("NonFavorite", "EditorIcons"), TTR("Remove from Favorites"), FILE_REMOVE_FAVORITE);
+			p_popup->add_icon_item(get_theme_icon(SNAME("NonFavorite"), SNAME("EditorIcons")), TTR("Remove from Favorites"), FILE_REMOVE_FAVORITE);
 		}
 		p_popup->add_separator();
 	}
@@ -2438,36 +2438,36 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 		}
 
 	} else if (all_folders && foldernames.size() > 0) {
-		p_popup->add_icon_item(get_theme_icon("Load", "EditorIcons"), TTR("Open"), FILE_OPEN);
+		p_popup->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open"), FILE_OPEN);
 		p_popup->add_separator();
 	}
 
 	if (p_paths.size() == 1) {
-		p_popup->add_icon_shortcut(get_theme_icon("ActionCopy", "EditorIcons"), ED_GET_SHORTCUT("filesystem_dock/copy_path"), FILE_COPY_PATH);
+		p_popup->add_icon_shortcut(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")), ED_GET_SHORTCUT("filesystem_dock/copy_path"), FILE_COPY_PATH);
 		if (p_paths[0] != "res://") {
-			p_popup->add_icon_shortcut(get_theme_icon("Rename", "EditorIcons"), ED_GET_SHORTCUT("filesystem_dock/rename"), FILE_RENAME);
-			p_popup->add_icon_shortcut(get_theme_icon("Duplicate", "EditorIcons"), ED_GET_SHORTCUT("filesystem_dock/duplicate"), FILE_DUPLICATE);
+			p_popup->add_icon_shortcut(get_theme_icon(SNAME("Rename"), SNAME("EditorIcons")), ED_GET_SHORTCUT("filesystem_dock/rename"), FILE_RENAME);
+			p_popup->add_icon_shortcut(get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")), ED_GET_SHORTCUT("filesystem_dock/duplicate"), FILE_DUPLICATE);
 		}
 	}
 
 	if (p_paths.size() > 1 || p_paths[0] != "res://") {
-		p_popup->add_icon_item(get_theme_icon("MoveUp", "EditorIcons"), TTR("Move To..."), FILE_MOVE);
-		p_popup->add_icon_shortcut(get_theme_icon("Remove", "EditorIcons"), ED_GET_SHORTCUT("filesystem_dock/delete"), FILE_REMOVE);
+		p_popup->add_icon_item(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")), TTR("Move To..."), FILE_MOVE);
+		p_popup->add_icon_shortcut(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ED_GET_SHORTCUT("filesystem_dock/delete"), FILE_REMOVE);
 	}
 
 	if (p_paths.size() == 1) {
 		p_popup->add_separator();
 		if (p_display_path_dependent_options) {
-			p_popup->add_icon_item(get_theme_icon("Folder", "EditorIcons"), TTR("New Folder..."), FILE_NEW_FOLDER);
-			p_popup->add_icon_item(get_theme_icon("PackedScene", "EditorIcons"), TTR("New Scene..."), FILE_NEW_SCENE);
-			p_popup->add_icon_item(get_theme_icon("Script", "EditorIcons"), TTR("New Script..."), FILE_NEW_SCRIPT);
-			p_popup->add_icon_item(get_theme_icon("Object", "EditorIcons"), TTR("New Resource..."), FILE_NEW_RESOURCE);
+			p_popup->add_icon_item(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), TTR("New Folder..."), FILE_NEW_FOLDER);
+			p_popup->add_icon_item(get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")), TTR("New Scene..."), FILE_NEW_SCENE);
+			p_popup->add_icon_item(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), TTR("New Script..."), FILE_NEW_SCRIPT);
+			p_popup->add_icon_item(get_theme_icon(SNAME("Object"), SNAME("EditorIcons")), TTR("New Resource..."), FILE_NEW_RESOURCE);
 			p_popup->add_separator();
 		}
 
 		String fpath = p_paths[0];
 		String item_text = fpath.ends_with("/") ? TTR("Open in File Manager") : TTR("Show in File Manager");
-		p_popup->add_icon_item(get_theme_icon("Filesystem", "EditorIcons"), item_text, FILE_SHOW_IN_EXPLORER);
+		p_popup->add_icon_item(get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")), item_text, FILE_SHOW_IN_EXPLORER);
 	}
 }
 
@@ -2478,8 +2478,8 @@ void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
 	tree_popup->clear();
 	if (paths.size() == 1) {
 		if (paths[0].ends_with("/")) {
-			tree_popup->add_icon_item(get_theme_icon("GuiTreeArrowDown", "EditorIcons"), TTR("Expand All"), FOLDER_EXPAND_ALL);
-			tree_popup->add_icon_item(get_theme_icon("GuiTreeArrowRight", "EditorIcons"), TTR("Collapse All"), FOLDER_COLLAPSE_ALL);
+			tree_popup->add_icon_item(get_theme_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")), TTR("Expand All"), FOLDER_EXPAND_ALL);
+			tree_popup->add_icon_item(get_theme_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")), TTR("Collapse All"), FOLDER_COLLAPSE_ALL);
 			tree_popup->add_separator();
 		}
 	}
@@ -2498,10 +2498,10 @@ void FileSystemDock::_tree_rmb_empty(const Vector2 &p_pos) {
 	path = "res://";
 	tree_popup->clear();
 	tree_popup->set_size(Size2(1, 1));
-	tree_popup->add_icon_item(get_theme_icon("Folder", "EditorIcons"), TTR("New Folder..."), FILE_NEW_FOLDER);
-	tree_popup->add_icon_item(get_theme_icon("PackedScene", "EditorIcons"), TTR("New Scene..."), FILE_NEW_SCENE);
-	tree_popup->add_icon_item(get_theme_icon("Script", "EditorIcons"), TTR("New Script..."), FILE_NEW_SCRIPT);
-	tree_popup->add_icon_item(get_theme_icon("Object", "EditorIcons"), TTR("New Resource..."), FILE_NEW_RESOURCE);
+	tree_popup->add_icon_item(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), TTR("New Folder..."), FILE_NEW_FOLDER);
+	tree_popup->add_icon_item(get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")), TTR("New Scene..."), FILE_NEW_SCENE);
+	tree_popup->add_icon_item(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), TTR("New Script..."), FILE_NEW_SCRIPT);
+	tree_popup->add_icon_item(get_theme_icon(SNAME("Object"), SNAME("EditorIcons")), TTR("New Resource..."), FILE_NEW_RESOURCE);
 	tree_popup->set_position(tree->get_global_position() + p_pos);
 	tree_popup->popup();
 }
@@ -2543,12 +2543,12 @@ void FileSystemDock::_file_list_rmb_pressed(const Vector2 &p_pos) {
 	file_list_popup->clear();
 	file_list_popup->set_size(Size2(1, 1));
 
-	file_list_popup->add_icon_item(get_theme_icon("Folder", "EditorIcons"), TTR("New Folder..."), FILE_NEW_FOLDER);
-	file_list_popup->add_icon_item(get_theme_icon("PackedScene", "EditorIcons"), TTR("New Scene..."), FILE_NEW_SCENE);
-	file_list_popup->add_icon_item(get_theme_icon("Script", "EditorIcons"), TTR("New Script..."), FILE_NEW_SCRIPT);
-	file_list_popup->add_icon_item(get_theme_icon("Object", "EditorIcons"), TTR("New Resource..."), FILE_NEW_RESOURCE);
+	file_list_popup->add_icon_item(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), TTR("New Folder..."), FILE_NEW_FOLDER);
+	file_list_popup->add_icon_item(get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")), TTR("New Scene..."), FILE_NEW_SCENE);
+	file_list_popup->add_icon_item(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), TTR("New Script..."), FILE_NEW_SCRIPT);
+	file_list_popup->add_icon_item(get_theme_icon(SNAME("Object"), SNAME("EditorIcons")), TTR("New Resource..."), FILE_NEW_RESOURCE);
 	file_list_popup->add_separator();
-	file_list_popup->add_icon_item(get_theme_icon("Filesystem", "EditorIcons"), TTR("Open in File Manager"), FILE_SHOW_IN_EXPLORER);
+	file_list_popup->add_icon_item(get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")), TTR("Open in File Manager"), FILE_SHOW_IN_EXPLORER);
 	file_list_popup->set_position(files->get_global_position() + p_pos);
 	file_list_popup->popup();
 }
@@ -2572,7 +2572,7 @@ void FileSystemDock::_file_multi_selected(int p_index, bool p_selected) {
 
 	// Update the import dock.
 	import_dock_needs_update = true;
-	call_deferred("_update_import_dock");
+	call_deferred(SNAME("_update_import_dock"));
 }
 
 void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -116,12 +116,12 @@ void FindInFiles::_notification(int p_notification) {
 void FindInFiles::start() {
 	if (_pattern == "") {
 		print_verbose("Nothing to search, pattern is empty");
-		emit_signal(SIGNAL_FINISHED);
+		emit_signal(SNAME(SIGNAL_FINISHED));
 		return;
 	}
 	if (_extension_filter.size() == 0) {
 		print_verbose("Nothing to search, filter matches no files");
-		emit_signal(SIGNAL_FINISHED);
+		emit_signal(SNAME(SIGNAL_FINISHED));
 		return;
 	}
 
@@ -201,7 +201,7 @@ void FindInFiles::_iterate() {
 		set_process(false);
 		_current_dir = "";
 		_searching = false;
-		emit_signal(SIGNAL_FINISHED);
+		emit_signal(SNAME(SIGNAL_FINISHED));
 	}
 }
 
@@ -267,7 +267,7 @@ void FindInFiles::_scan_file(String fpath) {
 		String line = f->get_line();
 
 		while (find_next(line, _pattern, end, _match_case, _whole_words, begin, end)) {
-			emit_signal(SIGNAL_RESULT_FOUND, fpath, line_number, begin, end, line);
+			emit_signal(SNAME(SIGNAL_RESULT_FOUND), fpath, line_number, begin, end, line);
 		}
 	}
 
@@ -457,7 +457,7 @@ void FindInFilesDialog::_notification(int p_what) {
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 		if (is_visible()) {
 			// Doesn't work more than once if not deferred...
-			_search_text_line_edit->call_deferred("grab_focus");
+			_search_text_line_edit->call_deferred(SNAME("grab_focus"));
 			_search_text_line_edit->select_all();
 			// Extensions might have changed in the meantime, we clean them and instance them again.
 			for (int i = 0; i < _filters_container->get_child_count(); i++) {
@@ -487,10 +487,10 @@ void FindInFilesDialog::custom_action(const String &p_action) {
 		_filters_preferences[cb->get_text()] = cb->is_pressed();
 	}
 	if (p_action == "find") {
-		emit_signal(SIGNAL_FIND_REQUESTED);
+		emit_signal(SNAME(SIGNAL_FIND_REQUESTED));
 		hide();
 	} else if (p_action == "replace") {
-		emit_signal(SIGNAL_REPLACE_REQUESTED);
+		emit_signal(SNAME(SIGNAL_REPLACE_REQUESTED));
 		hide();
 	}
 }
@@ -565,8 +565,8 @@ FindInFilesPanel::FindInFilesPanel() {
 		hbc->add_child(find_label);
 
 		_search_text_label = memnew(Label);
-		_search_text_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("source", "EditorFonts"));
-		_search_text_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("source_size", "EditorFonts"));
+		_search_text_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+		_search_text_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts")));
 		hbc->add_child(_search_text_label);
 
 		_progress_bar = memnew(ProgressBar);
@@ -594,8 +594,8 @@ FindInFilesPanel::FindInFilesPanel() {
 	}
 
 	_results_display = memnew(Tree);
-	_results_display->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("source", "EditorFonts"));
-	_results_display->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("source_size", "EditorFonts"));
+	_results_display->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+	_results_display->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts")));
 	_results_display->set_v_size_flags(SIZE_EXPAND_FILL);
 	_results_display->connect("item_selected", callable_mp(this, &FindInFilesPanel::_on_result_selected));
 	_results_display->connect("item_edited", callable_mp(this, &FindInFilesPanel::_on_item_edited));
@@ -688,8 +688,8 @@ void FindInFilesPanel::_notification(int p_what) {
 	if (p_what == NOTIFICATION_PROCESS) {
 		_progress_bar->set_as_ratio(_finder->get_progress());
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		_search_text_label->add_theme_font_override("font", get_theme_font("source", "EditorFonts"));
-		_results_display->add_theme_font_override("font", get_theme_font("source", "EditorFonts"));
+		_search_text_label->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+		_results_display->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
 	}
 }
 
@@ -754,8 +754,8 @@ void FindInFilesPanel::draw_result_text(Object *item_obj, Rect2 rect) {
 	}
 	Result r = E->value();
 	String item_text = item->get_text(_with_replace ? 1 : 0);
-	Ref<Font> font = _results_display->get_theme_font("font");
-	int font_size = _results_display->get_theme_font_size("font_size");
+	Ref<Font> font = _results_display->get_theme_font(SNAME("font"));
+	int font_size = _results_display->get_theme_font_size(SNAME("font_size"));
 
 	Rect2 match_rect = rect;
 	match_rect.position.x += font->get_string_size(item_text.left(r.begin_trimmed), font_size).x;
@@ -764,7 +764,7 @@ void FindInFilesPanel::draw_result_text(Object *item_obj, Rect2 rect) {
 	match_rect.size.y -= 2 * EDSCALE;
 
 	// Use the inverted accent color to help match rectangles stand out even on the currently selected line.
-	_results_display->draw_rect(match_rect, get_theme_color("accent_color", "Editor").inverted() * Color(1, 1, 1, 0.5));
+	_results_display->draw_rect(match_rect, get_theme_color(SNAME("accent_color"), SNAME("Editor")).inverted() * Color(1, 1, 1, 0.5));
 
 	// Text is drawn by Tree already.
 }
@@ -773,11 +773,11 @@ void FindInFilesPanel::_on_item_edited() {
 	TreeItem *item = _results_display->get_selected();
 
 	if (item->is_checked(0)) {
-		item->set_custom_color(1, _results_display->get_theme_color("font_color"));
+		item->set_custom_color(1, _results_display->get_theme_color(SNAME("font_color")));
 
 	} else {
 		// Grey out
-		Color color = _results_display->get_theme_color("font_color");
+		Color color = _results_display->get_theme_color(SNAME("font_color"));
 		color.a /= 2.0;
 		item->set_custom_color(1, color);
 	}
@@ -823,7 +823,7 @@ void FindInFilesPanel::_on_result_selected() {
 	TreeItem *file_item = item->get_parent();
 	String fpath = file_item->get_metadata(0);
 
-	emit_signal(SIGNAL_RESULT_SELECTED, fpath, r.line_number, r.begin, r.end);
+	emit_signal(SNAME(SIGNAL_RESULT_SELECTED), fpath, r.line_number, r.begin, r.end);
 }
 
 void FindInFilesPanel::_on_replace_text_changed(String text) {
@@ -860,7 +860,7 @@ void FindInFilesPanel::_on_replace_all_clicked() {
 	// Hide replace bar so we can't trigger the action twice without doing a new search
 	_replace_container->hide();
 
-	emit_signal(SIGNAL_FILES_MODIFIED, modified_files);
+	emit_signal(SNAME(SIGNAL_FILES_MODIFIED), modified_files);
 }
 
 // Same as get_line, but preserves line ending characters

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -94,7 +94,7 @@ void GroupDialog::_load_nodes(Node *p_current) {
 
 		if (!_can_edit(p_current, selected_group)) {
 			node->set_selectable(0, false);
-			node->set_custom_color(0, groups->get_theme_color("disabled_font_color", "Editor"));
+			node->set_custom_color(0, groups->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 		}
 	}
 
@@ -204,7 +204,7 @@ void GroupDialog::_add_group(String p_name) {
 
 	TreeItem *new_group = groups->create_item(groups_root);
 	new_group->set_text(0, name);
-	new_group->add_button(0, groups->get_theme_icon("Remove", "EditorIcons"), 0);
+	new_group->add_button(0, groups->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0);
 	new_group->set_editable(0, true);
 	new_group->select(0);
 	groups->ensure_cursor_is_visible();
@@ -365,16 +365,16 @@ void GroupDialog::_notification(int p_what) {
 		case Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
 			if (is_layout_rtl()) {
-				add_button->set_icon(groups->get_theme_icon("Back", "EditorIcons"));
-				remove_button->set_icon(groups->get_theme_icon("Forward", "EditorIcons"));
+				add_button->set_icon(groups->get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
+				remove_button->set_icon(groups->get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 			} else {
-				add_button->set_icon(groups->get_theme_icon("Forward", "EditorIcons"));
-				remove_button->set_icon(groups->get_theme_icon("Back", "EditorIcons"));
+				add_button->set_icon(groups->get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
+				remove_button->set_icon(groups->get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 			}
 
-			add_filter->set_right_icon(groups->get_theme_icon("Search", "EditorIcons"));
+			add_filter->set_right_icon(groups->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			add_filter->set_clear_button_enabled(true);
-			remove_filter->set_right_icon(groups->get_theme_icon("Search", "EditorIcons"));
+			remove_filter->set_right_icon(groups->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			remove_filter->set_clear_button_enabled(true);
 		} break;
 	}
@@ -655,7 +655,7 @@ void GroupsEditor::update_tree() {
 		TreeItem *item = tree->create_item(root);
 		item->set_text(0, gi.name);
 		if (can_be_deleted) {
-			item->add_button(0, get_theme_icon("Remove", "EditorIcons"), 0);
+			item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0);
 		} else {
 			item->set_selectable(0, false);
 		}

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -105,7 +105,7 @@ void SceneImportSettings::_fill_material(Tree *p_tree, const Ref<Material> &p_ma
 
 	MaterialData &material_data = material_map[import_id];
 
-	Ref<Texture2D> icon = get_theme_icon("StandardMaterial3D", "EditorIcons");
+	Ref<Texture2D> icon = get_theme_icon(SNAME("StandardMaterial3D"), SNAME("EditorIcons"));
 
 	TreeItem *item = p_tree->create_item(p_parent);
 	item->set_text(0, p_material->get_name());
@@ -161,7 +161,7 @@ void SceneImportSettings::_fill_mesh(Tree *p_tree, const Ref<Mesh> &p_mesh, Tree
 
 	MeshData &mesh_data = mesh_map[import_id];
 
-	Ref<Texture2D> icon = get_theme_icon("Mesh", "EditorIcons");
+	Ref<Texture2D> icon = get_theme_icon(SNAME("Mesh"), SNAME("EditorIcons"));
 
 	TreeItem *item = p_tree->create_item(p_parent);
 	item->set_text(0, p_mesh->get_name());
@@ -211,7 +211,7 @@ void SceneImportSettings::_fill_animation(Tree *p_tree, const Ref<Animation> &p_
 
 	AnimationData &animation_data = animation_map[p_name];
 
-	Ref<Texture2D> icon = get_theme_icon("Animation", "EditorIcons");
+	Ref<Texture2D> icon = get_theme_icon(SNAME("Animation"), SNAME("EditorIcons"));
 
 	TreeItem *item = p_tree->create_item(p_parent);
 	item->set_text(0, p_name);
@@ -255,17 +255,17 @@ void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
 
 	String type = p_node->get_class();
 
-	if (!has_theme_icon(type, "EditorIcons")) {
+	if (!has_theme_icon(type, SNAME("EditorIcons"))) {
 		type = "Node3D";
 	}
 
-	Ref<Texture2D> icon = get_theme_icon(type, "EditorIcons");
+	Ref<Texture2D> icon = get_theme_icon(type, SNAME("EditorIcons"));
 
 	TreeItem *item = scene_tree->create_item(p_parent_item);
 	item->set_text(0, p_node->get_name());
 
 	if (p_node == scene) {
-		icon = get_theme_icon("PackedScene", "EditorIcons");
+		icon = get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
 		item->set_text(0, "Scene");
 	}
 
@@ -795,11 +795,11 @@ void SceneImportSettings::_save_path_changed(const String &p_path) {
 	if (FileAccess::exists(p_path)) {
 		save_path_item->set_text(2, "Warning: File exists");
 		save_path_item->set_tooltip(2, TTR("Existing file with the same name will be replaced."));
-		save_path_item->set_icon(2, get_theme_icon("StatusWarning", "EditorIcons"));
+		save_path_item->set_icon(2, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 
 	} else {
 		save_path_item->set_text(2, "Will create new File");
-		save_path_item->set_icon(2, get_theme_icon("StatusSuccess", "EditorIcons"));
+		save_path_item->set_icon(2, get_theme_icon(SNAME("StatusSuccess"), SNAME("EditorIcons")));
 	}
 }
 
@@ -829,7 +829,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 				String name = md.material_node->get_text(0);
 
 				item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-				item->set_icon(0, get_theme_icon("StandardMaterial3D", "EditorIcons"));
+				item->set_icon(0, get_theme_icon(SNAME("StandardMaterial3D"), SNAME("EditorIcons")));
 				item->set_text(0, name);
 
 				if (md.has_import_id) {
@@ -851,20 +851,20 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 						if (FileAccess::exists(path)) {
 							item->set_text(2, "Warning: File exists");
 							item->set_tooltip(2, TTR("Existing file with the same name will be replaced."));
-							item->set_icon(2, get_theme_icon("StatusWarning", "EditorIcons"));
+							item->set_icon(2, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 
 						} else {
 							item->set_text(2, "Will create new File");
-							item->set_icon(2, get_theme_icon("StatusSuccess", "EditorIcons"));
+							item->set_icon(2, get_theme_icon(SNAME("StatusSuccess"), SNAME("EditorIcons")));
 						}
 
-						item->add_button(1, get_theme_icon("Folder", "EditorIcons"));
+						item->add_button(1, get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 					}
 
 				} else {
 					item->set_text(2, "No import ID");
 					item->set_tooltip(2, TTR("Material has no name nor any other way to identify on re-import.\nPlease name it or ensure it is exported with an unique ID."));
-					item->set_icon(2, get_theme_icon("StatusError", "EditorIcons"));
+					item->set_icon(2, get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
 				}
 
 				save_path_items.push_back(item);
@@ -882,7 +882,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 				String name = md.mesh_node->get_text(0);
 
 				item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-				item->set_icon(0, get_theme_icon("Mesh", "EditorIcons"));
+				item->set_icon(0, get_theme_icon(SNAME("Mesh"), SNAME("EditorIcons")));
 				item->set_text(0, name);
 
 				if (md.has_import_id) {
@@ -904,20 +904,20 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 						if (FileAccess::exists(path)) {
 							item->set_text(2, "Warning: File exists");
 							item->set_tooltip(2, TTR("Existing file with the same name will be replaced on import."));
-							item->set_icon(2, get_theme_icon("StatusWarning", "EditorIcons"));
+							item->set_icon(2, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 
 						} else {
 							item->set_text(2, "Will save to new File");
-							item->set_icon(2, get_theme_icon("StatusSuccess", "EditorIcons"));
+							item->set_icon(2, get_theme_icon(SNAME("StatusSuccess"), SNAME("EditorIcons")));
 						}
 
-						item->add_button(1, get_theme_icon("Folder", "EditorIcons"));
+						item->add_button(1, get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 					}
 
 				} else {
 					item->set_text(2, "No import ID");
 					item->set_tooltip(2, TTR("Mesh has no name nor any other way to identify on re-import.\nPlease name it or ensure it is exported with an unique ID."));
-					item->set_icon(2, get_theme_icon("StatusError", "EditorIcons"));
+					item->set_icon(2, get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
 				}
 
 				save_path_items.push_back(item);
@@ -935,7 +935,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 				String name = ad.scene_node->get_text(0);
 
 				item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-				item->set_icon(0, get_theme_icon("Animation", "EditorIcons"));
+				item->set_icon(0, get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")));
 				item->set_text(0, name);
 
 				if (ad.settings.has("save_to_file/enabled") && bool(ad.settings["save_to_file/enabled"])) {
@@ -956,14 +956,14 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 					if (FileAccess::exists(path)) {
 						item->set_text(2, "Warning: File exists");
 						item->set_tooltip(2, TTR("Existing file with the same name will be replaced on import."));
-						item->set_icon(2, get_theme_icon("StatusWarning", "EditorIcons"));
+						item->set_icon(2, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 
 					} else {
 						item->set_text(2, "Will save to new File");
-						item->set_icon(2, get_theme_icon("StatusSuccess", "EditorIcons"));
+						item->set_icon(2, get_theme_icon(SNAME("StatusSuccess"), SNAME("EditorIcons")));
 					}
 
-					item->add_button(1, get_theme_icon("Folder", "EditorIcons"));
+					item->add_button(1, get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 				}
 
 				save_path_items.push_back(item);

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -98,7 +98,7 @@ void ImportDefaultsEditor::_save() {
 			ProjectSettings::get_singleton()->set("importer_defaults/" + settings->importer->get_importer_name(), Variant());
 		}
 
-		emit_signal("project_settings_changed");
+		emit_signal(SNAME("project_settings_changed"));
 	}
 }
 

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -526,18 +526,18 @@ void ImportDock::_reimport() {
 	}
 
 	EditorFileSystem::get_singleton()->reimport_files(params->paths);
-	EditorFileSystem::get_singleton()->emit_signal("filesystem_changed"); //it changed, so force emitting the signal
+	EditorFileSystem::get_singleton()->emit_signal(SNAME("filesystem_changed")); //it changed, so force emitting the signal
 }
 
 void ImportDock::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			imported->add_theme_style_override("normal", get_theme_stylebox("normal", "LineEdit"));
+			imported->add_theme_style_override("normal", get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
 			import_opts->edit(params);
-			label_warning->add_theme_color_override("font_color", get_theme_color("warning_color", "Editor"));
+			label_warning->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		} break;
 	}
 }
@@ -563,7 +563,7 @@ void ImportDock::initialize_import_options() const {
 ImportDock::ImportDock() {
 	set_name("Import");
 	imported = memnew(Label);
-	imported->add_theme_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("normal", "LineEdit"));
+	imported->add_theme_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 	imported->set_clip_text(true);
 	add_child(imported);
 	HBoxContainer *hb = memnew(HBoxContainer);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -63,7 +63,7 @@ void InspectorDock::_menu_option(int p_option) {
 		case OBJECT_REQUEST_HELP: {
 			if (current) {
 				editor->set_visible_editor(EditorNode::EDITOR_SCRIPT);
-				emit_signal("request_help", current->get_class());
+				emit_signal(SNAME("request_help"), current->get_class());
 			}
 		} break;
 
@@ -216,7 +216,7 @@ void InspectorDock::_prepare_history() {
 
 	history_menu->get_popup()->clear();
 
-	Ref<Texture2D> base_icon = get_theme_icon("Object", "EditorIcons");
+	Ref<Texture2D> base_icon = get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
 	Set<ObjectID> already;
 	for (int i = editor_history->get_history_len() - 1; i >= history_to; i--) {
 		ObjectID id = editor_history->get_history_obj(i);
@@ -337,27 +337,27 @@ void InspectorDock::_notification(int p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			set_theme(editor->get_gui_base()->get_theme());
 
-			resource_new_button->set_icon(get_theme_icon("New", "EditorIcons"));
-			resource_load_button->set_icon(get_theme_icon("Load", "EditorIcons"));
-			resource_save_button->set_icon(get_theme_icon("Save", "EditorIcons"));
-			resource_extra_button->set_icon(get_theme_icon("GuiTabMenu", "EditorIcons"));
+			resource_new_button->set_icon(get_theme_icon(SNAME("New"), SNAME("EditorIcons")));
+			resource_load_button->set_icon(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")));
+			resource_save_button->set_icon(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")));
+			resource_extra_button->set_icon(get_theme_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
 
 			PopupMenu *resource_extra_popup = resource_extra_button->get_popup();
-			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_EDIT_CLIPBOARD), get_theme_icon("ActionPaste", "EditorIcons"));
-			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_COPY), get_theme_icon("ActionCopy", "EditorIcons"));
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_EDIT_CLIPBOARD), get_theme_icon(SNAME("ActionPaste"), SNAME("EditorIcons")));
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_COPY), get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")));
 
 			if (is_layout_rtl()) {
-				backward_button->set_icon(get_theme_icon("Forward", "EditorIcons"));
-				forward_button->set_icon(get_theme_icon("Back", "EditorIcons"));
+				backward_button->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
+				forward_button->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 			} else {
-				backward_button->set_icon(get_theme_icon("Back", "EditorIcons"));
-				forward_button->set_icon(get_theme_icon("Forward", "EditorIcons"));
+				backward_button->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
+				forward_button->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 			}
 
-			history_menu->set_icon(get_theme_icon("History", "EditorIcons"));
-			object_menu->set_icon(get_theme_icon("Tools", "EditorIcons"));
-			warning->set_icon(get_theme_icon("NodeWarning", "EditorIcons"));
-			warning->add_theme_color_override("font_color", get_theme_color("warning_color", "Editor"));
+			history_menu->set_icon(get_theme_icon(SNAME("History"), SNAME("EditorIcons")));
+			object_menu->set_icon(get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
+			warning->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
+			warning->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		} break;
 	}
 }
@@ -433,8 +433,8 @@ void InspectorDock::update(Object *p_object) {
 	PopupMenu *p = object_menu->get_popup();
 
 	p->clear();
-	p->add_icon_shortcut(get_theme_icon("GuiTreeArrowDown", "EditorIcons"), ED_SHORTCUT("property_editor/expand_all", TTR("Expand All")), EXPAND_ALL);
-	p->add_icon_shortcut(get_theme_icon("GuiTreeArrowRight", "EditorIcons"), ED_SHORTCUT("property_editor/collapse_all", TTR("Collapse All")), COLLAPSE_ALL);
+	p->add_icon_shortcut(get_theme_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")), ED_SHORTCUT("property_editor/expand_all", TTR("Expand All")), EXPAND_ALL);
+	p->add_icon_shortcut(get_theme_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")), ED_SHORTCUT("property_editor/collapse_all", TTR("Collapse All")), COLLAPSE_ALL);
 	p->add_separator();
 
 	p->add_shortcut(ED_SHORTCUT("property_editor/copy_params", TTR("Copy Properties")), OBJECT_COPY_PARAMS);
@@ -499,7 +499,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	resource_new_button = memnew(Button);
 	resource_new_button->set_flat(true);
 	resource_new_button->set_tooltip(TTR("Create a new resource in memory and edit it."));
-	resource_new_button->set_icon(get_theme_icon("New", "EditorIcons"));
+	resource_new_button->set_icon(get_theme_icon(SNAME("New"), SNAME("EditorIcons")));
 	general_options_hb->add_child(resource_new_button);
 	resource_new_button->connect("pressed", callable_mp(this, &InspectorDock::_new_resource));
 	resource_new_button->set_focus_mode(Control::FOCUS_NONE);
@@ -507,14 +507,14 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	resource_load_button = memnew(Button);
 	resource_load_button->set_flat(true);
 	resource_load_button->set_tooltip(TTR("Load an existing resource from disk and edit it."));
-	resource_load_button->set_icon(get_theme_icon("Load", "EditorIcons"));
+	resource_load_button->set_icon(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")));
 	general_options_hb->add_child(resource_load_button);
 	resource_load_button->connect("pressed", callable_mp(this, &InspectorDock::_open_resource_selector));
 	resource_load_button->set_focus_mode(Control::FOCUS_NONE);
 
 	resource_save_button = memnew(MenuButton);
 	resource_save_button->set_tooltip(TTR("Save the currently edited resource."));
-	resource_save_button->set_icon(get_theme_icon("Save", "EditorIcons"));
+	resource_save_button->set_icon(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")));
 	general_options_hb->add_child(resource_save_button);
 	resource_save_button->get_popup()->add_item(TTR("Save"), RESOURCE_SAVE);
 	resource_save_button->get_popup()->add_item(TTR("Save As..."), RESOURCE_SAVE_AS);
@@ -523,10 +523,10 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	resource_save_button->set_disabled(true);
 
 	resource_extra_button = memnew(MenuButton);
-	resource_extra_button->set_icon(get_theme_icon("GuiTabMenu", "EditorIcons"));
+	resource_extra_button->set_icon(get_theme_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
 	general_options_hb->add_child(resource_extra_button);
-	resource_extra_button->get_popup()->add_icon_shortcut(get_theme_icon("ActionPaste", "EditorIcons"), ED_SHORTCUT("property_editor/paste_resource", TTR("Edit Resource from Clipboard")), RESOURCE_EDIT_CLIPBOARD);
-	resource_extra_button->get_popup()->add_icon_shortcut(get_theme_icon("ActionCopy", "EditorIcons"), ED_SHORTCUT("property_editor/copy_resource", TTR("Copy Resource")), RESOURCE_COPY);
+	resource_extra_button->get_popup()->add_icon_shortcut(get_theme_icon(SNAME("ActionPaste"), SNAME("EditorIcons")), ED_SHORTCUT("property_editor/paste_resource", TTR("Edit Resource from Clipboard")), RESOURCE_EDIT_CLIPBOARD);
+	resource_extra_button->get_popup()->add_icon_shortcut(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")), ED_SHORTCUT("property_editor/copy_resource", TTR("Copy Resource")), RESOURCE_COPY);
 	resource_extra_button->get_popup()->set_item_disabled(1, true);
 	resource_extra_button->get_popup()->add_separator();
 	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/unref_resource", TTR("Make Resource Built-In")), RESOURCE_MAKE_BUILT_IN);
@@ -539,9 +539,9 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	backward_button->set_flat(true);
 	general_options_hb->add_child(backward_button);
 	if (is_layout_rtl()) {
-		backward_button->set_icon(get_theme_icon("Forward", "EditorIcons"));
+		backward_button->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 	} else {
-		backward_button->set_icon(get_theme_icon("Back", "EditorIcons"));
+		backward_button->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 	}
 	backward_button->set_tooltip(TTR("Go to the previous edited object in history."));
 	backward_button->set_disabled(true);
@@ -551,9 +551,9 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	forward_button->set_flat(true);
 	general_options_hb->add_child(forward_button);
 	if (is_layout_rtl()) {
-		forward_button->set_icon(get_theme_icon("Back", "EditorIcons"));
+		forward_button->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 	} else {
-		forward_button->set_icon(get_theme_icon("Forward", "EditorIcons"));
+		forward_button->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 	}
 	forward_button->set_tooltip(TTR("Go to the next edited object in history."));
 	forward_button->set_disabled(true);
@@ -561,7 +561,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 
 	history_menu = memnew(MenuButton);
 	history_menu->set_tooltip(TTR("History of recently edited objects."));
-	history_menu->set_icon(get_theme_icon("History", "EditorIcons"));
+	history_menu->set_icon(get_theme_icon(SNAME("History"), SNAME("EditorIcons")));
 	general_options_hb->add_child(history_menu);
 	history_menu->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_history));
 	history_menu->get_popup()->connect("id_pressed", callable_mp(this, &InspectorDock::_select_history));
@@ -576,7 +576,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	open_docs_button->set_flat(true);
 	open_docs_button->set_visible(false);
 	open_docs_button->set_tooltip(TTR("Open documentation for this object."));
-	open_docs_button->set_icon(get_theme_icon("HelpSearch", "EditorIcons"));
+	open_docs_button->set_icon(get_theme_icon(SNAME("HelpSearch"), SNAME("EditorIcons")));
 	open_docs_button->set_shortcut(ED_SHORTCUT("property_editor/open_help", TTR("Open Documentation")));
 	subresource_hb->add_child(open_docs_button);
 	open_docs_button->connect("pressed", callable_mp(this, &InspectorDock::_menu_option), varray(OBJECT_REQUEST_HELP));
@@ -592,13 +592,13 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	search = memnew(LineEdit);
 	search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search->set_placeholder(TTR("Filter properties"));
-	search->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+	search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	search->set_clear_button_enabled(true);
 	property_tools_hb->add_child(search);
 
 	object_menu = memnew(MenuButton);
 	object_menu->set_shortcut_context(this);
-	object_menu->set_icon(get_theme_icon("Tools", "EditorIcons"));
+	object_menu->set_icon(get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 	property_tools_hb->add_child(object_menu);
 	object_menu->set_tooltip(TTR("Manage object properties."));
 	object_menu->get_popup()->connect("id_pressed", callable_mp(this, &InspectorDock::_menu_option));
@@ -606,8 +606,8 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	warning = memnew(Button);
 	add_child(warning);
 	warning->set_text(TTR("Changes may be lost!"));
-	warning->set_icon(get_theme_icon("NodeWarning", "EditorIcons"));
-	warning->add_theme_color_override("font_color", get_theme_color("warning_color", "Editor"));
+	warning->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
+	warning->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 	warning->set_clip_text(true);
 	warning->hide();
 	warning->connect("pressed", callable_mp(this, &InspectorDock::_warning_pressed));

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -176,7 +176,7 @@ void LocalizationEditor::_translation_res_select() {
 		return;
 	}
 
-	call_deferred("update_translations");
+	call_deferred(SNAME("update_translations"));
 }
 
 void LocalizationEditor::_translation_res_option_changed() {
@@ -453,7 +453,7 @@ void LocalizationEditor::update_translations() {
 			t->set_text(0, translations[i].replace_first("res://", ""));
 			t->set_tooltip(0, translations[i]);
 			t->set_metadata(0, i);
-			t->add_button(0, get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
+			t->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
 		}
 	}
 
@@ -571,7 +571,7 @@ void LocalizationEditor::update_translations() {
 			t->set_text(0, keys[i].replace_first("res://", ""));
 			t->set_tooltip(0, keys[i]);
 			t->set_metadata(0, keys[i]);
-			t->add_button(0, get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
+			t->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
 			if (keys[i] == remap_selected) {
 				t->select(0);
 				translation_res_option_add_button->set_disabled(false);
@@ -588,7 +588,7 @@ void LocalizationEditor::update_translations() {
 					t2->set_text(0, path.replace_first("res://", ""));
 					t2->set_tooltip(0, path);
 					t2->set_metadata(0, j);
-					t2->add_button(0, get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
+					t2->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
 					t2->set_cell_mode(1, TreeItem::CELL_MODE_RANGE);
 					t2->set_text(1, langnames);
 					t2->set_editable(1, true);
@@ -621,7 +621,7 @@ void LocalizationEditor::update_translations() {
 			t->set_text(0, pot_translations[i].replace_first("res://", ""));
 			t->set_tooltip(0, pot_translations[i]);
 			t->set_metadata(0, i);
-			t->add_button(0, get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
+			t->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
 		}
 	}
 

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -782,9 +782,9 @@ Light3DGizmoPlugin::Light3DGizmoPlugin() {
 	create_material("lines_secondary", Color(1, 1, 1, 0.35), false, false, true);
 	create_material("lines_billboard", Color(1, 1, 1), true, false, true);
 
-	create_icon_material("light_directional_icon", Node3DEditor::get_singleton()->get_theme_icon("GizmoDirectionalLight", "EditorIcons"));
-	create_icon_material("light_omni_icon", Node3DEditor::get_singleton()->get_theme_icon("GizmoLight", "EditorIcons"));
-	create_icon_material("light_spot_icon", Node3DEditor::get_singleton()->get_theme_icon("GizmoSpotLight", "EditorIcons"));
+	create_icon_material("light_directional_icon", Node3DEditor::get_singleton()->get_theme_icon(SNAME("GizmoDirectionalLight"), SNAME("EditorIcons")));
+	create_icon_material("light_omni_icon", Node3DEditor::get_singleton()->get_theme_icon(SNAME("GizmoLight"), SNAME("EditorIcons")));
+	create_icon_material("light_spot_icon", Node3DEditor::get_singleton()->get_theme_icon(SNAME("GizmoSpotLight"), SNAME("EditorIcons")));
 
 	create_handle_material("handles");
 	create_handle_material("handles_billboard", true);
@@ -1050,7 +1050,7 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 AudioStreamPlayer3DGizmoPlugin::AudioStreamPlayer3DGizmoPlugin() {
 	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/stream_player_3d", Color(0.4, 0.8, 1));
 
-	create_icon_material("stream_player_3d_icon", Node3DEditor::get_singleton()->get_theme_icon("Gizmo3DSamplePlayer", "EditorIcons"));
+	create_icon_material("stream_player_3d_icon", Node3DEditor::get_singleton()->get_theme_icon(SNAME("Gizmo3DSamplePlayer"), SNAME("EditorIcons")));
 	create_material("stream_player_3d_material_primary", gizmo_color);
 	create_material("stream_player_3d_material_secondary", gizmo_color * Color(1, 1, 1, 0.35));
 	create_handle_material("handles");
@@ -1558,7 +1558,7 @@ Position3DGizmoPlugin::Position3DGizmoPlugin() {
 	// Use a darkened axis color for the negative axis.
 	// This makes it possible to see in which direction the Position3D node is rotated
 	// (which can be important depending on how it's used).
-	const Color color_x = EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_x_color", "Editor");
+	const Color color_x = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("axis_x_color"), SNAME("Editor"));
 	cursor_colors.push_back(color_x);
 	cursor_colors.push_back(color_x);
 	// FIXME: Use less strong darkening factor once GH-48573 is fixed.
@@ -1566,13 +1566,13 @@ Position3DGizmoPlugin::Position3DGizmoPlugin() {
 	cursor_colors.push_back(color_x.lerp(Color(0, 0, 0), 0.75));
 	cursor_colors.push_back(color_x.lerp(Color(0, 0, 0), 0.75));
 
-	const Color color_y = EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_y_color", "Editor");
+	const Color color_y = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("axis_y_color"), SNAME("Editor"));
 	cursor_colors.push_back(color_y);
 	cursor_colors.push_back(color_y);
 	cursor_colors.push_back(color_y.lerp(Color(0, 0, 0), 0.75));
 	cursor_colors.push_back(color_y.lerp(Color(0, 0, 0), 0.75));
 
-	const Color color_z = EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_z_color", "Editor");
+	const Color color_z = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("axis_z_color"), SNAME("Editor"));
 	cursor_colors.push_back(color_z);
 	cursor_colors.push_back(color_z);
 	cursor_colors.push_back(color_z.lerp(Color(0, 0, 0), 0.75));
@@ -2284,7 +2284,7 @@ void VisibleOnScreenNotifier3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 CPUParticles3DGizmoPlugin::CPUParticles3DGizmoPlugin() {
-	create_icon_material("particles_icon", Node3DEditor::get_singleton()->get_theme_icon("GizmoCPUParticles3D", "EditorIcons"));
+	create_icon_material("particles_icon", Node3DEditor::get_singleton()->get_theme_icon(SNAME("GizmoCPUParticles3D"), SNAME("EditorIcons")));
 }
 
 bool CPUParticles3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -2315,7 +2315,7 @@ GPUParticles3DGizmoPlugin::GPUParticles3DGizmoPlugin() {
 	create_material("particles_material", gizmo_color);
 	gizmo_color.a = 0.1;
 	create_material("particles_solid_material", gizmo_color);
-	create_icon_material("particles_icon", Node3DEditor::get_singleton()->get_theme_icon("GizmoGPUParticles3D", "EditorIcons"));
+	create_icon_material("particles_icon", Node3DEditor::get_singleton()->get_theme_icon(SNAME("GizmoGPUParticles3D"), SNAME("EditorIcons")));
 	create_handle_material("handles");
 }
 
@@ -2746,7 +2746,7 @@ ReflectionProbeGizmoPlugin::ReflectionProbeGizmoPlugin() {
 	gizmo_color.a = 0.1;
 	create_material("reflection_probe_solid_material", gizmo_color);
 
-	create_icon_material("reflection_probe_icon", Node3DEditor::get_singleton()->get_theme_icon("GizmoReflectionProbe", "EditorIcons"));
+	create_icon_material("reflection_probe_icon", Node3DEditor::get_singleton()->get_theme_icon(SNAME("GizmoReflectionProbe"), SNAME("EditorIcons")));
 	create_handle_material("handles");
 }
 
@@ -3072,7 +3072,7 @@ VoxelGIGizmoPlugin::VoxelGIGizmoPlugin() {
 	gizmo_color.a = 0.05;
 	create_material("voxel_gi_solid_material", gizmo_color);
 
-	create_icon_material("voxel_gi_icon", Node3DEditor::get_singleton()->get_theme_icon("GizmoVoxelGI", "EditorIcons"));
+	create_icon_material("voxel_gi_icon", Node3DEditor::get_singleton()->get_theme_icon(SNAME("GizmoVoxelGI"), SNAME("EditorIcons")));
 	create_handle_material("handles");
 }
 
@@ -3254,7 +3254,7 @@ LightmapGIGizmoPlugin::LightmapGIGizmoPlugin() {
 
 	add_material("lightmap_probe_material", mat);
 
-	create_icon_material("baked_indirect_light_icon", Node3DEditor::get_singleton()->get_theme_icon("GizmoLightmapGI", "EditorIcons"));
+	create_icon_material("baked_indirect_light_icon", Node3DEditor::get_singleton()->get_theme_icon(SNAME("GizmoLightmapGI"), SNAME("EditorIcons")));
 }
 
 String LightmapGIGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
@@ -4589,7 +4589,7 @@ Joint3DGizmoPlugin::Joint3DGizmoPlugin() {
 	update_timer->set_wait_time(1.0 / 120.0);
 	update_timer->connect("timeout", callable_mp(this, &Joint3DGizmoPlugin::incremental_update_gizmos));
 	update_timer->set_autostart(true);
-	EditorNode::get_singleton()->call_deferred("add_child", update_timer);
+	EditorNode::get_singleton()->call_deferred(SNAME("add_child"), update_timer);
 }
 
 void Joint3DGizmoPlugin::incremental_update_gizmos() {

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -52,8 +52,8 @@ void NodeDock::_bind_methods() {
 
 void NodeDock::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		connections_button->set_icon(get_theme_icon("Signals", "EditorIcons"));
-		groups_button->set_icon(get_theme_icon("Groups", "EditorIcons"));
+		connections_button->set_icon(get_theme_icon(SNAME("Signals"), SNAME("EditorIcons")));
+		groups_button->set_icon(get_theme_icon(SNAME("Groups"), SNAME("EditorIcons")));
 	}
 }
 

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -113,7 +113,7 @@ void PluginConfigDialog::_on_confirmed() {
 		}
 #endif
 
-		emit_signal("plugin_ready", script.operator->(), active_edit->is_pressed() ? _to_absolute_plugin_path(subfolder_edit->get_text()) : "");
+		emit_signal(SNAME("plugin_ready"), script.operator->(), active_edit->is_pressed() ? _to_absolute_plugin_path(subfolder_edit->get_text()) : "");
 	} else {
 		EditorNode::get_singleton()->get_project_settings()->update_plugins();
 	}
@@ -128,8 +128,8 @@ void PluginConfigDialog::_on_required_text_changed(const String &) {
 	int lang_idx = script_option_edit->get_selected();
 	String ext = ScriptServer::get_language(lang_idx)->get_extension();
 
-	Ref<Texture2D> valid_icon = get_theme_icon("StatusSuccess", "EditorIcons");
-	Ref<Texture2D> invalid_icon = get_theme_icon("StatusWarning", "EditorIcons");
+	Ref<Texture2D> valid_icon = get_theme_icon(SNAME("StatusSuccess"), SNAME("EditorIcons"));
+	Ref<Texture2D> invalid_icon = get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons"));
 
 	// Set variables to assume all is valid
 	bool is_valid = true;

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -150,9 +150,9 @@ void AbstractPolygon2DEditor::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			disable_polygon_editing(false, String());
 
-			button_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveCreate", "EditorIcons"));
-			button_edit->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveEdit", "EditorIcons"));
-			button_delete->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveDelete", "EditorIcons"));
+			button_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveCreate"), SNAME("EditorIcons")));
+			button_edit->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveEdit"), SNAME("EditorIcons")));
+			button_delete->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveDelete"), SNAME("EditorIcons")));
 			button_edit->set_pressed(true);
 
 			get_tree()->connect("node_removed", callable_mp(this, &AbstractPolygon2DEditor::_node_removed));
@@ -477,7 +477,7 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 
 	Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_global_transform();
 	// All polygon points are sharp, so use the sharp handle icon
-	const Ref<Texture2D> handle = get_theme_icon("EditorPathSharpHandle", "EditorIcons");
+	const Ref<Texture2D> handle = get_theme_icon(SNAME("EditorPathSharpHandle"), SNAME("EditorIcons"));
 
 	const Vertex active_point = get_active_point();
 	const int n_polygons = _get_polygon_count();
@@ -550,8 +550,8 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 			p_overlay->draw_texture(handle, point - handle->get_size() * 0.5, modulate);
 
 			if (vertex == hover_point) {
-				Ref<Font> font = get_theme_font("font", "Label");
-				int font_size = get_theme_font_size("font_size", "Label");
+				Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+				int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 				String num = String::num(vertex.vertex);
 				Size2 num_size = font->get_string_size(num, font_size);
 				p_overlay->draw_string(font, point - num_size * 0.5, num, HALIGN_LEFT, -1, font_size, Color(1.0, 1.0, 1.0, 0.5));
@@ -560,7 +560,7 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 	}
 
 	if (edge_point.valid()) {
-		Ref<Texture2D> add_handle = get_theme_icon("EditorHandleAdd", "EditorIcons");
+		Ref<Texture2D> add_handle = get_theme_icon(SNAME("EditorHandleAdd"), SNAME("EditorIcons"));
 		p_overlay->draw_texture(add_handle, edge_point.pos - add_handle->get_size() * 0.5);
 	}
 }

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -73,7 +73,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 				ap->get_animation_list(&names);
 
 				for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-					animations_menu->add_icon_item(get_theme_icon("Animation", "EditorIcons"), E->get());
+					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E->get());
 					animations_to_add.push_back(E->get());
 				}
 			}
@@ -196,19 +196,19 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 }
 
 void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
-	Color linecolor = get_theme_color("font_color", "Label");
+	Color linecolor = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	Color linecolor_soft = linecolor;
 	linecolor_soft.a *= 0.5;
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
-	Ref<Texture2D> icon = get_theme_icon("KeyValue", "EditorIcons");
-	Ref<Texture2D> icon_selected = get_theme_icon("KeySelected", "EditorIcons");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+	Ref<Texture2D> icon = get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons"));
+	Ref<Texture2D> icon_selected = get_theme_icon(SNAME("KeySelected"), SNAME("EditorIcons"));
 
 	Size2 s = blend_space_draw->get_size();
 
 	if (blend_space_draw->has_focus()) {
-		Color color = get_theme_color("accent_color", "Editor");
+		Color color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		blend_space_draw->draw_rect(Rect2(Point2(), s), color, false);
 	}
 
@@ -279,7 +279,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 	{
 		Color color;
 		if (tool_blend->is_pressed()) {
-			color = get_theme_color("accent_color", "Editor");
+			color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		} else {
 			color = linecolor;
 			color.a *= 0.5;
@@ -529,15 +529,15 @@ void AnimationNodeBlendSpace1DEditor::_open_editor() {
 
 void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		error_panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-		error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
-		panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-		tool_blend->set_icon(get_theme_icon("EditPivot", "EditorIcons"));
-		tool_select->set_icon(get_theme_icon("ToolSelect", "EditorIcons"));
-		tool_create->set_icon(get_theme_icon("EditKey", "EditorIcons"));
-		tool_erase->set_icon(get_theme_icon("Remove", "EditorIcons"));
-		snap->set_icon(get_theme_icon("SnapGrid", "EditorIcons"));
-		open_editor->set_icon(get_theme_icon("Edit", "EditorIcons"));
+		error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		tool_blend->set_icon(get_theme_icon(SNAME("EditPivot"), SNAME("EditorIcons")));
+		tool_select->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
+		tool_create->set_icon(get_theme_icon(SNAME("EditKey"), SNAME("EditorIcons")));
+		tool_erase->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+		snap->set_icon(get_theme_icon(SNAME("SnapGrid"), SNAME("EditorIcons")));
+		open_editor->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 	}
 
 	if (p_what == NOTIFICATION_PROCESS) {

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -97,7 +97,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 				List<StringName> names;
 				ap->get_animation_list(&names);
 				for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-					animations_menu->add_icon_item(get_theme_icon("Animation", "EditorIcons"), E->get());
+					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E->get());
 					animations_to_add.push_back(E->get());
 				}
 			}
@@ -392,18 +392,18 @@ void AnimationNodeBlendSpace2DEditor::_tool_switch(int p_tool) {
 }
 
 void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
-	Color linecolor = get_theme_color("font_color", "Label");
+	Color linecolor = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	Color linecolor_soft = linecolor;
 	linecolor_soft.a *= 0.5;
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
-	Ref<Texture2D> icon = get_theme_icon("KeyValue", "EditorIcons");
-	Ref<Texture2D> icon_selected = get_theme_icon("KeySelected", "EditorIcons");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+	Ref<Texture2D> icon = get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons"));
+	Ref<Texture2D> icon_selected = get_theme_icon(SNAME("KeySelected"), SNAME("EditorIcons"));
 
 	Size2 s = blend_space_draw->get_size();
 
 	if (blend_space_draw->has_focus()) {
-		Color color = get_theme_color("accent_color", "Editor");
+		Color color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		blend_space_draw->draw_rect(Rect2(Point2(), s), color, false);
 	}
 	blend_space_draw->draw_line(Point2(1, 0), Point2(1, s.height - 1), linecolor);
@@ -483,7 +483,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 
 		Color color;
 		if (i == selected_triangle) {
-			color = get_theme_color("accent_color", "Editor");
+			color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			color.a *= 0.5;
 		} else {
 			color = linecolor;
@@ -543,7 +543,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 	{
 		Color color;
 		if (tool_blend->is_pressed()) {
-			color = get_theme_color("accent_color", "Editor");
+			color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		} else {
 			color = linecolor;
 			color.a *= 0.5;
@@ -733,21 +733,21 @@ void AnimationNodeBlendSpace2DEditor::_edit_point_pos(double) {
 
 void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		error_panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-		error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
-		panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-		tool_blend->set_icon(get_theme_icon("EditPivot", "EditorIcons"));
-		tool_select->set_icon(get_theme_icon("ToolSelect", "EditorIcons"));
-		tool_create->set_icon(get_theme_icon("EditKey", "EditorIcons"));
-		tool_triangle->set_icon(get_theme_icon("ToolTriangle", "EditorIcons"));
-		tool_erase->set_icon(get_theme_icon("Remove", "EditorIcons"));
-		snap->set_icon(get_theme_icon("SnapGrid", "EditorIcons"));
-		open_editor->set_icon(get_theme_icon("Edit", "EditorIcons"));
-		auto_triangles->set_icon(get_theme_icon("AutoTriangle", "EditorIcons"));
+		error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		tool_blend->set_icon(get_theme_icon(SNAME("EditPivot"), SNAME("EditorIcons")));
+		tool_select->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
+		tool_create->set_icon(get_theme_icon(SNAME("EditKey"), SNAME("EditorIcons")));
+		tool_triangle->set_icon(get_theme_icon(SNAME("ToolTriangle"), SNAME("EditorIcons")));
+		tool_erase->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+		snap->set_icon(get_theme_icon(SNAME("SnapGrid"), SNAME("EditorIcons")));
+		open_editor->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+		auto_triangles->set_icon(get_theme_icon(SNAME("AutoTriangle"), SNAME("EditorIcons")));
 		interpolation->clear();
-		interpolation->add_icon_item(get_theme_icon("TrackContinuous", "EditorIcons"), "", 0);
-		interpolation->add_icon_item(get_theme_icon("TrackDiscrete", "EditorIcons"), "", 1);
-		interpolation->add_icon_item(get_theme_icon("TrackCapture", "EditorIcons"), "", 2);
+		interpolation->add_icon_item(get_theme_icon(SNAME("TrackContinuous"), SNAME("EditorIcons")), "", 0);
+		interpolation->add_icon_item(get_theme_icon(SNAME("TrackDiscrete"), SNAME("EditorIcons")), "", 1);
+		interpolation->add_icon_item(get_theme_icon(SNAME("TrackCapture"), SNAME("EditorIcons")), "", 2);
 	}
 
 	if (p_what == NOTIFICATION_PROCESS) {

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -138,7 +138,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			name->set_text(E->get());
 			name->set_expand_to_text_length_enabled(true);
 			node->add_child(name);
-			node->set_slot(0, false, 0, Color(), true, 0, get_theme_color("font_color", "Label"));
+			node->set_slot(0, false, 0, Color(), true, 0, get_theme_color(SNAME("font_color"), SNAME("Label")));
 			name->connect("text_submitted", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed), varray(agnode), CONNECT_DEFERRED);
 			name->connect("focus_exited", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed_focus_out), varray(name, agnode), CONNECT_DEFERRED);
 			base = 1;
@@ -150,7 +150,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			Label *in_name = memnew(Label);
 			node->add_child(in_name);
 			in_name->set_text(agnode->get_input_name(i));
-			node->set_slot(base + i, true, 0, get_theme_color("font_color", "Label"), false, 0, Color());
+			node->set_slot(base + i, true, 0, get_theme_color(SNAME("font_color"), SNAME("Label")), false, 0, Color());
 		}
 
 		List<PropertyInfo> pinfo;
@@ -177,7 +177,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			node->add_child(memnew(HSeparator));
 			Button *open_in_editor = memnew(Button);
 			open_in_editor->set_text(TTR("Open Editor"));
-			open_in_editor->set_icon(get_theme_icon("Edit", "EditorIcons"));
+			open_in_editor->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 			node->add_child(open_in_editor);
 			open_in_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_open_in_editor), varray(E->get()), CONNECT_DEFERRED);
 			open_in_editor->set_h_size_flags(SIZE_SHRINK_CENTER);
@@ -187,7 +187,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			node->add_child(memnew(HSeparator));
 			Button *edit_filters = memnew(Button);
 			edit_filters->set_text(TTR("Edit Filters"));
-			edit_filters->set_icon(get_theme_icon("AnimationFilter", "EditorIcons"));
+			edit_filters->set_icon(get_theme_icon(SNAME("AnimationFilter"), SNAME("EditorIcons")));
 			node->add_child(edit_filters);
 			edit_filters->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_edit_filters), varray(E->get()), CONNECT_DEFERRED);
 			edit_filters->set_h_size_flags(SIZE_SHRINK_CENTER);
@@ -197,7 +197,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 		if (anim.is_valid()) {
 			MenuButton *mb = memnew(MenuButton);
 			mb->set_text(anim->get_animation());
-			mb->set_icon(get_theme_icon("Animation", "EditorIcons"));
+			mb->set_icon(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")));
 			Array options;
 
 			node->add_child(memnew(HSeparator));
@@ -231,7 +231,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			mb->get_popup()->connect("index_pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_anim_selected), varray(options, E->get()), CONNECT_DEFERRED);
 		}
 
-		Ref<StyleBoxFlat> sb = node->get_theme_stylebox("frame", "GraphNode");
+		Ref<StyleBoxFlat> sb = node->get_theme_stylebox(SNAME("frame"), SNAME("GraphNode"));
 		Color c = sb->get_border_color();
 		Color mono_color = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0) : Color(0.0, 0.0, 0.0);
 		mono_color.a = 0.85;
@@ -617,7 +617,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 						ti->set_text(0, F->get());
 						ti->set_selectable(0, false);
 						ti->set_editable(0, false);
-						ti->set_icon(0, get_theme_icon("BoneAttachment3D", "EditorIcons"));
+						ti->set_icon(0, get_theme_icon(SNAME("BoneAttachment3D"), SNAME("EditorIcons")));
 					} else {
 						ti = parenthood[accum];
 					}
@@ -628,7 +628,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 				ti->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 				ti->set_text(0, concat);
 				ti->set_checked(0, anode->is_path_filtered(path));
-				ti->set_icon(0, get_theme_icon("BoneAttachment3D", "EditorIcons"));
+				ti->set_icon(0, get_theme_icon(SNAME("BoneAttachment3D"), SNAME("EditorIcons")));
 				ti->set_metadata(0, path);
 
 			} else {
@@ -690,8 +690,8 @@ void AnimationNodeBlendTreeEditor::_removed_from_graph() {
 
 void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		error_panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-		error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
+		error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
 		if (p_what == NOTIFICATION_THEME_CHANGED && is_visible_in_tree()) {
 			_update_graph();

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -99,23 +99,23 @@ void AnimationPlayerEditor::_notification(int p_what) {
 
 			get_tree()->connect("node_removed", callable_mp(this, &AnimationPlayerEditor::_node_removed));
 
-			add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox("panel", "Panel"));
+			add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox("panel", "Panel"));
+			add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
-			autoplay->set_icon(get_theme_icon("AutoPlay", "EditorIcons"));
+			autoplay->set_icon(get_theme_icon(SNAME("AutoPlay"), SNAME("EditorIcons")));
 
-			play->set_icon(get_theme_icon("PlayStart", "EditorIcons"));
-			play_from->set_icon(get_theme_icon("Play", "EditorIcons"));
-			play_bw->set_icon(get_theme_icon("PlayStartBackwards", "EditorIcons"));
-			play_bw_from->set_icon(get_theme_icon("PlayBackwards", "EditorIcons"));
+			play->set_icon(get_theme_icon(SNAME("PlayStart"), SNAME("EditorIcons")));
+			play_from->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+			play_bw->set_icon(get_theme_icon(SNAME("PlayStartBackwards"), SNAME("EditorIcons")));
+			play_bw_from->set_icon(get_theme_icon(SNAME("PlayBackwards"), SNAME("EditorIcons")));
 
-			autoplay_icon = get_theme_icon("AutoPlay", "EditorIcons");
-			reset_icon = get_theme_icon("Reload", "EditorIcons");
+			autoplay_icon = get_theme_icon(SNAME("AutoPlay"), SNAME("EditorIcons"));
+			reset_icon = get_theme_icon(SNAME("Reload"), SNAME("EditorIcons"));
 			{
 				Ref<Image> autoplay_img = autoplay_icon->get_image();
 				Ref<Image> reset_img = reset_icon->get_image();
@@ -128,17 +128,17 @@ void AnimationPlayerEditor::_notification(int p_what) {
 				autoplay_reset_icon.instantiate();
 				autoplay_reset_icon->create_from_image(autoplay_reset_img);
 			}
-			stop->set_icon(get_theme_icon("Stop", "EditorIcons"));
+			stop->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 
-			onion_toggle->set_icon(get_theme_icon("Onion", "EditorIcons"));
-			onion_skinning->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
+			onion_toggle->set_icon(get_theme_icon(SNAME("Onion"), SNAME("EditorIcons")));
+			onion_skinning->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
-			pin->set_icon(get_theme_icon("Pin", "EditorIcons"));
+			pin->set_icon(get_theme_icon(SNAME("Pin"), SNAME("EditorIcons")));
 
-			tool_anim->add_theme_style_override("normal", get_theme_stylebox("normal", "Button"));
-			track_editor->get_edit_menu()->add_theme_style_override("normal", get_theme_stylebox("normal", "Button"));
+			tool_anim->add_theme_style_override("normal", get_theme_stylebox(SNAME("normal"), SNAME("Button")));
+			track_editor->get_edit_menu()->add_theme_style_override("normal", get_theme_stylebox(SNAME("normal"), SNAME("Button")));
 
-#define ITEM_ICON(m_item, m_icon) tool_anim->get_popup()->set_item_icon(tool_anim->get_popup()->get_item_index(m_item), get_theme_icon(m_icon, "EditorIcons"))
+#define ITEM_ICON(m_item, m_icon) tool_anim->get_popup()->set_item_icon(tool_anim->get_popup()->get_item_index(m_item), get_theme_icon(SNAME(m_icon), SNAME("EditorIcons")))
 
 			ITEM_ICON(TOOL_NEW_ANIM, "New");
 			ITEM_ICON(TOOL_LOAD_ANIM, "Load");
@@ -373,7 +373,7 @@ void AnimationPlayerEditor::_animation_save_in_path(const Ref<Resource> &p_resou
 	}
 
 	((Resource *)p_resource.ptr())->set_path(path);
-	editor->emit_signal("resource_saved", p_resource);
+	editor->emit_signal(SNAME("resource_saved"), p_resource);
 }
 
 void AnimationPlayerEditor::_animation_save(const Ref<Resource> &p_resource) {
@@ -1324,11 +1324,11 @@ void AnimationPlayerEditor::_prepare_onion_layers_1() {
 	}
 
 	// And go to next step afterwards.
-	call_deferred("_prepare_onion_layers_2");
+	call_deferred(SNAME("_prepare_onion_layers_2"));
 }
 
 void AnimationPlayerEditor::_prepare_onion_layers_1_deferred() {
-	call_deferred("_prepare_onion_layers_1");
+	call_deferred(SNAME("_prepare_onion_layers_1"));
 }
 
 void AnimationPlayerEditor::_prepare_onion_layers_2() {

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -94,7 +94,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				List<StringName> names;
 				ap->get_animation_list(&names);
 				for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-					animations_menu->add_icon_item(get_theme_icon("Animation", "EditorIcons"), E->get());
+					animations_menu->add_icon_item(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")), E->get());
 					animations_to_add.push_back(E->get());
 				}
 			}
@@ -145,7 +145,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 			if (node_rects[i].name.has_point(mb->get_position())) { //edit name
 
-				Ref<StyleBox> line_sb = get_theme_stylebox("normal", "LineEdit");
+				Ref<StyleBox> line_sb = get_theme_stylebox(SNAME("normal"), SNAME("LineEdit"));
 
 				Rect2 edit_rect = node_rects[i].name;
 				edit_rect.position -= line_sb->get_offset();
@@ -163,7 +163,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			}
 
 			if (node_rects[i].edit.has_point(mb->get_position())) { //edit name
-				call_deferred("_open_editor", node_rects[i].node_name);
+				call_deferred(SNAME("_open_editor"), node_rects[i].node_name);
 				return;
 			}
 
@@ -487,9 +487,9 @@ void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 }
 
 void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, bool p_auto_advance) {
-	Color linecolor = get_theme_color("font_color", "Label");
+	Color linecolor = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	Color icon_color(1, 1, 1);
-	Color accent = get_theme_color("accent_color", "Editor");
+	Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 
 	if (!p_enabled) {
 		linecolor.a *= 0.2;
@@ -498,12 +498,12 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 	}
 
 	Ref<Texture2D> icons[6] = {
-		get_theme_icon("TransitionImmediateBig", "EditorIcons"),
-		get_theme_icon("TransitionSyncBig", "EditorIcons"),
-		get_theme_icon("TransitionEndBig", "EditorIcons"),
-		get_theme_icon("TransitionImmediateAutoBig", "EditorIcons"),
-		get_theme_icon("TransitionSyncAutoBig", "EditorIcons"),
-		get_theme_icon("TransitionEndAutoBig", "EditorIcons")
+		get_theme_icon(SNAME("TransitionImmediateBig"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("TransitionSyncBig"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("TransitionEndBig"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("TransitionImmediateAutoBig"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("TransitionSyncAutoBig"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("TransitionEndAutoBig"), SNAME("EditorIcons"))
 	};
 
 	if (p_selected) {
@@ -555,19 +555,19 @@ void AnimationNodeStateMachineEditor::_clip_dst_line_to_rect(Vector2 &r_from, Ve
 void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	Ref<AnimationNodeStateMachinePlayback> playback = AnimationTreeEditor::get_singleton()->get_tree()->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
 
-	Ref<StyleBox> style = get_theme_stylebox("state_machine_frame", "GraphNode");
-	Ref<StyleBox> style_selected = get_theme_stylebox("state_machine_selectedframe", "GraphNode");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("state_machine_frame"), SNAME("GraphNode"));
+	Ref<StyleBox> style_selected = get_theme_stylebox(SNAME("state_machine_selectedframe"), SNAME("GraphNode"));
 
-	Ref<Font> font = get_theme_font("title_font", "GraphNode");
-	int font_size = get_theme_font_size("title_font_size", "GraphNode");
-	Color font_color = get_theme_color("title_color", "GraphNode");
-	Ref<Texture2D> play = get_theme_icon("Play", "EditorIcons");
-	Ref<Texture2D> auto_play = get_theme_icon("AutoPlay", "EditorIcons");
-	Ref<Texture2D> edit = get_theme_icon("Edit", "EditorIcons");
-	Color accent = get_theme_color("accent_color", "Editor");
-	Color linecolor = get_theme_color("font_color", "Label");
+	Ref<Font> font = get_theme_font(SNAME("title_font"), SNAME("GraphNode"));
+	int font_size = get_theme_font_size(SNAME("title_font_size"), SNAME("GraphNode"));
+	Color font_color = get_theme_color(SNAME("title_color"), SNAME("GraphNode"));
+	Ref<Texture2D> play = get_theme_icon(SNAME("Play"), SNAME("EditorIcons"));
+	Ref<Texture2D> auto_play = get_theme_icon(SNAME("AutoPlay"), SNAME("EditorIcons"));
+	Ref<Texture2D> edit = get_theme_icon(SNAME("Edit"), SNAME("EditorIcons"));
+	Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+	Color linecolor = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	linecolor.a *= 0.3;
-	Ref<StyleBox> playing_overlay = get_theme_stylebox("position", "GraphNode");
+	Ref<StyleBox> playing_overlay = get_theme_stylebox(SNAME("position"), SNAME("GraphNode"));
 
 	bool playing = false;
 	StringName current;
@@ -667,7 +667,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		_connection_draw(from, to, AnimationNodeStateMachineTransition::SwitchMode(transition_mode->get_selected()), true, false, false, false);
 	}
 
-	Ref<Texture2D> tr_reference_icon = get_theme_icon("TransitionImmediateBig", "EditorIcons");
+	Ref<Texture2D> tr_reference_icon = get_theme_icon(SNAME("TransitionImmediateBig"), SNAME("EditorIcons"));
 	float tr_bidi_offset = int(tr_reference_icon->get_height() * 0.8);
 
 	//draw transition lines
@@ -857,7 +857,7 @@ void AnimationNodeStateMachineEditor::_state_machine_pos_draw() {
 
 	float pos = CLAMP(play_pos, 0, len);
 	float c = pos / len;
-	Color fg = get_theme_color("font_color", "Label");
+	Color fg = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	Color bg = fg;
 	bg.a *= 0.3;
 
@@ -882,26 +882,26 @@ void AnimationNodeStateMachineEditor::_update_graph() {
 
 void AnimationNodeStateMachineEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		error_panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-		error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
-		panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
+		error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 
-		tool_select->set_icon(get_theme_icon("ToolSelect", "EditorIcons"));
-		tool_create->set_icon(get_theme_icon("ToolAddNode", "EditorIcons"));
-		tool_connect->set_icon(get_theme_icon("ToolConnect", "EditorIcons"));
+		tool_select->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
+		tool_create->set_icon(get_theme_icon(SNAME("ToolAddNode"), SNAME("EditorIcons")));
+		tool_connect->set_icon(get_theme_icon(SNAME("ToolConnect"), SNAME("EditorIcons")));
 
 		transition_mode->clear();
-		transition_mode->add_icon_item(get_theme_icon("TransitionImmediate", "EditorIcons"), TTR("Immediate"));
-		transition_mode->add_icon_item(get_theme_icon("TransitionSync", "EditorIcons"), TTR("Sync"));
-		transition_mode->add_icon_item(get_theme_icon("TransitionEnd", "EditorIcons"), TTR("At End"));
+		transition_mode->add_icon_item(get_theme_icon(SNAME("TransitionImmediate"), SNAME("EditorIcons")), TTR("Immediate"));
+		transition_mode->add_icon_item(get_theme_icon(SNAME("TransitionSync"), SNAME("EditorIcons")), TTR("Sync"));
+		transition_mode->add_icon_item(get_theme_icon(SNAME("TransitionEnd"), SNAME("EditorIcons")), TTR("At End"));
 
-		tool_erase->set_icon(get_theme_icon("Remove", "EditorIcons"));
-		tool_autoplay->set_icon(get_theme_icon("AutoPlay", "EditorIcons"));
-		tool_end->set_icon(get_theme_icon("AutoEnd", "EditorIcons"));
+		tool_erase->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+		tool_autoplay->set_icon(get_theme_icon(SNAME("AutoPlay"), SNAME("EditorIcons")));
+		tool_end->set_icon(get_theme_icon(SNAME("AutoEnd"), SNAME("EditorIcons")));
 
 		play_mode->clear();
-		play_mode->add_icon_item(get_theme_icon("PlayTravel", "EditorIcons"), TTR("Travel"));
-		play_mode->add_icon_item(get_theme_icon("Play", "EditorIcons"), TTR("Immediate"));
+		play_mode->add_icon_item(get_theme_icon(SNAME("PlayTravel"), SNAME("EditorIcons")), TTR("Travel"));
+		play_mode->add_icon_item(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")), TTR("Immediate"));
 	}
 
 	if (p_what == NOTIFICATION_PROCESS) {

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -58,7 +58,7 @@ void EditorAssetLibraryItem::set_image(int p_type, int p_index, const Ref<Textur
 
 void EditorAssetLibraryItem::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		icon->set_normal_texture(get_theme_icon("ProjectIconLoading", "EditorIcons"));
+		icon->set_normal_texture(get_theme_icon(SNAME("ProjectIconLoading"), SNAME("EditorIcons")));
 		category->add_theme_color_override("font_color", Color(0.5, 0.5, 0.5));
 		author->add_theme_color_override("font_color", Color(0.5, 0.5, 0.5));
 		price->add_theme_color_override("font_color", Color(0.5, 0.5, 0.5));
@@ -66,15 +66,15 @@ void EditorAssetLibraryItem::_notification(int p_what) {
 }
 
 void EditorAssetLibraryItem::_asset_clicked() {
-	emit_signal("asset_selected", asset_id);
+	emit_signal(SNAME("asset_selected"), asset_id);
 }
 
 void EditorAssetLibraryItem::_category_clicked() {
-	emit_signal("category_selected", category_id);
+	emit_signal(SNAME("category_selected"), category_id);
 }
 
 void EditorAssetLibraryItem::_author_clicked() {
-	emit_signal("author_selected", author_id);
+	emit_signal(SNAME("author_selected"), author_id);
 }
 
 void EditorAssetLibraryItem::_bind_methods() {
@@ -144,7 +144,7 @@ void EditorAssetLibraryItemDescription::set_image(int p_type, int p_index, const
 			for (int i = 0; i < preview_images.size(); i++) {
 				if (preview_images[i].id == p_index) {
 					if (preview_images[i].is_video) {
-						Ref<Image> overlay = previews->get_theme_icon("PlayOverlay", "EditorIcons")->get_image();
+						Ref<Image> overlay = previews->get_theme_icon(SNAME("PlayOverlay"), SNAME("EditorIcons"))->get_image();
 						Ref<Image> thumbnail = p_image->get_image();
 						thumbnail = thumbnail->duplicate();
 						Point2 overlay_pos = Point2((thumbnail->get_width() - overlay->get_width()) / 2, (thumbnail->get_height() - overlay->get_height()) / 2);
@@ -185,7 +185,7 @@ void EditorAssetLibraryItemDescription::set_image(int p_type, int p_index, const
 void EditorAssetLibraryItemDescription::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			previews_bg->add_theme_style_override("panel", previews->get_theme_stylebox("normal", "TextEdit"));
+			previews_bg->add_theme_style_override("panel", previews->get_theme_stylebox(SNAME("normal"), SNAME("TextEdit")));
 		} break;
 	}
 }
@@ -240,12 +240,12 @@ void EditorAssetLibraryItemDescription::add_preview(int p_id, bool p_video, cons
 	preview.video_link = p_url;
 	preview.is_video = p_video;
 	preview.button = memnew(Button);
-	preview.button->set_icon(previews->get_theme_icon("ThumbnailWait", "EditorIcons"));
+	preview.button->set_icon(previews->get_theme_icon(SNAME("ThumbnailWait"), SNAME("EditorIcons")));
 	preview.button->set_toggle_mode(true);
 	preview.button->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDescription::_preview_click), varray(p_id));
 	preview_hb->add_child(preview.button);
 	if (!p_video) {
-		preview.image = previews->get_theme_icon("ThumbnailWait", "EditorIcons");
+		preview.image = previews->get_theme_icon(SNAME("ThumbnailWait"), SNAME("EditorIcons"));
 	}
 	preview_images.push_back(preview);
 	if (preview_images.size() == 1 && !p_video) {
@@ -379,7 +379,7 @@ void EditorAssetLibraryItemDownload::configure(const String &p_title, int p_asse
 	icon->set_texture(p_preview);
 	asset_id = p_asset_id;
 	if (!p_preview.is_valid()) {
-		icon->set_texture(get_theme_icon("FileBrokenBigThumb", "EditorIcons"));
+		icon->set_texture(get_theme_icon(SNAME("FileBrokenBigThumb"), SNAME("EditorIcons")));
 	}
 	host = p_download_url;
 	sha256 = p_sha256_hash;
@@ -390,8 +390,8 @@ void EditorAssetLibraryItemDownload::_notification(int p_what) {
 	switch (p_what) {
 		// FIXME: The editor crashes if 'NOTICATION_THEME_CHANGED' is used.
 		case NOTIFICATION_ENTER_TREE: {
-			add_theme_style_override("panel", get_theme_stylebox("panel", "TabContainer"));
-			dismiss->set_normal_texture(get_theme_icon("Close", "EditorIcons"));
+			add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
+			dismiss->set_normal_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 		} break;
 		case NOTIFICATION_PROCESS: {
 			// Make the progress bar visible again when retrying the download.
@@ -455,7 +455,7 @@ void EditorAssetLibraryItemDownload::_install() {
 	String file = download->get_download_file();
 
 	if (external_install) {
-		emit_signal("install_asset", file, title->get_text());
+		emit_signal(SNAME("install_asset"), file, title->get_text());
 		return;
 	}
 
@@ -553,8 +553,8 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 void EditorAssetLibrary::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			error_tr->set_texture(get_theme_icon("Error", "EditorIcons"));
-			filter->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			error_tr->set_texture(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
+			filter->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			filter->set_clear_button_enabled(true);
 
 			error_label->raise();
@@ -588,10 +588,10 @@ void EditorAssetLibrary::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			library_scroll_bg->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-			downloads_scroll->add_theme_style_override("bg", get_theme_stylebox("bg", "Tree"));
-			error_tr->set_texture(get_theme_icon("Error", "EditorIcons"));
-			filter->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			library_scroll_bg->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			downloads_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			error_tr->set_texture(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
+			filter->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			filter->set_clear_button_enabled(true);
 		} break;
 
@@ -773,7 +773,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PackedB
 		}
 
 		if (!image_set && final) {
-			obj->call("set_image", image_queue[p_queue_id].image_type, image_queue[p_queue_id].image_index, get_theme_icon("FileBrokenBigThumb", "EditorIcons"));
+			obj->call("set_image", image_queue[p_queue_id].image_type, image_queue[p_queue_id].image_index, get_theme_icon(SNAME("FileBrokenBigThumb"), SNAME("EditorIcons")));
 		}
 	}
 }
@@ -816,7 +816,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 		WARN_PRINT("Error getting image file from URL: " + image_queue[p_queue_id].image_url);
 		Object *obj = ObjectDB::get_instance(image_queue[p_queue_id].target);
 		if (obj) {
-			obj->call("set_image", image_queue[p_queue_id].image_type, image_queue[p_queue_id].image_index, get_theme_icon("FileBrokenBigThumb", "EditorIcons"));
+			obj->call("set_image", image_queue[p_queue_id].image_type, image_queue[p_queue_id].image_index, get_theme_icon(SNAME("FileBrokenBigThumb"), SNAME("EditorIcons")));
 		}
 	}
 
@@ -1315,7 +1315,7 @@ void EditorAssetLibrary::_manage_plugins() {
 }
 
 void EditorAssetLibrary::_install_external_asset(String p_zip_path, String p_title) {
-	emit_signal("install_asset", p_zip_path, p_title);
+	emit_signal(SNAME("install_asset"), p_zip_path, p_title);
 }
 
 void EditorAssetLibrary::disable_community_support() {
@@ -1490,7 +1490,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	error_hb = memnew(HBoxContainer);
 	library_main->add_child(error_hb);
 	error_label = memnew(Label);
-	error_label->add_theme_color_override("color", get_theme_color("error_color", "Editor"));
+	error_label->add_theme_color_override("color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	error_hb->add_child(error_label);
 	error_tr = memnew(TextureRect);
 	error_tr->set_v_size_flags(Control::SIZE_SHRINK_CENTER);

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -43,10 +43,10 @@ void AudioStreamEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
-		_play_button->set_icon(get_theme_icon("MainPlay", "EditorIcons"));
-		_stop_button->set_icon(get_theme_icon("Stop", "EditorIcons"));
-		_preview->set_color(get_theme_color("dark_color_2", "Editor"));
-		set_color(get_theme_color("dark_color_1", "Editor"));
+		_play_button->set_icon(get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
+		_stop_button->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
+		_preview->set_color(get_theme_color(SNAME("dark_color_2"), SNAME("Editor")));
+		set_color(get_theme_color(SNAME("dark_color_1"), SNAME("Editor")));
 
 		_indicator->update();
 		_preview->update();
@@ -86,7 +86,7 @@ void AudioStreamEditor::_draw_preview() {
 	}
 
 	Vector<Color> color;
-	color.push_back(get_theme_color("contrast_color_2", "Editor"));
+	color.push_back(get_theme_color(SNAME("contrast_color_2"), SNAME("Editor")));
 
 	RS::get_singleton()->canvas_item_add_multiline(_preview->get_canvas_item(), lines, color);
 }
@@ -109,25 +109,25 @@ void AudioStreamEditor::_play() {
 		// '_pausing' variable indicates that we want to pause the audio player, not stop it. See '_on_finished()'.
 		_pausing = true;
 		_player->stop();
-		_play_button->set_icon(get_theme_icon("MainPlay", "EditorIcons"));
+		_play_button->set_icon(get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
 		set_process(false);
 	} else {
 		_player->play(_current);
-		_play_button->set_icon(get_theme_icon("Pause", "EditorIcons"));
+		_play_button->set_icon(get_theme_icon(SNAME("Pause"), SNAME("EditorIcons")));
 		set_process(true);
 	}
 }
 
 void AudioStreamEditor::_stop() {
 	_player->stop();
-	_play_button->set_icon(get_theme_icon("MainPlay", "EditorIcons"));
+	_play_button->set_icon(get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
 	_current = 0;
 	_indicator->update();
 	set_process(false);
 }
 
 void AudioStreamEditor::_on_finished() {
-	_play_button->set_icon(get_theme_icon("MainPlay", "EditorIcons"));
+	_play_button->set_icon(get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
 	if (!_pausing) {
 		_current = 0;
 		_indicator->update();
@@ -145,11 +145,11 @@ void AudioStreamEditor::_draw_indicator() {
 	Rect2 rect = _preview->get_rect();
 	float len = stream->get_length();
 	float ofs_x = _current / len * rect.size.width;
-	const Color color = get_theme_color("accent_color", "Editor");
+	const Color color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 	_indicator->draw_line(Point2(ofs_x, 0), Point2(ofs_x, rect.size.height), color, Math::round(2 * EDSCALE));
 	_indicator->draw_texture(
-			get_theme_icon("TimelineIndicator", "EditorIcons"),
-			Point2(ofs_x - get_theme_icon("TimelineIndicator", "EditorIcons")->get_width() * 0.5, 0),
+			get_theme_icon(SNAME("TimelineIndicator"), SNAME("EditorIcons")),
+			Point2(ofs_x - get_theme_icon(SNAME("TimelineIndicator"), SNAME("EditorIcons"))->get_width() * 0.5, 0),
 			color);
 
 	_current_label->set_text(String::num(_current, 2).pad_decimals(2) + " /");
@@ -243,14 +243,14 @@ AudioStreamEditor::AudioStreamEditor() {
 	_current_label = memnew(Label);
 	_current_label->set_align(Label::ALIGN_RIGHT);
 	_current_label->set_h_size_flags(SIZE_EXPAND_FILL);
-	_current_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
-	_current_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
+	_current_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	_current_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 	_current_label->set_modulate(Color(1, 1, 1, 0.5));
 	hbox->add_child(_current_label);
 
 	_duration_label = memnew(Label);
-	_duration_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
-	_duration_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
+	_duration_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	_duration_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 	hbox->add_child(_duration_label);
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -903,7 +903,7 @@ void CanvasItemEditor::_node_created(Node *p_node) {
 		c->_edit_set_position(xform.xform(node_create_position));
 	}
 
-	call_deferred("_reset_create_position"); // Defer the call in case more than one node is added.
+	call_deferred(SNAME("_reset_create_position")); // Defer the call in case more than one node is added.
 }
 
 void CanvasItemEditor::_reset_create_position() {
@@ -2529,7 +2529,7 @@ void CanvasItemEditor::_gui_input_viewport(const Ref<InputEvent> &p_event) {
 
 	// Grab focus
 	if (!viewport->has_focus() && (!get_focus_owner() || !get_focus_owner()->is_text_field())) {
-		viewport->call_deferred("grab_focus");
+		viewport->call_deferred(SNAME("grab_focus"));
 	}
 }
 
@@ -2617,10 +2617,10 @@ void CanvasItemEditor::_update_cursor() {
 }
 
 void CanvasItemEditor::_draw_text_at_position(Point2 p_position, String p_string, Side p_side) {
-	Color color = get_theme_color("font_color", "Editor");
+	Color color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 	color.a = 0.8;
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	Size2 text_size = font->get_string_size(p_string, font_size);
 	switch (p_side) {
 		case SIDE_LEFT:
@@ -2656,7 +2656,7 @@ void CanvasItemEditor::_draw_percentage_at_position(float p_value, Point2 p_posi
 void CanvasItemEditor::_draw_focus() {
 	// Draw the focus around the base viewport
 	if (viewport->has_focus()) {
-		get_theme_stylebox("Focus", "EditorStyles")->draw(viewport->get_canvas_item(), Rect2(Point2(), viewport->get_size()));
+		get_theme_stylebox(SNAME("Focus"), SNAME("EditorStyles"))->draw(viewport->get_canvas_item(), Rect2(Point2(), viewport->get_size()));
 	}
 }
 
@@ -2688,21 +2688,21 @@ void CanvasItemEditor::_draw_guides() {
 	}
 
 	// Dragged guide
-	Color text_color = get_theme_color("font_color", "Editor");
+	Color text_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 	Color outline_color = text_color.inverted();
 	const float outline_size = 2;
 	if (drag_type == DRAG_DOUBLE_GUIDE || drag_type == DRAG_V_GUIDE) {
 		String str = TS->format_number(vformat("%d px", Math::round(xform.affine_inverse().xform(dragged_guide_pos).x)));
-		Ref<Font> font = get_theme_font("bold", "EditorFonts");
-		int font_size = get_theme_font_size("bold_size", "EditorFonts");
+		Ref<Font> font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
+		int font_size = get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts"));
 		Size2 text_size = font->get_string_size(str, font_size);
 		viewport->draw_string(font, Point2(dragged_guide_pos.x + 10, RULER_WIDTH + text_size.y / 2 + 10), str, HALIGN_LEFT, -1, font_size, text_color, outline_size, outline_color);
 		viewport->draw_line(Point2(dragged_guide_pos.x, 0), Point2(dragged_guide_pos.x, viewport->get_size().y), guide_color, Math::round(EDSCALE));
 	}
 	if (drag_type == DRAG_DOUBLE_GUIDE || drag_type == DRAG_H_GUIDE) {
 		String str = TS->format_number(vformat("%d px", Math::round(xform.affine_inverse().xform(dragged_guide_pos).y)));
-		Ref<Font> font = get_theme_font("bold", "EditorFonts");
-		int font_size = get_theme_font_size("bold_size", "EditorFonts");
+		Ref<Font> font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
+		int font_size = get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts"));
 		Size2 text_size = font->get_string_size(str, font_size);
 		viewport->draw_string(font, Point2(RULER_WIDTH + 10, dragged_guide_pos.y + text_size.y / 2 + 10), str, HALIGN_LEFT, -1, font_size, text_color, outline_size, outline_color);
 		viewport->draw_line(Point2(0, dragged_guide_pos.y), Point2(viewport->get_size().x, dragged_guide_pos.y), guide_color, Math::round(EDSCALE));
@@ -2724,12 +2724,12 @@ void CanvasItemEditor::_draw_smart_snapping() {
 }
 
 void CanvasItemEditor::_draw_rulers() {
-	Color bg_color = get_theme_color("dark_color_2", "Editor");
-	Color graduation_color = get_theme_color("font_color", "Editor").lerp(bg_color, 0.5);
-	Color font_color = get_theme_color("font_color", "Editor");
+	Color bg_color = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
+	Color graduation_color = get_theme_color(SNAME("font_color"), SNAME("Editor")).lerp(bg_color, 0.5);
+	Color font_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 	font_color.a = 0.8;
-	Ref<Font> font = get_theme_font("rulers", "EditorFonts");
-	int font_size = get_theme_font_size("rulers_size", "EditorFonts");
+	Ref<Font> font = get_theme_font(SNAME("rulers"), SNAME("EditorFonts"));
+	int font_size = get_theme_font_size(SNAME("rulers_size"), SNAME("EditorFonts"));
 
 	// The rule transform
 	Transform2D ruler_transform = Transform2D();
@@ -2890,7 +2890,7 @@ void CanvasItemEditor::_draw_ruler_tool() {
 	}
 
 	if (ruler_tool_active) {
-		Color ruler_primary_color = get_theme_color("accent_color", "Editor");
+		Color ruler_primary_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 		Color ruler_secondary_color = ruler_primary_color;
 		ruler_secondary_color.a = 0.5;
 
@@ -2907,9 +2907,9 @@ void CanvasItemEditor::_draw_ruler_tool() {
 			viewport->draw_line(corner, end, ruler_secondary_color, Math::round(EDSCALE));
 		}
 
-		Ref<Font> font = get_theme_font("bold", "EditorFonts");
-		int font_size = get_theme_font_size("bold_size", "EditorFonts");
-		Color font_color = get_theme_color("font_color", "Editor");
+		Ref<Font> font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
+		int font_size = get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts"));
+		Color font_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 		Color font_secondary_color = font_color;
 		font_secondary_color.set_v(font_secondary_color.get_v() > 0.5 ? 0.7 : 0.3);
 		Color outline_color = font_color.inverted();
@@ -3010,8 +3010,8 @@ void CanvasItemEditor::_draw_ruler_tool() {
 		}
 	} else {
 		if (grid_snap_active) {
-			Ref<Texture2D> position_icon = get_theme_icon("EditorPosition", "EditorIcons");
-			viewport->draw_texture(get_theme_icon("EditorPosition", "EditorIcons"), (ruler_tool_origin - view_offset) * zoom - position_icon->get_size() / 2);
+			Ref<Texture2D> position_icon = get_theme_icon(SNAME("EditorPosition"), SNAME("EditorIcons"));
+			viewport->draw_texture(get_theme_icon(SNAME("EditorPosition"), SNAME("EditorIcons")), (ruler_tool_origin - view_offset) * zoom - position_icon->get_size() / 2);
 		}
 	}
 }
@@ -3229,9 +3229,9 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 }
 
 void CanvasItemEditor::_draw_selection() {
-	Ref<Texture2D> pivot_icon = get_theme_icon("EditorPivot", "EditorIcons");
-	Ref<Texture2D> position_icon = get_theme_icon("EditorPosition", "EditorIcons");
-	Ref<Texture2D> previous_position_icon = get_theme_icon("EditorPositionPrevious", "EditorIcons");
+	Ref<Texture2D> pivot_icon = get_theme_icon(SNAME("EditorPivot"), SNAME("EditorIcons"));
+	Ref<Texture2D> position_icon = get_theme_icon(SNAME("EditorPosition"), SNAME("EditorIcons"));
+	Ref<Texture2D> previous_position_icon = get_theme_icon(SNAME("EditorPositionPrevious"), SNAME("EditorIcons"));
 
 	RID ci = viewport->get_canvas_item();
 
@@ -3357,16 +3357,16 @@ void CanvasItemEditor::_draw_selection() {
 					points.push_back(Vector2(move_factor.x * EDSCALE, -5 * EDSCALE));
 					points.push_back(Vector2((move_factor.x + 10) * EDSCALE, 0));
 
-					viewport->draw_colored_polygon(points, get_theme_color("axis_x_color", "Editor"));
-					viewport->draw_line(Point2(), Point2(move_factor.x * EDSCALE, 0), get_theme_color("axis_x_color", "Editor"), Math::round(EDSCALE));
+					viewport->draw_colored_polygon(points, get_theme_color(SNAME("axis_x_color"), SNAME("Editor")));
+					viewport->draw_line(Point2(), Point2(move_factor.x * EDSCALE, 0), get_theme_color(SNAME("axis_x_color"), SNAME("Editor")), Math::round(EDSCALE));
 
 					points.clear();
 					points.push_back(Vector2(5 * EDSCALE, move_factor.y * EDSCALE));
 					points.push_back(Vector2(-5 * EDSCALE, move_factor.y * EDSCALE));
 					points.push_back(Vector2(0, (move_factor.y + 10) * EDSCALE));
 
-					viewport->draw_colored_polygon(points, get_theme_color("axis_y_color", "Editor"));
-					viewport->draw_line(Point2(), Point2(0, move_factor.y * EDSCALE), get_theme_color("axis_y_color", "Editor"), Math::round(EDSCALE));
+					viewport->draw_colored_polygon(points, get_theme_color(SNAME("axis_y_color"), SNAME("Editor")));
+					viewport->draw_line(Point2(), Point2(0, move_factor.y * EDSCALE), get_theme_color(SNAME("axis_y_color"), SNAME("Editor")), Math::round(EDSCALE));
 
 					viewport->draw_set_transform_matrix(viewport->get_transform());
 				}
@@ -3396,12 +3396,12 @@ void CanvasItemEditor::_draw_selection() {
 
 					viewport->draw_set_transform_matrix(simple_xform);
 					Rect2 x_handle_rect = Rect2(scale_factor.x * EDSCALE, -5 * EDSCALE, 10 * EDSCALE, 10 * EDSCALE);
-					viewport->draw_rect(x_handle_rect, get_theme_color("axis_x_color", "Editor"));
-					viewport->draw_line(Point2(), Point2(scale_factor.x * EDSCALE, 0), get_theme_color("axis_x_color", "Editor"), Math::round(EDSCALE));
+					viewport->draw_rect(x_handle_rect, get_theme_color(SNAME("axis_x_color"), SNAME("Editor")));
+					viewport->draw_line(Point2(), Point2(scale_factor.x * EDSCALE, 0), get_theme_color(SNAME("axis_x_color"), SNAME("Editor")), Math::round(EDSCALE));
 
 					Rect2 y_handle_rect = Rect2(-5 * EDSCALE, scale_factor.y * EDSCALE, 10 * EDSCALE, 10 * EDSCALE);
-					viewport->draw_rect(y_handle_rect, get_theme_color("axis_y_color", "Editor"));
-					viewport->draw_line(Point2(), Point2(0, scale_factor.y * EDSCALE), get_theme_color("axis_y_color", "Editor"), Math::round(EDSCALE));
+					viewport->draw_rect(y_handle_rect, get_theme_color(SNAME("axis_y_color"), SNAME("Editor")));
+					viewport->draw_line(Point2(), Point2(0, scale_factor.y * EDSCALE), get_theme_color(SNAME("axis_y_color"), SNAME("Editor")), Math::round(EDSCALE));
 
 					viewport->draw_set_transform_matrix(viewport->get_transform());
 				}
@@ -3416,11 +3416,11 @@ void CanvasItemEditor::_draw_selection() {
 
 		viewport->draw_rect(
 				Rect2(bsfrom, bsto - bsfrom),
-				get_theme_color("box_selection_fill_color", "Editor"));
+				get_theme_color(SNAME("box_selection_fill_color"), SNAME("Editor")));
 
 		viewport->draw_rect(
 				Rect2(bsfrom, bsto - bsfrom),
-				get_theme_color("box_selection_stroke_color", "Editor"),
+				get_theme_color(SNAME("box_selection_stroke_color"), SNAME("Editor")),
 				false,
 				Math::round(EDSCALE));
 	}
@@ -3430,7 +3430,7 @@ void CanvasItemEditor::_draw_selection() {
 		viewport->draw_line(
 				transform.xform(drag_rotation_center),
 				transform.xform(drag_to),
-				get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.6),
+				get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.6),
 				Math::round(2 * EDSCALE));
 	}
 }
@@ -3478,8 +3478,8 @@ void CanvasItemEditor::_draw_straight_line(Point2 p_from, Point2 p_to, Color p_c
 
 void CanvasItemEditor::_draw_axis() {
 	if (show_origin) {
-		_draw_straight_line(Point2(), Point2(1, 0), get_theme_color("axis_x_color", "Editor") * Color(1, 1, 1, 0.75));
-		_draw_straight_line(Point2(), Point2(0, 1), get_theme_color("axis_y_color", "Editor") * Color(1, 1, 1, 0.75));
+		_draw_straight_line(Point2(), Point2(1, 0), get_theme_color(SNAME("axis_x_color"), SNAME("Editor")) * Color(1, 1, 1, 0.75));
+		_draw_straight_line(Point2(), Point2(0, 1), get_theme_color(SNAME("axis_y_color"), SNAME("Editor")) * Color(1, 1, 1, 0.75));
 	}
 
 	if (show_viewport) {
@@ -3533,7 +3533,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 		Transform2D xform = transform * canvas_xform * parent_xform;
 
 		// Draw the node's position
-		Ref<Texture2D> position_icon = get_theme_icon("EditorPositionUnselected", "EditorIcons");
+		Ref<Texture2D> position_icon = get_theme_icon(SNAME("EditorPositionUnselected"), SNAME("EditorIcons"));
 		Transform2D unscaled_transform = (xform * canvas_item->get_transform().affine_inverse() * canvas_item->_edit_get_transform()).orthonormalized();
 		Transform2D simple_xform = viewport->get_transform() * unscaled_transform;
 		viewport->draw_set_transform_matrix(simple_xform);
@@ -3549,8 +3549,8 @@ void CanvasItemEditor::_draw_hover() {
 		Ref<Texture2D> node_icon = hovering_results[i].icon;
 		String node_name = hovering_results[i].name;
 
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		Size2 node_name_size = font->get_string_size(node_name);
 		Size2 item_size = Size2(node_icon->get_size().x + 4 + node_name_size.x, MAX(node_icon->get_size().y, node_name_size.y - 3));
 
@@ -3603,13 +3603,13 @@ void CanvasItemEditor::_draw_locks_and_groups(Node *p_node, const Transform2D &p
 	if (canvas_item) {
 		float offset = 0;
 
-		Ref<Texture2D> lock = get_theme_icon("LockViewport", "EditorIcons");
+		Ref<Texture2D> lock = get_theme_icon(SNAME("LockViewport"), SNAME("EditorIcons"));
 		if (p_node->has_meta("_edit_lock_") && show_edit_locks) {
 			lock->draw(viewport_canvas_item, (transform * canvas_xform * parent_xform).xform(Point2(0, 0)) + Point2(offset, 0));
 			offset += lock->get_size().x;
 		}
 
-		Ref<Texture2D> group = get_theme_icon("GroupViewport", "EditorIcons");
+		Ref<Texture2D> group = get_theme_icon(SNAME("GroupViewport"), SNAME("EditorIcons"));
 		if (canvas_item->has_meta("_edit_group_") && show_edit_locks) {
 			group->draw(viewport_canvas_item, (transform * canvas_xform * parent_xform).xform(Point2(0, 0)) + Point2(offset, 0));
 			//offset += group->get_size().x;
@@ -3809,7 +3809,7 @@ void CanvasItemEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		select_sb->set_texture(get_theme_icon("EditorRect2D", "EditorIcons"));
+		select_sb->set_texture(get_theme_icon(SNAME("EditorRect2D"), SNAME("EditorIcons")));
 		for (int i = 0; i < 4; i++) {
 			select_sb->set_margin_size(Side(i), 4);
 			select_sb->set_default_margin(Side(i), 4);
@@ -3819,92 +3819,92 @@ void CanvasItemEditor::_notification(int p_what) {
 		_keying_changed();
 
 	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		select_sb->set_texture(get_theme_icon("EditorRect2D", "EditorIcons"));
+		select_sb->set_texture(get_theme_icon(SNAME("EditorRect2D"), SNAME("EditorIcons")));
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		select_button->set_icon(get_theme_icon("ToolSelect", "EditorIcons"));
-		list_select_button->set_icon(get_theme_icon("ListSelect", "EditorIcons"));
-		move_button->set_icon(get_theme_icon("ToolMove", "EditorIcons"));
-		scale_button->set_icon(get_theme_icon("ToolScale", "EditorIcons"));
-		rotate_button->set_icon(get_theme_icon("ToolRotate", "EditorIcons"));
-		smart_snap_button->set_icon(get_theme_icon("Snap", "EditorIcons"));
-		grid_snap_button->set_icon(get_theme_icon("SnapGrid", "EditorIcons"));
-		snap_config_menu->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
-		skeleton_menu->set_icon(get_theme_icon("Bone", "EditorIcons"));
-		override_camera_button->set_icon(get_theme_icon("Camera2D", "EditorIcons"));
-		pan_button->set_icon(get_theme_icon("ToolPan", "EditorIcons"));
-		ruler_button->set_icon(get_theme_icon("Ruler", "EditorIcons"));
-		pivot_button->set_icon(get_theme_icon("EditPivot", "EditorIcons"));
-		select_handle = get_theme_icon("EditorHandle", "EditorIcons");
-		anchor_handle = get_theme_icon("EditorControlAnchor", "EditorIcons");
-		lock_button->set_icon(get_theme_icon("Lock", "EditorIcons"));
-		unlock_button->set_icon(get_theme_icon("Unlock", "EditorIcons"));
-		group_button->set_icon(get_theme_icon("Group", "EditorIcons"));
-		ungroup_button->set_icon(get_theme_icon("Ungroup", "EditorIcons"));
-		key_loc_button->set_icon(get_theme_icon("KeyPosition", "EditorIcons"));
-		key_rot_button->set_icon(get_theme_icon("KeyRotation", "EditorIcons"));
-		key_scale_button->set_icon(get_theme_icon("KeyScale", "EditorIcons"));
-		key_insert_button->set_icon(get_theme_icon("Key", "EditorIcons"));
-		key_auto_insert_button->set_icon(get_theme_icon("AutoKey", "EditorIcons"));
+		select_button->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
+		list_select_button->set_icon(get_theme_icon(SNAME("ListSelect"), SNAME("EditorIcons")));
+		move_button->set_icon(get_theme_icon(SNAME("ToolMove"), SNAME("EditorIcons")));
+		scale_button->set_icon(get_theme_icon(SNAME("ToolScale"), SNAME("EditorIcons")));
+		rotate_button->set_icon(get_theme_icon(SNAME("ToolRotate"), SNAME("EditorIcons")));
+		smart_snap_button->set_icon(get_theme_icon(SNAME("Snap"), SNAME("EditorIcons")));
+		grid_snap_button->set_icon(get_theme_icon(SNAME("SnapGrid"), SNAME("EditorIcons")));
+		snap_config_menu->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
+		skeleton_menu->set_icon(get_theme_icon(SNAME("Bone"), SNAME("EditorIcons")));
+		override_camera_button->set_icon(get_theme_icon(SNAME("Camera2D"), SNAME("EditorIcons")));
+		pan_button->set_icon(get_theme_icon(SNAME("ToolPan"), SNAME("EditorIcons")));
+		ruler_button->set_icon(get_theme_icon(SNAME("Ruler"), SNAME("EditorIcons")));
+		pivot_button->set_icon(get_theme_icon(SNAME("EditPivot"), SNAME("EditorIcons")));
+		select_handle = get_theme_icon(SNAME("EditorHandle"), SNAME("EditorIcons"));
+		anchor_handle = get_theme_icon(SNAME("EditorControlAnchor"), SNAME("EditorIcons"));
+		lock_button->set_icon(get_theme_icon(SNAME("Lock"), SNAME("EditorIcons")));
+		unlock_button->set_icon(get_theme_icon(SNAME("Unlock"), SNAME("EditorIcons")));
+		group_button->set_icon(get_theme_icon(SNAME("Group"), SNAME("EditorIcons")));
+		ungroup_button->set_icon(get_theme_icon(SNAME("Ungroup"), SNAME("EditorIcons")));
+		key_loc_button->set_icon(get_theme_icon(SNAME("KeyPosition"), SNAME("EditorIcons")));
+		key_rot_button->set_icon(get_theme_icon(SNAME("KeyRotation"), SNAME("EditorIcons")));
+		key_scale_button->set_icon(get_theme_icon(SNAME("KeyScale"), SNAME("EditorIcons")));
+		key_insert_button->set_icon(get_theme_icon(SNAME("Key"), SNAME("EditorIcons")));
+		key_auto_insert_button->set_icon(get_theme_icon(SNAME("AutoKey"), SNAME("EditorIcons")));
 		// Use a different color for the active autokey icon to make them easier
 		// to distinguish from the other key icons at the top. On a light theme,
 		// the icon will be dark, so we need to lighten it before blending it
 		// with the red color.
 		const Color key_auto_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25);
 		key_auto_insert_button->add_theme_color_override("icon_pressed_color", key_auto_color.lerp(Color(1, 0, 0), 0.55));
-		animation_menu->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
+		animation_menu->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
-		presets_menu->set_icon(get_theme_icon("ControlLayout", "EditorIcons"));
+		presets_menu->set_icon(get_theme_icon(SNAME("ControlLayout"), SNAME("EditorIcons")));
 		PopupMenu *p = presets_menu->get_popup();
 
 		p->clear();
-		p->add_icon_item(get_theme_icon("ControlAlignTopLeft", "EditorIcons"), TTR("Top Left"), ANCHORS_AND_OFFSETS_PRESET_TOP_LEFT);
-		p->add_icon_item(get_theme_icon("ControlAlignTopRight", "EditorIcons"), TTR("Top Right"), ANCHORS_AND_OFFSETS_PRESET_TOP_RIGHT);
-		p->add_icon_item(get_theme_icon("ControlAlignBottomRight", "EditorIcons"), TTR("Bottom Right"), ANCHORS_AND_OFFSETS_PRESET_BOTTOM_RIGHT);
-		p->add_icon_item(get_theme_icon("ControlAlignBottomLeft", "EditorIcons"), TTR("Bottom Left"), ANCHORS_AND_OFFSETS_PRESET_BOTTOM_LEFT);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignTopLeft"), SNAME("EditorIcons")), TTR("Top Left"), ANCHORS_AND_OFFSETS_PRESET_TOP_LEFT);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignTopRight"), SNAME("EditorIcons")), TTR("Top Right"), ANCHORS_AND_OFFSETS_PRESET_TOP_RIGHT);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignBottomRight"), SNAME("EditorIcons")), TTR("Bottom Right"), ANCHORS_AND_OFFSETS_PRESET_BOTTOM_RIGHT);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignBottomLeft"), SNAME("EditorIcons")), TTR("Bottom Left"), ANCHORS_AND_OFFSETS_PRESET_BOTTOM_LEFT);
 		p->add_separator();
-		p->add_icon_item(get_theme_icon("ControlAlignLeftCenter", "EditorIcons"), TTR("Center Left"), ANCHORS_AND_OFFSETS_PRESET_CENTER_LEFT);
-		p->add_icon_item(get_theme_icon("ControlAlignTopCenter", "EditorIcons"), TTR("Center Top"), ANCHORS_AND_OFFSETS_PRESET_CENTER_TOP);
-		p->add_icon_item(get_theme_icon("ControlAlignRightCenter", "EditorIcons"), TTR("Center Right"), ANCHORS_AND_OFFSETS_PRESET_CENTER_RIGHT);
-		p->add_icon_item(get_theme_icon("ControlAlignBottomCenter", "EditorIcons"), TTR("Center Bottom"), ANCHORS_AND_OFFSETS_PRESET_CENTER_BOTTOM);
-		p->add_icon_item(get_theme_icon("ControlAlignCenter", "EditorIcons"), TTR("Center"), ANCHORS_AND_OFFSETS_PRESET_CENTER);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignLeftCenter"), SNAME("EditorIcons")), TTR("Center Left"), ANCHORS_AND_OFFSETS_PRESET_CENTER_LEFT);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignTopCenter"), SNAME("EditorIcons")), TTR("Center Top"), ANCHORS_AND_OFFSETS_PRESET_CENTER_TOP);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignRightCenter"), SNAME("EditorIcons")), TTR("Center Right"), ANCHORS_AND_OFFSETS_PRESET_CENTER_RIGHT);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignBottomCenter"), SNAME("EditorIcons")), TTR("Center Bottom"), ANCHORS_AND_OFFSETS_PRESET_CENTER_BOTTOM);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignCenter"), SNAME("EditorIcons")), TTR("Center"), ANCHORS_AND_OFFSETS_PRESET_CENTER);
 		p->add_separator();
-		p->add_icon_item(get_theme_icon("ControlAlignLeftWide", "EditorIcons"), TTR("Left Wide"), ANCHORS_AND_OFFSETS_PRESET_LEFT_WIDE);
-		p->add_icon_item(get_theme_icon("ControlAlignTopWide", "EditorIcons"), TTR("Top Wide"), ANCHORS_AND_OFFSETS_PRESET_TOP_WIDE);
-		p->add_icon_item(get_theme_icon("ControlAlignRightWide", "EditorIcons"), TTR("Right Wide"), ANCHORS_AND_OFFSETS_PRESET_RIGHT_WIDE);
-		p->add_icon_item(get_theme_icon("ControlAlignBottomWide", "EditorIcons"), TTR("Bottom Wide"), ANCHORS_AND_OFFSETS_PRESET_BOTTOM_WIDE);
-		p->add_icon_item(get_theme_icon("ControlVcenterWide", "EditorIcons"), TTR("VCenter Wide"), ANCHORS_AND_OFFSETS_PRESET_VCENTER_WIDE);
-		p->add_icon_item(get_theme_icon("ControlHcenterWide", "EditorIcons"), TTR("HCenter Wide"), ANCHORS_AND_OFFSETS_PRESET_HCENTER_WIDE);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignLeftWide"), SNAME("EditorIcons")), TTR("Left Wide"), ANCHORS_AND_OFFSETS_PRESET_LEFT_WIDE);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignTopWide"), SNAME("EditorIcons")), TTR("Top Wide"), ANCHORS_AND_OFFSETS_PRESET_TOP_WIDE);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignRightWide"), SNAME("EditorIcons")), TTR("Right Wide"), ANCHORS_AND_OFFSETS_PRESET_RIGHT_WIDE);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignBottomWide"), SNAME("EditorIcons")), TTR("Bottom Wide"), ANCHORS_AND_OFFSETS_PRESET_BOTTOM_WIDE);
+		p->add_icon_item(get_theme_icon(SNAME("ControlVcenterWide"), SNAME("EditorIcons")), TTR("VCenter Wide"), ANCHORS_AND_OFFSETS_PRESET_VCENTER_WIDE);
+		p->add_icon_item(get_theme_icon(SNAME("ControlHcenterWide"), SNAME("EditorIcons")), TTR("HCenter Wide"), ANCHORS_AND_OFFSETS_PRESET_HCENTER_WIDE);
 		p->add_separator();
-		p->add_icon_item(get_theme_icon("ControlAlignWide", "EditorIcons"), TTR("Full Rect"), ANCHORS_AND_OFFSETS_PRESET_WIDE);
-		p->add_icon_item(get_theme_icon("Anchor", "EditorIcons"), TTR("Keep Ratio"), ANCHORS_AND_OFFSETS_PRESET_KEEP_RATIO);
+		p->add_icon_item(get_theme_icon(SNAME("ControlAlignWide"), SNAME("EditorIcons")), TTR("Full Rect"), ANCHORS_AND_OFFSETS_PRESET_WIDE);
+		p->add_icon_item(get_theme_icon(SNAME("Anchor"), SNAME("EditorIcons")), TTR("Keep Ratio"), ANCHORS_AND_OFFSETS_PRESET_KEEP_RATIO);
 		p->add_separator();
 		p->add_submenu_item(TTR("Anchors only"), "Anchors");
-		p->set_item_icon(21, get_theme_icon("Anchor", "EditorIcons"));
+		p->set_item_icon(21, get_theme_icon(SNAME("Anchor"), SNAME("EditorIcons")));
 
 		anchors_popup->clear();
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignTopLeft", "EditorIcons"), TTR("Top Left"), ANCHORS_PRESET_TOP_LEFT);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignTopRight", "EditorIcons"), TTR("Top Right"), ANCHORS_PRESET_TOP_RIGHT);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignBottomRight", "EditorIcons"), TTR("Bottom Right"), ANCHORS_PRESET_BOTTOM_RIGHT);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignBottomLeft", "EditorIcons"), TTR("Bottom Left"), ANCHORS_PRESET_BOTTOM_LEFT);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignTopLeft"), SNAME("EditorIcons")), TTR("Top Left"), ANCHORS_PRESET_TOP_LEFT);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignTopRight"), SNAME("EditorIcons")), TTR("Top Right"), ANCHORS_PRESET_TOP_RIGHT);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignBottomRight"), SNAME("EditorIcons")), TTR("Bottom Right"), ANCHORS_PRESET_BOTTOM_RIGHT);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignBottomLeft"), SNAME("EditorIcons")), TTR("Bottom Left"), ANCHORS_PRESET_BOTTOM_LEFT);
 		anchors_popup->add_separator();
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignLeftCenter", "EditorIcons"), TTR("Center Left"), ANCHORS_PRESET_CENTER_LEFT);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignTopCenter", "EditorIcons"), TTR("Center Top"), ANCHORS_PRESET_CENTER_TOP);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignRightCenter", "EditorIcons"), TTR("Center Right"), ANCHORS_PRESET_CENTER_RIGHT);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignBottomCenter", "EditorIcons"), TTR("Center Bottom"), ANCHORS_PRESET_CENTER_BOTTOM);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignCenter", "EditorIcons"), TTR("Center"), ANCHORS_PRESET_CENTER);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignLeftCenter"), SNAME("EditorIcons")), TTR("Center Left"), ANCHORS_PRESET_CENTER_LEFT);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignTopCenter"), SNAME("EditorIcons")), TTR("Center Top"), ANCHORS_PRESET_CENTER_TOP);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignRightCenter"), SNAME("EditorIcons")), TTR("Center Right"), ANCHORS_PRESET_CENTER_RIGHT);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignBottomCenter"), SNAME("EditorIcons")), TTR("Center Bottom"), ANCHORS_PRESET_CENTER_BOTTOM);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignCenter"), SNAME("EditorIcons")), TTR("Center"), ANCHORS_PRESET_CENTER);
 		anchors_popup->add_separator();
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignLeftWide", "EditorIcons"), TTR("Left Wide"), ANCHORS_PRESET_LEFT_WIDE);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignTopWide", "EditorIcons"), TTR("Top Wide"), ANCHORS_PRESET_TOP_WIDE);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignRightWide", "EditorIcons"), TTR("Right Wide"), ANCHORS_PRESET_RIGHT_WIDE);
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignBottomWide", "EditorIcons"), TTR("Bottom Wide"), ANCHORS_PRESET_BOTTOM_WIDE);
-		anchors_popup->add_icon_item(get_theme_icon("ControlVcenterWide", "EditorIcons"), TTR("VCenter Wide"), ANCHORS_PRESET_VCENTER_WIDE);
-		anchors_popup->add_icon_item(get_theme_icon("ControlHcenterWide", "EditorIcons"), TTR("HCenter Wide"), ANCHORS_PRESET_HCENTER_WIDE);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignLeftWide"), SNAME("EditorIcons")), TTR("Left Wide"), ANCHORS_PRESET_LEFT_WIDE);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignTopWide"), SNAME("EditorIcons")), TTR("Top Wide"), ANCHORS_PRESET_TOP_WIDE);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignRightWide"), SNAME("EditorIcons")), TTR("Right Wide"), ANCHORS_PRESET_RIGHT_WIDE);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignBottomWide"), SNAME("EditorIcons")), TTR("Bottom Wide"), ANCHORS_PRESET_BOTTOM_WIDE);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlVcenterWide"), SNAME("EditorIcons")), TTR("VCenter Wide"), ANCHORS_PRESET_VCENTER_WIDE);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlHcenterWide"), SNAME("EditorIcons")), TTR("HCenter Wide"), ANCHORS_PRESET_HCENTER_WIDE);
 		anchors_popup->add_separator();
-		anchors_popup->add_icon_item(get_theme_icon("ControlAlignWide", "EditorIcons"), TTR("Full Rect"), ANCHORS_PRESET_WIDE);
+		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignWide"), SNAME("EditorIcons")), TTR("Full Rect"), ANCHORS_PRESET_WIDE);
 
-		anchor_mode_button->set_icon(get_theme_icon("Anchor", "EditorIcons"));
+		anchor_mode_button->set_icon(get_theme_icon(SNAME("Anchor"), SNAME("EditorIcons")));
 	}
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
@@ -4889,7 +4889,7 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 			zoom *= 0.90;
 			viewport->update();
 			zoom_widget->set_zoom(zoom);
-			call_deferred("_popup_callback", VIEW_CENTER_TO_SELECTION);
+			call_deferred(SNAME("_popup_callback"), VIEW_CENTER_TO_SELECTION);
 		}
 	}
 }
@@ -5215,8 +5215,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	editor->get_scene_tree_dock()->connect("node_created", callable_mp(this, &CanvasItemEditor::_node_created));
 	editor->get_scene_tree_dock()->connect("add_node_used", callable_mp(this, &CanvasItemEditor::_reset_create_position));
 
-	editor->call_deferred("connect", "play_pressed", Callable(this, "_update_override_camera_button"), make_binds(true));
-	editor->call_deferred("connect", "stop_pressed", Callable(this, "_update_override_camera_button"), make_binds(false));
+	editor->call_deferred(SNAME("connect"), "play_pressed", Callable(this, "_update_override_camera_button"), make_binds(true));
+	editor->call_deferred(SNAME("connect"), "stop_pressed", Callable(this, "_update_override_camera_button"), make_binds(false));
 
 	hb = memnew(HBoxContainer);
 	add_child(hb);
@@ -5276,9 +5276,9 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	warning_child_of_container = memnew(Label);
 	warning_child_of_container->hide();
 	warning_child_of_container->set_text(TTR("Warning: Children of a container get their position and size determined only by their parent."));
-	warning_child_of_container->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("warning_color", "Editor"));
-	warning_child_of_container->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("main", "EditorFonts"));
-	warning_child_of_container->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("main_size", "EditorFonts"));
+	warning_child_of_container->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+	warning_child_of_container->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("main"), SNAME("EditorFonts")));
+	warning_child_of_container->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("main_size"), SNAME("EditorFonts")));
 	add_control_to_info_overlay(warning_child_of_container);
 
 	h_scroll = memnew(HScrollBar);
@@ -5615,8 +5615,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	add_node_menu = memnew(PopupMenu);
 	add_child(add_node_menu);
-	add_node_menu->add_icon_item(editor->get_scene_tree_dock()->get_theme_icon("Add", "EditorIcons"), TTR("Add Node Here"));
-	add_node_menu->add_icon_item(editor->get_scene_tree_dock()->get_theme_icon("Instance", "EditorIcons"), TTR("Instance Scene Here"));
+	add_node_menu->add_icon_item(editor->get_scene_tree_dock()->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), TTR("Add Node Here"));
+	add_node_menu->add_icon_item(editor->get_scene_tree_dock()->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Instance Scene Here"));
 	add_node_menu->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_add_node_pressed));
 
 	multiply_grid_step_shortcut = ED_SHORTCUT("canvas_item_editor/multiply_grid_step", TTR("Multiply grid step by 2"), KEY_KP_MULTIPLY);
@@ -5639,7 +5639,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	set_process_unhandled_key_input(true);
 
 	// Update the menus' checkboxes
-	call_deferred("set_state", get_state());
+	call_deferred(SNAME("set_state"), get_state());
 }
 
 CanvasItemEditor *CanvasItemEditor::singleton = nullptr;
@@ -6075,7 +6075,7 @@ void CanvasItemEditorViewport::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			connect("mouse_exited", callable_mp(this, &CanvasItemEditorViewport::_on_mouse_exit));
-			label->add_theme_color_override("font_color", get_theme_color("warning_color", "Editor"));
+			label->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect("mouse_exited", callable_mp(this, &CanvasItemEditorViewport::_on_mouse_exit));

--- a/editor/plugins/collision_polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_3d_editor_plugin.cpp
@@ -42,8 +42,8 @@
 void CollisionPolygon3DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			button_create->set_icon(get_theme_icon("Edit", "EditorIcons"));
-			button_edit->set_icon(get_theme_icon("MovePoint", "EditorIcons"));
+			button_create->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+			button_edit->set_icon(get_theme_icon(SNAME("MovePoint"), SNAME("EditorIcons")));
 			button_edit->set_pressed(true);
 			get_tree()->connect("node_removed", callable_mp(this, &CollisionPolygon3DEditor::_node_removed));
 
@@ -531,7 +531,7 @@ CollisionPolygon3DEditor::CollisionPolygon3DEditor(EditorNode *p_editor) {
 	handle_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	handle_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 	handle_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
-	Ref<Texture2D> handle = editor->get_gui_base()->get_theme_icon("Editor3DHandle", "EditorIcons");
+	Ref<Texture2D> handle = editor->get_gui_base()->get_theme_icon(SNAME("Editor3DHandle"), SNAME("EditorIcons"));
 	handle_material->set_point_size(handle->get_width());
 	handle_material->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, handle);
 

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -430,7 +430,7 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 
 	Transform2D gt = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
 
-	Ref<Texture2D> h = get_theme_icon("EditorHandle", "EditorIcons");
+	Ref<Texture2D> h = get_theme_icon(SNAME("EditorHandle"), SNAME("EditorIcons"));
 	Vector2 size = h->get_size() * 0.5;
 
 	handles.clear();

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -224,7 +224,7 @@ void CPUParticles2DEditorPlugin::_generate_emission_mask() {
 void CPUParticles2DEditorPlugin::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		menu->get_popup()->connect("id_pressed", callable_mp(this, &CPUParticles2DEditorPlugin::_menu_callback));
-		menu->set_icon(epoints->get_theme_icon("CPUParticles2D", "EditorIcons"));
+		menu->set_icon(epoints->get_theme_icon(SNAME("CPUParticles2D"), SNAME("EditorIcons")));
 		file->connect("file_selected", callable_mp(this, &CPUParticles2DEditorPlugin::_file_selected));
 	}
 }

--- a/editor/plugins/cpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.cpp
@@ -41,7 +41,7 @@ void CPUParticles3DEditor::_node_removed(Node *p_node) {
 
 void CPUParticles3DEditor::_notification(int p_notification) {
 	if (p_notification == NOTIFICATION_ENTER_TREE) {
-		options->set_icon(get_theme_icon("CPUParticles3D", "EditorIcons"));
+		options->set_icon(get_theme_icon(SNAME("CPUParticles3D"), SNAME("EditorIcons")));
 	}
 }
 

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -519,8 +519,8 @@ void CurveEditor::set_hover_point_index(int index) {
 }
 
 void CurveEditor::update_view_transform() {
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 
 	const real_t margin = font->get_height(font_size) + 2 * EDSCALE;
 
@@ -635,7 +635,7 @@ void CurveEditor::_draw() {
 	// Background
 
 	Vector2 view_size = get_rect().size;
-	draw_style_box(get_theme_stylebox("bg", "Tree"), Rect2(Point2(), view_size));
+	draw_style_box(get_theme_stylebox(SNAME("bg"), SNAME("Tree")), Rect2(Point2(), view_size));
 
 	// Grid
 
@@ -644,8 +644,8 @@ void CurveEditor::_draw() {
 	Vector2 min_edge = get_world_pos(Vector2(0, view_size.y));
 	Vector2 max_edge = get_world_pos(Vector2(view_size.x, 0));
 
-	const Color grid_color0 = get_theme_color("mono_color", "Editor") * Color(1, 1, 1, 0.15);
-	const Color grid_color1 = get_theme_color("mono_color", "Editor") * Color(1, 1, 1, 0.07);
+	const Color grid_color0 = get_theme_color(SNAME("mono_color"), SNAME("Editor")) * Color(1, 1, 1, 0.15);
+	const Color grid_color1 = get_theme_color(SNAME("mono_color"), SNAME("Editor")) * Color(1, 1, 1, 0.07);
 	draw_line(Vector2(min_edge.x, curve.get_min_value()), Vector2(max_edge.x, curve.get_min_value()), grid_color0);
 	draw_line(Vector2(max_edge.x, curve.get_max_value()), Vector2(min_edge.x, curve.get_max_value()), grid_color0);
 	draw_line(Vector2(0, min_edge.y), Vector2(0, max_edge.y), grid_color0);
@@ -665,10 +665,10 @@ void CurveEditor::_draw() {
 
 	draw_set_transform_matrix(Transform2D());
 
-	Ref<Font> font = get_theme_font("font", "Label");
-	int font_size = get_theme_font_size("font_size", "Label");
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	float font_height = font->get_height(font_size);
-	Color text_color = get_theme_color("font_color", "Editor");
+	Color text_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 
 	{
 		// X axis
@@ -695,7 +695,7 @@ void CurveEditor::_draw() {
 	// Draw tangents for current point
 
 	if (_selected_point >= 0) {
-		const Color tangent_color = get_theme_color("accent_color", "Editor");
+		const Color tangent_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 
 		int i = _selected_point;
 		Vector2 pos = curve.get_point_position(i);
@@ -717,8 +717,8 @@ void CurveEditor::_draw() {
 
 	draw_set_transform_matrix(_world_to_view);
 
-	const Color line_color = get_theme_color("font_color", "Editor");
-	const Color edge_line_color = get_theme_color("highlight_color", "Editor");
+	const Color line_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
+	const Color edge_line_color = get_theme_color(SNAME("highlight_color"), SNAME("Editor"));
 
 	CanvasItemPlotCurve plot_func(*this, line_color, edge_line_color);
 	plot_curve_accurate(curve, 4.f / view_size.x, plot_func);
@@ -727,8 +727,8 @@ void CurveEditor::_draw() {
 
 	draw_set_transform_matrix(Transform2D());
 
-	const Color point_color = get_theme_color("font_color", "Editor");
-	const Color selected_point_color = get_theme_color("accent_color", "Editor");
+	const Color point_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
+	const Color selected_point_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 
 	for (int i = 0; i < curve.get_point_count(); ++i) {
 		Vector2 pos = curve.get_point_position(i);

--- a/editor/plugins/editor_debugger_plugin.cpp
+++ b/editor/plugins/editor_debugger_plugin.cpp
@@ -34,18 +34,18 @@
 
 void EditorDebuggerPlugin::_breaked(bool p_really_did, bool p_can_debug) {
 	if (p_really_did) {
-		emit_signal("breaked", p_can_debug);
+		emit_signal(SNAME("breaked"), p_can_debug);
 	} else {
-		emit_signal("continued");
+		emit_signal(SNAME("continued"));
 	}
 }
 
 void EditorDebuggerPlugin::_started() {
-	emit_signal("started");
+	emit_signal(SNAME("started"));
 }
 
 void EditorDebuggerPlugin::_stopped() {
-	emit_signal("stopped");
+	emit_signal(SNAME("stopped"));
 }
 
 void EditorDebuggerPlugin::_bind_methods() {

--- a/editor/plugins/font_editor_plugin.cpp
+++ b/editor/plugins/font_editor_plugin.cpp
@@ -34,7 +34,7 @@
 
 void FontDataPreview::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
-		Color text_color = get_theme_color("font_color", "Label");
+		Color text_color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 		Color line_color = text_color;
 		line_color.a *= 0.6;
 		Vector2 pos = (get_size() - line->get_size()) / 2;
@@ -127,7 +127,7 @@ FontDataPreview::FontDataPreview() {
 void FontDataEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
 		int split_width = get_name_split_ratio() * get_size().width;
-		button->set_size(Size2(get_theme_icon("Add", "EditorIcons")->get_width(), get_size().height));
+		button->set_size(Size2(get_theme_icon(SNAME("Add"), SNAME("EditorIcons"))->get_width(), get_size().height));
 		if (is_layout_rtl()) {
 			if (le != nullptr) {
 				fit_child_in_rect(le, Rect2(Vector2(split_width, 0), Size2(split_width, get_size().height)));
@@ -145,7 +145,7 @@ void FontDataEditor::_notification(int p_what) {
 	}
 	if (p_what == NOTIFICATION_DRAW) {
 		int split_width = get_name_split_ratio() * get_size().width;
-		Color dark_color = get_theme_color("dark_color_2", "Editor");
+		Color dark_color = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
 		if (is_layout_rtl()) {
 			draw_rect(Rect2(Vector2(0, 0), Size2(split_width, get_size().height)), dark_color);
 		} else {
@@ -154,9 +154,9 @@ void FontDataEditor::_notification(int p_what) {
 	}
 	if (p_what == NOTIFICATION_THEME_CHANGED) {
 		if (le != nullptr) {
-			button->set_icon(get_theme_icon("Add", "EditorIcons"));
+			button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		} else {
-			button->set_icon(get_theme_icon("Remove", "EditorIcons"));
+			button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 		}
 		queue_sort();
 	}
@@ -187,12 +187,12 @@ void FontDataEditor::init_lang_add() {
 	le->set_editable(true);
 	add_child(le);
 
-	button->set_icon(get_theme_icon("Add", "EditorIcons"));
+	button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 	button->connect("pressed", callable_mp(this, &FontDataEditor::add_lang));
 }
 
 void FontDataEditor::init_lang_edit() {
-	button->set_icon(get_theme_icon("Remove", "EditorIcons"));
+	button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 	button->connect("pressed", callable_mp(this, &FontDataEditor::remove_lang));
 	chk->connect("toggled", callable_mp(this, &FontDataEditor::toggle_lang));
 }
@@ -204,12 +204,12 @@ void FontDataEditor::init_script_add() {
 	le->set_editable(true);
 	add_child(le);
 
-	button->set_icon(get_theme_icon("Add", "EditorIcons"));
+	button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 	button->connect("pressed", callable_mp(this, &FontDataEditor::add_script));
 }
 
 void FontDataEditor::init_script_edit() {
-	button->set_icon(get_theme_icon("Remove", "EditorIcons"));
+	button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 	button->connect("pressed", callable_mp(this, &FontDataEditor::remove_script));
 	chk->connect("toggled", callable_mp(this, &FontDataEditor::toggle_script));
 }

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -329,7 +329,7 @@ void GPUParticles2DEditorPlugin::_generate_emission_mask() {
 void GPUParticles2DEditorPlugin::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		menu->get_popup()->connect("id_pressed", callable_mp(this, &GPUParticles2DEditorPlugin::_menu_callback));
-		menu->set_icon(menu->get_theme_icon("GPUParticles2D", "EditorIcons"));
+		menu->set_icon(menu->get_theme_icon(SNAME("GPUParticles2D"), SNAME("EditorIcons")));
 		file->connect("file_selected", callable_mp(this, &GPUParticles2DEditorPlugin::_file_selected));
 	}
 }

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -230,7 +230,7 @@ void GPUParticles3DEditor::_node_removed(Node *p_node) {
 
 void GPUParticles3DEditor::_notification(int p_notification) {
 	if (p_notification == NOTIFICATION_ENTER_TREE) {
-		options->set_icon(options->get_popup()->get_theme_icon("GPUParticles3D", "EditorIcons"));
+		options->set_icon(options->get_popup()->get_theme_icon(SNAME("GPUParticles3D"), SNAME("EditorIcons")));
 		get_tree()->connect("node_removed", callable_mp(this, &GPUParticles3DEditor::_node_removed));
 	}
 }

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -83,13 +83,13 @@ void GPUParticlesCollisionSDFEditorPlugin::_notification(int p_what) {
 		Color color;
 		if (size_mb <= 16.0 + CMP_EPSILON) {
 			// Fast.
-			color = bake_info->get_theme_color("success_color", "Editor");
+			color = bake_info->get_theme_color(SNAME("success_color"), SNAME("Editor"));
 		} else if (size_mb <= 64.0 + CMP_EPSILON) {
 			// Medium.
-			color = bake_info->get_theme_color("warning_color", "Editor");
+			color = bake_info->get_theme_color(SNAME("warning_color"), SNAME("Editor"));
 		} else {
 			// Slow.
-			color = bake_info->get_theme_color("error_color", "Editor");
+			color = bake_info->get_theme_color(SNAME("error_color"), SNAME("Editor"));
 		}
 		bake_info->add_theme_color_override("font_color", color);
 
@@ -174,7 +174,7 @@ GPUParticlesCollisionSDFEditorPlugin::GPUParticlesCollisionSDFEditorPlugin(Edito
 	bake_hb->hide();
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(editor->get_gui_base()->get_theme_icon("Bake", "EditorIcons"));
+	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake SDF"));
 	bake->connect("pressed", callable_mp(this, &GPUParticlesCollisionSDFEditorPlugin::_bake));
 	bake_hb->add_child(bake);

--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -243,8 +243,8 @@ void ItemListEditor::_node_removed(Node *p_node) {
 
 void ItemListEditor::_notification(int p_notification) {
 	if (p_notification == NOTIFICATION_ENTER_TREE || p_notification == NOTIFICATION_THEME_CHANGED) {
-		add_button->set_icon(get_theme_icon("Add", "EditorIcons"));
-		del_button->set_icon(get_theme_icon("Remove", "EditorIcons"));
+		add_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		del_button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 	} else if (p_notification == NOTIFICATION_READY) {
 		get_tree()->connect("node_removed", callable_mp(this, &ItemListEditor::_node_removed));
 	}

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -119,7 +119,7 @@ LightmapGIEditorPlugin::LightmapGIEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(editor->get_gui_base()->get_theme_icon("Bake", "EditorIcons"));
+	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake Lightmaps"));
 	bake->hide();
 	bake->connect("pressed", Callable(this, "_bake"));

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -42,22 +42,22 @@ void MaterialEditor::_notification(int p_what) {
 		if (first_enter) {
 			//it's in propertyeditor so.. could be moved around
 
-			light_1_switch->set_normal_texture(get_theme_icon("MaterialPreviewLight1", "EditorIcons"));
-			light_1_switch->set_pressed_texture(get_theme_icon("MaterialPreviewLight1Off", "EditorIcons"));
-			light_2_switch->set_normal_texture(get_theme_icon("MaterialPreviewLight2", "EditorIcons"));
-			light_2_switch->set_pressed_texture(get_theme_icon("MaterialPreviewLight2Off", "EditorIcons"));
+			light_1_switch->set_normal_texture(get_theme_icon(SNAME("MaterialPreviewLight1"), SNAME("EditorIcons")));
+			light_1_switch->set_pressed_texture(get_theme_icon(SNAME("MaterialPreviewLight1Off"), SNAME("EditorIcons")));
+			light_2_switch->set_normal_texture(get_theme_icon(SNAME("MaterialPreviewLight2"), SNAME("EditorIcons")));
+			light_2_switch->set_pressed_texture(get_theme_icon(SNAME("MaterialPreviewLight2Off"), SNAME("EditorIcons")));
 
-			sphere_switch->set_normal_texture(get_theme_icon("MaterialPreviewSphereOff", "EditorIcons"));
-			sphere_switch->set_pressed_texture(get_theme_icon("MaterialPreviewSphere", "EditorIcons"));
-			box_switch->set_normal_texture(get_theme_icon("MaterialPreviewCubeOff", "EditorIcons"));
-			box_switch->set_pressed_texture(get_theme_icon("MaterialPreviewCube", "EditorIcons"));
+			sphere_switch->set_normal_texture(get_theme_icon(SNAME("MaterialPreviewSphereOff"), SNAME("EditorIcons")));
+			sphere_switch->set_pressed_texture(get_theme_icon(SNAME("MaterialPreviewSphere"), SNAME("EditorIcons")));
+			box_switch->set_normal_texture(get_theme_icon(SNAME("MaterialPreviewCubeOff"), SNAME("EditorIcons")));
+			box_switch->set_pressed_texture(get_theme_icon(SNAME("MaterialPreviewCube"), SNAME("EditorIcons")));
 
 			first_enter = false;
 		}
 	}
 
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Texture2D> checkerboard = get_theme_icon("Checkerboard", "EditorIcons");
+		Ref<Texture2D> checkerboard = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
 		Size2 size = get_size();
 
 		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -55,10 +55,10 @@ void MeshEditor::_notification(int p_what) {
 		if (first_enter) {
 			//it's in propertyeditor so. could be moved around
 
-			light_1_switch->set_normal_texture(get_theme_icon("MaterialPreviewLight1", "EditorIcons"));
-			light_1_switch->set_pressed_texture(get_theme_icon("MaterialPreviewLight1Off", "EditorIcons"));
-			light_2_switch->set_normal_texture(get_theme_icon("MaterialPreviewLight2", "EditorIcons"));
-			light_2_switch->set_pressed_texture(get_theme_icon("MaterialPreviewLight2Off", "EditorIcons"));
+			light_1_switch->set_normal_texture(get_theme_icon(SNAME("MaterialPreviewLight1"), SNAME("EditorIcons")));
+			light_1_switch->set_pressed_texture(get_theme_icon(SNAME("MaterialPreviewLight1Off"), SNAME("EditorIcons")));
+			light_2_switch->set_normal_texture(get_theme_icon(SNAME("MaterialPreviewLight2"), SNAME("EditorIcons")));
+			light_2_switch->set_pressed_texture(get_theme_icon(SNAME("MaterialPreviewLight2Off"), SNAME("EditorIcons")));
 			first_enter = false;
 		}
 	}

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -441,7 +441,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->set_text(TTR("Mesh"));
-	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("MeshInstance3D", "EditorIcons"));
+	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("MeshInstance3D"), SNAME("EditorIcons")));
 
 	options->get_popup()->add_item(TTR("Create Trimesh Static Body"), MENU_OPTION_CREATE_STATIC_TRIMESH_BODY);
 	options->get_popup()->set_item_tooltip(options->get_popup()->get_item_count() - 1, TTR("Creates a StaticBody3D and assigns a polygon-based collision shape to it automatically.\nThis is the most accurate (but slowest) option for collision detection."));

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -254,7 +254,7 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(menu);
 	menu->set_position(Point2(1, 1));
 	menu->set_text(TTR("Mesh Library"));
-	menu->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("MeshLibrary", "EditorIcons"));
+	menu->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("MeshLibrary"), SNAME("EditorIcons")));
 	menu->get_popup()->add_item(TTR("Add Item"), MENU_OPTION_ADD_ITEM);
 	menu->get_popup()->add_item(TTR("Remove Selected Item"), MENU_OPTION_REMOVE_ITEM);
 	menu->get_popup()->add_separator();

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -268,7 +268,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->set_text("MultiMesh");
-	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("MultiMeshInstance3D", "EditorIcons"));
+	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("MultiMeshInstance3D"), SNAME("EditorIcons")));
 
 	options->get_popup()->add_item(TTR("Populate Surface"));
 	options->get_popup()->connect("id_pressed", callable_mp(this, &MultiMeshEditor::_menu_option));

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -92,9 +92,9 @@ void ViewportRotationControl::_notification(int p_what) {
 		axis_menu_options.push_back(Node3DEditorViewport::VIEW_FRONT);
 
 		axis_colors.clear();
-		axis_colors.push_back(get_theme_color("axis_x_color", "Editor"));
-		axis_colors.push_back(get_theme_color("axis_y_color", "Editor"));
-		axis_colors.push_back(get_theme_color("axis_z_color", "Editor"));
+		axis_colors.push_back(get_theme_color(SNAME("axis_x_color"), SNAME("Editor")));
+		axis_colors.push_back(get_theme_color(SNAME("axis_y_color"), SNAME("Editor")));
+		axis_colors.push_back(get_theme_color(SNAME("axis_z_color"), SNAME("Editor")));
 		update();
 
 		if (!is_connected("mouse_exited", callable_mp(this, &ViewportRotationControl::_on_mouse_exited))) {
@@ -143,7 +143,7 @@ void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
 	if (front) {
 		String axis_name = direction == 0 ? "X" : (direction == 1 ? "Y" : "Z");
 		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS, c);
-		draw_char(get_theme_font("rotation_control", "EditorFonts"), p_axis.screen_point + Vector2i(-4, 5) * EDSCALE, axis_name, "", get_theme_font_size("rotation_control_size", "EditorFonts"), Color(0.3, 0.3, 0.3));
+		draw_char(get_theme_font(SNAME("rotation_control"), SNAME("EditorFonts")), p_axis.screen_point + Vector2i(-4, 5) * EDSCALE, axis_name, "", get_theme_font_size(SNAME("rotation_control_size"), SNAME("EditorFonts")), Color(0.3, 0.3, 0.3));
 	} else {
 		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS * (0.55 + (0.2 * (1.0 + p_axis.z_axis))), c);
 	}
@@ -1135,7 +1135,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> b = p_event;
 
 	if (b.is_valid()) {
-		emit_signal("clicked", this);
+		emit_signal(SNAME("clicked"), this);
 
 		float zoom_factor = 1 + (ZOOM_FREELOOK_MULTIPLIER - 1) * b->get_factor();
 		switch (b->get_button_index()) {
@@ -2045,7 +2045,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					continue;
 				}
 
-				spatial_editor->emit_signal("transform_key_request", sp, "", sp->get_transform());
+				spatial_editor->emit_signal(SNAME("transform_key_request"), sp, "", sp->get_transform());
 			}
 
 			set_message(TTR("Animation Key Inserted."));
@@ -2061,7 +2061,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 		if (k->get_keycode() == KEY_SPACE) {
 			if (!k->is_pressed()) {
-				emit_signal("toggle_maximize_view", this);
+				emit_signal(SNAME("toggle_maximize_view"), this);
 			}
 		}
 	}
@@ -2415,12 +2415,12 @@ void Node3DEditorViewport::_notification(int p_what) {
 		} else {
 			set_freelook_active(false);
 		}
-		call_deferred("update_transform_gizmo_view");
+		call_deferred(SNAME("update_transform_gizmo_view"));
 		rotation_control->set_visible(EditorSettings::get_singleton()->get("editors/3d/navigation/show_viewport_rotation_gizmo"));
 	}
 
 	if (p_what == NOTIFICATION_RESIZED) {
-		call_deferred("update_transform_gizmo_view");
+		call_deferred(SNAME("update_transform_gizmo_view"));
 	}
 
 	if (p_what == NOTIFICATION_PROCESS) {
@@ -2633,31 +2633,31 @@ void Node3DEditorViewport::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_THEME_CHANGED) {
-		view_menu->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
-		preview_camera->set_icon(get_theme_icon("Camera3D", "EditorIcons"));
+		view_menu->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
+		preview_camera->set_icon(get_theme_icon(SNAME("Camera3D"), SNAME("EditorIcons")));
 
-		view_menu->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		view_menu->add_theme_style_override("hover", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		view_menu->add_theme_style_override("pressed", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		view_menu->add_theme_style_override("focus", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		view_menu->add_theme_style_override("disabled", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
+		view_menu->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("hover", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("pressed", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("focus", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("disabled", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 
-		preview_camera->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		preview_camera->add_theme_style_override("hover", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		preview_camera->add_theme_style_override("pressed", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		preview_camera->add_theme_style_override("focus", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		preview_camera->add_theme_style_override("disabled", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
+		preview_camera->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("hover", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("pressed", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("focus", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("disabled", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 
-		frame_time_gradient->set_color(0, get_theme_color("success_color", "Editor"));
-		frame_time_gradient->set_color(1, get_theme_color("warning_color", "Editor"));
-		frame_time_gradient->set_color(2, get_theme_color("error_color", "Editor"));
+		frame_time_gradient->set_color(0, get_theme_color(SNAME("success_color"), SNAME("Editor")));
+		frame_time_gradient->set_color(1, get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+		frame_time_gradient->set_color(2, get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
-		info_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		cpu_time_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		gpu_time_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		fps_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		cinema_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
-		locked_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("Information3dViewport", "EditorStyles"));
+		info_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		cpu_time_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		gpu_time_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		fps_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		cinema_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		locked_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 	}
 }
 
@@ -2698,7 +2698,7 @@ void Node3DEditorViewport::_draw() {
 	if (surface->has_focus()) {
 		Size2 size = surface->get_size();
 		Rect2 r = Rect2(Point2(), size);
-		get_theme_stylebox("Focus", "EditorStyles")->draw(surface->get_canvas_item(), r);
+		get_theme_stylebox(SNAME("Focus"), SNAME("EditorStyles"))->draw(surface->get_canvas_item(), r);
 	}
 
 	if (cursor.region_select) {
@@ -2706,11 +2706,11 @@ void Node3DEditorViewport::_draw() {
 
 		surface->draw_rect(
 				selection_rect,
-				get_theme_color("box_selection_fill_color", "Editor"));
+				get_theme_color(SNAME("box_selection_fill_color"), SNAME("Editor")));
 
 		surface->draw_rect(
 				selection_rect,
-				get_theme_color("box_selection_stroke_color", "Editor"),
+				get_theme_color(SNAME("box_selection_stroke_color"), SNAME("Editor")),
 				false,
 				Math::round(EDSCALE));
 	}
@@ -2718,8 +2718,8 @@ void Node3DEditorViewport::_draw() {
 	RID ci = surface->get_canvas_item();
 
 	if (message_time > 0) {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		Point2 msgpos = Point2(5, get_size().y - 20);
 		font->draw_string(ci, msgpos + Point2(1, 1), message, HALIGN_LEFT, -1, font_size, Color(0, 0, 0, 0.8));
 		font->draw_string(ci, msgpos + Point2(-1, -1), message, HALIGN_LEFT, -1, font_size, Color(0, 0, 0, 0.8));
@@ -2732,16 +2732,16 @@ void Node3DEditorViewport::_draw() {
 		Color handle_color;
 		switch (_edit.plane) {
 			case TRANSFORM_X_AXIS:
-				handle_color = get_theme_color("axis_x_color", "Editor");
+				handle_color = get_theme_color(SNAME("axis_x_color"), SNAME("Editor"));
 				break;
 			case TRANSFORM_Y_AXIS:
-				handle_color = get_theme_color("axis_y_color", "Editor");
+				handle_color = get_theme_color(SNAME("axis_y_color"), SNAME("Editor"));
 				break;
 			case TRANSFORM_Z_AXIS:
-				handle_color = get_theme_color("axis_z_color", "Editor");
+				handle_color = get_theme_color(SNAME("axis_z_color"), SNAME("Editor"));
 				break;
 			default:
-				handle_color = get_theme_color("accent_color", "Editor");
+				handle_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 				break;
 		}
 		handle_color.a = 1.0;
@@ -2798,9 +2798,9 @@ void Node3DEditorViewport::_draw() {
 					draw_indicator_bar(
 							*surface,
 							1.0 - logscale_t,
-							get_theme_icon("ViewportSpeed", "EditorIcons"),
-							get_theme_font("font", "Label"),
-							get_theme_font_size("font_size", "Label"),
+							get_theme_icon(SNAME("ViewportSpeed"), SNAME("EditorIcons")),
+							get_theme_font(SNAME("font"), SNAME("Label")),
+							get_theme_font_size(SNAME("font_size"), SNAME("Label")),
 							vformat("%s u/s", String::num(freelook_speed).pad_decimals(precision)));
 				}
 
@@ -2820,9 +2820,9 @@ void Node3DEditorViewport::_draw() {
 					draw_indicator_bar(
 							*surface,
 							logscale_t,
-							get_theme_icon("ViewportZoom", "EditorIcons"),
-							get_theme_font("font", "Label"),
-							get_theme_font_size("font_size", "Label"),
+							get_theme_icon(SNAME("ViewportZoom"), SNAME("EditorIcons")),
+							get_theme_font(SNAME("font"), SNAME("Label")),
+							get_theme_font_size(SNAME("font_size"), SNAME("Label")),
 							vformat("%s u", String::num(cursor.distance).pad_decimals(precision)));
 				}
 			}
@@ -2976,7 +2976,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_ORTHOGONAL), false);
 			orthogonal = false;
 			auto_orthogonal = false;
-			call_deferred("update_transform_gizmo_view");
+			call_deferred(SNAME("update_transform_gizmo_view"));
 			_update_name();
 
 		} break;
@@ -2985,7 +2985,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_ORTHOGONAL), true);
 			orthogonal = true;
 			auto_orthogonal = false;
-			call_deferred("update_transform_gizmo_view");
+			call_deferred(SNAME("update_transform_gizmo_view"));
 			_update_name();
 
 		} break;
@@ -4251,8 +4251,8 @@ void Node3DEditorViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
 		if (mb->is_pressed()) {
 			Vector2 size = get_size();
 
-			int h_sep = get_theme_constant("separation", "HSplitContainer");
-			int v_sep = get_theme_constant("separation", "VSplitContainer");
+			int h_sep = get_theme_constant(SNAME("separation"), SNAME("HSplitContainer"));
+			int v_sep = get_theme_constant(SNAME("separation"), SNAME("VSplitContainer"));
 
 			int mid_w = size.width * ratio_h;
 			int mid_h = size.height * ratio_v;
@@ -4297,8 +4297,8 @@ void Node3DEditorViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
 		if (view == VIEW_USE_3_VIEWPORTS || view == VIEW_USE_3_VIEWPORTS_ALT || view == VIEW_USE_4_VIEWPORTS) {
 			Vector2 size = get_size();
 
-			int h_sep = get_theme_constant("separation", "HSplitContainer");
-			int v_sep = get_theme_constant("separation", "VSplitContainer");
+			int h_sep = get_theme_constant(SNAME("separation"), SNAME("HSplitContainer"));
+			int v_sep = get_theme_constant(SNAME("separation"), SNAME("VSplitContainer"));
 
 			int mid_w = size.width * ratio_h;
 			int mid_h = size.height * ratio_v;
@@ -4337,18 +4337,18 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_DRAW && mouseover) {
-		Ref<Texture2D> h_grabber = get_theme_icon("grabber", "HSplitContainer");
-		Ref<Texture2D> v_grabber = get_theme_icon("grabber", "VSplitContainer");
+		Ref<Texture2D> h_grabber = get_theme_icon(SNAME("grabber"), SNAME("HSplitContainer"));
+		Ref<Texture2D> v_grabber = get_theme_icon(SNAME("grabber"), SNAME("VSplitContainer"));
 
-		Ref<Texture2D> hdiag_grabber = get_theme_icon("GuiViewportHdiagsplitter", "EditorIcons");
-		Ref<Texture2D> vdiag_grabber = get_theme_icon("GuiViewportVdiagsplitter", "EditorIcons");
-		Ref<Texture2D> vh_grabber = get_theme_icon("GuiViewportVhsplitter", "EditorIcons");
+		Ref<Texture2D> hdiag_grabber = get_theme_icon(SNAME("GuiViewportHdiagsplitter"), SNAME("EditorIcons"));
+		Ref<Texture2D> vdiag_grabber = get_theme_icon(SNAME("GuiViewportVdiagsplitter"), SNAME("EditorIcons"));
+		Ref<Texture2D> vh_grabber = get_theme_icon(SNAME("GuiViewportVhsplitter"), SNAME("EditorIcons"));
 
 		Vector2 size = get_size();
 
-		int h_sep = get_theme_constant("separation", "HSplitContainer");
+		int h_sep = get_theme_constant(SNAME("separation"), SNAME("HSplitContainer"));
 
-		int v_sep = get_theme_constant("separation", "VSplitContainer");
+		int v_sep = get_theme_constant(SNAME("separation"), SNAME("VSplitContainer"));
 
 		int mid_w = size.width * ratio_h;
 		int mid_h = size.height * ratio_v;
@@ -4434,9 +4434,9 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 			}
 			return;
 		}
-		int h_sep = get_theme_constant("separation", "HSplitContainer");
+		int h_sep = get_theme_constant(SNAME("separation"), SNAME("HSplitContainer"));
 
-		int v_sep = get_theme_constant("separation", "VSplitContainer");
+		int v_sep = get_theme_constant(SNAME("separation"), SNAME("VSplitContainer"));
 
 		int mid_w = size.width * ratio_h;
 		int mid_h = size.height * ratio_v;
@@ -5054,13 +5054,13 @@ void Node3DEditor::_menu_gizmo_toggled(int p_option) {
 	const int state = gizmos_menu->get_item_state(idx);
 	switch (state) {
 		case EditorNode3DGizmoPlugin::VISIBLE:
-			gizmos_menu->set_item_icon(idx, view_menu->get_popup()->get_theme_icon("visibility_visible"));
+			gizmos_menu->set_item_icon(idx, view_menu->get_popup()->get_theme_icon(SNAME("visibility_visible")));
 			break;
 		case EditorNode3DGizmoPlugin::ON_TOP:
-			gizmos_menu->set_item_icon(idx, view_menu->get_popup()->get_theme_icon("visibility_xray"));
+			gizmos_menu->set_item_icon(idx, view_menu->get_popup()->get_theme_icon(SNAME("visibility_xray")));
 			break;
 		case EditorNode3DGizmoPlugin::HIDDEN:
-			gizmos_menu->set_item_icon(idx, view_menu->get_popup()->get_theme_icon("visibility_hidden"));
+			gizmos_menu->set_item_icon(idx, view_menu->get_popup()->get_theme_icon(SNAME("visibility_hidden")));
 			break;
 	}
 
@@ -5347,13 +5347,13 @@ void Node3DEditor::_init_indicators() {
 			Color origin_color;
 			switch (i) {
 				case 0:
-					origin_color = get_theme_color("axis_x_color", "Editor");
+					origin_color = get_theme_color(SNAME("axis_x_color"), SNAME("Editor"));
 					break;
 				case 1:
-					origin_color = get_theme_color("axis_y_color", "Editor");
+					origin_color = get_theme_color(SNAME("axis_y_color"), SNAME("Editor"));
 					break;
 				case 2:
-					origin_color = get_theme_color("axis_z_color", "Editor");
+					origin_color = get_theme_color(SNAME("axis_z_color"), SNAME("Editor"));
 					break;
 				default:
 					origin_color = Color();
@@ -5448,13 +5448,13 @@ void Node3DEditor::_init_indicators() {
 			Color col;
 			switch (i) {
 				case 0:
-					col = get_theme_color("axis_x_color", "Editor");
+					col = get_theme_color(SNAME("axis_x_color"), SNAME("Editor"));
 					break;
 				case 1:
-					col = get_theme_color("axis_y_color", "Editor");
+					col = get_theme_color(SNAME("axis_y_color"), SNAME("Editor"));
 					break;
 				case 2:
-					col = get_theme_color("axis_z_color", "Editor");
+					col = get_theme_color(SNAME("axis_z_color"), SNAME("Editor"));
 					break;
 				default:
 					col = Color();
@@ -5814,13 +5814,13 @@ void Node3DEditor::_update_gizmos_menu() {
 				TTR("Click to toggle between visibility states.\n\nOpen eye: Gizmo is visible.\nClosed eye: Gizmo is hidden.\nHalf-open eye: Gizmo is also visible through opaque surfaces (\"x-ray\")."));
 		switch (plugin_state) {
 			case EditorNode3DGizmoPlugin::VISIBLE:
-				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon("visibility_visible"));
+				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon(SNAME("visibility_visible")));
 				break;
 			case EditorNode3DGizmoPlugin::ON_TOP:
-				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon("visibility_xray"));
+				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon(SNAME("visibility_xray")));
 				break;
 			case EditorNode3DGizmoPlugin::HIDDEN:
-				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon("visibility_hidden"));
+				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon(SNAME("visibility_hidden")));
 				break;
 		}
 	}
@@ -5835,13 +5835,13 @@ void Node3DEditor::_update_gizmos_menu_theme() {
 		const int idx = gizmos_menu->get_item_index(i);
 		switch (plugin_state) {
 			case EditorNode3DGizmoPlugin::VISIBLE:
-				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon("visibility_visible"));
+				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon(SNAME("visibility_visible")));
 				break;
 			case EditorNode3DGizmoPlugin::ON_TOP:
-				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon("visibility_xray"));
+				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon(SNAME("visibility_xray")));
 				break;
 			case EditorNode3DGizmoPlugin::HIDDEN:
-				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon("visibility_hidden"));
+				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon(SNAME("visibility_hidden")));
 				break;
 		}
 	}
@@ -6291,26 +6291,26 @@ void Node3DEditor::_add_environment_to_scene(bool p_already_added_sun) {
 
 void Node3DEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
-		tool_button[Node3DEditor::TOOL_MODE_SELECT]->set_icon(get_theme_icon("ToolSelect", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_MODE_MOVE]->set_icon(get_theme_icon("ToolMove", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_MODE_ROTATE]->set_icon(get_theme_icon("ToolRotate", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_MODE_SCALE]->set_icon(get_theme_icon("ToolScale", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_MODE_LIST_SELECT]->set_icon(get_theme_icon("ListSelect", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_LOCK_SELECTED]->set_icon(get_theme_icon("Lock", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_UNLOCK_SELECTED]->set_icon(get_theme_icon("Unlock", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_GROUP_SELECTED]->set_icon(get_theme_icon("Group", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_UNGROUP_SELECTED]->set_icon(get_theme_icon("Ungroup", "EditorIcons"));
+		tool_button[Node3DEditor::TOOL_MODE_SELECT]->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_MODE_MOVE]->set_icon(get_theme_icon(SNAME("ToolMove"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_MODE_ROTATE]->set_icon(get_theme_icon(SNAME("ToolRotate"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_MODE_SCALE]->set_icon(get_theme_icon(SNAME("ToolScale"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_MODE_LIST_SELECT]->set_icon(get_theme_icon(SNAME("ListSelect"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_LOCK_SELECTED]->set_icon(get_theme_icon(SNAME("Lock"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_UNLOCK_SELECTED]->set_icon(get_theme_icon(SNAME("Unlock"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_GROUP_SELECTED]->set_icon(get_theme_icon(SNAME("Group"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_UNGROUP_SELECTED]->set_icon(get_theme_icon(SNAME("Ungroup"), SNAME("EditorIcons")));
 
-		tool_option_button[Node3DEditor::TOOL_OPT_LOCAL_COORDS]->set_icon(get_theme_icon("Object", "EditorIcons"));
-		tool_option_button[Node3DEditor::TOOL_OPT_USE_SNAP]->set_icon(get_theme_icon("Snap", "EditorIcons"));
-		tool_option_button[Node3DEditor::TOOL_OPT_OVERRIDE_CAMERA]->set_icon(get_theme_icon("Camera3D", "EditorIcons"));
+		tool_option_button[Node3DEditor::TOOL_OPT_LOCAL_COORDS]->set_icon(get_theme_icon(SNAME("Object"), SNAME("EditorIcons")));
+		tool_option_button[Node3DEditor::TOOL_OPT_USE_SNAP]->set_icon(get_theme_icon(SNAME("Snap"), SNAME("EditorIcons")));
+		tool_option_button[Node3DEditor::TOOL_OPT_OVERRIDE_CAMERA]->set_icon(get_theme_icon(SNAME("Camera3D"), SNAME("EditorIcons")));
 
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), get_theme_icon("Panels1", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), get_theme_icon("Panels2", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), get_theme_icon("Panels2Alt", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), get_theme_icon("Panels3", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), get_theme_icon("Panels3Alt", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), get_theme_icon("Panels4", "EditorIcons"));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), get_theme_icon(SNAME("Panels1"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), get_theme_icon(SNAME("Panels2"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), get_theme_icon(SNAME("Panels2Alt"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), get_theme_icon(SNAME("Panels3"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), get_theme_icon(SNAME("Panels3Alt"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), get_theme_icon(SNAME("Panels4"), SNAME("EditorIcons")));
 
 		_menu_item_pressed(MENU_VIEW_USE_1_VIEWPORT);
 
@@ -6324,13 +6324,13 @@ void Node3DEditor::_notification(int p_what) {
 		editor->connect("stop_pressed", callable_mp(this, &Node3DEditor::_update_camera_override_button), make_binds(false));
 		editor->connect("play_pressed", callable_mp(this, &Node3DEditor::_update_camera_override_button), make_binds(true));
 
-		sun_button->set_icon(get_theme_icon("DirectionalLight3D", "EditorIcons"));
-		environ_button->set_icon(get_theme_icon("WorldEnvironment", "EditorIcons"));
-		sun_environ_settings->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
+		sun_button->set_icon(get_theme_icon(SNAME("DirectionalLight3D"), SNAME("EditorIcons")));
+		environ_button->set_icon(get_theme_icon(SNAME("WorldEnvironment"), SNAME("EditorIcons")));
+		sun_environ_settings->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
 		_update_preview_environment();
-		sun_title->add_theme_font_override("font", get_theme_font("title_font", "Window"));
-		environ_title->add_theme_font_override("font", get_theme_font("title_font", "Window"));
+		sun_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
+		environ_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
 
 		sun_state->set_custom_minimum_size(sun_vb->get_combined_minimum_size());
 		environ_state->set_custom_minimum_size(environ_vb->get_combined_minimum_size());
@@ -6340,30 +6340,30 @@ void Node3DEditor::_notification(int p_what) {
 		_init_indicators();
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
 		_update_gizmos_menu_theme();
-		sun_title->add_theme_font_override("font", get_theme_font("title_font", "Window"));
-		environ_title->add_theme_font_override("font", get_theme_font("title_font", "Window"));
+		sun_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
+		environ_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
 	} else if (p_what == NOTIFICATION_EXIT_TREE) {
 		_finish_indicators();
 	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		tool_button[Node3DEditor::TOOL_MODE_SELECT]->set_icon(get_theme_icon("ToolSelect", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_MODE_MOVE]->set_icon(get_theme_icon("ToolMove", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_MODE_ROTATE]->set_icon(get_theme_icon("ToolRotate", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_MODE_SCALE]->set_icon(get_theme_icon("ToolScale", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_MODE_LIST_SELECT]->set_icon(get_theme_icon("ListSelect", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_LOCK_SELECTED]->set_icon(get_theme_icon("Lock", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_UNLOCK_SELECTED]->set_icon(get_theme_icon("Unlock", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_GROUP_SELECTED]->set_icon(get_theme_icon("Group", "EditorIcons"));
-		tool_button[Node3DEditor::TOOL_UNGROUP_SELECTED]->set_icon(get_theme_icon("Ungroup", "EditorIcons"));
+		tool_button[Node3DEditor::TOOL_MODE_SELECT]->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_MODE_MOVE]->set_icon(get_theme_icon(SNAME("ToolMove"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_MODE_ROTATE]->set_icon(get_theme_icon(SNAME("ToolRotate"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_MODE_SCALE]->set_icon(get_theme_icon(SNAME("ToolScale"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_MODE_LIST_SELECT]->set_icon(get_theme_icon(SNAME("ListSelect"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_LOCK_SELECTED]->set_icon(get_theme_icon(SNAME("Lock"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_UNLOCK_SELECTED]->set_icon(get_theme_icon(SNAME("Unlock"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_GROUP_SELECTED]->set_icon(get_theme_icon(SNAME("Group"), SNAME("EditorIcons")));
+		tool_button[Node3DEditor::TOOL_UNGROUP_SELECTED]->set_icon(get_theme_icon(SNAME("Ungroup"), SNAME("EditorIcons")));
 
-		tool_option_button[Node3DEditor::TOOL_OPT_LOCAL_COORDS]->set_icon(get_theme_icon("Object", "EditorIcons"));
-		tool_option_button[Node3DEditor::TOOL_OPT_USE_SNAP]->set_icon(get_theme_icon("Snap", "EditorIcons"));
+		tool_option_button[Node3DEditor::TOOL_OPT_LOCAL_COORDS]->set_icon(get_theme_icon(SNAME("Object"), SNAME("EditorIcons")));
+		tool_option_button[Node3DEditor::TOOL_OPT_USE_SNAP]->set_icon(get_theme_icon(SNAME("Snap"), SNAME("EditorIcons")));
 
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), get_theme_icon("Panels1", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), get_theme_icon("Panels2", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), get_theme_icon("Panels2Alt", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), get_theme_icon("Panels3", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), get_theme_icon("Panels3Alt", "EditorIcons"));
-		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), get_theme_icon("Panels4", "EditorIcons"));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), get_theme_icon(SNAME("Panels1"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), get_theme_icon(SNAME("Panels2"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), get_theme_icon(SNAME("Panels2Alt"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), get_theme_icon(SNAME("Panels3"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), get_theme_icon(SNAME("Panels3Alt"), SNAME("EditorIcons")));
+		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), get_theme_icon(SNAME("Panels4"), SNAME("EditorIcons")));
 
 		// Update grid color by rebuilding grid.
 		_finish_grid();
@@ -7514,7 +7514,7 @@ void EditorNode3DGizmoPlugin::create_handle_material(const String &p_name, bool 
 
 	handle_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	handle_material->set_flag(StandardMaterial3D::FLAG_USE_POINT_SIZE, true);
-	Ref<Texture2D> handle_t = p_icon != nullptr ? p_icon : Node3DEditor::get_singleton()->get_theme_icon("Editor3DHandle", "EditorIcons");
+	Ref<Texture2D> handle_t = p_icon != nullptr ? p_icon : Node3DEditor::get_singleton()->get_theme_icon(SNAME("Editor3DHandle"), SNAME("EditorIcons"));
 	handle_material->set_point_size(handle_t->get_width());
 	handle_material->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, handle_t);
 	handle_material->set_albedo(Color(1, 1, 1));

--- a/editor/plugins/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.cpp
@@ -98,7 +98,7 @@ OccluderInstance3DEditorPlugin::OccluderInstance3DEditorPlugin(EditorNode *p_nod
 	editor = p_node;
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(editor->get_gui_base()->get_theme_icon("Bake", "EditorIcons"));
+	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake Occluders"));
 	bake->hide();
 	bake->connect("pressed", Callable(this, "_bake"));

--- a/editor/plugins/ot_features_plugin.cpp
+++ b/editor/plugins/ot_features_plugin.cpp
@@ -49,10 +49,10 @@ void OpenTypeFeaturesEditor::update_property() {
 
 void OpenTypeFeaturesEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Color base = get_theme_color("accent_color", "Editor");
+		Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 
-		button->set_icon(get_theme_icon("Remove", "EditorIcons"));
-		button->set_size(get_theme_icon("Remove", "EditorIcons")->get_size());
+		button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+		button->set_size(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons"))->get_size());
 		spin->set_custom_label_color(true, base);
 	}
 }
@@ -106,7 +106,7 @@ void OpenTypeFeaturesAdd::update_property() {
 	bool have_ss = false;
 	bool have_cv = false;
 	bool have_cu = false;
-	Dictionary features = Object::cast_to<Control>(get_edited_object())->get_theme_font("font")->get_feature_list();
+	Dictionary features = Object::cast_to<Control>(get_edited_object())->get_theme_font(SNAME("font"))->get_feature_list();
 	for (const Variant *ftr = features.next(nullptr); ftr != nullptr; ftr = features.next(ftr)) {
 		String ftr_name = TS->tag_to_name(*ftr);
 		if (ftr_name.begins_with("stylistic_set_")) {
@@ -142,8 +142,8 @@ void OpenTypeFeaturesAdd::_features_menu() {
 void OpenTypeFeaturesAdd::_notification(int p_what) {
 	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
 		set_label("");
-		button->set_icon(get_theme_icon("Add", "EditorIcons"));
-		button->set_size(get_theme_icon("Add", "EditorIcons")->get_size());
+		button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		button->set_size(get_theme_icon(SNAME("Add"), SNAME("EditorIcons"))->get_size());
 	}
 }
 

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -364,12 +364,12 @@ void Path2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 
 	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
 
-	const Ref<Texture2D> path_sharp_handle = get_theme_icon("EditorPathSharpHandle", "EditorIcons");
-	const Ref<Texture2D> path_smooth_handle = get_theme_icon("EditorPathSmoothHandle", "EditorIcons");
+	const Ref<Texture2D> path_sharp_handle = get_theme_icon(SNAME("EditorPathSharpHandle"), SNAME("EditorIcons"));
+	const Ref<Texture2D> path_smooth_handle = get_theme_icon(SNAME("EditorPathSmoothHandle"), SNAME("EditorIcons"));
 	// Both handle icons must be of the same size
 	const Size2 handle_size = path_sharp_handle->get_size();
 
-	const Ref<Texture2D> curve_handle = get_theme_icon("EditorCurveHandle", "EditorIcons");
+	const Ref<Texture2D> curve_handle = get_theme_icon(SNAME("EditorCurveHandle"), SNAME("EditorIcons"));
 	const Size2 curve_handle_size = curve_handle->get_size();
 
 	Ref<Curve2D> curve = node->get_curve();
@@ -411,7 +411,7 @@ void Path2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 	}
 
 	if (on_edge) {
-		Ref<Texture2D> add_handle = get_theme_icon("EditorHandleAdd", "EditorIcons");
+		Ref<Texture2D> add_handle = get_theme_icon(SNAME("EditorHandleAdd"), SNAME("EditorIcons"));
 		p_overlay->draw_texture(add_handle, edge_point - add_handle->get_size() * 0.5);
 	}
 }
@@ -534,7 +534,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	base_hb->add_child(sep);
 	curve_edit = memnew(Button);
 	curve_edit->set_flat(true);
-	curve_edit->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveEdit", "EditorIcons"));
+	curve_edit->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveEdit"), SNAME("EditorIcons")));
 	curve_edit->set_toggle_mode(true);
 	curve_edit->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit->set_tooltip(TTR("Select Points") + "\n" + TTR("Shift+Drag: Select Control Points") + "\n" + keycode_get_string(KEY_MASK_CMD) + TTR("Click: Add Point") + "\n" + TTR("Left Click: Split Segment (in curve)") + "\n" + TTR("Right Click: Delete Point"));
@@ -542,7 +542,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	base_hb->add_child(curve_edit);
 	curve_edit_curve = memnew(Button);
 	curve_edit_curve->set_flat(true);
-	curve_edit_curve->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveCurve", "EditorIcons"));
+	curve_edit_curve->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveCurve"), SNAME("EditorIcons")));
 	curve_edit_curve->set_toggle_mode(true);
 	curve_edit_curve->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit_curve->set_tooltip(TTR("Select Control Points (Shift+Drag)"));
@@ -550,7 +550,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	base_hb->add_child(curve_edit_curve);
 	curve_create = memnew(Button);
 	curve_create->set_flat(true);
-	curve_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveCreate", "EditorIcons"));
+	curve_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveCreate"), SNAME("EditorIcons")));
 	curve_create->set_toggle_mode(true);
 	curve_create->set_focus_mode(Control::FOCUS_NONE);
 	curve_create->set_tooltip(TTR("Add Point (in empty space)"));
@@ -558,7 +558,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	base_hb->add_child(curve_create);
 	curve_del = memnew(Button);
 	curve_del->set_flat(true);
-	curve_del->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveDelete", "EditorIcons"));
+	curve_del->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveDelete"), SNAME("EditorIcons")));
 	curve_del->set_toggle_mode(true);
 	curve_del->set_focus_mode(Control::FOCUS_NONE);
 	curve_del->set_tooltip(TTR("Delete Point"));
@@ -566,7 +566,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	base_hb->add_child(curve_del);
 	curve_close = memnew(Button);
 	curve_close->set_flat(true);
-	curve_close->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveClose", "EditorIcons"));
+	curve_close->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveClose"), SNAME("EditorIcons")));
 	curve_close->set_focus_mode(Control::FOCUS_NONE);
 	curve_close->set_tooltip(TTR("Close Curve"));
 	curve_close->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(ACTION_CLOSE));

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -453,14 +453,14 @@ void Path3DEditorPlugin::edit(Object *p_object) {
 		path = Object::cast_to<Path3D>(p_object);
 		if (path) {
 			if (path->get_curve().is_valid()) {
-				path->get_curve()->emit_signal("changed");
+				path->get_curve()->emit_signal(SNAME("changed"));
 			}
 		}
 	} else {
 		Path3D *pre = path;
 		path = nullptr;
 		if (pre) {
-			pre->get_curve()->emit_signal("changed");
+			pre->get_curve()->emit_signal(SNAME("changed"));
 		}
 	}
 	//collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
@@ -490,7 +490,7 @@ void Path3DEditorPlugin::make_visible(bool p_visible) {
 			Path3D *pre = path;
 			path = nullptr;
 			if (pre && pre->get_curve().is_valid()) {
-				pre->get_curve()->emit_signal("changed");
+				pre->get_curve()->emit_signal(SNAME("changed"));
 			}
 		}
 	}
@@ -562,7 +562,7 @@ Path3DEditorPlugin::Path3DEditorPlugin(EditorNode *p_node) {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(sep);
 	curve_edit = memnew(Button);
 	curve_edit->set_flat(true);
-	curve_edit->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveEdit", "EditorIcons"));
+	curve_edit->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveEdit"), SNAME("EditorIcons")));
 	curve_edit->set_toggle_mode(true);
 	curve_edit->hide();
 	curve_edit->set_focus_mode(Control::FOCUS_NONE);
@@ -570,7 +570,7 @@ Path3DEditorPlugin::Path3DEditorPlugin(EditorNode *p_node) {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(curve_edit);
 	curve_create = memnew(Button);
 	curve_create->set_flat(true);
-	curve_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveCreate", "EditorIcons"));
+	curve_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveCreate"), SNAME("EditorIcons")));
 	curve_create->set_toggle_mode(true);
 	curve_create->hide();
 	curve_create->set_focus_mode(Control::FOCUS_NONE);
@@ -578,7 +578,7 @@ Path3DEditorPlugin::Path3DEditorPlugin(EditorNode *p_node) {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(curve_create);
 	curve_del = memnew(Button);
 	curve_del->set_flat(true);
-	curve_del->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveDelete", "EditorIcons"));
+	curve_del->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveDelete"), SNAME("EditorIcons")));
 	curve_del->set_toggle_mode(true);
 	curve_del->hide();
 	curve_del->set_focus_mode(Control::FOCUS_NONE);
@@ -586,7 +586,7 @@ Path3DEditorPlugin::Path3DEditorPlugin(EditorNode *p_node) {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(curve_del);
 	curve_close = memnew(Button);
 	curve_close->set_flat(true);
-	curve_close->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveClose", "EditorIcons"));
+	curve_close->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveClose"), SNAME("EditorIcons")));
 	curve_close->hide();
 	curve_close->set_focus_mode(Control::FOCUS_NONE);
 	curve_close->set_tooltip(TTR("Close Curve"));
@@ -644,6 +644,6 @@ Path3DGizmoPlugin::Path3DGizmoPlugin() {
 	Color path_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/path", Color(0.5, 0.5, 1.0, 0.8));
 	create_material("path_material", path_color);
 	create_material("path_thin_material", Color(0.5, 0.5, 0.5));
-	create_handle_material("handles", false, Node3DEditor::get_singleton()->get_theme_icon("EditorPathSmoothHandle", "EditorIcons"));
-	create_handle_material("sec_handles", false, Node3DEditor::get_singleton()->get_theme_icon("EditorCurveHandle", "EditorIcons"));
+	create_handle_material("handles", false, Node3DEditor::get_singleton()->get_theme_icon(SNAME("EditorPathSmoothHandle"), SNAME("EditorIcons")));
+	create_handle_material("sec_handles", false, Node3DEditor::get_singleton()->get_theme_icon(SNAME("EditorCurveHandle"), SNAME("EditorIcons")));
 }

--- a/editor/plugins/physical_bone_3d_editor_plugin.cpp
+++ b/editor/plugins/physical_bone_3d_editor_plugin.cpp
@@ -60,7 +60,7 @@ PhysicalBone3DEditor::PhysicalBone3DEditor(EditorNode *p_editor) :
 	spatial_editor_hb->add_child(button_transform_joint);
 
 	button_transform_joint->set_text(TTR("Move Joint"));
-	button_transform_joint->set_icon(Node3DEditor::get_singleton()->get_theme_icon("PhysicalBone3D", "EditorIcons"));
+	button_transform_joint->set_icon(Node3DEditor::get_singleton()->get_theme_icon(SNAME("PhysicalBone3D"), SNAME("EditorIcons")));
 	button_transform_joint->set_toggle_mode(true);
 	button_transform_joint->connect("toggled", callable_mp(this, &PhysicalBone3DEditor::_on_toggle_button_transform_joint));
 

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -64,27 +64,27 @@ void Polygon2DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			uv_edit_draw->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-			bone_scroll->add_theme_style_override("bg", get_theme_stylebox("bg", "Tree"));
+			uv_edit_draw->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			bone_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 		case NOTIFICATION_READY: {
-			button_uv->set_icon(get_theme_icon("Uv", "EditorIcons"));
+			button_uv->set_icon(get_theme_icon(SNAME("Uv"), SNAME("EditorIcons")));
 
-			uv_button[UV_MODE_CREATE]->set_icon(get_theme_icon("Edit", "EditorIcons"));
-			uv_button[UV_MODE_CREATE_INTERNAL]->set_icon(get_theme_icon("EditInternal", "EditorIcons"));
-			uv_button[UV_MODE_REMOVE_INTERNAL]->set_icon(get_theme_icon("RemoveInternal", "EditorIcons"));
-			uv_button[UV_MODE_EDIT_POINT]->set_icon(get_theme_icon("ToolSelect", "EditorIcons"));
-			uv_button[UV_MODE_MOVE]->set_icon(get_theme_icon("ToolMove", "EditorIcons"));
-			uv_button[UV_MODE_ROTATE]->set_icon(get_theme_icon("ToolRotate", "EditorIcons"));
-			uv_button[UV_MODE_SCALE]->set_icon(get_theme_icon("ToolScale", "EditorIcons"));
-			uv_button[UV_MODE_ADD_POLYGON]->set_icon(get_theme_icon("Edit", "EditorIcons"));
-			uv_button[UV_MODE_REMOVE_POLYGON]->set_icon(get_theme_icon("Close", "EditorIcons"));
-			uv_button[UV_MODE_PAINT_WEIGHT]->set_icon(get_theme_icon("Bucket", "EditorIcons"));
-			uv_button[UV_MODE_CLEAR_WEIGHT]->set_icon(get_theme_icon("Clear", "EditorIcons"));
+			uv_button[UV_MODE_CREATE]->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_CREATE_INTERNAL]->set_icon(get_theme_icon(SNAME("EditInternal"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_REMOVE_INTERNAL]->set_icon(get_theme_icon(SNAME("RemoveInternal"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_EDIT_POINT]->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_MOVE]->set_icon(get_theme_icon(SNAME("ToolMove"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_ROTATE]->set_icon(get_theme_icon(SNAME("ToolRotate"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_SCALE]->set_icon(get_theme_icon(SNAME("ToolScale"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_ADD_POLYGON]->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_REMOVE_POLYGON]->set_icon(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_PAINT_WEIGHT]->set_icon(get_theme_icon(SNAME("Bucket"), SNAME("EditorIcons")));
+			uv_button[UV_MODE_CLEAR_WEIGHT]->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
 
-			b_snap_grid->set_icon(get_theme_icon("Grid", "EditorIcons"));
-			b_snap_enable->set_icon(get_theme_icon("SnapGrid", "EditorIcons"));
-			uv_icon_zoom->set_texture(get_theme_icon("Zoom", "EditorIcons"));
+			b_snap_grid->set_icon(get_theme_icon(SNAME("Grid"), SNAME("EditorIcons")));
+			b_snap_enable->set_icon(get_theme_icon(SNAME("SnapGrid"), SNAME("EditorIcons")));
+			uv_icon_zoom->set_texture(get_theme_icon(SNAME("Zoom"), SNAME("EditorIcons")));
 
 			uv_vscroll->set_anchors_and_offsets_preset(PRESET_RIGHT_WIDE);
 			uv_hscroll->set_anchors_and_offsets_preset(PRESET_BOTTOM_WIDE);
@@ -1015,7 +1015,7 @@ void Polygon2DEditor::_uv_draw() {
 	}
 
 	// All UV points are sharp, so use the sharp handle icon
-	Ref<Texture2D> handle = get_theme_icon("EditorPathSharpHandle", "EditorIcons");
+	Ref<Texture2D> handle = get_theme_icon(SNAME("EditorPathSharpHandle"), SNAME("EditorIcons"));
 
 	Color poly_line_color = Color(0.9, 0.5, 0.5);
 	if (polygons.size() || polygon_create.size()) {

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -40,7 +40,7 @@ void ResourcePreloaderEditor::_gui_input(Ref<InputEvent> p_event) {
 
 void ResourcePreloaderEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		load->set_icon(get_theme_icon("Folder", "EditorIcons"));
+		load->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 	}
 
 	if (p_what == NOTIFICATION_READY) {
@@ -208,11 +208,11 @@ void ResourcePreloaderEditor::_update_library() {
 		ti->set_selectable(1, false);
 
 		if (type == "PackedScene") {
-			ti->add_button(1, get_theme_icon("InstanceOptions", "EditorIcons"), BUTTON_OPEN_SCENE, false, TTR("Open in Editor"));
+			ti->add_button(1, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_OPEN_SCENE, false, TTR("Open in Editor"));
 		} else {
-			ti->add_button(1, get_theme_icon("Load", "EditorIcons"), BUTTON_EDIT_RESOURCE, false, TTR("Open in Editor"));
+			ti->add_button(1, get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), BUTTON_EDIT_RESOURCE, false, TTR("Open in Editor"));
 		}
-		ti->add_button(1, get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE, false, TTR("Remove"));
+		ti->add_button(1, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE, false, TTR("Remove"));
 	}
 
 	//player->add_resource("default",resource);

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -149,7 +149,7 @@ void EditorPropertyRootMotion::_node_assign() {
 						ti->set_text(0, F->get());
 						ti->set_selectable(0, true);
 						ti->set_editable(0, false);
-						ti->set_icon(0, get_theme_icon("BoneAttachment3D", "EditorIcons"));
+						ti->set_icon(0, get_theme_icon(SNAME("BoneAttachment3D"), SNAME("EditorIcons")));
 						ti->set_metadata(0, accum);
 					} else {
 						ti = parenthood[accum];
@@ -158,7 +158,7 @@ void EditorPropertyRootMotion::_node_assign() {
 
 				ti->set_selectable(0, true);
 				ti->set_text(0, concat);
-				ti->set_icon(0, get_theme_icon("BoneAttachment3D", "EditorIcons"));
+				ti->set_icon(0, get_theme_icon(SNAME("BoneAttachment3D"), SNAME("EditorIcons")));
 				ti->set_metadata(0, path);
 				if (path == current) {
 					ti->select(0);
@@ -234,7 +234,7 @@ void EditorPropertyRootMotion::setup(const NodePath &p_base_hint) {
 
 void EditorPropertyRootMotion::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Ref<Texture2D> t = get_theme_icon("Clear", "EditorIcons");
+		Ref<Texture2D> t = get_theme_icon(SNAME("Clear"), SNAME("EditorIcons"));
 		clear->set_icon(t);
 	}
 }

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -355,7 +355,7 @@ void ScriptEditorQuickOpen::_confirmed() {
 	}
 	int line = ti->get_text(0).get_slice(":", 1).to_int();
 
-	emit_signal("goto_line", line - 1);
+	emit_signal(SNAME("goto_line"), line - 1);
 	hide();
 }
 
@@ -368,7 +368,7 @@ void ScriptEditorQuickOpen::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			search_box->set_right_icon(search_options->get_theme_icon("Search", "EditorIcons"));
+			search_box->set_right_icon(search_options->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect("confirmed", callable_mp(this, &ScriptEditorQuickOpen::_confirmed));
@@ -577,7 +577,7 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 	}
 	if (Object::cast_to<EditorHelp>(c)) {
 		script_name_label->set_text(Object::cast_to<EditorHelp>(c)->get_class());
-		script_icon->set_texture(get_theme_icon("Help", "EditorIcons"));
+		script_icon->set_texture(get_theme_icon(SNAME("Help"), SNAME("EditorIcons")));
 		if (is_visible_in_tree()) {
 			Object::cast_to<EditorHelp>(c)->set_focused();
 		}
@@ -631,7 +631,7 @@ void ScriptEditor::_open_recent_script(int p_idx) {
 	// clear button
 	if (p_idx == recent_scripts->get_item_count() - 1) {
 		EditorSettings::get_singleton()->set_project_metadata("recent_files", "scripts", Array());
-		call_deferred("_update_recent_scripts");
+		call_deferred(SNAME("_update_recent_scripts"));
 		return;
 	}
 
@@ -946,7 +946,7 @@ void ScriptEditor::_res_saved_callback(const Ref<Resource> &p_res) {
 	_update_script_names();
 
 	if (!pending_auto_reload && auto_reload_running_scripts) {
-		call_deferred("_live_auto_reload_running_scripts");
+		call_deferred(SNAME("_live_auto_reload_running_scripts"));
 		pending_auto_reload = true;
 	}
 }
@@ -997,7 +997,7 @@ bool ScriptEditor::_test_script_times_on_disk(RES p_for_script) {
 			script_editor->_reload_scripts();
 			need_reload = false;
 		} else {
-			disk_changed->call_deferred("popup_centered_ratio", 0.5);
+			disk_changed->call_deferred(SNAME("popup_centered_ratio"), 0.5);
 		}
 	}
 
@@ -1155,7 +1155,7 @@ void ScriptEditor::_menu_option(int p_option) {
 					if (ResourceLoader::get_resource_type(res_path) == "PackedScene") {
 						if (!EditorNode::get_singleton()->is_scene_open(res_path)) {
 							EditorNode::get_singleton()->load_scene(res_path);
-							script_editor->call_deferred("_menu_option", p_option);
+							script_editor->call_deferred(SNAME("_menu_option"), p_option);
 							previous_scripts.push_back(path); //repeat the operation
 							return;
 						}
@@ -1486,23 +1486,23 @@ void ScriptEditor::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
-			help_search->set_icon(get_theme_icon("HelpSearch", "EditorIcons"));
-			site_search->set_icon(get_theme_icon("Instance", "EditorIcons"));
+			help_search->set_icon(get_theme_icon(SNAME("HelpSearch"), SNAME("EditorIcons")));
+			site_search->set_icon(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
 
 			if (is_layout_rtl()) {
-				script_forward->set_icon(get_theme_icon("Back", "EditorIcons"));
-				script_back->set_icon(get_theme_icon("Forward", "EditorIcons"));
+				script_forward->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
+				script_back->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 			} else {
-				script_forward->set_icon(get_theme_icon("Forward", "EditorIcons"));
-				script_back->set_icon(get_theme_icon("Back", "EditorIcons"));
+				script_forward->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
+				script_back->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 			}
 
-			members_overview_alphabeta_sort_button->set_icon(get_theme_icon("Sort", "EditorIcons"));
+			members_overview_alphabeta_sort_button->set_icon(get_theme_icon(SNAME("Sort"), SNAME("EditorIcons")));
 
-			filter_scripts->set_right_icon(get_theme_icon("Search", "EditorIcons"));
-			filter_methods->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			filter_scripts->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+			filter_methods->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
-			filename->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("normal", "LineEdit"));
+			filename->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 
 			recent_scripts->set_as_minsize();
 
@@ -1576,11 +1576,11 @@ void ScriptEditor::edited_scene_changed() {
 }
 
 void ScriptEditor::notify_script_close(const Ref<Script> &p_script) {
-	emit_signal("script_close", p_script);
+	emit_signal(SNAME("script_close"), p_script);
 }
 
 void ScriptEditor::notify_script_changed(const Ref<Script> &p_script) {
-	emit_signal("editor_script_changed", p_script);
+	emit_signal(SNAME("editor_script_changed"), p_script);
 }
 
 void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
@@ -1796,8 +1796,8 @@ void ScriptEditor::_update_script_colors() {
 	bool script_temperature_enabled = EditorSettings::get_singleton()->get("text_editor/script_list/script_temperature_enabled");
 
 	int hist_size = EditorSettings::get_singleton()->get("text_editor/script_list/script_temperature_history_size");
-	Color hot_color = get_theme_color("accent_color", "Editor");
-	Color cold_color = get_theme_color("font_color", "Editor");
+	Color hot_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+	Color cold_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 
 	for (int i = 0; i < script_list->get_item_count(); i++) {
 		int c = script_list->get_item_metadata(i);
@@ -1946,7 +1946,7 @@ void ScriptEditor::_update_script_names() {
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 		if (eh) {
 			String name = eh->get_class();
-			Ref<Texture2D> icon = get_theme_icon("Help", "EditorIcons");
+			Ref<Texture2D> icon = get_theme_icon(SNAME("Help"), SNAME("EditorIcons"));
 			String tooltip = vformat(TTR("%s Class Reference"), name);
 
 			_ScriptEditorItemData sd;
@@ -2554,8 +2554,8 @@ void ScriptEditor::_tree_changed() {
 	}
 
 	waiting_update_names = true;
-	call_deferred("_update_script_names");
-	call_deferred("_update_script_connections");
+	call_deferred(SNAME("_update_script_names"));
+	call_deferred(SNAME("_update_script_connections"));
 }
 
 void ScriptEditor::_script_split_dragged(float) {
@@ -2581,7 +2581,7 @@ Variant ScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 	EditorHelp *eh = Object::cast_to<EditorHelp>(cur_node);
 	if (eh) {
 		preview_name = eh->get_class();
-		preview_icon = get_theme_icon("Help", "EditorIcons");
+		preview_icon = get_theme_icon(SNAME("Help"), SNAME("EditorIcons"));
 	}
 
 	if (!preview_icon.is_null()) {
@@ -3362,7 +3362,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	filename = memnew(Label);
 	filename->set_clip_text(true);
 	filename->set_h_size_flags(SIZE_EXPAND_FILL);
-	filename->add_theme_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("normal", "LineEdit"));
+	filename->add_theme_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 	buttons_hbox->add_child(filename);
 
 	members_overview_alphabeta_sort_button = memnew(Button);
@@ -3612,8 +3612,8 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	ScriptServer::edit_request_func = _open_script_request;
 
-	add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox("ScriptEditorPanel", "EditorStyles"));
-	tab_container->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox("ScriptEditor", "EditorStyles"));
+	add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
+	tab_container->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditor"), SNAME("EditorStyles")));
 }
 
 ScriptEditor::~ScriptEditor() {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -66,7 +66,7 @@ void ConnectionInfoDialog::popup_connections(String p_method, Vector<Node *> p_n
 
 			node_item->set_text(1, connection.signal.get_name());
 			Control *p = Object::cast_to<Control>(get_parent());
-			node_item->set_icon(1, p->get_theme_icon("Slot", "EditorIcons"));
+			node_item->set_icon(1, p->get_theme_icon(SNAME("Slot"), SNAME("EditorIcons")));
 			node_item->set_selectable(1, false);
 			node_item->set_editable(1, false);
 
@@ -147,7 +147,7 @@ void ScriptTextEditor::set_edited_resource(const RES &p_res) {
 	code_editor->get_text_editor()->clear_undo_history();
 	code_editor->get_text_editor()->tag_saved_version();
 
-	emit_signal("name_changed");
+	emit_signal(SNAME("name_changed"));
 	code_editor->update_line_and_column();
 }
 
@@ -440,7 +440,7 @@ void ScriptTextEditor::_validate_script() {
 				String target_path = base == connection.callable.get_object() ? base_path : base_path + "/" + base->get_path_to(Object::cast_to<Node>(connection.callable.get_object()));
 
 				warnings_panel->push_cell();
-				warnings_panel->push_color(warnings_panel->get_theme_color("warning_color", "Editor"));
+				warnings_panel->push_color(warnings_panel->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 				warnings_panel->add_text(vformat(TTR("Missing connected method '%s' for signal '%s' from node '%s' to node '%s'."), connection.callable.get_method(), connection.signal.get_name(), source_path, target_path));
 				warnings_panel->pop(); // Color.
 				warnings_panel->pop(); // Cell.
@@ -465,7 +465,7 @@ void ScriptTextEditor::_validate_script() {
 		warnings_panel->push_cell();
 		warnings_panel->push_meta(ignore_meta);
 		warnings_panel->push_color(
-				warnings_panel->get_theme_color("accent_color", "Editor").lerp(warnings_panel->get_theme_color("mono_color", "Editor"), 0.5));
+				warnings_panel->get_theme_color(SNAME("accent_color"), SNAME("Editor")).lerp(warnings_panel->get_theme_color(SNAME("mono_color"), SNAME("Editor")), 0.5));
 		warnings_panel->add_text(TTR("[Ignore]"));
 		warnings_panel->pop(); // Color.
 		warnings_panel->pop(); // Meta ignore.
@@ -473,7 +473,7 @@ void ScriptTextEditor::_validate_script() {
 
 		warnings_panel->push_cell();
 		warnings_panel->push_meta(w.start_line - 1);
-		warnings_panel->push_color(warnings_panel->get_theme_color("warning_color", "Editor"));
+		warnings_panel->push_color(warnings_panel->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		warnings_panel->add_text(TTR("Line") + " " + itos(w.start_line));
 		warnings_panel->add_text(" (" + w.string_code + "):");
 		warnings_panel->pop(); // Color.
@@ -493,7 +493,7 @@ void ScriptTextEditor::_validate_script() {
 
 		errors_panel->push_cell();
 		errors_panel->push_meta(err.line - 1);
-		errors_panel->push_color(warnings_panel->get_theme_color("error_color", "Editor"));
+		errors_panel->push_color(warnings_panel->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		errors_panel->add_text(TTR("Line") + " " + itos(err.line) + ":");
 		errors_panel->pop(); // Color.
 		errors_panel->pop(); // Meta goto.
@@ -535,8 +535,8 @@ void ScriptTextEditor::_validate_script() {
 		}
 	}
 
-	emit_signal("name_changed");
-	emit_signal("edited_script_changed");
+	emit_signal(SNAME("name_changed"));
+	emit_signal(SNAME("edited_script_changed"));
 }
 
 void ScriptTextEditor::_update_bookmark_list() {
@@ -725,7 +725,7 @@ void ScriptTextEditor::_breakpoint_item_pressed(int p_idx) {
 		_edit_option(breakpoints_menu->get_item_id(p_idx));
 	} else {
 		code_editor->goto_line(breakpoints_menu->get_item_metadata(p_idx));
-		code_editor->get_text_editor()->call_deferred("center_viewport_to_cursor"); //Need to be deferred, because goto uses call_deferred().
+		code_editor->get_text_editor()->call_deferred(SNAME("center_viewport_to_cursor")); //Need to be deferred, because goto uses call_deferred().
 	}
 }
 
@@ -760,14 +760,14 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 		switch (result.type) {
 			case ScriptLanguage::LookupResult::RESULT_SCRIPT_LOCATION: {
 				if (result.script.is_valid()) {
-					emit_signal("request_open_script_at_line", result.script, result.location - 1);
+					emit_signal(SNAME("request_open_script_at_line"), result.script, result.location - 1);
 				} else {
-					emit_signal("request_save_history");
+					emit_signal(SNAME("request_save_history"));
 					goto_line_centered(result.location - 1);
 				}
 			} break;
 			case ScriptLanguage::LookupResult::RESULT_CLASS: {
-				emit_signal("go_to_help", "class_name:" + result.class_name);
+				emit_signal(SNAME("go_to_help"), "class_name:" + result.class_name);
 			} break;
 			case ScriptLanguage::LookupResult::RESULT_CLASS_CONSTANT: {
 				StringName cname = result.class_name;
@@ -782,11 +782,11 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 					}
 				}
 
-				emit_signal("go_to_help", "class_constant:" + result.class_name + ":" + result.class_member);
+				emit_signal(SNAME("go_to_help"), "class_constant:" + result.class_name + ":" + result.class_member);
 
 			} break;
 			case ScriptLanguage::LookupResult::RESULT_CLASS_PROPERTY: {
-				emit_signal("go_to_help", "class_property:" + result.class_name + ":" + result.class_member);
+				emit_signal(SNAME("go_to_help"), "class_property:" + result.class_name + ":" + result.class_member);
 
 			} break;
 			case ScriptLanguage::LookupResult::RESULT_CLASS_METHOD: {
@@ -801,7 +801,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 					}
 				}
 
-				emit_signal("go_to_help", "class_method:" + result.class_name + ":" + result.class_member);
+				emit_signal(SNAME("go_to_help"), "class_method:" + result.class_name + ":" + result.class_member);
 
 			} break;
 			case ScriptLanguage::LookupResult::RESULT_CLASS_ENUM: {
@@ -817,11 +817,11 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 					}
 				}
 
-				emit_signal("go_to_help", "class_enum:" + result.class_name + ":" + result.class_member);
+				emit_signal(SNAME("go_to_help"), "class_enum:" + result.class_name + ":" + result.class_member);
 
 			} break;
 			case ScriptLanguage::LookupResult::RESULT_CLASS_TBD_GLOBALSCOPE: {
-				emit_signal("go_to_help", "class_global:" + result.class_name + ":" + result.class_member);
+				emit_signal(SNAME("go_to_help"), "class_global:" + result.class_name + ":" + result.class_member);
 			} break;
 		}
 	} else if (ProjectSettings::get_singleton()->has_autoload(p_symbol)) {
@@ -934,7 +934,7 @@ void ScriptTextEditor::_update_connected_methods() {
 					if (name == connection.callable.get_method()) {
 						line = functions[j].get_slice(":", 1).to_int() - 1;
 						text_edit->set_line_gutter_metadata(line, connection_gutter, connection.callable.get_method());
-						text_edit->set_line_gutter_icon(line, connection_gutter, get_parent_control()->get_theme_icon("Slot", "EditorIcons"));
+						text_edit->set_line_gutter_icon(line, connection_gutter, get_parent_control()->get_theme_icon(SNAME("Slot"), SNAME("EditorIcons")));
 						text_edit->set_line_gutter_clickable(line, connection_gutter, true);
 						methods_found.insert(connection.callable.get_method());
 						break;
@@ -1004,27 +1004,27 @@ void ScriptTextEditor::_edit_option(int p_op) {
 	switch (p_op) {
 		case EDIT_UNDO: {
 			tx->undo();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_REDO: {
 			tx->redo();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_CUT: {
 			tx->cut();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_COPY: {
 			tx->copy();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_PASTE: {
 			tx->paste();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_SELECT_ALL: {
 			tx->select_all();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_MOVE_LINE_UP: {
 			code_editor->move_lines_up();
@@ -1163,12 +1163,12 @@ void ScriptTextEditor::_edit_option(int p_op) {
 
 			// Yep, because it doesn't make sense to instance this dialog for every single script open...
 			// So this will be delegated to the ScriptEditor.
-			emit_signal("search_in_files_requested", selected_text);
+			emit_signal(SNAME("search_in_files_requested"), selected_text);
 		} break;
 		case REPLACE_IN_FILES: {
 			String selected_text = code_editor->get_text_editor()->get_selection_text();
 
-			emit_signal("replace_in_files_requested", selected_text);
+			emit_signal(SNAME("replace_in_files_requested"), selected_text);
 		} break;
 		case SEARCH_LOCATE_FUNCTION: {
 			quick_open->popup_dialog(get_functions());
@@ -1262,7 +1262,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				text = tx->get_word_under_cursor();
 			}
 			if (text != "") {
-				emit_signal("request_help", text);
+				emit_signal(SNAME("request_help"), text);
 			}
 		} break;
 		case LOOKUP_SYMBOL: {
@@ -1686,16 +1686,16 @@ void ScriptTextEditor::_enable_code_editor() {
 
 	editor_box->add_child(warnings_panel);
 	warnings_panel->add_theme_font_override(
-			"normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("main", "EditorFonts"));
+			"normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("main"), SNAME("EditorFonts")));
 	warnings_panel->add_theme_font_size_override(
-			"normal_font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("main_size", "EditorFonts"));
+			"normal_font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("main_size"), SNAME("EditorFonts")));
 	warnings_panel->connect("meta_clicked", callable_mp(this, &ScriptTextEditor::_warning_clicked));
 
 	editor_box->add_child(errors_panel);
 	errors_panel->add_theme_font_override(
-			"normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("main", "EditorFonts"));
+			"normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("main"), SNAME("EditorFonts")));
 	errors_panel->add_theme_font_size_override(
-			"normal_font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("main_size", "EditorFonts"));
+			"normal_font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("main_size"), SNAME("EditorFonts")));
 	errors_panel->connect("meta_clicked", callable_mp(this, &ScriptTextEditor::_error_clicked));
 
 	add_child(context_menu);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -63,8 +63,8 @@ void ShaderTextEditor::set_edited_shader(const Ref<Shader> &p_shader) {
 
 	get_text_editor()->set_text(p_shader->get_code());
 	get_text_editor()->clear_undo_history();
-	get_text_editor()->call_deferred("set_h_scroll", 0);
-	get_text_editor()->call_deferred("set_v_scroll", 0);
+	get_text_editor()->call_deferred(SNAME("set_h_scroll"), 0);
+	get_text_editor()->call_deferred(SNAME("set_v_scroll"), 0);
 
 	_validate_script();
 	_line_col_changed();
@@ -160,8 +160,8 @@ void ShaderTextEditor::_load_theme_settings() {
 
 	if (warnings_panel) {
 		// Warnings panel
-		warnings_panel->add_theme_font_override("normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("main", "EditorFonts"));
-		warnings_panel->add_theme_font_size_override("normal_font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("main_size", "EditorFonts"));
+		warnings_panel->add_theme_font_override("normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("main"), SNAME("EditorFonts")));
+		warnings_panel->add_theme_font_size_override("normal_font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("main_size"), SNAME("EditorFonts")));
 	}
 }
 
@@ -242,7 +242,7 @@ void ShaderTextEditor::_validate_script() {
 	} else {
 		set_warning_count(0);
 	}
-	emit_signal("script_changed");
+	emit_signal(SNAME("script_changed"));
 }
 
 void ShaderTextEditor::_update_warning_panel() {
@@ -266,7 +266,7 @@ void ShaderTextEditor::_update_warning_panel() {
 		// First cell.
 		warnings_panel->push_cell();
 		warnings_panel->push_meta(w.get_line() - 1);
-		warnings_panel->push_color(warnings_panel->get_theme_color("warning_color", "Editor"));
+		warnings_panel->push_color(warnings_panel->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		warnings_panel->add_text(TTR("Line") + " " + itos(w.get_line()));
 		warnings_panel->add_text(" (" + w.get_name() + "):");
 		warnings_panel->pop(); // Color.
@@ -380,7 +380,7 @@ void ShaderEditor::_menu_option(int p_option) {
 		} break;
 	}
 	if (p_option != SEARCH_FIND && p_option != SEARCH_REPLACE && p_option != SEARCH_GOTO_LINE) {
-		shader_editor->get_text_editor()->call_deferred("grab_focus");
+		shader_editor->get_text_editor()->call_deferred(SNAME("grab_focus"));
 	}
 }
 
@@ -484,7 +484,7 @@ void ShaderEditor::_check_for_external_edit() {
 		if (use_autoreload) {
 			_reload_shader_from_disk();
 		} else {
-			disk_changed->call_deferred("popup_centered");
+			disk_changed->call_deferred(SNAME("popup_centered"));
 		}
 	}
 }
@@ -728,7 +728,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	help_menu = memnew(MenuButton);
 	help_menu->set_text(TTR("Help"));
 	help_menu->set_switch_on_hover(true);
-	help_menu->get_popup()->add_icon_item(p_node->get_gui_base()->get_theme_icon("Instance", "EditorIcons"), TTR("Online Docs"), HELP_DOCS);
+	help_menu->get_popup()->add_icon_item(p_node->get_gui_base()->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Online Docs"), HELP_DOCS);
 	help_menu->get_popup()->connect("id_pressed", callable_mp(this, &ShaderEditor::_menu_option));
 
 	add_child(main_container);
@@ -737,7 +737,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	hbc->add_child(edit_menu);
 	hbc->add_child(goto_menu);
 	hbc->add_child(help_menu);
-	hbc->add_theme_style_override("panel", p_node->get_gui_base()->get_theme_stylebox("ScriptEditorPanel", "EditorStyles"));
+	hbc->add_theme_style_override("panel", p_node->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
 
 	VSplitContainer *editor_box = memnew(VSplitContainer);
 	main_container->add_child(editor_box);

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -66,9 +66,9 @@ void ShaderFileEditor::_version_selected(int p_option) {
 
 		Ref<Texture2D> icon;
 		if (bytecode->get_stage_compile_error(RD::ShaderStage(i)) != String()) {
-			icon = get_theme_icon("ImportFail", "EditorIcons");
+			icon = get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons"));
 		} else {
-			icon = get_theme_icon("ImportCheck", "EditorIcons");
+			icon = get_theme_icon(SNAME("ImportCheck"), SNAME("EditorIcons"));
 		}
 		stages[i]->set_icon(icon);
 
@@ -95,7 +95,7 @@ void ShaderFileEditor::_version_selected(int p_option) {
 
 	String error = bytecode->get_stage_compile_error(stage);
 
-	error_text->push_font(get_theme_font("source", "EditorFonts"));
+	error_text->push_font(get_theme_font(SNAME("source"), SNAME("EditorFonts")));
 
 	if (error == String()) {
 		error_text->add_text(TTR("Shader stage compiled without errors."));
@@ -111,7 +111,7 @@ void ShaderFileEditor::_update_options() {
 		stage_hb->hide();
 		versions->hide();
 		error_text->clear();
-		error_text->push_font(get_theme_font("source", "EditorFonts"));
+		error_text->push_font(get_theme_font(SNAME("source"), SNAME("EditorFonts")));
 		error_text->add_text(vformat(TTR("File structure for '%s' contains unrecoverable errors:\n\n"), shader_file->get_path().get_file()));
 		error_text->add_text(shader_file->get_base_error());
 		return;
@@ -154,9 +154,9 @@ void ShaderFileEditor::_update_options() {
 		}
 
 		if (failed) {
-			icon = get_theme_icon("ImportFail", "EditorIcons");
+			icon = get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons"));
 		} else {
-			icon = get_theme_icon("ImportCheck", "EditorIcons");
+			icon = get_theme_icon(SNAME("ImportCheck"), SNAME("EditorIcons"));
 		}
 
 		versions->add_item(title, icon);

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -96,7 +96,7 @@ Skeleton2DEditor::Skeleton2DEditor() {
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->set_text(TTR("Skeleton2D"));
-	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Skeleton2D", "EditorIcons"));
+	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Skeleton2D"), SNAME("EditorIcons")));
 
 	options->get_popup()->add_item(TTR("Make Rest Pose (From Bones)"), MENU_OPTION_MAKE_REST);
 	options->get_popup()->add_separator();

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -44,7 +44,7 @@
 #include "scene/resources/sphere_shape_3d.h"
 
 void BoneTransformEditor::create_editors() {
-	const Color section_color = get_theme_color("prop_subsection", "Editor");
+	const Color section_color = get_theme_color(SNAME("prop_subsection"), SNAME("Editor"));
 
 	section = memnew(EditorInspectorSection);
 	section->setup("trf_properties", label, this, section_color, true);
@@ -53,7 +53,7 @@ void BoneTransformEditor::create_editors() {
 	key_button = memnew(Button);
 	key_button->set_text(TTR("Key Transform"));
 	key_button->set_visible(keyable);
-	key_button->set_icon(get_theme_icon("Key", "EditorIcons"));
+	key_button->set_icon(get_theme_icon(SNAME("Key"), SNAME("EditorIcons")));
 	key_button->set_flat(true);
 	section->get_vbox()->add_child(key_button);
 
@@ -113,19 +113,19 @@ void BoneTransformEditor::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_SORT_CHILDREN: {
-			const Ref<Font> font = get_theme_font("font", "Tree");
-			int font_size = get_theme_font_size("font_size", "Tree");
+			const Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Tree"));
+			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Tree"));
 
 			Point2 buffer;
-			buffer.x += get_theme_constant("inspector_margin", "Editor");
+			buffer.x += get_theme_constant(SNAME("inspector_margin"), SNAME("Editor"));
 			buffer.y += font->get_height(font_size);
-			buffer.y += get_theme_constant("vseparation", "Tree");
+			buffer.y += get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
 
 			const float vector_height = translation_property->get_size().y;
 			const float transform_height = transform_property->get_size().y;
 			const float button_height = key_button->get_size().y;
 
-			const float width = get_size().x - get_theme_constant("inspector_margin", "Editor");
+			const float width = get_size().x - get_theme_constant(SNAME("inspector_margin"), SNAME("Editor"));
 			Vector<Rect2> input_rects;
 			if (keyable && section->get_vbox()->is_visible()) {
 				input_rects.push_back(Rect2(key_button->get_position() + buffer, Size2(width, button_height)));
@@ -155,7 +155,7 @@ void BoneTransformEditor::_notification(int p_what) {
 			break;
 		}
 		case NOTIFICATION_DRAW: {
-			const Color dark_color = get_theme_color("dark_color_2", "Editor");
+			const Color dark_color = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
 
 			for (int i = 0; i < 5; ++i) {
 				draw_rect(background_rects[i], dark_color);
@@ -552,7 +552,7 @@ void Skeleton3DEditor::update_joint_tree() {
 	items.insert(-1, root);
 
 	const Vector<int> &joint_porder = skeleton->get_bone_process_orders();
-	Ref<Texture> bone_icon = get_theme_icon("BoneAttachment3D", "EditorIcons");
+	Ref<Texture> bone_icon = get_theme_icon(SNAME("BoneAttachment3D"), SNAME("EditorIcons"));
 
 	for (int i = 0; i < joint_porder.size(); ++i) {
 		const int b_idx = joint_porder[i];
@@ -584,13 +584,13 @@ void Skeleton3DEditor::create_editors() {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->set_text(TTR("Skeleton3D"));
-	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Skeleton3D", "EditorIcons"));
+	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Skeleton3D"), SNAME("EditorIcons")));
 
 	options->get_popup()->add_item(TTR("Create physical skeleton"), MENU_OPTION_CREATE_PHYSICAL_SKELETON);
 
 	options->get_popup()->connect("id_pressed", callable_mp(this, &Skeleton3DEditor::_on_click_option));
 
-	const Color section_color = get_theme_color("prop_subsection", "Editor");
+	const Color section_color = get_theme_color(SNAME("prop_subsection"), SNAME("Editor"));
 
 	EditorInspectorSection *bones_section = memnew(EditorInspectorSection);
 	bones_section->setup("bones", "Bones", skeleton, section_color, true);

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
@@ -83,7 +83,7 @@ void SkeletonIK3DEditorPlugin::_bind_methods() {
 SkeletonIK3DEditorPlugin::SkeletonIK3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	play_btn = memnew(Button);
-	play_btn->set_icon(editor->get_gui_base()->get_theme_icon("Play", "EditorIcons"));
+	play_btn->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 	play_btn->set_text(TTR("Play IK"));
 	play_btn->set_toggle_mode(true);
 	play_btn->hide();

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -506,7 +506,7 @@ Sprite2DEditor::Sprite2DEditor() {
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->set_text(TTR("Sprite2D"));
-	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Sprite2D", "EditorIcons"));
+	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Sprite2D"), SNAME("EditorIcons")));
 
 	options->get_popup()->add_item(TTR("Convert to Mesh2D"), MENU_OPTION_CONVERT_TO_MESH_2D);
 	options->get_popup()->add_item(TTR("Convert to Polygon2D"), MENU_OPTION_CONVERT_TO_POLYGON_2D);

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -80,7 +80,7 @@ void SpriteFramesEditor::_sheet_preview_draw() {
 		return;
 	}
 
-	Color accent = get_theme_color("accent_color", "Editor");
+	Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 
 	for (Set<int>::Element *E = frames_selected.front(); E; E = E->next()) {
 		int idx = E->get();
@@ -308,27 +308,27 @@ void SpriteFramesEditor::_prepare_sprite_sheet(const String &p_file) {
 void SpriteFramesEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			load->set_icon(get_theme_icon("Load", "EditorIcons"));
-			load_sheet->set_icon(get_theme_icon("SpriteSheet", "EditorIcons"));
-			copy->set_icon(get_theme_icon("ActionCopy", "EditorIcons"));
-			paste->set_icon(get_theme_icon("ActionPaste", "EditorIcons"));
-			empty->set_icon(get_theme_icon("InsertBefore", "EditorIcons"));
-			empty2->set_icon(get_theme_icon("InsertAfter", "EditorIcons"));
-			move_up->set_icon(get_theme_icon("MoveLeft", "EditorIcons"));
-			move_down->set_icon(get_theme_icon("MoveRight", "EditorIcons"));
-			_delete->set_icon(get_theme_icon("Remove", "EditorIcons"));
-			zoom_out->set_icon(get_theme_icon("ZoomLess", "EditorIcons"));
-			zoom_reset->set_icon(get_theme_icon("ZoomReset", "EditorIcons"));
-			zoom_in->set_icon(get_theme_icon("ZoomMore", "EditorIcons"));
-			new_anim->set_icon(get_theme_icon("New", "EditorIcons"));
-			remove_anim->set_icon(get_theme_icon("Remove", "EditorIcons"));
-			split_sheet_zoom_out->set_icon(get_theme_icon("ZoomLess", "EditorIcons"));
-			split_sheet_zoom_reset->set_icon(get_theme_icon("ZoomReset", "EditorIcons"));
-			split_sheet_zoom_in->set_icon(get_theme_icon("ZoomMore", "EditorIcons"));
+			load->set_icon(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")));
+			load_sheet->set_icon(get_theme_icon(SNAME("SpriteSheet"), SNAME("EditorIcons")));
+			copy->set_icon(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")));
+			paste->set_icon(get_theme_icon(SNAME("ActionPaste"), SNAME("EditorIcons")));
+			empty->set_icon(get_theme_icon(SNAME("InsertBefore"), SNAME("EditorIcons")));
+			empty2->set_icon(get_theme_icon(SNAME("InsertAfter"), SNAME("EditorIcons")));
+			move_up->set_icon(get_theme_icon(SNAME("MoveLeft"), SNAME("EditorIcons")));
+			move_down->set_icon(get_theme_icon(SNAME("MoveRight"), SNAME("EditorIcons")));
+			_delete->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+			zoom_out->set_icon(get_theme_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));
+			zoom_reset->set_icon(get_theme_icon(SNAME("ZoomReset"), SNAME("EditorIcons")));
+			zoom_in->set_icon(get_theme_icon(SNAME("ZoomMore"), SNAME("EditorIcons")));
+			new_anim->set_icon(get_theme_icon(SNAME("New"), SNAME("EditorIcons")));
+			remove_anim->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+			split_sheet_zoom_out->set_icon(get_theme_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));
+			split_sheet_zoom_reset->set_icon(get_theme_icon(SNAME("ZoomReset"), SNAME("EditorIcons")));
+			split_sheet_zoom_in->set_icon(get_theme_icon(SNAME("ZoomMore"), SNAME("EditorIcons")));
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
-			split_sheet_scroll->add_theme_style_override("bg", get_theme_stylebox("bg", "Tree"));
+			split_sheet_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 		case NOTIFICATION_READY: {
 			add_theme_constant_override("autohide", 1); // Fixes the dragger always showing up.

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -100,7 +100,7 @@ void TextEditor::set_edited_resource(const RES &p_res) {
 	code_editor->get_text_editor()->clear_undo_history();
 	code_editor->get_text_editor()->tag_saved_version();
 
-	emit_signal("name_changed");
+	emit_signal(SNAME("name_changed"));
 	code_editor->update_line_and_column();
 }
 
@@ -149,8 +149,8 @@ void TextEditor::reload_text() {
 }
 
 void TextEditor::_validate_script() {
-	emit_signal("name_changed");
-	emit_signal("edited_script_changed");
+	emit_signal(SNAME("name_changed"));
+	emit_signal(SNAME("edited_script_changed"));
 }
 
 void TextEditor::_update_bookmark_list() {
@@ -291,27 +291,27 @@ void TextEditor::_edit_option(int p_op) {
 	switch (p_op) {
 		case EDIT_UNDO: {
 			tx->undo();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_REDO: {
 			tx->redo();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_CUT: {
 			tx->cut();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_COPY: {
 			tx->copy();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_PASTE: {
 			tx->paste();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_SELECT_ALL: {
 			tx->select_all();
-			tx->call_deferred("grab_focus");
+			tx->call_deferred(SNAME("grab_focus"));
 		} break;
 		case EDIT_MOVE_LINE_UP: {
 			code_editor->move_lines_up();
@@ -378,12 +378,12 @@ void TextEditor::_edit_option(int p_op) {
 
 			// Yep, because it doesn't make sense to instance this dialog for every single script open...
 			// So this will be delegated to the ScriptEditor.
-			emit_signal("search_in_files_requested", selected_text);
+			emit_signal(SNAME("search_in_files_requested"), selected_text);
 		} break;
 		case REPLACE_IN_FILES: {
 			String selected_text = code_editor->get_text_editor()->get_selection_text();
 
-			emit_signal("replace_in_files_requested", selected_text);
+			emit_signal(SNAME("replace_in_files_requested"), selected_text);
 		} break;
 		case SEARCH_GOTO_LINE: {
 			goto_line_dialog->popup_find_line(tx);

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -50,7 +50,7 @@ void Texture3DEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Texture2D> checkerboard = get_theme_icon("Checkerboard", "EditorIcons");
+		Ref<Texture2D> checkerboard = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
 		Size2 size = get_size();
 
 		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -58,7 +58,7 @@ void TextureLayeredEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Texture2D> checkerboard = get_theme_icon("Checkerboard", "EditorIcons");
+		Ref<Texture2D> checkerboard = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
 		Size2 size = get_size();
 
 		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -47,14 +47,14 @@ void draw_margin_line(Control *edit_draw, Vector2 from, Vector2 to) {
 	edit_draw->draw_line(
 			from,
 			to,
-			EditorNode::get_singleton()->get_theme_base()->get_theme_color("mono_color", "Editor").inverted() * Color(1, 1, 1, 0.5),
+			EditorNode::get_singleton()->get_theme_base()->get_theme_color(SNAME("mono_color"), SNAME("Editor")).inverted() * Color(1, 1, 1, 0.5),
 			Math::round(2 * EDSCALE));
 
 	while ((to - from).length_squared() > 200) {
 		edit_draw->draw_line(
 				from,
 				from + line,
-				EditorNode::get_singleton()->get_theme_base()->get_theme_color("mono_color", "Editor"),
+				EditorNode::get_singleton()->get_theme_base()->get_theme_color(SNAME("mono_color"), SNAME("Editor")),
 				Math::round(2 * EDSCALE));
 
 		from += line * 2;
@@ -159,7 +159,7 @@ void TextureRegionEditor::_region_draw() {
 		}
 	}
 
-	Ref<Texture2D> select_handle = get_theme_icon("EditorHandle", "EditorIcons");
+	Ref<Texture2D> select_handle = get_theme_icon(SNAME("EditorHandle"), SNAME("EditorIcons"));
 
 	Rect2 scroll_rect(Point2(), base_tex->get_size());
 
@@ -175,7 +175,7 @@ void TextureRegionEditor::_region_draw() {
 		mtx.basis_xform(raw_endpoints[2]),
 		mtx.basis_xform(raw_endpoints[3])
 	};
-	Color color = get_theme_color("mono_color", "Editor");
+	Color color = get_theme_color(SNAME("mono_color"), SNAME("Editor"));
 	for (int i = 0; i < 4; i++) {
 		int prev = (i + 3) % 4;
 		int next = (i + 1) % 4;
@@ -799,12 +799,12 @@ void TextureRegionEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			edit_draw->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
+			edit_draw->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 		case NOTIFICATION_READY: {
-			zoom_out->set_icon(get_theme_icon("ZoomLess", "EditorIcons"));
-			zoom_reset->set_icon(get_theme_icon("ZoomReset", "EditorIcons"));
-			zoom_in->set_icon(get_theme_icon("ZoomMore", "EditorIcons"));
+			zoom_out->set_icon(get_theme_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));
+			zoom_reset->set_icon(get_theme_icon(SNAME("ZoomReset"), SNAME("EditorIcons")));
+			zoom_in->set_icon(get_theme_icon(SNAME("ZoomMore"), SNAME("EditorIcons")));
 
 			vscroll->set_anchors_and_offsets_preset(PRESET_RIGHT_WIDE);
 			hscroll->set_anchors_and_offsets_preset(PRESET_BOTTOM_WIDE);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -127,7 +127,7 @@ void ThemeItemImportTree::_update_items_tree() {
 
 			switch (dt) {
 				case Theme::DATA_TYPE_COLOR:
-					data_type_node->set_icon(0, get_theme_icon("Color", "EditorIcons"));
+					data_type_node->set_icon(0, get_theme_icon(SNAME("Color"), SNAME("EditorIcons")));
 					data_type_node->set_text(0, TTR("Colors"));
 
 					item_list = &tree_color_items;
@@ -135,7 +135,7 @@ void ThemeItemImportTree::_update_items_tree() {
 					break;
 
 				case Theme::DATA_TYPE_CONSTANT:
-					data_type_node->set_icon(0, get_theme_icon("MemberConstant", "EditorIcons"));
+					data_type_node->set_icon(0, get_theme_icon(SNAME("MemberConstant"), SNAME("EditorIcons")));
 					data_type_node->set_text(0, TTR("Constants"));
 
 					item_list = &tree_constant_items;
@@ -143,7 +143,7 @@ void ThemeItemImportTree::_update_items_tree() {
 					break;
 
 				case Theme::DATA_TYPE_FONT:
-					data_type_node->set_icon(0, get_theme_icon("Font", "EditorIcons"));
+					data_type_node->set_icon(0, get_theme_icon(SNAME("Font"), SNAME("EditorIcons")));
 					data_type_node->set_text(0, TTR("Fonts"));
 
 					item_list = &tree_font_items;
@@ -151,7 +151,7 @@ void ThemeItemImportTree::_update_items_tree() {
 					break;
 
 				case Theme::DATA_TYPE_FONT_SIZE:
-					data_type_node->set_icon(0, get_theme_icon("FontSize", "EditorIcons"));
+					data_type_node->set_icon(0, get_theme_icon(SNAME("FontSize"), SNAME("EditorIcons")));
 					data_type_node->set_text(0, TTR("Font Sizes"));
 
 					item_list = &tree_font_size_items;
@@ -159,7 +159,7 @@ void ThemeItemImportTree::_update_items_tree() {
 					break;
 
 				case Theme::DATA_TYPE_ICON:
-					data_type_node->set_icon(0, get_theme_icon("ImageTexture", "EditorIcons"));
+					data_type_node->set_icon(0, get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")));
 					data_type_node->set_text(0, TTR("Icons"));
 
 					item_list = &tree_icon_items;
@@ -167,7 +167,7 @@ void ThemeItemImportTree::_update_items_tree() {
 					break;
 
 				case Theme::DATA_TYPE_STYLEBOX:
-					data_type_node->set_icon(0, get_theme_icon("StyleBoxFlat", "EditorIcons"));
+					data_type_node->set_icon(0, get_theme_icon(SNAME("StyleBoxFlat"), SNAME("EditorIcons")));
 					data_type_node->set_text(0, TTR("Styleboxes"));
 
 					item_list = &tree_stylebox_items;
@@ -821,7 +821,7 @@ void ThemeItemImportTree::_import_selected() {
 	ProgressDialog::get_singleton()->task_step("import_theme_items", TTR("Finalizing"), idx++);
 
 	ProgressDialog::get_singleton()->end_task("import_theme_items");
-	emit_signal("items_imported");
+	emit_signal(SNAME("items_imported"));
 }
 
 void ThemeItemImportTree::set_edited_theme(const Ref<Theme> &p_theme) {
@@ -854,47 +854,47 @@ void ThemeItemImportTree::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			select_icons_warning_icon->set_texture(get_theme_icon("StatusWarning", "EditorIcons"));
-			select_icons_warning->add_theme_color_override("font_color", get_theme_color("disabled_font_color", "Editor"));
+			select_icons_warning_icon->set_texture(get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
+			select_icons_warning->add_theme_color_override("font_color", get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 
 			// Bottom panel buttons.
-			import_collapse_types_button->set_icon(get_theme_icon("CollapseTree", "EditorIcons"));
-			import_expand_types_button->set_icon(get_theme_icon("ExpandTree", "EditorIcons"));
+			import_collapse_types_button->set_icon(get_theme_icon(SNAME("CollapseTree"), SNAME("EditorIcons")));
+			import_expand_types_button->set_icon(get_theme_icon(SNAME("ExpandTree"), SNAME("EditorIcons")));
 
-			import_select_all_button->set_icon(get_theme_icon("ThemeSelectAll", "EditorIcons"));
-			import_select_full_button->set_icon(get_theme_icon("ThemeSelectFull", "EditorIcons"));
-			import_deselect_all_button->set_icon(get_theme_icon("ThemeDeselectAll", "EditorIcons"));
+			import_select_all_button->set_icon(get_theme_icon(SNAME("ThemeSelectAll"), SNAME("EditorIcons")));
+			import_select_full_button->set_icon(get_theme_icon(SNAME("ThemeSelectFull"), SNAME("EditorIcons")));
+			import_deselect_all_button->set_icon(get_theme_icon(SNAME("ThemeDeselectAll"), SNAME("EditorIcons")));
 
 			// Side panel buttons.
-			select_colors_icon->set_texture(get_theme_icon("Color", "EditorIcons"));
-			deselect_all_colors_button->set_icon(get_theme_icon("ThemeDeselectAll", "EditorIcons"));
-			select_all_colors_button->set_icon(get_theme_icon("ThemeSelectAll", "EditorIcons"));
-			select_full_colors_button->set_icon(get_theme_icon("ThemeSelectFull", "EditorIcons"));
+			select_colors_icon->set_texture(get_theme_icon(SNAME("Color"), SNAME("EditorIcons")));
+			deselect_all_colors_button->set_icon(get_theme_icon(SNAME("ThemeDeselectAll"), SNAME("EditorIcons")));
+			select_all_colors_button->set_icon(get_theme_icon(SNAME("ThemeSelectAll"), SNAME("EditorIcons")));
+			select_full_colors_button->set_icon(get_theme_icon(SNAME("ThemeSelectFull"), SNAME("EditorIcons")));
 
-			select_constants_icon->set_texture(get_theme_icon("MemberConstant", "EditorIcons"));
-			deselect_all_constants_button->set_icon(get_theme_icon("ThemeDeselectAll", "EditorIcons"));
-			select_all_constants_button->set_icon(get_theme_icon("ThemeSelectAll", "EditorIcons"));
-			select_full_constants_button->set_icon(get_theme_icon("ThemeSelectFull", "EditorIcons"));
+			select_constants_icon->set_texture(get_theme_icon(SNAME("MemberConstant"), SNAME("EditorIcons")));
+			deselect_all_constants_button->set_icon(get_theme_icon(SNAME("ThemeDeselectAll"), SNAME("EditorIcons")));
+			select_all_constants_button->set_icon(get_theme_icon(SNAME("ThemeSelectAll"), SNAME("EditorIcons")));
+			select_full_constants_button->set_icon(get_theme_icon(SNAME("ThemeSelectFull"), SNAME("EditorIcons")));
 
-			select_fonts_icon->set_texture(get_theme_icon("Font", "EditorIcons"));
-			deselect_all_fonts_button->set_icon(get_theme_icon("ThemeDeselectAll", "EditorIcons"));
-			select_all_fonts_button->set_icon(get_theme_icon("ThemeSelectAll", "EditorIcons"));
-			select_full_fonts_button->set_icon(get_theme_icon("ThemeSelectFull", "EditorIcons"));
+			select_fonts_icon->set_texture(get_theme_icon(SNAME("Font"), SNAME("EditorIcons")));
+			deselect_all_fonts_button->set_icon(get_theme_icon(SNAME("ThemeDeselectAll"), SNAME("EditorIcons")));
+			select_all_fonts_button->set_icon(get_theme_icon(SNAME("ThemeSelectAll"), SNAME("EditorIcons")));
+			select_full_fonts_button->set_icon(get_theme_icon(SNAME("ThemeSelectFull"), SNAME("EditorIcons")));
 
-			select_font_sizes_icon->set_texture(get_theme_icon("FontSize", "EditorIcons"));
-			deselect_all_font_sizes_button->set_icon(get_theme_icon("ThemeDeselectAll", "EditorIcons"));
-			select_all_font_sizes_button->set_icon(get_theme_icon("ThemeSelectAll", "EditorIcons"));
-			select_full_font_sizes_button->set_icon(get_theme_icon("ThemeSelectFull", "EditorIcons"));
+			select_font_sizes_icon->set_texture(get_theme_icon(SNAME("FontSize"), SNAME("EditorIcons")));
+			deselect_all_font_sizes_button->set_icon(get_theme_icon(SNAME("ThemeDeselectAll"), SNAME("EditorIcons")));
+			select_all_font_sizes_button->set_icon(get_theme_icon(SNAME("ThemeSelectAll"), SNAME("EditorIcons")));
+			select_full_font_sizes_button->set_icon(get_theme_icon(SNAME("ThemeSelectFull"), SNAME("EditorIcons")));
 
-			select_icons_icon->set_texture(get_theme_icon("ImageTexture", "EditorIcons"));
-			deselect_all_icons_button->set_icon(get_theme_icon("ThemeDeselectAll", "EditorIcons"));
-			select_all_icons_button->set_icon(get_theme_icon("ThemeSelectAll", "EditorIcons"));
-			select_full_icons_button->set_icon(get_theme_icon("ThemeSelectFull", "EditorIcons"));
+			select_icons_icon->set_texture(get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")));
+			deselect_all_icons_button->set_icon(get_theme_icon(SNAME("ThemeDeselectAll"), SNAME("EditorIcons")));
+			select_all_icons_button->set_icon(get_theme_icon(SNAME("ThemeSelectAll"), SNAME("EditorIcons")));
+			select_full_icons_button->set_icon(get_theme_icon(SNAME("ThemeSelectFull"), SNAME("EditorIcons")));
 
-			select_styleboxes_icon->set_texture(get_theme_icon("StyleBoxFlat", "EditorIcons"));
-			deselect_all_styleboxes_button->set_icon(get_theme_icon("ThemeDeselectAll", "EditorIcons"));
-			select_all_styleboxes_button->set_icon(get_theme_icon("ThemeSelectAll", "EditorIcons"));
-			select_full_styleboxes_button->set_icon(get_theme_icon("ThemeSelectFull", "EditorIcons"));
+			select_styleboxes_icon->set_texture(get_theme_icon(SNAME("StyleBoxFlat"), SNAME("EditorIcons")));
+			deselect_all_styleboxes_button->set_icon(get_theme_icon(SNAME("ThemeDeselectAll"), SNAME("EditorIcons")));
+			select_all_styleboxes_button->set_icon(get_theme_icon(SNAME("ThemeSelectAll"), SNAME("EditorIcons")));
+			select_full_styleboxes_button->set_icon(get_theme_icon(SNAME("ThemeSelectFull"), SNAME("EditorIcons")));
 		} break;
 	}
 }
@@ -1239,7 +1239,7 @@ void ThemeItemEditorDialog::_update_edit_types() {
 	for (List<StringName>::Element *E = theme_types.front(); E; E = E->next()) {
 		Ref<Texture2D> item_icon;
 		if (E->get() == "") {
-			item_icon = get_theme_icon("NodeDisabled", "EditorIcons");
+			item_icon = get_theme_icon(SNAME("NodeDisabled"), SNAME("EditorIcons"));
 		} else {
 			item_icon = EditorNode::get_singleton()->get_class_icon(E->get(), "NodeDisabled");
 		}
@@ -1313,16 +1313,16 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 		if (names.size() > 0) {
 			TreeItem *color_root = edit_items_tree->create_item(root);
 			color_root->set_metadata(0, Theme::DATA_TYPE_COLOR);
-			color_root->set_icon(0, get_theme_icon("Color", "EditorIcons"));
+			color_root->set_icon(0, get_theme_icon(SNAME("Color"), SNAME("EditorIcons")));
 			color_root->set_text(0, TTR("Colors"));
-			color_root->add_button(0, get_theme_icon("Clear", "EditorIcons"), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Color Items"));
+			color_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Color Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
 			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 				TreeItem *item = edit_items_tree->create_item(color_root);
 				item->set_text(0, E->get());
-				item->add_button(0, get_theme_icon("Edit", "EditorIcons"), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
-				item->add_button(0, get_theme_icon("Remove", "EditorIcons"), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
+				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
+				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
 		}
 	}
@@ -1334,16 +1334,16 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 		if (names.size() > 0) {
 			TreeItem *constant_root = edit_items_tree->create_item(root);
 			constant_root->set_metadata(0, Theme::DATA_TYPE_CONSTANT);
-			constant_root->set_icon(0, get_theme_icon("MemberConstant", "EditorIcons"));
+			constant_root->set_icon(0, get_theme_icon(SNAME("MemberConstant"), SNAME("EditorIcons")));
 			constant_root->set_text(0, TTR("Constants"));
-			constant_root->add_button(0, get_theme_icon("Clear", "EditorIcons"), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Constant Items"));
+			constant_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Constant Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
 			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 				TreeItem *item = edit_items_tree->create_item(constant_root);
 				item->set_text(0, E->get());
-				item->add_button(0, get_theme_icon("Edit", "EditorIcons"), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
-				item->add_button(0, get_theme_icon("Remove", "EditorIcons"), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
+				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
+				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
 		}
 	}
@@ -1355,16 +1355,16 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 		if (names.size() > 0) {
 			TreeItem *font_root = edit_items_tree->create_item(root);
 			font_root->set_metadata(0, Theme::DATA_TYPE_FONT);
-			font_root->set_icon(0, get_theme_icon("Font", "EditorIcons"));
+			font_root->set_icon(0, get_theme_icon(SNAME("Font"), SNAME("EditorIcons")));
 			font_root->set_text(0, TTR("Fonts"));
-			font_root->add_button(0, get_theme_icon("Clear", "EditorIcons"), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Font Items"));
+			font_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Font Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
 			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 				TreeItem *item = edit_items_tree->create_item(font_root);
 				item->set_text(0, E->get());
-				item->add_button(0, get_theme_icon("Edit", "EditorIcons"), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
-				item->add_button(0, get_theme_icon("Remove", "EditorIcons"), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
+				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
+				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
 		}
 	}
@@ -1376,16 +1376,16 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 		if (names.size() > 0) {
 			TreeItem *font_size_root = edit_items_tree->create_item(root);
 			font_size_root->set_metadata(0, Theme::DATA_TYPE_FONT_SIZE);
-			font_size_root->set_icon(0, get_theme_icon("FontSize", "EditorIcons"));
+			font_size_root->set_icon(0, get_theme_icon(SNAME("FontSize"), SNAME("EditorIcons")));
 			font_size_root->set_text(0, TTR("Font Sizes"));
-			font_size_root->add_button(0, get_theme_icon("Clear", "EditorIcons"), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Font Size Items"));
+			font_size_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Font Size Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
 			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 				TreeItem *item = edit_items_tree->create_item(font_size_root);
 				item->set_text(0, E->get());
-				item->add_button(0, get_theme_icon("Edit", "EditorIcons"), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
-				item->add_button(0, get_theme_icon("Remove", "EditorIcons"), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
+				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
+				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
 		}
 	}
@@ -1397,16 +1397,16 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 		if (names.size() > 0) {
 			TreeItem *icon_root = edit_items_tree->create_item(root);
 			icon_root->set_metadata(0, Theme::DATA_TYPE_ICON);
-			icon_root->set_icon(0, get_theme_icon("ImageTexture", "EditorIcons"));
+			icon_root->set_icon(0, get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")));
 			icon_root->set_text(0, TTR("Icons"));
-			icon_root->add_button(0, get_theme_icon("Clear", "EditorIcons"), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Icon Items"));
+			icon_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All Icon Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
 			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 				TreeItem *item = edit_items_tree->create_item(icon_root);
 				item->set_text(0, E->get());
-				item->add_button(0, get_theme_icon("Edit", "EditorIcons"), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
-				item->add_button(0, get_theme_icon("Remove", "EditorIcons"), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
+				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
+				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
 		}
 	}
@@ -1418,16 +1418,16 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 		if (names.size() > 0) {
 			TreeItem *stylebox_root = edit_items_tree->create_item(root);
 			stylebox_root->set_metadata(0, Theme::DATA_TYPE_STYLEBOX);
-			stylebox_root->set_icon(0, get_theme_icon("StyleBoxFlat", "EditorIcons"));
+			stylebox_root->set_icon(0, get_theme_icon(SNAME("StyleBoxFlat"), SNAME("EditorIcons")));
 			stylebox_root->set_text(0, TTR("Styleboxes"));
-			stylebox_root->add_button(0, get_theme_icon("Clear", "EditorIcons"), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All StyleBox Items"));
+			stylebox_root->add_button(0, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTR("Remove All StyleBox Items"));
 
 			names.sort_custom<StringName::AlphCompare>();
 			for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 				TreeItem *item = edit_items_tree->create_item(stylebox_root);
 				item->set_text(0, E->get());
-				item->add_button(0, get_theme_icon("Edit", "EditorIcons"), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
-				item->add_button(0, get_theme_icon("Remove", "EditorIcons"), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
+				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
+				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
 		}
 	}
@@ -1718,21 +1718,21 @@ void ThemeItemEditorDialog::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
-			edit_items_add_color->set_icon(get_theme_icon("Color", "EditorIcons"));
-			edit_items_add_constant->set_icon(get_theme_icon("MemberConstant", "EditorIcons"));
-			edit_items_add_font->set_icon(get_theme_icon("Font", "EditorIcons"));
-			edit_items_add_font_size->set_icon(get_theme_icon("FontSize", "EditorIcons"));
-			edit_items_add_icon->set_icon(get_theme_icon("ImageTexture", "EditorIcons"));
-			edit_items_add_stylebox->set_icon(get_theme_icon("StyleBoxFlat", "EditorIcons"));
+			edit_items_add_color->set_icon(get_theme_icon(SNAME("Color"), SNAME("EditorIcons")));
+			edit_items_add_constant->set_icon(get_theme_icon(SNAME("MemberConstant"), SNAME("EditorIcons")));
+			edit_items_add_font->set_icon(get_theme_icon(SNAME("Font"), SNAME("EditorIcons")));
+			edit_items_add_font_size->set_icon(get_theme_icon(SNAME("FontSize"), SNAME("EditorIcons")));
+			edit_items_add_icon->set_icon(get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")));
+			edit_items_add_stylebox->set_icon(get_theme_icon(SNAME("StyleBoxFlat"), SNAME("EditorIcons")));
 
-			edit_items_remove_class->set_icon(get_theme_icon("Control", "EditorIcons"));
-			edit_items_remove_custom->set_icon(get_theme_icon("ThemeRemoveCustomItems", "EditorIcons"));
-			edit_items_remove_all->set_icon(get_theme_icon("ThemeRemoveAllItems", "EditorIcons"));
+			edit_items_remove_class->set_icon(get_theme_icon(SNAME("Control"), SNAME("EditorIcons")));
+			edit_items_remove_custom->set_icon(get_theme_icon(SNAME("ThemeRemoveCustomItems"), SNAME("EditorIcons")));
+			edit_items_remove_all->set_icon(get_theme_icon(SNAME("ThemeRemoveAllItems"), SNAME("EditorIcons")));
 
-			import_another_theme_button->set_icon(get_theme_icon("Folder", "EditorIcons"));
+			import_another_theme_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 
-			tc->add_theme_style_override("tab_selected", get_theme_stylebox("tab_selected_odd", "TabContainer"));
-			tc->add_theme_style_override("panel", get_theme_stylebox("panel_odd", "TabContainer"));
+			tc->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("tab_selected_odd"), SNAME("TabContainer")));
+			tc->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
 		} break;
 	}
 }
@@ -1951,7 +1951,7 @@ void ThemeTypeDialog::_dialog_about_to_show() {
 }
 
 void ThemeTypeDialog::ok_pressed() {
-	emit_signal("type_selected", add_type_filter->get_text().strip_edges());
+	emit_signal(SNAME("type_selected"), add_type_filter->get_text().strip_edges());
 }
 
 void ThemeTypeDialog::_update_add_type_options(const String &p_filter) {
@@ -1979,7 +1979,7 @@ void ThemeTypeDialog::_update_add_type_options(const String &p_filter) {
 
 		Ref<Texture2D> item_icon;
 		if (E->get() == "") {
-			item_icon = get_theme_icon("NodeDisabled", "EditorIcons");
+			item_icon = get_theme_icon(SNAME("NodeDisabled"), SNAME("EditorIcons"));
 		} else {
 			item_icon = EditorNode::get_singleton()->get_class_icon(E->get(), "NodeDisabled");
 		}
@@ -1997,12 +1997,12 @@ void ThemeTypeDialog::_add_type_options_cbk(int p_index) {
 }
 
 void ThemeTypeDialog::_add_type_dialog_entered(const String &p_value) {
-	emit_signal("type_selected", p_value.strip_edges());
+	emit_signal(SNAME("type_selected"), p_value.strip_edges());
 	hide();
 }
 
 void ThemeTypeDialog::_add_type_dialog_activated(int p_index) {
-	emit_signal("type_selected", add_type_options->get_item_text(p_index));
+	emit_signal(SNAME("type_selected"), add_type_options->get_item_text(p_index));
 	hide();
 }
 
@@ -2131,7 +2131,7 @@ void ThemeTypeEditor::_update_type_list() {
 		for (List<StringName>::Element *E = theme_types.front(); E; E = E->next()) {
 			Ref<Texture2D> item_icon;
 			if (E->get() == "") {
-				item_icon = get_theme_icon("NodeDisabled", "EditorIcons");
+				item_icon = get_theme_icon(SNAME("NodeDisabled"), SNAME("EditorIcons"));
 			} else {
 				item_icon = EditorNode::get_singleton()->get_class_icon(E->get(), "NodeDisabled");
 			}
@@ -2230,21 +2230,21 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		item_name_edit->hide();
 
 		Button *item_rename_button = memnew(Button);
-		item_rename_button->set_icon(get_theme_icon("Edit", "EditorIcons"));
+		item_rename_button->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 		item_rename_button->set_tooltip(TTR("Rename Item"));
 		item_rename_button->set_flat(true);
 		item_name_container->add_child(item_rename_button);
 		item_rename_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_rename_cbk), varray(p_data_type, p_item_name, item_name_container));
 
 		Button *item_remove_button = memnew(Button);
-		item_remove_button->set_icon(get_theme_icon("Remove", "EditorIcons"));
+		item_remove_button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 		item_remove_button->set_tooltip(TTR("Remove Item"));
 		item_remove_button->set_flat(true);
 		item_name_container->add_child(item_remove_button);
 		item_remove_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_remove_cbk), varray(p_data_type, p_item_name));
 
 		Button *item_rename_confirm_button = memnew(Button);
-		item_rename_confirm_button->set_icon(get_theme_icon("ImportCheck", "EditorIcons"));
+		item_rename_confirm_button->set_icon(get_theme_icon(SNAME("ImportCheck"), SNAME("EditorIcons")));
 		item_rename_confirm_button->set_tooltip(TTR("Confirm Item Rename"));
 		item_rename_confirm_button->set_flat(true);
 		item_name_container->add_child(item_rename_confirm_button);
@@ -2252,17 +2252,17 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		item_rename_confirm_button->hide();
 
 		Button *item_rename_cancel_button = memnew(Button);
-		item_rename_cancel_button->set_icon(get_theme_icon("ImportFail", "EditorIcons"));
+		item_rename_cancel_button->set_icon(get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons")));
 		item_rename_cancel_button->set_tooltip(TTR("Cancel Item Rename"));
 		item_rename_cancel_button->set_flat(true);
 		item_name_container->add_child(item_rename_cancel_button);
 		item_rename_cancel_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_rename_canceled), varray(p_data_type, p_item_name, item_name_container));
 		item_rename_cancel_button->hide();
 	} else {
-		item_name->add_theme_color_override("font_color", get_theme_color("disabled_font_color", "Editor"));
+		item_name->add_theme_color_override("font_color", get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 
 		Button *item_override_button = memnew(Button);
-		item_override_button->set_icon(get_theme_icon("Add", "EditorIcons"));
+		item_override_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		item_override_button->set_tooltip(TTR("Override Item"));
 		item_override_button->set_flat(true);
 		item_name_container->add_child(item_override_button);
@@ -2471,7 +2471,7 @@ void ThemeTypeEditor::_update_type_items() {
 			pin_leader_button->set_flat(true);
 			pin_leader_button->set_toggle_mode(true);
 			pin_leader_button->set_pressed(true);
-			pin_leader_button->set_icon(get_theme_icon("Pin", "EditorIcons"));
+			pin_leader_button->set_icon(get_theme_icon(SNAME("Pin"), SNAME("EditorIcons")));
 			pin_leader_button->set_tooltip(TTR("Unpin this StyleBox as a main style."));
 			item_control->add_child(pin_leader_button);
 			pin_leader_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_unpin_leading_stylebox));
@@ -2516,7 +2516,7 @@ void ThemeTypeEditor::_update_type_items() {
 				Button *pin_leader_button = memnew(Button);
 				pin_leader_button->set_flat(true);
 				pin_leader_button->set_toggle_mode(true);
-				pin_leader_button->set_icon(get_theme_icon("Pin", "EditorIcons"));
+				pin_leader_button->set_icon(get_theme_icon(SNAME("Pin"), SNAME("EditorIcons")));
 				pin_leader_button->set_tooltip(TTR("Pin this StyleBox as a main style. Editing its properties will update the same properties in all other StyleBoxes of this type."));
 				item_control->add_child(pin_leader_button);
 				pin_leader_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_pin_leading_stylebox), varray(item_editor, E.key()));
@@ -2942,20 +2942,20 @@ void ThemeTypeEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			add_type_button->set_icon(get_theme_icon("Add", "EditorIcons"));
+			add_type_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 
-			data_type_tabs->set_tab_icon(0, get_theme_icon("Color", "EditorIcons"));
-			data_type_tabs->set_tab_icon(1, get_theme_icon("MemberConstant", "EditorIcons"));
-			data_type_tabs->set_tab_icon(2, get_theme_icon("Font", "EditorIcons"));
-			data_type_tabs->set_tab_icon(3, get_theme_icon("FontSize", "EditorIcons"));
-			data_type_tabs->set_tab_icon(4, get_theme_icon("ImageTexture", "EditorIcons"));
-			data_type_tabs->set_tab_icon(5, get_theme_icon("StyleBoxFlat", "EditorIcons"));
-			data_type_tabs->set_tab_icon(6, get_theme_icon("Tools", "EditorIcons"));
+			data_type_tabs->set_tab_icon(0, get_theme_icon(SNAME("Color"), SNAME("EditorIcons")));
+			data_type_tabs->set_tab_icon(1, get_theme_icon(SNAME("MemberConstant"), SNAME("EditorIcons")));
+			data_type_tabs->set_tab_icon(2, get_theme_icon(SNAME("Font"), SNAME("EditorIcons")));
+			data_type_tabs->set_tab_icon(3, get_theme_icon(SNAME("FontSize"), SNAME("EditorIcons")));
+			data_type_tabs->set_tab_icon(4, get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")));
+			data_type_tabs->set_tab_icon(5, get_theme_icon(SNAME("StyleBoxFlat"), SNAME("EditorIcons")));
+			data_type_tabs->set_tab_icon(6, get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 
-			data_type_tabs->add_theme_style_override("tab_selected", get_theme_stylebox("tab_selected_odd", "TabContainer"));
-			data_type_tabs->add_theme_style_override("panel", get_theme_stylebox("panel_odd", "TabContainer"));
+			data_type_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("tab_selected_odd"), SNAME("TabContainer")));
+			data_type_tabs->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
 
-			type_variation_button->set_icon(get_theme_icon("Add", "EditorIcons"));
+			type_variation_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		} break;
 	}
 }
@@ -3139,7 +3139,7 @@ void ThemeEditor::_preview_scene_dialog_cbk(const String &p_path) {
 		return;
 	}
 
-	_add_preview_tab(preview_tab, p_path.get_file(), get_theme_icon("PackedScene", "EditorIcons"));
+	_add_preview_tab(preview_tab, p_path.get_file(), get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")));
 	preview_tab->connect("scene_invalidated", callable_mp(this, &ThemeEditor::_remove_preview_tab_invalid), varray(preview_tab));
 	preview_tab->connect("scene_reloaded", callable_mp(this, &ThemeEditor::_update_preview_tab), varray(preview_tab));
 }
@@ -3149,7 +3149,7 @@ void ThemeEditor::_add_preview_tab(ThemeEditorPreview *p_preview_tab, const Stri
 
 	preview_tabs->add_tab(p_preview_name, p_icon);
 	preview_tabs_content->add_child(p_preview_tab);
-	preview_tabs->set_tab_right_button(preview_tabs->get_tab_count() - 1, EditorNode::get_singleton()->get_gui_base()->get_theme_icon("close", "Tabs"));
+	preview_tabs->set_tab_right_button(preview_tabs->get_tab_count() - 1, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("close"), SNAME("Tabs")));
 	p_preview_tab->connect("control_picked", callable_mp(this, &ThemeEditor::_preview_control_picked));
 
 	preview_tabs->set_current_tab(preview_tabs->get_tab_count() - 1);
@@ -3212,11 +3212,11 @@ void ThemeEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			preview_tabs->add_theme_style_override("tab_selected", get_theme_stylebox("ThemeEditorPreviewFG", "EditorStyles"));
-			preview_tabs->add_theme_style_override("tab_unselected", get_theme_stylebox("ThemeEditorPreviewBG", "EditorStyles"));
-			preview_tabs_content->add_theme_style_override("panel", get_theme_stylebox("panel_odd", "TabContainer"));
+			preview_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("ThemeEditorPreviewFG"), SNAME("EditorStyles")));
+			preview_tabs->add_theme_style_override("tab_unselected", get_theme_stylebox(SNAME("ThemeEditorPreviewBG"), SNAME("EditorStyles")));
+			preview_tabs_content->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
 
-			add_preview_button->set_icon(get_theme_icon("Add", "EditorIcons"));
+			add_preview_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		} break;
 	}
 }

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -151,7 +151,7 @@ void ThemeEditorPreview::_gui_input_picker_overlay(const Ref<InputEvent> &p_even
 				theme_type = hovered_control->get_class_name();
 			}
 
-			emit_signal("control_picked", theme_type);
+			emit_signal(SNAME("control_picked"), theme_type);
 			picker_button->set_pressed(false);
 			picker_overlay->set_visible(false);
 		}
@@ -182,12 +182,12 @@ void ThemeEditorPreview::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
-			picker_button->set_icon(get_theme_icon("ColorPick", "EditorIcons"));
+			picker_button->set_icon(get_theme_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
 
-			theme_cache.preview_picker_overlay = get_theme_stylebox("preview_picker_overlay", "ThemeEditor");
-			theme_cache.preview_picker_overlay_color = get_theme_color("preview_picker_overlay_color", "ThemeEditor");
-			theme_cache.preview_picker_label = get_theme_stylebox("preview_picker_label", "ThemeEditor");
-			theme_cache.preview_picker_font = get_theme_font("status_source", "EditorFonts");
+			theme_cache.preview_picker_overlay = get_theme_stylebox(SNAME("preview_picker_overlay"), SNAME("ThemeEditor"));
+			theme_cache.preview_picker_overlay_color = get_theme_color(SNAME("preview_picker_overlay_color"), SNAME("ThemeEditor"));
+			theme_cache.preview_picker_label = get_theme_stylebox(SNAME("preview_picker_label"), SNAME("ThemeEditor"));
+			theme_cache.preview_picker_font = get_theme_font(SNAME("status_source"), SNAME("EditorFonts"));
 		} break;
 		case NOTIFICATION_PROCESS: {
 			time_left -= get_process_delta_time();
@@ -428,7 +428,7 @@ void SceneThemeEditorPreview::_reload_scene() {
 
 	if (loaded_scene->get_path().is_empty() || !ResourceLoader::exists(loaded_scene->get_path())) {
 		EditorNode::get_singleton()->show_warning(TTR("Invalid path, the PackedScene resource was probably moved or removed."));
-		emit_signal("scene_invalidated");
+		emit_signal(SNAME("scene_invalidated"));
 		return;
 	}
 
@@ -441,19 +441,19 @@ void SceneThemeEditorPreview::_reload_scene() {
 	Node *instance = loaded_scene->instantiate();
 	if (!instance || !Object::cast_to<Control>(instance)) {
 		EditorNode::get_singleton()->show_warning(TTR("Invalid PackedScene resource, must have a Control node at its root."));
-		emit_signal("scene_invalidated");
+		emit_signal(SNAME("scene_invalidated"));
 		return;
 	}
 
 	preview_content->add_child(instance);
-	emit_signal("scene_reloaded");
+	emit_signal(SNAME("scene_reloaded"));
 }
 
 void SceneThemeEditorPreview::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			reload_scene_button->set_icon(get_theme_icon("Reload", "EditorIcons"));
+			reload_scene_button->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 		} break;
 	}
 }

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -49,7 +49,7 @@ void TileAtlasView::_gui_input(const Ref<InputEvent> &p_event) {
 		if (ctrl && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_WHEEL_DOWN) {
 			// Zoom out
 			zoom_widget->set_zoom_by_increments(-2);
-			emit_signal("transform_changed", zoom_widget->get_zoom(), panning);
+			emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
 			_update_zoom_and_panning(true);
 			accept_event();
 		}
@@ -57,7 +57,7 @@ void TileAtlasView::_gui_input(const Ref<InputEvent> &p_event) {
 		if (ctrl && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_WHEEL_UP) {
 			// Zoom in
 			zoom_widget->set_zoom_by_increments(2);
-			emit_signal("transform_changed", zoom_widget->get_zoom(), panning);
+			emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
 			_update_zoom_and_panning(true);
 			accept_event();
 		}
@@ -77,7 +77,7 @@ void TileAtlasView::_gui_input(const Ref<InputEvent> &p_event) {
 		if (drag_type == DRAG_TYPE_PAN) {
 			panning += mm->get_relative();
 			_update_zoom_and_panning();
-			emit_signal("transform_changed", zoom_widget->get_zoom(), panning);
+			emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
 			accept_event();
 		}
 	}
@@ -176,14 +176,14 @@ void TileAtlasView::_update_zoom_and_panning(bool p_zoom_on_mouse_pos) {
 
 void TileAtlasView::_zoom_widget_changed() {
 	_update_zoom_and_panning();
-	emit_signal("transform_changed", zoom_widget->get_zoom(), panning);
+	emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
 }
 
 void TileAtlasView::_center_view() {
 	panning = Vector2();
 	button_center_view->set_disabled(true);
 	_update_zoom_and_panning();
-	emit_signal("transform_changed", zoom_widget->get_zoom(), panning);
+	emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
 }
 
 void TileAtlasView::_base_tiles_root_control_gui_input(const Ref<InputEvent> &p_event) {
@@ -382,13 +382,13 @@ void TileAtlasView::_draw_alternatives() {
 }
 
 void TileAtlasView::_draw_background_left() {
-	Ref<Texture2D> texture = get_theme_icon("Checkerboard", "EditorIcons");
+	Ref<Texture2D> texture = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
 	background_left->set_size(base_tiles_root_control->get_custom_minimum_size());
 	background_left->draw_texture_rect(texture, Rect2(Vector2(), background_left->get_size()), true);
 }
 
 void TileAtlasView::_draw_background_right() {
-	Ref<Texture2D> texture = get_theme_icon("Checkerboard", "EditorIcons");
+	Ref<Texture2D> texture = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
 	background_right->set_size(alternative_tiles_root_control->get_custom_minimum_size());
 	background_right->draw_texture_rect(texture, Rect2(Vector2(), background_right->get_size()), true);
 }
@@ -535,7 +535,7 @@ void TileAtlasView::update() {
 void TileAtlasView::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY:
-			button_center_view->set_icon(get_theme_icon("CenterView", "EditorIcons"));
+			button_center_view->set_icon(get_theme_icon(SNAME("CenterView"), SNAME("EditorIcons")));
 			break;
 	}
 }
@@ -564,7 +564,7 @@ TileAtlasView::TileAtlasView() {
 	zoom_widget->connect("zoom_changed", callable_mp(this, &TileAtlasView::_zoom_widget_changed).unbind(1));
 
 	button_center_view = memnew(Button);
-	button_center_view->set_icon(get_theme_icon("CenterView", "EditorIcons"));
+	button_center_view->set_icon(get_theme_icon(SNAME("CenterView"), SNAME("EditorIcons")));
 	button_center_view->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT, Control::PRESET_MODE_MINSIZE, 5);
 	button_center_view->connect("pressed", callable_mp(this, &TileAtlasView::_center_view));
 	button_center_view->set_flat(true);

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -113,8 +113,8 @@ void GenericTilePolygonEditor::_base_control_draw() {
 	real_t grab_threshold = EDITOR_GET("editors/poly_editor/point_grab_radius");
 
 	Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
-	const Ref<Texture2D> handle = get_theme_icon("EditorPathSharpHandle", "EditorIcons");
-	const Ref<Texture2D> add_handle = get_theme_icon("EditorHandleAdd", "EditorIcons");
+	const Ref<Texture2D> handle = get_theme_icon(SNAME("EditorPathSharpHandle"), SNAME("EditorIcons"));
+	const Ref<Texture2D> add_handle = get_theme_icon(SNAME("EditorHandleAdd"), SNAME("EditorIcons"));
 
 	Size2 tile_size = tile_set->get_tile_size();
 
@@ -195,8 +195,8 @@ void GenericTilePolygonEditor::_base_control_draw() {
 
 	// Draw the text on top of the selected point.
 	if (tinted_polygon_index >= 0) {
-		Ref<Font> font = get_theme_font("font", "Label");
-		int font_size = get_theme_font_size("font_size", "Label");
+		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 		String text = multiple_polygon_mode ? vformat("%d:%d", tinted_polygon_index, tinted_point_index) : vformat("%d", tinted_point_index);
 		Size2 text_size = font->get_string_size(text, font_size);
 		base_control->draw_string(font, xform.xform(polygons[tinted_polygon_index][tinted_point_index]) - text_size * 0.5, text, HALIGN_LEFT, -1, font_size, Color(1.0, 1.0, 1.0, 0.5));
@@ -413,7 +413,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 						undo_redo->add_undo_method(this, "remove_polygon", added);
 						undo_redo->add_undo_method(base_control, "update");
 						undo_redo->commit_action(false);
-						emit_signal("polygons_changed");
+						emit_signal(SNAME("polygons_changed"));
 					} else {
 						// Create a new point.
 						drag_type = DRAG_TYPE_CREATE_POINT;
@@ -460,7 +460,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 						undo_redo->add_do_method(base_control, "update");
 						undo_redo->add_undo_method(base_control, "update");
 						undo_redo->commit_action(false);
-						emit_signal("polygons_changed");
+						emit_signal(SNAME("polygons_changed"));
 					}
 				}
 			} else {
@@ -471,7 +471,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 					undo_redo->add_undo_method(this, "set_polygon", drag_polygon_index, drag_old_polygon);
 					undo_redo->add_undo_method(base_control, "update");
 					undo_redo->commit_action(false);
-					emit_signal("polygons_changed");
+					emit_signal(SNAME("polygons_changed"));
 				} else if (drag_type == DRAG_TYPE_CREATE_POINT) {
 					Point2 point = xform.affine_inverse().xform(mb->get_position());
 					float distance = grab_threshold * 2;
@@ -507,7 +507,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 						undo_redo->add_do_method(base_control, "update");
 						undo_redo->add_undo_method(base_control, "update");
 						undo_redo->commit_action(false);
-						emit_signal("polygons_changed");
+						emit_signal(SNAME("polygons_changed"));
 					} else {
 						drag_type = DRAG_TYPE_PAN;
 						drag_last_pos = mb->get_position();
@@ -615,12 +615,12 @@ void GenericTilePolygonEditor::set_multiple_polygon_mode(bool p_multiple_polygon
 void GenericTilePolygonEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY:
-			button_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveCreate", "EditorIcons"));
-			button_edit->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveEdit", "EditorIcons"));
-			button_delete->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CurveDelete", "EditorIcons"));
-			button_center_view->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CenterView", "EditorIcons"));
-			button_pixel_snap->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Snap", "EditorIcons"));
-			button_advanced_menu->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("GuiTabMenu", "EditorIcons"));
+			button_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveCreate"), SNAME("EditorIcons")));
+			button_edit->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveEdit"), SNAME("EditorIcons")));
+			button_delete->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveDelete"), SNAME("EditorIcons")));
+			button_center_view->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CenterView"), SNAME("EditorIcons")));
+			button_pixel_snap->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Snap"), SNAME("EditorIcons")));
+			button_advanced_menu->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
 			break;
 	}
 }
@@ -702,7 +702,7 @@ GenericTilePolygonEditor::GenericTilePolygonEditor() {
 	root->add_child(editor_zoom_widget);
 
 	button_center_view = memnew(Button);
-	button_center_view->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("CenterView", "EditorIcons"));
+	button_center_view->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CenterView"), SNAME("EditorIcons")));
 	button_center_view->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT, Control::PRESET_MODE_MINSIZE, 5);
 	button_center_view->connect("pressed", callable_mp(this, &GenericTilePolygonEditor::_center_view));
 	button_center_view->set_flat(true);
@@ -963,7 +963,7 @@ void TileDataDefaultEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2
 		Rect2 rect = p_transform.xform(Rect2(Vector2(-size / 2, -size / 2), Vector2(size, size)));
 		p_canvas_item->draw_rect(rect, value);
 	} else {
-		Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font("bold", "EditorFonts");
+		Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
 		String text;
 		switch (value.get_type()) {
 			case Variant::INT:
@@ -1039,9 +1039,9 @@ void TileDataDefaultEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			picker_button->set_icon(get_theme_icon("ColorPick", "EditorIcons"));
-			tile_bool_checked = get_theme_icon("TileChecked", "EditorIcons");
-			tile_bool_unchecked = get_theme_icon("TileUnchecked", "EditorIcons");
+			picker_button->set_icon(get_theme_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
+			tile_bool_checked = get_theme_icon(SNAME("TileChecked"), SNAME("EditorIcons"));
+			tile_bool_unchecked = get_theme_icon(SNAME("TileUnchecked"), SNAME("EditorIcons"));
 			break;
 		default:
 			break;
@@ -1099,7 +1099,7 @@ void TileDataPositionEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform
 		Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
 		color = selection_color;
 	}
-	Ref<Texture2D> position_icon = TileSetEditor::get_singleton()->get_theme_icon("EditorPosition", "EditorIcons");
+	Ref<Texture2D> position_icon = TileSetEditor::get_singleton()->get_theme_icon(SNAME("EditorPosition"), SNAME("EditorIcons"));
 	p_canvas_item->draw_texture(position_icon, p_transform.xform(Vector2(value)) - position_icon->get_size() / 2, color);
 }
 
@@ -1113,7 +1113,7 @@ void TileDataYSortEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2D 
 		Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
 		color = selection_color;
 	}
-	Ref<Texture2D> position_icon = TileSetEditor::get_singleton()->get_theme_icon("EditorPosition", "EditorIcons");
+	Ref<Texture2D> position_icon = TileSetEditor::get_singleton()->get_theme_icon(SNAME("EditorPosition"), SNAME("EditorIcons"));
 	p_canvas_item->draw_texture(position_icon, p_transform.xform(Vector2(0, tile_data->get_y_sort_origin())) - position_icon->get_size() / 2, color);
 }
 
@@ -1458,7 +1458,7 @@ void TileDataTerrainsEditor::_property_value_changed(StringName p_property, Vari
 		}
 		_update_terrain_selector();
 	}
-	emit_signal("needs_redraw");
+	emit_signal(SNAME("needs_redraw"));
 }
 
 void TileDataTerrainsEditor::_tile_set_changed() {
@@ -1521,7 +1521,7 @@ void TileDataTerrainsEditor::forward_draw_over_atlas(TileAtlasView *p_tile_atlas
 	}
 
 	// Dim terrains with wrong terrain set.
-	Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font("bold", "EditorFonts");
+	Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
 	for (int i = 0; i < p_tile_set_atlas_source->get_tiles_count(); i++) {
 		Vector2i coords = p_tile_set_atlas_source->get_tile_id(i);
 		if (coords != hovered_coords) {
@@ -1693,7 +1693,7 @@ void TileDataTerrainsEditor::forward_draw_over_alternatives(TileAtlasView *p_til
 	}
 
 	// Dim terrains with wrong terrain set.
-	Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font("bold", "EditorFonts");
+	Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
 	for (int i = 0; i < p_tile_set_atlas_source->get_tiles_count(); i++) {
 		Vector2i coords = p_tile_set_atlas_source->get_tile_id(i);
 		for (int j = 1; j < p_tile_set_atlas_source->get_alternative_tiles_count(coords); j++) {
@@ -2303,7 +2303,7 @@ void TileDataTerrainsEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			picker_button->set_icon(get_theme_icon("ColorPick", "EditorIcons"));
+			picker_button->set_icon(get_theme_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
 			break;
 		default:
 			break;

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -47,18 +47,18 @@ void TileMapEditorTilesPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			select_tool_button->set_icon(get_theme_icon("ToolSelect", "EditorIcons"));
-			paint_tool_button->set_icon(get_theme_icon("Edit", "EditorIcons"));
-			line_tool_button->set_icon(get_theme_icon("CurveLinear", "EditorIcons"));
-			rect_tool_button->set_icon(get_theme_icon("Rectangle", "EditorIcons"));
-			bucket_tool_button->set_icon(get_theme_icon("Bucket", "EditorIcons"));
+			select_tool_button->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
+			paint_tool_button->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+			line_tool_button->set_icon(get_theme_icon(SNAME("CurveLinear"), SNAME("EditorIcons")));
+			rect_tool_button->set_icon(get_theme_icon(SNAME("Rectangle"), SNAME("EditorIcons")));
+			bucket_tool_button->set_icon(get_theme_icon(SNAME("Bucket"), SNAME("EditorIcons")));
 
-			picker_button->set_icon(get_theme_icon("ColorPick", "EditorIcons"));
-			erase_button->set_icon(get_theme_icon("Eraser", "EditorIcons"));
+			picker_button->set_icon(get_theme_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
+			erase_button->set_icon(get_theme_icon(SNAME("Eraser"), SNAME("EditorIcons")));
 
-			toggle_grid_button->set_icon(get_theme_icon("Grid", "EditorIcons"));
+			toggle_grid_button->set_icon(get_theme_icon(SNAME("Grid"), SNAME("EditorIcons")));
 
-			missing_atlas_texture_icon = get_theme_icon("TileSet", "EditorIcons");
+			missing_atlas_texture_icon = get_theme_icon(SNAME("TileSet"), SNAME("EditorIcons"));
 
 			toggle_grid_button->set_pressed(EditorSettings::get_singleton()->get("editors/tiles_editor/display_grid"));
 			break;
@@ -177,7 +177,7 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		// Scene collection source.
 		TileSetScenesCollectionSource *scene_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);
 		if (scene_collection_source) {
-			texture = get_theme_icon("PackedScene", "EditorIcons");
+			texture = get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
 			item_text = vformat(TTR("Scene Collection Source (id:%d)"), source_id);
 		}
 
@@ -200,7 +200,7 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		} else {
 			sources_list->set_current(0);
 		}
-		sources_list->emit_signal("item_selected", sources_list->get_current());
+		sources_list->emit_signal(SNAME("item_selected"), sources_list->get_current());
 	}
 
 	// Synchronize
@@ -306,7 +306,7 @@ void TileMapEditorTilesPlugin::_update_scenes_collection_view() {
 			Variant udata = i;
 			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(scene, this, "_scene_thumbnail_done", udata);
 		} else {
-			item_index = scene_tiles_list->add_item(TTR("Tile with Invalid Scene"), get_theme_icon("PackedScene", "EditorIcons"));
+			item_index = scene_tiles_list->add_item(TTR("Tile with Invalid Scene"), get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")));
 		}
 		scene_tiles_list->set_item_metadata(item_index, scene_id);
 
@@ -1955,9 +1955,9 @@ void TileMapEditorTerrainsPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			paint_tool_button->set_icon(get_theme_icon("Edit", "EditorIcons"));
-			picker_button->set_icon(get_theme_icon("ColorPick", "EditorIcons"));
-			erase_button->set_icon(get_theme_icon("Eraser", "EditorIcons"));
+			paint_tool_button->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+			picker_button->set_icon(get_theme_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
+			erase_button->set_icon(get_theme_icon(SNAME("Eraser"), SNAME("EditorIcons")));
 			break;
 	}
 }
@@ -2995,13 +2995,13 @@ void TileMapEditorTerrainsPlugin::_update_terrains_tree() {
 		TreeItem *terrain_set_tree_item = terrains_tree->create_item();
 		String matches;
 		if (tile_set->get_terrain_set_mode(terrain_set_index) == TileSet::TERRAIN_MODE_MATCH_CORNERS_AND_SIDES) {
-			terrain_set_tree_item->set_icon(0, get_theme_icon("TerrainMatchCornersAndSides", "EditorIcons"));
+			terrain_set_tree_item->set_icon(0, get_theme_icon(SNAME("TerrainMatchCornersAndSides"), SNAME("EditorIcons")));
 			matches = String(TTR("Matches Corners and Sides"));
 		} else if (tile_set->get_terrain_set_mode(terrain_set_index) == TileSet::TERRAIN_MODE_MATCH_CORNERS) {
-			terrain_set_tree_item->set_icon(0, get_theme_icon("TerrainMatchCorners", "EditorIcons"));
+			terrain_set_tree_item->set_icon(0, get_theme_icon(SNAME("TerrainMatchCorners"), SNAME("EditorIcons")));
 			matches = String(TTR("Matches Corners Only"));
 		} else {
-			terrain_set_tree_item->set_icon(0, get_theme_icon("TerrainMatchSides", "EditorIcons"));
+			terrain_set_tree_item->set_icon(0, get_theme_icon(SNAME("TerrainMatchSides"), SNAME("EditorIcons")));
 			matches = String(TTR("Matches Sides Only"));
 		}
 		terrain_set_tree_item->set_text(0, vformat("Terrain Set %d (%s)", terrain_set_index, matches));
@@ -3187,8 +3187,8 @@ void TileMapEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			missing_tile_texture = get_theme_icon("StatusWarning", "EditorIcons");
-			warning_pattern_texture = get_theme_icon("WarningPattern", "EditorIcons");
+			missing_tile_texture = get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons"));
+			warning_pattern_texture = get_theme_icon(SNAME("WarningPattern"), SNAME("EditorIcons"));
 			break;
 		case NOTIFICATION_INTERNAL_PROCESS:
 			if (is_visible_in_tree() && tileset_changed_needs_update) {
@@ -3438,7 +3438,7 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 	}
 
 	// Draw the IDs for debug.
-	/*Ref<Font> font = get_theme_font("font", "Label");
+	/*Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
 	for (int x = displayed_rect.position.x; x < (displayed_rect.position.x + displayed_rect.size.x); x++) {
 		for (int y = displayed_rect.position.y; y < (displayed_rect.position.y + displayed_rect.size.y); y++) {
 			p_overlay->draw_string(font, xform.xform(tile_map->map_to_world(Vector2(x, y))) + Vector2i(-tile_shape_size.x / 2, 0), vformat("%s", Vector2(x, y)));

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -58,7 +58,7 @@ void TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::set_id(int p_id) {
 	int previous_source = source_id;
 	source_id = p_id; // source_id must be updated before, because it's used by the source list update.
 	tile_set->set_source_id(previous_source, p_id);
-	emit_signal("changed", "id");
+	emit_signal(SNAME("changed"), "id");
 }
 
 int TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::get_id() {
@@ -69,7 +69,7 @@ bool TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::_set(const StringN
 	bool valid = false;
 	tile_set_atlas_source->set(p_name, p_value, &valid);
 	if (valid) {
-		emit_signal("changed", String(p_name).utf8().get_data());
+		emit_signal(SNAME("changed"), String(p_name).utf8().get_data());
 	}
 	return valid;
 }
@@ -148,14 +148,14 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(const StringName &p_na
 			tile_set_atlas_source->move_tile_in_atlas(coords, as_vector2i);
 			tiles.clear();
 			tiles.insert({ as_vector2i, 0 });
-			emit_signal("changed", "atlas_coords");
+			emit_signal(SNAME("changed"), "atlas_coords");
 			return true;
 		} else if (alternative == 0 && p_name == "size_in_atlas") {
 			Vector2i as_vector2i = Vector2i(p_value);
 			ERR_FAIL_COND_V(!tile_set_atlas_source->can_move_tile_in_atlas(coords, TileSetSource::INVALID_ATLAS_COORDS, as_vector2i), false);
 
 			tile_set_atlas_source->move_tile_in_atlas(coords, TileSetSource::INVALID_ATLAS_COORDS, as_vector2i);
-			emit_signal("changed", "size_in_atlas");
+			emit_signal(SNAME("changed"), "size_in_atlas");
 			return true;
 		} else if (alternative > 0 && p_name == "alternative_id") {
 			int as_int = int(p_value);
@@ -172,7 +172,7 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(const StringName &p_na
 			tiles.insert({ coords, as_int }); // tiles must be updated before.
 			tile_set_atlas_source->set_alternative_tile_id(coords, previous_alternative_tile, as_int);
 
-			emit_signal("changed", "alternative_id");
+			emit_signal(SNAME("changed"), "alternative_id");
 			return true;
 		}
 	}
@@ -191,7 +191,7 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(const StringName &p_na
 	}
 
 	if (any_valid) {
-		emit_signal("changed", String(p_name).utf8().get_data());
+		emit_signal(SNAME("changed"), String(p_name).utf8().get_data());
 	}
 
 	return any_valid;
@@ -453,7 +453,7 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	tile_data_editors_tree->add_theme_constant_override("vseparation", 1);
 	tile_data_editors_tree->add_theme_constant_override("hseparation", 3);
 
-	Color group_color = get_theme_color("prop_category", "Editor");
+	Color group_color = get_theme_color(SNAME("prop_category"), SNAME("Editor"));
 
 	// List of editors.
 	// --- Rendering ---
@@ -660,26 +660,26 @@ void TileSetAtlasSourceEditor::_update_current_tile_data_editor() {
 }
 
 void TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_draw() {
-	if (!has_theme_icon("arrow", "OptionButton")) {
+	if (!has_theme_icon(SNAME("arrow"), SNAME("OptionButton"))) {
 		return;
 	}
 
 	RID ci = tile_data_editor_dropdown_button->get_canvas_item();
-	Ref<Texture2D> arrow = Control::get_theme_icon("arrow", "OptionButton");
+	Ref<Texture2D> arrow = Control::get_theme_icon(SNAME("arrow"), SNAME("OptionButton"));
 	Color clr = Color(1, 1, 1);
-	if (get_theme_constant("modulate_arrow")) {
+	if (get_theme_constant(SNAME("modulate_arrow"))) {
 		switch (tile_data_editor_dropdown_button->get_draw_mode()) {
 			case BaseButton::DRAW_PRESSED:
-				clr = get_theme_color("font_pressed_color");
+				clr = get_theme_color(SNAME("font_pressed_color"));
 				break;
 			case BaseButton::DRAW_HOVER:
-				clr = get_theme_color("font_hover_color");
+				clr = get_theme_color(SNAME("font_hover_color"));
 				break;
 			case BaseButton::DRAW_DISABLED:
-				clr = get_theme_color("font_disabled_color");
+				clr = get_theme_color(SNAME("font_disabled_color"));
 				break;
 			default:
-				clr = get_theme_color("font_color");
+				clr = get_theme_color(SNAME("font_color"));
 		}
 	}
 
@@ -687,9 +687,9 @@ void TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_draw() {
 
 	Point2 ofs;
 	if (is_layout_rtl()) {
-		ofs = Point2(get_theme_constant("arrow_margin", "OptionButton"), int(Math::abs((size.height - arrow->get_height()) / 2)));
+		ofs = Point2(get_theme_constant(SNAME("arrow_margin"), SNAME("OptionButton")), int(Math::abs((size.height - arrow->get_height()) / 2)));
 	} else {
-		ofs = Point2(size.width - arrow->get_width() - get_theme_constant("arrow_margin", "OptionButton"), int(Math::abs((size.height - arrow->get_height()) / 2)));
+		ofs = Point2(size.width - arrow->get_width() - get_theme_constant(SNAME("arrow_margin"), SNAME("OptionButton")), int(Math::abs((size.height - arrow->get_height()) / 2)));
 	}
 	arrow->draw(ci, ofs, clr);
 }
@@ -702,7 +702,7 @@ void TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_pressed() {
 }
 
 void TileSetAtlasSourceEditor::_tile_data_editors_tree_selected() {
-	tile_data_editors_popup->call_deferred("hide");
+	tile_data_editors_popup->call_deferred(SNAME("hide"));
 	_update_current_tile_data_editor();
 	tile_atlas_control->update();
 	tile_atlas_control_unscaled->update();
@@ -740,7 +740,7 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 			Button *button = memnew(Button);
 			alternative_tiles_control->add_child(button);
 			button->set_flat(true);
-			button->set_icon(get_theme_icon("Add", "EditorIcons"));
+			button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			button->add_theme_style_override("normal", memnew(StyleBoxEmpty));
 			button->add_theme_style_override("hover", memnew(StyleBoxEmpty));
 			button->add_theme_style_override("focus", memnew(StyleBoxEmpty));
@@ -1858,7 +1858,7 @@ void TileSetAtlasSourceEditor::_atlas_source_proxy_object_changed(String p_what)
 	if (p_what == "texture" && !atlas_source_proxy_object->get("texture").is_null()) {
 		confirm_auto_create_tiles->popup_centered();
 	} else if (p_what == "id") {
-		emit_signal("source_id_changed", atlas_source_proxy_object->get_id());
+		emit_signal(SNAME("source_id_changed"), atlas_source_proxy_object->get_id());
 	}
 }
 
@@ -2049,16 +2049,16 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			tool_setup_atlas_source_button->set_icon(get_theme_icon("Tools", "EditorIcons"));
-			tool_select_button->set_icon(get_theme_icon("ToolSelect", "EditorIcons"));
-			tool_paint_button->set_icon(get_theme_icon("CanvasItem", "EditorIcons"));
+			tool_setup_atlas_source_button->set_icon(get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
+			tool_select_button->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
+			tool_paint_button->set_icon(get_theme_icon(SNAME("CanvasItem"), SNAME("EditorIcons")));
 
-			tools_settings_erase_button->set_icon(get_theme_icon("Eraser", "EditorIcons"));
+			tools_settings_erase_button->set_icon(get_theme_icon(SNAME("Eraser"), SNAME("EditorIcons")));
 
-			tool_advanced_menu_buttom->set_icon(get_theme_icon("GuiTabMenu", "EditorIcons"));
+			tool_advanced_menu_buttom->set_icon(get_theme_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
 
-			resize_handle = get_theme_icon("EditorHandle", "EditorIcons");
-			resize_handle_disabled = get_theme_icon("EditorHandleDisabled", "EditorIcons");
+			resize_handle = get_theme_icon(SNAME("EditorHandle"), SNAME("EditorIcons"));
+			resize_handle_disabled = get_theme_icon(SNAME("EditorHandleDisabled"), SNAME("EditorIcons"));
 			break;
 		case NOTIFICATION_INTERNAL_PROCESS:
 			if (tile_set_atlas_source_changed_needs_update) {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -159,7 +159,7 @@ void TileSetEditor::_update_atlas_sources_list(int force_selected_id) {
 		// Scene collection source.
 		TileSetScenesCollectionSource *scene_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);
 		if (scene_collection_source) {
-			texture = get_theme_icon("PackedScene", "EditorIcons");
+			texture = get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
 			item_text = vformat(TTR("Scene Collection Source (id:%d)"), source_id);
 		}
 
@@ -181,7 +181,7 @@ void TileSetEditor::_update_atlas_sources_list(int force_selected_id) {
 			if ((int)sources_list->get_item_metadata(i) == to_select) {
 				sources_list->set_current(i);
 				if (old_selected != to_select) {
-					sources_list->emit_signal("item_selected", sources_list->get_current());
+					sources_list->emit_signal(SNAME("item_selected"), sources_list->get_current());
 				}
 				break;
 			}
@@ -192,7 +192,7 @@ void TileSetEditor::_update_atlas_sources_list(int force_selected_id) {
 	if (sources_list->get_current() < 0 && sources_list->get_item_count() > 0) {
 		sources_list->set_current(0);
 		if (old_selected != int(sources_list->get_item_metadata(0))) {
-			sources_list->emit_signal("item_selected", sources_list->get_current());
+			sources_list->emit_signal(SNAME("item_selected"), sources_list->get_current());
 		}
 	}
 
@@ -292,9 +292,9 @@ void TileSetEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			sources_delete_button->set_icon(get_theme_icon("Remove", "EditorIcons"));
-			sources_add_button->set_icon(get_theme_icon("Add", "EditorIcons"));
-			missing_texture_texture = get_theme_icon("TileSet", "EditorIcons");
+			sources_delete_button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+			sources_add_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			missing_texture_texture = get_theme_icon(SNAME("TileSet"), SNAME("EditorIcons"));
 			break;
 		case NOTIFICATION_INTERNAL_PROCESS:
 			if (tile_set_changed_needs_update) {

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -48,7 +48,7 @@ void TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::se
 	int previous_source = source_id;
 	source_id = p_id; // source_id must be updated before, because it's used by the source list update.
 	tile_set->set_source_id(previous_source, p_id);
-	emit_signal("changed", "id");
+	emit_signal(SNAME("changed"), "id");
 }
 
 int TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::get_id() {
@@ -59,7 +59,7 @@ bool TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::_s
 	bool valid = false;
 	tile_set_scenes_collection_source->set(p_name, p_value, &valid);
 	if (valid) {
-		emit_signal("changed", String(p_name).utf8().get_data());
+		emit_signal(SNAME("changed"), String(p_name).utf8().get_data());
 	}
 	return valid;
 }
@@ -120,7 +120,7 @@ bool TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_set(const Strin
 		ERR_FAIL_COND_V(tile_set_scenes_collection_source->has_scene_tile_id(as_int), false);
 		tile_set_scenes_collection_source->set_scene_tile_id(scene_id, as_int);
 		scene_id = as_int;
-		emit_signal("changed", "id");
+		emit_signal(SNAME("changed"), "id");
 		for (int i = 0; i < tile_set_scenes_collection_source_editor->scene_tiles_list->get_item_count(); i++) {
 			if (int(tile_set_scenes_collection_source_editor->scene_tiles_list->get_item_metadata(i)) == scene_id) {
 				tile_set_scenes_collection_source_editor->scene_tiles_list->select(i);
@@ -130,11 +130,11 @@ bool TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_set(const Strin
 		return true;
 	} else if (p_name == "scene") {
 		tile_set_scenes_collection_source->set_scene_tile_scene(scene_id, p_value);
-		emit_signal("changed", "scene");
+		emit_signal(SNAME("changed"), "scene");
 		return true;
 	} else if (p_name == "display_placeholder") {
 		tile_set_scenes_collection_source->set_scene_tile_display_placeholder(scene_id, p_value);
-		emit_signal("changed", "display_placeholder");
+		emit_signal(SNAME("changed"), "display_placeholder");
 		return true;
 	}
 
@@ -186,7 +186,7 @@ void TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_bind_methods() 
 
 void TileSetScenesCollectionSourceEditor::_scenes_collection_source_proxy_object_changed(String p_what) {
 	if (p_what == "id") {
-		emit_signal("source_id_changed", scenes_collection_source_proxy_object->get_id());
+		emit_signal(SNAME("source_id_changed"), scenes_collection_source_proxy_object->get_id());
 	}
 }
 
@@ -284,7 +284,7 @@ void TileSetScenesCollectionSourceEditor::_update_scenes_list() {
 			Variant udata = i;
 			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(scene, this, "_scene_thumbnail_done", udata);
 		} else {
-			item_index = scene_tiles_list->add_item(TTR("Tile with Invalid Scene"), get_theme_icon("PackedScene", "EditorIcons"));
+			item_index = scene_tiles_list->add_item(TTR("Tile with Invalid Scene"), get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")));
 		}
 		scene_tiles_list->set_item_metadata(item_index, scene_id);
 
@@ -307,8 +307,8 @@ void TileSetScenesCollectionSourceEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED:
-			scene_tile_add_button->set_icon(get_theme_icon("Add", "EditorIcons"));
-			scene_tile_delete_button->set_icon(get_theme_icon("Remove", "EditorIcons"));
+			scene_tile_add_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			scene_tile_delete_button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 			_update_scenes_list();
 			break;
 		case NOTIFICATION_INTERNAL_PROCESS:

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -50,7 +50,7 @@ void TilesEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			tileset_tilemap_switch_button->set_icon(get_theme_icon("TileSet", "EditorIcons"));
+			tileset_tilemap_switch_button->set_icon(get_theme_icon(SNAME("TileSet"), SNAME("EditorIcons")));
 		} break;
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (tile_map_changed_needs_update) {
@@ -131,7 +131,7 @@ void TilesEditor::synchronize_atlas_sources_list(Object *p_current) {
 			item_list->deselect_all();
 		} else {
 			item_list->set_current(atlas_sources_lists_current);
-			item_list->emit_signal("item_selected", atlas_sources_lists_current);
+			item_list->emit_signal(SNAME("item_selected"), atlas_sources_lists_current);
 		}
 	}
 }

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -184,11 +184,11 @@ void VersionControlEditorPlugin::_stage_selected() {
 		while (file_entry) {
 			if (file_entry->is_checked(0)) {
 				EditorVCSInterface::get_singleton()->stage_file(file_entry->get_metadata(0));
-				file_entry->set_icon_modulate(0, EditorNode::get_singleton()->get_gui_base()->get_theme_color("success_color", "Editor"));
+				file_entry->set_icon_modulate(0, EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 				staged_files_count++;
 			} else {
 				EditorVCSInterface::get_singleton()->unstage_file(file_entry->get_metadata(0));
-				file_entry->set_icon_modulate(0, EditorNode::get_singleton()->get_gui_base()->get_theme_color("error_color", "Editor"));
+				file_entry->set_icon_modulate(0, EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 			}
 
 			file_entry = file_entry->get_next();
@@ -210,7 +210,7 @@ void VersionControlEditorPlugin::_stage_all() {
 		TreeItem *file_entry = root->get_first_child();
 		while (file_entry) {
 			EditorVCSInterface::get_singleton()->stage_file(file_entry->get_metadata(0));
-			file_entry->set_icon_modulate(0, EditorNode::get_singleton()->get_gui_base()->get_theme_color("success_color", "Editor"));
+			file_entry->set_icon_modulate(0, EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 			file_entry->set_checked(0, true);
 			staged_files_count++;
 
@@ -235,16 +235,16 @@ void VersionControlEditorPlugin::_display_file_diff(String p_file_path) {
 	diff_file_name->set_text(p_file_path);
 
 	diff->clear();
-	diff->push_font(EditorNode::get_singleton()->get_gui_base()->get_theme_font("source", "EditorFonts"));
+	diff->push_font(EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("source"), SNAME("EditorFonts")));
 	for (int i = 0; i < diff_content.size(); i++) {
 		Dictionary line_result = diff_content[i];
 
 		if (line_result["status"] == "+") {
-			diff->push_color(EditorNode::get_singleton()->get_gui_base()->get_theme_color("success_color", "Editor"));
+			diff->push_color(EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 		} else if (line_result["status"] == "-") {
-			diff->push_color(EditorNode::get_singleton()->get_gui_base()->get_theme_color("error_color", "Editor"));
+			diff->push_color(EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		} else {
-			diff->push_color(EditorNode::get_singleton()->get_gui_base()->get_theme_color("font_color", "Label"));
+			diff->push_color(EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("font_color"), SNAME("Label")));
 		}
 
 		diff->add_text((String)line_result["content"]);
@@ -407,7 +407,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	refresh_button = memnew(Button);
 	refresh_button->set_tooltip(TTR("Detect new changes"));
 	refresh_button->set_text(TTR("Refresh"));
-	refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Reload", "EditorIcons"));
+	refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 	refresh_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area));
 	stage_tools->add_child(refresh_button);
 
@@ -432,11 +432,11 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	change_type_to_strings[CHANGE_TYPE_DELETED] = TTR("Deleted");
 	change_type_to_strings[CHANGE_TYPE_TYPECHANGE] = TTR("Typechange");
 
-	change_type_to_color[CHANGE_TYPE_NEW] = EditorNode::get_singleton()->get_gui_base()->get_theme_color("success_color", "Editor");
-	change_type_to_color[CHANGE_TYPE_MODIFIED] = EditorNode::get_singleton()->get_gui_base()->get_theme_color("warning_color", "Editor");
-	change_type_to_color[CHANGE_TYPE_RENAMED] = EditorNode::get_singleton()->get_gui_base()->get_theme_color("disabled_font_color", "Editor");
-	change_type_to_color[CHANGE_TYPE_DELETED] = EditorNode::get_singleton()->get_gui_base()->get_theme_color("error_color", "Editor");
-	change_type_to_color[CHANGE_TYPE_TYPECHANGE] = EditorNode::get_singleton()->get_gui_base()->get_theme_color("font_color", "Editor");
+	change_type_to_color[CHANGE_TYPE_NEW] = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("success_color"), SNAME("Editor"));
+	change_type_to_color[CHANGE_TYPE_MODIFIED] = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor"));
+	change_type_to_color[CHANGE_TYPE_RENAMED] = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor"));
+	change_type_to_color[CHANGE_TYPE_DELETED] = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor"));
+	change_type_to_color[CHANGE_TYPE_TYPECHANGE] = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("font_color"), SNAME("Editor"));
 
 	stage_buttons = memnew(HSplitContainer);
 	stage_buttons->set_dragger_visibility(SplitContainer::DRAGGER_HIDDEN_COLLAPSED);
@@ -501,7 +501,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	diff_refresh_button = memnew(Button);
 	diff_refresh_button->set_tooltip(TTR("Detect changes in file diff"));
-	diff_refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Reload", "EditorIcons"));
+	diff_refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 	diff_refresh_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_refresh_file_diff));
 	diff_hbc->add_child(diff_refresh_button);
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -164,7 +164,7 @@ void VisualShaderGraphPlugin::show_port_preview(VisualShader::Type p_type, int p
 }
 
 void VisualShaderGraphPlugin::update_node_deferred(VisualShader::Type p_type, int p_node_id) {
-	call_deferred("update_node", p_type, p_node_id);
+	call_deferred(SNAME("update_node"), p_type, p_node_id);
 }
 
 void VisualShaderGraphPlugin::update_node(VisualShader::Type p_type, int p_node_id) {
@@ -335,9 +335,9 @@ void VisualShaderGraphPlugin::register_uniform_name(int p_node_id, LineEdit *p_u
 }
 
 void VisualShaderGraphPlugin::update_theme() {
-	vector_expanded_color[0] = VisualShaderEditor::get_singleton()->get_theme_color("axis_x_color", "Editor"); // red
-	vector_expanded_color[1] = VisualShaderEditor::get_singleton()->get_theme_color("axis_y_color", "Editor"); // green
-	vector_expanded_color[2] = VisualShaderEditor::get_singleton()->get_theme_color("axis_z_color", "Editor"); // blue
+	vector_expanded_color[0] = VisualShaderEditor::get_singleton()->get_theme_color(SNAME("axis_x_color"), SNAME("Editor")); // red
+	vector_expanded_color[1] = VisualShaderEditor::get_singleton()->get_theme_color(SNAME("axis_y_color"), SNAME("Editor")); // green
+	vector_expanded_color[2] = VisualShaderEditor::get_singleton()->get_theme_color(SNAME("axis_z_color"), SNAME("Editor")); // blue
 }
 
 void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
@@ -465,7 +465,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		vsnode->remove_meta("shader_type");
 		if (custom_editor) {
 			if (vsnode->is_show_prop_names()) {
-				custom_editor->call_deferred("_show_prop_names", true);
+				custom_editor->call_deferred(SNAME("_show_prop_names"), true);
 			}
 			break;
 		}
@@ -526,8 +526,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 			TextureButton *preview = memnew(TextureButton);
 			preview->set_toggle_mode(true);
-			preview->set_normal_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiVisibilityHidden", "EditorIcons"));
-			preview->set_pressed_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiVisibilityVisible", "EditorIcons"));
+			preview->set_normal_texture(VisualShaderEditor::get_singleton()->get_theme_icon(SNAME("GuiVisibilityHidden"), SNAME("EditorIcons")));
+			preview->set_pressed_texture(VisualShaderEditor::get_singleton()->get_theme_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
 			preview->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 
 			register_output_port(p_id, 0, preview);
@@ -585,7 +585,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			VisualShaderNode::PortType port_right = vsnode->get_output_port_type(0);
 			node->set_slot(0, true, port_left, type_color[port_left], true, port_right, type_color[port_right]);
 
-			VisualShaderEditor::get_singleton()->call_deferred("_set_node_size", (int)p_type, p_id, size);
+			VisualShaderEditor::get_singleton()->call_deferred(SNAME("_set_node_size"), (int)p_type, p_id, size);
 		}
 
 		if (vsnode->is_use_prop_slots()) {
@@ -733,7 +733,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					name_box->connect("focus_exited", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_port_name_focus_out), varray(name_box, p_id, i, false), CONNECT_DEFERRED);
 
 					Button *remove_btn = memnew(Button);
-					remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Remove", "EditorIcons"));
+					remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
 					remove_btn->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_remove_input_port), varray(p_id, i), CONNECT_DEFERRED);
 					hb->add_child(remove_btn);
@@ -746,7 +746,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					if (vsnode->get_input_port_default_hint(i) != "" && !port_left_used) {
 						Label *hint_label = memnew(Label);
 						hint_label->set_text("[" + vsnode->get_input_port_default_hint(i) + "]");
-						hint_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color("font_readonly_color", "TextEdit"));
+						hint_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color(SNAME("font_readonly_color"), SNAME("TextEdit")));
 						hint_label->add_theme_style_override("normal", label_style);
 						hb->add_child(hint_label);
 					}
@@ -760,7 +760,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			if (valid_right) {
 				if (is_group) {
 					Button *remove_btn = memnew(Button);
-					remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Remove", "EditorIcons"));
+					remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
 					remove_btn->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_remove_output_port), varray(p_id, i), CONNECT_DEFERRED);
 					hb->add_child(remove_btn);
@@ -796,8 +796,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			if (vsnode->is_output_port_expandable(i)) {
 				TextureButton *expand = memnew(TextureButton);
 				expand->set_toggle_mode(true);
-				expand->set_normal_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiTreeArrowDown", "EditorIcons"));
-				expand->set_pressed_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiTreeArrowRight", "EditorIcons"));
+				expand->set_normal_texture(VisualShaderEditor::get_singleton()->get_theme_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")));
+				expand->set_pressed_texture(VisualShaderEditor::get_singleton()->get_theme_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")));
 				expand->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 				expand->set_pressed(vsnode->_is_output_port_expanded(i));
 				expand->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_expand_output_port), varray(p_id, i, !vsnode->_is_output_port_expanded(i)), CONNECT_DEFERRED);
@@ -806,8 +806,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			if (visual_shader->get_shader_type() == VisualShader::TYPE_FRAGMENT && port_right != VisualShaderNode::PORT_TYPE_TRANSFORM && port_right != VisualShaderNode::PORT_TYPE_SAMPLER) {
 				TextureButton *preview = memnew(TextureButton);
 				preview->set_toggle_mode(true);
-				preview->set_normal_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiVisibilityHidden", "EditorIcons"));
-				preview->set_pressed_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiVisibilityVisible", "EditorIcons"));
+				preview->set_normal_texture(VisualShaderEditor::get_singleton()->get_theme_icon(SNAME("GuiVisibilityHidden"), SNAME("EditorIcons")));
+				preview->set_pressed_texture(VisualShaderEditor::get_singleton()->get_theme_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
 				preview->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 
 				register_output_port(p_id, j, preview);
@@ -873,7 +873,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	String error = vsnode->get_warning(visual_shader->get_mode(), p_type);
 	if (error != String()) {
 		Label *error_label = memnew(Label);
-		error_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color("error_color", "Editor"));
+		error_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		error_label->set_text(error);
 		node->add_child(error_label);
 	}
@@ -907,8 +907,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			}
 		}
 
-		expression_box->add_theme_font_override("font", VisualShaderEditor::get_singleton()->get_theme_font("expression", "EditorFonts"));
-		expression_box->add_theme_font_size_override("font_size", VisualShaderEditor::get_singleton()->get_theme_font_size("expression_size", "EditorFonts"));
+		expression_box->add_theme_font_override("font", VisualShaderEditor::get_singleton()->get_theme_font(SNAME("expression"), SNAME("EditorFonts")));
+		expression_box->add_theme_font_size_override("font_size", VisualShaderEditor::get_singleton()->get_theme_font_size(SNAME("expression_size"), SNAME("EditorFonts")));
 		expression_box->add_theme_color_override("font_color", text_color);
 		expression_syntax_highlighter->set_number_color(number_color);
 		expression_syntax_highlighter->set_symbol_color(symbol_color);
@@ -935,7 +935,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		}
 		VisualShaderEditor::get_singleton()->_update_created_node(node);
 		if (is_resizable) {
-			VisualShaderEditor::get_singleton()->call_deferred("_set_node_size", (int)p_type, p_id, size);
+			VisualShaderEditor::get_singleton()->call_deferred(SNAME("_set_node_size"), (int)p_type, p_id, size);
 		}
 	}
 }
@@ -1211,8 +1211,8 @@ void VisualShaderEditor::_update_options_menu() {
 
 	bool is_first_item = true;
 
-	Color unsupported_color = get_theme_color("error_color", "Editor");
-	Color supported_color = get_theme_color("warning_color", "Editor");
+	Color unsupported_color = get_theme_color(SNAME("error_color"), SNAME("Editor"));
+	Color supported_color = get_theme_color(SNAME("warning_color"), SNAME("Editor"));
 
 	static bool low_driver = ProjectSettings::get_singleton()->get("rendering/driver/driver_name") == "GLES2";
 
@@ -1285,22 +1285,22 @@ void VisualShaderEditor::_update_options_menu() {
 		}
 		switch (options[i].return_type) {
 			case VisualShaderNode::PORT_TYPE_SCALAR:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon("float", "EditorIcons"));
+				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_SCALAR_INT:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon("int", "EditorIcons"));
+				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("int"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_VECTOR:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Vector3", "EditorIcons"));
+				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_BOOLEAN:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon("bool", "EditorIcons"));
+				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_TRANSFORM:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Transform3D", "EditorIcons"));
+				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_SAMPLER:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon("ImageTexture", "EditorIcons"));
+				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")));
 				break;
 			default:
 				break;
@@ -1349,12 +1349,12 @@ void VisualShaderEditor::_draw_color_over_button(Object *obj, Color p_color) {
 		return;
 	}
 
-	Ref<StyleBox> normal = get_theme_stylebox("normal", "Button");
+	Ref<StyleBox> normal = get_theme_stylebox(SNAME("normal"), SNAME("Button"));
 	button->draw_rect(Rect2(normal->get_offset(), button->get_size() - normal->get_minimum_size()), p_color);
 }
 
 void VisualShaderEditor::_update_created_node(GraphNode *node) {
-	const Ref<StyleBoxFlat> sb = node->get_theme_stylebox("frame", "GraphNode");
+	const Ref<StyleBoxFlat> sb = node->get_theme_stylebox(SNAME("frame"), SNAME("GraphNode"));
 	Color c = sb->get_border_color();
 	const Color mono_color = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0, 0.85) : Color(0.0, 0.0, 0.0, 0.85);
 	c = mono_color;
@@ -2470,12 +2470,12 @@ void VisualShaderEditor::_add_node(int p_idx, int p_op_idx, String p_resource_pa
 
 	VisualShaderNodeCurveTexture *curve = Object::cast_to<VisualShaderNodeCurveTexture>(vsnode.ptr());
 	if (curve) {
-		graph_plugin->call_deferred("update_curve", id_to_use);
+		graph_plugin->call_deferred(SNAME("update_curve"), id_to_use);
 	}
 
 	VisualShaderNodeCurveXYZTexture *curve_xyz = Object::cast_to<VisualShaderNodeCurveXYZTexture>(vsnode.ptr());
 	if (curve_xyz) {
-		graph_plugin->call_deferred("update_curve_xyz", id_to_use);
+		graph_plugin->call_deferred(SNAME("update_curve_xyz"), id_to_use);
 	}
 
 	if (p_resource_path.is_empty()) {
@@ -2508,7 +2508,7 @@ void VisualShaderEditor::_node_dragged(const Vector2 &p_from, const Vector2 &p_t
 	VisualShader::Type type = get_current_shader_type();
 	drag_buffer.push_back({ type, p_node, p_from, p_to });
 	if (!drag_dirty) {
-		call_deferred("_nodes_dragged");
+		call_deferred(SNAME("_nodes_dragged"));
 	}
 	drag_dirty = true;
 }
@@ -3032,7 +3032,7 @@ void VisualShaderEditor::_show_members_dialog(bool at_mouse_pos) {
 		members_dialog->set_position(members_dialog->get_position() - Point2(difference, 0));
 	}
 
-	node_filter->call_deferred("grab_focus"); // still not visible
+	node_filter->call_deferred(SNAME("grab_focus")); // still not visible
 	node_filter->select_all();
 }
 
@@ -3075,11 +3075,11 @@ void VisualShaderEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		highend_label->set_modulate(get_theme_color("vulkan_color", "Editor"));
+		highend_label->set_modulate(get_theme_color(SNAME("vulkan_color"), SNAME("Editor")));
 
-		node_filter->set_right_icon(Control::get_theme_icon("Search", "EditorIcons"));
+		node_filter->set_right_icon(Control::get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
-		preview_shader->set_icon(Control::get_theme_icon("Shader", "EditorIcons"));
+		preview_shader->set_icon(Control::get_theme_icon(SNAME("Shader"), SNAME("EditorIcons")));
 
 		{
 			Color background_color = EDITOR_GET("text_editor/highlighting/background_color");
@@ -3102,8 +3102,8 @@ void VisualShaderEditor::_notification(int p_what) {
 				}
 			}
 
-			preview_text->add_theme_font_override("font", get_theme_font("expression", "EditorFonts"));
-			preview_text->add_theme_font_size_override("font_size", get_theme_font_size("expression_size", "EditorFonts"));
+			preview_text->add_theme_font_override("font", get_theme_font(SNAME("expression"), SNAME("EditorFonts")));
+			preview_text->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("expression_size"), SNAME("EditorFonts")));
 			preview_text->add_theme_color_override("font_color", text_color);
 			syntax_highlighter->set_number_color(number_color);
 			syntax_highlighter->set_symbol_color(symbol_color);
@@ -3117,13 +3117,13 @@ void VisualShaderEditor::_notification(int p_what) {
 			preview_text->add_comment_delimiter("/*", "*/", false);
 			preview_text->add_comment_delimiter("//", "", true);
 
-			error_panel->add_theme_style_override("panel", get_theme_stylebox("panel", "Panel"));
-			error_label->add_theme_font_override("font", get_theme_font("status_source", "EditorFonts"));
-			error_label->add_theme_font_size_override("font_size", get_theme_font_size("status_source_size", "EditorFonts"));
-			error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
+			error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+			error_label->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+			error_label->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+			error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		}
 
-		tools->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Tools", "EditorIcons"));
+		tools->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 
 		if (p_what == NOTIFICATION_THEME_CHANGED && is_visible_in_tree()) {
 			_update_graph();
@@ -4605,18 +4605,18 @@ public:
 	}
 
 	void _item_selected(int p_item) {
-		VisualShaderEditor::get_singleton()->call_deferred("_input_select_item", input, get_item_text(p_item));
+		VisualShaderEditor::get_singleton()->call_deferred(SNAME("_input_select_item"), input, get_item_text(p_item));
 	}
 
 	void setup(const Ref<VisualShaderNodeInput> &p_input) {
 		input = p_input;
 		Ref<Texture2D> type_icon[6] = {
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("float", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("int", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Vector3", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("bool", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Transform3D", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("ImageTexture", "EditorIcons"),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")),
 		};
 
 		add_item("[None]");
@@ -4649,20 +4649,20 @@ public:
 	}
 
 	void _item_selected(int p_item) {
-		VisualShaderEditor::get_singleton()->call_deferred("_uniform_select_item", uniform_ref, get_item_text(p_item));
+		VisualShaderEditor::get_singleton()->call_deferred(SNAME("_uniform_select_item"), uniform_ref, get_item_text(p_item));
 	}
 
 	void setup(const Ref<VisualShaderNodeUniformRef> &p_uniform_ref) {
 		uniform_ref = p_uniform_ref;
 
 		Ref<Texture2D> type_icon[7] = {
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("float", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("int", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("bool", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Vector3", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Transform3D", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Color", "EditorIcons"),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon("ImageTexture", "EditorIcons"),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")),
 		};
 
 		add_item("[None]");
@@ -4870,7 +4870,7 @@ Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_par
 
 void EditorPropertyShaderMode::_option_selected(int p_which) {
 	//will not use this, instead will do all the logic setting manually
-	//emit_signal("property_changed", get_edited_property(), p_which);
+	//emit_signal(SNAME("property_changed"), get_edited_property(), p_which);
 
 	Ref<VisualShader> visual_shader(Object::cast_to<VisualShader>(get_edited_object()));
 

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -81,13 +81,13 @@ void VoxelGIEditorPlugin::_notification(int p_what) {
 		Color color;
 		if (size_mb <= 16.0 + CMP_EPSILON) {
 			// Fast.
-			color = bake_info->get_theme_color("success_color", "Editor");
+			color = bake_info->get_theme_color(SNAME("success_color"), SNAME("Editor"));
 		} else if (size_mb <= 64.0 + CMP_EPSILON) {
 			// Medium.
-			color = bake_info->get_theme_color("warning_color", "Editor");
+			color = bake_info->get_theme_color(SNAME("warning_color"), SNAME("Editor"));
 		} else {
 			// Slow.
-			color = bake_info->get_theme_color("error_color", "Editor");
+			color = bake_info->get_theme_color(SNAME("error_color"), SNAME("Editor"));
 		}
 		bake_info->add_theme_color_override("font_color", color);
 
@@ -143,7 +143,7 @@ VoxelGIEditorPlugin::VoxelGIEditorPlugin(EditorNode *p_node) {
 	bake_hb->hide();
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(editor->get_gui_base()->get_theme_icon("Bake", "EditorIcons"));
+	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake GI Probe"));
 	bake->connect("pressed", callable_mp(this, &VoxelGIEditorPlugin::_bake));
 	bake_hb->add_child(bake);

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -139,7 +139,7 @@ void ProgressDialog::_popup() {
 	Size2 ms = main->get_combined_minimum_size();
 	ms.width = MAX(500 * EDSCALE, ms.width);
 
-	Ref<StyleBox> style = main->get_theme_stylebox("panel", "PopupMenu");
+	Ref<StyleBox> style = main->get_theme_stylebox(SNAME("panel"), SNAME("PopupMenu"));
 	ms += style->get_minimum_size();
 	main->set_offset(SIDE_LEFT, style->get_margin(SIDE_LEFT));
 	main->set_offset(SIDE_RIGHT, -style->get_margin(SIDE_RIGHT));

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -49,8 +49,8 @@
 #include "servers/display_server.h"
 
 void ProjectExportDialog::_theme_changed() {
-	duplicate_preset->set_icon(presets->get_theme_icon("Duplicate", "EditorIcons"));
-	delete_preset->set_icon(presets->get_theme_icon("Remove", "EditorIcons"));
+	duplicate_preset->set_icon(presets->get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")));
+	delete_preset->set_icon(presets->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 }
 
 void ProjectExportDialog::_notification(int p_what) {
@@ -61,8 +61,8 @@ void ProjectExportDialog::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_READY: {
-			duplicate_preset->set_icon(presets->get_theme_icon("Duplicate", "EditorIcons"));
-			delete_preset->set_icon(presets->get_theme_icon("Remove", "EditorIcons"));
+			duplicate_preset->set_icon(presets->get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")));
+			delete_preset->set_icon(presets->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 			connect("confirmed", callable_mp(this, &ProjectExportDialog::_export_pck_zip));
 			_update_export_all();
 		} break;
@@ -730,7 +730,7 @@ void ProjectExportDialog::_fill_resource_tree() {
 
 bool ProjectExportDialog::_fill_tree(EditorFileSystemDirectory *p_dir, TreeItem *p_item, Ref<EditorExportPreset> &current, bool p_only_scenes) {
 	p_item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-	p_item->set_icon(0, presets->get_theme_icon("folder", "FileDialog"));
+	p_item->set_icon(0, presets->get_theme_icon(SNAME("folder"), SNAME("FileDialog")));
 	p_item->set_text(0, p_dir->get_name() + "/");
 	p_item->set_editable(0, true);
 	p_item->set_metadata(0, p_dir->get_path());
@@ -1172,7 +1172,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_key->connect("text_changed", callable_mp(this, &ProjectExportDialog::_script_encryption_key_changed));
 	script_key_error = memnew(Label);
 	script_key_error->set_text("- " + TTR("Invalid Encryption Key (must be 64 hexadecimal characters long)"));
-	script_key_error->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("error_color", "Editor"));
+	script_key_error->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	sec_vb->add_margin_child(TTR("Encryption Key (256-bits as hexadecimal):"), script_key);
 	sec_vb->add_child(script_key_error);
 	sections->add_child(sec_vb);
@@ -1241,7 +1241,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_error = memnew(Label);
 	main_vb->add_child(export_error);
 	export_error->hide();
-	export_error->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("error_color", "Editor"));
+	export_error->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
 	export_templates_error = memnew(HBoxContainer);
 	main_vb->add_child(export_templates_error);
@@ -1249,7 +1249,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	Label *export_error2 = memnew(Label);
 	export_templates_error->add_child(export_error2);
-	export_error2->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("error_color", "Editor"));
+	export_error2->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	export_error2->set_text(" - " + TTR("Export templates for this platform are missing:") + " ");
 
 	error_dialog = memnew(AcceptDialog);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -113,20 +113,20 @@ private:
 
 		switch (p_type) {
 			case MESSAGE_ERROR: {
-				msg->add_theme_color_override("font_color", msg->get_theme_color("error_color", "Editor"));
+				msg->add_theme_color_override("font_color", msg->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 				msg->set_modulate(Color(1, 1, 1, 1));
-				new_icon = msg->get_theme_icon("StatusError", "EditorIcons");
+				new_icon = msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"));
 
 			} break;
 			case MESSAGE_WARNING: {
-				msg->add_theme_color_override("font_color", msg->get_theme_color("warning_color", "Editor"));
+				msg->add_theme_color_override("font_color", msg->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 				msg->set_modulate(Color(1, 1, 1, 1));
-				new_icon = msg->get_theme_icon("StatusWarning", "EditorIcons");
+				new_icon = msg->get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons"));
 
 			} break;
 			case MESSAGE_SUCCESS: {
 				msg->set_modulate(Color(1, 1, 1, 0));
-				new_icon = msg->get_theme_icon("StatusSuccess", "EditorIcons");
+				new_icon = msg->get_theme_icon(SNAME("StatusSuccess"), SNAME("EditorIcons"));
 
 			} break;
 		}
@@ -336,9 +336,9 @@ private:
 		project_path->set_text(sp);
 		_path_text_changed(sp);
 		if (p.ends_with(".zip")) {
-			install_path->call_deferred("grab_focus");
+			install_path->call_deferred(SNAME("grab_focus"));
 		} else {
-			get_ok_button()->call_deferred("grab_focus");
+			get_ok_button()->call_deferred(SNAME("grab_focus"));
 		}
 	}
 
@@ -346,14 +346,14 @@ private:
 		String sp = p_path.simplify_path();
 		project_path->set_text(sp);
 		_path_text_changed(sp);
-		get_ok_button()->call_deferred("grab_focus");
+		get_ok_button()->call_deferred(SNAME("grab_focus"));
 	}
 
 	void _install_path_selected(const String &p_path) {
 		String sp = p_path.simplify_path();
 		install_path->set_text(sp);
 		_path_text_changed(sp);
-		get_ok_button()->call_deferred("grab_focus");
+		get_ok_button()->call_deferred(SNAME("grab_focus"));
 	}
 
 	void _browse_path() {
@@ -448,7 +448,7 @@ private:
 			}
 
 			hide();
-			emit_signal("projects_updated");
+			emit_signal(SNAME("projects_updated"));
 
 		} else {
 			if (mode == MODE_IMPORT) {
@@ -617,7 +617,7 @@ private:
 			EditorSettings::get_singleton()->save();
 
 			hide();
-			emit_signal("project_created", dir);
+			emit_signal(SNAME("project_created"), dir);
 		}
 	}
 
@@ -640,11 +640,11 @@ private:
 		project_name->clear();
 		_text_changed("");
 
-		if (status_rect->get_texture() == msg->get_theme_icon("StatusError", "EditorIcons")) {
+		if (status_rect->get_texture() == msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"))) {
 			msg->show();
 		}
 
-		if (install_status_rect->get_texture() == msg->get_theme_icon("StatusError", "EditorIcons")) {
+		if (install_status_rect->get_texture() == msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"))) {
 			msg->show();
 		}
 	}
@@ -715,7 +715,7 @@ public:
 				_text_changed(proj);
 			}
 
-			project_name->call_deferred("grab_focus");
+			project_name->call_deferred(SNAME("grab_focus"));
 
 			create_dir->hide();
 
@@ -758,8 +758,8 @@ public:
 				name_container->show();
 				install_path_container->hide();
 				rasterizer_container->show();
-				project_name->call_deferred("grab_focus");
-				project_name->call_deferred("select_all");
+				project_name->call_deferred(SNAME("grab_focus"));
+				project_name->call_deferred(SNAME("select_all"));
 
 			} else if (mode == MODE_INSTALL) {
 				set_title(TTR("Install Project:") + " " + zip_title);
@@ -966,7 +966,7 @@ public:
 			} break;
 			case NOTIFICATION_DRAW: {
 				if (hover) {
-					draw_style_box(get_theme_stylebox("hover", "Tree"), Rect2(Point2(), get_size()));
+					draw_style_box(get_theme_stylebox(SNAME("hover"), SNAME("Tree")), Rect2(Point2(), get_size()));
 				}
 			} break;
 		}
@@ -1141,7 +1141,7 @@ void ProjectList::_notification(int p_what) {
 void ProjectList::load_project_icon(int p_index) {
 	Item &item = _projects.write[p_index];
 
-	Ref<Texture2D> default_icon = get_theme_icon("DefaultProjectIcon", "EditorIcons");
+	Ref<Texture2D> default_icon = get_theme_icon(SNAME("DefaultProjectIcon"), SNAME("EditorIcons"));
 	Ref<Texture2D> icon;
 	if (item.icon != "") {
 		Ref<Image> img;
@@ -1327,8 +1327,8 @@ void ProjectList::create_project_item_control(int p_index) {
 	Item &item = _projects.write[p_index];
 	ERR_FAIL_COND(item.control != nullptr); // Already created
 
-	Ref<Texture2D> favorite_icon = get_theme_icon("Favorites", "EditorIcons");
-	Color font_color = get_theme_color("font_color", "Tree");
+	Ref<Texture2D> favorite_icon = get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons"));
+	Color font_color = get_theme_color(SNAME("font_color"), SNAME("Tree"));
 
 	ProjectListItemControl *hb = memnew(ProjectListItemControl);
 	hb->connect("draw", callable_mp(this, &ProjectList::_panel_draw), varray(hb));
@@ -1353,7 +1353,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	TextureRect *tf = memnew(TextureRect);
 	// The project icon may not be loaded by the time the control is displayed,
 	// so use a loading placeholder.
-	tf->set_texture(get_theme_icon("ProjectIconLoading", "EditorIcons"));
+	tf->set_texture(get_theme_icon(SNAME("ProjectIconLoading"), SNAME("EditorIcons")));
 	tf->set_v_size_flags(SIZE_SHRINK_CENTER);
 	if (item.missing) {
 		tf->set_modulate(Color(1, 1, 1, 0.5));
@@ -1372,8 +1372,8 @@ void ProjectList::create_project_item_control(int p_index) {
 	ec->set_mouse_filter(MOUSE_FILTER_PASS);
 	vb->add_child(ec);
 	Label *title = memnew(Label(!item.missing ? item.project_name : TTR("Missing Project")));
-	title->add_theme_font_override("font", get_theme_font("title", "EditorFonts"));
-	title->add_theme_font_size_override("font_size", get_theme_font_size("title_size", "EditorFonts"));
+	title->add_theme_font_override("font", get_theme_font(SNAME("title"), SNAME("EditorFonts")));
+	title->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("title_size"), SNAME("EditorFonts")));
 	title->add_theme_color_override("font_color", font_color);
 	title->set_clip_text(true);
 	vb->add_child(title);
@@ -1726,15 +1726,15 @@ void ProjectList::_panel_draw(Node *p_hb) {
 	Control *hb = Object::cast_to<Control>(p_hb);
 
 	if (is_layout_rtl() && get_v_scrollbar()->is_visible_in_tree()) {
-		hb->draw_line(Point2(get_v_scrollbar()->get_minimum_size().x, hb->get_size().y + 1), Point2(hb->get_size().x, hb->get_size().y + 1), get_theme_color("guide_color", "Tree"));
+		hb->draw_line(Point2(get_v_scrollbar()->get_minimum_size().x, hb->get_size().y + 1), Point2(hb->get_size().x, hb->get_size().y + 1), get_theme_color(SNAME("guide_color"), SNAME("Tree")));
 	} else {
-		hb->draw_line(Point2(0, hb->get_size().y + 1), Point2(hb->get_size().x, hb->get_size().y + 1), get_theme_color("guide_color", "Tree"));
+		hb->draw_line(Point2(0, hb->get_size().y + 1), Point2(hb->get_size().x, hb->get_size().y + 1), get_theme_color(SNAME("guide_color"), SNAME("Tree")));
 	}
 
 	String key = _projects[p_hb->get_index()].project_key;
 
 	if (_selected_project_keys.has(key)) {
-		hb->draw_style_box(get_theme_stylebox("selected", "Tree"), Rect2(Point2(), hb->get_size()));
+		hb->draw_style_box(get_theme_stylebox(SNAME("selected"), SNAME("Tree")), Rect2(Point2(), hb->get_size()));
 	}
 }
 
@@ -1765,10 +1765,10 @@ void ProjectList::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 			select_project(clicked_index);
 		}
 
-		emit_signal(SIGNAL_SELECTION_CHANGED);
+		emit_signal(SNAME(SIGNAL_SELECTION_CHANGED));
 
 		if (!mb->is_ctrl_pressed() && mb->is_double_click()) {
-			emit_signal(SIGNAL_PROJECT_ASK_OPEN);
+			emit_signal(SNAME(SIGNAL_PROJECT_ASK_OPEN));
 		}
 	}
 }
@@ -1826,7 +1826,7 @@ void ProjectManager::_notification(int p_what) {
 			update();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
-			search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			search_box->set_clear_button_enabled(true);
 
 			Engine::get_singleton()->set_editor_hint(false);
@@ -2446,7 +2446,7 @@ ProjectManager::ProjectManager() {
 	Panel *panel = memnew(Panel);
 	add_child(panel);
 	panel->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-	panel->add_theme_style_override("panel", get_theme_stylebox("Background", "EditorStyles"));
+	panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 	panel->add_child(vb);
@@ -2484,7 +2484,7 @@ ProjectManager::ProjectManager() {
 		hb->add_child(search_box);
 
 		loading_label = memnew(Label(TTR("Loading, please wait...")));
-		loading_label->add_theme_font_override("font", get_theme_font("bold", "EditorFonts"));
+		loading_label->add_theme_font_override("font", get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
 		loading_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		hb->add_child(loading_label);
 		// Hide the label but make it still take up space. This prevents reflows when showing the label.
@@ -2510,7 +2510,7 @@ ProjectManager::ProjectManager() {
 		}
 
 		PanelContainer *pc = memnew(PanelContainer);
-		pc->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
+		pc->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		pc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		search_tree_vb->add_child(pc);
 
@@ -2618,7 +2618,7 @@ ProjectManager::ProjectManager() {
 
 		language_btn = memnew(OptionButton);
 		language_btn->set_flat(true);
-		language_btn->set_icon(get_theme_icon("Environment", "EditorIcons"));
+		language_btn->set_icon(get_theme_icon(SNAME("Environment"), SNAME("EditorIcons")));
 		language_btn->set_focus_mode(Control::FOCUS_NONE);
 		language_btn->connect("item_selected", callable_mp(this, &ProjectManager::_language_selected));
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -444,7 +444,7 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 	List<PropertyInfo> props;
 	ProjectSettings::get_singleton()->get_property_list(&props);
 
-	const Ref<Texture2D> builtin_icon = get_theme_icon("PinPressed", "EditorIcons");
+	const Ref<Texture2D> builtin_icon = get_theme_icon(SNAME("PinPressed"), SNAME("EditorIcons"));
 	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 		const String property_name = E->get().name;
 
@@ -483,18 +483,18 @@ void ProjectSettingsEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			inspector->edit(ps);
 
-			search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			search_box->set_clear_button_enabled(true);
 
-			restart_close_button->set_icon(get_theme_icon("Close", "EditorIcons"));
-			restart_container->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-			restart_icon->set_texture(get_theme_icon("StatusWarning", "EditorIcons"));
-			restart_label->add_theme_color_override("font_color", get_theme_color("warning_color", "Editor"));
+			restart_close_button->set_icon(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+			restart_container->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			restart_icon->set_texture(get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
+			restart_label->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 
 			_update_action_map_editor();
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			search_box->set_clear_button_enabled(true);
 		} break;
 	}

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -119,16 +119,16 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 				}
 
 				v = val;
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 			} else if (hint == PROPERTY_HINT_ENUM) {
 				v = menu->get_item_metadata(p_which);
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 			}
 		} break;
 		case Variant::STRING: {
 			if (hint == PROPERTY_HINT_ENUM) {
 				v = hint_text.get_slice(",", p_which);
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 			}
 		} break;
 		case Variant::OBJECT: {
@@ -159,13 +159,13 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 					REF r = v;
 
 					if (!r.is_null()) {
-						emit_signal("resource_edit_request");
+						emit_signal(SNAME("resource_edit_request"));
 						hide();
 					}
 				} break;
 				case OBJ_MENU_CLEAR: {
 					v = Variant();
-					emit_signal("variant_changed");
+					emit_signal(SNAME("variant_changed"));
 					hide();
 				} break;
 
@@ -204,7 +204,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 					}
 
 					v = res;
-					emit_signal("variant_changed");
+					emit_signal(SNAME("variant_changed"));
 					hide();
 				} break;
 
@@ -214,7 +214,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 				} break;
 				case OBJ_MENU_PASTE: {
 					v = EditorSettings::get_singleton()->get_resource_clipboard();
-					emit_signal("variant_changed");
+					emit_signal(SNAME("variant_changed"));
 
 				} break;
 				case OBJ_MENU_NEW_SCRIPT: {
@@ -248,7 +248,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 						Ref<Resource> new_res = conversions[to_type]->convert(v);
 
 						v = new_res;
-						emit_signal("variant_changed");
+						emit_signal(SNAME("variant_changed"));
 						break;
 					}
 					ERR_FAIL_COND(inheritors_array.is_empty());
@@ -281,7 +281,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 					}
 
 					v = obj;
-					emit_signal("variant_changed");
+					emit_signal(SNAME("variant_changed"));
 
 				} break;
 			}
@@ -544,8 +544,8 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				text_edit->set_text(v);
 				text_edit->deselect();
 
-				int button_margin = text_edit->get_theme_constant("button_margin", "Dialogs");
-				int margin = text_edit->get_theme_constant("margin", "Dialogs");
+				int button_margin = text_edit->get_theme_constant(SNAME("button_margin"), SNAME("Dialogs"));
+				int margin = text_edit->get_theme_constant(SNAME("margin"), SNAME("Dialogs"));
 
 				action_buttons[0]->set_anchor(SIDE_LEFT, Control::ANCHOR_END);
 				action_buttons[0]->set_anchor(SIDE_TOP, Control::ANCHOR_END);
@@ -1016,13 +1016,13 @@ void CustomPropertyEditor::_file_selected(String p_file) {
 		case Variant::STRING: {
 			if (hint == PROPERTY_HINT_FILE || hint == PROPERTY_HINT_DIR) {
 				v = ProjectSettings::get_singleton()->localize_path(p_file);
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 				hide();
 			}
 
 			if (hint == PROPERTY_HINT_GLOBAL_FILE || hint == PROPERTY_HINT_GLOBAL_DIR) {
 				v = p_file;
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 				hide();
 			}
 
@@ -1037,7 +1037,7 @@ void CustomPropertyEditor::_file_selected(String p_file) {
 				break;
 			}
 			v = res;
-			emit_signal("variant_changed");
+			emit_signal(SNAME("variant_changed"));
 			hide();
 		} break;
 		default: {
@@ -1070,7 +1070,7 @@ void CustomPropertyEditor::_type_create_selected(int p_idx) {
 		}
 
 		v = newval;
-		emit_signal("variant_changed");
+		emit_signal(SNAME("variant_changed"));
 		easing_draw->update();
 
 	} else if (type == Variant::OBJECT) {
@@ -1092,14 +1092,14 @@ void CustomPropertyEditor::_type_create_selected(int p_idx) {
 		ERR_FAIL_COND(!Object::cast_to<Resource>(obj));
 
 		v = obj;
-		emit_signal("variant_changed");
+		emit_signal(SNAME("variant_changed"));
 		hide();
 	}
 }
 
 void CustomPropertyEditor::_color_changed(const Color &p_color) {
 	v = p_color;
-	emit_signal("variant_changed");
+	emit_signal(SNAME("variant_changed"));
 }
 
 void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
@@ -1115,7 +1115,7 @@ void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
 		vt->set_viewport_path_in_scene(get_tree()->get_edited_scene_root()->get_path_to(to_node));
 		vt->setup_local_to_scene();
 		v = vt;
-		emit_signal("variant_changed");
+		emit_signal(SNAME("variant_changed"));
 		return;
 	}
 
@@ -1140,8 +1140,8 @@ void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
 		}
 		if (!node) {
 			v = p_path;
-			emit_signal("variant_changed");
-			call_deferred("hide"); //to not mess with dialogs
+			emit_signal(SNAME("variant_changed"));
+			call_deferred(SNAME("hide")); //to not mess with dialogs
 			return;
 		}
 
@@ -1152,8 +1152,8 @@ void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
 	}
 
 	v = p_path;
-	emit_signal("variant_changed");
-	call_deferred("hide"); //to not mess with dialogs
+	emit_signal(SNAME("variant_changed"));
+	call_deferred(SNAME("hide")); //to not mess with dialogs
 }
 
 void CustomPropertyEditor::_action_pressed(int p_which) {
@@ -1164,7 +1164,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 	switch (type) {
 		case Variant::BOOL: {
 			v = checks20[0]->is_pressed();
-			emit_signal("variant_changed");
+			emit_signal(SNAME("variant_changed"));
 		} break;
 		case Variant::INT: {
 			if (hint == PROPERTY_HINT_LAYERS_2D_PHYSICS ||
@@ -1181,7 +1181,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 				}
 
 				v = f;
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 			}
 
 		} break;
@@ -1218,7 +1218,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 					file->popup_file_dialog();
 				} else {
 					v = "";
-					emit_signal("variant_changed");
+					emit_signal(SNAME("variant_changed"));
 					hide();
 				}
 
@@ -1234,7 +1234,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 					file->popup_file_dialog();
 				} else {
 					v = "";
-					emit_signal("variant_changed");
+					emit_signal(SNAME("variant_changed"));
 					hide();
 				}
 			}
@@ -1248,7 +1248,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 			} else if (p_which == 1) {
 				v = NodePath();
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 				hide();
 			} else if (p_which == 2) {
 				if (owner->is_class("Node") && (v.get_type() == Variant::NODE_PATH) && Object::cast_to<Node>(owner)->has_node(v)) {
@@ -1282,7 +1282,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 					ERR_BREAK(!Object::cast_to<Resource>(obj));
 
 					v = obj;
-					emit_signal("variant_changed");
+					emit_signal(SNAME("variant_changed"));
 					hide();
 				}
 			} else if (p_which == 1) {
@@ -1303,13 +1303,13 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 				RES r = v;
 
 				if (!r.is_null()) {
-					emit_signal("resource_edit_request");
+					emit_signal(SNAME("resource_edit_request"));
 					hide();
 				}
 
 			} else if (p_which == 3) {
 				v = Variant();
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 				hide();
 			} else if (p_which == 4) {
 				Ref<Resource> res_orig = v;
@@ -1342,7 +1342,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 				}
 
 				v = res;
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 				hide();
 			}
 
@@ -1386,7 +1386,7 @@ void CustomPropertyEditor::_drag_easing(const Ref<InputEvent> &p_ev) {
 
 		v = val;
 		easing_draw->update();
-		emit_signal("variant_changed");
+		emit_signal(SNAME("variant_changed"));
 	}
 }
 
@@ -1396,7 +1396,7 @@ void CustomPropertyEditor::_draw_easing() {
 	Size2 s = easing_draw->get_size();
 	Rect2 r(Point2(), s);
 	r = r.grow(3);
-	easing_draw->get_theme_stylebox("normal", "LineEdit")->draw(ci, r);
+	easing_draw->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit"))->draw(ci, r);
 
 	int points = 48;
 
@@ -1404,9 +1404,9 @@ void CustomPropertyEditor::_draw_easing() {
 	float exp = v;
 	bool flip = hint_text == "attenuation";
 
-	Ref<Font> f = easing_draw->get_theme_font("font", "Label");
-	int font_size = easing_draw->get_theme_font_size("font_size", "Label");
-	Color color = easing_draw->get_theme_color("font_color", "Label");
+	Ref<Font> f = easing_draw->get_theme_font(SNAME("font"), SNAME("Label"));
+	int font_size = easing_draw->get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+	Color color = easing_draw->get_theme_color(SNAME("font_color"), SNAME("Label"));
 
 	for (int i = 1; i <= points; i++) {
 		float ifl = i / float(points);
@@ -1428,17 +1428,17 @@ void CustomPropertyEditor::_draw_easing() {
 
 void CustomPropertyEditor::_text_edit_changed() {
 	v = text_edit->get_text();
-	emit_signal("variant_changed");
+	emit_signal(SNAME("variant_changed"));
 }
 
 void CustomPropertyEditor::_create_dialog_callback() {
 	v = create_dialog->get_selected_type();
-	emit_signal("variant_changed");
+	emit_signal(SNAME("variant_changed"));
 }
 
 void CustomPropertyEditor::_create_selected_property(const String &p_prop) {
 	v = p_prop;
-	emit_signal("variant_changed");
+	emit_signal(SNAME("variant_changed"));
 }
 
 void CustomPropertyEditor::_modified(String p_string) {
@@ -1463,7 +1463,7 @@ void CustomPropertyEditor::_modified(String p_string) {
 			}
 
 			if (v != prev_v) {
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 			}
 		} break;
 		case Variant::FLOAT: {
@@ -1471,14 +1471,14 @@ void CustomPropertyEditor::_modified(String p_string) {
 				String text = TS->parse_number(value_editor[0]->get_text());
 				v = _parse_real_expression(text);
 				if (v != prev_v) {
-					emit_signal("variant_changed");
+					emit_signal(SNAME("variant_changed"));
 				}
 			}
 
 		} break;
 		case Variant::STRING: {
 			v = value_editor[0]->get_text();
-			emit_signal("variant_changed");
+			emit_signal(SNAME("variant_changed"));
 		} break;
 		case Variant::VECTOR2: {
 			Vector2 vec;
@@ -1603,7 +1603,7 @@ void CustomPropertyEditor::_modified(String p_string) {
 		case Variant::NODE_PATH: {
 			v = NodePath(value_editor[0]->get_text());
 			if (v != prev_v) {
-				emit_signal("variant_changed");
+				emit_signal(SNAME("variant_changed"));
 			}
 		} break;
 		case Variant::DICTIONARY: {
@@ -1642,15 +1642,15 @@ real_t CustomPropertyEditor::_parse_real_expression(String text) {
 
 void CustomPropertyEditor::_emit_changed_whole_or_field() {
 	if (!Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
-		emit_signal("variant_changed");
+		emit_signal(SNAME("variant_changed"));
 	} else {
-		emit_signal("variant_field_changed", field_names[focused_value_editor]);
+		emit_signal(SNAME("variant_field_changed"), field_names[focused_value_editor]);
 	}
 }
 
 void CustomPropertyEditor::_range_modified(double p_value) {
 	v = p_value;
-	emit_signal("variant_changed");
+	emit_signal(SNAME("variant_changed"));
 }
 
 void CustomPropertyEditor::_focus_enter() {
@@ -1684,7 +1684,7 @@ void CustomPropertyEditor::_focus_exit() {
 }
 
 void CustomPropertyEditor::config_action_buttons(const List<String> &p_strings) {
-	Ref<StyleBox> sb = action_buttons[0]->get_theme_stylebox("panel");
+	Ref<StyleBox> sb = action_buttons[0]->get_theme_stylebox(SNAME("panel"));
 	int margin_top = sb->get_margin(SIDE_TOP);
 	int margin_left = sb->get_margin(SIDE_LEFT);
 	int margin_bottom = sb->get_margin(SIDE_BOTTOM);

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -119,38 +119,38 @@ void PropertySelector::_update_search() {
 		bool found = false;
 
 		Ref<Texture2D> type_icons[Variant::VARIANT_MAX] = {
-			search_options->get_theme_icon("Variant", "EditorIcons"),
-			search_options->get_theme_icon("bool", "EditorIcons"),
-			search_options->get_theme_icon("int", "EditorIcons"),
-			search_options->get_theme_icon("float", "EditorIcons"),
-			search_options->get_theme_icon("String", "EditorIcons"),
-			search_options->get_theme_icon("Vector2", "EditorIcons"),
-			search_options->get_theme_icon("Vector2i", "EditorIcons"),
-			search_options->get_theme_icon("Rect2", "EditorIcons"),
-			search_options->get_theme_icon("Rect2i", "EditorIcons"),
-			search_options->get_theme_icon("Vector3", "EditorIcons"),
-			search_options->get_theme_icon("Vector3i", "EditorIcons"),
-			search_options->get_theme_icon("Transform2D", "EditorIcons"),
-			search_options->get_theme_icon("Plane", "EditorIcons"),
-			search_options->get_theme_icon("Quaternion", "EditorIcons"),
-			search_options->get_theme_icon("AABB", "EditorIcons"),
-			search_options->get_theme_icon("Basis", "EditorIcons"),
-			search_options->get_theme_icon("Transform3D", "EditorIcons"),
-			search_options->get_theme_icon("Color", "EditorIcons"),
-			search_options->get_theme_icon("NodePath", "EditorIcons"),
-			search_options->get_theme_icon("RID", "EditorIcons"),
-			search_options->get_theme_icon("MiniObject", "EditorIcons"),
-			search_options->get_theme_icon("Callable", "EditorIcons"),
-			search_options->get_theme_icon("Signal", "EditorIcons"),
-			search_options->get_theme_icon("Dictionary", "EditorIcons"),
-			search_options->get_theme_icon("Array", "EditorIcons"),
-			search_options->get_theme_icon("PackedByteArray", "EditorIcons"),
-			search_options->get_theme_icon("PackedInt32Array", "EditorIcons"),
-			search_options->get_theme_icon("PackedFloat32Array", "EditorIcons"),
-			search_options->get_theme_icon("PackedStringArray", "EditorIcons"),
-			search_options->get_theme_icon("PackedVector2Array", "EditorIcons"),
-			search_options->get_theme_icon("PackedVector3Array", "EditorIcons"),
-			search_options->get_theme_icon("PackedColorArray", "EditorIcons")
+			search_options->get_theme_icon(SNAME("Variant"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("String"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Vector2i"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Rect2"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Rect2i"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Vector3i"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Transform2D"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Plane"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Quaternion"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("AABB"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Basis"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("NodePath"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("RID"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("MiniObject"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Callable"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Signal"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Dictionary"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("Array"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("PackedByteArray"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("PackedInt32Array"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("PackedFloat32Array"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("PackedStringArray"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("PackedVector2Array"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("PackedVector3Array"), SNAME("EditorIcons")),
+			search_options->get_theme_icon(SNAME("PackedColorArray"), SNAME("EditorIcons"))
 		};
 
 		for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
@@ -164,7 +164,7 @@ void PropertySelector::_update_search() {
 
 				Ref<Texture2D> icon;
 				if (E->get().name == "Script Variables") {
-					icon = search_options->get_theme_icon("Script", "EditorIcons");
+					icon = search_options->get_theme_icon(SNAME("Script"), SNAME("EditorIcons"));
 				} else {
 					icon = EditorNode::get_singleton()->get_class_icon(E->get().name);
 				}
@@ -241,7 +241,7 @@ void PropertySelector::_update_search() {
 				script_methods = false;
 				String rep = E->get().name.replace("*", "");
 				if (E->get().name == "*Script Methods") {
-					icon = search_options->get_theme_icon("Script", "EditorIcons");
+					icon = search_options->get_theme_icon(SNAME("Script"), SNAME("EditorIcons"));
 					script_methods = true;
 				} else {
 					icon = EditorNode::get_singleton()->get_class_icon(rep);
@@ -334,7 +334,7 @@ void PropertySelector::_confirmed() {
 	if (!ti) {
 		return;
 	}
-	emit_signal("selected", ti->get_metadata(0));
+	emit_signal(SNAME("selected"), ti->get_metadata(0));
 	hide();
 }
 

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -64,7 +64,7 @@ void EditorQuickOpen::_build_search_cache(EditorFileSystemDirectory *p_efsd) {
 			// Store refs to used icons.
 			String ext = file.get_extension();
 			if (!icons.has(ext)) {
-				icons.insert(ext, get_theme_icon((has_theme_icon(file_type, "EditorIcons") ? file_type : "Object"), "EditorIcons"));
+				icons.insert(ext, get_theme_icon((has_theme_icon(file_type, SNAME("EditorIcons")) ? file_type : String("Object")), SNAME("EditorIcons")));
 			}
 		}
 	}
@@ -140,7 +140,7 @@ void EditorQuickOpen::_confirmed() {
 		return;
 	}
 	_cleanup();
-	emit_signal("quick_open");
+	emit_signal(SNAME("quick_open"));
 	hide();
 }
 
@@ -228,7 +228,7 @@ void EditorQuickOpen::_notification(int p_what) {
 }
 
 void EditorQuickOpen::_theme_changed() {
-	search_box->set_right_icon(search_options->get_theme_icon("Search", "EditorIcons"));
+	search_box->set_right_icon(search_options->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 }
 
 void EditorQuickOpen::_bind_methods() {

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -391,11 +391,11 @@ void RenameDialog::_update_preview(String new_text) {
 
 		if (new_name == preview_node->get_name()) {
 			// New name is identical to the old one. Don't color it as much to avoid distracting the user.
-			const Color accent_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color("accent_color", "Editor");
-			const Color text_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color("default_color", "RichTextLabel");
+			const Color accent_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+			const Color text_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("default_color"), SNAME("RichTextLabel"));
 			lbl_preview->add_theme_color_override("font_color", accent_color.lerp(text_color, 0.5));
 		} else {
-			lbl_preview->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("success_color", "Editor"));
+			lbl_preview->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 		}
 	}
 
@@ -481,7 +481,7 @@ void RenameDialog::_error_handler(void *p_self, const char *p_func, const char *
 
 	self->has_errors = true;
 	self->lbl_preview_title->set_text(TTR("Regular Expression Error:"));
-	self->lbl_preview->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("error_color", "Editor"));
+	self->lbl_preview->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	self->lbl_preview->set_text(vformat(TTR("At character %s"), err_str));
 }
 
@@ -594,7 +594,7 @@ void RenameDialog::rename() {
 				continue;
 			}
 
-			scene_tree_editor->emit_signal("node_prerename", n, new_name);
+			scene_tree_editor->emit_signal(SNAME("node_prerename"), n, new_name);
 			undo_redo->add_do_method(scene_tree_editor, "_rename_node", n->get_instance_id(), new_name);
 			undo_redo->add_undo_method(scene_tree_editor, "_rename_node", n->get_instance_id(), n->get_name());
 		}

--- a/editor/reparent_dialog.cpp
+++ b/editor/reparent_dialog.cpp
@@ -50,7 +50,7 @@ void ReparentDialog::_cancel() {
 
 void ReparentDialog::_reparent() {
 	if (tree->get_selected()) {
-		emit_signal("reparent", tree->get_selected()->get_path(), keep_transform->is_pressed());
+		emit_signal(SNAME("reparent"), tree->get_selected()->get_path(), keep_transform->is_pressed());
 		hide();
 	}
 }

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -229,7 +229,7 @@ void SceneTreeDock::_perform_instantiate_scenes(const Vector<String> &p_files, N
 	editor_data->get_undo_redo().commit_action();
 	editor->push_item(instances[instances.size() - 1]);
 	for (int i = 0; i < instances.size(); i++) {
-		emit_signal("node_created", instances[i]);
+		emit_signal(SNAME("node_created"), instances[i]);
 	}
 }
 
@@ -385,7 +385,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			create_dialog->popup_create(true);
 			if (!p_confirm_override) {
-				emit_signal("add_node_used");
+				emit_signal(SNAME("add_node_used"));
 			}
 		} break;
 		case TOOL_INSTANTIATE: {
@@ -402,7 +402,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			quick_open->popup_dialog("PackedScene", true);
 			quick_open->set_title(TTR("Instantiate Child Scene"));
 			if (!p_confirm_override) {
-				emit_signal("add_node_used");
+				emit_signal(SNAME("add_node_used"));
 			}
 		} break;
 		case TOOL_EXPAND_COLLAPSE: {
@@ -1057,7 +1057,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (e) {
 				Node *node = e->get();
 				if (node) {
-					scene_tree->emit_signal("open", node->get_filename());
+					scene_tree->emit_signal(SNAME("open"), node->get_filename());
 				}
 			}
 		} break;
@@ -1090,7 +1090,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (e) {
 				Node *node = e->get();
 				if (node && node->get_scene_inherited_state().is_valid()) {
-					scene_tree->emit_signal("open", node->get_scene_inherited_state()->get_path());
+					scene_tree->emit_signal(SNAME("open"), node->get_scene_inherited_state()->get_path());
 				}
 			}
 		} break;
@@ -1198,12 +1198,12 @@ void SceneTreeDock::_notification(int p_what) {
 			spatial_editor_plugin->get_spatial_editor()->connect("item_lock_status_changed", Callable(scene_tree, "_update_tree"));
 			spatial_editor_plugin->get_spatial_editor()->connect("item_group_status_changed", Callable(scene_tree, "_update_tree"));
 
-			button_add->set_icon(get_theme_icon("Add", "EditorIcons"));
-			button_instance->set_icon(get_theme_icon("Instance", "EditorIcons"));
-			button_create_script->set_icon(get_theme_icon("ScriptCreate", "EditorIcons"));
-			button_detach_script->set_icon(get_theme_icon("ScriptRemove", "EditorIcons"));
+			button_add->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			button_instance->set_icon(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
+			button_create_script->set_icon(get_theme_icon(SNAME("ScriptCreate"), SNAME("EditorIcons")));
+			button_detach_script->set_icon(get_theme_icon(SNAME("ScriptRemove"), SNAME("EditorIcons")));
 
-			filter->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			filter->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			filter->set_clear_button_enabled(true);
 
 			// create_root_dialog
@@ -1218,7 +1218,7 @@ void SceneTreeDock::_notification(int p_what) {
 			Button *node_shortcuts_toggle = memnew(Button);
 			node_shortcuts_toggle->set_flat(true);
 			node_shortcuts_toggle->set_name("NodeShortcutsToggle");
-			node_shortcuts_toggle->set_icon(get_theme_icon("Favorites", "EditorIcons"));
+			node_shortcuts_toggle->set_icon(get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")));
 			node_shortcuts_toggle->set_toggle_mode(true);
 			node_shortcuts_toggle->set_tooltip(TTR("Switch to Favorite Nodes"));
 			node_shortcuts_toggle->set_pressed(EDITOR_GET("_use_favorites_root_selection"));
@@ -1238,19 +1238,19 @@ void SceneTreeDock::_notification(int p_what) {
 			button_2d = memnew(Button);
 			beginner_node_shortcuts->add_child(button_2d);
 			button_2d->set_text(TTR("2D Scene"));
-			button_2d->set_icon(get_theme_icon("Node2D", "EditorIcons"));
+			button_2d->set_icon(get_theme_icon(SNAME("Node2D"), SNAME("EditorIcons")));
 			button_2d->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_2D_SCENE, false));
 
 			button_3d = memnew(Button);
 			beginner_node_shortcuts->add_child(button_3d);
 			button_3d->set_text(TTR("3D Scene"));
-			button_3d->set_icon(get_theme_icon("Node3D", "EditorIcons"));
+			button_3d->set_icon(get_theme_icon(SNAME("Node3D"), SNAME("EditorIcons")));
 			button_3d->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_3D_SCENE, false));
 
 			button_ui = memnew(Button);
 			beginner_node_shortcuts->add_child(button_ui);
 			button_ui->set_text(TTR("User Interface"));
-			button_ui->set_icon(get_theme_icon("Control", "EditorIcons"));
+			button_ui->set_icon(get_theme_icon(SNAME("Control"), SNAME("EditorIcons")));
 			button_ui->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_USER_INTERFACE, false));
 
 			VBoxContainer *favorite_node_shortcuts = memnew(VBoxContainer);
@@ -1260,7 +1260,7 @@ void SceneTreeDock::_notification(int p_what) {
 			button_custom = memnew(Button);
 			node_shortcuts->add_child(button_custom);
 			button_custom->set_text(TTR("Other Node"));
-			button_custom->set_icon(get_theme_icon("Add", "EditorIcons"));
+			button_custom->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			button_custom->connect("pressed", callable_bind(callable_mp(this, &SceneTreeDock::_tool_selected), TOOL_NEW, false));
 
 			node_shortcuts->add_spacer();
@@ -1276,16 +1276,16 @@ void SceneTreeDock::_notification(int p_what) {
 			clear_inherit_confirm->disconnect("confirmed", callable_mp(this, &SceneTreeDock::_tool_selected));
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			button_add->set_icon(get_theme_icon("Add", "EditorIcons"));
-			button_instance->set_icon(get_theme_icon("Instance", "EditorIcons"));
-			button_create_script->set_icon(get_theme_icon("ScriptCreate", "EditorIcons"));
-			button_detach_script->set_icon(get_theme_icon("ScriptRemove", "EditorIcons"));
-			button_2d->set_icon(get_theme_icon("Node2D", "EditorIcons"));
-			button_3d->set_icon(get_theme_icon("Node3D", "EditorIcons"));
-			button_ui->set_icon(get_theme_icon("Control", "EditorIcons"));
-			button_custom->set_icon(get_theme_icon("Add", "EditorIcons"));
+			button_add->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			button_instance->set_icon(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
+			button_create_script->set_icon(get_theme_icon(SNAME("ScriptCreate"), SNAME("EditorIcons")));
+			button_detach_script->set_icon(get_theme_icon(SNAME("ScriptRemove"), SNAME("EditorIcons")));
+			button_2d->set_icon(get_theme_icon(SNAME("Node2D"), SNAME("EditorIcons")));
+			button_3d->set_icon(get_theme_icon(SNAME("Node3D"), SNAME("EditorIcons")));
+			button_ui->set_icon(get_theme_icon(SNAME("Control"), SNAME("EditorIcons")));
+			button_custom->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 
-			filter->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			filter->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			filter->set_clear_button_enabled(true);
 		} break;
 		case NOTIFICATION_PROCESS: {
@@ -2172,7 +2172,7 @@ void SceneTreeDock::_do_create(Node *p_parent) {
 		ct->set_size(ms);
 	}
 
-	emit_signal("node_created", c);
+	emit_signal(SNAME("node_created"), c);
 }
 
 void SceneTreeDock::_create() {
@@ -2268,7 +2268,7 @@ void SceneTreeDock::_create() {
 		_do_reparent(last_created, -1, nodes, true);
 	}
 
-	scene_tree->get_scene_tree()->call_deferred("grab_focus");
+	scene_tree->get_scene_tree()->call_deferred(SNAME("grab_focus"));
 }
 
 void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties, bool p_remove_old) {
@@ -2599,8 +2599,8 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	if (!EditorNode::get_singleton()->get_edited_scene()) {
 		menu->clear();
 		if (profile_allow_editing) {
-			menu->add_icon_shortcut(get_theme_icon("Add", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
-			menu->add_icon_shortcut(get_theme_icon("Instance", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/instance_scene"), TOOL_INSTANTIATE);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/instance_scene"), TOOL_INSTANTIATE);
 		}
 
 		menu->set_size(Size2(1, 1));
@@ -2632,10 +2632,10 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				menu->add_separator();
 			}
 
-			menu->add_icon_shortcut(get_theme_icon("Add", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
-			menu->add_icon_shortcut(get_theme_icon("Instance", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/instance_scene"), TOOL_INSTANTIATE);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/instance_scene"), TOOL_INSTANTIATE);
 		}
-		menu->add_icon_shortcut(get_theme_icon("Collapse", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/expand_collapse_all"), TOOL_EXPAND_COLLAPSE);
+		menu->add_icon_shortcut(get_theme_icon(SNAME("Collapse"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/expand_collapse_all"), TOOL_EXPAND_COLLAPSE);
 		menu->add_separator();
 
 		existing_script = selected->get_script();
@@ -2659,14 +2659,14 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 		if (full_selection.size() == 1) {
 			add_separator = true;
-			menu->add_icon_shortcut(get_theme_icon("ScriptCreate", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/attach_script"), TOOL_ATTACH_SCRIPT);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("ScriptCreate"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/attach_script"), TOOL_ATTACH_SCRIPT);
 			if (existing_script.is_valid()) {
-				menu->add_icon_shortcut(get_theme_icon("ScriptExtend", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/extend_script"), TOOL_EXTEND_SCRIPT);
+				menu->add_icon_shortcut(get_theme_icon(SNAME("ScriptExtend"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/extend_script"), TOOL_EXTEND_SCRIPT);
 			}
 		}
 		if (existing_script.is_valid() && existing_script_removable) {
 			add_separator = true;
-			menu->add_icon_shortcut(get_theme_icon("ScriptRemove", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/detach_script"), TOOL_DETACH_SCRIPT);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("ScriptRemove"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/detach_script"), TOOL_DETACH_SCRIPT);
 		} else if (full_selection.size() > 1) {
 			bool script_exists = false;
 			for (List<Node *>::Element *E = full_selection.front(); E; E = E->next()) {
@@ -2678,7 +2678,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 			if (script_exists) {
 				add_separator = true;
-				menu->add_icon_shortcut(get_theme_icon("ScriptRemove", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/detach_script"), TOOL_DETACH_SCRIPT);
+				menu->add_icon_shortcut(get_theme_icon(SNAME("ScriptRemove"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/detach_script"), TOOL_DETACH_SCRIPT);
 			}
 		}
 
@@ -2689,7 +2689,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 	if (profile_allow_editing) {
 		if (full_selection.size() == 1) {
-			menu->add_icon_shortcut(get_theme_icon("Rename", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/rename"), TOOL_RENAME);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Rename"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/rename"), TOOL_RENAME);
 		}
 
 		bool can_replace = true;
@@ -2701,29 +2701,29 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		}
 
 		if (can_replace) {
-			menu->add_icon_shortcut(get_theme_icon("Reload", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/change_node_type"), TOOL_REPLACE);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/change_node_type"), TOOL_REPLACE);
 		}
 
 		if (scene_tree->get_selected() != edited_scene) {
 			menu->add_separator();
-			menu->add_icon_shortcut(get_theme_icon("MoveUp", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/move_up"), TOOL_MOVE_UP);
-			menu->add_icon_shortcut(get_theme_icon("MoveDown", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/move_down"), TOOL_MOVE_DOWN);
-			menu->add_icon_shortcut(get_theme_icon("Duplicate", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/duplicate"), TOOL_DUPLICATE);
-			menu->add_icon_shortcut(get_theme_icon("Reparent", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/reparent"), TOOL_REPARENT);
-			menu->add_icon_shortcut(get_theme_icon("ReparentToNewNode", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/reparent_to_new_node"), TOOL_REPARENT_TO_NEW_NODE);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/move_up"), TOOL_MOVE_UP);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/move_down"), TOOL_MOVE_DOWN);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/duplicate"), TOOL_DUPLICATE);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Reparent"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/reparent"), TOOL_REPARENT);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("ReparentToNewNode"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/reparent_to_new_node"), TOOL_REPARENT_TO_NEW_NODE);
 			if (selection.size() == 1) {
-				menu->add_icon_shortcut(get_theme_icon("NewRoot", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/make_root"), TOOL_MAKE_ROOT);
+				menu->add_icon_shortcut(get_theme_icon(SNAME("NewRoot"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/make_root"), TOOL_MAKE_ROOT);
 			}
 		}
 	}
 	if (selection.size() == 1) {
 		if (profile_allow_editing) {
 			menu->add_separator();
-			menu->add_icon_shortcut(get_theme_icon("CreateNewSceneFrom", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/save_branch_as_scene"), TOOL_NEW_SCENE_FROM);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("CreateNewSceneFrom"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/save_branch_as_scene"), TOOL_NEW_SCENE_FROM);
 		}
 		if (full_selection.size() == 1) {
 			menu->add_separator();
-			menu->add_icon_shortcut(get_theme_icon("CopyNodePath", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/copy_node_path"), TOOL_COPY_NODE_PATH);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("CopyNodePath"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/copy_node_path"), TOOL_COPY_NODE_PATH);
 		}
 
 		bool is_external = (selection[0]->get_filename() != "");
@@ -2735,7 +2735,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				if (profile_allow_editing) {
 					menu->add_item(TTR("Clear Inheritance"), TOOL_SCENE_CLEAR_INHERITANCE);
 				}
-				menu->add_icon_item(get_theme_icon("Load", "EditorIcons"), TTR("Open in Editor"), TOOL_SCENE_OPEN_INHERITED);
+				menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open in Editor"), TOOL_SCENE_OPEN_INHERITED);
 			} else if (!is_top_level) {
 				menu->add_separator();
 				bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(selection[0]);
@@ -2745,7 +2745,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 					menu->add_check_item(TTR("Load As Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
 					menu->add_item(TTR("Make Local"), TOOL_SCENE_MAKE_LOCAL);
 				}
-				menu->add_icon_item(get_theme_icon("Load", "EditorIcons"), TTR("Open in Editor"), TOOL_SCENE_OPEN);
+				menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open in Editor"), TOOL_SCENE_OPEN);
 				if (profile_allow_editing) {
 					menu->set_item_checked(menu->get_item_idx_from_text(TTR("Editable Children")), editable);
 					menu->set_item_checked(menu->get_item_idx_from_text(TTR("Load As Placeholder")), placeholder);
@@ -2757,14 +2757,14 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	if (profile_allow_editing && selection.size() > 1) {
 		//this is not a commonly used action, it makes no sense for it to be where it was nor always present.
 		menu->add_separator();
-		menu->add_icon_shortcut(get_theme_icon("Rename", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/batch_rename"), TOOL_BATCH_RENAME);
+		menu->add_icon_shortcut(get_theme_icon(SNAME("Rename"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/batch_rename"), TOOL_BATCH_RENAME);
 	}
 	menu->add_separator();
-	menu->add_icon_item(get_theme_icon("Help", "EditorIcons"), TTR("Open Documentation"), TOOL_OPEN_DOCUMENTATION);
+	menu->add_icon_item(get_theme_icon(SNAME("Help"), SNAME("EditorIcons")), TTR("Open Documentation"), TOOL_OPEN_DOCUMENTATION);
 
 	if (profile_allow_editing) {
 		menu->add_separator();
-		menu->add_icon_shortcut(get_theme_icon("Remove", "EditorIcons"), ED_SHORTCUT("scene_tree/delete", TTR("Delete Node(s)"), KEY_DELETE), TOOL_ERASE);
+		menu->add_icon_shortcut(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ED_SHORTCUT("scene_tree/delete", TTR("Delete Node(s)"), KEY_DELETE), TOOL_ERASE);
 	}
 	menu->set_size(Size2(1, 1));
 	menu->set_position(p_menu_pos);
@@ -2906,7 +2906,7 @@ void SceneTreeDock::_remote_tree_selected() {
 	edit_remote->set_pressed(true);
 	edit_local->set_pressed(false);
 
-	emit_signal("remote_tree_selected");
+	emit_signal(SNAME("remote_tree_selected"));
 }
 
 void SceneTreeDock::_local_tree_selected() {

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -63,15 +63,15 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 	if (p_id == BUTTON_SUBSCENE) {
 		if (n == get_scene_node()) {
 			if (n && n->get_scene_inherited_state().is_valid()) {
-				emit_signal("open", n->get_scene_inherited_state()->get_path());
+				emit_signal(SNAME("open"), n->get_scene_inherited_state()->get_path());
 			}
 		} else {
-			emit_signal("open", n->get_filename());
+			emit_signal(SNAME("open"), n->get_filename());
 		}
 	} else if (p_id == BUTTON_SCRIPT) {
 		Ref<Script> script_typed = n->get_script();
 		if (!script_typed.is_null()) {
-			emit_signal("open_script", script_typed);
+			emit_signal(SNAME("open_script"), script_typed);
 		}
 
 	} else if (p_id == BUTTON_VISIBILITY) {
@@ -197,19 +197,19 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 	item->set_metadata(0, p_node->get_path());
 
 	if (connect_to_script_mode) {
-		Color accent = get_theme_color("accent_color", "Editor");
+		Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 
 		Ref<Script> script = p_node->get_script();
 		if (!script.is_null() && EditorNode::get_singleton()->get_object_custom_type_base(p_node) != script) {
 			//has script
-			item->add_button(0, get_theme_icon("Script", "EditorIcons"), BUTTON_SCRIPT);
+			item->add_button(0, get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), BUTTON_SCRIPT);
 		} else {
 			//has no script (or script is a custom type)
-			item->set_custom_color(0, get_theme_color("disabled_font_color", "Editor"));
+			item->set_custom_color(0, get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 			item->set_selectable(0, false);
 
 			if (!script.is_null()) { // make sure to mark the script if a custom type
-				item->add_button(0, get_theme_icon("Script", "EditorIcons"), BUTTON_SCRIPT);
+				item->add_button(0, get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), BUTTON_SCRIPT);
 				item->set_button_disabled(0, item->get_button_count(0) - 1, true);
 			}
 
@@ -226,7 +226,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		}
 	} else if (part_of_subscene) {
 		if (valid_types.size() == 0) {
-			item->set_custom_color(0, get_theme_color("disabled_font_color", "Editor"));
+			item->set_custom_color(0, get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 		}
 	} else if (marked.has(p_node)) {
 		String node_name = p_node->get_name();
@@ -235,15 +235,15 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		}
 		item->set_text(0, node_name);
 		item->set_selectable(0, marked_selectable);
-		item->set_custom_color(0, get_theme_color("accent_color", "Editor"));
+		item->set_custom_color(0, get_theme_color(SNAME("accent_color"), SNAME("Editor")));
 	} else if (!p_node->can_process()) {
-		item->set_custom_color(0, get_theme_color("disabled_font_color", "Editor"));
+		item->set_custom_color(0, get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 	} else if (!marked_selectable && !marked_children_selectable) {
 		Node *node = p_node;
 		while (node) {
 			if (marked.has(node)) {
 				item->set_selectable(0, false);
-				item->set_custom_color(0, get_theme_color("error_color", "Editor"));
+				item->set_custom_color(0, get_theme_color(SNAME("error_color"), SNAME("Editor")));
 				break;
 			}
 			node = node->get_parent();
@@ -254,7 +254,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 
 		String warning = p_node->get_configuration_warnings_as_string();
 		if (!warning.is_empty()) {
-			item->add_button(0, get_theme_icon("NodeWarning", "EditorIcons"), BUTTON_WARNING, false, TTR("Node configuration warning:") + "\n" + warning);
+			item->add_button(0, get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")), BUTTON_WARNING, false, TTR("Node configuration warning:") + "\n" + warning);
 		}
 
 		int num_connections = p_node->get_persistent_signal_connection_count();
@@ -279,11 +279,11 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		Ref<Texture2D> icon_temp;
 		SceneTreeEditorButton signal_temp = BUTTON_SIGNALS;
 		if (num_connections >= 1 && num_groups >= 1) {
-			icon_temp = get_theme_icon("SignalsAndGroups", "EditorIcons");
+			icon_temp = get_theme_icon(SNAME("SignalsAndGroups"), SNAME("EditorIcons"));
 		} else if (num_connections >= 1) {
-			icon_temp = get_theme_icon("Signals", "EditorIcons");
+			icon_temp = get_theme_icon(SNAME("Signals"), SNAME("EditorIcons"));
 		} else if (num_groups >= 1) {
-			icon_temp = get_theme_icon("Groups", "EditorIcons");
+			icon_temp = get_theme_icon(SNAME("Groups"), SNAME("EditorIcons"));
 			signal_temp = BUTTON_GROUPS;
 		}
 
@@ -293,7 +293,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 	}
 
 	if (p_node == get_scene_node() && p_node->get_scene_inherited_state().is_valid()) {
-		item->add_button(0, get_theme_icon("InstanceOptions", "EditorIcons"), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+		item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
 
 		String tooltip = TTR("Inherits:") + " " + p_node->get_scene_inherited_state()->get_path() + "\n" + TTR("Type:") + " " + p_node->get_class();
 		if (p_node->get_editor_description() != String()) {
@@ -302,7 +302,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 
 		item->set_tooltip(0, tooltip);
 	} else if (p_node != get_scene_node() && p_node->get_filename() != "" && can_open_instance) {
-		item->add_button(0, get_theme_icon("InstanceOptions", "EditorIcons"), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+		item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
 
 		String tooltip = TTR("Instance:") + " " + p_node->get_filename() + "\n" + TTR("Type:") + " " + p_node->get_class();
 		if (p_node->get_editor_description() != String()) {
@@ -332,7 +332,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 
 		Ref<Script> script = p_node->get_script();
 		if (!script.is_null()) {
-			item->add_button(0, get_theme_icon("Script", "EditorIcons"), BUTTON_SCRIPT, false, TTR("Open Script:") + " " + script->get_path());
+			item->add_button(0, get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), BUTTON_SCRIPT, false, TTR("Open Script:") + " " + script->get_path());
 			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == script) {
 				item->set_button_color(0, item->get_button_count(0) - 1, Color(1, 1, 1, 0.5));
 			}
@@ -341,19 +341,19 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		if (p_node->is_class("CanvasItem")) {
 			bool is_locked = p_node->has_meta("_edit_lock_"); //_edit_group_
 			if (is_locked) {
-				item->add_button(0, get_theme_icon("Lock", "EditorIcons"), BUTTON_LOCK, false, TTR("Node is locked.\nClick to unlock it."));
+				item->add_button(0, get_theme_icon(SNAME("Lock"), SNAME("EditorIcons")), BUTTON_LOCK, false, TTR("Node is locked.\nClick to unlock it."));
 			}
 
 			bool is_grouped = p_node->has_meta("_edit_group_");
 			if (is_grouped) {
-				item->add_button(0, get_theme_icon("Group", "EditorIcons"), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make selectable."));
+				item->add_button(0, get_theme_icon(SNAME("Group"), SNAME("EditorIcons")), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make selectable."));
 			}
 
 			bool v = p_node->call("is_visible");
 			if (v) {
-				item->add_button(0, get_theme_icon("GuiVisibilityVisible", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
+				item->add_button(0, get_theme_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
 			} else {
-				item->add_button(0, get_theme_icon("GuiVisibilityHidden", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
+				item->add_button(0, get_theme_icon(SNAME("GuiVisibilityHidden"), SNAME("EditorIcons")), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
 			}
 
 			if (!p_node->is_connected("visibility_changed", callable_mp(this, &SceneTreeEditor::_node_visibility_changed))) {
@@ -364,19 +364,19 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		} else if (p_node->is_class("Node3D")) {
 			bool is_locked = p_node->has_meta("_edit_lock_");
 			if (is_locked) {
-				item->add_button(0, get_theme_icon("Lock", "EditorIcons"), BUTTON_LOCK, false, TTR("Node is locked.\nClick to unlock it."));
+				item->add_button(0, get_theme_icon(SNAME("Lock"), SNAME("EditorIcons")), BUTTON_LOCK, false, TTR("Node is locked.\nClick to unlock it."));
 			}
 
 			bool is_grouped = p_node->has_meta("_edit_group_");
 			if (is_grouped) {
-				item->add_button(0, get_theme_icon("Group", "EditorIcons"), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make selectable."));
+				item->add_button(0, get_theme_icon(SNAME("Group"), SNAME("EditorIcons")), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make selectable."));
 			}
 
 			bool v = p_node->call("is_visible");
 			if (v) {
-				item->add_button(0, get_theme_icon("GuiVisibilityVisible", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
+				item->add_button(0, get_theme_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
 			} else {
-				item->add_button(0, get_theme_icon("GuiVisibilityHidden", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
+				item->add_button(0, get_theme_icon(SNAME("GuiVisibilityHidden"), SNAME("EditorIcons")), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
 			}
 
 			if (!p_node->is_connected("visibility_changed", callable_mp(this, &SceneTreeEditor::_node_visibility_changed))) {
@@ -388,7 +388,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 			bool is_pinned = AnimationPlayerEditor::singleton->get_player() == p_node && AnimationPlayerEditor::singleton->is_pinned();
 
 			if (is_pinned) {
-				item->add_button(0, get_theme_icon("Pin", "EditorIcons"), BUTTON_PIN, false, TTR("AnimationPlayer is pinned.\nClick to unpin."));
+				item->add_button(0, get_theme_icon(SNAME("Pin"), SNAME("EditorIcons")), BUTTON_PIN, false, TTR("AnimationPlayer is pinned.\nClick to unpin."));
 			}
 		}
 	}
@@ -429,7 +429,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 
 		if (!valid) {
 			//item->set_selectable(0,marked_selectable);
-			item->set_custom_color(0, get_theme_color("disabled_font_color", "Editor"));
+			item->set_custom_color(0, get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 			item->set_selectable(0, false);
 		}
 	}
@@ -475,9 +475,9 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 	}
 
 	if (visible) {
-		item->set_button(0, idx, get_theme_icon("GuiVisibilityVisible", "EditorIcons"));
+		item->set_button(0, idx, get_theme_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
 	} else {
-		item->set_button(0, idx, get_theme_icon("GuiVisibilityHidden", "EditorIcons"));
+		item->set_button(0, idx, get_theme_icon(SNAME("GuiVisibilityHidden"), SNAME("EditorIcons")));
 	}
 
 	_update_visibility_color(p_node, item);
@@ -530,7 +530,7 @@ void SceneTreeEditor::_node_renamed(Node *p_node) {
 		return;
 	}
 
-	emit_signal("node_renamed");
+	emit_signal(SNAME("node_renamed"));
 
 	if (!tree_dirty) {
 		MessageQueue::get_singleton()->push_call(this, "_update_tree");
@@ -619,13 +619,13 @@ void SceneTreeEditor::_deselect_items() {
 	// Clear currently selected items in scene tree dock.
 	if (editor_selection) {
 		editor_selection->clear();
-		emit_signal("node_changed");
+		emit_signal(SNAME("node_changed"));
 	}
 }
 
 void SceneTreeEditor::_emit_node_selected() {
 	blocked++;
-	emit_signal("node_selected");
+	emit_signal(SNAME("node_selected"));
 	blocked--;
 }
 
@@ -657,7 +657,7 @@ void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_
 		selected = editor_selection->get_selected_node_list()[0];
 		_emit_node_selected();
 	} else {
-		emit_signal("node_changed");
+		emit_signal(SNAME("node_changed"));
 	}
 }
 
@@ -804,10 +804,10 @@ void SceneTreeEditor::_renamed() {
 	if (!undo_redo) {
 		n->set_name(new_name);
 		which->set_metadata(0, n->get_path());
-		emit_signal("node_renamed");
+		emit_signal(SNAME("node_renamed"));
 	} else {
 		undo_redo->create_action(TTR("Rename Node"));
-		emit_signal("node_prerename", n, new_name);
+		emit_signal(SNAME("node_prerename"), n, new_name);
 		undo_redo->add_do_method(this, "_rename_node", n->get_instance_id(), new_name);
 		undo_redo->add_undo_method(this, "_rename_node", n->get_instance_id(), n->get_name());
 		undo_redo->commit_action();
@@ -984,7 +984,7 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 	drag_data["nodes"] = objs;
 
 	tree->set_drop_mode_flags(Tree::DROP_MODE_INBETWEEN | Tree::DROP_MODE_ON_ITEM);
-	emit_signal("nodes_dragged");
+	emit_signal(SNAME("nodes_dragged"));
 
 	return drag_data;
 }
@@ -1076,7 +1076,7 @@ void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 
 	if (String(d["type"]) == "nodes") {
 		Array nodes = d["nodes"];
-		emit_signal("nodes_rearranged", nodes, np, section);
+		emit_signal(SNAME("nodes_rearranged"), nodes, np, section);
 	}
 
 	if (String(d["type"]) == "files") {
@@ -1084,9 +1084,9 @@ void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 
 		String ftype = EditorFileSystem::get_singleton()->get_file_type(files[0]);
 		if (_is_script_type(ftype)) {
-			emit_signal("script_dropped", files[0], np);
+			emit_signal(SNAME("script_dropped"), files[0], np);
 		} else {
-			emit_signal("files_dropped", files, np, section);
+			emit_signal(SNAME("files_dropped"), files, np, section);
 		}
 	}
 
@@ -1095,14 +1095,14 @@ void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 		if (se) {
 			String sp = se->get_edited_resource()->get_path();
 			if (_is_script_type(EditorFileSystem::get_singleton()->get_file_type(sp))) {
-				emit_signal("script_dropped", sp, np);
+				emit_signal(SNAME("script_dropped"), sp, np);
 			}
 		}
 	}
 }
 
 void SceneTreeEditor::_rmb_select(const Vector2 &p_pos) {
-	emit_signal("rmb_pressed", tree->get_screen_transform().xform(p_pos));
+	emit_signal(SNAME("rmb_pressed"), tree->get_screen_transform().xform(p_pos));
 }
 
 void SceneTreeEditor::update_warning() {
@@ -1237,7 +1237,7 @@ void SceneTreeDialog::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 			connect("confirmed", callable_mp(this, &SceneTreeDialog::_select));
-			filter->set_right_icon(tree->get_theme_icon("Search", "EditorIcons"));
+			filter->set_right_icon(tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			filter->set_clear_button_enabled(true);
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
@@ -1252,7 +1252,7 @@ void SceneTreeDialog::_cancel() {
 
 void SceneTreeDialog::_select() {
 	if (tree->get_selected()) {
-		emit_signal("selected", tree->get_selected()->get_path());
+		emit_signal(SNAME("selected"), tree->get_selected()->get_path());
 		hide();
 	}
 }

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -46,7 +46,7 @@ void ScriptCreateDialog::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 				String lang = ScriptServer::get_language(i)->get_type();
-				Ref<Texture2D> lang_icon = get_theme_icon(lang, "EditorIcons");
+				Ref<Texture2D> lang_icon = get_theme_icon(lang, SNAME("EditorIcons"));
 				if (lang_icon.is_valid()) {
 					language_menu->set_item_icon(i, lang_icon);
 				}
@@ -65,10 +65,10 @@ void ScriptCreateDialog::_notification(int p_what) {
 				language_menu->select(default_language);
 			}
 
-			path_button->set_icon(get_theme_icon("Folder", "EditorIcons"));
-			parent_browse_button->set_icon(get_theme_icon("Folder", "EditorIcons"));
-			parent_search_button->set_icon(get_theme_icon("ClassList", "EditorIcons"));
-			status_panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
+			path_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
+			parent_browse_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
+			parent_search_button->set_icon(get_theme_icon(SNAME("ClassList"), SNAME("EditorIcons")));
+			status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 	}
 }
@@ -326,7 +326,7 @@ void ScriptCreateDialog::_create_new() {
 		}
 	}
 
-	emit_signal("script_created", scr);
+	emit_signal(SNAME("script_created"), scr);
 	hide();
 }
 
@@ -339,7 +339,7 @@ void ScriptCreateDialog::_load_exist() {
 		return;
 	}
 
-	emit_signal("script_created", p_script);
+	emit_signal(SNAME("script_created"), p_script);
 	hide();
 }
 
@@ -448,7 +448,7 @@ void ScriptCreateDialog::_lang_changed(int l) {
 					override_info += ", ";
 				}
 			}
-			template_menu->set_item_icon(extended.id, get_theme_icon("Override", "EditorIcons"));
+			template_menu->set_item_icon(extended.id, get_theme_icon(SNAME("Override"), SNAME("EditorIcons")));
 			template_menu->get_popup()->set_item_tooltip(extended.id, override_info.as_string());
 		}
 		// Reselect last selected template
@@ -606,18 +606,18 @@ void ScriptCreateDialog::_path_submitted(const String &p_path) {
 void ScriptCreateDialog::_msg_script_valid(bool valid, const String &p_msg) {
 	error_label->set_text("- " + p_msg);
 	if (valid) {
-		error_label->add_theme_color_override("font_color", get_theme_color("success_color", "Editor"));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {
-		error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	}
 }
 
 void ScriptCreateDialog::_msg_path_valid(bool valid, const String &p_msg) {
 	path_error_label->set_text("- " + p_msg);
 	if (valid) {
-		path_error_label->add_theme_color_override("font_color", get_theme_color("success_color", "Editor"));
+		path_error_label->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {
-		path_error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
+		path_error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	}
 }
 

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -176,15 +176,15 @@ void EditorSettingsDialog::_unhandled_input(const Ref<InputEvent> &p_event) {
 }
 
 void EditorSettingsDialog::_update_icons() {
-	search_box->set_right_icon(shortcuts->get_theme_icon("Search", "EditorIcons"));
+	search_box->set_right_icon(shortcuts->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	search_box->set_clear_button_enabled(true);
-	shortcut_search_box->set_right_icon(shortcuts->get_theme_icon("Search", "EditorIcons"));
+	shortcut_search_box->set_right_icon(shortcuts->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	shortcut_search_box->set_clear_button_enabled(true);
 
-	restart_close_button->set_icon(shortcuts->get_theme_icon("Close", "EditorIcons"));
-	restart_container->add_theme_style_override("panel", shortcuts->get_theme_stylebox("bg", "Tree"));
-	restart_icon->set_texture(shortcuts->get_theme_icon("StatusWarning", "EditorIcons"));
-	restart_label->add_theme_color_override("font_color", shortcuts->get_theme_color("warning_color", "Editor"));
+	restart_close_button->set_icon(shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+	restart_container->add_theme_style_override("panel", shortcuts->get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+	restart_icon->set_texture(shortcuts->get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
+	restart_label->add_theme_color_override("font_color", shortcuts->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 }
 
 void EditorSettingsDialog::_event_config_confirmed() {
@@ -253,8 +253,8 @@ void EditorSettingsDialog::_update_shortcuts() {
 	if (collapsed.has("Common")) {
 		common_section->set_collapsed(collapsed["Common"]);
 	}
-	common_section->set_custom_bg_color(0, shortcuts->get_theme_color("prop_subsection", "Editor"));
-	common_section->set_custom_bg_color(1, shortcuts->get_theme_color("prop_subsection", "Editor"));
+	common_section->set_custom_bg_color(0, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
+	common_section->set_custom_bg_color(1, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 
 	// Get the action map for the editor, and add each item to the "Common" section.
 	OrderedHashMap<StringName, InputMap::Action> action_map = InputMap::get_singleton()->get_action_map();
@@ -303,16 +303,16 @@ void EditorSettingsDialog::_update_shortcuts() {
 		item->set_text(1, events_display_string);
 
 		if (!same_as_defaults) {
-			item->add_button(1, shortcuts->get_theme_icon("Reload", "EditorIcons"), 2);
+			item->add_button(1, shortcuts->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")), 2);
 		}
 
 		if (events_display_string == "None") {
 			// Fade out unassigned shortcut labels for easier visual grepping.
-			item->set_custom_color(1, shortcuts->get_theme_color("font_color", "Label") * Color(1, 1, 1, 0.5));
+			item->set_custom_color(1, shortcuts->get_theme_color(SNAME("font_color"), SNAME("Label")) * Color(1, 1, 1, 0.5));
 		}
 
-		item->add_button(1, shortcuts->get_theme_icon("Edit", "EditorIcons"), 0);
-		item->add_button(1, shortcuts->get_theme_icon("Close", "EditorIcons"), 1);
+		item->add_button(1, shortcuts->get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), 0);
+		item->add_button(1, shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")), 1);
 		item->set_tooltip(0, action_name);
 		item->set_tooltip(1, events_display_string);
 		item->set_metadata(0, "Common");
@@ -349,8 +349,8 @@ void EditorSettingsDialog::_update_shortcuts() {
 			}
 
 			sections[section_name] = section;
-			section->set_custom_bg_color(0, shortcuts->get_theme_color("prop_subsection", "Editor"));
-			section->set_custom_bg_color(1, shortcuts->get_theme_color("prop_subsection", "Editor"));
+			section->set_custom_bg_color(0, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
+			section->set_custom_bg_color(1, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 		}
 
 		// Don't match unassigned shortcuts when searching for assigned keys in search results.
@@ -362,16 +362,16 @@ void EditorSettingsDialog::_update_shortcuts() {
 			item->set_text(1, sc->get_as_text());
 
 			if (!sc->is_shortcut(original) && !(sc->get_shortcut().is_null() && original.is_null())) {
-				item->add_button(1, shortcuts->get_theme_icon("Reload", "EditorIcons"), 2);
+				item->add_button(1, shortcuts->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")), 2);
 			}
 
 			if (sc->get_as_text() == "None") {
 				// Fade out unassigned shortcut labels for easier visual grepping.
-				item->set_custom_color(1, shortcuts->get_theme_color("font_color", "Label") * Color(1, 1, 1, 0.5));
+				item->set_custom_color(1, shortcuts->get_theme_color(SNAME("font_color"), SNAME("Label")) * Color(1, 1, 1, 0.5));
 			}
 
-			item->add_button(1, shortcuts->get_theme_icon("Edit", "EditorIcons"), 0);
-			item->add_button(1, shortcuts->get_theme_icon("Close", "EditorIcons"), 1);
+			item->add_button(1, shortcuts->get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), 0);
+			item->add_button(1, shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")), 1);
 			item->set_tooltip(0, E->get());
 			item->set_metadata(0, E->get());
 		}
@@ -426,7 +426,7 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 
 				if (button_idx == SHORTCUT_EDIT) {
 					// If editing, add a button which can be used to add an additional event.
-					action_popup->add_icon_item(get_theme_icon("Add", "EditorIcons"), TTR("Add"));
+					action_popup->add_icon_item(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), TTR("Add"));
 				}
 
 				action_popup->set_position(get_position() + get_mouse_position());

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -66,7 +66,7 @@ class ShaderGlobalsEditorInterface : public Object {
 	GDCLASS(ShaderGlobalsEditorInterface, Object)
 
 	void _var_changed() {
-		emit_signal("var_changed");
+		emit_signal(SNAME("var_changed"));
 	}
 
 protected:
@@ -425,7 +425,7 @@ void ShaderGlobalsEditor::_variable_deleted(const String &p_variable) {
 }
 
 void ShaderGlobalsEditor::_changed() {
-	emit_signal("globals_changed");
+	emit_signal(SNAME("globals_changed"));
 	if (!interface->block_update) {
 		interface->notify_property_list_changed();
 	}

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -140,7 +140,7 @@ void CSGShape3D::_make_dirty() {
 	if (parent) {
 		parent->_make_dirty();
 	} else if (!dirty) {
-		call_deferred("_update_shape");
+		call_deferred(SNAME("_update_shape"));
 	}
 
 	dirty = true;

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -249,7 +249,7 @@ void ENetMultiplayerPeer::poll() {
 
 				connection_status = CONNECTION_CONNECTED; // If connecting, this means it connected to something!
 
-				emit_signal("peer_connected", *new_id);
+				emit_signal(SNAME("peer_connected"), *new_id);
 
 				if (server) {
 					// Do not notify other peers when server_relay is disabled.
@@ -274,7 +274,7 @@ void ENetMultiplayerPeer::poll() {
 						enet_peer_send(E->get(), SYSCH_CONFIG, packet);
 					}
 				} else {
-					emit_signal("connection_succeeded");
+					emit_signal(SNAME("connection_succeeded"));
 				}
 
 			} break;
@@ -285,7 +285,7 @@ void ENetMultiplayerPeer::poll() {
 
 				if (!id) {
 					if (!server) {
-						emit_signal("connection_failed");
+						emit_signal(SNAME("connection_failed"));
 					}
 					// Never fully connected.
 					break;
@@ -293,7 +293,7 @@ void ENetMultiplayerPeer::poll() {
 
 				if (!server) {
 					// Client just disconnected from server.
-					emit_signal("server_disconnected");
+					emit_signal(SNAME("server_disconnected"));
 					close_connection();
 					return;
 				} else if (server_relay) {
@@ -310,7 +310,7 @@ void ENetMultiplayerPeer::poll() {
 					}
 				}
 
-				emit_signal("peer_disconnected", *id);
+				emit_signal(SNAME("peer_disconnected"), *id);
 				peer_map.erase(*id);
 				memdelete(id);
 			} break;
@@ -328,12 +328,12 @@ void ENetMultiplayerPeer::poll() {
 					switch (msg) {
 						case SYSMSG_ADD_PEER: {
 							peer_map[id] = nullptr;
-							emit_signal("peer_connected", id);
+							emit_signal(SNAME("peer_connected"), id);
 
 						} break;
 						case SYSMSG_REMOVE_PEER: {
 							peer_map.erase(id);
-							emit_signal("peer_disconnected", id);
+							emit_signal(SNAME("peer_disconnected"), id);
 						} break;
 					}
 
@@ -491,7 +491,7 @@ void ENetMultiplayerPeer::disconnect_peer(int p_peer, bool now) {
 			memdelete(id);
 		}
 
-		emit_signal("peer_disconnected", p_peer);
+		emit_signal(SNAME("peer_disconnected"), p_peer);
 		peer_map.erase(p_peer);
 	} else {
 		enet_peer_disconnect_later(peer_map[p_peer], 0);

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -74,9 +74,9 @@ void GDNativeLibraryEditor::_update_tree() {
 		platform->set_text(0, E->get().name);
 		platform->set_metadata(0, E->get().library_extension);
 
-		platform->set_custom_bg_color(0, get_theme_color("prop_category", "Editor"));
-		platform->set_custom_bg_color(1, get_theme_color("prop_category", "Editor"));
-		platform->set_custom_bg_color(2, get_theme_color("prop_category", "Editor"));
+		platform->set_custom_bg_color(0, get_theme_color(SNAME("prop_category"), SNAME("Editor")));
+		platform->set_custom_bg_color(1, get_theme_color(SNAME("prop_category"), SNAME("Editor")));
+		platform->set_custom_bg_color(2, get_theme_color(SNAME("prop_category"), SNAME("Editor")));
 		platform->set_selectable(0, false);
 		platform->set_expand_right(0, true);
 
@@ -87,31 +87,31 @@ void GDNativeLibraryEditor::_update_tree() {
 			bit->set_text(0, it->get());
 			bit->set_metadata(0, target);
 			bit->set_selectable(0, false);
-			bit->set_custom_bg_color(0, get_theme_color("prop_subsection", "Editor"));
+			bit->set_custom_bg_color(0, get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 
-			bit->add_button(1, get_theme_icon("Folder", "EditorIcons"), BUTTON_SELECT_LIBRARY, false, TTR("Select the dynamic library for this entry"));
+			bit->add_button(1, get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), BUTTON_SELECT_LIBRARY, false, TTR("Select the dynamic library for this entry"));
 			String file = entry_configs[target].library;
 			if (!file.is_empty()) {
-				bit->add_button(1, get_theme_icon("Clear", "EditorIcons"), BUTTON_CLEAR_LIBRARY, false, TTR("Clear"));
+				bit->add_button(1, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), BUTTON_CLEAR_LIBRARY, false, TTR("Clear"));
 			}
 			bit->set_text(1, file);
 
-			bit->add_button(2, get_theme_icon("Folder", "EditorIcons"), BUTTON_SELECT_DEPENDENCES, false, TTR("Select dependencies of the library for this entry"));
+			bit->add_button(2, get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), BUTTON_SELECT_DEPENDENCES, false, TTR("Select dependencies of the library for this entry"));
 			Array files = entry_configs[target].dependencies;
 			if (files.size()) {
-				bit->add_button(2, get_theme_icon("Clear", "EditorIcons"), BUTTON_CLEAR_DEPENDENCES, false, TTR("Clear"));
+				bit->add_button(2, get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), BUTTON_CLEAR_DEPENDENCES, false, TTR("Clear"));
 			}
 			bit->set_text(2, Variant(files));
 
-			bit->add_button(3, get_theme_icon("MoveUp", "EditorIcons"), BUTTON_MOVE_UP, false, TTR("Move Up"));
-			bit->add_button(3, get_theme_icon("MoveDown", "EditorIcons"), BUTTON_MOVE_DOWN, false, TTR("Move Down"));
-			bit->add_button(3, get_theme_icon("Remove", "EditorIcons"), BUTTON_ERASE_ENTRY, false, TTR("Remove current entry"));
+			bit->add_button(3, get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")), BUTTON_MOVE_UP, false, TTR("Move Up"));
+			bit->add_button(3, get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")), BUTTON_MOVE_DOWN, false, TTR("Move Down"));
+			bit->add_button(3, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_ERASE_ENTRY, false, TTR("Remove current entry"));
 		}
 
 		TreeItem *new_arch = tree->create_item(platform);
 		new_arch->set_text(0, TTR("Double click to create a new entry"));
 		new_arch->set_text_align(0, TreeItem::ALIGN_CENTER);
-		new_arch->set_custom_color(0, get_theme_color("accent_color", "Editor"));
+		new_arch->set_custom_color(0, get_theme_color(SNAME("accent_color"), SNAME("Editor")));
 		new_arch->set_expand_right(0, true);
 		new_arch->set_metadata(1, E->key());
 

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -448,7 +448,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	color_regions.clear();
 	color_region_cache.clear();
 
-	font_color = text_edit->get_theme_color("font_color");
+	font_color = text_edit->get_theme_color(SNAME("font_color"));
 	symbol_color = EDITOR_GET("text_editor/highlighting/symbol_color");
 	function_color = EDITOR_GET("text_editor/highlighting/function_color");
 	number_color = EDITOR_GET("text_editor/highlighting/number_color");

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -262,9 +262,9 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 
 	if (completed) {
 		if (first_state.is_valid()) {
-			first_state->emit_signal("completed", ret);
+			first_state->emit_signal(SNAME("completed"), ret);
 		} else {
-			emit_signal("completed", ret);
+			emit_signal(SNAME("completed"), ret);
 		}
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -373,7 +373,7 @@ Variant GDScriptTextDocument::declaration(const Dictionary &p_params) {
 					id = "class_global:" + symbol->native_class + ":" + symbol->name;
 					break;
 			}
-			call_deferred("show_native_symbol_in_editor", id);
+			call_deferred(SNAME("show_native_symbol_in_editor"), id);
 		} else {
 			notify_client_show_symbol(symbol);
 		}
@@ -410,7 +410,7 @@ void GDScriptTextDocument::sync_script_content(const String &p_path, const Strin
 }
 
 void GDScriptTextDocument::show_native_symbol_in_editor(const String &p_symbol_id) {
-	ScriptEditor::get_singleton()->call_deferred("_help_class_goto", p_symbol_id);
+	ScriptEditor::get_singleton()->call_deferred(SNAME("_help_class_goto"), p_symbol_id);
 
 	DisplayServer::get_singleton()->window_move_to_foreground();
 }

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -221,7 +221,7 @@ void GridMap::set_cell_size(const Vector3 &p_size) {
 	ERR_FAIL_COND(p_size.x < 0.001 || p_size.y < 0.001 || p_size.z < 0.001);
 	cell_size = p_size;
 	_recreate_octant_data();
-	emit_signal("cell_size_changed", cell_size);
+	emit_signal(SNAME("cell_size_changed"), cell_size);
 }
 
 Vector3 GridMap::get_cell_size() const {

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1077,8 +1077,8 @@ void GridMapEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			options->set_icon(get_theme_icon("GridMap", "EditorIcons"));
-			search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+			options->set_icon(get_theme_icon(SNAME("GridMap"), SNAME("EditorIcons")));
+			search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 		} break;
 
 		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
@@ -1239,7 +1239,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	mode_thumbnail->set_flat(true);
 	mode_thumbnail->set_toggle_mode(true);
 	mode_thumbnail->set_pressed(true);
-	mode_thumbnail->set_icon(p_editor->get_gui_base()->get_theme_icon("FileThumbnail", "EditorIcons"));
+	mode_thumbnail->set_icon(p_editor->get_gui_base()->get_theme_icon(SNAME("FileThumbnail"), SNAME("EditorIcons")));
 	hb->add_child(mode_thumbnail);
 	mode_thumbnail->connect("pressed", callable_mp(this, &GridMapEditor::_set_display_mode), varray(DISPLAY_THUMBNAIL));
 
@@ -1247,7 +1247,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	mode_list->set_flat(true);
 	mode_list->set_toggle_mode(true);
 	mode_list->set_pressed(false);
-	mode_list->set_icon(p_editor->get_gui_base()->get_theme_icon("FileList", "EditorIcons"));
+	mode_list->set_icon(p_editor->get_gui_base()->get_theme_icon(SNAME("FileList"), SNAME("EditorIcons")));
 	hb->add_child(mode_list);
 	mode_list->connect("pressed", callable_mp(this, &GridMapEditor::_set_display_mode), varray(DISPLAY_LIST));
 

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -241,7 +241,7 @@ MonoBoolean godot_icall_Internal_IsAssembliesReloadingNeeded() {
 
 void godot_icall_Internal_ReloadAssemblies(MonoBoolean p_soft_reload) {
 #ifdef GD_MONO_HOT_RELOAD
-	_GodotSharp::get_singleton()->call_deferred("_reload_assemblies", (bool)p_soft_reload);
+	_GodotSharp::get_singleton()->call_deferred(SNAME("_reload_assemblies"), (bool)p_soft_reload);
 #endif
 }
 

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -536,7 +536,7 @@ void GodotNavigationServer::process(real_t p_delta_time) {
 		// Emit a signal if a map changed.
 		const uint32_t new_map_update_id = active_maps[i]->get_map_update_id();
 		if (new_map_update_id != active_maps_update_id[i]) {
-			emit_signal("map_changed", active_maps[i]->get_self());
+			emit_signal(SNAME("map_changed"), active_maps[i]->get_self());
 			active_maps_update_id[i] = new_map_update_id;
 		}
 	}

--- a/modules/navigation/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/navigation_mesh_editor_plugin.cpp
@@ -47,8 +47,8 @@ void NavigationMeshEditor::_node_removed(Node *p_node) {
 
 void NavigationMeshEditor::_notification(int p_option) {
 	if (p_option == NOTIFICATION_ENTER_TREE) {
-		button_bake->set_icon(get_theme_icon("Bake", "EditorIcons"));
-		button_reset->set_icon(get_theme_icon("Reload", "EditorIcons"));
+		button_bake->set_icon(get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+		button_reset->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 	}
 }
 

--- a/modules/opensimplex/noise_texture.cpp
+++ b/modules/opensimplex/noise_texture.cpp
@@ -109,7 +109,7 @@ void NoiseTexture::_thread_done(const Ref<Image> &p_image) {
 
 void NoiseTexture::_thread_function(void *p_ud) {
 	NoiseTexture *tex = (NoiseTexture *)p_ud;
-	tex->call_deferred("_thread_done", tex->_generate_texture());
+	tex->call_deferred(SNAME("_thread_done"), tex->_generate_texture());
 }
 
 void NoiseTexture::_queue_update() {
@@ -118,7 +118,7 @@ void NoiseTexture::_queue_update() {
 	}
 
 	update_queued = true;
-	call_deferred("_update_texture");
+	call_deferred(SNAME("_update_texture"));
 }
 
 Ref<Image> NoiseTexture::_generate_texture() {

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -46,7 +46,7 @@ bool VisualScriptNode::is_breakpoint() const {
 }
 
 void VisualScriptNode::ports_changed_notify() {
-	emit_signal("ports_changed");
+	emit_signal(SNAME("ports_changed"));
 }
 
 void VisualScriptNode::set_default_input_value(int p_port, const Variant &p_value) {
@@ -264,7 +264,7 @@ void VisualScript::_node_ports_changed(int p_id) {
 
 #ifdef TOOLS_ENABLED
 	set_edited(true); // Something changed, let's set as edited.
-	emit_signal("node_ports_changed", p_id);
+	emit_signal(SNAME("node_ports_changed"), p_id);
 #endif
 }
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -62,7 +62,7 @@ protected:
 
 	void _sig_changed() {
 		notify_property_list_changed();
-		emit_signal("changed");
+		emit_signal(SNAME("changed"));
 	}
 
 	bool _set(const StringName &p_name, const Variant &p_value) {
@@ -196,10 +196,10 @@ protected:
 
 	void _var_changed() {
 		notify_property_list_changed();
-		emit_signal("changed");
+		emit_signal(SNAME("changed"));
 	}
 	void _var_value_changed() {
-		emit_signal("changed");
+		emit_signal(SNAME("changed"));
 	}
 
 	bool _set(const StringName &p_name, const Variant &p_value) {
@@ -611,41 +611,41 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 	select_func_text->hide();
 
 	Ref<Texture2D> type_icons[Variant::VARIANT_MAX] = {
-		Control::get_theme_icon("Variant", "EditorIcons"),
-		Control::get_theme_icon("bool", "EditorIcons"),
-		Control::get_theme_icon("int", "EditorIcons"),
-		Control::get_theme_icon("float", "EditorIcons"),
-		Control::get_theme_icon("String", "EditorIcons"),
-		Control::get_theme_icon("Vector2", "EditorIcons"),
-		Control::get_theme_icon("Vector2i", "EditorIcons"),
-		Control::get_theme_icon("Rect2", "EditorIcons"),
-		Control::get_theme_icon("Rect2i", "EditorIcons"),
-		Control::get_theme_icon("Vector3", "EditorIcons"),
-		Control::get_theme_icon("Vector3i", "EditorIcons"),
-		Control::get_theme_icon("Transform2D", "EditorIcons"),
-		Control::get_theme_icon("Plane", "EditorIcons"),
-		Control::get_theme_icon("Quaternion", "EditorIcons"),
-		Control::get_theme_icon("AABB", "EditorIcons"),
-		Control::get_theme_icon("Basis", "EditorIcons"),
-		Control::get_theme_icon("Transform3D", "EditorIcons"),
-		Control::get_theme_icon("Color", "EditorIcons"),
-		Control::get_theme_icon("NodePath", "EditorIcons"),
-		Control::get_theme_icon("RID", "EditorIcons"),
-		Control::get_theme_icon("MiniObject", "EditorIcons"),
-		Control::get_theme_icon("Callable", "EditorIcons"),
-		Control::get_theme_icon("Signal", "EditorIcons"),
-		Control::get_theme_icon("Dictionary", "EditorIcons"),
-		Control::get_theme_icon("Array", "EditorIcons"),
-		Control::get_theme_icon("PackedByteArray", "EditorIcons"),
-		Control::get_theme_icon("PackedInt32Array", "EditorIcons"),
-		Control::get_theme_icon("PackedFloat32Array", "EditorIcons"),
-		Control::get_theme_icon("PackedStringArray", "EditorIcons"),
-		Control::get_theme_icon("PackedVector2Array", "EditorIcons"),
-		Control::get_theme_icon("PackedVector3Array", "EditorIcons"),
-		Control::get_theme_icon("PackedColorArray", "EditorIcons")
+		Control::get_theme_icon(SNAME("Variant"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("String"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Vector2i"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Rect2"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Rect2i"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Vector3i"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Transform2D"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Plane"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Quaternion"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("AABB"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Basis"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("NodePath"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("RID"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("MiniObject"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Callable"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Signal"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Dictionary"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedByteArray"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedInt32Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedFloat32Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedStringArray"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedVector2Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedVector3Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedColorArray"), SNAME("EditorIcons"))
 	};
 
-	Ref<Texture2D> seq_port = Control::get_theme_icon("VisualShaderPort", "EditorIcons");
+	Ref<Texture2D> seq_port = Control::get_theme_icon(SNAME("VisualShaderPort"), SNAME("EditorIcons"));
 	List<int> node_ids;
 	script->get_node_list(&node_ids);
 
@@ -711,7 +711,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			LineEdit *line_edit = memnew(LineEdit);
 			line_edit->set_text(node->get_text());
 			line_edit->set_expand_to_text_length_enabled(true);
-			line_edit->add_theme_font_override("font", get_theme_font("source", "EditorFonts"));
+			line_edit->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
 			gnode->add_child(line_edit);
 			line_edit->connect("text_changed", callable_mp(this, &VisualScriptEditor::_expression_text_changed), varray(E->get()));
 		} else {
@@ -735,7 +735,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 		if (node_styles.has(node->get_category())) {
 			Ref<StyleBoxFlat> sbf = node_styles[node->get_category()];
 			if (gnode->is_comment()) {
-				sbf = EditorNode::get_singleton()->get_theme_base()->get_theme()->get_stylebox("comment", "GraphNode");
+				sbf = EditorNode::get_singleton()->get_theme_base()->get_theme()->get_stylebox(SNAME("comment"), SNAME("GraphNode"));
 			}
 
 			Color c = sbf->get_border_color();
@@ -748,7 +748,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			gnode->add_theme_style_override("frame", sbf);
 		}
 
-		const Color mono_color = get_theme_color("mono_color", "Editor");
+		const Color mono_color = get_theme_color(SNAME("mono_color"), SNAME("Editor"));
 
 		int slot_idx = 0;
 
@@ -850,7 +850,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					}
 
 					Button *rmbtn = memnew(Button);
-					rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Remove", "EditorIcons"));
+					rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					hbc->add_child(rmbtn);
 					rmbtn->connect("pressed", callable_mp(this, &VisualScriptEditor::_remove_input_port), varray(E->get(), i), CONNECT_DEFERRED);
 				} else {
@@ -906,7 +906,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			if (right_ok) {
 				if (is_vslist) {
 					Button *rmbtn = memnew(Button);
-					rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Remove", "EditorIcons"));
+					rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					hbc->add_child(rmbtn);
 					rmbtn->connect("pressed", callable_mp(this, &VisualScriptEditor::_remove_output_port), varray(E->get(), i), CONNECT_DEFERRED);
 
@@ -950,7 +950,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 			gnode->add_child(vbc);
 
-			bool dark_theme = get_theme_constant("dark_theme", "Editor");
+			bool dark_theme = get_theme_constant(SNAME("dark_theme"), SNAME("Editor"));
 			if (i < mixed_seq_ports) {
 				gnode->set_slot(slot_idx, left_ok, left_type, _color_from_type(left_type, dark_theme), true, TYPE_SEQUENCE, mono_color, Ref<Texture2D>(), seq_port);
 			} else {
@@ -973,7 +973,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 	graph->set_minimap_opacity(graph_minimap_opacity);
 
 	// Use default_func instead of default_func for now I think that should be good stop gap solution to ensure not breaking anything.
-	graph->call_deferred("set_scroll_ofs", script->get_scroll() * EDSCALE);
+	graph->call_deferred(SNAME("set_scroll_ofs"), script->get_scroll() * EDSCALE);
 	updating_graph = false;
 }
 
@@ -1037,9 +1037,9 @@ void VisualScriptEditor::_update_members() {
 	TreeItem *functions = members->create_item(root);
 	functions->set_selectable(0, false);
 	functions->set_text(0, TTR("Functions:"));
-	functions->add_button(0, Control::get_theme_icon("Override", "EditorIcons"), 1, false, TTR("Override an existing built-in function."));
-	functions->add_button(0, Control::get_theme_icon("Add", "EditorIcons"), 0, false, TTR("Create a new function."));
-	functions->set_custom_color(0, Control::get_theme_color("mono_color", "Editor"));
+	functions->add_button(0, Control::get_theme_icon(SNAME("Override"), SNAME("EditorIcons")), 1, false, TTR("Override an existing built-in function."));
+	functions->add_button(0, Control::get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), 0, false, TTR("Create a new function."));
+	functions->set_custom_color(0, Control::get_theme_color(SNAME("mono_color"), SNAME("Editor")));
 
 	List<StringName> func_names;
 	script->get_function_list(&func_names);
@@ -1049,7 +1049,7 @@ void VisualScriptEditor::_update_members() {
 		ti->set_text(0, E->get());
 		ti->set_selectable(0, true);
 		ti->set_metadata(0, E->get());
-		ti->add_button(0, Control::get_theme_icon("Edit", "EditorIcons"), 0);
+		ti->add_button(0, Control::get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), 0);
 		if (selected == E->get()) {
 			ti->select(0);
 		}
@@ -1058,42 +1058,42 @@ void VisualScriptEditor::_update_members() {
 	TreeItem *variables = members->create_item(root);
 	variables->set_selectable(0, false);
 	variables->set_text(0, TTR("Variables:"));
-	variables->add_button(0, Control::get_theme_icon("Add", "EditorIcons"), -1, false, TTR("Create a new variable."));
-	variables->set_custom_color(0, Control::get_theme_color("mono_color", "Editor"));
+	variables->add_button(0, Control::get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), -1, false, TTR("Create a new variable."));
+	variables->set_custom_color(0, Control::get_theme_color(SNAME("mono_color"), SNAME("Editor")));
 
 	Ref<Texture2D> type_icons[Variant::VARIANT_MAX] = {
-		Control::get_theme_icon("Variant", "EditorIcons"),
-		Control::get_theme_icon("bool", "EditorIcons"),
-		Control::get_theme_icon("int", "EditorIcons"),
-		Control::get_theme_icon("float", "EditorIcons"),
-		Control::get_theme_icon("String", "EditorIcons"),
-		Control::get_theme_icon("Vector2", "EditorIcons"),
-		Control::get_theme_icon("Vector2i", "EditorIcons"),
-		Control::get_theme_icon("Rect2", "EditorIcons"),
-		Control::get_theme_icon("Rect2i", "EditorIcons"),
-		Control::get_theme_icon("Vector3", "EditorIcons"),
-		Control::get_theme_icon("Vector3i", "EditorIcons"),
-		Control::get_theme_icon("Transform2D", "EditorIcons"),
-		Control::get_theme_icon("Plane", "EditorIcons"),
-		Control::get_theme_icon("Quaternion", "EditorIcons"),
-		Control::get_theme_icon("AABB", "EditorIcons"),
-		Control::get_theme_icon("Basis", "EditorIcons"),
-		Control::get_theme_icon("Transform3D", "EditorIcons"),
-		Control::get_theme_icon("Color", "EditorIcons"),
-		Control::get_theme_icon("NodePath", "EditorIcons"),
-		Control::get_theme_icon("RID", "EditorIcons"),
-		Control::get_theme_icon("MiniObject", "EditorIcons"),
-		Control::get_theme_icon("Callable", "EditorIcons"),
-		Control::get_theme_icon("Signal", "EditorIcons"),
-		Control::get_theme_icon("Dictionary", "EditorIcons"),
-		Control::get_theme_icon("Array", "EditorIcons"),
-		Control::get_theme_icon("PackedByteArray", "EditorIcons"),
-		Control::get_theme_icon("PackedInt32Array", "EditorIcons"),
-		Control::get_theme_icon("PackedFloat32Array", "EditorIcons"),
-		Control::get_theme_icon("PackedStringArray", "EditorIcons"),
-		Control::get_theme_icon("PackedVector2Array", "EditorIcons"),
-		Control::get_theme_icon("PackedVector3Array", "EditorIcons"),
-		Control::get_theme_icon("PackedColorArray", "EditorIcons")
+		Control::get_theme_icon(SNAME("Variant"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("String"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Vector2i"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Rect2"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Rect2i"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Vector3i"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Transform2D"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Plane"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Quaternion"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("AABB"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Basis"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("NodePath"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("RID"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("MiniObject"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Callable"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Signal"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Dictionary"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedByteArray"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedInt32Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedFloat32Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedStringArray"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedVector2Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedVector3Array"), SNAME("EditorIcons")),
+		Control::get_theme_icon(SNAME("PackedColorArray"), SNAME("EditorIcons"))
 	};
 
 	List<StringName> var_names;
@@ -1117,8 +1117,8 @@ void VisualScriptEditor::_update_members() {
 	TreeItem *_signals = members->create_item(root);
 	_signals->set_selectable(0, false);
 	_signals->set_text(0, TTR("Signals:"));
-	_signals->add_button(0, Control::get_theme_icon("Add", "EditorIcons"), -1, false, TTR("Create a new signal."));
-	_signals->set_custom_color(0, Control::get_theme_color("mono_color", "Editor"));
+	_signals->add_button(0, Control::get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), -1, false, TTR("Create a new signal."));
+	_signals->set_custom_color(0, Control::get_theme_color(SNAME("mono_color"), SNAME("Editor")));
 
 	List<StringName> signal_names;
 	script->get_custom_signal_list(&signal_names);
@@ -1135,12 +1135,12 @@ void VisualScriptEditor::_update_members() {
 
 	String base_type = script->get_instance_base_type();
 	String icon_type = base_type;
-	if (!Control::has_theme_icon(base_type, "EditorIcons")) {
+	if (!Control::has_theme_icon(base_type, SNAME("EditorIcons"))) {
 		icon_type = "Object";
 	}
 
 	base_type_select->set_text(base_type);
-	base_type_select->set_icon(Control::get_theme_icon(icon_type, "EditorIcons"));
+	base_type_select->set_icon(Control::get_theme_icon(icon_type, SNAME("EditorIcons")));
 
 	updating_members = false;
 }
@@ -1366,7 +1366,7 @@ void VisualScriptEditor::_add_func_input() {
 	hbox->add_child(type_box);
 
 	Button *delete_button = memnew(Button);
-	delete_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Remove", "EditorIcons"));
+	delete_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 	delete_button->set_tooltip(vformat(TTR("Delete input port")));
 	hbox->add_child(delete_button);
 
@@ -2401,7 +2401,7 @@ void VisualScriptEditor::_draw_color_over_button(Object *obj, Color p_color) {
 		return;
 	}
 
-	Ref<StyleBox> normal = get_theme_stylebox("normal", "Button");
+	Ref<StyleBox> normal = get_theme_stylebox(SNAME("normal"), SNAME("Button"));
 	button->draw_rect(Rect2(normal->get_offset(), button->get_size() - normal->get_minimum_size()), p_color);
 }
 
@@ -2447,7 +2447,7 @@ void VisualScriptEditor::set_edited_resource(const RES &p_res) {
 	script->connect("node_ports_changed", callable_mp(this, &VisualScriptEditor::_node_ports_changed));
 
 	_update_graph();
-	call_deferred("_update_members");
+	call_deferred(SNAME("_update_members"));
 }
 
 void VisualScriptEditor::enable_editor() {
@@ -2481,7 +2481,7 @@ String VisualScriptEditor::get_name() {
 }
 
 Ref<Texture2D> VisualScriptEditor::get_theme_icon() {
-	return Control::get_theme_icon("VisualScript", "EditorIcons");
+	return Control::get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons"));
 }
 
 bool VisualScriptEditor::is_unsaved() {
@@ -2556,7 +2556,7 @@ void VisualScriptEditor::goto_line(int p_line, bool p_with_error) {
 			_update_graph();
 			_update_members();
 
-			call_deferred("call_deferred", "_center_on_node", E->get(), p_line); //editor might be just created and size might not exist yet
+			call_deferred(SNAME("call_deferred"), "_center_on_node", E->get(), p_line); //editor might be just created and size might not exist yet
 			return;
 		}
 	}
@@ -3547,9 +3547,9 @@ void VisualScriptEditor::_notification(int p_what) {
 				return;
 			}
 
-			edit_variable_edit->add_theme_style_override("bg", get_theme_stylebox("bg", "Tree"));
-			edit_signal_edit->add_theme_style_override("bg", get_theme_stylebox("bg", "Tree"));
-			func_input_scroll->add_theme_style_override("bg", get_theme_stylebox("bg", "Tree"));
+			edit_variable_edit->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			edit_signal_edit->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			func_input_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 
 			Ref<Theme> tm = EditorNode::get_singleton()->get_theme_base()->get_theme();
 
@@ -3572,7 +3572,7 @@ void VisualScriptEditor::_notification(int p_what) {
 			}
 
 			for (Map<StringName, Color>::Element *E = node_colors.front(); E; E = E->next()) {
-				const Ref<StyleBoxFlat> sb = tm->get_stylebox("frame", "GraphNode");
+				const Ref<StyleBoxFlat> sb = tm->get_stylebox(SNAME("frame"), SNAME("GraphNode"));
 
 				if (!sb.is_null()) {
 					Ref<StyleBoxFlat> frame_style = sb->duplicate();
@@ -4052,9 +4052,9 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 
 	TreeItem *root = members->get_root();
 
-	Ref<Texture2D> del_icon = Control::get_theme_icon("Remove", "EditorIcons");
+	Ref<Texture2D> del_icon = Control::get_theme_icon(SNAME("Remove"), SNAME("EditorIcons"));
 
-	Ref<Texture2D> edit_icon = Control::get_theme_icon("Edit", "EditorIcons");
+	Ref<Texture2D> edit_icon = Control::get_theme_icon(SNAME("Edit"), SNAME("EditorIcons"));
 
 	if (ti->get_parent() == root->get_first_child()) {
 		member_type = MEMBER_FUNCTION;
@@ -4223,7 +4223,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	members_section = memnew(VBoxContainer);
 	// Add but wait until done setting up this.
-	ScriptEditor::get_singleton()->get_left_list_split()->call_deferred("add_child", members_section);
+	ScriptEditor::get_singleton()->get_left_list_split()->call_deferred(SNAME("add_child"), members_section);
 	members_section->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	CheckButton *tool_script_check = memnew(CheckButton);
@@ -4489,14 +4489,14 @@ void _VisualScriptEditor::add_custom_node(const String &p_name, const String &p_
 	String node_name = "custom/" + p_category + "/" + p_name;
 	custom_nodes.insert(node_name, p_script);
 	VisualScriptLanguage::singleton->add_register_func(node_name, &_VisualScriptEditor::create_node_custom);
-	emit_signal("custom_nodes_updated");
+	emit_signal(SNAME("custom_nodes_updated"));
 }
 
 void _VisualScriptEditor::remove_custom_node(const String &p_name, const String &p_category) {
 	String node_name = "custom/" + p_category + "/" + p_name;
 	custom_nodes.erase(node_name);
 	VisualScriptLanguage::singleton->remove_register_func(node_name);
-	emit_signal("custom_nodes_updated");
+	emit_signal(SNAME("custom_nodes_updated"));
 }
 
 void _VisualScriptEditor::_bind_methods() {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2987,7 +2987,7 @@ VisualScriptNodeInstance *VisualScriptCustomNode::instantiate(VisualScriptInstan
 }
 
 void VisualScriptCustomNode::_script_changed() {
-	call_deferred("ports_changed_notify");
+	call_deferred(SNAME("ports_changed_notify"));
 }
 
 void VisualScriptCustomNode::_bind_methods() {

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -98,35 +98,35 @@ void VisualScriptPropertySelector::_update_search() {
 		List<PropertyInfo> props;
 		TreeItem *category = nullptr;
 		Ref<Texture2D> type_icons[Variant::VARIANT_MAX] = {
-			vbc->get_theme_icon("Variant", "EditorIcons"),
-			vbc->get_theme_icon("bool", "EditorIcons"),
-			vbc->get_theme_icon("int", "EditorIcons"),
-			vbc->get_theme_icon("float", "EditorIcons"),
-			vbc->get_theme_icon("String", "EditorIcons"),
-			vbc->get_theme_icon("Vector2", "EditorIcons"),
-			vbc->get_theme_icon("Rect2", "EditorIcons"),
-			vbc->get_theme_icon("Vector3", "EditorIcons"),
-			vbc->get_theme_icon("Transform2D", "EditorIcons"),
-			vbc->get_theme_icon("Plane", "EditorIcons"),
-			vbc->get_theme_icon("Quaternion", "EditorIcons"),
-			vbc->get_theme_icon("AABB", "EditorIcons"),
-			vbc->get_theme_icon("Basis", "EditorIcons"),
-			vbc->get_theme_icon("Transform3D", "EditorIcons"),
-			vbc->get_theme_icon("Color", "EditorIcons"),
-			vbc->get_theme_icon("Path", "EditorIcons"),
-			vbc->get_theme_icon("RID", "EditorIcons"),
-			vbc->get_theme_icon("Object", "EditorIcons"),
-			vbc->get_theme_icon("Dictionary", "EditorIcons"),
-			vbc->get_theme_icon("Array", "EditorIcons"),
-			vbc->get_theme_icon("PackedByteArray", "EditorIcons"),
-			vbc->get_theme_icon("PackedInt32Array", "EditorIcons"),
-			vbc->get_theme_icon("PackedFloat32Array", "EditorIcons"),
-			vbc->get_theme_icon("PackedInt64Array", "EditorIcons"),
-			vbc->get_theme_icon("PackedFloat64Array", "EditorIcons"),
-			vbc->get_theme_icon("PackedStringArray", "EditorIcons"),
-			vbc->get_theme_icon("PackedVector2Array", "EditorIcons"),
-			vbc->get_theme_icon("PackedVector3Array", "EditorIcons"),
-			vbc->get_theme_icon("PackedColorArray", "EditorIcons")
+			vbc->get_theme_icon(SNAME("Variant"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("String"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Rect2"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Transform2D"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Plane"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Quaternion"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("AABB"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Basis"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Path"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("RID"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Object"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Dictionary"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("Array"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("PackedByteArray"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("PackedInt32Array"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("PackedFloat32Array"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("PackedInt64Array"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("PackedFloat64Array"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("PackedStringArray"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("PackedVector2Array"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("PackedVector3Array"), SNAME("EditorIcons")),
+			vbc->get_theme_icon(SNAME("PackedColorArray"), SNAME("EditorIcons"))
 		};
 		{
 			String b = String(E->get());
@@ -253,7 +253,7 @@ void VisualScriptPropertySelector::_update_search() {
 
 			TreeItem *item = search_options->create_item(category ? category : root);
 			item->set_text(0, desc);
-			item->set_icon(0, vbc->get_theme_icon("MemberMethod", "EditorIcons"));
+			item->set_icon(0, vbc->get_theme_icon(SNAME("MemberMethod"), SNAME("EditorIcons")));
 			item->set_metadata(0, name);
 			item->set_selectable(0, true);
 
@@ -317,7 +317,7 @@ void VisualScriptPropertySelector::create_visualscript_item(const String &name, 
 	if (search_input == String() || text.findn(search_input) != -1) {
 		TreeItem *item = search_options->create_item(root);
 		item->set_text(0, text);
-		item->set_icon(0, vbc->get_theme_icon("VisualScript", "EditorIcons"));
+		item->set_icon(0, vbc->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
 		item->set_metadata(0, name);
 		item->set_metadata(1, "action");
 		item->set_selectable(0, true);
@@ -401,7 +401,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 		}
 
 		item->set_text(0, type_name + String("").join(desc));
-		item->set_icon(0, vbc->get_theme_icon("VisualScript", "EditorIcons"));
+		item->set_icon(0, vbc->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
 		item->set_selectable(0, true);
 		item->set_metadata(0, E->get());
 		item->set_selectable(0, true);
@@ -417,7 +417,7 @@ void VisualScriptPropertySelector::_confirmed() {
 	if (!ti) {
 		return;
 	}
-	emit_signal("selected", ti->get_metadata(0), ti->get_metadata(1), ti->get_metadata(2));
+	emit_signal(SNAME("selected"), ti->get_metadata(0), ti->get_metadata(1), ti->get_metadata(2));
 	set_visible(false);
 }
 

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -123,19 +123,19 @@ void WebRTCMultiplayerPeer::poll() {
 		// Already connected to server: simply notify new peer.
 		// NOTE: Mesh is always connected.
 		if (connection_status == CONNECTION_CONNECTED) {
-			emit_signal("peer_connected", E->get());
+			emit_signal(SNAME("peer_connected"), E->get());
 		}
 
 		// Server emulation mode suppresses peer_conencted until server connects.
 		if (server_compat && E->get() == TARGET_PEER_SERVER) {
 			// Server connected.
 			connection_status = CONNECTION_CONNECTED;
-			emit_signal("peer_connected", TARGET_PEER_SERVER);
-			emit_signal("connection_succeeded");
+			emit_signal(SNAME("peer_connected"), TARGET_PEER_SERVER);
+			emit_signal(SNAME("connection_succeeded"));
 			// Notify of all previously connected peers
 			for (Map<int, Ref<ConnectedPeer>>::Element *F = peer_map.front(); F; F = F->next()) {
 				if (F->key() != 1 && F->get()->connected) {
-					emit_signal("peer_connected", F->key());
+					emit_signal(SNAME("peer_connected"), F->key());
 				}
 			}
 			break; // Because we already notified of all newly added peers.
@@ -283,9 +283,9 @@ void WebRTCMultiplayerPeer::remove_peer(int p_peer_id) {
 	peer_map.erase(p_peer_id);
 	if (peer->connected) {
 		peer->connected = false;
-		emit_signal("peer_disconnected", p_peer_id);
+		emit_signal(SNAME("peer_disconnected"), p_peer_id);
 		if (server_compat && p_peer_id == TARGET_PEER_SERVER) {
-			emit_signal("server_disconnected");
+			emit_signal(SNAME("server_disconnected"));
 			connection_status = CONNECTION_DISCONNECTED;
 		}
 	}

--- a/modules/webrtc/webrtc_peer_connection_js.cpp
+++ b/modules/webrtc/webrtc_peer_connection_js.cpp
@@ -38,12 +38,12 @@
 
 void WebRTCPeerConnectionJS::_on_ice_candidate(void *p_obj, const char *p_mid_name, int p_mline_idx, const char *p_candidate) {
 	WebRTCPeerConnectionJS *peer = static_cast<WebRTCPeerConnectionJS *>(p_obj);
-	peer->emit_signal("ice_candidate_created", String(p_mid_name), p_mline_idx, String(p_candidate));
+	peer->emit_signal(SNAME("ice_candidate_created"), String(p_mid_name), p_mline_idx, String(p_candidate));
 }
 
 void WebRTCPeerConnectionJS::_on_session_created(void *p_obj, const char *p_type, const char *p_session) {
 	WebRTCPeerConnectionJS *peer = static_cast<WebRTCPeerConnectionJS *>(p_obj);
-	peer->emit_signal("session_description_created", String(p_type), String(p_session));
+	peer->emit_signal(SNAME("session_description_created"), String(p_type), String(p_session));
 }
 
 void WebRTCPeerConnectionJS::_on_connection_state_changed(void *p_obj, int p_state) {
@@ -57,7 +57,7 @@ void WebRTCPeerConnectionJS::_on_error(void *p_obj) {
 
 void WebRTCPeerConnectionJS::_on_data_channel(void *p_obj, int p_id) {
 	WebRTCPeerConnectionJS *peer = static_cast<WebRTCPeerConnectionJS *>(p_obj);
-	peer->emit_signal("data_channel_received", Ref<WebRTCDataChannelJS>(new WebRTCDataChannelJS(p_id)));
+	peer->emit_signal(SNAME("data_channel_received"), Ref<WebRTCDataChannelJS>(new WebRTCDataChannelJS(p_id)));
 }
 
 void WebRTCPeerConnectionJS::close() {

--- a/modules/websocket/websocket_client.cpp
+++ b/modules/websocket/websocket_client.cpp
@@ -86,7 +86,7 @@ void WebSocketClient::_on_peer_packet() {
 	if (_is_multiplayer) {
 		_process_multiplayer(get_peer(1), 1);
 	} else {
-		emit_signal("data_received");
+		emit_signal(SNAME("data_received"));
 	}
 }
 
@@ -94,27 +94,27 @@ void WebSocketClient::_on_connect(String p_protocol) {
 	if (_is_multiplayer) {
 		// need to wait for ID confirmation...
 	} else {
-		emit_signal("connection_established", p_protocol);
+		emit_signal(SNAME("connection_established"), p_protocol);
 	}
 }
 
 void WebSocketClient::_on_close_request(int p_code, String p_reason) {
-	emit_signal("server_close_request", p_code, p_reason);
+	emit_signal(SNAME("server_close_request"), p_code, p_reason);
 }
 
 void WebSocketClient::_on_disconnect(bool p_was_clean) {
 	if (_is_multiplayer) {
-		emit_signal("connection_failed");
+		emit_signal(SNAME("connection_failed"));
 	} else {
-		emit_signal("connection_closed", p_was_clean);
+		emit_signal(SNAME("connection_closed"), p_was_clean);
 	}
 }
 
 void WebSocketClient::_on_error() {
 	if (_is_multiplayer) {
-		emit_signal("connection_failed");
+		emit_signal(SNAME("connection_failed"));
 	} else {
-		emit_signal("connection_error");
+		emit_signal(SNAME("connection_error"));
 	}
 }
 

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -215,7 +215,7 @@ void WebSocketMultiplayerPeer::_store_pkt(int32_t p_source, int32_t p_dest, cons
 	packet.destination = p_dest;
 	memcpy(packet.data, &p_data[PROTO_SIZE], p_data_size);
 	_incoming_packets.push_back(packet);
-	emit_signal("peer_packet", p_source);
+	emit_signal(SNAME("peer_packet"), p_source);
 }
 
 Error WebSocketMultiplayerPeer::_server_relay(int32_t p_from, int32_t p_to, const uint8_t *p_buffer, uint32_t p_buffer_size) {
@@ -306,15 +306,15 @@ void WebSocketMultiplayerPeer::_process_multiplayer(Ref<WebSocketPeer> p_peer, u
 		switch (type) {
 			case SYS_ADD: // Add peer
 				_peer_map[id] = Ref<WebSocketPeer>();
-				emit_signal("peer_connected", id);
+				emit_signal(SNAME("peer_connected"), id);
 				if (id == 1) { // We just connected to the server
-					emit_signal("connection_succeeded");
+					emit_signal(SNAME("connection_succeeded"));
 				}
 				break;
 
 			case SYS_DEL: // Remove peer
 				_peer_map.erase(id);
-				emit_signal("peer_disconnected", id);
+				emit_signal(SNAME("peer_disconnected"), id);
 				break;
 			case SYS_ID: // Hello, server assigned ID
 				_peer_id = id;

--- a/modules/websocket/websocket_server.cpp
+++ b/modules/websocket/websocket_server.cpp
@@ -137,7 +137,7 @@ void WebSocketServer::_on_peer_packet(int32_t p_peer_id) {
 	if (_is_multiplayer) {
 		_process_multiplayer(get_peer(p_peer_id), p_peer_id);
 	} else {
-		emit_signal("data_received", p_peer_id);
+		emit_signal(SNAME("data_received"), p_peer_id);
 	}
 }
 
@@ -145,9 +145,9 @@ void WebSocketServer::_on_connect(int32_t p_peer_id, String p_protocol, String p
 	if (_is_multiplayer) {
 		// Send add to clients
 		_send_add(p_peer_id);
-		emit_signal("peer_connected", p_peer_id);
+		emit_signal(SNAME("peer_connected"), p_peer_id);
 	} else {
-		emit_signal("client_connected", p_peer_id, p_protocol, p_resource_name);
+		emit_signal(SNAME("client_connected"), p_peer_id, p_protocol, p_resource_name);
 	}
 }
 
@@ -155,12 +155,12 @@ void WebSocketServer::_on_disconnect(int32_t p_peer_id, bool p_was_clean) {
 	if (_is_multiplayer) {
 		// Send delete to clients
 		_send_del(p_peer_id);
-		emit_signal("peer_disconnected", p_peer_id);
+		emit_signal(SNAME("peer_disconnected"), p_peer_id);
 	} else {
-		emit_signal("client_disconnected", p_peer_id, p_was_clean);
+		emit_signal(SNAME("client_disconnected"), p_peer_id, p_was_clean);
 	}
 }
 
 void WebSocketServer::_on_close_request(int32_t p_peer_id, int p_code, String p_reason) {
-	emit_signal("client_close_request", p_peer_id, p_code, p_reason);
+	emit_signal(SNAME("client_close_request"), p_peer_id, p_code, p_reason);
 }

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -45,7 +45,7 @@ void _emwebxr_on_session_supported(char *p_session_mode, int p_supported) {
 	ERR_FAIL_COND(interface.is_null());
 
 	String session_mode = String(p_session_mode);
-	interface->emit_signal("session_supported", session_mode, p_supported ? true : false);
+	interface->emit_signal(SNAME("session_supported"), session_mode, p_supported ? true : false);
 }
 
 void _emwebxr_on_session_started(char *p_reference_space_type) {
@@ -57,7 +57,7 @@ void _emwebxr_on_session_started(char *p_reference_space_type) {
 
 	String reference_space_type = String(p_reference_space_type);
 	((WebXRInterfaceJS *)interface.ptr())->_set_reference_space_type(reference_space_type);
-	interface->emit_signal("session_started");
+	interface->emit_signal(SNAME("session_started"));
 }
 
 void _emwebxr_on_session_ended() {
@@ -68,7 +68,7 @@ void _emwebxr_on_session_ended() {
 	ERR_FAIL_COND(interface.is_null());
 
 	interface->uninitialize();
-	interface->emit_signal("session_ended");
+	interface->emit_signal(SNAME("session_ended"));
 }
 
 void _emwebxr_on_session_failed(char *p_message) {
@@ -81,7 +81,7 @@ void _emwebxr_on_session_failed(char *p_message) {
 	interface->uninitialize();
 
 	String message = String(p_message);
-	interface->emit_signal("session_failed", message);
+	interface->emit_signal(SNAME("session_failed"), message);
 }
 
 void _emwebxr_on_controller_changed() {
@@ -102,7 +102,7 @@ extern "C" EMSCRIPTEN_KEEPALIVE void _emwebxr_on_input_event(char *p_signal_name
 	ERR_FAIL_COND(interface.is_null());
 
 	StringName signal_name = StringName(p_signal_name);
-	interface->emit_signal(signal_name, p_input_source + 1);
+	interface->emit_signal(SNAME(signal_name), p_input_source + 1);
 }
 
 extern "C" EMSCRIPTEN_KEEPALIVE void _emwebxr_on_simple_event(char *p_signal_name) {
@@ -113,7 +113,7 @@ extern "C" EMSCRIPTEN_KEEPALIVE void _emwebxr_on_simple_event(char *p_signal_nam
 	ERR_FAIL_COND(interface.is_null());
 
 	StringName signal_name = StringName(p_signal_name);
-	interface->emit_signal(signal_name);
+	interface->emit_signal(SNAME(signal_name));
 }
 
 void WebXRInterfaceJS::is_session_supported(const String &p_session_mode) {

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -451,7 +451,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResu
 	}
 
 	if (os_android->get_main_loop()) {
-		os_android->get_main_loop()->emit_signal("on_request_permissions_result", permission, p_result == JNI_TRUE);
+		os_android->get_main_loop()->emit_signal(SNAME("on_request_permissions_result"), permission, p_result == JNI_TRUE);
 	}
 }
 

--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -126,7 +126,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitS
 		env->DeleteLocalRef(j_param);
 	};
 
-	singleton->emit_signal(signal_name, args, count);
+	singleton->emit_signal(SNAME(signal_name), args, count);
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeRegisterGDNativeLibraries(JNIEnv *env, jclass clazz, jobjectArray gdnlib_paths) {

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -97,7 +97,7 @@ extern EMSCRIPTEN_KEEPALIVE int godot_js_main(int argc, char *argv[]) {
 	if (Main::is_project_manager() && FileAccess::exists("/tmp/preload.zip")) {
 		PackedStringArray ps;
 		ps.push_back("/tmp/preload.zip");
-		os->get_main_loop()->emit_signal("files_dropped", ps, -1);
+		os->get_main_loop()->emit_signal(SNAME("files_dropped"), ps, -1);
 	}
 #endif
 	emscripten_set_main_loop(main_loop_callback, -1, false);

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -255,7 +255,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 		//stop playing if no longer active
 		if (!active.is_set()) {
 			set_physics_process_internal(false);
-			emit_signal("finished");
+			emit_signal(SNAME("finished"));
 		}
 	}
 }

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -235,7 +235,7 @@ void NavigationAgent2D::_avoidance_done(Vector3 p_new_velocity) {
 	}
 	velocity_submitted = false;
 
-	emit_signal("velocity_computed", velocity);
+	emit_signal(SNAME("velocity_computed"), velocity);
 }
 
 TypedArray<String> NavigationAgent2D::get_configuration_warnings() const {
@@ -287,7 +287,7 @@ void NavigationAgent2D::update_navigation() {
 		navigation_path = NavigationServer2D::get_singleton()->map_get_path(agent_parent->get_world_2d()->get_navigation_map(), o, target_location, true, navigable_layers);
 		navigation_finished = false;
 		nav_path_index = 0;
-		emit_signal("path_changed");
+		emit_signal(SNAME("path_changed"));
 	}
 
 	if (navigation_path.size() == 0) {
@@ -303,7 +303,7 @@ void NavigationAgent2D::update_navigation() {
 				_check_distance_to_target();
 				nav_path_index -= 1;
 				navigation_finished = true;
-				emit_signal("navigation_finished");
+				emit_signal(SNAME("navigation_finished"));
 				break;
 			}
 		}
@@ -313,7 +313,7 @@ void NavigationAgent2D::update_navigation() {
 void NavigationAgent2D::_check_distance_to_target() {
 	if (!target_reached) {
 		if (distance_to_target() < target_desired_distance) {
-			emit_signal("target_reached");
+			emit_signal(SNAME("target_reached"));
 			target_reached = true;
 		}
 	}

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -568,7 +568,7 @@ void Skeleton2D::_make_bone_setup_dirty() {
 	}
 	bone_setup_dirty = true;
 	if (is_inside_tree()) {
-		call_deferred("_update_bone_setup");
+		call_deferred(SNAME("_update_bone_setup"));
 	}
 }
 
@@ -597,7 +597,7 @@ void Skeleton2D::_update_bone_setup() {
 
 	transform_dirty = true;
 	_update_transform();
-	emit_signal("bone_setup_changed");
+	emit_signal(SNAME("bone_setup_changed"));
 }
 
 void Skeleton2D::_make_transform_dirty() {
@@ -606,7 +606,7 @@ void Skeleton2D::_make_transform_dirty() {
 	}
 	transform_dirty = true;
 	if (is_inside_tree()) {
-		call_deferred("_update_transform");
+		call_deferred(SNAME("_update_transform"));
 	}
 }
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -299,7 +299,7 @@ void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 		_recreate_quadrants();
 	}
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 int TileMap::get_quadrant_size() const {
@@ -311,13 +311,13 @@ void TileMap::set_quadrant_size(int p_size) {
 
 	quadrant_size = p_size;
 	_recreate_quadrants();
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 void TileMap::set_collision_visibility_mode(TileMap::VisibilityMode p_show_collision) {
 	show_collision = p_show_collision;
 	_recreate_quadrants();
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 TileMap::VisibilityMode TileMap::get_collision_visibility_mode() {
@@ -327,7 +327,7 @@ TileMap::VisibilityMode TileMap::get_collision_visibility_mode() {
 void TileMap::set_navigation_visibility_mode(TileMap::VisibilityMode p_show_navigation) {
 	show_navigation = p_show_navigation;
 	_recreate_quadrants();
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 TileMap::VisibilityMode TileMap::get_navigation_visibility_mode() {
@@ -337,7 +337,7 @@ TileMap::VisibilityMode TileMap::get_navigation_visibility_mode() {
 void TileMap::set_y_sort_enabled(bool p_enable) {
 	Node2D::set_y_sort_enabled(p_enable);
 	_recreate_quadrants();
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 void TileMap::update_dirty_quadrants() {
@@ -480,7 +480,7 @@ void TileMap::_make_all_quadrants_dirty(bool p_update) {
 		return;
 	}
 	if (p_update) {
-		call_deferred("update_dirty_quadrants");
+		call_deferred(SNAME("update_dirty_quadrants"));
 	}
 }
 
@@ -500,7 +500,7 @@ void TileMap::_make_quadrant_dirty(Map<Vector2i, TileMapQuadrant>::Element *Q, b
 	}
 
 	if (p_update) {
-		call_deferred("update_dirty_quadrants");
+		call_deferred(SNAME("update_dirty_quadrants"));
 	}
 }
 
@@ -1764,7 +1764,7 @@ void TileMap::_bind_methods() {
 }
 
 void TileMap::_tile_set_changed() {
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 	_make_all_quadrants_dirty(true);
 }
 

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -294,7 +294,7 @@ void TouchScreenButton::_press(int p_finger_pressed) {
 		get_viewport()->input(iea, true);
 	}
 
-	emit_signal("pressed");
+	emit_signal(SNAME("pressed"));
 	update();
 }
 
@@ -313,7 +313,7 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 	}
 
 	if (!p_exiting_tree) {
-		emit_signal("released");
+		emit_signal(SNAME("released"));
 		update();
 	}
 }

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -607,7 +607,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 		//stop playing if no longer active
 		if (!active.is_set()) {
 			set_physics_process_internal(false);
-			emit_signal("finished");
+			emit_signal(SNAME("finished"));
 		}
 	}
 }

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -242,7 +242,7 @@ void NavigationAgent3D::_avoidance_done(Vector3 p_new_velocity) {
 	}
 	velocity_submitted = false;
 
-	emit_signal("velocity_computed", p_new_velocity);
+	emit_signal(SNAME("velocity_computed"), p_new_velocity);
 }
 
 TypedArray<String> NavigationAgent3D::get_configuration_warnings() const {
@@ -296,7 +296,7 @@ void NavigationAgent3D::update_navigation() {
 		navigation_path = NavigationServer3D::get_singleton()->map_get_path(agent_parent->get_world_3d()->get_navigation_map(), o, target_location, true);
 		navigation_finished = false;
 		nav_path_index = 0;
-		emit_signal("path_changed");
+		emit_signal(SNAME("path_changed"));
 	}
 
 	if (navigation_path.size() == 0) {
@@ -312,7 +312,7 @@ void NavigationAgent3D::update_navigation() {
 				_check_distance_to_target();
 				nav_path_index -= 1;
 				navigation_finished = true;
-				emit_signal("navigation_finished");
+				emit_signal(SNAME("navigation_finished"));
 				break;
 			}
 		}
@@ -322,7 +322,7 @@ void NavigationAgent3D::update_navigation() {
 void NavigationAgent3D::_check_distance_to_target() {
 	if (!target_reached) {
 		if (distance_to_target() < target_desired_distance) {
-			emit_signal("target_reached");
+			emit_signal(SNAME("target_reached"));
 			target_reached = true;
 		}
 	}

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -132,7 +132,7 @@ void NavigationRegion3D::set_navigation_mesh(const Ref<NavigationMesh> &p_navmes
 		Object::cast_to<MeshInstance3D>(debug_view)->set_mesh(navmesh->get_debug_mesh());
 	}
 
-	emit_signal("navigation_mesh_changed");
+	emit_signal(SNAME("navigation_mesh_changed"));
 
 	update_gizmo();
 	update_configuration_warnings();
@@ -153,11 +153,11 @@ void _bake_navigation_mesh(void *p_user_data) {
 		Ref<NavigationMesh> nav_mesh = args->nav_region->get_navigation_mesh()->duplicate();
 
 		NavigationServer3D::get_singleton()->region_bake_navmesh(nav_mesh, args->nav_region);
-		args->nav_region->call_deferred("_bake_finished", nav_mesh);
+		args->nav_region->call_deferred(SNAME("_bake_finished"), nav_mesh);
 		memdelete(args);
 	} else {
 		ERR_PRINT("Can't bake the navigation mesh if the `NavigationMesh` resource doesn't exist");
-		args->nav_region->call_deferred("_bake_finished", Ref<NavigationMesh>());
+		args->nav_region->call_deferred(SNAME("_bake_finished"), Ref<NavigationMesh>());
 		memdelete(args);
 	}
 }
@@ -174,7 +174,7 @@ void NavigationRegion3D::bake_navigation_mesh() {
 void NavigationRegion3D::_bake_finished(Ref<NavigationMesh> p_nav_mesh) {
 	set_navigation_mesh(p_nav_mesh);
 	bake_thread.wait_to_finish();
-	emit_signal("bake_finished");
+	emit_signal(SNAME("bake_finished"));
 }
 
 TypedArray<String> NavigationRegion3D::get_configuration_warnings() const {

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -41,7 +41,7 @@ void Path3D::_curve_changed() {
 		update_gizmo();
 	}
 	if (is_inside_tree()) {
-		emit_signal("curve_changed");
+		emit_signal(SNAME("curve_changed"));
 	}
 
 	// update the configuration warnings of all children of type PathFollow

--- a/scene/3d/proximity_group_3d.cpp
+++ b/scene/3d/proximity_group_3d.cpp
@@ -130,7 +130,7 @@ void ProximityGroup3D::_proximity_group_broadcast(String p_method, Variant p_par
 	if (dispatch_mode == MODE_PROXY) {
 		get_parent()->call(p_method, p_parameters);
 	} else {
-		emit_signal("broadcast", p_method, p_parameters);
+		emit_signal(SNAME("broadcast"), p_method, p_parameters);
 	}
 }
 

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -425,8 +425,8 @@ void SoftBody3D::_draw_soft_mesh() {
 
 		/// Necessary in order to render the mesh correctly (Soft body nodes are in global space)
 		simulation_started = true;
-		call_deferred("set_as_top_level", true);
-		call_deferred("set_transform", Transform3D());
+		call_deferred(SNAME("set_as_top_level"), true);
+		call_deferred(SNAME("set_transform"), Transform3D());
 	}
 
 	_update_physics_server();

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -207,10 +207,10 @@ void XRController3D::_notification(int p_what) {
 						bool is_pressed = Input::get_singleton()->is_joy_button_pressed(joy_id, (JoyButton)i);
 
 						if (!was_pressed && is_pressed) {
-							emit_signal("button_pressed", i);
+							emit_signal(SNAME("button_pressed"), i);
 							button_states += mask;
 						} else if (was_pressed && !is_pressed) {
-							emit_signal("button_released", i);
+							emit_signal(SNAME("button_released"), i);
 							button_states -= mask;
 						};
 
@@ -225,7 +225,7 @@ void XRController3D::_notification(int p_what) {
 				Ref<Mesh> trackerMesh = tracker->get_mesh();
 				if (mesh != trackerMesh) {
 					mesh = trackerMesh;
-					emit_signal("mesh_updated", mesh);
+					emit_signal(SNAME("mesh_updated"), mesh);
 				}
 			};
 		}; break;
@@ -422,7 +422,7 @@ void XRAnchor3D::_notification(int p_what) {
 				Ref<Mesh> trackerMesh = tracker->get_mesh();
 				if (mesh != trackerMesh) {
 					mesh = trackerMesh;
-					emit_signal("mesh_updated", mesh);
+					emit_signal(SNAME("mesh_updated"), mesh);
 				}
 			};
 		}; break;

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -54,7 +54,7 @@ void AnimationNodeBlendSpace1D::_validate_property(PropertyInfo &property) const
 }
 
 void AnimationNodeBlendSpace1D::_tree_changed() {
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeBlendSpace1D::_bind_methods() {
@@ -120,7 +120,7 @@ void AnimationNodeBlendSpace1D::add_blend_point(const Ref<AnimationRootNode> &p_
 	blend_points[p_at_index].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 
 	blend_points_used++;
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeBlendSpace1D::set_blend_point_position(int p_point, float p_position) {
@@ -140,7 +140,7 @@ void AnimationNodeBlendSpace1D::set_blend_point_node(int p_point, const Ref<Anim
 	blend_points[p_point].node = p_node;
 	blend_points[p_point].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 float AnimationNodeBlendSpace1D::get_blend_point_position(int p_point) const {
@@ -164,7 +164,7 @@ void AnimationNodeBlendSpace1D::remove_blend_point(int p_point) {
 	}
 
 	blend_points_used--;
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 int AnimationNodeBlendSpace1D::get_blend_point_count() const {

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -84,7 +84,7 @@ void AnimationNodeBlendSpace2D::add_blend_point(const Ref<AnimationRootNode> &p_
 
 	_queue_auto_triangles();
 
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeBlendSpace2D::set_blend_point_position(int p_point, const Vector2 &p_position) {
@@ -103,7 +103,7 @@ void AnimationNodeBlendSpace2D::set_blend_point_node(int p_point, const Ref<Anim
 	blend_points[p_point].node = p_node;
 	blend_points[p_point].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace2D::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 Vector2 AnimationNodeBlendSpace2D::get_blend_point_position(int p_point) const {
@@ -143,7 +143,7 @@ void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 		blend_points[i] = blend_points[i + 1];
 	}
 	blend_points_used--;
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 int AnimationNodeBlendSpace2D::get_blend_point_count() const {
@@ -321,7 +321,7 @@ void AnimationNodeBlendSpace2D::_queue_auto_triangles() {
 	}
 
 	trianges_dirty = true;
-	call_deferred("_update_triangles");
+	call_deferred(SNAME("_update_triangles"));
 }
 
 void AnimationNodeBlendSpace2D::_update_triangles() {
@@ -332,7 +332,7 @@ void AnimationNodeBlendSpace2D::_update_triangles() {
 	trianges_dirty = false;
 	triangles.clear();
 	if (blend_points_used < 3) {
-		emit_signal("triangles_updated");
+		emit_signal(SNAME("triangles_updated"));
 		return;
 	}
 
@@ -347,7 +347,7 @@ void AnimationNodeBlendSpace2D::_update_triangles() {
 	for (int i = 0; i < triangles.size(); i++) {
 		add_triangle(triangles[i].points[0], triangles[i].points[1], triangles[i].points[2]);
 	}
-	emit_signal("triangles_updated");
+	emit_signal(SNAME("triangles_updated"));
 }
 
 Vector2 AnimationNodeBlendSpace2D::get_closest_point(const Vector2 &p_point) {
@@ -586,7 +586,7 @@ Ref<AnimationNode> AnimationNodeBlendSpace2D::get_child_by_name(const StringName
 }
 
 void AnimationNodeBlendSpace2D::_tree_changed() {
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeBlendSpace2D::set_blend_mode(BlendMode p_blend_mode) {

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -816,7 +816,7 @@ void AnimationNodeBlendTree::add_node(const StringName &p_name, Ref<AnimationNod
 	nodes[p_name] = n;
 
 	emit_changed();
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 
 	p_node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendTree::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	p_node->connect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed), varray(p_name), CONNECT_REFERENCE_COUNTED);
@@ -896,7 +896,7 @@ void AnimationNodeBlendTree::remove_node(const StringName &p_name) {
 	}
 
 	emit_changed();
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringName &p_new_name) {
@@ -921,7 +921,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 	//connection must be done with new name
 	nodes[p_new_name].node->connect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed), varray(p_new_name), CONNECT_REFERENCE_COUNTED);
 
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeBlendTree::connect_node(const StringName &p_input_node, int p_input_index, const StringName &p_output_node) {
@@ -1125,11 +1125,11 @@ void AnimationNodeBlendTree::reset_state() {
 	graph_offset = Vector2();
 	nodes.clear();
 	emit_changed();
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeBlendTree::_tree_changed() {
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeBlendTree::_node_changed(const StringName &p_node) {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -57,7 +57,7 @@ void AnimationNodeStateMachineTransition::set_advance_condition(const StringName
 	} else {
 		advance_condition_name = StringName();
 	}
-	emit_signal("advance_condition_changed");
+	emit_signal(SNAME("advance_condition_changed"));
 }
 
 StringName AnimationNodeStateMachineTransition::get_advance_condition() const {
@@ -539,7 +539,7 @@ void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<Animation
 	states[p_name] = state;
 
 	emit_changed();
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 
 	p_node->connect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 }
@@ -559,7 +559,7 @@ void AnimationNodeStateMachine::replace_node(const StringName &p_name, Ref<Anima
 	states[p_name].node = p_node;
 
 	emit_changed();
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 
 	p_node->connect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 }
@@ -636,7 +636,7 @@ void AnimationNodeStateMachine::remove_node(const StringName &p_name) {
 	}*/
 
 	emit_changed();
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeStateMachine::rename_node(const StringName &p_name, const StringName &p_new_name) {
@@ -669,7 +669,7 @@ void AnimationNodeStateMachine::rename_node(const StringName &p_name, const Stri
 	}*/
 
 	//path.clear(); //clear path
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeStateMachine::get_node_list(List<StringName> *r_nodes) const {
@@ -923,7 +923,7 @@ void AnimationNodeStateMachine::reset_state() {
 	graph_offset = Vector2();
 
 	emit_changed();
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeStateMachine::set_node_position(const StringName &p_name, const Vector2 &p_position) {
@@ -937,7 +937,7 @@ Vector2 AnimationNodeStateMachine::get_node_position(const StringName &p_name) c
 }
 
 void AnimationNodeStateMachine::_tree_changed() {
-	emit_signal("tree_changed");
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeStateMachine::_bind_methods() {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1325,7 +1325,7 @@ float AnimationPlayer::get_current_animation_length() const {
 
 void AnimationPlayer::_animation_changed() {
 	clear_caches();
-	emit_signal("caches_cleared");
+	emit_signal(SNAME("caches_cleared"));
 	if (is_playing()) {
 		playback.seeked = true; //need to restart stuff, like audio
 	}

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1327,7 +1327,7 @@ void AnimationTree::_tree_changed() {
 		return;
 	}
 
-	call_deferred("_update_properties");
+	call_deferred(SNAME("_update_properties"));
 	properties_dirty = true;
 }
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -264,7 +264,7 @@ bool Tween::step(float p_delta) {
 		rem_delta = step_delta;
 
 		if (!step_active) {
-			emit_signal("step_finished", current_step);
+			emit_signal(SNAME("step_finished"), current_step);
 			current_step++;
 
 			if (current_step == tweeners.size()) {
@@ -272,9 +272,9 @@ bool Tween::step(float p_delta) {
 				if (loops_done == loops) {
 					running = false;
 					dead = true;
-					emit_signal("finished");
+					emit_signal(SNAME("finished"));
 				} else {
-					emit_signal("loop_finished", loops_done);
+					emit_signal(SNAME("loop_finished"), loops_done);
 					current_step = 0;
 					start_tweeners();
 				}
@@ -690,7 +690,7 @@ bool PropertyTweener::step(float &r_delta) {
 	} else {
 		finished = true;
 		r_delta = elapsed_time - delay - duration;
-		emit_signal("finished");
+		emit_signal(SNAME("finished"));
 		return false;
 	}
 }
@@ -745,7 +745,7 @@ bool IntervalTweener::step(float &r_delta) {
 	} else {
 		finished = true;
 		r_delta = elapsed_time - duration;
-		emit_signal("finished");
+		emit_signal(SNAME("finished"));
 		return false;
 	}
 }
@@ -784,7 +784,7 @@ bool CallbackTweener::step(float &r_delta) {
 
 		finished = true;
 		r_delta = elapsed_time - delay;
-		emit_signal("finished");
+		emit_signal(SNAME("finished"));
 		return false;
 	}
 
@@ -854,7 +854,7 @@ bool MethodTweener::step(float &r_delta) {
 	} else {
 		finished = true;
 		r_delta = elapsed_time - delay - duration;
-		emit_signal("finished");
+		emit_signal(SNAME("finished"));
 		return false;
 	}
 }

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -146,7 +146,7 @@ void AudioStreamPlayer::_notification(int p_what) {
 		if (!active.is_set() || (setseek.get() < 0 && !stream_playback->is_playing())) {
 			active.clear();
 			set_process_internal(false);
-			emit_signal("finished");
+			emit_signal(SNAME("finished"));
 		}
 	}
 

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -125,7 +125,7 @@ void BaseButton::_pressed() {
 		get_script_instance()->call(SceneStringNames::get_singleton()->_pressed);
 	}
 	pressed();
-	emit_signal("pressed");
+	emit_signal(SNAME("pressed"));
 }
 
 void BaseButton::_toggled(bool p_pressed) {
@@ -133,14 +133,14 @@ void BaseButton::_toggled(bool p_pressed) {
 		get_script_instance()->call(SceneStringNames::get_singleton()->_toggled, p_pressed);
 	}
 	toggled(p_pressed);
-	emit_signal("toggled", p_pressed);
+	emit_signal(SNAME("toggled"), p_pressed);
 }
 
 void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 	if (p_event->is_pressed()) {
 		status.press_attempt = true;
 		status.pressing_inside = true;
-		emit_signal("button_down");
+		emit_signal(SNAME("button_down"));
 	}
 
 	if (status.press_attempt && status.pressing_inside) {
@@ -153,7 +153,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 				status.pressed = !status.pressed;
 				_unpress_group();
 				if (button_group.is_valid()) {
-					button_group->emit_signal("pressed", this);
+					button_group->emit_signal(SNAME("pressed"), this);
 				}
 				_toggled(status.pressed);
 				_pressed();
@@ -174,7 +174,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		}
 		status.press_attempt = false;
 		status.pressing_inside = false;
-		emit_signal("button_up");
+		emit_signal(SNAME("button_up"));
 	}
 
 	update();
@@ -218,7 +218,7 @@ void BaseButton::set_pressed(bool p_pressed) {
 	if (p_pressed) {
 		_unpress_group();
 		if (button_group.is_valid()) {
-			button_group->emit_signal("pressed", this);
+			button_group->emit_signal(SNAME("pressed"), this);
 		}
 	}
 	_toggled(status.pressed);

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -43,7 +43,7 @@ void BoxContainer::_resort() {
 
 	Size2i new_size = get_size();
 
-	int sep = get_theme_constant("separation"); //,vertical?"VBoxContainer":"HBoxContainer");
+	int sep = get_theme_constant(SNAME("separation")); //,vertical?"VBoxContainer":"HBoxContainer");
 	bool rtl = is_layout_rtl();
 
 	bool first = true;
@@ -247,7 +247,7 @@ Size2 BoxContainer::get_minimum_size() const {
 	/* Calculate MINIMUM SIZE */
 
 	Size2i minimum;
-	int sep = get_theme_constant("separation"); //,vertical?"VBoxContainer":"HBoxContainer");
+	int sep = get_theme_constant(SNAME("separation")); //,vertical?"VBoxContainer":"HBoxContainer");
 
 	bool first = true;
 

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -41,8 +41,8 @@ Size2 Button::get_minimum_size() const {
 
 	if (!expand_icon) {
 		Ref<Texture2D> _icon;
-		if (icon.is_null() && has_theme_icon("icon")) {
-			_icon = Control::get_theme_icon("icon");
+		if (icon.is_null() && has_theme_icon(SNAME("icon"))) {
+			_icon = Control::get_theme_icon(SNAME("icon"));
 		} else {
 			_icon = icon;
 		}
@@ -53,7 +53,7 @@ Size2 Button::get_minimum_size() const {
 			if (icon_align != ALIGN_CENTER) {
 				minsize.width += _icon->get_width();
 				if (xl_text != "") {
-					minsize.width += get_theme_constant("hseparation");
+					minsize.width += get_theme_constant(SNAME("hseparation"));
 				}
 			} else {
 				minsize.width = MAX(minsize.width, _icon->get_width());
@@ -61,12 +61,12 @@ Size2 Button::get_minimum_size() const {
 		}
 	}
 
-	Ref<Font> font = get_theme_font("font");
-	float font_height = font->get_height(get_theme_font_size("font_size"));
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	float font_height = font->get_height(get_theme_font_size(SNAME("font_size")));
 
 	minsize.height = MAX(font_height, minsize.height);
 
-	return get_theme_stylebox("normal")->get_minimum_size() + minsize;
+	return get_theme_stylebox(SNAME("normal"))->get_minimum_size() + minsize;
 }
 
 void Button::_set_internal_margin(Side p_side, float p_value) {
@@ -97,43 +97,43 @@ void Button::_notification(int p_what) {
 			Color color;
 			Color color_icon(1, 1, 1, 1);
 
-			Ref<StyleBox> style = get_theme_stylebox("normal");
+			Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 			bool rtl = is_layout_rtl();
 
 			switch (get_draw_mode()) {
 				case DRAW_NORMAL: {
-					if (rtl && has_theme_stylebox("normal_mirrored")) {
-						style = get_theme_stylebox("normal_mirrored");
+					if (rtl && has_theme_stylebox(SNAME("normal_mirrored"))) {
+						style = get_theme_stylebox(SNAME("normal_mirrored"));
 					} else {
-						style = get_theme_stylebox("normal");
+						style = get_theme_stylebox(SNAME("normal"));
 					}
 
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
-					color = get_theme_color("font_color");
-					if (has_theme_color("icon_normal_color")) {
-						color_icon = get_theme_color("icon_normal_color");
+					color = get_theme_color(SNAME("font_color"));
+					if (has_theme_color(SNAME("icon_normal_color"))) {
+						color_icon = get_theme_color(SNAME("icon_normal_color"));
 					}
 				} break;
 				case DRAW_HOVER_PRESSED: {
-					if (has_theme_stylebox("hover_pressed") && has_theme_stylebox_override("hover_pressed")) {
-						if (rtl && has_theme_stylebox("hover_pressed_mirrored")) {
-							style = get_theme_stylebox("hover_pressed_mirrored");
+					if (has_theme_stylebox(SNAME("hover_pressed")) && has_theme_stylebox_override("hover_pressed")) {
+						if (rtl && has_theme_stylebox(SNAME("hover_pressed_mirrored"))) {
+							style = get_theme_stylebox(SNAME("hover_pressed_mirrored"));
 						} else {
-							style = get_theme_stylebox("hover_pressed");
+							style = get_theme_stylebox(SNAME("hover_pressed"));
 						}
 
 						if (!flat) {
 							style->draw(ci, Rect2(Point2(0, 0), size));
 						}
-						if (has_theme_color("font_hover_pressed_color")) {
-							color = get_theme_color("font_hover_pressed_color");
+						if (has_theme_color(SNAME("font_hover_pressed_color"))) {
+							color = get_theme_color(SNAME("font_hover_pressed_color"));
 						} else {
-							color = get_theme_color("font_color");
+							color = get_theme_color(SNAME("font_color"));
 						}
-						if (has_theme_color("icon_hover_pressed_color")) {
-							color_icon = get_theme_color("icon_hover_pressed_color");
+						if (has_theme_color(SNAME("icon_hover_pressed_color"))) {
+							color_icon = get_theme_color(SNAME("icon_hover_pressed_color"));
 						}
 
 						break;
@@ -141,67 +141,67 @@ void Button::_notification(int p_what) {
 					[[fallthrough]];
 				}
 				case DRAW_PRESSED: {
-					if (rtl && has_theme_stylebox("pressed_mirrored")) {
-						style = get_theme_stylebox("pressed_mirrored");
+					if (rtl && has_theme_stylebox(SNAME("pressed_mirrored"))) {
+						style = get_theme_stylebox(SNAME("pressed_mirrored"));
 					} else {
-						style = get_theme_stylebox("pressed");
+						style = get_theme_stylebox(SNAME("pressed"));
 					}
 
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
-					if (has_theme_color("font_pressed_color")) {
-						color = get_theme_color("font_pressed_color");
+					if (has_theme_color(SNAME("font_pressed_color"))) {
+						color = get_theme_color(SNAME("font_pressed_color"));
 					} else {
-						color = get_theme_color("font_color");
+						color = get_theme_color(SNAME("font_color"));
 					}
-					if (has_theme_color("icon_pressed_color")) {
-						color_icon = get_theme_color("icon_pressed_color");
+					if (has_theme_color(SNAME("icon_pressed_color"))) {
+						color_icon = get_theme_color(SNAME("icon_pressed_color"));
 					}
 
 				} break;
 				case DRAW_HOVER: {
-					if (rtl && has_theme_stylebox("hover_mirrored")) {
-						style = get_theme_stylebox("hover_mirrored");
+					if (rtl && has_theme_stylebox(SNAME("hover_mirrored"))) {
+						style = get_theme_stylebox(SNAME("hover_mirrored"));
 					} else {
-						style = get_theme_stylebox("hover");
+						style = get_theme_stylebox(SNAME("hover"));
 					}
 
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
-					color = get_theme_color("font_hover_color");
-					if (has_theme_color("icon_hover_color")) {
-						color_icon = get_theme_color("icon_hover_color");
+					color = get_theme_color(SNAME("font_hover_color"));
+					if (has_theme_color(SNAME("icon_hover_color"))) {
+						color_icon = get_theme_color(SNAME("icon_hover_color"));
 					}
 
 				} break;
 				case DRAW_DISABLED: {
-					if (rtl && has_theme_stylebox("disabled_mirrored")) {
-						style = get_theme_stylebox("disabled_mirrored");
+					if (rtl && has_theme_stylebox(SNAME("disabled_mirrored"))) {
+						style = get_theme_stylebox(SNAME("disabled_mirrored"));
 					} else {
-						style = get_theme_stylebox("disabled");
+						style = get_theme_stylebox(SNAME("disabled"));
 					}
 
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
-					color = get_theme_color("font_disabled_color");
-					if (has_theme_color("icon_disabled_color")) {
-						color_icon = get_theme_color("icon_disabled_color");
+					color = get_theme_color(SNAME("font_disabled_color"));
+					if (has_theme_color(SNAME("icon_disabled_color"))) {
+						color_icon = get_theme_color(SNAME("icon_disabled_color"));
 					}
 
 				} break;
 			}
 
 			if (has_focus()) {
-				Ref<StyleBox> style2 = get_theme_stylebox("focus");
+				Ref<StyleBox> style2 = get_theme_stylebox(SNAME("focus"));
 				style2->draw(ci, Rect2(Point2(), size));
 			}
 
 			Ref<Texture2D> _icon;
-			if (icon.is_null() && has_theme_icon("icon")) {
-				_icon = Control::get_theme_icon("icon");
+			if (icon.is_null() && has_theme_icon(SNAME("icon"))) {
+				_icon = Control::get_theme_icon(SNAME("icon"));
 			} else {
 				_icon = icon;
 			}
@@ -234,21 +234,21 @@ void Button::_notification(int p_what) {
 				if (icon_align_rtl_checked == ALIGN_LEFT) {
 					style_offset.x = style->get_margin(SIDE_LEFT);
 					if (_internal_margin[SIDE_LEFT] > 0) {
-						icon_ofs_region = _internal_margin[SIDE_LEFT] + get_theme_constant("hseparation");
+						icon_ofs_region = _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("hseparation"));
 					}
 				} else if (icon_align_rtl_checked == ALIGN_CENTER) {
 					style_offset.x = 0.0;
 				} else if (icon_align_rtl_checked == ALIGN_RIGHT) {
 					style_offset.x = -style->get_margin(SIDE_RIGHT);
 					if (_internal_margin[SIDE_RIGHT] > 0) {
-						icon_ofs_region = -_internal_margin[SIDE_RIGHT] - get_theme_constant("hseparation");
+						icon_ofs_region = -_internal_margin[SIDE_RIGHT] - get_theme_constant(SNAME("hseparation"));
 					}
 				}
 				style_offset.y = style->get_margin(SIDE_TOP);
 
 				if (expand_icon) {
 					Size2 _size = get_size() - style->get_offset() * 2;
-					_size.width -= get_theme_constant("hseparation") + icon_ofs_region;
+					_size.width -= get_theme_constant(SNAME("hseparation")) + icon_ofs_region;
 					if (!clip_text && icon_align_rtl_checked != ALIGN_CENTER) {
 						_size.width -= text_buf->get_size().width;
 					}
@@ -276,7 +276,7 @@ void Button::_notification(int p_what) {
 				}
 			}
 
-			Point2 icon_ofs = !_icon.is_null() ? Point2(icon_region.size.width + get_theme_constant("hseparation"), 0) : Point2();
+			Point2 icon_ofs = !_icon.is_null() ? Point2(icon_region.size.width + get_theme_constant(SNAME("hseparation")), 0) : Point2();
 			if (align_rtl_checked == ALIGN_CENTER && icon_align_rtl_checked == ALIGN_CENTER) {
 				icon_ofs.x = 0.0;
 			}
@@ -286,10 +286,10 @@ void Button::_notification(int p_what) {
 			int text_width = clip_text ? MIN(text_clip, text_buf->get_size().x) : text_buf->get_size().x;
 
 			if (_internal_margin[SIDE_LEFT] > 0) {
-				text_clip -= _internal_margin[SIDE_LEFT] + get_theme_constant("hseparation");
+				text_clip -= _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("hseparation"));
 			}
 			if (_internal_margin[SIDE_RIGHT] > 0) {
-				text_clip -= _internal_margin[SIDE_RIGHT] + get_theme_constant("hseparation");
+				text_clip -= _internal_margin[SIDE_RIGHT] + get_theme_constant(SNAME("hseparation"));
 			}
 
 			Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - text_buf->get_size() - Point2(_internal_margin[SIDE_RIGHT] - _internal_margin[SIDE_LEFT], 0)) / 2.0;
@@ -300,7 +300,7 @@ void Button::_notification(int p_what) {
 						icon_ofs.x = 0.0;
 					}
 					if (_internal_margin[SIDE_LEFT] > 0) {
-						text_ofs.x = style->get_margin(SIDE_LEFT) + icon_ofs.x + _internal_margin[SIDE_LEFT] + get_theme_constant("hseparation");
+						text_ofs.x = style->get_margin(SIDE_LEFT) + icon_ofs.x + _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("hseparation"));
 					} else {
 						text_ofs.x = style->get_margin(SIDE_LEFT) + icon_ofs.x;
 					}
@@ -317,7 +317,7 @@ void Button::_notification(int p_what) {
 				} break;
 				case ALIGN_RIGHT: {
 					if (_internal_margin[SIDE_RIGHT] > 0) {
-						text_ofs.x = size.x - style->get_margin(SIDE_RIGHT) - text_width - _internal_margin[SIDE_RIGHT] - get_theme_constant("hseparation");
+						text_ofs.x = size.x - style->get_margin(SIDE_RIGHT) - text_width - _internal_margin[SIDE_RIGHT] - get_theme_constant(SNAME("hseparation"));
 					} else {
 						text_ofs.x = size.x - style->get_margin(SIDE_RIGHT) - text_width;
 					}
@@ -328,8 +328,8 @@ void Button::_notification(int p_what) {
 				} break;
 			}
 
-			Color font_outline_color = get_theme_color("font_outline_color");
-			int outline_size = get_theme_constant("outline_size");
+			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
 			if (outline_size > 0 && font_outline_color.a > 0) {
 				text_buf->draw_outline(ci, text_ofs, outline_size, font_outline_color);
 			}
@@ -340,8 +340,8 @@ void Button::_notification(int p_what) {
 }
 
 void Button::_shape() {
-	Ref<Font> font = get_theme_font("font");
-	int font_size = get_theme_font_size("font_size");
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	int font_size = get_theme_font_size(SNAME("font_size"));
 
 	text_buf->clear();
 	if (text_direction == Control::TEXT_DIRECTION_INHERITED) {

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -33,12 +33,12 @@
 #include "servers/rendering_server.h"
 
 Size2 CheckBox::get_icon_size() const {
-	Ref<Texture2D> checked = Control::get_theme_icon("checked");
-	Ref<Texture2D> checked_disabled = Control::get_theme_icon("checked_disabled");
-	Ref<Texture2D> unchecked = Control::get_theme_icon("unchecked");
-	Ref<Texture2D> unchecked_disabled = Control::get_theme_icon("unchecked_disabled");
-	Ref<Texture2D> radio_checked = Control::get_theme_icon("radio_checked");
-	Ref<Texture2D> radio_unchecked = Control::get_theme_icon("radio_unchecked");
+	Ref<Texture2D> checked = Control::get_theme_icon(SNAME("checked"));
+	Ref<Texture2D> checked_disabled = Control::get_theme_icon(SNAME("checked_disabled"));
+	Ref<Texture2D> unchecked = Control::get_theme_icon(SNAME("unchecked"));
+	Ref<Texture2D> unchecked_disabled = Control::get_theme_icon(SNAME("unchecked_disabled"));
+	Ref<Texture2D> radio_checked = Control::get_theme_icon(SNAME("radio_checked"));
+	Ref<Texture2D> radio_unchecked = Control::get_theme_icon(SNAME("radio_unchecked"));
 
 	Size2 tex_size = Size2(0, 0);
 	if (!checked.is_null()) {
@@ -61,9 +61,9 @@ Size2 CheckBox::get_minimum_size() const {
 	Size2 tex_size = get_icon_size();
 	minsize.width += tex_size.width;
 	if (get_text().length() > 0) {
-		minsize.width += get_theme_constant("hseparation");
+		minsize.width += get_theme_constant(SNAME("hseparation"));
 	}
-	Ref<StyleBox> sb = get_theme_stylebox("normal");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
 	minsize.height = MAX(minsize.height, tex_size.height + sb->get_margin(SIDE_TOP) + sb->get_margin(SIDE_BOTTOM));
 
 	return minsize;
@@ -83,7 +83,7 @@ void CheckBox::_notification(int p_what) {
 
 		Ref<Texture2D> on = Control::get_theme_icon(vformat("%s%s", is_radio() ? "radio_checked" : "checked", is_disabled() ? "_disabled" : ""));
 		Ref<Texture2D> off = Control::get_theme_icon(vformat("%s%s", is_radio() ? "radio_unchecked" : "unchecked", is_disabled() ? "_disabled" : ""));
-		Ref<StyleBox> sb = get_theme_stylebox("normal");
+		Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
 
 		Vector2 ofs;
 		if (is_layout_rtl()) {
@@ -91,7 +91,7 @@ void CheckBox::_notification(int p_what) {
 		} else {
 			ofs.x = sb->get_margin(SIDE_LEFT);
 		}
-		ofs.y = int((get_size().height - get_icon_size().height) / 2) + get_theme_constant("check_vadjust");
+		ofs.y = int((get_size().height - get_icon_size().height) / 2) + get_theme_constant(SNAME("check_vadjust"));
 
 		if (is_pressed()) {
 			on->draw(ci, ofs);

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -52,9 +52,9 @@ Size2 CheckButton::get_minimum_size() const {
 	Size2 tex_size = get_icon_size();
 	minsize.width += tex_size.width;
 	if (get_text().length() > 0) {
-		minsize.width += get_theme_constant("hseparation");
+		minsize.width += get_theme_constant(SNAME("hseparation"));
 	}
-	Ref<StyleBox> sb = get_theme_stylebox("normal");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
 	minsize.height = MAX(minsize.height, tex_size.height + sb->get_margin(SIDE_TOP) + sb->get_margin(SIDE_BOTTOM));
 
 	return minsize;
@@ -86,7 +86,7 @@ void CheckButton::_notification(int p_what) {
 			off = Control::get_theme_icon(is_disabled() ? "off_disabled" : "off");
 		}
 
-		Ref<StyleBox> sb = get_theme_stylebox("normal");
+		Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
 		Vector2 ofs;
 		Size2 tex_size = get_icon_size();
 
@@ -95,7 +95,7 @@ void CheckButton::_notification(int p_what) {
 		} else {
 			ofs.x = get_size().width - (tex_size.width + sb->get_margin(SIDE_RIGHT));
 		}
-		ofs.y = (get_size().height - tex_size.height) / 2 + get_theme_constant("check_vadjust");
+		ofs.y = (get_size().height - tex_size.height) / 2 + get_theme_constant(SNAME("check_vadjust"));
 
 		if (is_pressed()) {
 			on->draw(ci, ofs);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -50,28 +50,28 @@ void CodeEdit::_notification(int p_what) {
 			set_gutter_width(line_number_gutter, (line_number_digits + 1) * cache.font->get_char_size('0', 0, cache.font_size).width);
 			set_gutter_width(fold_gutter, get_row_height() / 1.2);
 
-			breakpoint_color = get_theme_color("breakpoint_color");
-			breakpoint_icon = get_theme_icon("breakpoint");
+			breakpoint_color = get_theme_color(SNAME("breakpoint_color"));
+			breakpoint_icon = get_theme_icon(SNAME("breakpoint"));
 
-			bookmark_color = get_theme_color("bookmark_color");
-			bookmark_icon = get_theme_icon("bookmark");
+			bookmark_color = get_theme_color(SNAME("bookmark_color"));
+			bookmark_icon = get_theme_icon(SNAME("bookmark"));
 
-			executing_line_color = get_theme_color("executing_line_color");
-			executing_line_icon = get_theme_icon("executing_line");
+			executing_line_color = get_theme_color(SNAME("executing_line_color"));
+			executing_line_icon = get_theme_icon(SNAME("executing_line"));
 
-			line_number_color = get_theme_color("line_number_color");
+			line_number_color = get_theme_color(SNAME("line_number_color"));
 
-			folding_color = get_theme_color("code_folding_color");
-			can_fold_icon = get_theme_icon("can_fold");
-			folded_icon = get_theme_icon("folded");
+			folding_color = get_theme_color(SNAME("code_folding_color"));
+			can_fold_icon = get_theme_icon(SNAME("can_fold"));
+			folded_icon = get_theme_icon(SNAME("folded"));
 
-			code_completion_max_width = get_theme_constant("completion_max_width") * cache.font->get_char_size('x').x;
-			code_completion_max_lines = get_theme_constant("completion_lines");
-			code_completion_scroll_width = get_theme_constant("completion_scroll_width");
-			code_completion_scroll_color = get_theme_color("completion_scroll_color");
-			code_completion_background_color = get_theme_color("completion_background_color");
-			code_completion_selected_color = get_theme_color("completion_selected_color");
-			code_completion_existing_color = get_theme_color("completion_existing_color");
+			code_completion_max_width = get_theme_constant(SNAME("completion_max_width")) * cache.font->get_char_size('x').x;
+			code_completion_max_lines = get_theme_constant(SNAME("completion_lines"));
+			code_completion_scroll_width = get_theme_constant(SNAME("completion_scroll_width"));
+			code_completion_scroll_color = get_theme_color(SNAME("completion_scroll_color"));
+			code_completion_background_color = get_theme_color(SNAME("completion_background_color"));
+			code_completion_selected_color = get_theme_color(SNAME("completion_selected_color"));
+			code_completion_existing_color = get_theme_color(SNAME("completion_existing_color"));
 		} break;
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
@@ -81,11 +81,11 @@ void CodeEdit::_notification(int p_what) {
 
 			bool code_completion_below = false;
 			if (caret_visible && code_completion_active && code_completion_options.size() > 0) {
-				Ref<StyleBox> csb = get_theme_stylebox("completion");
+				Ref<StyleBox> csb = get_theme_stylebox(SNAME("completion"));
 
 				const int code_completion_options_count = code_completion_options.size();
 				const int lines = MIN(code_completion_options_count, code_completion_max_lines);
-				const int icon_hsep = get_theme_constant("hseparation", "ItemList");
+				const int icon_hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
 				const Size2 icon_area_size(row_height, row_height);
 
 				code_completion_rect.size.width = code_completion_longest_line + icon_hsep + icon_area_size.width + 2;
@@ -164,8 +164,8 @@ void CodeEdit::_notification(int p_what) {
 			if (caret_visible && code_hint != "" && (!code_completion_active || (code_completion_below != code_hint_draw_below))) {
 				const Ref<Font> font = cache.font;
 				const int font_height = font->get_height(cache.font_size);
-				Ref<StyleBox> sb = get_theme_stylebox("panel", "TooltipPanel");
-				Color font_color = get_theme_color("font_color", "TooltipLabel");
+				Ref<StyleBox> sb = get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel"));
+				Color font_color = get_theme_color(SNAME("font_color"), SNAME("TooltipLabel"));
 
 				Vector<String> code_hint_lines = code_hint.split("\n");
 				int line_count = code_hint_lines.size();
@@ -969,7 +969,7 @@ void CodeEdit::set_line_as_breakpoint(int p_line, bool p_breakpointed) {
 	} else if (breakpointed_lines.has(p_line)) {
 		breakpointed_lines.erase(p_line);
 	}
-	emit_signal("breakpoint_toggled", p_line);
+	emit_signal(SNAME("breakpoint_toggled"), p_line);
 	update();
 }
 
@@ -1551,7 +1551,7 @@ void CodeEdit::request_code_completion(bool p_force) {
 	}
 
 	if (p_force) {
-		emit_signal("request_code_completion");
+		emit_signal(SNAME("request_code_completion"));
 		return;
 	}
 
@@ -1559,9 +1559,9 @@ void CodeEdit::request_code_completion(bool p_force) {
 	int ofs = CLAMP(cursor_get_column(), 0, line.length());
 
 	if (ofs > 0 && (is_in_string(cursor_get_line(), ofs) != -1 || _is_char(line[ofs - 1]) || code_completion_prefixes.has(String::chr(line[ofs - 1])))) {
-		emit_signal("request_code_completion");
+		emit_signal(SNAME("request_code_completion"));
 	} else if (ofs > 1 && line[ofs - 1] == ' ' && code_completion_prefixes.has(String::chr(line[ofs - 2]))) {
-		emit_signal("request_code_completion");
+		emit_signal(SNAME("request_code_completion"));
 	}
 }
 
@@ -2534,9 +2534,9 @@ void CodeEdit::_lines_edited_from(int p_from_line, int p_to_line) {
 		}
 		breakpointed_lines.erase(line);
 
-		emit_signal("breakpoint_toggled", line);
+		emit_signal(SNAME("breakpoint_toggled"), line);
 		if (line_count > 0 || line >= p_from_line) {
-			emit_signal("breakpoint_toggled", line + line_count);
+			emit_signal(SNAME("breakpoint_toggled"), line + line_count);
 			breakpointed_lines[line + line_count] = true;
 			continue;
 		}

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -45,14 +45,14 @@ List<Color> ColorPicker::preset_cache;
 void ColorPicker::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			btn_pick->set_icon(get_theme_icon("screen_picker", "ColorPicker"));
-			bt_add_preset->set_icon(get_theme_icon("add_preset"));
+			btn_pick->set_icon(get_theme_icon(SNAME("screen_picker"), SNAME("ColorPicker")));
+			bt_add_preset->set_icon(get_theme_icon(SNAME("add_preset")));
 
 			_update_controls();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
-			btn_pick->set_icon(get_theme_icon("screen_picker", "ColorPicker"));
-			bt_add_preset->set_icon(get_theme_icon("add_preset"));
+			btn_pick->set_icon(get_theme_icon(SNAME("screen_picker"), SNAME("ColorPicker")));
+			bt_add_preset->set_icon(get_theme_icon(SNAME("add_preset")));
 
 			_update_controls();
 			_update_color();
@@ -75,13 +75,13 @@ void ColorPicker::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_PARENTED: {
 			for (int i = 0; i < 4; i++) {
-				set_offset((Side)i, get_offset((Side)i) + get_theme_constant("margin"));
+				set_offset((Side)i, get_offset((Side)i) + get_theme_constant(SNAME("margin")));
 			}
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			Popup *p = Object::cast_to<Popup>(get_parent());
 			if (p) {
-				p->set_size(Size2(get_combined_minimum_size().width + get_theme_constant("margin") * 2, get_combined_minimum_size().height + get_theme_constant("margin") * 2));
+				p->set_size(Size2(get_combined_minimum_size().width + get_theme_constant(SNAME("margin")) * 2, get_combined_minimum_size().height + get_theme_constant(SNAME("margin")) * 2));
 			}
 		} break;
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
@@ -142,7 +142,7 @@ void ColorPicker::finish_shaders() {
 }
 
 void ColorPicker::set_focus_on_line_edit() {
-	c_text->call_deferred("grab_focus");
+	c_text->call_deferred(SNAME("grab_focus"));
 }
 
 void ColorPicker::_update_controls() {
@@ -180,7 +180,7 @@ void ColorPicker::_update_controls() {
 		}
 	} else {
 		Ref<StyleBoxEmpty> style_box_empty(memnew(StyleBoxEmpty));
-		Ref<Texture2D> bar_arrow = get_theme_icon("bar_arrow");
+		Ref<Texture2D> bar_arrow = get_theme_icon(SNAME("bar_arrow"));
 
 		for (int i = 0; i < 4; i++) {
 			scroll[i]->add_theme_icon_override("grabber", bar_arrow);
@@ -294,7 +294,7 @@ void ColorPicker::_value_changed(double) {
 	}
 
 	_set_pick_color(color, false);
-	emit_signal("color_changed", color);
+	emit_signal(SNAME("color_changed"), color);
 }
 
 void ColorPicker::_html_submitted(const String &p_html) {
@@ -313,7 +313,7 @@ void ColorPicker::_html_submitted(const String &p_html) {
 	}
 
 	set_pick_color(color);
-	emit_signal("color_changed", color);
+	emit_signal(SNAME("color_changed"), color);
 }
 
 void ColorPicker::_update_color(bool p_update_sliders) {
@@ -388,7 +388,7 @@ void ColorPicker::_text_type_toggled() {
 	text_is_constructor = !text_is_constructor;
 	if (text_is_constructor) {
 		text_type->set_text("");
-		text_type->set_icon(get_theme_icon("Script", "EditorIcons"));
+		text_type->set_icon(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")));
 
 		c_text->set_editable(false);
 	} else {
@@ -537,7 +537,7 @@ void ColorPicker::_sample_input(const Ref<InputEvent> &p_event) {
 			// Revert to the old color when left-clicking the old color sample.
 			color = old_color;
 			_update_color();
-			emit_signal("color_changed", color);
+			emit_signal(SNAME("color_changed"), color);
 		}
 	}
 }
@@ -554,28 +554,28 @@ void ColorPicker::_sample_draw() {
 		const Rect2 rect_old = Rect2(Point2(), Size2(sample->get_size().width * 0.5, sample->get_size().height * 0.95));
 
 		if (display_old_color && old_color.a < 1.0) {
-			sample->draw_texture_rect(get_theme_icon("preset_bg", "ColorPicker"), rect_old, true);
+			sample->draw_texture_rect(get_theme_icon(SNAME("preset_bg"), SNAME("ColorPicker")), rect_old, true);
 		}
 
 		sample->draw_rect(rect_old, old_color);
 
 		if (old_color.r > 1 || old_color.g > 1 || old_color.b > 1) {
 			// Draw an indicator to denote that the old color is "overbright" and can't be displayed accurately in the preview.
-			sample->draw_texture(get_theme_icon("overbright_indicator", "ColorPicker"), Point2());
+			sample->draw_texture(get_theme_icon(SNAME("overbright_indicator"), SNAME("ColorPicker")), Point2());
 		}
 	} else {
 		rect_new = Rect2(Point2(), Size2(sample->get_size().width, sample->get_size().height * 0.95));
 	}
 
 	if (color.a < 1.0) {
-		sample->draw_texture_rect(get_theme_icon("preset_bg", "ColorPicker"), rect_new, true);
+		sample->draw_texture_rect(get_theme_icon(SNAME("preset_bg"), SNAME("ColorPicker")), rect_new, true);
 	}
 
 	sample->draw_rect(rect_new, color);
 
 	if (color.r > 1 || color.g > 1 || color.b > 1) {
 		// Draw an indicator to denote that the new color is "overbright" and can't be displayed accurately in the preview.
-		sample->draw_texture(get_theme_icon("overbright_indicator", "ColorPicker"), Point2(uv_edit->get_size().width * 0.5, 0));
+		sample->draw_texture(get_theme_icon(SNAME("overbright_indicator"), SNAME("ColorPicker")), Point2(uv_edit->get_size().width * 0.5, 0));
 	}
 }
 
@@ -649,7 +649,7 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 			default: {
 			}
 		}
-		Ref<Texture2D> cursor = get_theme_icon("picker_cursor", "ColorPicker");
+		Ref<Texture2D> cursor = get_theme_icon(SNAME("picker_cursor"), SNAME("ColorPicker"));
 		int x;
 		int y;
 		if (picker_type == SHAPE_VHS_CIRCLE) {
@@ -679,7 +679,7 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 
 	} else if (p_which == 1) {
 		if (picker_type == SHAPE_HSV_RECTANGLE) {
-			Ref<Texture2D> hue = get_theme_icon("color_hue", "ColorPicker");
+			Ref<Texture2D> hue = get_theme_icon(SNAME("color_hue"), SNAME("ColorPicker"));
 			c->draw_texture_rect(hue, Rect2(Point2(), c->get_size()));
 			int y = c->get_size().y - c->get_size().y * (1.0 - h);
 			Color col;
@@ -728,7 +728,7 @@ void ColorPicker::_slider_draw(int p_which) {
 #endif
 
 	if (p_which == 3) {
-		scroll[p_which]->draw_texture_rect(get_theme_icon("preset_bg", "ColorPicker"), Rect2(Point2(0, margin), Size2(size.x, margin)), true);
+		scroll[p_which]->draw_texture_rect(get_theme_icon(SNAME("preset_bg"), SNAME("ColorPicker")), Rect2(Point2(0, margin), Size2(size.x, margin)), true);
 
 		left_color = color;
 		left_color.a = 0;
@@ -740,7 +740,7 @@ void ColorPicker::_slider_draw(int p_which) {
 		}
 		if (hsv_mode_enabled) {
 			if (p_which == 0) {
-				Ref<Texture2D> hue = get_theme_icon("color_hue", "ColorPicker");
+				Ref<Texture2D> hue = get_theme_icon(SNAME("color_hue"), SNAME("ColorPicker"));
 				scroll[p_which]->draw_set_transform(Point2(), -Math_PI / 2, Size2(1.0, 1.0));
 				scroll[p_which]->draw_texture_rect(hue, Rect2(Vector2(margin * -2, 0), Vector2(scroll[p_which]->get_size().x, margin)), false, Color(1, 1, 1), true);
 				return;
@@ -826,10 +826,10 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 			set_pick_color(color);
 			_update_color();
 			if (!deferred_mode_enabled) {
-				emit_signal("color_changed", color);
+				emit_signal(SNAME("color_changed"), color);
 			}
 		} else if (deferred_mode_enabled && !bev->is_pressed() && bev->get_button_index() == MOUSE_BUTTON_LEFT) {
-			emit_signal("color_changed", color);
+			emit_signal(SNAME("color_changed"), color);
 			changing_color = false;
 			spinning = false;
 		} else {
@@ -873,7 +873,7 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 		set_pick_color(color);
 		_update_color();
 		if (!deferred_mode_enabled) {
-			emit_signal("color_changed", color);
+			emit_signal(SNAME("color_changed"), color);
 		}
 	}
 }
@@ -898,9 +898,9 @@ void ColorPicker::_w_input(const Ref<InputEvent> &p_event) {
 		set_pick_color(color);
 		_update_color();
 		if (!deferred_mode_enabled) {
-			emit_signal("color_changed", color);
+			emit_signal(SNAME("color_changed"), color);
 		} else if (!bev->is_pressed() && bev->get_button_index() == MOUSE_BUTTON_LEFT) {
-			emit_signal("color_changed", color);
+			emit_signal(SNAME("color_changed"), color);
 		}
 	}
 
@@ -921,7 +921,7 @@ void ColorPicker::_w_input(const Ref<InputEvent> &p_event) {
 		set_pick_color(color);
 		_update_color();
 		if (!deferred_mode_enabled) {
-			emit_signal("color_changed", color);
+			emit_signal(SNAME("color_changed"), color);
 		}
 	}
 }
@@ -941,12 +941,12 @@ void ColorPicker::_preset_input(const Ref<InputEvent> &p_event) {
 			}
 			set_pick_color(presets[index]);
 			_update_color();
-			emit_signal("color_changed", color);
+			emit_signal(SNAME("color_changed"), color);
 		} else if (bev->is_pressed() && bev->get_button_index() == MOUSE_BUTTON_RIGHT && presets_enabled) {
 			index = bev->get_position().x / (preset->get_size().x / presets.size());
 			Color clicked_preset = presets[index];
 			erase_preset(clicked_preset);
-			emit_signal("preset_removed", clicked_preset);
+			emit_signal(SNAME("preset_removed"), clicked_preset);
 			bt_add_preset->show();
 		}
 	}
@@ -972,7 +972,7 @@ void ColorPicker::_screen_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> bev = p_event;
 	if (bev.is_valid() && bev->get_button_index() == MOUSE_BUTTON_LEFT && !bev->is_pressed()) {
-		emit_signal("color_changed", color);
+		emit_signal(SNAME("color_changed"), color);
 		screen->hide();
 	}
 
@@ -995,7 +995,7 @@ void ColorPicker::_screen_input(const Ref<InputEvent> &p_event) {
 
 void ColorPicker::_add_preset_pressed() {
 	add_preset(color);
-	emit_signal("preset_added", color);
+	emit_signal(SNAME("preset_added"), color);
 }
 
 void ColorPicker::_screen_pick_pressed() {
@@ -1012,7 +1012,7 @@ void ColorPicker::_screen_pick_pressed() {
 		screen->set_default_cursor_shape(CURSOR_POINTING_HAND);
 		screen->connect("gui_input", callable_mp(this, &ColorPicker::_screen_input));
 		// It immediately toggles off in the first press otherwise.
-		screen->call_deferred("connect", "hidden", Callable(btn_pick, "set_pressed"), varray(false));
+		screen->call_deferred(SNAME("connect"), "hidden", Callable(btn_pick, "set_pressed"), varray(false));
 	}
 	screen->raise();
 #ifndef _MSC_VER
@@ -1131,7 +1131,7 @@ ColorPicker::ColorPicker() :
 	uv_edit->set_mouse_filter(MOUSE_FILTER_PASS);
 	uv_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	uv_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	uv_edit->set_custom_minimum_size(Size2(get_theme_constant("sv_width"), get_theme_constant("sv_height")));
+	uv_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("sv_width")), get_theme_constant(SNAME("sv_height"))));
 	uv_edit->connect("draw", callable_mp(this, &ColorPicker::_hsv_draw), make_binds(0, uv_edit));
 
 	HBoxContainer *hb_smpl = memnew(HBoxContainer);
@@ -1161,7 +1161,7 @@ ColorPicker::ColorPicker() :
 		HBoxContainer *hbc = memnew(HBoxContainer);
 
 		labels[i] = memnew(Label());
-		labels[i]->set_custom_minimum_size(Size2(get_theme_constant("label_width"), 0));
+		labels[i]->set_custom_minimum_size(Size2(get_theme_constant(SNAME("label_width")), 0));
 		labels[i]->set_v_size_flags(SIZE_SHRINK_CENTER);
 		hbc->add_child(labels[i]);
 
@@ -1220,7 +1220,7 @@ ColorPicker::ColorPicker() :
 
 	wheel_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	wheel_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	wheel_edit->set_custom_minimum_size(Size2(get_theme_constant("sv_width"), get_theme_constant("sv_height")));
+	wheel_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("sv_width")), get_theme_constant(SNAME("sv_height"))));
 	hb_edit->add_child(wheel_edit);
 
 	wheel_mat.instantiate();
@@ -1245,7 +1245,7 @@ ColorPicker::ColorPicker() :
 	wheel_uv->connect("draw", callable_mp(this, &ColorPicker::_hsv_draw), make_binds(0, wheel_uv));
 
 	hb_edit->add_child(w_edit);
-	w_edit->set_custom_minimum_size(Size2(get_theme_constant("h_width"), 0));
+	w_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("h_width")), 0));
 	w_edit->set_h_size_flags(SIZE_FILL);
 	w_edit->set_v_size_flags(SIZE_EXPAND_FILL);
 	w_edit->connect("gui_input", callable_mp(this, &ColorPicker::_w_input));
@@ -1285,11 +1285,11 @@ void ColorPickerButton::_about_to_popup() {
 void ColorPickerButton::_color_changed(const Color &p_color) {
 	color = p_color;
 	update();
-	emit_signal("color_changed", color);
+	emit_signal(SNAME("color_changed"), color);
 }
 
 void ColorPickerButton::_modal_closed() {
-	emit_signal("popup_closed");
+	emit_signal(SNAME("popup_closed"));
 	set_pressed(false);
 }
 
@@ -1327,14 +1327,14 @@ void ColorPickerButton::pressed() {
 void ColorPickerButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			const Ref<StyleBox> normal = get_theme_stylebox("normal");
+			const Ref<StyleBox> normal = get_theme_stylebox(SNAME("normal"));
 			const Rect2 r = Rect2(normal->get_offset(), get_size() - normal->get_minimum_size());
-			draw_texture_rect(Control::get_theme_icon("bg", "ColorPickerButton"), r, true);
+			draw_texture_rect(Control::get_theme_icon(SNAME("bg"), SNAME("ColorPickerButton")), r, true);
 			draw_rect(r, color);
 
 			if (color.r > 1 || color.g > 1 || color.b > 1) {
 				// Draw an indicator to denote that the color is "overbright" and can't be displayed accurately in the preview
-				draw_texture(Control::get_theme_icon("overbright_indicator", "ColorPicker"), normal->get_offset());
+				draw_texture(Control::get_theme_icon(SNAME("overbright_indicator"), SNAME("ColorPicker")), normal->get_offset());
 			}
 		} break;
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
@@ -1399,7 +1399,7 @@ void ColorPickerButton::_update_picker() {
 		picker->set_pick_color(color);
 		picker->set_edit_alpha(edit_alpha);
 		picker->set_display_old_color(true);
-		emit_signal("picker_created");
+		emit_signal(SNAME("picker_created"));
 	}
 }
 

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -76,7 +76,7 @@ void AcceptDialog::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			bg->add_theme_style_override("panel", bg->get_theme_stylebox("panel", "AcceptDialog"));
+			bg->add_theme_style_override("panel", bg->get_theme_stylebox(SNAME("panel"), SNAME("AcceptDialog")));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -106,7 +106,7 @@ void AcceptDialog::_ok_pressed() {
 		set_visible(false);
 	}
 	ok_pressed();
-	emit_signal("confirmed");
+	emit_signal(SNAME("confirmed"));
 }
 
 void AcceptDialog::_cancel_pressed() {
@@ -116,9 +116,9 @@ void AcceptDialog::_cancel_pressed() {
 		parent_visible = nullptr;
 	}
 
-	call_deferred("hide");
+	call_deferred(SNAME("hide"));
 
-	emit_signal("cancelled");
+	emit_signal(SNAME("cancelled"));
 
 	cancel_pressed();
 
@@ -168,7 +168,7 @@ void AcceptDialog::_update_child_rects() {
 	if (label->get_text().is_empty()) {
 		label_size.height = 0;
 	}
-	int margin = hbc->get_theme_constant("margin", "Dialogs");
+	int margin = hbc->get_theme_constant(SNAME("margin"), SNAME("Dialogs"));
 	Size2 size = get_size();
 	Size2 hminsize = hbc->get_combined_minimum_size();
 
@@ -200,7 +200,7 @@ void AcceptDialog::_update_child_rects() {
 }
 
 Size2 AcceptDialog::_get_contents_minimum_size() const {
-	int margin = hbc->get_theme_constant("margin", "Dialogs");
+	int margin = hbc->get_theme_constant(SNAME("margin"), SNAME("Dialogs"));
 	Size2 minsize = label->get_combined_minimum_size();
 
 	for (int i = 0; i < get_child_count(); i++) {
@@ -230,7 +230,7 @@ Size2 AcceptDialog::_get_contents_minimum_size() const {
 }
 
 void AcceptDialog::_custom_action(const String &p_action) {
-	emit_signal("custom_action", p_action);
+	emit_signal(SNAME("custom_action"), p_action);
 	custom_action(p_action);
 }
 
@@ -326,8 +326,8 @@ AcceptDialog::AcceptDialog() {
 
 	hbc = memnew(HBoxContainer);
 
-	int margin = hbc->get_theme_constant("margin", "Dialogs");
-	int button_margin = hbc->get_theme_constant("button_margin", "Dialogs");
+	int margin = hbc->get_theme_constant(SNAME("margin"), SNAME("Dialogs"));
+	int button_margin = hbc->get_theme_constant(SNAME("button_margin"), SNAME("Dialogs"));
 
 	label = memnew(Label);
 	label->set_anchor(SIDE_RIGHT, Control::ANCHOR_END);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -49,9 +49,9 @@ VBoxContainer *FileDialog::get_vbox() {
 }
 
 void FileDialog::_theme_changed() {
-	Color font_color = vbox->get_theme_color("font_color", "Button");
-	Color font_hover_color = vbox->get_theme_color("font_hover_color", "Button");
-	Color font_pressed_color = vbox->get_theme_color("font_pressed_color", "Button");
+	Color font_color = vbox->get_theme_color(SNAME("font_color"), SNAME("Button"));
+	Color font_hover_color = vbox->get_theme_color(SNAME("font_hover_color"), SNAME("Button"));
+	Color font_pressed_color = vbox->get_theme_color(SNAME("font_pressed_color"), SNAME("Button"));
 
 	dir_up->add_theme_color_override("icon_normal_color", font_color);
 	dir_up->add_theme_color_override("icon_hover_color", font_hover_color);
@@ -81,16 +81,16 @@ void FileDialog::_notification(int p_what) {
 		}
 	}
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		dir_up->set_icon(vbox->get_theme_icon("parent_folder", "FileDialog"));
+		dir_up->set_icon(vbox->get_theme_icon(SNAME("parent_folder"), SNAME("FileDialog")));
 		if (vbox->is_layout_rtl()) {
-			dir_prev->set_icon(vbox->get_theme_icon("forward_folder", "FileDialog"));
-			dir_next->set_icon(vbox->get_theme_icon("back_folder", "FileDialog"));
+			dir_prev->set_icon(vbox->get_theme_icon(SNAME("forward_folder"), SNAME("FileDialog")));
+			dir_next->set_icon(vbox->get_theme_icon(SNAME("back_folder"), SNAME("FileDialog")));
 		} else {
-			dir_prev->set_icon(vbox->get_theme_icon("back_folder", "FileDialog"));
-			dir_next->set_icon(vbox->get_theme_icon("forward_folder", "FileDialog"));
+			dir_prev->set_icon(vbox->get_theme_icon(SNAME("back_folder"), SNAME("FileDialog")));
+			dir_next->set_icon(vbox->get_theme_icon(SNAME("forward_folder"), SNAME("FileDialog")));
 		}
-		refresh->set_icon(vbox->get_theme_icon("reload", "FileDialog"));
-		show_hidden->set_icon(vbox->get_theme_icon("toggle_hidden", "FileDialog"));
+		refresh->set_icon(vbox->get_theme_icon(SNAME("reload"), SNAME("FileDialog")));
+		show_hidden->set_icon(vbox->get_theme_icon(SNAME("toggle_hidden"), SNAME("FileDialog")));
 		_theme_changed();
 	}
 }
@@ -170,7 +170,7 @@ void FileDialog::_file_submitted(const String &p_file) {
 
 void FileDialog::_save_confirm_pressed() {
 	String f = dir_access->get_current_dir().plus_file(file->get_text());
-	emit_signal("file_selected", f);
+	emit_signal(SNAME("file_selected"), f);
 	hide();
 }
 
@@ -224,7 +224,7 @@ void FileDialog::_action_pressed() {
 		}
 
 		if (files.size()) {
-			emit_signal("files_selected", files);
+			emit_signal(SNAME("files_selected"), files);
 			hide();
 		}
 
@@ -234,7 +234,7 @@ void FileDialog::_action_pressed() {
 	String f = dir_access->get_current_dir().plus_file(file->get_text());
 
 	if ((mode == FILE_MODE_OPEN_ANY || mode == FILE_MODE_OPEN_FILE) && dir_access->file_exists(f)) {
-		emit_signal("file_selected", f);
+		emit_signal(SNAME("file_selected"), f);
 		hide();
 	} else if (mode == FILE_MODE_OPEN_ANY || mode == FILE_MODE_OPEN_DIR) {
 		String path = dir_access->get_current_dir();
@@ -248,7 +248,7 @@ void FileDialog::_action_pressed() {
 			}
 		}
 
-		emit_signal("dir_selected", path);
+		emit_signal(SNAME("dir_selected"), path);
 		hide();
 	}
 
@@ -308,7 +308,7 @@ void FileDialog::_action_pressed() {
 			confirm_save->set_text(TTRC("File exists, overwrite?"));
 			confirm_save->popup_centered(Size2(200, 80));
 		} else {
-			emit_signal("file_selected", f);
+			emit_signal(SNAME("file_selected"), f);
 			hide();
 		}
 	}
@@ -437,8 +437,8 @@ void FileDialog::_tree_item_activated() {
 		if (mode == FILE_MODE_OPEN_FILE || mode == FILE_MODE_OPEN_FILES || mode == FILE_MODE_OPEN_DIR || mode == FILE_MODE_OPEN_ANY) {
 			file->set_text("");
 		}
-		call_deferred("_update_file_list");
-		call_deferred("_update_dir");
+		call_deferred(SNAME("_update_file_list"));
+		call_deferred(SNAME("_update_dir"));
 		_push_history();
 	} else {
 		_action_pressed();
@@ -468,10 +468,10 @@ void FileDialog::update_file_list() {
 	dir_access->list_dir_begin();
 
 	TreeItem *root = tree->create_item();
-	Ref<Texture2D> folder = vbox->get_theme_icon("folder", "FileDialog");
-	Ref<Texture2D> file_icon = vbox->get_theme_icon("file", "FileDialog");
-	const Color folder_color = vbox->get_theme_color("folder_icon_modulate", "FileDialog");
-	const Color file_color = vbox->get_theme_color("file_icon_modulate", "FileDialog");
+	Ref<Texture2D> folder = vbox->get_theme_icon(SNAME("folder"), SNAME("FileDialog"));
+	Ref<Texture2D> file_icon = vbox->get_theme_icon(SNAME("file"), SNAME("FileDialog"));
+	const Color folder_color = vbox->get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"));
+	const Color file_color = vbox->get_theme_color(SNAME("file_icon_modulate"), SNAME("FileDialog"));
 	List<String> files;
 	List<String> dirs;
 
@@ -573,7 +573,7 @@ void FileDialog::update_file_list() {
 			ti->set_icon_modulate(0, file_color);
 
 			if (mode == FILE_MODE_OPEN_DIR) {
-				ti->set_custom_color(0, vbox->get_theme_color("files_disabled", "FileDialog"));
+				ti->set_custom_color(0, vbox->get_theme_color(SNAME("files_disabled"), SNAME("FileDialog")));
 				ti->set_selectable(0, false);
 			}
 			Dictionary d;

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -101,7 +101,7 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		grabbed = -1;
 		grabbing = false;
 		update();
-		emit_signal("ramp_changed");
+		emit_signal(SNAME("ramp_changed"));
 		accept_event();
 	}
 
@@ -121,7 +121,7 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			grabbed = -1;
 			grabbing = false;
 			update();
-			emit_signal("ramp_changed");
+			emit_signal(SNAME("ramp_changed"));
 			accept_event();
 		}
 	}
@@ -145,7 +145,7 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 
-			emit_signal("ramp_changed");
+			emit_signal(SNAME("ramp_changed"));
 			update();
 		}
 	}
@@ -214,13 +214,13 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		emit_signal("ramp_changed");
+		emit_signal(SNAME("ramp_changed"));
 	}
 
 	if (mb.is_valid() && mb->get_button_index() == 1 && !mb->is_pressed()) {
 		if (grabbing) {
 			grabbing = false;
-			emit_signal("ramp_changed");
+			emit_signal(SNAME("ramp_changed"));
 		}
 		update();
 	}
@@ -288,7 +288,7 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		emit_signal("ramp_changed");
+		emit_signal(SNAME("ramp_changed"));
 
 		update();
 	}
@@ -436,7 +436,7 @@ void GradientEdit::_color_changed(const Color &p_color) {
 	}
 	points.write[grabbed].color = p_color;
 	update();
-	emit_signal("ramp_changed");
+	emit_signal(SNAME("ramp_changed"));
 }
 
 void GradientEdit::set_ramp(const Vector<float> &p_offsets, const Vector<Color> &p_colors) {

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -162,7 +162,7 @@ void GraphEditMinimap::_gui_input(const Ref<InputEvent> &p_ev) {
 		if (mb->is_pressed()) {
 			is_pressing = true;
 
-			Ref<Texture2D> resizer = get_theme_icon("resizer");
+			Ref<Texture2D> resizer = get_theme_icon(SNAME("resizer"));
 			Rect2 resizer_hitbox = Rect2(Point2(), resizer->get_size());
 			if (resizer_hitbox.has_point(mb->get_position())) {
 				is_resizing = true;
@@ -257,7 +257,7 @@ Vector2 GraphEdit::get_scroll_ofs() const {
 
 void GraphEdit::_scroll_moved(double) {
 	if (!awaiting_scroll_offset_update) {
-		call_deferred("_update_scroll_offset");
+		call_deferred(SNAME("_update_scroll_offset"));
 		awaiting_scroll_offset_update = true;
 	}
 	top_layer->update();
@@ -265,7 +265,7 @@ void GraphEdit::_scroll_moved(double) {
 	update();
 
 	if (!setting_scroll_ofs) { //in godot, signals on change value are avoided as a convention
-		emit_signal("scroll_offset_changed", get_scroll_ofs());
+		emit_signal(SNAME("scroll_offset_changed"), get_scroll_ofs());
 	}
 }
 
@@ -345,7 +345,7 @@ void GraphEdit::_update_scroll() {
 	set_block_minimum_size_adjust(false);
 
 	if (!awaiting_scroll_offset_update) {
-		call_deferred("_update_scroll_offset");
+		call_deferred(SNAME("_update_scroll_offset"));
 		awaiting_scroll_offset_update = true;
 	}
 
@@ -371,7 +371,7 @@ void GraphEdit::_graph_node_raised(Node *p_gn) {
 
 	move_child(connections_layer, first_not_comment);
 	top_layer->raise();
-	emit_signal("node_selected", p_gn);
+	emit_signal(SNAME("node_selected"), p_gn);
 }
 
 void GraphEdit::_graph_node_moved(Node *p_gn) {
@@ -395,7 +395,7 @@ void GraphEdit::_graph_node_slot_updated(int p_index, Node *p_gn) {
 void GraphEdit::add_child_notify(Node *p_child) {
 	Control::add_child_notify(p_child);
 
-	top_layer->call_deferred("raise"); // Top layer always on top!
+	top_layer->call_deferred(SNAME("raise")); // Top layer always on top!
 
 	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
@@ -421,7 +421,7 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 	}
 
 	if (top_layer != nullptr && is_inside_tree()) {
-		top_layer->call_deferred("raise"); // Top layer always on top!
+		top_layer->call_deferred(SNAME("raise")); // Top layer always on top!
 	}
 
 	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
@@ -442,14 +442,14 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 
 void GraphEdit::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		port_grab_distance_horizontal = get_theme_constant("port_grab_distance_horizontal");
-		port_grab_distance_vertical = get_theme_constant("port_grab_distance_vertical");
+		port_grab_distance_horizontal = get_theme_constant(SNAME("port_grab_distance_horizontal"));
+		port_grab_distance_vertical = get_theme_constant(SNAME("port_grab_distance_vertical"));
 
-		zoom_minus->set_icon(get_theme_icon("minus"));
-		zoom_reset->set_icon(get_theme_icon("reset"));
-		zoom_plus->set_icon(get_theme_icon("more"));
-		snap_button->set_icon(get_theme_icon("snap"));
-		minimap_button->set_icon(get_theme_icon("minimap"));
+		zoom_minus->set_icon(get_theme_icon(SNAME("minus")));
+		zoom_reset->set_icon(get_theme_icon(SNAME("reset")));
+		zoom_plus->set_icon(get_theme_icon(SNAME("more")));
+		snap_button->set_icon(get_theme_icon(SNAME("snap")));
+		minimap_button->set_icon(get_theme_icon(SNAME("minimap")));
 	}
 	if (p_what == NOTIFICATION_READY) {
 		Size2 hmin = h_scroll->get_combined_minimum_size();
@@ -466,7 +466,7 @@ void GraphEdit::_notification(int p_what) {
 		v_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
 	}
 	if (p_what == NOTIFICATION_DRAW) {
-		draw_style_box(get_theme_stylebox("bg"), Rect2(Point2(), get_size()));
+		draw_style_box(get_theme_stylebox(SNAME("bg")), Rect2(Point2(), get_size()));
 
 		if (is_using_snap()) {
 			//draw grid
@@ -479,8 +479,8 @@ void GraphEdit::_notification(int p_what) {
 			Point2i from = (offset / float(snap)).floor();
 			Point2i len = (size / float(snap)).floor() + Vector2(1, 1);
 
-			Color grid_minor = get_theme_color("grid_minor");
-			Color grid_major = get_theme_color("grid_major");
+			Color grid_minor = get_theme_color(SNAME("grid_minor"));
+			Color grid_major = get_theme_color(SNAME("grid_major"));
 
 			for (int i = from.x; i < from.x + len.x; i++) {
 				Color color;
@@ -518,7 +518,7 @@ void GraphEdit::_notification(int p_what) {
 }
 
 bool GraphEdit::_filter_input(const Point2 &p_point) {
-	Ref<Texture2D> port = get_theme_icon("port", "GraphNode");
+	Ref<Texture2D> port = get_theme_icon(SNAME("port"), SNAME("GraphNode"));
 
 	for (int i = get_child_count() - 1; i >= 0; i--) {
 		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
@@ -548,7 +548,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 	Ref<InputEventMouseButton> mb = p_ev;
 	if (mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_LEFT && mb->is_pressed()) {
 		connecting_valid = false;
-		Ref<Texture2D> port = get_theme_icon("port", "GraphNode");
+		Ref<Texture2D> port = get_theme_icon(SNAME("port"), SNAME("GraphNode"));
 		click_pos = mb->get_position() / zoom;
 		for (int i = get_child_count() - 1; i >= 0; i--) {
 			GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
@@ -574,7 +574,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 									connecting_to = pos;
 									just_disconnected = true;
 
-									emit_signal("disconnection_request", E->get().from, E->get().from_port, E->get().to, E->get().to_port);
+									emit_signal(SNAME("disconnection_request"), E->get().from, E->get().from_port, E->get().to, E->get().to_port);
 									to = get_node(String(connecting_from)); //maybe it was erased
 									if (Object::cast_to<GraphNode>(to)) {
 										connecting = true;
@@ -616,7 +616,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 									connecting_to = pos;
 									just_disconnected = true;
 
-									emit_signal("disconnection_request", E->get().from, E->get().from_port, E->get().to, E->get().to_port);
+									emit_signal(SNAME("disconnection_request"), E->get().from, E->get().from_port, E->get().to, E->get().to_port);
 									fr = get_node(String(connecting_from)); //maybe it was erased
 									if (Object::cast_to<GraphNode>(fr)) {
 										connecting = true;
@@ -652,7 +652,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 		connecting_valid = just_disconnected || click_pos.distance_to(connecting_to / zoom) > 20.0 * zoom;
 
 		if (connecting_valid) {
-			Ref<Texture2D> port = get_theme_icon("port", "GraphNode");
+			Ref<Texture2D> port = get_theme_icon(SNAME("port"), SNAME("GraphNode"));
 			Vector2 mpos = mm->get_position() / zoom;
 			for (int i = get_child_count() - 1; i >= 0; i--) {
 				GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
@@ -701,7 +701,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 					SWAP(from, to);
 					SWAP(from_slot, to_slot);
 				}
-				emit_signal("connection_request", from, from_slot, to, to_slot);
+				emit_signal(SNAME("connection_request"), from, from_slot, to, to_slot);
 
 			} else if (!just_disconnected) {
 				String from = connecting_from;
@@ -709,9 +709,9 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 				Vector2 ofs = Vector2(mb->get_position().x, mb->get_position().y);
 
 				if (!connecting_out) {
-					emit_signal("connection_from_empty", from, from_slot, ofs);
+					emit_signal(SNAME("connection_from_empty"), from, from_slot, ofs);
 				} else {
-					emit_signal("connection_to_empty", from, from_slot, ofs);
+					emit_signal(SNAME("connection_to_empty"), from, from_slot, ofs);
 				}
 			}
 		}
@@ -819,8 +819,8 @@ void GraphEdit::_draw_cos_line(CanvasItem *p_where, const Vector2 &p_from, const
 	//cubic bezier code
 	float diff = p_to.x - p_from.x;
 	float cp_offset;
-	int cp_len = get_theme_constant("bezier_len_pos") * p_bezier_ratio;
-	int cp_neg_len = get_theme_constant("bezier_len_neg") * p_bezier_ratio;
+	int cp_len = get_theme_constant(SNAME("bezier_len_pos")) * p_bezier_ratio;
+	int cp_neg_len = get_theme_constant(SNAME("bezier_len_neg")) * p_bezier_ratio;
 
 	if (diff > 0) {
 		cp_offset = MIN(cp_len, diff * 0.5);
@@ -849,7 +849,7 @@ void GraphEdit::_draw_cos_line(CanvasItem *p_where, const Vector2 &p_from, const
 }
 
 void GraphEdit::_connections_layer_draw() {
-	Color activity_color = get_theme_color("activity");
+	Color activity_color = get_theme_color(SNAME("activity"));
 	//draw connections
 	List<List<Connection>::Element *> to_erase;
 	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
@@ -934,8 +934,8 @@ void GraphEdit::_top_layer_draw() {
 	}
 
 	if (box_selecting) {
-		top_layer->draw_rect(box_selecting_rect, get_theme_color("selection_fill"));
-		top_layer->draw_rect(box_selecting_rect, get_theme_color("selection_stroke"), false);
+		top_layer->draw_rect(box_selecting_rect, get_theme_color(SNAME("selection_fill")));
+		top_layer->draw_rect(box_selecting_rect, get_theme_color(SNAME("selection_stroke")), false);
 	}
 }
 
@@ -948,7 +948,7 @@ void GraphEdit::_minimap_draw() {
 
 	// Draw the minimap background.
 	Rect2 minimap_rect = Rect2(Point2(), minimap->get_size());
-	minimap->draw_style_box(minimap->get_theme_stylebox("bg"), minimap_rect);
+	minimap->draw_style_box(minimap->get_theme_stylebox(SNAME("bg")), minimap_rect);
 
 	Vector2 graph_offset = minimap->_get_graph_offset();
 	Vector2 minimap_offset = minimap->minimap_offset;
@@ -964,7 +964,7 @@ void GraphEdit::_minimap_draw() {
 		Vector2 node_size = minimap->_convert_from_graph_position(gn->get_size() * zoom);
 		Rect2 node_rect = Rect2(node_position, node_size);
 
-		Ref<StyleBoxFlat> sb_minimap = minimap->get_theme_stylebox("node")->duplicate();
+		Ref<StyleBoxFlat> sb_minimap = minimap->get_theme_stylebox(SNAME("node"))->duplicate();
 
 		// Override default values with colors provided by the GraphNode's stylebox, if possible.
 		Ref<StyleBoxFlat> sbf = gn->get_theme_stylebox(gn->is_selected() ? "commentfocus" : "comment");
@@ -987,7 +987,7 @@ void GraphEdit::_minimap_draw() {
 		Vector2 node_size = minimap->_convert_from_graph_position(gn->get_size() * zoom);
 		Rect2 node_rect = Rect2(node_position, node_size);
 
-		Ref<StyleBoxFlat> sb_minimap = minimap->get_theme_stylebox("node")->duplicate();
+		Ref<StyleBoxFlat> sb_minimap = minimap->get_theme_stylebox(SNAME("node"))->duplicate();
 
 		// Override default values with colors provided by the GraphNode's stylebox, if possible.
 		Ref<StyleBoxFlat> sbf = gn->get_theme_stylebox(gn->is_selected() ? "selectedframe" : "frame");
@@ -1000,7 +1000,7 @@ void GraphEdit::_minimap_draw() {
 	}
 
 	// Draw node connections.
-	Color activity_color = get_theme_color("activity");
+	Color activity_color = get_theme_color(SNAME("activity"));
 	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
 		NodePath fromnp(E->get().from);
 
@@ -1039,11 +1039,11 @@ void GraphEdit::_minimap_draw() {
 
 	// Draw the "camera" viewport.
 	Rect2 camera_rect = minimap->get_camera_rect();
-	minimap->draw_style_box(minimap->get_theme_stylebox("camera"), camera_rect);
+	minimap->draw_style_box(minimap->get_theme_stylebox(SNAME("camera")), camera_rect);
 
 	// Draw the resizer control.
-	Ref<Texture2D> resizer = minimap->get_theme_icon("resizer");
-	Color resizer_color = minimap->get_theme_color("resizer_color");
+	Ref<Texture2D> resizer = minimap->get_theme_icon(SNAME("resizer"));
+	Color resizer_color = minimap->get_theme_color(SNAME("resizer_color"));
 	minimap->draw_texture(resizer, Point2(), resizer_color);
 }
 
@@ -1070,7 +1070,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 	if (mm.is_valid() && dragging) {
 		if (!moving_selection) {
-			emit_signal("begin_node_move");
+			emit_signal(SNAME("begin_node_move"));
 			moving_selection = true;
 		}
 
@@ -1113,17 +1113,17 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 			if (in_box) {
 				if (!gn->is_selected() && box_selection_mode_additive) {
-					emit_signal("node_selected", gn);
+					emit_signal(SNAME("node_selected"), gn);
 				} else if (gn->is_selected() && !box_selection_mode_additive) {
-					emit_signal("node_deselected", gn);
+					emit_signal(SNAME("node_deselected"), gn);
 				}
 				gn->set_selected(box_selection_mode_additive);
 			} else {
 				bool select = (previous_selected.find(gn) != nullptr);
 				if (gn->is_selected() && !select) {
-					emit_signal("node_deselected", gn);
+					emit_signal(SNAME("node_deselected"), gn);
 				} else if (!gn->is_selected() && select) {
-					emit_signal("node_selected", gn);
+					emit_signal(SNAME("node_selected"), gn);
 				}
 				gn->set_selected(select);
 			}
@@ -1146,9 +1146,9 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 					bool select = (previous_selected.find(gn) != nullptr);
 					if (gn->is_selected() && !select) {
-						emit_signal("node_deselected", gn);
+						emit_signal(SNAME("node_deselected"), gn);
 					} else if (!gn->is_selected() && select) {
-						emit_signal("node_selected", gn);
+						emit_signal(SNAME("node_selected"), gn);
 					}
 					gn->set_selected(select);
 				}
@@ -1160,7 +1160,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 					top_layer->update();
 					minimap->update();
 				} else {
-					emit_signal("popup_request", b->get_global_position());
+					emit_signal(SNAME("popup_request"), b->get_global_position());
 				}
 			}
 		}
@@ -1175,7 +1175,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 						Rect2 r = gn->get_rect();
 						r.size *= zoom;
 						if (r.has_point(b->get_position())) {
-							emit_signal("node_deselected", gn);
+							emit_signal(SNAME("node_deselected"), gn);
 							gn->set_selected(false);
 						}
 					}
@@ -1192,7 +1192,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 			}
 
 			if (moving_selection) {
-				emit_signal("end_node_move");
+				emit_signal(SNAME("end_node_move"));
 				moving_selection = false;
 			}
 
@@ -1238,7 +1238,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 								o_gn->set_selected(true);
 							} else {
 								if (o_gn->is_selected()) {
-									emit_signal("node_deselected", o_gn);
+									emit_signal(SNAME("node_deselected"), o_gn);
 								}
 								o_gn->set_selected(false);
 							}
@@ -1298,7 +1298,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 							continue;
 						}
 						if (gn2->is_selected()) {
-							emit_signal("node_deselected", gn2);
+							emit_signal(SNAME("node_deselected"), gn2);
 						}
 						gn2->set_selected(false);
 					}
@@ -1333,16 +1333,16 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 	if (p_ev->is_pressed()) {
 		if (p_ev->is_action("ui_graph_duplicate")) {
-			emit_signal("duplicate_nodes_request");
+			emit_signal(SNAME("duplicate_nodes_request"));
 			accept_event();
 		} else if (p_ev->is_action("ui_copy")) {
-			emit_signal("copy_nodes_request");
+			emit_signal(SNAME("copy_nodes_request"));
 			accept_event();
 		} else if (p_ev->is_action("ui_paste")) {
-			emit_signal("paste_nodes_request");
+			emit_signal(SNAME("paste_nodes_request"));
 			accept_event();
 		} else if (p_ev->is_action("ui_graph_delete")) {
-			emit_signal("delete_nodes_request");
+			emit_signal(SNAME("delete_nodes_request"));
 			accept_event();
 		}
 	}

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -180,9 +180,9 @@ void GraphNode::_resort() {
 	/** First pass, determine minimum size AND amount of stretchable elements */
 
 	Size2i new_size = get_size();
-	Ref<StyleBox> sb = get_theme_stylebox("frame");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("frame"));
 
-	int sep = get_theme_constant("separation");
+	int sep = get_theme_constant(SNAME("separation"));
 
 	bool first = true;
 	int children_count = 0;
@@ -323,8 +323,8 @@ void GraphNode::_resort() {
 
 bool GraphNode::has_point(const Point2 &p_point) const {
 	if (comment) {
-		Ref<StyleBox> comment = get_theme_stylebox("comment");
-		Ref<Texture2D> resizer = get_theme_icon("resizer");
+		Ref<StyleBox> comment = get_theme_stylebox(SNAME("comment"));
+		Ref<Texture2D> resizer = get_theme_icon(SNAME("resizer"));
 
 		if (Rect2(get_size() - resizer->get_size(), resizer->get_size()).has_point(p_point)) {
 			return true;
@@ -355,18 +355,18 @@ void GraphNode::_notification(int p_what) {
 
 			//sb=sb->duplicate();
 			//sb->call("set_modulate",modulate);
-			Ref<Texture2D> port = get_theme_icon("port");
-			Ref<Texture2D> close = get_theme_icon("close");
-			Ref<Texture2D> resizer = get_theme_icon("resizer");
-			int close_offset = get_theme_constant("close_offset");
-			int close_h_offset = get_theme_constant("close_h_offset");
-			Color close_color = get_theme_color("close_color");
-			Color resizer_color = get_theme_color("resizer_color");
-			int title_offset = get_theme_constant("title_offset");
-			int title_h_offset = get_theme_constant("title_h_offset");
-			Color title_color = get_theme_color("title_color");
+			Ref<Texture2D> port = get_theme_icon(SNAME("port"));
+			Ref<Texture2D> close = get_theme_icon(SNAME("close"));
+			Ref<Texture2D> resizer = get_theme_icon(SNAME("resizer"));
+			int close_offset = get_theme_constant(SNAME("close_offset"));
+			int close_h_offset = get_theme_constant(SNAME("close_h_offset"));
+			Color close_color = get_theme_color(SNAME("close_color"));
+			Color resizer_color = get_theme_color(SNAME("resizer_color"));
+			int title_offset = get_theme_constant(SNAME("title_offset"));
+			int title_h_offset = get_theme_constant(SNAME("title_h_offset"));
+			Color title_color = get_theme_color(SNAME("title_color"));
 			Point2i icofs = -port->get_size() * 0.5;
-			int edgeofs = get_theme_constant("port_offset");
+			int edgeofs = get_theme_constant(SNAME("port_offset"));
 			icofs.y += sb->get_margin(SIDE_TOP);
 
 			draw_style_box(sb, Rect2(Point2(), get_size()));
@@ -375,10 +375,10 @@ void GraphNode::_notification(int p_what) {
 				case OVERLAY_DISABLED: {
 				} break;
 				case OVERLAY_BREAKPOINT: {
-					draw_style_box(get_theme_stylebox("breakpoint"), Rect2(Point2(), get_size()));
+					draw_style_box(get_theme_stylebox(SNAME("breakpoint")), Rect2(Point2(), get_size()));
 				} break;
 				case OVERLAY_POSITION: {
-					draw_style_box(get_theme_stylebox("position"), Rect2(Point2(), get_size()));
+					draw_style_box(get_theme_stylebox(SNAME("position")), Rect2(Point2(), get_size()));
 
 				} break;
 			}
@@ -446,8 +446,8 @@ void GraphNode::_notification(int p_what) {
 }
 
 void GraphNode::_shape() {
-	Ref<Font> font = get_theme_font("title_font");
-	int font_size = get_theme_font_size("title_font_size");
+	Ref<Font> font = get_theme_font(SNAME("title_font"));
+	int font_size = get_theme_font_size(SNAME("title_font_size"));
 
 	title_buf->clear();
 	if (text_direction == Control::TEXT_DIRECTION_INHERITED) {
@@ -481,7 +481,7 @@ void GraphNode::set_slot(int p_idx, bool p_enable_left, int p_type_left, const C
 	update();
 	connpos_dirty = true;
 
-	emit_signal("slot_updated", p_idx);
+	emit_signal(SNAME("slot_updated"), p_idx);
 }
 
 void GraphNode::clear_slot(int p_idx) {
@@ -510,7 +510,7 @@ void GraphNode::set_slot_enabled_left(int p_idx, bool p_enable_left) {
 	update();
 	connpos_dirty = true;
 
-	emit_signal("slot_updated", p_idx);
+	emit_signal(SNAME("slot_updated"), p_idx);
 }
 
 void GraphNode::set_slot_type_left(int p_idx, int p_type_left) {
@@ -520,7 +520,7 @@ void GraphNode::set_slot_type_left(int p_idx, int p_type_left) {
 	update();
 	connpos_dirty = true;
 
-	emit_signal("slot_updated", p_idx);
+	emit_signal(SNAME("slot_updated"), p_idx);
 }
 
 int GraphNode::get_slot_type_left(int p_idx) const {
@@ -537,7 +537,7 @@ void GraphNode::set_slot_color_left(int p_idx, const Color &p_color_left) {
 	update();
 	connpos_dirty = true;
 
-	emit_signal("slot_updated", p_idx);
+	emit_signal(SNAME("slot_updated"), p_idx);
 }
 
 Color GraphNode::get_slot_color_left(int p_idx) const {
@@ -561,7 +561,7 @@ void GraphNode::set_slot_enabled_right(int p_idx, bool p_enable_right) {
 	update();
 	connpos_dirty = true;
 
-	emit_signal("slot_updated", p_idx);
+	emit_signal(SNAME("slot_updated"), p_idx);
 }
 
 void GraphNode::set_slot_type_right(int p_idx, int p_type_right) {
@@ -571,7 +571,7 @@ void GraphNode::set_slot_type_right(int p_idx, int p_type_right) {
 	update();
 	connpos_dirty = true;
 
-	emit_signal("slot_updated", p_idx);
+	emit_signal(SNAME("slot_updated"), p_idx);
 }
 
 int GraphNode::get_slot_type_right(int p_idx) const {
@@ -588,7 +588,7 @@ void GraphNode::set_slot_color_right(int p_idx, const Color &p_color_right) {
 	update();
 	connpos_dirty = true;
 
-	emit_signal("slot_updated", p_idx);
+	emit_signal(SNAME("slot_updated"), p_idx);
 }
 
 Color GraphNode::get_slot_color_right(int p_idx) const {
@@ -599,14 +599,14 @@ Color GraphNode::get_slot_color_right(int p_idx) const {
 }
 
 Size2 GraphNode::get_minimum_size() const {
-	int sep = get_theme_constant("separation");
-	Ref<StyleBox> sb = get_theme_stylebox("frame");
+	int sep = get_theme_constant(SNAME("separation"));
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("frame"));
 	bool first = true;
 
 	Size2 minsize;
 	minsize.x = title_buf->get_size().x;
 	if (show_close) {
-		Ref<Texture2D> close = get_theme_icon("close");
+		Ref<Texture2D> close = get_theme_icon(SNAME("close"));
 		minsize.x += sep + close->get_width();
 	}
 
@@ -699,7 +699,7 @@ String GraphNode::get_language() const {
 
 void GraphNode::set_position_offset(const Vector2 &p_offset) {
 	position_offset = p_offset;
-	emit_signal("position_offset_changed");
+	emit_signal(SNAME("position_offset_changed"));
 	update();
 }
 
@@ -720,7 +720,7 @@ void GraphNode::set_drag(bool p_drag) {
 	if (p_drag) {
 		drag_from = get_position_offset();
 	} else {
-		emit_signal("dragged", drag_from, get_position_offset()); //useful for undo/redo
+		emit_signal(SNAME("dragged"), drag_from, get_position_offset()); //useful for undo/redo
 	}
 }
 
@@ -738,10 +738,10 @@ bool GraphNode::is_close_button_visible() const {
 }
 
 void GraphNode::_connpos_update() {
-	int edgeofs = get_theme_constant("port_offset");
-	int sep = get_theme_constant("separation");
+	int edgeofs = get_theme_constant(SNAME("port_offset"));
+	int sep = get_theme_constant(SNAME("separation"));
 
-	Ref<StyleBox> sb = get_theme_stylebox("frame");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("frame"));
 	conn_input_cache.clear();
 	conn_output_cache.clear();
 	int vofs = 0;
@@ -875,12 +875,12 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 			if (close_rect.size != Size2() && close_rect.has_point(mpos)) {
 				//send focus to parent
 				get_parent_control()->grab_focus();
-				emit_signal("close_request");
+				emit_signal(SNAME("close_request"));
 				accept_event();
 				return;
 			}
 
-			Ref<Texture2D> resizer = get_theme_icon("resizer");
+			Ref<Texture2D> resizer = get_theme_icon(SNAME("resizer"));
 
 			if (resizable && mpos.x > get_size().x - resizer->get_width() && mpos.y > get_size().y - resizer->get_height()) {
 				resizing = true;
@@ -890,7 +890,7 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 				return;
 			}
 
-			emit_signal("raise_request");
+			emit_signal(SNAME("raise_request"));
 		}
 
 		if (!mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
@@ -904,7 +904,7 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 
 		Vector2 diff = mpos - resizing_from;
 
-		emit_signal("resize_request", resizing_from_size + diff);
+		emit_signal(SNAME("resize_request"), resizing_from_size + diff);
 	}
 }
 

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -38,8 +38,8 @@ void GridContainer::_notification(int p_what) {
 			Set<int> col_expanded; // Columns which have the SIZE_EXPAND flag set.
 			Set<int> row_expanded; // Rows which have the SIZE_EXPAND flag set.
 
-			int hsep = get_theme_constant("hseparation");
-			int vsep = get_theme_constant("vseparation");
+			int hsep = get_theme_constant(SNAME("hseparation"));
+			int vsep = get_theme_constant(SNAME("vseparation"));
 			int max_col = MIN(get_child_count(), columns);
 			int max_row = ceil((float)get_child_count() / (float)columns);
 
@@ -213,8 +213,8 @@ Size2 GridContainer::get_minimum_size() const {
 	Map<int, int> col_minw;
 	Map<int, int> row_minh;
 
-	int hsep = get_theme_constant("hseparation");
-	int vsep = get_theme_constant("vseparation");
+	int hsep = get_theme_constant(SNAME("hseparation"));
+	int vsep = get_theme_constant(SNAME("vseparation"));
 
 	int max_row = 0;
 	int max_col = 0;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -42,7 +42,7 @@ void ItemList::_shape(int p_idx) {
 	} else {
 		item.text_buf->set_direction((TextServer::Direction)item.text_direction);
 	}
-	item.text_buf->add_string(item.text, get_theme_font("font"), get_theme_font_size("font_size"), item.opentype_features, (item.language != "") ? item.language : TranslationServer::get_singleton()->get_tool_locale());
+	item.text_buf->add_string(item.text, get_theme_font(SNAME("font")), get_theme_font_size(SNAME("font_size")), item.opentype_features, (item.language != "") ? item.language : TranslationServer::get_singleton()->get_tool_locale());
 	if (icon_mode == ICON_MODE_TOP && max_text_lines > 0) {
 		item.text_buf->set_flags(TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND | TextServer::BREAK_GRAPHEME_BOUND);
 	} else {
@@ -548,7 +548,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 	if (defer_select_single >= 0 && mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_LEFT && !mb->is_pressed()) {
 		select(defer_select_single, true);
 
-		emit_signal("multi_selected", defer_select_single, true);
+		emit_signal(SNAME("multi_selected"), defer_select_single, true);
 		defer_select_single = -1;
 		return;
 	}
@@ -556,7 +556,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && (mb->get_button_index() == MOUSE_BUTTON_LEFT || (allow_rmb_select && mb->get_button_index() == MOUSE_BUTTON_RIGHT)) && mb->is_pressed()) {
 		search_string = ""; //any mousepress cancels
 		Vector2 pos = mb->get_position();
-		Ref<StyleBox> bg = get_theme_stylebox("bg");
+		Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
 		pos -= bg->get_offset();
 		pos.y += scroll_bar->get_value();
 
@@ -583,7 +583,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 			if (select_mode == SELECT_MULTI && items[i].selected && mb->is_command_pressed()) {
 				deselect(i);
-				emit_signal("multi_selected", i, false);
+				emit_signal(SNAME("multi_selected"), i, false);
 
 			} else if (select_mode == SELECT_MULTI && mb->is_shift_pressed() && current >= 0 && current < items.size() && current != i) {
 				int from = current;
@@ -595,12 +595,12 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 					bool selected = !items[j].selected;
 					select(j, false);
 					if (selected) {
-						emit_signal("multi_selected", j, true);
+						emit_signal(SNAME("multi_selected"), j, true);
 					}
 				}
 
 				if (mb->get_button_index() == MOUSE_BUTTON_RIGHT) {
-					emit_signal("item_rmb_selected", i, get_local_mouse_position());
+					emit_signal(SNAME("item_rmb_selected"), i, get_local_mouse_position());
 				}
 			} else {
 				if (!mb->is_double_click() && !mb->is_command_pressed() && select_mode == SELECT_MULTI && items[i].selectable && !items[i].disabled && items[i].selected && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
@@ -609,7 +609,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 				}
 
 				if (items[i].selected && mb->get_button_index() == MOUSE_BUTTON_RIGHT) {
-					emit_signal("item_rmb_selected", i, get_local_mouse_position());
+					emit_signal(SNAME("item_rmb_selected"), i, get_local_mouse_position());
 				} else {
 					bool selected = items[i].selected;
 
@@ -617,16 +617,16 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 					if (!selected || allow_reselect) {
 						if (select_mode == SELECT_SINGLE) {
-							emit_signal("item_selected", i);
+							emit_signal(SNAME("item_selected"), i);
 						} else {
-							emit_signal("multi_selected", i, true);
+							emit_signal(SNAME("multi_selected"), i, true);
 						}
 					}
 
 					if (mb->get_button_index() == MOUSE_BUTTON_RIGHT) {
-						emit_signal("item_rmb_selected", i, get_local_mouse_position());
+						emit_signal(SNAME("item_rmb_selected"), i, get_local_mouse_position());
 					} else if (/*select_mode==SELECT_SINGLE &&*/ mb->is_double_click()) {
-						emit_signal("item_activated", i);
+						emit_signal(SNAME("item_activated"), i);
 					}
 				}
 			}
@@ -634,13 +634,13 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 		if (mb->get_button_index() == MOUSE_BUTTON_RIGHT) {
-			emit_signal("rmb_clicked", mb->get_position());
+			emit_signal(SNAME("rmb_clicked"), mb->get_position());
 
 			return;
 		}
 
 		// Since closest is null, more likely we clicked on empty space, so send signal to interested controls. Allows, for example, implement items deselecting.
-		emit_signal("nothing_selected");
+		emit_signal(SNAME("nothing_selected"));
 	}
 	if (mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_WHEEL_UP && mb->is_pressed()) {
 		scroll_bar->set_value(scroll_bar->get_value() - scroll_bar->get_page() * mb->get_factor() / 8);
@@ -661,7 +661,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 							set_current(i);
 							ensure_current_is_visible();
 							if (select_mode == SELECT_SINGLE) {
-								emit_signal("item_selected", current);
+								emit_signal(SNAME("item_selected"), current);
 							}
 
 							break;
@@ -676,7 +676,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 				set_current(current - current_columns);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
-					emit_signal("item_selected", current);
+					emit_signal(SNAME("item_selected"), current);
 				}
 				accept_event();
 			}
@@ -691,7 +691,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 							set_current(i);
 							ensure_current_is_visible();
 							if (select_mode == SELECT_SINGLE) {
-								emit_signal("item_selected", current);
+								emit_signal(SNAME("item_selected"), current);
 							}
 							break;
 						}
@@ -705,7 +705,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 				set_current(current + current_columns);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
-					emit_signal("item_selected", current);
+					emit_signal(SNAME("item_selected"), current);
 				}
 				accept_event();
 			}
@@ -717,7 +717,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 					set_current(current - current_columns * i);
 					ensure_current_is_visible();
 					if (select_mode == SELECT_SINGLE) {
-						emit_signal("item_selected", current);
+						emit_signal(SNAME("item_selected"), current);
 					}
 					accept_event();
 					break;
@@ -731,7 +731,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 					set_current(current + current_columns * i);
 					ensure_current_is_visible();
 					if (select_mode == SELECT_SINGLE) {
-						emit_signal("item_selected", current);
+						emit_signal(SNAME("item_selected"), current);
 					}
 					accept_event();
 
@@ -745,7 +745,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 				set_current(current - 1);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
-					emit_signal("item_selected", current);
+					emit_signal(SNAME("item_selected"), current);
 				}
 				accept_event();
 			}
@@ -756,7 +756,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 				set_current(current + 1);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
-					emit_signal("item_selected", current);
+					emit_signal(SNAME("item_selected"), current);
 				}
 				accept_event();
 			}
@@ -766,17 +766,17 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 			if (current >= 0 && current < items.size()) {
 				if (items[current].selectable && !items[current].disabled && !items[current].selected) {
 					select(current, false);
-					emit_signal("multi_selected", current, true);
+					emit_signal(SNAME("multi_selected"), current, true);
 				} else if (items[current].selected) {
 					deselect(current);
-					emit_signal("multi_selected", current, false);
+					emit_signal(SNAME("multi_selected"), current, false);
 				}
 			}
 		} else if (p_event->is_action("ui_accept")) {
 			search_string = ""; //any mousepress cancels
 
 			if (current >= 0 && current < items.size()) {
-				emit_signal("item_activated", current);
+				emit_signal(SNAME("item_activated"), current);
 			}
 		} else {
 			Ref<InputEventKey> k = p_event;
@@ -812,7 +812,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 						set_current(i);
 						ensure_current_is_visible();
 						if (select_mode == SELECT_SINGLE) {
-							emit_signal("item_selected", current);
+							emit_signal(SNAME("item_selected"), current);
 						}
 						break;
 					}
@@ -867,7 +867,7 @@ void ItemList::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<StyleBox> bg = get_theme_stylebox("bg");
+		Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
 
 		int mw = scroll_bar->get_minimum_size().x;
 		scroll_bar->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -mw);
@@ -884,24 +884,24 @@ void ItemList::_notification(int p_what) {
 
 		draw_style_box(bg, Rect2(Point2(), size));
 
-		int hseparation = get_theme_constant("hseparation");
-		int vseparation = get_theme_constant("vseparation");
-		int icon_margin = get_theme_constant("icon_margin");
-		int line_separation = get_theme_constant("line_separation");
-		Color font_outline_color = get_theme_color("font_outline_color");
-		int outline_size = get_theme_constant("outline_size");
+		int hseparation = get_theme_constant(SNAME("hseparation"));
+		int vseparation = get_theme_constant(SNAME("vseparation"));
+		int icon_margin = get_theme_constant(SNAME("icon_margin"));
+		int line_separation = get_theme_constant(SNAME("line_separation"));
+		Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+		int outline_size = get_theme_constant(SNAME("outline_size"));
 
-		Ref<StyleBox> sbsel = has_focus() ? get_theme_stylebox("selected_focus") : get_theme_stylebox("selected");
-		Ref<StyleBox> cursor = has_focus() ? get_theme_stylebox("cursor") : get_theme_stylebox("cursor_unfocused");
+		Ref<StyleBox> sbsel = has_focus() ? get_theme_stylebox(SNAME("selected_focus")) : get_theme_stylebox(SNAME("selected"));
+		Ref<StyleBox> cursor = has_focus() ? get_theme_stylebox(SNAME("cursor")) : get_theme_stylebox(SNAME("cursor_unfocused"));
 		bool rtl = is_layout_rtl();
 
-		Color guide_color = get_theme_color("guide_color");
-		Color font_color = get_theme_color("font_color");
-		Color font_selected_color = get_theme_color("font_selected_color");
+		Color guide_color = get_theme_color(SNAME("guide_color"));
+		Color font_color = get_theme_color(SNAME("font_color"));
+		Color font_selected_color = get_theme_color(SNAME("font_selected_color"));
 
 		if (has_focus()) {
 			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
-			draw_style_box(get_theme_stylebox("bg_focus"), Rect2(Point2(), size));
+			draw_style_box(get_theme_stylebox(SNAME("bg_focus")), Rect2(Point2(), size));
 			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), false);
 		}
 
@@ -1299,7 +1299,7 @@ void ItemList::_scroll_changed(double) {
 
 int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 	Vector2 pos = p_pos;
-	Ref<StyleBox> bg = get_theme_stylebox("bg");
+	Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
 	pos -= bg->get_offset();
 	pos.y += scroll_bar->get_value();
 
@@ -1337,7 +1337,7 @@ bool ItemList::is_pos_at_end_of_items(const Point2 &p_pos) const {
 	}
 
 	Vector2 pos = p_pos;
-	Ref<StyleBox> bg = get_theme_stylebox("bg");
+	Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
 	pos -= bg->get_offset();
 	pos.y += scroll_bar->get_value();
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -64,7 +64,7 @@ bool Label::is_uppercase() const {
 }
 
 int Label::get_line_height(int p_line) const {
-	Ref<Font> font = get_theme_font("font");
+	Ref<Font> font = get_theme_font(SNAME("font"));
 	if (p_line >= 0 && p_line < lines_rid.size()) {
 		return TS->shaped_text_get_size(lines_rid[p_line]).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM);
 	} else if (lines_rid.size() > 0) {
@@ -74,12 +74,12 @@ int Label::get_line_height(int p_line) const {
 		}
 		return h;
 	} else {
-		return font->get_height(get_theme_font_size("font_size"));
+		return font->get_height(get_theme_font_size(SNAME("font_size")));
 	}
 }
 
 void Label::_shape() {
-	Ref<StyleBox> style = get_theme_stylebox("normal", "Label");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"), SNAME("Label"));
 	int width = (get_size().width - style->get_minimum_size().width);
 
 	if (dirty) {
@@ -89,7 +89,7 @@ void Label::_shape() {
 		} else {
 			TS->shaped_text_set_direction(text_rid, (TextServer::Direction)text_direction);
 		}
-		TS->shaped_text_add_string(text_rid, (uppercase) ? xl_text.to_upper() : xl_text, get_theme_font("font")->get_rids(), get_theme_font_size("font_size"), opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+		TS->shaped_text_add_string(text_rid, (uppercase) ? xl_text.to_upper() : xl_text, get_theme_font(SNAME("font"))->get_rids(), get_theme_font_size(SNAME("font_size")), opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
 		TS->shaped_text_set_bidi_override(text_rid, structured_text_parser(st_parser, st_args, xl_text));
 		dirty = false;
 		lines_dirty = true;
@@ -200,9 +200,9 @@ void Label::_shape() {
 }
 
 void Label::_update_visible() {
-	int line_spacing = get_theme_constant("line_spacing", "Label");
-	Ref<StyleBox> style = get_theme_stylebox("normal", "Label");
-	Ref<Font> font = get_theme_font("font");
+	int line_spacing = get_theme_constant(SNAME("line_spacing"), SNAME("Label"));
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"), SNAME("Label"));
+	Ref<Font> font = get_theme_font(SNAME("font"));
 	int lines_visible = lines_rid.size();
 
 	if (max_lines_visible >= 0 && lines_visible > max_lines_visible) {
@@ -244,15 +244,15 @@ void Label::_notification(int p_what) {
 
 		Size2 string_size;
 		Size2 size = get_size();
-		Ref<StyleBox> style = get_theme_stylebox("normal");
-		Ref<Font> font = get_theme_font("font");
-		Color font_color = get_theme_color("font_color");
-		Color font_shadow_color = get_theme_color("font_shadow_color");
-		Point2 shadow_ofs(get_theme_constant("shadow_offset_x"), get_theme_constant("shadow_offset_y"));
-		int line_spacing = get_theme_constant("line_spacing");
-		Color font_outline_color = get_theme_color("font_outline_color");
-		int outline_size = get_theme_constant("outline_size");
-		int shadow_outline_size = get_theme_constant("shadow_outline_size");
+		Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
+		Ref<Font> font = get_theme_font(SNAME("font"));
+		Color font_color = get_theme_color(SNAME("font_color"));
+		Color font_shadow_color = get_theme_color(SNAME("font_shadow_color"));
+		Point2 shadow_ofs(get_theme_constant(SNAME("shadow_offset_x")), get_theme_constant(SNAME("shadow_offset_y")));
+		int line_spacing = get_theme_constant(SNAME("line_spacing"));
+		Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+		int outline_size = get_theme_constant(SNAME("outline_size"));
+		int shadow_outline_size = get_theme_constant(SNAME("shadow_outline_size"));
 		bool rtl = is_layout_rtl();
 
 		style->draw(ci, Rect2(Point2(0, 0), get_size()));
@@ -429,10 +429,10 @@ Size2 Label::get_minimum_size() const {
 
 	Size2 min_size = minsize;
 
-	Ref<Font> font = get_theme_font("font");
-	min_size.height = MAX(min_size.height, font->get_height(get_theme_font_size("font_size")) + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM));
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	min_size.height = MAX(min_size.height, font->get_height(get_theme_font_size(SNAME("font_size"))) + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM));
 
-	Size2 min_style = get_theme_stylebox("normal")->get_minimum_size();
+	Size2 min_style = get_theme_stylebox(SNAME("normal"))->get_minimum_size();
 	if (autowrap_mode != AUTOWRAP_OFF) {
 		return Size2(1, (clip || overrun_behavior != OVERRUN_NO_TRIMMING) ? 1 : min_size.height) + min_style;
 	} else {
@@ -455,9 +455,9 @@ int Label::get_line_count() const {
 }
 
 int Label::get_visible_line_count() const {
-	Ref<Font> font = get_theme_font("font");
-	Ref<StyleBox> style = get_theme_stylebox("normal");
-	int line_spacing = get_theme_constant("line_spacing");
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
+	int line_spacing = get_theme_constant(SNAME("line_spacing"));
 	int lines_visible = 0;
 	float total_h = 0.0;
 	for (int64_t i = lines_skipped; i < lines_rid.size(); i++) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -350,7 +350,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 		if (context_menu_enabled) {
 			if (k->is_action("ui_menu", true)) {
 				_ensure_menu();
-				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + get_theme_font("font")->get_height(get_theme_font_size("font_size"))) / 2);
+				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + get_theme_font(SNAME("font"))->get_height(get_theme_font_size(SNAME("font_size")))) / 2);
 				menu->set_position(get_global_transform().xform(pos));
 				menu->set_size(Vector2(1, 1));
 				_generate_context_menu();
@@ -361,7 +361,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 		// Default is ENTER and KP_ENTER. Cannot use ui_accept as default includes SPACE
 		if (k->is_action("ui_text_submit", false)) {
-			emit_signal("text_submitted", text);
+			emit_signal(SNAME("text_submitted"), text);
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
 				DisplayServer::get_singleton()->virtual_keyboard_hide();
 			}
@@ -569,8 +569,8 @@ bool LineEdit::_is_over_clear_button(const Point2 &p_pos) const {
 	if (!clear_button_enabled || !has_point(p_pos)) {
 		return false;
 	}
-	Ref<Texture2D> icon = Control::get_theme_icon("clear");
-	int x_ofs = get_theme_stylebox("normal")->get_offset().x;
+	Ref<Texture2D> icon = Control::get_theme_icon(SNAME("clear"));
+	int x_ofs = get_theme_stylebox(SNAME("normal"))->get_offset().x;
 	return p_pos.x > get_size().width - icon->get_width() - x_ofs;
 }
 
@@ -627,17 +627,17 @@ void LineEdit::_notification(int p_what) {
 
 			RID ci = get_canvas_item();
 
-			Ref<StyleBox> style = get_theme_stylebox("normal");
+			Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 			if (!is_editable()) {
-				style = get_theme_stylebox("read_only");
+				style = get_theme_stylebox(SNAME("read_only"));
 				draw_caret = false;
 			}
-			Ref<Font> font = get_theme_font("font");
+			Ref<Font> font = get_theme_font(SNAME("font"));
 
 			style->draw(ci, Rect2(Point2(), size));
 
 			if (has_focus()) {
-				get_theme_stylebox("focus")->draw(ci, Rect2(Point2(), size));
+				get_theme_stylebox(SNAME("focus"))->draw(ci, Rect2(Point2(), size));
 			}
 
 			int x_ofs = 0;
@@ -675,10 +675,10 @@ void LineEdit::_notification(int p_what) {
 			int y_area = height - style->get_minimum_size().height;
 			int y_ofs = style->get_offset().y + (y_area - text_height) / 2;
 
-			Color selection_color = get_theme_color("selection_color");
-			Color font_color = is_editable() ? get_theme_color("font_color") : get_theme_color("font_uneditable_color");
-			Color font_selected_color = get_theme_color("font_selected_color");
-			Color caret_color = get_theme_color("caret_color");
+			Color selection_color = get_theme_color(SNAME("selection_color"));
+			Color font_color = is_editable() ? get_theme_color(SNAME("font_color")) : get_theme_color(SNAME("font_uneditable_color"));
+			Color font_selected_color = get_theme_color(SNAME("font_selected_color"));
+			Color caret_color = get_theme_color(SNAME("caret_color"));
 
 			// Draw placeholder color.
 			if (using_placeholder) {
@@ -687,13 +687,13 @@ void LineEdit::_notification(int p_what) {
 
 			bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 			if (right_icon.is_valid() || display_clear_icon) {
-				Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
+				Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
 				Color color_icon(1, 1, 1, !is_editable() ? .5 * .9 : .9);
 				if (display_clear_icon) {
 					if (clear_button_status.press_attempt && clear_button_status.pressing_inside) {
-						color_icon = get_theme_color("clear_button_color_pressed");
+						color_icon = get_theme_color(SNAME("clear_button_color_pressed"));
 					} else {
-						color_icon = get_theme_color("clear_button_color");
+						color_icon = get_theme_color(SNAME("clear_button_color"));
 					}
 				}
 
@@ -740,8 +740,8 @@ void LineEdit::_notification(int p_what) {
 
 			// Draw text.
 			ofs.y += TS->shaped_text_get_ascent(text_rid);
-			Color font_outline_color = get_theme_color("font_outline_color");
-			int outline_size = get_theme_constant("outline_size");
+			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
 			if (outline_size > 0 && font_outline_color.a > 0) {
 				Vector2 oofs = ofs;
 				for (int i = 0; i < gl_size; i++) {
@@ -786,7 +786,7 @@ void LineEdit::_notification(int p_what) {
 
 					if (l_caret == Rect2() && t_caret == Rect2()) {
 						// No carets, add one at the start.
-						int h = get_theme_font("font")->get_height(get_theme_font_size("font_size"));
+						int h = get_theme_font(SNAME("font"))->get_height(get_theme_font_size(SNAME("font_size")));
 						int y = style->get_offset().y + (y_area - h) / 2;
 						if (rtl) {
 							l_dir = TextServer::DIRECTION_RTL;
@@ -1008,7 +1008,7 @@ void LineEdit::shift_selection_check_post(bool p_shift) {
 }
 
 void LineEdit::set_caret_at_pixel_pos(int p_x) {
-	Ref<StyleBox> style = get_theme_stylebox("normal");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 	bool rtl = is_layout_rtl();
 
 	int x_ofs = 0;
@@ -1041,7 +1041,7 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 	bool using_placeholder = text.is_empty() && ime_text.is_empty();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
-		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
+		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
 		if (align == ALIGN_CENTER) {
 			if (scroll_offset == 0) {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
@@ -1056,7 +1056,7 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 }
 
 Vector2i LineEdit::get_caret_pixel_pos() {
-	Ref<StyleBox> style = get_theme_stylebox("normal");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 	bool rtl = is_layout_rtl();
 
 	int x_ofs = 0;
@@ -1089,7 +1089,7 @@ Vector2i LineEdit::get_caret_pixel_pos() {
 	bool using_placeholder = text.is_empty() && ime_text.is_empty();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
-		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
+		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
 		if (align == ALIGN_CENTER) {
 			if (scroll_offset == 0) {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
@@ -1402,7 +1402,7 @@ void LineEdit::set_caret_column(int p_column) {
 		return;
 	}
 
-	Ref<StyleBox> style = get_theme_stylebox("normal");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 	bool rtl = is_layout_rtl();
 
 	int x_ofs = 0;
@@ -1436,7 +1436,7 @@ void LineEdit::set_caret_column(int p_column) {
 	bool using_placeholder = text.is_empty() && ime_text.is_empty();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
-		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
+		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
 		if (align == ALIGN_CENTER) {
 			if (scroll_offset == 0) {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
@@ -1480,7 +1480,7 @@ void LineEdit::insert_text_at_caret(String p_text) {
 		// Truncate text to append to fit in max_length, if needed.
 		int available_chars = max_length - text.length();
 		if (p_text.length() > available_chars) {
-			emit_signal("text_change_rejected", p_text.substr(available_chars));
+			emit_signal(SNAME("text_change_rejected"), p_text.substr(available_chars));
 			p_text = p_text.substr(0, available_chars);
 		}
 	}
@@ -1507,15 +1507,15 @@ void LineEdit::clear_internal() {
 }
 
 Size2 LineEdit::get_minimum_size() const {
-	Ref<StyleBox> style = get_theme_stylebox("normal");
-	Ref<Font> font = get_theme_font("font");
-	int font_size = get_theme_font_size("font_size");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	int font_size = get_theme_font_size(SNAME("font_size"));
 
 	Size2 min_size;
 
 	// Minimum size of text.
 	int em_space_size = font->get_char_size('M', 0, font_size).x;
-	min_size.width = get_theme_constant("minimum_character_width") * em_space_size;
+	min_size.width = get_theme_constant(SNAME("minimum_character_width")) * em_space_size;
 
 	if (expand_to_text_length) {
 		// Add a space because some fonts are too exact, and because caret needs a bit more when at the end.
@@ -1528,7 +1528,7 @@ Size2 LineEdit::get_minimum_size() const {
 	bool using_placeholder = text.is_empty() && ime_text.is_empty();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
-		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
+		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
 		min_size.width += r_icon->get_width();
 		min_size.height = MAX(min_size.height, r_icon->get_height());
 	}
@@ -1908,7 +1908,7 @@ void LineEdit::_text_changed() {
 }
 
 void LineEdit::_emit_text_change() {
-	emit_signal("text_changed", text);
+	emit_signal(SNAME("text_changed"), text);
 	text_changed_dirty = false;
 }
 
@@ -1935,8 +1935,8 @@ void LineEdit::_shape() {
 	}
 	TS->shaped_text_set_preserve_control(text_rid, draw_control_chars);
 
-	const Ref<Font> &font = get_theme_font("font");
-	int font_size = get_theme_font_size("font_size");
+	const Ref<Font> &font = get_theme_font(SNAME("font"));
+	int font_size = get_theme_font_size(SNAME("font_size"));
 	TS->shaped_text_add_string(text_rid, t, font->get_rids(), font_size, opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
 	TS->shaped_text_set_bidi_override(text_rid, structured_text_parser(st_parser, st_args, t));
 
@@ -1952,12 +1952,12 @@ void LineEdit::_shape() {
 
 void LineEdit::_fit_to_width() {
 	if (align == ALIGN_FILL) {
-		Ref<StyleBox> style = get_theme_stylebox("normal");
+		Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 		int t_width = get_size().width - style->get_margin(SIDE_RIGHT) - style->get_margin(SIDE_LEFT);
 		bool using_placeholder = text.is_empty() && ime_text.is_empty();
 		bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 		if (right_icon.is_valid() || display_clear_icon) {
-			Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
+			Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
 			t_width -= r_icon->get_width();
 		}
 		TS->shaped_text_fit_to_width(text_rid, MAX(t_width, full_width));

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -32,8 +32,8 @@
 #include "core/string/translation.h"
 
 void LinkButton::_shape() {
-	Ref<Font> font = get_theme_font("font");
-	int font_size = get_theme_font_size("font_size");
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	int font_size = get_theme_font_size(SNAME("font_size"));
 
 	text_buf->clear();
 	if (text_direction == Control::TEXT_DIRECTION_INHERITED) {
@@ -158,41 +158,41 @@ void LinkButton::_notification(int p_what) {
 
 			switch (get_draw_mode()) {
 				case DRAW_NORMAL: {
-					color = get_theme_color("font_color");
+					color = get_theme_color(SNAME("font_color"));
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
 				} break;
 				case DRAW_HOVER_PRESSED:
 				case DRAW_PRESSED: {
-					if (has_theme_color("font_pressed_color")) {
-						color = get_theme_color("font_pressed_color");
+					if (has_theme_color(SNAME("font_pressed_color"))) {
+						color = get_theme_color(SNAME("font_pressed_color"));
 					} else {
-						color = get_theme_color("font_color");
+						color = get_theme_color(SNAME("font_color"));
 					}
 
 					do_underline = underline_mode != UNDERLINE_MODE_NEVER;
 
 				} break;
 				case DRAW_HOVER: {
-					color = get_theme_color("font_hover_color");
+					color = get_theme_color(SNAME("font_hover_color"));
 					do_underline = underline_mode != UNDERLINE_MODE_NEVER;
 
 				} break;
 				case DRAW_DISABLED: {
-					color = get_theme_color("font_disabled_color");
+					color = get_theme_color(SNAME("font_disabled_color"));
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
 
 				} break;
 			}
 
 			if (has_focus()) {
-				Ref<StyleBox> style = get_theme_stylebox("focus");
+				Ref<StyleBox> style = get_theme_stylebox(SNAME("focus"));
 				style->draw(ci, Rect2(Point2(), size));
 			}
 
 			int width = text_buf->get_line_width();
 
-			Color font_outline_color = get_theme_color("font_outline_color");
-			int outline_size = get_theme_constant("outline_size");
+			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
 			if (is_layout_rtl()) {
 				if (outline_size > 0 && font_outline_color.a > 0) {
 					text_buf->draw_outline(get_canvas_item(), Vector2(size.width - width, 0), outline_size, font_outline_color);
@@ -206,7 +206,7 @@ void LinkButton::_notification(int p_what) {
 			}
 
 			if (do_underline) {
-				int underline_spacing = get_theme_constant("underline_spacing") + text_buf->get_line_underline_position();
+				int underline_spacing = get_theme_constant(SNAME("underline_spacing")) + text_buf->get_line_underline_position();
 				int y = text_buf->get_line_ascent() + underline_spacing;
 
 				if (is_layout_rtl()) {

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -31,10 +31,10 @@
 #include "margin_container.h"
 
 Size2 MarginContainer::get_minimum_size() const {
-	int margin_left = get_theme_constant("margin_left");
-	int margin_top = get_theme_constant("margin_top");
-	int margin_right = get_theme_constant("margin_right");
-	int margin_bottom = get_theme_constant("margin_bottom");
+	int margin_left = get_theme_constant(SNAME("margin_left"));
+	int margin_top = get_theme_constant(SNAME("margin_top"));
+	int margin_right = get_theme_constant(SNAME("margin_right"));
+	int margin_bottom = get_theme_constant(SNAME("margin_bottom"));
 
 	Size2 max;
 
@@ -68,10 +68,10 @@ Size2 MarginContainer::get_minimum_size() const {
 void MarginContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
-			int margin_left = get_theme_constant("margin_left");
-			int margin_top = get_theme_constant("margin_top");
-			int margin_right = get_theme_constant("margin_right");
-			int margin_bottom = get_theme_constant("margin_bottom");
+			int margin_left = get_theme_constant(SNAME("margin_left"));
+			int margin_top = get_theme_constant(SNAME("margin_top"));
+			int margin_right = get_theme_constant(SNAME("margin_right"));
+			int margin_bottom = get_theme_constant(SNAME("margin_bottom"));
 
 			Size2 s = get_size();
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -35,12 +35,12 @@
 Size2 OptionButton::get_minimum_size() const {
 	Size2 minsize = Button::get_minimum_size();
 
-	if (has_theme_icon("arrow")) {
-		const Size2 padding = get_theme_stylebox("normal")->get_minimum_size();
-		const Size2 arrow_size = Control::get_theme_icon("arrow")->get_size();
+	if (has_theme_icon(SNAME("arrow"))) {
+		const Size2 padding = get_theme_stylebox(SNAME("normal"))->get_minimum_size();
+		const Size2 arrow_size = Control::get_theme_icon(SNAME("arrow"))->get_size();
 
 		Size2 content_size = minsize - padding;
-		content_size.width += arrow_size.width + get_theme_constant("hseparation");
+		content_size.width += arrow_size.width + get_theme_constant(SNAME("hseparation"));
 		content_size.height = MAX(content_size.height, arrow_size.height);
 
 		minsize = content_size + padding;
@@ -52,26 +52,26 @@ Size2 OptionButton::get_minimum_size() const {
 void OptionButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			if (!has_theme_icon("arrow")) {
+			if (!has_theme_icon(SNAME("arrow"))) {
 				return;
 			}
 
 			RID ci = get_canvas_item();
-			Ref<Texture2D> arrow = Control::get_theme_icon("arrow");
+			Ref<Texture2D> arrow = Control::get_theme_icon(SNAME("arrow"));
 			Color clr = Color(1, 1, 1);
-			if (get_theme_constant("modulate_arrow")) {
+			if (get_theme_constant(SNAME("modulate_arrow"))) {
 				switch (get_draw_mode()) {
 					case DRAW_PRESSED:
-						clr = get_theme_color("font_pressed_color");
+						clr = get_theme_color(SNAME("font_pressed_color"));
 						break;
 					case DRAW_HOVER:
-						clr = get_theme_color("font_hover_color");
+						clr = get_theme_color(SNAME("font_hover_color"));
 						break;
 					case DRAW_DISABLED:
-						clr = get_theme_color("font_disabled_color");
+						clr = get_theme_color(SNAME("font_disabled_color"));
 						break;
 					default:
-						clr = get_theme_color("font_color");
+						clr = get_theme_color(SNAME("font_color"));
 				}
 			}
 
@@ -79,22 +79,22 @@ void OptionButton::_notification(int p_what) {
 
 			Point2 ofs;
 			if (is_layout_rtl()) {
-				ofs = Point2(get_theme_constant("arrow_margin"), int(Math::abs((size.height - arrow->get_height()) / 2)));
+				ofs = Point2(get_theme_constant(SNAME("arrow_margin")), int(Math::abs((size.height - arrow->get_height()) / 2)));
 			} else {
-				ofs = Point2(size.width - arrow->get_width() - get_theme_constant("arrow_margin"), int(Math::abs((size.height - arrow->get_height()) / 2)));
+				ofs = Point2(size.width - arrow->get_width() - get_theme_constant(SNAME("arrow_margin")), int(Math::abs((size.height - arrow->get_height()) / 2)));
 			}
 			arrow->draw(ci, ofs, clr);
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
-			if (has_theme_icon("arrow")) {
+			if (has_theme_icon(SNAME("arrow"))) {
 				if (is_layout_rtl()) {
-					_set_internal_margin(SIDE_LEFT, Control::get_theme_icon("arrow")->get_width());
+					_set_internal_margin(SIDE_LEFT, Control::get_theme_icon(SNAME("arrow"))->get_width());
 					_set_internal_margin(SIDE_RIGHT, 0.f);
 				} else {
 					_set_internal_margin(SIDE_LEFT, 0.f);
-					_set_internal_margin(SIDE_RIGHT, Control::get_theme_icon("arrow")->get_width());
+					_set_internal_margin(SIDE_RIGHT, Control::get_theme_icon(SNAME("arrow"))->get_width());
 				}
 			}
 		} break;
@@ -107,7 +107,7 @@ void OptionButton::_notification(int p_what) {
 }
 
 void OptionButton::_focused(int p_which) {
-	emit_signal("item_focused", p_which);
+	emit_signal(SNAME("item_focused"), p_which);
 }
 
 void OptionButton::_selected(int p_which) {
@@ -220,7 +220,7 @@ void OptionButton::_select(int p_which, bool p_emit) {
 	set_icon(popup->get_item_icon(current));
 
 	if (is_inside_tree() && p_emit) {
-		emit_signal("item_selected", current);
+		emit_signal(SNAME("item_selected"), current);
 	}
 }
 
@@ -339,12 +339,12 @@ OptionButton::OptionButton() {
 	set_toggle_mode(true);
 	set_text_align(ALIGN_LEFT);
 	if (is_layout_rtl()) {
-		if (has_theme_icon("arrow")) {
-			_set_internal_margin(SIDE_LEFT, Control::get_theme_icon("arrow")->get_width());
+		if (has_theme_icon(SNAME("arrow"))) {
+			_set_internal_margin(SIDE_LEFT, Control::get_theme_icon(SNAME("arrow"))->get_width());
 		}
 	} else {
-		if (has_theme_icon("arrow")) {
-			_set_internal_margin(SIDE_RIGHT, Control::get_theme_icon("arrow")->get_width());
+		if (has_theme_icon(SNAME("arrow"))) {
+			_set_internal_margin(SIDE_RIGHT, Control::get_theme_icon(SNAME("arrow"))->get_width());
 		}
 	}
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);

--- a/scene/gui/panel.cpp
+++ b/scene/gui/panel.cpp
@@ -35,7 +35,7 @@
 void Panel::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
 		RID ci = get_canvas_item();
-		Ref<StyleBox> style = mode == MODE_BACKGROUND ? get_theme_stylebox("panel") : get_theme_stylebox("panel_fg");
+		Ref<StyleBox> style = mode == MODE_BACKGROUND ? get_theme_stylebox(SNAME("panel")) : get_theme_stylebox(SNAME("panel_fg"));
 		style->draw(ci, Rect2(Point2(), get_size()));
 	}
 }

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -33,10 +33,10 @@
 Size2 PanelContainer::get_minimum_size() const {
 	Ref<StyleBox> style;
 
-	if (has_theme_stylebox("panel")) {
-		style = get_theme_stylebox("panel");
+	if (has_theme_stylebox(SNAME("panel"))) {
+		style = get_theme_stylebox(SNAME("panel"));
 	} else {
-		style = get_theme_stylebox("panel", "PanelContainer");
+		style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
 	}
 
 	Size2 ms;
@@ -65,10 +65,10 @@ void PanelContainer::_notification(int p_what) {
 		RID ci = get_canvas_item();
 		Ref<StyleBox> style;
 
-		if (has_theme_stylebox("panel")) {
-			style = get_theme_stylebox("panel");
+		if (has_theme_stylebox(SNAME("panel"))) {
+			style = get_theme_stylebox(SNAME("panel"));
 		} else {
-			style = get_theme_stylebox("panel", "PanelContainer");
+			style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
 		}
 
 		style->draw(ci, Rect2(Point2(), get_size()));
@@ -77,10 +77,10 @@ void PanelContainer::_notification(int p_what) {
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
 		Ref<StyleBox> style;
 
-		if (has_theme_stylebox("panel")) {
-			style = get_theme_stylebox("panel");
+		if (has_theme_stylebox(SNAME("panel"))) {
+			style = get_theme_stylebox(SNAME("panel"));
 		} else {
-			style = get_theme_stylebox("panel", "PanelContainer");
+			style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
 		}
 
 		Size2 size = get_size();

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -71,7 +71,7 @@ void Popup::_notification(int p_what) {
 				_initialize_visible_parents();
 			} else {
 				_deinitialize_visible_parents();
-				emit_signal("popup_hide");
+				emit_signal(SNAME("popup_hide"));
 			}
 
 		} break;
@@ -103,9 +103,9 @@ void Popup::_close_pressed() {
 
 	_deinitialize_visible_parents();
 
-	call_deferred("hide");
+	call_deferred(SNAME("hide"));
 
-	emit_signal("cancelled");
+	emit_signal(SNAME("cancelled"));
 }
 
 void Popup::set_as_minsize() {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -46,15 +46,15 @@ String PopupMenu::_get_accel_text(const Item &p_item) const {
 }
 
 Size2 PopupMenu::_get_contents_minimum_size() const {
-	int vseparation = get_theme_constant("vseparation");
-	int hseparation = get_theme_constant("hseparation");
+	int vseparation = get_theme_constant(SNAME("vseparation"));
+	int hseparation = get_theme_constant(SNAME("hseparation"));
 
-	Size2 minsize = get_theme_stylebox("panel")->get_minimum_size(); // Accounts for margin in the margin container
+	Size2 minsize = get_theme_stylebox(SNAME("panel"))->get_minimum_size(); // Accounts for margin in the margin container
 	minsize.x += scroll_container->get_v_scrollbar()->get_size().width * 2; // Adds a buffer so that the scrollbar does not render over the top of content
 
 	float max_w = 0.0;
 	float icon_w = 0.0;
-	int check_w = MAX(get_theme_icon("checked")->get_width(), get_theme_icon("radio_checked")->get_width()) + hseparation;
+	int check_w = MAX(get_theme_icon(SNAME("checked"))->get_width(), get_theme_icon(SNAME("radio_checked"))->get_width()) + hseparation;
 	int accel_max_w = 0;
 	bool has_check = false;
 
@@ -81,7 +81,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 		}
 
 		if (items[i].submenu != "") {
-			size.width += get_theme_icon("submenu")->get_width();
+			size.width += get_theme_icon(SNAME("submenu"))->get_width();
 		}
 
 		max_w = MAX(max_w, size.width);
@@ -89,7 +89,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 		minsize.height += size.height;
 	}
 
-	int item_side_padding = get_theme_constant("item_start_padding") + get_theme_constant("item_end_padding");
+	int item_side_padding = get_theme_constant(SNAME("item_start_padding")) + get_theme_constant(SNAME("item_end_padding"));
 	minsize.width += max_w + icon_w + accel_max_w + item_side_padding;
 
 	if (has_check) {
@@ -112,24 +112,24 @@ int PopupMenu::_get_item_height(int p_item) const {
 
 	int icon_height = items[p_item].get_icon_size().height;
 	if (items[p_item].checkable_type) {
-		icon_height = MAX(icon_height, MAX(get_theme_icon("checked")->get_height(), get_theme_icon("radio_checked")->get_height()));
+		icon_height = MAX(icon_height, MAX(get_theme_icon(SNAME("checked"))->get_height(), get_theme_icon(SNAME("radio_checked"))->get_height()));
 	}
 
 	int text_height = items[p_item].text_buf->get_size().height;
 	if (text_height == 0 && !items[p_item].separator) {
-		text_height = get_theme_font("font")->get_height(get_theme_font_size("font_size"));
+		text_height = get_theme_font(SNAME("font"))->get_height(get_theme_font_size(SNAME("font_size")));
 	}
 
 	int separator_height = 0;
 	if (items[p_item].separator) {
-		separator_height = MAX(get_theme_stylebox("separator")->get_minimum_size().height, MAX(get_theme_stylebox("labeled_separator_left")->get_minimum_size().height, get_theme_stylebox("labeled_separator_right")->get_minimum_size().height));
+		separator_height = MAX(get_theme_stylebox(SNAME("separator"))->get_minimum_size().height, MAX(get_theme_stylebox(SNAME("labeled_separator_left"))->get_minimum_size().height, get_theme_stylebox(SNAME("labeled_separator_right"))->get_minimum_size().height));
 	}
 
 	return MAX(separator_height, MAX(text_height, icon_height));
 }
 
 int PopupMenu::_get_items_total_height() const {
-	int vsep = get_theme_constant("vseparation");
+	int vsep = get_theme_constant(SNAME("vseparation"));
 
 	// Get total height of all items by taking max of icon height and font height
 	int items_total_height = 0;
@@ -163,9 +163,9 @@ int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
 		return -1;
 	}
 
-	Ref<StyleBox> style = get_theme_stylebox("panel"); // Accounts for margin in the margin container
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("panel")); // Accounts for margin in the margin container
 
-	int vseparation = get_theme_constant("vseparation");
+	int vseparation = get_theme_constant(SNAME("vseparation"));
 
 	Point2 ofs = style->get_offset() + Point2(0, vseparation / 2);
 
@@ -195,8 +195,8 @@ void PopupMenu::_activate_submenu(int p_over) {
 		return; //already visible!
 	}
 
-	Ref<StyleBox> style = get_theme_stylebox("panel");
-	int vsep = get_theme_constant("vseparation");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("panel"));
+	int vsep = get_theme_constant(SNAME("vseparation"));
 
 	Point2 this_pos = get_position();
 	Rect2 this_rect(this_pos, get_size());
@@ -264,7 +264,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 		for (int i = search_from; i < items.size(); i++) {
 			if (!items[i].separator && !items[i].disabled) {
 				mouse_over = i;
-				emit_signal("id_focused", i);
+				emit_signal(SNAME("id_focused"), i);
 				_scroll_to_item(i);
 				control->update();
 				set_input_as_handled();
@@ -278,7 +278,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 			for (int i = 0; i < search_from; i++) {
 				if (!items[i].separator && !items[i].disabled) {
 					mouse_over = i;
-					emit_signal("id_focused", i);
+					emit_signal(SNAME("id_focused"), i);
 					_scroll_to_item(i);
 					control->update();
 					set_input_as_handled();
@@ -296,7 +296,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 		for (int i = search_from; i >= 0; i--) {
 			if (!items[i].separator && !items[i].disabled) {
 				mouse_over = i;
-				emit_signal("id_focused", i);
+				emit_signal(SNAME("id_focused"), i);
 				_scroll_to_item(i);
 				control->update();
 				set_input_as_handled();
@@ -310,7 +310,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 			for (int i = items.size() - 1; i >= search_from; i--) {
 				if (!items[i].separator && !items[i].disabled) {
 					mouse_over = i;
-					emit_signal("id_focused", i);
+					emit_signal(SNAME("id_focused"), i);
 					_scroll_to_item(i);
 					control->update();
 					set_input_as_handled();
@@ -459,7 +459,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 
 			if (items[i].text.findn(search_string) == 0) {
 				mouse_over = i;
-				emit_signal("id_focused", i);
+				emit_signal(SNAME("id_focused"), i);
 				_scroll_to_item(i);
 				control->update();
 				set_input_as_handled();
@@ -474,37 +474,37 @@ void PopupMenu::_draw_items() {
 	RID ci = control->get_canvas_item();
 
 	Size2 margin_size;
-	margin_size.width = margin_container->get_theme_constant("margin_right") + margin_container->get_theme_constant("margin_left");
-	margin_size.height = margin_container->get_theme_constant("margin_top") + margin_container->get_theme_constant("margin_bottom");
+	margin_size.width = margin_container->get_theme_constant(SNAME("margin_right")) + margin_container->get_theme_constant(SNAME("margin_left"));
+	margin_size.height = margin_container->get_theme_constant(SNAME("margin_top")) + margin_container->get_theme_constant(SNAME("margin_bottom"));
 
 	// Space between the item content and the sides of popup menu.
-	int item_start_padding = get_theme_constant("item_start_padding");
-	int item_end_padding = get_theme_constant("item_end_padding");
+	int item_start_padding = get_theme_constant(SNAME("item_start_padding"));
+	int item_end_padding = get_theme_constant(SNAME("item_end_padding"));
 
 	bool rtl = control->is_layout_rtl();
-	Ref<StyleBox> style = get_theme_stylebox("panel");
-	Ref<StyleBox> hover = get_theme_stylebox("hover");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("panel"));
+	Ref<StyleBox> hover = get_theme_stylebox(SNAME("hover"));
 	// In Item::checkable_type enum order (less the non-checkable member)
-	Ref<Texture2D> check[] = { get_theme_icon("checked"), get_theme_icon("radio_checked") };
-	Ref<Texture2D> uncheck[] = { get_theme_icon("unchecked"), get_theme_icon("radio_unchecked") };
+	Ref<Texture2D> check[] = { get_theme_icon(SNAME("checked")), get_theme_icon(SNAME("radio_checked")) };
+	Ref<Texture2D> uncheck[] = { get_theme_icon(SNAME("unchecked")), get_theme_icon(SNAME("radio_unchecked")) };
 	Ref<Texture2D> submenu;
 	if (rtl) {
-		submenu = get_theme_icon("submenu_mirrored");
+		submenu = get_theme_icon(SNAME("submenu_mirrored"));
 	} else {
-		submenu = get_theme_icon("submenu");
+		submenu = get_theme_icon(SNAME("submenu"));
 	}
 
-	Ref<StyleBox> separator = get_theme_stylebox("separator");
-	Ref<StyleBox> labeled_separator_left = get_theme_stylebox("labeled_separator_left");
-	Ref<StyleBox> labeled_separator_right = get_theme_stylebox("labeled_separator_right");
+	Ref<StyleBox> separator = get_theme_stylebox(SNAME("separator"));
+	Ref<StyleBox> labeled_separator_left = get_theme_stylebox(SNAME("labeled_separator_left"));
+	Ref<StyleBox> labeled_separator_right = get_theme_stylebox(SNAME("labeled_separator_right"));
 
-	int vseparation = get_theme_constant("vseparation");
-	int hseparation = get_theme_constant("hseparation");
-	Color font_color = get_theme_color("font_color");
-	Color font_disabled_color = get_theme_color("font_disabled_color");
-	Color font_accelerator_color = get_theme_color("font_accelerator_color");
-	Color font_hover_color = get_theme_color("font_hover_color");
-	Color font_separator_color = get_theme_color("font_separator_color");
+	int vseparation = get_theme_constant(SNAME("vseparation"));
+	int hseparation = get_theme_constant(SNAME("hseparation"));
+	Color font_color = get_theme_color(SNAME("font_color"));
+	Color font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
+	Color font_accelerator_color = get_theme_color(SNAME("font_accelerator_color"));
+	Color font_hover_color = get_theme_color(SNAME("font_hover_color"));
+	Color font_separator_color = get_theme_color(SNAME("font_separator_color"));
 
 	float scroll_width = scroll_container->get_v_scrollbar()->is_visible_in_tree() ? scroll_container->get_v_scrollbar()->get_size().width : 0;
 	float display_width = control->get_size().width - scroll_width;
@@ -525,7 +525,7 @@ void PopupMenu::_draw_items() {
 
 	float check_ofs = 0.0;
 	if (has_check) {
-		check_ofs = MAX(get_theme_icon("checked")->get_width(), get_theme_icon("radio_checked")->get_width()) + hseparation;
+		check_ofs = MAX(get_theme_icon(SNAME("checked"))->get_width(), get_theme_icon(SNAME("radio_checked"))->get_width()) + hseparation;
 	}
 
 	Point2 ofs = Point2();
@@ -606,8 +606,8 @@ void PopupMenu::_draw_items() {
 		}
 
 		// Text
-		Color font_outline_color = get_theme_color("font_outline_color");
-		int outline_size = get_theme_constant("outline_size");
+		Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+		int outline_size = get_theme_constant(SNAME("outline_size"));
 		if (items[i].separator) {
 			if (text != String()) {
 				int center = (display_width - items[i].text_buf->get_size().width) / 2;
@@ -657,7 +657,7 @@ void PopupMenu::_draw_items() {
 }
 
 void PopupMenu::_draw_background() {
-	Ref<StyleBox> style = get_theme_stylebox("panel");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("panel"));
 	RID ci2 = margin_container->get_canvas_item();
 	style->draw(ci2, Rect2(Point2(), margin_container->get_size()));
 }
@@ -691,8 +691,8 @@ void PopupMenu::_shape_item(int p_item) {
 	if (items.write[p_item].dirty) {
 		items.write[p_item].text_buf->clear();
 
-		Ref<Font> font = get_theme_font("font");
-		int font_size = get_theme_font_size("font_size");
+		Ref<Font> font = get_theme_font(SNAME("font"));
+		int font_size = get_theme_font_size(SNAME("font_size"));
 
 		if (items[p_item].text_direction == Control::TEXT_DIRECTION_INHERITED) {
 			items.write[p_item].text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
@@ -791,7 +791,7 @@ void PopupMenu::_notification(int p_what) {
 				}
 
 				// Set margin on the margin container
-				Ref<StyleBox> panel_style = get_theme_stylebox("panel");
+				Ref<StyleBox> panel_style = get_theme_stylebox(SNAME("panel"));
 				margin_container->add_theme_constant_override("margin_top", panel_style->get_margin(Side::SIDE_TOP));
 				margin_container->add_theme_constant_override("margin_bottom", panel_style->get_margin(Side::SIDE_BOTTOM));
 				margin_container->add_theme_constant_override("margin_left", panel_style->get_margin(Side::SIDE_LEFT));
@@ -1376,8 +1376,8 @@ void PopupMenu::activate_item(int p_item) {
 		need_hide = false;
 	}
 
-	emit_signal("id_pressed", id);
-	emit_signal("index_pressed", p_item);
+	emit_signal(SNAME("id_pressed"), id);
+	emit_signal(SNAME("index_pressed"), p_item);
 
 	if (need_hide) {
 		hide();

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -32,10 +32,10 @@
 #include "scene/resources/text_line.h"
 
 Size2 ProgressBar::get_minimum_size() const {
-	Ref<StyleBox> bg = get_theme_stylebox("bg");
-	Ref<StyleBox> fg = get_theme_stylebox("fg");
-	Ref<Font> font = get_theme_font("font");
-	int font_size = get_theme_font_size("font_size");
+	Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
+	Ref<StyleBox> fg = get_theme_stylebox(SNAME("fg"));
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	int font_size = get_theme_font_size(SNAME("font_size"));
 
 	Size2 minimum_size = bg->get_minimum_size();
 	minimum_size.height = MAX(minimum_size.height, fg->get_minimum_size().height);
@@ -53,11 +53,11 @@ Size2 ProgressBar::get_minimum_size() const {
 
 void ProgressBar::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<StyleBox> bg = get_theme_stylebox("bg");
-		Ref<StyleBox> fg = get_theme_stylebox("fg");
-		Ref<Font> font = get_theme_font("font");
-		int font_size = get_theme_font_size("font_size");
-		Color font_color = get_theme_color("font_color");
+		Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
+		Ref<StyleBox> fg = get_theme_stylebox(SNAME("fg"));
+		Ref<Font> font = get_theme_font(SNAME("font"));
+		int font_size = get_theme_font_size(SNAME("font_size"));
+		Color font_color = get_theme_color(SNAME("font_color"));
 
 		draw_style_box(bg, Rect2(Point2(), get_size()));
 		float r = get_as_ratio();
@@ -75,8 +75,8 @@ void ProgressBar::_notification(int p_what) {
 			String txt = TS->format_number(itos(int(get_as_ratio() * 100))) + TS->percent_sign();
 			TextLine tl = TextLine(txt, font, font_size);
 			Vector2 text_pos = (Point2(get_size().width - tl.get_size().x, get_size().height - tl.get_size().y) / 2).round();
-			Color font_outline_color = get_theme_color("font_outline_color");
-			int outline_size = get_theme_constant("outline_size");
+			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
 			if (outline_size > 0 && font_outline_color.a > 0) {
 				tl.draw_outline(get_canvas_item(), text_pos, outline_size, font_outline_color);
 			}

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -42,7 +42,7 @@ TypedArray<String> Range::get_configuration_warnings() const {
 
 void Range::_value_changed_notify() {
 	_value_changed(shared->val);
-	emit_signal("value_changed", shared->val);
+	emit_signal(SNAME("value_changed"), shared->val);
 	update();
 }
 
@@ -57,7 +57,7 @@ void Range::Shared::emit_value_changed() {
 }
 
 void Range::_changed_notify(const char *p_what) {
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 	update();
 }
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -136,7 +136,7 @@ RichTextLabel::Item *RichTextLabel::_get_prev_item(Item *p_item, bool p_free) co
 }
 
 Rect2 RichTextLabel::_get_text_rect() {
-	Ref<StyleBox> style = get_theme_stylebox("normal");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 	return Rect2(style->get_offset(), get_size() - style->get_minimum_size());
 }
 
@@ -229,8 +229,8 @@ void RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 		switch (it->type) {
 			case ITEM_TABLE: {
 				ItemTable *table = static_cast<ItemTable *>(it);
-				int hseparation = get_theme_constant("table_hseparation");
-				int vseparation = get_theme_constant("table_vseparation");
+				int hseparation = get_theme_constant(SNAME("table_hseparation"));
+				int vseparation = get_theme_constant(SNAME("table_vseparation"));
 				int col_count = table->columns.size();
 
 				for (int i = 0; i < col_count; i++) {
@@ -458,8 +458,8 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 			} break;
 			case ITEM_TABLE: {
 				ItemTable *table = static_cast<ItemTable *>(it);
-				int hseparation = get_theme_constant("table_hseparation");
-				int vseparation = get_theme_constant("table_vseparation");
+				int hseparation = get_theme_constant(SNAME("table_hseparation"));
+				int vseparation = get_theme_constant(SNAME("table_vseparation"));
 				int col_count = table->columns.size();
 				int t_char_count = 0;
 				// Set minimums to zero.
@@ -672,11 +672,11 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 	if (prefix != "") {
 		Ref<Font> font = _find_font(l.from);
 		if (font.is_null()) {
-			font = get_theme_font("normal_font");
+			font = get_theme_font(SNAME("normal_font"));
 		}
 		int font_size = _find_font_size(l.from);
 		if (font_size == -1) {
-			font_size = get_theme_font_size("normal_font_size");
+			font_size = get_theme_font_size(SNAME("normal_font_size"));
 		}
 		if (rtl) {
 			float offx = 0.0f;
@@ -775,10 +775,10 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 					} break;
 					case ITEM_TABLE: {
 						ItemTable *table = static_cast<ItemTable *>(it);
-						Color odd_row_bg = get_theme_color("table_odd_row_bg");
-						Color even_row_bg = get_theme_color("table_even_row_bg");
-						Color border = get_theme_color("table_border");
-						int hseparation = get_theme_constant("table_hseparation");
+						Color odd_row_bg = get_theme_color(SNAME("table_odd_row_bg"));
+						Color even_row_bg = get_theme_color(SNAME("table_even_row_bg"));
+						Color border = get_theme_color(SNAME("table_border"));
+						int hseparation = get_theme_constant(SNAME("table_hseparation"));
 						int col_count = table->columns.size();
 						int row_count = table->rows.size();
 
@@ -916,7 +916,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 				}
 			}
 
-			Point2 shadow_ofs(get_theme_constant("shadow_offset_x"), get_theme_constant("shadow_offset_y"));
+			Point2 shadow_ofs(get_theme_constant(SNAME("shadow_offset_x")), get_theme_constant(SNAME("shadow_offset_y")));
 
 			// Draw glyph outlines.
 			for (int j = 0; j < glyphs[i].repeat; j++) {
@@ -940,8 +940,8 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 		_draw_fbg_boxes(ci, rid, fbg_line_off, it_from, it_to, chr_range.x, chr_range.y, 0);
 
 		// Draw main text.
-		Color selection_fg = get_theme_color("font_selected_color");
-		Color selection_bg = get_theme_color("selection_color");
+		Color selection_fg = get_theme_color(SNAME("font_selected_color"));
+		Color selection_bg = get_theme_color(SNAME("selection_color"));
 
 		int sel_start = -1;
 		int sel_end = -1;
@@ -1192,8 +1192,8 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 				if (rect.has_point(p_click - p_ofs - off)) {
 					switch (it->type) {
 						case ITEM_TABLE: {
-							int hseparation = get_theme_constant("table_hseparation");
-							int vseparation = get_theme_constant("table_vseparation");
+							int hseparation = get_theme_constant(SNAME("table_hseparation"));
+							int vseparation = get_theme_constant(SNAME("table_vseparation"));
 
 							ItemTable *table = static_cast<ItemTable *>(it);
 
@@ -1362,7 +1362,7 @@ void RichTextLabel::_notification(int p_what) {
 		case NOTIFICATION_MOUSE_EXIT: {
 			if (meta_hovering) {
 				meta_hovering = nullptr;
-				emit_signal("meta_hover_ended", current_meta);
+				emit_signal(SNAME("meta_hover_ended"), current_meta);
 				current_meta = false;
 				update();
 			}
@@ -1395,11 +1395,11 @@ void RichTextLabel::_notification(int p_what) {
 			Size2 size = get_size();
 			Rect2 text_rect = _get_text_rect();
 
-			draw_style_box(get_theme_stylebox("normal"), Rect2(Point2(), size));
+			draw_style_box(get_theme_stylebox(SNAME("normal")), Rect2(Point2(), size));
 
 			if (has_focus()) {
 				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, true);
-				draw_style_box(get_theme_stylebox("focus"), Rect2(Point2(), size));
+				draw_style_box(get_theme_stylebox(SNAME("focus")), Rect2(Point2(), size));
 				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, false);
 			}
 
@@ -1419,13 +1419,13 @@ void RichTextLabel::_notification(int p_what) {
 			if (from_line >= main->lines.size()) {
 				break; //nothing to draw
 			}
-			Ref<Font> base_font = get_theme_font("normal_font");
-			Color base_color = get_theme_color("default_color");
-			Color outline_color = get_theme_color("font_outline_color");
-			int outline_size = get_theme_constant("outline_size");
-			Color font_shadow_color = get_theme_color("font_shadow_color");
-			bool use_outline = get_theme_constant("shadow_as_outline");
-			Point2 shadow_ofs(get_theme_constant("shadow_offset_x"), get_theme_constant("shadow_offset_y"));
+			Ref<Font> base_font = get_theme_font(SNAME("normal_font"));
+			Color base_color = get_theme_color(SNAME("default_color"));
+			Color outline_color = get_theme_color(SNAME("font_outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
+			Color font_shadow_color = get_theme_color(SNAME("font_shadow_color"));
+			bool use_outline = get_theme_constant(SNAME("shadow_as_outline"));
+			Point2 shadow_ofs(get_theme_constant(SNAME("shadow_offset_x")), get_theme_constant(SNAME("shadow_offset_y")));
 
 			visible_paragraph_count = 0;
 			visible_line_count = 0;
@@ -1568,7 +1568,7 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 						Variant meta;
 						if (!outside && _find_meta(c_item, &meta)) {
 							//meta clicked
-							emit_signal("meta_clicked", meta);
+							emit_signal(SNAME("meta_clicked"), meta);
 						}
 					}
 				}
@@ -1611,11 +1611,11 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 				handled = true;
 			}
 			if (k->is_action("ui_up") && vscroll->is_visible_in_tree()) {
-				vscroll->set_value(vscroll->get_value() - get_theme_font("normal_font")->get_height(get_theme_font_size("normal_font_size")));
+				vscroll->set_value(vscroll->get_value() - get_theme_font(SNAME("normal_font"))->get_height(get_theme_font_size(SNAME("normal_font_size"))));
 				handled = true;
 			}
 			if (k->is_action("ui_down") && vscroll->is_visible_in_tree()) {
-				vscroll->set_value(vscroll->get_value() + get_theme_font("normal_font")->get_height(get_theme_font_size("normal_font_size")));
+				vscroll->set_value(vscroll->get_value() + get_theme_font(SNAME("normal_font"))->get_height(get_theme_font_size(SNAME("normal_font_size"))));
 				handled = true;
 			}
 			if (k->is_action("ui_home") && vscroll->is_visible_in_tree()) {
@@ -1693,15 +1693,15 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 		if (c_item && !outside && _find_meta(c_item, &meta, &item_meta)) {
 			if (meta_hovering != item_meta) {
 				if (meta_hovering) {
-					emit_signal("meta_hover_ended", current_meta);
+					emit_signal(SNAME("meta_hover_ended"), current_meta);
 				}
 				meta_hovering = item_meta;
 				current_meta = meta;
-				emit_signal("meta_hover_started", meta);
+				emit_signal(SNAME("meta_hover_started"), meta);
 			}
 		} else if (meta_hovering) {
 			meta_hovering = nullptr;
-			emit_signal("meta_hover_ended", current_meta);
+			emit_signal(SNAME("meta_hover_ended"), current_meta);
 			current_meta = false;
 		}
 	}
@@ -2105,8 +2105,8 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 		}
 		Rect2 text_rect = _get_text_rect();
 
-		Ref<Font> base_font = get_theme_font("normal_font");
-		int base_font_size = get_theme_font_size("normal_font_size");
+		Ref<Font> base_font = get_theme_font(SNAME("normal_font"));
+		int base_font_size = get_theme_font_size(SNAME("normal_font_size"));
 
 		for (int i = p_frame->first_resized_line; i < p_frame->lines.size(); i++) {
 			_resize_line(p_frame, i, base_font, base_font_size, text_rect.get_size().width - scroll_w);
@@ -2140,8 +2140,8 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 	}
 	Rect2 text_rect = _get_text_rect();
 
-	Ref<Font> base_font = get_theme_font("normal_font");
-	int base_font_size = get_theme_font_size("normal_font_size");
+	Ref<Font> base_font = get_theme_font(SNAME("normal_font"));
+	int base_font_size = get_theme_font_size(SNAME("normal_font_size"));
 
 	int total_chars = (p_frame->first_invalid_line == 0) ? 0 : (p_frame->lines[p_frame->first_invalid_line].char_offset + p_frame->lines[p_frame->first_invalid_line].char_count);
 	for (int i = p_frame->first_invalid_line; i < p_frame->lines.size(); i++) {
@@ -2406,35 +2406,35 @@ void RichTextLabel::push_font(const Ref<Font> &p_font) {
 }
 
 void RichTextLabel::push_normal() {
-	Ref<Font> normal_font = get_theme_font("normal_font");
+	Ref<Font> normal_font = get_theme_font(SNAME("normal_font"));
 	ERR_FAIL_COND(normal_font.is_null());
 
 	push_font(normal_font);
 }
 
 void RichTextLabel::push_bold() {
-	Ref<Font> bold_font = get_theme_font("bold_font");
+	Ref<Font> bold_font = get_theme_font(SNAME("bold_font"));
 	ERR_FAIL_COND(bold_font.is_null());
 
 	push_font(bold_font);
 }
 
 void RichTextLabel::push_bold_italics() {
-	Ref<Font> bold_italics_font = get_theme_font("bold_italics_font");
+	Ref<Font> bold_italics_font = get_theme_font(SNAME("bold_italics_font"));
 	ERR_FAIL_COND(bold_italics_font.is_null());
 
 	push_font(bold_italics_font);
 }
 
 void RichTextLabel::push_italics() {
-	Ref<Font> italics_font = get_theme_font("italics_font");
+	Ref<Font> italics_font = get_theme_font(SNAME("italics_font"));
 	ERR_FAIL_COND(italics_font.is_null());
 
 	push_font(italics_font);
 }
 
 void RichTextLabel::push_mono() {
-	Ref<Font> mono_font = get_theme_font("mono_font");
+	Ref<Font> mono_font = get_theme_font(SNAME("mono_font"));
 	ERR_FAIL_COND(mono_font.is_null());
 
 	push_font(mono_font);
@@ -2774,13 +2774,13 @@ Error RichTextLabel::append_bbcode(const String &p_bbcode) {
 	int pos = 0;
 
 	List<String> tag_stack;
-	Ref<Font> normal_font = get_theme_font("normal_font");
-	Ref<Font> bold_font = get_theme_font("bold_font");
-	Ref<Font> italics_font = get_theme_font("italics_font");
-	Ref<Font> bold_italics_font = get_theme_font("bold_italics_font");
-	Ref<Font> mono_font = get_theme_font("mono_font");
+	Ref<Font> normal_font = get_theme_font(SNAME("normal_font"));
+	Ref<Font> bold_font = get_theme_font(SNAME("bold_font"));
+	Ref<Font> italics_font = get_theme_font(SNAME("italics_font"));
+	Ref<Font> bold_italics_font = get_theme_font(SNAME("bold_italics_font"));
+	Ref<Font> mono_font = get_theme_font(SNAME("mono_font"));
 
-	Color base_color = get_theme_color("default_color");
+	Color base_color = get_theme_color(SNAME("default_color"));
 
 	int indent_level = 0;
 
@@ -3140,11 +3140,11 @@ Error RichTextLabel::append_bbcode(const String &p_bbcode) {
 			tag_stack.push_front("url");
 		} else if (tag.begins_with("dropcap")) {
 			Vector<String> subtag = tag.substr(5, tag.length()).split(" ");
-			Ref<Font> f = get_theme_font("normal_font");
-			int fs = get_theme_font_size("normal_font_size") * 3;
-			Color color = get_theme_color("default_color");
-			Color outline_color = get_theme_color("outline_color");
-			int outline_size = get_theme_constant("outline_size");
+			Ref<Font> f = get_theme_font(SNAME("normal_font"));
+			int fs = get_theme_font_size(SNAME("normal_font_size")) * 3;
+			Color color = get_theme_color(SNAME("default_color"));
+			Color outline_color = get_theme_color(SNAME("outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
 			Rect2 dropcap_margins = Rect2();
 
 			for (int i = 0; i < subtag.size(); i++) {
@@ -4168,7 +4168,7 @@ void RichTextLabel::set_fixed_size_to_width(int p_width) {
 }
 
 Size2 RichTextLabel::get_minimum_size() const {
-	Ref<StyleBox> style = get_theme_stylebox("normal");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 	Size2 size = style->get_minimum_size();
 
 	if (fixed_width != -1) {

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -46,7 +46,7 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 
 	Ref<InputEventMouseMotion> m = p_event;
 	if (!m.is_valid() || drag.active) {
-		emit_signal("scrolling");
+		emit_signal(SNAME("scrolling"));
 	}
 
 	Ref<InputEventMouseButton> b = p_event;
@@ -70,8 +70,8 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 
 		if (b->is_pressed()) {
 			double ofs = orientation == VERTICAL ? b->get_position().y : b->get_position().x;
-			Ref<Texture2D> decr = get_theme_icon("decrement");
-			Ref<Texture2D> incr = get_theme_icon("increment");
+			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
+			Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
 
 			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
 			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
@@ -140,7 +140,7 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 
 		if (drag.active) {
 			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
-			Ref<Texture2D> decr = get_theme_icon("decrement");
+			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
 
 			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
 			ofs -= decr_size;
@@ -150,8 +150,8 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 			set_as_ratio(drag.value_at_click + diff);
 		} else {
 			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
-			Ref<Texture2D> decr = get_theme_icon("decrement");
-			Ref<Texture2D> incr = get_theme_icon("increment");
+			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
+			Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
 
 			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
 			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
@@ -215,17 +215,17 @@ void ScrollBar::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
 		RID ci = get_canvas_item();
 
-		Ref<Texture2D> decr = highlight == HIGHLIGHT_DECR ? get_theme_icon("decrement_highlight") : get_theme_icon("decrement");
-		Ref<Texture2D> incr = highlight == HIGHLIGHT_INCR ? get_theme_icon("increment_highlight") : get_theme_icon("increment");
-		Ref<StyleBox> bg = has_focus() ? get_theme_stylebox("scroll_focus") : get_theme_stylebox("scroll");
+		Ref<Texture2D> decr = highlight == HIGHLIGHT_DECR ? get_theme_icon(SNAME("decrement_highlight")) : get_theme_icon(SNAME("decrement"));
+		Ref<Texture2D> incr = highlight == HIGHLIGHT_INCR ? get_theme_icon(SNAME("increment_highlight")) : get_theme_icon(SNAME("increment"));
+		Ref<StyleBox> bg = has_focus() ? get_theme_stylebox(SNAME("scroll_focus")) : get_theme_stylebox(SNAME("scroll"));
 
 		Ref<StyleBox> grabber;
 		if (drag.active) {
-			grabber = get_theme_stylebox("grabber_pressed");
+			grabber = get_theme_stylebox(SNAME("grabber_pressed"));
 		} else if (highlight == HIGHLIGHT_RANGE) {
-			grabber = get_theme_stylebox("grabber_highlight");
+			grabber = get_theme_stylebox(SNAME("grabber_highlight"));
 		} else {
-			grabber = get_theme_stylebox("grabber");
+			grabber = get_theme_stylebox(SNAME("grabber"));
 		}
 
 		Point2 ofs;
@@ -389,7 +389,7 @@ void ScrollBar::_notification(int p_what) {
 }
 
 double ScrollBar::get_grabber_min_size() const {
-	Ref<StyleBox> grabber = get_theme_stylebox("grabber");
+	Ref<StyleBox> grabber = get_theme_stylebox(SNAME("grabber"));
 	Size2 gminsize = grabber->get_minimum_size() + grabber->get_center_size();
 	return (orientation == VERTICAL) ? gminsize.height : gminsize.width;
 }
@@ -415,17 +415,17 @@ double ScrollBar::get_area_size() const {
 	switch (orientation) {
 		case VERTICAL: {
 			double area = get_size().height;
-			area -= get_theme_stylebox("scroll")->get_minimum_size().height;
-			area -= get_theme_icon("increment")->get_height();
-			area -= get_theme_icon("decrement")->get_height();
+			area -= get_theme_stylebox(SNAME("scroll"))->get_minimum_size().height;
+			area -= get_theme_icon(SNAME("increment"))->get_height();
+			area -= get_theme_icon(SNAME("decrement"))->get_height();
 			area -= get_grabber_min_size();
 			return area;
 		} break;
 		case HORIZONTAL: {
 			double area = get_size().width;
-			area -= get_theme_stylebox("scroll")->get_minimum_size().width;
-			area -= get_theme_icon("increment")->get_width();
-			area -= get_theme_icon("decrement")->get_width();
+			area -= get_theme_stylebox(SNAME("scroll"))->get_minimum_size().width;
+			area -= get_theme_icon(SNAME("increment"))->get_width();
+			area -= get_theme_icon(SNAME("decrement"))->get_width();
 			area -= get_grabber_min_size();
 			return area;
 		} break;
@@ -439,13 +439,13 @@ double ScrollBar::get_area_offset() const {
 	double ofs = 0.0;
 
 	if (orientation == VERTICAL) {
-		ofs += get_theme_stylebox("hscroll")->get_margin(SIDE_TOP);
-		ofs += get_theme_icon("decrement")->get_height();
+		ofs += get_theme_stylebox(SNAME("hscroll"))->get_margin(SIDE_TOP);
+		ofs += get_theme_icon(SNAME("decrement"))->get_height();
 	}
 
 	if (orientation == HORIZONTAL) {
-		ofs += get_theme_stylebox("hscroll")->get_margin(SIDE_LEFT);
-		ofs += get_theme_icon("decrement")->get_width();
+		ofs += get_theme_stylebox(SNAME("hscroll"))->get_margin(SIDE_LEFT);
+		ofs += get_theme_icon(SNAME("decrement"))->get_width();
 	}
 
 	return ofs;
@@ -456,9 +456,9 @@ double ScrollBar::get_grabber_offset() const {
 }
 
 Size2 ScrollBar::get_minimum_size() const {
-	Ref<Texture2D> incr = get_theme_icon("increment");
-	Ref<Texture2D> decr = get_theme_icon("decrement");
-	Ref<StyleBox> bg = get_theme_stylebox("scroll");
+	Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
+	Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
+	Ref<StyleBox> bg = get_theme_stylebox(SNAME("scroll"));
 	Size2 minsize;
 
 	if (orientation == VERTICAL) {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -33,7 +33,7 @@
 #include "scene/main/window.h"
 
 Size2 ScrollContainer::get_minimum_size() const {
-	Ref<StyleBox> sb = get_theme_stylebox("bg");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
 	Size2 min_size;
 
 	for (int i = 0; i < get_child_count(); i++) {
@@ -77,7 +77,7 @@ void ScrollContainer::_cancel_drag() {
 	drag_from = Vector2();
 
 	if (beyond_deadzone) {
-		emit_signal("scroll_ended");
+		emit_signal(SNAME("scroll_ended"));
 		propagate_notification(NOTIFICATION_SCROLL_END);
 		beyond_deadzone = false;
 	}
@@ -173,7 +173,7 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (beyond_deadzone || (scroll_h && Math::abs(drag_accum.x) > deadzone) || (scroll_v && Math::abs(drag_accum.y) > deadzone)) {
 				if (!beyond_deadzone) {
 					propagate_notification(NOTIFICATION_SCROLL_BEGIN);
-					emit_signal("scroll_started");
+					emit_signal(SNAME("scroll_started"));
 
 					beyond_deadzone = true;
 					// resetting drag_accum here ensures smooth scrolling after reaching deadzone
@@ -260,7 +260,7 @@ void ScrollContainer::_update_dimensions() {
 	Size2 size = get_size();
 	Point2 ofs;
 
-	Ref<StyleBox> sb = get_theme_stylebox("bg");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
 	size -= sb->get_minimum_size();
 	ofs += sb->get_offset();
 	bool rtl = is_layout_rtl();
@@ -319,7 +319,7 @@ void ScrollContainer::_update_dimensions() {
 void ScrollContainer::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 		_updating_scrollbars = true;
-		call_deferred("_update_scrollbar_position");
+		call_deferred(SNAME("_update_scrollbar_position"));
 	};
 
 	if (p_what == NOTIFICATION_READY) {
@@ -332,7 +332,7 @@ void ScrollContainer::_notification(int p_what) {
 	};
 
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<StyleBox> sb = get_theme_stylebox("bg");
+		Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
 		draw_style_box(sb, Rect2(Vector2(), get_size()));
 
 		update_scrollbars();
@@ -409,7 +409,7 @@ void ScrollContainer::_notification(int p_what) {
 
 void ScrollContainer::update_scrollbars() {
 	Size2 size = get_size();
-	Ref<StyleBox> sb = get_theme_stylebox("bg");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
 	size -= sb->get_minimum_size();
 
 	Size2 hmin;

--- a/scene/gui/separator.cpp
+++ b/scene/gui/separator.cpp
@@ -33,9 +33,9 @@
 Size2 Separator::get_minimum_size() const {
 	Size2 ms(3, 3);
 	if (orientation == VERTICAL) {
-		ms.x = get_theme_constant("separation");
+		ms.x = get_theme_constant(SNAME("separation"));
 	} else { // HORIZONTAL
-		ms.y = get_theme_constant("separation");
+		ms.y = get_theme_constant(SNAME("separation"));
 	}
 	return ms;
 }
@@ -44,7 +44,7 @@ void Separator::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
 			Size2i size = get_size();
-			Ref<StyleBox> style = get_theme_stylebox("separator");
+			Ref<StyleBox> style = get_theme_stylebox(SNAME("separator"));
 			Size2i ssize = style->get_minimum_size() + style->get_center_size();
 
 			if (orientation == VERTICAL) {

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -32,10 +32,10 @@
 #include "core/os/keyboard.h"
 
 Size2 Slider::get_minimum_size() const {
-	Ref<StyleBox> style = get_theme_stylebox("slider");
+	Ref<StyleBox> style = get_theme_stylebox(SNAME("slider"));
 	Size2i ss = style->get_minimum_size() + style->get_center_size();
 
-	Ref<Texture2D> grabber = get_theme_icon("grabber");
+	Ref<Texture2D> grabber = get_theme_icon(SNAME("grabber"));
 	Size2i rs = grabber->get_size();
 
 	if (orientation == HORIZONTAL) {
@@ -89,7 +89,7 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 	if (mm.is_valid()) {
 		if (grab.active) {
 			Size2i size = get_size();
-			Ref<Texture2D> grabber = get_theme_icon("grabber");
+			Ref<Texture2D> grabber = get_theme_icon(SNAME("grabber"));
 			float motion = (orientation == VERTICAL ? mm->get_position().y : mm->get_position().x) - grab.pos;
 			if (orientation == VERTICAL) {
 				motion = -motion;
@@ -161,11 +161,11 @@ void Slider::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
 			Size2i size = get_size();
-			Ref<StyleBox> style = get_theme_stylebox("slider");
+			Ref<StyleBox> style = get_theme_stylebox(SNAME("slider"));
 			bool highlighted = mouse_inside || has_focus();
 			Ref<StyleBox> grabber_area = get_theme_stylebox(highlighted ? "grabber_area_highlight" : "grabber_area");
 			Ref<Texture2D> grabber = get_theme_icon(editable ? (highlighted ? "grabber_highlight" : "grabber") : "grabber_disabled");
-			Ref<Texture2D> tick = get_theme_icon("tick");
+			Ref<Texture2D> tick = get_theme_icon(SNAME("tick"));
 			double ratio = Math::is_nan(get_as_ratio()) ? 0 : get_as_ratio();
 
 			if (orientation == VERTICAL) {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -188,7 +188,7 @@ inline void SpinBox::_adjust_width_for_icon(const Ref<Texture2D> &icon) {
 
 void SpinBox::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Texture2D> updown = get_theme_icon("updown");
+		Ref<Texture2D> updown = get_theme_icon(SNAME("updown"));
 
 		_adjust_width_for_icon(updown);
 
@@ -204,15 +204,15 @@ void SpinBox::_notification(int p_what) {
 	} else if (p_what == NOTIFICATION_FOCUS_EXIT) {
 		//_value_changed(0);
 	} else if (p_what == NOTIFICATION_ENTER_TREE) {
-		_adjust_width_for_icon(get_theme_icon("updown"));
+		_adjust_width_for_icon(get_theme_icon(SNAME("updown")));
 		_value_changed(0);
 	} else if (p_what == NOTIFICATION_EXIT_TREE) {
 		_release_mouse();
 	} else if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 		_value_changed(0);
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		call_deferred("minimum_size_changed");
-		get_line_edit()->call_deferred("minimum_size_changed");
+		call_deferred(SNAME("minimum_size_changed"));
+		get_line_edit()->call_deferred(SNAME("minimum_size_changed"));
 	} else if (p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 		update();
 	}

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -76,8 +76,8 @@ void SplitContainer::_resort() {
 	bool second_expanded = (vertical ? second->get_v_size_flags() : second->get_h_size_flags()) & SIZE_EXPAND;
 
 	// Determine the separation between items
-	Ref<Texture2D> g = get_theme_icon("grabber");
-	int sep = get_theme_constant("separation");
+	Ref<Texture2D> g = get_theme_icon(SNAME("grabber"));
+	int sep = get_theme_constant(SNAME("separation"));
 	sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(sep, vertical ? g->get_height() : g->get_width()) : 0;
 
 	// Compute the minimum size
@@ -131,8 +131,8 @@ Size2 SplitContainer::get_minimum_size() const {
 	/* Calculate MINIMUM SIZE */
 
 	Size2i minimum;
-	Ref<Texture2D> g = get_theme_icon("grabber");
-	int sep = get_theme_constant("separation");
+	Ref<Texture2D> g = get_theme_icon(SNAME("grabber"));
+	int sep = get_theme_constant(SNAME("separation"));
 	sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(sep, vertical ? g->get_height() : g->get_width()) : 0;
 
 	for (int i = 0; i < 2; i++) {
@@ -173,7 +173,7 @@ void SplitContainer::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_MOUSE_EXIT: {
 			mouse_inside = false;
-			if (get_theme_constant("autohide")) {
+			if (get_theme_constant(SNAME("autohide"))) {
 				update();
 			}
 		} break;
@@ -182,7 +182,7 @@ void SplitContainer::_notification(int p_what) {
 				return;
 			}
 
-			if (collapsed || (!dragging && !mouse_inside && get_theme_constant("autohide"))) {
+			if (collapsed || (!dragging && !mouse_inside && get_theme_constant(SNAME("autohide")))) {
 				return;
 			}
 
@@ -190,8 +190,8 @@ void SplitContainer::_notification(int p_what) {
 				return;
 			}
 
-			int sep = dragger_visibility != DRAGGER_HIDDEN_COLLAPSED ? get_theme_constant("separation") : 0;
-			Ref<Texture2D> tex = get_theme_icon("grabber");
+			int sep = dragger_visibility != DRAGGER_HIDDEN_COLLAPSED ? get_theme_constant(SNAME("separation")) : 0;
+			Ref<Texture2D> tex = get_theme_icon(SNAME("grabber"));
 			Size2 size = get_size();
 
 			if (vertical) {
@@ -218,7 +218,7 @@ void SplitContainer::_gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid()) {
 		if (mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 			if (mb->is_pressed()) {
-				int sep = get_theme_constant("separation");
+				int sep = get_theme_constant(SNAME("separation"));
 
 				if (vertical) {
 					if (mb->get_position().y > middle_sep && mb->get_position().y < middle_sep + sep) {
@@ -244,14 +244,14 @@ void SplitContainer::_gui_input(const Ref<InputEvent> &p_event) {
 	if (mm.is_valid()) {
 		bool mouse_inside_state = false;
 		if (vertical) {
-			mouse_inside_state = mm->get_position().y > middle_sep && mm->get_position().y < middle_sep + get_theme_constant("separation");
+			mouse_inside_state = mm->get_position().y > middle_sep && mm->get_position().y < middle_sep + get_theme_constant(SNAME("separation"));
 		} else {
-			mouse_inside_state = mm->get_position().x > middle_sep && mm->get_position().x < middle_sep + get_theme_constant("separation");
+			mouse_inside_state = mm->get_position().x > middle_sep && mm->get_position().x < middle_sep + get_theme_constant(SNAME("separation"));
 		}
 
 		if (mouse_inside != mouse_inside_state) {
 			mouse_inside = mouse_inside_state;
-			if (get_theme_constant("autohide")) {
+			if (get_theme_constant(SNAME("autohide"))) {
 				update();
 			}
 		}
@@ -267,7 +267,7 @@ void SplitContainer::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 		should_clamp_split_offset = true;
 		queue_sort();
-		emit_signal("dragged", get_split_offset());
+		emit_signal(SNAME("dragged"), get_split_offset());
 	}
 }
 
@@ -277,7 +277,7 @@ Control::CursorShape SplitContainer::get_cursor_shape(const Point2 &p_pos) const
 	}
 
 	if (!collapsed && _getch(0) && _getch(1) && dragger_visibility == DRAGGER_VISIBLE) {
-		int sep = get_theme_constant("separation");
+		int sep = get_theme_constant(SNAME("separation"));
 
 		if (vertical) {
 			if (p_pos.y > middle_sep && p_pos.y < middle_sep + sep) {

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -43,9 +43,9 @@ int TabContainer::_get_top_margin() const {
 	}
 
 	// Respect the minimum tab height.
-	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
-	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
-	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
+	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
+	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
 
 	int tab_height = MAX(MAX(tab_unselected->get_minimum_size().height, tab_selected->get_minimum_size().height), tab_disabled->get_minimum_size().height);
 
@@ -88,11 +88,11 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		// Handle menu button.
-		Ref<Texture2D> menu = get_theme_icon("menu");
+		Ref<Texture2D> menu = get_theme_icon(SNAME("menu"));
 
 		if (is_layout_rtl()) {
 			if (popup && pos.x < menu->get_width()) {
-				emit_signal("pre_popup_pressed");
+				emit_signal(SNAME("pre_popup_pressed"));
 
 				Vector2 popup_pos = get_screen_position();
 				popup_pos.y += menu->get_height();
@@ -103,7 +103,7 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 		} else {
 			if (popup && pos.x > size.width - menu->get_width()) {
-				emit_signal("pre_popup_pressed");
+				emit_signal(SNAME("pre_popup_pressed"));
 
 				Vector2 popup_pos = get_screen_position();
 				popup_pos.x += size.width - popup->get_size().width;
@@ -129,8 +129,8 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 				popup_ofs = menu->get_width();
 			}
 
-			Ref<Texture2D> increment = get_theme_icon("increment");
-			Ref<Texture2D> decrement = get_theme_icon("decrement");
+			Ref<Texture2D> increment = get_theme_icon(SNAME("increment"));
+			Ref<Texture2D> decrement = get_theme_icon(SNAME("decrement"));
 			if (is_layout_rtl()) {
 				if (pos.x < popup_ofs + decrement->get_width()) {
 					if (last_tab_cache < tabs.size() - 1) {
@@ -203,7 +203,7 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
-		Ref<Texture2D> menu = get_theme_icon("menu");
+		Ref<Texture2D> menu = get_theme_icon(SNAME("menu"));
 		if (popup) {
 			if (is_layout_rtl()) {
 				if (pos.x <= menu->get_width()) {
@@ -248,8 +248,8 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 			popup_ofs = menu->get_width();
 		}
 
-		Ref<Texture2D> increment = get_theme_icon("increment");
-		Ref<Texture2D> decrement = get_theme_icon("decrement");
+		Ref<Texture2D> increment = get_theme_icon(SNAME("increment"));
+		Ref<Texture2D> decrement = get_theme_icon(SNAME("decrement"));
 
 		if (is_layout_rtl()) {
 			if (pos.x <= popup_ofs + decrement->get_width()) {
@@ -289,10 +289,10 @@ void TabContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_RESIZED: {
 			Vector<Control *> tabs = _get_tabs();
-			int side_margin = get_theme_constant("side_margin");
-			Ref<Texture2D> menu = get_theme_icon("menu");
-			Ref<Texture2D> increment = get_theme_icon("increment");
-			Ref<Texture2D> decrement = get_theme_icon("decrement");
+			int side_margin = get_theme_constant(SNAME("side_margin"));
+			Ref<Texture2D> menu = get_theme_icon(SNAME("menu"));
+			Ref<Texture2D> increment = get_theme_icon(SNAME("increment"));
+			Ref<Texture2D> decrement = get_theme_icon(SNAME("decrement"));
 			int header_width = get_size().width - side_margin * 2;
 
 			// Find the width of the header area.
@@ -332,26 +332,26 @@ void TabContainer::_notification(int p_what) {
 			bool rtl = is_layout_rtl();
 
 			// Draw only the tab area if the header is hidden.
-			Ref<StyleBox> panel = get_theme_stylebox("panel");
+			Ref<StyleBox> panel = get_theme_stylebox(SNAME("panel"));
 			if (!tabs_visible) {
 				panel->draw(canvas, Rect2(0, 0, size.width, size.height));
 				return;
 			}
 
 			Vector<Control *> tabs = _get_tabs();
-			Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
-			Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
-			Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
-			Ref<Texture2D> increment = get_theme_icon("increment");
-			Ref<Texture2D> increment_hl = get_theme_icon("increment_highlight");
-			Ref<Texture2D> decrement = get_theme_icon("decrement");
-			Ref<Texture2D> decrement_hl = get_theme_icon("decrement_highlight");
-			Ref<Texture2D> menu = get_theme_icon("menu");
-			Ref<Texture2D> menu_hl = get_theme_icon("menu_highlight");
-			Color font_selected_color = get_theme_color("font_selected_color");
-			Color font_unselected_color = get_theme_color("font_unselected_color");
-			Color font_disabled_color = get_theme_color("font_disabled_color");
-			int side_margin = get_theme_constant("side_margin");
+			Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
+			Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
+			Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
+			Ref<Texture2D> increment = get_theme_icon(SNAME("increment"));
+			Ref<Texture2D> increment_hl = get_theme_icon(SNAME("increment_highlight"));
+			Ref<Texture2D> decrement = get_theme_icon(SNAME("decrement"));
+			Ref<Texture2D> decrement_hl = get_theme_icon(SNAME("decrement_highlight"));
+			Ref<Texture2D> menu = get_theme_icon(SNAME("menu"));
+			Ref<Texture2D> menu_hl = get_theme_icon(SNAME("menu_highlight"));
+			Color font_selected_color = get_theme_color(SNAME("font_selected_color"));
+			Color font_unselected_color = get_theme_color(SNAME("font_unselected_color"));
+			Color font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
+			int side_margin = get_theme_constant(SNAME("side_margin"));
 
 			// Find out start and width of the header area.
 			int header_x = side_margin;
@@ -529,7 +529,7 @@ void TabContainer::_notification(int p_what) {
 				text_buf.write[i]->clear();
 			}
 			_theme_changing = true;
-			call_deferred("_on_theme_changed"); // Wait until all changed theme.
+			call_deferred(SNAME("_on_theme_changed")); // Wait until all changed theme.
 		} break;
 	}
 }
@@ -537,10 +537,10 @@ void TabContainer::_notification(int p_what) {
 void TabContainer::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_index, float p_x) {
 	Vector<Control *> tabs = _get_tabs();
 	RID canvas = get_canvas_item();
-	Ref<Font> font = get_theme_font("font");
-	Color font_outline_color = get_theme_color("font_outline_color");
-	int outline_size = get_theme_constant("outline_size");
-	int icon_text_distance = get_theme_constant("icon_separation");
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+	int outline_size = get_theme_constant(SNAME("outline_size"));
+	int icon_text_distance = get_theme_constant(SNAME("icon_separation"));
 	int tab_width = _get_tab_width(p_index);
 	int header_height = _get_top_margin();
 
@@ -580,8 +580,8 @@ void TabContainer::_refresh_texts() {
 	text_buf.clear();
 	Vector<Control *> tabs = _get_tabs();
 	bool rtl = is_layout_rtl();
-	Ref<Font> font = get_theme_font("font");
-	int font_size = get_theme_font_size("font_size");
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	int font_size = get_theme_font_size(SNAME("font_size"));
 	for (int i = 0; i < tabs.size(); i++) {
 		Control *control = Object::cast_to<Control>(tabs[i]);
 		String text = control->has_meta("_tab_name") ? String(tr(String(control->get_meta("_tab_name")))) : String(tr(control->get_name()));
@@ -609,7 +609,7 @@ void TabContainer::_on_theme_changed() {
 }
 
 void TabContainer::_repaint() {
-	Ref<StyleBox> sb = get_theme_stylebox("panel");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("panel"));
 	Vector<Control *> tabs = _get_tabs();
 	for (int i = 0; i < tabs.size(); i++) {
 		Control *c = tabs[i];
@@ -646,8 +646,8 @@ int TabContainer::_get_tab_width(int p_index) const {
 	}
 
 	// Get the width of the text displayed on the tab.
-	Ref<Font> font = get_theme_font("font");
-	int font_size = get_theme_font_size("font_size");
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	int font_size = get_theme_font_size(SNAME("font_size"));
 	String text = control->has_meta("_tab_name") ? String(tr(String(control->get_meta("_tab_name")))) : String(tr(control->get_name()));
 	int width = font->get_string_size(text, font_size).width;
 
@@ -657,15 +657,15 @@ int TabContainer::_get_tab_width(int p_index) const {
 		if (icon.is_valid()) {
 			width += icon->get_width();
 			if (text != "") {
-				width += get_theme_constant("icon_separation");
+				width += get_theme_constant(SNAME("icon_separation"));
 			}
 		}
 	}
 
 	// Respect a minimum size.
-	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
-	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
-	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
+	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
+	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
 	if (get_tab_disabled(p_index)) {
 		width += tab_disabled->get_minimum_size().width;
 	} else if (p_index == current) {
@@ -715,7 +715,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 		c->hide();
 	} else {
 		c->show();
-		//call_deferred("set_current_tab",0);
+		//call_deferred(SNAME("set_current_tab"),0);
 		first = true;
 		current = 0;
 		previous = 0;
@@ -724,7 +724,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 	if (tabs_visible) {
 		c->set_offset(SIDE_TOP, _get_top_margin());
 	}
-	Ref<StyleBox> sb = get_theme_stylebox("panel");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("panel"));
 	c->set_offset(Side(SIDE_TOP), c->get_offset(Side(SIDE_TOP)) + sb->get_margin(Side(SIDE_TOP)));
 	c->set_offset(Side(SIDE_LEFT), c->get_offset(Side(SIDE_LEFT)) + sb->get_margin(Side(SIDE_LEFT)));
 	c->set_offset(Side(SIDE_RIGHT), c->get_offset(Side(SIDE_RIGHT)) - sb->get_margin(Side(SIDE_RIGHT)));
@@ -732,13 +732,13 @@ void TabContainer::add_child_notify(Node *p_child) {
 	update();
 	p_child->connect("renamed", callable_mp(this, &TabContainer::_child_renamed_callback));
 	if (first && is_inside_tree()) {
-		emit_signal("tab_changed", current);
+		emit_signal(SNAME("tab_changed"), current);
 	}
 }
 
 void TabContainer::move_child_notify(Node *p_child) {
 	Container::move_child_notify(p_child);
-	call_deferred("_update_current_tab");
+	call_deferred(SNAME("_update_current_tab"));
 	_refresh_texts();
 	update();
 }
@@ -756,11 +756,11 @@ void TabContainer::set_current_tab(int p_current) {
 	_repaint();
 
 	if (pending_previous == current) {
-		emit_signal("tab_selected", current);
+		emit_signal(SNAME("tab_selected"), current);
 	} else {
 		previous = pending_previous;
-		emit_signal("tab_selected", current);
-		emit_signal("tab_changed", current);
+		emit_signal(SNAME("tab_selected"), current);
+		emit_signal(SNAME("tab_changed"), current);
 	}
 
 	update();
@@ -799,7 +799,7 @@ void TabContainer::remove_child_notify(Node *p_child) {
 		return;
 	}
 
-	call_deferred("_update_current_tab");
+	call_deferred(SNAME("_update_current_tab"));
 
 	p_child->disconnect("renamed", callable_mp(this, &TabContainer::_child_renamed_callback));
 
@@ -913,7 +913,7 @@ void TabContainer::drop_data(const Point2 &p_point, const Variant &p_data) {
 				}
 				move_child(moving_tabc, hover_now);
 				set_current_tab(hover_now);
-				emit_signal("tab_changed", hover_now);
+				emit_signal(SNAME("tab_changed"), hover_now);
 			}
 		}
 	}
@@ -944,12 +944,12 @@ int TabContainer::get_tab_idx_at_point(const Point2 &p_point) const {
 
 	Popup *popup = get_popup();
 	if (popup) {
-		Ref<Texture2D> menu = get_theme_icon("menu");
+		Ref<Texture2D> menu = get_theme_icon(SNAME("menu"));
 		button_ofs += menu->get_width();
 	}
 	if (buttons_visible_cache) {
-		Ref<Texture2D> increment = get_theme_icon("increment");
-		Ref<Texture2D> decrement = get_theme_icon("decrement");
+		Ref<Texture2D> increment = get_theme_icon(SNAME("increment"));
+		Ref<Texture2D> decrement = get_theme_icon(SNAME("decrement"));
 		button_ofs += increment->get_width() + decrement->get_width();
 	}
 	if (px > size.width - button_ofs) {
@@ -1136,17 +1136,17 @@ Size2 TabContainer::get_minimum_size() const {
 		ms.y = MAX(ms.y, cms.y);
 	}
 
-	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
-	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
-	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
-	Ref<Font> font = get_theme_font("font");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
+	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
+	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
+	Ref<Font> font = get_theme_font(SNAME("font"));
 
 	if (tabs_visible) {
 		ms.y += MAX(MAX(tab_unselected->get_minimum_size().y, tab_selected->get_minimum_size().y), tab_disabled->get_minimum_size().y);
 		ms.y += _get_top_margin();
 	}
 
-	Ref<StyleBox> sb = get_theme_stylebox("panel");
+	Ref<StyleBox> sb = get_theme_stylebox(SNAME("panel"));
 	ms += sb->get_minimum_size();
 
 	return ms;

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -38,9 +38,9 @@
 #include "scene/gui/texture_rect.h"
 
 Size2 Tabs::get_minimum_size() const {
-	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
-	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
-	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
+	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
+	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
 
 	int y_margin = MAX(MAX(tab_unselected->get_minimum_size().height, tab_selected->get_minimum_size().height), tab_disabled->get_minimum_size().height);
 
@@ -51,7 +51,7 @@ Size2 Tabs::get_minimum_size() const {
 		if (tex.is_valid()) {
 			ms.height = MAX(ms.height, tex->get_size().height);
 			if (tabs[i].text != "") {
-				ms.width += get_theme_constant("hseparation");
+				ms.width += get_theme_constant(SNAME("hseparation"));
 			}
 		}
 
@@ -69,15 +69,15 @@ Size2 Tabs::get_minimum_size() const {
 		if (tabs[i].right_button.is_valid()) {
 			Ref<Texture2D> rb = tabs[i].right_button;
 			Size2 bms = rb->get_size();
-			bms.width += get_theme_constant("hseparation");
+			bms.width += get_theme_constant(SNAME("hseparation"));
 			ms.width += bms.width;
 			ms.height = MAX(bms.height + tab_unselected->get_minimum_size().height, ms.height);
 		}
 
 		if (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current)) {
-			Ref<Texture2D> cb = get_theme_icon("close");
+			Ref<Texture2D> cb = get_theme_icon(SNAME("close"));
 			Size2 bms = cb->get_size();
-			bms.width += get_theme_constant("hseparation");
+			bms.width += get_theme_constant(SNAME("hseparation"));
 			ms.width += bms.width;
 			ms.height = MAX(bms.height + tab_unselected->get_minimum_size().height, ms.height);
 		}
@@ -100,8 +100,8 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 
 		highlight_arrow = -1;
 		if (buttons_visible) {
-			Ref<Texture2D> incr = get_theme_icon("increment");
-			Ref<Texture2D> decr = get_theme_icon("decrement");
+			Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
+			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
 
 			if (is_layout_rtl()) {
 				if (pos.x < decr->get_width()) {
@@ -148,7 +148,7 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 		if (rb_pressing && !mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 			if (rb_hover != -1) {
 				//pressed
-				emit_signal("right_button_pressed", rb_hover);
+				emit_signal(SNAME("right_button_pressed"), rb_hover);
 			}
 
 			rb_pressing = false;
@@ -158,7 +158,7 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 		if (cb_pressing && !mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 			if (cb_hover != -1) {
 				//pressed
-				emit_signal("tab_closed", cb_hover);
+				emit_signal(SNAME("tab_closed"), cb_hover);
 			}
 
 			cb_pressing = false;
@@ -170,8 +170,8 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 			Point2 pos(mb->get_position().x, mb->get_position().y);
 
 			if (buttons_visible) {
-				Ref<Texture2D> incr = get_theme_icon("increment");
-				Ref<Texture2D> decr = get_theme_icon("decrement");
+				Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
+				Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
 
 				if (is_layout_rtl()) {
 					if (pos.x < decr->get_width()) {
@@ -229,15 +229,15 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 
 			if (found != -1) {
 				set_current_tab(found);
-				emit_signal("tab_clicked", found);
+				emit_signal(SNAME("tab_clicked"), found);
 			}
 		}
 	}
 }
 
 void Tabs::_shape(int p_tab) {
-	Ref<Font> font = get_theme_font("font");
-	int font_size = get_theme_font_size("font_size");
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	int font_size = get_theme_font_size(SNAME("font_size"));
 
 	tabs.write[p_tab].xl_text = tr(tabs[p_tab].text);
 	tabs.write[p_tab].text_buf->clear();
@@ -274,15 +274,15 @@ void Tabs::_notification(int p_what) {
 			_update_cache();
 			RID ci = get_canvas_item();
 
-			Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
-			Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
-			Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
-			Color font_selected_color = get_theme_color("font_selected_color");
-			Color font_unselected_color = get_theme_color("font_unselected_color");
-			Color font_disabled_color = get_theme_color("font_disabled_color");
-			Ref<Texture2D> close = get_theme_icon("close");
-			Color font_outline_color = get_theme_color("font_outline_color");
-			int outline_size = get_theme_constant("outline_size");
+			Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
+			Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
+			Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
+			Color font_selected_color = get_theme_color(SNAME("font_selected_color"));
+			Color font_unselected_color = get_theme_color(SNAME("font_unselected_color"));
+			Color font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
+			Ref<Texture2D> close = get_theme_icon(SNAME("close"));
+			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
 
 			Vector2 size = get_size();
 			bool rtl = is_layout_rtl();
@@ -306,10 +306,10 @@ void Tabs::_notification(int p_what) {
 				w = 0;
 			}
 
-			Ref<Texture2D> incr = get_theme_icon("increment");
-			Ref<Texture2D> decr = get_theme_icon("decrement");
-			Ref<Texture2D> incr_hl = get_theme_icon("increment_highlight");
-			Ref<Texture2D> decr_hl = get_theme_icon("decrement_highlight");
+			Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
+			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
+			Ref<Texture2D> incr_hl = get_theme_icon(SNAME("increment_highlight"));
+			Ref<Texture2D> decr_hl = get_theme_icon(SNAME("decrement_highlight"));
 
 			int limit = get_size().width;
 			int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
@@ -363,7 +363,7 @@ void Tabs::_notification(int p_what) {
 						icon->draw(ci, Point2i(w, sb->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - icon->get_height()) / 2));
 					}
 					if (tabs[i].text != "") {
-						w += icon->get_width() + get_theme_constant("hseparation");
+						w += icon->get_width() + get_theme_constant(SNAME("hseparation"));
 					}
 				}
 
@@ -384,10 +384,10 @@ void Tabs::_notification(int p_what) {
 				w += tabs[i].size_text;
 
 				if (tabs[i].right_button.is_valid()) {
-					Ref<StyleBox> style = get_theme_stylebox("button");
+					Ref<StyleBox> style = get_theme_stylebox(SNAME("button"));
 					Ref<Texture2D> rb = tabs[i].right_button;
 
-					w += get_theme_constant("hseparation");
+					w += get_theme_constant(SNAME("hseparation"));
 
 					Rect2 rb_rect;
 					rb_rect.size = style->get_minimum_size() + rb->get_size();
@@ -400,7 +400,7 @@ void Tabs::_notification(int p_what) {
 
 					if (rb_hover == i) {
 						if (rb_pressing) {
-							get_theme_stylebox("button_pressed")->draw(ci, rb_rect);
+							get_theme_stylebox(SNAME("button_pressed"))->draw(ci, rb_rect);
 						} else {
 							style->draw(ci, rb_rect);
 						}
@@ -416,10 +416,10 @@ void Tabs::_notification(int p_what) {
 				}
 
 				if (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current)) {
-					Ref<StyleBox> style = get_theme_stylebox("button");
+					Ref<StyleBox> style = get_theme_stylebox(SNAME("button"));
 					Ref<Texture2D> cb = close;
 
-					w += get_theme_constant("hseparation");
+					w += get_theme_constant(SNAME("hseparation"));
 
 					Rect2 cb_rect;
 					cb_rect.size = style->get_minimum_size() + cb->get_size();
@@ -432,7 +432,7 @@ void Tabs::_notification(int p_what) {
 
 					if (!tabs[i].disabled && cb_hover == i) {
 						if (cb_pressing) {
-							get_theme_stylebox("button_pressed")->draw(ci, cb_rect);
+							get_theme_stylebox(SNAME("button_pressed"))->draw(ci, cb_rect);
 						} else {
 							style->draw(ci, cb_rect);
 						}
@@ -503,7 +503,7 @@ void Tabs::set_current_tab(int p_current) {
 	_update_cache();
 	update();
 
-	emit_signal("tab_changed", p_current);
+	emit_signal(SNAME("tab_changed"), p_current);
 }
 
 int Tabs::get_current_tab() const {
@@ -659,7 +659,7 @@ void Tabs::_update_hover() {
 	}
 	if (hover != hover_now) {
 		hover = hover_now;
-		emit_signal("tab_hovered", hover);
+		emit_signal(SNAME("tab_hovered"), hover);
 	}
 
 	if (hover_buttons == -1) { // no hover
@@ -669,11 +669,11 @@ void Tabs::_update_hover() {
 }
 
 void Tabs::_update_cache() {
-	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
-	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
-	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
-	Ref<Texture2D> incr = get_theme_icon("increment");
-	Ref<Texture2D> decr = get_theme_icon("decrement");
+	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
+	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
+	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
+	Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
+	Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
 	int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
 
 	int w = 0;
@@ -712,12 +712,12 @@ void Tabs::_update_cache() {
 				slen = m_width - (sb->get_margin(SIDE_LEFT) + sb->get_margin(SIDE_RIGHT));
 				if (tabs[i].icon.is_valid()) {
 					slen -= tabs[i].icon->get_width();
-					slen -= get_theme_constant("hseparation");
+					slen -= get_theme_constant(SNAME("hseparation"));
 				}
 				if (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current)) {
-					Ref<Texture2D> cb = get_theme_icon("close");
+					Ref<Texture2D> cb = get_theme_icon(SNAME("close"));
 					slen -= cb->get_width();
-					slen -= get_theme_constant("hseparation");
+					slen -= get_theme_constant(SNAME("hseparation"));
 				}
 				slen = MAX(slen, 1);
 				lsize = m_width;
@@ -745,7 +745,7 @@ void Tabs::add_tab(const String &p_str, const Ref<Texture2D> &p_icon) {
 	t.xl_text = tr(p_str);
 	t.text_buf.instantiate();
 	t.text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
-	t.text_buf->add_string(t.xl_text, get_theme_font("font"), get_theme_font_size("font_size"), Dictionary(), TranslationServer::get_singleton()->get_tool_locale());
+	t.text_buf->add_string(t.xl_text, get_theme_font(SNAME("font")), get_theme_font_size(SNAME("font_size")), Dictionary(), TranslationServer::get_singleton()->get_tool_locale());
 	t.icon = p_icon;
 	t.disabled = false;
 	t.ofs_cache = 0;
@@ -753,7 +753,7 @@ void Tabs::add_tab(const String &p_str, const Ref<Texture2D> &p_icon) {
 
 	tabs.push_back(t);
 	_update_cache();
-	call_deferred("_update_hover");
+	call_deferred(SNAME("_update_hover"));
 	update();
 	minimum_size_changed();
 }
@@ -762,7 +762,7 @@ void Tabs::clear_tabs() {
 	tabs.clear();
 	current = 0;
 	previous = 0;
-	call_deferred("_update_hover");
+	call_deferred(SNAME("_update_hover"));
 	update();
 }
 
@@ -773,7 +773,7 @@ void Tabs::remove_tab(int p_idx) {
 		current--;
 	}
 	_update_cache();
-	call_deferred("_update_hover");
+	call_deferred(SNAME("_update_hover"));
 	update();
 	minimum_size_changed();
 
@@ -870,7 +870,7 @@ void Tabs::drop_data(const Point2 &p_point, const Variant &p_data) {
 				hover_now = get_tab_count() - 1;
 			}
 			move_tab(tab_from_id, hover_now);
-			emit_signal("reposition_active_tab_request", hover_now);
+			emit_signal(SNAME("reposition_active_tab_request"), hover_now);
 			set_current_tab(hover_now);
 		} else if (get_tabs_rearrange_group() != -1) {
 			// drag and drop between Tabs
@@ -887,7 +887,7 @@ void Tabs::drop_data(const Point2 &p_point, const Variant &p_data) {
 				tabs.insert(hover_now, moving_tab);
 				from_tabs->remove_tab(tab_from_id);
 				set_current_tab(hover_now);
-				emit_signal("tab_changed", hover_now);
+				emit_signal(SNAME("tab_changed"), hover_now);
 				_update_cache();
 			}
 		}
@@ -949,9 +949,9 @@ void Tabs::move_tab(int from, int to) {
 int Tabs::get_tab_width(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, tabs.size(), 0);
 
-	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
-	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
-	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
+	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
+	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
 
 	int x = 0;
 
@@ -959,7 +959,7 @@ int Tabs::get_tab_width(int p_idx) const {
 	if (tex.is_valid()) {
 		x += tex->get_width();
 		if (tabs[p_idx].text != "") {
-			x += get_theme_constant("hseparation");
+			x += get_theme_constant(SNAME("hseparation"));
 		}
 	}
 
@@ -976,13 +976,13 @@ int Tabs::get_tab_width(int p_idx) const {
 	if (tabs[p_idx].right_button.is_valid()) {
 		Ref<Texture2D> rb = tabs[p_idx].right_button;
 		x += rb->get_width();
-		x += get_theme_constant("hseparation");
+		x += get_theme_constant(SNAME("hseparation"));
 	}
 
 	if (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && p_idx == current)) {
-		Ref<Texture2D> cb = get_theme_icon("close");
+		Ref<Texture2D> cb = get_theme_icon(SNAME("close"));
 		x += cb->get_width();
-		x += get_theme_constant("hseparation");
+		x += get_theme_constant(SNAME("hseparation"));
 	}
 
 	return x;
@@ -993,8 +993,8 @@ void Tabs::_ensure_no_over_offset() {
 		return;
 	}
 
-	Ref<Texture2D> incr = get_theme_icon("increment");
-	Ref<Texture2D> decr = get_theme_icon("decrement");
+	Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
+	Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
 
 	int limit = get_size().width;
 	int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
@@ -1034,8 +1034,8 @@ void Tabs::ensure_tab_visible(int p_idx) {
 	}
 
 	int prev_offset = offset;
-	Ref<Texture2D> incr = get_theme_icon("increment");
-	Ref<Texture2D> decr = get_theme_icon("decrement");
+	Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
+	Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
 	int limit = get_size().width;
 	int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -542,8 +542,8 @@ void TextEdit::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible()) {
-				call_deferred("_update_scrollbars");
-				call_deferred("_update_wrap_at");
+				call_deferred(SNAME("_update_scrollbars"));
+				call_deferred(SNAME("_update_wrap_at"));
 			}
 		} break;
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
@@ -2361,7 +2361,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					}
 
 					if (mpos.x > left_margin && mpos.x <= (left_margin + gutters[i].width) - 3) {
-						emit_signal("gutter_clicked", row, i);
+						emit_signal(SNAME("gutter_clicked"), row, i);
 						return;
 					}
 
@@ -2483,7 +2483,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					int row, col;
 					_get_mouse_pos(Point2i(mpos.x, mpos.y), row, col);
 
-					emit_signal("symbol_lookup", highlighted_word, row, col);
+					emit_signal(SNAME("symbol_lookup"), highlighted_word, row, col);
 					return;
 				}
 
@@ -2525,7 +2525,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (!dragging_minimap && !dragging_selection && mm->is_command_pressed() && mm->get_button_mask() == 0) {
 				String new_word = get_word_at_pos(mpos);
 				if (new_word != highlighted_word) {
-					emit_signal("symbol_validate", new_word);
+					emit_signal(SNAME("symbol_validate"), new_word);
 				}
 			} else {
 				if (highlighted_word != String()) {
@@ -2576,7 +2576,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (select_identifiers_enabled) {
 				if (k->is_pressed() && !dragging_minimap && !dragging_selection) {
 					Point2 mp = _get_local_mouse_pos();
-					emit_signal("symbol_validate", get_word_at_pos(mp));
+					emit_signal(SNAME("symbol_validate"), get_word_at_pos(mp));
 				} else {
 					set_highlighted_word(String());
 				}
@@ -2992,7 +2992,7 @@ void TextEdit::_base_insert_text(int p_line, int p_char, const String &p_text, i
 		}
 		text_changed_dirty = true;
 	}
-	emit_signal("lines_edited_from", p_line, r_end_line);
+	emit_signal(SNAME("lines_edited_from"), p_line, r_end_line);
 }
 
 String TextEdit::_base_get_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column) const {
@@ -3043,7 +3043,7 @@ void TextEdit::_base_remove_text(int p_from_line, int p_from_column, int p_to_li
 		}
 		text_changed_dirty = true;
 	}
-	emit_signal("lines_edited_from", p_to_line, p_from_line);
+	emit_signal(SNAME("lines_edited_from"), p_to_line, p_from_line);
 }
 
 void TextEdit::_insert_text(int p_line, int p_char, const String &p_text, int *r_end_line, int *r_end_char) {
@@ -4034,35 +4034,35 @@ void TextEdit::_toggle_draw_caret() {
 }
 
 void TextEdit::_update_caches() {
-	cache.style_normal = get_theme_stylebox("normal");
-	cache.style_focus = get_theme_stylebox("focus");
-	cache.style_readonly = get_theme_stylebox("read_only");
-	cache.font = get_theme_font("font");
-	cache.font_size = get_theme_font_size("font_size");
-	cache.outline_color = get_theme_color("font_outline_color");
-	cache.outline_size = get_theme_constant("outline_size");
-	cache.caret_color = get_theme_color("caret_color");
-	cache.caret_background_color = get_theme_color("caret_background_color");
-	cache.font_color = get_theme_color("font_color");
-	cache.font_selected_color = get_theme_color("font_selected_color");
-	cache.font_readonly_color = get_theme_color("font_readonly_color");
-	cache.selection_color = get_theme_color("selection_color");
-	cache.current_line_color = get_theme_color("current_line_color");
-	cache.line_length_guideline_color = get_theme_color("line_length_guideline_color");
-	cache.code_folding_color = get_theme_color("code_folding_color", "CodeEdit");
-	cache.brace_mismatch_color = get_theme_color("brace_mismatch_color");
-	cache.word_highlighted_color = get_theme_color("word_highlighted_color");
-	cache.search_result_color = get_theme_color("search_result_color");
-	cache.search_result_border_color = get_theme_color("search_result_border_color");
-	cache.background_color = get_theme_color("background_color");
+	cache.style_normal = get_theme_stylebox(SNAME("normal"));
+	cache.style_focus = get_theme_stylebox(SNAME("focus"));
+	cache.style_readonly = get_theme_stylebox(SNAME("read_only"));
+	cache.font = get_theme_font(SNAME("font"));
+	cache.font_size = get_theme_font_size(SNAME("font_size"));
+	cache.outline_color = get_theme_color(SNAME("font_outline_color"));
+	cache.outline_size = get_theme_constant(SNAME("outline_size"));
+	cache.caret_color = get_theme_color(SNAME("caret_color"));
+	cache.caret_background_color = get_theme_color(SNAME("caret_background_color"));
+	cache.font_color = get_theme_color(SNAME("font_color"));
+	cache.font_selected_color = get_theme_color(SNAME("font_selected_color"));
+	cache.font_readonly_color = get_theme_color(SNAME("font_readonly_color"));
+	cache.selection_color = get_theme_color(SNAME("selection_color"));
+	cache.current_line_color = get_theme_color(SNAME("current_line_color"));
+	cache.line_length_guideline_color = get_theme_color(SNAME("line_length_guideline_color"));
+	cache.code_folding_color = get_theme_color(SNAME("code_folding_color"), SNAME("CodeEdit"));
+	cache.brace_mismatch_color = get_theme_color(SNAME("brace_mismatch_color"));
+	cache.word_highlighted_color = get_theme_color(SNAME("word_highlighted_color"));
+	cache.search_result_color = get_theme_color(SNAME("search_result_color"));
+	cache.search_result_border_color = get_theme_color(SNAME("search_result_border_color"));
+	cache.background_color = get_theme_color(SNAME("background_color"));
 #ifdef TOOLS_ENABLED
-	cache.line_spacing = get_theme_constant("line_spacing") * EDSCALE;
+	cache.line_spacing = get_theme_constant(SNAME("line_spacing")) * EDSCALE;
 #else
-	cache.line_spacing = get_theme_constant("line_spacing");
+	cache.line_spacing = get_theme_constant(SNAME("line_spacing"));
 #endif
-	cache.tab_icon = get_theme_icon("tab");
-	cache.space_icon = get_theme_icon("space");
-	cache.folded_eol_icon = get_theme_icon("folded_eol_icon", "CodeEdit");
+	cache.tab_icon = get_theme_icon(SNAME("tab"));
+	cache.space_icon = get_theme_icon(SNAME("space"));
+	cache.folded_eol_icon = get_theme_icon(SNAME("folded_eol_icon"), SNAME("CodeEdit"));
 
 	TextServer::Direction dir;
 	if (text_direction == Control::TEXT_DIRECTION_INHERITED) {
@@ -4119,7 +4119,7 @@ void TextEdit::add_gutter(int p_at) {
 	for (int i = 0; i < text.size() + 1; i++) {
 		text.add_gutter(p_at);
 	}
-	emit_signal("gutter_added");
+	emit_signal(SNAME("gutter_added"));
 	update();
 }
 
@@ -4131,7 +4131,7 @@ void TextEdit::remove_gutter(int p_gutter) {
 	for (int i = 0; i < text.size() + 1; i++) {
 		text.remove_gutter(p_gutter);
 	}
-	emit_signal("gutter_removed");
+	emit_signal(SNAME("gutter_removed"));
 	update();
 }
 
@@ -4755,12 +4755,12 @@ bool TextEdit::search(const String &p_key, uint32_t p_search_flags, int p_from_l
 }
 
 void TextEdit::_cursor_changed_emit() {
-	emit_signal("cursor_changed");
+	emit_signal(SNAME("cursor_changed"));
 	cursor_changed_dirty = false;
 }
 
 void TextEdit::_text_changed_emit() {
-	emit_signal("text_changed");
+	emit_signal(SNAME("text_changed"));
 	text_changed_dirty = false;
 }
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -416,7 +416,7 @@ void TreeItem::set_collapsed(bool p_collapsed) {
 
 			if (tree->select_mode == Tree::SELECT_MULTI) {
 				tree->selected_item = this;
-				emit_signal("cell_selected");
+				emit_signal(SNAME("cell_selected"));
 			} else {
 				select(tree->selected_col);
 			}
@@ -426,7 +426,7 @@ void TreeItem::set_collapsed(bool p_collapsed) {
 	}
 
 	_changed_notify();
-	tree->emit_signal("item_collapsed", this);
+	tree->emit_signal(SNAME("item_collapsed"), this);
 }
 
 bool TreeItem::is_collapsed() {
@@ -1215,62 +1215,62 @@ TreeItem::~TreeItem() {
 /**********************************************/
 
 void Tree::update_cache() {
-	cache.font = get_theme_font("font");
-	cache.font_size = get_theme_font_size("font_size");
-	cache.tb_font = get_theme_font("title_button_font");
-	cache.tb_font_size = get_theme_font_size("title_button_font_size");
-	cache.bg = get_theme_stylebox("bg");
-	cache.selected = get_theme_stylebox("selected");
-	cache.selected_focus = get_theme_stylebox("selected_focus");
-	cache.cursor = get_theme_stylebox("cursor");
-	cache.cursor_unfocus = get_theme_stylebox("cursor_unfocused");
-	cache.button_pressed = get_theme_stylebox("button_pressed");
+	cache.font = get_theme_font(SNAME("font"));
+	cache.font_size = get_theme_font_size(SNAME("font_size"));
+	cache.tb_font = get_theme_font(SNAME("title_button_font"));
+	cache.tb_font_size = get_theme_font_size(SNAME("title_button_font_size"));
+	cache.bg = get_theme_stylebox(SNAME("bg"));
+	cache.selected = get_theme_stylebox(SNAME("selected"));
+	cache.selected_focus = get_theme_stylebox(SNAME("selected_focus"));
+	cache.cursor = get_theme_stylebox(SNAME("cursor"));
+	cache.cursor_unfocus = get_theme_stylebox(SNAME("cursor_unfocused"));
+	cache.button_pressed = get_theme_stylebox(SNAME("button_pressed"));
 
-	cache.checked = get_theme_icon("checked");
-	cache.unchecked = get_theme_icon("unchecked");
+	cache.checked = get_theme_icon(SNAME("checked"));
+	cache.unchecked = get_theme_icon(SNAME("unchecked"));
 	if (is_layout_rtl()) {
-		cache.arrow_collapsed = get_theme_icon("arrow_collapsed_mirrored");
+		cache.arrow_collapsed = get_theme_icon(SNAME("arrow_collapsed_mirrored"));
 	} else {
-		cache.arrow_collapsed = get_theme_icon("arrow_collapsed");
+		cache.arrow_collapsed = get_theme_icon(SNAME("arrow_collapsed"));
 	}
-	cache.arrow = get_theme_icon("arrow");
-	cache.select_arrow = get_theme_icon("select_arrow");
-	cache.updown = get_theme_icon("updown");
+	cache.arrow = get_theme_icon(SNAME("arrow"));
+	cache.select_arrow = get_theme_icon(SNAME("select_arrow"));
+	cache.updown = get_theme_icon(SNAME("updown"));
 
-	cache.custom_button = get_theme_stylebox("custom_button");
-	cache.custom_button_hover = get_theme_stylebox("custom_button_hover");
-	cache.custom_button_pressed = get_theme_stylebox("custom_button_pressed");
-	cache.custom_button_font_highlight = get_theme_color("custom_button_font_highlight");
+	cache.custom_button = get_theme_stylebox(SNAME("custom_button"));
+	cache.custom_button_hover = get_theme_stylebox(SNAME("custom_button_hover"));
+	cache.custom_button_pressed = get_theme_stylebox(SNAME("custom_button_pressed"));
+	cache.custom_button_font_highlight = get_theme_color(SNAME("custom_button_font_highlight"));
 
-	cache.font_color = get_theme_color("font_color");
-	cache.font_selected_color = get_theme_color("font_selected_color");
-	cache.drop_position_color = get_theme_color("drop_position_color");
-	cache.hseparation = get_theme_constant("hseparation");
-	cache.vseparation = get_theme_constant("vseparation");
-	cache.item_margin = get_theme_constant("item_margin");
-	cache.button_margin = get_theme_constant("button_margin");
+	cache.font_color = get_theme_color(SNAME("font_color"));
+	cache.font_selected_color = get_theme_color(SNAME("font_selected_color"));
+	cache.drop_position_color = get_theme_color(SNAME("drop_position_color"));
+	cache.hseparation = get_theme_constant(SNAME("hseparation"));
+	cache.vseparation = get_theme_constant(SNAME("vseparation"));
+	cache.item_margin = get_theme_constant(SNAME("item_margin"));
+	cache.button_margin = get_theme_constant(SNAME("button_margin"));
 
-	cache.font_outline_color = get_theme_color("font_outline_color");
-	cache.font_outline_size = get_theme_constant("outline_size");
+	cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
+	cache.font_outline_size = get_theme_constant(SNAME("outline_size"));
 
-	cache.draw_guides = get_theme_constant("draw_guides");
-	cache.guide_color = get_theme_color("guide_color");
-	cache.draw_relationship_lines = get_theme_constant("draw_relationship_lines");
-	cache.relationship_line_width = get_theme_constant("relationship_line_width");
-	cache.parent_hl_line_width = get_theme_constant("parent_hl_line_width");
-	cache.children_hl_line_width = get_theme_constant("children_hl_line_width");
-	cache.parent_hl_line_margin = get_theme_constant("parent_hl_line_margin");
-	cache.relationship_line_color = get_theme_color("relationship_line_color");
-	cache.parent_hl_line_color = get_theme_color("parent_hl_line_color");
-	cache.children_hl_line_color = get_theme_color("children_hl_line_color");
+	cache.draw_guides = get_theme_constant(SNAME("draw_guides"));
+	cache.guide_color = get_theme_color(SNAME("guide_color"));
+	cache.draw_relationship_lines = get_theme_constant(SNAME("draw_relationship_lines"));
+	cache.relationship_line_width = get_theme_constant(SNAME("relationship_line_width"));
+	cache.parent_hl_line_width = get_theme_constant(SNAME("parent_hl_line_width"));
+	cache.children_hl_line_width = get_theme_constant(SNAME("children_hl_line_width"));
+	cache.parent_hl_line_margin = get_theme_constant(SNAME("parent_hl_line_margin"));
+	cache.relationship_line_color = get_theme_color(SNAME("relationship_line_color"));
+	cache.parent_hl_line_color = get_theme_color(SNAME("parent_hl_line_color"));
+	cache.children_hl_line_color = get_theme_color(SNAME("children_hl_line_color"));
 
-	cache.scroll_border = get_theme_constant("scroll_border");
-	cache.scroll_speed = get_theme_constant("scroll_speed");
+	cache.scroll_border = get_theme_constant(SNAME("scroll_border"));
+	cache.scroll_speed = get_theme_constant(SNAME("scroll_speed"));
 
-	cache.title_button = get_theme_stylebox("title_button_normal");
-	cache.title_button_pressed = get_theme_stylebox("title_button_pressed");
-	cache.title_button_hover = get_theme_stylebox("title_button_hover");
-	cache.title_button_color = get_theme_color("title_button_color");
+	cache.title_button = get_theme_stylebox(SNAME("title_button_normal"));
+	cache.title_button_pressed = get_theme_stylebox(SNAME("title_button_pressed"));
+	cache.title_button_hover = get_theme_stylebox(SNAME("title_button_hover"));
+	cache.title_button_color = get_theme_color(SNAME("title_button_color"));
 
 	v_scroll->set_custom_step(cache.font->get_height(cache.font_size));
 }
@@ -2075,7 +2075,7 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 				selected_item = p_selected;
 				selected_col = 0;
 				if (!emitted_row) {
-					emit_signal("item_selected");
+					emit_signal(SNAME("item_selected"));
 					emitted_row = true;
 				}
 				/*
@@ -2095,28 +2095,28 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 					selected_item = p_selected;
 					selected_col = i;
 
-					emit_signal("cell_selected");
+					emit_signal(SNAME("cell_selected"));
 					if (select_mode == SELECT_MULTI) {
-						emit_signal("multi_selected", p_current, i, true);
+						emit_signal(SNAME("multi_selected"), p_current, i, true);
 					} else if (select_mode == SELECT_SINGLE) {
-						emit_signal("item_selected");
+						emit_signal(SNAME("item_selected"));
 					}
 
 				} else if (select_mode == SELECT_MULTI && (selected_item != p_selected || selected_col != i)) {
 					selected_item = p_selected;
 					selected_col = i;
-					emit_signal("cell_selected");
+					emit_signal(SNAME("cell_selected"));
 				}
 			} else {
 				if (r_in_range && *r_in_range && !p_force_deselect) {
 					if (!c.selected && c.selectable) {
 						c.selected = true;
-						emit_signal("multi_selected", p_current, i, true);
+						emit_signal(SNAME("multi_selected"), p_current, i, true);
 					}
 
 				} else if (!r_in_range || p_force_deselect) {
 					if (select_mode == SELECT_MULTI && c.selected) {
-						emit_signal("multi_selected", p_current, i, false);
+						emit_signal(SNAME("multi_selected"), p_current, i, false);
 					}
 					c.selected = false;
 				}
@@ -2184,7 +2184,7 @@ void Tree::_range_click_timeout() {
 		}
 
 		if (propagate_mouse_activated) {
-			emit_signal("item_activated");
+			emit_signal(SNAME("item_activated"));
 			propagate_mouse_activated = false;
 		}
 
@@ -2297,7 +2297,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 				cache.click_column = col;
 				cache.click_pos = get_global_mouse_position() - get_global_position();
 				update();
-				//emit_signal("button_pressed");
+				//emit_signal(SNAME("button_pressed"));
 				return -1;
 			}
 
@@ -2318,15 +2318,15 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			if (select_mode == SELECT_MULTI && p_mod->is_command_pressed() && c.selectable) {
 				if (!c.selected || p_button == MOUSE_BUTTON_RIGHT) {
 					p_item->select(col);
-					emit_signal("multi_selected", p_item, col, true);
+					emit_signal(SNAME("multi_selected"), p_item, col, true);
 					if (p_button == MOUSE_BUTTON_RIGHT) {
-						emit_signal("item_rmb_selected", get_local_mouse_position());
+						emit_signal(SNAME("item_rmb_selected"), get_local_mouse_position());
 					}
 
 					//p_item->selected_signal.call(col);
 				} else {
 					p_item->deselect(col);
-					emit_signal("multi_selected", p_item, col, false);
+					emit_signal(SNAME("multi_selected"), p_item, col, false);
 					//p_item->deselected_signal.call(col);
 				}
 
@@ -2337,7 +2337,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 						select_single_item(p_item, root, col, selected_item, &inrange);
 						if (p_button == MOUSE_BUTTON_RIGHT) {
-							emit_signal("item_rmb_selected", get_local_mouse_position());
+							emit_signal(SNAME("item_rmb_selected"), get_local_mouse_position());
 						}
 					} else {
 						int icount = _count_selected_items(root);
@@ -2351,14 +2351,14 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 							}
 
 							if (p_button == MOUSE_BUTTON_RIGHT) {
-								emit_signal("item_rmb_selected", get_local_mouse_position());
+								emit_signal(SNAME("item_rmb_selected"), get_local_mouse_position());
 							}
 						}
 					}
 
 					/*
 					if (!c.selected && select_mode==SELECT_MULTI) {
-						emit_signal("multi_selected",p_item,col,true);
+						emit_signal(SNAME("multi_selected"),p_item,col,true);
 					}
 					*/
 					update();
@@ -2472,7 +2472,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 				custom_popup_rect = Rect2i(get_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h - cache.offset.y), Size2(get_column_width(col), item_h));
 
 				if (on_arrow || !p_item->cells[col].custom_button) {
-					emit_signal("custom_popup_edited", ((bool)(x >= (col_width - item_h / 2))));
+					emit_signal(SNAME("custom_popup_edited"), ((bool)(x >= (col_width - item_h / 2))));
 				}
 
 				if (!p_item->cells[col].custom_button || !on_arrow) {
@@ -2524,7 +2524,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			}
 		}
 		if (p_item == root && p_button == MOUSE_BUTTON_RIGHT) {
-			emit_signal("empty_rmb", get_local_mouse_position());
+			emit_signal(SNAME("empty_rmb"), get_local_mouse_position());
 		}
 	}
 
@@ -2630,7 +2630,7 @@ void Tree::_go_left() {
 	} else {
 		if (select_mode == SELECT_MULTI) {
 			selected_col--;
-			emit_signal("cell_selected");
+			emit_signal(SNAME("cell_selected"));
 		} else {
 			selected_item->select(selected_col - 1);
 		}
@@ -2651,7 +2651,7 @@ void Tree::_go_right() {
 	} else {
 		if (select_mode == SELECT_MULTI) {
 			selected_col++;
-			emit_signal("cell_selected");
+			emit_signal(SNAME("cell_selected"));
 		} else {
 			selected_item->select(selected_col + 1);
 		}
@@ -2684,7 +2684,7 @@ void Tree::_go_up() {
 			return;
 		}
 		selected_item = prev;
-		emit_signal("cell_selected");
+		emit_signal(SNAME("cell_selected"));
 		update();
 	} else {
 		int col = selected_col < 0 ? 0 : selected_col;
@@ -2727,7 +2727,7 @@ void Tree::_go_down() {
 		}
 
 		selected_item = next;
-		emit_signal("cell_selected");
+		emit_signal(SNAME("cell_selected"));
 		update();
 	} else {
 		int col = selected_col < 0 ? 0 : selected_col;
@@ -2828,7 +2828,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 		if (select_mode == SELECT_MULTI) {
 			selected_item = next;
-			emit_signal("cell_selected");
+			emit_signal(SNAME("cell_selected"));
 			update();
 		} else {
 			while (next && !next->cells[selected_col].selectable) {
@@ -2866,7 +2866,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 		if (select_mode == SELECT_MULTI) {
 			selected_item = prev;
-			emit_signal("cell_selected");
+			emit_signal(SNAME("cell_selected"));
 			update();
 		} else {
 			while (prev && !prev->cells[selected_col].selectable) {
@@ -2882,7 +2882,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 		if (selected_item) {
 			//bring up editor if possible
 			if (!edit_selected()) {
-				emit_signal("item_activated");
+				emit_signal(SNAME("item_activated"));
 				incr_search.clear();
 			}
 		}
@@ -2894,10 +2894,10 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 			}
 			if (selected_item->is_selected(selected_col)) {
 				selected_item->deselect(selected_col);
-				emit_signal("multi_selected", selected_item, selected_col, false);
+				emit_signal(SNAME("multi_selected"), selected_item, selected_col, false);
 			} else if (selected_item->is_selectable(selected_col)) {
 				selected_item->select(selected_col);
-				emit_signal("multi_selected", selected_item, selected_col, true);
+				emit_signal(SNAME("multi_selected"), selected_item, selected_col, true);
 			}
 		}
 		accept_event();
@@ -3081,7 +3081,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 						for (int i = 0; i < columns.size(); i++) {
 							len += get_column_width(i);
 							if (pos.x < len) {
-								emit_signal("column_title_pressed", i);
+								emit_signal(SNAME("column_title_pressed"), i);
 								break;
 							}
 						}
@@ -3108,10 +3108,10 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 						}
 						if (rect.has_point(mpos)) {
 							if (!edit_selected()) {
-								emit_signal("item_double_clicked");
+								emit_signal(SNAME("item_double_clicked"));
 							}
 						} else {
-							emit_signal("item_double_clicked");
+							emit_signal(SNAME("item_double_clicked"));
 						}
 					}
 					pressing_for_editor = false;
@@ -3120,7 +3120,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 				if (cache.click_type == Cache::CLICK_BUTTON && cache.click_item != nullptr) {
 					// make sure in case of wrong reference after reconstructing whole TreeItems
 					cache.click_item = get_item_at_position(cache.click_pos);
-					emit_signal("button_pressed", cache.click_item, cache.click_column, cache.click_id);
+					emit_signal(SNAME("button_pressed"), cache.click_item, cache.click_column, cache.click_id);
 				}
 				cache.click_type = Cache::CLICK_NONE;
 				cache.click_index = -1;
@@ -3180,7 +3180,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 				}
 				if (!root || (!root->get_first_child() && hide_root)) {
 					if (b->get_button_index() == MOUSE_BUTTON_RIGHT && allow_rmb_select) {
-						emit_signal("empty_tree_rmb_selected", get_local_mouse_position());
+						emit_signal(SNAME("empty_tree_rmb_selected"), get_local_mouse_position());
 					}
 					break;
 				}
@@ -3231,13 +3231,13 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 					if (b->get_button_index() == MOUSE_BUTTON_LEFT) {
 						if (get_item_at_position(b->get_position()) == nullptr && !b->is_shift_pressed() && !b->is_ctrl_pressed() && !b->is_command_pressed()) {
-							emit_signal("nothing_selected");
+							emit_signal(SNAME("nothing_selected"));
 						}
 					}
 				}
 
 				if (propagate_mouse_activated) {
-					emit_signal("item_activated");
+					emit_signal(SNAME("item_activated"));
 					propagate_mouse_activated = false;
 				}
 
@@ -3306,7 +3306,7 @@ bool Tree::edit_selected() {
 		edited_item = s;
 		edited_col = col;
 		custom_popup_rect = Rect2i(get_global_position() + rect.position, rect.size);
-		emit_signal("custom_popup_edited", false);
+		emit_signal(SNAME("custom_popup_edited"), false);
 		item_edited(col, s);
 
 		return true;
@@ -3542,8 +3542,8 @@ void Tree::_notification(int p_what) {
 		RID ci = get_canvas_item();
 
 		Ref<StyleBox> bg = cache.bg;
-		Color font_outline_color = get_theme_color("font_outline_color");
-		int outline_size = get_theme_constant("outline_size");
+		Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+		int outline_size = get_theme_constant(SNAME("outline_size"));
 
 		Point2 draw_ofs;
 		draw_ofs += bg->get_offset();
@@ -3593,7 +3593,7 @@ void Tree::_notification(int p_what) {
 		// Otherwise, section heading backgrounds can appear to be in front of the focus outline when scrolling.
 		if (has_focus()) {
 			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, true);
-			const Ref<StyleBox> bg_focus = get_theme_stylebox("bg_focus");
+			const Ref<StyleBox> bg_focus = get_theme_stylebox(SNAME("bg_focus"));
 			bg_focus->draw(ci, Rect2(Point2(), get_size()));
 			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, false);
 		}
@@ -3694,9 +3694,9 @@ void Tree::item_edited(int p_column, TreeItem *p_item, bool p_lmb) {
 		edited_item->cells.write[p_column].dirty = true;
 	}
 	if (p_lmb) {
-		emit_signal("item_edited");
+		emit_signal(SNAME("item_edited"));
 	} else {
-		emit_signal("item_rmb_edited");
+		emit_signal(SNAME("item_rmb_edited"));
 	}
 }
 
@@ -3714,7 +3714,7 @@ void Tree::item_selected(int p_column, TreeItem *p_item) {
 		}
 
 		p_item->cells.write[p_column].selected = true;
-		//emit_signal("multi_selected",p_item,p_column,true); - NO this is for TreeItem::select
+		//emit_signal(SNAME("multi_selected"),p_item,p_column,true); - NO this is for TreeItem::select
 
 		selected_col = p_column;
 		if (!selected_item) {
@@ -4075,7 +4075,7 @@ void Tree::ensure_cursor_is_visible() {
 		if (cell_h > screen_h) { // Screen size is too small, maybe it was not resized yet.
 			v_scroll->set_value(y_offset);
 		} else if (y_offset + cell_h > v_scroll->get_value() + screen_h) {
-			v_scroll->call_deferred("set_value", y_offset - screen_h + cell_h);
+			v_scroll->call_deferred(SNAME("set_value"), y_offset - screen_h + cell_h);
 		} else if (y_offset < v_scroll->get_value()) {
 			v_scroll->set_value(y_offset);
 		}
@@ -4093,7 +4093,7 @@ void Tree::ensure_cursor_is_visible() {
 		if (cell_w > screen_w) {
 			h_scroll->set_value(x_offset);
 		} else if (x_offset + cell_w > h_scroll->get_value() + screen_w) {
-			h_scroll->call_deferred("set_value", x_offset - screen_w + cell_w);
+			h_scroll->call_deferred(SNAME("set_value"), x_offset - screen_w + cell_w);
 		} else if (x_offset < h_scroll->get_value()) {
 			h_scroll->set_value(x_offset);
 		}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -442,7 +442,7 @@ void Node::set_process_mode(ProcessMode p_mode) {
 	// This is required for the editor to update the visibility of disabled nodes
 	// It's very expensive during runtime to change, so editor-only
 	if (Engine::get_singleton()->is_editor_hint()) {
-		get_tree()->emit_signal("tree_process_mode_changed");
+		get_tree()->emit_signal(SNAME("tree_process_mode_changed"));
 	}
 #endif
 }
@@ -868,7 +868,7 @@ void Node::set_name(const String &p_name) {
 	propagate_notification(NOTIFICATION_PATH_CHANGED);
 
 	if (is_inside_tree()) {
-		emit_signal("renamed");
+		emit_signal(SNAME("renamed"));
 		get_tree()->node_renamed(this);
 		get_tree()->tree_changed();
 	}

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -406,7 +406,7 @@ bool SceneTree::physics_process(float p_time) {
 	MainLoop::physics_process(p_time);
 	physics_process_time = p_time;
 
-	emit_signal("physics_frame");
+	emit_signal(SNAME("physics_frame"));
 
 	_notify_group_pause("physics_process_internal", Node::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	call_group_flags(GROUP_CALL_REALTIME, "_viewports", "_process_picking");
@@ -436,7 +436,7 @@ bool SceneTree::process(float p_time) {
 		multiplayer->poll();
 	}
 
-	emit_signal("process_frame");
+	emit_signal(SNAME("process_frame"));
 
 	MessageQueue::get_singleton()->flush(); //small little hack
 
@@ -471,7 +471,7 @@ bool SceneTree::process(float p_time) {
 		E->get()->set_time_left(time_left);
 
 		if (time_left < 0) {
-			E->get()->emit_signal("timeout");
+			E->get()->emit_signal(SNAME("timeout"));
 			timers.erase(E);
 		}
 		if (E == L) {
@@ -1097,7 +1097,7 @@ Error SceneTree::change_scene_to(const Ref<PackedScene> &p_scene) {
 		ERR_FAIL_COND_V(!new_scene, ERR_CANT_CREATE);
 	}
 
-	call_deferred("_change_scene", new_scene);
+	call_deferred(SNAME("_change_scene"), new_scene);
 	return OK;
 }
 

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -58,7 +58,7 @@ void Timer::_notification(int p_what) {
 					stop();
 				}
 
-				emit_signal("timeout");
+				emit_signal(SNAME("timeout"));
 			}
 
 		} break;
@@ -74,7 +74,7 @@ void Timer::_notification(int p_what) {
 				} else {
 					stop();
 				}
-				emit_signal("timeout");
+				emit_signal(SNAME("timeout"));
 			}
 
 		} break;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -248,16 +248,16 @@ void Viewport::_sub_window_update(Window *p_window) {
 	Rect2i r = Rect2i(p_window->get_position(), sw.window->get_size());
 
 	if (!p_window->get_flag(Window::FLAG_BORDERLESS)) {
-		Ref<StyleBox> panel = p_window->get_theme_stylebox("panel_window");
+		Ref<StyleBox> panel = p_window->get_theme_stylebox(SNAME("panel_window"));
 		panel->draw(sw.canvas_item, r);
 
 		// Draw the title bar text.
-		Ref<Font> title_font = p_window->get_theme_font("title_font");
-		int font_size = p_window->get_theme_font_size("title_font_size");
-		Color title_color = p_window->get_theme_color("title_color");
-		int title_height = p_window->get_theme_constant("title_height");
-		int close_h_ofs = p_window->get_theme_constant("close_h_ofs");
-		int close_v_ofs = p_window->get_theme_constant("close_v_ofs");
+		Ref<Font> title_font = p_window->get_theme_font(SNAME("title_font"));
+		int font_size = p_window->get_theme_font_size(SNAME("title_font_size"));
+		Color title_color = p_window->get_theme_color(SNAME("title_color"));
+		int title_height = p_window->get_theme_constant(SNAME("title_height"));
+		int close_h_ofs = p_window->get_theme_constant(SNAME("close_h_ofs"));
+		int close_v_ofs = p_window->get_theme_constant(SNAME("close_v_ofs"));
 
 		TextLine title_text = TextLine(p_window->get_title(), title_font, font_size, Dictionary(), TranslationServer::get_singleton()->get_tool_locale());
 		title_text.set_width(r.size.width - panel->get_minimum_size().x - close_h_ofs);
@@ -265,8 +265,8 @@ void Viewport::_sub_window_update(Window *p_window) {
 		int x = (r.size.width - title_text.get_size().x) / 2;
 		int y = (-title_height - title_text.get_size().y) / 2;
 
-		Color font_outline_color = p_window->get_theme_color("title_outline_modulate");
-		int outline_size = p_window->get_theme_constant("title_outline_size");
+		Color font_outline_color = p_window->get_theme_color(SNAME("title_outline_modulate"));
+		int outline_size = p_window->get_theme_constant(SNAME("title_outline_size"));
 		if (outline_size > 0 && font_outline_color.a > 0) {
 			title_text.draw_outline(sw.canvas_item, r.position + Point2(x, y), outline_size, font_outline_color);
 		}
@@ -847,7 +847,7 @@ void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override,
 
 	update_canvas_items();
 
-	emit_signal("size_changed");
+	emit_signal(SNAME("size_changed"));
 }
 
 Size2i Viewport::_get_size() const {
@@ -2211,7 +2211,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					Window *sw = embedder->gui.sub_windows[i].window;
 					Rect2 swrect = Rect2i(sw->get_position(), sw->get_size());
 					if (!sw->get_flag(Window::FLAG_BORDERLESS)) {
-						int title_height = sw->get_theme_constant("title_height");
+						int title_height = sw->get_theme_constant(SNAME("title_height"));
 						swrect.position.y -= title_height;
 						swrect.size.y += title_height;
 					}
@@ -2560,7 +2560,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 	}
 	get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, "_viewports", "_gui_remove_focus_for_window", (Node *)get_base_window());
 	gui.key_focus = p_control;
-	emit_signal("gui_focus_changed", p_control);
+	emit_signal(SNAME("gui_focus_changed"), p_control);
 	p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
 	p_control->update();
 }
@@ -2670,7 +2670,7 @@ Control *Viewport::_gui_get_focus_owner() {
 
 void Viewport::_gui_grab_click_focus(Control *p_control) {
 	gui.mouse_click_grabber = p_control;
-	call_deferred("_post_gui_grab_click_focus");
+	call_deferred(SNAME("_post_gui_grab_click_focus"));
 }
 
 void Viewport::_post_gui_grab_click_focus() {
@@ -2743,7 +2743,7 @@ Viewport::SubWindowResize Viewport::_sub_window_get_resize_margin(Window *p_subw
 
 	Rect2i r = Rect2i(p_subwindow->get_position(), p_subwindow->get_size());
 
-	int title_height = p_subwindow->get_theme_constant("title_height");
+	int title_height = p_subwindow->get_theme_constant(SNAME("title_height"));
 
 	r.position.y -= title_height;
 	r.size.y += title_height;
@@ -2755,7 +2755,7 @@ Viewport::SubWindowResize Viewport::_sub_window_get_resize_margin(Window *p_subw
 	int dist_x = p_point.x < r.position.x ? (p_point.x - r.position.x) : (p_point.x > (r.position.x + r.size.x) ? (p_point.x - (r.position.x + r.size.x)) : 0);
 	int dist_y = p_point.y < r.position.y ? (p_point.y - r.position.y) : (p_point.y > (r.position.y + r.size.y) ? (p_point.y - (r.position.y + r.size.y)) : 0);
 
-	int limit = p_subwindow->get_theme_constant("resize_margin");
+	int limit = p_subwindow->get_theme_constant(SNAME("resize_margin"));
 
 	if (ABS(dist_x) > limit) {
 		return SUB_WINDOW_RESIZE_DISABLED;
@@ -2837,7 +2837,7 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 						new_rect.position.x = 0;
 					}
 
-					int title_height = gui.subwindow_focused->get_flag(Window::FLAG_BORDERLESS) ? 0 : gui.subwindow_focused->get_theme_constant("title_height");
+					int title_height = gui.subwindow_focused->get_flag(Window::FLAG_BORDERLESS) ? 0 : gui.subwindow_focused->get_theme_constant(SNAME("title_height"));
 
 					if (new_rect.position.y < title_height) {
 						new_rect.position.y = title_height;
@@ -2941,7 +2941,7 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 
 			if (!sw.window->get_flag(Window::FLAG_BORDERLESS)) {
 				//check top bar
-				int title_height = sw.window->get_theme_constant("title_height");
+				int title_height = sw.window->get_theme_constant(SNAME("title_height"));
 				Rect2i title_bar = r;
 				title_bar.position.y -= title_height;
 				title_bar.size.y = title_height;
@@ -2949,9 +2949,9 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 				if (title_bar.has_point(mb->get_position())) {
 					click_on_window = true;
 
-					int close_h_ofs = sw.window->get_theme_constant("close_h_ofs");
-					int close_v_ofs = sw.window->get_theme_constant("close_v_ofs");
-					Ref<Texture2D> close_icon = sw.window->get_theme_icon("close");
+					int close_h_ofs = sw.window->get_theme_constant(SNAME("close_h_ofs"));
+					int close_v_ofs = sw.window->get_theme_constant(SNAME("close_v_ofs"));
+					Ref<Texture2D> close_icon = sw.window->get_theme_icon(SNAME("close"));
 
 					Rect2 close_rect;
 					close_rect.position = Vector2(r.position.x + r.size.x - close_v_ofs, r.position.y - close_h_ofs);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -313,39 +313,39 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 	switch (p_event) {
 		case DisplayServer::WINDOW_EVENT_MOUSE_ENTER: {
 			_propagate_window_notification(this, NOTIFICATION_WM_MOUSE_ENTER);
-			emit_signal("mouse_entered");
+			emit_signal(SNAME("mouse_entered"));
 			DisplayServer::get_singleton()->cursor_set_shape(DisplayServer::CURSOR_ARROW); //restore cursor shape
 		} break;
 		case DisplayServer::WINDOW_EVENT_MOUSE_EXIT: {
 			_propagate_window_notification(this, NOTIFICATION_WM_MOUSE_EXIT);
-			emit_signal("mouse_exited");
+			emit_signal(SNAME("mouse_exited"));
 		} break;
 		case DisplayServer::WINDOW_EVENT_FOCUS_IN: {
 			focused = true;
 			_propagate_window_notification(this, NOTIFICATION_WM_WINDOW_FOCUS_IN);
-			emit_signal("focus_entered");
+			emit_signal(SNAME("focus_entered"));
 
 		} break;
 		case DisplayServer::WINDOW_EVENT_FOCUS_OUT: {
 			focused = false;
 			_propagate_window_notification(this, NOTIFICATION_WM_WINDOW_FOCUS_OUT);
-			emit_signal("focus_exited");
+			emit_signal(SNAME("focus_exited"));
 		} break;
 		case DisplayServer::WINDOW_EVENT_CLOSE_REQUEST: {
 			if (exclusive_child != nullptr) {
 				break; //has an exclusive child, can't get events until child is closed
 			}
 			_propagate_window_notification(this, NOTIFICATION_WM_CLOSE_REQUEST);
-			emit_signal("close_requested");
+			emit_signal(SNAME("close_requested"));
 		} break;
 		case DisplayServer::WINDOW_EVENT_GO_BACK_REQUEST: {
 			_propagate_window_notification(this, NOTIFICATION_WM_GO_BACK_REQUEST);
-			emit_signal("go_back_requested");
+			emit_signal(SNAME("go_back_requested"));
 		} break;
 		case DisplayServer::WINDOW_EVENT_DPI_CHANGE: {
 			_update_viewport_size();
 			_propagate_window_notification(this, NOTIFICATION_WM_DPI_CHANGE);
-			emit_signal("dpi_changed");
+			emit_signal(SNAME("dpi_changed"));
 		} break;
 	}
 }
@@ -882,7 +882,7 @@ void Window::child_controls_changed() {
 	}
 
 	updating_child_controls = true;
-	call_deferred("_update_child_controls");
+	call_deferred(SNAME("_update_child_controls"));
 }
 
 bool Window::_can_consume_input_events() const {
@@ -925,7 +925,7 @@ void Window::_window_input_text(const String &p_text) {
 }
 
 void Window::_window_drop_files(const Vector<String> &p_files) {
-	emit_signal("files_dropped", p_files, current_screen);
+	emit_signal(SNAME("files_dropped"), p_files, current_screen);
 }
 
 Viewport *Window::get_parent_viewport() const {
@@ -1043,7 +1043,7 @@ void Window::popup_centered_ratio(float p_ratio) {
 }
 
 void Window::popup(const Rect2i &p_screen_rect) {
-	emit_signal("about_to_popup");
+	emit_signal(SNAME("about_to_popup"));
 
 	// Update window size to calculate the actual window size based on contents minimum size and minimum size.
 	_update_window_size();

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -286,7 +286,7 @@ void Curve::set_min_value(float p_min) {
 	}
 	// Note: min and max are indicative values,
 	// it's still possible that existing points are out of range at this point.
-	emit_signal(SIGNAL_RANGE_CHANGED);
+	emit_signal(SNAME(SIGNAL_RANGE_CHANGED));
 }
 
 void Curve::set_max_value(float p_max) {
@@ -296,7 +296,7 @@ void Curve::set_max_value(float p_max) {
 		_minmax_set_once |= 0b01; // second bit is "max set"
 		_max_value = p_max;
 	}
-	emit_signal(SIGNAL_RANGE_CHANGED);
+	emit_signal(SNAME(SIGNAL_RANGE_CHANGED));
 }
 
 real_t Curve::interpolate(real_t offset) const {

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -405,7 +405,7 @@ void CodeHighlighter::_clear_highlighting_cache() {
 }
 
 void CodeHighlighter::_update_cache() {
-	font_color = text_edit->get_theme_color("font_color");
+	font_color = text_edit->get_theme_color(SNAME("font_color"));
 }
 
 void CodeHighlighter::add_keyword_color(const String &p_keyword, const Color &p_color) {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1790,7 +1790,7 @@ void GradientTexture::_queue_update() {
 	}
 
 	update_pending = true;
-	call_deferred("_update");
+	call_deferred(SNAME("_update"));
 }
 
 void GradientTexture::_update() {

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -2569,7 +2569,7 @@ void TileSetAtlasSource::create_tile(const Vector2i p_atlas_coords, const Vector
 		}
 	}
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 void TileSetAtlasSource::remove_tile(Vector2i p_atlas_coords) {
@@ -2595,7 +2595,7 @@ void TileSetAtlasSource::remove_tile(Vector2i p_atlas_coords) {
 	tiles_ids.erase(p_atlas_coords);
 	tiles_ids.sort();
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 bool TileSetAtlasSource::has_tile(Vector2i p_atlas_coords) const {
@@ -2723,7 +2723,7 @@ void TileSetAtlasSource::move_tile_in_atlas(Vector2i p_atlas_coords, Vector2i p_
 		}
 	}
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 bool TileSetAtlasSource::has_tiles_outside_texture() {
@@ -2768,7 +2768,7 @@ int TileSetAtlasSource::create_alternative_tile(const Vector2i p_atlas_coords, i
 	tiles[p_atlas_coords].alternatives_ids.sort();
 	_compute_next_alternative_id(p_atlas_coords);
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 
 	return new_alternative_id;
 }
@@ -2783,7 +2783,7 @@ void TileSetAtlasSource::remove_alternative_tile(const Vector2i p_atlas_coords, 
 	tiles[p_atlas_coords].alternatives_ids.erase(p_alternative_tile);
 	tiles[p_atlas_coords].alternatives_ids.sort();
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 void TileSetAtlasSource::set_alternative_tile_id(const Vector2i p_atlas_coords, int p_alternative_tile, int p_new_id) {
@@ -2800,7 +2800,7 @@ void TileSetAtlasSource::set_alternative_tile_id(const Vector2i p_atlas_coords, 
 	tiles[p_atlas_coords].alternatives_ids.erase(p_alternative_tile);
 	tiles[p_atlas_coords].alternatives_ids.sort();
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 bool TileSetAtlasSource::has_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile) const {
@@ -2958,7 +2958,7 @@ int TileSetScenesCollectionSource::create_scene_tile(Ref<PackedScene> p_packed_s
 	set_scene_tile_scene(new_scene_id, p_packed_scene);
 	_compute_next_alternative_id();
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 
 	return new_scene_id;
 }
@@ -2978,7 +2978,7 @@ void TileSetScenesCollectionSource::set_scene_tile_id(int p_id, int p_new_id) {
 	scenes.erase(p_id);
 	scenes_ids.erase(p_id);
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 void TileSetScenesCollectionSource::set_scene_tile_scene(int p_id, Ref<PackedScene> p_packed_scene) {
@@ -2997,7 +2997,7 @@ void TileSetScenesCollectionSource::set_scene_tile_scene(int p_id, Ref<PackedSce
 	} else {
 		scenes[p_id].scene = Ref<PackedScene>();
 	}
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 Ref<PackedScene> TileSetScenesCollectionSource::get_scene_tile_scene(int p_id) const {
@@ -3010,7 +3010,7 @@ void TileSetScenesCollectionSource::set_scene_tile_display_placeholder(int p_id,
 
 	scenes[p_id].display_placeholder = p_display_placeholder;
 
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 bool TileSetScenesCollectionSource::get_scene_tile_display_placeholder(int p_id) const {
@@ -3023,7 +3023,7 @@ void TileSetScenesCollectionSource::remove_scene_tile(int p_id) {
 
 	scenes.erase(p_id);
 	scenes_ids.erase(p_id);
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 int TileSetScenesCollectionSource::get_next_scene_tile_id() const {
@@ -3144,7 +3144,7 @@ void TileData::notify_tile_data_properties_should_change() {
 	}
 
 	notify_property_list_changed();
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 void TileData::reset_state() {
@@ -3166,7 +3166,7 @@ bool TileData::is_allowing_transform() const {
 void TileData::set_flip_h(bool p_flip_h) {
 	ERR_FAIL_COND_MSG(!allow_transform && p_flip_h, "Transform is only allowed for alternative tiles (with its alternative_id != 0)");
 	flip_h = p_flip_h;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 bool TileData::get_flip_h() const {
 	return flip_h;
@@ -3175,7 +3175,7 @@ bool TileData::get_flip_h() const {
 void TileData::set_flip_v(bool p_flip_v) {
 	ERR_FAIL_COND_MSG(!allow_transform && p_flip_v, "Transform is only allowed for alternative tiles (with its alternative_id != 0)");
 	flip_v = p_flip_v;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 bool TileData::get_flip_v() const {
@@ -3185,7 +3185,7 @@ bool TileData::get_flip_v() const {
 void TileData::set_transpose(bool p_transpose) {
 	ERR_FAIL_COND_MSG(!allow_transform && p_transpose, "Transform is only allowed for alternative tiles (with its alternative_id != 0)");
 	transpose = p_transpose;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 bool TileData::get_transpose() const {
 	return transpose;
@@ -3193,7 +3193,7 @@ bool TileData::get_transpose() const {
 
 void TileData::set_texture_offset(Vector2i p_texture_offset) {
 	tex_offset = p_texture_offset;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 Vector2i TileData::get_texture_offset() const {
@@ -3202,7 +3202,7 @@ Vector2i TileData::get_texture_offset() const {
 
 void TileData::tile_set_material(Ref<ShaderMaterial> p_material) {
 	material = p_material;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 Ref<ShaderMaterial> TileData::tile_get_material() const {
 	return material;
@@ -3210,7 +3210,7 @@ Ref<ShaderMaterial> TileData::tile_get_material() const {
 
 void TileData::set_modulate(Color p_modulate) {
 	modulate = p_modulate;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 Color TileData::get_modulate() const {
 	return modulate;
@@ -3218,7 +3218,7 @@ Color TileData::get_modulate() const {
 
 void TileData::set_z_index(int p_z_index) {
 	z_index = p_z_index;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 int TileData::get_z_index() const {
 	return z_index;
@@ -3226,7 +3226,7 @@ int TileData::get_z_index() const {
 
 void TileData::set_y_sort_origin(int p_y_sort_origin) {
 	y_sort_origin = p_y_sort_origin;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 int TileData::get_y_sort_origin() const {
 	return y_sort_origin;
@@ -3235,7 +3235,7 @@ int TileData::get_y_sort_origin() const {
 void TileData::set_occluder(int p_layer_id, Ref<OccluderPolygon2D> p_occluder_polygon) {
 	ERR_FAIL_INDEX(p_layer_id, occluders.size());
 	occluders.write[p_layer_id] = p_occluder_polygon;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 Ref<OccluderPolygon2D> TileData::get_occluder(int p_layer_id) const {
@@ -3254,20 +3254,20 @@ void TileData::set_collision_polygons_count(int p_layer_id, int p_polygons_count
 	ERR_FAIL_COND(p_polygons_count < 0);
 	physics.write[p_layer_id].polygons.resize(p_polygons_count);
 	notify_property_list_changed();
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 void TileData::add_collision_polygon(int p_layer_id) {
 	ERR_FAIL_INDEX(p_layer_id, physics.size());
 	physics.write[p_layer_id].polygons.push_back(PhysicsLayerTileData::PolygonShapeTileData());
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 void TileData::remove_collision_polygon(int p_layer_id, int p_polygon_index) {
 	ERR_FAIL_INDEX(p_layer_id, physics.size());
 	ERR_FAIL_INDEX(p_polygon_index, physics[p_layer_id].polygons.size());
 	physics.write[p_layer_id].polygons.remove(p_polygon_index);
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 void TileData::set_collision_polygon_points(int p_layer_id, int p_polygon_index, Vector<Vector2> p_polygon) {
@@ -3291,7 +3291,7 @@ void TileData::set_collision_polygon_points(int p_layer_id, int p_polygon_index,
 		}
 	}
 	physics.write[p_layer_id].polygons.write[p_polygon_index].polygon = p_polygon;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 Vector<Vector2> TileData::get_collision_polygon_points(int p_layer_id, int p_polygon_index) const {
@@ -3304,7 +3304,7 @@ void TileData::set_collision_polygon_one_way(int p_layer_id, int p_polygon_index
 	ERR_FAIL_INDEX(p_layer_id, physics.size());
 	ERR_FAIL_INDEX(p_polygon_index, physics[p_layer_id].polygons.size());
 	physics.write[p_layer_id].polygons.write[p_polygon_index].one_way = p_one_way;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 bool TileData::is_collision_polygon_one_way(int p_layer_id, int p_polygon_index) const {
@@ -3317,7 +3317,7 @@ void TileData::set_collision_polygon_one_way_margin(int p_layer_id, int p_polygo
 	ERR_FAIL_INDEX(p_layer_id, physics.size());
 	ERR_FAIL_INDEX(p_polygon_index, physics[p_layer_id].polygons.size());
 	physics.write[p_layer_id].polygons.write[p_polygon_index].one_way_margin = p_one_way_margin;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 float TileData::get_collision_polygon_one_way_margin(int p_layer_id, int p_polygon_index) const {
@@ -3353,7 +3353,7 @@ void TileData::set_terrain_set(int p_terrain_set) {
 	}
 	terrain_set = p_terrain_set;
 	notify_property_list_changed();
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 int TileData::get_terrain_set() const {
@@ -3368,7 +3368,7 @@ void TileData::set_peering_bit_terrain(TileSet::CellNeighbor p_peering_bit, int 
 		ERR_FAIL_COND(!is_valid_peering_bit_terrain(p_peering_bit));
 	}
 	terrain_peering_bits[p_peering_bit] = p_terrain_index;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 int TileData::get_peering_bit_terrain(TileSet::CellNeighbor p_peering_bit) const {
@@ -3386,7 +3386,7 @@ bool TileData::is_valid_peering_bit_terrain(TileSet::CellNeighbor p_peering_bit)
 void TileData::set_navigation_polygon(int p_layer_id, Ref<NavigationPolygon> p_navigation_polygon) {
 	ERR_FAIL_INDEX(p_layer_id, navigation.size());
 	navigation.write[p_layer_id] = p_navigation_polygon;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 Ref<NavigationPolygon> TileData::get_navigation_polygon(int p_layer_id) const {
@@ -3398,7 +3398,7 @@ Ref<NavigationPolygon> TileData::get_navigation_polygon(int p_layer_id) const {
 void TileData::set_probability(float p_probability) {
 	ERR_FAIL_COND(p_probability < 0.0);
 	probability = p_probability;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 float TileData::get_probability() const {
 	return probability;
@@ -3422,7 +3422,7 @@ Variant TileData::get_custom_data(String p_layer_name) const {
 void TileData::set_custom_data_by_layer_id(int p_layer_id, Variant p_value) {
 	ERR_FAIL_INDEX(p_layer_id, custom_data.size());
 	custom_data.write[p_layer_id] = p_value;
-	emit_signal("changed");
+	emit_signal(SNAME("changed"));
 }
 
 Variant TileData::get_custom_data_by_layer_id(int p_layer_id) const {

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1943,7 +1943,7 @@ void VisualShader::_update_shader() const {
 		const_cast<VisualShader *>(this)->set_default_texture_param(default_tex_params[i].name, default_tex_params[i].param);
 	}
 	if (previous_code != final_code) {
-		const_cast<VisualShader *>(this)->emit_signal("changed");
+		const_cast<VisualShader *>(this)->emit_signal(SNAME("changed"));
 	}
 	previous_code = final_code;
 }
@@ -1954,7 +1954,7 @@ void VisualShader::_queue_update() {
 	}
 
 	dirty.set();
-	call_deferred("_update_shader");
+	call_deferred(SNAME("_update_shader"));
 }
 
 void VisualShader::_input_type_changed(Type p_type, int p_id) {
@@ -2436,7 +2436,7 @@ void VisualShaderNodeInput::set_input_name(String p_name) {
 	input_name = p_name;
 	emit_changed();
 	if (get_input_type_by_name(input_name) != prev_type) {
-		emit_signal("input_type_changed");
+		emit_signal(SNAME("input_type_changed"));
 	}
 }
 
@@ -2977,7 +2977,7 @@ VisualShaderNodeOutput::VisualShaderNodeOutput() {
 
 void VisualShaderNodeUniform::set_uniform_name(const String &p_name) {
 	uniform_name = p_name;
-	emit_signal("name_changed");
+	emit_signal(SNAME("name_changed"));
 	emit_changed();
 }
 

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -707,7 +707,7 @@ void VisualShaderNodeTexture::set_source(Source p_source) {
 			break;
 	}
 	emit_changed();
-	emit_signal("editor_refresh_request");
+	emit_signal(SNAME("editor_refresh_request"));
 }
 
 VisualShaderNodeTexture::Source VisualShaderNodeTexture::get_source() const {
@@ -1076,7 +1076,7 @@ String VisualShaderNodeSample3D::generate_code(Shader::Mode p_mode, VisualShader
 void VisualShaderNodeSample3D::set_source(Source p_source) {
 	source = p_source;
 	emit_changed();
-	emit_signal("editor_refresh_request");
+	emit_signal(SNAME("editor_refresh_request"));
 }
 
 VisualShaderNodeSample3D::Source VisualShaderNodeSample3D::get_source() const {
@@ -1366,7 +1366,7 @@ String VisualShaderNodeCubemap::get_input_port_default_hint(int p_port) const {
 void VisualShaderNodeCubemap::set_source(Source p_source) {
 	source = p_source;
 	emit_changed();
-	emit_signal("editor_refresh_request");
+	emit_signal(SNAME("editor_refresh_request"));
 }
 
 VisualShaderNodeCubemap::Source VisualShaderNodeCubemap::get_source() const {

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -561,7 +561,7 @@ void AudioServer::set_bus_count(int p_count) {
 
 	unlock();
 
-	emit_signal("bus_layout_changed");
+	emit_signal(SNAME("bus_layout_changed"));
 }
 
 void AudioServer::remove_bus(int p_index) {
@@ -576,7 +576,7 @@ void AudioServer::remove_bus(int p_index) {
 	buses.remove(p_index);
 	unlock();
 
-	emit_signal("bus_layout_changed");
+	emit_signal(SNAME("bus_layout_changed"));
 }
 
 void AudioServer::add_bus(int p_at_pos) {
@@ -630,7 +630,7 @@ void AudioServer::add_bus(int p_at_pos) {
 		buses.insert(p_at_pos, bus);
 	}
 
-	emit_signal("bus_layout_changed");
+	emit_signal(SNAME("bus_layout_changed"));
 }
 
 void AudioServer::move_bus(int p_bus, int p_to_pos) {
@@ -654,7 +654,7 @@ void AudioServer::move_bus(int p_bus, int p_to_pos) {
 		buses.insert(p_to_pos - 1, bus);
 	}
 
-	emit_signal("bus_layout_changed");
+	emit_signal(SNAME("bus_layout_changed"));
 }
 
 int AudioServer::get_bus_count() const {
@@ -700,7 +700,7 @@ void AudioServer::set_bus_name(int p_bus, const String &p_name) {
 	bus_map[attempt] = buses[p_bus];
 	unlock();
 
-	emit_signal("bus_layout_changed");
+	emit_signal(SNAME("bus_layout_changed"));
 }
 
 String AudioServer::get_bus_name(int p_bus) const {

--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -110,7 +110,7 @@ void CameraServer::add_feed(const Ref<CameraFeed> &p_feed) {
 #endif
 
 	// let whomever is interested know
-	emit_signal("camera_feed_added", p_feed->get_id());
+	emit_signal(SNAME("camera_feed_added"), p_feed->get_id());
 };
 
 void CameraServer::remove_feed(const Ref<CameraFeed> &p_feed) {
@@ -127,7 +127,7 @@ void CameraServer::remove_feed(const Ref<CameraFeed> &p_feed) {
 			feeds.remove(i);
 
 			// let whomever is interested know
-			emit_signal("camera_feed_removed", feed_id);
+			emit_signal(SNAME("camera_feed_removed"), feed_id);
 			return;
 		};
 	};

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -158,7 +158,7 @@ static Ref<NavigationMesh> poly_to_mesh(Ref<NavigationPolygon> d) {
 }
 
 void NavigationServer2D::_emit_map_changed(RID p_map) {
-	emit_signal("map_changed", p_map);
+	emit_signal(SNAME("map_changed"), p_map);
 }
 
 void NavigationServer2D::_bind_methods() {

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -73,7 +73,7 @@ void RenderingServerDefault::request_frame_drawn_callback(Object *p_where, const
 
 void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	//needs to be done before changes is reset to 0, to not force the editor to redraw
-	RS::get_singleton()->emit_signal("frame_pre_draw");
+	RS::get_singleton()->emit_signal(SNAME("frame_pre_draw"));
 
 	changes = 0;
 
@@ -113,7 +113,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 
 		frame_drawn_callbacks.pop_front();
 	}
-	RS::get_singleton()->emit_signal("frame_post_draw");
+	RS::get_singleton()->emit_signal(SNAME("frame_post_draw"));
 
 	if (RSG::storage->get_captured_timestamps_count()) {
 		Vector<FrameProfileArea> new_profile;

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -164,7 +164,7 @@ void XRServer::add_interface(const Ref<XRInterface> &p_interface) {
 	};
 
 	interfaces.push_back(p_interface);
-	emit_signal("interface_added", p_interface->get_name());
+	emit_signal(SNAME("interface_added"), p_interface->get_name());
 };
 
 void XRServer::remove_interface(const Ref<XRInterface> &p_interface) {
@@ -182,7 +182,7 @@ void XRServer::remove_interface(const Ref<XRInterface> &p_interface) {
 
 	print_verbose("XR: Removed interface" + p_interface->get_name());
 
-	emit_signal("interface_removed", p_interface->get_name());
+	emit_signal(SNAME("interface_removed"), p_interface->get_name());
 	interfaces.remove(idx);
 };
 
@@ -269,7 +269,7 @@ void XRServer::add_tracker(Ref<XRPositionalTracker> p_tracker) {
 	ERR_FAIL_COND(p_tracker.is_null());
 
 	trackers.push_back(p_tracker);
-	emit_signal("tracker_added", p_tracker->get_tracker_name(), p_tracker->get_tracker_type(), p_tracker->get_tracker_id());
+	emit_signal(SNAME("tracker_added"), p_tracker->get_tracker_name(), p_tracker->get_tracker_type(), p_tracker->get_tracker_id());
 };
 
 void XRServer::remove_tracker(Ref<XRPositionalTracker> p_tracker) {
@@ -285,7 +285,7 @@ void XRServer::remove_tracker(Ref<XRPositionalTracker> p_tracker) {
 
 	ERR_FAIL_COND(idx == -1);
 
-	emit_signal("tracker_removed", p_tracker->get_tracker_name(), p_tracker->get_tracker_type(), p_tracker->get_tracker_id());
+	emit_signal(SNAME("tracker_removed"), p_tracker->get_tracker_name(), p_tracker->get_tracker_type(), p_tracker->get_tracker_id());
 	trackers.remove(idx);
 };
 

--- a/tests/test_gui.cpp
+++ b/tests/test_gui.cpp
@@ -217,7 +217,7 @@ public:
 		richtext->add_text("faeries.\n");
 		richtext->pop();
 		richtext->add_text("In this new episode, we will attempt to ");
-		richtext->push_font(richtext->get_theme_font("mono_font", "Fonts"));
+		richtext->push_font(richtext->get_theme_font(SNAME("mono_font"), SNAME("Fonts")));
 		richtext->push_color(Color(0.7, 0.5, 1.0));
 		richtext->add_text("deliver something nice");
 		richtext->pop();


### PR DESCRIPTION
* Added a new macro SNAME() that constructs and caches a local stringname.
* Subsequent usages use the cached version.
* Since these use a global static variable, a second refcounter of static usages need to be kept for cleanup time.
* Replaced all theme usages by this new macro.
* Replace all signal emission usages by this new macro.
* Replace all call_deferred usages by this new macro.


This is part of ongoing work to optimize GUI and the editor. Review VERY appreciated, so I can merge this as soon as possible, as it changes so much code it will be a hassle to rebase.

Contrary to what it might look like, SNAME() is thread safe. The static value may be assigned twice or more if ran from different threads, but this changes nothing in practice. This level of unsafety is what makes C++ so beautiful.
