### PR TITLE
Fix crash in EditorSpinSlider

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -389,6 +389,11 @@ void EditorSpinSlider::_notification(int p_what) {
 	}
 }
 
+LineEdit *EditorSpinSlider::get_line_edit() {
+	_ensure_input_popup();
+	return value_input;
+}
+
 Size2 EditorSpinSlider::get_minimum_size() const {
 	Ref<StyleBox> sb = get_theme_stylebox("normal", "LineEdit");
 	Ref<Font> font = get_theme_font("font", "LineEdit");

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -112,7 +112,7 @@ public:
 	void set_custom_label_color(bool p_use_custom_label_color, Color p_custom_label_color);
 
 	void setup_and_show() { _focus_entered(); }
-	LineEdit *get_line_edit() { return value_input; }
+	LineEdit *get_line_edit();
 
 	virtual Size2 get_minimum_size() const override;
 	EditorSpinSlider();


### PR DESCRIPTION
Fixes crash introduced in #50530

You can reproduce the crash e.g. by creating a StandardMaterial3D in a MeshInstance3D node.