### PR TITLE
Fix "IDHandler.get_prop is not a function" error when calling some methods on WebRTCDataChannel

### DIFF
--- a/modules/webrtc/library_godot_webrtc.js
+++ b/modules/webrtc/library_godot_webrtc.js
@@ -133,12 +133,12 @@ const GodotRTCDataChannel = {
 
 	godot_js_rtc_datachannel_is_ordered__sig: 'ii',
 	godot_js_rtc_datachannel_is_ordered: function (p_id) {
-		return IDHandler.get_prop(p_id, 'ordered', true);
+		return GodotRTCDataChannel.get_prop(p_id, 'ordered', true);
 	},
 
 	godot_js_rtc_datachannel_id_get__sig: 'ii',
 	godot_js_rtc_datachannel_id_get: function (p_id) {
-		return IDHandler.get_prop(p_id, 'id', 65535);
+		return GodotRTCDataChannel.get_prop(p_id, 'id', 65535);
 	},
 
 	godot_js_rtc_datachannel_max_packet_lifetime_get__sig: 'ii',
@@ -158,12 +158,12 @@ const GodotRTCDataChannel = {
 
 	godot_js_rtc_datachannel_max_retransmits_get__sig: 'ii',
 	godot_js_rtc_datachannel_max_retransmits_get: function (p_id) {
-		return IDHandler.get_prop(p_id, 'maxRetransmits', 65535);
+		return GodotRTCDataChannel.get_prop(p_id, 'maxRetransmits', 65535);
 	},
 
 	godot_js_rtc_datachannel_is_negotiated__sig: 'ii',
 	godot_js_rtc_datachannel_is_negotiated: function (p_id) {
-		return IDHandler.get_prop(p_id, 'negotiated', 65535);
+		return GodotRTCDataChannel.get_prop(p_id, 'negotiated', 65535);
 	},
 
 	godot_js_rtc_datachannel_label_get__sig: 'ii',


### PR DESCRIPTION
When calling `WebRTCDataChannel.is_negotiated()` and a few other methods on `WebRTCDataChannel`, I get this error when using the HTML5 export:

```
IDHandler.get_prop is not a function
```

It looks like this method is really on `GodotRTCDataChannel`!

With the changes in this PR, I'm able to call those methods.

This should cherry-pick to Godot 3.x