### PR TITLE
Improve tooltips in the editor profiler to mention the script name

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -356,7 +356,7 @@ void EditorProfiler::_update_frame() {
 			item->set_metadata(1, it.script);
 			item->set_metadata(2, it.line);
 			item->set_text_align(2, TreeItem::ALIGN_RIGHT);
-			item->set_tooltip(0, it.script + ":" + itos(it.line));
+			item->set_tooltip(0, it.name + "\n" + it.script + ":" + itos(it.line));
 
 			float time = dtime == DISPLAY_SELF_TIME ? it.self : it.total;
 


### PR DESCRIPTION
Port of https://github.com/godotengine/godot/pull/49247 to `master`, which can be cherry-picked to `3.x`.

This closes https://github.com/godotengine/godot/issues/48835.