### PR TITLE
Implement indirect specular occlusion in StandardMaterial3D

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -701,6 +701,7 @@ void main() {
 #endif
 
 	float ao = 1.0;
+	float ao_original = 1.0;
 	float ao_light_affect = 0.0;
 
 	float alpha = 1.0;
@@ -1196,7 +1197,12 @@ void main() {
 #endif // AMBIENT_LIGHT_DISABLED
 	}
 
-	// convert ao to direct light ao
+	// Store original AO for specular occlusion approximation, because we want
+	// Light Affect to always be treated as 1.0 for specular lighting.
+	// This is not physically accurate, but it often looks better in practice.
+	ao_original = ao;
+
+	// Convert AO to direct light AO.
 	ao = mix(1.0, ao, ao_light_affect);
 
 	//this saves some VGPRs
@@ -1721,7 +1727,7 @@ void main() {
 
 	// apply direct light AO
 	ao = unpackUnorm4x8(orms).x;
-	specular_light *= ao;
+	specular_light *= ao_original;
 	diffuse_light *= ao;
 
 	// apply metallic


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/50603.

Both sources of AO (SSAO and AO texture maps) are used for this effect. The difference is most noticeable when SSAO is enabled (especially with height maps), but this effect also helps when SSAO is disabled.

It is an approximate effect with a very low performance cost, but makes specular reflections more believable overall.

**Testing project:** [test_ao_specular_occlusion_master.zip](https://github.com/godotengine/godot/files/8018158/test_ao_specular_occlusion_master.zip)

## Preview

*SSAO intensity was doubled to make the difference more noticeable. In real world scenarios, the difference will be more subtle.*
*Light Affect is set to 0 (default) both in the SSAO and material settings.*

*Left: partially metallic material (0.5), right: fully metallic material (1.0)*

### SSAO and height enabled

#### Forward+

Before | After
-|-
![Screenshot_20230526_234722 webp](https://github.com/godotengine/godot/assets/180032/e3e88bd1-cd68-4875-8718-62f4187b5c8a) | ![Screenshot_20230526_234703 webp](https://github.com/godotengine/godot/assets/180032/9e89fe48-a042-4d8e-ae22-c3656682e7ff)

#### Mobile[^1]

[^1]: This currently uses a faster, but *supposedly* more approximate approach to indirect specular occlusion.

Before | After
-|-
![Screenshot_20230526_234747 webp](https://github.com/godotengine/godot/assets/180032/f7a586b4-8784-4eff-a477-c381d492bb32) | ![Screenshot_20230526_234735 webp](https://github.com/godotengine/godot/assets/180032/deada2af-646b-43ab-b8dd-a757e78b030f)

### No SSAO and no height (only AO map in material)

#### Forward+

Before | After
-|-
![Screenshot_20230526_234445 webp](https://github.com/godotengine/godot/assets/180032/fc36db5f-8ef9-497a-a35b-8bb0750fc3ef) | ![Screenshot_20230526_234424 webp](https://github.com/godotengine/godot/assets/180032/64fbd2ad-0c0e-4bfa-a683-4dba53b80989)

#### Mobile[^1]

Before | After
-|-
![Screenshot_20230526_234602 webp](https://github.com/godotengine/godot/assets/180032/b103f3fe-a015-47af-95a7-071342e40b8e) | ![Screenshot_20230526_234549 webp](https://github.com/godotengine/godot/assets/180032/0aafec3d-076d-4630-a315-ef09587f5a9d)

[^1]: This currently uses a faster, but *supposedly* more approximate approach to indirect specular occlusion.