### PR TITLE
[3.x] Implement specular occlusion in SpatialMaterial

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1749,6 +1749,15 @@ FRAGMENT_SHADER_CODE
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 		specular_light *= env.x * F + env.y;
 
+#if defined(ENABLE_AO)
+		// Use a cheap approximation of specular occlusion + horizon specular occlusion
+		// based on ambient occlusion.
+		// See https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion.
+		specular_light *= clamp(pow(ndotv + ao, exp2(-16.0 * roughness - 1.0)) - 1.0 + ao, 0.0, 1.0);
+		float horizon = min(1.0 + dot(reflect(-view, normal), normal), 1.0);
+		specular_light *= horizon * horizon;
+#endif //ENABLE_AO
+
 #endif
 	}
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1981,6 +1981,16 @@ FRAGMENT_SHADER_CODE
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 		specular_light *= env.x * F + env.y;
+
+#if defined(ENABLE_AO)
+		// Use a cheap approximation of specular occlusion + horizon specular occlusion
+		// based on ambient occlusion.
+		// See https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion.
+		specular_light *= clamp(pow(ndotv + ao, exp2(-16.0 * roughness - 1.0)) - 1.0 + ao, 0.0, 1.0);
+		float horizon = min(1.0 + dot(reflect(-view, normal), normal), 1.0);
+		specular_light *= horizon * horizon;
+#endif //ENABLE_AO
+
 #endif
 	}
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50601.

Unlike https://github.com/godotengine/godot/pull/50601, `ao_light_affect` isn't taken into account at this point in the shader, so we don't need to move it.

Specular occlusion works by:

- Applying specular occlusion and horizon specular occlusion as advised by Filament: https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion
- Always treating Light Affect is if it was set to 1.0 for the purposes of specular lighting.

It is an approximate effect with a very low performance cost, but makes specular reflections more believable overall.

## Preview

### GLES3

| Before | After |
|--------|-------|
| ![Before](https://user-images.githubusercontent.com/180032/126093278-fc11d9c1-f480-45bb-b0f2-b2097ac0f61b.png) | ![After](https://user-images.githubusercontent.com/180032/126093266-626c2d92-3dd5-4514-bc94-a15af6bb4b91.png) |

### GLES2

| Before | After |
|--------|-------|
| ![Before](https://user-images.githubusercontent.com/180032/126093291-1b5ac20e-c57b-495e-987c-b071beebd627.png) | ![After](https://user-images.githubusercontent.com/180032/126093258-44be2af8-581c-4be6-b0e5-a6187fdb729c.png) |
