### PR TITLE
Explicitly cast real_t to float when creating a float array

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -583,10 +583,10 @@ void Sprite3D::_draw() {
 			aabb.expand_to(vtx);
 		}
 
-		float v_uv[2] = { uvs[i].x, uvs[i].y };
+		float v_uv[2] = { (float)uvs[i].x, (float)uvs[i].y };
 		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_TEX_UV]], v_uv, 8);
 
-		float v_vertex[3] = { vtx.x, vtx.y, vtx.z };
+		float v_vertex[3] = { (float)vtx.x, (float)vtx.y, (float)vtx.z };
 
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_NORMAL]], &v_normal, 4);
@@ -949,10 +949,10 @@ void AnimatedSprite3D::_draw() {
 			aabb.expand_to(vtx);
 		}
 
-		float v_uv[2] = { uvs[i].x, uvs[i].y };
+		float v_uv[2] = { (float)uvs[i].x, (float)uvs[i].y };
 		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_TEX_UV]], v_uv, 8);
 
-		float v_vertex[3] = { vtx.x, vtx.y, vtx.z };
+		float v_vertex[3] = { (float)vtx.x, (float)vtx.y, (float)vtx.z };
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_NORMAL]], &v_normal, 4);
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_TANGENT]], &v_tangent, 4);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -350,7 +350,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 
 					{
 						for (int i = 0; i < p_vertex_array_len; i++) {
-							float vector[2] = { src[i].x, src[i].y };
+							float vector[2] = { (float)src[i].x, (float)src[i].y };
 
 							memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(float) * 2);
 
@@ -375,7 +375,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 
 					{
 						for (int i = 0; i < p_vertex_array_len; i++) {
-							float vector[3] = { src[i].x, src[i].y, src[i].z };
+							float vector[3] = { (float)src[i].x, (float)src[i].y, (float)src[i].z };
 
 							memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(float) * 3);
 
@@ -461,7 +461,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 				const Vector2 *src = array.ptr();
 
 				for (int i = 0; i < p_vertex_array_len; i++) {
-					float uv[2] = { src[i].x, src[i].y };
+					float uv[2] = { (float)src[i].x, (float)src[i].y };
 
 					memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 2 * 4);
 				}
@@ -478,7 +478,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 				const Vector2 *src = array.ptr();
 
 				for (int i = 0; i < p_vertex_array_len; i++) {
-					float uv[2] = { src[i].x, src[i].y };
+					float uv[2] = { (float)src[i].x, (float)src[i].y };
 					memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 2 * 4);
 				}
 			} break;


### PR DESCRIPTION
These lines construct float arrays from vectors, which use `real_t`. When compiling Godot with doubles enabled, these lines produce a warning which causes the build to fail. This PR fixes those warnings by making the float cast explicit.