### PR TITLE
[TextEdit] Improve block/insert caret drawing.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1110,20 +1110,37 @@ void TextEdit::_notification(int p_what) {
 												t_caret.size.y = h;
 											}
 											t_caret.position += Vector2(char_margin + ofs_x, ofs_y);
+											draw_rect(t_caret, caret_color, overtype_mode);
 
-											draw_rect(t_caret, caret_color, false);
+											if (l_caret != Rect2() && l_dir != t_dir) {
+												l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
+												l_caret.size.x = caret_width;
+												draw_rect(l_caret, caret_color * Color(1, 1, 1, 0.5));
+											}
 										} else { // End of the line.
-											if (overtype_mode) {
-												l_caret.position.y = TS->shaped_text_get_descent(rid);
+											if (gl_size > 0) {
+												// Adjust for actual line dimensions.
+												if (overtype_mode) {
+													l_caret.position.y = TS->shaped_text_get_descent(rid);
+													l_caret.size.y = caret_width;
+												} else {
+													l_caret.position.y = -TS->shaped_text_get_ascent(rid);
+													l_caret.size.y = h;
+												}
+											} else if (overtype_mode) {
+												l_caret.position.y += l_caret.size.y;
 												l_caret.size.y = caret_width;
+											}
+											if (l_caret.position.x >= TS->shaped_text_get_size(rid).x) {
+												l_caret.size.x = font->get_char_size('m', 0, font_size).x;
 											} else {
-												l_caret.position.y = -TS->shaped_text_get_ascent(rid);
-												l_caret.size.y = h;
+												l_caret.size.x = 3 * caret_width;
 											}
 											l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
-											l_caret.size.x = font->get_char_size('M', 0, font_size).x;
-
-											draw_rect(l_caret, caret_color, false);
+											if (l_dir == TextServer::DIRECTION_RTL) {
+												l_caret.position.x -= l_caret.size.x;
+											}
+											draw_rect(l_caret, caret_color, overtype_mode);
 										}
 									} else {
 										// Normal caret.


### PR DESCRIPTION
Fix block caret alignment on empty line:
<img width="141" alt="empty" src="https://user-images.githubusercontent.com/7645683/126145376-b832e19a-07d0-4b53-8d70-b3d7adfe81a4.png">

Fix block caret width, when the logical end of the line is visually in the middle:
<img width="141" alt="endl" src="https://user-images.githubusercontent.com/7645683/126145466-aa787ab4-6fbe-4f2d-9563-3363c13cc37d.png">

Add secondary caret indicator:
<img width="141" alt="sec" src="https://user-images.githubusercontent.com/7645683/126145526-7a9cf145-e67d-4418-8ff0-15d19a3f87e9.png">

Always draw insert caret as solid box.
<img width="141" alt="solid" src="https://user-images.githubusercontent.com/7645683/126155386-7bce6824-ba8d-433e-aa65-ec70d4df8fe6.png">

Fixes #50245