### PR TITLE
Optimize usage of Transform::xform and unit tests

### DIFF
--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -298,6 +298,9 @@ Vector<Plane> CameraMatrix::get_projection_planes(const Transform &p_transform) 
 
 	Plane new_plane;
 
+	// precalculating this makes the transforms faster
+	Basis b_inverse_transpose = p_transform.basis.inverse_transposed();
+
 	///////--- Near Plane ---///////
 	new_plane = Plane(matrix[3] + matrix[2],
 			matrix[7] + matrix[6],
@@ -307,7 +310,7 @@ Vector<Plane> CameraMatrix::get_projection_planes(const Transform &p_transform) 
 	new_plane.normal = -new_plane.normal;
 	new_plane.normalize();
 
-	planes.push_back(p_transform.xform(new_plane));
+	planes.push_back(p_transform.xform_fast(new_plane, b_inverse_transpose));
 
 	///////--- Far Plane ---///////
 	new_plane = Plane(matrix[3] - matrix[2],
@@ -318,7 +321,7 @@ Vector<Plane> CameraMatrix::get_projection_planes(const Transform &p_transform) 
 	new_plane.normal = -new_plane.normal;
 	new_plane.normalize();
 
-	planes.push_back(p_transform.xform(new_plane));
+	planes.push_back(p_transform.xform_fast(new_plane, b_inverse_transpose));
 
 	///////--- Left Plane ---///////
 	new_plane = Plane(matrix[3] + matrix[0],
@@ -329,7 +332,7 @@ Vector<Plane> CameraMatrix::get_projection_planes(const Transform &p_transform) 
 	new_plane.normal = -new_plane.normal;
 	new_plane.normalize();
 
-	planes.push_back(p_transform.xform(new_plane));
+	planes.push_back(p_transform.xform_fast(new_plane, b_inverse_transpose));
 
 	///////--- Top Plane ---///////
 	new_plane = Plane(matrix[3] - matrix[1],
@@ -340,7 +343,7 @@ Vector<Plane> CameraMatrix::get_projection_planes(const Transform &p_transform) 
 	new_plane.normal = -new_plane.normal;
 	new_plane.normalize();
 
-	planes.push_back(p_transform.xform(new_plane));
+	planes.push_back(p_transform.xform_fast(new_plane, b_inverse_transpose));
 
 	///////--- Right Plane ---///////
 	new_plane = Plane(matrix[3] - matrix[0],
@@ -351,7 +354,7 @@ Vector<Plane> CameraMatrix::get_projection_planes(const Transform &p_transform) 
 	new_plane.normal = -new_plane.normal;
 	new_plane.normalize();
 
-	planes.push_back(p_transform.xform(new_plane));
+	planes.push_back(p_transform.xform_fast(new_plane, b_inverse_transpose));
 
 	///////--- Bottom Plane ---///////
 	new_plane = Plane(matrix[3] + matrix[1],
@@ -362,7 +365,7 @@ Vector<Plane> CameraMatrix::get_projection_planes(const Transform &p_transform) 
 	new_plane.normal = -new_plane.normal;
 	new_plane.normalize();
 
-	planes.push_back(p_transform.xform(new_plane));
+	planes.push_back(p_transform.xform_fast(new_plane, b_inverse_transpose));
 
 	return planes;
 }

--- a/core/math/transform.h
+++ b/core/math/transform.h
@@ -101,7 +101,7 @@ public:
 	// Note there are no fast versions for non-planes. In those cases simply precompute the affine_inverse,
 	// and xform by that.
 	_FORCE_INLINE_ Plane xform_fast(const Plane &p_plane, const Basis &p_basis_inverse_transpose) const;
-	_FORCE_INLINE_ Plane xform_inv_fast(const Plane &p_plane, const Transform &p_inverse, const Basis &p_basis_transpose) const;
+	static _FORCE_INLINE_ Plane xform_inv_fast(const Plane &p_plane, const Transform &p_inverse, const Basis &p_basis_transpose);
 
 	// Uniform scale versions of functions.
 	// These are faster but will return incorrect results with non-uniform scales.
@@ -170,7 +170,7 @@ _FORCE_INLINE_ Plane Transform::xform_fast(const Plane &p_plane, const Basis &p_
 	return Plane(normal, d);
 }
 
-_FORCE_INLINE_ Plane Transform::xform_inv_fast(const Plane &p_plane, const Transform &p_inverse, const Basis &p_basis_transpose) const {
+_FORCE_INLINE_ Plane Transform::xform_inv_fast(const Plane &p_plane, const Transform &p_inverse, const Basis &p_basis_transpose) {
 	// transform a single point on the plane
 	Vector3 point = p_plane.normal * p_plane.d;
 	point = p_inverse.xform(point);

--- a/main/tests/test_main.cpp
+++ b/main/tests/test_main.cpp
@@ -47,6 +47,7 @@
 #include "test_render.h"
 #include "test_shader_lang.h"
 #include "test_string.h"
+#include "test_transform.h"
 #include "test_xml_parser.h"
 
 const char **tests_get_names() {
@@ -54,6 +55,7 @@ const char **tests_get_names() {
 		"string",
 		"math",
 		"basis",
+		"transform",
 		"physics",
 		"physics_2d",
 		"render",
@@ -84,6 +86,10 @@ MainLoop *test_main(String p_test, const List<String> &p_args) {
 
 	if (p_test == "basis") {
 		return TestBasis::test();
+	}
+
+	if (p_test == "transform") {
+		return TestTransform::test();
 	}
 
 	if (p_test == "physics") {

--- a/main/tests/test_transform.cpp
+++ b/main/tests/test_transform.cpp
@@ -1,0 +1,135 @@
+/*************************************************************************/
+/*  test_transform.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "test_transform.h"
+
+#include "core/math/random_number_generator.h"
+#include "core/math/transform.h"
+#include "core/math/vector3.h"
+#include "core/os/os.h"
+#include "core/ustring.h"
+
+namespace TestTransform {
+
+bool test_plane() {
+	bool pass = true;
+
+	// test non-uniform scaling, forward and inverse
+	Transform tr;
+	tr.scale(Vector3(1, 2, 3));
+
+	Plane p(Vector3(1, 1, 1), Vector3(1, 1, 1).normalized());
+
+	Plane p2 = tr.xform(p);
+	Plane p3 = tr.xform_inv(p2);
+
+	if (!p3.normal.is_equal_approx(p.normal)) {
+		OS::get_singleton()->print("Fail due to Transform::xform(Plane)\n");
+		pass = false;
+	}
+
+	return pass;
+}
+
+bool test_aabb() {
+	bool pass = true;
+
+	Transform tr;
+	tr.scale(Vector3(1, 2, 3));
+
+	AABB bb(Vector3(1, 1, 1), Vector3(2, 3, 4));
+
+	AABB bb2 = tr.xform(bb);
+	bb2 = tr.xform_inv(bb2);
+
+	if (!bb2.position.is_equal_approx(bb.position)) {
+		OS::get_singleton()->print("Fail due to Transform::xform(AABB) position\n");
+		pass = false;
+	}
+
+	if (!bb2.size.is_equal_approx(bb.size)) {
+		OS::get_singleton()->print("Fail due to Transform::xform(AABB) size\n");
+		pass = false;
+	}
+
+	return pass;
+}
+
+bool test_vector3() {
+	bool pass = true;
+
+	Transform tr;
+	tr.scale(Vector3(1, 2, 3));
+
+	Vector3 pt(1, 1, 1);
+	Vector3 res = tr.xform(pt);
+
+	if (!res.is_equal_approx(Vector3(1, 2, 3))) {
+		OS::get_singleton()->print("Fail due to Transform::xform(Vector3)\n");
+		pass = false;
+	}
+
+	pt = Vector3(1, 2, 3);
+	res = tr.xform_inv(pt);
+	if (!res.is_equal_approx(Vector3(1, 1, 1))) {
+		OS::get_singleton()->print("Fail due to Transform::xform_inv(Vector3)\n");
+		pass = false;
+	}
+
+	return pass;
+}
+
+MainLoop *test() {
+	OS::get_singleton()->print("Start Transform checks.\n");
+
+	bool success = true;
+
+	if (!test_vector3()) {
+		success = false;
+	}
+
+	if (!test_plane()) {
+		success = false;
+	}
+
+	if (!test_aabb()) {
+		success = false;
+	}
+
+	if (success) {
+		OS::get_singleton()->print("Transform checks passed.\n");
+	} else {
+		OS::get_singleton()->print("Transform checks FAILED.\n");
+	}
+
+	return nullptr;
+}
+
+} // namespace TestTransform

--- a/main/tests/test_transform.h
+++ b/main/tests/test_transform.h
@@ -1,0 +1,40 @@
+/*************************************************************************/
+/*  test_transform.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_TRANSFORM_H
+#define TEST_TRANSFORM_H
+
+#include "core/os/main_loop.h"
+
+namespace TestTransform {
+MainLoop *test();
+}
+
+#endif

--- a/servers/physics/collision_solver_sat.cpp
+++ b/servers/physics/collision_solver_sat.cpp
@@ -953,9 +953,12 @@ static void _collision_sphere_convex_polygon(const ShapeSW *p_a, const Transform
 	const Vector3 *vertices = mesh.vertices.ptr();
 	int vertex_count = mesh.vertices.size();
 
+	// precalculating this makes the transforms faster
+	Basis b_inverse_transpose = p_transform_b.basis.inverse_transposed();
+
 	// faces of B
 	for (int i = 0; i < face_count; i++) {
-		Vector3 axis = p_transform_b.xform(faces[i].plane).normal;
+		Vector3 axis = Basis::xform_normal_fast(faces[i].plane.normal, b_inverse_transpose);
 
 		if (!separator.test_axis(axis)) {
 			return;
@@ -1191,13 +1194,14 @@ static void _collision_box_capsule(const ShapeSW *p_a, const Transform &p_transf
 	}
 
 	// capsule balls, edges of A
+	Transform transform_a_inverse = p_transform_a.affine_inverse();
 
 	for (int i = 0; i < 2; i++) {
 		Vector3 capsule_axis = p_transform_b.basis.get_axis(2) * (capsule_B->get_height() * 0.5);
 
 		Vector3 sphere_pos = p_transform_b.origin + ((i == 0) ? capsule_axis : -capsule_axis);
 
-		Vector3 cnormal = p_transform_a.xform_inv(sphere_pos);
+		Vector3 cnormal = transform_a_inverse.xform(sphere_pos);
 
 		Vector3 cpoint = p_transform_a.xform(Vector3(
 
@@ -1368,9 +1372,12 @@ static void _collision_box_convex_polygon(const ShapeSW *p_a, const Transform &p
 		}
 	}
 
+	// precalculating this makes the transforms faster
+	Basis b_inverse_transpose = p_transform_b.basis.inverse_transposed();
+
 	// faces of B
 	for (int i = 0; i < face_count; i++) {
-		Vector3 axis = p_transform_b.xform(faces[i].plane).normal;
+		Vector3 axis = Basis::xform_normal_fast(faces[i].plane.normal, b_inverse_transpose);
 
 		if (!separator.test_axis(axis)) {
 			return;
@@ -1701,9 +1708,12 @@ static void _collision_capsule_convex_polygon(const ShapeSW *p_a, const Transfor
 	int edge_count = mesh.edges.size();
 	const Vector3 *vertices = mesh.vertices.ptr();
 
+	// precalculating this makes the transforms faster
+	Basis b_inverse_transpose = p_transform_b.basis.inverse_transposed();
+
 	// faces of B
 	for (int i = 0; i < face_count; i++) {
-		Vector3 axis = p_transform_b.xform(faces[i].plane).normal;
+		Vector3 axis = Basis::xform_normal_fast(faces[i].plane.normal, b_inverse_transpose);
 
 		if (!separator.test_axis(axis)) {
 			return;
@@ -1995,20 +2005,24 @@ static void _collision_convex_polygon_convex_polygon(const ShapeSW *p_a, const T
 	const Vector3 *vertices_B = mesh_B.vertices.ptr();
 	int vertex_count_B = mesh_B.vertices.size();
 
+	// precalculating this makes the transforms faster
+	Basis a_inverse_transpose = p_transform_a.basis.inverse_transposed();
+
 	// faces of A
 	for (int i = 0; i < face_count_A; i++) {
-		Vector3 axis = p_transform_a.xform(faces_A[i].plane).normal;
-		//Vector3 axis = p_transform_a.basis.xform( faces_A[i].plane.normal ).normalized();
+		Vector3 axis = Basis::xform_normal_fast(faces_A[i].plane.normal, a_inverse_transpose);
 
 		if (!separator.test_axis(axis)) {
 			return;
 		}
 	}
 
+	// precalculating this makes the transforms faster
+	Basis b_inverse_transpose = p_transform_b.basis.inverse_transposed();
+
 	// faces of B
 	for (int i = 0; i < face_count_B; i++) {
-		Vector3 axis = p_transform_b.xform(faces_B[i].plane).normal;
-		//Vector3 axis = p_transform_b.basis.xform( faces_B[i].plane.normal ).normalized();
+		Vector3 axis = Basis::xform_normal_fast(faces_B[i].plane.normal, b_inverse_transpose);
 
 		if (!separator.test_axis(axis)) {
 			return;


### PR DESCRIPTION
With the change to safer slower versions of the Transform::xform and xform_inv functions, this PR goes through the engine to make better use of fast versions of the functions so as not to reduce performance.

Also adds some unit tests for Transform.

## Notes
* This is dependent on #50549 which should be merged first, then I can rebase this PR.
* The unit tests are very basic but should get us started for Transform, which has no tests. In particular it tests non-uniform scales.
* The optimized versions in the physics using fast xform for planes should be faster and more accurate.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
