### PR TITLE
Make `MenuButton`'s `switch_on_hover` work again

### DIFF
--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -47,6 +47,8 @@ class MenuButton : public Button {
 
 	void _gui_input(Ref<InputEvent> p_event) override;
 
+	void _popup_visibility_changed(bool p_visible);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -140,7 +140,6 @@ class PopupMenu : public Popup {
 	void _close_pressed();
 
 protected:
-	friend class MenuButton;
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1710,7 +1710,7 @@ void Viewport::_gui_call_notification(Control *p_control, int p_what) {
 	//_unblock();
 }
 
-Control *Viewport::_gui_find_control(const Point2 &p_global) {
+Control *Viewport::gui_find_control(const Point2 &p_global) {
 	//aca va subwindows
 	_gui_sort_roots();
 
@@ -1850,7 +1850,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					parent_xform=data.parent_canvas_item->get_global_transform();
 				*/
 
-				gui.mouse_focus = _gui_find_control(pos);
+				gui.mouse_focus = gui_find_control(pos);
 				gui.last_mouse_focus = gui.mouse_focus;
 
 				if (!gui.mouse_focus) {
@@ -1991,7 +1991,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			if (gui.mouse_focus) {
 				over = gui.mouse_focus;
 			} else {
-				over = _gui_find_control(mpos);
+				over = gui_find_control(mpos);
 			}
 
 			if (gui.mouse_focus_mask == 0 && over != gui.mouse_over) {
@@ -2074,7 +2074,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (gui.mouse_focus) {
 			over = gui.mouse_focus;
 		} else {
-			over = _gui_find_control(mpos);
+			over = gui_find_control(mpos);
 		}
 
 		if (over != gui.mouse_over) {
@@ -2262,7 +2262,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				Transform2D ai = (viewport_under->get_final_transform().affine_inverse() * viewport_under->_get_input_pre_xform());
 				viewport_pos = ai.xform(viewport_pos);
 				//find control under at pos
-				gui.drag_mouse_over = viewport_under->_gui_find_control(viewport_pos);
+				gui.drag_mouse_over = viewport_under->gui_find_control(viewport_pos);
 				if (gui.drag_mouse_over) {
 					Transform2D localizer = gui.drag_mouse_over->get_global_transform_with_canvas().affine_inverse();
 					gui.drag_mouse_over_pos = localizer.xform(viewport_pos);
@@ -2290,7 +2290,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 	if (touch_event.is_valid()) {
 		Size2 pos = touch_event->get_position();
 		if (touch_event->is_pressed()) {
-			Control *over = _gui_find_control(pos);
+			Control *over = gui_find_control(pos);
 			if (over) {
 				if (over->can_process()) {
 					touch_event = touch_event->xformed_by(Transform2D()); //make a copy
@@ -2325,7 +2325,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 		Size2 pos = gesture_event->get_position();
 
-		Control *over = _gui_find_control(pos);
+		Control *over = gui_find_control(pos);
 		if (over) {
 			if (over->can_process()) {
 				gesture_event = gesture_event->xformed_by(Transform2D()); //make a copy
@@ -2346,7 +2346,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 	if (drag_event.is_valid()) {
 		Control *over = gui.mouse_focus;
 		if (!over) {
-			over = _gui_find_control(drag_event->get_position());
+			over = gui_find_control(drag_event->get_position());
 		}
 		if (over) {
 			if (over->can_process()) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -404,7 +404,6 @@ private:
 	void _gui_call_notification(Control *p_control, int p_what);
 
 	void _gui_sort_roots();
-	Control *_gui_find_control(const Point2 &p_global);
 	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform, Transform2D &r_inv_xform);
 
 	void _gui_input_event(Ref<InputEvent> p_event);
@@ -628,6 +627,8 @@ public:
 	bool is_handling_input_locally() const;
 
 	bool gui_is_dragging() const;
+
+	Control *gui_find_control(const Point2 &p_global);
 
 	void set_sdf_oversize(SDFOversize p_sdf_oversize);
 	SDFOversize get_sdf_oversize() const;


### PR DESCRIPTION
Since `Popup`s were made into full-fledged windows, the `switch_on_hover` feature (which allowed to switch from the popup of one `MenuButton` to another) broke completely. This PR fixes that.

Things that needed to be done to make this PR work:
- Make the code reside in `MenuButton` instead of `Viewport`, which since this is the only node that cares about it, is a good thing.
- Make `Viewport::_gui_find_control()` a public function, so it could be used outside of it.
- Make the code work via internal process to detect mouse input, as the mouse position can't be detected if it's outside the window in OSes like Windows. So when the popup is visible, `set_process_internal()` is enabled, and the position verified with `DisplayServer::mouse_get_position()`. Not the prettiest solution, but it's the one that works.
- Removed `MenuButton` as a friend class of `PopupMenu`. Not really related to the PR itself, but doesn't seem to be doing anything useful, and likely a leftover of something in the past.