### PR TITLE
Add scrolling to tile atlas view

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -41,25 +41,31 @@
 #include "editor/editor_settings.h"
 
 void TileAtlasView::_gui_input(const Ref<InputEvent> &p_event) {
-	bool ctrl = Input::get_singleton()->is_key_pressed(KEY_CTRL);
-
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
 		drag_type = DRAG_TYPE_NONE;
-		if (ctrl && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_WHEEL_DOWN) {
-			// Zoom out
-			zoom_widget->set_zoom_by_increments(-2);
-			emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
-			_update_zoom_and_panning(true);
-			accept_event();
-		}
 
-		if (ctrl && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_WHEEL_UP) {
-			// Zoom in
-			zoom_widget->set_zoom_by_increments(2);
-			emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
-			_update_zoom_and_panning(true);
-			accept_event();
+		Vector2i scroll_vec = Vector2((mb->get_button_index() == MOUSE_BUTTON_WHEEL_LEFT) - (mb->get_button_index() == MOUSE_BUTTON_WHEEL_RIGHT), (mb->get_button_index() == MOUSE_BUTTON_WHEEL_UP) - (mb->get_button_index() == MOUSE_BUTTON_WHEEL_DOWN));
+		if (scroll_vec != Vector2()) {
+			if (mb->is_ctrl_pressed()) {
+				if (mb->is_shift_pressed()) {
+					panning.x += 32 * mb->get_factor() * scroll_vec.y;
+					panning.y += 32 * mb->get_factor() * scroll_vec.x;
+				} else {
+					panning.y += 32 * mb->get_factor() * scroll_vec.y;
+					panning.x += 32 * mb->get_factor() * scroll_vec.x;
+				}
+
+				emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
+				_update_zoom_and_panning(true);
+				accept_event();
+
+			} else if (!mb->is_shift_pressed()) {
+				zoom_widget->set_zoom_by_increments(scroll_vec.y * 2);
+				emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
+				_update_zoom_and_panning(true);
+				accept_event();
+			}
 		}
 
 		if (mb->get_button_index() == MOUSE_BUTTON_MIDDLE || mb->get_button_index() == MOUSE_BUTTON_RIGHT) {


### PR DESCRIPTION
This PR add scrolling to the atlas area in tile editor, which was missing after scrollbars were removed.
![g1SNlF1Nrh](https://user-images.githubusercontent.com/2223172/126230773-09964796-659a-4229-8fd4-a33abd4688b4.gif)

It uses the same control scheme as GraphEdit, i.e. wheel to zoom, Ctrl+wheel to scroll vertically, Ctrl+Shift+wheel to scroll horizontally. I used it mostly for consistency, but tbh I don't like this scheme :/ (maybe it's better when you get used to it)

Also there's this hard-coded `32` that I wasn't sure what better to use.