### PR TITLE
Improve add item type UI in theme editor

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1459,13 +1459,16 @@ void ThemeItemEditorDialog::_item_tree_button_pressed(Object *p_item, int p_colu
 	_update_edit_item_tree(edited_item_type);
 }
 
-void ThemeItemEditorDialog::_add_theme_type() {
-	edited_theme->add_icon_type(edit_add_type_value->get_text());
-	edited_theme->add_stylebox_type(edit_add_type_value->get_text());
-	edited_theme->add_font_type(edit_add_type_value->get_text());
-	edited_theme->add_font_size_type(edit_add_type_value->get_text());
-	edited_theme->add_color_type(edit_add_type_value->get_text());
-	edited_theme->add_constant_type(edit_add_type_value->get_text());
+void ThemeItemEditorDialog::_add_theme_type(const String &p_new_text) {
+	const String new_type = edit_add_type_value->get_text().strip_edges();
+	edit_add_type_value->clear();
+
+	edited_theme->add_icon_type(new_type);
+	edited_theme->add_stylebox_type(new_type);
+	edited_theme->add_font_type(new_type);
+	edited_theme->add_font_size_type(new_type);
+	edited_theme->add_color_type(new_type);
+	edited_theme->add_constant_type(new_type);
 	_update_edit_types();
 
 	// Force emit a change so that other parts of the editor can update.
@@ -1776,11 +1779,12 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	edit_dialog_side_vb->add_child(edit_add_type_hb);
 	edit_add_type_value = memnew(LineEdit);
 	edit_add_type_value->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	edit_add_type_value->connect("text_submitted", callable_mp(this, &ThemeItemEditorDialog::_add_theme_type));
 	edit_add_type_hb->add_child(edit_add_type_value);
 	Button *edit_add_type_button = memnew(Button);
 	edit_add_type_button->set_text(TTR("Add"));
 	edit_add_type_hb->add_child(edit_add_type_button);
-	edit_add_type_button->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_add_theme_type));
+	edit_add_type_button->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_add_theme_type), varray(""));
 
 	VBoxContainer *edit_items_vb = memnew(VBoxContainer);
 	edit_items_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -239,7 +239,7 @@ class ThemeItemEditorDialog : public AcceptDialog {
 	void _update_edit_item_tree(String p_item_type);
 	void _item_tree_button_pressed(Object *p_item, int p_column, int p_id);
 
-	void _add_theme_type();
+	void _add_theme_type(const String &p_new_text);
 	void _add_theme_item(Theme::DataType p_data_type, String p_item_name, String p_item_type);
 	void _remove_data_type_items(Theme::DataType p_data_type, String p_item_type);
 	void _remove_class_items();


### PR DESCRIPTION
In the "Manage Theme Items" dialog:
* Trim the received type name, as did in the add item type dialog.
* Allow the user to submit the type in line edit using enter.
* Clear the type name line edit after the type is added.