### PR TITLE
Improve tilemap compatibility

### DIFF
--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -300,6 +300,14 @@ struct Vector2i {
 		return p_idx ? y : x;
 	}
 
+	_FORCE_INLINE_ int min_axis() const {
+		return x < y ? 0 : 1;
+	}
+
+	_FORCE_INLINE_ int max_axis() const {
+		return x < y ? 1 : 0;
+	}
+
 	Vector2i min(const Vector2i &p_vector2i) const {
 		return Vector2(MIN(x, p_vector2i.x), MIN(y, p_vector2i.y));
 	}

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -36,6 +36,8 @@
 			</return>
 			<argument index="0" name="coords" type="Vector2i">
 			</argument>
+			<argument index="1" name="use_proxies" type="bool">
+			</argument>
 			<description>
 			</description>
 		</method>
@@ -44,6 +46,8 @@
 			</return>
 			<argument index="0" name="coords" type="Vector2i">
 			</argument>
+			<argument index="1" name="use_proxies" type="bool">
+			</argument>
 			<description>
 			</description>
 		</method>
@@ -51,6 +55,8 @@
 			<return type="int">
 			</return>
 			<argument index="0" name="coords" type="Vector2i">
+			</argument>
+			<argument index="1" name="use_proxies" type="bool">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -27,6 +27,40 @@
 			<description>
 			</description>
 		</method>
+		<method name="cleanup_invalid_tile_proxies">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="clear_tile_proxies">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_alternative_level_tile_proxy">
+			<return type="Array">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<argument index="1" name="coords_from" type="Vector2i">
+			</argument>
+			<argument index="2" name="alternative_from" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_coords_level_tile_proxy">
+			<return type="Array">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<argument index="1" name="coords_from" type="Vector2i">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_navigation_layer_layers" qualifiers="const">
 			<return type="int">
 			</return>
@@ -103,6 +137,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_source_level_tile_proxy">
+			<return type="int">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_terrain_color" qualifiers="const">
 			<return type="Color">
 			</return>
@@ -139,6 +181,28 @@
 			<description>
 			</description>
 		</method>
+		<method name="has_alternative_level_tile_proxy">
+			<return type="bool">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<argument index="1" name="coords_from" type="Vector2i">
+			</argument>
+			<argument index="2" name="alternative_from" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="has_coords_level_tile_proxy">
+			<return type="bool">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<argument index="1" name="coords_from" type="Vector2i">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="has_source" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -147,10 +211,92 @@
 			<description>
 			</description>
 		</method>
+		<method name="has_source_level_tile_proxy">
+			<return type="bool">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="map_tile_proxy" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<argument index="1" name="coords_from" type="Vector2i">
+			</argument>
+			<argument index="2" name="alternative_from" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="remove_alternative_level_tile_proxy">
+			<return type="void">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<argument index="1" name="coords_from" type="Vector2i">
+			</argument>
+			<argument index="2" name="alternative_from" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="remove_coords_level_tile_proxy">
+			<return type="void">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<argument index="1" name="coords_from" type="Vector2i">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="remove_source">
 			<return type="void">
 			</return>
 			<argument index="0" name="source_id" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="remove_source_level_tile_proxy">
+			<return type="void">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_alternative_level_tile_proxy">
+			<return type="void">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<argument index="1" name="coords_from" type="Vector2i">
+			</argument>
+			<argument index="2" name="alternative_from" type="int">
+			</argument>
+			<argument index="3" name="source_to" type="int">
+			</argument>
+			<argument index="4" name="coords_to" type="Vector2i">
+			</argument>
+			<argument index="5" name="alternative_to" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_coords_level_tile_proxy">
+			<return type="void">
+			</return>
+			<argument index="0" name="p_source_from" type="int">
+			</argument>
+			<argument index="1" name="coords_from" type="Vector2i">
+			</argument>
+			<argument index="2" name="source_to" type="int">
+			</argument>
+			<argument index="3" name="coords_to" type="Vector2i">
 			</argument>
 			<description>
 			</description>
@@ -221,6 +367,16 @@
 			<argument index="0" name="source_id" type="int">
 			</argument>
 			<argument index="1" name="arg1" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_source_level_tile_proxy">
+			<return type="void">
+			</return>
+			<argument index="0" name="source_from" type="int">
+			</argument>
+			<argument index="1" name="source_to" type="int">
 			</argument>
 			<description>
 			</description>

--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -1,0 +1,320 @@
+/*************************************************************************/
+/*  atlas_merging_dialog.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "atlas_merging_dialog.h"
+
+#include "editor/editor_scale.h"
+
+#include "scene/gui/control.h"
+#include "scene/gui/split_container.h"
+
+void AtlasMergingDialog::_property_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing) {
+	_set(p_property, p_value);
+}
+
+void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atlas_sources, int p_max_columns) {
+	merged.instantiate();
+	merged_mapping.clear();
+
+	if (p_atlas_sources.size() >= 2) {
+		Ref<Image> output_image;
+		output_image.instantiate();
+		output_image->create(1, 1, false, Image::FORMAT_RGBA8);
+
+		// Compute the new texture region size.
+		Vector2i new_texture_region_size;
+		for (int source_index = 0; source_index < p_atlas_sources.size(); source_index++) {
+			Ref<TileSetAtlasSource> atlas_source = p_atlas_sources[source_index];
+			new_texture_region_size = new_texture_region_size.max(atlas_source->get_texture_region_size());
+		}
+
+		// Generate the merged TileSetAtlasSource.
+		Vector2i atlas_offset;
+		int line_height = 0;
+		for (int source_index = 0; source_index < p_atlas_sources.size(); source_index++) {
+			Ref<TileSetAtlasSource> atlas_source = p_atlas_sources[source_index];
+			merged_mapping.push_back(Map<Vector2i, Vector2i>());
+
+			// Layout the tiles.
+			Vector2i atlas_size;
+
+			for (int tile_index = 0; tile_index < atlas_source->get_tiles_count(); tile_index++) {
+				Vector2i tile_id = atlas_source->get_tile_id(tile_index);
+				atlas_size = atlas_size.max(tile_id + atlas_source->get_tile_size_in_atlas(tile_id));
+
+				Rect2i new_tile_rect_in_altas = Rect2i(atlas_offset + tile_id, atlas_source->get_tile_size_in_atlas(tile_id));
+
+				// Create tiles and alternatives, then copy their properties.
+				for (int alternative_index = 0; alternative_index < atlas_source->get_alternative_tiles_count(tile_id); alternative_index++) {
+					int alternative_id = atlas_source->get_alternative_tile_id(tile_id, alternative_index);
+					if (alternative_id == 0) {
+						merged->create_tile(new_tile_rect_in_altas.position, new_tile_rect_in_altas.size);
+					} else {
+						merged->create_alternative_tile(new_tile_rect_in_altas.position, alternative_index);
+					}
+
+					// Copy the properties.
+					TileData *original_tile_data = Object::cast_to<TileData>(atlas_source->get_tile_data(tile_id, alternative_id));
+					List<PropertyInfo> properties;
+					original_tile_data->get_property_list(&properties);
+					for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
+						const StringName &property_name = E->get().name;
+						merged->set(property_name, original_tile_data->get(property_name));
+					}
+
+					// Add to the mapping.
+					merged_mapping[source_index][tile_id] = new_tile_rect_in_altas.position;
+				}
+
+				// Copy the texture.
+				Rect2i src_rect = atlas_source->get_tile_texture_region(tile_id);
+				Rect2 dst_rect_wide = Rect2i(new_tile_rect_in_altas.position * new_texture_region_size, new_tile_rect_in_altas.size * new_texture_region_size);
+				if (dst_rect_wide.get_end().x > output_image->get_width() || dst_rect_wide.get_end().y > output_image->get_height()) {
+					output_image->crop(MAX(dst_rect_wide.get_end().x, output_image->get_width()), MAX(dst_rect_wide.get_end().y, output_image->get_height()));
+				}
+				output_image->blit_rect(atlas_source->get_texture()->get_image(), src_rect, (dst_rect_wide.get_position() + dst_rect_wide.get_end()) / 2 - src_rect.size / 2);
+			}
+
+			// Compute the atlas offset.
+			line_height = MAX(atlas_size.y, line_height);
+			atlas_offset.x += atlas_size.x;
+			if (atlas_offset.x >= p_max_columns) {
+				atlas_offset.x = 0;
+				atlas_offset.y += line_height;
+				line_height = 0;
+			}
+		}
+
+		Ref<ImageTexture> output_image_texture;
+		output_image_texture.instantiate();
+		output_image_texture->create_from_image(output_image);
+
+		merged->set_texture(output_image_texture);
+		merged->set_texture_region_size(new_texture_region_size);
+	}
+}
+
+void AtlasMergingDialog::_update_texture() {
+	Vector<int> selected = atlas_merging_atlases_list->get_selected_items();
+	if (selected.size() >= 2) {
+		Vector<Ref<TileSetAtlasSource>> to_merge;
+		for (int i = 0; i < selected.size(); i++) {
+			int source_id = atlas_merging_atlases_list->get_item_metadata(selected[i]);
+			to_merge.push_back(tile_set->get_source(source_id));
+		}
+		_generate_merged(to_merge, next_line_after_column);
+		preview->set_texture(merged->get_texture());
+		preview->show();
+		select_2_atlases_label->hide();
+		get_ok_button()->set_disabled(false);
+		merge_button->set_disabled(false);
+	} else {
+		_generate_merged(Vector<Ref<TileSetAtlasSource>>(), next_line_after_column);
+		preview->set_texture(Ref<Texture2D>());
+		preview->hide();
+		select_2_atlases_label->show();
+		get_ok_button()->set_disabled(true);
+		merge_button->set_disabled(true);
+	}
+}
+
+void AtlasMergingDialog::_merge_confirmed(String p_path) {
+	ERR_FAIL_COND(!merged.is_valid());
+
+	Ref<ImageTexture> output_image_texture = merged->get_texture();
+	output_image_texture->get_image()->save_png(p_path);
+
+	Ref<Texture2D> new_texture_resource = ResourceLoader::load(p_path, "Texture2D");
+	merged->set_texture(new_texture_resource);
+
+	undo_redo->create_action("Merge TileSetAtlasSource");
+	int next_id = tile_set->get_next_source_id();
+	undo_redo->add_do_method(*tile_set, "add_source", merged, next_id);
+	undo_redo->add_undo_method(*tile_set, "remove_source", next_id);
+
+	if (delete_original_atlases) {
+		// Delete originals if needed.
+		Vector<int> selected = atlas_merging_atlases_list->get_selected_items();
+		for (int i = 0; i < selected.size(); i++) {
+			int source_id = atlas_merging_atlases_list->get_item_metadata(selected[i]);
+			Ref<TileSetAtlasSource> tas = tile_set->get_source(source_id);
+			undo_redo->add_do_method(*tile_set, "remove_source", source_id);
+			undo_redo->add_undo_method(*tile_set, "add_source", tas, source_id);
+
+			// Add the tile proxies.
+			for (int tile_index = 0; tile_index < tas->get_tiles_count(); tile_index++) {
+				Vector2i tile_id = tas->get_tile_id(tile_index);
+				undo_redo->add_do_method(*tile_set, "set_coords_level_tile_proxy", source_id, tile_id, next_id, merged_mapping[i][tile_id]);
+				if (tile_set->has_coords_level_tile_proxy(source_id, tile_id)) {
+					Array a = tile_set->get_coords_level_tile_proxy(source_id, tile_id);
+					undo_redo->add_undo_method(*tile_set, "set_coords_level_tile_proxy", a[0], a[1]);
+				} else {
+					undo_redo->add_undo_method(*tile_set, "remove_coords_level_tile_proxy", source_id, tile_id);
+				}
+			}
+		}
+	}
+	undo_redo->commit_action();
+	commited_actions_count++;
+
+	hide();
+}
+
+void AtlasMergingDialog::ok_pressed() {
+	delete_original_atlases = false;
+	editor_file_dialog->popup_file_dialog();
+}
+
+void AtlasMergingDialog::cancel_pressed() {
+	for (int i = 0; i < commited_actions_count; i++) {
+		undo_redo->undo();
+	}
+	commited_actions_count = 0;
+}
+
+void AtlasMergingDialog::custom_action(const String &p_action) {
+	if (p_action == "merge") {
+		delete_original_atlases = true;
+		editor_file_dialog->popup_file_dialog();
+	}
+}
+
+bool AtlasMergingDialog::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "next_line_after_column" && p_value.get_type() == Variant::INT) {
+		next_line_after_column = p_value;
+		_update_texture();
+		return true;
+	}
+	return false;
+}
+
+bool AtlasMergingDialog::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "next_line_after_column") {
+		r_ret = next_line_after_column;
+		return true;
+	}
+	return false;
+}
+
+void AtlasMergingDialog::update_tile_set(Ref<TileSet> p_tile_set) {
+	ERR_FAIL_COND(!p_tile_set.is_valid());
+	tile_set = p_tile_set;
+
+	atlas_merging_atlases_list->clear();
+	for (int i = 0; i < p_tile_set->get_source_count(); i++) {
+		int source_id = p_tile_set->get_source_id(i);
+		Ref<TileSetAtlasSource> atlas_source = p_tile_set->get_source(source_id);
+		if (atlas_source.is_valid()) {
+			Ref<Texture2D> texture = atlas_source->get_texture();
+			if (texture.is_valid()) {
+				String item_text = vformat("%s (id:%d)", texture->get_path().get_file(), source_id);
+				atlas_merging_atlases_list->add_item(item_text, texture);
+				atlas_merging_atlases_list->set_item_metadata(atlas_merging_atlases_list->get_item_count() - 1, source_id);
+			}
+		}
+	}
+
+	get_ok_button()->set_disabled(true);
+	merge_button->set_disabled(true);
+
+	commited_actions_count = 0;
+}
+
+AtlasMergingDialog::AtlasMergingDialog() {
+	// Atlas merging window.
+	set_title(TTR("Atlas Merging"));
+	set_hide_on_ok(false);
+
+	// Ok buttons
+	get_ok_button()->set_text(TTR("Merge (Keep original Atlases)"));
+	get_ok_button()->set_disabled(true);
+	merge_button = add_button(TTR("Merge"), true, "merge");
+	merge_button->set_disabled(true);
+
+	HSplitContainer *atlas_merging_h_split_container = memnew(HSplitContainer);
+	atlas_merging_h_split_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	atlas_merging_h_split_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(atlas_merging_h_split_container);
+
+	// Atlas sources item list.
+	atlas_merging_atlases_list = memnew(ItemList);
+	atlas_merging_atlases_list->set_fixed_icon_size(Size2i(60, 60) * EDSCALE);
+	atlas_merging_atlases_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	atlas_merging_atlases_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	atlas_merging_atlases_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
+	atlas_merging_atlases_list->set_custom_minimum_size(Size2(100, 200));
+	atlas_merging_atlases_list->set_select_mode(ItemList::SELECT_MULTI);
+	atlas_merging_atlases_list->connect("multi_selected", callable_mp(this, &AtlasMergingDialog::_update_texture).unbind(2));
+	atlas_merging_h_split_container->add_child(atlas_merging_atlases_list);
+
+	VBoxContainer *atlas_merging_right_panel = memnew(VBoxContainer);
+	atlas_merging_right_panel->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	atlas_merging_h_split_container->add_child(atlas_merging_right_panel);
+
+	// Settings.
+	Label *settings_label = memnew(Label);
+	settings_label->set_text(TTR("Settings:"));
+	atlas_merging_right_panel->add_child(settings_label);
+
+	columns_editor_property = memnew(EditorPropertyInteger);
+	columns_editor_property->set_label(TTR("Next Line After Column"));
+	columns_editor_property->set_object_and_property(this, "next_line_after_column");
+	columns_editor_property->update_property();
+	columns_editor_property->connect("property_changed", callable_mp(this, &AtlasMergingDialog::_property_changed));
+	atlas_merging_right_panel->add_child(columns_editor_property);
+
+	// Preview.
+	Label *preview_label = memnew(Label);
+	preview_label->set_text(TTR("Preview:"));
+	atlas_merging_right_panel->add_child(preview_label);
+
+	preview = memnew(TextureRect);
+	preview->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	preview->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	preview->set_expand(true);
+	preview->hide();
+	preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+	atlas_merging_right_panel->add_child(preview);
+
+	select_2_atlases_label = memnew(Label);
+	select_2_atlases_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	select_2_atlases_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	select_2_atlases_label->set_align(Label::ALIGN_CENTER);
+	select_2_atlases_label->set_valign(Label::VALIGN_CENTER);
+	select_2_atlases_label->set_text(TTR("Please select two atlases or more."));
+	atlas_merging_right_panel->add_child(select_2_atlases_label);
+
+	// The file dialog to choose the texture path.
+	editor_file_dialog = memnew(EditorFileDialog);
+	editor_file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+	editor_file_dialog->add_filter("*.png");
+	editor_file_dialog->connect("file_selected", callable_mp(this, &AtlasMergingDialog::_merge_confirmed));
+	add_child(editor_file_dialog);
+}

--- a/editor/plugins/tiles/atlas_merging_dialog.h
+++ b/editor/plugins/tiles/atlas_merging_dialog.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  tile_set_editor.h                                                    */
+/*  atlas_merging_dialog.h                                               */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,64 +28,59 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef TILE_SET_EDITOR_H
-#define TILE_SET_EDITOR_H
+#ifndef ATLAS_MERGING_DIALOG_H
+#define ATLAS_MERGING_DIALOG_H
 
-#include "atlas_merging_dialog.h"
-#include "scene/gui/box_container.h"
+#include "editor/editor_node.h"
+#include "editor/editor_properties.h"
+
+#include "scene/gui/dialogs.h"
+#include "scene/gui/item_list.h"
+#include "scene/gui/texture_rect.h"
 #include "scene/resources/tile_set.h"
-#include "tile_proxies_manager_dialog.h"
-#include "tile_set_atlas_source_editor.h"
-#include "tile_set_scenes_collection_source_editor.h"
 
-class TileSetEditor : public VBoxContainer {
-	GDCLASS(TileSetEditor, VBoxContainer);
-
-	static TileSetEditor *singleton;
+class AtlasMergingDialog : public ConfirmationDialog {
+	GDCLASS(AtlasMergingDialog, ConfirmationDialog);
 
 private:
+	int commited_actions_count = 0;
+	bool delete_original_atlases = true;
+	Ref<TileSetAtlasSource> merged;
+	LocalVector<Map<Vector2i, Vector2i>> merged_mapping;
 	Ref<TileSet> tile_set;
-	bool tile_set_changed_needs_update = false;
 
-	Label *no_source_selected_label;
-	TileSetAtlasSourceEditor *tile_set_atlas_source_editor;
-	TileSetScenesCollectionSourceEditor *tile_set_scenes_collection_source_editor;
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
-	UndoRedo *undo_redo = EditorNode::get_undo_redo();
+	// Settings.
+	int next_line_after_column = 30;
 
-	void _update_sources_list(int force_selected_id = -1);
+	// GUI.
+	ItemList *atlas_merging_atlases_list;
+	EditorPropertyVector2i *texture_region_size_editor_property;
+	EditorPropertyInteger *columns_editor_property;
+	TextureRect *preview;
+	Label *select_2_atlases_label;
+	EditorFileDialog *editor_file_dialog;
+	Button *merge_button;
 
-	// Sources management.
-	Button *sources_delete_button;
-	MenuButton *sources_add_button;
-	MenuButton *sources_advanced_menu_button;
-	ItemList *sources_list;
-	Ref<Texture2D> missing_texture_texture;
-	void _source_selected(int p_source_index);
-	void _source_delete_pressed();
-	void _source_add_id_pressed(int p_id_pressed);
-	void _sources_advanced_menu_id_pressed(int p_id_pressed);
+	void _property_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);
 
-	AtlasMergingDialog *atlas_merging_dialog;
-	TileProxiesManagerDialog *tile_proxies_manager_dialog;
-
-	void _tile_set_changed();
-
-	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value);
+	void _generate_merged(Vector<Ref<TileSetAtlasSource>> p_atlas_sources, int p_max_columns);
+	void _update_texture();
+	void _merge_confirmed(String p_path);
 
 protected:
-	void _notification(int p_what);
-	static void _bind_methods();
+	virtual void ok_pressed() override;
+	virtual void cancel_pressed() override;
+	virtual void custom_action(const String &) override;
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
 
 public:
-	_FORCE_INLINE_ static TileSetEditor *get_singleton() { return singleton; }
+	void update_tile_set(Ref<TileSet> p_tile_set);
 
-	void edit(Ref<TileSet> p_tile_set);
-	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
-	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
-
-	TileSetEditor();
-	~TileSetEditor();
+	AtlasMergingDialog();
 };
 
-#endif // TILE_SET_EDITOR_PLUGIN_H
+#endif // ATLAS_MERGING_DIALOG_H

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -47,7 +47,7 @@ class TileAtlasView : public Control {
 private:
 	TileSet *tile_set;
 	TileSetAtlasSource *tile_set_atlas_source;
-	int source_id = -1;
+	int source_id = TileSet::INVALID_SOURCE;
 
 	enum DragType {
 		DRAG_TYPE_NONE,

--- a/editor/plugins/tiles/tile_map_editor.h
+++ b/editor/plugins/tiles/tile_map_editor.h
@@ -82,9 +82,6 @@ private:
 	void _on_random_tile_checkbox_toggled(bool p_pressed);
 	void _on_scattering_spinbox_changed(double p_value);
 
-	Button *toggle_grid_button;
-	void _on_grid_toggled(bool p_pressed);
-
 	void _update_toolbar();
 
 	///// Tilemap editing. /////
@@ -300,6 +297,7 @@ class TileMapEditor : public VBoxContainer {
 	GDCLASS(TileMapEditor, VBoxContainer);
 
 private:
+	UndoRedo *undo_redo = EditorNode::get_undo_redo();
 	bool tileset_changed_needs_update = false;
 	ObjectID tile_map_id;
 
@@ -308,6 +306,12 @@ private:
 
 	// Toolbar.
 	HBoxContainer *tilemap_toolbar;
+
+	Button *toggle_grid_button;
+	void _on_grid_toggled(bool p_pressed);
+
+	MenuButton *advanced_menu_button;
+	void _advanced_menu_button_id_pressed(int p_id);
 
 	// Bottom panel
 	Label *missing_tileset_label;

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
@@ -1,0 +1,476 @@
+/*************************************************************************/
+/*  tile_proxies_manager_dialog.cpp                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "tile_proxies_manager_dialog.h"
+
+#include "editor/editor_scale.h"
+
+void TileProxiesManagerDialog::_right_clicked(int p_item, Vector2 p_local_mouse_pos, Object *p_item_list) {
+	ItemList *item_list = Object::cast_to<ItemList>(p_item_list);
+	popup_menu->set_size(Vector2(1, 1));
+	popup_menu->set_position(get_position() + item_list->get_global_mouse_position());
+	popup_menu->popup();
+}
+
+void TileProxiesManagerDialog::_menu_id_pressed(int p_id) {
+	if (p_id == 0) {
+		// Delete.
+		_delete_selected_bindings();
+	}
+}
+
+void TileProxiesManagerDialog::_delete_selected_bindings() {
+	undo_redo->create_action("Remove Tile Proxies");
+
+	Vector<int> source_level_selected = source_level_list->get_selected_items();
+	for (int i = 0; i < source_level_selected.size(); i++) {
+		int key = source_level_list->get_item_metadata(source_level_selected[i]);
+		int val = tile_set->get_source_level_tile_proxy(key);
+		undo_redo->add_do_method(*tile_set, "remove_source_level_tile_proxy", key);
+		undo_redo->add_undo_method(*tile_set, "set_source_level_tile_proxy", key, val);
+	}
+
+	Vector<int> coords_level_selected = coords_level_list->get_selected_items();
+	for (int i = 0; i < coords_level_selected.size(); i++) {
+		Array key = coords_level_list->get_item_metadata(coords_level_selected[i]);
+		Array val = tile_set->get_coords_level_tile_proxy(key[0], key[1]);
+		undo_redo->add_do_method(*tile_set, "remove_coords_level_tile_proxy", key[0], key[1]);
+		undo_redo->add_undo_method(*tile_set, "set_coords_level_tile_proxy", key[0], key[1], val[0], val[1]);
+	}
+
+	Vector<int> alternative_level_selected = alternative_level_list->get_selected_items();
+	for (int i = 0; i < alternative_level_selected.size(); i++) {
+		Array key = alternative_level_list->get_item_metadata(alternative_level_selected[i]);
+		Array val = tile_set->get_coords_level_tile_proxy(key[0], key[1]);
+		undo_redo->add_do_method(*tile_set, "remove_alternative_level_tile_proxy", key[0], key[1], key[2]);
+		undo_redo->add_undo_method(*tile_set, "set_alternative_level_tile_proxy", key[0], key[1], key[2], val[0], val[1], val[2]);
+	}
+	undo_redo->add_do_method(this, "_update_lists");
+	undo_redo->add_undo_method(this, "_update_lists");
+	undo_redo->commit_action();
+
+	commited_actions_count += 1;
+}
+
+void TileProxiesManagerDialog::_update_lists() {
+	source_level_list->clear();
+	coords_level_list->clear();
+	alternative_level_list->clear();
+
+	Array proxies = tile_set->get_source_level_tile_proxies();
+	for (int i = 0; i < proxies.size(); i++) {
+		Array proxy = proxies[i];
+		String text = vformat("%s", proxy[0]).rpad(5) + "-> " + vformat("%s", proxy[1]);
+		int id = source_level_list->add_item(text);
+		source_level_list->set_item_metadata(id, proxy[0]);
+	}
+
+	proxies = tile_set->get_coords_level_tile_proxies();
+	for (int i = 0; i < proxies.size(); i++) {
+		Array proxy = proxies[i];
+		String text = vformat("%s, %s", proxy[0], proxy[1]).rpad(17) + "-> " + vformat("%s, %s", proxy[2], proxy[3]);
+		int id = coords_level_list->add_item(text);
+		coords_level_list->set_item_metadata(id, proxy.slice(0, 2));
+	}
+
+	proxies = tile_set->get_alternative_level_tile_proxies();
+	for (int i = 0; i < proxies.size(); i++) {
+		Array proxy = proxies[i];
+		String text = vformat("%s, %s, %s", proxy[0], proxy[1], proxy[2]).rpad(24) + "-> " + vformat("%s, %s, %s", proxy[3], proxy[4], proxy[5]);
+		int id = alternative_level_list->add_item(text);
+		alternative_level_list->set_item_metadata(id, proxy.slice(0, 3));
+	}
+}
+
+void TileProxiesManagerDialog::_update_enabled_property_editors() {
+	if (from.source_id == TileSet::INVALID_SOURCE) {
+		from.set_atlas_coords(TileSetSource::INVALID_ATLAS_COORDS);
+		to.set_atlas_coords(TileSetSource::INVALID_ATLAS_COORDS);
+		from.alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE;
+		to.alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE;
+		coords_from_property_editor->hide();
+		coords_to_property_editor->hide();
+		alternative_from_property_editor->hide();
+		alternative_to_property_editor->hide();
+	} else if (from.get_atlas_coords().x == -1 || from.get_atlas_coords().y == -1) {
+		from.alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE;
+		to.alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE;
+		coords_from_property_editor->show();
+		coords_to_property_editor->show();
+		alternative_from_property_editor->hide();
+		alternative_to_property_editor->hide();
+	} else {
+		coords_from_property_editor->show();
+		coords_to_property_editor->show();
+		alternative_from_property_editor->show();
+		alternative_to_property_editor->show();
+	}
+
+	source_from_property_editor->update_property();
+	source_to_property_editor->update_property();
+	coords_from_property_editor->update_property();
+	coords_to_property_editor->update_property();
+	alternative_from_property_editor->update_property();
+	alternative_to_property_editor->update_property();
+}
+
+void TileProxiesManagerDialog::_property_changed(const String &p_path, const Variant &p_value, const String &p_name, bool p_changing) {
+	_set(p_path, p_value);
+}
+
+void TileProxiesManagerDialog::_add_button_pressed() {
+	if (from.source_id != TileSet::INVALID_SOURCE && to.source_id != TileSet::INVALID_SOURCE) {
+		Vector2i from_coords = from.get_atlas_coords();
+		Vector2i to_coords = to.get_atlas_coords();
+		if (from_coords.x >= 0 && from_coords.y >= 0 && to_coords.x >= 0 && to_coords.y >= 0) {
+			if (from.alternative_tile != TileSetSource::INVALID_TILE_ALTERNATIVE && to.alternative_tile != TileSetSource::INVALID_TILE_ALTERNATIVE) {
+				undo_redo->create_action("Create Alternative-level Tile Proxy");
+				undo_redo->add_do_method(*tile_set, "set_alternative_level_tile_proxy", from.source_id, from.get_atlas_coords(), from.alternative_tile, to.source_id, to.get_atlas_coords(), to.alternative_tile);
+				if (tile_set->has_alternative_level_tile_proxy(from.source_id, from.get_atlas_coords(), from.alternative_tile)) {
+					Array a = tile_set->get_alternative_level_tile_proxy(from.source_id, from.get_atlas_coords(), from.alternative_tile);
+					undo_redo->add_undo_method(*tile_set, "set_alternative_level_tile_proxy", to.source_id, to.get_atlas_coords(), to.alternative_tile, a[0], a[1], a[2]);
+				} else {
+					undo_redo->add_undo_method(*tile_set, "remove_alternative_level_tile_proxy", from.source_id, from.get_atlas_coords(), from.alternative_tile);
+				}
+			} else {
+				undo_redo->create_action("Create Coords-level Tile Proxy");
+				undo_redo->add_do_method(*tile_set, "set_coords_level_tile_proxy", from.source_id, from.get_atlas_coords(), to.source_id, to.get_atlas_coords());
+				if (tile_set->has_coords_level_tile_proxy(from.source_id, from.get_atlas_coords())) {
+					Array a = tile_set->get_coords_level_tile_proxy(from.source_id, from.get_atlas_coords());
+					undo_redo->add_undo_method(*tile_set, "set_coords_level_tile_proxy", to.source_id, to.get_atlas_coords(), a[0], a[1]);
+				} else {
+					undo_redo->add_undo_method(*tile_set, "remove_coords_level_tile_proxy", from.source_id, from.get_atlas_coords());
+				}
+			}
+		} else {
+			undo_redo->create_action("Create source-level Tile Proxy");
+			undo_redo->add_do_method(*tile_set, "set_source_level_tile_proxy", from.source_id, to.source_id);
+			if (tile_set->has_source_level_tile_proxy(from.source_id)) {
+				undo_redo->add_undo_method(*tile_set, "set_source_level_tile_proxy", to.source_id, tile_set->get_source_level_tile_proxy(from.source_id));
+			} else {
+				undo_redo->add_undo_method(*tile_set, "remove_source_level_tile_proxy", from.source_id);
+			}
+		}
+		undo_redo->add_do_method(this, "_update_lists");
+		undo_redo->add_undo_method(this, "_update_lists");
+		undo_redo->commit_action();
+		commited_actions_count++;
+	}
+}
+
+void TileProxiesManagerDialog::_clear_invalid_button_pressed() {
+	undo_redo->create_action("Delete All Invalid Tile Proxies");
+
+	undo_redo->add_do_method(*tile_set, "cleanup_invalid_tile_proxies");
+
+	Array proxies = tile_set->get_source_level_tile_proxies();
+	for (int i = 0; i < proxies.size(); i++) {
+		Array proxy = proxies[i];
+		undo_redo->add_undo_method(*tile_set, "set_source_level_tile_proxy", proxy[0], proxy[1]);
+	}
+
+	proxies = tile_set->get_coords_level_tile_proxies();
+	for (int i = 0; i < proxies.size(); i++) {
+		Array proxy = proxies[i];
+		undo_redo->add_undo_method(*tile_set, "set_coords_level_tile_proxy", proxy[0], proxy[1], proxy[2], proxy[3]);
+	}
+
+	proxies = tile_set->get_alternative_level_tile_proxies();
+	for (int i = 0; i < proxies.size(); i++) {
+		Array proxy = proxies[i];
+		undo_redo->add_undo_method(*tile_set, "set_alternative_level_tile_proxy", proxy[0], proxy[1], proxy[2], proxy[3], proxy[4], proxy[5]);
+	}
+	undo_redo->add_do_method(this, "_update_lists");
+	undo_redo->add_undo_method(this, "_update_lists");
+	undo_redo->commit_action();
+}
+
+void TileProxiesManagerDialog::_clear_all_button_pressed() {
+	undo_redo->create_action("Delete All Tile Proxies");
+
+	undo_redo->add_do_method(*tile_set, "clear_tile_proxies");
+
+	Array proxies = tile_set->get_source_level_tile_proxies();
+	for (int i = 0; i < proxies.size(); i++) {
+		Array proxy = proxies[i];
+		undo_redo->add_undo_method(*tile_set, "set_source_level_tile_proxy", proxy[0], proxy[1]);
+	}
+
+	proxies = tile_set->get_coords_level_tile_proxies();
+	for (int i = 0; i < proxies.size(); i++) {
+		Array proxy = proxies[i];
+		undo_redo->add_undo_method(*tile_set, "set_coords_level_tile_proxy", proxy[0], proxy[1], proxy[2], proxy[3]);
+	}
+
+	proxies = tile_set->get_alternative_level_tile_proxies();
+	for (int i = 0; i < proxies.size(); i++) {
+		Array proxy = proxies[i];
+		undo_redo->add_undo_method(*tile_set, "set_alternative_level_tile_proxy", proxy[0], proxy[1], proxy[2], proxy[3], proxy[4], proxy[5]);
+	}
+	undo_redo->add_do_method(this, "_update_lists");
+	undo_redo->add_undo_method(this, "_update_lists");
+	undo_redo->commit_action();
+}
+
+bool TileProxiesManagerDialog::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "from_source") {
+		from.source_id = MAX(int(p_value), -1);
+	} else if (p_name == "from_coords") {
+		from.set_atlas_coords(Vector2i(p_value).max(Vector2i(-1, -1)));
+	} else if (p_name == "from_alternative") {
+		from.alternative_tile = MAX(int(p_value), -1);
+	} else if (p_name == "to_source") {
+		to.source_id = MAX(int(p_value), 0);
+	} else if (p_name == "to_coords") {
+		to.set_atlas_coords(Vector2i(p_value).max(Vector2i(0, 0)));
+	} else if (p_name == "to_alternative") {
+		to.alternative_tile = MAX(int(p_value), 0);
+	} else {
+		return false;
+	}
+	_update_enabled_property_editors();
+	return true;
+}
+
+bool TileProxiesManagerDialog::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "from_source") {
+		r_ret = from.source_id;
+	} else if (p_name == "from_coords") {
+		r_ret = from.get_atlas_coords();
+	} else if (p_name == "from_alternative") {
+		r_ret = from.alternative_tile;
+	} else if (p_name == "to_source") {
+		r_ret = to.source_id;
+	} else if (p_name == "to_coords") {
+		r_ret = to.get_atlas_coords();
+	} else if (p_name == "to_alternative") {
+		r_ret = to.alternative_tile;
+	} else {
+		return false;
+	}
+	return true;
+}
+
+void TileProxiesManagerDialog::_unhandled_key_input(Ref<InputEvent> p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	if (p_event->is_pressed() && !p_event->is_echo() && (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventAction>(*p_event))) {
+		if (!is_inside_tree() || !is_visible()) {
+			return;
+		}
+
+		if (popup_menu->activate_item_by_event(p_event, false)) {
+			set_input_as_handled();
+		}
+	}
+}
+
+void TileProxiesManagerDialog::cancel_pressed() {
+	for (int i = 0; i < commited_actions_count; i++) {
+		undo_redo->undo();
+	}
+	commited_actions_count = 0;
+}
+
+void TileProxiesManagerDialog::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_update_lists"), &TileProxiesManagerDialog::_update_lists);
+	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &TileProxiesManagerDialog::_unhandled_key_input);
+}
+
+void TileProxiesManagerDialog::update_tile_set(Ref<TileSet> p_tile_set) {
+	ERR_FAIL_COND(!p_tile_set.is_valid());
+	tile_set = p_tile_set;
+	commited_actions_count = 0;
+	_update_lists();
+}
+
+TileProxiesManagerDialog::TileProxiesManagerDialog() {
+	// Tile proxy management window.
+	set_title(TTR("Tile Proxies Management"));
+	set_process_unhandled_key_input(true);
+
+	to.source_id = 0;
+	to.set_atlas_coords(Vector2i());
+	to.alternative_tile = 0;
+
+	VBoxContainer *vbox_container = memnew(VBoxContainer);
+	vbox_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbox_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(vbox_container);
+
+	Label *source_level_label = memnew(Label);
+	source_level_label->set_text(TTR("Source-level proxies"));
+	vbox_container->add_child(source_level_label);
+
+	source_level_list = memnew(ItemList);
+	source_level_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	source_level_list->set_select_mode(ItemList::SELECT_MULTI);
+	source_level_list->set_allow_rmb_select(true);
+	source_level_list->connect("item_rmb_selected", callable_mp(this, &TileProxiesManagerDialog::_right_clicked), varray(source_level_list));
+	vbox_container->add_child(source_level_list);
+
+	Label *coords_level_label = memnew(Label);
+	coords_level_label->set_text(TTR("Coords-level proxies"));
+	vbox_container->add_child(coords_level_label);
+
+	coords_level_list = memnew(ItemList);
+	coords_level_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	coords_level_list->set_select_mode(ItemList::SELECT_MULTI);
+	coords_level_list->set_allow_rmb_select(true);
+	coords_level_list->connect("item_rmb_selected", callable_mp(this, &TileProxiesManagerDialog::_right_clicked), varray(coords_level_list));
+	vbox_container->add_child(coords_level_list);
+
+	Label *alternative_level_label = memnew(Label);
+	alternative_level_label->set_text(TTR("Alternative-level proxies"));
+	vbox_container->add_child(alternative_level_label);
+
+	alternative_level_list = memnew(ItemList);
+	alternative_level_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	alternative_level_list->set_select_mode(ItemList::SELECT_MULTI);
+	alternative_level_list->set_allow_rmb_select(true);
+	alternative_level_list->connect("item_rmb_selected", callable_mp(this, &TileProxiesManagerDialog::_right_clicked), varray(alternative_level_list));
+	vbox_container->add_child(alternative_level_list);
+
+	popup_menu = memnew(PopupMenu);
+	popup_menu->add_shortcut(ED_GET_SHORTCUT("ui_text_delete"));
+	popup_menu->connect("id_pressed", callable_mp(this, &TileProxiesManagerDialog::_menu_id_pressed));
+	add_child(popup_menu);
+
+	// Add proxy panel.
+	HSeparator *h_separator = memnew(HSeparator);
+	vbox_container->add_child(h_separator);
+
+	Label *add_label = memnew(Label);
+	add_label->set_text(TTR("Add a new tile proxy:"));
+	vbox_container->add_child(add_label);
+
+	HBoxContainer *hboxcontainer = memnew(HBoxContainer);
+	vbox_container->add_child(hboxcontainer);
+
+	// From
+	VBoxContainer *vboxcontainer_from = memnew(VBoxContainer);
+	vboxcontainer_from->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	hboxcontainer->add_child(vboxcontainer_from);
+
+	source_from_property_editor = memnew(EditorPropertyInteger);
+	source_from_property_editor->set_label(TTR("From Source"));
+	source_from_property_editor->set_object_and_property(this, "from_source");
+	source_from_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
+	source_from_property_editor->set_selectable(false);
+	source_from_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	source_from_property_editor->setup(-1, 99999, 1, true, false);
+	vboxcontainer_from->add_child(source_from_property_editor);
+
+	coords_from_property_editor = memnew(EditorPropertyVector2i);
+	coords_from_property_editor->set_label(TTR("From Coords"));
+	coords_from_property_editor->set_object_and_property(this, "from_coords");
+	coords_from_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
+	coords_from_property_editor->set_selectable(false);
+	coords_from_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	coords_from_property_editor->setup(-1, 99999, true);
+	coords_from_property_editor->hide();
+	vboxcontainer_from->add_child(coords_from_property_editor);
+
+	alternative_from_property_editor = memnew(EditorPropertyInteger);
+	alternative_from_property_editor->set_label(TTR("From Alternative"));
+	alternative_from_property_editor->set_object_and_property(this, "from_alternative");
+	alternative_from_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
+	alternative_from_property_editor->set_selectable(false);
+	alternative_from_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	alternative_from_property_editor->setup(-1, 99999, 1, true, false);
+	alternative_from_property_editor->hide();
+	vboxcontainer_from->add_child(alternative_from_property_editor);
+
+	// To
+	VBoxContainer *vboxcontainer_to = memnew(VBoxContainer);
+	vboxcontainer_to->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	hboxcontainer->add_child(vboxcontainer_to);
+
+	source_to_property_editor = memnew(EditorPropertyInteger);
+	source_to_property_editor->set_label(TTR("To Source"));
+	source_to_property_editor->set_object_and_property(this, "to_source");
+	source_to_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
+	source_to_property_editor->set_selectable(false);
+	source_to_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	source_to_property_editor->setup(-1, 99999, 1, true, false);
+	vboxcontainer_to->add_child(source_to_property_editor);
+
+	coords_to_property_editor = memnew(EditorPropertyVector2i);
+	coords_to_property_editor->set_label(TTR("To Coords"));
+	coords_to_property_editor->set_object_and_property(this, "to_coords");
+	coords_to_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
+	coords_to_property_editor->set_selectable(false);
+	coords_to_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	coords_to_property_editor->setup(-1, 99999, true);
+	coords_to_property_editor->hide();
+	vboxcontainer_to->add_child(coords_to_property_editor);
+
+	alternative_to_property_editor = memnew(EditorPropertyInteger);
+	alternative_to_property_editor->set_label(TTR("To Alternative"));
+	alternative_to_property_editor->set_object_and_property(this, "to_alternative");
+	alternative_to_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
+	alternative_to_property_editor->set_selectable(false);
+	alternative_to_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	alternative_to_property_editor->setup(-1, 99999, 1, true, false);
+	alternative_to_property_editor->hide();
+	vboxcontainer_to->add_child(alternative_to_property_editor);
+
+	Button *add_button = memnew(Button);
+	add_button->set_text(TTR("Add"));
+	add_button->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
+	add_button->connect("pressed", callable_mp(this, &TileProxiesManagerDialog::_add_button_pressed));
+	vbox_container->add_child(add_button);
+
+	h_separator = memnew(HSeparator);
+	vbox_container->add_child(h_separator);
+
+	// Generic actions.
+	Label *generic_actions_label = memnew(Label);
+	generic_actions_label->set_text(TTR("Global actions:"));
+	vbox_container->add_child(generic_actions_label);
+
+	hboxcontainer = memnew(HBoxContainer);
+	vbox_container->add_child(hboxcontainer);
+
+	Button *clear_invalid_button = memnew(Button);
+	clear_invalid_button->set_text(TTR("Clear Invalid"));
+	clear_invalid_button->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
+	clear_invalid_button->connect("pressed", callable_mp(this, &TileProxiesManagerDialog::_clear_invalid_button_pressed));
+	hboxcontainer->add_child(clear_invalid_button);
+
+	Button *clear_all_button = memnew(Button);
+	clear_all_button->set_text(TTR("Clear All"));
+	clear_all_button->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
+	clear_all_button->connect("pressed", callable_mp(this, &TileProxiesManagerDialog::_clear_all_button_pressed));
+	hboxcontainer->add_child(clear_all_button);
+
+	h_separator = memnew(HSeparator);
+	vbox_container->add_child(h_separator);
+}

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.h
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  tile_set_editor.h                                                    */
+/*  tile_proxies_manager_dialog.h                                        */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,64 +28,63 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef TILE_SET_EDITOR_H
-#define TILE_SET_EDITOR_H
+#ifndef TILE_PROXIES_MANAGER_DIALOG_H
+#define TILE_PROXIES_MANAGER_DIALOG_H
 
-#include "atlas_merging_dialog.h"
-#include "scene/gui/box_container.h"
+#include "editor/editor_node.h"
+#include "editor/editor_properties.h"
+
+#include "scene/gui/dialogs.h"
+#include "scene/gui/item_list.h"
 #include "scene/resources/tile_set.h"
-#include "tile_proxies_manager_dialog.h"
-#include "tile_set_atlas_source_editor.h"
-#include "tile_set_scenes_collection_source_editor.h"
 
-class TileSetEditor : public VBoxContainer {
-	GDCLASS(TileSetEditor, VBoxContainer);
-
-	static TileSetEditor *singleton;
+class TileProxiesManagerDialog : public ConfirmationDialog {
+	GDCLASS(TileProxiesManagerDialog, ConfirmationDialog);
 
 private:
+	int commited_actions_count = 0;
 	Ref<TileSet> tile_set;
-	bool tile_set_changed_needs_update = false;
 
-	Label *no_source_selected_label;
-	TileSetAtlasSourceEditor *tile_set_atlas_source_editor;
-	TileSetScenesCollectionSourceEditor *tile_set_scenes_collection_source_editor;
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
-	UndoRedo *undo_redo = EditorNode::get_undo_redo();
+	TileMapCell from;
+	TileMapCell to;
 
-	void _update_sources_list(int force_selected_id = -1);
+	// GUI
+	ItemList *source_level_list;
+	ItemList *coords_level_list;
+	ItemList *alternative_level_list;
 
-	// Sources management.
-	Button *sources_delete_button;
-	MenuButton *sources_add_button;
-	MenuButton *sources_advanced_menu_button;
-	ItemList *sources_list;
-	Ref<Texture2D> missing_texture_texture;
-	void _source_selected(int p_source_index);
-	void _source_delete_pressed();
-	void _source_add_id_pressed(int p_id_pressed);
-	void _sources_advanced_menu_id_pressed(int p_id_pressed);
+	EditorPropertyInteger *source_from_property_editor;
+	EditorPropertyVector2i *coords_from_property_editor;
+	EditorPropertyInteger *alternative_from_property_editor;
+	EditorPropertyInteger *source_to_property_editor;
+	EditorPropertyVector2i *coords_to_property_editor;
+	EditorPropertyInteger *alternative_to_property_editor;
 
-	AtlasMergingDialog *atlas_merging_dialog;
-	TileProxiesManagerDialog *tile_proxies_manager_dialog;
+	PopupMenu *popup_menu;
+	void _right_clicked(int p_item, Vector2 p_local_mouse_pos, Object *p_item_list);
+	void _menu_id_pressed(int p_id);
+	void _delete_selected_bindings();
+	void _update_lists();
+	void _update_enabled_property_editors();
+	void _property_changed(const String &p_path, const Variant &p_value, const String &p_name, bool p_changing);
+	void _add_button_pressed();
 
-	void _tile_set_changed();
-
-	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value);
+	void _clear_invalid_button_pressed();
+	void _clear_all_button_pressed();
 
 protected:
-	void _notification(int p_what);
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _unhandled_key_input(Ref<InputEvent> p_event);
+	virtual void cancel_pressed() override;
 	static void _bind_methods();
 
 public:
-	_FORCE_INLINE_ static TileSetEditor *get_singleton() { return singleton; }
+	void update_tile_set(Ref<TileSet> p_tile_set);
 
-	void edit(Ref<TileSet> p_tile_set);
-	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
-	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
-
-	TileSetEditor();
-	~TileSetEditor();
+	TileProxiesManagerDialog();
 };
 
-#endif // TILE_SET_EDITOR_PLUGIN_H
+#endif // TILE_PROXIES_MANAGER_DIALOG_H

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -745,7 +745,7 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 			button->add_theme_style_override("hover", memnew(StyleBoxEmpty));
 			button->add_theme_style_override("focus", memnew(StyleBoxEmpty));
 			button->add_theme_style_override("pressed", memnew(StyleBoxEmpty));
-			button->connect("pressed", callable_mp(tile_set_atlas_source, &TileSetAtlasSource::create_alternative_tile), varray(tile_id, -1));
+			button->connect("pressed", callable_mp(tile_set_atlas_source, &TileSetAtlasSource::create_alternative_tile), varray(tile_id, TileSetSource::INVALID_TILE_ALTERNATIVE));
 			button->set_rect(Rect2(Vector2(pos.x, pos.y + (y_increment - texture_region_base_size.y) / 2.0), Vector2(texture_region_base_size_min, texture_region_base_size_min)));
 			button->set_expand_icon(true);
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -65,7 +65,7 @@ private:
 	private:
 		Ref<TileSet> tile_set;
 		TileSetAtlasSource *tile_set_atlas_source = nullptr;
-		int source_id = -1;
+		int source_id = TileSet::INVALID_SOURCE;
 
 	protected:
 		bool _set(const StringName &p_name, const Variant &p_value);
@@ -108,7 +108,7 @@ private:
 
 	Ref<TileSet> tile_set;
 	TileSetAtlasSource *tile_set_atlas_source = nullptr;
-	int tile_set_atlas_source_id = -1;
+	int tile_set_atlas_source_id = TileSet::INVALID_SOURCE;
 
 	UndoRedo *undo_redo = EditorNode::get_undo_redo();
 

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -118,11 +118,11 @@ void TilesEditor::_update_editors() {
 	CanvasItemEditor::get_singleton()->update_viewport();
 }
 
-void TilesEditor::set_atlas_sources_lists_current(int p_current) {
+void TilesEditor::set_sources_lists_current(int p_current) {
 	atlas_sources_lists_current = p_current;
 }
 
-void TilesEditor::synchronize_atlas_sources_list(Object *p_current) {
+void TilesEditor::synchronize_sources_list(Object *p_current) {
 	ItemList *item_list = Object::cast_to<ItemList>(p_current);
 	ERR_FAIL_COND(!item_list);
 

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -76,8 +76,8 @@ public:
 	void forward_canvas_draw_over_viewport(Control *p_overlay) { tilemap_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
 	// To synchronize the atlas sources lists.
-	void set_atlas_sources_lists_current(int p_current);
-	void synchronize_atlas_sources_list(Object *p_current);
+	void set_sources_lists_current(int p_current);
+	void synchronize_sources_list(Object *p_current);
 
 	void set_atlas_view_transform(float p_zoom, Vector2 p_scroll);
 	void synchronize_atlas_view(Object *p_current);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -265,16 +265,16 @@ public:
 	VisibilityMode get_navigation_visibility_mode();
 
 	void set_cell(const Vector2i &p_coords, int p_source_id = -1, const Vector2i p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE);
-	int get_cell_source_id(const Vector2i &p_coords) const;
-	Vector2i get_cell_atlas_coords(const Vector2i &p_coords) const;
-	int get_cell_alternative_tile(const Vector2i &p_coords) const;
+	int get_cell_source_id(const Vector2i &p_coords, bool p_use_proxies = false) const;
+	Vector2i get_cell_atlas_coords(const Vector2i &p_coords, bool p_use_proxies = false) const;
+	int get_cell_alternative_tile(const Vector2i &p_coords, bool p_use_proxies = false) const;
 
 	TileMapPattern *get_pattern(TypedArray<Vector2i> p_coords_array);
 	Vector2i map_pattern(Vector2i p_position_in_tilemap, Vector2i p_coords_in_pattern, const TileMapPattern *p_pattern);
 	void set_pattern(Vector2i p_position, const TileMapPattern *p_pattern);
 
 	// Not exposed to users
-	TileMapCell get_cell(const Vector2i &p_coords) const;
+	TileMapCell get_cell(const Vector2i &p_coords, bool p_use_proxies = false) const;
 	Map<Vector2i, TileMapQuadrant> &get_quadrant_map();
 	int get_effective_quadrant_size() const;
 

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -120,6 +120,8 @@ public:
 #endif // DISABLE_DEPRECATED
 
 public:
+	static const int INVALID_SOURCE; // -1;
+
 	enum CellNeighbor {
 		CELL_NEIGHBOR_RIGHT_SIDE = 0,
 		CELL_NEIGHBOR_RIGHT_CORNER,
@@ -169,7 +171,6 @@ public:
 		TILE_OFFSET_AXIS_VERTICAL,
 	};
 
-public:
 	struct PackedSceneSource {
 		Ref<PackedScene> scene;
 		Vector2 offset;
@@ -249,6 +250,11 @@ private:
 
 	void _compute_next_source_id();
 	void _source_changed();
+
+	// Tile proxies
+	Map<int, int> source_level_proxies;
+	Map<Array, Array> coords_level_proxies;
+	Map<Array, Array> alternative_level_proxies;
 
 	// Helpers
 	Vector<Point2> _get_square_corner_or_side_terrain_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit);
@@ -344,6 +350,31 @@ public:
 	String get_custom_data_name(int p_layer_id) const;
 	void set_custom_data_type(int p_layer_id, Variant::Type p_value);
 	Variant::Type get_custom_data_type(int p_layer_id) const;
+
+	// Tiles proxies.
+	void set_source_level_tile_proxy(int p_source_from, int p_source_to);
+	int get_source_level_tile_proxy(int p_source_from);
+	bool has_source_level_tile_proxy(int p_source_from);
+	void remove_source_level_tile_proxy(int p_source_from);
+
+	void set_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_source_to, Vector2i p_coords_to);
+	Array get_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from);
+	bool has_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from);
+	void remove_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from);
+
+	void set_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from, int p_source_to, Vector2i p_coords_to, int p_alternative_to);
+	Array get_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from);
+	bool has_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from);
+	void remove_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from);
+
+	Array get_source_level_tile_proxies() const;
+	Array get_coords_level_tile_proxies() const;
+	Array get_alternative_level_tile_proxies() const;
+
+	Array map_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) const;
+
+	void cleanup_invalid_tile_proxies();
+	void clear_tile_proxies();
 
 	// Helpers
 	Vector<Vector2> get_tile_shape_polygon();

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -79,15 +79,15 @@ private:
 		Vector2 tex_offset;
 		Ref<ShaderMaterial> material;
 		Rect2 region;
-		int tile_mode;
-		Color modulate;
+		int tile_mode = 0;
+		Color modulate = Color(1, 1, 1);
 
 		// Atlas or autotiles data
-		int autotile_bitmask_mode;
+		int autotile_bitmask_mode = 0;
 		Vector2 autotile_icon_coordinate;
 		Size2i autotile_tile_size = Size2i(16, 16);
 
-		int autotile_spacing;
+		int autotile_spacing = 0;
 		Map<Vector2i, int> autotile_bitmask_flags;
 		Map<Vector2i, Ref<OccluderPolygon2D>> autotile_occluder_map;
 		Map<Vector2i, Ref<NavigationPolygon>> autotile_navpoly_map;
@@ -99,20 +99,24 @@ private:
 		Vector2 occluder_offset;
 		Ref<NavigationPolygon> navigation;
 		Vector2 navigation_offset;
-		int z_index;
+		int z_index = 0;
 	};
 
-	Map<int, CompatibilityTileData *> compatibility_data = Map<int, CompatibilityTileData *>();
-	Map<int, int> compatibility_source_mapping = Map<int, int>();
+	enum CompatibilityTileMode {
+		COMPATIBILITY_TILE_MODE_SINGLE_TILE = 0,
+		COMPATIBILITY_TILE_MODE_AUTO_TILE,
+		COMPATIBILITY_TILE_MODE_ATLAS_TILE,
+	};
 
-private:
-	void compatibility_conversion();
+	Map<int, CompatibilityTileData *> compatibility_data;
+	Map<int, int> compatibility_tilemap_mapping_tile_modes;
+	Map<int, Map<Array, Array>> compatibility_tilemap_mapping;
+
+	void _compatibility_conversion();
 
 public:
-	int compatibility_get_source_for_tile_id(int p_old_source) {
-		return compatibility_source_mapping[p_old_source];
-	};
-
+	// Format of output array [source_id, atlas_coords, alternative]
+	Array compatibility_tilemap_map(int p_tile_id, Vector2i p_coords, bool p_flip_h, bool p_flip_v, bool p_transpose);
 #endif // DISABLE_DEPRECATED
 
 public:


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
This PR implements several things:
- Imports 3.x tiles with the SINGLE_TILE mode as atlases.
- Implements an interface allowing the merge of atlases. This is needed to allow to merging single tiles into one big atlas.
- Implements _"Tile proxies"_. Those allow allow mapping a tile ID (source ID, atlas coords and alternative ID) to another. This, in our case, allows keeping the correct tiles even some atlases got merged. Tiles that are proxied are displayed with a warning icon in the editor (not in the game), and can be automatically replaced by their correct ID thanks to an option added to the TileMap's editor toolbar.
- Implements an interface to manage tile proxies.
- Adds min_axis and and max_axis to Vector2i, as I needed them.
- Create an `TileSet::INVALID_SOURCE` constant to identify invalid TileSet source.

Here is me, porting the isometric demo to 4.0 in few clicks:

![Peek 20-07-2021 13-31](https://user-images.githubusercontent.com/6093119/126317259-ee361752-027a-431f-bd55-fa0f4c40b9f4.gif)


