### PR TITLE
Use fragment shader instead of compute shader in mobile

### DIFF
--- a/servers/rendering/renderer_rd/effects_rd.h
+++ b/servers/rendering/renderer_rd/effects_rd.h
@@ -33,6 +33,7 @@
 
 #include "core/math/camera_matrix.h"
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
+#include "servers/rendering/renderer_rd/shaders/blur_raster.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/bokeh_dof.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/copy.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/copy_to_fb.glsl.gen.h"
@@ -41,6 +42,7 @@
 #include "servers/rendering/renderer_rd/shaders/cubemap_filter.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/cubemap_roughness.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/luminance_reduce.glsl.gen.h"
+#include "servers/rendering/renderer_rd/shaders/luminance_reduce_raster.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/resolve.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/roughness_limiter.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/screen_space_reflection.glsl.gen.h"
@@ -60,6 +62,63 @@
 #include "servers/rendering_server.h"
 
 class EffectsRD {
+	enum BlurRasterMode {
+		BLUR_MODE_GAUSSIAN_BLUR,
+		BLUR_MODE_GAUSSIAN_GLOW,
+		BLUR_MODE_GAUSSIAN_GLOW_AUTO_EXPOSURE,
+
+		BLUR_MODE_DOF_LOW,
+		BLUR_MODE_DOF_MEDIUM,
+		BLUR_MODE_DOF_HIGH,
+
+		BLUR_MODE_MAX
+	};
+
+	enum {
+		BLUR_FLAG_HORIZONTAL = (1 << 0),
+		BLUR_FLAG_USE_ORTHOGONAL_PROJECTION = (1 << 1),
+		BLUR_FLAG_GLOW_FIRST_PASS = (1 << 2),
+		BLUR_FLAG_DOF_FAR = (1 << 3),
+		BLUR_FLAG_DOF_NEAR = (1 << 4),
+	};
+
+	struct BlurRasterPushConstant {
+		float pixel_size[2];
+		uint32_t flags;
+		uint32_t pad;
+
+		//glow
+		float glow_strength;
+		float glow_bloom;
+		float glow_hdr_threshold;
+		float glow_hdr_scale;
+
+		float glow_exposure;
+		float glow_white;
+		float glow_luminance_cap;
+		float glow_auto_exposure_grey;
+
+		//dof
+		float dof_far_begin;
+		float dof_far_end;
+		float dof_near_begin;
+		float dof_near_end;
+
+		float dof_radius;
+		float dof_pad[3];
+
+		float dof_dir[2];
+		float camera_z_far;
+		float camera_z_near;
+	};
+
+	struct BlurRaster {
+		BlurRasterPushConstant push_constant;
+		BlurRasterShaderRD shader;
+		RID shader_version;
+		PipelineCacheRD pipelines[BLUR_MODE_MAX];
+	} blur_raster;
+
 	enum CopyMode {
 		COPY_MODE_GAUSSIAN_COPY,
 		COPY_MODE_GAUSSIAN_COPY_8BIT,
@@ -238,6 +297,29 @@ class EffectsRD {
 		RID shader_version;
 		RID pipelines[LUMINANCE_REDUCE_MAX];
 	} luminance_reduce;
+
+	enum LuminanceReduceRasterMode {
+		LUMINANCE_REDUCE_FRAGMENT_FIRST,
+		LUMINANCE_REDUCE_FRAGMENT,
+		LUMINANCE_REDUCE_FRAGMENT_FINAL,
+		LUMINANCE_REDUCE_FRAGMENT_MAX
+	};
+
+	struct LuminanceReduceRasterPushConstant {
+		int32_t source_size[2];
+		int32_t dest_size[2];
+		float exposure_adjust;
+		float min_luminance;
+		float max_luminance;
+		float pad[1];
+	};
+
+	struct LuminanceReduceFragment {
+		LuminanceReduceRasterPushConstant push_constant;
+		LuminanceReduceRasterShaderRD shader;
+		RID shader_version;
+		PipelineCacheRD pipelines[LUMINANCE_REDUCE_FRAGMENT_MAX];
+	} luminance_reduce_raster;
 
 	struct CopyToDPPushConstant {
 		float z_far;
@@ -656,6 +738,8 @@ class EffectsRD {
 	RID _get_compute_uniform_set_from_texture_pair(RID p_texture, RID p_texture2, bool p_use_mipmaps = false);
 	RID _get_compute_uniform_set_from_image_pair(RID p_texture, RID p_texture2);
 
+	bool prefer_raster_effects;
+
 public:
 	void copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_alpha_to_zero = false, bool p_srgb = false, RID p_secondary = RID());
 	void copy_to_rect(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_all_source = false, bool p_8_bit_dst = false, bool p_alpha_to_one = false);
@@ -666,12 +750,16 @@ public:
 	void gaussian_blur(RID p_source_rd_texture, RID p_texture, RID p_back_texture, const Rect2i &p_region, bool p_8bit_dst = false);
 	void set_color(RID p_dest_texture, const Color &p_color, const Rect2i &p_region, bool p_8bit_dst = false);
 	void gaussian_glow(RID p_source_rd_texture, RID p_back_texture, const Size2i &p_size, float p_strength = 1.0, bool p_high_quality = false, bool p_first_pass = false, float p_luminance_cap = 16.0, float p_exposure = 1.0, float p_bloom = 0.0, float p_hdr_bleed_treshold = 1.0, float p_hdr_bleed_scale = 1.0, RID p_auto_exposure = RID(), float p_auto_exposure_grey = 1.0);
+	void gaussian_glow_raster(RID p_source_rd_texture, RID p_framebuffer_half, RID p_rd_texture_half, RID p_dest_framebuffer, const Vector2 &p_pixel_size, float p_strength = 1.0, bool p_high_quality = false, bool p_first_pass = false, float p_luminance_cap = 16.0, float p_exposure = 1.0, float p_bloom = 0.0, float p_hdr_bleed_treshold = 1.0, float p_hdr_bleed_scale = 1.0, RID p_auto_exposure = RID(), float p_auto_exposure_grey = 1.0);
 
 	void cubemap_roughness(RID p_source_rd_texture, RID p_dest_framebuffer, uint32_t p_face_id, uint32_t p_sample_count, float p_roughness, float p_size);
 	void make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const Size2i &p_size);
 	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dest_texture, const Rect2 &p_rect, float p_z_near, float p_z_far, bool p_dp_flip);
 	void luminance_reduction(RID p_source_texture, const Size2i p_source_size, const Vector<RID> p_reduce, RID p_prev_luminance, float p_min_luminance, float p_max_luminance, float p_adjust, bool p_set = false);
+	void luminance_reduction_raster(RID p_source_texture, const Size2i p_source_size, const Vector<RID> p_reduce, Vector<RID> p_fb, RID p_prev_luminance, float p_min_luminance, float p_max_luminance, float p_adjust, bool p_set = false);
+
 	void bokeh_dof(RID p_base_texture, RID p_depth_texture, const Size2i &p_base_texture_size, RID p_secondary_texture, RID p_bokeh_texture1, RID p_bokeh_texture2, bool p_dof_far, float p_dof_far_begin, float p_dof_far_size, bool p_dof_near, float p_dof_near_begin, float p_dof_near_size, float p_bokeh_size, RS::DOFBokehShape p_bokeh_shape, RS::DOFBlurQuality p_quality, bool p_use_jitter, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
+	void blur_dof_raster(RID p_base_texture, RID p_depth_texture, const Size2i &p_base_texture_size, RID p_base_fb, RID p_secondary_texture, RID p_secondary_fb, bool p_dof_far, float p_dof_far_begin, float p_dof_far_size, bool p_dof_near, float p_dof_near_begin, float p_dof_near_size, float p_dof_blur_amount, RS::DOFBlurQuality p_quality, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
 
 	struct TonemapSettings {
 		bool use_glow = false;
@@ -751,7 +839,7 @@ public:
 
 	void sort_buffer(RID p_uniform_set, int p_size);
 
-	EffectsRD();
+	EffectsRD(bool p_prefer_raster_effects);
 	~EffectsRD();
 };
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -96,10 +96,6 @@ void RenderForwardMobile::RenderBufferDataForwardMobile::configure(RID p_color_b
 	RD::DataFormat color_format = RenderForwardMobile::singleton->_render_buffers_get_color_format();
 
 	if (p_msaa == RS::VIEWPORT_MSAA_DISABLED) {
-		if (color_format == RD::DATA_FORMAT_A2B10G10R10_UNORM_PACK32) {
-			// @TODO add a second color buffer for alpha as this format is RGB only
-		}
-
 		Vector<RID> fb;
 		fb.push_back(p_color_buffer);
 		fb.push_back(depth);
@@ -165,15 +161,12 @@ bool RenderForwardMobile::free(RID p_rid) {
 
 RD::DataFormat RenderForwardMobile::_render_buffers_get_color_format() {
 	// Using 32bit buffers enables AFBC on mobile devices which should have a definate performance improvement (MALI G710 and newer support this on 64bit RTs)
-	// NO ALPHA and unsigned float.
-	// @TODO No alpha is an issue, recommendation here is to add a second RT for alpha
 	return RD::DATA_FORMAT_A2B10G10R10_UNORM_PACK32;
 }
 
 bool RenderForwardMobile::_render_buffers_can_be_storage() {
 	// Using 32bit buffers enables AFBC on mobile devices which should have a definate performance improvement (MALI G710 and newer support this on 64bit RTs)
-	// NO ALPHA and unsigned float.
-	// @TODO No alpha is an issue, recommendation here is to add a second RT for alpha
+	// Doesn't support storage
 	return false;
 }
 

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -280,6 +280,9 @@ RendererCompositorRD::RendererCompositorRD() {
 		// default to our high end renderer
 		scene = memnew(RendererSceneRenderImplementation::RenderForwardClustered(storage));
 	}
+
+	// now we're ready to create our effects,
+	storage->init_effects(!scene->_render_buffers_can_be_storage());
 }
 
 RendererCompositorRD::~RendererCompositorRD() {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -446,6 +446,7 @@ private:
 
 		RID texture; //main texture for rendering to, must be filled after done rendering
 		RID depth_texture; //main depth texture
+		RID texture_fb; // framebuffer for the main texture, ONLY USED FOR MOBILE RENDERER POST EFFECTS, DO NOT USE FOR RENDERING 3D!!!
 
 		RendererSceneGIRD::SDFGI *sdfgi = nullptr;
 		VolumetricFog *volumetric_fog = nullptr;
@@ -461,6 +462,11 @@ private:
 				RID texture;
 				int width;
 				int height;
+
+				// only used on mobile renderer
+				RID fb;
+				RID half_texture;
+				RID half_fb;
 			};
 
 			Vector<Mipmap> mipmaps;
@@ -471,6 +477,10 @@ private:
 		struct Luminance {
 			Vector<RID> reduce;
 			RID current;
+
+			// used only on mobile renderer
+			Vector<RID> fb;
+			RID current_fb;
 		} luminance;
 
 		struct SSAO {

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -1290,7 +1290,7 @@ private:
 	void _update_global_variables();
 	/* EFFECTS */
 
-	EffectsRD effects;
+	EffectsRD *effects = NULL;
 
 public:
 	virtual bool can_create_resources_async() const;
@@ -2374,6 +2374,7 @@ public:
 
 	static RendererStorageRD *base_singleton;
 
+	void init_effects(bool p_prefer_raster_effects);
 	EffectsRD *get_effects();
 
 	RendererStorageRD();

--- a/servers/rendering/renderer_rd/shaders/blur_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/blur_raster.glsl
@@ -1,0 +1,228 @@
+/* clang-format off */
+#[vertex]
+
+#version 450
+
+#VERSION_DEFINES
+
+#include "blur_raster_inc.glsl"
+
+layout(location = 0) out vec2 uv_interp;
+/* clang-format on */
+
+void main() {
+	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
+	uv_interp = base_arr[gl_VertexIndex];
+
+	gl_Position = vec4(uv_interp * 2.0 - 1.0, 0.0, 1.0);
+}
+
+/* clang-format off */
+#[fragment]
+
+#version 450
+
+#VERSION_DEFINES
+
+#include "blur_raster_inc.glsl"
+
+layout(location = 0) in vec2 uv_interp;
+/* clang-format on */
+
+layout(set = 0, binding = 0) uniform sampler2D source_color;
+
+#ifdef GLOW_USE_AUTO_EXPOSURE
+layout(set = 1, binding = 0) uniform sampler2D source_auto_exposure;
+#endif
+
+layout(location = 0) out vec4 frag_color;
+
+//DOF
+#ifdef MODE_DOF_BLUR
+
+layout(set = 1, binding = 0) uniform sampler2D dof_source_depth;
+
+#ifdef DOF_QUALITY_LOW
+const int dof_kernel_size = 5;
+const int dof_kernel_from = 2;
+const float dof_kernel[5] = float[](0.153388, 0.221461, 0.250301, 0.221461, 0.153388);
+#endif
+
+#ifdef DOF_QUALITY_MEDIUM
+const int dof_kernel_size = 11;
+const int dof_kernel_from = 5;
+const float dof_kernel[11] = float[](0.055037, 0.072806, 0.090506, 0.105726, 0.116061, 0.119726, 0.116061, 0.105726, 0.090506, 0.072806, 0.055037);
+
+#endif
+
+#ifdef DOF_QUALITY_HIGH
+const int dof_kernel_size = 21;
+const int dof_kernel_from = 10;
+const float dof_kernel[21] = float[](0.028174, 0.032676, 0.037311, 0.041944, 0.046421, 0.050582, 0.054261, 0.057307, 0.059587, 0.060998, 0.061476, 0.060998, 0.059587, 0.057307, 0.054261, 0.050582, 0.046421, 0.041944, 0.037311, 0.032676, 0.028174);
+#endif
+
+#endif
+
+void main() {
+#ifdef MODE_MIPMAP
+
+	vec2 pix_size = blur.pixel_size;
+	vec4 color = texture(source_color, uv_interp + vec2(-0.5, -0.5) * pix_size);
+	color += texture(source_color, uv_interp + vec2(0.5, -0.5) * pix_size);
+	color += texture(source_color, uv_interp + vec2(0.5, 0.5) * pix_size);
+	color += texture(source_color, uv_interp + vec2(-0.5, 0.5) * pix_size);
+	frag_color = color / 4.0;
+
+#endif
+
+#ifdef MODE_GAUSSIAN_BLUR
+
+	//Simpler blur uses SIGMA2 for the gaussian kernel for a stronger effect
+
+	if (bool(blur.flags & FLAG_HORIZONTAL)) {
+		vec2 pix_size = blur.pixel_size;
+		pix_size *= 0.5; //reading from larger buffer, so use more samples
+		vec4 color = texture(source_color, uv_interp + vec2(0.0, 0.0) * pix_size) * 0.214607;
+		color += texture(source_color, uv_interp + vec2(1.0, 0.0) * pix_size) * 0.189879;
+		color += texture(source_color, uv_interp + vec2(2.0, 0.0) * pix_size) * 0.131514;
+		color += texture(source_color, uv_interp + vec2(3.0, 0.0) * pix_size) * 0.071303;
+		color += texture(source_color, uv_interp + vec2(-1.0, 0.0) * pix_size) * 0.189879;
+		color += texture(source_color, uv_interp + vec2(-2.0, 0.0) * pix_size) * 0.131514;
+		color += texture(source_color, uv_interp + vec2(-3.0, 0.0) * pix_size) * 0.071303;
+		frag_color = color;
+	} else {
+		vec2 pix_size = blur.pixel_size;
+		vec4 color = texture(source_color, uv_interp + vec2(0.0, 0.0) * pix_size) * 0.38774;
+		color += texture(source_color, uv_interp + vec2(0.0, 1.0) * pix_size) * 0.24477;
+		color += texture(source_color, uv_interp + vec2(0.0, 2.0) * pix_size) * 0.06136;
+		color += texture(source_color, uv_interp + vec2(0.0, -1.0) * pix_size) * 0.24477;
+		color += texture(source_color, uv_interp + vec2(0.0, -2.0) * pix_size) * 0.06136;
+		frag_color = color;
+	}
+#endif
+
+#ifdef MODE_GAUSSIAN_GLOW
+
+	//Glow uses larger sigma 1 for a more rounded blur effect
+
+#define GLOW_ADD(m_ofs, m_mult)                                                  \
+	{                                                                            \
+		vec2 ofs = uv_interp + m_ofs * pix_size;                                 \
+		vec4 c = texture(source_color, ofs) * m_mult;                            \
+		if (any(lessThan(ofs, vec2(0.0))) || any(greaterThan(ofs, vec2(1.0)))) { \
+			c *= 0.0;                                                            \
+		}                                                                        \
+		color += c;                                                              \
+	}
+
+	if (bool(blur.flags & FLAG_HORIZONTAL)) {
+		vec2 pix_size = blur.pixel_size;
+		pix_size *= 0.5; //reading from larger buffer, so use more samples
+		vec4 color = texture(source_color, uv_interp + vec2(0.0, 0.0) * pix_size) * 0.174938;
+		GLOW_ADD(vec2(1.0, 0.0), 0.165569);
+		GLOW_ADD(vec2(2.0, 0.0), 0.140367);
+		GLOW_ADD(vec2(3.0, 0.0), 0.106595);
+		GLOW_ADD(vec2(-1.0, 0.0), 0.165569);
+		GLOW_ADD(vec2(-2.0, 0.0), 0.140367);
+		GLOW_ADD(vec2(-3.0, 0.0), 0.106595);
+		color *= blur.glow_strength;
+		frag_color = color;
+	} else {
+		vec2 pix_size = blur.pixel_size;
+		vec4 color = texture(source_color, uv_interp + vec2(0.0, 0.0) * pix_size) * 0.288713;
+		GLOW_ADD(vec2(0.0, 1.0), 0.233062);
+		GLOW_ADD(vec2(0.0, 2.0), 0.122581);
+		GLOW_ADD(vec2(0.0, -1.0), 0.233062);
+		GLOW_ADD(vec2(0.0, -2.0), 0.122581);
+		color *= blur.glow_strength;
+		frag_color = color;
+	}
+
+#undef GLOW_ADD
+
+	if (bool(blur.flags & FLAG_GLOW_FIRST_PASS)) {
+#ifdef GLOW_USE_AUTO_EXPOSURE
+
+		frag_color /= texelFetch(source_auto_exposure, ivec2(0, 0), 0).r / blur.glow_auto_exposure_grey;
+#endif
+		frag_color *= blur.glow_exposure;
+
+		float luminance = max(frag_color.r, max(frag_color.g, frag_color.b));
+		float feedback = max(smoothstep(blur.glow_hdr_threshold, blur.glow_hdr_threshold + blur.glow_hdr_scale, luminance), blur.glow_bloom);
+
+		frag_color = min(frag_color * feedback, vec4(blur.glow_luminance_cap));
+	}
+
+#endif
+
+#ifdef MODE_DOF_BLUR
+
+	vec4 color_accum = vec4(0.0);
+
+	float depth = texture(dof_source_depth, uv_interp, 0.0).r;
+	depth = depth * 2.0 - 1.0;
+
+	if (bool(blur.flags & FLAG_USE_ORTHOGONAL_PROJECTION)) {
+		depth = ((depth + (blur.camera_z_far + blur.camera_z_near) / (blur.camera_z_far - blur.camera_z_near)) * (blur.camera_z_far - blur.camera_z_near)) / 2.0;
+	} else {
+		depth = 2.0 * blur.camera_z_near * blur.camera_z_far / (blur.camera_z_far + blur.camera_z_near - depth * (blur.camera_z_far - blur.camera_z_near));
+	}
+
+	// mix near and far blur amount
+	float amount = 1.0;
+	if (bool(blur.flags & FLAG_DOF_FAR)) {
+		amount *= 1.0 - smoothstep(blur.dof_far_begin, blur.dof_far_end, depth);
+	}
+	if (bool(blur.flags & FLAG_DOF_NEAR)) {
+		amount *= smoothstep(blur.dof_near_end, blur.dof_near_begin, depth);
+	}
+	amount = 1.0 - amount;
+
+	if (amount > 0.0) {
+		float k_accum = 0.0;
+
+		for (int i = 0; i < dof_kernel_size; i++) {
+			int int_ofs = i - dof_kernel_from;
+			vec2 tap_uv = uv_interp + blur.dof_dir * float(int_ofs) * amount * blur.dof_radius;
+
+			float tap_k = dof_kernel[i];
+
+			float tap_depth = texture(dof_source_depth, tap_uv, 0.0).r;
+			tap_depth = tap_depth * 2.0 - 1.0;
+
+			if (bool(blur.flags & FLAG_USE_ORTHOGONAL_PROJECTION)) {
+				tap_depth = ((tap_depth + (blur.camera_z_far + blur.camera_z_near) / (blur.camera_z_far - blur.camera_z_near)) * (blur.camera_z_far - blur.camera_z_near)) / 2.0;
+			} else {
+				tap_depth = 2.0 * blur.camera_z_near * blur.camera_z_far / (blur.camera_z_far + blur.camera_z_near - tap_depth * (blur.camera_z_far - blur.camera_z_near));
+			}
+
+			// mix near and far blur amount
+			float tap_amount = 1.0;
+			if (bool(blur.flags & FLAG_DOF_FAR)) {
+				tap_amount *= mix(1.0 - smoothstep(blur.dof_far_begin, blur.dof_far_end, tap_depth), 0.0, int_ofs == 0);
+			}
+			if (bool(blur.flags & FLAG_DOF_NEAR)) {
+				tap_amount *= mix(smoothstep(blur.dof_near_end, blur.dof_near_begin, tap_depth), 0.0, int_ofs == 0);
+			}
+			tap_amount = 1.0 - tap_amount;
+
+			tap_amount *= tap_amount * tap_amount; //prevent undesired glow effect
+
+			vec4 tap_color = texture(source_color, tap_uv, 0.0) * tap_k;
+
+			k_accum += tap_k * tap_amount;
+			color_accum += tap_color * tap_amount;
+		}
+
+		if (k_accum > 0.0) {
+			color_accum /= k_accum;
+		}
+
+		frag_color = color_accum; ///k_accum;
+	} else {
+		// we are in focus, don't waste time
+		frag_color = texture(source_color, uv_interp, 0.0);
+	}
+
+#endif
+}

--- a/servers/rendering/renderer_rd/shaders/blur_raster_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/blur_raster_inc.glsl
@@ -1,0 +1,36 @@
+#define FLAG_HORIZONTAL (1 << 0)
+#define FLAG_USE_ORTHOGONAL_PROJECTION (1 << 1)
+#define FLAG_GLOW_FIRST_PASS (1 << 2)
+#define FLAG_DOF_FAR (1 << 3)
+#define FLAG_DOF_NEAR (1 << 4)
+
+layout(push_constant, binding = 1, std430) uniform Blur {
+	vec2 pixel_size;
+	uint flags;
+	uint pad;
+
+	// Glow.
+	float glow_strength;
+	float glow_bloom;
+	float glow_hdr_threshold;
+	float glow_hdr_scale;
+
+	float glow_exposure;
+	float glow_white;
+	float glow_luminance_cap;
+	float glow_auto_exposure_grey;
+
+	// DOF.
+	float dof_far_begin;
+	float dof_far_end;
+	float dof_near_begin;
+	float dof_near_end;
+
+	float dof_radius;
+	float dof_pad[3];
+
+	vec2 dof_dir;
+	float camera_z_far;
+	float camera_z_near;
+}
+blur;

--- a/servers/rendering/renderer_rd/shaders/luminance_reduce_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/luminance_reduce_raster.glsl
@@ -1,0 +1,74 @@
+/* clang-format off */
+#[vertex]
+
+#version 450
+
+#VERSION_DEFINES
+
+#include "luminance_reduce_raster_inc.glsl"
+
+layout(location = 0) out vec2 uv_interp;
+/* clang-format on */
+
+void main() {
+	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
+	uv_interp = base_arr[gl_VertexIndex];
+
+	gl_Position = vec4(uv_interp * 2.0 - 1.0, 0.0, 1.0);
+}
+
+/* clang-format off */
+#[fragment]
+
+#version 450
+
+#VERSION_DEFINES
+
+#include "luminance_reduce_raster_inc.glsl"
+
+layout(location = 0) in vec2 uv_interp;
+/* clang-format on */
+
+layout(set = 0, binding = 0) uniform sampler2D source_exposure;
+
+#ifdef FINAL_PASS
+layout(set = 1, binding = 0) uniform sampler2D prev_luminance;
+#endif
+
+layout(location = 0) out highp float luminance;
+
+void main() {
+	ivec2 dest_pos = ivec2(uv_interp * settings.dest_size);
+	ivec2 src_pos = ivec2(uv_interp * settings.source_size);
+
+	ivec2 next_pos = (dest_pos + ivec2(1)) * settings.source_size / settings.dest_size;
+	next_pos = max(next_pos, src_pos + ivec2(1)); //so it at least reads one pixel
+
+	highp vec3 source_color = vec3(0.0);
+	for (int i = src_pos.x; i < next_pos.x; i++) {
+		for (int j = src_pos.y; j < next_pos.y; j++) {
+			source_color += texelFetch(source_exposure, ivec2(i, j), 0).rgb;
+		}
+	}
+
+	source_color /= float((next_pos.x - src_pos.x) * (next_pos.y - src_pos.y));
+
+#ifdef FIRST_PASS
+	luminance = max(source_color.r, max(source_color.g, source_color.b));
+
+	// This formula should be more "accurate" but gave an overexposed result when testing.
+	// Leaving it here so we can revisit it if we want.
+	// luminance = source_color.r * 0.21 + source_color.g * 0.71 + source_color.b * 0.07;
+#else
+	luminance = source_color.r;
+#endif
+
+#ifdef FINAL_PASS
+	// Obtain our target luminance
+	luminance = clamp(luminance, settings.min_luminance, settings.max_luminance);
+
+	// Now smooth to our transition
+	highp float prev_lum = texelFetch(prev_luminance, ivec2(0, 0), 0).r; //1 pixel previous luminance
+	luminance = prev_lum + (luminance - prev_lum) * clamp(settings.exposure_adjust, 0.0, 1.0);
+#endif
+}

--- a/servers/rendering/renderer_rd/shaders/luminance_reduce_raster_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/luminance_reduce_raster_inc.glsl
@@ -1,0 +1,11 @@
+
+layout(push_constant, binding = 1, std430) uniform PushConstant {
+	ivec2 source_size;
+	ivec2 dest_size;
+
+	float exposure_adjust;
+	float min_luminance;
+	float max_luminance;
+	float pad;
+}
+settings;


### PR DESCRIPTION
On the mobile renderer it turns out that compute shaders are much more limited then on desktop. Some of the techniques we currently implemented as compute shaders therefor do not work.

This PR ensures that on the mobile renderer we're using fragment shaders to perform these effects while on the clustered renderer we are using compute.

The effects implemented in this PR are:
- DOF
- Auto exposure
- Glow