### PR TITLE
Fix Illegible text in audio bus editor 3.x

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -380,6 +380,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	const Color font_color = mono_color.linear_interpolate(base_color, 0.25);
 	const Color font_color_hl = mono_color.linear_interpolate(base_color, 0.15);
+	const Color font_color_hover = mono_color.linear_interpolate(base_color, 0.125);
 	const Color font_color_disabled = Color(mono_color.r, mono_color.g, mono_color.b, 0.3);
 	const Color font_color_selection = accent_color * Color(1, 1, 1, 0.4);
 	const Color color_disabled = mono_color.inverted().linear_interpolate(base_color, 0.7);
@@ -954,6 +955,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("focus", "LineEdit", style_widget_focus);
 	theme->set_stylebox("read_only", "LineEdit", style_widget_disabled);
 	theme->set_icon("clear", "LineEdit", theme->get_icon("GuiClose", "EditorIcons"));
+	theme->set_color("font_color_uneditable", "LineEdit", font_color_disabled);
 	theme->set_color("read_only", "LineEdit", font_color_disabled);
 	theme->set_color("font_color", "LineEdit", font_color);
 	theme->set_color("font_color_selected", "LineEdit", mono_color);
@@ -1095,11 +1097,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tooltip->set_default_margin(MARGIN_TOP, v);
 	style_tooltip->set_default_margin(MARGIN_RIGHT, v);
 	style_tooltip->set_default_margin(MARGIN_BOTTOM, v);
-	style_tooltip->set_bg_color(Color(mono_color.r, mono_color.g, mono_color.b, 0.9));
+	style_tooltip->set_bg_color(mono_color.inverted());
 	style_tooltip->set_border_width_all(border_width);
-	style_tooltip->set_border_color(mono_color);
-	theme->set_color("font_color", "TooltipLabel", font_color.inverted());
-	theme->set_color("font_color_shadow", "TooltipLabel", mono_color.inverted() * Color(1, 1, 1, 0.1));
+	style_tooltip->set_border_color(mono_color.inverted());
+	theme->set_color("font_color", "TooltipLabel", font_color_hover);
+	theme->set_color("font_color_shadow", "TooltipLabel", Color(0, 0, 0, 0));
 	theme->set_stylebox("panel", "TooltipPanel", style_tooltip);
 
 	// PopupPanel


### PR DESCRIPTION
This pull request fixes an issue where the text within the audio bus editor would be illegible. This version is tailored for 3.x.

These changes help significantly improve legibility.

See: #50593

Before, the tooltip text would become practically unreadable regardless of the theme being used when you started moving the scroll bar for the audio level of the buses. The label of the master audio bus would also be unreadable when using a light theme.

https://user-images.githubusercontent.com/62965063/126401017-4bc11dbf-0904-415e-b57e-ac886ec9f9a4.mp4

With the changes I've made it becomes significantly easier to parse and read what's on-screen when using any theme:

https://user-images.githubusercontent.com/62965063/126401028-42e8cb61-f574-4953-a131-f00c22df6644.mp4
