### PR TITLE
 Remove leftover prints when using shader global variables

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2367,7 +2367,6 @@ void EditorInspector::_property_keyed(const String &p_path, bool p_advance) {
 }
 
 void EditorInspector::_property_deleted(const String &p_path) {
-	print_line("deleted pressed?");
 	if (!object) {
 		return;
 	}

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -110,7 +110,6 @@ protected:
 		undo_redo->commit_action();
 		block_update = false;
 
-		print_line("all good?");
 		return true;
 	}
 
@@ -410,7 +409,6 @@ void ShaderGlobalsEditor::_variable_added() {
 }
 
 void ShaderGlobalsEditor::_variable_deleted(const String &p_variable) {
-	print_line("deleted " + p_variable);
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	undo_redo->create_action("Add Shader Global Variable");
@@ -439,7 +437,6 @@ void ShaderGlobalsEditor::_bind_methods() {
 void ShaderGlobalsEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 		if (is_visible_in_tree()) {
-			print_line("OK load settings in globalseditor");
 			inspector->edit(interface);
 		}
 	}


### PR DESCRIPTION
When using shader global variables, these prints pop up in the output that are worth removing.

![godot windows tools 64_2021-07-19_15-22-33](https://user-images.githubusercontent.com/12120644/126345250-eb83e84a-b3b5-4d84-8286-b9d8e09467a5.png)

