### PR TITLE
Fix Change Node Type after Add Node Here

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -544,6 +544,11 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
+			if (reset_create_dialog) {
+				create_dialog->set_base_type("Node");
+				reset_create_dialog = false;
+			}
+
 			Node *selected = scene_tree->get_selected();
 			if (!selected && !editor_selection->get_selected_node_list().is_empty()) {
 				selected = editor_selection->get_selected_node_list().front()->get();


### PR DESCRIPTION
Just spotted another bug with Add Node Here.
When you use it, the Change Node Type option will only display CanvasItems.