### PR TITLE
[3.x] Fix array reorder methods not being bound

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -573,6 +573,9 @@ void EditorPropertyArray::_bind_methods() {
 	ClassDB::bind_method("_change_type_menu", &EditorPropertyArray::_change_type_menu);
 	ClassDB::bind_method("_object_id_selected", &EditorPropertyArray::_object_id_selected);
 	ClassDB::bind_method("_remove_pressed", &EditorPropertyArray::_remove_pressed);
+	ClassDB::bind_method("_reorder_button_gui_input", &EditorPropertyArray::_reorder_button_gui_input);
+	ClassDB::bind_method("_reorder_button_down", &EditorPropertyArray::_reorder_button_down);
+	ClassDB::bind_method("_reorder_button_up", &EditorPropertyArray::_reorder_button_up);
 }
 
 EditorPropertyArray::EditorPropertyArray() {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixup to https://github.com/godotengine/godot/pull/50651
Should've probably marked https://github.com/godotengine/godot/pull/50651 as a draft before I got around to testing it, found out it didn't work because I forgot to bind some methods.