### PR TITLE
Add get_buffered_amount() to WebRTCDataChannel

### DIFF
--- a/modules/gdnative/include/net/godot_webrtc.h
+++ b/modules/gdnative/include/net/godot_webrtc.h
@@ -101,6 +101,7 @@ typedef struct {
 	int (*get_max_retransmits)(const void *);
 	const char *(*get_protocol)(const void *);
 	bool (*is_negotiated)(const void *);
+	int (*get_buffered_amount)(const void *);
 
 	godot_error (*poll)(void *);
 	void (*close)(void *);

--- a/modules/webrtc/doc_classes/WebRTCDataChannel.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannel.xml
@@ -14,6 +14,13 @@
 				Closes this data channel, notifying the other peer.
 			</description>
 		</method>
+		<method name="get_buffered_amount" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the number of bytes currently queued to be sent over this channel.
+			</description>
+		</method>
 		<method name="get_id" qualifiers="const">
 			<return type="int">
 			</return>

--- a/modules/webrtc/library_godot_webrtc.js
+++ b/modules/webrtc/library_godot_webrtc.js
@@ -166,6 +166,11 @@ const GodotRTCDataChannel = {
 		return GodotRTCDataChannel.get_prop(p_id, 'negotiated', 65535);
 	},
 
+	godot_js_rtc_datachannel_get_buffered_amount__sig: 'ii',
+	godot_js_rtc_datachannel_get_buffered_amount: function (p_id) {
+		return GodotRTCDataChannel.get_prop(p_id, 'bufferedAmount', 0);
+	},
+
 	godot_js_rtc_datachannel_label_get__sig: 'ii',
 	godot_js_rtc_datachannel_label_get: function (p_id) {
 		const ref = IDHandler.get(p_id);

--- a/modules/webrtc/webrtc_data_channel.cpp
+++ b/modules/webrtc/webrtc_data_channel.cpp
@@ -46,6 +46,7 @@ void WebRTCDataChannel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_max_retransmits"), &WebRTCDataChannel::get_max_retransmits);
 	ClassDB::bind_method(D_METHOD("get_protocol"), &WebRTCDataChannel::get_protocol);
 	ClassDB::bind_method(D_METHOD("is_negotiated"), &WebRTCDataChannel::is_negotiated);
+	ClassDB::bind_method(D_METHOD("get_buffered_amount"), &WebRTCDataChannel::get_buffered_amount);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "write_mode", PROPERTY_HINT_ENUM), "set_write_mode", "get_write_mode");
 

--- a/modules/webrtc/webrtc_data_channel.h
+++ b/modules/webrtc/webrtc_data_channel.h
@@ -70,6 +70,8 @@ public:
 	virtual String get_protocol() const = 0;
 	virtual bool is_negotiated() const = 0;
 
+	virtual int get_buffered_amount() const = 0;
+
 	virtual Error poll() = 0;
 	virtual void close() = 0;
 

--- a/modules/webrtc/webrtc_data_channel_gdnative.cpp
+++ b/modules/webrtc/webrtc_data_channel_gdnative.cpp
@@ -111,6 +111,11 @@ bool WebRTCDataChannelGDNative::is_negotiated() const {
 	return interface->is_negotiated(interface->data);
 }
 
+int WebRTCDataChannelGDNative::get_buffered_amount() const {
+	ERR_FAIL_COND_V(interface == NULL, 0);
+	return interface->get_buffered_amount(interface->data);
+}
+
 Error WebRTCDataChannelGDNative::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 	ERR_FAIL_COND_V(interface == nullptr, ERR_UNCONFIGURED);
 	return (Error)interface->get_packet(interface->data, r_buffer, &r_buffer_size);

--- a/modules/webrtc/webrtc_data_channel_gdnative.h
+++ b/modules/webrtc/webrtc_data_channel_gdnative.h
@@ -60,6 +60,7 @@ public:
 	virtual int get_max_retransmits() const override;
 	virtual String get_protocol() const override;
 	virtual bool is_negotiated() const override;
+	virtual int get_buffered_amount() const override;
 
 	virtual Error poll() override;
 	virtual void close() override;

--- a/modules/webrtc/webrtc_data_channel_js.cpp
+++ b/modules/webrtc/webrtc_data_channel_js.cpp
@@ -46,6 +46,7 @@ extern int godot_js_rtc_datachannel_id_get(int p_id);
 extern int godot_js_rtc_datachannel_max_packet_lifetime_get(int p_id);
 extern int godot_js_rtc_datachannel_max_retransmits_get(int p_id);
 extern int godot_js_rtc_datachannel_is_negotiated(int p_id);
+extern int godot_js_rtc_datachannel_get_buffered_amount(int p_id);
 extern char *godot_js_rtc_datachannel_label_get(int p_id); // Must free the returned string.
 extern char *godot_js_rtc_datachannel_protocol_get(int p_id); // Must free the returned string.
 extern void godot_js_rtc_datachannel_destroy(int p_id);
@@ -179,6 +180,10 @@ String WebRTCDataChannelJS::get_protocol() const {
 
 bool WebRTCDataChannelJS::is_negotiated() const {
 	return godot_js_rtc_datachannel_is_negotiated(_js_id);
+}
+
+int WebRTCDataChannelJS::get_buffered_amount() const {
+	return godot_js_rtc_datachannel_get_buffered_amount(_js_id);
 }
 
 WebRTCDataChannelJS::WebRTCDataChannelJS() {

--- a/modules/webrtc/webrtc_data_channel_js.h
+++ b/modules/webrtc/webrtc_data_channel_js.h
@@ -72,6 +72,7 @@ public:
 	virtual int get_max_retransmits() const override;
 	virtual String get_protocol() const override;
 	virtual bool is_negotiated() const override;
+	virtual int get_buffered_amount() const override;
 
 	virtual Error poll() override;
 	virtual void close() override;


### PR DESCRIPTION
This methods gives access to `RTCDataChannel.bufferedAmount` - see:

https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/bufferedAmount

This can be useful for checking if SCTP is buffering data (possibly due to its flow control kicking in) and then waiting to send more data until the buffer clears.

This comment on `DataChannelInterface::Send()` is a really good explanation of the motivation for this:

```
  // Sends |data| to the remote peer. If the data can't be sent at the SCTP
  // level (due to congestion control), it's buffered at the data channel level,
  // up to a maximum of 16MB. If Send is called while this buffer is full, the
  // data channel will be closed abruptly.
  //
  // So, it's important to use buffered_amount() and OnBufferedAmountChange to
  // ensure the data channel is used efficiently but without filling this
  // buffer.
  virtual bool Send(const DataBuffer& buffer) = 0;
```

https://github.com/maitrungduc1410/webrtc/blob/master/api/data_channel_interface.h#L191

This won't cleanly cherry-pick to 3.x and requires some minor changes, so I'll make a separate PR.

I'll also make a PR to the GDNative plugin, but I'm not sure how the GDNative part will work with backward compatibility? This changes the `godot_net_webrtc_data_channel` struct which will cause old version of the GDNative plugin to not work until updated, and also updated versions of the GDNative plugin won't work with older versions of Godot.