### PR TITLE
Adds ability to debug stringnames

### DIFF
--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -52,10 +52,11 @@ class StringName {
 	struct _Data {
 		SafeRefCount refcount;
 		SafeNumeric<uint32_t> static_count;
-		SafeRefCount static_refcount;
 		const char *cname = nullptr;
 		String name;
-
+#ifdef DEBUG_ENABLED
+		uint32_t debug_references = 0;
+#endif
 		String get_name() const { return cname ? String(cname) : name; }
 		int idx = 0;
 		uint32_t hash = 0;
@@ -81,6 +82,15 @@ class StringName {
 	static void setup();
 	static void cleanup();
 	static bool configured;
+#ifdef DEBUG_ENABLED
+	struct DebugSortReferences {
+		bool operator()(const _Data *p_left, const _Data *p_right) const {
+			return p_left->debug_references > p_right->debug_references;
+		}
+	};
+
+	static bool debug_stringname;
+#endif
 
 	StringName(_Data *p_data) { _data = p_data; }
 
@@ -158,6 +168,10 @@ public:
 			unref();
 		}
 	}
+
+#ifdef DEBUG_ENABLED
+	static void set_debug_stringnames(bool p_enable) { debug_stringname = p_enable; }
+#endif
 };
 
 bool operator==(const String &p_name, const StringName &p_string_name);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -986,11 +986,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "-d" || I->get() == "--debug") {
 			debug_uri = "local://";
 			OS::get_singleton()->_debug_stdout = true;
-#if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
+#if defined(DEBUG_ENABLED)
 		} else if (I->get() == "--debug-collisions") {
 			debug_collisions = true;
 		} else if (I->get() == "--debug-navigation") {
 			debug_navigation = true;
+		} else if (I->get() == "--debug-stringnames") {
+			StringName::set_debug_stringnames(true);
 #endif
 		} else if (I->get() == "--remote-debug") {
 			if (I->next()) {


### PR DESCRIPTION
* References (which include hash tables) can be profiled with `--debug-stringnames`