### PR TITLE
Disable resource optimizations for release builds

### DIFF
--- a/platform/android/java/app/gradle.properties
+++ b/platform/android/java/app/gradle.properties
@@ -1,10 +1,7 @@
-# Project-wide Gradle settings.
-# NOTE: This should be kept in sync with 'godot/platform/android/java/app/gradle.properties' except
+# Godot custom build Gradle settings.
+# These properties apply when running custom build from the Godot editor.
+# NOTE: This should be kept in sync with 'godot/platform/android/java/gradle.properties' except
 # where otherwise specified.
-
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
 
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
@@ -23,6 +20,6 @@ org.gradle.jvmargs=-Xmx4536m
 
 org.gradle.warning.mode=all
 
-# Disable resource optimizations for template release build.
-# NOTE: This is turned on for custom build in order to improve the release build.
-android.enableResourceOptimizations=false
+# Enable resource optimizations for release build.
+# NOTE: This is turned off for template release build in order to support the build legacy process.
+android.enableResourceOptimizations=true

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -115,7 +115,7 @@ task zipCustomBuild(type: Zip) {
     doFirst {
         logger.lifecycle("Generating Godot custom build template")
     }
-    from(fileTree(dir: 'app', excludes: ['**/build/**', '**/.gradle/**', '**/*.iml']), fileTree(dir: '.', includes: ['gradle.properties', 'gradlew', 'gradlew.bat', 'gradle/**']))
+    from(fileTree(dir: 'app', excludes: ['**/build/**', '**/.gradle/**', '**/*.iml']), fileTree(dir: '.', includes: ['gradlew', 'gradlew.bat', 'gradle/**']))
     include '**/*'
     archiveFileName = 'android_source.zip'
     destinationDirectory = file(binDir)


### PR DESCRIPTION
The behavior was enabled by default with AGP 4.2 but it breaks the legacy build system.

Fix #50623 