### PR TITLE
[3.x] Add "far distance" to SpatialMaterial proximity fade

### DIFF
--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -299,10 +299,13 @@
 			The number of vertical frames in the particle sprite sheet. Only enabled when using [constant BILLBOARD_PARTICLES]. See [member params_billboard_mode].
 		</member>
 		<member name="proximity_fade_distance" type="float" setter="set_proximity_fade_distance" getter="get_proximity_fade_distance">
-			Distance over which the fade effect takes place. The larger the distance the longer it takes for an object to fade.
+			The distance over which the fade effect takes place. The larger the distance, the longer it takes for an object to fade. See also [member proximity_fade_far_distance].
 		</member>
 		<member name="proximity_fade_enable" type="bool" setter="set_proximity_fade" getter="is_proximity_fade_enabled" default="false">
 			If [code]true[/code], the proximity fade effect is enabled. The proximity fade effect fades out each pixel based on its distance to another object.
+		</member>
+		<member name="proximity_fade_far_distance" type="float" setter="set_proximity_fade_far_distance" getter="get_proximity_fade_far_distance">
+			If set to a value greater than [code]0.0[/code], this will fade the material as it gets further away from other solid materials. This can be used for things such as decals, "cutting torch" effects and shockwave/explosion effects. The larger the distance, the longer it takes for an object to fade. See also [member proximity_fade_distance].
 		</member>
 		<member name="refraction_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
 			If [code]true[/code], the refraction effect is enabled. Distorts transparency based on light from behind the object.

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -340,6 +340,7 @@ private:
 		StringName uv2_blend_sharpness;
 		StringName grow;
 		StringName proximity_fade_distance;
+		StringName proximity_fade_far_distance;
 		StringName distance_fade_min;
 		StringName distance_fade_max;
 		StringName ao_light_affect;
@@ -410,6 +411,7 @@ private:
 
 	bool proximity_fade_enabled;
 	float proximity_fade_distance;
+	float proximity_fade_far_distance;
 
 	DistanceFadeMode distance_fade;
 	float distance_fade_max_distance;
@@ -599,6 +601,9 @@ public:
 
 	void set_proximity_fade_distance(float p_distance);
 	float get_proximity_fade_distance() const;
+
+	void set_proximity_fade_far_distance(float p_far_distance);
+	float get_proximity_fade_far_distance() const;
 
 	void set_distance_fade(DistanceFadeMode p_mode);
 	DistanceFadeMode get_distance_fade() const;


### PR DESCRIPTION
**Note:** Opened against `3.x` first due to [the feature not being testable in `master`](https://github.com/godotengine/godot/issues/35646).

This is the opposite of standard proximity fade. When set to a value greater than 0, it will fade the material's alpha as it gets further away from a solid material.

This can be used for:

- Fading quads used as decals if there is no surface close to them (useful to prevent "flying" blob shadows).
- Welding/cutting torch effects (https://simonschreibt.de/gat/alien-vs-wolfenstein-cutting-torch/).
- Area-of-effect and explosion VFX.

This closes https://github.com/godotengine/godot-proposals/issues/3021.

## Preview

![image](https://user-images.githubusercontent.com/180032/126403149-0b0060fe-49d7-424c-a846-12abd912d03f.png)
