### PR TITLE
Reorganize buttons in the project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1977,10 +1977,10 @@ void ProjectManager::_notification(int p_what) {
 				real_t size = get_size().x / EDSCALE;
 				// Adjust names of tabs to fit the new size.
 				if (size < 650) {
-					local_projects_hb->set_name(TTR("Local"));
+					local_projects_vb->set_name(TTR("Local"));
 					asset_library->set_name(TTR("Asset Library"));
 				} else {
-					local_projects_hb->set_name(TTR("Local Projects"));
+					local_projects_vb->set_name(TTR("Local Projects"));
 					asset_library->set_name(TTR("Asset Library Projects"));
 				}
 			}
@@ -2845,19 +2845,39 @@ ProjectManager::ProjectManager() {
 	tabs->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	tabs->connect("tab_changed", callable_mp(this, &ProjectManager::_on_tab_changed));
 
-	local_projects_hb = memnew(HBoxContainer);
-	local_projects_hb->set_name(TTR("Local Projects"));
-	tabs->add_child(local_projects_hb);
+	local_projects_vb = memnew(VBoxContainer);
+	local_projects_vb->set_name(TTR("Local Projects"));
+	tabs->add_child(local_projects_vb);
 
 	{
-		// Projects + search bar
-		VBoxContainer *search_tree_vb = memnew(VBoxContainer);
-		local_projects_hb->add_child(search_tree_vb);
-		search_tree_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-
+		// A bar at top with buttons and options.
 		HBoxContainer *hb = memnew(HBoxContainer);
 		hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		search_tree_vb->add_child(hb);
+		local_projects_vb->add_child(hb);
+
+		create_btn = memnew(Button);
+		create_btn->set_text(TTR("New"));
+		create_btn->set_shortcut(ED_SHORTCUT("project_manager/new_project", TTR("New Project"), KeyModifierMask::CMD_OR_CTRL | Key::N));
+		create_btn->connect("pressed", callable_mp(this, &ProjectManager::_new_project));
+		hb->add_child(create_btn);
+
+		import_btn = memnew(Button);
+		import_btn->set_text(TTR("Import"));
+		import_btn->set_shortcut(ED_SHORTCUT("project_manager/import_project", TTR("Import Project"), KeyModifierMask::CMD_OR_CTRL | Key::I));
+		import_btn->connect("pressed", callable_mp(this, &ProjectManager::_import_project));
+		hb->add_child(import_btn);
+
+		scan_btn = memnew(Button);
+		scan_btn->set_text(TTR("Scan"));
+		scan_btn->set_shortcut(ED_SHORTCUT("project_manager/scan_projects", TTR("Scan Projects"), KeyModifierMask::CMD_OR_CTRL | Key::S));
+		scan_btn->connect("pressed", callable_mp(this, &ProjectManager::_scan_projects));
+		hb->add_child(scan_btn);
+
+		loading_label = memnew(Label(TTR("Loading, please wait...")));
+		loading_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		hb->add_child(loading_label);
+		// The loading label is shown later.
+		loading_label->hide();
 
 		search_box = memnew(LineEdit);
 		search_box->set_placeholder(TTR("Filter Projects"));
@@ -2867,12 +2887,6 @@ ProjectManager::ProjectManager() {
 		search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		hb->add_child(search_box);
 
-		loading_label = memnew(Label(TTR("Loading, please wait...")));
-		loading_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		hb->add_child(loading_label);
-		// The loading label is shown later.
-		loading_label->hide();
-
 		Label *sort_label = memnew(Label);
 		sort_label->set_text(TTR("Sort:"));
 		hb->add_child(sort_label);
@@ -2880,6 +2894,7 @@ ProjectManager::ProjectManager() {
 		filter_option = memnew(OptionButton);
 		filter_option->set_clip_text(true);
 		filter_option->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		filter_option->set_stretch_ratio(0.3);
 		filter_option->connect("item_selected", callable_mp(this, &ProjectManager::_on_order_option_changed));
 		hb->add_child(filter_option);
 
@@ -2892,41 +2907,28 @@ ProjectManager::ProjectManager() {
 		for (int i = 0; i < sort_filter_titles.size(); i++) {
 			filter_option->add_item(sort_filter_titles[i]);
 		}
+	}
+
+	{
+		// A container for the project list and for the side bar with buttons.
+		HBoxContainer *search_tree_hb = memnew(HBoxContainer);
+		local_projects_vb->add_child(search_tree_hb);
+		search_tree_hb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 		search_panel = memnew(PanelContainer);
-		search_panel->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		search_tree_vb->add_child(search_panel);
+		search_panel->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		search_tree_hb->add_child(search_panel);
 
 		_project_list = memnew(ProjectList);
 		_project_list->connect(ProjectList::SIGNAL_SELECTION_CHANGED, callable_mp(this, &ProjectManager::_update_project_buttons));
 		_project_list->connect(ProjectList::SIGNAL_PROJECT_ASK_OPEN, callable_mp(this, &ProjectManager::_open_selected_projects_ask));
 		_project_list->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 		search_panel->add_child(_project_list);
-	}
 
-	{
-		// Project tab side bar
+		// The side bar with the edit, run, rename, etc. buttons.
 		VBoxContainer *tree_vb = memnew(VBoxContainer);
 		tree_vb->set_custom_minimum_size(Size2(120, 120));
-		local_projects_hb->add_child(tree_vb);
-
-		create_btn = memnew(Button);
-		create_btn->set_text(TTR("New Project"));
-		create_btn->set_shortcut(ED_SHORTCUT("project_manager/new_project", TTR("New Project"), KeyModifierMask::CMD_OR_CTRL | Key::N));
-		create_btn->connect("pressed", callable_mp(this, &ProjectManager::_new_project));
-		tree_vb->add_child(create_btn);
-
-		import_btn = memnew(Button);
-		import_btn->set_text(TTR("Import"));
-		import_btn->set_shortcut(ED_SHORTCUT("project_manager/import_project", TTR("Import Project"), KeyModifierMask::CMD_OR_CTRL | Key::I));
-		import_btn->connect("pressed", callable_mp(this, &ProjectManager::_import_project));
-		tree_vb->add_child(import_btn);
-
-		scan_btn = memnew(Button);
-		scan_btn->set_text(TTR("Scan"));
-		scan_btn->set_shortcut(ED_SHORTCUT("project_manager/scan_projects", TTR("Scan Projects"), KeyModifierMask::CMD_OR_CTRL | Key::S));
-		scan_btn->connect("pressed", callable_mp(this, &ProjectManager::_scan_projects));
-		tree_vb->add_child(scan_btn);
+		search_tree_hb->add_child(tree_vb);
 
 		tree_vb->add_child(memnew(HSeparator));
 

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -349,7 +349,7 @@ class ProjectManager : public Control {
 	Button *erase_missing_btn = nullptr;
 	Button *about_btn = nullptr;
 
-	HBoxContainer *local_projects_hb = nullptr;
+	VBoxContainer *local_projects_vb = nullptr;
 	EditorAssetLibrary *asset_library = nullptr;
 
 	Ref<StyleBox> tag_stylebox;


### PR DESCRIPTION
So each time I recommend Godot to someone, I'm ashamed of the Project Manager (the welcome screen, not the person).

This PR addresses the main problem with it - mixing buttons which affect the project list with buttons which affect the project selected. All other "overhaul" ideas are not going to be included in this PR.

[More detailed explanation why this change is suggested at all](https://github.com/godotengine/godot/pull/50674#issuecomment-1650194666)

Notes:
1) The loading_label ("Loading, please wait...") is overlapped by Filter projects when invisible, and I don't know how to make Filter projects fixed size regardless of loading_label visibility... Ideally, I wanted this space between Scan and Filter projects given by loading_label, even when invisible.
2) Technically "Remove Missing" also belongs in the top panel (and "About" does as well), but they don't feel as out of place as the other 3, so not sure

Before:
![before](https://github.com/godotengine/godot/assets/11571820/77c3b775-ab8e-497b-b1e7-60ce2391cf5e)

After:
![after](https://github.com/godotengine/godot/assets/11571820/2e3537bc-1654-4c2f-ab84-5aa6ce2d1800)

Implements https://github.com/godotengine/godot/issues/25305
This is a first step towards something like https://github.com/godotengine/godot/issues/31342