### PR TITLE
Document `Image.save_exr()` only being available in editor builds

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -465,6 +465,7 @@
 			</argument>
 			<description>
 				Saves the image as an EXR file to [code]path[/code]. If [code]grayscale[/code] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
+				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return [constant ERR_UNAVAILABLE] when it is called from an exported project.
 			</description>
 		</method>
 		<method name="save_png" qualifiers="const">


### PR DESCRIPTION
See https://godotforums.org/discussion/comment/51257/#Comment_51257.