### PR TITLE
Enable single-window mode by default in projects

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2105,7 +2105,7 @@ bool Main::start() {
 		}
 #endif
 
-		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", false);
+		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", true);
 
 		if (single_window || (!project_manager && !editor && embed_subwindows)) {
 			sml->get_root()->set_embed_subwindows_hint(true);


### PR DESCRIPTION
There are many issues with using multiple windows by default:

- Taking screenshots of a specific window will not capture subwindows. This also applies when recording a video using tools such as OBS.
- Subwindows may not behave correctly when fullscreen mode is enabled, especially if exclusive fullscreen is implemented in the future to decrease input lag on Windows.
- Subwindows do not inherit scaling applied by the `2d` and `viewport` stretch modes. This is problematic for dropdown menus, as they will be tiny if using the `2d` or `viewport` stretch mode and playing at a higher resolution than the project's base resolution.

"Subwindows" is quite general here, and also refers to dropdown menus (e.g. those spawned by OptionButton) and Control tooltips.

Therefore, it's safer to embed subwindows by default in projects. This will also avoid various surprises when upgrading projects from `3.x` to 4.0.

Multi-window mode remains the default in the editor.

See [discussion on the Godot Contributors Chat](https://chat.godotengine.org/channel/devel?msg=HwdRmMnFBaczx7EYZ) for more information.

**There remains an open question:** should we do this for [custom Viewports](https://github.com/godotengine/godot/blob/e248d2629ab9cb1dcfa91af5202af4f17754e44f/scene/main/viewport.h#L383) by default?