### PR TITLE
Set the surface name when GLTF file is imported.

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2796,7 +2796,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> state) {
 				mat = mat3d;
 			}
 
-			import_mesh->add_surface(primitive, array, morphs, Dictionary(), mat);
+			import_mesh->add_surface(primitive, array, morphs, Dictionary(), mat, mat->get_name());
 		}
 
 		Vector<float> blend_weights;


### PR DESCRIPTION
When the models are imported using GLTF the surface name wasn't set, so was impossible to differentiate one surface from the other.

The `add_surface` API is correctly used in all the other parts of the GLTF importer (and FBX too).