### PR TITLE
Make Sky initialize shaders only once

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1085,6 +1085,10 @@ void unregister_scene_types() {
 	BaseMaterial3D::finish_shaders();
 #endif // _3D_DISABLED
 
+	PhysicalSkyMaterial::cleanup_shader();
+	PanoramaSkyMaterial::cleanup_shader();
+	ProceduralSkyMaterial::cleanup_shader();
+
 	ParticlesMaterial::finish_shaders();
 	CanvasItemMaterial::finish_shaders();
 	ColorPicker::finish_shaders();

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -51,7 +51,10 @@ private:
 	float sun_angle_max;
 	float sun_curve;
 
-	RID shader;
+	static Mutex shader_mutex;
+	static RID shader;
+	static void _update_shader();
+	mutable bool shader_set = false;
 
 protected:
 	static void _bind_methods();
@@ -90,6 +93,9 @@ public:
 
 	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;
+	virtual RID get_rid() const override;
+
+	static void cleanup_shader();
 
 	ProceduralSkyMaterial();
 	~ProceduralSkyMaterial();
@@ -103,7 +109,11 @@ class PanoramaSkyMaterial : public Material {
 
 private:
 	Ref<Texture2D> panorama;
-	RID shader;
+
+	static Mutex shader_mutex;
+	static RID shader;
+	static void _update_shader();
+	mutable bool shader_set = false;
 
 protected:
 	static void _bind_methods();
@@ -115,6 +125,9 @@ public:
 
 	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;
+	virtual RID get_rid() const override;
+
+	static void cleanup_shader();
 
 	PanoramaSkyMaterial();
 	~PanoramaSkyMaterial();
@@ -127,7 +140,8 @@ class PhysicalSkyMaterial : public Material {
 	GDCLASS(PhysicalSkyMaterial, Material);
 
 private:
-	RID shader;
+	static Mutex shader_mutex;
+	static RID shader;
 
 	float rayleigh;
 	Color rayleigh_color;
@@ -140,6 +154,8 @@ private:
 	float exposure;
 	float dither_strength;
 	Ref<Texture2D> night_sky;
+	static void _update_shader();
+	mutable bool shader_set = false;
 
 protected:
 	static void _bind_methods();
@@ -181,6 +197,9 @@ public:
 
 	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;
+
+	static void cleanup_shader();
+	virtual RID get_rid() const override;
 
 	PhysicalSkyMaterial();
 	~PhysicalSkyMaterial();


### PR DESCRIPTION
* Create the shader on demand.
* Makes sure compilation happens only once, then shader is cached.
* Speeds up scene loading times.
* Speeds up editor initialization.