### PR TITLE
[3.x] Allow dropping custom node scripts in VisualScript editor

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2180,6 +2180,11 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	}
 
 	if (String(d["type"]) == "files") {
+#ifdef OSX_ENABLED
+		bool use_preload = Input::get_singleton()->is_key_pressed(KEY_META);
+#else
+		bool use_preload = Input::get_singleton()->is_key_pressed(KEY_CONTROL);
+#endif
 		Vector2 pos = _get_pos_in_graph(p_point);
 
 		Array files = d["files"];
@@ -2195,13 +2200,22 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				if (!res.is_valid()) {
 					continue;
 				}
+				Ref<Script> drop_script = ResourceLoader::load(files[i]);
+				if (drop_script.is_valid() && drop_script->is_tool() && drop_script->get_instance_base_type() == "VisualScriptCustomNode" && !use_preload) {
+					Ref<VisualScriptCustomNode> vscn;
+					vscn.instance();
+					vscn->set_script(drop_script.get_ref_ptr());
 
-				Ref<VisualScriptPreload> prnode;
-				prnode.instance();
-				prnode->set_preload(res);
+					undo_redo->add_do_method(script.ptr(), "add_node", default_func, new_id, vscn, pos);
+					undo_redo->add_undo_method(script.ptr(), "remove_node", default_func, new_id);
+				} else {
+					Ref<VisualScriptPreload> prnode;
+					prnode.instance();
+					prnode->set_preload(res);
 
-				undo_redo->add_do_method(script.ptr(), "add_node", default_func, new_id, prnode, pos);
-				undo_redo->add_undo_method(script.ptr(), "remove_node", default_func, new_id);
+					undo_redo->add_do_method(script.ptr(), "add_node", default_func, new_id, prnode, pos);
+					undo_redo->add_undo_method(script.ptr(), "remove_node", default_func, new_id);
+				}
 				new_ids.push_back(new_id);
 				new_id++;
 				pos += Vector2(20, 20);


### PR DESCRIPTION
3.x Version of #50581

Only UX change.
I see no backport issues.

> Allows to drop custom node scripts directly in VisualScript.
> 
> Current 
> 
> order of operations
> * RMB
> * search and select custom_node
> * select that new custom_node
> * drag and drop custom script in custom_node/script
> 
> new order of operations
> * drag and drop custom script to location
> 
> ![drop_CustomNodes](https://user-images.githubusercontent.com/20573784/126067796-c53184c6-0a15-4d64-93f9-72c260879f61.gif)
> 
> Its a quality of life improvement simple to backported to 3.x