### PR TITLE
Improve relevancy of Quick Open Scene results

### DIFF
--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -118,6 +118,11 @@ void EditorQuickOpen::_update_search() {
 float EditorQuickOpen::_score_path(const String &p_search, const String &p_path) {
 	float score = 0.9f + .1f * (p_search.length() / (float)p_path.length());
 
+	// Exact match.
+	if (p_search == p_path) {
+		return 1.2f;
+	}
+
 	// Positive bias for matches close to the beginning of the file name.
 	String file = p_path.get_file();
 	int pos = file.findn(p_search);
@@ -128,11 +133,11 @@ float EditorQuickOpen::_score_path(const String &p_search, const String &p_path)
 	// Positive bias for matches close to the end of the path.
 	pos = p_path.rfindn(p_search);
 	if (pos != -1) {
-		return score * (0.8f - 0.1f * (float(p_path.length() - pos) / p_path.length()));
+		return 1.1f + 0.09 / (p_path.length() - pos + 1);
 	}
 
-	// Remaining results belong to the same class of results.
-	return score * 0.69f;
+	// Similarity
+	return p_path.to_lower().similarity(p_search.to_lower());
 }
 
 void EditorQuickOpen::_confirmed() {


### PR DESCRIPTION
This pull request improves the accuracy of the quick open scene results.

Resolves: #50672


https://user-images.githubusercontent.com/62965063/126517931-b112b265-883b-4d84-a6b5-33768fb0a5cc.mp4