### PR TITLE
[3.x] Improve and streamline VisualScriptFuncNodes Call Set Get

### DIFF
--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -179,6 +179,9 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	void _port_action_menu(int p_option, const StringName &p_func);
 
+	NodePath drop_path;
+	Node *drop_node = nullptr;
+	Vector2 drop_position;
 	void connect_data(Ref<VisualScriptNode> vnode_old, Ref<VisualScriptNode> vnode, int new_id);
 
 	void _selected_connect_node(const String &p_text, const String &p_category, const bool p_connecting = true);

--- a/modules/visual_script/visual_script_func_nodes.h
+++ b/modules/visual_script/visual_script_func_nodes.h
@@ -272,6 +272,8 @@ private:
 	void _set_type_cache(Variant::Type p_type);
 	Variant::Type _get_type_cache() const;
 
+	void _adjust_input_index(PropertyInfo &pinfo) const;
+
 protected:
 	virtual void _validate_property(PropertyInfo &property) const;
 


### PR DESCRIPTION
This PR improves and streamlines the workflow for VisualScriptFunctionNodes Call Set Get
Uniform design.
Drag in set-get from tree is now working.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
3.x version of #49749
![image](https://user-images.githubusercontent.com/20573784/126541000-5b37fd7e-0a42-4036-be29-6ab7a8e8eb6b.png)
[Controlsgc.zip](https://github.com/godotengine/godot/files/6858074/Controlsgc.zip)

Compatibility whit older scripts is **NOT** guaranteed as I added the pass output port for get instance.
I do want to note that the other changes is are a real big improvement to the UX