### PR TITLE
Fix logic for Popup closing when parent is focused

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -72,6 +72,7 @@ void Popup::_notification(int p_what) {
 			} else {
 				_deinitialize_visible_parents();
 				emit_signal(SNAME("popup_hide"));
+				popped_up = false;
 			}
 
 		} break;


### PR DESCRIPTION
The member `popped_up` is used to avoid closing a `Popup` before it had a chance to be focused. It wasn't reset properly when the popup is hidden, causing the Popup to close right after showing in some random cases (spotted on X11, might not happen on Windows).

Fixes some bugs detected with PR #50619, but it might also happen in some other cases.
