### PR TITLE
Tweak behaviour of drag and drop for 3D scenes to make them less glitchy

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3782,63 +3782,16 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos) const 
 	Vector3 world_ray = _get_ray(p_pos);
 	Vector3 world_pos = _get_ray_pos(p_pos);
 
-	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(world_pos, world_ray, get_tree()->get_root()->get_world_3d()->get_scenario());
-	Set<Ref<EditorNode3DGizmo>> found_gizmos;
-
-	float closest_dist = MAX_DISTANCE;
-
 	Vector3 point = world_pos + world_ray * MAX_DISTANCE;
-	Vector3 normal = Vector3(0.0, 0.0, 0.0);
 
-	for (int i = 0; i < instances.size(); i++) {
-		MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(ObjectDB::get_instance(instances[i]));
+	PhysicsDirectSpaceState3D *ss = get_tree()->get_root()->get_world_3d()->get_direct_space_state();
+	PhysicsDirectSpaceState3D::RayResult result;
 
-		if (!mesh_instance) {
-			continue;
-		}
-
-		Vector<Ref<Node3DGizmo>> gizmos = mesh_instance->get_gizmos();
-
-		for (int j = 0; j < gizmos.size(); j++) {
-			Ref<EditorNode3DGizmo> seg = gizmos[j];
-
-			if ((!seg.is_valid()) || found_gizmos.has(seg)) {
-				continue;
-			}
-
-			found_gizmos.insert(seg);
-
-			Vector3 hit_point;
-			Vector3 hit_normal;
-			bool inters = seg->intersect_ray(camera, p_pos, hit_point, hit_normal);
-
-			if (!inters) {
-				continue;
-			}
-
-			float dist = world_pos.distance_to(hit_point);
-
-			if (dist < 0) {
-				continue;
-			}
-
-			if (dist < closest_dist) {
-				closest_dist = dist;
-				point = hit_point;
-				normal = hit_normal;
-			}
-		}
+	if (ss->intersect_ray(world_pos, world_pos + world_ray * MAX_DISTANCE, result)) {
+		point = result.position;
 	}
 
-	Vector3 offset = Vector3();
-	for (int i = 0; i < 3; i++) {
-		if (normal[i] > 0.0) {
-			offset[i] = (preview_bounds->get_size()[i] - (preview_bounds->get_size()[i] + preview_bounds->get_position()[i]));
-		} else if (normal[i] < 0.0) {
-			offset[i] = -(preview_bounds->get_size()[i] + preview_bounds->get_position()[i]);
-		}
-	}
-	return point + offset;
+	return point;
 }
 
 AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, bool p_exclude_top_level_transform) {


### PR DESCRIPTION
Based some discussions in the #editor channel in RocketChat, I determined that the initial implementation I did for dragging and dropping 3D scenes into 3D viewport regressed and/or was a somewhat flawed implementation to begin with to. To that effect, I've changed it now so that it no longer attempts to do a bounding box calculation for the scene it is dropping, it simply drops it at its exact origin point now. I have also switched the collision raycast from being calculated against visual instances to the physics server. This feels like it will be more intuitive in greater variety of scenarios (for example, dropping props into a field of grass).

This new implementation should be overall simpler and less glitch prone.