### PR TITLE
[3.x] Fixes depth sorting of meshes with transparent textures

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -2547,9 +2547,6 @@ void VisualServerScene::_prepare_scene(const Transform p_cam_transform, const Ca
 
 				geom->gi_probes_dirty = false;
 			}
-			Vector3 aabb_center = ins->transformed_aabb.position + (ins->transformed_aabb.size * 0.5);
-			ins->depth = near_plane.distance_to(aabb_center);
-			ins->depth_layer = CLAMP(int(ins->depth * 16 / z_far), 0, 15);
 		}
 
 		if (!keep) {
@@ -2696,6 +2693,17 @@ void VisualServerScene::_prepare_scene(const Transform p_cam_transform, const Ca
 				//must redraw!
 				light->shadow_dirty = _light_instance_update_shadow(ins, p_cam_transform, p_cam_projection, p_cam_orthogonal, p_shadow_atlas, scenario);
 			}
+		}
+	}
+
+	// Calculate instance->depth from the camera, after shadow calculation has stopped overwriting instance->depth
+	for (int i = 0; i < instance_cull_count; i++) {
+		Instance *ins = instance_cull_result[i];
+
+		if (((1 << ins->base_type) & VS::INSTANCE_GEOMETRY_MASK) && ins->visible && ins->cast_shadows != VS::SHADOW_CASTING_SETTING_SHADOWS_ONLY) {
+			Vector3 aabb_center = ins->transformed_aabb.position + (ins->transformed_aabb.size * 0.5);
+			ins->depth = near_plane.distance_to(aabb_center);
+			ins->depth_layer = CLAMP(int(ins->depth * 16 / z_far), 0, 15);
 		}
 	}
 }


### PR DESCRIPTION
Currently, VisualServer calculates object depth from the camera. Then it overwrites that information with shadow data, then sends the wrong information to the renderer, which is used to sort all objects.

It is incorrect for all objects, but there's likely another reason in OpenGL or the renderer as to why opaque objects are sorted correctly.

This problem becomes apparent with transparent objects, when shadows are calculated. It affects all light types. However Omni and Spotlights have another caveat in that they don't calculate shadows every frame, so it's only wrong on the frames they do.

<img src="https://user-images.githubusercontent.com/632766/126083365-a0c6e87d-5acb-4b8f-9f2e-4fa4aa598461.png"/>

This PR moves the unused camera depth calculation to after the shadow calculation. The correct information is sent to the renderer which now properly sorts objects based on camera depth.

![image](https://user-images.githubusercontent.com/632766/126577040-4db89ca2-477a-4514-b850-59c4768bc3ce.png)

Fixes #43253 
See issue for more details.

*Bugsquad edit:* Fixes #49389.