### PR TITLE
Allow using vertex varying in custom functions under any circumstances

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -876,6 +876,14 @@ private:
 
 	VaryingFunctionNames varying_function_names;
 
+	struct VaryingUsage {
+		ShaderNode::Varying *var;
+		int line;
+	};
+	List<VaryingUsage> unknown_varying_usages;
+
+	bool _check_varying_usages(int *r_error_line, String *r_error_message) const;
+
 	TkPos _get_tkpos() {
 		TkPos tkp;
 		tkp.char_idx = char_idx;


### PR DESCRIPTION
Currently if varying declared at vertex function but used in a function declared before it - there is error emitting, because the state of the varying is unknown at this stage.

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/3036176/126609674-26c1de11-83f5-4a0b-95cb-b512af3909c3.png)

</details>

I fixed it by adding a buffer to store the line and varying reference to check them later after their initialization. Fragment-stage varying should be forbidden from usage in custom functions as @lyuma pointed at https://github.com/godotengine/godot/issues/48949#issuecomment-884539356 (to prevent crashes if the function is called in `vertex` function):

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/3036176/126610624-4b20262f-5ccd-4260-841f-ac440d883f66.png)

</details>

