### PR TITLE
Fix MoltenVK static linking on macOS.

### DIFF
--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -105,7 +105,7 @@ elif env["builtin_vulkan"]:
 
 else:  # Always build VMA.
     thirdparty_dir = "#thirdparty/vulkan"
-    env.Prepend(CPPPATH=[thirdparty_dir])
+    env.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "/include"])
 
     # Build Vulkan loader library
     env_thirdparty = env.Clone()

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -24,6 +24,7 @@ def get_opts():
     return [
         ("osxcross_sdk", "OSXCross SDK version", "darwin16"),
         ("MACOS_SDK_PATH", "Path to the macOS SDK", ""),
+        ("VULKAN_SDK_PATH", "Path to the Vulkan SDK", ""),
         BoolVariable(
             "use_static_mvk",
             "Link MoltenVK statically as Level-0 driver (better portability) or use Vulkan ICD loader (enables"
@@ -190,7 +191,7 @@ def configure(env):
     env.Append(CPPDEFINES=["VULKAN_ENABLED"])
     env.Append(LINKFLAGS=["-framework", "Metal", "-framework", "QuartzCore", "-framework", "IOSurface"])
     if env["use_static_mvk"]:
-        env.Append(LINKFLAGS=["-framework", "MoltenVK"])
+        env.Append(LINKFLAGS=["-L$VULKAN_SDK_PATH/MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64/", "-lMoltenVK"])
         env["builtin_vulkan"] = False
     elif not env["builtin_vulkan"]:
         env.Append(LIBS=["vulkan"])


### PR DESCRIPTION
- Adds missing include path.
- Adds Vulkan SDK path option.
- Uses xcframework instead of static framework (newer SDK versions are distribution with a single xcframework for macOS, iOS and tvOS).

Export templates with static MoltenVK can be compiled using:
```
scons p=osx arch=arm64 tools=no target=release_debug use_static_mvk=yes VULKAN_SDK_PATH=/path/to/VulkanSDK/1.2.182.0/
```