### PR TITLE
Re-enable building position-independent executables on Linux/*BSD

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -201,11 +201,6 @@ def configure(env):
     env.Append(CCFLAGS=["-pipe"])
     env.Append(LINKFLAGS=["-pipe"])
 
-    # -fpie and -no-pie is supported on GCC 6+ and Clang 4+, both below our
-    # minimal requirements.
-    env.Append(CCFLAGS=["-fpie"])
-    env.Append(LINKFLAGS=["-no-pie"])
-
     ## Dependencies
 
     env.ParseConfig("pkg-config x11 --cflags --libs")


### PR DESCRIPTION
This provides better security at the cost of having misleading binary icons on some file managers.

Now that recent Linux distributions no longer allow executing binaries by double-clicking them in a file manager (even if the binary is set to be executable), the usability cost of PIE is lowered. You have to use a terminal or install a `.desktop` file nowadays.

I would recommend doing this only for 4.0. As far as I know, people on old LTS Linux distributions are still able to run binaries by double-clicking them. Due to this, we should wait for the number of users on old LTS Linux distributions to decrease a bit until this is done in a stable release. Hopefully, this number of users should be low enough by the time Godot 4.0 is released :slightly_smiling_face: 

This reverts https://github.com/godotengine/godot/pull/23542.