### PR TITLE
[3.x] Fix `TexturePreview` crashing

### DIFF
--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -41,6 +41,12 @@ class TexturePreview : public MarginContainer {
 private:
 	TextureRect *texture_display;
 
+	TextureRect *checkerboard;
+	Label *metadata_label;
+
+protected:
+	void _notification(int p_what);
+
 public:
 	TextureRect *get_texture_display();
 	TexturePreview(Ref<Texture> p_texture, bool p_show_metadata);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes https://github.com/godotengine/godot/issues/50702 for `3.x`