### PR TITLE
Fix `TexturePreview` crashing

### DIFF
--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -36,9 +36,28 @@ TextureRect *TexturePreview::get_texture_display() {
 	return texture_display;
 }
 
+void TexturePreview::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			if (!is_inside_tree()) {
+				// TODO: This is a workaround because `NOTIFICATION_THEME_CHANGED`
+				// is getting called for some reason when the `TexturePreview` is
+				// getting destroyed, which causes `get_theme_font()` to return `nullptr`.
+				// See https://github.com/godotengine/godot/issues/50743.
+				break;
+			}
+
+			Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), SNAME("EditorFonts"));
+			metadata_label->add_theme_font_override("font", metadata_label_font);
+
+			checkerboard->set_texture(get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons")));
+		} break;
+	}
+}
+
 TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
-	TextureRect *checkerboard = memnew(TextureRect);
-	checkerboard->set_texture(get_theme_icon("Checkerboard", "EditorIcons"));
+	checkerboard = memnew(TextureRect);
 	checkerboard->set_stretch_mode(TextureRect::STRETCH_TILE);
 	checkerboard->set_texture_repeat(CanvasItem::TEXTURE_REPEAT_ENABLED);
 	checkerboard->set_custom_minimum_size(Size2(0.0, 256.0) * EDSCALE);
@@ -52,7 +71,7 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 	add_child(texture_display);
 
 	if (p_show_metadata) {
-		Label *metadata_label = memnew(Label);
+		metadata_label = memnew(Label);
 
 		String format;
 		if (Object::cast_to<ImageTexture>(*p_texture)) {
@@ -65,15 +84,13 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 
 		metadata_label->set_text(itos(p_texture->get_width()) + "x" + itos(p_texture->get_height()) + " " + format);
 
-		metadata_label->add_theme_font_size_override("font_size", 16 * EDSCALE);
-		metadata_label->add_theme_color_override("font_outline_color", Color::named("black"));
-		metadata_label->add_theme_constant_override("outline_size", 2 * EDSCALE);
-		Ref<Font> metadata_label_font = get_theme_font("expression", "EditorFonts");
-		metadata_label->add_theme_font_override("font", metadata_label_font);
-
 		// It's okay that these colors are static since the grid color is static too.
 		metadata_label->add_theme_color_override("font_color", Color::named("white"));
 		metadata_label->add_theme_color_override("font_color_shadow", Color::named("black"));
+
+		metadata_label->add_theme_font_size_override("font_size", 16 * EDSCALE);
+		metadata_label->add_theme_color_override("font_outline_color", Color::named("black"));
+		metadata_label->add_theme_constant_override("outline_size", 2 * EDSCALE);
 
 		metadata_label->add_theme_constant_override("shadow_as_outline", 1);
 		metadata_label->set_h_size_flags(Control::SIZE_SHRINK_END);

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -41,6 +41,12 @@ class TexturePreview : public MarginContainer {
 private:
 	TextureRect *texture_display;
 
+	TextureRect *checkerboard;
+	Label *metadata_label;
+
+protected:
+	void _notification(int p_what);
+
 public:
 	TextureRect *get_texture_display();
 	TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes https://github.com/godotengine/godot/issues/50702 for `master`