### PR TITLE
Portals - fix adding statics twice

### DIFF
--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -1141,6 +1141,12 @@ void RoomManager::_autoplace_recursive(Spatial *p_node) {
 		return;
 	}
 
+	// as soon as we hit a room, quit the recursion as the objects
+	// will already have been added inside rooms
+	if (Object::cast_to<Room>(p_node)) {
+		return;
+	}
+
 	VisualInstance *vi = Object::cast_to<VisualInstance>(p_node);
 
 	// we are only interested in VIs with static or dynamic mode


### PR DESCRIPTION
Due to an oversight in the autoplace recursive search for static objects, static objects were getting added twice to the portal renderer, which meant they were being rendered twice, lowering performance.

This PR corrects this horrendous error.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
