### PR TITLE
Make Object "meta" functions take StringName.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -922,11 +922,11 @@ Variant Object::get_script() const {
 	return script;
 }
 
-bool Object::has_meta(const String &p_name) const {
+bool Object::has_meta(const StringName &p_name) const {
 	return metadata.has(p_name);
 }
 
-void Object::set_meta(const String &p_name, const Variant &p_value) {
+void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 	if (p_value.get_type() == Variant::NIL) {
 		metadata.erase(p_name);
 		return;
@@ -935,12 +935,12 @@ void Object::set_meta(const String &p_name, const Variant &p_value) {
 	metadata[p_name] = p_value;
 }
 
-Variant Object::get_meta(const String &p_name) const {
+Variant Object::get_meta(const StringName &p_name) const {
 	ERR_FAIL_COND_V_MSG(!metadata.has(p_name), Variant(), "The object does not have any 'meta' values with the key '" + p_name + "'.");
 	return metadata[p_name];
 }
 
-void Object::remove_meta(const String &p_name) {
+void Object::remove_meta(const StringName &p_name) {
 	metadata.erase(p_name);
 }
 
@@ -964,8 +964,8 @@ Array Object::_get_method_list_bind() const {
 	return ret;
 }
 
-Vector<String> Object::_get_meta_list_bind() const {
-	Vector<String> _metaret;
+Vector<StringName> Object::_get_meta_list_bind() const {
+	Vector<StringName> _metaret;
 
 	List<Variant> keys;
 	metadata.get_key_list(&keys);
@@ -976,7 +976,7 @@ Vector<String> Object::_get_meta_list_bind() const {
 	return _metaret;
 }
 
-void Object::get_meta_list(List<String> *p_list) const {
+void Object::get_meta_list(List<StringName> *p_list) const {
 	List<Variant> keys;
 	metadata.get_key_list(&keys);
 	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -615,7 +615,7 @@ protected:
 		return &_class_name;
 	}
 
-	Vector<String> _get_meta_list_bind() const;
+	Vector<StringName> _get_meta_list_bind() const;
 	Array _get_property_list_bind() const;
 	Array _get_method_list_bind() const;
 
@@ -743,11 +743,11 @@ public:
 
 	/* SCRIPT */
 
-	bool has_meta(const String &p_name) const;
-	void set_meta(const String &p_name, const Variant &p_value);
-	void remove_meta(const String &p_name);
-	Variant get_meta(const String &p_name) const;
-	void get_meta_list(List<String> *p_list) const;
+	bool has_meta(const StringName &p_name) const;
+	void set_meta(const StringName &p_name, const Variant &p_value);
+	void remove_meta(const StringName &p_name);
+	Variant get_meta(const StringName &p_name) const;
+	void get_meta_list(List<StringName> *p_list) const;
 
 #ifdef TOOLS_ENABLED
 	void set_edited(bool p_edited);

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -400,7 +400,7 @@
 		<method name="get_meta" qualifiers="const">
 			<return type="Variant">
 			</return>
-			<argument index="0" name="name" type="String">
+			<argument index="0" name="name" type="StringName">
 			</argument>
 			<description>
 				Returns the object's metadata entry for the given [code]name[/code].
@@ -454,7 +454,7 @@
 		<method name="has_meta" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="name" type="String">
+			<argument index="0" name="name" type="StringName">
 			</argument>
 			<description>
 				Returns [code]true[/code] if a metadata entry is found with the given [code]name[/code].
@@ -543,7 +543,7 @@
 		<method name="remove_meta">
 			<return type="void">
 			</return>
-			<argument index="0" name="name" type="String">
+			<argument index="0" name="name" type="StringName">
 			</argument>
 			<description>
 				Removes a given entry from the object's metadata. See also [method set_meta].
@@ -619,7 +619,7 @@
 		<method name="set_meta">
 			<return type="void">
 			</return>
-			<argument index="0" name="name" type="String">
+			<argument index="0" name="name" type="StringName">
 			</argument>
 			<argument index="1" name="value" type="Variant">
 			</argument>

--- a/tests/test_object.h
+++ b/tests/test_object.h
@@ -139,7 +139,7 @@ TEST_CASE("[Object] Metadata") {
 			Color(object.get_meta(meta_path)).is_equal_approx(Color(0, 1, 0)),
 			"The returned object metadata after setting should match the expected value.");
 
-	List<String> meta_list;
+	List<StringName> meta_list;
 	object.get_meta_list(&meta_list);
 	CHECK_MESSAGE(
 			meta_list.size() == 1,
@@ -154,7 +154,7 @@ TEST_CASE("[Object] Metadata") {
 			"The returned object metadata after removing should match the expected value.");
 	ERR_PRINT_ON;
 
-	List<String> meta_list2;
+	List<StringName> meta_list2;
 	object.get_meta_list(&meta_list2);
 	CHECK_MESSAGE(
 			meta_list2.size() == 0,


### PR DESCRIPTION
The various get_meta, set_meta, has_meta, get_meta_list, remove_meta functions now uses StringName, allowing further optimizations via the SNAME macro when used from C++ (this PR does not change the various usage though).