### PR TITLE
Add global_position and global_rotation to Node3D

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -281,6 +281,13 @@
 		<member name="basis" type="Basis" setter="set_basis" getter="get_basis">
 			Direct access to the 3x3 basis of the [Transform3D] property.
 		</member>
+		<member name="global_position" type="Vector3" setter="set_global_position" getter="get_global_position">
+			Global position of this node. This is equivalent to [code]global_transform.origin[/code].
+		</member>
+		<member name="global_rotation" type="Vector3" setter="set_global_rotation" getter="get_global_rotation">
+			Rotation part of the global transformation in radians, specified in terms of YXZ-Euler angles in the format (X angle, Y angle, Z angle).
+			[b]Note:[/b] In the mathematical sense, rotation is a matrix and not a vector. The three Euler angles, which are the three independent parameters of the Euler-angle parametrization of the rotation matrix, are stored in a [Vector3] data structure not because the rotation is a vector, but only because [Vector3] exists as a convenient data-structure to store 3 floating-point numbers. Therefore, applying affine operations on the rotation "vector" is not meaningful.
+		</member>
 		<member name="global_transform" type="Transform3D" setter="set_global_transform" getter="get_global_transform">
 			World3D space (global) [Transform3D] of this node.
 		</member>

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -237,6 +237,28 @@ void Node3D::set_quaternion(const Quaternion &p_quaternion) {
 	}
 }
 
+Vector3 Node3D::get_global_position() const {
+	return get_global_transform().get_origin();
+}
+
+void Node3D::set_global_position(const Vector3 &p_position) {
+	Transform3D transform = get_global_transform();
+	transform.set_origin(p_position);
+	set_global_transform(transform);
+}
+
+Vector3 Node3D::get_global_rotation() const {
+	return get_global_transform().get_basis().get_euler();
+}
+
+void Node3D::set_global_rotation(const Vector3 &p_euler_rad) {
+	Transform3D transform = get_global_transform();
+	Basis new_basis = transform.get_basis();
+	new_basis.set_euler(p_euler_rad);
+	transform.set_basis(new_basis);
+	set_global_transform(transform);
+}
+
 void Node3D::set_transform(const Transform3D &p_transform) {
 	data.local_transform = p_transform;
 	data.dirty = DIRTY_EULER_ROTATION_AND_SCALE; // Make rot/scale dirty.
@@ -950,8 +972,14 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_quaternion"), &Node3D::get_quaternion);
 	ClassDB::bind_method(D_METHOD("set_basis", "basis"), &Node3D::set_basis);
 	ClassDB::bind_method(D_METHOD("get_basis"), &Node3D::get_basis);
+
 	ClassDB::bind_method(D_METHOD("set_global_transform", "global"), &Node3D::set_global_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &Node3D::get_global_transform);
+	ClassDB::bind_method(D_METHOD("set_global_position", "position"), &Node3D::set_global_position);
+	ClassDB::bind_method(D_METHOD("get_global_position"), &Node3D::get_global_position);
+	ClassDB::bind_method(D_METHOD("set_global_rotation", "radians"), &Node3D::set_global_rotation);
+	ClassDB::bind_method(D_METHOD("get_global_rotation"), &Node3D::get_global_rotation);
+
 	ClassDB::bind_method(D_METHOD("get_parent_node_3d"), &Node3D::get_parent_node_3d);
 	ClassDB::bind_method(D_METHOD("set_ignore_transform_notification", "enabled"), &Node3D::set_ignore_transform_notification);
 	ClassDB::bind_method(D_METHOD("set_as_top_level", "enable"), &Node3D::set_as_top_level);
@@ -1034,6 +1062,9 @@ void Node3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rotation_edit_mode", PROPERTY_HINT_ENUM, "Euler,Quaternion,Basis"), "set_rotation_edit_mode", "get_rotation_edit_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rotation_order", PROPERTY_HINT_ENUM, "XYZ,XZY,YXZ,YZX,ZXY,ZYX"), "set_rotation_order", "get_rotation_order");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "top_level"), "set_as_top_level", "is_set_as_top_level");
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_position", "get_global_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_rotation", "get_global_rotation");
 	ADD_GROUP("Visibility", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "visibility_parent", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "GeometryInstance3D"), "set_visibility_parent", "get_visibility_parent");

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -182,11 +182,17 @@ public:
 	void set_rotation(const Vector3 &p_euler_rad);
 	void set_scale(const Vector3 &p_scale);
 
+	void set_global_position(const Vector3 &p_position);
+	void set_global_rotation(const Vector3 &p_euler_rad);
+
 	Vector3 get_position() const;
 
 	RotationOrder get_rotation_order() const;
 	Vector3 get_rotation() const;
 	Vector3 get_scale() const;
+
+	Vector3 get_global_position() const;
+	Vector3 get_global_rotation() const;
 
 	void set_transform(const Transform3D &p_transform);
 	void set_basis(const Basis &p_basis);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/3033

Adds a `global_position` and `global_rotation` property to Node3D. These properties already existed for Node2D, so it makes sense to have them for Node3D as well to lessen the differences between 2D and 3D.

Here's the project that I used for testing that they work properly:
[testing_node3d_global_properties.zip](https://github.com/godotengine/godot/files/6859480/testing_node3d_global_properties.zip)
