### PR TITLE
Add a simple C# `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,15 +13,11 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[{*.{py,cs},SConstruct,SCsub}]
+[{*.py,SConstruct,SCsub}]
 indent_style = space
 indent_size = 4
 
 # YAML requires indentation with spaces instead of tabs.
 [*.{yml,yaml}]
-indent_style = space
-indent_size = 2
-
-[*.{csproj,props,targets,nuspec}]
 indent_style = space
 indent_size = 2

--- a/modules/mono/.editorconfig
+++ b/modules/mono/.editorconfig
@@ -1,0 +1,14 @@
+[*.sln]
+indent_style = tab
+
+[*.{csproj,props,targets,nuspec,resx}]
+indent_style = space
+indent_size = 2
+
+[*.cs]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+csharp_indent_case_contents_when_block = false

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
@@ -15,8 +15,9 @@
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild> <!-- Generates a package at build -->
-    <IncludeBuildOutput>false</IncludeBuildOutput> <!-- Do not include the generator as a lib dependency -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- Do not include the generator as a lib dependency -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />

--- a/modules/mono/editor/GodotTools/.gitignore
+++ b/modules/mono/editor/GodotTools/.gitignore
@@ -353,4 +353,3 @@ healthchecksdb
 
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
-

--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging.CLI/Program.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging.CLI/Program.cs
@@ -113,8 +113,7 @@ namespace GodotTools.IdeMessaging.CLI
                         }
                     }
 
-                    ExitMainLoop:
-
+                ExitMainLoop:
                     await forwarder.WriteLineToOutput("Event=Quit");
                 }
 

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/DotNetSolution.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/DotNetSolution.cs
@@ -150,8 +150,8 @@ EndProject";
                 {"Tools|Any CPU", "ExportRelease|Any CPU"}
             };
 
-            var regex = new Regex(string.Join("|",dict.Keys.Select(Regex.Escape)));
-            var result = regex.Replace(input,m => dict[m.Value]);
+            var regex = new Regex(string.Join("|", dict.Keys.Select(Regex.Escape)));
+            var result = regex.Replace(input, m => dict[m.Value]);
 
             if (result != input)
             {

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -577,27 +577,27 @@ MONO_AOT_MODE_LAST = 1000,
             {
                 case OS.Platforms.Windows:
                 case OS.Platforms.UWP:
-                    {
-                        string arch = bits == "64" ? "x86_64" : "i686";
-                        return $"windows-{arch}";
-                    }
+                {
+                    string arch = bits == "64" ? "x86_64" : "i686";
+                    return $"windows-{arch}";
+                }
                 case OS.Platforms.MacOS:
-                    {
-                        Debug.Assert(bits == null || bits == "64");
-                        string arch = "x86_64";
-                        return $"{platform}-{arch}";
-                    }
+                {
+                    Debug.Assert(bits == null || bits == "64");
+                    string arch = "x86_64";
+                    return $"{platform}-{arch}";
+                }
                 case OS.Platforms.LinuxBSD:
                 case OS.Platforms.Server:
-                    {
-                        string arch = bits == "64" ? "x86_64" : "i686";
-                        return $"linux-{arch}";
-                    }
+                {
+                    string arch = bits == "64" ? "x86_64" : "i686";
+                    return $"linux-{arch}";
+                }
                 case OS.Platforms.Haiku:
-                    {
-                        string arch = bits == "64" ? "x86_64" : "i686";
-                        return $"{platform}-{arch}";
-                    }
+                {
+                    string arch = bits == "64" ? "x86_64" : "i686";
+                    return $"{platform}-{arch}";
+                }
                 default:
                     throw new NotSupportedException($"Platform not supported: {platform}");
             }

--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -3,7 +3,8 @@
     <ProjectGuid>{27B00618-A6F2-4828-B922-05CAEB08C286}</ProjectGuid>
     <TargetFramework>net472</TargetFramework>
     <LangVersion>7.2</LangVersion>
-    <GodotApiConfiguration>Debug</GodotApiConfiguration> <!-- The Godot editor uses the Debug Godot API assemblies -->
+    <!-- The Godot editor uses the Debug Godot API assemblies -->
+    <GodotApiConfiguration>Debug</GodotApiConfiguration>
     <GodotSourceRootPath>$(SolutionDir)/../../../../</GodotSourceRootPath>
     <GodotOutputDataDir>$(GodotSourceRootPath)/bin/GodotSharp</GodotOutputDataDir>
     <GodotApiAssembliesDir>$(GodotOutputDataDir)/Api/$(GodotApiConfiguration)</GodotApiAssembliesDir>

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -57,7 +57,7 @@ namespace GodotTools.Ides.Rider
 
         public static bool IsExternalEditorSetToRider(EditorSettings editorSettings)
         {
-            return editorSettings.HasSetting(EditorPathSettingName) && IsRider((string) editorSettings.GetSetting(EditorPathSettingName));
+            return editorSettings.HasSetting(EditorPathSettingName) && IsRider((string)editorSettings.GetSetting(EditorPathSettingName));
         }
 
         public static bool IsRider(string path)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -1,16 +1,10 @@
-// file: core/math/aabb.h
-// commit: 7ad14e7a3e6f87ddc450f7e34621eb5200808451
-// file: core/math/aabb.cpp
-// commit: bd282ff43f23fe845f29a3e25c8efc01bd65ffb0
-// file: core/variant_call.cpp
-// commit: 5ad9be4c24e9d7dc5672fdc42cea896622fe5685
-using System;
-using System.Runtime.InteropServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Godot

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -61,7 +61,7 @@ namespace Godot
                     using (var stream = new MemoryStream())
                     using (var writer = new BinaryWriter(stream))
                     {
-                        writer.Write((ulong) TargetKind.Static);
+                        writer.Write((ulong)TargetKind.Static);
 
                         SerializeType(writer, @delegate.GetType());
 
@@ -77,8 +77,8 @@ namespace Godot
                     using (var stream = new MemoryStream())
                     using (var writer = new BinaryWriter(stream))
                     {
-                        writer.Write((ulong) TargetKind.GodotObject);
-                        writer.Write((ulong) godotObject.GetInstanceId());
+                        writer.Write((ulong)TargetKind.GodotObject);
+                        writer.Write((ulong)godotObject.GetInstanceId());
 
                         SerializeType(writer, @delegate.GetType());
 
@@ -100,7 +100,7 @@ namespace Godot
                         using (var stream = new MemoryStream())
                         using (var writer = new BinaryWriter(stream))
                         {
-                            writer.Write((ulong) TargetKind.CompilerGenerated);
+                            writer.Write((ulong)TargetKind.CompilerGenerated);
                             SerializeType(writer, targetType);
 
                             SerializeType(writer, @delegate.GetType());
@@ -149,14 +149,14 @@ namespace Godot
             int flags = 0;
 
             if (methodInfo.IsPublic)
-                flags |= (int) BindingFlags.Public;
+                flags |= (int)BindingFlags.Public;
             else
-                flags |= (int) BindingFlags.NonPublic;
+                flags |= (int)BindingFlags.NonPublic;
 
             if (methodInfo.IsStatic)
-                flags |= (int) BindingFlags.Static;
+                flags |= (int)BindingFlags.Static;
             else
-                flags |= (int) BindingFlags.Instance;
+                flags |= (int)BindingFlags.Instance;
 
             writer.Write(flags);
 
@@ -238,7 +238,7 @@ namespace Godot
                 }
                 else
                 {
-                    if (TryDeserializeSingleDelegate((byte[]) elem, out Delegate oneDelegate))
+                    if (TryDeserializeSingleDelegate((byte[])elem, out Delegate oneDelegate))
                         delegates.Add(oneDelegate);
                 }
             }
@@ -257,7 +257,7 @@ namespace Godot
             using (var stream = new MemoryStream(buffer, writable: false))
             using (var reader = new BinaryReader(stream))
             {
-                var targetKind = (TargetKind) reader.ReadUInt64();
+                var targetKind = (TargetKind)reader.ReadUInt64();
 
                 switch (targetKind)
                 {
@@ -353,11 +353,11 @@ namespace Godot
                     parameterTypes[i] = parameterType;
                 }
 
-                methodInfo = declaringType.GetMethod(methodName, (BindingFlags) flags, null, parameterTypes, null);
+                methodInfo = declaringType.GetMethod(methodName, (BindingFlags)flags, null, parameterTypes, null);
                 return methodInfo != null && methodInfo.ReturnType == returnType;
             }
 
-            methodInfo = declaringType.GetMethod(methodName, (BindingFlags) flags);
+            methodInfo = declaringType.GetMethod(methodName, (BindingFlags)flags);
             return methodInfo != null && methodInfo.ReturnType == returnType;
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DynamicObject.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DynamicObject.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Generic;
 using System.Dynamic;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -1,12 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
-
 #endif
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 // TODO: Add comments describing what this class does. It is not obvious.
 
@@ -26,7 +25,7 @@ namespace Godot
 
         public static real_t Db2Linear(real_t db)
         {
-            return (real_t) Math.Exp(db * 0.11512925464970228420089957273422);
+            return (real_t)Math.Exp(db * 0.11512925464970228420089957273422);
         }
 
         public static real_t DecTime(real_t value, real_t amount, real_t step)
@@ -51,7 +50,7 @@ namespace Godot
 
         public static real_t Linear2Db(real_t linear)
         {
-            return (real_t) (Math.Log(linear) * 8.6858896380650365530225783783321);
+            return (real_t)(Math.Log(linear) * 8.6858896380650365530225783783321);
         }
 
         public static Resource Load(string path)
@@ -76,7 +75,7 @@ namespace Godot
 
         public static void Print(params object[] what)
         {
-            godot_icall_GD_print(Array.ConvertAll(what ?? new object[]{"null"}, x => x != null ? x.ToString() : "null"));
+            godot_icall_GD_print(Array.ConvertAll(what ?? new object[] { "null" }, x => x != null ? x.ToString() : "null"));
         }
 
         public static void PrintStack()
@@ -86,22 +85,22 @@ namespace Godot
 
         public static void PrintErr(params object[] what)
         {
-            godot_icall_GD_printerr(Array.ConvertAll(what ?? new object[]{"null"}, x => x != null ? x.ToString() : "null"));
+            godot_icall_GD_printerr(Array.ConvertAll(what ?? new object[] { "null" }, x => x != null ? x.ToString() : "null"));
         }
 
         public static void PrintRaw(params object[] what)
         {
-            godot_icall_GD_printraw(Array.ConvertAll(what ?? new object[]{"null"}, x => x != null ? x.ToString() : "null"));
+            godot_icall_GD_printraw(Array.ConvertAll(what ?? new object[] { "null" }, x => x != null ? x.ToString() : "null"));
         }
 
         public static void PrintS(params object[] what)
         {
-            godot_icall_GD_prints(Array.ConvertAll(what ?? new object[]{"null"}, x => x != null ? x.ToString() : "null"));
+            godot_icall_GD_prints(Array.ConvertAll(what ?? new object[] { "null" }, x => x != null ? x.ToString() : "null"));
         }
 
         public static void PrintT(params object[] what)
         {
-            godot_icall_GD_printt(Array.ConvertAll(what ?? new object[]{"null"}, x => x != null ? x.ToString() : "null"));
+            godot_icall_GD_printt(Array.ConvertAll(what ?? new object[] { "null" }, x => x != null ? x.ToString() : "null"));
         }
 
         public static float Randf()

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTraceListener.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTraceListener.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 
 namespace Godot

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotUnhandledExceptionEvent.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotUnhandledExceptionEvent.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/MarshalUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/MarshalUtils.cs
@@ -1,12 +1,8 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Godot
 {
-    using Array = Godot.Collections.Array;
-    using Dictionary = Godot.Collections.Dictionary;
-
     static class MarshalUtils
     {
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -1,9 +1,9 @@
-using System;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
 
 namespace Godot
 {
@@ -14,13 +14,15 @@ namespace Godot
         /// <summary>
         /// The circle constant, the circumference of the unit circle in radians.
         /// </summary>
-        public const real_t Tau = (real_t) 6.2831853071795864769252867666M; // 6.2831855f and 6.28318530717959
+        // 6.2831855f and 6.28318530717959
+        public const real_t Tau = (real_t)6.2831853071795864769252867666M;
 
         /// <summary>
         /// Constant that represents how many times the diameter of a circle
         /// fits around its perimeter. This is equivalent to `Mathf.Tau / 2`.
         /// </summary>
-        public const real_t Pi = (real_t) 3.1415926535897932384626433833M; // 3.1415927f and 3.14159265358979
+        // 3.1415927f and 3.14159265358979
+        public const real_t Pi = (real_t)3.1415926535897932384626433833M;
 
         /// <summary>
         /// Positive infinity. For negative infinity, use `-Mathf.Inf`.
@@ -34,8 +36,10 @@ namespace Godot
         /// </summary>
         public const real_t NaN = real_t.NaN;
 
-        private const real_t Deg2RadConst = (real_t) 0.0174532925199432957692369077M; // 0.0174532924f and 0.0174532925199433
-        private const real_t Rad2DegConst = (real_t) 57.295779513082320876798154814M; // 57.29578f and 57.2957795130823
+        // 0.0174532924f and 0.0174532925199433
+        private const real_t Deg2RadConst = (real_t)0.0174532925199432957692369077M;
+        // 57.29578f and 57.2957795130823
+        private const real_t Rad2DegConst = (real_t)57.295779513082320876798154814M;
 
         /// <summary>
         /// Returns the absolute value of `s` (i.e. positive value).
@@ -515,7 +519,8 @@ namespace Godot
         /// <returns>One of three possible values: `1`, `-1`, or `0`.</returns>
         public static int Sign(int s)
         {
-            if (s == 0) return 0;
+            if (s == 0)
+                return 0;
             return s < 0 ? -1 : 1;
         }
 
@@ -526,7 +531,8 @@ namespace Godot
         /// <returns>One of three possible values: `1`, `-1`, or `0`.</returns>
         public static int Sign(real_t s)
         {
-            if (s == 0) return 0;
+            if (s == 0)
+                return 0;
             return s < 0 ? -1 : 1;
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/MathfEx.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/MathfEx.cs
@@ -1,10 +1,9 @@
-using System;
-
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
 
 namespace Godot
 {
@@ -15,12 +14,12 @@ namespace Godot
         /// <summary>
         /// The natural number `e`.
         /// </summary>
-        public const real_t E = (real_t) 2.7182818284590452353602874714M; // 2.7182817f and 2.718281828459045
+        public const real_t E = (real_t)2.7182818284590452353602874714M; // 2.7182817f and 2.718281828459045
 
         /// <summary>
         /// The square root of 2.
         /// </summary>
-        public const real_t Sqrt2 = (real_t) 1.4142135623730950488016887242M; // 1.4142136f and 1.414213562373095
+        public const real_t Sqrt2 = (real_t)1.4142135623730950488016887242M; // 1.4142136f and 1.414213562373095
 
         /// <summary>
         /// A very small number used for float comparison with error tolerance.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {
@@ -177,7 +177,7 @@ namespace Godot
                 return null;
             }
 
-            return from + dir * -dist;
+            return from - (dir * dist);
         }
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace Godot
                 return null;
             }
 
-            return begin + segment * -dist;
+            return begin - (segment * dist);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -124,7 +124,7 @@ namespace Godot
                 instance = instance.Substring(2);
             }
 
-            return sign * Convert.ToInt32(instance, 2);;
+            return sign * Convert.ToInt32(instance, 2);
         }
 
         // <summary>
@@ -468,7 +468,7 @@ namespace Godot
         {
             uint hash = 5381;
 
-            foreach(uint c in instance)
+            foreach (uint c in instance)
             {
                 hash = (hash << 5) + hash + c; // hash * 33 + c
             }
@@ -798,8 +798,11 @@ namespace Godot
                 case '?':
                     return instance.Length > 0 && instance[0] != '.' && ExprMatch(instance.Substring(1), expr.Substring(1), caseSensitive);
                 default:
-                    if (instance.Length == 0) return false;
-                    return (caseSensitive ? instance[0] == expr[0] : char.ToUpper(instance[0]) == char.ToUpper(expr[0])) && ExprMatch(instance.Substring(1), expr.Substring(1), caseSensitive);
+                    if (instance.Length == 0)
+                        return false;
+                    if (caseSensitive)
+                        return instance[0] == expr[0];
+                    return (char.ToUpper(instance[0]) == char.ToUpper(expr[0])) && ExprMatch(instance.Substring(1), expr.Substring(1), caseSensitive);
             }
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -1,16 +1,10 @@
-// file: core/math/math_2d.h
-// commit: 7ad14e7a3e6f87ddc450f7e34621eb5200808451
-// file: core/math/math_2d.cpp
-// commit: 7ad14e7a3e6f87ddc450f7e34621eb5200808451
-// file: core/variant_call.cpp
-// commit: 5ad9be4c24e9d7dc5672fdc42cea896622fe5685
-using System;
-using System.Runtime.InteropServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -1,11 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
-
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -1,16 +1,10 @@
-// file: core/math/vector3.h
-// commit: bd282ff43f23fe845f29a3e25c8efc01bd65ffb0
-// file: core/math/vector3.cpp
-// commit: 7ad14e7a3e6f87ddc450f7e34621eb5200808451
-// file: core/variant_call.cpp
-// commit: 5ad9be4c24e9d7dc5672fdc42cea896622fe5685
-using System;
-using System.Runtime.InteropServices;
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -1,11 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
-
 #if REAL_T_IS_DOUBLE
 using real_t = System.Double;
 #else
 using real_t = System.Single;
 #endif
+using System;
+using System.Runtime.InteropServices;
 
 namespace Godot
 {


### PR DESCRIPTION
This PR adds a simple `.editorconfig` for C#. This PR was inspired by #49352, but is not a replacement for it.

This PR does not contain the majority of the rules of #49352, and only uses VS Code's C# formatter, which does only style changes, not code refactoring. The goal here is to knock out some of the "worst offenders" in an easy-to-review PR, and then there can be a follow-up PR that ports the rest of #49352 to master. Also, I can make a version of this PR for 3.x, if so #49352 will have to be rebased on top of it.