### PR TITLE
Revert "Fix duplicate selection in SceneTree (3.x)"

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -426,6 +426,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		}
 
 		if (!valid) {
+			//item->set_selectable(0,marked_selectable);
 			item->set_custom_color(0, get_color("disabled_font_color", "Editor"));
 			item->set_selectable(0, false);
 		}
@@ -533,7 +534,7 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 
 	if (p_node == selected) {
 		selected = nullptr;
-		_emit_node_selected();
+		emit_signal("node_selected");
 	}
 }
 
@@ -618,18 +619,30 @@ void SceneTreeEditor::_tree_changed() {
 	pending_test_update = true;
 }
 
+void SceneTreeEditor::_selected_changed() {
+	TreeItem *s = tree->get_selected();
+	ERR_FAIL_COND(!s);
+	NodePath np = s->get_metadata(0);
+
+	Node *n = get_node(np);
+
+	if (n == selected) {
+		return;
+	}
+
+	selected = get_node(np);
+
+	blocked++;
+	emit_signal("node_selected");
+	blocked--;
+}
+
 void SceneTreeEditor::_deselect_items() {
 	// Clear currently selected items in scene tree dock.
 	if (editor_selection) {
 		editor_selection->clear();
 		emit_signal("node_changed");
 	}
-}
-
-void SceneTreeEditor::_emit_node_selected() {
-	blocked++;
-	emit_signal("node_selected");
-	blocked--;
 }
 
 void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_selected) {
@@ -654,13 +667,7 @@ void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_
 	} else {
 		editor_selection->remove_node(n);
 	}
-
-	if (editor_selection->get_selected_nodes().size() == 1) {
-		selected = editor_selection->get_selected_node_list()[0];
-		_emit_node_selected();
-	} else {
-		emit_signal("node_changed");
-	}
+	emit_signal("node_changed");
 }
 
 void SceneTreeEditor::_notification(int p_what) {
@@ -747,7 +754,7 @@ void SceneTreeEditor::set_selected(Node *p_node, bool p_emit_selected) {
 	}
 
 	if (p_emit_selected) {
-		_emit_node_selected();
+		emit_signal("node_selected");
 	}
 }
 
@@ -1135,6 +1142,7 @@ void SceneTreeEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_tree", "scroll_to_selected"), &SceneTreeEditor::_update_tree, DEFVAL(false));
 	ClassDB::bind_method("_node_removed", &SceneTreeEditor::_node_removed);
 	ClassDB::bind_method("_node_renamed", &SceneTreeEditor::_node_renamed);
+	ClassDB::bind_method("_selected_changed", &SceneTreeEditor::_selected_changed);
 	ClassDB::bind_method("_deselect_items", &SceneTreeEditor::_deselect_items);
 	ClassDB::bind_method("_renamed", &SceneTreeEditor::_renamed);
 	ClassDB::bind_method("_rename_node", &SceneTreeEditor::_rename_node);
@@ -1208,10 +1216,12 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 		tree->connect("empty_tree_rmb_selected", this, "_rmb_select");
 	}
 
+	tree->connect("cell_selected", this, "_selected_changed");
 	tree->connect("item_edited", this, "_renamed", varray(), CONNECT_DEFERRED);
 	tree->connect("multi_selected", this, "_cell_multi_selected");
 	tree->connect("button_pressed", this, "_cell_button_pressed");
 	tree->connect("nothing_selected", this, "_deselect_items");
+	//tree->connect("item_edited", this,"_renamed",Vector<Variant>(),true);
 
 	error = memnew(AcceptDialog);
 	add_child(error);

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -132,8 +132,6 @@ class SceneTreeEditor : public Control {
 
 	Vector<StringName> valid_types;
 
-	void _emit_node_selected();
-
 public:
 	void set_filter(const String &p_filter);
 	String get_filter() const;


### PR DESCRIPTION
Reverts godotengine/godot#50561

Fixes #50744.

Related to #50762 but that PR handles further bug fixes for `master`-specific regressions.