### PR TITLE
Expose an ImportOrder enum in ResourceImporter

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -445,3 +445,8 @@ ResourceFormatImporter *ResourceFormatImporter::singleton = nullptr;
 ResourceFormatImporter::ResourceFormatImporter() {
 	singleton = this;
 }
+
+void ResourceImporter::_bind_methods() {
+	BIND_ENUM_CONSTANT(IMPORT_ORDER_DEFAULT);
+	BIND_ENUM_CONSTANT(IMPORT_ORDER_SCENE);
+}

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -96,6 +96,9 @@ public:
 class ResourceImporter : public RefCounted {
 	GDCLASS(ResourceImporter, RefCounted);
 
+protected:
+	static void _bind_methods();
+
 public:
 	virtual String get_importer_name() const = 0;
 	virtual String get_visible_name() const = 0;
@@ -103,7 +106,7 @@ public:
 	virtual String get_save_extension() const = 0;
 	virtual String get_resource_type() const = 0;
 	virtual float get_priority() const { return 1.0; }
-	virtual int get_import_order() const { return 0; }
+	virtual int get_import_order() const { return IMPORT_ORDER_DEFAULT; }
 	virtual int get_format_version() const { return 0; }
 
 	struct ImportOption {
@@ -115,6 +118,11 @@ public:
 				default_value(p_default) {
 		}
 		ImportOption() {}
+	};
+
+	enum ImportOrder {
+		IMPORT_ORDER_DEFAULT = 0,
+		IMPORT_ORDER_SCENE = 100,
 	};
 
 	virtual bool has_advanced_options() const { return false; }
@@ -136,5 +144,7 @@ public:
 	virtual bool are_import_settings_valid(const String &p_path) const { return true; }
 	virtual String get_import_settings_string() const { return String(); }
 };
+
+VARIANT_ENUM_CAST(ResourceImporter::ImportOrder);
 
 #endif // RESOURCE_IMPORTER_H

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -126,7 +126,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Gets the order of this importer to be run when importing resources. Higher values will be called later. Use this to ensure the importer runs after the dependencies are already imported.
+				Gets the order of this importer to be run when importing resources. Importers with [i]lower[/i] import orders will be called first, and higher values will be called later. Use this to ensure the importer runs after the dependencies are already imported. The default import order is [code]0[/code] unless overridden by a specific importer. See [enum ResourceImporter.ImportOrder] for some predefined values.
 			</description>
 		</method>
 		<method name="_get_importer_name" qualifiers="virtual">

--- a/doc/classes/ResourceImporter.xml
+++ b/doc/classes/ResourceImporter.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporter" inherits="RefCounted" version="4.0">
 	<brief_description>
+		Base class for the implementation of core resource importers.
 	</brief_description>
 	<description>
+		This is the base class for the resource importers implemented in core. To implement your own resource importers using editor plugins, see [EditorImportPlugin].
 	</description>
 	<tutorials>
+		<link title="Import plugins">https://docs.godotengine.org/en/latest/tutorials/plugins/editor/import_plugins.html</link>
 	</tutorials>
 	<methods>
 	</methods>
 	<constants>
+		<constant name="IMPORT_ORDER_DEFAULT" value="0" enum="ImportOrder">
+			The default import order.
+		</constant>
+		<constant name="IMPORT_ORDER_SCENE" value="100" enum="ImportOrder">
+			The import order for scenes, which ensures scenes are imported [i]after[/i] all other core resources such as textures. Custom importers should generally have an import order lower than [code]100[/code] to avoid issues when importing scenes that rely on custom resources.
+		</constant>
 	</constants>
 </class>

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -155,7 +155,8 @@ public:
 
 	virtual void get_import_options(List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const override;
-	virtual int get_import_order() const override { return 100; } //after everything
+	// Import scenes *after* everything else (such as textures).
+	virtual int get_import_order() const override { return ResourceImporter::IMPORT_ORDER_SCENE; }
 
 	Node *_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<EditorSceneImporterMesh>, List<Ref<Shape3D>>> &collision_map);
 	Node *_post_fix_node(Node *p_node, Node *p_root, Map<Ref<EditorSceneImporterMesh>, List<Ref<Shape3D>>> &collision_map, Set<Ref<EditorSceneImporterMesh>> &r_scanned_meshes, const Dictionary &p_node_data, const Dictionary &p_material_data, const Dictionary &p_animation_data, float p_animation_fps);


### PR DESCRIPTION
This avoids using magic numbers in code.

This closes https://github.com/godotengine/godot-proposals/issues/3034.