### PR TITLE
Portals - Config warning for Rooms with too many planes

### DIFF
--- a/scene/3d/room.cpp
+++ b/scene/3d/room.cpp
@@ -225,6 +225,13 @@ String Room::get_configuration_warning() const {
 		}
 	}
 
+	if (_planes.size() > 80) {
+		if (!warning.empty()) {
+			warning += "\n\n";
+		}
+		warning += TTR("Room convex hull contains a large number of planes.\nConsider simplifying the room bound in order to increase performance.");
+	}
+
 	return warning;
 }
 

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -796,6 +796,7 @@ void RoomManager::_third_pass_rooms(const LocalVector<Portal *> &p_portals) {
 			found_errors = true;
 		}
 		room->update_gizmo();
+		room->update_configuration_warning();
 	}
 
 	if (found_errors) {


### PR DESCRIPTION
Just a small addition, a config warning if the user creates a Room with a large number of bounding planes, letting them know to simplify it.

## Notes
* 80 planes is probably more than ideal, most rooms can get by with <20 planes, but at least this should warn against pathological cases, without being overly annoying
* Reminder to myself to add some info to the docs about the relationship between the number of points and planes in the convex hull

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
