### PR TITLE
Clarify the purpose of the default asset library URLs in the editor

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -603,8 +603,7 @@ void EditorAssetLibrary::_notification(int p_what) {
 
 void EditorAssetLibrary::_update_repository_options() {
 	Dictionary default_urls;
-	default_urls["godotengine.org"] = "https://godotengine.org/asset-library/api";
-	default_urls["localhost"] = "http://127.0.0.1/asset-library/api";
+	default_urls["godotengine.org (Official)"] = "https://godotengine.org/asset-library/api";
 	Dictionary available_urls = _EDITOR_DEF("asset_library/available_urls", default_urls, true);
 	repository->clear();
 	Array keys = available_urls.keys();


### PR DESCRIPTION
`localhost` was removed as it won't work out of the box. It can be added by the user if they're working on the asset library itself.

This won't affect existing installations due to how the editor settings are stored, but existing installations will keep working fine.

**Note:** There's also the question of whether we should still list `localhost` by default, since the editor asset library URLs can now be configured freely by the user. Most people won't be hosting their development server on port 80 since it requires root privileges.

## Preview

![image](https://user-images.githubusercontent.com/180032/126773047-296a2494-d8db-49fc-9f03-8acd5992cb99.png)

<details>
<summary>Old reversion of this PR</summary>

![image](https://user-images.githubusercontent.com/180032/126772336-c12ebdf6-628a-437f-95ca-1f79b480ca82.png)
</details>