### PR TITLE
Don't set metadata_label font if it doesn't exist

### DIFF
--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -48,8 +48,10 @@ void TexturePreview::_notification(int p_what) {
 				break;
 			}
 
-			Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), SNAME("EditorFonts"));
-			metadata_label->add_theme_font_override("font", metadata_label_font);
+			if (metadata_label) {
+				Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), SNAME("EditorFonts"));
+				metadata_label->add_theme_font_override("font", metadata_label_font);
+			}
 
 			checkerboard->set_texture(get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons")));
 		} break;

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -39,10 +39,10 @@ class TexturePreview : public MarginContainer {
 	GDCLASS(TexturePreview, MarginContainer);
 
 private:
-	TextureRect *texture_display;
+	TextureRect *texture_display = nullptr;
 
-	TextureRect *checkerboard;
-	Label *metadata_label;
+	TextureRect *checkerboard = nullptr;
+	Label *metadata_label = nullptr;
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Otherwise it causes crash when clicking SubViewport node.