### PR TITLE
Revert unnecessary changes to VisualScriptEmitSignal

### DIFF
--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -2268,7 +2268,7 @@ int VisualScriptEmitSignal::get_input_value_port_count() const {
 }
 
 int VisualScriptEmitSignal::get_output_value_port_count() const {
-	return 1;
+	return 0;
 }
 
 String VisualScriptEmitSignal::get_output_sequence_port_text(int p_port) const {
@@ -2309,16 +2309,6 @@ void VisualScriptEmitSignal::set_signal(const StringName &p_type) {
 
 StringName VisualScriptEmitSignal::get_signal() const {
 	return name;
-}
-
-void VisualScriptEmitSignal::_adjust_input_index(PropertyInfo &pinfo) const {
-	if (index != StringName()) {
-		Variant v;
-		Callable::CallError ce;
-		Variant::construct(pinfo.type, v, nullptr, 0, ce);
-		Variant i = v.get(index);
-		pinfo.type = i.get_type();
-	}
 }
 
 void VisualScriptEmitSignal::_validate_property(PropertyInfo &property) const {

--- a/modules/visual_script/visual_script_func_nodes.h
+++ b/modules/visual_script/visual_script_func_nodes.h
@@ -328,9 +328,6 @@ class VisualScriptEmitSignal : public VisualScriptNode {
 
 private:
 	StringName name;
-	StringName index;
-
-	void _adjust_input_index(PropertyInfo &pinfo) const;
 
 protected:
 	virtual void _validate_property(PropertyInfo &property) const override;


### PR DESCRIPTION
a few changes to many sneaked in to PR #49749 my apologies
This reverts part of commit 2032b56005b2f6add6b105a00f04c05f9b292eec.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
