### PR TITLE
Fix UndoRedo crash when clearing history

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -41,9 +41,13 @@ void UndoRedo::_discard_redo() {
 	for (int i = current_action + 1; i < actions.size(); i++) {
 		for (List<Operation>::Element *E = actions.write[i].do_ops.front(); E; E = E->next()) {
 			if (E->get().type == Operation::TYPE_REFERENCE) {
-				Object *obj = ObjectDB::get_instance(E->get().object);
-				if (obj) {
-					memdelete(obj);
+				if (E->get().ref.is_valid()) {
+					E->get().ref.unref();
+				} else {
+					Object *obj = ObjectDB::get_instance(E->get().object);
+					if (obj) {
+						memdelete(obj);
+					}
 				}
 			}
 		}
@@ -242,9 +246,13 @@ void UndoRedo::_pop_history_tail() {
 
 	for (List<Operation>::Element *E = actions.write[0].undo_ops.front(); E; E = E->next()) {
 		if (E->get().type == Operation::TYPE_REFERENCE) {
-			Object *obj = ObjectDB::get_instance(E->get().object);
-			if (obj) {
-				memdelete(obj);
+			if (E->get().ref.is_valid()) {
+				E->get().ref.unref();
+			} else {
+				Object *obj = ObjectDB::get_instance(E->get().object);
+				if (obj) {
+					memdelete(obj);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When the parameter of `add_{,un}do_reference` is an `Reference`, `UndoRedo` will hold an `Ref` to that reference.

When clearing action history (either discarding redo or clearing all history), the referenced object was manually `memdelete`d and might then be deleted again when the `Ref` is destructed.

So, I think an `unref` is enough in that case.

Fixes #50769 
Fixes #48756