### PR TITLE
Improve select tool's tooltip for 2D and 3D

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5325,7 +5325,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	select_button->set_pressed(true);
 	select_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/select_mode", TTR("Select Mode"), KEY_Q));
 	select_button->set_shortcut_context(this);
-	select_button->set_tooltip(keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate") + "\n" + TTR("Alt+Drag: Move") + "\n" + TTR("Press 'v' to Change Pivot, 'Shift+v' to Drag Pivot (while moving).") + "\n" + TTR("Alt+RMB: Show list of all nodes at position clicked, including locked."));
+	select_button->set_tooltip(keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate selected node around pivot.") + "\n" + TTR("Alt+Drag: Move selected node.") + "\n" + TTR("V: Set selected node's pivot position.") + "\n" + TTR("Alt+RMB: Show list of all nodes at position clicked, including locked.") + "\n" + keycode_get_string(KEY_MASK_CMD) + TTR("RMB: Add node at position clicked."));
 
 	hb->add_child(memnew(VSeparator));
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7021,8 +7021,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SELECT]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_SELECT]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_select", TTR("Select Mode"), KEY_Q));
 	tool_button[TOOL_MODE_SELECT]->set_shortcut_context(this);
-	tool_button[TOOL_MODE_SELECT]->set_tooltip(keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate\nAlt+Drag: Move\nAlt+RMB: Show list of all nodes at position clicked, including locked."));
-
+	tool_button[TOOL_MODE_SELECT]->set_tooltip(keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate selected node around pivot.") + "\n" + TTR("Alt+RMB: Show list of all nodes at position clicked, including locked."));
 	hbc_menu->add_child(memnew(VSeparator));
 
 	tool_button[TOOL_MODE_MOVE] = memnew(Button);


### PR DESCRIPTION
Makes tips clearer and more consistent.
Removes outdated `Shift+V` that isn't a thing anymore.
Adds tip for `Ctrl+RMB` for adding nodes at position.
Removes tip for `Alt+Drag` in 3D select tool, because it does not do anything. It could be added back if it is ever implemented, but for now it's just confusing.

| Before (2D) | After (2D) |
| - | - |
| ![image](https://user-images.githubusercontent.com/12120644/126838497-6bb2eeeb-1374-4d0c-9837-7c25cfb9cd48.png) | ![image](https://user-images.githubusercontent.com/12120644/126843790-fd2fd6f0-a21a-4037-a285-58d6c8439076.png) |

| Before (3D) | After (3D) |
| - | - |
| ![image](https://user-images.githubusercontent.com/12120644/126841433-eac00dde-3f03-4c8b-8497-c11b5a7f8ab6.png) | ![image](https://user-images.githubusercontent.com/12120644/126843803-92bd6e55-542d-42bc-9df0-0a128ec2d4b2.png) |

I think all of these changes can be added to 3.x as well.