### PR TITLE
Add a tooltip for Inclusive and Self in the editor profiler

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -588,8 +588,8 @@ EditorProfiler::EditorProfiler() {
 	hb->add_child(memnew(Label(TTR("Measure:"))));
 
 	display_mode = memnew(OptionButton);
-	display_mode->add_item(TTR("Frame Time (sec)"));
-	display_mode->add_item(TTR("Average Time (sec)"));
+	display_mode->add_item(TTR("Frame Time (ms)"));
+	display_mode->add_item(TTR("Average Time (ms)"));
 	display_mode->add_item(TTR("Frame %"));
 	display_mode->add_item(TTR("Physics Frame %"));
 	display_mode->connect("item_selected", callable_mp(this, &EditorProfiler::_combo_changed));
@@ -601,6 +601,7 @@ EditorProfiler::EditorProfiler() {
 	display_time = memnew(OptionButton);
 	display_time->add_item(TTR("Inclusive"));
 	display_time->add_item(TTR("Self"));
+	display_time->set_tooltip(TTR("Inclusive: Includes time from other functions called by this function.\nUse this to spot bottlenecks.\n\nSelf: Only count the time spent in the function itself, not in other functions called by that function.\nUse this to find individual functions to optimize."));
 	display_time->connect("item_selected", callable_mp(this, &EditorProfiler::_combo_changed));
 
 	hb->add_child(display_time);


### PR DESCRIPTION
This also changes the display mode tooltips to reflect the fact that times are now displayed in milliseconds instead of seconds.

## Preview

![image](https://user-images.githubusercontent.com/180032/126857616-69e2c886-826f-41e3-8863-01fe054fd980.png)