### PR TITLE
Fix Static & Rigid body generation on mesh import.

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -233,21 +233,6 @@ static String _fixstr(const String &p_what, const String &p_str) {
 	return what;
 }
 
-static void _gen_shape_list(const Ref<Mesh> &mesh, List<Ref<Shape3D>> &r_shape_list, bool p_convex) {
-	ERR_FAIL_NULL_MSG(mesh, "Cannot generate shape list with null mesh value");
-	if (!p_convex) {
-		Ref<Shape3D> shape = mesh->create_trimesh_shape();
-		r_shape_list.push_back(shape);
-	} else {
-		Vector<Ref<Shape3D>> cd = mesh->convex_decompose();
-		if (cd.size()) {
-			for (int i = 0; i < cd.size(); i++) {
-				r_shape_list.push_back(cd[i]);
-			}
-		}
-	}
-}
-
 static void _pre_gen_shape_list(const Ref<EditorSceneImporterMesh> &mesh, List<Ref<Shape3D>> &r_shape_list, bool p_convex) {
 	ERR_FAIL_NULL_MSG(mesh, "Cannot generate shape list with null mesh value");
 	if (!p_convex) {
@@ -425,7 +410,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<E
 			if (collision_map.has(mesh)) {
 				shapes = collision_map[mesh];
 			} else {
-				_gen_shape_list(mesh, shapes, true);
+				_pre_gen_shape_list(mesh, shapes, true);
 			}
 
 			RigidBody3D *rigid_body = memnew(RigidBody3D);
@@ -451,10 +436,10 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<E
 			if (collision_map.has(mesh)) {
 				shapes = collision_map[mesh];
 			} else if (_teststr(name, "col")) {
-				_gen_shape_list(mesh, shapes, false);
+				_pre_gen_shape_list(mesh, shapes, false);
 				collision_map[mesh] = shapes;
 			} else if (_teststr(name, "convcol")) {
-				_gen_shape_list(mesh, shapes, true);
+				_pre_gen_shape_list(mesh, shapes, true);
 				collision_map[mesh] = shapes;
 			}
 
@@ -509,11 +494,11 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<E
 			if (collision_map.has(mesh)) {
 				shapes = collision_map[mesh];
 			} else if (_teststr(mesh->get_name(), "col")) {
-				_gen_shape_list(mesh, shapes, false);
+				_pre_gen_shape_list(mesh, shapes, false);
 				collision_map[mesh] = shapes;
 				mesh->set_name(_fixstr(mesh->get_name(), "col"));
 			} else if (_teststr(mesh->get_name(), "convcol")) {
-				_gen_shape_list(mesh, shapes, true);
+				_pre_gen_shape_list(mesh, shapes, true);
 				collision_map[mesh] = shapes;
 				mesh->set_name(_fixstr(mesh->get_name(), "convcol"));
 			}


### PR DESCRIPTION
The function `_gen_shape_list` is using the resource `Res<Mesh>`, but during the import phase the resource used is instead `Ref<EditorSceneImporterMesh>`.

Note: the `Ref<EditorSceneImporterMesh>` is an intermediate resource, that will be used to create a `Res<Mesh>` at the end of the import process. `Ref<EditorSceneImporterMesh>` and `Ref<Mesh>` are not inheriting each other, so the internal cast done by `Ref<>` during the assignment, is always null:

```c++
Ref<EditorSceneImporterMesh> import_mesh(/* Assume it's initialized */);
CRASH_NOW(import_mesh.is_null());

Ref<Mesh> mesh = import_mesh;
CRASH_NOW(mesh.is_null()); // <--- Here we have a crash, since it's impossible perform the above cast, and the `mesh` is always null.
```

Here the full list of call to `_gen_shape_list`, where we can notice that a `Ref<EditorSceneImporterMesh>` is passed:
- https://github.com/AndreaCatania/godot/blob/master/editor/import/resource_importer_scene.cpp#L428
- https://github.com/AndreaCatania/godot/blob/master/editor/import/resource_importer_scene.cpp#L454-L458
- https://github.com/AndreaCatania/godot/blob/master/editor/import/resource_importer_scene.cpp#L512-L516

As you can notice, we always pass the following mesh: `Ref<EditorSceneImporterMesh> mesh = mi->get_mesh();`.

We already have the function `_pre_gen_shape_list` that executes the exact same job but using the correct type; Since there is no further usage of the function `_gen_shape_list` in the code base, I think it's just some leftover code, so I removed it entirely to use the proper function.

Now we have collision generation back 🤘
![Screenshot from 2021-07-24 08-38-52](https://user-images.githubusercontent.com/8342599/126859991-864a482a-ccd7-4265-aa65-1acff2d75954.png)
