### PR TITLE
Use dithering to fade DirectionalLight shadow splits between each other

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1953,7 +1953,8 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 
 	real_t texture_size = scene_render->get_directional_light_shadow_size(light->instance);
 
-	bool overlap = RSG::storage->light_directional_get_blend_splits(p_instance->base);
+	// FIXME: Overlap is always required because dithering is used if blend splitting is disabled.
+	const bool overlap = true;
 
 	real_t first_radius = 0.0;
 


### PR DESCRIPTION
See also https://github.com/godotengine/godot/pull/48776 (this does not supersede it, as both techniques can work together).

This provides a cheaper alternative to the Blend Splits property. It doesn't look as good, but it still helps make split transitions much less noticeable.

This PR is marked as a draft, since we'll need to revise how blend splitting is defined in DirectionalLight to move it to an enum project setting instead (`None (Fastest), Dither (Fast), Blend (Average)`).

This can be backported to `3.x`'s GLES3 backend and possibly GLES2.

### Performance comparison

**OS:** Fedora 34
**GPU:** NVIDIA GeForce GTX 1080 (driver version 465.31)

With the project used for the screenshots:

```yaml
No dithering
Project FPS: 200 (5.0 mspf)

Dithering
Project FPS: 198 (5.0 mspf)

Blending
Project FPS: 194 (5.1 mspf)
```

## Preview

*Directional shadow size was decreased from 4096 to 1024 to make the difference between each split blending mode more noticeable. In practice, the dithering pattern won't be as noticeable as it is here.*

*Click to view at full size.*

### No dithering

![No dithering](https://user-images.githubusercontent.com/180032/126860105-cb7a16e7-6076-4ff0-9580-83841c2ff322.png)

### Dithering

![Dithering](https://user-images.githubusercontent.com/180032/126860104-76d55ade-4be1-4a06-b1ae-81503c8f16aa.png)

### Blending

![Blending](https://user-images.githubusercontent.com/180032/126860106-cff1a2d0-89ed-4a25-85ef-96adba03c692.png)