### PR TITLE
Add a vertex color property to PrimitiveMesh

### DIFF
--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -44,5 +44,11 @@
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The current [Material] of the primitive mesh.
 		</member>
+		<member name="vertex_color" type="Color" setter="set_vertex_color" getter="get_vertex_color">
+			The vertex color to use for all of the primitive's points. This can reduce the need to use multiple materials when using the same mesh several times. You will still need to make the mesh resource unique for the vertex color to be editable individually from other instances, but the material will no longer need to be made unique. This can improve performance thanks to materials being reused more often.
+			[b]Note:[/b] This vertex color is only visible if the mesh's [BaseMaterial3D] has [member BaseMaterial3D.vertex_color_use_as_albedo] set to [code]true[/code]. If the mesh is using a custom [ShaderMaterial], the shader will have to make use of [code]COLOR[/code] in [code]vertex()[/code] for [member vertex_color] to have any effect.
+			[b]Note:[/b] Setting [member vertex_color] will cause the mesh to be regenerated, which can be relatively slow if the mesh has hundreds of triangles or more. Avoid changing [member vertex_color] every frame, except for simple cases such as quads or boxes or low-detail cylinders/spheres.
+			[b]Note:[/b] Vertex colors are clamped between [code]Color(0, 0, 0)[/code] and [code]Color(1, 1, 1)[/code]. This means HDR colors cannot be stored in the mesh itself.
+		</member>
 	</members>
 </class>

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -44,6 +44,7 @@ void PrimitiveMesh::_update() const {
 	}
 
 	Vector<Vector3> points = arr[RS::ARRAY_VERTEX];
+	Vector<Color> colors;
 
 	ERR_FAIL_COND_MSG(points.size() == 0, "_create_mesh_array must return at least a vertex array.");
 
@@ -54,6 +55,8 @@ void PrimitiveMesh::_update() const {
 	{
 		const Vector3 *r = points.ptr();
 		for (int i = 0; i < pc; i++) {
+			colors.push_back(vertex_color);
+
 			if (i == 0) {
 				aabb.position = r[i];
 			} else {
@@ -61,6 +64,8 @@ void PrimitiveMesh::_update() const {
 			}
 		}
 	}
+
+	arr[RS::ARRAY_COLOR] = colors;
 
 	Vector<int> indices = arr[RS::ARRAY_INDEX];
 
@@ -213,9 +218,13 @@ void PrimitiveMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flip_faces", "flip_faces"), &PrimitiveMesh::set_flip_faces);
 	ClassDB::bind_method(D_METHOD("get_flip_faces"), &PrimitiveMesh::get_flip_faces);
 
+	ClassDB::bind_method(D_METHOD("set_vertex_color", "modulate"), &PrimitiveMesh::set_vertex_color);
+	ClassDB::bind_method(D_METHOD("get_vertex_color"), &PrimitiveMesh::get_vertex_color);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::AABB, "custom_aabb", PROPERTY_HINT_NONE, ""), "set_custom_aabb", "get_custom_aabb");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_faces"), "set_flip_faces", "get_flip_faces");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "vertex_color"), "set_vertex_color", "get_vertex_color");
 
 	GDVIRTUAL_BIND(_create_mesh_array);
 }
@@ -255,6 +264,15 @@ void PrimitiveMesh::set_flip_faces(bool p_enable) {
 
 bool PrimitiveMesh::get_flip_faces() const {
 	return flip_faces;
+}
+
+void PrimitiveMesh::set_vertex_color(const Color &p_color) {
+	vertex_color = p_color;
+	_request_update();
+}
+
+Color PrimitiveMesh::get_vertex_color() const {
+	return vertex_color;
 }
 
 PrimitiveMesh::PrimitiveMesh() {

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -53,6 +53,7 @@ private:
 
 	Ref<Material> material;
 	bool flip_faces = false;
+	Color vertex_color = Color(1, 1, 1);
 
 	// make sure we do an update after we've finished constructing our object
 	mutable bool pending_request = true;
@@ -95,6 +96,9 @@ public:
 
 	void set_flip_faces(bool p_enable);
 	bool get_flip_faces() const;
+
+	void set_vertex_color(const Color &p_color);
+	Color get_vertex_color() const;
 
 	PrimitiveMesh();
 	~PrimitiveMesh();


### PR DESCRIPTION
This property can be used to color primitive meshes individually.

- This can be used to color billboards such as light flares without having to use a unique material for each color, improving performance.
- This can be used when prototyping to color different objects while keeping a single material for all meshes.
  - **Note:** Until https://github.com/godotengine/godot-proposals/issues/3031 is implemented, you will have to create a StandardMaterial3D resource, assign it to the mesh and enable **Vertex Color > Use As Albedo** for the color to be visible.
- This can be used in custom shaders to provide configurable per-instance information.

## Preview

***Note:** The property is now called `vertex_color` instead of `vertex_color_modulate`.*

https://user-images.githubusercontent.com/180032/126866782-bed89b28-bb2a-4ac3-9cf0-c115ad6ef125.mp4
