### PR TITLE
Fixed drag and drop not respecting type on exported arrays.

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -429,6 +429,12 @@ void EditorPropertyArray::_button_draw() {
 bool EditorPropertyArray::_is_drop_valid(const Dictionary &p_drag_data) const {
 	String allowed_type = Variant::get_type_name(subtype);
 
+	// When the subtype is of type Object, an additional subtype may be specified in the hint string
+	// (e.g. Resource, Texture2D, ShaderMaterial, etc). We want the allowed type to be that, not just "Object".
+	if (subtype == Variant::OBJECT && subtype_hint_string != "") {
+		allowed_type = subtype_hint_string;
+	}
+
 	Dictionary drag_data = p_drag_data;
 
 	if (drag_data.has("type") && String(drag_data["type"]) == "files") {


### PR DESCRIPTION
See #50718

Before: drag and drop of invalid type was allowed, and also created empty value in array.

https://user-images.githubusercontent.com/41730826/126869563-0d1b875c-6fcb-4e4d-acdc-969fa6a38e9d.mp4

After: drag and drop not allowed in the first place.

https://user-images.githubusercontent.com/41730826/126869529-849f31a6-f034-4ed3-88e7-83eea01c1500.mp4


