### PR TITLE
Fix documentation in StringExtensions

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -61,9 +61,9 @@ namespace Godot
             return string.Empty;
         }
 
-        // <summary>
-        // If the string is a path to a file, return the path to the file without the extension.
-        // </summary>
+        /// <summary>
+        /// If the string is a path to a file, return the path to the file without the extension.
+        /// </summary>
         public static string BaseName(this string instance)
         {
             int index = instance.LastIndexOf('.');
@@ -74,17 +74,17 @@ namespace Godot
             return instance;
         }
 
-        // <summary>
-        // Return true if the strings begins with the given string.
-        // </summary>
+        /// <summary>
+        /// Return <see langword="true"/> if the strings begins with the given string.
+        /// </summary>
         public static bool BeginsWith(this string instance, string text)
         {
             return instance.StartsWith(text);
         }
 
-        // <summary>
-        // Return the bigrams (pairs of consecutive letters) of this string.
-        // </summary>
+        /// <summary>
+        /// Return the bigrams (pairs of consecutive letters) of this string.
+        /// </summary>
         public static string[] Bigrams(this string instance)
         {
             var b = new string[instance.Length - 1];
@@ -127,9 +127,9 @@ namespace Godot
             return sign * Convert.ToInt32(instance, 2);
         }
 
-        // <summary>
-        // Return the amount of substrings in string.
-        // </summary>
+        /// <summary>
+        /// Return the amount of substrings in string.
+        /// </summary>
         public static int Count(this string instance, string what, bool caseSensitive = true, int from = 0, int to = 0)
         {
             if (what.Length == 0)
@@ -187,9 +187,9 @@ namespace Godot
             return c;
         }
 
-        // <summary>
-        // Return a copy of the string with special characters escaped using the C language standard.
-        // </summary>
+        /// <summary>
+        /// Return a copy of the string with special characters escaped using the C language standard.
+        /// </summary>
         public static string CEscape(this string instance)
         {
             var sb = new StringBuilder(string.Copy(instance));
@@ -209,9 +209,10 @@ namespace Godot
             return sb.ToString();
         }
 
-        // <summary>
-        // Return a copy of the string with escaped characters replaced by their meanings according to the C language standard.
-        // </summary>
+        /// <summary>
+        /// Return a copy of the string with escaped characters replaced by their meanings
+        /// according to the C language standard.
+        /// </summary>
         public static string CUnescape(this string instance)
         {
             var sb = new StringBuilder(string.Copy(instance));
@@ -231,9 +232,12 @@ namespace Godot
             return sb.ToString();
         }
 
-        // <summary>
-        // Change the case of some letters. Replace underscores with spaces, convert all letters to lowercase then capitalize first and every letter following the space character. For [code]capitalize camelCase mixed_with_underscores[/code] it will return [code]Capitalize Camelcase Mixed With Underscores[/code].
-        // </summary>
+        /// <summary>
+        /// Change the case of some letters. Replace underscores with spaces, convert all letters
+        /// to lowercase then capitalize first and every letter following the space character.
+        /// For <c>capitalize camelCase mixed_with_underscores</c> it will return
+        /// <c>Capitalize Camelcase Mixed With Underscores</c>.
+        /// </summary>
         public static string Capitalize(this string instance)
         {
             string aux = instance.Replace("_", " ").ToLower();
@@ -254,17 +258,17 @@ namespace Godot
             return cap;
         }
 
-        // <summary>
-        // Perform a case-sensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
-        // </summary>
+        /// <summary>
+        /// Perform a case-sensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
+        /// </summary>
         public static int CasecmpTo(this string instance, string to)
         {
             return instance.CompareTo(to, caseSensitive: true);
         }
 
-        // <summary>
-        // Perform a comparison to another string, return -1 if less, 0 if equal and +1 if greater.
-        // </summary>
+        /// <summary>
+        /// Perform a comparison to another string, return -1 if less, 0 if equal and +1 if greater.
+        /// </summary>
         public static int CompareTo(this string instance, string to, bool caseSensitive = true)
         {
             if (string.IsNullOrEmpty(instance))
@@ -316,25 +320,25 @@ namespace Godot
             }
         }
 
-        // <summary>
-        // Return true if the strings ends with the given string.
-        // </summary>
+        /// <summary>
+        /// Return <see langword="true"/> if the strings ends with the given string.
+        /// </summary>
         public static bool EndsWith(this string instance, string text)
         {
             return instance.EndsWith(text);
         }
 
-        // <summary>
-        // Erase [code]chars[/code] characters from the string starting from [code]pos[/code].
-        // </summary>
+        /// <summary>
+        /// Erase <paramref name="chars"/> characters from the string starting from <paramref name="pos"/>.
+        /// </summary>
         public static void Erase(this StringBuilder instance, int pos, int chars)
         {
             instance.Remove(pos, chars);
         }
 
-        // <summary>
-        // If the string is a path to a file, return the extension.
-        // </summary>
+        /// <summary>
+        /// If the string is a path to a file, return the extension.
+        /// </summary>
         public static string Extension(this string instance)
         {
             int pos = instance.FindLast(".");
@@ -345,14 +349,18 @@ namespace Godot
             return instance.Substring(pos + 1);
         }
 
-        /// <summary>Find the first occurrence of a substring. Optionally, the search starting position can be passed.</summary>
+        /// <summary>
+        /// Find the first occurrence of a substring. Optionally, the search starting position can be passed.
+        /// </summary>
         /// <returns>The starting position of the substring, or -1 if not found.</returns>
         public static int Find(this string instance, string what, int from = 0, bool caseSensitive = true)
         {
             return instance.IndexOf(what, from, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
         }
 
-        /// <summary>Find the first occurrence of a char. Optionally, the search starting position can be passed.</summary>
+        /// <summary>
+        /// Find the first occurrence of a char. Optionally, the search starting position can be passed.
+        /// </summary>
         /// <returns>The first instance of the char, or -1 if not found.</returns>
         public static int Find(this string instance, char what, int from = 0, bool caseSensitive = true)
         {
@@ -375,16 +383,19 @@ namespace Godot
             return instance.LastIndexOf(what, from, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
         }
 
-        /// <summary>Find the first occurrence of a substring but search as case-insensitive. Optionally, the search starting position can be passed.</summary>
+        /// <summary>
+        /// Find the first occurrence of a substring but search as case-insensitive.
+        /// Optionally, the search starting position can be passed.
+        /// </summary>
         /// <returns>The starting position of the substring, or -1 if not found.</returns>
         public static int FindN(this string instance, string what, int from = 0)
         {
             return instance.IndexOf(what, from, StringComparison.OrdinalIgnoreCase);
         }
 
-        // <summary>
-        // If the string is a path to a file, return the base directory.
-        // </summary>
+        /// <summary>
+        /// If the string is a path to a file, return the base directory.
+        /// </summary>
         public static string GetBaseDir(this string instance)
         {
             int basepos = instance.Find("://");
@@ -419,9 +430,9 @@ namespace Godot
             return @base + rs.Substr(0, sep);
         }
 
-        // <summary>
-        // If the string is a path to a file, return the file and ignore the base directory.
-        // </summary>
+        /// <summary>
+        /// If the string is a path to a file, return the file and ignore the base directory.
+        /// </summary>
         public static string GetFile(this string instance)
         {
             int sep = Mathf.Max(instance.FindLast("/"), instance.FindLast("\\"));
@@ -461,9 +472,9 @@ namespace Godot
             return Encoding.UTF8.GetString(bytes);
         }
 
-        // <summary>
-        // Hash the string and return a 32 bits unsigned integer.
-        // </summary>
+        /// <summary>
+        /// Hash the string and return a 32 bits unsigned integer.
+        /// </summary>
         public static uint Hash(this string instance)
         {
             uint hash = 5381;
@@ -553,17 +564,17 @@ namespace Godot
             return sign * int.Parse(instance, NumberStyles.HexNumber);
         }
 
-        // <summary>
-        // Insert a substring at a given position.
-        // </summary>
+        /// <summary>
+        /// Insert a substring at a given position.
+        /// </summary>
         public static string Insert(this string instance, int pos, string what)
         {
             return instance.Insert(pos, what);
         }
 
-        // <summary>
-        // If the string is a path to a file or directory, return true if the path is absolute.
-        // </summary>
+        /// <summary>
+        /// If the string is a path to a file or directory, return <see langword="true"/> if the path is absolute.
+        /// </summary>
         public static bool IsAbsPath(this string instance)
         {
             if (string.IsNullOrEmpty(instance))
@@ -574,17 +585,17 @@ namespace Godot
                 return instance[0] == '/' || instance[0] == '\\';
         }
 
-        // <summary>
-        // If the string is a path to a file or directory, return true if the path is relative.
-        // </summary>
+        /// <summary>
+        /// If the string is a path to a file or directory, return <see langword="true"/> if the path is relative.
+        /// </summary>
         public static bool IsRelPath(this string instance)
         {
             return !IsAbsPath(instance);
         }
 
-        // <summary>
-        // Check whether this string is a subsequence of the given string.
-        // </summary>
+        /// <summary>
+        /// Check whether this string is a subsequence of the given string.
+        /// </summary>
         public static bool IsSubsequenceOf(this string instance, string text, bool caseSensitive = true)
         {
             int len = instance.Length;
@@ -625,34 +636,36 @@ namespace Godot
             return false;
         }
 
-        // <summary>
-        // Check whether this string is a subsequence of the given string, ignoring case differences.
-        // </summary>
+        /// <summary>
+        /// Check whether this string is a subsequence of the given string, ignoring case differences.
+        /// </summary>
         public static bool IsSubsequenceOfI(this string instance, string text)
         {
             return instance.IsSubsequenceOf(text, caseSensitive: false);
         }
 
-        // <summary>
-        // Check whether the string contains a valid float.
-        // </summary>
+        /// <summary>
+        /// Check whether the string contains a valid <see langword="float"/>.
+        /// </summary>
         public static bool IsValidFloat(this string instance)
         {
             float f;
             return float.TryParse(instance, out f);
         }
 
-        // <summary>
-        // Check whether the string contains a valid color in HTML notation.
-        // </summary>
+        /// <summary>
+        /// Check whether the string contains a valid color in HTML notation.
+        /// </summary>
         public static bool IsValidHtmlColor(this string instance)
         {
             return Color.HtmlIsValid(instance);
         }
 
-        // <summary>
-        // Check whether the string is a valid identifier. As is common in programming languages, a valid identifier may contain only letters, digits and underscores (_) and the first character may not be a digit.
-        // </summary>
+        /// <summary>
+        /// Check whether the string is a valid identifier. As is common in
+        /// programming languages, a valid identifier may contain only letters,
+        /// digits and underscores (_) and the first character may not be a digit.
+        /// </summary>
         public static bool IsValidIdentifier(this string instance)
         {
             int len = instance.Length;
@@ -680,18 +693,18 @@ namespace Godot
             return true;
         }
 
-        // <summary>
-        // Check whether the string contains a valid integer.
-        // </summary>
+        /// <summary>
+        /// Check whether the string contains a valid integer.
+        /// </summary>
         public static bool IsValidInteger(this string instance)
         {
             int f;
             return int.TryParse(instance, out f);
         }
 
-        // <summary>
-        // Check whether the string contains a valid IP address.
-        // </summary>
+        /// <summary>
+        /// Check whether the string contains a valid IP address.
+        /// </summary>
         public static bool IsValidIPAddress(this string instance)
         {
             // TODO: Support IPv6 addresses
@@ -714,9 +727,9 @@ namespace Godot
             return true;
         }
 
-        // <summary>
-        // Return a copy of the string with special characters escaped using the JSON standard.
-        // </summary>
+        /// <summary>
+        /// Return a copy of the string with special characters escaped using the JSON standard.
+        /// </summary>
         public static string JSONEscape(this string instance)
         {
             var sb = new StringBuilder(string.Copy(instance));
@@ -733,9 +746,9 @@ namespace Godot
             return sb.ToString();
         }
 
-        // <summary>
-        // Return an amount of characters from the left of the string.
-        // </summary>
+        /// <summary>
+        /// Return an amount of characters from the left of the string.
+        /// </summary>
         public static string Left(this string instance, int pos)
         {
             if (pos <= 0)
@@ -783,7 +796,8 @@ namespace Godot
         }
 
         /// <summary>
-        /// Do a simple expression match, where '*' matches zero or more arbitrary characters and '?' matches any single character except '.'.
+        /// Do a simple expression match, where '*' matches zero or more
+        /// arbitrary characters and '?' matches any single character except '.'.
         /// </summary>
         private static bool ExprMatch(this string instance, string expr, bool caseSensitive)
         {
@@ -807,7 +821,8 @@ namespace Godot
         }
 
         /// <summary>
-        /// Do a simple case sensitive expression match, using ? and * wildcards (see [method expr_match]).
+        /// Do a simple case sensitive expression match, using ? and * wildcards
+        /// (see <see cref="ExprMatch(string, string, bool)"/>).
         /// </summary>
         public static bool Match(this string instance, string expr, bool caseSensitive = true)
         {
@@ -818,7 +833,8 @@ namespace Godot
         }
 
         /// <summary>
-        /// Do a simple case insensitive expression match, using ? and * wildcards (see [method expr_match]).
+        /// Do a simple case insensitive expression match, using ? and * wildcards
+        /// (see <see cref="ExprMatch(string, string, bool)"/>).
         /// </summary>
         public static bool MatchN(this string instance, string expr)
         {
@@ -828,9 +844,9 @@ namespace Godot
             return instance.ExprMatch(expr, caseSensitive: false);
         }
 
-        // <summary>
-        // Return the MD5 hash of the string as an array of bytes.
-        // </summary>
+        /// <summary>
+        /// Return the MD5 hash of the string as an array of bytes.
+        /// </summary>
         public static byte[] MD5Buffer(this string instance)
         {
             return godot_icall_String_md5_buffer(instance);
@@ -839,9 +855,9 @@ namespace Godot
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static byte[] godot_icall_String_md5_buffer(string str);
 
-        // <summary>
-        // Return the MD5 hash of the string as a string.
-        // </summary>
+        /// <summary>
+        /// Return the MD5 hash of the string as a string.
+        /// </summary>
         public static string MD5Text(this string instance)
         {
             return godot_icall_String_md5_text(instance);
@@ -850,25 +866,25 @@ namespace Godot
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static string godot_icall_String_md5_text(string str);
 
-        // <summary>
-        // Perform a case-insensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
-        // </summary>
+        /// <summary>
+        /// Perform a case-insensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
+        /// </summary>
         public static int NocasecmpTo(this string instance, string to)
         {
             return instance.CompareTo(to, caseSensitive: false);
         }
 
-        // <summary>
-        // Return the character code at position [code]at[/code].
-        // </summary>
+        /// <summary>
+        /// Return the character code at position <paramref name="at"/>.
+        /// </summary>
         public static int OrdAt(this string instance, int at)
         {
             return instance[at];
         }
 
-        // <summary>
-        // Format a number to have an exact number of [code]digits[/code] after the decimal point.
-        // </summary>
+        /// <summary>
+        /// Format a number to have an exact number of <paramref name="digits"/> after the decimal point.
+        /// </summary>
         public static string PadDecimals(this string instance, int digits)
         {
             int c = instance.Find(".");
@@ -902,9 +918,9 @@ namespace Godot
             return instance;
         }
 
-        // <summary>
-        // Format a number to have an exact number of [code]digits[/code] before the decimal point.
-        // </summary>
+        /// <summary>
+        /// Format a number to have an exact number of <paramref name="digits"/> before the decimal point.
+        /// </summary>
         public static string PadZeros(this string instance, int digits)
         {
             string s = instance;
@@ -935,9 +951,10 @@ namespace Godot
             return s;
         }
 
-        // <summary>
-        // If the string is a path, this concatenates [code]file[/code] at the end of the string as a subpath. E.g. [code]"this/is".plus_file("path") == "this/is/path"[/code].
-        // </summary>
+        /// <summary>
+        /// If the string is a path, this concatenates <paramref name="file"/> at the end of the string as a subpath.
+        /// E.g. <c>"this/is".PlusFile("path") == "this/is/path"</c>.
+        /// </summary>
         public static string PlusFile(this string instance, string file)
         {
             if (instance.Length > 0 && instance[instance.Length - 1] == '/')
@@ -945,25 +962,25 @@ namespace Godot
             return instance + "/" + file;
         }
 
-        // <summary>
-        // Replace occurrences of a substring for different ones inside the string.
-        // </summary>
+        /// <summary>
+        /// Replace occurrences of a substring for different ones inside the string.
+        /// </summary>
         public static string Replace(this string instance, string what, string forwhat)
         {
             return instance.Replace(what, forwhat);
         }
 
-        // <summary>
-        // Replace occurrences of a substring for different ones inside the string, but search case-insensitive.
-        // </summary>
+        /// <summary>
+        /// Replace occurrences of a substring for different ones inside the string, but search case-insensitive.
+        /// </summary>
         public static string ReplaceN(this string instance, string what, string forwhat)
         {
             return Regex.Replace(instance, what, forwhat, RegexOptions.IgnoreCase);
         }
 
-        // <summary>
-        // Perform a search for a substring, but start from the end of the string instead of the beginning.
-        // </summary>
+        /// <summary>
+        /// Perform a search for a substring, but start from the end of the string instead of the beginning.
+        /// </summary>
         public static int RFind(this string instance, string what, int from = -1)
         {
             return godot_icall_String_rfind(instance, what, from);
@@ -972,9 +989,10 @@ namespace Godot
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static int godot_icall_String_rfind(string str, string what, int from);
 
-        // <summary>
-        // Perform a search for a substring, but start from the end of the string instead of the beginning. Also search case-insensitive.
-        // </summary>
+        /// <summary>
+        /// Perform a search for a substring, but start from the end of the string instead of the beginning.
+        /// Also search case-insensitive.
+        /// </summary>
         public static int RFindN(this string instance, string what, int from = -1)
         {
             return godot_icall_String_rfindn(instance, what, from);
@@ -983,9 +1001,9 @@ namespace Godot
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static int godot_icall_String_rfindn(string str, string what, int from);
 
-        // <summary>
-        // Return the right side of the string from a given position.
-        // </summary>
+        /// <summary>
+        /// Return the right side of the string from a given position.
+        /// </summary>
         public static string Right(this string instance, int pos)
         {
             if (pos >= instance.Length)
@@ -1032,9 +1050,9 @@ namespace Godot
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static byte[] godot_icall_String_sha256_buffer(string str);
 
-        // <summary>
-        // Return the SHA-256 hash of the string as a string.
-        // </summary>
+        /// <summary>
+        /// Return the SHA-256 hash of the string as a string.
+        /// </summary>
         public static string SHA256Text(this string instance)
         {
             return godot_icall_String_sha256_text(instance);
@@ -1043,9 +1061,10 @@ namespace Godot
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static string godot_icall_String_sha256_text(string str);
 
-        // <summary>
-        // Return the similarity index of the text compared to this string. 1 means totally similar and 0 means totally dissimilar.
-        // </summary>
+        /// <summary>
+        /// Return the similarity index of the text compared to this string.
+        /// 1 means totally similar and 0 means totally dissimilar.
+        /// </summary>
         public static float Similarity(this string instance, string text)
         {
             if (instance == text)
@@ -1083,17 +1102,19 @@ namespace Godot
             return 2.0f * inter / sum;
         }
 
-        // <summary>
-        // Split the string by a divisor string, return an array of the substrings. Example "One,Two,Three" will return ["One","Two","Three"] if split by ",".
-        // </summary>
+        /// <summary>
+        /// Split the string by a divisor string, return an array of the substrings.
+        /// Example "One,Two,Three" will return ["One","Two","Three"] if split by ",".
+        /// </summary>
         public static string[] Split(this string instance, string divisor, bool allowEmpty = true)
         {
             return instance.Split(new[] { divisor }, StringSplitOptions.RemoveEmptyEntries);
         }
 
-        // <summary>
-        // Split the string in floats by using a divisor string, return an array of the substrings. Example "1,2.5,3" will return [1,2.5,3] if split by ",".
-        // </summary>
+        /// <summary>
+        /// Split the string in floats by using a divisor string, return an array of the substrings.
+        /// Example "1,2.5,3" will return [1,2.5,3] if split by ",".
+        /// </summary>
         public static float[] SplitFloats(this string instance, string divisor, bool allowEmpty = true)
         {
             var ret = new List<float>();
@@ -1125,9 +1146,10 @@ namespace Godot
             (char)30, (char)31, (char)32
         };
 
-        // <summary>
-        // Return a copy of the string stripped of any non-printable character at the beginning and the end. The optional arguments are used to toggle stripping on the left and right edges respectively.
-        // </summary>
+        /// <summary>
+        /// Return a copy of the string stripped of any non-printable character at the beginning and the end.
+        /// The optional arguments are used to toggle stripping on the left and right edges respectively.
+        /// </summary>
         public static string StripEdges(this string instance, bool left = true, bool right = true)
         {
             if (left)
@@ -1140,58 +1162,62 @@ namespace Godot
             return instance.TrimEnd(_nonPrintable);
         }
 
-        // <summary>
-        // Return part of the string from the position [code]from[/code], with length [code]len[/code].
-        // </summary>
+        /// <summary>
+        /// Return part of the string from the position <paramref name="from"/>, with length <paramref name="len"/>.
+        /// </summary>
         public static string Substr(this string instance, int from, int len)
         {
             int max = instance.Length - from;
             return instance.Substring(from, len > max ? max : len);
         }
 
-        // <summary>
-        // Convert the String (which is a character array) to PackedByteArray (which is an array of bytes). The conversion is speeded up in comparison to to_utf8() with the assumption that all the characters the String contains are only ASCII characters.
-        // </summary>
+        /// <summary>
+        /// Convert the String (which is a character array) to PackedByteArray (which is an array of bytes).
+        /// The conversion is speeded up in comparison to <see cref="ToUTF8(string)"/> with the assumption
+        /// that all the characters the String contains are only ASCII characters.
+        /// </summary>
         public static byte[] ToAscii(this string instance)
         {
             return Encoding.ASCII.GetBytes(instance);
         }
 
-        // <summary>
-        // Convert a string, containing a decimal number, into a [code]float[/code].
-        // </summary>
+        /// <summary>
+        /// Convert a string, containing a decimal number, into a <see langword="float" />.
+        /// </summary>
         public static float ToFloat(this string instance)
         {
             return float.Parse(instance);
         }
 
-        // <summary>
-        // Convert a string, containing an integer number, into an [code]int[/code].
-        // </summary>
+        /// <summary>
+        /// Convert a string, containing an integer number, into an <see langword="int" />.
+        /// </summary>
         public static int ToInt(this string instance)
         {
             return int.Parse(instance);
         }
 
-        // <summary>
-        // Return the string converted to lowercase.
-        // </summary>
+        /// <summary>
+        /// Return the string converted to lowercase.
+        /// </summary>
         public static string ToLower(this string instance)
         {
             return instance.ToLower();
         }
 
-        // <summary>
-        // Return the string converted to uppercase.
-        // </summary>
+        /// <summary>
+        /// Return the string converted to uppercase.
+        /// </summary>
         public static string ToUpper(this string instance)
         {
             return instance.ToUpper();
         }
 
-        // <summary>
-        // Convert the String (which is an array of characters) to PackedByteArray (which is an array of bytes). The conversion is a bit slower than to_ascii(), but supports all UTF-8 characters. Therefore, you should prefer this function over to_ascii().
-        // </summary>
+        /// <summary>
+        /// Convert the String (which is an array of characters) to PackedByteArray (which is an array of bytes).
+        /// The conversion is a bit slower than <see cref="ToAscii(string)"/>, but supports all UTF-8 characters.
+        /// Therefore, you should prefer this function over <see cref="ToAscii(string)"/>.
+        /// </summary>
         public static byte[] ToUTF8(this string instance)
         {
             return Encoding.UTF8.GetBytes(instance);
@@ -1224,17 +1250,18 @@ namespace Godot
             return Uri.EscapeDataString(instance);
         }
 
-        // <summary>
-        // Return a copy of the string with special characters escaped using the XML standard.
-        // </summary>
+        /// <summary>
+        /// Return a copy of the string with special characters escaped using the XML standard.
+        /// </summary>
         public static string XMLEscape(this string instance)
         {
             return SecurityElement.Escape(instance);
         }
 
-        // <summary>
-        // Return a copy of the string with escaped characters replaced by their meanings according to the XML standard.
-        // </summary>
+        /// <summary>
+        /// Return a copy of the string with escaped characters replaced by their meanings
+        /// according to the XML standard.
+        /// </summary>
         public static string XMLUnescape(this string instance)
         {
             return SecurityElement.FromString(instance).Text;


### PR DESCRIPTION
I noticed the documentation in `StringExtensions.cs` was wrongly formatted, this PR fixes it.
