### PR TITLE
Fix typo in CollisionObject documentation

### DIFF
--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -107,8 +107,8 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
-				If [code]value[/value] is [code]true[/code], sets the specified [code]bit[/code] in the the [member collision_layer].
-				If [code]value[/value] is [code]false[/code], clears the specified [code]bit[/code] in the the [member collision_layer].
+				If [code]value[/code] is [code]true[/code], sets the specified [code]bit[/code] in the the [member collision_layer].
+				If [code]value[/code] is [code]false[/code], clears the specified [code]bit[/code] in the the [member collision_layer].
 			</description>
 		</method>
 		<method name="set_collision_mask_bit">
@@ -119,8 +119,8 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
-				If [code]value[/value] is [code]true[/code], sets the specified [code]bit[/code] in the the [member collision_mask].
-				If [code]value[/value] is [code]false[/code], clears the specified [code]bit[/code] in the the [member collision_mask].
+				If [code]value[/code] is [code]true[/code], sets the specified [code]bit[/code] in the the [member collision_mask].
+				If [code]value[/code] is [code]false[/code], clears the specified [code]bit[/code] in the the [member collision_mask].
 			</description>
 		</method>
 		<method name="shape_find_owner" qualifiers="const">

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -93,8 +93,8 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
-				If [code]value[/value] is [code]true[/code], sets the specified [code]bit[/code] in the the [member collision_layer].
-				If [code]value[/value] is [code]false[/code], clears the specified [code]bit[/code] in the the [member collision_layer].
+				If [code]value[/code] is [code]true[/code], sets the specified [code]bit[/code] in the the [member collision_layer].
+				If [code]value[/code] is [code]false[/code], clears the specified [code]bit[/code] in the the [member collision_layer].
 			</description>
 		</method>
 		<method name="set_collision_mask_bit">
@@ -105,8 +105,8 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
-				If [code]value[/value] is [code]true[/code], sets the specified [code]bit[/code] in the the [member collision_mask].
-				If [code]value[/value] is [code]false[/code], clears the specified [code]bit[/code] in the the [member collision_mask].
+				If [code]value[/code] is [code]true[/code], sets the specified [code]bit[/code] in the the [member collision_mask].
+				If [code]value[/code] is [code]false[/code], clears the specified [code]bit[/code] in the the [member collision_mask].
 			</description>
 		</method>
 		<method name="shape_find_owner" qualifiers="const">


### PR DESCRIPTION
Fixes a typo I found in the documentation for `CollisionObject3D` and `CollisionObject2D`.