### PR TITLE
Fix check for the first key in JSON stringify from Dictionary code

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -121,8 +121,11 @@ String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_
 				keys.sort();
 			}
 
+			bool first_key = true;
 			for (Variant &E : keys) {
-				if (E != keys.front()) {
+				if (first_key) {
+					first_key = false;
+				} else {
 					s += ",";
 					s += end_statement;
 				}


### PR DESCRIPTION
Fixes part of #50822, a regression introduced by #50511.

We can leave that issue open for now since @Razoric480 says he was investigating issues with LSP symbols.