### PR TITLE
Modulate albedo by vertex color in the fallback 3D material

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -691,7 +691,7 @@ void vertex() {
 }
 
 void fragment() {
-	ALBEDO = vec3(0.6);
+	ALBEDO = vec3(0.6) * vec3(COLOR.r, COLOR.g, COLOR.b);
 	ROUGHNESS = 0.8;
 	METALLIC = 0.2;
 }


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/50801.

This lets people preview vertex color without having to assign a material to a mesh.

This makes the process of debugging procedural geometry generation more convenient, in addition to allowing the customization of primitive mesh colors out of the box.

**This change does not affect the default StandardMaterial3D configuration**, and should therefore not impact performance in a finished project that won't use any fallback materials.

This closes https://github.com/godotengine/godot-proposals/issues/3031.