### PR TITLE
Optimise `is_layout_rtl`.

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -179,6 +179,8 @@ private:
 		GrowDirection v_grow = GROW_DIRECTION_END;
 
 		LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
+		bool is_rtl_dirty = true;
+		bool is_rtl = false;
 
 		real_t rotation = 0.0;
 		Vector2 scale = Vector2(1, 1);


### PR DESCRIPTION
Caches the return value of the `is_layout_rtl`, to avoid calling it recursively for all control parents on each call. It's recalculated only when layout direction property is changed, control changes parent or translation.