### PR TITLE
Add shortcut to toggle the 3D editor's camera preview

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4290,6 +4290,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 
 	preview_camera = memnew(CheckBox);
 	preview_camera->set_text(TTR("Preview"));
+	preview_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTR("Toggle Camera Preview"), KEY_MASK_CMD | KEY_P));
 	vbox->add_child(preview_camera);
 	preview_camera->set_h_size_flags(0);
 	preview_camera->hide();


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/50837.

A Camera3D node still has to be selected to initially enable camera preview, but another node can then be selected and the preview can be disabled by pressing the shortcut key again.

This closes https://github.com/godotengine/godot-proposals/issues/3039.