### PR TITLE
Add shortcut to toggle the 3D editor's camera preview (3.x)

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -3910,6 +3910,7 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 
 	preview_camera = memnew(CheckBox);
 	preview_camera->set_text(TTR("Preview"));
+	preview_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTR("Toggle Camera Preview"), KEY_MASK_CMD | KEY_P));
 	vbox->add_child(preview_camera);
 	preview_camera->set_h_size_flags(0);
 	preview_camera->hide();


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50836.

A Camera node still has to be selected to initially enable camera preview, but another node can then be selected and the preview can be disabled by pressing the shortcut key again.