### PR TITLE
Fix various typos

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -935,7 +935,7 @@ void ResourceLoaderBinary::open(FileAccess *p_f, bool p_no_resources, bool p_kee
 					// If a UID is found and the path is valid, it will be used, otherwise, it falls back to the path.
 					er.path = ResourceUID::get_singleton()->get_id_path(er.uid);
 				} else {
-					WARN_PRINT(String(res_path + ": In external resouce #" + itos(i) + ", invalid UUID: " + ResourceUID::get_singleton()->id_to_text(er.uid) + " - using text path instead: " + er.path).utf8().get_data());
+					WARN_PRINT(String(res_path + ": In external resource #" + itos(i) + ", invalid UUID: " + ResourceUID::get_singleton()->id_to_text(er.uid) + " - using text path instead: " + er.path).utf8().get_data());
 				}
 			}
 		}

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -6037,7 +6037,7 @@ RID RenderingDeviceVulkan::render_pipeline_create(RID p_shader, FramebufferForma
 		specialization_info.resize(pipeline_stages.size());
 		specialization_map_entries.resize(pipeline_stages.size());
 		for (int i = 0; i < shader->specialization_constants.size(); i++) {
-			//see if overriden
+			//see if overridden
 			const Shader::SpecializationConstant &sc = shader->specialization_constants[i];
 			data_ptr[i] = sc.constant.int_value; //just copy the 32 bits
 
@@ -6181,7 +6181,7 @@ RID RenderingDeviceVulkan::compute_pipeline_create(RID p_shader, const Vector<Pi
 		specialization_constant_data.resize(shader->specialization_constants.size());
 		uint32_t *data_ptr = specialization_constant_data.ptrw();
 		for (int i = 0; i < shader->specialization_constants.size(); i++) {
-			//see if overriden
+			//see if overridden
 			const Shader::SpecializationConstant &sc = shader->specialization_constants[i];
 			data_ptr[i] = sc.constant.int_value; //just copy the 32 bits
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -126,7 +126,7 @@ Vector<String> EditorFileSystemDirectory::get_file_deps(int p_idx) const {
 		}
 		ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(dep);
 		if (uid != ResourceUID::INVALID_ID) {
-			//return proper dependency resoure from uid
+			//return proper dependency resource from uid
 			if (ResourceUID::get_singleton()->has_id(uid)) {
 				dep = ResourceUID::get_singleton()->get_id_path(uid);
 			} else {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1555,7 +1555,7 @@ int EditorNode::_save_external_resources() {
 		if (!res->get_path().is_resource_file()) {
 			continue;
 		}
-		//not only check if this resourec is edited, check contained subresources too
+		//not only check if this resource is edited, check contained subresources too
 		if (_find_edited_resources(res, edited_subresources)) {
 			ResourceSaver::save(res->get_path(), res, flg);
 			saved++;

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -150,7 +150,7 @@ void PluginConfigDialog::_on_required_text_changed(const String &) {
 	if (script_edit->get_text().get_extension() != ext) {
 		is_valid = false;
 		script_validation->set_texture(invalid_icon);
-		script_validation->set_tooltip(vformat(TTR("Script extension must match chosen langauge extension (.%s)."), ext));
+		script_validation->set_tooltip(vformat(TTR("Script extension must match chosen language extension (.%s)."), ext));
 	}
 	if (script_edit->get_text().get_basename().is_empty()) {
 		is_valid = false;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -160,12 +160,12 @@ bool RenderForwardMobile::free(RID p_rid) {
 /* Render functions */
 
 RD::DataFormat RenderForwardMobile::_render_buffers_get_color_format() {
-	// Using 32bit buffers enables AFBC on mobile devices which should have a definate performance improvement (MALI G710 and newer support this on 64bit RTs)
+	// Using 32bit buffers enables AFBC on mobile devices which should have a definite performance improvement (MALI G710 and newer support this on 64bit RTs)
 	return RD::DATA_FORMAT_A2B10G10R10_UNORM_PACK32;
 }
 
 bool RenderForwardMobile::_render_buffers_can_be_storage() {
-	// Using 32bit buffers enables AFBC on mobile devices which should have a definate performance improvement (MALI G710 and newer support this on 64bit RTs)
+	// Using 32bit buffers enables AFBC on mobile devices which should have a definite performance improvement (MALI G710 and newer support this on 64bit RTs)
 	// Doesn't support storage
 	return false;
 }

--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -1214,7 +1214,7 @@ void main() {
 		specular_light *= specular * metallic * albedo * 2.0;
 #else
 
-		// scales the specular reflections, needs to be be computed before lighting happens,
+		// scales the specular reflections, needs to be computed before lighting happens,
 		// but after environment, GI, and reflection probes are added
 		// Environment brdf approximation (Lazarov 2013)
 		// see https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -981,7 +981,7 @@ void main() {
 		specular_light *= specular * metallic * albedo * 2.0;
 #else
 
-		// scales the specular reflections, needs to be be computed before lighting happens,
+		// scales the specular reflections, needs to be computed before lighting happens,
 		// but after environment, GI, and reflection probes are added
 		// Environment brdf approximation (Lazarov 2013)
 		// see https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile


### PR DESCRIPTION
Follow-up typos found via `codespell -q 3 -S ./thirdparty,*.po,./DONORS.md -L ackward,ang,ans,ba,beng,cas,childs,childrens,dof,doubleclick,fave,findn,hist,inout,leapyear,lod,nd,numer,ois,ony,paket,seeked,sinc,switchs,te,uint`