### PR TITLE
Implement Binary Shader Compilation

### DIFF
--- a/doc/classes/RDShaderFile.xml
+++ b/doc/classes/RDShaderFile.xml
@@ -7,8 +7,8 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_bytecode" qualifiers="const">
-			<return type="RDShaderBytecode">
+		<method name="get_spirv" qualifiers="const">
+			<return type="RDShaderSPIRV">
 			</return>
 			<argument index="0" name="version" type="StringName" default="&amp;&quot;&quot;">
 			</argument>
@@ -24,7 +24,7 @@
 		<method name="set_bytecode">
 			<return type="void">
 			</return>
-			<argument index="0" name="bytecode" type="RDShaderBytecode">
+			<argument index="0" name="bytecode" type="RDShaderSPIRV">
 			</argument>
 			<argument index="1" name="version" type="StringName" default="&amp;&quot;&quot;">
 			</argument>

--- a/doc/classes/RDShaderSPIRV.xml
+++ b/doc/classes/RDShaderSPIRV.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="RDShaderBytecode" inherits="Resource" version="4.0">
+<class name="RDShaderSPIRV" inherits="Resource" version="4.0">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -635,8 +635,16 @@
 			<description>
 			</description>
 		</method>
-		<method name="shader_compile_from_source">
-			<return type="RDShaderBytecode">
+		<method name="shader_compile_binary_from_spirv">
+			<return type="PackedByteArray">
+			</return>
+			<argument index="0" name="spirv_data" type="RDShaderSPIRV">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="shader_compile_spirv_from_source">
+			<return type="RDShaderSPIRV">
 			</return>
 			<argument index="0" name="shader_source" type="RDShaderSource">
 			</argument>
@@ -645,10 +653,18 @@
 			<description>
 			</description>
 		</method>
-		<method name="shader_create">
+		<method name="shader_create_from_bytecode">
 			<return type="RID">
 			</return>
-			<argument index="0" name="shader_data" type="RDShaderBytecode">
+			<argument index="0" name="binary_data" type="PackedByteArray">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="shader_create_from_spirv">
+			<return type="PackedByteArray">
+			</return>
+			<argument index="0" name="spirv_data" type="RDShaderSPIRV">
 			</argument>
 			<description>
 			</description>

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1083,7 +1083,11 @@ public:
 	/**** SHADER ****/
 	/****************/
 
-	virtual RID shader_create(const Vector<ShaderStageData> &p_stages);
+	virtual String shader_get_binary_cache_key() const;
+	virtual Vector<uint8_t> shader_compile_binary_from_spirv(const Vector<ShaderStageSPIRVData> &p_spirv);
+
+	virtual RID shader_create_from_bytecode(const Vector<uint8_t> &p_shader_binary);
+
 	virtual uint32_t shader_get_vertex_input_attribute_mask(RID p_shader);
 
 	/*****************/

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -55,7 +55,7 @@ void ShaderFileEditor::_version_selected(int p_option) {
 	RD::ShaderStage stage = RD::SHADER_STAGE_MAX;
 	int first_found = -1;
 
-	Ref<RDShaderBytecode> bytecode = shader_file->get_bytecode(version_txt);
+	Ref<RDShaderSPIRV> bytecode = shader_file->get_spirv(version_txt);
 	ERR_FAIL_COND(bytecode.is_null());
 
 	for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
@@ -142,7 +142,7 @@ void ShaderFileEditor::_update_options() {
 
 		Ref<Texture2D> icon;
 
-		Ref<RDShaderBytecode> bytecode = shader_file->get_bytecode(version_list[i]);
+		Ref<RDShaderSPIRV> bytecode = shader_file->get_spirv(version_list[i]);
 		ERR_FAIL_COND(bytecode.is_null());
 
 		bool failed = false;
@@ -175,7 +175,7 @@ void ShaderFileEditor::_update_options() {
 		return;
 	}
 
-	Ref<RDShaderBytecode> bytecode = shader_file->get_bytecode(current_version);
+	Ref<RDShaderSPIRV> bytecode = shader_file->get_spirv(current_version);
 	ERR_FAIL_COND(bytecode.is_null());
 	int first_valid = -1;
 	int current = -1;

--- a/modules/glslang/register_types.cpp
+++ b/modules/glslang/register_types.cpp
@@ -193,7 +193,7 @@ void preregister_glslang_types() {
 	// initialize in case it's not initialized. This is done once per thread
 	// and it's safe to call multiple times
 	glslang::InitializeProcess();
-	RenderingDevice::shader_set_compile_function(_compile_shader_glsl);
+	RenderingDevice::shader_set_compile_to_spirv_function(_compile_shader_glsl);
 	RenderingDevice::shader_set_get_cache_key_function(_get_cache_key_function_glsl);
 }
 

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -794,7 +794,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	}
 	ERR_FAIL_COND_V(err != OK, BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 
-	RID rasterize_shader = rd->shader_create_from_bytecode(raster_shader->get_bytecode());
+	RID rasterize_shader = rd->shader_create_from_spirv(raster_shader->get_spirv_stages());
 
 	ERR_FAIL_COND_V(rasterize_shader.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES); //this is a bug check, though, should not happen
 
@@ -945,27 +945,27 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	ERR_FAIL_COND_V(err != OK, BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 
 	// Unoccluder
-	RID compute_shader_unocclude = rd->shader_create_from_bytecode(compute_shader->get_bytecode("unocclude"));
+	RID compute_shader_unocclude = rd->shader_create_from_spirv(compute_shader->get_spirv_stages("unocclude"));
 	ERR_FAIL_COND_V(compute_shader_unocclude.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES); // internal check, should not happen
 	RID compute_shader_unocclude_pipeline = rd->compute_pipeline_create(compute_shader_unocclude);
 
 	// Direct light
-	RID compute_shader_primary = rd->shader_create_from_bytecode(compute_shader->get_bytecode("primary"));
+	RID compute_shader_primary = rd->shader_create_from_spirv(compute_shader->get_spirv_stages("primary"));
 	ERR_FAIL_COND_V(compute_shader_primary.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES); // internal check, should not happen
 	RID compute_shader_primary_pipeline = rd->compute_pipeline_create(compute_shader_primary);
 
 	// Indirect light
-	RID compute_shader_secondary = rd->shader_create_from_bytecode(compute_shader->get_bytecode("secondary"));
+	RID compute_shader_secondary = rd->shader_create_from_spirv(compute_shader->get_spirv_stages("secondary"));
 	ERR_FAIL_COND_V(compute_shader_secondary.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES); //internal check, should not happen
 	RID compute_shader_secondary_pipeline = rd->compute_pipeline_create(compute_shader_secondary);
 
 	// Dilate
-	RID compute_shader_dilate = rd->shader_create_from_bytecode(compute_shader->get_bytecode("dilate"));
+	RID compute_shader_dilate = rd->shader_create_from_spirv(compute_shader->get_spirv_stages("dilate"));
 	ERR_FAIL_COND_V(compute_shader_dilate.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES); //internal check, should not happen
 	RID compute_shader_dilate_pipeline = rd->compute_pipeline_create(compute_shader_dilate);
 
 	// Light probes
-	RID compute_shader_light_probes = rd->shader_create_from_bytecode(compute_shader->get_bytecode("light_probes"));
+	RID compute_shader_light_probes = rd->shader_create_from_spirv(compute_shader->get_spirv_stages("light_probes"));
 	ERR_FAIL_COND_V(compute_shader_light_probes.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES); //internal check, should not happen
 	RID compute_shader_light_probes_pipeline = rd->compute_pipeline_create(compute_shader_light_probes);
 
@@ -1506,11 +1506,11 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	}
 	ERR_FAIL_COND_V(err != OK, BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 
-	RID blendseams_line_raster_shader = rd->shader_create_from_bytecode(blendseams_shader->get_bytecode("lines"));
+	RID blendseams_line_raster_shader = rd->shader_create_from_spirv(blendseams_shader->get_spirv_stages("lines"));
 
 	ERR_FAIL_COND_V(blendseams_line_raster_shader.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 
-	RID blendseams_triangle_raster_shader = rd->shader_create_from_bytecode(blendseams_shader->get_bytecode("triangles"));
+	RID blendseams_triangle_raster_shader = rd->shader_create_from_spirv(blendseams_shader->get_spirv_stages("triangles"));
 
 	ERR_FAIL_COND_V(blendseams_triangle_raster_shader.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -205,7 +205,7 @@ void register_server_types() {
 	GDREGISTER_CLASS(RDPipelineColorBlendStateAttachment);
 	GDREGISTER_CLASS(RDPipelineColorBlendState);
 	GDREGISTER_CLASS(RDShaderSource);
-	GDREGISTER_CLASS(RDShaderBytecode);
+	GDREGISTER_CLASS(RDShaderSPIRV);
 	GDREGISTER_CLASS(RDShaderFile);
 	GDREGISTER_CLASS(RDPipelineSpecializationConstant);
 

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -59,7 +59,7 @@ class ShaderRD {
 		Map<StringName, CharString> code_sections;
 		Vector<CharString> custom_defines;
 
-		Vector<RD::ShaderStageData> *variant_stages = nullptr;
+		Vector<uint8_t> *variant_data = nullptr;
 		RID *variants = nullptr; //same size as version defines
 
 		bool valid;

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -172,7 +172,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 		/* STEP 2, Compile the versions, add to shader file */
 
 		for (Map<StringName, String>::Element *E = version_texts.front(); E; E = E->next()) {
-			Ref<RDShaderBytecode> bytecode;
+			Ref<RDShaderSPIRV> bytecode;
 			bytecode.instantiate();
 
 			for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
@@ -182,7 +182,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 				}
 				code = code.replace("VERSION_DEFINES", E->get());
 				String error;
-				Vector<uint8_t> spirv = RenderingDevice::get_singleton()->shader_compile_from_source(RD::ShaderStage(i), code, RD::SHADER_LANGUAGE_GLSL, &error, false);
+				Vector<uint8_t> spirv = RenderingDevice::get_singleton()->shader_compile_spirv_from_source(RD::ShaderStage(i), code, RD::SHADER_LANGUAGE_GLSL, &error, false);
 				bytecode->set_stage_bytecode(RD::ShaderStage(i), spirv);
 				if (error != "") {
 					error += String() + "\n\nStage '" + stage_str[i] + "' source code: \n\n";


### PR DESCRIPTION
* Added an extra stage before compiling shader, which is generating a binary blob.
* On Vulkan, this allows caching the SPIRV reflection information, which is expensive to parse.
* On other (future) RenderingDevices, it allows caching converted binary data, such as DXIL (DirectX12) or MSL (Metal).

This PR makes the shader cache include the reflection information, hence **editor and game startup times are significantly improved**.
I tested this well and it appears to work, and I added a lot of consistency checks, but because it includes writing and reading binary information, rare bugs may pop up, so be aware.

I dislike binary formats but, in this case, there was not much of a choice for storing the reflection information, given shaders can be a lot, and take a lot of space and time to parse.

Some timing information here:

First start up (no cache): **14s**
Subsequent start up (using cache): **8.5s**

*Bugsquad edit:* Fixes #50844.