### PR TITLE
Fix dead code in `gdnative_interface.cpp`

### DIFF
--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -281,8 +281,9 @@ static GDNativeBool gdnative_variant_has_key(const GDNativeVariantPtr p_self, co
 	const Variant *self = (const Variant *)p_self;
 	const Variant *key = (const Variant *)p_key;
 	bool valid;
-	return self->has_key(*key, valid);
+	bool ret = self->has_key(*key, valid);
 	*r_valid = valid;
+	return ret;
 }
 
 static void gdnative_variant_get_type_name(GDNativeVariantType p_type, GDNativeStringPtr r_ret) {


### PR DESCRIPTION
This pull request fixes dead code found in `gdnative_interface.cpp`.

This code originally had an assignment operation done after a `return` statement. This code would never be reached during execution, so this pull request solves that.

Resolves: #50843