### PR TITLE
Use `Array.Empty` instead of allocating a every time

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -76,9 +76,9 @@ namespace GodotTools.Export
             GlobalDef("mono/export/aot/use_interpreter", true);
 
             // --aot or --aot=opt1,opt2 (use 'mono --aot=help AuxAssembly.dll' to list AOT options)
-            GlobalDef("mono/export/aot/extra_aot_options", new string[] { });
+            GlobalDef("mono/export/aot/extra_aot_options", Array.Empty<string>());
             // --optimize/-O=opt1,opt2 (use 'mono --list-opt'' to list optimize options)
-            GlobalDef("mono/export/aot/extra_optimizer_options", new string[] { });
+            GlobalDef("mono/export/aot/extra_optimizer_options", Array.Empty<string>());
 
             GlobalDef("mono/export/aot/android_toolchain_path", "");
         }
@@ -188,7 +188,7 @@ namespace GodotTools.Export
                 // However, at least in the case of 'WebAssembly.Net.Http' for some reason the BCL assemblies
                 // reference a different version even though the assembly is the same, for some weird reason.
 
-                var wasmFrameworkAssemblies = new[] {"WebAssembly.Bindings", "WebAssembly.Net.WebSockets"};
+                var wasmFrameworkAssemblies = new[] { "WebAssembly.Bindings", "WebAssembly.Net.WebSockets" };
 
                 foreach (string thisWasmFrameworkAssemblyName in wasmFrameworkAssemblies)
                 {
@@ -298,8 +298,8 @@ namespace GodotTools.Export
                     LLVMOutputPath = "",
                     FullAot = platform == OS.Platforms.iOS || (bool)(ProjectSettings.GetSetting("mono/export/aot/full_aot") ?? false),
                     UseInterpreter = (bool)ProjectSettings.GetSetting("mono/export/aot/use_interpreter"),
-                    ExtraAotOptions = (string[])ProjectSettings.GetSetting("mono/export/aot/extra_aot_options") ?? new string[] { },
-                    ExtraOptimizerOptions = (string[])ProjectSettings.GetSetting("mono/export/aot/extra_optimizer_options") ?? new string[] { },
+                    ExtraAotOptions = (string[])ProjectSettings.GetSetting("mono/export/aot/extra_aot_options") ?? Array.Empty<string>(),
+                    ExtraOptimizerOptions = (string[])ProjectSettings.GetSetting("mono/export/aot/extra_optimizer_options") ?? Array.Empty<string>(),
                     ToolchainPath = aotToolchainPath
                 };
 
@@ -381,7 +381,7 @@ namespace GodotTools.Export
         private static bool PlatformHasTemplateDir(string platform)
         {
             // OSX export templates are contained in a zip, so we place our custom template inside it and let Godot do the rest.
-            return !new[] {OS.Platforms.MacOS, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5}.Contains(platform);
+            return !new[] { OS.Platforms.MacOS, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5 }.Contains(platform);
         }
 
         private static bool DeterminePlatformFromFeatures(IEnumerable<string> features, out string platform)
@@ -430,7 +430,7 @@ namespace GodotTools.Export
         /// </summary>
         private static bool PlatformRequiresCustomBcl(string platform)
         {
-            if (new[] {OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5}.Contains(platform))
+            if (new[] { OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5 }.Contains(platform))
                 return true;
 
             // The 'net_4_x' BCL is not compatible between Windows and the other platforms.

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
@@ -47,7 +47,7 @@ namespace GodotTools.Ides.Rider
                 GD.PushWarning(e.Message);
             }
 
-            return new RiderInfo[0];
+            return Array.Empty<RiderInfo>();
         }
 
         private static RiderInfo[] CollectAllRiderPathsLinux()
@@ -249,7 +249,7 @@ namespace GodotTools.Ides.Rider
           bool isMac)
         {
             if (!Directory.Exists(toolboxRiderRootPath))
-                return new string[0];
+                return Array.Empty<string>();
 
             var channelDirs = Directory.GetDirectories(toolboxRiderRootPath);
             var paths = channelDirs.SelectMany(channelDir =>
@@ -295,7 +295,7 @@ namespace GodotTools.Ides.Rider
                       Logger.Warn($"Failed to get RiderPath from {channelDir}", e);
                   }
 
-                  return new string[0];
+                  return Array.Empty<string>();
               })
               .Where(c => !string.IsNullOrEmpty(c))
               .ToArray();
@@ -306,7 +306,7 @@ namespace GodotTools.Ides.Rider
         {
             var folder = new DirectoryInfo(Path.Combine(buildDir, dirName));
             if (!folder.Exists)
-                return new string[0];
+                return Array.Empty<string>();
 
             if (!isMac)
                 return new[] { Path.Combine(folder.FullName, searchPattern) }.Where(File.Exists).ToArray();

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -74,10 +74,10 @@ namespace GodotTools.Utils
         }
 
         private static readonly IEnumerable<string> LinuxBSDPlatforms =
-            new[] {Names.Linux, Names.FreeBSD, Names.NetBSD, Names.BSD};
+            new[] { Names.Linux, Names.FreeBSD, Names.NetBSD, Names.BSD };
 
         private static readonly IEnumerable<string> UnixLikePlatforms =
-            new[] {Names.MacOS, Names.Server, Names.Haiku, Names.Android, Names.iOS}
+            new[] { Names.MacOS, Names.Server, Names.Haiku, Names.Android, Names.iOS }
                 .Concat(LinuxBSDPlatforms).ToArray();
 
         private static readonly Lazy<bool> _isWindows = new Lazy<bool>(() => IsOS(Names.Windows));
@@ -111,7 +111,7 @@ namespace GodotTools.Utils
 
         private static string PathWhichWindows([NotNull] string name)
         {
-            string[] windowsExts = Environment.GetEnvironmentVariable("PATHEXT")?.Split(PathSep) ?? new string[] { };
+            string[] windowsExts = Environment.GetEnvironmentVariable("PATHEXT")?.Split(PathSep) ?? Array.Empty<string>();
             string[] pathDirs = Environment.GetEnvironmentVariable("PATH")?.Split(PathSep);
 
             var searchDirs = new List<string>();
@@ -128,10 +128,10 @@ namespace GodotTools.Utils
                 return searchDirs.Select(dir => Path.Combine(dir, name)).FirstOrDefault(File.Exists);
 
             return (from dir in searchDirs
-                select Path.Combine(dir, name)
+                    select Path.Combine(dir, name)
                 into path
-                from ext in windowsExts
-                select path + ext).FirstOrDefault(File.Exists);
+                    from ext in windowsExts
+                    select path + ext).FirstOrDefault(File.Exists);
         }
 
         private static string PathWhichUnix([NotNull] string name)
@@ -196,7 +196,7 @@ namespace GodotTools.Utils
 
             startInfo.UseShellExecute = false;
 
-            using (var process = new Process {StartInfo = startInfo})
+            using (var process = new Process { StartInfo = startInfo })
             {
                 process.Start();
                 process.WaitForExit();


### PR DESCRIPTION
Use `System.Array.Empty<T>` to get an empty array instead of allocating a new one every time. Since arrays are immutable there is no need to allocate them every time.

- Replaced all the occurrences I could find of `new T[] {}` with `Array.Empty<T>()`. Used the regex: `new ([a-zA-Z_][a-zA-Z0-9]+)((\[\][ ]*\{[ ]*\})|(\[0\]))`
- Modified the `bindings_generator.cpp` to use `Array.Empty<T>()` as the default value for array arguments instead of allocating an empty array.

There are some formatting changes due to the new `.editorconfig` format being applied automatically on saving the files I modified, I can undo them if that's preferred.