### PR TITLE
Fix always true expression `radius > 0.98 || radius < 1.02` in `cluster_builder_rd.h`

### DIFF
--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -235,7 +235,7 @@ public:
 		Transform3D xform = view_xform * p_transform;
 
 		float radius = xform.basis.get_uniform_scale();
-		if (radius > 0.98 || radius < 1.02) {
+		if (radius > 0.98 && radius < 1.02) {
 			xform.basis.orthonormalize();
 		}
 


### PR DESCRIPTION
This pull request fixes an issue where an expression would always evaluate to `true` no matter what.

The original expression was: 
``` c++
if (radius > 0.98 || radius < 1.02)
```
This will always return `true` because the radius will always either be greater than .98 or less than 1.02.

*Bugsquad edit: This closes #50846.*