### PR TITLE
Generate editor docs on a thread

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -31,6 +31,7 @@
 #ifndef EDITOR_HELP_H
 #define EDITOR_HELP_H
 
+#include "core/os/thread.h"
 #include "editor/code_editor.h"
 #include "editor/doc_tools.h"
 #include "editor/editor_plugin.h"
@@ -164,13 +165,19 @@ class EditorHelp : public VBoxContainer {
 	String _fix_constant(const String &p_constant) const;
 	void _toggle_scripts_pressed();
 
+	static Thread thread;
+
+	static void _wait_for_thread();
+	static void _gen_doc_thread(void *p_udata);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
 	static void generate_doc();
-	static DocTools *get_doc_data() { return doc; }
+	static DocTools *get_doc_data();
+	static void cleanup_doc();
 
 	void go_to_help(const String &p_help);
 	void go_to_class(const String &p_class, int p_scroll = 0);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7211,7 +7211,7 @@ EditorNode::~EditorNode() {
 	EditorTranslationParser::get_singleton()->clean_parsers();
 
 	remove_print_handler(&print_handler);
-	memdelete(EditorHelp::get_doc_data());
+	EditorHelp::cleanup_doc();
 	memdelete(editor_selection);
 	memdelete(editor_plugins_over);
 	memdelete(editor_plugins_force_over);


### PR DESCRIPTION
* The main generation could not be moved to a thread, unfortunately, as it instantiates classes to get default values, interacts with ProjectSettings, etc.
* Only uncompressing documentation and merging it is threaded.
* Seems to improve editor load times by 0.5 seconds.