### PR TITLE
Document caveats with Control's `mouse_entered`/`mouse_exited` signals

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1229,11 +1229,13 @@
 		<signal name="mouse_entered">
 			<description>
 				Emitted when the mouse enters the control's [code]Rect[/code] area, provided its [member mouse_filter] lets the event reach it.
+				[b]Note:[/b] [signal mouse_entered] will not be emitted if the mouse enters a child [Control] node before entering the parent's [code]Rect[/code] area, at least until the mouse is moved to reach the parent's [code]Rect[/code] area.
 			</description>
 		</signal>
 		<signal name="mouse_exited">
 			<description>
 				Emitted when the mouse leaves the control's [code]Rect[/code] area, provided its [member mouse_filter] lets the event reach it.
+				[b]Note:[/b] [signal mouse_exited] will be emitted if the mouse enters a child [Control] node, even if the mouse cursor is still inside the parent's [code]Rect[/code] area.
 			</description>
 		</signal>
 		<signal name="resized">


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/16854.