### PR TITLE
Some more C# formatting and style fixes

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.BuildLogger/GodotBuildLogger.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.BuildLogger/GodotBuildLogger.cs
@@ -12,12 +12,16 @@ namespace GodotTools.BuildLogger
         public string Parameters { get; set; }
         public LoggerVerbosity Verbosity { get; set; }
 
+        private StreamWriter _logStreamWriter;
+        private StreamWriter _issuesStreamWriter;
+        private int _indent;
+
         public void Initialize(IEventSource eventSource)
         {
             if (null == Parameters)
                 throw new LoggerException("Log directory parameter not specified.");
 
-            var parameters = Parameters.Split(new[] { ';' });
+            string[] parameters = Parameters.Split(new[] { ';' });
 
             string logDir = parameters[0];
 
@@ -35,8 +39,8 @@ namespace GodotTools.BuildLogger
                 if (!Directory.Exists(logDir))
                     Directory.CreateDirectory(logDir);
 
-                logStreamWriter = new StreamWriter(logFile);
-                issuesStreamWriter = new StreamWriter(issuesFile);
+                _logStreamWriter = new StreamWriter(logFile);
+                _issuesStreamWriter = new StreamWriter(issuesFile);
             }
             catch (Exception ex)
             {
@@ -66,12 +70,12 @@ namespace GodotTools.BuildLogger
         private void eventSource_ProjectStarted(object sender, ProjectStartedEventArgs e)
         {
             WriteLine(e.Message);
-            indent++;
+            _indent++;
         }
 
         private void eventSource_ProjectFinished(object sender, ProjectFinishedEventArgs e)
         {
-            indent--;
+            _indent--;
             WriteLine(e.Message);
         }
 
@@ -87,7 +91,7 @@ namespace GodotTools.BuildLogger
             string errorLine = $@"error,{e.File.CsvEscape()},{e.LineNumber},{e.ColumnNumber}," +
                                $"{e.Code?.CsvEscape() ?? string.Empty},{e.Message.CsvEscape()}," +
                                $"{e.ProjectFile?.CsvEscape() ?? string.Empty}";
-            issuesStreamWriter.WriteLine(errorLine);
+            _issuesStreamWriter.WriteLine(errorLine);
         }
 
         private void eventSource_WarningRaised(object sender, BuildWarningEventArgs e)
@@ -102,7 +106,7 @@ namespace GodotTools.BuildLogger
             string warningLine = $@"warning,{e.File.CsvEscape()},{e.LineNumber},{e.ColumnNumber}," +
                                  $"{e.Code?.CsvEscape() ?? string.Empty},{e.Message.CsvEscape()}," +
                                  $"{e.ProjectFile?.CsvEscape() ?? string.Empty}";
-            issuesStreamWriter.WriteLine(warningLine);
+            _issuesStreamWriter.WriteLine(warningLine);
         }
 
         private void eventSource_MessageRaised(object sender, BuildMessageEventArgs e)
@@ -136,28 +140,24 @@ namespace GodotTools.BuildLogger
 
         private void WriteLine(string line)
         {
-            for (int i = indent; i > 0; i--)
+            for (int i = _indent; i > 0; i--)
             {
-                logStreamWriter.Write("\t");
+                _logStreamWriter.Write("\t");
             }
 
-            logStreamWriter.WriteLine(line);
+            _logStreamWriter.WriteLine(line);
         }
 
         public void Shutdown()
         {
-            logStreamWriter.Close();
-            issuesStreamWriter.Close();
+            _logStreamWriter.Close();
+            _issuesStreamWriter.Close();
         }
 
         private bool IsVerbosityAtLeast(LoggerVerbosity checkVerbosity)
         {
             return Verbosity >= checkVerbosity;
         }
-
-        private StreamWriter logStreamWriter;
-        private StreamWriter issuesStreamWriter;
-        private int indent;
     }
 
     internal static class StringExtensions

--- a/modules/mono/editor/GodotTools/GodotTools.Core/ProcessExtensions.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/ProcessExtensions.cs
@@ -7,7 +7,7 @@ namespace GodotTools.Core
 {
     public static class ProcessExtensions
     {
-        public static async Task WaitForExitAsync(this Process process, CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task WaitForExitAsync(this Process process, CancellationToken cancellationToken = default)
         {
             var tcs = new TaskCompletionSource<bool>();
 

--- a/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
@@ -7,6 +7,8 @@ namespace GodotTools.Core
 {
     public static class StringExtensions
     {
+        private static readonly string _driveRoot = Path.GetPathRoot(Environment.CurrentDirectory);
+
         public static string RelativeToPath(this string path, string dir)
         {
             // Make sure the directory ends with a path separator
@@ -49,13 +51,11 @@ namespace GodotTools.Core
             return Path.DirectorySeparatorChar + path;
         }
 
-        private static readonly string DriveRoot = Path.GetPathRoot(Environment.CurrentDirectory);
-
         public static bool IsAbsolutePath(this string path)
         {
             return path.StartsWith("/", StringComparison.Ordinal) ||
                    path.StartsWith("\\", StringComparison.Ordinal) ||
-                   path.StartsWith(DriveRoot, StringComparison.Ordinal);
+                   path.StartsWith(_driveRoot, StringComparison.Ordinal);
         }
 
         public static string ToSafeDirName(this string dirName, bool allowDirSeparator = false)

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/DotNetSolution.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/DotNetSolution.cs
@@ -9,95 +9,7 @@ namespace GodotTools.ProjectEditor
 {
     public class DotNetSolution
     {
-        private string directoryPath;
-        private readonly Dictionary<string, ProjectInfo> projects = new Dictionary<string, ProjectInfo>();
-
-        public string Name { get; }
-
-        public string DirectoryPath
-        {
-            get => directoryPath;
-            set => directoryPath = value.IsAbsolutePath() ? value : Path.GetFullPath(value);
-        }
-
-        public class ProjectInfo
-        {
-            public string Guid;
-            public string PathRelativeToSolution;
-            public List<string> Configs = new List<string>();
-        }
-
-        public void AddNewProject(string name, ProjectInfo projectInfo)
-        {
-            projects[name] = projectInfo;
-        }
-
-        public bool HasProject(string name)
-        {
-            return projects.ContainsKey(name);
-        }
-
-        public ProjectInfo GetProjectInfo(string name)
-        {
-            return projects[name];
-        }
-
-        public bool RemoveProject(string name)
-        {
-            return projects.Remove(name);
-        }
-
-        public void Save()
-        {
-            if (!Directory.Exists(DirectoryPath))
-                throw new FileNotFoundException("The solution directory does not exist.");
-
-            string projectsDecl = string.Empty;
-            string slnPlatformsCfg = string.Empty;
-            string projPlatformsCfg = string.Empty;
-
-            bool isFirstProject = true;
-
-            foreach (var pair in projects)
-            {
-                string name = pair.Key;
-                ProjectInfo projectInfo = pair.Value;
-
-                if (!isFirstProject)
-                    projectsDecl += "\n";
-
-                projectsDecl += string.Format(ProjectDeclaration,
-                    name, projectInfo.PathRelativeToSolution.Replace("/", "\\"), projectInfo.Guid);
-
-                for (int i = 0; i < projectInfo.Configs.Count; i++)
-                {
-                    string config = projectInfo.Configs[i];
-
-                    if (i != 0 || !isFirstProject)
-                    {
-                        slnPlatformsCfg += "\n";
-                        projPlatformsCfg += "\n";
-                    }
-
-                    slnPlatformsCfg += string.Format(SolutionPlatformsConfig, config);
-                    projPlatformsCfg += string.Format(ProjectPlatformsConfig, projectInfo.Guid, config);
-                }
-
-                isFirstProject = false;
-            }
-
-            string solutionPath = Path.Combine(DirectoryPath, Name + ".sln");
-            string content = string.Format(SolutionTemplate, projectsDecl, slnPlatformsCfg, projPlatformsCfg);
-
-            File.WriteAllText(solutionPath, content, Encoding.UTF8); // UTF-8 with BOM
-        }
-
-        public DotNetSolution(string name)
-        {
-            Name = name;
-        }
-
-        const string SolutionTemplate =
+        private const string _solutionTemplate =
 @"Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 {0}
@@ -111,23 +23,111 @@ Global
 EndGlobal
 ";
 
-        const string ProjectDeclaration =
+        private const string _projectDeclaration =
 @"Project(""{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}"") = ""{0}"", ""{1}"", ""{{{2}}}""
 EndProject";
 
-        const string SolutionPlatformsConfig =
+        private const string _solutionPlatformsConfig =
 @"	{0}|Any CPU = {0}|Any CPU";
 
-        const string ProjectPlatformsConfig =
+        private const string _projectPlatformsConfig =
 @"		{{{0}}}.{1}|Any CPU.ActiveCfg = {1}|Any CPU
 		{{{0}}}.{1}|Any CPU.Build.0 = {1}|Any CPU";
+
+        private string _directoryPath;
+        private readonly Dictionary<string, ProjectInfo> _projects = new Dictionary<string, ProjectInfo>();
+
+        public string Name { get; }
+
+        public string DirectoryPath
+        {
+            get => _directoryPath;
+            set => _directoryPath = value.IsAbsolutePath() ? value : Path.GetFullPath(value);
+        }
+
+        public class ProjectInfo
+        {
+            public string Guid;
+            public string PathRelativeToSolution;
+            public List<string> Configs = new List<string>();
+        }
+
+        public void AddNewProject(string name, ProjectInfo projectInfo)
+        {
+            _projects[name] = projectInfo;
+        }
+
+        public bool HasProject(string name)
+        {
+            return _projects.ContainsKey(name);
+        }
+
+        public ProjectInfo GetProjectInfo(string name)
+        {
+            return _projects[name];
+        }
+
+        public bool RemoveProject(string name)
+        {
+            return _projects.Remove(name);
+        }
+
+        public void Save()
+        {
+            if (!Directory.Exists(DirectoryPath))
+                throw new FileNotFoundException("The solution directory does not exist.");
+
+            string projectsDecl = string.Empty;
+            string slnPlatformsCfg = string.Empty;
+            string projPlatformsCfg = string.Empty;
+
+            bool isFirstProject = true;
+
+            foreach (var pair in _projects)
+            {
+                string name = pair.Key;
+                ProjectInfo projectInfo = pair.Value;
+
+                if (!isFirstProject)
+                    projectsDecl += "\n";
+
+                projectsDecl += string.Format(_projectDeclaration,
+                    name, projectInfo.PathRelativeToSolution.Replace("/", "\\"), projectInfo.Guid);
+
+                for (int i = 0; i < projectInfo.Configs.Count; i++)
+                {
+                    string config = projectInfo.Configs[i];
+
+                    if (i != 0 || !isFirstProject)
+                    {
+                        slnPlatformsCfg += "\n";
+                        projPlatformsCfg += "\n";
+                    }
+
+                    slnPlatformsCfg += string.Format(_solutionPlatformsConfig, config);
+                    projPlatformsCfg += string.Format(_projectPlatformsConfig, projectInfo.Guid, config);
+                }
+
+                isFirstProject = false;
+            }
+
+            string solutionPath = Path.Combine(DirectoryPath, Name + ".sln");
+            string content = string.Format(_solutionTemplate, projectsDecl, slnPlatformsCfg, projPlatformsCfg);
+
+            File.WriteAllText(solutionPath, content, Encoding.UTF8); // UTF-8 with BOM
+        }
+
+        public DotNetSolution(string name)
+        {
+            Name = name;
+        }
 
         public static void MigrateFromOldConfigNames(string slnPath)
         {
             if (!File.Exists(slnPath))
                 return;
 
-            var input = File.ReadAllText(slnPath);
+            string input = File.ReadAllText(slnPath);
 
             if (!Regex.IsMatch(input, Regex.Escape("Tools|Any CPU")))
                 return;
@@ -151,7 +151,7 @@ EndProject";
             };
 
             var regex = new Regex(string.Join("|", dict.Keys.Select(Regex.Escape)));
-            var result = regex.Replace(input, m => dict[m.Value]);
+            string result = regex.Replace(input, m => dict[m.Value]);
 
             if (result != input)
             {

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/IdentifierUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/IdentifierUtils.cs
@@ -91,7 +91,7 @@ namespace GodotTools.ProjectEditor
             return identifier;
         }
 
-        static bool IsKeyword(string value, bool anyDoubleUnderscore)
+        private static bool IsKeyword(string value, bool anyDoubleUnderscore)
         {
             // Identifiers that start with double underscore are meant to be used for reserved keywords.
             // Only existing keywords are enforced, but it may be useful to forbid any identifier
@@ -103,14 +103,14 @@ namespace GodotTools.ProjectEditor
             }
             else
             {
-                if (DoubleUnderscoreKeywords.Contains(value))
+                if (_doubleUnderscoreKeywords.Contains(value))
                     return true;
             }
 
-            return Keywords.Contains(value);
+            return _keywords.Contains(value);
         }
 
-        private static readonly HashSet<string> DoubleUnderscoreKeywords = new HashSet<string>
+        private static readonly HashSet<string> _doubleUnderscoreKeywords = new HashSet<string>
         {
             "__arglist",
             "__makeref",
@@ -118,7 +118,7 @@ namespace GodotTools.ProjectEditor
             "__refvalue",
         };
 
-        private static readonly HashSet<string> Keywords = new HashSet<string>
+        private static readonly HashSet<string> _keywords = new HashSet<string>
         {
             "as",
             "do",

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
@@ -13,7 +13,8 @@ namespace GodotTools.Build
         public string[] Targets { get; }
         public string Configuration { get; }
         public bool Restore { get; }
-        public Array<string> CustomProperties { get; } = new Array<string>(); // TODO Use List once we have proper serialization
+        // TODO Use List once we have proper serialization
+        public Array<string> CustomProperties { get; } = new Array<string>();
 
         public string LogsDirPath => Path.Combine(GodotSharpDirs.BuildLogsDirs, $"{Solution.MD5Text()}_{Configuration}");
 
@@ -32,12 +33,12 @@ namespace GodotTools.Build
             unchecked
             {
                 int hash = 17;
-                hash = hash * 29 + Solution.GetHashCode();
-                hash = hash * 29 + Targets.GetHashCode();
-                hash = hash * 29 + Configuration.GetHashCode();
-                hash = hash * 29 + Restore.GetHashCode();
-                hash = hash * 29 + CustomProperties.GetHashCode();
-                hash = hash * 29 + LogsDirPath.GetHashCode();
+                hash = (hash * 29) + Solution.GetHashCode();
+                hash = (hash * 29) + Targets.GetHashCode();
+                hash = (hash * 29) + Configuration.GetHashCode();
+                hash = (hash * 29) + Restore.GetHashCode();
+                hash = (hash * 29) + CustomProperties.GetHashCode();
+                hash = (hash * 29) + LogsDirPath.GetHashCode();
                 return hash;
             }
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -32,7 +32,7 @@ namespace GodotTools.Build
 
         private static void RemoveOldIssuesFile(BuildInfo buildInfo)
         {
-            var issuesFile = GetIssuesFilePath(buildInfo);
+            string issuesFile = GetIssuesFilePath(buildInfo);
 
             if (!File.Exists(issuesFile))
                 return;

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
@@ -22,14 +22,6 @@ namespace GodotTools.Build
             public string ProjectFile { get; set; }
         }
 
-        private readonly Array<BuildIssue> issues = new Array<BuildIssue>(); // TODO Use List once we have proper serialization
-        private ItemList issuesList;
-        private TextEdit buildLog;
-        private PopupMenu issuesListContextMenu;
-
-        private readonly object pendingBuildLogTextLock = new object();
-        [NotNull] private string pendingBuildLogText = string.Empty;
-
         [Signal] public event Action BuildStateChanged;
 
         public bool HasBuildExited { get; private set; } = false;
@@ -60,12 +52,20 @@ namespace GodotTools.Build
             }
         }
 
-        private BuildInfo BuildInfo { get; set; }
-
         public bool LogVisible
         {
-            set => buildLog.Visible = value;
+            set => _buildLog.Visible = value;
         }
+
+        // TODO Use List once we have proper serialization.
+        private readonly Array<BuildIssue> _issues = new Array<BuildIssue>();
+        private ItemList _issuesList;
+        private PopupMenu _issuesListContextMenu;
+        private TextEdit _buildLog;
+        private BuildInfo _buildInfo;
+
+        private readonly object _pendingBuildLogTextLock = new object();
+        [NotNull] private string _pendingBuildLogText = string.Empty;
 
         private void LoadIssuesFromFile(string csvFile)
         {
@@ -107,7 +107,7 @@ namespace GodotTools.Build
                         else
                             ErrorCount += 1;
 
-                        issues.Add(issue);
+                        _issues.Add(issue);
                     }
                 }
                 finally
@@ -119,21 +119,21 @@ namespace GodotTools.Build
 
         private void IssueActivated(int idx)
         {
-            if (idx < 0 || idx >= issuesList.GetItemCount())
+            if (idx < 0 || idx >= _issuesList.GetItemCount())
                 throw new IndexOutOfRangeException("Item list index out of range");
 
             // Get correct issue idx from issue list
-            int issueIndex = (int)(long)issuesList.GetItemMetadata(idx);
+            int issueIndex = (int)(long)_issuesList.GetItemMetadata(idx);
 
-            if (issueIndex < 0 || issueIndex >= issues.Count)
+            if (issueIndex < 0 || issueIndex >= _issues.Count)
                 throw new IndexOutOfRangeException("Issue index out of range");
 
-            BuildIssue issue = issues[issueIndex];
+            BuildIssue issue = _issues[issueIndex];
 
             if (string.IsNullOrEmpty(issue.ProjectFile) && string.IsNullOrEmpty(issue.File))
                 return;
 
-            string projectDir = issue.ProjectFile.Length > 0 ? issue.ProjectFile.GetBaseDir() : BuildInfo.Solution.GetBaseDir();
+            string projectDir = issue.ProjectFile.Length > 0 ? issue.ProjectFile.GetBaseDir() : _buildInfo.Solution.GetBaseDir();
 
             string file = Path.Combine(projectDir.SimplifyGodotPath(), issue.File.SimplifyGodotPath());
 
@@ -153,14 +153,14 @@ namespace GodotTools.Build
 
         public void UpdateIssuesList()
         {
-            issuesList.Clear();
+            _issuesList.Clear();
 
             using (var warningIcon = GetThemeIcon("Warning", "EditorIcons"))
             using (var errorIcon = GetThemeIcon("Error", "EditorIcons"))
             {
-                for (int i = 0; i < issues.Count; i++)
+                for (int i = 0; i < _issues.Count; i++)
                 {
-                    BuildIssue issue = issues[i];
+                    BuildIssue issue = _issues[i];
 
                     if (!(issue.Warning ? WarningsVisible : ErrorsVisible))
                         continue;
@@ -191,11 +191,11 @@ namespace GodotTools.Build
 
                     int lineBreakIdx = text.IndexOf("\n", StringComparison.Ordinal);
                     string itemText = lineBreakIdx == -1 ? text : text.Substring(0, lineBreakIdx);
-                    issuesList.AddItem(itemText, issue.Warning ? warningIcon : errorIcon);
+                    _issuesList.AddItem(itemText, issue.Warning ? warningIcon : errorIcon);
 
-                    int index = issuesList.GetItemCount() - 1;
-                    issuesList.SetItemTooltip(index, tooltip);
-                    issuesList.SetItemMetadata(index, i);
+                    int index = _issuesList.GetItemCount() - 1;
+                    _issuesList.SetItemTooltip(index, tooltip);
+                    _issuesList.SetItemMetadata(index, i);
                 }
             }
         }
@@ -205,12 +205,12 @@ namespace GodotTools.Build
             HasBuildExited = true;
             BuildResult = Build.BuildResult.Error;
 
-            issuesList.Clear();
+            _issuesList.Clear();
 
             var issue = new BuildIssue {Message = cause, Warning = false};
 
             ErrorCount += 1;
-            issues.Add(issue);
+            _issues.Add(issue);
 
             UpdateIssuesList();
 
@@ -219,13 +219,13 @@ namespace GodotTools.Build
 
         private void BuildStarted(BuildInfo buildInfo)
         {
-            BuildInfo = buildInfo;
+            _buildInfo = buildInfo;
             HasBuildExited = false;
 
-            issues.Clear();
+            _issues.Clear();
             WarningCount = 0;
             ErrorCount = 0;
-            buildLog.Text = string.Empty;
+            _buildLog.Text = string.Empty;
 
             UpdateIssuesList();
 
@@ -237,7 +237,7 @@ namespace GodotTools.Build
             HasBuildExited = true;
             BuildResult = result;
 
-            LoadIssuesFromFile(Path.Combine(BuildInfo.LogsDirPath, BuildManager.MsBuildIssuesFileName));
+            LoadIssuesFromFile(Path.Combine(_buildInfo.LogsDirPath, BuildManager.MsBuildIssuesFileName));
 
             UpdateIssuesList();
 
@@ -246,46 +246,46 @@ namespace GodotTools.Build
 
         private void UpdateBuildLogText()
         {
-            lock (pendingBuildLogTextLock)
+            lock (_pendingBuildLogTextLock)
             {
-                buildLog.Text += pendingBuildLogText;
-                pendingBuildLogText = string.Empty;
+                _buildLog.Text += _pendingBuildLogText;
+                _pendingBuildLogText = string.Empty;
                 ScrollToLastNonEmptyLogLine();
             }
         }
 
         private void StdOutputReceived(string text)
         {
-            lock (pendingBuildLogTextLock)
+            lock (_pendingBuildLogTextLock)
             {
-                if (pendingBuildLogText.Length == 0)
+                if (_pendingBuildLogText.Length == 0)
                     CallDeferred(nameof(UpdateBuildLogText));
-                pendingBuildLogText += text + "\n";
+                _pendingBuildLogText += text + "\n";
             }
         }
 
         private void StdErrorReceived(string text)
         {
-            lock (pendingBuildLogTextLock)
+            lock (_pendingBuildLogTextLock)
             {
-                if (pendingBuildLogText.Length == 0)
+                if (_pendingBuildLogText.Length == 0)
                     CallDeferred(nameof(UpdateBuildLogText));
-                pendingBuildLogText += text + "\n";
+                _pendingBuildLogText += text + "\n";
             }
         }
 
         private void ScrollToLastNonEmptyLogLine()
         {
             int line;
-            for (line = buildLog.GetLineCount(); line > 0; line--)
+            for (line = _buildLog.GetLineCount(); line > 0; line--)
             {
-                string lineText = buildLog.GetLine(line);
+                string lineText = _buildLog.GetLine(line);
 
                 if (!string.IsNullOrEmpty(lineText) || !string.IsNullOrEmpty(lineText?.Trim()))
                     break;
             }
 
-            buildLog.SetCaretLine(line);
+            _buildLog.SetCaretLine(line);
         }
 
         public void RestartBuild()
@@ -318,11 +318,11 @@ namespace GodotTools.Build
                     // We don't allow multi-selection but just in case that changes later...
                     string text = null;
 
-                    foreach (int issueIndex in issuesList.GetSelectedItems())
+                    foreach (int issueIndex in _issuesList.GetSelectedItems())
                     {
                         if (text != null)
                             text += "\n";
-                        text += issuesList.GetItemText(issueIndex);
+                        text += _issuesList.GetItemText(issueIndex);
                     }
 
                     if (text != null)
@@ -338,20 +338,20 @@ namespace GodotTools.Build
         {
             _ = index; // Unused
 
-            issuesListContextMenu.Clear();
-            issuesListContextMenu.Size = new Vector2i(1, 1);
+            _issuesListContextMenu.Clear();
+            _issuesListContextMenu.Size = new Vector2i(1, 1);
 
-            if (issuesList.IsAnythingSelected())
+            if (_issuesList.IsAnythingSelected())
             {
                 // Add menu entries for the selected item
-                issuesListContextMenu.AddIconItem(GetThemeIcon("ActionCopy", "EditorIcons"),
+                _issuesListContextMenu.AddIconItem(GetThemeIcon("ActionCopy", "EditorIcons"),
                     label: "Copy Error".TTR(), (int)IssuesContextMenuOption.Copy);
             }
 
-            if (issuesListContextMenu.GetItemCount() > 0)
+            if (_issuesListContextMenu.GetItemCount() > 0)
             {
-                issuesListContextMenu.Position = (Vector2i)(issuesList.RectGlobalPosition + atPosition);
-                issuesListContextMenu.Popup();
+                _issuesListContextMenu.Position = (Vector2i)(_issuesList.RectGlobalPosition + atPosition);
+                _issuesListContextMenu.Popup();
             }
         }
 
@@ -368,27 +368,27 @@ namespace GodotTools.Build
             };
             AddChild(hsc);
 
-            issuesList = new ItemList
+            _issuesList = new ItemList
             {
                 SizeFlagsVertical = (int)SizeFlags.ExpandFill,
                 SizeFlagsHorizontal = (int)SizeFlags.ExpandFill // Avoid being squashed by the build log
             };
-            issuesList.ItemActivated += IssueActivated;
-            issuesList.AllowRmbSelect = true;
-            issuesList.ItemRmbSelected += IssuesListRmbSelected;
-            hsc.AddChild(issuesList);
+            _issuesList.ItemActivated += IssueActivated;
+            _issuesList.AllowRmbSelect = true;
+            _issuesList.ItemRmbSelected += IssuesListRmbSelected;
+            hsc.AddChild(_issuesList);
 
-            issuesListContextMenu = new PopupMenu();
-            issuesListContextMenu.IdPressed += IssuesListContextOptionPressed;
-            issuesList.AddChild(issuesListContextMenu);
+            _issuesListContextMenu = new PopupMenu();
+            _issuesListContextMenu.IdPressed += IssuesListContextOptionPressed;
+            _issuesList.AddChild(_issuesListContextMenu);
 
-            buildLog = new TextEdit
+            _buildLog = new TextEdit
             {
                 Editable = false,
                 SizeFlagsVertical = (int)SizeFlags.ExpandFill,
                 SizeFlagsHorizontal = (int)SizeFlags.ExpandFill // Avoid being squashed by the issues list
             };
-            hsc.AddChild(buildLog);
+            hsc.AddChild(_buildLog);
 
             AddBuildEventListeners();
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -11,10 +11,10 @@ namespace GodotTools.Build
     {
         public BuildOutputView BuildOutputView { get; private set; }
 
-        private MenuButton buildMenuBtn;
-        private Button errorsBtn;
-        private Button warningsBtn;
-        private Button viewLogBtn;
+        private MenuButton _buildMenuBtn;
+        private Button _errorsBtn;
+        private Button _warningsBtn;
+        private Button _viewLogBtn;
 
         private void WarningsToggled(bool pressed)
         {
@@ -132,16 +132,16 @@ namespace GodotTools.Build
             var toolBarHBox = new HBoxContainer { SizeFlagsHorizontal = (int)SizeFlags.ExpandFill };
             AddChild(toolBarHBox);
 
-            buildMenuBtn = new MenuButton { Text = "Build", Icon = GetThemeIcon("Play", "EditorIcons") };
-            toolBarHBox.AddChild(buildMenuBtn);
+            _buildMenuBtn = new MenuButton { Text = "Build", Icon = GetThemeIcon("Play", "EditorIcons") };
+            toolBarHBox.AddChild(_buildMenuBtn);
 
-            var buildMenu = buildMenuBtn.GetPopup();
+            var buildMenu = _buildMenuBtn.GetPopup();
             buildMenu.AddItem("Build Solution".TTR(), (int)BuildMenuOptions.BuildSolution);
             buildMenu.AddItem("Rebuild Solution".TTR(), (int)BuildMenuOptions.RebuildSolution);
             buildMenu.AddItem("Clean Solution".TTR(), (int)BuildMenuOptions.CleanSolution);
             buildMenu.IdPressed += BuildMenuOptionPressed;
 
-            errorsBtn = new Button
+            _errorsBtn = new Button
             {
                 HintTooltip = "Show Errors".TTR(),
                 Icon = GetThemeIcon("StatusError", "EditorIcons"),
@@ -150,10 +150,10 @@ namespace GodotTools.Build
                 Pressed = true,
                 FocusMode = FocusModeEnum.None
             };
-            errorsBtn.Toggled += ErrorsToggled;
-            toolBarHBox.AddChild(errorsBtn);
+            _errorsBtn.Toggled += ErrorsToggled;
+            toolBarHBox.AddChild(_errorsBtn);
 
-            warningsBtn = new Button
+            _warningsBtn = new Button
             {
                 HintTooltip = "Show Warnings".TTR(),
                 Icon = GetThemeIcon("NodeWarning", "EditorIcons"),
@@ -162,18 +162,18 @@ namespace GodotTools.Build
                 Pressed = true,
                 FocusMode = FocusModeEnum.None
             };
-            warningsBtn.Toggled += WarningsToggled;
-            toolBarHBox.AddChild(warningsBtn);
+            _warningsBtn.Toggled += WarningsToggled;
+            toolBarHBox.AddChild(_warningsBtn);
 
-            viewLogBtn = new Button
+            _viewLogBtn = new Button
             {
                 Text = "Show Output".TTR(),
                 ToggleMode = true,
                 Pressed = true,
                 FocusMode = FocusModeEnum.None
             };
-            viewLogBtn.Toggled += ViewLogToggled;
-            toolBarHBox.AddChild(viewLogBtn);
+            _viewLogBtn.Toggled += ViewLogToggled;
+            toolBarHBox.AddChild(_viewLogBtn);
 
             BuildOutputView = new BuildOutputView();
             AddChild(BuildOutputView);
@@ -185,12 +185,12 @@ namespace GodotTools.Build
 
             if (what == NotificationThemeChanged)
             {
-                if (buildMenuBtn != null)
-                    buildMenuBtn.Icon = GetThemeIcon("Play", "EditorIcons");
-                if (errorsBtn != null)
-                    errorsBtn.Icon = GetThemeIcon("StatusError", "EditorIcons");
-                if (warningsBtn != null)
-                    warningsBtn.Icon = GetThemeIcon("NodeWarning", "EditorIcons");
+                if (_buildMenuBtn != null)
+                    _buildMenuBtn.Icon = GetThemeIcon("Play", "EditorIcons");
+                if (_errorsBtn != null)
+                    _errorsBtn.Icon = GetThemeIcon("StatusError", "EditorIcons");
+                if (_warningsBtn != null)
+                    _warningsBtn.Icon = GetThemeIcon("NodeWarning", "EditorIcons");
             }
         }
     }

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
@@ -61,7 +61,7 @@ namespace GodotTools.Build
                     }
                     case BuildTool.JetBrainsMsBuild:
                     {
-                        var editorPath = (string)editorSettings.GetSetting(RiderPathManager.EditorPathSettingName);
+                        string editorPath = (string)editorSettings.GetSetting(RiderPathManager.EditorPathSettingName);
 
                         if (!File.Exists(editorPath))
                             throw new FileNotFoundException($"Cannot find Rider executable. Tried with path: {editorPath}");
@@ -165,7 +165,9 @@ namespace GodotTools.Build
 
             // Try to find 15.0 with vswhere
 
-            var envNames = Internal.GodotIs32Bits() ? new[] {"ProgramFiles", "ProgramW6432"} : new[] {"ProgramFiles(x86)", "ProgramFiles"};
+            string[] envNames = Internal.GodotIs32Bits() ?
+                envNames = new[] { "ProgramFiles", "ProgramW6432" } :
+                envNames = new[] { "ProgramFiles(x86)", "ProgramFiles" };
 
             string vsWherePath = null;
             foreach (var envName in envNames)

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -65,12 +65,12 @@ namespace GodotTools.Export
 
             if (platform == OS.Platforms.iOS)
             {
-                var architectures = GetEnablediOSArchs(features).ToArray();
+                string[] architectures = GetEnablediOSArchs(features).ToArray();
                 CompileAssembliesForiOS(exporter, isDebug, architectures, aotOpts, aotTempDir, assembliesPrepared, bclDir);
             }
             else if (platform == OS.Platforms.Android)
             {
-                var abis = GetEnabledAndroidAbis(features).ToArray();
+                string[] abis = GetEnabledAndroidAbis(features).ToArray();
                 CompileAssembliesForAndroid(exporter, isDebug, abis, aotOpts, aotTempDir, assembliesPrepared, bclDir);
             }
             else
@@ -138,7 +138,8 @@ namespace GodotTools.Export
                 }
                 else
                 {
-                    string outputDataLibDir = Path.Combine(outputDataDir, "Mono", platform == OS.Platforms.Windows ? "bin" : "lib");
+                    string libDir = platform == OS.Platforms.Windows ? "bin" : "lib";
+                    string outputDataLibDir = Path.Combine(outputDataDir, "Mono", libDir);
                     File.Copy(tempOutputFilePath, Path.Combine(outputDataLibDir, outputFileName));
                 }
             }

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -20,7 +20,7 @@ namespace GodotTools.Export
     public class ExportPlugin : EditorExportPlugin
     {
         [Flags]
-        enum I18NCodesets : long
+        private enum I18NCodesets : long
         {
             None = 0,
             CJK = 1,
@@ -30,6 +30,8 @@ namespace GodotTools.Export
             West = 16,
             All = CJK | MidEast | Other | Rare | West
         }
+
+        private string _maybeLastExportError;
 
         private void AddI18NAssemblies(Godot.Collections.Dictionary<string, string> assemblies, string bclDir)
         {
@@ -83,8 +85,6 @@ namespace GodotTools.Export
             GlobalDef("mono/export/aot/android_toolchain_path", "");
         }
 
-        private string maybeLastExportError;
-
         private void AddFile(string srcPath, string dstPath, bool remap = false)
         {
             // Add file to the PCK
@@ -129,14 +129,14 @@ namespace GodotTools.Export
             }
             catch (Exception e)
             {
-                maybeLastExportError = e.Message;
+                _maybeLastExportError = e.Message;
 
                 // 'maybeLastExportError' cannot be null or empty if there was an error, so we
                 // must consider the possibility of exceptions being thrown without a message.
-                if (string.IsNullOrEmpty(maybeLastExportError))
-                    maybeLastExportError = $"Exception thrown: {e.GetType().Name}";
+                if (string.IsNullOrEmpty(_maybeLastExportError))
+                    _maybeLastExportError = $"Exception thrown: {e.GetType().Name}";
 
-                GD.PushError($"Failed to export project: {maybeLastExportError}");
+                GD.PushError($"Failed to export project: {_maybeLastExportError}");
                 Console.Error.WriteLine(e);
                 // TODO: Do something on error once _ExportBegin supports failing.
             }
@@ -317,10 +317,10 @@ namespace GodotTools.Export
                 Directory.Delete(aotTempDir, recursive: true);
 
             // TODO: Just a workaround until the export plugins can be made to abort with errors
-            if (!string.IsNullOrEmpty(maybeLastExportError)) // Check empty as well, because it's set to empty after hot-reloading
+            if (!string.IsNullOrEmpty(_maybeLastExportError)) // Check empty as well, because it's set to empty after hot-reloading
             {
-                string lastExportError = maybeLastExportError;
-                maybeLastExportError = null;
+                string lastExportError = _maybeLastExportError;
+                _maybeLastExportError = null;
 
                 GodotSharpEditor.Instance.ShowErrorDialog(lastExportError, "Failed to export C# project");
             }
@@ -470,7 +470,7 @@ namespace GodotTools.Export
 
         private static string DetermineDataDirNameForProject()
         {
-            var appName = (string)ProjectSettings.GetSetting("application/config/name");
+            string appName = (string)ProjectSettings.GetSetting("application/config/name");
             string appNameSafe = appName.ToSafeDirName();
             return $"data_{appNameSafe}";
         }

--- a/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
@@ -6,7 +6,7 @@ namespace GodotTools
 {
     public class HotReloadAssemblyWatcher : Node
     {
-        private Timer watchTimer;
+        private Timer _watchTimer;
 
         public override void _Notification(int what)
         {
@@ -27,22 +27,22 @@ namespace GodotTools
 
         public void RestartTimer()
         {
-            watchTimer.Stop();
-            watchTimer.Start();
+            _watchTimer.Stop();
+            _watchTimer.Start();
         }
 
         public override void _Ready()
         {
             base._Ready();
 
-            watchTimer = new Timer
+            _watchTimer = new Timer
             {
                 OneShot = false,
                 WaitTime = (float)EditorDef("mono/assembly_watch_interval_sec", 0.5)
             };
-            watchTimer.Timeout += TimerTimeout;
-            AddChild(watchTimer);
-            watchTimer.Start();
+            _watchTimer.Timeout += TimerTimeout;
+            AddChild(_watchTimer);
+            _watchTimer.Start();
         }
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -10,22 +10,22 @@ namespace GodotTools.Ides
 {
     public sealed class GodotIdeManager : Node, ISerializationListener
     {
-        private MessagingServer MessagingServer { get; set; }
+        private MessagingServer _messagingServer;
 
-        private MonoDevelop.Instance monoDevelInstance;
-        private MonoDevelop.Instance vsForMacInstance;
+        private MonoDevelop.Instance _monoDevelInstance;
+        private MonoDevelop.Instance _vsForMacInstance;
 
         private MessagingServer GetRunningOrNewServer()
         {
-            if (MessagingServer != null && !MessagingServer.IsDisposed)
-                return MessagingServer;
+            if (_messagingServer != null && !_messagingServer.IsDisposed)
+                return _messagingServer;
 
-            MessagingServer?.Dispose();
-            MessagingServer = new MessagingServer(OS.GetExecutablePath(), ProjectSettings.GlobalizePath(GodotSharpDirs.ResMetadataDir), new GodotLogger());
+            _messagingServer?.Dispose();
+            _messagingServer = new MessagingServer(OS.GetExecutablePath(), ProjectSettings.GlobalizePath(GodotSharpDirs.ResMetadataDir), new GodotLogger());
 
-            _ = MessagingServer.Listen();
+            _ = _messagingServer.Listen();
 
-            return MessagingServer;
+            return _messagingServer;
         }
 
         public override void _Ready()
@@ -48,7 +48,7 @@ namespace GodotTools.Ides
 
             if (disposing)
             {
-                MessagingServer?.Dispose();
+                _messagingServer?.Dispose();
             }
         }
 
@@ -113,14 +113,14 @@ namespace GodotTools.Ides
                     {
                         if (Utils.OS.IsMacOS && editorId == ExternalEditorId.VisualStudioForMac)
                         {
-                            vsForMacInstance = (vsForMacInstance?.IsDisposed ?? true ? null : vsForMacInstance) ??
+                            _vsForMacInstance = (_vsForMacInstance?.IsDisposed ?? true ? null : _vsForMacInstance) ??
                                                new MonoDevelop.Instance(solutionPath, MonoDevelop.EditorId.VisualStudioForMac);
-                            return vsForMacInstance;
+                            return _vsForMacInstance;
                         }
 
-                        monoDevelInstance = (monoDevelInstance?.IsDisposed ?? true ? null : monoDevelInstance) ??
+                        _monoDevelInstance = (_monoDevelInstance?.IsDisposed ?? true ? null : _monoDevelInstance) ??
                                             new MonoDevelop.Instance(solutionPath, MonoDevelop.EditorId.MonoDevelop);
-                        return monoDevelInstance;
+                        return _monoDevelInstance;
                     }
 
                     try
@@ -159,15 +159,15 @@ namespace GodotTools.Ides
 
         public readonly struct EditorPick
         {
-            private readonly string identity;
+            private readonly string _identity;
 
             public EditorPick(string identity)
             {
-                this.identity = identity;
+                _identity = identity;
             }
 
             public bool IsAnyConnected() =>
-                GodotSharpEditor.Instance.GodotIdeManager.GetRunningOrNewServer().IsAnyConnected(identity);
+                GodotSharpEditor.Instance.GodotIdeManager.GetRunningOrNewServer().IsAnyConnected(_identity);
 
             private void SendRequest<TResponse>(Request request)
                 where TResponse : Response, new()
@@ -175,7 +175,7 @@ namespace GodotTools.Ides
                 // Logs an error if no client is connected with the specified identity
                 GodotSharpEditor.Instance.GodotIdeManager
                     .GetRunningOrNewServer()
-                    .BroadcastRequest<TResponse>(identity, request);
+                    .BroadcastRequest<TResponse>(_identity, request);
             }
 
             public void SendOpenFile(string file)

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/MessagingServer.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/MessagingServer.cs
@@ -21,24 +21,26 @@ namespace GodotTools.Ides
 {
     public sealed class MessagingServer : IDisposable
     {
-        private readonly ILogger logger;
+        private readonly ILogger _logger;
 
-        private readonly FileStream metaFile;
-        private string MetaFilePath { get; }
+        private readonly FileStream _metaFile;
+        private string _metaFilePath;
 
-        private readonly SemaphoreSlim peersSem = new SemaphoreSlim(1);
+        private readonly SemaphoreSlim _peersSem = new SemaphoreSlim(1);
 
-        private readonly TcpListener listener;
+        private readonly TcpListener _listener;
 
-        private readonly Dictionary<string, Queue<NotifyAwaiter<bool>>> clientConnectedAwaiters = new Dictionary<string, Queue<NotifyAwaiter<bool>>>();
-        private readonly Dictionary<string, Queue<NotifyAwaiter<bool>>> clientDisconnectedAwaiters = new Dictionary<string, Queue<NotifyAwaiter<bool>>>();
+        private readonly Dictionary<string, Queue<NotifyAwaiter<bool>>> _clientConnectedAwaiters =
+            new Dictionary<string, Queue<NotifyAwaiter<bool>>>();
+        private readonly Dictionary<string, Queue<NotifyAwaiter<bool>>> _clientDisconnectedAwaiters =
+            new Dictionary<string, Queue<NotifyAwaiter<bool>>>();
 
         public async Task<bool> AwaitClientConnected(string identity)
         {
-            if (!clientConnectedAwaiters.TryGetValue(identity, out var queue))
+            if (!_clientConnectedAwaiters.TryGetValue(identity, out var queue))
             {
                 queue = new Queue<NotifyAwaiter<bool>>();
-                clientConnectedAwaiters.Add(identity, queue);
+                _clientConnectedAwaiters.Add(identity, queue);
             }
 
             var awaiter = new NotifyAwaiter<bool>();
@@ -48,10 +50,10 @@ namespace GodotTools.Ides
 
         public async Task<bool> AwaitClientDisconnected(string identity)
         {
-            if (!clientDisconnectedAwaiters.TryGetValue(identity, out var queue))
+            if (!_clientDisconnectedAwaiters.TryGetValue(identity, out var queue))
             {
                 queue = new Queue<NotifyAwaiter<bool>>();
-                clientDisconnectedAwaiters.Add(identity, queue);
+                _clientDisconnectedAwaiters.Add(identity, queue);
             }
 
             var awaiter = new NotifyAwaiter<bool>();
@@ -77,7 +79,7 @@ namespace GodotTools.Ides
             if (IsDisposed)
                 return;
 
-            using (await peersSem.UseAsync())
+            using (await _peersSem.UseAsync())
             {
                 if (IsDisposed) // lock may not be fair
                     return;
@@ -95,19 +97,19 @@ namespace GodotTools.Ides
                 foreach (var connection in Peers)
                     connection.Dispose();
                 Peers.Clear();
-                listener?.Stop();
+                _listener?.Stop();
 
-                metaFile?.Dispose();
+                _metaFile?.Dispose();
 
-                File.Delete(MetaFilePath);
+                File.Delete(_metaFilePath);
             }
         }
 
         public MessagingServer(string editorExecutablePath, string projectMetadataDir, ILogger logger)
         {
-            this.logger = logger;
+            this._logger = logger;
 
-            MetaFilePath = Path.Combine(projectMetadataDir, GodotIdeMetadata.DefaultFileName);
+            _metaFilePath = Path.Combine(projectMetadataDir, GodotIdeMetadata.DefaultFileName);
 
             // Make sure the directory exists
             Directory.CreateDirectory(projectMetadataDir);
@@ -115,13 +117,13 @@ namespace GodotTools.Ides
             // The Godot editor's file system thread can keep the file open for writing, so we are forced to allow write sharing...
             const FileShare metaFileShare = FileShare.ReadWrite;
 
-            metaFile = File.Open(MetaFilePath, FileMode.Create, FileAccess.Write, metaFileShare);
+            _metaFile = File.Open(_metaFilePath, FileMode.Create, FileAccess.Write, metaFileShare);
 
-            listener = new TcpListener(new IPEndPoint(IPAddress.Loopback, port: 0));
-            listener.Start();
+            _listener = new TcpListener(new IPEndPoint(IPAddress.Loopback, port: 0));
+            _listener.Start();
 
-            int port = ((IPEndPoint)listener.Server.LocalEndPoint).Port;
-            using (var metaFileWriter = new StreamWriter(metaFile, Encoding.UTF8))
+            int port = ((IPEndPoint)_listener.Server.LocalEndPoint).Port;
+            using (var metaFileWriter = new StreamWriter(_metaFile, Encoding.UTF8))
             {
                 metaFileWriter.WriteLine(port);
                 metaFileWriter.WriteLine(editorExecutablePath);
@@ -130,30 +132,30 @@ namespace GodotTools.Ides
 
         private async Task AcceptClient(TcpClient tcpClient)
         {
-            logger.LogDebug("Accept client...");
+            _logger.LogDebug("Accept client...");
 
-            using (var peer = new Peer(tcpClient, new ServerHandshake(), new ServerMessageHandler(), logger))
+            using (var peer = new Peer(tcpClient, new ServerHandshake(), new ServerMessageHandler(), _logger))
             {
                 // ReSharper disable AccessToDisposedClosure
                 peer.Connected += () =>
                 {
-                    logger.LogInfo("Connection open with Ide Client");
+                    _logger.LogInfo("Connection open with Ide Client");
 
-                    if (clientConnectedAwaiters.TryGetValue(peer.RemoteIdentity, out var queue))
+                    if (_clientConnectedAwaiters.TryGetValue(peer.RemoteIdentity, out var queue))
                     {
                         while (queue.Count > 0)
                             queue.Dequeue().SetResult(true);
-                        clientConnectedAwaiters.Remove(peer.RemoteIdentity);
+                        _clientConnectedAwaiters.Remove(peer.RemoteIdentity);
                     }
                 };
 
                 peer.Disconnected += () =>
                 {
-                    if (clientDisconnectedAwaiters.TryGetValue(peer.RemoteIdentity, out var queue))
+                    if (_clientDisconnectedAwaiters.TryGetValue(peer.RemoteIdentity, out var queue))
                     {
                         while (queue.Count > 0)
                             queue.Dequeue().SetResult(true);
-                        clientDisconnectedAwaiters.Remove(peer.RemoteIdentity);
+                        _clientDisconnectedAwaiters.Remove(peer.RemoteIdentity);
                     }
                 };
                 // ReSharper restore AccessToDisposedClosure
@@ -162,17 +164,17 @@ namespace GodotTools.Ides
                 {
                     if (!await peer.DoHandshake("server"))
                     {
-                        logger.LogError("Handshake failed");
+                        _logger.LogError("Handshake failed");
                         return;
                     }
                 }
                 catch (Exception e)
                 {
-                    logger.LogError("Handshake failed with unhandled exception: ", e);
+                    _logger.LogError("Handshake failed with unhandled exception: ", e);
                     return;
                 }
 
-                using (await peersSem.UseAsync())
+                using (await _peersSem.UseAsync())
                     Peers.Add(peer);
 
                 try
@@ -181,7 +183,7 @@ namespace GodotTools.Ides
                 }
                 finally
                 {
-                    using (await peersSem.UseAsync())
+                    using (await _peersSem.UseAsync())
                         Peers.Remove(peer);
                 }
             }
@@ -192,7 +194,7 @@ namespace GodotTools.Ides
             try
             {
                 while (!IsDisposed)
-                    _ = AcceptClient(await listener.AcceptTcpClientAsync());
+                    _ = AcceptClient(await _listener.AcceptTcpClientAsync());
             }
             catch (Exception e)
             {
@@ -204,11 +206,11 @@ namespace GodotTools.Ides
         public async void BroadcastRequest<TResponse>(string identity, Request request)
             where TResponse : Response, new()
         {
-            using (await peersSem.UseAsync())
+            using (await _peersSem.UseAsync())
             {
                 if (!IsAnyConnected(identity))
                 {
-                    logger.LogError("Cannot write request. No client connected to the Godot Ide Server.");
+                    _logger.LogError("Cannot write request. No client connected to the Godot Ide Server.");
                     return;
                 }
 
@@ -225,16 +227,19 @@ namespace GodotTools.Ides
 
         private class ServerHandshake : IHandshake
         {
-            private static readonly string ServerHandshakeBase = $"{Peer.ServerHandshakeName},Version={Peer.ProtocolVersionMajor}.{Peer.ProtocolVersionMinor}.{Peer.ProtocolVersionRevision}";
-            private static readonly string ClientHandshakePattern = $@"{Regex.Escape(Peer.ClientHandshakeName)},Version=([0-9]+)\.([0-9]+)\.([0-9]+),([_a-zA-Z][_a-zA-Z0-9]{{0,63}})";
+            private static readonly string _serverHandshakeBase =
+                $"{Peer.ServerHandshakeName},Version={Peer.ProtocolVersionMajor}.{Peer.ProtocolVersionMinor}.{Peer.ProtocolVersionRevision}";
 
-            public string GetHandshakeLine(string identity) => $"{ServerHandshakeBase},{identity}";
+            private static readonly string _clientHandshakePattern =
+                $@"{Regex.Escape(Peer.ClientHandshakeName)},Version=([0-9]+)\.([0-9]+)\.([0-9]+),([_a-zA-Z][_a-zA-Z0-9]{{0,63}})";
+
+            public string GetHandshakeLine(string identity) => $"{_serverHandshakeBase},{identity}";
 
             public bool IsValidPeerHandshake(string handshake, out string identity, ILogger logger)
             {
                 identity = null;
 
-                var match = Regex.Match(handshake, ClientHandshakePattern);
+                var match = Regex.Match(handshake, _clientHandshakePattern);
 
                 if (!match.Success)
                     return false;

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/MonoDevelop/Instance.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/MonoDevelop/Instance.cs
@@ -10,17 +10,17 @@ namespace GodotTools.Ides.MonoDevelop
     public class Instance : IDisposable
     {
         public DateTime LaunchTime { get; private set; }
-        private readonly string solutionFile;
-        private readonly EditorId editorId;
+        private readonly string _solutionFile;
+        private readonly EditorId _editorId;
 
-        private Process process;
+        private Process _process;
 
-        public bool IsRunning => process != null && !process.HasExited;
+        public bool IsRunning => _process != null && !_process.HasExited;
         public bool IsDisposed { get; private set; }
 
         public void Execute()
         {
-            bool newWindow = process == null || process.HasExited;
+            bool newWindow = _process == null || _process.HasExited;
 
             var args = new List<string>();
 
@@ -28,7 +28,7 @@ namespace GodotTools.Ides.MonoDevelop
 
             if (OS.IsMacOS)
             {
-                string bundleId = BundleIds[editorId];
+                string bundleId = BundleIds[_editorId];
 
                 if (Internal.IsOsxAppBundleInstalled(bundleId))
                 {
@@ -45,18 +45,18 @@ namespace GodotTools.Ides.MonoDevelop
                 }
                 else
                 {
-                    command = OS.PathWhich(ExecutableNames[editorId]);
+                    command = OS.PathWhich(ExecutableNames[_editorId]);
                 }
             }
             else
             {
-                command = OS.PathWhich(ExecutableNames[editorId]);
+                command = OS.PathWhich(ExecutableNames[_editorId]);
             }
 
             args.Add("--ipc-tcp");
 
             if (newWindow)
-                args.Add("\"" + Path.GetFullPath(solutionFile) + "\"");
+                args.Add("\"" + Path.GetFullPath(_solutionFile) + "\"");
 
             if (command == null)
                 throw new FileNotFoundException();
@@ -65,7 +65,7 @@ namespace GodotTools.Ides.MonoDevelop
 
             if (newWindow)
             {
-                process = Process.Start(new ProcessStartInfo
+                _process = Process.Start(new ProcessStartInfo
                 {
                     FileName = command,
                     Arguments = string.Join(" ", args),
@@ -88,14 +88,14 @@ namespace GodotTools.Ides.MonoDevelop
             if (editorId == EditorId.VisualStudioForMac && !OS.IsMacOS)
                 throw new InvalidOperationException($"{nameof(EditorId.VisualStudioForMac)} not supported on this platform");
 
-            this.solutionFile = solutionFile;
-            this.editorId = editorId;
+            _solutionFile = solutionFile;
+            _editorId = editorId;
         }
 
         public void Dispose()
         {
             IsDisposed = true;
-            process?.Dispose();
+            _process?.Dispose();
         }
 
         private static readonly IReadOnlyDictionary<EditorId, string> ExecutableNames;

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
@@ -11,6 +11,7 @@ using Environment = System.Environment;
 using File = System.IO.File;
 using Path = System.IO.Path;
 using OS = GodotTools.Utils.OS;
+
 // ReSharper disable UnassignedField.Local
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnassignedField.Global
@@ -53,10 +54,10 @@ namespace GodotTools.Ides.Rider
         private static RiderInfo[] CollectAllRiderPathsLinux()
         {
             var installInfos = new List<RiderInfo>();
-            var home = Environment.GetEnvironmentVariable("HOME");
+            string home = Environment.GetEnvironmentVariable("HOME");
             if (!string.IsNullOrEmpty(home))
             {
-                var toolboxRiderRootPath = GetToolboxBaseDir();
+                string toolboxRiderRootPath = GetToolboxBaseDir();
                 installInfos.AddRange(CollectPathsFromToolbox(toolboxRiderRootPath, "bin", "rider.sh", false)
                   .Select(a => new RiderInfo(a, true)).ToList());
 
@@ -65,12 +66,12 @@ namespace GodotTools.Ides.Rider
 
                 if (shortcut.Exists)
                 {
-                    var lines = File.ReadAllLines(shortcut.FullName);
-                    foreach (var line in lines)
+                    string[] lines = File.ReadAllLines(shortcut.FullName);
+                    foreach (string line in lines)
                     {
                         if (!line.StartsWith("Exec=\""))
                             continue;
-                        var path = line.Split('"').Where((item, index) => index == 1).SingleOrDefault();
+                        string path = line.Split('"').Where((item, index) => index == 1).SingleOrDefault();
                         if (string.IsNullOrEmpty(path))
                             continue;
 
@@ -82,7 +83,7 @@ namespace GodotTools.Ides.Rider
             }
 
             // snap install
-            var snapInstallPath = "/snap/rider/current/bin/rider.sh";
+            string snapInstallPath = "/snap/rider/current/bin/rider.sh";
             if (new FileInfo(snapInstallPath).Exists)
                 installInfos.Add(new RiderInfo(snapInstallPath, false));
 
@@ -98,15 +99,15 @@ namespace GodotTools.Ides.Rider
             if (folder.Exists)
             {
                 installInfos.AddRange(folder.GetDirectories("*Rider*.app")
-                  .Select(a => new RiderInfo(Path.Combine(a.FullName, "Contents/MacOS/rider"), false))
-                  .ToList());
+                    .Select(a => new RiderInfo(Path.Combine(a.FullName, "Contents/MacOS/rider"), false))
+                    .ToList());
             }
 
             // /Users/user/Library/Application Support/JetBrains/Toolbox/apps/Rider/ch-1/181.3870.267/Rider EAP.app
             // should be combined with "Contents/MacOS/rider"
-            var toolboxRiderRootPath = GetToolboxBaseDir();
+            string toolboxRiderRootPath = GetToolboxBaseDir();
             var paths = CollectPathsFromToolbox(toolboxRiderRootPath, "", "Rider*.app", true)
-              .Select(a => new RiderInfo(Path.Combine(a, "Contents/MacOS/rider"), true));
+                .Select(a => new RiderInfo(Path.Combine(a, "Contents/MacOS/rider"), true));
             installInfos.AddRange(paths);
 
             return installInfos.ToArray();
@@ -134,7 +135,7 @@ namespace GodotTools.Ides.Rider
         {
             if (OS.IsWindows)
             {
-                var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                 return GetToolboxRiderRootPath(localAppData);
             }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -49,7 +49,7 @@ namespace GodotTools.Ides.Rider
                 if (!paths.Any())
                     return;
 
-                var newPath = paths.Last().Path;
+                string newPath = paths.Last().Path;
                 Globals.EditorDef(EditorPathSettingName, newPath);
                 editorSettings.SetSetting(EditorPathSettingName, newPath);
             }
@@ -57,7 +57,8 @@ namespace GodotTools.Ides.Rider
 
         public static bool IsExternalEditorSetToRider(EditorSettings editorSettings)
         {
-            return editorSettings.HasSetting(EditorPathSettingName) && IsRider((string)editorSettings.GetSetting(EditorPathSettingName));
+            return editorSettings.HasSetting(EditorPathSettingName) &&
+                IsRider((string)editorSettings.GetSetting(EditorPathSettingName));
         }
 
         public static bool IsRider(string path)
@@ -66,7 +67,7 @@ namespace GodotTools.Ides.Rider
                 return false;
 
             var fileInfo = new FileInfo(path);
-            var filename = fileInfo.Name.ToLowerInvariant();
+            string filename = fileInfo.Name.ToLowerInvariant();
             return filename.StartsWith("rider", StringComparison.Ordinal);
         }
 
@@ -83,7 +84,7 @@ namespace GodotTools.Ides.Rider
             if (!paths.Any())
                 return null;
 
-            var newPath = paths.Last().Path;
+            string newPath = paths.Last().Path;
             editorSettings.SetSetting(EditorPathSettingName, newPath);
             Globals.EditorDef(EditorPathSettingName, newPath);
             return newPath;
@@ -96,8 +97,8 @@ namespace GodotTools.Ides.Rider
 
         public static void OpenFile(string slnPath, string scriptPath, int line)
         {
-            var pathFromSettings = GetRiderPathFromSettings();
-            var path = CheckAndUpdatePath(pathFromSettings);
+            string pathFromSettings = GetRiderPathFromSettings();
+            string path = CheckAndUpdatePath(pathFromSettings);
 
             var args = new List<string>();
             args.Add(slnPath);

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -39,45 +39,57 @@ namespace GodotTools.Internals
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ResDataDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ResMetadataDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ResAssembliesBaseDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ResAssembliesDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ResConfigDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ResTempDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ResTempAssembliesBaseDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ResTempAssembliesDir();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_MonoUserDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_MonoLogsDir();
 
         #region Tools-only
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_MonoSolutionsDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_BuildLogsDirs();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ProjectSlnPath();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ProjectCsProjPath();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_DataEditorToolsDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_DataEditorPrebuiltApiDir();
         #endregion
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_DataMonoEtcDir();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_DataMonoLibDir();
 

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/FsPathUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/FsPathUtils.cs
@@ -8,7 +8,7 @@ namespace GodotTools.Utils
 {
     public static class FsPathUtils
     {
-        private static readonly string ResourcePath = ProjectSettings.GlobalizePath("res://");
+        private static readonly string _resourcePath = ProjectSettings.GlobalizePath("res://");
 
         private static bool PathStartsWithAlreadyNorm(this string childPath, string parentPath)
         {
@@ -34,7 +34,7 @@ namespace GodotTools.Utils
         public static string LocalizePathWithCaseChecked(string path)
         {
             string pathNorm = path.NormalizePath() + Path.DirectorySeparatorChar;
-            string resourcePathNorm = ResourcePath.NormalizePath() + Path.DirectorySeparatorChar;
+            string resourcePathNorm = _resourcePath.NormalizePath() + Path.DirectorySeparatorChar;
 
             if (!pathNorm.PathStartsWithAlreadyNorm(resourcePathNorm))
                 return null;

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -13,10 +13,10 @@ namespace GodotTools.Utils
     public static class OS
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
-        static extern string GetPlatformName();
+        private static extern string GetPlatformName();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        static extern bool UnixFileHasExecutableAccess(string filePath);
+        private static extern bool UnixFileHasExecutableAccess(string filePath);
 
         public static class Names
         {
@@ -106,7 +106,10 @@ namespace GodotTools.Utils
 
         public static string PathWhich([NotNull] string name)
         {
-            return IsWindows ? PathWhichWindows(name) : PathWhichUnix(name);
+            if (IsWindows)
+                return PathWhichWindows(name);
+
+            return PathWhichUnix(name);
         }
 
         private static string PathWhichWindows([NotNull] string name)
@@ -129,7 +132,8 @@ namespace GodotTools.Utils
             }
 
             string nameExt = Path.GetExtension(name);
-            bool hasPathExt = !string.IsNullOrEmpty(nameExt) && windowsExts.Contains(nameExt, StringComparer.OrdinalIgnoreCase);
+            bool hasPathExt = !string.IsNullOrEmpty(nameExt) &&
+                windowsExts.Contains(nameExt, StringComparer.OrdinalIgnoreCase);
 
             searchDirs.Add(System.IO.Directory.GetCurrentDirectory()); // last in the list
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -70,17 +70,17 @@ namespace Godot
         /// <returns>A bool for whether or not this AABB encloses `b`.</returns>
         public bool Encloses(AABB with)
         {
-            Vector3 src_min = _position;
-            Vector3 src_max = _position + _size;
-            Vector3 dst_min = with._position;
-            Vector3 dst_max = with._position + with._size;
+            Vector3 srcMin = _position;
+            Vector3 srcMax = _position + _size;
+            Vector3 dstMin = with._position;
+            Vector3 dstMax = with._position + with._size;
 
-            return src_min.x <= dst_min.x &&
-                   src_max.x > dst_max.x &&
-                   src_min.y <= dst_min.y &&
-                   src_max.y > dst_max.y &&
-                   src_min.z <= dst_min.z &&
-                   src_max.z > dst_max.z;
+            return srcMin.x <= dstMin.x &&
+                   srcMax.x > dstMax.x &&
+                   srcMin.y <= dstMin.y &&
+                   srcMax.y > dstMax.y &&
+                   srcMin.z <= dstMin.z &&
+                   srcMax.z > dstMax.z;
         }
 
         /// <summary>
@@ -157,7 +157,10 @@ namespace Godot
                 case 7:
                     return new Vector3(_position.x + _size.x, _position.y + _size.y, _position.z + _size.z);
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(idx), String.Format("Index is {0}, but a value from 0 to 7 is expected.", idx));
+                {
+                    throw new ArgumentOutOfRangeException(nameof(idx),
+                        $"Index is {idx}, but a value from 0 to 7 is expected.");
+                }
             }
         }
 
@@ -168,15 +171,15 @@ namespace Godot
         public Vector3 GetLongestAxis()
         {
             var axis = new Vector3(1f, 0f, 0f);
-            real_t max_size = _size.x;
+            real_t maxSize = _size.x;
 
-            if (_size.y > max_size)
+            if (_size.y > maxSize)
             {
                 axis = new Vector3(0f, 1f, 0f);
-                max_size = _size.y;
+                maxSize = _size.y;
             }
 
-            if (_size.z > max_size)
+            if (_size.z > maxSize)
             {
                 axis = new Vector3(0f, 0f, 1f);
             }
@@ -191,15 +194,15 @@ namespace Godot
         public Vector3.Axis GetLongestAxisIndex()
         {
             var axis = Vector3.Axis.X;
-            real_t max_size = _size.x;
+            real_t maxSize = _size.x;
 
-            if (_size.y > max_size)
+            if (_size.y > maxSize)
             {
                 axis = Vector3.Axis.Y;
-                max_size = _size.y;
+                maxSize = _size.y;
             }
 
-            if (_size.z > max_size)
+            if (_size.z > maxSize)
             {
                 axis = Vector3.Axis.Z;
             }
@@ -213,15 +216,15 @@ namespace Godot
         /// <returns>The scalar length of the longest axis of the AABB.</returns>
         public real_t GetLongestAxisSize()
         {
-            real_t max_size = _size.x;
+            real_t maxSize = _size.x;
 
-            if (_size.y > max_size)
-                max_size = _size.y;
+            if (_size.y > maxSize)
+                maxSize = _size.y;
 
-            if (_size.z > max_size)
-                max_size = _size.z;
+            if (_size.z > maxSize)
+                maxSize = _size.z;
 
-            return max_size;
+            return maxSize;
         }
 
         /// <summary>
@@ -231,15 +234,15 @@ namespace Godot
         public Vector3 GetShortestAxis()
         {
             var axis = new Vector3(1f, 0f, 0f);
-            real_t max_size = _size.x;
+            real_t maxSize = _size.x;
 
-            if (_size.y < max_size)
+            if (_size.y < maxSize)
             {
                 axis = new Vector3(0f, 1f, 0f);
-                max_size = _size.y;
+                maxSize = _size.y;
             }
 
-            if (_size.z < max_size)
+            if (_size.z < maxSize)
             {
                 axis = new Vector3(0f, 0f, 1f);
             }
@@ -254,15 +257,15 @@ namespace Godot
         public Vector3.Axis GetShortestAxisIndex()
         {
             var axis = Vector3.Axis.X;
-            real_t max_size = _size.x;
+            real_t maxSize = _size.x;
 
-            if (_size.y < max_size)
+            if (_size.y < maxSize)
             {
                 axis = Vector3.Axis.Y;
-                max_size = _size.y;
+                maxSize = _size.y;
             }
 
-            if (_size.z < max_size)
+            if (_size.z < maxSize)
             {
                 axis = Vector3.Axis.Z;
             }
@@ -276,15 +279,15 @@ namespace Godot
         /// <returns>The scalar length of the shortest axis of the AABB.</returns>
         public real_t GetShortestAxisSize()
         {
-            real_t max_size = _size.x;
+            real_t maxSize = _size.x;
 
-            if (_size.y < max_size)
-                max_size = _size.y;
+            if (_size.y < maxSize)
+                maxSize = _size.y;
 
-            if (_size.z < max_size)
-                max_size = _size.z;
+            if (_size.z < maxSize)
+                maxSize = _size.z;
 
-            return max_size;
+            return maxSize;
         }
 
         /// <summary>
@@ -295,13 +298,13 @@ namespace Godot
         /// <returns>A vector representing the support.</returns>
         public Vector3 GetSupport(Vector3 dir)
         {
-            Vector3 half_extents = _size * 0.5f;
-            Vector3 ofs = _position + half_extents;
+            Vector3 halfExtents = _size * 0.5f;
+            Vector3 ofs = _position + halfExtents;
 
             return ofs + new Vector3(
-                dir.x > 0f ? -half_extents.x : half_extents.x,
-                dir.y > 0f ? -half_extents.y : half_extents.y,
-                dir.z > 0f ? -half_extents.z : half_extents.z);
+                dir.x > 0f ? -halfExtents.x : halfExtents.x,
+                dir.y > 0f ? -halfExtents.y : halfExtents.y,
+                dir.z > 0f ? -halfExtents.z : halfExtents.z);
         }
 
         /// <summary>
@@ -311,7 +314,7 @@ namespace Godot
         /// <returns>The grown AABB.</returns>
         public AABB Grow(real_t by)
         {
-            var res = this;
+            AABB res = this;
 
             res._position.x -= by;
             res._position.y -= by;
@@ -371,36 +374,36 @@ namespace Godot
         /// <returns>The clipped AABB.</returns>
         public AABB Intersection(AABB with)
         {
-            Vector3 src_min = _position;
-            Vector3 src_max = _position + _size;
-            Vector3 dst_min = with._position;
-            Vector3 dst_max = with._position + with._size;
+            Vector3 srcMin = _position;
+            Vector3 srcMax = _position + _size;
+            Vector3 dstMin = with._position;
+            Vector3 dstMax = with._position + with._size;
 
             Vector3 min, max;
 
-            if (src_min.x > dst_max.x || src_max.x < dst_min.x)
+            if (srcMin.x > dstMax.x || srcMax.x < dstMin.x)
             {
                 return new AABB();
             }
 
-            min.x = src_min.x > dst_min.x ? src_min.x : dst_min.x;
-            max.x = src_max.x < dst_max.x ? src_max.x : dst_max.x;
+            min.x = srcMin.x > dstMin.x ? srcMin.x : dstMin.x;
+            max.x = srcMax.x < dstMax.x ? srcMax.x : dstMax.x;
 
-            if (src_min.y > dst_max.y || src_max.y < dst_min.y)
+            if (srcMin.y > dstMax.y || srcMax.y < dstMin.y)
             {
                 return new AABB();
             }
 
-            min.y = src_min.y > dst_min.y ? src_min.y : dst_min.y;
-            max.y = src_max.y < dst_max.y ? src_max.y : dst_max.y;
+            min.y = srcMin.y > dstMin.y ? srcMin.y : dstMin.y;
+            max.y = srcMax.y < dstMax.y ? srcMax.y : dstMax.y;
 
-            if (src_min.z > dst_max.z || src_max.z < dst_min.z)
+            if (srcMin.z > dstMax.z || srcMax.z < dstMin.z)
             {
                 return new AABB();
             }
 
-            min.z = src_min.z > dst_min.z ? src_min.z : dst_min.z;
-            max.z = src_max.z < dst_max.z ? src_max.z : dst_max.z;
+            min.z = srcMin.z > dstMin.z ? srcMin.z : dstMin.z;
+            max.z = srcMax.z < dstMax.z ? srcMax.z : dstMax.z;
 
             return new AABB(min, max - min);
         }
@@ -561,16 +564,16 @@ namespace Godot
             var end2 = new Vector3(with._size.x, with._size.y, with._size.z) + beg2;
 
             var min = new Vector3(
-                              beg1.x < beg2.x ? beg1.x : beg2.x,
-                              beg1.y < beg2.y ? beg1.y : beg2.y,
-                              beg1.z < beg2.z ? beg1.z : beg2.z
-                          );
+                beg1.x < beg2.x ? beg1.x : beg2.x,
+                beg1.y < beg2.y ? beg1.y : beg2.y,
+                beg1.z < beg2.z ? beg1.z : beg2.z
+            );
 
             var max = new Vector3(
-                              end1.x > end2.x ? end1.x : end2.x,
-                              end1.y > end2.y ? end1.y : end2.y,
-                              end1.z > end2.z ? end1.z : end2.z
-                          );
+                end1.x > end2.x ? end1.x : end2.x,
+                end1.y > end2.y ? end1.y : end2.y,
+                end1.z > end2.z ? end1.z : end2.z
+            );
 
             return new AABB(min, max - min);
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace Godot.Collections
 {
-    class ArraySafeHandle : SafeHandle
+    internal class ArraySafeHandle : SafeHandle
     {
         public ArraySafeHandle(IntPtr handle) : base(IntPtr.Zero, true)
         {
@@ -33,15 +33,15 @@ namespace Godot.Collections
     /// </summary>
     public class Array : IList, IDisposable
     {
-        ArraySafeHandle safeHandle;
-        bool disposed = false;
+        private ArraySafeHandle _safeHandle;
+        private bool _disposed = false;
 
         /// <summary>
         /// Constructs a new empty <see cref="Array"/>.
         /// </summary>
         public Array()
         {
-            safeHandle = new ArraySafeHandle(godot_icall_Array_Ctor());
+            _safeHandle = new ArraySafeHandle(godot_icall_Array_Ctor());
         }
 
         /// <summary>
@@ -69,25 +69,25 @@ namespace Godot.Collections
             {
                 throw new NullReferenceException($"Parameter '{nameof(array)} cannot be null.'");
             }
-            safeHandle = new ArraySafeHandle(godot_icall_Array_Ctor_MonoArray(array));
+            _safeHandle = new ArraySafeHandle(godot_icall_Array_Ctor_MonoArray(array));
         }
 
         internal Array(ArraySafeHandle handle)
         {
-            safeHandle = handle;
+            _safeHandle = handle;
         }
 
         internal Array(IntPtr handle)
         {
-            safeHandle = new ArraySafeHandle(handle);
+            _safeHandle = new ArraySafeHandle(handle);
         }
 
         internal IntPtr GetPtr()
         {
-            if (disposed)
+            if (_disposed)
                 throw new ObjectDisposedException(GetType().FullName);
 
-            return safeHandle.DangerousGetHandle();
+            return _safeHandle.DangerousGetHandle();
         }
 
         /// <summary>
@@ -136,16 +136,16 @@ namespace Godot.Collections
         /// </summary>
         public void Dispose()
         {
-            if (disposed)
+            if (_disposed)
                 return;
 
-            if (safeHandle != null)
+            if (_safeHandle != null)
             {
-                safeHandle.Dispose();
-                safeHandle = null;
+                _safeHandle.Dispose();
+                _safeHandle = null;
             }
 
-            disposed = true;
+            _disposed = true;
         }
 
         // IList
@@ -272,67 +272,67 @@ namespace Godot.Collections
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_Array_Ctor();
+        internal static extern IntPtr godot_icall_Array_Ctor();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_Array_Ctor_MonoArray(System.Array array);
+        internal static extern IntPtr godot_icall_Array_Ctor_MonoArray(System.Array array);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Array_Dtor(IntPtr ptr);
+        internal static extern void godot_icall_Array_Dtor(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static object godot_icall_Array_At(IntPtr ptr, int index);
+        internal static extern object godot_icall_Array_At(IntPtr ptr, int index);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static object godot_icall_Array_At_Generic(IntPtr ptr, int index, int elemTypeEncoding, IntPtr elemTypeClass);
+        internal static extern object godot_icall_Array_At_Generic(IntPtr ptr, int index, int elemTypeEncoding, IntPtr elemTypeClass);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Array_SetAt(IntPtr ptr, int index, object value);
+        internal static extern void godot_icall_Array_SetAt(IntPtr ptr, int index, object value);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_Array_Count(IntPtr ptr);
+        internal static extern int godot_icall_Array_Count(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_Array_Add(IntPtr ptr, object item);
+        internal static extern int godot_icall_Array_Add(IntPtr ptr, object item);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Array_Clear(IntPtr ptr);
+        internal static extern void godot_icall_Array_Clear(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_Array_Concatenate(IntPtr left, IntPtr right);
+        internal static extern IntPtr godot_icall_Array_Concatenate(IntPtr left, IntPtr right);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_Array_Contains(IntPtr ptr, object item);
+        internal static extern bool godot_icall_Array_Contains(IntPtr ptr, object item);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Array_CopyTo(IntPtr ptr, System.Array array, int arrayIndex);
+        internal static extern void godot_icall_Array_CopyTo(IntPtr ptr, System.Array array, int arrayIndex);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_Array_Duplicate(IntPtr ptr, bool deep);
+        internal static extern IntPtr godot_icall_Array_Duplicate(IntPtr ptr, bool deep);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_Array_IndexOf(IntPtr ptr, object item);
+        internal static extern int godot_icall_Array_IndexOf(IntPtr ptr, object item);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Array_Insert(IntPtr ptr, int index, object item);
+        internal static extern void godot_icall_Array_Insert(IntPtr ptr, int index, object item);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_Array_Remove(IntPtr ptr, object item);
+        internal static extern bool godot_icall_Array_Remove(IntPtr ptr, object item);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Array_RemoveAt(IntPtr ptr, int index);
+        internal static extern void godot_icall_Array_RemoveAt(IntPtr ptr, int index);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static Error godot_icall_Array_Resize(IntPtr ptr, int newSize);
+        internal static extern Error godot_icall_Array_Resize(IntPtr ptr, int newSize);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static Error godot_icall_Array_Shuffle(IntPtr ptr);
+        internal static extern Error godot_icall_Array_Shuffle(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Array_Generic_GetElementTypeInfo(Type elemType, out int elemTypeEncoding, out IntPtr elemTypeClass);
+        internal static extern void godot_icall_Array_Generic_GetElementTypeInfo(Type elemType, out int elemTypeEncoding, out IntPtr elemTypeClass);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static string godot_icall_Array_ToString(IntPtr ptr);
+        internal static extern string godot_icall_Array_ToString(IntPtr ptr);
     }
 
     /// <summary>
@@ -344,7 +344,7 @@ namespace Godot.Collections
     /// <typeparam name="T">The type of the array.</typeparam>
     public class Array<T> : IList<T>, ICollection<T>, IEnumerable<T>
     {
-        Array objectArray;
+        private Array _objectArray;
 
         internal static int elemTypeEncoding;
         internal static IntPtr elemTypeClass;
@@ -359,7 +359,7 @@ namespace Godot.Collections
         /// </summary>
         public Array()
         {
-            objectArray = new Array();
+            _objectArray = new Array();
         }
 
         /// <summary>
@@ -372,7 +372,7 @@ namespace Godot.Collections
             if (collection == null)
                 throw new NullReferenceException($"Parameter '{nameof(collection)} cannot be null.'");
 
-            objectArray = new Array(collection);
+            _objectArray = new Array(collection);
         }
 
         /// <summary>
@@ -386,7 +386,7 @@ namespace Godot.Collections
             {
                 throw new NullReferenceException($"Parameter '{nameof(array)} cannot be null.'");
             }
-            objectArray = new Array(array);
+            _objectArray = new Array(array);
         }
 
         /// <summary>
@@ -395,22 +395,22 @@ namespace Godot.Collections
         /// <param name="array">The untyped array to construct from.</param>
         public Array(Array array)
         {
-            objectArray = array;
+            _objectArray = array;
         }
 
         internal Array(IntPtr handle)
         {
-            objectArray = new Array(handle);
+            _objectArray = new Array(handle);
         }
 
         internal Array(ArraySafeHandle handle)
         {
-            objectArray = new Array(handle);
+            _objectArray = new Array(handle);
         }
 
         internal IntPtr GetPtr()
         {
-            return objectArray.GetPtr();
+            return _objectArray.GetPtr();
         }
 
         /// <summary>
@@ -419,7 +419,7 @@ namespace Godot.Collections
         /// <param name="from">The typed array to convert.</param>
         public static explicit operator Array(Array<T> from)
         {
-            return from.objectArray;
+            return from._objectArray;
         }
 
         /// <summary>
@@ -429,7 +429,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Array.</returns>
         public Array<T> Duplicate(bool deep = false)
         {
-            return new Array<T>(objectArray.Duplicate(deep));
+            return new Array<T>(_objectArray.Duplicate(deep));
         }
 
         /// <summary>
@@ -439,7 +439,7 @@ namespace Godot.Collections
         /// <returns><see cref="Error.Ok"/> if successful, or an error code.</returns>
         public Error Resize(int newSize)
         {
-            return objectArray.Resize(newSize);
+            return _objectArray.Resize(newSize);
         }
 
         /// <summary>
@@ -447,7 +447,7 @@ namespace Godot.Collections
         /// </summary>
         public void Shuffle()
         {
-            objectArray.Shuffle();
+            _objectArray.Shuffle();
         }
 
         /// <summary>
@@ -458,7 +458,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Array with the contents of both arrays.</returns>
         public static Array<T> operator +(Array<T> left, Array<T> right)
         {
-            return new Array<T>(left.objectArray + right.objectArray);
+            return new Array<T>(left._objectArray + right._objectArray);
         }
 
         // IList<T>
@@ -470,7 +470,7 @@ namespace Godot.Collections
         public T this[int index]
         {
             get { return (T)Array.godot_icall_Array_At_Generic(GetPtr(), index, elemTypeEncoding, elemTypeClass); }
-            set { objectArray[index] = value; }
+            set { _objectArray[index] = value; }
         }
 
         /// <summary>
@@ -481,7 +481,7 @@ namespace Godot.Collections
         /// <returns>The index of the item, or -1 if not found.</returns>
         public int IndexOf(T item)
         {
-            return objectArray.IndexOf(item);
+            return _objectArray.IndexOf(item);
         }
 
         /// <summary>
@@ -494,7 +494,7 @@ namespace Godot.Collections
         /// <param name="item">The item to insert.</param>
         public void Insert(int index, T item)
         {
-            objectArray.Insert(index, item);
+            _objectArray.Insert(index, item);
         }
 
         /// <summary>
@@ -503,7 +503,7 @@ namespace Godot.Collections
         /// <param name="index">The index of the element to remove.</param>
         public void RemoveAt(int index)
         {
-            objectArray.RemoveAt(index);
+            _objectArray.RemoveAt(index);
         }
 
         // ICollection<T>
@@ -515,7 +515,7 @@ namespace Godot.Collections
         /// <returns>The number of elements.</returns>
         public int Count
         {
-            get { return objectArray.Count; }
+            get { return _objectArray.Count; }
         }
 
         bool ICollection<T>.IsReadOnly => false;
@@ -528,7 +528,7 @@ namespace Godot.Collections
         /// <returns>The new size after adding the item.</returns>
         public void Add(T item)
         {
-            objectArray.Add(item);
+            _objectArray.Add(item);
         }
 
         /// <summary>
@@ -536,7 +536,7 @@ namespace Godot.Collections
         /// </summary>
         public void Clear()
         {
-            objectArray.Clear();
+            _objectArray.Clear();
         }
 
         /// <summary>
@@ -546,7 +546,7 @@ namespace Godot.Collections
         /// <returns>Whether or not this array contains the given item.</returns>
         public bool Contains(T item)
         {
-            return objectArray.Contains(item);
+            return _objectArray.Contains(item);
         }
 
         /// <summary>
@@ -566,7 +566,7 @@ namespace Godot.Collections
             // TODO This may be quite slow because every element access is an internal call.
             // It could be moved entirely to an internal call if we find out how to do the cast there.
 
-            int count = objectArray.Count;
+            int count = _objectArray.Count;
 
             if (array.Length < (arrayIndex + count))
                 throw new ArgumentException("Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
@@ -597,7 +597,7 @@ namespace Godot.Collections
         /// <returns>An enumerator.</returns>
         public IEnumerator<T> GetEnumerator()
         {
-            int count = objectArray.Count;
+            int count = _objectArray.Count;
 
             for (int i = 0; i < count; i++)
             {
@@ -614,6 +614,6 @@ namespace Godot.Collections
         /// Converts this <see cref="Array{T}"/> to a string.
         /// </summary>
         /// <returns>A string representation of this array.</returns>
-        public override string ToString() => objectArray.ToString();
+        public override string ToString() => _objectArray.ToString();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -88,9 +88,9 @@ namespace Godot
             get => new Vector3(Row0.x, Row1.x, Row2.x);
             set
             {
-                this.Row0.x = value.x;
-                this.Row1.x = value.y;
-                this.Row2.x = value.z;
+                Row0.x = value.x;
+                Row1.x = value.y;
+                Row2.x = value.z;
             }
         }
 
@@ -103,9 +103,9 @@ namespace Godot
             get => new Vector3(Row0.y, Row1.y, Row2.y);
             set
             {
-                this.Row0.y = value.x;
-                this.Row1.y = value.y;
-                this.Row2.y = value.z;
+                Row0.y = value.x;
+                Row1.y = value.y;
+                Row2.y = value.z;
             }
         }
 
@@ -118,9 +118,9 @@ namespace Godot
             get => new Vector3(Row0.z, Row1.z, Row2.z);
             set
             {
-                this.Row0.z = value.x;
-                this.Row1.z = value.y;
-                this.Row2.z = value.z;
+                Row0.z = value.x;
+                Row1.z = value.y;
+                Row2.z = value.z;
             }
         }
 
@@ -504,7 +504,7 @@ namespace Godot
         /// <returns>The resulting dot product.</returns>
         public real_t Tdotx(Vector3 with)
         {
-            return this.Row0[0] * with[0] + this.Row1[0] * with[1] + this.Row2[0] * with[2];
+            return Row0[0] * with[0] + Row1[0] * with[1] + Row2[0] * with[2];
         }
 
         /// <summary>
@@ -514,7 +514,7 @@ namespace Godot
         /// <returns>The resulting dot product.</returns>
         public real_t Tdoty(Vector3 with)
         {
-            return this.Row0[1] * with[0] + this.Row1[1] * with[1] + this.Row2[1] * with[2];
+            return Row0[1] * with[0] + Row1[1] * with[1] + Row2[1] * with[2];
         }
 
         /// <summary>
@@ -524,7 +524,7 @@ namespace Godot
         /// <returns>The resulting dot product.</returns>
         public real_t Tdotz(Vector3 with)
         {
-            return this.Row0[2] * with[0] + this.Row1[2] * with[1] + this.Row2[2] * with[2];
+            return Row0[2] * with[0] + Row1[2] * with[1] + Row2[2] * with[2];
         }
 
         /// <summary>
@@ -533,7 +533,7 @@ namespace Godot
         /// <returns>The transposed basis matrix.</returns>
         public Basis Transposed()
         {
-            var tr = this;
+            Basis tr = this;
 
             real_t temp = tr.Row0[1];
             tr.Row0[1] = tr.Row1[0];
@@ -559,9 +559,9 @@ namespace Godot
         {
             return new Vector3
             (
-                this.Row0.Dot(v),
-                this.Row1.Dot(v),
-                this.Row2.Dot(v)
+                Row0.Dot(v),
+                Row1.Dot(v),
+                Row2.Dot(v)
             );
         }
 
@@ -577,9 +577,9 @@ namespace Godot
         {
             return new Vector3
             (
-                this.Row0[0] * v.x + this.Row1[0] * v.y + this.Row2[0] * v.z,
-                this.Row0[1] * v.x + this.Row1[1] * v.y + this.Row2[1] * v.z,
-                this.Row0[2] * v.x + this.Row1[2] * v.y + this.Row2[2] * v.z
+                Row0[0] * v.x + Row1[0] * v.y + Row2[0] * v.z,
+                Row0[1] * v.x + Row1[1] * v.y + Row2[1] * v.z,
+                Row0[2] * v.x + Row1[2] * v.y + Row2[2] * v.z
             );
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -127,11 +127,11 @@ namespace Godot
                 }
                 else if (g == max)
                 {
-                    h = 2 + (b - r) / delta; // Between cyan & yellow
+                    h = 2 + ((b - r) / delta); // Between cyan & yellow
                 }
                 else
                 {
-                    h = 4 + (r - g) / delta; // Between magenta & cyan
+                    h = 4 + ((r - g) / delta); // Between magenta & cyan
                 }
 
                 h /= 6.0f;
@@ -242,16 +242,16 @@ namespace Godot
             Color res;
 
             float sa = 1.0f - over.a;
-            res.a = a * sa + over.a;
+            res.a = (a * sa) + over.a;
 
             if (res.a == 0)
             {
                 return new Color(0, 0, 0, 0);
             }
 
-            res.r = (r * a * sa + over.r * over.a) / res.a;
-            res.g = (g * a * sa + over.g * over.a) / res.a;
-            res.b = (b * a * sa + over.b * over.a) / res.a;
+            res.r = ((r * a * sa) + (over.r * over.a)) / res.a;
+            res.g = ((g * a * sa) + (over.g * over.a)) / res.a;
+            res.b = ((b * a * sa) + (over.b * over.a)) / res.a;
 
             return res;
         }
@@ -286,9 +286,9 @@ namespace Godot
         public Color Darkened(float amount)
         {
             Color res = this;
-            res.r = res.r * (1.0f - amount);
-            res.g = res.g * (1.0f - amount);
-            res.b = res.b * (1.0f - amount);
+            res.r *= 1.0f - amount;
+            res.g *= 1.0f - amount;
+            res.b *= 1.0f - amount;
             return res;
         }
 
@@ -315,9 +315,9 @@ namespace Godot
         public Color Lightened(float amount)
         {
             Color res = this;
-            res.r = res.r + (1.0f - res.r) * amount;
-            res.g = res.g + (1.0f - res.g) * amount;
-            res.b = res.b + (1.0f - res.b) * amount;
+            res.r += (1.0f - res.r) * amount;
+            res.g += (1.0f - res.g) * amount;
+            res.b += (1.0f - res.b) * amount;
             return res;
         }
 
@@ -478,7 +478,7 @@ namespace Godot
         /// <returns>A string for the HTML hexadecimal representation of this color.</returns>
         public string ToHTML(bool includeAlpha = true)
         {
-            var txt = string.Empty;
+            string txt = string.Empty;
 
             txt += ToHex32(r);
             txt += ToHex32(g);
@@ -627,7 +627,8 @@ namespace Godot
             }
             else
             {
-                throw new ArgumentOutOfRangeException("Invalid color code. Length is " + rgba.Length + " but a length of 6 or 8 is expected: " + rgba);
+                throw new ArgumentOutOfRangeException(
+                    $"Invalid color code. Length is {rgba.Length}, but a length of 6 or 8 is expected: {rgba}");
             }
 
             c.a = 1.0f;
@@ -697,11 +698,11 @@ namespace Godot
         /// <returns>The constructed color.</returns>
         private static Color Named(string name)
         {
-            name = name.Replace(" ", String.Empty);
-            name = name.Replace("-", String.Empty);
-            name = name.Replace("_", String.Empty);
-            name = name.Replace("'", String.Empty);
-            name = name.Replace(".", String.Empty);
+            name = name.Replace(" ", string.Empty);
+            name = name.Replace("-", string.Empty);
+            name = name.Replace("_", string.Empty);
+            name = name.Replace("'", string.Empty);
+            name = name.Replace(".", string.Empty);
             name = name.ToUpper();
 
             if (!Colors.namedColors.ContainsKey(name))
@@ -739,8 +740,8 @@ namespace Godot
 
             f = hue - i;
             p = value * (1 - saturation);
-            q = value * (1 - saturation * f);
-            t = value * (1 - saturation * (1 - f));
+            q = value * (1 - (saturation * f));
+            t = value * (1 - (saturation * (1 - f)));
 
             switch (i)
             {
@@ -785,22 +786,24 @@ namespace Godot
                 }
                 else if (g == max)
                 {
-                    hue = 2 + (b - r) / delta; // Between cyan & yellow
+                    hue = 2 + ((b - r) / delta); // Between cyan & yellow
                 }
                 else
                 {
-                    hue = 4 + (r - g) / delta; // Between magenta & cyan
+                    hue = 4 + ((r - g) / delta); // Between magenta & cyan
                 }
 
                 hue /= 6.0f;
 
                 if (hue < 0)
-                {
                     hue += 1.0f;
-                }
             }
 
-            saturation = max == 0 ? 0 : 1f - 1f * min / max;
+            if (max == 0)
+                saturation = 0;
+            else
+                saturation = 1 - (min / max);
+
             value = max;
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Godot.Collections
 {
-    class DictionarySafeHandle : SafeHandle
+    internal class DictionarySafeHandle : SafeHandle
     {
         public DictionarySafeHandle(IntPtr handle) : base(IntPtr.Zero, true)
         {
@@ -31,19 +31,17 @@ namespace Godot.Collections
     /// typed elements allocated in the engine in C++. Useful when
     /// interfacing with the engine.
     /// </summary>
-    public class Dictionary :
-        IDictionary,
-        IDisposable
+    public class Dictionary : IDictionary, IDisposable
     {
-        DictionarySafeHandle safeHandle;
-        bool disposed = false;
+        private DictionarySafeHandle _safeHandle;
+        private bool _disposed = false;
 
         /// <summary>
         /// Constructs a new empty <see cref="Dictionary"/>.
         /// </summary>
         public Dictionary()
         {
-            safeHandle = new DictionarySafeHandle(godot_icall_Dictionary_Ctor());
+            _safeHandle = new DictionarySafeHandle(godot_icall_Dictionary_Ctor());
         }
 
         /// <summary>
@@ -62,20 +60,20 @@ namespace Godot.Collections
 
         internal Dictionary(DictionarySafeHandle handle)
         {
-            safeHandle = handle;
+            _safeHandle = handle;
         }
 
         internal Dictionary(IntPtr handle)
         {
-            safeHandle = new DictionarySafeHandle(handle);
+            _safeHandle = new DictionarySafeHandle(handle);
         }
 
         internal IntPtr GetPtr()
         {
-            if (disposed)
+            if (_disposed)
                 throw new ObjectDisposedException(GetType().FullName);
 
-            return safeHandle.DangerousGetHandle();
+            return _safeHandle.DangerousGetHandle();
         }
 
         /// <summary>
@@ -83,16 +81,16 @@ namespace Godot.Collections
         /// </summary>
         public void Dispose()
         {
-            if (disposed)
+            if (_disposed)
                 return;
 
-            if (safeHandle != null)
+            if (_safeHandle != null)
             {
-                safeHandle.Dispose();
-                safeHandle = null;
+                _safeHandle.Dispose();
+                _safeHandle = null;
             }
 
-            disposed = true;
+            _disposed = true;
         }
 
         /// <summary>
@@ -230,17 +228,17 @@ namespace Godot.Collections
 
         private class DictionaryEnumerator : IDictionaryEnumerator
         {
-            private readonly Dictionary dictionary;
-            private readonly int count;
-            private int index = -1;
-            private bool dirty = true;
+            private readonly Dictionary _dictionary;
+            private readonly int _count;
+            private int _index = -1;
+            private bool _dirty = true;
 
-            private DictionaryEntry entry;
+            private DictionaryEntry _entry;
 
             public DictionaryEnumerator(Dictionary dictionary)
             {
-                this.dictionary = dictionary;
-                count = dictionary.Count;
+                _dictionary = dictionary;
+                _count = dictionary.Count;
             }
 
             public object Current => Entry;
@@ -249,19 +247,19 @@ namespace Godot.Collections
             {
                 get
                 {
-                    if (dirty)
+                    if (_dirty)
                     {
                         UpdateEntry();
                     }
-                    return entry;
+                    return _entry;
                 }
             }
 
             private void UpdateEntry()
             {
-                dirty = false;
-                godot_icall_Dictionary_KeyValuePairAt(dictionary.GetPtr(), index, out object key, out object value);
-                entry = new DictionaryEntry(key, value);
+                _dirty = false;
+                godot_icall_Dictionary_KeyValuePairAt(_dictionary.GetPtr(), _index, out object key, out object value);
+                _entry = new DictionaryEntry(key, value);
             }
 
             public object Key => Entry.Key;
@@ -270,15 +268,15 @@ namespace Godot.Collections
 
             public bool MoveNext()
             {
-                index++;
-                dirty = true;
-                return index < count;
+                _index++;
+                _dirty = true;
+                return _index < _count;
             }
 
             public void Reset()
             {
-                index = -1;
-                dirty = true;
+                _index = -1;
+                _dirty = true;
             }
         }
 
@@ -292,28 +290,28 @@ namespace Godot.Collections
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_Dictionary_Ctor();
+        internal static extern IntPtr godot_icall_Dictionary_Ctor();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Dictionary_Dtor(IntPtr ptr);
+        internal static extern void godot_icall_Dictionary_Dtor(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static object godot_icall_Dictionary_GetValue(IntPtr ptr, object key);
+        internal static extern object godot_icall_Dictionary_GetValue(IntPtr ptr, object key);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static object godot_icall_Dictionary_GetValue_Generic(IntPtr ptr, object key, int valTypeEncoding, IntPtr valTypeClass);
+        internal static extern object godot_icall_Dictionary_GetValue_Generic(IntPtr ptr, object key, int valTypeEncoding, IntPtr valTypeClass);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Dictionary_SetValue(IntPtr ptr, object key, object value);
+        internal static extern void godot_icall_Dictionary_SetValue(IntPtr ptr, object key, object value);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_Dictionary_Keys(IntPtr ptr);
+        internal static extern IntPtr godot_icall_Dictionary_Keys(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_Dictionary_Values(IntPtr ptr);
+        internal static extern IntPtr godot_icall_Dictionary_Values(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_Dictionary_Count(IntPtr ptr);
+        internal static extern int godot_icall_Dictionary_Count(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static int godot_icall_Dictionary_KeyValuePairs(IntPtr ptr, out IntPtr keys, out IntPtr values);
@@ -325,34 +323,34 @@ namespace Godot.Collections
         internal extern static void godot_icall_Dictionary_Add(IntPtr ptr, object key, object value);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Dictionary_Clear(IntPtr ptr);
+        internal static extern void godot_icall_Dictionary_Clear(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_Dictionary_Contains(IntPtr ptr, object key, object value);
+        internal static extern bool godot_icall_Dictionary_Contains(IntPtr ptr, object key, object value);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_Dictionary_ContainsKey(IntPtr ptr, object key);
+        internal static extern bool godot_icall_Dictionary_ContainsKey(IntPtr ptr, object key);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_Dictionary_Duplicate(IntPtr ptr, bool deep);
+        internal static extern IntPtr godot_icall_Dictionary_Duplicate(IntPtr ptr, bool deep);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_Dictionary_RemoveKey(IntPtr ptr, object key);
+        internal static extern bool godot_icall_Dictionary_RemoveKey(IntPtr ptr, object key);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_Dictionary_Remove(IntPtr ptr, object key, object value);
+        internal static extern bool godot_icall_Dictionary_Remove(IntPtr ptr, object key, object value);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_Dictionary_TryGetValue(IntPtr ptr, object key, out object value);
+        internal static extern bool godot_icall_Dictionary_TryGetValue(IntPtr ptr, object key, out object value);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_Dictionary_TryGetValue_Generic(IntPtr ptr, object key, out object value, int valTypeEncoding, IntPtr valTypeClass);
+        internal static extern bool godot_icall_Dictionary_TryGetValue_Generic(IntPtr ptr, object key, out object value, int valTypeEncoding, IntPtr valTypeClass);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Dictionary_Generic_GetValueTypeInfo(Type valueType, out int valTypeEncoding, out IntPtr valTypeClass);
+        internal static extern void godot_icall_Dictionary_Generic_GetValueTypeInfo(Type valueType, out int valTypeEncoding, out IntPtr valTypeClass);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static string godot_icall_Dictionary_ToString(IntPtr ptr);
+        internal static extern string godot_icall_Dictionary_ToString(IntPtr ptr);
     }
 
     /// <summary>
@@ -363,10 +361,9 @@ namespace Godot.Collections
     /// </summary>
     /// <typeparam name="TKey">The type of the dictionary's keys.</typeparam>
     /// <typeparam name="TValue">The type of the dictionary's values.</typeparam>
-    public class Dictionary<TKey, TValue> :
-        IDictionary<TKey, TValue>
+    public class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>
     {
-        private readonly Dictionary objectDict;
+        private readonly Dictionary _objectDict;
 
         internal static int valTypeEncoding;
         internal static IntPtr valTypeClass;
@@ -381,7 +378,7 @@ namespace Godot.Collections
         /// </summary>
         public Dictionary()
         {
-            objectDict = new Dictionary();
+            _objectDict = new Dictionary();
         }
 
         /// <summary>
@@ -391,7 +388,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Dictionary.</returns>
         public Dictionary(IDictionary<TKey, TValue> dictionary)
         {
-            objectDict = new Dictionary();
+            _objectDict = new Dictionary();
 
             if (dictionary == null)
                 throw new NullReferenceException($"Parameter '{nameof(dictionary)} cannot be null.'");
@@ -413,17 +410,17 @@ namespace Godot.Collections
         /// <returns>A new Godot Dictionary.</returns>
         public Dictionary(Dictionary dictionary)
         {
-            objectDict = dictionary;
+            _objectDict = dictionary;
         }
 
         internal Dictionary(IntPtr handle)
         {
-            objectDict = new Dictionary(handle);
+            _objectDict = new Dictionary(handle);
         }
 
         internal Dictionary(DictionarySafeHandle handle)
         {
-            objectDict = new Dictionary(handle);
+            _objectDict = new Dictionary(handle);
         }
 
         /// <summary>
@@ -432,12 +429,12 @@ namespace Godot.Collections
         /// <param name="from">The typed dictionary to convert.</param>
         public static explicit operator Dictionary(Dictionary<TKey, TValue> from)
         {
-            return from.objectDict;
+            return from._objectDict;
         }
 
         internal IntPtr GetPtr()
         {
-            return objectDict.GetPtr();
+            return _objectDict.GetPtr();
         }
 
         /// <summary>
@@ -447,7 +444,7 @@ namespace Godot.Collections
         /// <returns>A new Godot Dictionary.</returns>
         public Dictionary<TKey, TValue> Duplicate(bool deep = false)
         {
-            return new Dictionary<TKey, TValue>(objectDict.Duplicate(deep));
+            return new Dictionary<TKey, TValue>(_objectDict.Duplicate(deep));
         }
 
         // IDictionary<TKey, TValue>
@@ -458,8 +455,8 @@ namespace Godot.Collections
         /// <value>The value at the given <paramref name="key"/>.</value>
         public TValue this[TKey key]
         {
-            get { return (TValue)Dictionary.godot_icall_Dictionary_GetValue_Generic(objectDict.GetPtr(), key, valTypeEncoding, valTypeClass); }
-            set { objectDict[key] = value; }
+            get { return (TValue)Dictionary.godot_icall_Dictionary_GetValue_Generic(_objectDict.GetPtr(), key, valTypeEncoding, valTypeClass); }
+            set { _objectDict[key] = value; }
         }
 
         /// <summary>
@@ -469,7 +466,7 @@ namespace Godot.Collections
         {
             get
             {
-                IntPtr handle = Dictionary.godot_icall_Dictionary_Keys(objectDict.GetPtr());
+                IntPtr handle = Dictionary.godot_icall_Dictionary_Keys(_objectDict.GetPtr());
                 return new Array<TKey>(new ArraySafeHandle(handle));
             }
         }
@@ -481,7 +478,7 @@ namespace Godot.Collections
         {
             get
             {
-                IntPtr handle = Dictionary.godot_icall_Dictionary_Values(objectDict.GetPtr());
+                IntPtr handle = Dictionary.godot_icall_Dictionary_Values(_objectDict.GetPtr());
                 return new Array<TValue>(new ArraySafeHandle(handle));
             }
         }
@@ -500,7 +497,7 @@ namespace Godot.Collections
         /// <param name="value">The object to add.</param>
         public void Add(TKey key, TValue value)
         {
-            objectDict.Add(key, value);
+            _objectDict.Add(key, value);
         }
 
         /// <summary>
@@ -510,7 +507,7 @@ namespace Godot.Collections
         /// <returns>Whether or not this dictionary contains the given key.</returns>
         public bool ContainsKey(TKey key)
         {
-            return objectDict.Contains(key);
+            return _objectDict.Contains(key);
         }
 
         /// <summary>
@@ -544,14 +541,14 @@ namespace Godot.Collections
         /// <returns>The number of elements.</returns>
         public int Count
         {
-            get { return objectDict.Count; }
+            get { return _objectDict.Count; }
         }
 
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
 
         void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
         {
-            objectDict.Add(item.Key, item.Value);
+            _objectDict.Add(item.Key, item.Value);
         }
 
         /// <summary>
@@ -559,12 +556,12 @@ namespace Godot.Collections
         /// </summary>
         public void Clear()
         {
-            objectDict.Clear();
+            _objectDict.Clear();
         }
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
         {
-            return objectDict.Contains(new KeyValuePair<object, object>(item.Key, item.Value));
+            return _objectDict.Contains(new KeyValuePair<object, object>(item.Key, item.Value));
         }
 
         /// <summary>
@@ -622,6 +619,6 @@ namespace Godot.Collections
         /// Converts this <see cref="Dictionary{TKey, TValue}"/> to a string.
         /// </summary>
         /// <returns>A string representation of this dictionary.</returns>
-        public override string ToString() => objectDict.ToString();
+        public override string ToString() => _objectDict.ToString();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DynamicObject.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DynamicObject.cs
@@ -72,7 +72,7 @@ namespace Godot
             if (godotObject == null)
                 throw new ArgumentNullException(nameof(godotObject));
 
-            this.Value = godotObject;
+            Value = godotObject;
         }
 
         public override IEnumerable<string> GetDynamicMemberNames()
@@ -181,16 +181,16 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static string[] godot_icall_DynamicGodotObject_SetMemberList(IntPtr godotObject);
+        internal static extern string[] godot_icall_DynamicGodotObject_SetMemberList(IntPtr godotObject);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_DynamicGodotObject_InvokeMember(IntPtr godotObject, string name, object[] args, out object result);
+        internal static extern bool godot_icall_DynamicGodotObject_InvokeMember(IntPtr godotObject, string name, object[] args, out object result);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_DynamicGodotObject_GetMember(IntPtr godotObject, string name, out object result);
+        internal static extern bool godot_icall_DynamicGodotObject_GetMember(IntPtr godotObject, string name, out object result);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_DynamicGodotObject_SetMember(IntPtr godotObject, string name, object value);
+        internal static extern bool godot_icall_DynamicGodotObject_SetMember(IntPtr godotObject, string name, object value);
 
         #region We don't override these methods
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ObjectExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ObjectExtensions.cs
@@ -16,6 +16,6 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static WeakRef godot_icall_Object_weakref(IntPtr obj);
+        internal static extern WeakRef godot_icall_Object_weakref(IntPtr obj);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/SceneTreeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/SceneTreeExtensions.cs
@@ -12,6 +12,6 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_SceneTree_get_nodes_in_group_Generic(IntPtr obj, IntPtr group, Type elemType);
+        internal static extern IntPtr godot_icall_SceneTree_get_nodes_in_group_Generic(IntPtr obj, IntPtr group, Type elemType);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -199,73 +199,73 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static object godot_icall_GD_bytes2var(byte[] bytes, bool allowObjects);
+        internal static extern object godot_icall_GD_bytes2var(byte[] bytes, bool allowObjects);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static object godot_icall_GD_convert(object what, Variant.Type type);
+        internal static extern object godot_icall_GD_convert(object what, Variant.Type type);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_GD_hash(object var);
+        internal static extern int godot_icall_GD_hash(object var);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static Object godot_icall_GD_instance_from_id(ulong instanceId);
+        internal static extern Object godot_icall_GD_instance_from_id(ulong instanceId);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_print(object[] what);
+        internal static extern void godot_icall_GD_print(object[] what);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_printerr(object[] what);
+        internal static extern void godot_icall_GD_printerr(object[] what);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_printraw(object[] what);
+        internal static extern void godot_icall_GD_printraw(object[] what);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_prints(object[] what);
+        internal static extern void godot_icall_GD_prints(object[] what);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_printt(object[] what);
+        internal static extern void godot_icall_GD_printt(object[] what);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static float godot_icall_GD_randf();
+        internal static extern float godot_icall_GD_randf();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static uint godot_icall_GD_randi();
+        internal static extern uint godot_icall_GD_randi();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_randomize();
+        internal static extern void godot_icall_GD_randomize();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static double godot_icall_GD_randf_range(double from, double to);
+        internal static extern double godot_icall_GD_randf_range(double from, double to);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_GD_randi_range(int from, int to);
+        internal static extern int godot_icall_GD_randi_range(int from, int to);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static uint godot_icall_GD_rand_seed(ulong seed, out ulong newSeed);
+        internal static extern uint godot_icall_GD_rand_seed(ulong seed, out ulong newSeed);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_seed(ulong seed);
+        internal static extern void godot_icall_GD_seed(ulong seed);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static string godot_icall_GD_str(object[] what);
+        internal static extern string godot_icall_GD_str(object[] what);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static object godot_icall_GD_str2var(string str);
+        internal static extern object godot_icall_GD_str2var(string str);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static bool godot_icall_GD_type_exists(IntPtr type);
+        internal static extern bool godot_icall_GD_type_exists(IntPtr type);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static byte[] godot_icall_GD_var2bytes(object what, bool fullObjects);
+        internal static extern byte[] godot_icall_GD_var2bytes(object what, bool fullObjects);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static string godot_icall_GD_var2str(object var);
+        internal static extern string godot_icall_GD_var2str(object var);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_pusherror(string type);
+        internal static extern void godot_icall_GD_pusherror(string type);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_GD_pushwarning(string type);
+        internal static extern void godot_icall_GD_pushwarning(string type);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern Variant.Type godot_icall_TypeToVariantType(Type type);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
@@ -6,7 +6,8 @@ namespace Godot
 {
     public class GodotSynchronizationContext : SynchronizationContext
     {
-        private readonly BlockingCollection<KeyValuePair<SendOrPostCallback, object>> _queue = new BlockingCollection<KeyValuePair<SendOrPostCallback, object>>();
+        private readonly BlockingCollection<KeyValuePair<SendOrPostCallback, object>> _queue =
+            new BlockingCollection<KeyValuePair<SendOrPostCallback, object>>();
 
         public override void Post(SendOrPostCallback d, object state)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTraceListener.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTraceListener.cs
@@ -24,7 +24,7 @@ namespace Godot
 
             try
             {
-                var stackTrace = new StackTrace(true).ToString();
+                string stackTrace = new StackTrace(true).ToString();
                 GD.PrintErr(stackTrace);
             }
             catch

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/MarshalUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/MarshalUtils.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Godot
 {
-    static class MarshalUtils
+    internal static class MarshalUtils
     {
         /// <summary>
         /// Returns <see langword="true"/> if the generic type definition of <paramref name="type"/>
@@ -12,7 +12,7 @@ namespace Godot
         /// <exception cref="System.InvalidOperationException">
         /// <paramref name="type"/> is not a generic type. That is, IsGenericType returns false.
         /// </exception>
-        static bool TypeIsGenericArray(Type type) =>
+        private static bool TypeIsGenericArray(Type type) =>
             type.GetGenericTypeDefinition() == typeof(Godot.Collections.Array<>);
 
         /// <summary>
@@ -22,39 +22,39 @@ namespace Godot
         /// <exception cref="System.InvalidOperationException">
         /// <paramref name="type"/> is not a generic type. That is, IsGenericType returns false.
         /// </exception>
-        static bool TypeIsGenericDictionary(Type type) =>
+        private static bool TypeIsGenericDictionary(Type type) =>
             type.GetGenericTypeDefinition() == typeof(Godot.Collections.Dictionary<,>);
 
-        static bool TypeIsSystemGenericList(Type type) =>
+        private static bool TypeIsSystemGenericList(Type type) =>
             type.GetGenericTypeDefinition() == typeof(System.Collections.Generic.List<>);
 
-        static bool TypeIsSystemGenericDictionary(Type type) =>
+        private static bool TypeIsSystemGenericDictionary(Type type) =>
             type.GetGenericTypeDefinition() == typeof(System.Collections.Generic.Dictionary<,>);
 
-        static bool TypeIsGenericIEnumerable(Type type) => type.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+        private static bool TypeIsGenericIEnumerable(Type type) => type.GetGenericTypeDefinition() == typeof(IEnumerable<>);
 
-        static bool TypeIsGenericICollection(Type type) => type.GetGenericTypeDefinition() == typeof(ICollection<>);
+        private static bool TypeIsGenericICollection(Type type) => type.GetGenericTypeDefinition() == typeof(ICollection<>);
 
-        static bool TypeIsGenericIDictionary(Type type) => type.GetGenericTypeDefinition() == typeof(IDictionary<,>);
+        private static bool TypeIsGenericIDictionary(Type type) => type.GetGenericTypeDefinition() == typeof(IDictionary<,>);
 
-        static void ArrayGetElementType(Type arrayType, out Type elementType)
+        private static void ArrayGetElementType(Type arrayType, out Type elementType)
         {
             elementType = arrayType.GetGenericArguments()[0];
         }
 
-        static void DictionaryGetKeyValueTypes(Type dictionaryType, out Type keyType, out Type valueType)
+        private static void DictionaryGetKeyValueTypes(Type dictionaryType, out Type keyType, out Type valueType)
         {
             var genericArgs = dictionaryType.GetGenericArguments();
             keyType = genericArgs[0];
             valueType = genericArgs[1];
         }
 
-        static Type MakeGenericArrayType(Type elemType)
+        private static Type MakeGenericArrayType(Type elemType)
         {
             return typeof(Godot.Collections.Array<>).MakeGenericType(elemType);
         }
 
-        static Type MakeGenericDictionaryType(Type keyType, Type valueType)
+        private static Type MakeGenericDictionaryType(Type keyType, Type valueType)
         {
             return typeof(Godot.Collections.Dictionary<,>).MakeGenericType(keyType, valueType);
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -37,9 +37,9 @@ namespace Godot
         public const real_t NaN = real_t.NaN;
 
         // 0.0174532924f and 0.0174532925199433
-        private const real_t Deg2RadConst = (real_t)0.0174532925199432957692369077M;
+        private const real_t _deg2RadConst = (real_t)0.0174532925199432957692369077M;
         // 57.29578f and 57.2957795130823
-        private const real_t Rad2DegConst = (real_t)57.295779513082320876798154814M;
+        private const real_t _rad2DegConst = (real_t)57.295779513082320876798154814M;
 
         /// <summary>
         /// Returns the absolute value of `s` (i.e. positive value).
@@ -170,7 +170,7 @@ namespace Godot
         /// <returns>The same angle expressed in radians.</returns>
         public static real_t Deg2Rad(real_t deg)
         {
-            return deg * Deg2RadConst;
+            return deg * _deg2RadConst;
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Godot
                     return Pow(s * 2.0f, -curve) * 0.5f;
                 }
 
-                return (1.0f - Pow(1.0f - (s - 0.5f) * 2.0f, -curve)) * 0.5f + 0.5f;
+                return ((1.0f - Pow(1.0f - ((s - 0.5f) * 2.0f), -curve)) * 0.5f) + 0.5f;
             }
 
             return 0f;
@@ -315,7 +315,7 @@ namespace Godot
         /// <returns>The resulting value of the interpolation.</returns>
         public static real_t Lerp(real_t from, real_t to, real_t weight)
         {
-            return from + (to - from) * weight;
+            return from + ((to - from) * weight);
         }
 
         /// <summary>
@@ -332,7 +332,7 @@ namespace Godot
         {
             real_t difference = (to - from) % Mathf.Tau;
             real_t distance = ((2 * difference) % Mathf.Tau) - difference;
-            return from + distance * weight;
+            return from + (distance * weight);
         }
 
         /// <summary>
@@ -402,7 +402,10 @@ namespace Godot
         /// <returns>The value after moving.</returns>
         public static real_t MoveToward(real_t from, real_t to, real_t delta)
         {
-            return Abs(to - from) <= delta ? to : from + Sign(to - from) * delta;
+            if (Abs(to - from) <= delta)
+                return to;
+
+            return from + (Sign(to - from) * delta);
         }
 
         /// <summary>
@@ -472,7 +475,7 @@ namespace Godot
         /// <returns>The same angle expressed in degrees.</returns>
         public static real_t Rad2Deg(real_t rad)
         {
-            return rad * Rad2DegConst;
+            return rad * _rad2DegConst;
         }
 
         /// <summary>
@@ -546,7 +549,7 @@ namespace Godot
                 return from;
             }
             real_t x = Clamp((weight - from) / (to - from), (real_t)0.0, (real_t)1.0);
-            return x * x * (3 - 2 * x);
+            return x * x * (3 - (2 * x));
         }
 
         /// <summary>
@@ -570,7 +573,8 @@ namespace Godot
         /// <returns>The position of the first non-zero digit.</returns>
         public static int StepDecimals(real_t step)
         {
-            double[] sd = new double[] {
+            double[] sd = new double[]
+            {
                 0.9999,
                 0.09999,
                 0.009999,
@@ -581,7 +585,7 @@ namespace Godot
                 0.00000009999,
                 0.000000009999,
             };
-            double abs = Mathf.Abs(step);
+            double abs = Abs(step);
             double decs = abs - (int)abs; // Strip away integer part
             for (int i = 0; i < sd.Length; i++)
             {
@@ -605,7 +609,7 @@ namespace Godot
         {
             if (step != 0f)
             {
-                return Floor(s / step + 0.5f) * step;
+                return Floor((s / step) + 0.5f) * step;
             }
 
             return s;
@@ -643,7 +647,10 @@ namespace Godot
         public static int Wrap(int value, int min, int max)
         {
             int range = max - min;
-            return range == 0 ? min : min + ((value - min) % range + range) % range;
+            if (range == 0)
+                return min;
+
+            return min + ((((value - min) % range) + range) % range);
         }
 
         /// <summary>
@@ -658,7 +665,11 @@ namespace Godot
         public static real_t Wrap(real_t value, real_t min, real_t max)
         {
             real_t range = max - min;
-            return IsZeroApprox(range) ? min : min + ((value - min) % range + range) % range;
+            if (IsZeroApprox(range))
+            {
+                return min;
+            }
+            return min + ((((value - min) % range) + range) % range);
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
@@ -5,7 +5,7 @@ namespace Godot
 {
     public sealed partial class NodePath : IDisposable
     {
-        private bool disposed = false;
+        private bool _disposed = false;
 
         private IntPtr ptr;
 
@@ -14,7 +14,7 @@ namespace Godot
             if (instance == null)
                 throw new NullReferenceException($"The instance of type {nameof(NodePath)} is null.");
 
-            if (instance.disposed)
+            if (instance._disposed)
                 throw new ObjectDisposedException(instance.GetType().FullName);
 
             return instance.ptr;
@@ -33,7 +33,7 @@ namespace Godot
 
         private void Dispose(bool disposing)
         {
-            if (disposed)
+            if (_disposed)
                 return;
 
             if (ptr != IntPtr.Zero)
@@ -42,7 +42,7 @@ namespace Godot
                 ptr = IntPtr.Zero;
             }
 
-            disposed = true;
+            _disposed = true;
         }
 
         internal NodePath(IntPtr ptr)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
@@ -5,7 +5,7 @@ namespace Godot
 {
     public partial class Object : IDisposable
     {
-        private bool disposed = false;
+        private bool _disposed = false;
 
         private static StringName nativeName = "Object";
 
@@ -39,7 +39,7 @@ namespace Godot
             if (instance == null)
                 return IntPtr.Zero;
 
-            if (instance.disposed)
+            if (instance._disposed)
                 throw new ObjectDisposedException(instance.GetType().FullName);
 
             return instance.ptr;
@@ -58,7 +58,7 @@ namespace Godot
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposed)
+            if (_disposed)
                 return;
 
             if (ptr != IntPtr.Zero)
@@ -73,10 +73,10 @@ namespace Godot
                     godot_icall_Object_Disposed(this, ptr);
                 }
 
-                this.ptr = IntPtr.Zero;
+                ptr = IntPtr.Zero;
             }
 
-            disposed = true;
+            _disposed = true;
         }
 
         public override string ToString()

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -145,9 +145,9 @@ namespace Godot
                 return null;
             }
 
-            Vector3 result = b._normal.Cross(c._normal) * D +
-                                c._normal.Cross(_normal) * b.D +
-                                _normal.Cross(b._normal) * c.D;
+            Vector3 result = (b._normal.Cross(c._normal) * D) +
+                                (c._normal.Cross(_normal) * b.D) +
+                                (_normal.Cross(b._normal) * c.D);
 
             return result / denom;
         }
@@ -242,7 +242,7 @@ namespace Godot
         /// <returns>The projected point.</returns>
         public Vector3 Project(Vector3 point)
         {
-            return point - _normal * DistanceTo(point);
+            return point - (_normal * DistanceTo(point));
         }
 
         // Constants
@@ -280,7 +280,7 @@ namespace Godot
         public Plane(real_t a, real_t b, real_t c, real_t d)
         {
             _normal = new Vector3(a, b, c);
-            this.D = d;
+            D = d;
         }
 
         /// <summary>
@@ -290,8 +290,8 @@ namespace Godot
         /// <param name="d">The plane's distance from the origin. This value is typically non-negative.</param>
         public Plane(Vector3 normal, real_t d)
         {
-            this._normal = normal;
-            this.D = d;
+            _normal = normal;
+            D = d;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -154,7 +154,7 @@ namespace Godot
         /// <returns>The dot product.</returns>
         public real_t Dot(Quaternion b)
         {
-            return x * b.x + y * b.y + z * b.z + w * b.w;
+            return (x * b.x) + (y * b.y) + (z * b.z) + (w * b.w);
         }
 
         /// <summary>
@@ -274,10 +274,10 @@ namespace Godot
             // Calculate final values.
             return new Quaternion
             (
-                scale0 * x + scale1 * to1.x,
-                scale0 * y + scale1 * to1.y,
-                scale0 * z + scale1 * to1.z,
-                scale0 * w + scale1 * to1.w
+                (scale0 * x) + (scale1 * to1.x),
+                (scale0 * y) + (scale1 * to1.y),
+                (scale0 * z) + (scale1 * to1.z),
+                (scale0 * w) + (scale1 * to1.w)
             );
         }
 
@@ -305,10 +305,10 @@ namespace Godot
 
             return new Quaternion
             (
-                invFactor * x + newFactor * to.x,
-                invFactor * y + newFactor * to.y,
-                invFactor * z + newFactor * to.z,
-                invFactor * w + newFactor * to.w
+                (invFactor * x) + (newFactor * to.x),
+                (invFactor * y) + (newFactor * to.y),
+                (invFactor * z) + (newFactor * to.z),
+                (invFactor * w) + (newFactor * to.w)
             );
         }
 
@@ -327,7 +327,7 @@ namespace Godot
 #endif
             var u = new Vector3(x, y, z);
             Vector3 uv = u.Cross(v);
-            return v + ((uv * w) + u.Cross(uv)) * 2;
+            return v + (((uv * w) + u.Cross(uv)) * 2);
         }
 
         // Constants
@@ -383,25 +383,25 @@ namespace Godot
         /// <param name="eulerYXZ"></param>
         public Quaternion(Vector3 eulerYXZ)
         {
-            real_t half_a1 = eulerYXZ.y * 0.5f;
-            real_t half_a2 = eulerYXZ.x * 0.5f;
-            real_t half_a3 = eulerYXZ.z * 0.5f;
+            real_t halfA1 = eulerYXZ.y * 0.5f;
+            real_t halfA2 = eulerYXZ.x * 0.5f;
+            real_t halfA3 = eulerYXZ.z * 0.5f;
 
             // R = Y(a1).X(a2).Z(a3) convention for Euler angles.
             // Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)
             // a3 is the angle of the first rotation, following the notation in this reference.
 
-            real_t cos_a1 = Mathf.Cos(half_a1);
-            real_t sin_a1 = Mathf.Sin(half_a1);
-            real_t cos_a2 = Mathf.Cos(half_a2);
-            real_t sin_a2 = Mathf.Sin(half_a2);
-            real_t cos_a3 = Mathf.Cos(half_a3);
-            real_t sin_a3 = Mathf.Sin(half_a3);
+            real_t cosA1 = Mathf.Cos(halfA1);
+            real_t sinA1 = Mathf.Sin(halfA1);
+            real_t cosA2 = Mathf.Cos(halfA2);
+            real_t sinA2 = Mathf.Sin(halfA2);
+            real_t cosA3 = Mathf.Cos(halfA3);
+            real_t sinA3 = Mathf.Sin(halfA3);
 
-            x = sin_a1 * cos_a2 * sin_a3 + cos_a1 * sin_a2 * cos_a3;
-            y = sin_a1 * cos_a2 * cos_a3 - cos_a1 * sin_a2 * sin_a3;
-            z = cos_a1 * cos_a2 * sin_a3 - sin_a1 * sin_a2 * cos_a3;
-            w = sin_a1 * sin_a2 * sin_a3 + cos_a1 * cos_a2 * cos_a3;
+            x = (sinA1 * cosA2 * sinA3) + (cosA1 * sinA2 * cosA3);
+            y = (sinA1 * cosA2 * cosA3) - (cosA1 * sinA2 * sinA3);
+            z = (cosA1 * cosA2 * sinA3) - (sinA1 * sinA2 * cosA3);
+            w = (sinA1 * sinA2 * sinA3) + (cosA1 * cosA2 * cosA3);
         }
 
         /// <summary>
@@ -445,10 +445,10 @@ namespace Godot
         {
             return new Quaternion
             (
-                left.w * right.x + left.x * right.w + left.y * right.z - left.z * right.y,
-                left.w * right.y + left.y * right.w + left.z * right.x - left.x * right.z,
-                left.w * right.z + left.z * right.w + left.x * right.y - left.y * right.x,
-                left.w * right.w - left.x * right.x - left.y * right.y - left.z * right.z
+                (left.w * right.x) + (left.x * right.w) + (left.y * right.z) - (left.z * right.y),
+                (left.w * right.y) + (left.y * right.w) + (left.z * right.x) - (left.x * right.z),
+                (left.w * right.z) + (left.z * right.w) + (left.x * right.y) - (left.y * right.x),
+                (left.w * right.w) - (left.x * right.x) - (left.y * right.y) - (left.z * right.z)
             );
         }
 
@@ -471,10 +471,10 @@ namespace Godot
         {
             return new Quaternion
             (
-                left.w * right.x + left.y * right.z - left.z * right.y,
-                left.w * right.y + left.z * right.x - left.x * right.z,
-                left.w * right.z + left.x * right.y - left.y * right.x,
-                -left.x * right.x - left.y * right.y - left.z * right.z
+                (left.w * right.x) + (left.y * right.z) - (left.z * right.y),
+                (left.w * right.y) + (left.z * right.x) - (left.x * right.z),
+                (left.w * right.z) + (left.x * right.y) - (left.y * right.x),
+                -(left.x * right.x) - (left.y * right.y) - (left.z * right.z)
             );
         }
 
@@ -482,10 +482,10 @@ namespace Godot
         {
             return new Quaternion
             (
-                right.w * left.x + right.y * left.z - right.z * left.y,
-                right.w * left.y + right.z * left.x - right.x * left.z,
-                right.w * left.z + right.x * left.y - right.y * left.x,
-                -right.x * left.x - right.y * left.y - right.z * left.z
+                (right.w * left.x) + (right.y * left.z) - (right.z * left.y),
+                (right.w * left.y) + (right.z * left.x) - (right.x * left.z),
+                (right.w * left.z) + (right.x * left.y) - (right.y * left.x),
+                -(right.x * left.x) - (right.y * left.y) - (right.z * left.z)
             );
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/RID.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/RID.cs
@@ -5,7 +5,7 @@ namespace Godot
 {
     public sealed partial class RID : IDisposable
     {
-        private bool disposed = false;
+        private bool _disposed = false;
 
         internal IntPtr ptr;
 
@@ -14,7 +14,7 @@ namespace Godot
             if (instance == null)
                 throw new NullReferenceException($"The instance of type {nameof(RID)} is null.");
 
-            if (instance.disposed)
+            if (instance._disposed)
                 throw new ObjectDisposedException(instance.GetType().FullName);
 
             return instance.ptr;
@@ -33,7 +33,7 @@ namespace Godot
 
         private void Dispose(bool disposing)
         {
-            if (disposed)
+            if (_disposed)
                 return;
 
             if (ptr != IntPtr.Zero)
@@ -42,7 +42,7 @@ namespace Godot
                 ptr = IntPtr.Zero;
             }
 
-            disposed = true;
+            _disposed = true;
         }
 
         internal RID(IntPtr ptr)
@@ -73,12 +73,12 @@ namespace Godot
         public override string ToString() => "[RID]";
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static IntPtr godot_icall_RID_Ctor(IntPtr from);
+        internal static extern IntPtr godot_icall_RID_Ctor(IntPtr from);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_RID_Dtor(IntPtr ptr);
+        internal static extern void godot_icall_RID_Dtor(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_RID_get_id(IntPtr ptr);
+        internal static extern int godot_icall_RID_get_id(IntPtr ptr);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -80,7 +80,7 @@ namespace Godot
         /// <returns>The intersection of this Rect2 and `b`, or an empty Rect2 if they do not intersect.</returns>
         public Rect2 Intersection(Rect2 b)
         {
-            var newRect = b;
+            Rect2 newRect = b;
 
             if (!Intersects(newRect))
             {
@@ -118,7 +118,7 @@ namespace Godot
         /// <returns>The expanded Rect2.</returns>
         public Rect2 Expand(Vector2 to)
         {
-            var expanded = this;
+            Rect2 expanded = this;
 
             Vector2 begin = expanded._position;
             Vector2 end = expanded._position + expanded._size;
@@ -163,7 +163,7 @@ namespace Godot
         /// <returns>The grown Rect2.</returns>
         public Rect2 Grow(real_t by)
         {
-            var g = this;
+            Rect2 g = this;
 
             g._position.x -= by;
             g._position.y -= by;
@@ -183,7 +183,7 @@ namespace Godot
         /// <returns>The grown Rect2.</returns>
         public Rect2 GrowIndividual(real_t left, real_t top, real_t right, real_t bottom)
         {
-            var g = this;
+            Rect2 g = this;
 
             g._position.x -= left;
             g._position.y -= top;
@@ -201,7 +201,7 @@ namespace Godot
         /// <returns>The grown Rect2.</returns>
         public Rect2 GrowSide(Side side, real_t by)
         {
-            var g = this;
+            Rect2 g = this;
 
             g = g.GrowIndividual(Side.Left == side ? by : 0,
                     Side.Top == side ? by : 0,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -75,7 +75,7 @@ namespace Godot
         /// <returns>The intersection of this Rect2i and `b`, or an empty Rect2i if they do not intersect.</returns>
         public Rect2i Intersection(Rect2i b)
         {
-            var newRect = b;
+            Rect2i newRect = b;
 
             if (!Intersects(newRect))
             {
@@ -113,7 +113,7 @@ namespace Godot
         /// <returns>The expanded Rect2i.</returns>
         public Rect2i Expand(Vector2i to)
         {
-            var expanded = this;
+            Rect2i expanded = this;
 
             Vector2i begin = expanded._position;
             Vector2i end = expanded._position + expanded._size;
@@ -158,7 +158,7 @@ namespace Godot
         /// <returns>The grown Rect2i.</returns>
         public Rect2i Grow(int by)
         {
-            var g = this;
+            Rect2i g = this;
 
             g._position.x -= by;
             g._position.y -= by;
@@ -178,7 +178,7 @@ namespace Godot
         /// <returns>The grown Rect2i.</returns>
         public Rect2i GrowIndividual(int left, int top, int right, int bottom)
         {
-            var g = this;
+            Rect2i g = this;
 
             g._position.x -= left;
             g._position.y -= top;
@@ -196,7 +196,7 @@ namespace Godot
         /// <returns>The grown Rect2i.</returns>
         public Rect2i GrowSide(Side side, int by)
         {
-            var g = this;
+            Rect2i g = this;
 
             g = g.GrowIndividual(Side.Left == side ? by : 0,
                     Side.Top == side ? by : 0,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
@@ -5,9 +5,9 @@ namespace Godot
 {
     public class SignalAwaiter : IAwaiter<object[]>, IAwaitable<object[]>
     {
-        private bool completed;
-        private object[] result;
-        private Action action;
+        private bool _completed;
+        private object[] _result;
+        private Action _action;
 
         public SignalAwaiter(Object source, StringName signal, Object target)
         {
@@ -15,24 +15,24 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static Error godot_icall_SignalAwaiter_connect(IntPtr source, IntPtr signal, IntPtr target, SignalAwaiter awaiter);
+        internal static extern Error godot_icall_SignalAwaiter_connect(IntPtr source, IntPtr signal, IntPtr target, SignalAwaiter awaiter);
 
         public bool IsCompleted
         {
             get
             {
-                return completed;
+                return _completed;
             }
         }
 
         public void OnCompleted(Action action)
         {
-            this.action = action;
+            this._action = action;
         }
 
         public object[] GetResult()
         {
-            return result;
+            return _result;
         }
 
         public IAwaiter<object[]> GetAwaiter()
@@ -42,13 +42,9 @@ namespace Godot
 
         internal void SignalCallback(object[] args)
         {
-            completed = true;
-            result = args;
-
-            if (action != null)
-            {
-                action();
-            }
+            _completed = true;
+            _result = args;
+            _action?.Invoke();
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -87,7 +87,7 @@ namespace Godot
         /// </summary>
         public static string[] Bigrams(this string instance)
         {
-            var b = new string[instance.Length - 1];
+            string[] b = new string[instance.Length - 1];
 
             for (int i = 0; i < b.Length; i++)
             {
@@ -241,7 +241,7 @@ namespace Godot
         public static string Capitalize(this string instance)
         {
             string aux = instance.Replace("_", " ").ToLower();
-            var cap = string.Empty;
+            string cap = string.Empty;
 
             for (int i = 0; i < aux.GetSliceCount(" "); i++)
             {
@@ -401,20 +401,20 @@ namespace Godot
             int basepos = instance.Find("://");
 
             string rs;
-            var @base = string.Empty;
+            string directory = string.Empty;
 
             if (basepos != -1)
             {
-                var end = basepos + 3;
+                int end = basepos + 3;
                 rs = instance.Substring(end);
-                @base = instance.Substring(0, end);
+                directory = instance.Substring(0, end);
             }
             else
             {
                 if (instance.BeginsWith("/"))
                 {
                     rs = instance.Substring(1);
-                    @base = "/";
+                    directory = "/";
                 }
                 else
                 {
@@ -425,9 +425,9 @@ namespace Godot
             int sep = Mathf.Max(rs.FindLast("/"), rs.FindLast("\\"));
 
             if (sep == -1)
-                return @base;
+                return directory;
 
-            return @base + rs.Substr(0, sep);
+            return directory + rs.Substr(0, sep);
         }
 
         /// <summary>
@@ -494,7 +494,7 @@ namespace Godot
         /// <returns>The hexadecimal representation of this byte.</returns>
         internal static string HexEncode(this byte b)
         {
-            var ret = string.Empty;
+            string ret = string.Empty;
 
             for (int i = 0; i < 2; i++)
             {
@@ -524,7 +524,7 @@ namespace Godot
         /// <returns>The hexadecimal representation of this byte array.</returns>
         public static string HexEncode(this byte[] bytes)
         {
-            var ret = string.Empty;
+            string ret = string.Empty;
 
             foreach (byte b in bytes)
             {
@@ -673,18 +673,15 @@ namespace Godot
             if (len == 0)
                 return false;
 
+            if (instance[0] >= '0' && instance[0] <= '9')
+                return false; // Identifiers cannot start with numbers.
+
             for (int i = 0; i < len; i++)
             {
-                if (i == 0)
-                {
-                    if (instance[0] >= '0' && instance[0] <= '9')
-                        return false; // Don't start with number plz
-                }
-
-                bool validChar = instance[i] >= '0' &&
-                                  instance[i] <= '9' || instance[i] >= 'a' &&
-                                  instance[i] <= 'z' || instance[i] >= 'A' &&
-                                  instance[i] <= 'Z' || instance[i] == '_';
+                bool validChar = instance[i] == '_' ||
+                    (instance[i] >= 'a' && instance[i] <= 'z') ||
+                    (instance[i] >= 'A' && instance[i] <= 'Z') ||
+                    (instance[i] >= '0' && instance[i] <= '9');
 
                 if (!validChar)
                     return false;
@@ -853,7 +850,7 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static byte[] godot_icall_String_md5_buffer(string str);
+        internal static extern byte[] godot_icall_String_md5_buffer(string str);
 
         /// <summary>
         /// Return the MD5 hash of the string as a string.
@@ -864,7 +861,7 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static string godot_icall_String_md5_text(string str);
+        internal static extern string godot_icall_String_md5_text(string str);
 
         /// <summary>
         /// Perform a case-insensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
@@ -987,7 +984,7 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_String_rfind(string str, string what, int from);
+        internal static extern int godot_icall_String_rfind(string str, string what, int from);
 
         /// <summary>
         /// Perform a search for a substring, but start from the end of the string instead of the beginning.
@@ -999,7 +996,7 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_String_rfindn(string str, string what, int from);
+        internal static extern int godot_icall_String_rfindn(string str, string what, int from);
 
         /// <summary>
         /// Return the right side of the string from a given position.
@@ -1048,7 +1045,7 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static byte[] godot_icall_String_sha256_buffer(string str);
+        internal static extern byte[] godot_icall_String_sha256_buffer(string str);
 
         /// <summary>
         /// Return the SHA-256 hash of the string as a string.
@@ -1059,7 +1056,7 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static string godot_icall_String_sha256_text(string str);
+        internal static extern string godot_icall_String_sha256_text(string str);
 
         /// <summary>
         /// Return the similarity index of the text compared to this string.
@@ -1148,7 +1145,8 @@ namespace Godot
             return ret.ToArray();
         }
 
-        private static readonly char[] _nonPrintable = {
+        private static readonly char[] _nonPrintable =
+        {
             (char)00, (char)01, (char)02, (char)03, (char)04, (char)05,
             (char)06, (char)07, (char)08, (char)09, (char)10, (char)11,
             (char)12, (char)13, (char)14, (char)15, (char)16, (char)17,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -146,7 +146,7 @@ namespace Godot
             if (det == 0)
                 throw new InvalidOperationException("Matrix determinant is zero and cannot be inverted.");
 
-            var inv = this;
+            Transform2D inv = this;
 
             real_t temp = inv[0, 0];
             inv[0, 0] = inv[1, 1];
@@ -173,7 +173,7 @@ namespace Godot
         /// <returns>The determinant of the basis matrix.</returns>
         private real_t BasisDeterminant()
         {
-            return x.x * y.y - x.y * y.x;
+            return (x.x * y.y) - (x.y * y.x);
         }
 
         /// <summary>
@@ -233,8 +233,8 @@ namespace Godot
             else
             {
                 real_t angle = weight * Mathf.Acos(dot);
-                Vector2 v3 = (v2 - v1 * dot).Normalized();
-                v = v1 * Mathf.Cos(angle) + v3 * Mathf.Sin(angle);
+                Vector2 v3 = (v2 - (v1 * dot)).Normalized();
+                v = (v1 * Mathf.Cos(angle)) + (v3 * Mathf.Sin(angle));
             }
 
             // Extract parameters
@@ -258,7 +258,7 @@ namespace Godot
         /// <returns>The inverse matrix.</returns>
         public Transform2D Inverse()
         {
-            var inv = this;
+            Transform2D inv = this;
 
             // Swap
             real_t temp = inv.x.y;
@@ -277,13 +277,13 @@ namespace Godot
         /// <returns>The orthonormalized transform.</returns>
         public Transform2D Orthonormalized()
         {
-            var on = this;
+            Transform2D on = this;
 
             Vector2 onX = on.x;
             Vector2 onY = on.y;
 
             onX.Normalize();
-            onY = onY - onX * onX.Dot(onY);
+            onY = onY - (onX * onX.Dot(onY));
             onY.Normalize();
 
             on.x = onX;
@@ -309,7 +309,7 @@ namespace Godot
         /// <returns>The scaled transformation matrix.</returns>
         public Transform2D Scaled(Vector2 scale)
         {
-            var copy = this;
+            Transform2D copy = this;
             copy.x *= scale;
             copy.y *= scale;
             copy.origin *= scale;
@@ -326,12 +326,12 @@ namespace Godot
 
         private real_t Tdotx(Vector2 with)
         {
-            return this[0, 0] * with[0] + this[1, 0] * with[1];
+            return (this[0, 0] * with[0]) + (this[1, 0] * with[1]);
         }
 
         private real_t Tdoty(Vector2 with)
         {
-            return this[0, 1] * with[0] + this[1, 1] * with[1];
+            return (this[0, 1] * with[0]) + (this[1, 1] * with[1]);
         }
 
         /// <summary>
@@ -345,7 +345,7 @@ namespace Godot
         /// <returns>The translated matrix.</returns>
         public Transform2D Translated(Vector2 offset)
         {
-            var copy = this;
+            Transform2D copy = this;
             copy.origin += copy.BasisXform(offset);
             return copy;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -132,7 +132,9 @@ namespace Godot
             Vector3 destinationLocation = transform.origin;
 
             var interpolated = new Transform3D();
-            interpolated.basis.SetQuaternionScale(sourceRotation.Slerp(destinationRotation, weight).Normalized(), sourceScale.Lerp(destinationScale, weight));
+            Quaternion quaternion = sourceRotation.Slerp(destinationRotation, weight).Normalized();
+            Vector3 scale = sourceScale.Lerp(destinationScale, weight);
+            interpolated.basis.SetQuaternionScale(quaternion, scale);
             interpolated.origin = sourceLocation.Lerp(destinationLocation, weight);
 
             return interpolated;
@@ -165,7 +167,7 @@ namespace Godot
         /// <returns>The resulting transform.</returns>
         public Transform3D LookingAt(Vector3 target, Vector3 up)
         {
-            var t = this;
+            Transform3D t = this;
             t.SetLookAt(origin, target, up);
             return t;
         }
@@ -273,9 +275,9 @@ namespace Godot
 
             return new Vector3
             (
-                basis.Row0[0] * vInv.x + basis.Row1[0] * vInv.y + basis.Row2[0] * vInv.z,
-                basis.Row0[1] * vInv.x + basis.Row1[1] * vInv.y + basis.Row2[1] * vInv.z,
-                basis.Row0[2] * vInv.x + basis.Row1[2] * vInv.y + basis.Row2[2] * vInv.z
+                (basis.Row0[0] * vInv.x) + (basis.Row1[0] * vInv.y) + (basis.Row2[0] * vInv.z),
+                (basis.Row0[1] * vInv.x) + (basis.Row1[1] * vInv.y) + (basis.Row2[1] * vInv.z),
+                (basis.Row0[2] * vInv.x) + (basis.Row1[2] * vInv.y) + (basis.Row2[2] * vInv.z)
             );
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -29,6 +29,7 @@ namespace Godot
         /// The vector's X component. Also accessible by using the index position `[0]`.
         /// </summary>
         public real_t x;
+
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position `[1]`.
         /// </summary>
@@ -177,7 +178,7 @@ namespace Godot
         /// <returns>The cross product value.</returns>
         public real_t Cross(Vector2 b)
         {
-            return x * b.y - y * b.x;
+            return (x * b.y) - (y * b.x);
         }
 
         /// <summary>
@@ -199,10 +200,12 @@ namespace Godot
             real_t t2 = t * t;
             real_t t3 = t2 * t;
 
-            return 0.5f * (p1 * 2.0f +
-                                (-p0 + p2) * t +
-                                (2.0f * p0 - 5.0f * p1 + 4 * p2 - p3) * t2 +
-                                (-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3);
+            return 0.5f * (
+                (p1 * 2.0f) +
+                ((-p0 + p2) * t) +
+                (((2.0f * p0) - (5.0f * p1) + (4 * p2) - p3) * t2) +
+                ((-p0 + (3.0f * p1) - (3.0f * p2) + p3) * t3)
+            );
         }
 
         /// <summary>
@@ -244,7 +247,7 @@ namespace Godot
         /// <returns>The dot product of the two vectors.</returns>
         public real_t Dot(Vector2 with)
         {
-            return x * with.x + y * with.y;
+            return (x * with.x) + (y * with.y);
         }
 
         /// <summary>
@@ -280,7 +283,7 @@ namespace Godot
         /// <returns>The length of this vector.</returns>
         public real_t Length()
         {
-            return Mathf.Sqrt(x * x + y * y);
+            return Mathf.Sqrt((x * x) + (y * y));
         }
 
         /// <summary>
@@ -291,7 +294,7 @@ namespace Godot
         /// <returns>The squared length of this vector.</returns>
         public real_t LengthSquared()
         {
-            return x * x + y * y;
+            return (x * x) + (y * y);
         }
 
         /// <summary>
@@ -373,10 +376,13 @@ namespace Godot
         /// <returns>The resulting vector.</returns>
         public Vector2 MoveToward(Vector2 to, real_t delta)
         {
-            var v = this;
-            var vd = to - v;
-            var len = vd.Length();
-            return len <= delta || len < Mathf.Epsilon ? to : v + vd / len * delta;
+            Vector2 v = this;
+            Vector2 vd = to - v;
+            real_t len = vd.Length();
+            if (len <= delta || len < Mathf.Epsilon)
+                return to;
+
+            return v + (vd / len * delta);
         }
 
         /// <summary>
@@ -385,7 +391,7 @@ namespace Godot
         /// <returns>A normalized version of the vector.</returns>
         public Vector2 Normalized()
         {
-            var v = this;
+            Vector2 v = this;
             v.Normalize();
             return v;
         }
@@ -439,7 +445,7 @@ namespace Godot
                 throw new ArgumentException("Argument is not normalized", nameof(normal));
             }
 #endif
-            return 2 * Dot(normal) * normal - this;
+            return (2 * Dot(normal) * normal) - this;
         }
 
         /// <summary>
@@ -511,7 +517,7 @@ namespace Godot
         /// <returns>The slid vector.</returns>
         public Vector2 Slide(Vector2 normal)
         {
-            return this - normal * Dot(normal);
+            return this - (normal * Dot(normal));
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -29,6 +29,7 @@ namespace Godot
         /// The vector's X component. Also accessible by using the index position `[0]`.
         /// </summary>
         public int x;
+
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position `[1]`.
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -30,10 +30,12 @@ namespace Godot
         /// The vector's X component. Also accessible by using the index position `[0]`.
         /// </summary>
         public real_t x;
+
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position `[1]`.
         /// </summary>
         public real_t y;
+
         /// <summary>
         /// The vector's Z component. Also accessible by using the index position `[2]`.
         /// </summary>
@@ -160,9 +162,9 @@ namespace Godot
         {
             return new Vector3
             (
-                y * b.z - z * b.y,
-                z * b.x - x * b.z,
-                x * b.y - y * b.x
+                (y * b.z) - (z * b.y),
+                (z * b.x) - (x * b.z),
+                (x * b.y) - (y * b.x)
             );
         }
 
@@ -187,10 +189,10 @@ namespace Godot
             real_t t3 = t2 * t;
 
             return 0.5f * (
-                        p1 * 2.0f + (-p0 + p2) * t +
-                        (2.0f * p0 - 5.0f * p1 + 4f * p2 - p3) * t2 +
-                        (-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3
-                    );
+                (p1 * 2.0f) + ((-p0 + p2) * t) +
+                (((2.0f * p0) - (5.0f * p1) + (4f * p2) - p3) * t2) +
+                ((-p0 + (3.0f * p1) - (3.0f * p2) + p3) * t3)
+            );
         }
 
         /// <summary>
@@ -232,7 +234,7 @@ namespace Godot
         /// <returns>The dot product of the two vectors.</returns>
         public real_t Dot(Vector3 b)
         {
-            return x * b.x + y * b.y + z * b.z;
+            return (x * b.x) + (y * b.y) + (z * b.z);
         }
 
         /// <summary>
@@ -371,10 +373,13 @@ namespace Godot
         /// <returns>The resulting vector.</returns>
         public Vector3 MoveToward(Vector3 to, real_t delta)
         {
-            var v = this;
-            var vd = to - v;
-            var len = vd.Length();
-            return len <= delta || len < Mathf.Epsilon ? to : v + vd / len * delta;
+            Vector3 v = this;
+            Vector3 vd = to - v;
+            real_t len = vd.Length();
+            if (len <= delta || len < Mathf.Epsilon)
+                return to;
+
+            return v + (vd / len * delta);
         }
 
         /// <summary>
@@ -383,7 +388,7 @@ namespace Godot
         /// <returns>A normalized version of the vector.</returns>
         public Vector3 Normalized()
         {
-            var v = this;
+            Vector3 v = this;
             v.Normalize();
             return v;
         }
@@ -453,7 +458,7 @@ namespace Godot
                 throw new ArgumentException("Argument is not normalized", nameof(normal));
             }
 #endif
-            return 2.0f * Dot(normal) * normal - this;
+            return (2.0f * Dot(normal) * normal) - this;
         }
 
         /// <summary>
@@ -548,7 +553,7 @@ namespace Godot
         /// <returns>The slid vector.</returns>
         public Vector3 Slide(Vector3 normal)
         {
-            return this - normal * Dot(normal);
+            return this - (normal * Dot(normal));
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -30,10 +30,12 @@ namespace Godot
         /// The vector's X component. Also accessible by using the index position `[0]`.
         /// </summary>
         public int x;
+
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position `[1]`.
         /// </summary>
         public int y;
+
         /// <summary>
         /// The vector's Z component. Also accessible by using the index position `[2]`.
         /// </summary>


### PR DESCRIPTION
Follow-up to #50757. This PR manually picks out some of the changes of #49352, anything that is easy to decide if it's a benefit.

This PR does the following:
* Use `_` for private fields/constants.
* Replace `extern static` with `static extern`.
* Replace `String` with `string`.
* Add explicit access modifiers.
* Add explicit parenthesis.
* Use camelCase for local variables.
* Use static types where 49352 does.
* Manually break up some of the lines that were automatically broken up by the formatter in 49352.

I can make a version of this PR for 3.x, if so #49352 will have to be rebased on top of it. As with #50757 the goal here is to break down #49352 into smaller pieces so we can more easily review the remaining style changes. There are also a few places where the automatic formatter produced sub-par results that I've replaced with better alternatives in this PR.