### PR TITLE
Prevent 2D editor plugins from breaking editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3779,6 +3779,9 @@ void CanvasItemEditor::_draw_viewport() {
 		force_over_plugin_list->forward_canvas_force_draw_over_viewport(viewport);
 	}
 
+	// Reset the transform in case some plugin changed it, potentially breaking the editor.
+	RenderingServer::get_singleton()->canvas_item_add_set_transform(ci, Transform2D());
+
 	if (show_rulers) {
 		_draw_rulers();
 	}


### PR DESCRIPTION
See https://github.com/godotengine/godot-proposals/issues/3038#issuecomment-886194459

Plugin can still break another plugin, not sure if setting transform is cheap enough to call it after every plugin.