### PR TITLE
[3.x] Fix selection of spaced atlas tile when using priority

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -662,7 +662,8 @@ Vector2 TileSet::atlastile_get_subtile_by_priority(int p_id, const Node *p_tilem
 		}
 	}
 
-	Vector2 coord = tile_get_region(p_id).size / autotile_get_size(p_id);
+	const Vector2 spacing(autotile_get_spacing(p_id), autotile_get_spacing(p_id));
+	const Vector2 coord = tile_get_region(p_id).size / (autotile_get_size(p_id) + spacing);
 
 	List<Vector2> coords;
 	for (int x = 0; x < coord.x; x++) {


### PR DESCRIPTION
Spacing was not taken into account when calculating the number of subtiles, so extra tiles were included as candidates.

This targets `3.x` because TileSet code on `master` got a rewrite for the new TileSet editor.

Fixes #43331