### PR TITLE
Add `GraphEdit` drag notifications

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -109,6 +109,14 @@
 				Removes the connection between the [code]from_port[/code] slot of the [code]from[/code] GraphNode and the [code]to_port[/code] slot of the [code]to[/code] GraphNode. If the connection does not exist, no connection is removed.
 			</description>
 		</method>
+		<method name="force_connection_drag_end">
+			<return type="void" />
+			<description>
+				Ends the creation of the current connection. In other words, if you are dragging a connection you can use this method to abort the process and remove the line that followed your cursor.
+				This is best used together with [signal connection_drag_begun] and [signal connection_drag_ended] to add custom behavior like node addition through shortcuts.
+				[b]Note:[/b] This method suppresses any other connection request signals apart from [signal connection_drag_ended].
+			</description>
+		</method>
 		<method name="get_connection_line">
 			<return type="PackedVector2Array" />
 			<argument index="0" name="from" type="Vector2" />
@@ -239,6 +247,19 @@
 		<signal name="begin_node_move">
 			<description>
 				Emitted at the beginning of a GraphNode movement.
+			</description>
+		</signal>
+		<signal name="connection_drag_begun">
+			<argument index="0" name="from" type="String" />
+			<argument index="1" name="slot" type="String" />
+			<argument index="2" name="is_output" type="bool" />
+			<description>
+				Emitted at the beginning of a connection drag.
+			</description>
+		</signal>
+		<signal name="connection_drag_ended">
+			<description>
+				Emitted at the end of a connection drag.
 			</description>
 		</signal>
 		<signal name="connection_from_empty">

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -267,6 +267,7 @@ public:
 	bool is_node_connected(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	void disconnect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	void clear_connections();
+	void force_connection_drag_end();
 
 	void set_connection_activity(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port, float p_activity);
 


### PR DESCRIPTION
# Context

I am working on a graph based tool and wanted to implement shortcuts to add nodes while I am dragging a node. To increase usability the newly created node should be connected to the current connection and the connection dragging should end.

![AudioTool3](https://user-images.githubusercontent.com/14185889/127008201-4d46ecbd-7fd4-400c-ba96-0801caff5ac2.gif)
*(I press `O` and `S+T` in the gif)*

# Implementation

I added two new signals `connection_drag_begun` and `connection_drag_ended`. Those are called whenever a connection drag starts or ends. `connection_drag_begun` passes the node, port, and a boolean to determine on which side the port is. As a user, I save node, port and the flag and clear the node when the drag ends. In my shortcut logic, I can spawn a connection with the new node, if the node is not empty. Because the graph node is still in its connection drag mode, you need to end that mode without calling any other signals. With `force_connection_drag_end()` you can do that.

<details>
<summary>Example Code</summary>

```gdscript
var shortcuts := {}
var from_node_d := ""
var from_slot_d := 0
var from_output_d := false

func _unhandled_key_input(event: InputEventKey):
	if !event.pressed:
		return
	
	var was_invoked := false
	
	for shortcut in shortcuts:
		if shortcut.size() != 1:
			continue
		if event.keycode == shortcut[0]:
			if from_node_d.is_empty():
				add_graph_node(shortcuts[shortcut])
			else:
				add_graph_node_and_connection(shortcuts[shortcut], from_output_d, from_node_d, from_slot_d)
			was_invoked = true

	if was_invoked && !from_node_d.is_empty():
		force_connection_drag_end()

func _on_SoundGraph_connection_drag_begun(from, slot, is_output):
	from_node_d = from
	from_slot_d = slot
	from_output_d = is_output

func _on_SoundGraph_connection_drag_ended():
	from_node_d = ""
```

</details>

I have a 3.x version of this change as well (because I use 3.x), which I could PR, too.