### PR TITLE
Make `switch_on_hover` work on embedded windows

### DIFF
--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -42,6 +42,8 @@ class MenuButton : public Button {
 	bool disable_shortcuts = false;
 	PopupMenu *popup;
 
+	Vector2i mouse_pos_adjusted;
+
 	Array _get_items() const;
 	void _set_items(const Array &p_items);
 


### PR DESCRIPTION
This PR makes the `MenuButton`'s `switch_on_hover` system work properly on embedded windows. It also optimizes the way the mouse offset is calculated by doing it only once when the button is pressed.