### PR TITLE
Allow multiple collision direction at the same time

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1187,9 +1187,6 @@ void CharacterBody2D::move_and_slide() {
 }
 
 void CharacterBody2D::_set_collision_direction(const PhysicsServer2D::MotionResult &p_result) {
-	on_floor = false;
-	on_ceiling = false;
-	on_wall = false;
 	if (up_direction == Vector2()) {
 		//all is a wall
 		on_wall = true;


### PR DESCRIPTION
Fix a regression introduced by #50314

To handle diagonal collision we need to keep the collision at each slide:

before:

![Screenshot 2021-07-26 at 19 46 56](https://user-images.githubusercontent.com/6397893/127034834-086ad2f0-6939-4b17-9836-b9f4435af344.png)

after:

![Screenshot 2021-07-26 at 19 45 29](https://user-images.githubusercontent.com/6397893/127034851-3220f57c-a2d4-49d4-895b-accb86bb9f07.png)
