### PR TITLE
[3.x] Add SSR resolution selection

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -244,6 +244,10 @@
 		<member name="ss_reflections_max_steps" type="int" setter="set_ssr_max_steps" getter="get_ssr_max_steps" default="64">
 			The maximum number of steps for screen-space reflections. Higher values are slower.
 		</member>
+		<member name="ss_reflections_resolution" type="int" setter="set_ssr_resolution" getter="get_ssr_resolution" enum="Environment.SSRResolution" default="1">
+			The resolution scale to use for screen-space reflections. Higher resolutions result in better-looking screen-space reflections, but are significantly slower, especially after adjusting the number of steps.
+			[b]Note:[/b] The higher the resolution scale, the shorter the reflection will appear to be (and vice versa). When setting the resolution scale to [constant SSR_RESOLUTION_FULL], double the value of [member ss_reflections_max_steps] to compensate for this. When setting the resolution scale to [constant SSR_RESOLUTION_QUARTER], halve the value of [member ss_reflections_max_steps] to compensate for this.
+		</member>
 		<member name="ss_reflections_roughness" type="bool" setter="set_ssr_rough" getter="is_ssr_rough" default="true">
 			If [code]true[/code], screen-space reflections will take the material roughness into account.
 		</member>
@@ -353,6 +357,15 @@
 		</constant>
 		<constant name="DOF_BLUR_QUALITY_HIGH" value="2" enum="DOFBlurQuality">
 			High depth-of-field blur quality (slowest).
+		</constant>
+		<constant name="SSR_RESOLUTION_QUARTER" value="0" enum="SSRResolution">
+			25% resolution scale for screen-space reflections (fastest). Remember to halve the value of [member ss_reflections_max_steps] to make the reflection length identical to what it would be when using [constant SSR_RESOLUTION_HALF].
+		</constant>
+		<constant name="SSR_RESOLUTION_HALF" value="1" enum="SSRResolution">
+			50% resolution scale for screen-space reflections.
+		</constant>
+		<constant name="SSR_RESOLUTION_FULL" value="2" enum="SSRResolution">
+			100% resolution scale for screen-space reflections (slowest). Remember to double the value of [member ss_reflections_max_steps] to make the reflection length identical to what it would be when using [constant SSR_RESOLUTION_HALF].
 		</constant>
 		<constant name="SSAO_BLUR_DISABLED" value="0" enum="SSAOBlur">
 			No blur for the screen-space ambient occlusion effect (fastest).

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -918,6 +918,7 @@
 			<argument index="4" name="fade_out" type="float" />
 			<argument index="5" name="depth_tolerance" type="float" />
 			<argument index="6" name="roughness" type="bool" />
+			<argument index="7" name="resolution" type="int" enum="VisualServer.EnvironmentSSRResolution" />
 			<description>
 				Sets the variables to be used with the "screen space reflections" post-process effect. See [Environment] for more details.
 			</description>
@@ -3802,6 +3803,15 @@
 		</constant>
 		<constant name="ENV_TONE_MAPPER_ACES_FITTED" value="4" enum="EnvironmentToneMapper">
 			Use the ACES Fitted tonemapper.
+		</constant>
+		<constant name="ENV_SSR_RESOLUTION_QUARTER" value="0" enum="EnvironmentSSRResolution">
+			25% resolution scale for screen-space reflections (fastest). Remember to halve the value of [member Environment.ss_reflections_max_steps] to make the reflection length identical to what it would be when using [constant ENV_SSR_RESOLUTION_HALF].
+		</constant>
+		<constant name="ENV_SSR_RESOLUTION_HALF" value="1" enum="EnvironmentSSRResolution">
+			50% resolution scale for screen-space reflections.
+		</constant>
+		<constant name="ENV_SSR_RESOLUTION_FULL" value="2" enum="EnvironmentSSRResolution">
+			100% resolution scale for screen-space reflections (slowest). Remember to double the value of [member Environment.ss_reflections_max_steps] to make the reflection length identical to what it would be when using [constant ENV_SSR_RESOLUTION_HALF].
 		</constant>
 		<constant name="ENV_SSAO_QUALITY_LOW" value="0" enum="EnvironmentSSAOQuality">
 			Lowest quality of screen space ambient occlusion.

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -69,7 +69,7 @@ public:
 
 	void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) {}
 
-	void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness) {}
+	void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness, VS::EnvironmentSSRResolution p_resolution) {}
 	void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) {}
 
 	void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) {}

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -794,7 +794,7 @@ void RasterizerSceneGLES2::environment_set_fog(RID p_env, bool p_enable, float p
 	ERR_FAIL_COND(!env);
 }
 
-void RasterizerSceneGLES2::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) {
+void RasterizerSceneGLES2::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, VS::EnvironmentSSRResolution p_resolution) {
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
 }

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -483,7 +483,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale, bool p_high_quality);
 	virtual void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture);
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness);
+	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, VS::EnvironmentSSRResolution p_resolution = VS::ENV_SSR_RESOLUTION_FULL);
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness);
 
 	virtual void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -857,7 +857,7 @@ void RasterizerSceneGLES3::environment_set_glow(RID p_env, bool p_enable, int p_
 void RasterizerSceneGLES3::environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) {
 }
 
-void RasterizerSceneGLES3::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) {
+void RasterizerSceneGLES3::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, VS::EnvironmentSSRResolution p_resolution) {
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
 
@@ -867,6 +867,7 @@ void RasterizerSceneGLES3::environment_set_ssr(RID p_env, bool p_enable, int p_m
 	env->ssr_fade_out = p_fade_out;
 	env->ssr_depth_tolerance = p_depth_tolerance;
 	env->ssr_roughness = p_roughness;
+	env->ssr_resolution = p_resolution;
 }
 
 void RasterizerSceneGLES3::environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VisualServer::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) {
@@ -3405,10 +3406,24 @@ void RasterizerSceneGLES3::_render_mrts(Environment *env, const CameraMatrix &p_
 
 		state.ssr_shader.bind();
 
+		float resolution_multiplier;
+		switch (env->ssr_resolution) {
+			case VS::ENV_SSR_RESOLUTION_QUARTER:
+				resolution_multiplier = 0.25;
+				break;
+			case VS::ENV_SSR_RESOLUTION_HALF:
+				resolution_multiplier = 0.5;
+				break;
+			case VS::ENV_SSR_RESOLUTION_FULL:
+				resolution_multiplier = 1.0;
+				break;
+		}
+
 		int ssr_w = storage->frame.current_rt->effects.mip_maps[1].sizes[0].width;
 		int ssr_h = storage->frame.current_rt->effects.mip_maps[1].sizes[0].height;
 
-		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::PIXEL_SIZE, Vector2(1.0 / (ssr_w * 0.5), 1.0 / (ssr_h * 0.5)));
+		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::PIXEL_SIZE, Vector2(1.0 / (ssr_w * resolution_multiplier), 1.0 / (ssr_h * resolution_multiplier)));
+		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::RESOLUTION_MULTIPLIER, resolution_multiplier);
 		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::CAMERA_Z_NEAR, p_cam_projection.get_z_near());
 		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::CAMERA_Z_FAR, p_cam_projection.get_z_far());
 		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::PROJECTION, p_cam_projection);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -379,6 +379,7 @@ public:
 		int canvas_max_layer;
 
 		bool ssr_enabled;
+		VS::EnvironmentSSRResolution ssr_resolution;
 		int ssr_max_steps;
 		float ssr_fade_in;
 		float ssr_fade_out;
@@ -463,6 +464,7 @@ public:
 				ambient_sky_contribution(0.0),
 				canvas_max_layer(0),
 				ssr_enabled(false),
+				ssr_resolution(VS::ENV_SSR_RESOLUTION_HALF),
 				ssr_max_steps(64),
 				ssr_fade_in(0.15),
 				ssr_fade_out(2.0),
@@ -549,7 +551,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale, bool p_high_quality);
 	virtual void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture);
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness);
+	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, VS::EnvironmentSSRResolution p_resolution = VS::ENV_SSR_RESOLUTION_FULL);
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness);
 
 	virtual void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale);

--- a/drivers/gles3/shaders/screen_space_reflection.glsl
+++ b/drivers/gles3/shaders/screen_space_reflection.glsl
@@ -30,6 +30,7 @@ uniform float camera_z_far;
 
 uniform vec2 viewport_size;
 uniform vec2 pixel_size;
+uniform float resolution_multiplier;
 
 uniform float filter_mipmap_levels;
 
@@ -170,8 +171,8 @@ void main() {
 	if (found) {
 		float margin_blend = 1.0;
 
-		vec2 margin = vec2((viewport_size.x + viewport_size.y) * 0.5 * 0.05); // make a uniform margin
-		if (any(bvec4(lessThan(pos, vec2(0.0, 0.0)), greaterThan(pos, viewport_size * 0.5)))) {
+		vec2 margin = vec2((viewport_size.x + viewport_size.y) * resolution_multiplier * 0.05); // make a uniform margin
+		if (any(bvec4(lessThan(pos, vec2(0.0, 0.0)), greaterThan(pos, viewport_size * resolution_multiplier)))) {
 			// clip at the screen edges
 			frag_color = vec4(0.0);
 			return;
@@ -179,8 +180,7 @@ void main() {
 
 		{
 			//blend fading out towards inner margin
-			// 0.25 = midpoint of half-resolution reflection
-			vec2 margin_grad = mix(viewport_size * 0.5 - pos, pos, lessThan(pos, viewport_size * 0.25));
+			vec2 margin_grad = mix(viewport_size * resolution_multiplier - pos, pos, lessThan(pos, viewport_size * resolution_multiplier * 0.5));
 			margin_blend = smoothstep(0.0, margin.x * margin.y, margin_grad.x * margin_grad.y);
 			//margin_blend = 1.0;
 		}

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -337,7 +337,7 @@ void Environment::_validate_property(PropertyInfo &property) const {
 
 void Environment::set_ssr_enabled(bool p_enable) {
 	ssr_enabled = p_enable;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, VS::EnvironmentSSRResolution(ssr_resolution));
 	_change_notify();
 }
 
@@ -345,9 +345,17 @@ bool Environment::is_ssr_enabled() const {
 	return ssr_enabled;
 }
 
+void Environment::set_ssr_resolution(SSRResolution p_resolution) {
+	ssr_resolution = p_resolution;
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, VS::EnvironmentSSRResolution(ssr_resolution));
+}
+Environment::SSRResolution Environment::get_ssr_resolution() const {
+	return ssr_resolution;
+}
+
 void Environment::set_ssr_max_steps(int p_steps) {
 	ssr_max_steps = p_steps;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, VS::EnvironmentSSRResolution(ssr_resolution));
 }
 int Environment::get_ssr_max_steps() const {
 	return ssr_max_steps;
@@ -355,7 +363,7 @@ int Environment::get_ssr_max_steps() const {
 
 void Environment::set_ssr_fade_in(float p_fade_in) {
 	ssr_fade_in = p_fade_in;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, VS::EnvironmentSSRResolution(ssr_resolution));
 }
 float Environment::get_ssr_fade_in() const {
 	return ssr_fade_in;
@@ -363,7 +371,7 @@ float Environment::get_ssr_fade_in() const {
 
 void Environment::set_ssr_fade_out(float p_fade_out) {
 	ssr_fade_out = p_fade_out;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, VS::EnvironmentSSRResolution(ssr_resolution));
 }
 float Environment::get_ssr_fade_out() const {
 	return ssr_fade_out;
@@ -371,7 +379,7 @@ float Environment::get_ssr_fade_out() const {
 
 void Environment::set_ssr_depth_tolerance(float p_depth_tolerance) {
 	ssr_depth_tolerance = p_depth_tolerance;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, VS::EnvironmentSSRResolution(ssr_resolution));
 }
 float Environment::get_ssr_depth_tolerance() const {
 	return ssr_depth_tolerance;
@@ -379,7 +387,7 @@ float Environment::get_ssr_depth_tolerance() const {
 
 void Environment::set_ssr_rough(bool p_enable) {
 	ssr_roughness = p_enable;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, VS::EnvironmentSSRResolution(ssr_resolution));
 }
 bool Environment::is_ssr_rough() const {
 	return ssr_roughness;
@@ -941,6 +949,9 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ssr_enabled", "enabled"), &Environment::set_ssr_enabled);
 	ClassDB::bind_method(D_METHOD("is_ssr_enabled"), &Environment::is_ssr_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_ssr_resolution", "resolution"), &Environment::set_ssr_resolution);
+	ClassDB::bind_method(D_METHOD("get_ssr_resolution"), &Environment::get_ssr_resolution);
+
 	ClassDB::bind_method(D_METHOD("set_ssr_max_steps", "max_steps"), &Environment::set_ssr_max_steps);
 	ClassDB::bind_method(D_METHOD("get_ssr_max_steps"), &Environment::get_ssr_max_steps);
 
@@ -958,6 +969,7 @@ void Environment::_bind_methods() {
 
 	ADD_GROUP("SS Reflections", "ss_reflections_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ss_reflections_enabled"), "set_ssr_enabled", "is_ssr_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "ss_reflections_resolution", PROPERTY_HINT_ENUM, "Quarter (Fast), Half (Average), Full (Slow)"), "set_ssr_resolution", "get_ssr_resolution");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ss_reflections_max_steps", PROPERTY_HINT_RANGE, "1,512,1"), "set_ssr_max_steps", "get_ssr_max_steps");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ss_reflections_fade_in", PROPERTY_HINT_EXP_EASING), "set_ssr_fade_in", "get_ssr_fade_in");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ss_reflections_fade_out", PROPERTY_HINT_EXP_EASING), "set_ssr_fade_out", "get_ssr_fade_out");
@@ -1157,6 +1169,10 @@ void Environment::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOF_BLUR_QUALITY_MEDIUM);
 	BIND_ENUM_CONSTANT(DOF_BLUR_QUALITY_HIGH);
 
+	BIND_ENUM_CONSTANT(SSR_RESOLUTION_QUARTER);
+	BIND_ENUM_CONSTANT(SSR_RESOLUTION_HALF);
+	BIND_ENUM_CONSTANT(SSR_RESOLUTION_FULL);
+
 	BIND_ENUM_CONSTANT(SSAO_BLUR_DISABLED);
 	BIND_ENUM_CONSTANT(SSAO_BLUR_1x1);
 	BIND_ENUM_CONSTANT(SSAO_BLUR_2x2);
@@ -1170,6 +1186,7 @@ void Environment::_bind_methods() {
 Environment::Environment() :
 		bg_mode(BG_CLEAR_COLOR),
 		tone_mapper(TONE_MAPPER_LINEAR),
+		ssr_resolution(SSR_RESOLUTION_HALF),
 		ssao_blur(SSAO_BLUR_3x3),
 		ssao_quality(SSAO_QUALITY_MEDIUM),
 		glow_blend_mode(GLOW_BLEND_MODE_ADDITIVE),
@@ -1206,6 +1223,7 @@ Environment::Environment() :
 	set_adjustment_enable(adjustment_enabled); //update
 
 	ssr_enabled = false;
+	ssr_resolution = SSR_RESOLUTION_HALF;
 	ssr_max_steps = 64;
 	ssr_fade_in = 0.15;
 	ssr_fade_out = 2.0;

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -73,6 +73,12 @@ public:
 		DOF_BLUR_QUALITY_HIGH,
 	};
 
+	enum SSRResolution {
+		SSR_RESOLUTION_QUARTER,
+		SSR_RESOLUTION_HALF,
+		SSR_RESOLUTION_FULL,
+	};
+
 	enum SSAOBlur {
 		SSAO_BLUR_DISABLED,
 		SSAO_BLUR_1x1,
@@ -117,6 +123,7 @@ private:
 	Ref<Texture> adjustment_color_correction;
 
 	bool ssr_enabled;
+	SSRResolution ssr_resolution;
 	int ssr_max_steps;
 	float ssr_fade_in;
 	float ssr_fade_out;
@@ -252,6 +259,9 @@ public:
 
 	void set_ssr_enabled(bool p_enable);
 	bool is_ssr_enabled() const;
+
+	void set_ssr_resolution(SSRResolution p_resolution);
+	SSRResolution get_ssr_resolution() const;
 
 	void set_ssr_max_steps(int p_steps);
 	int get_ssr_max_steps() const;
@@ -419,6 +429,7 @@ VARIANT_ENUM_CAST(Environment::BGMode)
 VARIANT_ENUM_CAST(Environment::ToneMapper)
 VARIANT_ENUM_CAST(Environment::GlowBlendMode)
 VARIANT_ENUM_CAST(Environment::DOFBlurQuality)
+VARIANT_ENUM_CAST(Environment::SSRResolution)
 VARIANT_ENUM_CAST(Environment::SSAOQuality)
 VARIANT_ENUM_CAST(Environment::SSAOBlur)
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -67,7 +67,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale, bool p_high_quality) = 0;
 	virtual void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) = 0;
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness) = 0;
+	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness, VS::EnvironmentSSRResolution p_resolution = VS::ENV_SSR_RESOLUTION_FULL) = 0;
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) = 0;
 
 	virtual void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -512,7 +512,7 @@ public:
 	BIND2(environment_set_canvas_max_layer, RID, int)
 	BIND4(environment_set_ambient_light, RID, const Color &, float, float)
 	BIND2(environment_set_camera_feed_id, RID, int)
-	BIND7(environment_set_ssr, RID, bool, int, float, float, float, bool)
+	BIND8(environment_set_ssr, RID, bool, int, float, float, float, bool, EnvironmentSSRResolution)
 	BIND13(environment_set_ssao, RID, bool, float, float, float, float, float, float, float, const Color &, EnvironmentSSAOQuality, EnvironmentSSAOBlur, float)
 
 	BIND6(environment_set_dof_blur_near, RID, bool, float, float, float, EnvironmentDOFBlurQuality)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -440,7 +440,7 @@ public:
 	FUNC2(environment_set_canvas_max_layer, RID, int)
 	FUNC4(environment_set_ambient_light, RID, const Color &, float, float)
 	FUNC2(environment_set_camera_feed_id, RID, int)
-	FUNC7(environment_set_ssr, RID, bool, int, float, float, float, bool)
+	FUNC8(environment_set_ssr, RID, bool, int, float, float, float, bool, EnvironmentSSRResolution)
 	FUNC13(environment_set_ssao, RID, bool, float, float, float, float, float, float, float, const Color &, EnvironmentSSAOQuality, EnvironmentSSAOBlur, float)
 
 	FUNC6(environment_set_dof_blur_near, RID, bool, float, float, float, EnvironmentDOFBlurQuality)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2104,7 +2104,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_glow", "env", "enable", "level_flags", "intensity", "strength", "bloom_threshold", "blend_mode", "hdr_bleed_threshold", "hdr_bleed_scale", "hdr_luminance_cap", "bicubic_upscale", "high_quality"), &VisualServer::environment_set_glow);
 	ClassDB::bind_method(D_METHOD("environment_set_tonemap", "env", "tone_mapper", "exposure", "white", "auto_exposure", "min_luminance", "max_luminance", "auto_exp_speed", "auto_exp_grey"), &VisualServer::environment_set_tonemap);
 	ClassDB::bind_method(D_METHOD("environment_set_adjustment", "env", "enable", "brightness", "contrast", "saturation", "ramp"), &VisualServer::environment_set_adjustment);
-	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "max_steps", "fade_in", "fade_out", "depth_tolerance", "roughness"), &VisualServer::environment_set_ssr);
+	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "max_steps", "fade_in", "fade_out", "depth_tolerance", "roughness", "resolution"), &VisualServer::environment_set_ssr);
 	ClassDB::bind_method(D_METHOD("environment_set_ssao", "env", "enable", "radius", "intensity", "radius2", "intensity2", "bias", "light_affect", "ao_channel_affect", "color", "quality", "blur", "bilateral_sharpness"), &VisualServer::environment_set_ssao);
 	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "color", "sun_color", "sun_amount"), &VisualServer::environment_set_fog);
 
@@ -2505,6 +2505,10 @@ void VisualServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_FILMIC);
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_ACES);
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_ACES_FITTED);
+
+	BIND_ENUM_CONSTANT(ENV_SSR_RESOLUTION_QUARTER);
+	BIND_ENUM_CONSTANT(ENV_SSR_RESOLUTION_HALF);
+	BIND_ENUM_CONSTANT(ENV_SSR_RESOLUTION_FULL);
 
 	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_LOW);
 	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_MEDIUM);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -785,7 +785,13 @@ public:
 	virtual void environment_set_tonemap(RID p_env, EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_grey) = 0;
 	virtual void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) = 0;
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) = 0;
+	enum EnvironmentSSRResolution {
+		ENV_SSR_RESOLUTION_QUARTER,
+		ENV_SSR_RESOLUTION_HALF,
+		ENV_SSR_RESOLUTION_FULL,
+	};
+
+	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, EnvironmentSSRResolution p_resolution = ENV_SSR_RESOLUTION_FULL) = 0;
 
 	enum EnvironmentSSAOQuality {
 		ENV_SSAO_QUALITY_LOW,
@@ -1200,6 +1206,7 @@ VARIANT_ENUM_CAST(VisualServer::EnvironmentBG);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentDOFBlurQuality);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentGlowBlendMode);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentToneMapper);
+VARIANT_ENUM_CAST(VisualServer::EnvironmentSSRResolution);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentSSAOQuality);
 VARIANT_ENUM_CAST(VisualServer::EnvironmentSSAOBlur);
 VARIANT_ENUM_CAST(VisualServer::InstanceFlags);


### PR DESCRIPTION
This salvages https://github.com/godotengine/godot/pull/28502.

- Full, Half, and Quarter setting in WorldEnvironment under Ss Reflections.
- Replaces 0.5 with a custom multiplier.
- Higher resolution requires more steps, else the range of the reflections is shorter.
- Slight performance changes per resolution. Quarter res and lowering max depth may be useful for lower end devices.

See also a partial rework of this PR I didn't get to work yet: https://github.com/Calinou/godot/tree/ssr-add-step-resolution-3.x

**Testing project:** [test_ssr_resolution_3.x.zip](https://github.com/godotengine/godot/files/6881423/test_ssr_resolution_3.x.zip)

## Preview

### Half resolution (default, existing behavior)

![2021-07-26_23 41 23](https://user-images.githubusercontent.com/180032/127064217-d0237896-450c-46f4-a999-fae234fe0323.png)

### Full resolution + doubled max steps

![2021-07-26_23 41 13](https://user-images.githubusercontent.com/180032/127064211-a9ae021d-672e-46de-9ad4-78ff6a9b5ae8.png)

### Quarter resolution + halved max steps

![2021-07-26_23 41 34](https://user-images.githubusercontent.com/180032/127064218-b5f9a93f-1e6f-409e-b5cc-499a23b3224a.png)