### PR TITLE
Fix Set range iterator implementation, Use C++ iterators in the Mono module

### DIFF
--- a/core/templates/set.h
+++ b/core/templates/set.h
@@ -71,6 +71,9 @@ public:
 		Element *prev() {
 			return _prev;
 		}
+		T &get() {
+			return value;
+		}
 		const T &get() const {
 			return value;
 		};
@@ -118,8 +121,8 @@ public:
 			return *this;
 		}
 
-		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
+		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
+		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
 
 		_FORCE_INLINE_ ConstIterator(const Element *p_E) { E = p_E; }
 		_FORCE_INLINE_ ConstIterator() {}

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -655,9 +655,7 @@ int BindingsGenerator::_determine_enum_prefix(const EnumInterface &p_ienum) {
 		return 0;
 	}
 
-	for (const List<ConstantInterface>::Element *E = p_ienum.constants.front()->next(); E; E = E->next()) {
-		const ConstantInterface &iconstant = E->get();
-
+	for (const ConstantInterface &iconstant : p_ienum.constants) {
 		Vector<String> parts = iconstant.name.split("_", /* p_allow_empty: */ true);
 
 		int i;

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -123,8 +123,8 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				// AutoLoads
 				Map<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
 
-				for (Map<StringName, ProjectSettings::AutoloadInfo>::Element *E = autoloads.front(); E; E = E->next()) {
-					const ProjectSettings::AutoloadInfo &info = E->value();
+				for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
+					const ProjectSettings::AutoloadInfo &info = E.value;
 					suggestions.push_back(quoted("/root/" + String(info.name)));
 				}
 			}

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -330,8 +330,8 @@ no_pdb:
 void GDMonoAssembly::unload() {
 	ERR_FAIL_NULL(image); // Should not be called if already unloaded
 
-	for (Map<MonoClass *, GDMonoClass *>::Element *E = cached_raw.front(); E; E = E->next()) {
-		memdelete(E->value());
+	for (const KeyValue<MonoClass *, GDMonoClass *> &E : cached_raw) {
+		memdelete(E.value);
 	}
 
 	cached_classes.clear();

--- a/modules/mono/mono_gd/gd_mono_class.cpp
+++ b/modules/mono/mono_gd/gd_mono_class.cpp
@@ -522,12 +522,12 @@ GDMonoClass::~GDMonoClass() {
 		mono_custom_attrs_free(attributes);
 	}
 
-	for (Map<StringName, GDMonoField *>::Element *E = fields.front(); E; E = E->next()) {
-		memdelete(E->value());
+	for (const KeyValue<StringName, GDMonoField *> &E : fields) {
+		memdelete(E.value);
 	}
 
-	for (Map<StringName, GDMonoProperty *>::Element *E = properties.front(); E; E = E->next()) {
-		memdelete(E->value());
+	for (const KeyValue<StringName, GDMonoProperty *> &E : properties) {
+		memdelete(E.value);
 	}
 
 	{


### PR DESCRIPTION
Follow-up to #50511, #50809 and #50899.

This PR converts all the for loops in the **Mono** module to use C++ Range Iterators for `List`, `Map` and `Set`. Using `const` whenever possible.

I had to fix the `Set` implementation to be able to convert those, otherwise it wouldn't compile.

There are for loops using `SelfList` and `OrderedHashMap` but since those structures don't implement Range Iterators I couldn't translate those.

I'm not well-versed in C++ so I may have made mistakes.