### PR TITLE
[3.x] Fix crash when executing PopupMenu.new()._submenu_timeout()

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -179,6 +179,8 @@ void PopupMenu::_activate_submenu(int over) {
 }
 
 void PopupMenu::_submenu_timeout() {
+	ERR_FAIL_COND(submenu_over == -1);
+
 	if (mouse_over == submenu_over) {
 		_activate_submenu(mouse_over);
 	}


### PR DESCRIPTION
Fixes #45981.

Normally, `submenu_over` will be set to the index of the hovering submenu when the timer starts. Calling the method manually will leave `submenu_over` to be -1, and will crash when using it as an array index.

`_submenu_timeout()` is not exposed to GDScript on `master`, so the fail condition would never be true (unless an internal bug).