### PR TITLE
Add checks to internal methods to prevent crash

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -795,6 +795,7 @@ void TileMap::_set_tile_data(const Vector<int> &p_data) {
 	const int *r = p_data.ptr();
 
 	int offset = (format >= FORMAT_2) ? 3 : 2;
+	ERR_FAIL_COND_MSG(c % offset != 0, "Corrupted tile data.");
 
 	clear();
 

--- a/scene/3d/proximity_group_3d.cpp
+++ b/scene/3d/proximity_group_3d.cpp
@@ -128,6 +128,7 @@ void ProximityGroup3D::broadcast(String p_method, Variant p_parameters) {
 
 void ProximityGroup3D::_proximity_group_broadcast(String p_method, Variant p_parameters) {
 	if (dispatch_mode == MODE_PROXY) {
+		ERR_FAIL_COND(!is_inside_tree());
 		get_parent()->call(p_method, p_parameters);
 	} else {
 		emit_signal(SNAME("broadcast"), p_method, p_parameters);


### PR DESCRIPTION
* `TileMap::_set_tile_data()`
    * this method may also be called by `TileMap::set`, parameters are passed directly.
    * the function assumes the size of input array to be a multiple of 2 or 3 according to the format version, will cause an out of bound read otherwise.
* `ProximityGroup3D::_proximity_group_broadcast()` (`ProximityGroup` on `3.x`)
    * `get_parent()` will be null when not in tree

Fixes #46015
Fixes #46002