### PR TITLE
Removed Redundant initialization of probe_half_size

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
@@ -793,8 +793,7 @@ void RendererSceneGIRD::SDFGI::update(RendererSceneEnvironmentRD *p_env, const V
 		SDFGI::Cascade &cascade = cascades[i];
 		cascade.dirty_regions = Vector3i();
 
-		Vector3 probe_half_size = Vector3(1, 1, 1) * cascade.cell_size * float(cascade_size / SDFGI::PROBE_DIVISOR) * 0.5;
-		probe_half_size = Vector3(0, 0, 0);
+		Vector3 probe_half_size = Vector3(0, 0, 0);
 
 		Vector3 world_position = p_world_position;
 		world_position.y *= y_mult;


### PR DESCRIPTION
Fixes #50903
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
