### PR TITLE
Portals - Fix default portal margin loading

### DIFF
--- a/scene/3d/portal.cpp
+++ b/scene/3d/portal.cpp
@@ -54,8 +54,7 @@ Portal::Portal() {
 	_pts_local_raw.resize(0);
 	_pt_center_world = Vector3();
 	_plane = Plane();
-	_margin = 1.0f;
-	_default_margin = 1.0f;
+	_margin = 1.0;
 	_use_default_margin = true;
 
 	// the visual server portal lifetime is linked to the lifetime of this object
@@ -508,7 +507,7 @@ void Portal::portal_update() {
 
 real_t Portal::get_active_portal_margin() const {
 	if (_use_default_margin) {
-		return _default_margin;
+		return RoomManager::_get_default_portal_margin();
 	}
 	return _margin;
 }

--- a/scene/3d/portal.h
+++ b/scene/3d/portal.h
@@ -152,7 +152,6 @@ private:
 
 	// extension margin
 	real_t _margin;
-	real_t _default_margin;
 	bool _use_default_margin;
 
 	// for editing

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -58,6 +58,10 @@
 RoomManager *RoomManager::active_room_manager = nullptr;
 #endif
 
+// This needs to be static because it cannot easily be propagated to portals
+// during load (as the RoomManager may be loaded before Portals enter the scene tree)
+real_t RoomManager::_default_portal_margin = 1.0;
+
 RoomManager::RoomManager() {
 	// some high value, we want room manager to be processed after other
 	// nodes because the camera should be moved first
@@ -343,14 +347,13 @@ void RoomManager::set_default_portal_margin(real_t p_dist) {
 		return;
 	}
 
-	_update_portal_margins(roomlist, _default_portal_margin);
+	_update_portal_gizmos(roomlist);
 }
 
-void RoomManager::_update_portal_margins(Spatial *p_node, real_t p_margin) {
+void RoomManager::_update_portal_gizmos(Spatial *p_node) {
 	Portal *portal = Object::cast_to<Portal>(p_node);
 
 	if (portal) {
-		portal->_default_margin = p_margin;
 		portal->update_gizmo();
 	}
 
@@ -359,7 +362,7 @@ void RoomManager::_update_portal_margins(Spatial *p_node, real_t p_margin) {
 		Spatial *child = Object::cast_to<Spatial>(p_node->get_child(n));
 
 		if (child) {
-			_update_portal_margins(child, p_margin);
+			_update_portal_gizmos(child);
 		}
 	}
 }

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -179,7 +179,7 @@ private:
 
 	// misc
 	bool _add_plane_if_unique(const Room *p_room, LocalVector<Plane, int32_t> &r_planes, const Plane &p);
-	void _update_portal_margins(Spatial *p_node, real_t p_margin);
+	void _update_portal_gizmos(Spatial *p_node);
 	bool _check_roomlist_validity(Node *p_node);
 	void _cleanup_after_conversion();
 	Error _build_room_convex_hull(const Room *p_room, const Vector<Vector3> &p_points, Geometry::MeshData &r_mesh);
@@ -217,6 +217,7 @@ private:
 public:
 	static String _find_name_after(Node *p_node, String p_string_start);
 	static void show_warning(const String &p_string, const String &p_extra_string = "", bool p_alert = true);
+	static real_t _get_default_portal_margin() { return _default_portal_margin; }
 
 private:
 	// accessible from UI
@@ -256,7 +257,7 @@ private:
 	LocalVector<Room *, int32_t> _rooms;
 
 	// advanced params
-	real_t _default_portal_margin = 1.0;
+	static real_t _default_portal_margin;
 	real_t _overlap_warning_threshold = 1.0;
 	Room::SimplifyInfo _room_simplify_info;
 	int _settings_portal_depth_limit = 16;


### PR DESCRIPTION
The default portal margin is stored in the RoomManager. Previously this was propagated to Portals when the value was changed, and Portals each stored this default value.

This caused a bug during loading, if the RoomManager was loaded before Portals, the value was never propagated.

This PR makes the default margin a static value stored in the RoomManager, and the Portals now read directly from the static value when required, and do not store locally. This gets around the problem.

## Notes
* Just noticed this bug yesterday, so too late for beta 2. However it shouldn't interfere with users getting to know the system - the margins is fairly advanced level. But will be good to have fixed for next beta.
* Obviously using static values can get confusing if there is more than one RoomManager in a scene tree. This should be avoided anyway, there are some existing warnings to try and prevent users from creating more than one RoomManager.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
