### PR TITLE
Change Variant bool conversion to uint8_t

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -134,7 +134,7 @@ typedef void *GDNativeObjectPtr;
 typedef void *GDNativeTypePtr;
 typedef void *GDNativeMethodBindPtr;
 typedef int64_t GDNativeInt;
-typedef uint32_t GDNativeBool;
+typedef uint8_t GDNativeBool;
 typedef uint64_t GDObjectInstanceID;
 
 /* VARIANT DATA I/O */

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -105,7 +105,7 @@ struct PtrToArg {};
 		}                                                                     \
 	}
 
-MAKE_PTRARGCONV(bool, uint32_t);
+MAKE_PTRARGCONV(bool, uint8_t);
 // Integer types.
 MAKE_PTRARGCONV(uint8_t, int64_t);
 MAKE_PTRARGCONV(int8_t, int64_t);


### PR DESCRIPTION
This ensures more portable conversion since not every path assume bool is 32-bits and there's no loss converting to 8-bits anyway.

Fix #50435