### PR TITLE
Bind `Input.mouse_mode` as a property

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -135,6 +135,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_accumulated_input", "enable"), &Input::set_use_accumulated_input);
 	ClassDB::bind_method(D_METHOD("flush_buffered_events"), &Input::flush_buffered_events);
 
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_mode", PROPERTY_HINT_ENUM), "set_mouse_mode", "get_mouse_mode");
+
 	BIND_ENUM_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_HIDDEN);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_CAPTURED);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -160,12 +160,6 @@
 				Returns mouse buttons as a bitmask. If multiple mouse buttons are pressed at the same time, the bits are added together.
 			</description>
 		</method>
-		<method name="get_mouse_mode" qualifiers="const">
-			<return type="int" enum="Input.MouseMode" />
-			<description>
-				Returns the mouse mode. See the constants for more information.
-			</description>
-		</method>
 		<method name="get_vector" qualifiers="const">
 			<return type="Vector2" />
 			<argument index="0" name="negative_x" type="StringName" />
@@ -330,13 +324,6 @@
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
 			</description>
 		</method>
-		<method name="set_mouse_mode">
-			<return type="void" />
-			<argument index="0" name="mode" type="int" enum="Input.MouseMode" />
-			<description>
-				Sets the mouse mode. See the constants for more information.
-			</description>
-		</method>
 		<method name="set_use_accumulated_input">
 			<return type="void" />
 			<argument index="0" name="enable" type="bool" />
@@ -379,6 +366,11 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="mouse_mode" type="int" setter="set_mouse_mode" getter="get_mouse_mode" enum="Input.MouseMode">
+			Sets the visiblity/constraints of the mouse cursor. See [enum MouseMode] for more details.
+		</member>
+	</members>
 	<signals>
 		<signal name="joy_connection_changed">
 			<argument index="0" name="device" type="int" />


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
It seems this was an oversight, `mouse_mode` already has both a setter and a getter.

Doesn't break compatibility, 3.x version here: https://github.com/godotengine/godot/pull/50943#issue-953926325