### PR TITLE
[3.x] Improve the script editor's executing line icon

### DIFF
--- a/editor/icons/icon_execution_marker.svg
+++ b/editor/icons/icon_execution_marker.svg
@@ -1,0 +1,1 @@
+<svg height="21" viewBox="0 0 21 21" width="21" xmlns="http://www.w3.org/2000/svg"><path d="m2 18.4v-15.7l15.747368 8.3z" fill="none" stroke="#e0e0e0" stroke-linecap="square" stroke-width="2"/></svg>

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1295,12 +1295,20 @@ void TextEdit::_notification(int p_what) {
 						// Draw execution marker.
 						if (executing_line == line) {
 							if (draw_breakpoint_gutter) {
-								int icon_extra_size = 4;
-								int vertical_gap = (get_row_height() * 40) / 100;
-								int horizontal_gap = (cache.breakpoint_gutter_width * 30) / 100;
-								int marker_height = get_row_height() - (vertical_gap * 2) + icon_extra_size;
-								int marker_width = cache.breakpoint_gutter_width - (horizontal_gap * 2) + icon_extra_size;
-								cache.executing_icon->draw_rect(ci, Rect2(cache.style_normal->get_margin(MARGIN_LEFT) + horizontal_gap - 2 - icon_extra_size / 2, ofs_y + vertical_gap - icon_extra_size / 2, marker_width, marker_height), false, Color(cache.executing_line_color.r, cache.executing_line_color.g, cache.executing_line_color.b));
+								const int vertical_gap = (get_row_height() * 40) / 100;
+								const int horizontal_gap = (cache.breakpoint_gutter_width * 30) / 100;
+								const int marker_width = cache.executing_icon->get_width();
+								const int marker_height = cache.executing_icon->get_height();
+								// Position the execution marker icon origin to visually "contain" the breakpoint icon.
+								cache.executing_icon->draw_rect(
+										ci,
+										Rect2(
+												cache.style_normal->get_margin(MARGIN_LEFT) + horizontal_gap - marker_width * 0.275,
+												ofs_y + vertical_gap - marker_height * 0.375,
+												marker_width,
+												marker_height),
+										false,
+										Color(cache.executing_line_color.r, cache.executing_line_color.g, cache.executing_line_color.b));
 							} else {
 #ifdef TOOLS_ENABLED
 								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(xmargin_beg + ofs_x, ofs_y + get_row_height() - EDSCALE, xmargin_end - xmargin_beg, EDSCALE), cache.executing_line_color);
@@ -5457,7 +5465,7 @@ void TextEdit::_update_caches() {
 	cache.folded_icon = get_icon("folded");
 	cache.can_fold_icon = get_icon("fold");
 	cache.folded_eol_icon = get_icon("GuiEllipsis", "EditorIcons");
-	cache.executing_icon = get_icon("TextEditorPlay", "EditorIcons");
+	cache.executing_icon = get_icon("ExecutionMarker", "EditorIcons");
 	text.set_font(cache.font);
 
 	if (syntax_highlighter) {


### PR DESCRIPTION
The executing line icon now surrounds the breakpoint icon with an outline instead of being drawn inside.

I tested this at editor scales 100% and 200% and it works well in both.

This addresses https://github.com/godotengine/godot/issues/50950 for `3.x`. A `master` PR needs to be made too – the code is entirely different, and the breakpoint icon was also changed.

## Preview

![image](https://user-images.githubusercontent.com/180032/127230769-8821c02f-872e-4c73-948e-699ff3f9e89d.png)