### PR TITLE
Pause the project execution if `get_node()` can't find the node

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -35,6 +35,7 @@
 #include "core/object/message_queue.h"
 #include "core/string/print_string.h"
 #include "instance_placeholder.h"
+#include "modules/gdscript/gdscript.h"
 #include "scene/animation/tween.h"
 #include "scene/debugger/scene_debugger.h"
 #include "scene/resources/packed_scene.h"
@@ -1266,12 +1267,18 @@ Node *Node::get_node_or_null(const NodePath &p_path) const {
 Node *Node::get_node(const NodePath &p_path) const {
 	Node *node = get_node_or_null(p_path);
 
-	if (p_path.is_absolute()) {
-		ERR_FAIL_COND_V_MSG(!node, nullptr,
-				vformat(R"(Node not found: "%s" (absolute path attempted from "%s").)", p_path, get_path()));
-	} else {
-		ERR_FAIL_COND_V_MSG(!node, nullptr,
-				vformat(R"(Node not found: "%s" (relative to "%s").)", p_path, get_path()));
+	if (!node) {
+		String message;
+		if (p_path.is_absolute()) {
+			message = vformat(R"(Node not found: "%s" (absolute path attempted from "%s").)", p_path, get_path());
+		} else {
+			message = vformat(R"(Node not found: "%s" (relative to "%s").)", p_path, get_path());
+		}
+		// Print error message before breaking, so that it can be seen in the console while the engine is paused.
+		ERR_PRINT(message);
+		// Break to make debugging easier.
+		GDScriptLanguage::get_singleton()->debug_break(message, true);
+		return nullptr;
 	}
 
 	return node;


### PR DESCRIPTION
This makes troubleshooting easier by requiring the user to fix their script, while still printing a message to the console. The script can be manually continued if desired.

If the node may not be found at run-time, `get_node_or_null()` should be used instead.

The implementation is a proof-of-concept and most likely doesn't work with C# and visual scripting. We'll most likely want to put this behind a `break_on_runtime_error` project setting (enabled by default in `master`, disabled by default in `3.x`).

Once we figure out a good implementation, we can extend it to other things such as nonexistent Input action names.

This partially addresses https://github.com/godotengine/godot-proposals/issues/1729.

## Preview

![Editor break](https://user-images.githubusercontent.com/180032/127233650-dde3ee52-d4b2-4b02-a7fd-6621d651ee3e.png)