### PR TITLE
Portals - fix autolink portals to detect internal

### DIFF
--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -924,6 +924,10 @@ void RoomManager::_autolink_portals(Spatial *p_roomlist, LocalVector<Portal *> &
 					// send complete link to visual server so the portal will be active in the visual server room system
 					VisualServer::get_singleton()->portal_link(portal->_portal_rid, source_room->_room_rid, room->_room_rid, portal->_settings_two_way);
 
+					// make the portal internal if necessary
+					// (this prevents the portal plane clipping the room bound)
+					portal->_internal = source_room->_room_priority > room->_room_priority;
+
 					autolink_found = true;
 					break;
 				}


### PR DESCRIPTION
Although explicit portals did a check to detect internal portals, this check was missing from autolinked portals. This meant they were incorrectly clipping the room bounds of the enclosing outer room.

This PR adds a check for internal rooms during the autolinking and sets the internal flag where needed.

## Notes
* This is improving the behaviour of internal rooms, previously these wouldn't work properly with autolinked portals and relied on explicitly linked portals.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
