### PR TITLE
Portals - add autoplace priority to CullInstance, further work

### DIFF
--- a/doc/classes/CullInstance.xml
+++ b/doc/classes/CullInstance.xml
@@ -15,6 +15,11 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="autoplace_priority" type="int" setter="set_portal_autoplace_priority" getter="get_portal_autoplace_priority" default="0">
+			When set to [code]0[/code], [CullInstance]s will be autoplaced in the [Room] with the highest priority.
+			When set to a value other than [code]0[/code], the system will attempt to autoplace in a [Room] with the [code]autoplace_priority[/code], if it is present.
+			This can be used to control autoplacement of building exteriors in an outer [RoomGroup].
+		</member>
 		<member name="include_in_bound" type="bool" setter="set_include_in_bound" getter="get_include_in_bound" default="true">
 			When a manual bound has not been explicitly specified for a [Room], the convex hull bound will be estimated from the geometry of the objects within the room. This setting determines whether the geometry of an object is included in this estimate of the room bound.
 			[b]Note:[/b] This setting is only relevant when the object is set to [code]PORTAL_MODE_STATIC[/code] or [code]PORTAL_MODE_DYNAMIC[/code], and for [Portal]s.

--- a/scene/3d/cull_instance.cpp
+++ b/scene/3d/cull_instance.cpp
@@ -48,6 +48,9 @@ void CullInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_include_in_bound"), &CullInstance::set_include_in_bound);
 	ClassDB::bind_method(D_METHOD("get_include_in_bound"), &CullInstance::get_include_in_bound);
 
+	ClassDB::bind_method(D_METHOD("set_portal_autoplace_priority", "priority"), &CullInstance::set_portal_autoplace_priority);
+	ClassDB::bind_method(D_METHOD("get_portal_autoplace_priority"), &CullInstance::get_portal_autoplace_priority);
+
 	ADD_GROUP("Portals", "");
 
 	BIND_ENUM_CONSTANT(PORTAL_MODE_STATIC);
@@ -58,9 +61,11 @@ void CullInstance::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "portal_mode", PROPERTY_HINT_ENUM, "Static,Dynamic,Roaming,Global,Ignore"), "set_portal_mode", "get_portal_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "include_in_bound"), "set_include_in_bound", "get_include_in_bound");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "autoplace_priority", PROPERTY_HINT_RANGE, "-16,16,1", PROPERTY_USAGE_DEFAULT), "set_portal_autoplace_priority", "get_portal_autoplace_priority");
 }
 
 CullInstance::CullInstance() {
 	_portal_mode = PORTAL_MODE_STATIC;
 	_include_in_bound = true;
+	_portal_autoplace_priority = 0;
 }

--- a/scene/3d/cull_instance.h
+++ b/scene/3d/cull_instance.h
@@ -51,6 +51,9 @@ public:
 	void set_include_in_bound(bool p_enable) { _include_in_bound = p_enable; }
 	bool get_include_in_bound() const { return _include_in_bound; }
 
+	void set_portal_autoplace_priority(int p_priority) { _portal_autoplace_priority = p_priority; }
+	int get_portal_autoplace_priority() const { return _portal_autoplace_priority; }
+
 	CullInstance();
 
 protected:
@@ -61,6 +64,14 @@ protected:
 private:
 	PortalMode _portal_mode;
 	bool _include_in_bound;
+
+	// Allows instances to prefer to be autoplaced
+	// in specific RoomGroups. This allows building exteriors
+	// to be autoplaced in outside RoomGroups, allowing a complete
+	// exterior / interior of building in one reusable Scene.
+	// The default value 0 gives no preference (chooses the highest priority).
+	// All other values will autoplace in the selected RoomGroup priority by preference.
+	int _portal_autoplace_priority;
 };
 
 #endif

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -1121,13 +1121,25 @@ bool RoomManager::_autoplace_object(VisualInstance *p_vi) {
 	int best_priority = -INT32_MAX;
 	Room *best_room = nullptr;
 
+	// if not set to zero (no preference) this can override a preference
+	// for a certain RoomGroup priority to ensure the instance gets placed in the correct
+	// RoomGroup (e.g. outside, for building exteriors)
+	int preferred_priority = p_vi->get_portal_autoplace_priority();
+
 	for (int n = 0; n < _rooms.size(); n++) {
 		Room *room = _rooms[n];
 
 		if (room->contains_point(centre)) {
+			// the standard routine autoplaces in the highest priority room
 			if (room->_room_priority > best_priority) {
 				best_priority = room->_room_priority;
 				best_room = room;
+			}
+
+			// if we override the preferred priority we always choose this
+			if (preferred_priority && (room->_room_priority == preferred_priority)) {
+				best_room = room;
+				break;
 			}
 		}
 	}

--- a/servers/visual/portals/portal_renderer.cpp
+++ b/servers/visual/portals/portal_renderer.cpp
@@ -240,12 +240,13 @@ void PortalRenderer::portal_destroy(PortalHandle p_portal) {
 	_portal_pool.free(p_portal);
 }
 
-void PortalRenderer::portal_set_geometry(PortalHandle p_portal, const Vector<Vector3> &p_points) {
+void PortalRenderer::portal_set_geometry(PortalHandle p_portal, const Vector<Vector3> &p_points, real_t p_margin) {
 	ERR_FAIL_COND(!p_portal);
 	p_portal--; // plus 1 based
 	VSPortal &portal = _portal_pool[p_portal];
 
 	portal._pts_world = p_points;
+	portal._margin = p_margin;
 
 	if (portal._pts_world.size() < 3) {
 		WARN_PRINT("Portal must have at least 3 vertices");

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -132,7 +132,7 @@ public:
 
 	PortalHandle portal_create();
 	void portal_destroy(PortalHandle p_portal);
-	void portal_set_geometry(PortalHandle p_portal, const Vector<Vector3> &p_points);
+	void portal_set_geometry(PortalHandle p_portal, const Vector<Vector3> &p_points, real_t p_margin);
 	void portal_link(PortalHandle p_portal, RoomHandle p_room_from, RoomHandle p_room_to, bool p_two_way);
 	void portal_set_active(PortalHandle p_portal, bool p_active);
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -567,7 +567,7 @@ public:
 
 	BIND0R(RID, portal_create)
 	BIND2(portal_set_scenario, RID, RID)
-	BIND3(portal_set_geometry, RID, const Vector<Vector3> &, float)
+	BIND3(portal_set_geometry, RID, const Vector<Vector3> &, real_t)
 	BIND4(portal_link, RID, RID, RID, bool)
 	BIND2(portal_set_active, RID, bool)
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1006,11 +1006,11 @@ void VisualServerScene::portal_set_scenario(RID p_portal, RID p_scenario) {
 	}
 }
 
-void VisualServerScene::portal_set_geometry(RID p_portal, const Vector<Vector3> &p_points, float p_margin) {
+void VisualServerScene::portal_set_geometry(RID p_portal, const Vector<Vector3> &p_points, real_t p_margin) {
 	Portal *portal = portal_owner.getornull(p_portal);
 	ERR_FAIL_COND(!portal);
 	ERR_FAIL_COND(!portal->scenario);
-	portal->scenario->_portal_renderer.portal_set_geometry(portal->scenario_portal_id, p_points);
+	portal->scenario->_portal_renderer.portal_set_geometry(portal->scenario_portal_id, p_points, p_margin);
 }
 
 void VisualServerScene::portal_link(RID p_portal, RID p_room_from, RID p_room_to, bool p_two_way) {

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -593,7 +593,7 @@ public:
 
 	virtual RID portal_create();
 	virtual void portal_set_scenario(RID p_portal, RID p_scenario);
-	virtual void portal_set_geometry(RID p_portal, const Vector<Vector3> &p_points, float p_margin);
+	virtual void portal_set_geometry(RID p_portal, const Vector<Vector3> &p_points, real_t p_margin);
 	virtual void portal_link(RID p_portal, RID p_room_from, RID p_room_to, bool p_two_way);
 	virtual void portal_set_active(RID p_portal, bool p_active);
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -490,7 +490,7 @@ public:
 
 	FUNCRID(portal)
 	FUNC2(portal_set_scenario, RID, RID)
-	FUNC3(portal_set_geometry, RID, const Vector<Vector3> &, float)
+	FUNC3(portal_set_geometry, RID, const Vector<Vector3> &, real_t)
 	FUNC4(portal_link, RID, RID, RID, bool)
 	FUNC2(portal_set_active, RID, bool)
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -874,7 +874,7 @@ public:
 
 	virtual RID portal_create() = 0;
 	virtual void portal_set_scenario(RID p_portal, RID p_scenario) = 0;
-	virtual void portal_set_geometry(RID p_portal, const Vector<Vector3> &p_points, float p_margin) = 0;
+	virtual void portal_set_geometry(RID p_portal, const Vector<Vector3> &p_points, real_t p_margin) = 0;
 	virtual void portal_link(RID p_portal, RID p_room_from, RID p_room_to, bool p_two_way) = 0;
 	virtual void portal_set_active(RID p_portal, bool p_active) = 0;
 


### PR DESCRIPTION
## Autoplace priority
The default autoplace algorithm places instances in the highest priority Room. It became apparent that there are some situations in which users will want to override this and force placement in a Room from a particular RoomGroup, especially an "outside" RoomGroup.

This setting allows the user to specify a preference for Room priority. When set to 0, the setting is ignored and the highest priority Room is chosen.

## Portal Margin
Fixes margins not being sent correctly to the VisualServer (only the default value for margin (1.0) was actually being used).

## Notes
While developing the terrain portalling demo I noticed an important quality of life improvement. The primary use for internal rooms is to place buildings with terrain Rooms. To do this the most convenient way is to have a tscn file for a building, containing both a Room containing the building interior, and a MeshInstance (or several) for the building exterior.

With this 'single tscn file' approach we are relying on autoplace to place the exterior of the building into the terrain Room. The problem is, that the centre of the exterior building is *inside* the interior building room, and it gets autoplaced there. This means the exterior doesn't get rendered when you are outside.

It is possible to get around this by explicitly placing exteriors in the terrain Room, but this is not very convenient for users. So a way around this problem is to allow any CullInstance to _override_ the choice of RoomGroup, by setting a preferred RoomGroup priority.

I've tried this out and it works well in practice, it is very simple to make e.g. a house with interior and exterior in a tscn file, and duplicate it multiple times in a main scene within a terrain, and get occlusion culled buildings for very little effort.

I'm trying to keep the variables stored in CullInstance to a minimum, simply because all VisualInstances derive from this. However in this case I couldn't see an easy way around the desire to express a preference _per mesh_, without putting the setting here.

It is also possible to have two settings, including an additional one to switch this on and off, so we could use RoomGroup 0 in the functionality. On balance though to prevent settings creep I suspect it would be better to do it all with one setting. It's fairly easy for users to ensure they aren't using priority zero if they want to use this functionality. Another possibility would be to set the default value to something like -32, or some hard coded value, but zero is easy to remember as _off_.

* Let me know any better ideas for achieving this
* I would appreciate a second opinion on the setting naming

_Example house scene which can easily be placed on terrain. Note the House_exterior mesh for autoplacement into the outside, and the pre-prepared internal room containing the interior, portal (for autolinking) and other meshes._
![house_scene](https://user-images.githubusercontent.com/21999379/127362527-62b38807-53b0-4de6-87ad-15cfead458e2.png)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
