### PR TITLE
Expose Vulkan's clustered and mobile backends in the project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -474,13 +474,7 @@ private:
 						return;
 					}
 					ProjectSettings::CustomMap initial_settings;
-					if (rasterizer_button_group->get_pressed_button()->get_meta("driver_name") == "Vulkan") {
-						initial_settings["rendering/driver/driver_name"] = "Vulkan";
-					} else {
-						initial_settings["rendering/driver/driver_name"] = "GLES2";
-						initial_settings["rendering/textures/vram_compression/import_etc2"] = false;
-						initial_settings["rendering/textures/vram_compression/import_etc"] = true;
-					}
+					initial_settings["rendering/vulkan/rendering/back_end"] = rasterizer_button_group->get_pressed_button()->get_meta(SNAME("driver_name"));
 					initial_settings["application/config/name"] = project_name->get_text().strip_edges();
 					initial_settings["application/config/icon"] = "res://icon.png";
 					initial_settings["rendering/environment/defaults/default_environment"] = "res://default_env.tres";
@@ -869,37 +863,36 @@ public:
 		rshb->add_child(rvb);
 		Button *rs_button = memnew(CheckBox);
 		rs_button->set_button_group(rasterizer_button_group);
-		rs_button->set_text(TTR("Vulkan"));
-		rs_button->set_meta("driver_name", "Vulkan");
+		rs_button->set_text(TTR("Vulkan Clustered"));
+		rs_button->set_meta(SNAME("driver_name"), 0); // Vulkan backend "Forward Clustered"
 		rs_button->set_pressed(true);
 		rvb->add_child(rs_button);
 		l = memnew(Label);
-		l->set_text(TTR("- Higher visual quality\n- More accurate API, which produces very fast code\n- Some features not implemented yet - work in progress\n- Incompatible with older hardware\n- Not recommended for web and mobile games"));
+		l->set_text(
+				String::utf8("•  ") + TTR("Supports desktop platforms only.") +
+				String::utf8("\n•  ") + TTR("Advanced 3D graphics available.") +
+				String::utf8("\n•  ") + TTR("Can scale to large complex scenes.") +
+				String::utf8("\n•  ") + TTR("Slower rendering of simple scenes."));
 		l->set_modulate(Color(1, 1, 1, 0.7));
 		rvb->add_child(l);
 
 		rshb->add_child(memnew(VSeparator));
-
-		const String gles2_unsupported_tooltip =
-				TTR("The GLES2 renderer is currently unavailable, as it needs to be reworked for Godot 4.0.\nUse Godot 3.2 if you need GLES2 support.");
 
 		rvb = memnew(VBoxContainer);
 		rvb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		rshb->add_child(rvb);
 		rs_button = memnew(CheckBox);
 		rs_button->set_button_group(rasterizer_button_group);
-		rs_button->set_text(TTR("OpenGL ES 2.0 (currently unavailable)"));
-		rs_button->set_meta("driver_name", "GLES2");
-		rs_button->set_disabled(true);
-		rs_button->set_tooltip(gles2_unsupported_tooltip);
+		rs_button->set_text(TTR("Vulkan Mobile"));
+		rs_button->set_meta(SNAME("driver_name"), 1); // Vulkan backend "Forward Mobile"
 		rvb->add_child(rs_button);
 		l = memnew(Label);
-		l->set_text(TTR("- Lower visual quality\n- Some features not available\n- Works on most hardware\n- Recommended for web and mobile games"));
+		l->set_text(
+				String::utf8("•  ") + TTR("Supports desktop + mobile platforms.") +
+				String::utf8("\n•  ") + TTR("Less advanced 3D graphics.") +
+				String::utf8("\n•  ") + TTR("Less scalable for complex scenes.") +
+				String::utf8("\n•  ") + TTR("Faster rendering of simple scenes."));
 		l->set_modulate(Color(1, 1, 1, 0.7));
-		// Also set the tooltip on the label so it appears when hovering either the checkbox or label.
-		l->set_tooltip(gles2_unsupported_tooltip);
-		// Required for the tooltip to show.
-		l->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 		rvb->add_child(l);
 
 		l = memnew(Label);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2763,12 +2763,12 @@ RenderingServer::RenderingServer() {
 
 	GLOBAL_DEF("rendering/2d/shadow_atlas/size", 2048);
 
-	GLOBAL_DEF_RST("rendering/vulkan/rendering/back_end", 0);
-	GLOBAL_DEF_RST("rendering/vulkan/rendering/back_end.mobile", 1);
+	GLOBAL_DEF_RST_BASIC("rendering/vulkan/rendering/back_end", 0);
+	GLOBAL_DEF_RST_BASIC("rendering/vulkan/rendering/back_end.mobile", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/vulkan/rendering/back_end",
 			PropertyInfo(Variant::INT,
 					"rendering/vulkan/rendering/back_end",
-					PROPERTY_HINT_ENUM, "ForwardClustered,ForwardMobile"));
+					PROPERTY_HINT_ENUM, "Forward Clustered (Supports Desktop Only),Forward Mobile (Supports Desktop and Mobile)"));
 
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/enabled", true);
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/compress", true);


### PR DESCRIPTION
Since [OpenGL will not be available in Godot 4.0](https://godotengine.org/article/about-godot4-vulkan-gles3-and-gles2) (but only in a future 4.x release), this exposes a choice between Vulkan clustered and Vulkan mobile in the project manager.

Despite the name, Vulkan mobile has many benefits on desktop platforms. It provides better performance on simple scenes, and ensures that you won't accidentally use unsupported features while testing your project on desktop platforms.

The Vulkan backend setting was made into a "basic" setting so that it can be changed without having to enable the Advanced Settings toggle.

This also improves list formatting to use bullet points and tweaks the property hint to be more descriptive.

## Preview

![image](https://user-images.githubusercontent.com/180032/127376189-fee3d844-98d4-4216-b9ca-4c7529ef646e.png)