### PR TITLE
Fix duplicate shortcut for paint and erase in TileMap editor

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -1756,7 +1756,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	paint_tool_button->set_flat(true);
 	paint_tool_button->set_toggle_mode(true);
 	paint_tool_button->set_button_group(tool_buttons_group);
-	paint_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/paint_tool", "Paint", KEY_E));
+	paint_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/paint_tool", "Paint", KEY_D));
 	paint_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(paint_tool_button);
 


### PR DESCRIPTION
This pull request fixes an issue where the paint and erase tools in the TileMap editor had the same shortcut (E). The erase tool having "E" be its shortcut makes more sense than the paint tool having that be its shortcut. So I changed the paint tool's shortcut to be "D" since nothing else uses it.

![shortcut](https://user-images.githubusercontent.com/62965063/127399429-cd9deaea-2eeb-4c2d-9a42-d38c2e3cc14e.jpg)

Resolves: #50974