### PR TITLE
Disable open doc button when not inspecting anything

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -409,6 +409,7 @@ void InspectorDock::update(Object *p_object) {
 	current = p_object;
 
 	if (!p_object) {
+		open_docs_button->set_disabled(true);
 		object_menu->set_disabled(true);
 		warning->hide();
 		search->set_editable(false);
@@ -424,7 +425,7 @@ void InspectorDock::update(Object *p_object) {
 	editor_path->enable_path();
 
 	resource_save_button->set_disabled(!is_resource);
-	open_docs_button->set_visible(is_resource || is_node);
+	open_docs_button->set_disabled(!is_resource && !is_node);
 
 	PopupMenu *resource_extra_popup = resource_extra_button->get_popup();
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_COPY), !is_resource);
@@ -575,7 +576,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 
 	open_docs_button = memnew(Button);
 	open_docs_button->set_flat(true);
-	open_docs_button->set_visible(false);
+	open_docs_button->set_disabled(true);
 	open_docs_button->set_tooltip(TTR("Open documentation for this object."));
 	open_docs_button->set_icon(get_theme_icon(SNAME("HelpSearch"), SNAME("EditorIcons")));
 	open_docs_button->set_shortcut(ED_SHORTCUT("property_editor/open_help", TTR("Open Documentation")));


### PR DESCRIPTION
The button is hidden initially (and will also be hidden when the current object is not `Resource` or `Node` according to the code):
![initial](https://user-images.githubusercontent.com/372476/127425437-9820bfa8-5f5b-41a5-a78c-5651a3cda0a4.png)

The button will become visible when something is selected:
![inspecting](https://user-images.githubusercontent.com/372476/127425443-3b8915e5-e2c1-44f0-ac56-d94267e49089.png)

But after deselecting, the button remains visible. Clicking it has no effect.
![deselect](https://user-images.githubusercontent.com/372476/127425449-b1489a1b-09f0-422e-9e59-5193cb025263.png)

This PR disables the button in the first and last case.