### PR TITLE
Add script to make source tarball with `.git/HEAD`

### DIFF
--- a/misc/scripts/make_tarball.sh
+++ b/misc/scripts/make_tarball.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+if [ ! -e "version.py" ]; then
+  echo "This script should be ran from the root folder of the Godot repository."
+  exit 1
+fi
+
+while getopts "h?sv:g:" opt; do
+  case "$opt" in
+  h|\?)
+    echo "Usage: $0 [OPTIONS...]"
+    echo
+    echo "  -s script friendly file name (godot.tar.gz)"
+    echo "  -v godot version for file name (e.g. 4.0-stable)"
+    echo "  -g git treeish to archive (e.g. master)"
+    echo
+    exit 1
+    ;;
+  s)
+    script_friendly_name=1
+    ;;
+  v)
+    godot_version=$OPTARG
+    ;;
+  g)
+    git_treeish=$OPTARG
+    ;;
+  esac
+done
+
+if [ ! -z "$git_treeish" ]; then
+  HEAD=$(git rev-parse $git_treeish)
+else
+  HEAD=$(git rev-parse HEAD)
+fi
+
+if [ ! -z "$script_friendly_name" ]; then
+  NAME=godot
+else
+  if [ ! -z "$godot_version" ]; then
+    NAME=godot-$godot_version
+  else
+    NAME=godot-$HEAD
+  fi
+fi
+
+CURDIR=$(pwd)
+TMPDIR=$(mktemp -d -t godot-XXXXXX)
+
+echo "Generating tarball for revision $HEAD with folder name '$NAME'."
+echo
+echo "The tarball will be written to the parent folder:"
+echo "    $(dirname $CURDIR)/$NAME.tar.gz"
+
+git archive $HEAD --prefix=$NAME/ -o $TMPDIR/$NAME.tar
+
+# Adding custom .git/HEAD to tarball so that we can generate VERSION_HASH.
+cd $TMPDIR
+mkdir -p $NAME/.git
+echo $HEAD > $NAME/.git/HEAD
+tar -uf $NAME.tar $NAME
+
+cd $CURDIR
+gzip -c $TMPDIR/$NAME.tar > ../$NAME.tar.gz
+
+rm -rf $TMPDIR


### PR DESCRIPTION
This allows to generate the `VERSION_HASH` constant with the Git commit hash
even when building from a source tarball which is not a Git repository (and
without dependency on Git itself).

Specifically, `git/HEAD` is parsed by [methods.py](https://github.com/godotengine/godot/blob/master/methods.py#L98-L110) which is used to define `VERSION_HASH` in `core/version_hash.gen.h`.

Not having this file in tarballs was the reason why official builds lack information on their source commit.