### PR TITLE
Allow overriding `VERSION_STATUS` with `GODOT_VERSION_STATUS` in env

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -61,10 +61,9 @@ def add_module_version_string(self, s):
 
 
 def update_version(module_version_string=""):
-
     build_name = "custom_build"
     if os.getenv("BUILD_NAME") != None:
-        build_name = os.getenv("BUILD_NAME")
+        build_name = str(os.getenv("BUILD_NAME"))
         print("Using custom build name: " + build_name)
 
     import version
@@ -79,7 +78,13 @@ def update_version(module_version_string=""):
     f.write("#define VERSION_MAJOR " + str(version.major) + "\n")
     f.write("#define VERSION_MINOR " + str(version.minor) + "\n")
     f.write("#define VERSION_PATCH " + str(version.patch) + "\n")
-    f.write('#define VERSION_STATUS "' + str(version.status) + '"\n')
+    # For dev snapshots (alpha, beta, RC, etc.) we do not commit status change to Git,
+    # so this define provides a way to override it without having to modify the source.
+    godot_status = str(version.status)
+    if os.getenv("GODOT_VERSION_STATUS") != None:
+        godot_status = str(os.getenv("GODOT_VERSION_STATUS"))
+        print("Using version status '%s', overriding the original '%s'.".format(godot_status, str(version.status)))
+    f.write('#define VERSION_STATUS "' + godot_status + '"\n')
     f.write('#define VERSION_BUILD "' + str(build_name) + '"\n')
     f.write('#define VERSION_MODULE_CONFIG "' + str(version.module_config) + module_version_string + '"\n')
     f.write("#define VERSION_YEAR " + str(version.year) + "\n")


### PR DESCRIPTION
`VERSION_STATUS` is part of what constitutes the reference version for a given
Godot build, and is part of the version check for compatible export templates.

For dev snapshots (alpha, beta, RCs), we usually set the `VERSION_STATUS` to
a specific build number (e.g. `beta2`), but this change doesn't end up
committed to the Git repository as we don't want to keep changing `version.py`
for testing builds.

So this new environment override will be what can be used in official builds
and by users making custom builds for specific snapshots.

---

Together with #51001, this means that official builds can now be properly named
`3.4.beta2.official.a71169c0e`, and users have a guarantee that this build did
use a71169c0e without any custom changes. The only changes which make it special
are `BUILD_NAME=official` and `GODOT_VERSION_STATUS=beta2`, which users can
define themselves for custom builds (well, please don't use `BUILD_NAME=official`
for custom builds as it defeats its purpose ;)).

On the other hand, it means that the tarballs we distribute do not include e.g.
`beta2` in `version.py`, and users *must* set `GODOT_VERSION_STATUS` if they want
to build a custom `beta2` from that tarball.

The "previous" workflow of directly editing `version.py` to set the values one
wants is still possible of course.