### PR TITLE
[Net] Implement RPC channels in MultiplayerAPI.

### DIFF
--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -132,7 +132,7 @@ public:
 	Node *get_root_node();
 	void set_network_peer(const Ref<MultiplayerPeer> &p_peer);
 	Ref<MultiplayerPeer> get_network_peer() const;
-	Error send_bytes(Vector<uint8_t> p_data, int p_to = MultiplayerPeer::TARGET_PEER_BROADCAST, MultiplayerPeer::TransferMode p_mode = MultiplayerPeer::TRANSFER_MODE_RELIABLE);
+	Error send_bytes(Vector<uint8_t> p_data, int p_to = MultiplayerPeer::TARGET_PEER_BROADCAST, MultiplayerPeer::TransferMode p_mode = MultiplayerPeer::TRANSFER_MODE_RELIABLE, int p_channel = 0);
 
 	// Called by Node.rpc
 	void rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const StringName &p_method, const Variant **p_arg, int p_argcount);

--- a/core/io/multiplayer_peer.cpp
+++ b/core/io/multiplayer_peer.cpp
@@ -54,6 +54,8 @@ uint32_t MultiplayerPeer::generate_unique_id() const {
 }
 
 void MultiplayerPeer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_transfer_channel", "channel"), &MultiplayerPeer::set_transfer_channel);
+	ClassDB::bind_method(D_METHOD("get_transfer_channel"), &MultiplayerPeer::get_transfer_channel);
 	ClassDB::bind_method(D_METHOD("set_transfer_mode", "mode"), &MultiplayerPeer::set_transfer_mode);
 	ClassDB::bind_method(D_METHOD("get_transfer_mode"), &MultiplayerPeer::get_transfer_mode);
 	ClassDB::bind_method(D_METHOD("set_target_peer", "id"), &MultiplayerPeer::set_target_peer);
@@ -71,6 +73,7 @@ void MultiplayerPeer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_connections"), "set_refuse_new_connections", "is_refusing_new_connections");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transfer_mode", PROPERTY_HINT_ENUM, "Unreliable,Unreliable Ordered,Reliable"), "set_transfer_mode", "get_transfer_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "transfer_channel", PROPERTY_HINT_RANGE, "0,255,1"), "set_transfer_channel", "get_transfer_channel");
 
 	BIND_ENUM_CONSTANT(TRANSFER_MODE_UNRELIABLE);
 	BIND_ENUM_CONSTANT(TRANSFER_MODE_UNRELIABLE_ORDERED);

--- a/core/io/multiplayer_peer.h
+++ b/core/io/multiplayer_peer.h
@@ -56,6 +56,8 @@ public:
 		CONNECTION_CONNECTED,
 	};
 
+	virtual void set_transfer_channel(int p_channel) = 0;
+	virtual int get_transfer_channel() const = 0;
 	virtual void set_transfer_mode(TransferMode p_mode) = 0;
 	virtual TransferMode get_transfer_mode() const = 0;
 	virtual void set_target_peer(int p_peer_id) = 0;

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -61,6 +61,7 @@
 			<argument index="0" name="bytes" type="PackedByteArray" />
 			<argument index="1" name="id" type="int" default="0" />
 			<argument index="2" name="mode" type="int" enum="MultiplayerPeer.TransferMode" default="2" />
+			<argument index="3" name="channel" type="int" default="0" />
 			<description>
 				Sends the given raw [code]bytes[/code] to a specific peer identified by [code]id[/code] (see [method MultiplayerPeer.set_target_peer]). Default ID is [code]0[/code], i.e. broadcast to all peers.
 			</description>

--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -55,6 +55,10 @@
 		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" default="true">
 			If [code]true[/code], this [MultiplayerPeer] refuses new connections.
 		</member>
+		<member name="transfer_channel" type="int" setter="set_transfer_channel" getter="get_transfer_channel" default="0">
+			The channel to use to send packets. Many network APIs such as ENet and WebRTC allow the creation of multiple independent channels which behaves, in a way, like separate connections. This means that reliable data will only block delivery of other packets on that channel, and ordering will only be in respect to the channel the packet is being sent on. Using different channels to send [b]different and independent[/b] state updates is a common way to optimize network usage and decrease latency in fast-paced games.
+			[b]Note:[/b] The default channel ([code]0[/code]) actually works as 3 separate channels (one for each [enum TransferMode]) so that [constant TRANSFER_MODE_RELIABLE] and [constant TRANSFER_MODE_UNRELIABLE_ORDERED] does not interact with each other by default. Refer to the specific network API documentation (e.g. ENet or WebRTC) to learn how to set up channels correctly.
+		</member>
 		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" enum="MultiplayerPeer.TransferMode" default="0">
 			The manner in which to send packets to the [code]target_peer[/code]. See [enum TransferMode].
 		</member>

--- a/modules/enet/enet_multiplayer_peer.h
+++ b/modules/enet/enet_multiplayer_peer.h
@@ -47,10 +47,10 @@ private:
 	};
 
 	enum {
-		SYSCH_CONFIG,
-		SYSCH_RELIABLE,
-		SYSCH_UNRELIABLE,
-		SYSCH_MAX
+		SYSCH_CONFIG = 0,
+		SYSCH_RELIABLE = 1,
+		SYSCH_UNRELIABLE = 2,
+		SYSCH_MAX = 3
 	};
 
 	enum Mode {
@@ -65,6 +65,7 @@ private:
 	uint32_t unique_id = 0;
 
 	int target_peer = 0;
+	int transfer_channel = 0;
 	TransferMode transfer_mode = TRANSFER_MODE_RELIABLE;
 
 	bool refuse_connections = false;
@@ -100,6 +101,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void set_transfer_channel(int p_channel) override;
+	virtual int get_transfer_channel() const override;
+
 	virtual void set_transfer_mode(TransferMode p_mode) override;
 	virtual TransferMode get_transfer_mode() const override;
 	virtual void set_target_peer(int p_peer) override;

--- a/modules/gdnative/include/net/godot_net.h
+++ b/modules/gdnative/include/net/godot_net.h
@@ -91,6 +91,8 @@ typedef struct {
 	godot_int (*get_max_packet_size)(const void *);
 
 	/* This is MultiplayerPeer */
+	void (*set_transfer_channel)(void *, godot_int);
+	godot_int (*get_transfer_channel)(void *);
 	void (*set_transfer_mode)(void *, godot_int);
 	godot_int (*get_transfer_mode)(const void *);
 	// 0 = broadcast, 1 = server, <0 = all but abs(value)

--- a/modules/gdnative/net/multiplayer_peer_gdnative.cpp
+++ b/modules/gdnative/net/multiplayer_peer_gdnative.cpp
@@ -62,6 +62,16 @@ int MultiplayerPeerGDNative::get_available_packet_count() const {
 }
 
 /* MultiplayerPeer */
+void MultiplayerPeerGDNative::set_transfer_channel(int p_channel) {
+	ERR_FAIL_COND(interface == nullptr);
+	return interface->set_transfer_channel(interface->data, p_channel);
+}
+
+int MultiplayerPeerGDNative::get_transfer_channel() const {
+	ERR_FAIL_COND_V(interface == nullptr, 0);
+	return interface->get_transfer_channel(interface->data);
+}
+
 void MultiplayerPeerGDNative::set_transfer_mode(TransferMode p_mode) {
 	ERR_FAIL_COND(interface == nullptr);
 	interface->set_transfer_mode(interface->data, (godot_int)p_mode);
@@ -113,6 +123,7 @@ MultiplayerPeer::ConnectionStatus MultiplayerPeerGDNative::get_connection_status
 }
 
 void MultiplayerPeerGDNative::_bind_methods() {
+	ADD_PROPERTY_DEFAULT("transfer_channel", 0);
 	ADD_PROPERTY_DEFAULT("transfer_mode", TRANSFER_MODE_UNRELIABLE);
 	ADD_PROPERTY_DEFAULT("refuse_new_connections", true);
 }

--- a/modules/gdnative/net/multiplayer_peer_gdnative.h
+++ b/modules/gdnative/net/multiplayer_peer_gdnative.h
@@ -56,6 +56,8 @@ public:
 	virtual int get_available_packet_count() const override;
 
 	/* Specific to MultiplayerPeer */
+	virtual void set_transfer_channel(int p_channel) override;
+	virtual int get_transfer_channel() const override;
 	virtual void set_transfer_mode(TransferMode p_mode) override;
 	virtual TransferMode get_transfer_mode() const override;
 	virtual void set_target_peer(int p_peer_id) override;

--- a/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
+++ b/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
@@ -51,10 +51,12 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="peer_id" type="int" />
 			<argument index="1" name="server_compatibility" type="bool" default="false" />
+			<argument index="2" name="channels_config" type="Array" default="[]" />
 			<description>
 				Initialize the multiplayer peer with the given [code]peer_id[/code] (must be between 1 and 2147483647).
 				If [code]server_compatibilty[/code] is [code]false[/code] (default), the multiplayer peer will be immediately in state [constant MultiplayerPeer.CONNECTION_CONNECTED] and [signal MultiplayerPeer.connection_succeeded] will not be emitted.
 				If [code]server_compatibilty[/code] is [code]true[/code] the peer will suppress all [signal MultiplayerPeer.peer_connected] signals until a peer with id [constant MultiplayerPeer.TARGET_PEER_SERVER] connects and then emit [signal MultiplayerPeer.connection_succeeded]. After that the signal [signal MultiplayerPeer.peer_connected] will be emitted for every already connected peer, and any new peer that might connect. If the server peer disconnects after that, signal [signal MultiplayerPeer.server_disconnected] will be emitted and state will become [constant MultiplayerPeer.CONNECTION_CONNECTED].
+				You can optionally specify a [code]channels_config[/code] array of [enum MultiplayerPeer.TransferMode] which will be used to create extra channels (WebRTC only supports one transfer mode per channel).
 			</description>
 		</method>
 		<method name="remove_peer">

--- a/modules/webrtc/webrtc_multiplayer_peer.h
+++ b/modules/webrtc/webrtc_multiplayer_peer.h
@@ -62,25 +62,27 @@ private:
 		}
 	};
 
-	uint32_t unique_id;
-	int target_peer;
-	int client_count;
-	bool refuse_connections;
-	ConnectionStatus connection_status;
-	TransferMode transfer_mode;
-	int next_packet_peer;
-	bool server_compat;
+	uint32_t unique_id = 0;
+	int target_peer = 0;
+	int client_count = 0;
+	bool refuse_connections = false;
+	ConnectionStatus connection_status = CONNECTION_DISCONNECTED;
+	int transfer_channel = 0;
+	TransferMode transfer_mode = TRANSFER_MODE_RELIABLE;
+	int next_packet_peer = 0;
+	bool server_compat = false;
 
 	Map<int, Ref<ConnectedPeer>> peer_map;
+	List<Dictionary> channels_config;
 
 	void _peer_to_dict(Ref<ConnectedPeer> p_connected_peer, Dictionary &r_dict);
 	void _find_next_peer();
 
 public:
-	WebRTCMultiplayerPeer();
+	WebRTCMultiplayerPeer() {}
 	~WebRTCMultiplayerPeer();
 
-	Error initialize(int p_self_id, bool p_server_compat = false);
+	Error initialize(int p_self_id, bool p_server_compat = false, Array p_channels_config = Array());
 	Error add_peer(Ref<WebRTCPeerConnection> p_peer, int p_peer_id, int p_unreliable_lifetime = 1);
 	void remove_peer(int p_peer_id);
 	bool has_peer(int p_peer_id);
@@ -95,6 +97,8 @@ public:
 	int get_max_packet_size() const override;
 
 	// MultiplayerPeer
+	void set_transfer_channel(int p_channel) override;
+	int get_transfer_channel() const override;
 	void set_transfer_mode(TransferMode p_mode) override;
 	TransferMode get_transfer_mode() const override;
 	void set_target_peer(int p_peer_id) override;

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -105,6 +105,14 @@ Error WebSocketMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer
 //
 // MultiplayerPeer
 //
+void WebSocketMultiplayerPeer::set_transfer_channel(int p_channel) {
+	// Websocket does not have channels.
+}
+
+int WebSocketMultiplayerPeer::get_transfer_channel() const {
+	return 0;
+}
+
 void WebSocketMultiplayerPeer::set_transfer_mode(TransferMode p_mode) {
 	// Websocket uses TCP, reliable
 }

--- a/modules/websocket/websocket_multiplayer_peer.h
+++ b/modules/websocket/websocket_multiplayer_peer.h
@@ -78,6 +78,8 @@ protected:
 
 public:
 	/* MultiplayerPeer */
+	void set_transfer_channel(int p_channel) override;
+	int get_transfer_channel() const override;
 	void set_transfer_mode(TransferMode p_mode) override;
 	TransferMode get_transfer_mode() const override;
 	void set_target_peer(int p_target_peer) override;


### PR DESCRIPTION
In this PR:
- Add `transfer_channel` property to `MultiplayerPeer`.
- Implement `transfer_channel` in `ENetMultiplayerPeer` (tested) and `WebRTCMultiplayerPeer` (untested*).
- `MultiplayerAPI` uses `MultiplayerPeer.transfer_channel` based on RPC configuration.

**Note**: The default channel (`0`) is actually implemented in both `ENet` and `WebRTC` as 3 separate channels (one for each transfer mode). The reason for this in `WebRTC` is that transfer mode must be configured per channel (you can't have a channel that sends some packets unreliable and some other reliable). In `ENet`, I just assumed that for people who "just prototypes" it makes sense (would be somehow expected) without knowing about channels, that `reliable` RPCs are independent from `ordered` RPCs (this is documented in the `transfer_channel` property).

`(*)` sadly, GDNative does not work yet, and the JavaScript platform is really tricky to interact with, given it has no rendering, so I couldn't test WebRTC