### PR TITLE
Name nodes added when drag & dropping an image by `name_casing`

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5780,7 +5780,22 @@ bool CanvasItemEditorViewport::_cyclical_dependency_exists(const String &p_targe
 }
 
 void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &path, const Point2 &p_point) {
-	child->set_name(path.get_file().get_basename());
+	// Adjust casing according to project setting. The file name is expected to be in snake_case, but will work for others.
+	String name = path.get_file().get_basename();
+	switch (ProjectSettings::get_singleton()->get("editor/node_naming/name_casing").operator int()) {
+		case NAME_CASING_PASCAL_CASE:
+			name = name.capitalize().replace(" ", "");
+			break;
+		case NAME_CASING_CAMEL_CASE:
+			name = name.capitalize().replace(" ", "");
+			name[0] = name.to_lower()[0];
+			break;
+		case NAME_CASING_SNAKE_CASE:
+			name = name.capitalize().replace(" ", "_").to_lower();
+			break;
+	}
+	child->set_name(name);
+
 	Ref<Texture2D> texture = Ref<Texture2D>(Object::cast_to<Texture2D>(ResourceCache::get(path)));
 	Size2 texture_size = texture->get_size();
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -67,6 +67,12 @@ public:
 #endif
 	};
 
+	enum NameCasing {
+		NAME_CASING_PASCAL_CASE,
+		NAME_CASING_CAMEL_CASE,
+		NAME_CASING_SNAKE_CASE
+	};
+
 	struct Comparator {
 		bool operator()(const Node *p_a, const Node *p_b) const { return p_b->is_greater_than(p_a); }
 	};
@@ -139,12 +145,6 @@ private:
 		mutable NodePath *path_cache = nullptr;
 
 	} data;
-
-	enum NameCasing {
-		NAME_CASING_PASCAL_CASE,
-		NAME_CASING_CAMEL_CASE,
-		NAME_CASING_SNAKE_CASE
-	};
 
 	Ref<MultiplayerAPI> multiplayer;
 


### PR DESCRIPTION
When dragging and dropping an image from the FileSystem dock, this PR makes it so the newly added node will be named according to the `editor/node_naming/name_casing` project setting. Previously, the added nodes would just be named after the file's name, so you'd have to manually rename them to match the desired casing.

By default, this means newly added nodes will be converted to PascalCase from the file's name:

https://user-images.githubusercontent.com/12120644/127465764-0df5f307-e292-45b1-b079-7b06b1c714e8.mp4
