### PR TITLE
C# renames to be more consistent with GDScript

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -207,7 +207,7 @@ namespace Godot
             }
         }
 
-        public Quaternion RotationQuaternion()
+        public Quaternion GetRotationQuaternion()
         {
             Basis orthonormalizedBasis = Orthonormalized();
             real_t det = orthonormalizedBasis.Determinant();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -128,9 +128,9 @@ namespace Godot
             return godot_icall_GD_randi_range(from, to);
         }
 
-        public static uint RandSeed(ulong seed, out ulong newSeed)
+        public static uint RandFromSeed(ref ulong seed)
         {
-            return godot_icall_GD_rand_seed(seed, out newSeed);
+            return godot_icall_GD_rand_seed(seed, out seed);
         }
 
         public static IEnumerable<int> Range(int end)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -124,11 +124,11 @@ namespace Godot
             /* not sure if very "efficient" but good enough? */
 
             Vector3 sourceScale = basis.Scale;
-            Quaternion sourceRotation = basis.RotationQuaternion();
+            Quaternion sourceRotation = basis.GetRotationQuaternion();
             Vector3 sourceLocation = origin;
 
             Vector3 destinationScale = transform.basis.Scale;
-            Quaternion destinationRotation = transform.basis.RotationQuaternion();
+            Quaternion destinationRotation = transform.basis.GetRotationQuaternion();
             Vector3 destinationLocation = transform.origin;
 
             var interpolated = new Transform3D();


### PR DESCRIPTION
Some renames to the C# API to make it more consistent with GDScript, obviously this is a breaking change so I'd like to take the chance to do this for 4.0.

- `RandSeed` -> `RandFromSeed`
(also takes a `ref` parameter like the C++ method `Math::rand_from_seed` but not sure this is desired).
- `RotationQuaternion` -> `GetRotationQuaternion`
(not sure why the `Get` prefix was missing).