### PR TITLE
Portals - Fix CSG updates on room conversion

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -576,6 +576,17 @@ void CSGShape::_validate_property(PropertyInfo &property) const {
 	}
 }
 
+// Calling _make_dirty() normally calls a deferred _update_shape.
+// This is problematic if we need to read the geometry immediately.
+// This function provides a means to make sure the shape is updated
+// immediately. It should only be used where necessary to prevent
+// updating CSGs multiple times per frame. Use _make_dirty in preference.
+void CSGShape::force_update_shape() {
+	if (dirty) {
+		_update_shape();
+	}
+}
+
 Array CSGShape::get_meshes() const {
 	if (root_mesh.is_valid()) {
 		Array arr;

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -119,6 +119,8 @@ protected:
 public:
 	Array get_meshes() const;
 
+	void force_update_shape();
+
 	void set_operation(Operation p_operation);
 	Operation get_operation() const;
 

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -1596,6 +1596,11 @@ bool RoomManager::_bound_findpoints_geom_instance(GeometryInstance *p_gi, Vector
 #ifdef MODULE_CSG_ENABLED
 	CSGShape *shape = Object::cast_to<CSGShape>(p_gi);
 	if (shape) {
+		// Shapes will not be up to date on the first frame due to a quirk
+		// of CSG - it defers updates to the next frame. So we need to explicitly
+		// force an update to make sure the CSG is correct on level load.
+		shape->force_update_shape();
+
 		Array arr = shape->get_meshes();
 		if (!arr.size()) {
 			return false;


### PR DESCRIPTION
Due to a quirk in CSG Shapes, updating is usually deferred to the next frame. This is problematic as we need to read back the geometry on the first frame when converting levels.

This PR adds a function to CSGShape to force immediate updating (if dirty), and calls it during room conversion.

Fixes #51000

## Notes
* I don't think the existing CSGShape deferred updating is a *bug* per se, I'm guessing it is used to limit the updating in the editor to once per frame, to prevent runaway processor use.
* I haven't exposed the new function to the binding, however given that it may be exposed to gdscript etc at a later date, it would be good to ensure we are happy with the name of the function.
* Alternatively we could easily change the name if we decide to expose the binding, as it is only currently used from the portal system.
* I don't have a full knowledge of how the CSG shapes system operates. This seems to work, but there are probably a lot of order of operations involved in the CSG system as it operates with multiple nodes. So it would be good to get a review from someone who is familiar with the CSG. Alternatively we can just watch for any bugs in this area due to order of operations.
* As is, CSG shapes will probably end up being updated twice in the room conversion scenario, once during the forced update, and once during the next frame deferred update. Unless there's any evidence of this being a problem, I don't think it is something to worry about excessively.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
