### PR TITLE
[3.x] Fix a crash when trying to load a WebP `StreamTexture`

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -554,9 +554,10 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &tw_
 			}
 
 			Ref<Image> img;
-			if (df & FORMAT_BIT_PNG) {
+			bool is_png = df & FORMAT_BIT_PNG;
+			if (is_png && Image::png_unpacker) {
 				img = Image::png_unpacker(pv);
-			} else {
+			} else if (!is_png && Image::webp_unpacker) {
 				img = Image::webp_unpacker(pv);
 			}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/51003.

Though I am not sure exactly what is going on here. For some reason with the existence of a theme specifically a `StreamTexture` is attempting to get loaded when it reasonably cannot because, I think, `ImageLoaderWEBP` hasn't been initialized yet (hence the crash, `Image::webp_unpacker` points nowhere). I found other places checking for validity of `*_unpacker` methods, so I added same checks here.

It doesn't crash anymore, and still loads fine, but that only tells me there are some other problems which are hidden. First of all, it's weird to attempt to load a texture so early with a theme. Adding the same texture to a scene doesn't cause that (or I didn't test it properly). Second of all, the checks that I've added should prevent the texture from loading (as we cannot do that at that moment) yet it still loads in the end and there are no visible glitches for the user. So there is probably some redundancy somewhere that attempts to load it again later? Maybe it's not that bad, but it's still troubling.

Either way, the crash is fixed (from my testing) and the texture is loaded fine.