### PR TITLE
Make some small tweaks to the MIME info

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.xml
+++ b/misc/dist/linux/org.godotengine.Godot.xml
@@ -2,20 +2,20 @@
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/x-godot-project">
     <comment>Godot Engine project</comment>
-    <icon name="x-godot-project" />
-    <glob pattern="*.godot"/>
+    <icon name="x-godot-project"/>
+    <glob pattern="project.godot"/>
   </mime-type>
 
   <mime-type type="application/x-godot-resource">
     <comment>Godot Engine resource</comment>
-    <icon name="x-godot-resource" />
+    <icon name="x-godot-resource"/>
     <glob pattern="*.res"/>
     <glob pattern="*.tres"/>
   </mime-type>
 
   <mime-type type="application/x-godot-scene">
     <comment>Godot Engine scene</comment>
-    <icon name="x-godot-scene" />
+    <icon name="x-godot-scene"/>
     <glob pattern="*.scn"/>
     <glob pattern="*.tscn"/>
     <glob pattern="*.escn"/>
@@ -23,13 +23,15 @@
 
   <mime-type type="application/x-godot-shader">
     <comment>Godot Engine shader</comment>
-    <icon name="x-godot-shader" />
+    <sub-class-of type="text/plain"/>
+    <icon name="x-godot-shader"/>
     <glob pattern="*.gdshader"/>
   </mime-type>
 
   <mime-type type="application/x-gdscript">
     <comment>GDScript script</comment>
-    <icon name="x-gdscript" />
+    <sub-class-of type="text/plain"/>
+    <icon name="x-gdscript"/>
     <glob pattern="*.gd"/>
   </mime-type>
 </mime-info>


### PR DESCRIPTION
This PR does the following changes:

- Change the glob pattern of project files from `*.godot` to `project.godot`, as the name needs to be exactly that.
- Make the GDScript and GDShader files be sub-classes of plain text, as it's common for programming language files, and it makes sense for them to be open individually by something else besides Godot.
- Remove some unnecessary spaces.