### PR TITLE
Use C# interpolated strings

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -670,20 +670,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("{0}, {1}", new object[]
-                {
-                    _position.ToString(),
-                    _size.ToString()
-                });
+            return $"{_position}, {_size}";
         }
 
         public string ToString(string format)
         {
-            return String.Format("{0}, {1}", new object[]
-                {
-                    _position.ToString(format),
-                    _size.ToString(format)
-                });
+            return $"{_position.ToString(format)}, {_size.ToString(format)}";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -863,16 +863,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return "[X: " + x.ToString() +
-                    ", Y: " + y.ToString() +
-                    ", Z: " + z.ToString() + "]";
+            return $"[X: {x}, Y: {y}, Z: {z}]";
         }
 
         public string ToString(string format)
         {
-            return "[X: " + x.ToString(format) +
-                    ", Y: " + y.ToString(format) +
-                    ", Z: " + z.ToString(format) + "]";
+            return $"[X: {x.ToString(format)}, Y: {y.ToString(format)}, Z: {z.ToString(format)}]";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -1010,12 +1010,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1}, {2}, {3})", r.ToString(), g.ToString(), b.ToString(), a.ToString());
+            return $"({r}, {g}, {b}, {a})";
         }
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1}, {2}, {3})", r.ToString(format), g.ToString(format), b.ToString(format), a.ToString(format));
+            return $"({r.ToString(format)}, {g.ToString(format)}, {b.ToString(format)}, {a.ToString(format)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -355,20 +355,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("{0}, {1}", new object[]
-            {
-                _normal.ToString(),
-                D.ToString()
-            });
+            return $"{_normal}, {D}";
         }
 
         public string ToString(string format)
         {
-            return String.Format("{0}, {1}", new object[]
-            {
-                _normal.ToString(format),
-                D.ToString(format)
-            });
+            return $"{_normal.ToString(format)}, {D.ToString(format)}";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -547,12 +547,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1}, {2}, {3})", x.ToString(), y.ToString(), z.ToString(), w.ToString());
+            return $"({x}, {y}, {z}, {w})";
         }
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1}, {2}, {3})", x.ToString(format), y.ToString(format), z.ToString(format), w.ToString(format));
+            return $"({x.ToString(format)}, {y.ToString(format)}, {z.ToString(format)}, {w.ToString(format)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -405,20 +405,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("{0}, {1}", new object[]
-            {
-                _position.ToString(),
-                _size.ToString()
-            });
+            return $"{_position}, {_size}";
         }
 
         public string ToString(string format)
         {
-            return String.Format("{0}, {1}", new object[]
-            {
-                _position.ToString(format),
-                _size.ToString(format)
-            });
+            return $"{_position.ToString(format)}, {_size.ToString(format)}";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -383,20 +383,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("{0}, {1}", new object[]
-            {
-                _position.ToString(),
-                _size.ToString()
-            });
+            return $"{_position}, {_size}";
         }
 
         public string ToString(string format)
         {
-            return String.Format("{0}, {1}", new object[]
-            {
-                _position.ToString(format),
-                _size.ToString(format)
-            });
+            return $"{_position.ToString(format)}, {_size.ToString(format)}";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -492,16 +492,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return "[X: " + x.ToString() +
-                    ", Y: " + y.ToString() +
-                    ", O: " + origin.ToString() + "]";
+            return $"[X: {x}, Y: {y}, O: {origin}]";
         }
 
         public string ToString(string format)
         {
-            return "[X: " + x.ToString(format) +
-                    ", Y: " + y.ToString(format) +
-                    ", O: " + origin.ToString(format) + "]";
+            return $"[X: {x.ToString(format)}, Y: {y.ToString(format)}, O: {origin.ToString(format)}]";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -393,18 +393,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return "[X: " + basis.x.ToString() +
-                    ", Y: " + basis.y.ToString() +
-                    ", Z: " + basis.z.ToString() +
-                    ", O: " + origin.ToString() + "]";
+            return $"[X: {basis.x}, Y: {basis.y}, Z: {basis.z}, O: {origin}]";
         }
 
         public string ToString(string format)
         {
-            return "[X: " + basis.x.ToString(format) +
-                    ", Y: " + basis.y.ToString(format) +
-                    ", Z: " + basis.z.ToString(format) +
-                    ", O: " + origin.ToString(format) + "]";
+            return $"[X: {basis.x.ToString(format)}, Y: {basis.y.ToString(format)}, Z: {basis.z.ToString(format)}, O: {origin.ToString(format)}]";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -751,20 +751,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1})", new object[]
-            {
-                x.ToString(),
-                y.ToString()
-            });
+            return $"({x}, {y})";
         }
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1})", new object[]
-            {
-                x.ToString(format),
-                y.ToString(format)
-            });
+            return $"({x.ToString(format)}, {y.ToString(format)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -508,20 +508,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1})", new object[]
-            {
-                this.x.ToString(),
-                this.y.ToString()
-            });
+            return $"({x}, {y})";
         }
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1})", new object[]
-            {
-                this.x.ToString(format),
-                this.y.ToString(format)
-            });
+            return $"({x.ToString(format)}, {y.ToString(format)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -845,22 +845,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1}, {2})", new object[]
-            {
-                x.ToString(),
-                y.ToString(),
-                z.ToString()
-            });
+            return $"({x}, {y}, {z})";
         }
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1}, {2})", new object[]
-            {
-                x.ToString(format),
-                y.ToString(format),
-                z.ToString(format)
-            });
+            return $"({x.ToString(format)}, {y.ToString(format)}, {z.ToString(format)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -511,22 +511,12 @@ namespace Godot
 
         public override string ToString()
         {
-            return String.Format("({0}, {1}, {2})", new object[]
-            {
-                this.x.ToString(),
-                this.y.ToString(),
-                this.z.ToString()
-            });
+            return $"({x}, {y}, {z})";
         }
 
         public string ToString(string format)
         {
-            return String.Format("({0}, {1}, {2})", new object[]
-            {
-                this.x.ToString(format),
-                this.y.ToString(format),
-                this.z.ToString(format)
-            });
+            return $"({x.ToString(format)}, {y.ToString(format)}, {z.ToString(format)})";
         }
     }
 }


### PR DESCRIPTION
Follow-up to #50872.

Uses interpolated strings wherever possible.
String concatenations are still left where used for breaking long lines.
