### PR TITLE
Clear debug process identifiers array at `stop()` to prevent invalid checking of them

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -270,6 +270,7 @@ void EditorRun::stop() {
 		for (const OS::ProcessID &E : pids) {
 			OS::get_singleton()->kill(E);
 		}
+		pids.clear();
 	}
 
 	status = STATUS_STOP;


### PR DESCRIPTION
Processes are killed but an array of theirs identifiers is not cleared after that. Should fix https://github.com/godotengine/godot/issues/47087
