### PR TITLE
Portals - fix gizmo margin scaling

### DIFF
--- a/scene/3d/portal.cpp
+++ b/scene/3d/portal.cpp
@@ -167,6 +167,15 @@ void Portal::_notification(int p_what) {
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			// keep the world points and the visual server up to date
 			portal_update();
+
+			// In theory we shouldn't need to update the gizmo when the transform
+			// changes .. HOWEVER, the portal margin is displayed in world space units,
+			// back transformed to model space.
+			// If the Z scale is changed by the user, the portal margin length can become incorrect
+			// and needs 'resyncing' to the global scale of the portal node.
+			// We really only need to do this when Z scale is changed, but it is easier codewise
+			// to always change it, unless we have evidence this is a performance problem.
+			update_gizmo();
 		} break;
 	}
 }


### PR DESCRIPTION
If the user changed the portal Z scale in the editor the portal margin display could become incorrectly sized.

This is because the portal margin is measured in world space units, and has to be back calculated into model space using the inverse global transform of the portal node. The model space size of the margin is thus tied to the current scale of the node.

This PR forces updating the gizmo each time the transform is changed. This isn't super efficient, but as this is an editor only feature it should be okay, and it is unlikely to be a performance problem.

Fixes #50996

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
