### PR TITLE
Properly tag project files as a subclass of plain text in the MIME info

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.xml
+++ b/misc/dist/linux/org.godotengine.Godot.xml
@@ -2,6 +2,7 @@
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/x-godot-project">
     <comment>Godot Engine project</comment>
+    <sub-class-of type="text/plain"/>
     <icon name="x-godot-project"/>
     <glob pattern="project.godot"/>
   </mime-type>


### PR DESCRIPTION
Even if using that file only makes sense with the engine itself, it's still a plain text file, and should be noted as such.

Should be cherry-picked together with #51019.