### PR TITLE
Refactor layer property editor grid

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -820,8 +820,44 @@
 		<member name="layer_names/2d_navigation/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 2. If left empty, the layer will display as "Layer 2".
 		</member>
+		<member name="layer_names/2d_navigation/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 20. If left empty, the layer will display as "Layer 20".
+		</member>
+		<member name="layer_names/2d_navigation/layer_21" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 21. If left empty, the layer will display as "Layer 21".
+		</member>
+		<member name="layer_names/2d_navigation/layer_22" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 22. If left empty, the layer will display as "Layer 22".
+		</member>
+		<member name="layer_names/2d_navigation/layer_23" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 23. If left empty, the layer will display as "Layer 23".
+		</member>
+		<member name="layer_names/2d_navigation/layer_24" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 24. If left empty, the layer will display as "Layer 24".
+		</member>
+		<member name="layer_names/2d_navigation/layer_25" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 25. If left empty, the layer will display as "Layer 25".
+		</member>
+		<member name="layer_names/2d_navigation/layer_26" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 26. If left empty, the layer will display as "Layer 26".
+		</member>
+		<member name="layer_names/2d_navigation/layer_27" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 27. If left empty, the layer will display as "Layer 27".
+		</member>
+		<member name="layer_names/2d_navigation/layer_28" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 28. If left empty, the layer will display as "Layer 28".
+		</member>
+		<member name="layer_names/2d_navigation/layer_29" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 29. If left empty, the layer will display as "Layer 29".
+		</member>
 		<member name="layer_names/2d_navigation/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/2d_navigation/layer_30" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 30. If left empty, the layer will display as "Layer 30".
+		</member>
+		<member name="layer_names/2d_navigation/layer_31" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 31. If left empty, the layer will display as "Layer 31".
 		</member>
 		<member name="layer_names/2d_navigation/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 4. If left empty, the layer will display as "Layer 4".
@@ -880,8 +916,44 @@
 		<member name="layer_names/2d_physics/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 2. If left empty, the layer will display as "Layer 2".
 		</member>
+		<member name="layer_names/2d_physics/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 20. If left empty, the layer will display as "Layer 20".
+		</member>
+		<member name="layer_names/2d_physics/layer_21" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 21. If left empty, the layer will display as "Layer 21".
+		</member>
+		<member name="layer_names/2d_physics/layer_22" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 22. If left empty, the layer will display as "Layer 22".
+		</member>
+		<member name="layer_names/2d_physics/layer_23" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 23. If left empty, the layer will display as "Layer 23".
+		</member>
+		<member name="layer_names/2d_physics/layer_24" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 24. If left empty, the layer will display as "Layer 24".
+		</member>
+		<member name="layer_names/2d_physics/layer_25" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 25. If left empty, the layer will display as "Layer 25".
+		</member>
+		<member name="layer_names/2d_physics/layer_26" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 26. If left empty, the layer will display as "Layer 26".
+		</member>
+		<member name="layer_names/2d_physics/layer_27" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 27. If left empty, the layer will display as "Layer 27".
+		</member>
+		<member name="layer_names/2d_physics/layer_28" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 28. If left empty, the layer will display as "Layer 28".
+		</member>
+		<member name="layer_names/2d_physics/layer_29" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 29. If left empty, the layer will display as "Layer 29".
+		</member>
 		<member name="layer_names/2d_physics/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/2d_physics/layer_30" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 30. If left empty, the layer will display as "Layer 30".
+		</member>
+		<member name="layer_names/2d_physics/layer_31" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 31. If left empty, the layer will display as "Layer 31".
 		</member>
 		<member name="layer_names/2d_physics/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 4. If left empty, the layer will display as "Layer 4".
@@ -1000,8 +1072,44 @@
 		<member name="layer_names/3d_navigation/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 2. If left empty, the layer will display as "Layer 2".
 		</member>
+		<member name="layer_names/3d_navigation/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 20. If left empty, the layer will display as "Layer 20".
+		</member>
+		<member name="layer_names/3d_navigation/layer_21" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 21. If left empty, the layer will display as "Layer 21".
+		</member>
+		<member name="layer_names/3d_navigation/layer_22" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 22. If left empty, the layer will display as "Layer 22".
+		</member>
+		<member name="layer_names/3d_navigation/layer_23" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 23. If left empty, the layer will display as "Layer 23".
+		</member>
+		<member name="layer_names/3d_navigation/layer_24" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 24. If left empty, the layer will display as "Layer 24".
+		</member>
+		<member name="layer_names/3d_navigation/layer_25" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 25. If left empty, the layer will display as "Layer 25".
+		</member>
+		<member name="layer_names/3d_navigation/layer_26" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 26. If left empty, the layer will display as "Layer 26".
+		</member>
+		<member name="layer_names/3d_navigation/layer_27" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 27. If left empty, the layer will display as "Layer 27".
+		</member>
+		<member name="layer_names/3d_navigation/layer_28" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 28. If left empty, the layer will display as "Layer 28".
+		</member>
+		<member name="layer_names/3d_navigation/layer_29" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 29. If left empty, the layer will display as "Layer 29".
+		</member>
 		<member name="layer_names/3d_navigation/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/3d_navigation/layer_30" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 30. If left empty, the layer will display as "Layer 30".
+		</member>
+		<member name="layer_names/3d_navigation/layer_31" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 31. If left empty, the layer will display as "Layer 31".
 		</member>
 		<member name="layer_names/3d_navigation/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 4. If left empty, the layer will display as "Layer 4".
@@ -1060,8 +1168,44 @@
 		<member name="layer_names/3d_physics/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 2. If left empty, the layer will display as "Layer 2".
 		</member>
+		<member name="layer_names/3d_physics/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 20. If left empty, the layer will display as "Layer 20".
+		</member>
+		<member name="layer_names/3d_physics/layer_21" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 21. If left empty, the layer will display as "Layer 21".
+		</member>
+		<member name="layer_names/3d_physics/layer_22" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 22. If left empty, the layer will display as "Layer 22".
+		</member>
+		<member name="layer_names/3d_physics/layer_23" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 23. If left empty, the layer will display as "Layer 23".
+		</member>
+		<member name="layer_names/3d_physics/layer_24" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 24. If left empty, the layer will display as "Layer 24".
+		</member>
+		<member name="layer_names/3d_physics/layer_25" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 25. If left empty, the layer will display as "Layer 25".
+		</member>
+		<member name="layer_names/3d_physics/layer_26" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 26. If left empty, the layer will display as "Layer 26".
+		</member>
+		<member name="layer_names/3d_physics/layer_27" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 27. If left empty, the layer will display as "Layer 27".
+		</member>
+		<member name="layer_names/3d_physics/layer_28" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 28. If left empty, the layer will display as "Layer 28".
+		</member>
+		<member name="layer_names/3d_physics/layer_29" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 29. If left empty, the layer will display as "Layer 29".
+		</member>
 		<member name="layer_names/3d_physics/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/3d_physics/layer_30" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 30. If left empty, the layer will display as "Layer 30".
+		</member>
+		<member name="layer_names/3d_physics/layer_31" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 31. If left empty, the layer will display as "Layer 31".
 		</member>
 		<member name="layer_names/3d_physics/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 4. If left empty, the layer will display as "Layer 4".

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1000,9 +1000,12 @@ void register_scene_types() {
 
 	for (int i = 0; i < 20; i++) {
 		GLOBAL_DEF_BASIC(vformat("layer_names/2d_render/layer_%d", i), "");
+		GLOBAL_DEF_BASIC(vformat("layer_names/3d_render/layer_%d", i), "");
+	}
+
+	for (int i = 0; i < 32; i++) {
 		GLOBAL_DEF_BASIC(vformat("layer_names/2d_physics/layer_%d", i), "");
 		GLOBAL_DEF_BASIC(vformat("layer_names/2d_navigation/layer_%d", i), "");
-		GLOBAL_DEF_BASIC(vformat("layer_names/3d_render/layer_%d", i), "");
 		GLOBAL_DEF_BASIC(vformat("layer_names/3d_physics/layer_%d", i), "");
 		GLOBAL_DEF_BASIC(vformat("layer_names/3d_navigation/layer_%d", i), "");
 	}


### PR DESCRIPTION
Implements proposal https://github.com/godotengine/godot-proposals/issues/2770 on the master branch (see #51040 for 3.x), based on different comments and suggestions.

List of changes:
- Now able to display up to 32 layers for physics/navigation in 4x2 blocks (still 20 layers in 5x2 blocks for render because some layers are reserved)
- Also show 32 layers for physics/navigation layer names in project settings
- Adjustable grid size to fit available space in dock
- Expansion icon to display more layers vertically
- Layer numbers in cells to help with selection (cells are also slightly larger to fit the numbers)

For now I haven't implemented the label for layer names like in https://github.com/godotengine/godot-proposals/issues/2770#issuecomment-849099706, because tooltips are already displaying them and it can wait for feedback before doing further improvements if needed.

Physics layers:
<img width="193" alt="layer_grid_physics_4 0" src="https://user-images.githubusercontent.com/1075032/127578641-fc73eee5-af2a-440c-b962-2c44012ebec1.png">

Render layers:
<img width="192" alt="layer_grid_render_4 0" src="https://user-images.githubusercontent.com/1075032/127578646-5188abb1-32a5-4e6e-9d8d-05f481e19141.png">

Rescaling demo (on the 3.x version, but it works the same in the 4.0 version):
![collision_layers_grid](https://user-images.githubusercontent.com/1075032/127578169-8d93e601-29bf-42cf-afe2-ec76b70baef6.gif)