### PR TITLE
Name new resource files with `snake_case` 

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1168,7 +1168,8 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 			file->set_current_file(p_resource->get_path().get_file());
 		} else {
 			if (extensions.size()) {
-				file->set_current_file("new_" + p_resource->get_class().to_lower() + "." + preferred.front()->get().to_lower());
+				String resource_name_snake_case = p_resource->get_class().camelcase_to_underscore();
+				file->set_current_file("new_" + resource_name_snake_case + "." + preferred.front()->get().to_lower());
 			} else {
 				file->set_current_file(String());
 			}
@@ -1184,7 +1185,8 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 	} else if (preferred.size()) {
 		String existing;
 		if (extensions.size()) {
-			existing = "new_" + p_resource->get_class().to_lower() + "." + preferred.front()->get().to_lower();
+			String resource_name_snake_case = p_resource->get_class().camelcase_to_underscore();
+			existing = "new_" + resource_name_snake_case + "." + preferred.front()->get().to_lower();
 		}
 		file->set_current_path(existing);
 	}

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -408,7 +408,8 @@ void AnimationPlayerEditor::_animation_save_as(const Ref<Resource> &p_resource) 
 			if (p_resource->get_name() != "") {
 				path = p_resource->get_name() + "." + extensions.front()->get().to_lower();
 			} else {
-				path = "new_" + p_resource->get_class().to_lower() + "." + extensions.front()->get().to_lower();
+				String resource_name_snake_case = p_resource->get_class().camelcase_to_underscore();
+				path = "new_" + resource_name_snake_case + "." + extensions.front()->get().to_lower();
 			}
 		}
 	}


### PR DESCRIPTION
Prior to this, it would simply suggest the lowercase version of the resource's class name.

For example, when creating a `BoxMesh`, it will now suggest the name `new_box_mesh.tres`. Before, it would of suggested `new_boxmesh.tres`

![image](https://user-images.githubusercontent.com/12120644/127584148-cdc9aefb-c55a-4b6e-acfb-78225ba749e0.png)
