### PR TITLE
Fix binary resource loading and saving

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -906,7 +906,7 @@ void ResourceLoaderBinary::open(FileAccess *p_f, bool p_no_resources, bool p_kee
 		uid = ResourceUID::INVALID_ID;
 	}
 
-	for (int i = 0; i < 5; i++) {
+	for (int i = 0; i < 11; i++) {
 		f->get_32(); //skip a few reserved fields
 	}
 
@@ -1209,8 +1209,8 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	fw->store_32(flags);
 	fw->store_64(uid_data);
 
-	for (int i = 0; i < 5; i++) {
-		f->store_32(0); // reserved
+	for (int i = 0; i < 11; i++) {
+		fw->store_32(0); // reserved
 		f->get_32();
 	}
 
@@ -1264,7 +1264,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 
 		if (using_uids) {
 			ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(full_path);
-			f->store_64(uid);
+			fw->store_64(uid);
 		}
 	}
 
@@ -1902,7 +1902,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	f->store_32(FORMAT_FLAG_NAMED_SCENE_IDS | FORMAT_FLAG_UIDS);
 	ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(p_path, true);
 	f->store_64(uid);
-	for (int i = 0; i < 5; i++) {
+	for (int i = 0; i < 11; i++) {
 		f->store_32(0); // reserved
 	}
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -903,6 +903,7 @@ void ResourceLoaderBinary::open(FileAccess *p_f, bool p_no_resources, bool p_kee
 	if (using_uids) {
 		uid = f->get_64();
 	} else {
+		f->get_64(); // skip over uid field
 		uid = ResourceUID::INVALID_ID;
 	}
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -906,7 +906,7 @@ void ResourceLoaderBinary::open(FileAccess *p_f, bool p_no_resources, bool p_kee
 		uid = ResourceUID::INVALID_ID;
 	}
 
-	for (int i = 0; i < 11; i++) {
+	for (int i = 0; i < ResourceFormatSaverBinaryInstance::RESERVED_FIELDS; i++) {
 		f->get_32(); //skip a few reserved fields
 	}
 
@@ -1209,7 +1209,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	fw->store_32(flags);
 	fw->store_64(uid_data);
 
-	for (int i = 0; i < 11; i++) {
+	for (int i = 0; i < ResourceFormatSaverBinaryInstance::RESERVED_FIELDS; i++) {
 		fw->store_32(0); // reserved
 		f->get_32();
 	}
@@ -1902,7 +1902,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	f->store_32(FORMAT_FLAG_NAMED_SCENE_IDS | FORMAT_FLAG_UIDS);
 	ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(p_path, true);
 	f->store_64(uid);
-	for (int i = 0; i < 11; i++) {
+	for (int i = 0; i < ResourceFormatSaverBinaryInstance::RESERVED_FIELDS; i++) {
 		f->store_32(0); // reserved
 	}
 

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -164,6 +164,8 @@ public:
 	enum {
 		FORMAT_FLAG_NAMED_SCENE_IDS = 1,
 		FORMAT_FLAG_UIDS = 2,
+		// Amount of reserved 32-bit fields in resource header
+		RESERVED_FIELDS = 11
 	};
 	Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
 	static void write_variant(FileAccess *f, const Variant &p_property, Map<RES, int> &resource_map, Map<RES, int> &external_resources, Map<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1020,11 +1020,11 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 	bs_save_unicode_string(wf.f, is_scene ? "PackedScene" : resource_type);
 	wf->store_64(0); //offset to import metadata, this is no longer used
 
-	f->store_32(ResourceFormatSaverBinaryInstance::FORMAT_FLAG_NAMED_SCENE_IDS | ResourceFormatSaverBinaryInstance::FORMAT_FLAG_UIDS);
+	wf->store_32(ResourceFormatSaverBinaryInstance::FORMAT_FLAG_NAMED_SCENE_IDS | ResourceFormatSaverBinaryInstance::FORMAT_FLAG_UIDS);
 
-	f->store_64(res_uid);
+	wf->store_64(res_uid);
 
-	for (int i = 0; i < 5; i++) {
+	for (int i = 0; i < 11; i++) {
 		wf->store_32(0); // reserved
 	}
 
@@ -1074,7 +1074,7 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 
 		bs_save_unicode_string(wf.f, type);
 		bs_save_unicode_string(wf.f, path);
-		wf.f->store_64(uid);
+		wf->store_64(uid);
 
 		int lindex = dummy_read.external_resources.size();
 		Ref<DummyResource> dr;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1024,7 +1024,7 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 
 	wf->store_64(res_uid);
 
-	for (int i = 0; i < 11; i++) {
+	for (int i = 0; i < ResourceFormatSaverBinaryInstance::RESERVED_FIELDS; i++) {
 		wf->store_32(0); // reserved
 	}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
This fixes issues with binary resource saving and loading that were introduced in #50786 and broke backwards compatibility.

https://github.com/godotengine/godot/pull/50786#pullrequestreview-718630882

Previously, there were 13 32-bit reserved fields in binary resources. This PR added a 64-bit field `uid` after `flags`. This should have brought the number of remaining reserved fields to 11. However, the PR erroneously reduced it to 5. This ends up breaking compatibility with binary resources of previous format versions. I have changed the reserved fields remaining to 11, and set it as a constant.

The PR also had a number of erroneous writes to a read-only file handle in the save functions; I have corrected these.