### PR TITLE
Reduce C# Dictionary internal calls, Add documentation to Dictionary in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Godot.Collections
 {
@@ -25,6 +26,11 @@ namespace Godot.Collections
         }
     }
 
+    /// <summary>
+    /// Wrapper around Godot's Dictionary class, a dictionary of Variant
+    /// typed elements allocated in the engine in C++. Useful when
+    /// interfacing with the engine.
+    /// </summary>
     public class Dictionary :
         IDictionary,
         IDisposable
@@ -32,11 +38,19 @@ namespace Godot.Collections
         DictionarySafeHandle safeHandle;
         bool disposed = false;
 
+        /// <summary>
+        /// Constructs a new empty <see cref="Dictionary"/>.
+        /// </summary>
         public Dictionary()
         {
             safeHandle = new DictionarySafeHandle(godot_icall_Dictionary_Ctor());
         }
 
+        /// <summary>
+        /// Constructs a new <see cref="Dictionary"/> from the given dictionary's elements.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to construct from.</param>
+        /// <returns>A new Godot Dictionary.</returns>
         public Dictionary(IDictionary dictionary) : this()
         {
             if (dictionary == null)
@@ -64,6 +78,9 @@ namespace Godot.Collections
             return safeHandle.DangerousGetHandle();
         }
 
+        /// <summary>
+        /// Disposes of this <see cref="Dictionary"/>.
+        /// </summary>
         public void Dispose()
         {
             if (disposed)
@@ -78,6 +95,11 @@ namespace Godot.Collections
             disposed = true;
         }
 
+        /// <summary>
+        /// Duplicates this <see cref="Dictionary"/>.
+        /// </summary>
+        /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
+        /// <returns>A new Godot Dictionary.</returns>
         public Dictionary Duplicate(bool deep = false)
         {
             return new Dictionary(godot_icall_Dictionary_Duplicate(GetPtr(), deep));
@@ -85,6 +107,9 @@ namespace Godot.Collections
 
         // IDictionary
 
+        /// <summary>
+        /// Gets the collection of keys in this <see cref="Dictionary"/>.
+        /// </summary>
         public ICollection Keys
         {
             get
@@ -94,6 +119,9 @@ namespace Godot.Collections
             }
         }
 
+        /// <summary>
+        /// Gets the collection of elements in this <see cref="Dictionary"/>.
+        /// </summary>
         public ICollection Values
         {
             get
@@ -103,34 +131,71 @@ namespace Godot.Collections
             }
         }
 
-        public bool IsFixedSize => false;
+        bool IDictionary.IsFixedSize => false;
 
-        public bool IsReadOnly => false;
+        bool IDictionary.IsReadOnly => false;
 
+        /// <summary>
+        /// Returns the object at the given <paramref name="key"/>.
+        /// </summary>
+        /// <value>The object at the given <paramref name="key"/>.</value>
         public object this[object key]
         {
             get => godot_icall_Dictionary_GetValue(GetPtr(), key);
             set => godot_icall_Dictionary_SetValue(GetPtr(), key, value);
         }
 
+        /// <summary>
+        /// Adds an object <paramref name="value"/> at key <paramref name="key"/>
+        /// to this <see cref="Dictionary"/>.
+        /// </summary>
+        /// <param name="key">The key at which to add the object.</param>
+        /// <param name="value">The object to add.</param>
         public void Add(object key, object value) => godot_icall_Dictionary_Add(GetPtr(), key, value);
 
+        /// <summary>
+        /// Erases all items from this <see cref="Dictionary"/>.
+        /// </summary>
         public void Clear() => godot_icall_Dictionary_Clear(GetPtr());
 
+        /// <summary>
+        /// Checks if this <see cref="Dictionary"/> contains the given key.
+        /// </summary>
+        /// <param name="key">The key to look for.</param>
+        /// <returns>Whether or not this dictionary contains the given key.</returns>
         public bool Contains(object key) => godot_icall_Dictionary_ContainsKey(GetPtr(), key);
 
+        /// <summary>
+        /// Gets an enumerator for this <see cref="Dictionary"/>.
+        /// </summary>
+        /// <returns>An enumerator.</returns>
         public IDictionaryEnumerator GetEnumerator() => new DictionaryEnumerator(this);
 
+        /// <summary>
+        /// Removes an element from this <see cref="Dictionary"/> by key.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
         public void Remove(object key) => godot_icall_Dictionary_RemoveKey(GetPtr(), key);
 
         // ICollection
 
-        public object SyncRoot => this;
+        object ICollection.SyncRoot => this;
 
-        public bool IsSynchronized => false;
+        bool ICollection.IsSynchronized => false;
 
+        /// <summary>
+        /// Returns the number of elements in this <see cref="Dictionary"/>.
+        /// This is also known as the size or length of the dictionary.
+        /// </summary>
+        /// <returns>The number of elements.</returns>
         public int Count => godot_icall_Dictionary_Count(GetPtr());
 
+        /// <summary>
+        /// Copies the elements of this <see cref="Dictionary"/> to the given
+        /// untyped C# array, starting at the given index.
+        /// </summary>
+        /// <param name="array">The array to copy to.</param>
+        /// <param name="index">The index to start at.</param>
         public void CopyTo(System.Array array, int index)
         {
             // TODO Can be done with single internal call
@@ -161,10 +226,10 @@ namespace Godot.Collections
 
         private class DictionaryEnumerator : IDictionaryEnumerator
         {
-            Array keys;
-            Array values;
-            int count;
-            int index = -1;
+            private readonly Array keys;
+            private readonly Array values;
+            private readonly int count;
+            private int index = -1;
 
             public DictionaryEnumerator(Dictionary dictionary)
             {
@@ -196,6 +261,10 @@ namespace Godot.Collections
             }
         }
 
+        /// <summary>
+        /// Converts this <see cref="Dictionary"/> to a string.
+        /// </summary>
+        /// <returns>A string representation of this dictionary.</returns>
         public override string ToString()
         {
             return godot_icall_Dictionary_ToString(GetPtr());
@@ -259,10 +328,18 @@ namespace Godot.Collections
         internal extern static string godot_icall_Dictionary_ToString(IntPtr ptr);
     }
 
+    /// <summary>
+    /// Typed wrapper around Godot's Dictionary class, a dictionary of Variant
+    /// typed elements allocated in the engine in C++. Useful when
+    /// interfacing with the engine. Otherwise prefer .NET collections
+    /// such as <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the dictionary's keys.</typeparam>
+    /// <typeparam name="TValue">The type of the dictionary's values.</typeparam>
     public class Dictionary<TKey, TValue> :
         IDictionary<TKey, TValue>
     {
-        Dictionary objectDict;
+        private readonly Dictionary objectDict;
 
         internal static int valTypeEncoding;
         internal static IntPtr valTypeClass;
@@ -272,11 +349,19 @@ namespace Godot.Collections
             Dictionary.godot_icall_Dictionary_Generic_GetValueTypeInfo(typeof(TValue), out valTypeEncoding, out valTypeClass);
         }
 
+        /// <summary>
+        /// Constructs a new empty <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
         public Dictionary()
         {
             objectDict = new Dictionary();
         }
 
+        /// <summary>
+        /// Constructs a new <see cref="Dictionary{TKey, TValue}"/> from the given dictionary's elements.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to construct from.</param>
+        /// <returns>A new Godot Dictionary.</returns>
         public Dictionary(IDictionary<TKey, TValue> dictionary)
         {
             objectDict = new Dictionary();
@@ -294,6 +379,11 @@ namespace Godot.Collections
             }
         }
 
+        /// <summary>
+        /// Constructs a new <see cref="Dictionary{TKey, TValue}"/> from the given dictionary's elements.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to construct from.</param>
+        /// <returns>A new Godot Dictionary.</returns>
         public Dictionary(Dictionary dictionary)
         {
             objectDict = dictionary;
@@ -309,6 +399,10 @@ namespace Godot.Collections
             objectDict = new Dictionary(handle);
         }
 
+        /// <summary>
+        /// Converts this typed <see cref="Dictionary{TKey, TValue}"/> to an untyped <see cref="Dictionary"/>.
+        /// </summary>
+        /// <param name="from">The typed dictionary to convert.</param>
         public static explicit operator Dictionary(Dictionary<TKey, TValue> from)
         {
             return from.objectDict;
@@ -319,6 +413,11 @@ namespace Godot.Collections
             return objectDict.GetPtr();
         }
 
+        /// <summary>
+        /// Duplicates this <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
+        /// <returns>A new Godot Dictionary.</returns>
         public Dictionary<TKey, TValue> Duplicate(bool deep = false)
         {
             return new Dictionary<TKey, TValue>(objectDict.Duplicate(deep));
@@ -326,12 +425,19 @@ namespace Godot.Collections
 
         // IDictionary<TKey, TValue>
 
+        /// <summary>
+        /// Returns the value at the given <paramref name="key"/>.
+        /// </summary>
+        /// <value>The value at the given <paramref name="key"/>.</value>
         public TValue this[TKey key]
         {
             get { return (TValue)Dictionary.godot_icall_Dictionary_GetValue_Generic(objectDict.GetPtr(), key, valTypeEncoding, valTypeClass); }
             set { objectDict[key] = value; }
         }
 
+        /// <summary>
+        /// Gets the collection of keys in this <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
         public ICollection<TKey> Keys
         {
             get
@@ -341,6 +447,9 @@ namespace Godot.Collections
             }
         }
 
+        /// <summary>
+        /// Gets the collection of elements in this <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
         public ICollection<TValue> Values
         {
             get
@@ -350,56 +459,87 @@ namespace Godot.Collections
             }
         }
 
+        /// <summary>
+        /// Adds an object <paramref name="value"/> at key <paramref name="key"/>
+        /// to this <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="key">The key at which to add the object.</param>
+        /// <param name="value">The object to add.</param>
         public void Add(TKey key, TValue value)
         {
             objectDict.Add(key, value);
         }
 
+        /// <summary>
+        /// Checks if this <see cref="Dictionary{TKey, TValue}"/> contains the given key.
+        /// </summary>
+        /// <param name="key">The key to look for.</param>
+        /// <returns>Whether or not this dictionary contains the given key.</returns>
         public bool ContainsKey(TKey key)
         {
             return objectDict.Contains(key);
         }
 
+        /// <summary>
+        /// Removes an element from this <see cref="Dictionary{TKey, TValue}"/> by key.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
         public bool Remove(TKey key)
         {
             return Dictionary.godot_icall_Dictionary_RemoveKey(GetPtr(), key);
         }
 
-        public bool TryGetValue(TKey key, out TValue value)
+        /// <summary>
+        /// Gets the object at the given <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">The key of the element to get.</param>
+        /// <param name="value">The value at the given <paramref name="key"/>.</param>
+        /// <returns>If an object was found for the given <paramref name="key"/>.</returns>
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
         {
-            object retValue;
-            bool found = Dictionary.godot_icall_Dictionary_TryGetValue_Generic(GetPtr(), key, out retValue, valTypeEncoding, valTypeClass);
-            value = found ? (TValue)retValue : default(TValue);
+            bool found = Dictionary.godot_icall_Dictionary_TryGetValue_Generic(GetPtr(), key, out object retValue, valTypeEncoding, valTypeClass);
+            value = found ? (TValue)retValue : default;
             return found;
         }
 
         // ICollection<KeyValuePair<TKey, TValue>>
 
+        /// <summary>
+        /// Returns the number of elements in this <see cref="Dictionary{TKey, TValue}"/>.
+        /// This is also known as the size or length of the dictionary.
+        /// </summary>
+        /// <returns>The number of elements.</returns>
         public int Count
         {
             get { return objectDict.Count; }
         }
 
-        public bool IsReadOnly
-        {
-            get { return objectDict.IsReadOnly; }
-        }
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
 
-        public void Add(KeyValuePair<TKey, TValue> item)
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
         {
             objectDict.Add(item.Key, item.Value);
         }
 
+        /// <summary>
+        /// Erases all the items from this <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
         public void Clear()
         {
             objectDict.Clear();
         }
 
-        public bool Contains(KeyValuePair<TKey, TValue> item)
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
         {
             return objectDict.Contains(new KeyValuePair<object, object>(item.Key, item.Value));
         }
 
+        /// <summary>
+        /// Copies the elements of this <see cref="Dictionary{TKey, TValue}"/> to the given
+        /// untyped C# array, starting at the given index.
+        /// </summary>
+        /// <param name="array">The array to copy to.</param>
+        /// <param name="arrayIndex">The index to start at.</param>
         public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
             if (array == null)
@@ -424,7 +564,7 @@ namespace Godot.Collections
             }
         }
 
-        public bool Remove(KeyValuePair<TKey, TValue> item)
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
         {
             return Dictionary.godot_icall_Dictionary_Remove(GetPtr(), item.Key, item.Value);
             ;
@@ -432,6 +572,10 @@ namespace Godot.Collections
 
         // IEnumerable<KeyValuePair<TKey, TValue>>
 
+        /// <summary>
+        /// Gets an enumerator for this <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <returns>An enumerator.</returns>
         public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
         {
             // TODO 3 internal calls, can reduce to 1
@@ -451,6 +595,10 @@ namespace Godot.Collections
             return GetEnumerator();
         }
 
+        /// <summary>
+        /// Converts this <see cref="Dictionary{TKey, TValue}"/> to a string.
+        /// </summary>
+        /// <returns>A string representation of this dictionary.</returns>
         public override string ToString() => objectDict.ToString();
     }
 }

--- a/modules/mono/glue/collections_glue.cpp
+++ b/modules/mono/glue/collections_glue.cpp
@@ -230,6 +230,19 @@ int32_t godot_icall_Dictionary_Count(Dictionary *ptr) {
 	return ptr->size();
 }
 
+int32_t godot_icall_Dictionary_KeyValuePairs(Dictionary *ptr, Array **keys, Array **values) {
+	*keys = godot_icall_Dictionary_Keys(ptr);
+	*values = godot_icall_Dictionary_Values(ptr);
+	return godot_icall_Dictionary_Count(ptr);
+}
+
+void godot_icall_Dictionary_KeyValuePairAt(Dictionary *ptr, int index, MonoObject **key, MonoObject **value) {
+	Array *keys = godot_icall_Dictionary_Keys(ptr);
+	Array *values = godot_icall_Dictionary_Values(ptr);
+	*key = GDMonoMarshal::variant_to_mono_object(keys->get(index));
+	*value = GDMonoMarshal::variant_to_mono_object(values->get(index));
+}
+
 void godot_icall_Dictionary_Add(Dictionary *ptr, MonoObject *key, MonoObject *value) {
 	Variant varKey = GDMonoMarshal::mono_object_to_variant(key);
 	Variant *ret = ptr->getptr(varKey);
@@ -338,6 +351,8 @@ void godot_register_collections_icalls() {
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Keys", godot_icall_Dictionary_Keys);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Values", godot_icall_Dictionary_Values);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Count", godot_icall_Dictionary_Count);
+	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_KeyValuePairs", godot_icall_Dictionary_KeyValuePairs);
+	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_KeyValuePairAt", godot_icall_Dictionary_KeyValuePairAt);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Add", godot_icall_Dictionary_Add);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Clear", godot_icall_Dictionary_Clear);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Contains", godot_icall_Dictionary_Contains);


### PR DESCRIPTION
- Adds documentation to `Godot.Collections.Dictionary` in C#.
- Tries to reduce C# Dictionary internal calls, I'm not sure if this is what those `TODO` comments meant if I got it wrong I can drop these changes.
- Also caches `DictionaryEntry` to avoid having to make an internal call every time one of the properties is accessed if the index hasn't changed, since I guess the value shouldn't change.
