### PR TITLE
[3.x] Fix building with the FreeType module disabled

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -30,6 +30,8 @@
 
 #include "scene_tree.h"
 
+#include "modules/modules_enabled.gen.h"
+
 #include "core/io/marshalls.h"
 #include "core/io/resource_loader.h"
 #include "core/message_queue.h"
@@ -493,10 +495,12 @@ bool SceneTree::iteration(float p_time) {
 }
 
 void SceneTree::_update_font_oversampling(float p_ratio) {
+#ifdef MODULE_FREETYPE_ENABLED
 	if (use_font_oversampling) {
 		DynamicFontAtSize::font_oversampling = p_ratio;
 		DynamicFont::update_oversampling();
 	}
+#endif // MODULE_FREETYPE_ENABLED
 }
 
 bool SceneTree::idle(float p_time) {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -218,7 +218,9 @@
 static Ref<ResourceFormatSaverText> resource_saver_text;
 static Ref<ResourceFormatLoaderText> resource_loader_text;
 
+#ifdef MODULE_FREETYPE_ENABLED
 static Ref<ResourceFormatLoaderDynamicFont> resource_loader_dynamic_font;
+#endif // MODULE_FREETYPE_ENABLED
 
 static Ref<ResourceFormatLoaderStreamTexture> resource_loader_stream_texture;
 static Ref<ResourceFormatLoaderTextureLayered> resource_loader_texture_layered;
@@ -235,8 +237,10 @@ void register_scene_types() {
 
 	Node::init_node_hrcr();
 
+#ifdef MODULE_FREETYPE_ENABLED
 	resource_loader_dynamic_font.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_dynamic_font);
+#endif // MODULE_FREETYPE_ENABLED
 
 	resource_loader_stream_texture.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
@@ -681,10 +685,12 @@ void register_scene_types() {
 
 	ClassDB::register_class<TextFile>();
 
+#ifdef MODULE_FREETYPE_ENABLED
 	ClassDB::register_class<DynamicFontData>();
 	ClassDB::register_class<DynamicFont>();
 
 	DynamicFont::initialize_dynamic_fonts();
+#endif // MODULE_FREETYPE_ENABLED
 
 	ClassDB::register_virtual_class<StyleBox>();
 	ClassDB::register_class<StyleBoxEmpty>();
@@ -784,16 +790,18 @@ void register_scene_types() {
 void unregister_scene_types() {
 	clear_default_theme();
 
+#ifdef MODULE_FREETYPE_ENABLED
 	ResourceLoader::remove_resource_format_loader(resource_loader_dynamic_font);
 	resource_loader_dynamic_font.unref();
+
+	DynamicFont::finish_dynamic_fonts();
+#endif // MODULE_FREETYPE_ENABLED
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);
 	resource_loader_texture_layered.unref();
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_stream_texture);
 	resource_loader_stream_texture.unref();
-
-	DynamicFont::finish_dynamic_fonts();
 
 	ResourceSaver::remove_resource_format_saver(resource_saver_text);
 	resource_saver_text.unref();

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -307,6 +307,6 @@ public:
 	virtual String get_resource_type(const String &p_path) const;
 };
 
-#endif
+#endif // MODULE_FREETYPE_ENABLED
 
-#endif
+#endif // DYNAMIC_FONT_H


### PR DESCRIPTION
This PR fixes building with `module_freetype_enabled=no` in the 3.x branch.