### PR TITLE
Visual script modules draft

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -299,6 +299,13 @@
 			<description>
 			</description>
 		</signal>
+		<signal name="node_double_clicked">
+			<argument index="0" name="node" type="Node">
+			</argument>
+			<description>
+				Emitted when a GraphNode is double clicked.
+			</description>
+		</signal>
 		<signal name="node_selected">
 			<argument index="0" name="node" type="Node">
 			</argument>

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -313,6 +313,12 @@
 				Emitted when the GraphNode is requested to be closed. Happens on clicking the close button (see [member show_close]).
 			</description>
 		</signal>
+		<signal name="double_clicked">
++			<description>
+			<description>
+				Emitted when the GraphNode is double clicked.
+			</description>
+		</signal>
 		<signal name="dragged">
 			<argument index="0" name="from" type="Vector2">
 			</argument>

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -314,7 +314,6 @@
 			</description>
 		</signal>
 		<signal name="double_clicked">
-+			<description>
 			<description>
 				Emitted when the GraphNode is double clicked.
 			</description>

--- a/modules/visual_script/doc_classes/VisualScriptNode.xml
+++ b/modules/visual_script/doc_classes/VisualScriptNode.xml
@@ -8,7 +8,14 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
+		<methods>
+			<method name="get_container" qualifiers="const">
+			<return type="Resource">
+			</return>
+			<description>
+				Returns container
+			</description>
+		</method>
 		<method name="get_default_input_value" qualifiers="const">
 			<return type="Variant">
 			</return>

--- a/modules/visual_script/doc_classes/VisualScriptNode.xml
+++ b/modules/visual_script/doc_classes/VisualScriptNode.xml
@@ -8,8 +8,8 @@
 	</description>
 	<tutorials>
 	</tutorials>
-		<methods>
-			<method name="get_container" qualifiers="const">
+	<methods>
+		<method name="get_container" qualifiers="const">
 			<return type="Resource">
 			</return>
 			<description>
@@ -23,13 +23,6 @@
 			</argument>
 			<description>
 				Returns the default value of a given port. The default value is used when nothing is connected to the port.
-			</description>
-		</method>
-		<method name="get_visual_script" qualifiers="const">
-			<return type="VisualScript">
-			</return>
-			<description>
-				Returns the [VisualScript] instance the node is bound to.
 			</description>
 		</method>
 		<method name="ports_changed_notify">

--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -38,6 +38,7 @@
 #include "visual_script_expression.h"
 #include "visual_script_flow_control.h"
 #include "visual_script_func_nodes.h"
+#include "visual_script_module_nodes.h"
 #include "visual_script_nodes.h"
 #include "visual_script_yield_nodes.h"
 
@@ -72,7 +73,13 @@ void register_visual_script_types() {
 	GDREGISTER_CLASS(VisualScriptSceneTree);
 	GDREGISTER_CLASS(VisualScriptResourcePath);
 	GDREGISTER_CLASS(VisualScriptSelf);
+	GDREGISTER_CLASS(VisualScriptModule);
 	GDREGISTER_CLASS(VisualScriptCustomNode);
+
+	GDREGISTER_CLASS(VisualScriptModuleNode);
+	GDREGISTER_CLASS(VisualScriptModuleEntryNode);
+	GDREGISTER_CLASS(VisualScriptModuleExitNode);
+
 	GDREGISTER_CLASS(VisualScriptSubCall);
 	GDREGISTER_CLASS(VisualScriptComment);
 	GDREGISTER_CLASS(VisualScriptConstructor);
@@ -111,6 +118,7 @@ void register_visual_script_types() {
 	register_visual_script_flow_control_nodes();
 	register_visual_script_yield_nodes();
 	register_visual_script_expression_node();
+	register_visual_script_module_nodes();
 
 #ifdef TOOLS_ENABLED
 	ClassDB::set_current_api(ClassDB::API_EDITOR);

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2327,7 +2327,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 			int node_id_offset = 0;
 			Function function;
 			if (!is_module) {
-				const VisualScript::Function vsfn = p_script->functions[E->get()];
+				const VisualScript::Function vsfn = p_script->functions[E];
 				function.node = vsfn.func_id;
 				function.max_stack = 0;
 				function.flow_stack_size = 0;
@@ -2335,7 +2335,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				function.node_count = 0;
 			} else {
 				// for Module add the node count to the offset_node_id
-				offset_node_id += script->modules[E->get()]->get_available_id();
+				offset_node_id += script->modules[E]->get_available_id();
 				node_id_offset = script_end + offset_node_id;
 				function.node = 0;
 				function.max_stack = 0;
@@ -2364,10 +2364,10 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				function.flow_stack_size = func_node->is_stack_less() ? 0 : func_node->get_stack_size();
 				max_input_args = MAX(max_input_args, function.argument_count);
 			} else {
-				Ref<VisualScriptModuleEntryNode> entry_node = script->modules[E->get()]->get_node(function.node);
+				Ref<VisualScriptModuleEntryNode> entry_node = script->modules[E]->get_node(function.node);
 
 				if (entry_node.is_null()) {
-					VisualScriptLanguage::singleton->debug_break_parse(get_script()->get_path(), 0, "No VisualScriptModuleEntryNode typed start node in module: " + String(E->get()));
+					VisualScriptLanguage::singleton->debug_break_parse(get_script()->get_path(), 0, "No VisualScriptModuleEntryNode typed start node in module: " + String(E));
 				}
 
 				ERR_CONTINUE(!entry_node.is_valid());
@@ -2385,7 +2385,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 			{
 				List<int> nd_queue;
 				nd_queue.push_back(function.node);
-				Set<VisualScript::SequenceConnection> sequence_connections = is_module ? script->modules[E->get()]->sequence_connections : script->sequence_connections;
+				Set<VisualScript::SequenceConnection> sequence_connections = is_module ? script->modules[E]->sequence_connections : script->sequence_connections;
 				while (!nd_queue.is_empty()) {
 					if (!is_module && function.node != nd_queue.front()->get() && function_nodes.has(nd_queue.front()->get())) {
 						nd_queue.pop_front();
@@ -2402,7 +2402,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 					}
 					nd_queue.pop_front();
 				}
-				Set<VisualScript::DataConnection> data_connections = is_module ? script->modules[E->get()]->data_connections : script->data_connections;
+				Set<VisualScript::DataConnection> data_connections = is_module ? script->modules[E]->data_connections : script->data_connections;
 				HashMap<int, HashMap<int, Pair<int, int>>> dc_lut; // :: to -> to_port -> (from, from_port)
 				for (const Set<VisualScript::DataConnection>::Element *F = data_connections.front(); F; F = F->next()) {
 					dc_lut[F->get().to_node][F->get().to_port] = Pair<int, int>(F->get().from_node, F->get().from_port);
@@ -2448,11 +2448,11 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 			for (const Set<int>::Element *F = node_ids.front(); F; F = F->next()) {
 				Ref<VisualScriptNode> node;
 				if (is_module) {
-					node = script->modules[E->get()]->nodes[F->get()].node;
+					node = script->modules[E]->nodes[F->get()].node;
 				} else {
 					node = script->nodes[F->get()].node;
 				}
-				VisualScriptNodeInstance *instance = node->instance(this); // Create instance
+				VisualScriptNodeInstance *instance = node->instantiate(this); // Create instance
 				ERR_FAIL_COND(!instance);
 
 				instance->base = node.ptr();
@@ -2580,7 +2580,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				if (!is_module) {
 					node = script->nodes[F->get()].node;
 				} else {
-					node = script->modules[E->get()]->nodes[F->get()].node;
+					node = script->modules[E]->nodes[F->get()].node;
 				}
 				VisualScriptNodeInstance *instance = instances[instance_id];
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -34,6 +34,7 @@
 #include "core/core_string_names.h"
 #include "core/os/os.h"
 #include "scene/main/node.h"
+#include "visual_script_module_nodes.h"
 #include "visual_script_nodes.h"
 
 // Used by editor, this is not really saved.
@@ -55,8 +56,8 @@ void VisualScriptNode::set_default_input_value(int p_port, const Variant &p_valu
 	default_input_values[p_port] = p_value;
 
 #ifdef TOOLS_ENABLED
-	if (script_used.is_valid()) {
-		script_used->set_edited(true);
+	if (container.is_valid()) {
+		container->set_edited(true);
 	}
 #endif
 }
@@ -71,7 +72,7 @@ void VisualScriptNode::_set_default_input_values(Array p_values) {
 }
 
 void VisualScriptNode::validate_input_default_values() {
-	default_input_values.resize(MAX(default_input_values.size(), get_input_value_port_count())); //let it grow as big as possible, we don't want to lose values on resize
+	default_input_values.resize(MAX(default_input_values.size(), get_input_value_port_count())); // Let it grow as big as possible, we don't want to lose values on resize
 
 	// Actually validate on save.
 	for (int i = 0; i < get_input_value_port_count(); i++) {
@@ -106,7 +107,7 @@ String VisualScriptNode::get_text() const {
 }
 
 void VisualScriptNode::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_visual_script"), &VisualScriptNode::get_visual_script);
+	ClassDB::bind_method(D_METHOD("get_container"), &VisualScriptNode::get_container);
 	ClassDB::bind_method(D_METHOD("set_default_input_value", "port_idx", "value"), &VisualScriptNode::set_default_input_value);
 	ClassDB::bind_method(D_METHOD("get_default_input_value", "port_idx"), &VisualScriptNode::get_default_input_value);
 	ClassDB::bind_method(D_METHOD("ports_changed_notify"), &VisualScriptNode::ports_changed_notify);
@@ -132,8 +133,8 @@ VisualScriptNode::TypeGuess VisualScriptNode::guess_output_type(TypeGuess *p_inp
 	return tg;
 }
 
-Ref<VisualScript> VisualScriptNode::get_visual_script() const {
-	return script_used;
+Ref<Resource> VisualScriptNode::get_container() const {
+	return container;
 }
 
 VisualScriptNode::VisualScriptNode() {
@@ -143,8 +144,7 @@ VisualScriptNode::VisualScriptNode() {
 
 /////////////////////
 
-VisualScriptNodeInstance::VisualScriptNodeInstance() {
-}
+VisualScriptNodeInstance::VisualScriptNodeInstance() {}
 
 VisualScriptNodeInstance::~VisualScriptNodeInstance() {
 	if (sequence_outputs) {
@@ -158,6 +158,406 @@ VisualScriptNodeInstance::~VisualScriptNodeInstance() {
 	if (output_ports) {
 		memdelete_arr(output_ports);
 	}
+}
+
+////////////////
+////	VisualScriptModule
+/////////////////////
+
+void VisualScriptModule::_set_data(const Dictionary &p_data) {
+	// used to load data for the resource
+	module_name = p_data["module_name"];
+	base_type = p_data["module_base_type"];
+
+	Array nds = p_data["nodes"];
+	for (int i = 0; i < nds.size(); i++) {
+		Dictionary nd = nds[i];
+		add_node(nd["id"], nd["node"], nd["pos"]);
+	}
+	Array sequence_connections = p_data["sequence_connections"];
+	for (int j = 0; j < sequence_connections.size(); j += 3) {
+		sequence_connect(sequence_connections[j + 0], sequence_connections[j + 1], sequence_connections[j + 2]);
+	}
+
+	Array data_connections = p_data["data_connections"];
+	for (int j = 0; j < data_connections.size(); j += 4) {
+		data_connect(data_connections[j + 0], data_connections[j + 1], data_connections[j + 2], data_connections[j + 3]);
+	}
+
+	scroll = p_data["scroll"];
+}
+
+void VisualScriptModule::set_instance_base_type(const StringName &p_type) {
+	base_type = p_type;
+}
+
+Dictionary VisualScriptModule::_get_data() const {
+	// used to save data
+	Dictionary d;
+	d["module_name"] = module_name;
+	d["module_base_type"] = base_type;
+
+	Array nds;
+	List<int> keys;
+	nodes.get_key_list(&keys);
+	for (const List<int>::Element *E = keys.front(); E; E = E->next()) {
+		Dictionary nd;
+		nd["id"] = E->get();
+		nd["node"] = nodes[E->get()].node;
+		nd["pos"] = nodes[E->get()].pos;
+		nds.push_back(nd);
+	}
+	d["nodes"] = nds;
+
+	Array seqconns;
+	for (const Set<VisualScript::SequenceConnection>::Element *F = sequence_connections.front(); F; F = F->next()) {
+		seqconns.push_back(F->get().from_node);
+		seqconns.push_back(F->get().from_output);
+		seqconns.push_back(F->get().to_node);
+	}
+	d["sequence_connections"] = seqconns;
+
+	Array dataconns;
+	for (const Set<VisualScript::DataConnection>::Element *F = data_connections.front(); F; F = F->next()) {
+		dataconns.push_back(F->get().from_node);
+		dataconns.push_back(F->get().from_port);
+		dataconns.push_back(F->get().to_node);
+		dataconns.push_back(F->get().to_port);
+	}
+	d["data_connections"] = dataconns;
+
+	d["scroll"] = scroll;
+	return d;
+}
+
+void VisualScriptModule::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_set_data", "data"), &VisualScriptModule::_set_data);
+	ClassDB::bind_method(D_METHOD("_get_data"), &VisualScriptModule::_get_data);
+	ClassDB::bind_method(D_METHOD("set_scroll", "ofs"), &VisualScriptModule::set_scroll);
+	ClassDB::bind_method(D_METHOD("get_scroll"), &VisualScriptModule::get_scroll);
+
+	ClassDB::bind_method(D_METHOD("add_node", "id", "node", "position"), &VisualScriptModule::add_node, DEFVAL(Point2()));
+	ClassDB::bind_method(D_METHOD("remove_node", "id"), &VisualScriptModule::remove_node);
+
+	ClassDB::bind_method(D_METHOD("get_node", "id"), &VisualScriptModule::get_node);
+	ClassDB::bind_method(D_METHOD("has_node", "id"), &VisualScriptModule::has_node);
+	ClassDB::bind_method(D_METHOD("set_node_position", "id", "position"), &VisualScriptModule::set_node_position);
+	ClassDB::bind_method(D_METHOD("get_node_position", "id"), &VisualScriptModule::get_node_position);
+
+	ClassDB::bind_method(D_METHOD("sequence_connect", "from_node", "from_output", "to_node"), &VisualScriptModule::sequence_connect);
+	ClassDB::bind_method(D_METHOD("sequence_disconnect", "from_node", "from_output", "to_node"), &VisualScriptModule::sequence_disconnect);
+	ClassDB::bind_method(D_METHOD("has_sequence_connection", "from_node", "from_output", "to_node"), &VisualScriptModule::has_sequence_connection);
+
+	ClassDB::bind_method(D_METHOD("data_connect", "from_node", "from_port", "to_node", "to_port"), &VisualScriptModule::data_connect);
+	ClassDB::bind_method(D_METHOD("data_disconnect", "from_node", "from_port", "to_node", "to_port"), &VisualScriptModule::data_disconnect);
+	ClassDB::bind_method(D_METHOD("has_data_connection", "from_node", "from_port", "to_node", "to_port"), &VisualScriptModule::has_data_connection);
+	ClassDB::bind_method(D_METHOD("set_instance_base_type", "p_type"), &VisualScriptModule::set_instance_base_type);
+	ClassDB::bind_method(D_METHOD("get_instance_base_type"), &VisualScriptModule::get_instance_base_type);
+
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
+	ADD_SIGNAL(MethodInfo("node_ports_changed", PropertyInfo(Variant::INT, "id")));
+}
+
+void VisualScriptModule::set_scroll(Vector2 p_scroll) {
+	scroll = p_scroll;
+}
+
+Vector2 VisualScriptModule::get_scroll() const {
+	return scroll;
+}
+
+void VisualScriptModule::add_node(int p_id, const Ref<VisualScriptNode> &p_node, const Point2 &p_pos) {
+	ERR_FAIL_COND(nodes.has(p_id)); //id can exist only one in script
+
+	NodeData nd;
+	nd.node = p_node;
+	nd.pos = p_pos;
+
+	Ref<VisualScriptNode> vsn = p_node;
+	vsn->connect("ports_changed", callable_mp(this, &VisualScriptModule::_node_ports_changed), varray(p_id));
+	vsn->container = Ref<Resource>(this);
+	vsn->validate_input_default_values(); // Validate when fully loaded
+
+	nodes[p_id] = nd;
+}
+
+bool VisualScriptModule::get_input_value_port_connection_source(int p_node, int p_port, int *r_node, int *r_port) const {
+	for (const Set<VisualScript::DataConnection>::Element *E = data_connections.front(); E; E = E->next()) {
+		if (E->get().to_node == p_node && E->get().to_port == p_port) {
+			*r_node = E->get().from_node;
+			*r_port = E->get().from_port;
+			return true;
+		}
+	}
+	return false;
+}
+
+void VisualScriptModule::remove_node(int p_id) {
+	ERR_FAIL_COND(!nodes.has(p_id));
+	{
+		List<VisualScript::SequenceConnection> to_remove;
+
+		for (Set<VisualScript::SequenceConnection>::Element *E = sequence_connections.front(); E; E = E->next()) {
+			if (E->get().from_node == p_id || E->get().to_node == p_id) {
+				to_remove.push_back(E->get());
+			}
+		}
+
+		while (to_remove.size()) {
+			sequence_connections.erase(to_remove.front()->get());
+			to_remove.pop_front();
+		}
+	}
+
+	{
+		List<VisualScript::DataConnection> to_remove;
+
+		for (Set<VisualScript::DataConnection>::Element *E = data_connections.front(); E; E = E->next()) {
+			if (E->get().from_node == p_id || E->get().to_node == p_id) {
+				to_remove.push_back(E->get());
+			}
+		}
+
+		while (to_remove.size()) {
+			data_connections.erase(to_remove.front()->get());
+			to_remove.pop_front();
+		}
+	}
+
+	nodes[p_id].node->disconnect("ports_changed", callable_mp(this, &VisualScriptModule::_node_ports_changed));
+	nodes[p_id].node->container.unref();
+
+	nodes.erase(p_id);
+}
+
+bool VisualScriptModule::has_node(int p_id) const {
+	return nodes.has(p_id);
+}
+
+Ref<VisualScriptNode> VisualScriptModule::get_node(int p_id) const {
+	ERR_FAIL_COND_V(!nodes.has(p_id), Ref<VisualScriptNode>());
+	return nodes[p_id].node;
+}
+
+Vector2 VisualScriptModule::get_node_position(int p_id) const {
+	ERR_FAIL_COND_V(!nodes.has(p_id), Point2());
+	return nodes[p_id].pos;
+}
+
+void VisualScriptModule::set_node_position(int p_id, const Point2 &p_pos) {
+	ERR_FAIL_COND(!nodes.has(p_id));
+	nodes[p_id].pos = p_pos;
+}
+
+void VisualScriptModule::get_node_list(List<int> *r_nodes) const {
+	nodes.get_key_list(r_nodes);
+}
+
+Set<int> VisualScriptModule::get_output_sequence_ports_connected(int from_node) {
+	List<VisualScript::SequenceConnection> *sc = memnew(List<VisualScript::SequenceConnection>);
+	get_sequence_connection_list(sc);
+	Set<int> connected;
+	for (List<VisualScript::SequenceConnection>::Element *E = sc->front(); E; E = E->next()) {
+		if (E->get().from_node == from_node) {
+			connected.insert(E->get().from_output);
+		}
+	}
+	memdelete(sc);
+	return connected;
+}
+
+void VisualScriptModule::sequence_connect(int p_from_node, int p_from_output, int p_to_node) {
+	VisualScript::SequenceConnection sc;
+	sc.from_node = p_from_node;
+	sc.from_output = p_from_output;
+	sc.to_node = p_to_node;
+	ERR_FAIL_COND(sequence_connections.has(sc));
+
+	sequence_connections.insert(sc);
+}
+
+void VisualScriptModule::sequence_disconnect(int p_from_node, int p_from_output, int p_to_node) {
+	VisualScript::SequenceConnection sc;
+	sc.from_node = p_from_node;
+	sc.from_output = p_from_output;
+	sc.to_node = p_to_node;
+	ERR_FAIL_COND(!sequence_connections.has(sc));
+
+	sequence_connections.erase(sc);
+}
+
+bool VisualScriptModule::has_sequence_connection(int p_from_node, int p_from_output, int p_to_node) const {
+	VisualScript::SequenceConnection sc;
+	sc.from_node = p_from_node;
+	sc.from_output = p_from_output;
+	sc.to_node = p_to_node;
+	return sequence_connections.has(sc);
+}
+
+void VisualScriptModule::get_sequence_connection_list(List<VisualScript::SequenceConnection> *r_connection) const {
+	for (const Set<VisualScript::SequenceConnection>::Element *E = sequence_connections.front(); E; E = E->next()) {
+		r_connection->push_back(E->get());
+	}
+}
+
+bool VisualScriptModule::is_input_value_port_connected(int p_node, int p_port) const {
+	for (const Set<VisualScript::DataConnection>::Element *E = data_connections.front(); E; E = E->next()) {
+		if (E->get().to_node == p_node && E->get().to_port == p_port) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void VisualScriptModule::data_connect(int p_from_node, int p_from_port, int p_to_node, int p_to_port) {
+	VisualScript::DataConnection dc;
+	dc.from_node = p_from_node;
+	dc.from_port = p_from_port;
+	dc.to_node = p_to_node;
+	dc.to_port = p_to_port;
+	ERR_FAIL_COND(data_connections.has(dc));
+
+	data_connections.insert(dc);
+}
+
+void VisualScriptModule::data_disconnect(int p_from_node, int p_from_port, int p_to_node, int p_to_port) {
+	VisualScript::DataConnection dc;
+	dc.from_node = p_from_node;
+	dc.from_port = p_from_port;
+	dc.to_node = p_to_node;
+	dc.to_port = p_to_port;
+	ERR_FAIL_COND(!data_connections.has(dc));
+
+	data_connections.erase(dc);
+}
+
+bool VisualScriptModule::has_data_connection(int p_from_node, int p_from_port, int p_to_node, int p_to_port) const {
+	VisualScript::DataConnection dc;
+	dc.from_node = p_from_node;
+	dc.from_port = p_from_port;
+	dc.to_node = p_to_node;
+	dc.to_port = p_to_port;
+
+	return data_connections.has(dc);
+}
+
+void VisualScriptModule::get_data_connection_list(List<VisualScript::DataConnection> *r_connection) const {
+	for (const Set<VisualScript::DataConnection>::Element *E = data_connections.front(); E; E = E->next()) {
+		r_connection->push_back(E->get());
+	}
+}
+
+StringName VisualScriptModule::get_instance_base_type() const {
+	return base_type;
+}
+
+VisualScriptModule::VisualScriptModule() {
+	// maybe do some init here
+	module_name = "Module";
+	base_type = "Node";
+}
+
+VisualScriptModule::~VisualScriptModule() {}
+
+void VisualScriptModule::_node_ports_changed(int p_id) {
+	Ref<VisualScriptNode> vsn = nodes[p_id].node;
+
+	vsn->validate_input_default_values();
+
+	//must revalidate all the functions
+
+	{
+		List<VisualScript::SequenceConnection> to_remove;
+
+		for (Set<VisualScript::SequenceConnection>::Element *E = sequence_connections.front(); E; E = E->next()) {
+			if (E->get().from_node == p_id && E->get().from_output >= vsn->get_output_sequence_port_count()) {
+				to_remove.push_back(E->get());
+			}
+			if (E->get().to_node == p_id && !vsn->has_input_sequence_port()) {
+				to_remove.push_back(E->get());
+			}
+		}
+
+		while (to_remove.size()) {
+			sequence_connections.erase(to_remove.front()->get());
+			to_remove.pop_front();
+		}
+	}
+
+	{
+		List<VisualScript::DataConnection> to_remove;
+
+		for (Set<VisualScript::DataConnection>::Element *E = data_connections.front(); E; E = E->next()) {
+			if (E->get().from_node == p_id && E->get().from_port >= vsn->get_output_value_port_count()) {
+				to_remove.push_back(E->get());
+			}
+			if (E->get().to_node == p_id && E->get().to_port >= vsn->get_input_value_port_count()) {
+				to_remove.push_back(E->get());
+			}
+		}
+
+		while (to_remove.size()) {
+			data_connections.erase(to_remove.front()->get());
+			to_remove.pop_front();
+		}
+	}
+
+#ifdef TOOLS_ENABLED
+	set_edited(true); //something changed, let's set as edited
+	emit_signal("node_ports_changed", p_id);
+#endif
+}
+
+int VisualScriptModule::get_available_id() const {
+	List<int> nds;
+	nodes.get_key_list(&nds);
+	int max = 1; // keep it greater than 1 as 0 and 1 are input and output nodes respectively
+	for (const List<int>::Element *E = nds.front(); E; E = E->next()) {
+		if (E->get() > max) {
+			max = E->get();
+		}
+	}
+	return (max + 1);
+}
+
+/////////////////////
+//////// VisualScript
+//////////////////////
+
+void VisualScript::add_module(const StringName &p_name, Ref<VisualScriptModule> p_mod) {
+	ERR_FAIL_COND(has_module(p_name));
+	if (!has_module(p_name)) {
+		modules[p_name] = p_mod;
+	}
+}
+
+void VisualScript::remove_module(const StringName &p_name) {
+	ERR_FAIL_COND(!has_module(p_name));
+	modules.erase(p_name);
+}
+
+Ref<VisualScriptModule> VisualScript::get_module(const StringName &p_name) const {
+	ERR_FAIL_COND_V(!has_module(p_name), Ref<VisualScriptModule>());
+	return modules[p_name];
+}
+
+bool VisualScript::has_module(const StringName &p_name) const {
+	return modules.has(p_name);
+}
+
+String VisualScript::validate_module_name(const StringName &p_name) const {
+	int i = 1;
+	while (modules.has(p_name)) {
+		String t = String(p_name) + "_" + String::num_int64(i);
+		if (!modules.has(t))
+			return t;
+		i++;
+	}
+	return p_name;
+}
+
+void VisualScript::get_module_list(List<StringName> *r_module_names) const {
+	modules.get_key_list(r_module_names);
 }
 
 void VisualScript::add_function(const StringName &p_name, int p_func_node_id) {
@@ -278,8 +678,8 @@ void VisualScript::add_node(int p_id, const Ref<VisualScriptNode> &p_node, const
 
 	Ref<VisualScriptNode> vsn = p_node;
 	vsn->connect("ports_changed", callable_mp(this, &VisualScript::_node_ports_changed), varray(p_id));
-	vsn->script_used = Ref<VisualScript>(this);
-	vsn->validate_input_default_values(); // Validate when fully loaded.
+	vsn->container = Ref<Resource>(this); // Consider using more specilized containers if required in future
+	vsn->validate_input_default_values(); // Validate when fully loaded
 
 	nodes[p_id] = nd;
 }
@@ -318,7 +718,7 @@ void VisualScript::remove_node(int p_id) {
 	}
 
 	nodes[p_id].node->disconnect("ports_changed", callable_mp(this, &VisualScript::_node_ports_changed));
-	nodes[p_id].node->script_used.unref();
+	nodes[p_id].node->container.unref();
 
 	nodes.erase(p_id);
 }
@@ -1013,6 +1413,11 @@ void VisualScript::_set_data(const Dictionary &p_data) {
 	is_tool_script = d["is_tool_script"];
 	scroll = d["scroll"];
 
+	Array submods = d["modules"];
+	for (int i = 0; i < submods.size(); i += 2) {
+		add_module(submods[i], submods[i + 1]);
+	}
+
 	// Takes all the rpc methods.
 	rpc_functions.clear();
 	List<StringName> fns;
@@ -1111,6 +1516,15 @@ Dictionary VisualScript::_get_data() const {
 	d["is_tool_script"] = is_tool_script;
 	d["scroll"] = scroll;
 
+	Array smds;
+	List<StringName> mod_ids;
+	modules.get_key_list(&mod_ids);
+	for (const List<StringName>::Element *F = mod_ids.front(); F; F = F->next()) {
+		smds.push_back(F->get());
+		smds.push_back(modules[F->get()]);
+	}
+	d["modules"] = smds;
+
 	return d;
 }
 
@@ -1205,6 +1619,7 @@ VisualScript::~VisualScript() {
 	for (const int &E : nds) {
 		remove_node(E);
 	}
+	modules.clear();
 }
 
 ////////////////////////////////////////////
@@ -1449,10 +1864,33 @@ Variant VisualScriptInstance::_call_internal(const StringName &p_method, void *p
 			}
 		}
 
-		VSDEBUG("STEP - STARTSEQ: " + itos(start_mode));
+		int ret = 0;
+		Ref<VisualScriptModuleNode> modnode = node->get_base_node();
+		if (modnode.is_valid()) {
+			// call the module and get return?
+			String s = modnode->get_module_name();
+			Variant t = call(s, input_args, node->input_port_count, r_error);
+			if (node->output_port_count > 0) {
+				// NOTE TO SELF: Checking if a Variant `is_null()` is useless as it only works for VariantType::OBJECT and Arrays and stuff aren't OBJECTS WTF!!!!!!!!!!!!!!!!
+				if (node->output_port_count == 1) {
+					*output_args[0] = t; // make sure single arg is handled as a Variant
+				} else {
+					Array fields = t;
+					for (int field_idx = 0; field_idx < fields.size(); field_idx++)
+						*output_args[field_idx] = fields[field_idx];
+				}
+			}
+			if (r_error.error != Callable::CallError::CALL_OK) {
+				//use error from step
+				error = true;
+				break;
+			}
+			// _call_internal(modnode->get_module_name(), void *p_stack, int p_stack_size, VisualScriptNodeInstance *p_node, int p_flow_stack_pos, int p_pass, bool p_resuming_yield, Callable::CallError &r_error)
+		} else {
+			VSDEBUG("STEP - STARTSEQ: " + itos(start_mode));
 
-		int ret = node->step(input_args, output_args, start_mode, working_mem, r_error, error_str);
-
+			ret = node->step(input_args, output_args, start_mode, working_mem, r_error, error_str);
+		}
 		if (r_error.error != Callable::CallError::CALL_OK) {
 			// Use error from step.
 			error = true;
@@ -1767,7 +2205,7 @@ Variant VisualScriptInstance::call(const StringName &p_method, const Variant **p
 		flow_stack[0] = node->get_id();
 	}
 
-	VSDEBUG("ARGUMENTS: " + itos(f->argument_count) = " RECEIVED: " + itos(p_argcount));
+	VSDEBUG("ARGUMENTS: " + itos(f->argument_count) + " RECEIVED: " + itos(p_argcount));
 
 	if (p_argcount < f->argument_count) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
@@ -1877,15 +2315,34 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 	{
 		List<StringName> keys;
 		script->functions.get_key_list(&keys);
+		Set<int> function_nodes;
 		for (const StringName &E : keys) {
-			const VisualScript::Function vsfn = p_script->functions[E];
+			function_nodes.insert(script->functions[E].func_id);
+		}
+		script->modules.get_key_list(&keys);
+		int offset_node_id = 0;
+		int script_end = script->get_available_id();
+		for (const StringName &E : keys) {
+			bool is_module = script->modules.has(E);
+			int node_id_offset = 0;
 			Function function;
-			function.node = vsfn.func_id;
-			function.max_stack = 0;
-			function.flow_stack_size = 0;
-			function.pass_stack_size = 0;
-			function.node_count = 0;
-
+			if (!is_module) {
+				const VisualScript::Function vsfn = p_script->functions[E->get()];
+				function.node = vsfn.func_id;
+				function.max_stack = 0;
+				function.flow_stack_size = 0;
+				function.pass_stack_size = 0;
+				function.node_count = 0;
+			} else {
+				// for Module add the node count to the offset_node_id
+				offset_node_id += script->modules[E->get()]->get_available_id();
+				node_id_offset = script_end + offset_node_id;
+				function.node = 0;
+				function.max_stack = 0;
+				function.flow_stack_size = 0;
+				function.pass_stack_size = 0;
+				function.node_count = 0;
+			}
 			Map<StringName, int> local_var_indices;
 
 			if (function.node < 0) {
@@ -1893,8 +2350,8 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				ERR_CONTINUE(function.node < 0);
 			}
 
-			{
-				Ref<VisualScriptFunction> func_node = script->get_node(vsfn.func_id);
+			if (!is_module) {
+				Ref<VisualScriptFunction> func_node = script->get_node(function.node);
 
 				if (func_node.is_null()) {
 					VisualScriptLanguage::singleton->debug_break_parse(get_script()->get_path(), 0, "No VisualScriptFunction typed start node in function: " + String(E));
@@ -1906,6 +2363,19 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				function.max_stack += function.argument_count;
 				function.flow_stack_size = func_node->is_stack_less() ? 0 : func_node->get_stack_size();
 				max_input_args = MAX(max_input_args, function.argument_count);
+			} else {
+				Ref<VisualScriptModuleEntryNode> entry_node = script->modules[E->get()]->get_node(function.node);
+
+				if (entry_node.is_null()) {
+					VisualScriptLanguage::singleton->debug_break_parse(get_script()->get_path(), 0, "No VisualScriptModuleEntryNode typed start node in module: " + String(E->get()));
+				}
+
+				ERR_CONTINUE(!entry_node.is_valid());
+
+				function.argument_count = entry_node->get_output_value_port_count();
+				function.max_stack += function.argument_count;
+				function.flow_stack_size = entry_node->is_stack_less() ? 0 : entry_node->get_stack_size();
+				max_input_args = MAX(max_input_args, function.argument_count);
 			}
 			// Function nodes graphs.
 			Set<VisualScript::SequenceConnection> seqconns;
@@ -1915,8 +2385,13 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 			{
 				List<int> nd_queue;
 				nd_queue.push_back(function.node);
+				Set<VisualScript::SequenceConnection> sequence_connections = is_module ? script->modules[E->get()]->sequence_connections : script->sequence_connections;
 				while (!nd_queue.is_empty()) {
-					for (const Set<VisualScript::SequenceConnection>::Element *F = script->sequence_connections.front(); F; F = F->next()) {
+					if (!is_module && function.node != nd_queue.front()->get() && function_nodes.has(nd_queue.front()->get())) {
+						nd_queue.pop_front();
+						continue;
+					}
+					for (const Set<VisualScript::SequenceConnection>::Element *F = sequence_connections.front(); F; F = F->next()) {
 						if (nd_queue.front()->get() == F->get().from_node && !node_ids.has(F->get().to_node)) {
 							nd_queue.push_back(F->get().to_node);
 							node_ids.insert(F->get().to_node);
@@ -1927,8 +2402,9 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 					}
 					nd_queue.pop_front();
 				}
+				Set<VisualScript::DataConnection> data_connections = is_module ? script->modules[E->get()]->data_connections : script->data_connections;
 				HashMap<int, HashMap<int, Pair<int, int>>> dc_lut; // :: to -> to_port -> (from, from_port)
-				for (const Set<VisualScript::DataConnection>::Element *F = script->data_connections.front(); F; F = F->next()) {
+				for (const Set<VisualScript::DataConnection>::Element *F = data_connections.front(); F; F = F->next()) {
 					dc_lut[F->get().to_node][F->get().to_port] = Pair<int, int>(F->get().from_node, F->get().from_port);
 				}
 				for (const Set<int>::Element *F = node_ids.front(); F; F = F->next()) {
@@ -1941,6 +2417,9 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 					for (const int &F : dc_keys) {
 						VisualScript::DataConnection dc;
 						dc.from_node = dc_lut[ky][F].first;
+						if (!is_module && function.node != dc.from_node && function_nodes.has(dc.from_node)) {
+							continue;
+						}
 						dc.from_port = dc_lut[ky][F].second;
 						dc.to_node = ky;
 						dc.to_port = F;
@@ -1948,22 +2427,37 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 						nd_queue.push_back(dc.from_node);
 						node_ids.insert(dc.from_node);
 					}
-					dc_keys.clear(); // Necessary as get_key_list does a push_back not a set.
+					dc_keys.clear(); // Necessary as get_key_list does a push_back not a set
 					nd_queue.pop_front();
 				}
 			}
 
-			//Multiple passes are required to set up this complex thing..
-			//First create the nodes.
-			for (const Set<int>::Element *F = node_ids.front(); F; F = F->next()) {
-				Ref<VisualScriptNode> node = script->nodes[F->get()].node;
+			HashMap<int, int> node_ids_remap;
+			{
+				// Make sure all functions have unique instances of the overlapping nodes so as to allow for input typing
+				for (const Set<int>::Element *F = node_ids.front(); F; F = F->next()) {
+					if (instances.has(node_id_offset + F->get())) {
+						node_ids_remap[node_id_offset + F->get()] = script_end + offset_node_id;
+						offset_node_id += 1;
+					}
+				}
+			}
 
-				VisualScriptNodeInstance *instance = node->instantiate(this); // Create instance.
+			// Multiple passes are required to set up this complex thing..
+			// First create the nodes.
+			for (const Set<int>::Element *F = node_ids.front(); F; F = F->next()) {
+				Ref<VisualScriptNode> node;
+				if (is_module) {
+					node = script->modules[E->get()]->nodes[F->get()].node;
+				} else {
+					node = script->nodes[F->get()].node;
+				}
+				VisualScriptNodeInstance *instance = node->instance(this); // Create instance
 				ERR_FAIL_COND(!instance);
 
 				instance->base = node.ptr();
 
-				instance->id = F->get();
+				instance->id = node_ids_remap.has(node_id_offset + F->get()) ? node_ids_remap[node_id_offset + F->get()] : node_id_offset + F->get();
 				instance->input_port_count = node->get_input_value_port_count();
 				instance->input_ports = nullptr;
 				instance->output_port_count = node->get_output_value_port_count();
@@ -2023,7 +2517,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				max_input_args = MAX(max_input_args, instance->input_port_count);
 				max_output_args = MAX(max_output_args, instance->output_port_count);
 
-				instances[F->get()] = instance;
+				instances[instance->id] = instance; // move instance from available_id + module id for module nodes
 			}
 
 			function.trash_pos = function.max_stack++; // create pos for trash
@@ -2031,10 +2525,14 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 			// Second pass, do data connections.
 			for (const Set<VisualScript::DataConnection>::Element *F = dataconns.front(); F; F = F->next()) {
 				VisualScript::DataConnection dc = F->get();
-				ERR_CONTINUE(!instances.has(dc.from_node));
-				VisualScriptNodeInstance *from = instances[dc.from_node];
-				ERR_CONTINUE(!instances.has(dc.to_node));
-				VisualScriptNodeInstance *to = instances[dc.to_node];
+				int from_node = node_id_offset + dc.from_node;
+				from_node = node_ids_remap.has(from_node) ? node_ids_remap[from_node] : from_node;
+				ERR_CONTINUE(!instances.has(from_node));
+				VisualScriptNodeInstance *from = instances[from_node];
+				int to_node = node_id_offset + dc.to_node;
+				to_node = node_ids_remap.has(to_node) ? node_ids_remap[to_node] : to_node;
+				ERR_CONTINUE(!instances.has(to_node));
+				VisualScriptNodeInstance *to = instances[to_node];
 				ERR_CONTINUE(dc.from_port >= from->output_port_count);
 				ERR_CONTINUE(dc.to_port >= to->input_port_count);
 
@@ -2058,10 +2556,14 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 			// Third pass, do sequence connections.
 			for (const Set<VisualScript::SequenceConnection>::Element *F = seqconns.front(); F; F = F->next()) {
 				VisualScript::SequenceConnection sc = F->get();
-				ERR_CONTINUE(!instances.has(sc.from_node));
-				VisualScriptNodeInstance *from = instances[sc.from_node];
-				ERR_CONTINUE(!instances.has(sc.to_node));
-				VisualScriptNodeInstance *to = instances[sc.to_node];
+				int from_node = node_id_offset + sc.from_node;
+				from_node = node_ids_remap.has(from_node) ? node_ids_remap[from_node] : from_node;
+				ERR_CONTINUE(!instances.has(from_node)); // use offset for instance from available_id + module id for module nodes
+				VisualScriptNodeInstance *from = instances[from_node];
+				int to_node = node_id_offset + sc.to_node;
+				to_node = node_ids_remap.has(to_node) ? node_ids_remap[to_node] : to_node;
+				ERR_CONTINUE(!instances.has(to_node));
+				VisualScriptNodeInstance *to = instances[to_node];
 				ERR_CONTINUE(sc.from_output >= from->sequence_output_count);
 
 				from->sequence_outputs[sc.from_output] = to;
@@ -2071,10 +2573,16 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 			// 1) unassigned input ports to default values
 			// 2) connect unassigned output ports to trash
 			for (const Set<int>::Element *F = node_ids.front(); F; F = F->next()) {
-				ERR_CONTINUE(!instances.has(F->get()));
-
-				Ref<VisualScriptNode> node = script->nodes[F->get()].node;
-				VisualScriptNodeInstance *instance = instances[F->get()];
+				int instance_id = node_id_offset + F->get();
+				instance_id = node_ids_remap.has(instance_id) ? node_ids_remap[instance_id] : instance_id;
+				ERR_CONTINUE(!instances.has(instance_id)); // use offset for instance from available_id + module id for module nodes
+				Ref<VisualScriptNode> node;
+				if (!is_module) {
+					node = script->nodes[F->get()].node;
+				} else {
+					node = script->modules[E->get()]->nodes[F->get()].node;
+				}
+				VisualScriptNodeInstance *instance = instances[instance_id];
 
 				// Connect to default values.
 				for (int i = 0; i < instance->input_port_count; i++) {
@@ -2092,7 +2600,9 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 					}
 				}
 			}
-
+			if (is_module) {
+				function.node += script_end + offset_node_id;
+			}
 			functions[E] = function;
 		}
 	}
@@ -2103,6 +2613,9 @@ ScriptLanguage *VisualScriptInstance::get_language() {
 }
 
 VisualScriptInstance::VisualScriptInstance() {
+	owner = nullptr;
+	max_input_args = 0;
+	max_output_args = 0;
 }
 
 VisualScriptInstance::~VisualScriptInstance() {
@@ -2210,6 +2723,11 @@ void VisualScriptFunctionState::_bind_methods() {
 }
 
 VisualScriptFunctionState::VisualScriptFunctionState() {
+	node = nullptr;
+	working_mem_index = -1;
+	variant_stack_size = 0;
+	flow_stack_pos = 0;
+	pass = 0;
 }
 
 VisualScriptFunctionState::~VisualScriptFunctionState() {

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -578,7 +578,6 @@ void VisualScriptEditor::_update_graph_connections() {
 	}
 
 	for (VisualScript::DataConnection &dc : data_conns) {
-
 		Ref<VisualScriptNode> from_node;
 		Ref<VisualScriptNode> to_node;
 		if (inside_module) {
@@ -1103,7 +1102,6 @@ void VisualScriptEditor::_modules_panel_button(Object *p_item, int p_column, int
 		} else if (p_button == 1) {
 			_new_module();
 		}
-	//} else if (ti && ti->get_parent() == root->get_children()) {
 	} else if (ti && root->get_children().has(ti->get_parent())) {
 		if (p_button == 0) { // Edit
 			selected_module = ti->get_text(0);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3023,14 +3023,12 @@ void VisualScriptEditor::goto_line(int p_line, bool p_with_error) {
 
 	List<StringName> functions;
 	script->get_function_list(&functions);
-	for (const StringName &E : functions) {
-		if (script->has_node(p_line)) {
-			_update_graph();
-			_update_members();
+	if (script->has_node(p_line)) {
+		_update_graph();
+		_update_members();
 
-			call_deferred(SNAME("call_deferred"), "_center_on_node", p_line); // Editor might be just created and size might not exist yet
-			return;
-		}
+		call_deferred(SNAME("call_deferred"), "_center_on_node", p_line); // Editor might be just created and size might not exist yet
+		return;
 	}
 }
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -675,7 +675,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 	}
 	StringName editor_icons = "EditorIcons";
 
-	for (int &E : ids) {
+	for (int &E : node_ids) {
 		if (p_only_id >= 0 && p_only_id != E) {
 			continue;
 		}
@@ -734,7 +734,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			}
 			opbtn->select(f);
 			opbtn->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-			opbtn->connect("item_selected", callable_mp(this, &VisualScriptEditor::_load_module), varray(E->get()), CONNECT_DEFERRED);
+			opbtn->connect("item_selected", callable_mp(this, &VisualScriptEditor::_load_module), varray(E), CONNECT_DEFERRED);
 			gnode->add_child(opbtn);
 			has_gnode_text = true;
 		} else if (is_vslist) {
@@ -1041,14 +1041,14 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 void VisualScriptEditor::_new_module() {
 	String s = script->validate_module_name("New Module");
 	Ref<VisualScriptModule> new_module;
-	new_module.instance();
+	new_module.instantiate();
 	new_module->set_module_name(s);
 	if (!new_module->has_node(0)) {
 		Ref<VisualScriptModuleEntryNode> vsentry;
-		vsentry.instance();
+		vsentry.instantiate();
 		new_module->add_node(0, vsentry, Vector2(100, 100));
 		Ref<VisualScriptModuleExitNode> vsexit;
-		vsexit.instance();
+		vsexit.instantiate();
 		new_module->add_node(1, vsexit, Vector2(200, 200));
 	}
 	script->add_module(s, new_module);
@@ -1103,7 +1103,8 @@ void VisualScriptEditor::_modules_panel_button(Object *p_item, int p_column, int
 		} else if (p_button == 1) {
 			_new_module();
 		}
-	} else if (ti && ti->get_parent() == root->get_children()) {
+	//} else if (ti && ti->get_parent() == root->get_children()) {
+	} else if (ti && root->get_children().has(ti->get_parent())) {
 		if (p_button == 0) { // Edit
 			selected_module = ti->get_text(0);
 			module_name_edit->set_position(Input::get_singleton()->get_mouse_position() - Vector2(60, -10));
@@ -1143,9 +1144,9 @@ void VisualScriptEditor::_modules_panel_selected() {
 
 void VisualScriptEditor::_modules_panel_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mbt = p_event;
-	if (mbt.is_valid() && mbt->is_doubleclick()) {
+	if (mbt.is_valid() && mbt->is_double_click()) {
 		TreeItem *ti = modules_panel->get_selected();
-		if (ti && ti->get_parent() == modules_panel->get_root()->get_children()) {
+		if (ti && modules_panel->get_root()->get_children().has(ti->get_parent())) {
 			curr_module = script->get_module(ti->get_text(0));
 			_edit_module();
 		}
@@ -1268,10 +1269,10 @@ void VisualScriptEditor::_module_action(String p_file) {
 
 			if (!vsmod->has_node(0)) {
 				Ref<VisualScriptModuleEntryNode> vsentry;
-				vsentry.instance();
+				vsentry.instantiate();
 				vsmod->add_node(0, vsentry);
 				Ref<VisualScriptModuleExitNode> vsexit;
-				vsexit.instance();
+				vsexit.instantiate();
 				vsmod->add_node(1, vsexit);
 			}
 			script->add_module(vsmod->get_module_name(), vsmod);
@@ -2359,7 +2360,7 @@ Variant VisualScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 		Dictionary dd;
 		TreeItem *root = modules_panel->get_root();
 
-		if (it->get_parent() == root->get_children()) {
+		if (root->get_children().has(it->get_parent())) {
 			dd["type"] = "visual_script_module_drag";
 			dd["module_name"] = type;
 		} else {
@@ -2497,7 +2498,7 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 		ofs /= EDSCALE;
 
 		Ref<VisualScriptModuleNode> vnode;
-		vnode.instance();
+		vnode.instantiate();
 		vnode->set_module(String(d["module_name"]));
 
 		int new_id = script->get_available_id();
@@ -5015,7 +5016,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	module_name_edit = memnew(TextInputPopup);
 	module_name_edit_box = ((TextInputPopup *)module_name_edit)->get_line_edit();
 	module_name_edit_box->connect("gui_input", callable_mp(this, &VisualScriptEditor::_module_name_edit_box_input));
-	module_name_edit_box->set_expand_to_text_length(true);
+	module_name_edit_box->set_expand_to_text_length_enabled(true);
 	add_child(module_name_edit);
 
 	modules_panel_search_box = memnew(LineEdit);
@@ -5075,7 +5076,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	module_name_box->set_custom_minimum_size(Size2(70 * EDSCALE, 0));
 	module_name_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	module_name_box->set_text("");
-	module_name_box->set_expand_to_text_length(true);
+	module_name_box->set_expand_to_text_length_enabled(true);
 	module_name_box->connect("text_entered", callable_mp(this, &VisualScriptEditor::_module_name_save), varray(Ref<VisualScriptModule>()));
 	top_bar->add_child(module_name_box);
 	module_name_box->hide();

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -60,6 +60,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 		EDIT_CUT_NODES,
 		EDIT_PASTE_NODES,
 		EDIT_CREATE_FUNCTION,
+		EXIT_SUBMODULE,
 		REFRESH_GRAPH
 	};
 
@@ -85,7 +86,10 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	Ref<VisualScript> script;
 
+	HBoxContainer *base_type_select_hbc;
 	Button *base_type_select;
+
+	Button *save_module_btn;
 
 	LineEdit *func_name_box;
 	ScrollContainer *func_input_scroll;
@@ -160,6 +164,9 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	static Clipboard *clipboard;
 
+	Button *func_btn;
+	HBoxContainer *top_bar;
+
 	PopupMenu *member_popup;
 	MemberType member_type;
 	String member_name;
@@ -174,6 +181,42 @@ class VisualScriptEditor : public ScriptEditorBase {
 	Vector2 saved_position;
 
 	Vector2 mouse_up_position;
+
+	enum {
+		LOAD_MODULE = 0,
+		SAVE_MODULE = 1
+	} module_action;
+
+	Ref<VisualScriptModule> curr_module;
+	bool inside_module;
+
+	StringName selected_module;
+	bool updating_modules_panel;
+	Tree *modules_panel;
+	LineEdit *modules_panel_search_box;
+
+	AcceptDialog *module_name_edit;
+	LineEdit *module_name_edit_box;
+
+	void _update_module_panel();
+	void _modules_popup_option(int p_option);
+	void _search_module_list(const String &p_text);
+	void _modules_panel_button(Object *p_item, int p_column, int p_button);
+	void _modules_panel_edited();
+	void _modules_panel_selected();
+	void _module_name_edit_box_input(const Ref<InputEvent> &p_event);
+	void _modules_panel_gui_input(const Ref<InputEvent> &p_event);
+
+	LineEdit *module_name_box;
+	EditorFileDialog *module_resource_dialog;
+
+	void _load_module(int p_select, int p_id);
+	void _load_module_from_path();
+	void _new_module();
+	void _save_module();
+	void _edit_module();
+	void _module_name_save(const String &p_text, Ref<VisualScriptModule> p_module);
+	void _module_action(String p_file);
 
 	void _port_action_menu(int p_option);
 
@@ -192,6 +235,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 	int error_line;
 
 	void _node_selected(Node *p_node);
+	void _node_double_clicked(Node *p_node);
 	void _center_on_node(int p_id);
 
 	void _node_filter_changed(const String &p_text);
@@ -234,7 +278,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	bool node_has_sequence_connections(int p_id);
 
-	void _generic_search(String p_base_type = "", Vector2 pos = Vector2(), bool node_centered = false);
+	void _generic_search(String p_base_type = "", Vector2 pos = Vector2(), bool node_centered = false, bool p_from_nil = false);
 
 	void _input(const Ref<InputEvent> &p_event);
 	void _graph_gui_input(const Ref<InputEvent> &p_event);

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -78,7 +78,7 @@ static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const
 #endif
 Node *VisualScriptFunctionCall::_get_base_node() const {
 #ifdef TOOLS_ENABLED
-	Ref<Script> script = get_visual_script();
+	Ref<Script> script = get_container();
 	if (!script.is_valid()) {
 		return nullptr;
 	}
@@ -116,15 +116,21 @@ Node *VisualScriptFunctionCall::_get_base_node() const {
 }
 
 StringName VisualScriptFunctionCall::_get_base_type() const {
-	if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
-		return get_visual_script()->get_instance_base_type();
-	} else if (call_mode == CALL_MODE_NODE_PATH && get_visual_script().is_valid()) {
+	Ref<Resource> sr = get_container();
+	if (call_mode == CALL_MODE_SELF) {
+		Ref<Script> src = sr;
+		Ref<VisualScriptModule> srcmod = sr;
+		if (src.is_valid()) {
+			return src->get_instance_base_type();
+		} else if (srcmod.is_valid()) {
+			return srcmod->get_instance_base_type();
+		}
+	} else if (call_mode == CALL_MODE_NODE_PATH) {
 		Node *path = _get_base_node();
 		if (path) {
 			return path->get_class();
 		}
 	}
-
 	return base_type;
 }
 
@@ -355,10 +361,11 @@ void VisualScriptFunctionCall::_update_method_cache() {
 			script = node->get_script();
 		}
 	} else if (call_mode == CALL_MODE_SELF) {
-		if (get_visual_script().is_valid()) {
-			type = get_visual_script()->get_instance_base_type();
+		Ref<Script> sr = get_container();
+		if (sr.is_valid()) {
+			type = sr->get_instance_base_type();
 			base_type = type; //cache, too
-			script = get_visual_script();
+			script = sr;
 		}
 
 	} else if (call_mode == CALL_MODE_SINGLETON) {
@@ -564,9 +571,9 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 			property.hint = PROPERTY_HINT_METHOD_OF_VARIANT_TYPE;
 			property.hint_string = Variant::get_type_name(basic_type);
 
-		} else if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
+		} else if (call_mode == CALL_MODE_SELF && get_container().is_valid()) {
 			property.hint = PROPERTY_HINT_METHOD_OF_SCRIPT;
-			property.hint_string = itos(get_visual_script()->get_instance_id());
+			property.hint_string = itos(get_container()->get_instance_id());
 		} else if (call_mode == CALL_MODE_SINGLETON) {
 			Object *obj = Engine::get_singleton()->get_singleton_object(singleton);
 			if (obj) {
@@ -917,7 +924,7 @@ bool VisualScriptPropertySet::has_input_sequence_port() const {
 
 Node *VisualScriptPropertySet::_get_base_node() const {
 #ifdef TOOLS_ENABLED
-	Ref<Script> script = get_visual_script();
+	Ref<Script> script = get_container();
 	if (!script.is_valid()) {
 		return nullptr;
 	}
@@ -956,9 +963,10 @@ Node *VisualScriptPropertySet::_get_base_node() const {
 }
 
 StringName VisualScriptPropertySet::_get_base_type() const {
-	if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
-		return get_visual_script()->get_instance_base_type();
-	} else if (call_mode == CALL_MODE_NODE_PATH && get_visual_script().is_valid()) {
+	Ref<Script> sr = get_container();
+	if (call_mode == CALL_MODE_SELF && sr.is_valid()) {
+		return sr->get_instance_base_type();
+	} else if (call_mode == CALL_MODE_NODE_PATH && get_container().is_valid()) {
 		Node *path = _get_base_node();
 		if (path) {
 			return path->get_class();
@@ -1067,8 +1075,9 @@ void VisualScriptPropertySet::_update_base_type() {
 			base_type = node->get_class();
 		}
 	} else if (call_mode == CALL_MODE_SELF) {
-		if (get_visual_script().is_valid()) {
-			base_type = get_visual_script()->get_instance_base_type();
+		Ref<Script> sr = get_container();
+		if (sr.is_valid()) {
+			base_type = sr->get_instance_base_type();
 		}
 	}
 }
@@ -1154,10 +1163,11 @@ void VisualScriptPropertySet::_update_cache() {
 				script = node->get_script();
 			}
 		} else if (call_mode == CALL_MODE_SELF) {
-			if (get_visual_script().is_valid()) {
-				type = get_visual_script()->get_instance_base_type();
+			Ref<Script> sr = get_container();
+			if (sr.is_valid()) {
+				type = sr->get_instance_base_type();
 				base_type = type; //cache, too
-				script = get_visual_script();
+				script = get_container();
 			}
 		} else if (call_mode == CALL_MODE_INSTANCE) {
 			type = base_type;
@@ -1314,9 +1324,9 @@ void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE;
 			property.hint_string = Variant::get_type_name(basic_type);
 
-		} else if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
+		} else if (call_mode == CALL_MODE_SELF && get_container().is_valid()) {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
-			property.hint_string = itos(get_visual_script()->get_instance_id());
+			property.hint_string = itos(get_container()->get_instance_id());
 		} else if (call_mode == CALL_MODE_INSTANCE) {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
 			property.hint_string = base_type;
@@ -1653,15 +1663,16 @@ void VisualScriptPropertyGet::_update_base_type() {
 			base_type = node->get_class();
 		}
 	} else if (call_mode == CALL_MODE_SELF) {
-		if (get_visual_script().is_valid()) {
-			base_type = get_visual_script()->get_instance_base_type();
+		Ref<Script> sr = get_container();
+		if (sr.is_valid()) {
+			base_type = sr->get_instance_base_type();
 		}
 	}
 }
 
 Node *VisualScriptPropertyGet::_get_base_node() const {
 #ifdef TOOLS_ENABLED
-	Ref<Script> script = get_visual_script();
+	Ref<Script> script = get_container();
 	if (!script.is_valid()) {
 		return nullptr;
 	}
@@ -1700,9 +1711,10 @@ Node *VisualScriptPropertyGet::_get_base_node() const {
 }
 
 StringName VisualScriptPropertyGet::_get_base_type() const {
-	if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
-		return get_visual_script()->get_instance_base_type();
-	} else if (call_mode == CALL_MODE_NODE_PATH && get_visual_script().is_valid()) {
+	Ref<Script> sr = get_container();
+	if (call_mode == CALL_MODE_SELF && sr.is_valid()) {
+		return sr->get_instance_base_type();
+	} else if (call_mode == CALL_MODE_NODE_PATH && get_container().is_valid()) {
 		Node *path = _get_base_node();
 		if (path) {
 			return path->get_class();
@@ -1840,10 +1852,11 @@ void VisualScriptPropertyGet::_update_cache() {
 				script = node->get_script();
 			}
 		} else if (call_mode == CALL_MODE_SELF) {
-			if (get_visual_script().is_valid()) {
-				type = get_visual_script()->get_instance_base_type();
+			Ref<Script> sr = get_container();
+			if (sr.is_valid()) {
+				type = sr->get_instance_base_type();
 				base_type = type; //cache, too
-				script = get_visual_script();
+				script = get_container();
 			}
 		} else if (call_mode == CALL_MODE_INSTANCE) {
 			type = base_type;
@@ -2020,9 +2033,9 @@ void VisualScriptPropertyGet::_validate_property(PropertyInfo &property) const {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE;
 			property.hint_string = Variant::get_type_name(basic_type);
 
-		} else if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
+		} else if (call_mode == CALL_MODE_SELF && get_container().is_valid()) {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
-			property.hint_string = itos(get_visual_script()->get_instance_id());
+			property.hint_string = itos(get_container()->get_instance_id());
 		} else if (call_mode == CALL_MODE_INSTANCE) {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
 			property.hint_string = base_type;
@@ -2255,7 +2268,7 @@ bool VisualScriptEmitSignal::has_input_sequence_port() const {
 }
 
 int VisualScriptEmitSignal::get_input_value_port_count() const {
-	Ref<VisualScript> vs = get_visual_script();
+	Ref<VisualScript> vs = get_container();
 	if (vs.is_valid()) {
 		if (!vs->has_custom_signal(name)) {
 			return 0;
@@ -2276,7 +2289,7 @@ String VisualScriptEmitSignal::get_output_sequence_port_text(int p_port) const {
 }
 
 PropertyInfo VisualScriptEmitSignal::get_input_value_port_info(int p_idx) const {
-	Ref<VisualScript> vs = get_visual_script();
+	Ref<VisualScript> vs = get_container();
 	if (vs.is_valid()) {
 		if (!vs->has_custom_signal(name)) {
 			return PropertyInfo();
@@ -2317,7 +2330,7 @@ void VisualScriptEmitSignal::_validate_property(PropertyInfo &property) const {
 
 		List<StringName> sigs;
 
-		Ref<VisualScript> vs = get_visual_script();
+		Ref<VisualScript> vs = get_container();
 		if (vs.is_valid()) {
 			vs->get_custom_signal_list(&sigs);
 		}

--- a/modules/visual_script/visual_script_module_nodes.cpp
+++ b/modules/visual_script/visual_script_module_nodes.cpp
@@ -1,0 +1,360 @@
+/*************************************************************************/
+/*  visual_script_module_nodes.cpp                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "visual_script_module_nodes.h"
+
+void VisualScriptModuleNode::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_module", "module_name"), &VisualScriptModuleNode::set_module);
+	ClassDB::bind_method(D_METHOD("get_module_name"), &VisualScriptModuleNode::get_module_name);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "module_name"), "set_module", "get_module_name");
+}
+
+int VisualScriptModuleNode::get_output_sequence_port_count() const {
+	return 1; // until it's figured out how to have multiple sequence inputs this can't be more than 1
+}
+bool VisualScriptModuleNode::has_input_sequence_port() const {
+	return true;
+}
+String VisualScriptModuleNode::get_output_sequence_port_text(int p_port) const {
+	return "";
+}
+
+int VisualScriptModuleNode::update_module_data() {
+	ERR_FAIL_COND_V(module_name == "" || get_container().is_null(), 0);
+
+	Ref<VisualScript> vs = get_container(); // Modules can't work in other Modules (yet!)
+	ERR_FAIL_COND_V(!vs.is_valid(), 0);
+
+	if (!vs->has_module(module_name)) {
+		// reset
+		input_ports.clear();
+		output_ports.clear();
+		return -1;
+	}
+
+	Ref<VisualScriptModule> module = vs->get_module(module_name);
+	ERR_FAIL_COND_V(!module.is_valid(), 0);
+
+	Ref<VisualScriptNode> exit_node = module->get_node(1);
+	Ref<VisualScriptNode> entry_node = module->get_node(0);
+
+	int ret = -1;
+
+	// If `exit_node` and `entry_node` are same to current ones then dont do anything
+	if (exit_node.is_valid()) {
+		int cnt = exit_node->get_input_value_port_count();
+		if (cnt == output_ports.size()) {
+			PropertyInfo pi;
+			for (int i = 0; i < cnt; i++) {
+				pi = exit_node->get_input_value_port_info(i);
+				if (output_ports[i].name != pi.name && output_ports[i].type != pi.type) {
+					output_ports.write[i].name = pi.name;
+					output_ports.write[i].type = pi.type;
+					ret = 1;
+				}
+			}
+		} else {
+			// update everything
+			output_ports.resize(cnt);
+			PropertyInfo pi;
+			for (int i = 0; i < cnt; i++) {
+				pi = exit_node->get_input_value_port_info(i);
+				output_ports.write[i].name = pi.name;
+				output_ports.write[i].type = pi.type;
+			}
+			ret = 1;
+		}
+	} else {
+		ERR_FAIL_V_MSG(0, "Module doesn't have a valid Exit Node.");
+	}
+
+	if (entry_node.is_valid()) {
+		int cnt = entry_node->get_output_value_port_count();
+		if (cnt == input_ports.size()) {
+			PropertyInfo pi;
+			for (int i = 0; i < cnt; i++) {
+				pi = entry_node->get_output_value_port_info(i);
+				if (input_ports[i].name != pi.name && input_ports[i].type != pi.type) {
+					input_ports.write[i].name = pi.name;
+					input_ports.write[i].type = pi.type;
+					ret = 1;
+				}
+			}
+		} else {
+			// update everything
+			input_ports.resize(cnt);
+			PropertyInfo pi;
+			for (int i = 0; i < cnt; i++) {
+				pi = entry_node->get_output_value_port_info(i);
+				input_ports.write[i].name = pi.name;
+				input_ports.write[i].type = pi.type;
+			}
+			ret = 1;
+		}
+	} else {
+		ERR_FAIL_V_MSG(0, "Module doesn't have a valid Entry Node.");
+	}
+
+	return ret;
+}
+
+int VisualScriptModuleNode::get_input_value_port_count() const {
+	int updating_success = const_cast<VisualScriptModuleNode *>(this)->update_module_data();
+	ERR_FAIL_COND_V(!updating_success, 0);
+
+	if (updating_success == 1) {
+		const_cast<VisualScriptModuleNode *>(this)->validate_input_default_values(); // just make sure this is called if there is an update
+	}
+
+	return input_ports.size();
+}
+
+int VisualScriptModuleNode::get_output_value_port_count() const {
+	int updating_success = const_cast<VisualScriptModuleNode *>(this)->update_module_data();
+	ERR_FAIL_COND_V(!updating_success, 0);
+
+	return output_ports.size();
+}
+
+PropertyInfo VisualScriptModuleNode::get_input_value_port_info(int p_idx) const {
+	int updating_success = const_cast<VisualScriptModuleNode *>(this)->update_module_data();
+	ERR_FAIL_COND_V(!updating_success, PropertyInfo());
+
+	if (updating_success == 1) {
+		const_cast<VisualScriptModuleNode *>(this)->validate_input_default_values(); // just make sure this is called if there is an update
+	}
+
+	ERR_FAIL_INDEX_V(p_idx, input_ports.size(), PropertyInfo());
+
+	PropertyInfo pi;
+	pi.name = input_ports[p_idx].name;
+	pi.type = input_ports[p_idx].type;
+	return pi;
+}
+
+PropertyInfo VisualScriptModuleNode::get_output_value_port_info(int p_idx) const {
+	int updating_success = const_cast<VisualScriptModuleNode *>(this)->update_module_data();
+	ERR_FAIL_COND_V(!updating_success, PropertyInfo());
+
+	ERR_FAIL_INDEX_V(p_idx, output_ports.size(), PropertyInfo());
+
+	PropertyInfo pi;
+	pi.name = output_ports[p_idx].name;
+	pi.type = output_ports[p_idx].type;
+	return pi;
+}
+
+String VisualScriptModuleNode::get_caption() const {
+	return "Module Node";
+}
+String VisualScriptModuleNode::get_text() const {
+	return "";
+}
+
+void VisualScriptModuleNode::set_module(const String &p_name) {
+	module_name = p_name;
+	ports_changed_notify();
+	notify_property_list_changed();
+}
+
+String VisualScriptModuleNode::get_module_name() const {
+	return module_name;
+}
+
+class VisualScriptModuleNodeInstance : public VisualScriptNodeInstance {
+public:
+	VisualScriptModuleNode *node;
+	VisualScriptInstance *instance;
+
+	//virtual int get_working_memory_size() const { return 0; }
+	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
+	//virtual bool get_output_port_unsequenced(int p_idx,Variant* r_value,Variant* p_working_mem,String &r_error) const { return true; }
+
+	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) {
+		return 0;
+	}
+};
+
+VisualScriptNodeInstance *VisualScriptModuleNode::instance(VisualScriptInstance *p_instance) {
+	VisualScriptModuleNodeInstance *instance = memnew(VisualScriptModuleNodeInstance);
+	instance->node = this;
+	instance->instance = p_instance;
+	return instance;
+}
+
+VisualScriptModuleNode::VisualScriptModuleNode() {
+	module_name = "";
+}
+
+VisualScriptModuleNode::~VisualScriptModuleNode() {}
+
+// VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
+
+void register_visual_script_module_nodes() {
+	VisualScriptLanguage::singleton->add_register_func("modules/module_node", create_node_generic<VisualScriptModuleNode>);
+}
+
+int VisualScriptModuleEntryNode::get_output_value_port_count() const {
+	return outputports.size();
+}
+
+PropertyInfo VisualScriptModuleEntryNode::get_output_value_port_info(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, outputports.size(), PropertyInfo());
+
+	PropertyInfo pi;
+	pi.name = outputports[p_idx].name;
+	pi.type = outputports[p_idx].type;
+	return pi;
+}
+
+class VisualScriptModuleEntryNodeInstance : public VisualScriptNodeInstance {
+public:
+	//VisualScriptModuleNode *node;
+	VisualScriptInstance *instance;
+	VisualScriptModuleEntryNode *node;
+	//virtual int get_working_memory_size() const { return 0; }
+	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
+	//virtual bool get_output_port_unsequenced(int p_idx,Variant* r_value,Variant* p_working_mem,String &r_error) const { return true; }
+
+	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) {
+		int ac = node->get_output_value_port_count();
+
+		for (int i = 0; i < ac; i++) {
+#ifdef DEBUG_ENABLED
+			Variant::Type expected = node->get_output_value_port_info(i).type;
+			if (expected != Variant::NIL) {
+				if (!Variant::can_convert_strict(p_inputs[i]->get_type(), expected)) {
+					r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+					r_error.expected = expected;
+					r_error.argument = i;
+					return 0;
+				}
+			}
+#endif
+
+			*p_outputs[i] = *p_inputs[i];
+		}
+		return 0;
+	}
+};
+
+VisualScriptNodeInstance *VisualScriptModuleEntryNode::instance(VisualScriptInstance *p_instance) {
+	VisualScriptModuleEntryNodeInstance *instance = memnew(VisualScriptModuleEntryNodeInstance);
+	instance->node = this;
+	instance->instance = p_instance;
+	return instance;
+}
+
+VisualScriptModuleEntryNode::VisualScriptModuleEntryNode() {
+	stack_less = false;
+	stack_size = 256;
+}
+
+VisualScriptModuleEntryNode::~VisualScriptModuleEntryNode() {}
+
+void VisualScriptModuleEntryNode::set_stack_less(bool p_enable) {
+	stack_less = p_enable;
+	notify_property_list_changed();
+}
+
+bool VisualScriptModuleEntryNode::is_stack_less() const {
+	return stack_less;
+}
+
+void VisualScriptModuleEntryNode::set_sequenced(bool p_enable) {
+	sequenced = p_enable;
+}
+
+bool VisualScriptModuleEntryNode::is_sequenced() const {
+	return sequenced;
+}
+
+void VisualScriptModuleEntryNode::set_stack_size(int p_size) {
+	ERR_FAIL_COND(p_size < 1 || p_size > 100000);
+	stack_size = p_size;
+}
+
+int VisualScriptModuleEntryNode::get_stack_size() const {
+	return stack_size;
+}
+
+int VisualScriptModuleExitNode::get_input_value_port_count() const {
+	return inputports.size();
+}
+
+PropertyInfo VisualScriptModuleExitNode::get_input_value_port_info(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, inputports.size(), PropertyInfo());
+
+	PropertyInfo pi;
+	pi.name = inputports[p_idx].name;
+	pi.type = inputports[p_idx].type;
+	return pi;
+}
+
+class VisualScriptModuleExitNodeInstance : public VisualScriptNodeInstance {
+public:
+	VisualScriptModuleExitNode *node;
+	VisualScriptInstance *instance;
+	int output_count;
+
+	virtual int get_working_memory_size() const { return 1; }
+	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
+	//virtual bool get_output_port_unsequenced(int p_idx,Variant* r_value,Variant* p_working_mem,String &r_error) const { return true; }
+
+	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) {
+		if (output_count == 1) {
+			*p_working_mem = *p_inputs[0];
+			return STEP_EXIT_FUNCTION_BIT;
+		} else if (output_count > 1) {
+			Array arr;
+			for (int i = 0; i < output_count; i++) {
+				arr.append(*p_inputs[i]);
+			}
+			*p_working_mem = arr;
+			return STEP_EXIT_FUNCTION_BIT;
+		} else {
+			*p_working_mem = Variant();
+			return 0;
+		}
+	}
+};
+
+VisualScriptNodeInstance *VisualScriptModuleExitNode::instance(VisualScriptInstance *p_instance) {
+	VisualScriptModuleExitNodeInstance *instance = memnew(VisualScriptModuleExitNodeInstance);
+	instance->node = this;
+	instance->instance = p_instance;
+	instance->output_count = get_input_value_port_count();
+	return instance;
+}
+
+VisualScriptModuleExitNode::VisualScriptModuleExitNode() {}
+
+VisualScriptModuleExitNode::~VisualScriptModuleExitNode() {}

--- a/modules/visual_script/visual_script_module_nodes.cpp
+++ b/modules/visual_script/visual_script_module_nodes.cpp
@@ -203,7 +203,7 @@ public:
 	}
 };
 
-VisualScriptNodeInstance *VisualScriptModuleNode::instance(VisualScriptInstance *p_instance) {
+VisualScriptNodeInstance *VisualScriptModuleNode::instantiate(VisualScriptInstance *p_instance) {
 	VisualScriptModuleNodeInstance *instance = memnew(VisualScriptModuleNodeInstance);
 	instance->node = this;
 	instance->instance = p_instance;
@@ -266,7 +266,7 @@ public:
 	}
 };
 
-VisualScriptNodeInstance *VisualScriptModuleEntryNode::instance(VisualScriptInstance *p_instance) {
+VisualScriptNodeInstance *VisualScriptModuleEntryNode::instantiate(VisualScriptInstance *p_instance) {
 	VisualScriptModuleEntryNodeInstance *instance = memnew(VisualScriptModuleEntryNodeInstance);
 	instance->node = this;
 	instance->instance = p_instance;
@@ -347,7 +347,7 @@ public:
 	}
 };
 
-VisualScriptNodeInstance *VisualScriptModuleExitNode::instance(VisualScriptInstance *p_instance) {
+VisualScriptNodeInstance *VisualScriptModuleExitNode::instantiate(VisualScriptInstance *p_instance) {
 	VisualScriptModuleExitNodeInstance *instance = memnew(VisualScriptModuleExitNodeInstance);
 	instance->node = this;
 	instance->instance = p_instance;

--- a/modules/visual_script/visual_script_module_nodes.h
+++ b/modules/visual_script/visual_script_module_nodes.h
@@ -1,0 +1,162 @@
+/*************************************************************************/
+/*  visual_script_module_nodes.h                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef VISUAL_SCRIPT_MODULE_NODES_H
+#define VISUAL_SCRIPT_MODULE_NODES_H
+
+#include "visual_script.h"
+#include "visual_script_nodes.h"
+
+class VisualScriptModuleNode : public VisualScriptNode {
+	GDCLASS(VisualScriptModuleNode, VisualScriptNode);
+
+	String module_name;
+
+	struct Port {
+		String name;
+		Variant::Type type;
+	};
+
+	Vector<Port> output_ports;
+	Vector<Port> input_ports;
+
+private:
+	int update_module_data();
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual int get_output_sequence_port_count() const override;
+	virtual bool has_input_sequence_port() const override;
+
+	virtual String get_output_sequence_port_text(int p_port) const override;
+
+	virtual int get_input_value_port_count() const override;
+	virtual int get_output_value_port_count() const override;
+
+	virtual PropertyInfo get_input_value_port_info(int p_idx) const override;
+	virtual PropertyInfo get_output_value_port_info(int p_idx) const override;
+
+	virtual String get_caption() const override;
+	virtual String get_text() const override;
+	virtual String get_category() const override { return "functions"; }
+
+	void set_module(const String &p_name);
+	String get_module_name() const;
+	void set_module_by_name(const StringName &p_name);
+
+	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance) override;
+
+	VisualScriptModuleNode();
+	~VisualScriptModuleNode();
+};
+
+class VisualScriptModuleEntryNode : public VisualScriptLists {
+	GDCLASS(VisualScriptModuleEntryNode, VisualScriptLists);
+
+	int stack_size;
+	bool stack_less;
+
+public:
+	virtual bool is_output_port_editable() const override { return true; }
+	virtual bool is_output_port_name_editable() const override { return true; }
+	virtual bool is_output_port_type_editable() const override { return true; }
+
+	virtual bool is_input_port_editable() const override { return false; }
+	virtual bool is_input_port_name_editable() const override { return false; }
+	virtual bool is_input_port_type_editable() const override { return false; }
+
+	virtual int get_output_sequence_port_count() const override { return 1; }
+	virtual bool has_input_sequence_port() const override { return false; }
+
+	virtual String get_output_sequence_port_text(int p_port) const override { return ""; }
+
+	virtual int get_input_value_port_count() const override { return 0; }
+	virtual int get_output_value_port_count() const override;
+
+	virtual PropertyInfo get_input_value_port_info(int p_idx) const override { return PropertyInfo(); }
+	virtual PropertyInfo get_output_value_port_info(int p_idx) const override;
+
+	void set_stack_less(bool p_enable);
+	bool is_stack_less() const;
+	void set_sequenced(bool p_enable);
+	bool is_sequenced() const;
+	void set_stack_size(int p_size);
+	int get_stack_size() const;
+
+	virtual String get_caption() const override { return "Entry"; }
+	virtual String get_text() const override { return ""; }
+	virtual String get_category() const override { return "module"; }
+
+	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance) override;
+
+	VisualScriptModuleEntryNode();
+	~VisualScriptModuleEntryNode();
+};
+
+class VisualScriptModuleExitNode : public VisualScriptLists {
+	GDCLASS(VisualScriptModuleExitNode, VisualScriptLists);
+
+	bool with_value;
+
+public:
+	virtual bool is_output_port_editable() const override { return false; }
+	virtual bool is_output_port_name_editable() const override { return false; }
+	virtual bool is_output_port_type_editable() const override { return false; }
+
+	virtual bool is_input_port_editable() const override { return true; }
+	virtual bool is_input_port_name_editable() const override { return true; }
+	virtual bool is_input_port_type_editable() const override { return true; }
+
+	virtual int get_output_sequence_port_count() const override { return 0; }
+	virtual bool has_input_sequence_port() const override { return true; }
+
+	virtual String get_output_sequence_port_text(int p_port) const override { return ""; }
+
+	virtual int get_input_value_port_count() const override;
+	virtual int get_output_value_port_count() const override { return 0; }
+
+	virtual PropertyInfo get_input_value_port_info(int p_idx) const override;
+	virtual PropertyInfo get_output_value_port_info(int p_idx) const override { return PropertyInfo(); }
+
+	virtual String get_caption() const override { return "Exit"; }
+	virtual String get_text() const override { return ""; }
+	virtual String get_category() const override { return "module"; }
+
+	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance) override;
+
+	VisualScriptModuleExitNode();
+	~VisualScriptModuleExitNode();
+};
+
+void register_visual_script_module_nodes();
+
+#endif // VISUAL_SCRIPT_SUBMODULE_NODES_H

--- a/modules/visual_script/visual_script_module_nodes.h
+++ b/modules/visual_script/visual_script_module_nodes.h
@@ -73,7 +73,7 @@ public:
 	String get_module_name() const;
 	void set_module_by_name(const StringName &p_name);
 
-	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance) override;
+	virtual VisualScriptNodeInstance *instantiate(VisualScriptInstance *p_instance) override;
 
 	VisualScriptModuleNode();
 	~VisualScriptModuleNode();
@@ -116,7 +116,7 @@ public:
 	virtual String get_text() const override { return ""; }
 	virtual String get_category() const override { return "module"; }
 
-	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance) override;
+	virtual VisualScriptNodeInstance *instantiate(VisualScriptInstance *p_instance) override;
 
 	VisualScriptModuleEntryNode();
 	~VisualScriptModuleEntryNode();
@@ -151,7 +151,7 @@ public:
 	virtual String get_text() const override { return ""; }
 	virtual String get_category() const override { return "module"; }
 
-	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance) override;
+	virtual VisualScriptNodeInstance *instantiate(VisualScriptInstance *p_instance) override;
 
 	VisualScriptModuleExitNode();
 	~VisualScriptModuleExitNode();

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1274,8 +1274,9 @@ PropertyInfo VisualScriptVariableGet::get_input_value_port_info(int p_idx) const
 PropertyInfo VisualScriptVariableGet::get_output_value_port_info(int p_idx) const {
 	PropertyInfo pinfo;
 	pinfo.name = "value";
-	if (get_visual_script().is_valid() && get_visual_script()->has_variable(variable)) {
-		PropertyInfo vinfo = get_visual_script()->get_variable_info(variable);
+	Ref<VisualScript> vs = get_container();
+	if (vs.is_valid() && vs->has_variable(variable)) {
+		PropertyInfo vinfo = vs->get_variable_info(variable);
 		pinfo.type = vinfo.type;
 		pinfo.hint = vinfo.hint;
 		pinfo.hint_string = vinfo.hint_string;
@@ -1300,8 +1301,8 @@ StringName VisualScriptVariableGet::get_variable() const {
 }
 
 void VisualScriptVariableGet::_validate_property(PropertyInfo &property) const {
-	if (property.name == "var_name" && get_visual_script().is_valid()) {
-		Ref<VisualScript> vs = get_visual_script();
+	if (property.name == "var_name" && get_container().is_valid()) {
+		Ref<VisualScript> vs = get_container();
 		List<StringName> vars;
 		vs->get_variable_list(&vars);
 
@@ -1380,8 +1381,9 @@ String VisualScriptVariableSet::get_output_sequence_port_text(int p_port) const 
 PropertyInfo VisualScriptVariableSet::get_input_value_port_info(int p_idx) const {
 	PropertyInfo pinfo;
 	pinfo.name = "set";
-	if (get_visual_script().is_valid() && get_visual_script()->has_variable(variable)) {
-		PropertyInfo vinfo = get_visual_script()->get_variable_info(variable);
+	Ref<VisualScript> vs = get_container();
+	if (vs.is_valid() && vs->has_variable(variable)) {
+		PropertyInfo vinfo = vs->get_variable_info(variable);
 		pinfo.type = vinfo.type;
 		pinfo.hint = vinfo.hint;
 		pinfo.hint_string = vinfo.hint_string;
@@ -1410,8 +1412,8 @@ StringName VisualScriptVariableSet::get_variable() const {
 }
 
 void VisualScriptVariableSet::_validate_property(PropertyInfo &property) const {
-	if (property.name == "var_name" && get_visual_script().is_valid()) {
-		Ref<VisualScript> vs = get_visual_script();
+	if (property.name == "var_name" && get_container().is_valid()) {
+		Ref<VisualScript> vs = get_container();
 		List<StringName> vars;
 		vs->get_variable_list(&vars);
 
@@ -2498,7 +2500,7 @@ VisualScriptSceneNode::TypeGuess VisualScriptSceneNode::guess_output_type(TypeGu
 	tg.gdclass = "Node";
 
 #ifdef TOOLS_ENABLED
-	Ref<Script> script = get_visual_script();
+	Ref<Script> script = get_container();
 	if (!script.is_valid()) {
 		return tg;
 	}
@@ -2535,7 +2537,7 @@ VisualScriptSceneNode::TypeGuess VisualScriptSceneNode::guess_output_type(TypeGu
 void VisualScriptSceneNode::_validate_property(PropertyInfo &property) const {
 #ifdef TOOLS_ENABLED
 	if (property.name == "node_path") {
-		Ref<Script> script = get_visual_script();
+		Ref<Script> script = get_container();
 		if (!script.is_valid()) {
 			return;
 		}
@@ -2767,8 +2769,9 @@ PropertyInfo VisualScriptSelf::get_input_value_port_info(int p_idx) const {
 
 PropertyInfo VisualScriptSelf::get_output_value_port_info(int p_idx) const {
 	String type_name;
-	if (get_visual_script().is_valid()) {
-		type_name = get_visual_script()->get_instance_base_type();
+	Ref<VisualScript> vs = get_container();
+	if (vs.is_valid()) {
+		type_name = vs->get_instance_base_type();
 	} else {
 		type_name = "instance";
 	}
@@ -2803,7 +2806,7 @@ VisualScriptSelf::TypeGuess VisualScriptSelf::guess_output_type(TypeGuess *p_inp
 	tg.type = Variant::OBJECT;
 	tg.gdclass = "Object";
 
-	Ref<Script> script = get_visual_script();
+	Ref<Script> script = get_container();
 	if (!script.is_valid()) {
 		return tg;
 	}

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -244,7 +244,7 @@ static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const
 #endif
 Node *VisualScriptYieldSignal::_get_base_node() const {
 #ifdef TOOLS_ENABLED
-	Ref<Script> script = get_visual_script();
+	Ref<Script> script = get_container();
 	if (!script.is_valid()) {
 		return nullptr;
 	}
@@ -282,9 +282,10 @@ Node *VisualScriptYieldSignal::_get_base_node() const {
 }
 
 StringName VisualScriptYieldSignal::_get_base_type() const {
-	if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
-		return get_visual_script()->get_instance_base_type();
-	} else if (call_mode == CALL_MODE_NODE_PATH && get_visual_script().is_valid()) {
+	Ref<VisualScript> vs = get_container();
+	if (call_mode == CALL_MODE_SELF && vs.is_valid()) {
+		return vs->get_instance_base_type();
+	} else if (call_mode == CALL_MODE_NODE_PATH && get_container().is_valid()) {
 		Node *path = _get_base_node();
 		if (path) {
 			return path->get_class();

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -231,6 +231,10 @@ void AcceptDialog::_custom_action(const String &p_action) {
 	custom_action(p_action);
 }
 
+void AcceptDialog::_focus_exit_cancel() {
+	connect("focus_exited", callable_mp(this, &AcceptDialog::_cancel_pressed));
+}
+
 Button *AcceptDialog::add_button(const String &p_text, bool p_right, const String &p_action) {
 	Button *button = memnew(Button);
 	button->set_text(p_text);

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -68,6 +68,7 @@ protected:
 	virtual void cancel_pressed() {}
 	virtual void custom_action(const String &) {}
 
+	void _focus_exit_cancel();
 	// Not private since used by derived classes signal.
 	void _text_submitted(const String &p_text);
 	void _ok_pressed();

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -402,12 +402,20 @@ void GraphEdit::add_child_notify(Node *p_child) {
 		gn->set_scale(Vector2(zoom, zoom));
 		gn->connect("position_offset_changed", callable_mp(this, &GraphEdit::_graph_node_moved), varray(gn));
 		gn->connect("slot_updated", callable_mp(this, &GraphEdit::_graph_node_slot_updated), varray(gn));
+		gn->connect("double_clicked", callable_mp(this, &GraphEdit::_graph_double_clicked), varray(gn));
 		gn->connect("raise_request", callable_mp(this, &GraphEdit::_graph_node_raised), varray(gn));
 		gn->connect("item_rect_changed", callable_mp((CanvasItem *)connections_layer, &CanvasItem::update));
 		gn->connect("item_rect_changed", callable_mp((CanvasItem *)minimap, &GraphEditMinimap::update));
 		_graph_node_moved(gn);
 		gn->set_mouse_filter(MOUSE_FILTER_PASS);
 	}
+}
+
+void GraphEdit::_graph_double_clicked(Node *p_gn) {
+	GraphNode *gn = Object::cast_to<GraphNode>(p_gn);
+	ERR_FAIL_COND(!gn);
+
+	emit_signal("node_double_clicked", p_gn);
 }
 
 void GraphEdit::remove_child_notify(Node *p_child) {
@@ -429,7 +437,6 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 		gn->disconnect("position_offset_changed", callable_mp(this, &GraphEdit::_graph_node_moved));
 		gn->disconnect("slot_updated", callable_mp(this, &GraphEdit::_graph_node_slot_updated));
 		gn->disconnect("raise_request", callable_mp(this, &GraphEdit::_graph_node_raised));
-
 		// In case of the whole GraphEdit being destroyed these references can already be freed.
 		if (connections_layer != nullptr && connections_layer->is_inside_tree()) {
 			gn->disconnect("item_rect_changed", callable_mp((CanvasItem *)connections_layer, &CanvasItem::update));
@@ -437,6 +444,7 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 		if (minimap != nullptr && minimap->is_inside_tree()) {
 			gn->disconnect("item_rect_changed", callable_mp((CanvasItem *)minimap, &GraphEditMinimap::update));
 		}
+		gn->disconnect("double_clicked", callable_mp(this, &GraphEdit::_graph_double_clicked));
 	}
 }
 
@@ -1738,6 +1746,7 @@ void GraphEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("paste_nodes_request"));
 	ADD_SIGNAL(MethodInfo("node_selected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("node_deselected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
+	ADD_SIGNAL(MethodInfo("node_double_clicked", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("connection_to_empty", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("connection_from_empty", PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("delete_nodes_request"));

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -174,6 +174,7 @@ private:
 	void _graph_node_raised(Node *p_gn);
 	void _graph_node_moved(Node *p_gn);
 	void _graph_node_slot_updated(int p_index, Node *p_gn);
+	void _graph_double_clicked(Node *p_gn);
 
 	void _update_scroll();
 	void _scroll_moved(double);

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -870,6 +870,12 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 	if (mb.is_valid()) {
 		ERR_FAIL_COND_MSG(get_parent_control() == nullptr, "GraphNode must be the child of a GraphEdit node.");
 
+		if (mb->is_doubleclick() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
+			emit_signal("double_clicked");
+			accept_event();
+			return;
+		}
+
 		if (mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 			Vector2 mpos = Vector2(mb->get_position().x, mb->get_position().y);
 			if (close_rect.size != Size2() && close_rect.has_point(mpos)) {
@@ -1012,6 +1018,7 @@ void GraphNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("slot_updated", PropertyInfo(Variant::INT, "idx")));
 	ADD_SIGNAL(MethodInfo("dragged", PropertyInfo(Variant::VECTOR2, "from"), PropertyInfo(Variant::VECTOR2, "to")));
 	ADD_SIGNAL(MethodInfo("raise_request"));
+	ADD_SIGNAL(MethodInfo("double_clicked"));
 	ADD_SIGNAL(MethodInfo("close_request"));
 	ADD_SIGNAL(MethodInfo("resize_request", PropertyInfo(Variant::VECTOR2, "new_minsize")));
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -870,7 +870,7 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 	if (mb.is_valid()) {
 		ERR_FAIL_COND_MSG(get_parent_control() == nullptr, "GraphNode must be the child of a GraphEdit node.");
 
-		if (mb->is_doubleclick() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
+		if (mb->is_double_click() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 			emit_signal("double_clicked");
 			accept_event();
 			return;


### PR DESCRIPTION
Visualscript modules are similar to scripts but they allow for storing
and loading parts of the visualscript aka snippet/sub-graph/module as a
resource that can be utilized in any other visualscript.

Added:
VisualScriptModule Class as Resource types for allowing handling
visualscript code snippets as resource.
VisualScriptModuleNodes for interfacing with the Modules in
visualscript.

Changed:
Creation of visualscript instances for making room for modules.
Adding checks in the visualscript editor for handling modules.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

TEMP REBASED FOR TESTS AND DEVELOPMENT #45294
