### PR TITLE
glTF2 use alpha instead of depth prepass

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3515,7 +3515,7 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> state) {
 		if (d.has("alphaMode")) {
 			const String &am = d["alphaMode"];
 			if (am == "BLEND") {
-				material->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA_DEPTH_PRE_PASS);
+				material->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
 			} else if (am == "MASK") {
 				material->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA_SCISSOR);
 				if (d.has("alphaCutoff")) {


### PR DESCRIPTION
Not sure of the implications, but depth-prepass is broken.

Community reddit has had threads about trees and foilage.