### PR TITLE
Portals - Remove node naming restrictions + further work

### DIFF
--- a/scene/3d/portal.cpp
+++ b/scene/3d/portal.cpp
@@ -145,6 +145,7 @@ void Portal::clear() {
 	_internal = false;
 	_linkedroom_ID[0] = -1;
 	_linkedroom_ID[1] = -1;
+	_importing_portal = false;
 }
 
 void Portal::_notification(int p_what) {
@@ -279,34 +280,14 @@ bool Portal::try_set_unique_name(const String &p_name) {
 void Portal::set_linked_room(const NodePath &link_path) {
 	_settings_path_linkedroom = link_path;
 
-	// change the name of the portal as well, if the link looks legit
+	// see if the link looks legit
 	Room *linkedroom = nullptr;
 	if (has_node(link_path)) {
 		linkedroom = Object::cast_to<Room>(get_node(link_path));
 
 		if (linkedroom) {
 			if (linkedroom != get_parent()) {
-				_settings_path_linkedroom = link_path;
-
-				// change the portal name
-				String string_link_room = RoomManager::_find_name_after(linkedroom, "Room");
-
-				// we need a unique name for the portal
-				String string_name_base = "Portal" + GODOT_PORTAL_DELINEATOR + string_link_room;
-				if (!try_set_unique_name(string_name_base)) {
-					bool success = false;
-					for (int n = 0; n < 128; n++) {
-						String string_name = string_name_base + GODOT_PORTAL_WILDCARD + itos(n);
-						if (try_set_unique_name(string_name)) {
-							success = true;
-							break;
-						}
-					}
-
-					if (!success) {
-						WARN_PRINT("Could not set portal name, suggest setting name manually instead.");
-					}
-				}
+				// was ok
 			} else {
 				WARN_PRINT("Linked room cannot be the parent room of a portal.");
 			}

--- a/scene/3d/portal.h
+++ b/scene/3d/portal.h
@@ -154,6 +154,13 @@ private:
 	real_t _margin;
 	bool _use_default_margin;
 
+	// during conversion, we need to know
+	// whether this portal is being imported from a mesh
+	// and is using an explicitly named link room with prefix.
+	// If this is not the case, and it is already a Godot Portal node,
+	// we will either use the assigned nodepath, or autolink.
+	bool _importing_portal = false;
+
 	// for editing
 #ifdef TOOLS_ENABLED
 	ObjectID _room_manager_godot_ID;

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -41,8 +41,7 @@ class MeshInstance;
 class GeometryInstance;
 class VisualInstance;
 
-#define GODOT_PORTAL_DELINEATOR String("_")
-#define GODOT_PORTAL_WILDCARD String("*")
+#define GODOT_PORTAL_WILDCARD ('*')
 
 class RoomManager : public Spatial {
 	GDCLASS(RoomManager, Spatial);
@@ -194,8 +193,7 @@ private:
 	bool _remove_redundant_dangling_nodes(Spatial *p_node);
 
 	// helper funcs
-	bool _name_starts_with(const Node *p_node, String p_search_string, bool p_allow_no_delineator = false);
-	void _check_for_misnamed_node(const Node *p_node, String p_start_string);
+	bool _name_ends_with(const Node *p_node, String p_postfix) const;
 	template <class NODE_TYPE>
 	NODE_TYPE *_resolve_path(NodePath p_path) const;
 	template <class NODE_TYPE>
@@ -215,7 +213,7 @@ private:
 	void debug_print_line(String p_string, int p_priority = 0);
 
 public:
-	static String _find_name_after(Node *p_node, String p_prefix, bool p_allow_no_prefix = false);
+	static String _find_name_before(Node *p_node, String p_postfix, bool p_allow_no_postfix = false);
 	static void show_warning(const String &p_string, const String &p_extra_string = "", bool p_alert = true);
 	static real_t _get_default_portal_margin() { return _default_portal_margin; }
 

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -215,7 +215,7 @@ private:
 	void debug_print_line(String p_string, int p_priority = 0);
 
 public:
-	static String _find_name_after(Node *p_node, String p_string_start);
+	static String _find_name_after(Node *p_node, String p_prefix, bool p_allow_no_prefix = false);
 	static void show_warning(const String &p_string, const String &p_extra_string = "", bool p_alert = true);
 	static real_t _get_default_portal_margin() { return _default_portal_margin; }
 


### PR DESCRIPTION
## Portals - Remove node naming restrictions
The use of special prefixes is only actually required during the import phase - the first conversion of rooms, roomgroups, and portals from Spatials and MeshInstances (based on the workflow of importing from blender).

Once converted to the native Godot nodes there is no longer a need for the naming requirements.

This PR removes the requirements except for the import. Manual portal linking after the initial conversion is now done exclusively using the `linked_room` nodepath property of the Portal.

## Portals - change import naming convention to postfix
In response to user demand, the naming convention for importing levels from blender etc is changed from prefixes `Room_` and `Portal_` to postfixes `-room`, `-roomgroup`, `-portal`.

## Notes
* This is a popular request - there is no need to have the strict naming requirements for the rooms and portals once the initial import has taken place. Or indeed if a user is not using the import from blender workflow, and is creating the nodes manually in the editor.
* There is a small possibility of regressions, which is why I left changing this to after the first beta. I've tried to test this with as many scenarios as possible.
* This is well worth getting working as it should make things simpler for users, less things to get wrong / error messages during conversion.
* Naming conventions for import from Blender etc are changed to match Godot 2, and follow the `-col` type convention.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
