### PR TITLE
[Net] Fix ENet 'connect_to_host' creating only one channel.

### DIFF
--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -107,7 +107,7 @@ Ref<ENetPacketPeer> ENetConnection::connect_to_host(const String &p_address, int
 	address.port = p_port;
 
 	// Initiate connection, allocating enough channels
-	ENetPeer *peer = enet_host_connect(host, &address, p_channels, p_data);
+	ENetPeer *peer = enet_host_connect(host, &address, p_channels > 0 ? p_channels : ENET_PROTOCOL_MAXIMUM_CHANNEL_COUNT, p_data);
 
 	if (peer == nullptr) {
 		return nullptr;


### PR DESCRIPTION
Passing `0` to `enet_host_create` will allow the maximum amount of channel supported by ENet.
For some reasons, `connect_to_host` will instead only create 1 channel when passed `0`.
This commit normalize the behaviour to always allocate the maximum allowed channels when passing `0`.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
