### PR TITLE
Optimize theme change in code editor

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -31,6 +31,7 @@
 #include "code_editor.h"
 
 #include "core/input/input.h"
+#include "core/object/message_queue.h"
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"
 #include "editor/editor_scale.h"
@@ -1567,6 +1568,17 @@ void CodeTextEditor::_update_font() {
 }
 
 void CodeTextEditor::_on_settings_change() {
+	if (settings_changed) {
+		return;
+	}
+
+	settings_changed = true;
+	MessageQueue::get_singleton()->push_callable(callable_mp(this, &CodeTextEditor::_apply_settings_change));
+}
+
+void CodeTextEditor::_apply_settings_change() {
+	settings_changed = false;
+
 	_update_text_editor_theme();
 	_update_font();
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -162,7 +162,10 @@ class CodeTextEditor : public VBoxContainer {
 	int error_line;
 	int error_column;
 
+	bool settings_changed = false;
+
 	void _on_settings_change();
+	void _apply_settings_change();
 
 	void _update_text_editor_theme();
 	void _update_font();


### PR DESCRIPTION
Postpone applying the whole theme when a setting changes, to avoid updating everything many times when the whole editor theme is changed.

On my configuration (AMD Ryzen 9 4900HS / 8 cores / NVIDIA GeForce RTX 2060) the time spent to apply the theme goes from ~40 seconds to ~3 seconds (similar to 3.x).

Fixes #51075

The major part of the slowdown was due to this series of calls when the editor theme changes:
https://github.com/godotengine/godot/blob/1f6a81ceeac80ce95b5f686756c557b1be19a8b8/editor/editor_themes.cpp#L1431-L1466

Which for each `set_initial_value` call triggers an expensive update of the whole code editor theme:
https://github.com/godotengine/godot/blob/1f6a81ceeac80ce95b5f686756c557b1be19a8b8/editor/code_editor.cpp#L1519-L1545