### PR TITLE
Do nothing when dragging CSGBox handle perpendicular to the camera

### DIFF
--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -135,6 +135,12 @@ void CSGShape3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo, int p_i
 		Vector3 ra, rb;
 		Geometry3D::get_closest_points_between_segments(Vector3(), axis * 4096, sg[0], sg[1], ra, rb);
 		float d = ra[p_id];
+
+		if (Math::is_nan(d)) {
+			// The handle is perpendicular to the camera.
+			return;
+		}
+
 		if (Node3DEditor::get_singleton()->is_snap_enabled()) {
 			d = Math::snapped(d, Node3DEditor::get_singleton()->get_translate_snap());
 		}


### PR DESCRIPTION
Fixes #50995, also prevents the CSGBox from disappearing when dragging the center handle in other views.

Ideally, the handle perpendicular to the camera should disappear. But the camera info is not available in `redraw`.