### PR TITLE
Make "Find in Files" ignore directories with `.gdignore` in them

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -228,6 +228,11 @@ void FindInFiles::_scan_dir(String path, PackedStringArray &out_folders) {
 			break;
 		}
 
+		// If there is a .gdignore file in the directory, don't bother searching it
+		if (file == ".gdignore") {
+			break;
+		}
+
 		// Ignore special dirs (such as .git and .import)
 		if (file == "." || file == ".." || file.begins_with(".")) {
 			continue;


### PR DESCRIPTION
This pull request fixes an issue where searches using the "Find in Files" function would include folders with `.gdignore` files in them. The editor is supposed to ignore directories with these files in them altogether, this makes sure it does when using "Find in Files."

Resolves: #51069
