### PR TITLE
Fix AudioStream cubic resampling

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -63,12 +63,12 @@ void AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale,
 		AudioFrame y3 = internal_buffer[idx - 0];
 
 		float mu2 = mu * mu;
-		AudioFrame a0 = y3 - y2 - y0 + y1;
-		AudioFrame a1 = y0 - y1 - a0;
+		AudioFrame a0 = 3 * y1 - 3 * y2 + y3 - y0;
+		AudioFrame a1 = 2 * y0 - 5 * y1 + 4 * y2 - y3;
 		AudioFrame a2 = y2 - y0;
-		AudioFrame a3 = y1;
+		AudioFrame a3 = 2 * y1;
 
-		p_buffer[i] = (a0 * mu * mu2 + a1 * mu2 + a2 * mu + a3);
+		p_buffer[i] = (a0 * mu * mu2 + a1 * mu2 + a2 * mu + a3) / 2;
 
 		mix_offset += mix_increment;
 

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -54,21 +54,21 @@ void AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale,
 
 	for (int i = 0; i < p_frames; i++) {
 		uint32_t idx = CUBIC_INTERP_HISTORY + uint32_t(mix_offset >> FP_BITS);
-		// 4 point, 4th order optimal resampling algorithm from: http://yehar.com/blog/wp-content/uploads/2009/08/deip.pdf
+		//standard cubic interpolation (great quality/performance ratio)
+		//this used to be moved to a LUT for greater performance, but nowadays CPU speed is generally faster than memory.
 		float mu = (mix_offset & FP_MASK) / float(FP_LEN);
 		AudioFrame y0 = internal_buffer[idx - 3];
 		AudioFrame y1 = internal_buffer[idx - 2];
 		AudioFrame y2 = internal_buffer[idx - 1];
 		AudioFrame y3 = internal_buffer[idx - 0];
 
-		AudioFrame even1 = y2 + y1, odd1 = y2 - y1;
-		AudioFrame even2 = y3 + y0, odd2 = y3 - y0;
-		AudioFrame c0 = even1 * 0.46835497211269561 + even2 * 0.03164502784253309;
-		AudioFrame c1 = odd1 * 0.56001293337091440 + odd2 * 0.14666238593949288;
-		AudioFrame c2 = even1 * -0.250038759826233691 + even2 * 0.25003876124297131;
-		AudioFrame c3 = odd1 * -0.49949850957839148 + odd2 * 0.16649935475113800;
-		AudioFrame c4 = even1 * 0.00016095224137360 + even2 * -0.00016095810460478;
-		p_buffer[i] = (((c4 * mu + c3) * mu + c2) * mu + c1) * mu + c0;
+		float mu2 = mu * mu;
+		AudioFrame a0 = y3 - y2 - y0 + y1;
+		AudioFrame a1 = y0 - y1 - a0;
+		AudioFrame a2 = y2 - y0;
+		AudioFrame a3 = y1;
+
+		p_buffer[i] = (a0 * mu * mu2 + a1 * mu2 + a2 * mu + a3);
 
 		mix_offset += mix_increment;
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Reverts b2264cb48be48f7bcb16dfba126da8073b6e4c3f and fixes Godot's cubic resampling algorithm. Lots of context for this is in #23544 and #49131.

Fixes #49131.

This is implemented with some help from the math on this page: https://www.paulinternet.nl/?page=bicubic

I'm not really a math person. :)