### PR TITLE
VariantParser: Fix uninitialized ResourceParser funcs

### DIFF
--- a/core/variant/variant_parser.h
+++ b/core/variant/variant_parser.h
@@ -73,9 +73,9 @@ public:
 
 	struct ResourceParser {
 		void *userdata = nullptr;
-		ParseResourceFunc func;
-		ParseResourceFunc ext_func;
-		ParseResourceFunc sub_func;
+		ParseResourceFunc func = nullptr;
+		ParseResourceFunc ext_func = nullptr;
+		ParseResourceFunc sub_func = nullptr;
 	};
 
 	enum TokenType {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -982,7 +982,6 @@ void ResourceLoaderText::open(FileAccess *p_f, bool p_skip_first_tag) {
 
 	rp.ext_func = _parse_ext_resources;
 	rp.sub_func = _parse_sub_resources;
-	rp.func = nullptr;
 	rp.userdata = this;
 }
 


### PR DESCRIPTION
They could cause a segfault when parsing values with ID "Resource"
as apparently we never set a valid `func` for it:

https://github.com/godotengine/godot/blob/63be3c1f006c0f033925c3fe9afe5ba39f4df0ea/core/variant/variant_parser.cpp#L828-L835

Fixes crash part of #42115.

To fully fix #42115 we should however figure out why `ResourceParser.func` is never defined. `scene/resources/resource_format_text.cpp` needs a good review around its handling of `ResourceParser`, it has a member `ResourceParser rp;` in the header, and in the cpp it sets both the `rp` member and sometimes a local `ResourceParser rp;` which shadows the former, so the code is confusing.