### PR TITLE
[3.x] Warn when using the `dectime` method

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -91,6 +91,7 @@ int Math::range_step_decimals(double p_step) {
 }
 
 double Math::dectime(double p_value, double p_amount, double p_step) {
+	WARN_DEPRECATED_MSG("The `dectime()` function has been deprecated and will be removed in Godot 4.0. Use `move_toward()` instead.");
 	double sgn = p_value < 0 ? -1.0 : 1.0;
 	double val = Math::abs(p_value);
 	val -= p_amount * p_step;

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -224,6 +224,7 @@
 			<argument index="1" name="amount" type="float" />
 			<argument index="2" name="step" type="float" />
 			<description>
+				[b]Note:[/b] [code]dectime[/code] has been deprecated and will be removed in Godot 4.0, please use [method move_toward] instead.
 				Returns the result of [code]value[/code] decreased by [code]step[/code] * [code]amount[/code].
 				[codeblock]
 				a = dectime(60, 10, 0.1)) # a is 59.0

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -78,6 +78,7 @@ namespace Godot
         /// </param>
         /// <param name="step">Times the <paramref name="value"/> will be decreased by <paramref name="amount"/></param>
         /// <returns>The decreased value.</returns>
+        [Obsolete("DecTime has been deprecated and will be removed in Godot 4.0, use Mathf.MoveToward instead.")]
         public static real_t DecTime(real_t value, real_t amount, real_t step)
         {
             real_t sgn = Mathf.Sign(value);


### PR DESCRIPTION
`dectime` has been removed in the master branch (what will be Godot 4.0) as of #51084.

This PR does not prevent using the method, it only shows a warning. This can be helpful for users that want to future-proof their projects for Godot 4.0.

This PR doesn't wrap the method in `#ifndef DISABLE_DEPRECATED` because there are a lot of places where this method is bound so it would be a lot of additions. I can add these if desired though.