### PR TITLE
Portals - disable frustum culling gizmos with preview camera

### DIFF
--- a/servers/visual/portals/portal_renderer.cpp
+++ b/servers/visual/portals/portal_renderer.cpp
@@ -994,7 +994,7 @@ int PortalRenderer::cull_convex_implementation(const Vector3 &p_point, const Vec
 		return out_count;
 	}
 
-	out_count = _tracer.trace_globals(planes, p_result_array, out_count, p_result_max, p_mask);
+	out_count = _tracer.trace_globals(planes, p_result_array, out_count, p_result_max, p_mask, _override_camera);
 
 	return out_count;
 }

--- a/servers/visual/portals/portal_tracer.h
+++ b/servers/visual/portals/portal_tracer.h
@@ -105,7 +105,7 @@ public:
 	void trace(PortalRenderer &p_portal_renderer, const Vector3 &p_pos, const LocalVector<Plane> &p_planes, int p_start_room_id, TraceResult &r_result);
 
 	// globals are handled separately as they don't care about the rooms
-	int trace_globals(const LocalVector<Plane> &p_planes, VSInstance **p_result_array, int first_result, int p_result_max, uint32_t p_mask);
+	int trace_globals(const LocalVector<Plane> &p_planes, VSInstance **p_result_array, int first_result, int p_result_max, uint32_t p_mask, bool p_override_camera);
 
 	void set_depth_limit(int p_limit) { _depth_limit = p_limit; }
 


### PR DESCRIPTION
When using the preview camera feature it turns out as well as culling the game objects, this also culls the editor gizmos from the preview camera, which makes the editor hard to use in this mode.

To get around this problem we simply disable frustum culling for GLOBAL portal_mode objects when in preview camera mode. This could be a bit slower in an editor scene with lots of gizmos but is the simplest way of solving the problem.

Fixes #50999

## Notes
* This could be done more efficiently by marking the gizmos as debug somehow in the VisualServer, and culling the gizmos from the main camera, and other items from the preview camera. However, this would make the code required more complex, and I'm not convinced it is necessary for this use.
* If we have reports of a slowdown using the `preview_camera` and large scenes with lots of gizmos we could make the effort to do the above approach. But it seems unlikely. 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
