### PR TITLE
[3.x] Complain if casting a freed object in a debug session

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -803,6 +803,25 @@ bool Variant::is_one() const {
 	return false;
 }
 
+ObjectID Variant::get_object_instance_id() const {
+	if (type != OBJECT) {
+		return 0;
+	}
+#ifdef DEBUG_ENABLED
+	if (is_ref()) {
+		return !_get_obj().ref.is_null() ? _REF_OBJ_PTR(*this)->get_instance_id() : 0;
+	} else {
+		return _get_obj().rc->instance_id;
+	}
+#else
+	if (is_ref() && _get_obj().ref.is_null()) {
+		return 0;
+	} else {
+		return _get_obj().obj->get_instance_id();
+	}
+#endif
+}
+
 void Variant::reference(const Variant &p_variant) {
 	switch (type) {
 		case NIL:

--- a/core/variant.h
+++ b/core/variant.h
@@ -187,6 +187,8 @@ public:
 	bool is_zero() const;
 	bool is_one() const;
 
+	ObjectID get_object_instance_id() const;
+
 	operator bool() const;
 	operator signed int() const;
 	operator unsigned int() const; // this is the real one

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -846,6 +846,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				*dst = Variant::construct(to_type, (const Variant **)&src, 1, err);
 
 #ifdef DEBUG_ENABLED
+				if (src->get_type() == Variant::OBJECT && !src->is_ref() && ObjectDB::get_instance(src->get_object_instance_id()) == nullptr) {
+					err_text = "Trying to cast a deleted object.";
+					OPCODE_BREAK;
+				}
 				if (err.error != Variant::CallError::CALL_OK) {
 					err_text = "Invalid cast: could not convert value to '" + Variant::get_type_name(to_type) + "'.";
 					OPCODE_BREAK;
@@ -866,6 +870,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(!nc);
 
 #ifdef DEBUG_ENABLED
+				if (src->get_type() == Variant::OBJECT && !src->is_ref() && ObjectDB::get_instance(src->get_object_instance_id()) == nullptr) {
+					err_text = "Trying to cast a deleted object.";
+					OPCODE_BREAK;
+				}
 				if (src->get_type() != Variant::OBJECT && src->get_type() != Variant::NIL) {
 					err_text = "Invalid cast: can't convert a non-object value to an object type.";
 					OPCODE_BREAK;
@@ -894,6 +902,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(!base_type);
 
 #ifdef DEBUG_ENABLED
+				if (src->get_type() == Variant::OBJECT && !src->is_ref() && ObjectDB::get_instance(src->get_object_instance_id()) == nullptr) {
+					err_text = "Trying to cast a deleted object.";
+					OPCODE_BREAK;
+				}
 				if (src->get_type() != Variant::OBJECT && src->get_type() != Variant::NIL) {
 					err_text = "Trying to assign a non-object value to a variable of type '" + base_type->get_path().get_file() + "'.";
 					OPCODE_BREAK;


### PR DESCRIPTION
Version of #51094 for 3.x.

In this version I've needed to add `Variant::get_object_instance_id()`, which is the 3.x incarnation of 4.0's `Variant::operator ObjectID()`. In 3.x we can't have an operator like that because `ObjectID` is not a proper class but an alias of a primitive type.