### PR TITLE
[3.x] Convert TSCN files into binary .scn on export by default

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1776,21 +1776,39 @@ void EditorExportTextSceneToBinaryPlugin::_export_file(const String &p_path, con
 	if (!convert) {
 		return;
 	}
+
+	int flg = 0;
+	if (GLOBAL_GET("filesystem/on_save/compress_binary_resources")) {
+		flg |= ResourceSaver::FLAG_COMPRESS;
+	}
+
 	String tmp_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmpfile.res");
-	Error err = ResourceFormatLoaderText::convert_file_to_binary(p_path, tmp_path);
+	Error err;
+	RES res = ResourceFormatLoaderText::singleton->load(p_path, p_path, &err);
 	if (err != OK) {
 		DirAccess::remove_file_or_error(tmp_path);
-		ERR_FAIL();
+		ERR_FAIL_MSG("Cannot load text resource from path '" + p_path + "'.");
 	}
+
+	err = ResourceSaver::save(tmp_path, res, flg);
+	if (err != OK) {
+		DirAccess::remove_file_or_error(tmp_path);
+		ERR_FAIL_MSG("Cannot save resource to file '" + tmp_path);
+	}
+
 	Vector<uint8_t> data = FileAccess::get_file_as_array(tmp_path);
 	if (data.size() == 0) {
 		DirAccess::remove_file_or_error(tmp_path);
 		ERR_FAIL();
 	}
 	DirAccess::remove_file_or_error(tmp_path);
-	add_file(p_path + ".converted.res", data, true);
+	if (extension == "tscn") {
+		add_file(p_path + ".converted.scn", data, true);
+	} else {
+		add_file(p_path + ".converted.res", data, true);
+	}
 }
 
 EditorExportTextSceneToBinaryPlugin::EditorExportTextSceneToBinaryPlugin() {
-	GLOBAL_DEF("editor/convert_text_resources_to_binary_on_export", false);
+	GLOBAL_DEF("editor/convert_text_resources_to_binary_on_export", true);
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/5131 (.tscn scenes are properly compiled into compressed .scn)
Possible fix for https://github.com/godotengine/godot/issues/42115
