### PR TITLE
Print the Vulkan device name in release builds too

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -757,9 +757,9 @@ Error VulkanContext::_create_physical_device() {
 			vendor_idx++;
 		}
 	}
-#ifdef DEBUG_ENABLED
+
 	print_line("Using Vulkan Device #" + itos(device_index) + ": " + device_vendor + " - " + device_name);
-#endif
+
 	device_api_version = gpu_props.apiVersion;
 
 	err = vkEnumerateDeviceExtensionProperties(gpu, nullptr, &device_extension_count, nullptr);


### PR DESCRIPTION
This is important information to include in bug reports for exported projects, and is consistent with the behavior found in the GLES3 and GLES2 renderers in `3.x`.

The Vulkan API version supported is already printed in release builds.