### PR TITLE
[4.0] Fix output port type mismatch for some VisualScript nodes

### DIFF
--- a/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
+++ b/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
@@ -56,161 +56,162 @@
 		<constant name="MATH_FPOSMOD" value="12" enum="BuiltinFunc">
 			Return the positive remainder of one input divided by the other, using floating-point numbers.
 		</constant>
-		<constant name="MATH_FLOOR" value="13" enum="BuiltinFunc">
+		<constant name="MATH_POSMOD" value="13" enum="BuiltinFunc">
+			Return the positive remainder of one input divided by the other, using integers.
+		</constant>
+		<constant name="MATH_FLOOR" value="14" enum="BuiltinFunc">
 			Return the input rounded down.
 		</constant>
-		<constant name="MATH_CEIL" value="14" enum="BuiltinFunc">
+		<constant name="MATH_CEIL" value="15" enum="BuiltinFunc">
 			Return the input rounded up.
 		</constant>
-		<constant name="MATH_ROUND" value="15" enum="BuiltinFunc">
+		<constant name="MATH_ROUND" value="16" enum="BuiltinFunc">
 			Return the input rounded to the nearest integer.
 		</constant>
-		<constant name="MATH_ABS" value="16" enum="BuiltinFunc">
+		<constant name="MATH_ABS" value="17" enum="BuiltinFunc">
 			Return the absolute value of the input.
 		</constant>
-		<constant name="MATH_SIGN" value="17" enum="BuiltinFunc">
+		<constant name="MATH_SIGN" value="18" enum="BuiltinFunc">
 			Return the sign of the input, turning it into 1, -1, or 0. Useful to determine if the input is positive or negative.
 		</constant>
-		<constant name="MATH_POW" value="18" enum="BuiltinFunc">
+		<constant name="MATH_POW" value="19" enum="BuiltinFunc">
 			Return the input raised to a given power.
 		</constant>
-		<constant name="MATH_LOG" value="19" enum="BuiltinFunc">
+		<constant name="MATH_LOG" value="20" enum="BuiltinFunc">
 			Return the natural logarithm of the input. Note that this is not the typical base-10 logarithm function calculators use.
 		</constant>
-		<constant name="MATH_EXP" value="20" enum="BuiltinFunc">
+		<constant name="MATH_EXP" value="21" enum="BuiltinFunc">
 			Return the mathematical constant [b]e[/b] raised to the specified power of the input. [b]e[/b] has an approximate value of 2.71828.
 		</constant>
-		<constant name="MATH_ISNAN" value="21" enum="BuiltinFunc">
+		<constant name="MATH_ISNAN" value="22" enum="BuiltinFunc">
 			Return whether the input is NaN (Not a Number) or not. NaN is usually produced by dividing 0 by 0, though other ways exist.
 		</constant>
-		<constant name="MATH_ISINF" value="22" enum="BuiltinFunc">
+		<constant name="MATH_ISINF" value="23" enum="BuiltinFunc">
 			Return whether the input is an infinite floating-point number or not. Infinity is usually produced by dividing a number by 0, though other ways exist.
 		</constant>
-		<constant name="MATH_EASE" value="23" enum="BuiltinFunc">
+		<constant name="MATH_EASE" value="24" enum="BuiltinFunc">
 			Easing function, based on exponent. 0 is constant, 1 is linear, 0 to 1 is ease-in, 1+ is ease out. Negative values are in-out/out in.
 		</constant>
-		<constant name="MATH_STEP_DECIMALS" value="24" enum="BuiltinFunc">
+		<constant name="MATH_STEP_DECIMALS" value="25" enum="BuiltinFunc">
 			Return the number of digit places after the decimal that the first non-zero digit occurs.
 		</constant>
-		<constant name="MATH_SNAPPED" value="25" enum="BuiltinFunc">
+		<constant name="MATH_SNAPPED" value="26" enum="BuiltinFunc">
 			Return the input snapped to a given step.
 		</constant>
-		<constant name="MATH_LERP" value="26" enum="BuiltinFunc">
+		<constant name="MATH_LERP" value="27" enum="BuiltinFunc">
 			Return a number linearly interpolated between the first two inputs, based on the third input. Uses the formula [code]a + (a - b) * t[/code].
 		</constant>
-		<constant name="MATH_INVERSE_LERP" value="27" enum="BuiltinFunc">
+		<constant name="MATH_LERP_ANGLE" value="28" enum="BuiltinFunc">
 		</constant>
-		<constant name="MATH_RANGE_LERP" value="28" enum="BuiltinFunc">
+		<constant name="MATH_INVERSE_LERP" value="29" enum="BuiltinFunc">
 		</constant>
-		<constant name="MATH_MOVE_TOWARD" value="29" enum="BuiltinFunc">
-			Moves the number toward a value, based on the third input.
+		<constant name="MATH_RANGE_LERP" value="30" enum="BuiltinFunc">
 		</constant>
-		<constant name="MATH_RANDOMIZE" value="30" enum="BuiltinFunc">
-			Randomize the seed (or the internal state) of the random number generator. Current implementation reseeds using a number based on time.
-		</constant>
-		<constant name="MATH_RANDI" value="31" enum="BuiltinFunc">
-			Return a random 32 bits integer value. To obtain a random value between 0 to N (where N is smaller than 2^32 - 1), you can use it with the remainder function.
-		</constant>
-		<constant name="MATH_RANDF" value="32" enum="BuiltinFunc">
-			Return a random floating-point value between 0 and 1. To obtain a random value between 0 to N, you can use it with multiplication.
-		</constant>
-		<constant name="MATH_RANDF_RANGE" value="33" enum="BuiltinFunc">
-			Return a random floating-point value between the two inputs.
-		</constant>
-		<constant name="MATH_RANDI_RANGE" value="34" enum="BuiltinFunc">
-			Return a random 32-bit integer value between the two inputs.
-		</constant>
-		<constant name="MATH_SEED" value="35" enum="BuiltinFunc">
-			Set the seed for the random number generator.
-		</constant>
-		<constant name="MATH_RANDSEED" value="36" enum="BuiltinFunc">
-			Return a random value from the given seed, along with the new seed.
-		</constant>
-		<constant name="MATH_DEG2RAD" value="37" enum="BuiltinFunc">
-			Convert the input from degrees to radians.
-		</constant>
-		<constant name="MATH_RAD2DEG" value="38" enum="BuiltinFunc">
-			Convert the input from radians to degrees.
-		</constant>
-		<constant name="MATH_LINEAR2DB" value="39" enum="BuiltinFunc">
-			Convert the input from linear volume to decibel volume.
-		</constant>
-		<constant name="MATH_DB2LINEAR" value="40" enum="BuiltinFunc">
-			Convert the input from decibel volume to linear volume.
-		</constant>
-		<constant name="MATH_POLAR2CARTESIAN" value="41" enum="BuiltinFunc">
-			Converts a 2D point expressed in the polar coordinate system (a distance from the origin [code]r[/code] and an angle [code]th[/code]) to the cartesian coordinate system (X and Y axis).
-		</constant>
-		<constant name="MATH_CARTESIAN2POLAR" value="42" enum="BuiltinFunc">
-			Converts a 2D point expressed in the cartesian coordinate system (X and Y axis) to the polar coordinate system (a distance from the origin and an angle).
-		</constant>
-		<constant name="MATH_WRAP" value="43" enum="BuiltinFunc">
-		</constant>
-		<constant name="MATH_WRAPF" value="44" enum="BuiltinFunc">
-		</constant>
-		<constant name="LOGIC_MAX" value="45" enum="BuiltinFunc">
-			Return the greater of the two numbers, also known as their maximum.
-		</constant>
-		<constant name="LOGIC_MIN" value="46" enum="BuiltinFunc">
-			Return the lesser of the two numbers, also known as their minimum.
-		</constant>
-		<constant name="LOGIC_CLAMP" value="47" enum="BuiltinFunc">
-			Return the input clamped inside the given range, ensuring the result is never outside it. Equivalent to [code]min(max(input, range_low), range_high)[/code].
-		</constant>
-		<constant name="LOGIC_NEAREST_PO2" value="48" enum="BuiltinFunc">
-			Return the nearest power of 2 to the input.
-		</constant>
-		<constant name="OBJ_WEAKREF" value="49" enum="BuiltinFunc">
-			Create a [WeakRef] from the input.
-		</constant>
-		<constant name="TYPE_CONVERT" value="50" enum="BuiltinFunc">
-			Convert between types.
-		</constant>
-		<constant name="TYPE_OF" value="51" enum="BuiltinFunc">
-			Return the type of the input as an integer. Check [enum Variant.Type] for the integers that might be returned.
-		</constant>
-		<constant name="TYPE_EXISTS" value="52" enum="BuiltinFunc">
-			Checks if a type is registered in the [ClassDB].
-		</constant>
-		<constant name="TEXT_CHAR" value="53" enum="BuiltinFunc">
-			Return a character with the given ascii value.
-		</constant>
-		<constant name="TEXT_STR" value="54" enum="BuiltinFunc">
-			Convert the input to a string.
-		</constant>
-		<constant name="TEXT_PRINT" value="55" enum="BuiltinFunc">
-			Print the given string to the output window.
-		</constant>
-		<constant name="TEXT_PRINTERR" value="56" enum="BuiltinFunc">
-			Print the given string to the standard error output.
-		</constant>
-		<constant name="TEXT_PRINTRAW" value="57" enum="BuiltinFunc">
-			Print the given string to the standard output, without adding a newline.
-		</constant>
-		<constant name="VAR_TO_STR" value="58" enum="BuiltinFunc">
-			Serialize a [Variant] to a string.
-		</constant>
-		<constant name="STR_TO_VAR" value="59" enum="BuiltinFunc">
-			Deserialize a [Variant] from a string serialized using [constant VAR_TO_STR].
-		</constant>
-		<constant name="VAR_TO_BYTES" value="60" enum="BuiltinFunc">
-			Serialize a [Variant] to a [PackedByteArray].
-		</constant>
-		<constant name="BYTES_TO_VAR" value="61" enum="BuiltinFunc">
-			Deserialize a [Variant] from a [PackedByteArray] serialized using [constant VAR_TO_BYTES].
-		</constant>
-		<constant name="MATH_SMOOTHSTEP" value="62" enum="BuiltinFunc">
+		<constant name="MATH_SMOOTHSTEP" value="31" enum="BuiltinFunc">
 			Return a number smoothly interpolated between the first two inputs, based on the third input. Similar to [constant MATH_LERP], but interpolates faster at the beginning and slower at the end. Using Hermite interpolation formula:
 			[codeblock]
 			var t = clamp((weight - from) / (to - from), 0.0, 1.0)
 			return t * t * (3.0 - 2.0 * t)
 			[/codeblock]
 		</constant>
-		<constant name="MATH_POSMOD" value="63" enum="BuiltinFunc">
+		<constant name="MATH_MOVE_TOWARD" value="32" enum="BuiltinFunc">
+			Moves the number toward a value, based on the third input.
 		</constant>
-		<constant name="MATH_LERP_ANGLE" value="64" enum="BuiltinFunc">
+		<constant name="MATH_RANDOMIZE" value="33" enum="BuiltinFunc">
+			Randomize the seed (or the internal state) of the random number generator. Current implementation reseeds using a number based on time.
 		</constant>
-		<constant name="TEXT_ORD" value="65" enum="BuiltinFunc">
+		<constant name="MATH_RANDF" value="34" enum="BuiltinFunc">
+			Return a random floating-point value between 0 and 1. To obtain a random value between 0 to N, you can use it with multiplication.
+		</constant>
+		<constant name="MATH_RANDF_RANGE" value="35" enum="BuiltinFunc">
+			Return a random floating-point value between the two inputs.
+		</constant>
+		<constant name="MATH_RANDI" value="36" enum="BuiltinFunc">
+			Return a random 32 bits integer value. To obtain a random value between 0 to N (where N is smaller than 2^32 - 1), you can use it with the remainder function.
+		</constant>
+		<constant name="MATH_RANDI_RANGE" value="37" enum="BuiltinFunc">
+			Return a random 32-bit integer value between the two inputs.
+		</constant>
+		<constant name="MATH_SEED" value="38" enum="BuiltinFunc">
+			Set the seed for the random number generator.
+		</constant>
+		<constant name="MATH_RANDSEED" value="39" enum="BuiltinFunc">
+			Return a random value from the given seed, along with the new seed.
+		</constant>
+		<constant name="MATH_DEG2RAD" value="40" enum="BuiltinFunc">
+			Convert the input from degrees to radians.
+		</constant>
+		<constant name="MATH_RAD2DEG" value="41" enum="BuiltinFunc">
+			Convert the input from radians to degrees.
+		</constant>
+		<constant name="MATH_DB2LINEAR" value="42" enum="BuiltinFunc">
+			Convert the input from decibel volume to linear volume.
+		</constant>
+		<constant name="MATH_LINEAR2DB" value="43" enum="BuiltinFunc">
+			Convert the input from linear volume to decibel volume.
+		</constant>
+		<constant name="MATH_WRAPF" value="44" enum="BuiltinFunc">
+		</constant>
+		<constant name="MATH_WRAP" value="45" enum="BuiltinFunc">
+		</constant>
+		<constant name="MATH_POLAR2CARTESIAN" value="46" enum="BuiltinFunc">
+			Converts a 2D point expressed in the polar coordinate system (a distance from the origin [code]r[/code] and an angle [code]th[/code]) to the cartesian coordinate system (X and Y axis).
+		</constant>
+		<constant name="MATH_CARTESIAN2POLAR" value="47" enum="BuiltinFunc">
+			Converts a 2D point expressed in the cartesian coordinate system (X and Y axis) to the polar coordinate system (a distance from the origin and an angle).
+		</constant>
+		<constant name="LOGIC_MAX" value="48" enum="BuiltinFunc">
+			Return the greater of the two numbers, also known as their maximum.
+		</constant>
+		<constant name="LOGIC_MIN" value="49" enum="BuiltinFunc">
+			Return the lesser of the two numbers, also known as their minimum.
+		</constant>
+		<constant name="LOGIC_CLAMP" value="50" enum="BuiltinFunc">
+			Return the input clamped inside the given range, ensuring the result is never outside it. Equivalent to [code]min(max(input, range_low), range_high)[/code].
+		</constant>
+		<constant name="LOGIC_NEAREST_PO2" value="51" enum="BuiltinFunc">
+			Return the nearest power of 2 to the input.
+		</constant>
+		<constant name="OBJ_WEAKREF" value="52" enum="BuiltinFunc">
+			Create a [WeakRef] from the input.
+		</constant>
+		<constant name="TYPE_CONVERT" value="53" enum="BuiltinFunc">
+			Convert between types.
+		</constant>
+		<constant name="TYPE_OF" value="54" enum="BuiltinFunc">
+			Return the type of the input as an integer. Check [enum Variant.Type] for the integers that might be returned.
+		</constant>
+		<constant name="TYPE_EXISTS" value="55" enum="BuiltinFunc">
+			Checks if a type is registered in the [ClassDB].
+		</constant>
+		<constant name="TEXT_CHAR" value="56" enum="BuiltinFunc">
+			Return a character with the given ascii value.
+		</constant>
+		<constant name="TEXT_ORD" value="57" enum="BuiltinFunc">
+		</constant>
+		<constant name="TEXT_STR" value="58" enum="BuiltinFunc">
+			Convert the input to a string.
+		</constant>
+		<constant name="TEXT_PRINT" value="59" enum="BuiltinFunc">
+			Print the given string to the output window.
+		</constant>
+		<constant name="TEXT_PRINTERR" value="60" enum="BuiltinFunc">
+			Print the given string to the standard error output.
+		</constant>
+		<constant name="TEXT_PRINTRAW" value="61" enum="BuiltinFunc">
+			Print the given string to the standard output, without adding a newline.
+		</constant>
+		<constant name="VAR_TO_STR" value="62" enum="BuiltinFunc">
+			Serialize a [Variant] to a string.
+		</constant>
+		<constant name="STR_TO_VAR" value="63" enum="BuiltinFunc">
+			Deserialize a [Variant] from a string serialized using [constant VAR_TO_STR].
+		</constant>
+		<constant name="VAR_TO_BYTES" value="64" enum="BuiltinFunc">
+			Serialize a [Variant] to a [PackedByteArray].
+		</constant>
+		<constant name="BYTES_TO_VAR" value="65" enum="BuiltinFunc">
+			Deserialize a [Variant] from a [PackedByteArray] serialized using [constant VAR_TO_BYTES].
 		</constant>
 		<constant name="FUNC_MAX" value="66" enum="BuiltinFunc">
 			Represents the size of the [enum BuiltinFunc] enum.

--- a/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
+++ b/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
@@ -56,162 +56,162 @@
 		<constant name="MATH_FPOSMOD" value="12" enum="BuiltinFunc">
 			Return the positive remainder of one input divided by the other, using floating-point numbers.
 		</constant>
-		<constant name="MATH_POSMOD" value="13" enum="BuiltinFunc">
-			Return the positive remainder of one input divided by the other, using integers.
-		</constant>
-		<constant name="MATH_FLOOR" value="14" enum="BuiltinFunc">
+		<constant name="MATH_FLOOR" value="13" enum="BuiltinFunc">
 			Return the input rounded down.
 		</constant>
-		<constant name="MATH_CEIL" value="15" enum="BuiltinFunc">
+		<constant name="MATH_CEIL" value="14" enum="BuiltinFunc">
 			Return the input rounded up.
 		</constant>
-		<constant name="MATH_ROUND" value="16" enum="BuiltinFunc">
+		<constant name="MATH_ROUND" value="15" enum="BuiltinFunc">
 			Return the input rounded to the nearest integer.
 		</constant>
-		<constant name="MATH_ABS" value="17" enum="BuiltinFunc">
+		<constant name="MATH_ABS" value="16" enum="BuiltinFunc">
 			Return the absolute value of the input.
 		</constant>
-		<constant name="MATH_SIGN" value="18" enum="BuiltinFunc">
+		<constant name="MATH_SIGN" value="17" enum="BuiltinFunc">
 			Return the sign of the input, turning it into 1, -1, or 0. Useful to determine if the input is positive or negative.
 		</constant>
-		<constant name="MATH_POW" value="19" enum="BuiltinFunc">
+		<constant name="MATH_POW" value="18" enum="BuiltinFunc">
 			Return the input raised to a given power.
 		</constant>
-		<constant name="MATH_LOG" value="20" enum="BuiltinFunc">
+		<constant name="MATH_LOG" value="19" enum="BuiltinFunc">
 			Return the natural logarithm of the input. Note that this is not the typical base-10 logarithm function calculators use.
 		</constant>
-		<constant name="MATH_EXP" value="21" enum="BuiltinFunc">
+		<constant name="MATH_EXP" value="20" enum="BuiltinFunc">
 			Return the mathematical constant [b]e[/b] raised to the specified power of the input. [b]e[/b] has an approximate value of 2.71828.
 		</constant>
-		<constant name="MATH_ISNAN" value="22" enum="BuiltinFunc">
+		<constant name="MATH_ISNAN" value="21" enum="BuiltinFunc">
 			Return whether the input is NaN (Not a Number) or not. NaN is usually produced by dividing 0 by 0, though other ways exist.
 		</constant>
-		<constant name="MATH_ISINF" value="23" enum="BuiltinFunc">
+		<constant name="MATH_ISINF" value="22" enum="BuiltinFunc">
 			Return whether the input is an infinite floating-point number or not. Infinity is usually produced by dividing a number by 0, though other ways exist.
 		</constant>
-		<constant name="MATH_EASE" value="24" enum="BuiltinFunc">
+		<constant name="MATH_EASE" value="23" enum="BuiltinFunc">
 			Easing function, based on exponent. 0 is constant, 1 is linear, 0 to 1 is ease-in, 1+ is ease out. Negative values are in-out/out in.
 		</constant>
-		<constant name="MATH_STEP_DECIMALS" value="25" enum="BuiltinFunc">
+		<constant name="MATH_STEP_DECIMALS" value="24" enum="BuiltinFunc">
 			Return the number of digit places after the decimal that the first non-zero digit occurs.
 		</constant>
-		<constant name="MATH_SNAPPED" value="26" enum="BuiltinFunc">
+		<constant name="MATH_SNAPPED" value="25" enum="BuiltinFunc">
 			Return the input snapped to a given step.
 		</constant>
-		<constant name="MATH_LERP" value="27" enum="BuiltinFunc">
+		<constant name="MATH_LERP" value="26" enum="BuiltinFunc">
 			Return a number linearly interpolated between the first two inputs, based on the third input. Uses the formula [code]a + (a - b) * t[/code].
 		</constant>
-		<constant name="MATH_LERP_ANGLE" value="28" enum="BuiltinFunc">
+		<constant name="MATH_INVERSE_LERP" value="27" enum="BuiltinFunc">
 		</constant>
-		<constant name="MATH_INVERSE_LERP" value="29" enum="BuiltinFunc">
+		<constant name="MATH_RANGE_LERP" value="28" enum="BuiltinFunc">
 		</constant>
-		<constant name="MATH_RANGE_LERP" value="30" enum="BuiltinFunc">
+		<constant name="MATH_MOVE_TOWARD" value="29" enum="BuiltinFunc">
+			Moves the number toward a value, based on the third input.
 		</constant>
-		<constant name="MATH_SMOOTHSTEP" value="31" enum="BuiltinFunc">
+		<constant name="MATH_RANDOMIZE" value="30" enum="BuiltinFunc">
+			Randomize the seed (or the internal state) of the random number generator. Current implementation reseeds using a number based on time.
+		</constant>
+		<constant name="MATH_RANDI" value="31" enum="BuiltinFunc">
+			Return a random 32 bits integer value. To obtain a random value between 0 to N (where N is smaller than 2^32 - 1), you can use it with the remainder function.
+		</constant>
+		<constant name="MATH_RANDF" value="32" enum="BuiltinFunc">
+			Return a random floating-point value between 0 and 1. To obtain a random value between 0 to N, you can use it with multiplication.
+		</constant>
+		<constant name="MATH_RANDF_RANGE" value="33" enum="BuiltinFunc">
+			Return a random floating-point value between the two inputs.
+		</constant>
+		<constant name="MATH_RANDI_RANGE" value="34" enum="BuiltinFunc">
+			Return a random 32-bit integer value between the two inputs.
+		</constant>
+		<constant name="MATH_SEED" value="35" enum="BuiltinFunc">
+			Set the seed for the random number generator.
+		</constant>
+		<constant name="MATH_RANDSEED" value="36" enum="BuiltinFunc">
+			Return a random value from the given seed, along with the new seed.
+		</constant>
+		<constant name="MATH_DEG2RAD" value="37" enum="BuiltinFunc">
+			Convert the input from degrees to radians.
+		</constant>
+		<constant name="MATH_RAD2DEG" value="38" enum="BuiltinFunc">
+			Convert the input from radians to degrees.
+		</constant>
+		<constant name="MATH_LINEAR2DB" value="39" enum="BuiltinFunc">
+			Convert the input from linear volume to decibel volume.
+		</constant>
+		<constant name="MATH_DB2LINEAR" value="40" enum="BuiltinFunc">
+			Convert the input from decibel volume to linear volume.
+		</constant>
+		<constant name="MATH_POLAR2CARTESIAN" value="41" enum="BuiltinFunc">
+			Converts a 2D point expressed in the polar coordinate system (a distance from the origin [code]r[/code] and an angle [code]th[/code]) to the cartesian coordinate system (X and Y axis).
+		</constant>
+		<constant name="MATH_CARTESIAN2POLAR" value="42" enum="BuiltinFunc">
+			Converts a 2D point expressed in the cartesian coordinate system (X and Y axis) to the polar coordinate system (a distance from the origin and an angle).
+		</constant>
+		<constant name="MATH_WRAP" value="43" enum="BuiltinFunc">
+		</constant>
+		<constant name="MATH_WRAPF" value="44" enum="BuiltinFunc">
+		</constant>
+		<constant name="LOGIC_MAX" value="45" enum="BuiltinFunc">
+			Return the greater of the two numbers, also known as their maximum.
+		</constant>
+		<constant name="LOGIC_MIN" value="46" enum="BuiltinFunc">
+			Return the lesser of the two numbers, also known as their minimum.
+		</constant>
+		<constant name="LOGIC_CLAMP" value="47" enum="BuiltinFunc">
+			Return the input clamped inside the given range, ensuring the result is never outside it. Equivalent to [code]min(max(input, range_low), range_high)[/code].
+		</constant>
+		<constant name="LOGIC_NEAREST_PO2" value="48" enum="BuiltinFunc">
+			Return the nearest power of 2 to the input.
+		</constant>
+		<constant name="OBJ_WEAKREF" value="49" enum="BuiltinFunc">
+			Create a [WeakRef] from the input.
+		</constant>
+		<constant name="TYPE_CONVERT" value="50" enum="BuiltinFunc">
+			Convert between types.
+		</constant>
+		<constant name="TYPE_OF" value="51" enum="BuiltinFunc">
+			Return the type of the input as an integer. Check [enum Variant.Type] for the integers that might be returned.
+		</constant>
+		<constant name="TYPE_EXISTS" value="52" enum="BuiltinFunc">
+			Checks if a type is registered in the [ClassDB].
+		</constant>
+		<constant name="TEXT_CHAR" value="53" enum="BuiltinFunc">
+			Return a character with the given ascii value.
+		</constant>
+		<constant name="TEXT_STR" value="54" enum="BuiltinFunc">
+			Convert the input to a string.
+		</constant>
+		<constant name="TEXT_PRINT" value="55" enum="BuiltinFunc">
+			Print the given string to the output window.
+		</constant>
+		<constant name="TEXT_PRINTERR" value="56" enum="BuiltinFunc">
+			Print the given string to the standard error output.
+		</constant>
+		<constant name="TEXT_PRINTRAW" value="57" enum="BuiltinFunc">
+			Print the given string to the standard output, without adding a newline.
+		</constant>
+		<constant name="VAR_TO_STR" value="58" enum="BuiltinFunc">
+			Serialize a [Variant] to a string.
+		</constant>
+		<constant name="STR_TO_VAR" value="59" enum="BuiltinFunc">
+			Deserialize a [Variant] from a string serialized using [constant VAR_TO_STR].
+		</constant>
+		<constant name="VAR_TO_BYTES" value="60" enum="BuiltinFunc">
+			Serialize a [Variant] to a [PackedByteArray].
+		</constant>
+		<constant name="BYTES_TO_VAR" value="61" enum="BuiltinFunc">
+			Deserialize a [Variant] from a [PackedByteArray] serialized using [constant VAR_TO_BYTES].
+		</constant>
+		<constant name="MATH_SMOOTHSTEP" value="62" enum="BuiltinFunc">
 			Return a number smoothly interpolated between the first two inputs, based on the third input. Similar to [constant MATH_LERP], but interpolates faster at the beginning and slower at the end. Using Hermite interpolation formula:
 			[codeblock]
 			var t = clamp((weight - from) / (to - from), 0.0, 1.0)
 			return t * t * (3.0 - 2.0 * t)
 			[/codeblock]
 		</constant>
-		<constant name="MATH_MOVE_TOWARD" value="32" enum="BuiltinFunc">
-			Moves the number toward a value, based on the third input.
+		<constant name="MATH_POSMOD" value="63" enum="BuiltinFunc">
+			Return the positive remainder of one input divided by the other, using integers.
 		</constant>
-		<constant name="MATH_RANDOMIZE" value="33" enum="BuiltinFunc">
-			Randomize the seed (or the internal state) of the random number generator. Current implementation reseeds using a number based on time.
+		<constant name="MATH_LERP_ANGLE" value="64" enum="BuiltinFunc">
 		</constant>
-		<constant name="MATH_RANDF" value="34" enum="BuiltinFunc">
-			Return a random floating-point value between 0 and 1. To obtain a random value between 0 to N, you can use it with multiplication.
-		</constant>
-		<constant name="MATH_RANDF_RANGE" value="35" enum="BuiltinFunc">
-			Return a random floating-point value between the two inputs.
-		</constant>
-		<constant name="MATH_RANDI" value="36" enum="BuiltinFunc">
-			Return a random 32 bits integer value. To obtain a random value between 0 to N (where N is smaller than 2^32 - 1), you can use it with the remainder function.
-		</constant>
-		<constant name="MATH_RANDI_RANGE" value="37" enum="BuiltinFunc">
-			Return a random 32-bit integer value between the two inputs.
-		</constant>
-		<constant name="MATH_SEED" value="38" enum="BuiltinFunc">
-			Set the seed for the random number generator.
-		</constant>
-		<constant name="MATH_RANDSEED" value="39" enum="BuiltinFunc">
-			Return a random value from the given seed, along with the new seed.
-		</constant>
-		<constant name="MATH_DEG2RAD" value="40" enum="BuiltinFunc">
-			Convert the input from degrees to radians.
-		</constant>
-		<constant name="MATH_RAD2DEG" value="41" enum="BuiltinFunc">
-			Convert the input from radians to degrees.
-		</constant>
-		<constant name="MATH_DB2LINEAR" value="42" enum="BuiltinFunc">
-			Convert the input from decibel volume to linear volume.
-		</constant>
-		<constant name="MATH_LINEAR2DB" value="43" enum="BuiltinFunc">
-			Convert the input from linear volume to decibel volume.
-		</constant>
-		<constant name="MATH_WRAPF" value="44" enum="BuiltinFunc">
-		</constant>
-		<constant name="MATH_WRAP" value="45" enum="BuiltinFunc">
-		</constant>
-		<constant name="MATH_POLAR2CARTESIAN" value="46" enum="BuiltinFunc">
-			Converts a 2D point expressed in the polar coordinate system (a distance from the origin [code]r[/code] and an angle [code]th[/code]) to the cartesian coordinate system (X and Y axis).
-		</constant>
-		<constant name="MATH_CARTESIAN2POLAR" value="47" enum="BuiltinFunc">
-			Converts a 2D point expressed in the cartesian coordinate system (X and Y axis) to the polar coordinate system (a distance from the origin and an angle).
-		</constant>
-		<constant name="LOGIC_MAX" value="48" enum="BuiltinFunc">
-			Return the greater of the two numbers, also known as their maximum.
-		</constant>
-		<constant name="LOGIC_MIN" value="49" enum="BuiltinFunc">
-			Return the lesser of the two numbers, also known as their minimum.
-		</constant>
-		<constant name="LOGIC_CLAMP" value="50" enum="BuiltinFunc">
-			Return the input clamped inside the given range, ensuring the result is never outside it. Equivalent to [code]min(max(input, range_low), range_high)[/code].
-		</constant>
-		<constant name="LOGIC_NEAREST_PO2" value="51" enum="BuiltinFunc">
-			Return the nearest power of 2 to the input.
-		</constant>
-		<constant name="OBJ_WEAKREF" value="52" enum="BuiltinFunc">
-			Create a [WeakRef] from the input.
-		</constant>
-		<constant name="TYPE_CONVERT" value="53" enum="BuiltinFunc">
-			Convert between types.
-		</constant>
-		<constant name="TYPE_OF" value="54" enum="BuiltinFunc">
-			Return the type of the input as an integer. Check [enum Variant.Type] for the integers that might be returned.
-		</constant>
-		<constant name="TYPE_EXISTS" value="55" enum="BuiltinFunc">
-			Checks if a type is registered in the [ClassDB].
-		</constant>
-		<constant name="TEXT_CHAR" value="56" enum="BuiltinFunc">
-			Return a character with the given ascii value.
-		</constant>
-		<constant name="TEXT_ORD" value="57" enum="BuiltinFunc">
-		</constant>
-		<constant name="TEXT_STR" value="58" enum="BuiltinFunc">
-			Convert the input to a string.
-		</constant>
-		<constant name="TEXT_PRINT" value="59" enum="BuiltinFunc">
-			Print the given string to the output window.
-		</constant>
-		<constant name="TEXT_PRINTERR" value="60" enum="BuiltinFunc">
-			Print the given string to the standard error output.
-		</constant>
-		<constant name="TEXT_PRINTRAW" value="61" enum="BuiltinFunc">
-			Print the given string to the standard output, without adding a newline.
-		</constant>
-		<constant name="VAR_TO_STR" value="62" enum="BuiltinFunc">
-			Serialize a [Variant] to a string.
-		</constant>
-		<constant name="STR_TO_VAR" value="63" enum="BuiltinFunc">
-			Deserialize a [Variant] from a string serialized using [constant VAR_TO_STR].
-		</constant>
-		<constant name="VAR_TO_BYTES" value="64" enum="BuiltinFunc">
-			Serialize a [Variant] to a [PackedByteArray].
-		</constant>
-		<constant name="BYTES_TO_VAR" value="65" enum="BuiltinFunc">
-			Deserialize a [Variant] from a [PackedByteArray] serialized using [constant VAR_TO_BYTES].
+		<constant name="TEXT_ORD" value="65" enum="BuiltinFunc">
 		</constant>
 		<constant name="FUNC_MAX" value="66" enum="BuiltinFunc">
 			Represents the size of the [enum BuiltinFunc] enum.

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -524,7 +524,9 @@ PropertyInfo VisualScriptBuiltinFunc::get_output_value_port_info(int p_idx) cons
 		case MATH_INVERSE_LERP:
 		case MATH_RANGE_LERP:
 		case MATH_SMOOTHSTEP:
-		case MATH_MOVE_TOWARD:
+		case MATH_MOVE_TOWARD: {
+			t = Variant::FLOAT;
+		} break;
 		case MATH_RANDOMIZE: {
 		} break;
 		case MATH_RANDI: {

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -486,22 +486,20 @@ PropertyInfo VisualScriptBuiltinFunc::get_output_value_port_info(int p_idx) cons
 		case MATH_ATAN2:
 		case MATH_SQRT:
 		case MATH_FMOD:
-		case MATH_FPOSMOD:
-		case MATH_FLOOR:
-		case MATH_CEIL: {
+		case MATH_FPOSMOD: {
 			t = Variant::FLOAT;
 		} break;
 		case MATH_POSMOD: {
 			t = Variant::INT;
 		} break;
-		case MATH_ROUND: {
+		case MATH_FLOOR:
+		case MATH_CEIL:
+		case MATH_ROUND:
+		case MATH_ABS: {
 			t = Variant::FLOAT;
 		} break;
-		case MATH_ABS: {
-			t = Variant::NIL;
-		} break;
 		case MATH_SIGN: {
-			t = Variant::NIL;
+			t = Variant::INT;
 		} break;
 		case MATH_POW:
 		case MATH_LOG:
@@ -528,18 +526,18 @@ PropertyInfo VisualScriptBuiltinFunc::get_output_value_port_info(int p_idx) cons
 			t = Variant::FLOAT;
 		} break;
 		case MATH_RANDOMIZE: {
-		} break;
-		case MATH_RANDI: {
-			t = Variant::INT;
+			//No output
 		} break;
 		case MATH_RANDF:
 		case MATH_RANDF_RANGE: {
 			t = Variant::FLOAT;
 		} break;
+		case MATH_RANDI:
 		case MATH_RANDI_RANGE: {
 			t = Variant::INT;
 		} break;
 		case MATH_SEED: {
+			//No output
 		} break;
 		case MATH_RANDSEED: {
 			if (p_idx == 0) {
@@ -550,56 +548,61 @@ PropertyInfo VisualScriptBuiltinFunc::get_output_value_port_info(int p_idx) cons
 		} break;
 		case MATH_DEG2RAD:
 		case MATH_RAD2DEG:
+		case MATH_DB2LINEAR:
 		case MATH_LINEAR2DB:
-		case MATH_WRAPF:
-		case MATH_DB2LINEAR: {
+		case MATH_WRAPF: {
 			t = Variant::FLOAT;
+		} break;
+		case MATH_WRAP: {
+			t = Variant::INT;
 		} break;
 		case MATH_POLAR2CARTESIAN:
 		case MATH_CARTESIAN2POLAR: {
 			t = Variant::VECTOR2;
 		} break;
-		case MATH_WRAP: {
-			t = Variant::INT;
-		} break;
 		case LOGIC_MAX:
 		case LOGIC_MIN:
 		case LOGIC_CLAMP: {
+			t = Variant::FLOAT;
 		} break;
-
 		case LOGIC_NEAREST_PO2: {
-			t = Variant::NIL;
+			t = Variant::INT;
 		} break;
 		case OBJ_WEAKREF: {
 			t = Variant::OBJECT;
-
 		} break;
 		case TYPE_CONVERT: {
+			t = Variant::NIL;
 		} break;
-		case TEXT_ORD:
 		case TYPE_OF: {
 			t = Variant::INT;
-
 		} break;
 		case TYPE_EXISTS: {
 			t = Variant::BOOL;
-
 		} break;
-		case TEXT_CHAR:
+		case TEXT_CHAR: {
+			t = Variant::STRING;
+		} break;
+		case TEXT_ORD: {
+			t = Variant::INT;
+		} break;
 		case TEXT_STR: {
 			t = Variant::STRING;
-
 		} break;
 		case TEXT_PRINT: {
+			//No output
 		} break;
 		case TEXT_PRINTERR: {
+			//No output
 		} break;
 		case TEXT_PRINTRAW: {
+			//No output
 		} break;
 		case VAR_TO_STR: {
 			t = Variant::STRING;
 		} break;
 		case STR_TO_VAR: {
+			t = Variant::NIL;
 		} break;
 		case VAR_TO_BYTES: {
 			if (p_idx == 0) {
@@ -607,7 +610,6 @@ PropertyInfo VisualScriptBuiltinFunc::get_output_value_port_info(int p_idx) cons
 			} else {
 				t = Variant::BOOL;
 			}
-
 		} break;
 		case BYTES_TO_VAR: {
 			if (p_idx == 1) {
@@ -620,13 +622,6 @@ PropertyInfo VisualScriptBuiltinFunc::get_output_value_port_info(int p_idx) cons
 
 	return PropertyInfo(t, "");
 }
-
-/*
-String VisualScriptBuiltinFunc::get_caption() const {
-	return "BuiltinFunc";
-}
-
-*/
 
 String VisualScriptBuiltinFunc::get_caption() const {
 	return func_name[func];
@@ -826,10 +821,6 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 		} break;
 		case VisualScriptBuiltinFunc::MATH_RANDOMIZE: {
 			Math::randomize();
-
-		} break;
-		case VisualScriptBuiltinFunc::MATH_RANDI: {
-			*r_return = Math::rand();
 		} break;
 		case VisualScriptBuiltinFunc::MATH_RANDF: {
 			*r_return = Math::randf();
@@ -838,6 +829,9 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 			VALIDATE_ARG_NUM(0);
 			VALIDATE_ARG_NUM(1);
 			*r_return = Math::random((double)*p_inputs[0], (double)*p_inputs[1]);
+		} break;
+		case VisualScriptBuiltinFunc::MATH_RANDI: {
+			*r_return = Math::rand();
 		} break;
 		case VisualScriptBuiltinFunc::MATH_RANDI_RANGE: {
 			VALIDATE_ARG_NUM(0);
@@ -848,7 +842,6 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 			VALIDATE_ARG_NUM(0);
 			uint64_t seed = *p_inputs[0];
 			Math::seed(seed);
-
 		} break;
 		case VisualScriptBuiltinFunc::MATH_RANDSEED: {
 			VALIDATE_ARG_NUM(0);
@@ -858,7 +851,6 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 			reta.push_back(ret);
 			reta.push_back(seed);
 			*r_return = reta;
-
 		} break;
 		case VisualScriptBuiltinFunc::MATH_DEG2RAD: {
 			VALIDATE_ARG_NUM(0);
@@ -868,13 +860,25 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 			VALIDATE_ARG_NUM(0);
 			*r_return = Math::rad2deg((double)*p_inputs[0]);
 		} break;
+		case VisualScriptBuiltinFunc::MATH_DB2LINEAR: {
+			VALIDATE_ARG_NUM(0);
+			*r_return = Math::db2linear((double)*p_inputs[0]);
+		} break;
 		case VisualScriptBuiltinFunc::MATH_LINEAR2DB: {
 			VALIDATE_ARG_NUM(0);
 			*r_return = Math::linear2db((double)*p_inputs[0]);
 		} break;
-		case VisualScriptBuiltinFunc::MATH_DB2LINEAR: {
+		case VisualScriptBuiltinFunc::MATH_WRAPF: {
 			VALIDATE_ARG_NUM(0);
-			*r_return = Math::db2linear((double)*p_inputs[0]);
+			VALIDATE_ARG_NUM(1);
+			VALIDATE_ARG_NUM(2);
+			*r_return = Math::wrapf((double)*p_inputs[0], (double)*p_inputs[1], (double)*p_inputs[2]);
+		} break;
+		case VisualScriptBuiltinFunc::MATH_WRAP: {
+			VALIDATE_ARG_NUM(0);
+			VALIDATE_ARG_NUM(1);
+			VALIDATE_ARG_NUM(2);
+			*r_return = Math::wrapi((int64_t)*p_inputs[0], (int64_t)*p_inputs[1], (int64_t)*p_inputs[2]);
 		} break;
 		case VisualScriptBuiltinFunc::MATH_POLAR2CARTESIAN: {
 			VALIDATE_ARG_NUM(0);
@@ -890,18 +894,6 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 			double y = *p_inputs[1];
 			*r_return = Vector2(Math::sqrt(x * x + y * y), Math::atan2(y, x));
 		} break;
-		case VisualScriptBuiltinFunc::MATH_WRAP: {
-			VALIDATE_ARG_NUM(0);
-			VALIDATE_ARG_NUM(1);
-			VALIDATE_ARG_NUM(2);
-			*r_return = Math::wrapi((int64_t)*p_inputs[0], (int64_t)*p_inputs[1], (int64_t)*p_inputs[2]);
-		} break;
-		case VisualScriptBuiltinFunc::MATH_WRAPF: {
-			VALIDATE_ARG_NUM(0);
-			VALIDATE_ARG_NUM(1);
-			VALIDATE_ARG_NUM(2);
-			*r_return = Math::wrapf((double)*p_inputs[0], (double)*p_inputs[1], (double)*p_inputs[2]);
-		} break;
 		case VisualScriptBuiltinFunc::LOGIC_MAX: {
 			if (p_inputs[0]->get_type() == Variant::INT && p_inputs[1]->get_type() == Variant::INT) {
 				int64_t a = *p_inputs[0];
@@ -910,13 +902,10 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 			} else {
 				VALIDATE_ARG_NUM(0);
 				VALIDATE_ARG_NUM(1);
-
 				real_t a = *p_inputs[0];
 				real_t b = *p_inputs[1];
-
 				*r_return = MAX(a, b);
 			}
-
 		} break;
 		case VisualScriptBuiltinFunc::LOGIC_MIN: {
 			if (p_inputs[0]->get_type() == Variant::INT && p_inputs[1]->get_type() == Variant::INT) {
@@ -926,10 +915,8 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 			} else {
 				VALIDATE_ARG_NUM(0);
 				VALIDATE_ARG_NUM(1);
-
 				real_t a = *p_inputs[0];
 				real_t b = *p_inputs[1];
-
 				*r_return = MIN(a, b);
 			}
 		} break;
@@ -943,11 +930,9 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 				VALIDATE_ARG_NUM(0);
 				VALIDATE_ARG_NUM(1);
 				VALIDATE_ARG_NUM(2);
-
 				real_t a = *p_inputs[0];
 				real_t b = *p_inputs[1];
 				real_t c = *p_inputs[2];
-
 				*r_return = CLAMP(a, b, c);
 			}
 		} break;
@@ -961,7 +946,6 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.argument = 0;
 				r_error.expected = Variant::OBJECT;
-
 				return;
 			}
 
@@ -970,7 +954,6 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 				if (!r.is_valid()) {
 					return;
 				}
-
 				Ref<WeakRef> wref = memnew(WeakRef);
 				wref->set_ref(r);
 				*r_return = wref;
@@ -983,7 +966,6 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 				wref->set_obj(obj);
 				*r_return = wref;
 			}
-
 		} break;
 		case VisualScriptBuiltinFunc::TYPE_CONVERT: {
 			VALIDATE_ARG_NUM(1);
@@ -1001,24 +983,19 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 		} break;
 		case VisualScriptBuiltinFunc::TYPE_OF: {
 			*r_return = p_inputs[0]->get_type();
-
 		} break;
 		case VisualScriptBuiltinFunc::TYPE_EXISTS: {
 			*r_return = ClassDB::class_exists(*p_inputs[0]);
-
 		} break;
 		case VisualScriptBuiltinFunc::TEXT_CHAR: {
 			char32_t result[2] = { *p_inputs[0], 0 };
-
 			*r_return = String(result);
-
 		} break;
 		case VisualScriptBuiltinFunc::TEXT_ORD: {
 			if (p_inputs[0]->get_type() != Variant::STRING) {
 				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.argument = 0;
 				r_error.expected = Variant::STRING;
-
 				return;
 			}
 
@@ -1029,34 +1006,26 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 				r_error.argument = 0;
 				r_error.expected = Variant::STRING;
 				*r_return = "Expected a string of length 1 (a character).";
-
 				return;
 			}
 
 			*r_return = str.get(0);
-
 		} break;
 		case VisualScriptBuiltinFunc::TEXT_STR: {
 			String str = *p_inputs[0];
-
 			*r_return = str;
-
 		} break;
 		case VisualScriptBuiltinFunc::TEXT_PRINT: {
 			String str = *p_inputs[0];
 			print_line(str);
-
 		} break;
-
 		case VisualScriptBuiltinFunc::TEXT_PRINTERR: {
 			String str = *p_inputs[0];
 			print_error(str);
-
 		} break;
 		case VisualScriptBuiltinFunc::TEXT_PRINTRAW: {
 			String str = *p_inputs[0];
 			OS::get_singleton()->print("%s", str.utf8().get_data());
-
 		} break;
 		case VisualScriptBuiltinFunc::VAR_TO_STR: {
 			String vars;
@@ -1068,7 +1037,6 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.argument = 0;
 				r_error.expected = Variant::STRING;
-
 				return;
 			}
 
@@ -1086,7 +1054,6 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 				*r_return = "Parse error at line " + itos(line) + ": " + errs;
 				return;
 			}
-
 		} break;
 		case VisualScriptBuiltinFunc::VAR_TO_BYTES: {
 			if (p_inputs[1]->get_type() != Variant::BOOL) {
@@ -1142,9 +1109,7 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 					return;
 				}
 			}
-
 			*r_return = ret;
-
 		} break;
 		default: {
 		}
@@ -1203,6 +1168,7 @@ void VisualScriptBuiltinFunc::_bind_methods() {
 	BIND_ENUM_CONSTANT(MATH_SQRT);
 	BIND_ENUM_CONSTANT(MATH_FMOD);
 	BIND_ENUM_CONSTANT(MATH_FPOSMOD);
+	BIND_ENUM_CONSTANT(MATH_POSMOD);
 	BIND_ENUM_CONSTANT(MATH_FLOOR);
 	BIND_ENUM_CONSTANT(MATH_CEIL);
 	BIND_ENUM_CONSTANT(MATH_ROUND);
@@ -1217,24 +1183,26 @@ void VisualScriptBuiltinFunc::_bind_methods() {
 	BIND_ENUM_CONSTANT(MATH_STEP_DECIMALS);
 	BIND_ENUM_CONSTANT(MATH_SNAPPED);
 	BIND_ENUM_CONSTANT(MATH_LERP);
+	BIND_ENUM_CONSTANT(MATH_LERP_ANGLE);
 	BIND_ENUM_CONSTANT(MATH_INVERSE_LERP);
 	BIND_ENUM_CONSTANT(MATH_RANGE_LERP);
+	BIND_ENUM_CONSTANT(MATH_SMOOTHSTEP);
 	BIND_ENUM_CONSTANT(MATH_MOVE_TOWARD);
 	BIND_ENUM_CONSTANT(MATH_RANDOMIZE);
-	BIND_ENUM_CONSTANT(MATH_RANDI);
 	BIND_ENUM_CONSTANT(MATH_RANDF);
 	BIND_ENUM_CONSTANT(MATH_RANDF_RANGE);
+	BIND_ENUM_CONSTANT(MATH_RANDI);
 	BIND_ENUM_CONSTANT(MATH_RANDI_RANGE);
 	BIND_ENUM_CONSTANT(MATH_SEED);
 	BIND_ENUM_CONSTANT(MATH_RANDSEED);
 	BIND_ENUM_CONSTANT(MATH_DEG2RAD);
 	BIND_ENUM_CONSTANT(MATH_RAD2DEG);
-	BIND_ENUM_CONSTANT(MATH_LINEAR2DB);
 	BIND_ENUM_CONSTANT(MATH_DB2LINEAR);
+	BIND_ENUM_CONSTANT(MATH_LINEAR2DB);
+	BIND_ENUM_CONSTANT(MATH_WRAPF);
+	BIND_ENUM_CONSTANT(MATH_WRAP);
 	BIND_ENUM_CONSTANT(MATH_POLAR2CARTESIAN);
 	BIND_ENUM_CONSTANT(MATH_CARTESIAN2POLAR);
-	BIND_ENUM_CONSTANT(MATH_WRAP);
-	BIND_ENUM_CONSTANT(MATH_WRAPF);
 	BIND_ENUM_CONSTANT(LOGIC_MAX);
 	BIND_ENUM_CONSTANT(LOGIC_MIN);
 	BIND_ENUM_CONSTANT(LOGIC_CLAMP);
@@ -1244,6 +1212,7 @@ void VisualScriptBuiltinFunc::_bind_methods() {
 	BIND_ENUM_CONSTANT(TYPE_OF);
 	BIND_ENUM_CONSTANT(TYPE_EXISTS);
 	BIND_ENUM_CONSTANT(TEXT_CHAR);
+	BIND_ENUM_CONSTANT(TEXT_ORD);
 	BIND_ENUM_CONSTANT(TEXT_STR);
 	BIND_ENUM_CONSTANT(TEXT_PRINT);
 	BIND_ENUM_CONSTANT(TEXT_PRINTERR);
@@ -1252,10 +1221,6 @@ void VisualScriptBuiltinFunc::_bind_methods() {
 	BIND_ENUM_CONSTANT(STR_TO_VAR);
 	BIND_ENUM_CONSTANT(VAR_TO_BYTES);
 	BIND_ENUM_CONSTANT(BYTES_TO_VAR);
-	BIND_ENUM_CONSTANT(MATH_SMOOTHSTEP);
-	BIND_ENUM_CONSTANT(MATH_POSMOD);
-	BIND_ENUM_CONSTANT(MATH_LERP_ANGLE);
-	BIND_ENUM_CONSTANT(TEXT_ORD);
 	BIND_ENUM_CONSTANT(FUNC_MAX);
 }
 
@@ -1311,21 +1276,21 @@ void register_visual_script_builtin_func_node() {
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/smoothstep", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_SMOOTHSTEP>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/move_toward", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_MOVE_TOWARD>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/randomize", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_RANDOMIZE>);
-	VisualScriptLanguage::singleton->add_register_func("functions/built_in/randi", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_RANDI>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/randf", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_RANDF>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/randf_range", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_RANDF_RANGE>);
+	VisualScriptLanguage::singleton->add_register_func("functions/built_in/randi", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_RANDI>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/randi_range", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_RANDI_RANGE>);
 
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/seed", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_SEED>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/randseed", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_RANDSEED>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/deg2rad", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_DEG2RAD>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/rad2deg", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_RAD2DEG>);
-	VisualScriptLanguage::singleton->add_register_func("functions/built_in/linear2db", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_LINEAR2DB>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/db2linear", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_DB2LINEAR>);
-	VisualScriptLanguage::singleton->add_register_func("functions/built_in/polar2cartesian", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_POLAR2CARTESIAN>);
-	VisualScriptLanguage::singleton->add_register_func("functions/built_in/cartesian2polar", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_CARTESIAN2POLAR>);
+	VisualScriptLanguage::singleton->add_register_func("functions/built_in/linear2db", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_LINEAR2DB>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/wrapi", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_WRAP>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/wrapf", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_WRAPF>);
+	VisualScriptLanguage::singleton->add_register_func("functions/built_in/polar2cartesian", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_POLAR2CARTESIAN>);
+	VisualScriptLanguage::singleton->add_register_func("functions/built_in/cartesian2polar", create_builtin_func_node<VisualScriptBuiltinFunc::MATH_CARTESIAN2POLAR>);
 
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/max", create_builtin_func_node<VisualScriptBuiltinFunc::LOGIC_MAX>);
 	VisualScriptLanguage::singleton->add_register_func("functions/built_in/min", create_builtin_func_node<VisualScriptBuiltinFunc::LOGIC_MIN>);

--- a/modules/visual_script/visual_script_builtin_funcs.h
+++ b/modules/visual_script/visual_script_builtin_funcs.h
@@ -37,6 +37,9 @@ class VisualScriptBuiltinFunc : public VisualScriptNode {
 	GDCLASS(VisualScriptBuiltinFunc, VisualScriptNode);
 
 public:
+	//Changing the order of the enum break the compatibility between version
+	//If you change it for some reason you'll have to copy the order in
+	//VisualScriptBuiltinFunc::func_name
 	enum BuiltinFunc {
 		MATH_SIN,
 		MATH_COS,


### PR DESCRIPTION
#51084 brought bug with it.
Visual nodes snapped, lerp, lerp_angle, inverse_lerp, range_lerp, smoothstep and move_toward had a float output before #51084
After the PR theses nodes had the output 'any'

Before fix:
![image](https://user-images.githubusercontent.com/28917197/127741109-e4fc9383-f71c-48ca-bf36-6762d7ddd0e0.png)

After fix:
![image](https://user-images.githubusercontent.com/28917197/127741128-60ad4eb3-e98d-4a8f-bad6-188f94106eb4.png)
