### PR TITLE
Add `get_video_adapter_api_version()` to RenderingServer

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1252,6 +1252,13 @@
 				Returns the id of the test texture. Creates one if none exists.
 			</description>
 		</method>
+		<method name="get_video_adapter_api_version" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the version of the graphics video adapter [i]currently in use[/i] (e.g. "1.2.189" for Vulkan, "3.3.0 NVIDIA 510.60.02" for OpenGL). This version may be different from the actual latest version supported by the hardware, as Godot may not always request the latest version.
+				[b]Note:[/b] When running a headless or server binary, this function returns an empty string.
+			</description>
+		</method>
 		<method name="get_video_adapter_name" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -627,6 +627,10 @@ RenderingDevice::DeviceType RasterizerStorageGLES3::get_video_adapter_type() con
 	return RenderingDevice::DeviceType::DEVICE_TYPE_OTHER;
 }
 
+String RasterizerStorageGLES3::get_video_adapter_api_version() const {
+	return (const char *)glGetString(GL_VERSION);
+}
+
 void RasterizerStorageGLES3::initialize() {
 	config = GLES3::Config::get_singleton();
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -234,6 +234,7 @@ public:
 	String get_video_adapter_name() const override;
 	String get_video_adapter_vendor() const override;
 	RenderingDevice::DeviceType get_video_adapter_type() const override;
+	String get_video_adapter_api_version() const override;
 
 	void capture_timestamps_begin() override {}
 	void capture_timestamp(const String &p_name) override {}

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8649,12 +8649,17 @@ void RenderingDeviceVulkan::draw_command_end_label() {
 String RenderingDeviceVulkan::get_device_vendor_name() const {
 	return context->get_device_vendor_name();
 }
+
 String RenderingDeviceVulkan::get_device_name() const {
 	return context->get_device_name();
 }
 
 RenderingDevice::DeviceType RenderingDeviceVulkan::get_device_type() const {
 	return context->get_device_type();
+}
+
+String RenderingDeviceVulkan::get_device_api_version() const {
+	return context->get_device_api_version();
 }
 
 String RenderingDeviceVulkan::get_device_pipeline_cache_uuid() const {

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1229,6 +1229,7 @@ public:
 	virtual String get_device_vendor_name() const;
 	virtual String get_device_name() const;
 	virtual RenderingDevice::DeviceType get_device_type() const;
+	virtual String get_device_api_version() const;
 	virtual String get_device_pipeline_cache_uuid() const;
 
 	virtual uint64_t get_driver_resource(DriverResource p_resource, RID p_rid = RID(), uint64_t p_index = 0);

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -2364,12 +2364,17 @@ void VulkanContext::set_object_name(VkObjectType p_object_type, uint64_t p_objec
 String VulkanContext::get_device_vendor_name() const {
 	return device_vendor;
 }
+
 String VulkanContext::get_device_name() const {
 	return device_name;
 }
 
 RenderingDevice::DeviceType VulkanContext::get_device_type() const {
 	return RenderingDevice::DeviceType(device_type);
+}
+
+String VulkanContext::get_device_api_version() const {
+	return vformat("%d.%d.%d", vulkan_major, vulkan_minor, vulkan_patch);
 }
 
 String VulkanContext::get_device_pipeline_cache_uuid() const {

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -305,6 +305,7 @@ public:
 	String get_device_vendor_name() const;
 	String get_device_name() const;
 	RenderingDevice::DeviceType get_device_type() const;
+	String get_device_api_version() const;
 	String get_device_pipeline_cache_uuid() const;
 
 	void set_vsync_mode(DisplayServer::WindowID p_window, DisplayServer::VSyncMode p_mode);

--- a/servers/rendering/dummy/rasterizer_storage_dummy.h
+++ b/servers/rendering/dummy/rasterizer_storage_dummy.h
@@ -128,6 +128,7 @@ public:
 	String get_video_adapter_name() const override { return String(); }
 	String get_video_adapter_vendor() const override { return String(); }
 	RenderingDevice::DeviceType get_video_adapter_type() const override { return RenderingDevice::DeviceType::DEVICE_TYPE_OTHER; }
+	String get_video_adapter_api_version() const override { return String(); }
 
 	static RendererStorage *base_singleton;
 

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -727,6 +727,10 @@ RenderingDevice::DeviceType RendererStorageRD::get_video_adapter_type() const {
 	return RenderingDevice::get_singleton()->get_device_type();
 }
 
+String RendererStorageRD::get_video_adapter_api_version() const {
+	return RenderingDevice::get_singleton()->get_device_api_version();
+}
+
 RendererStorageRD *RendererStorageRD::base_singleton = nullptr;
 
 RendererStorageRD::RendererStorageRD() {

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -284,6 +284,7 @@ public:
 	String get_video_adapter_name() const;
 	String get_video_adapter_vendor() const;
 	RenderingDevice::DeviceType get_video_adapter_type() const;
+	String get_video_adapter_api_version() const;
 
 	virtual void capture_timestamps_begin();
 	virtual void capture_timestamp(const String &p_name);

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -199,6 +199,7 @@ public:
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
 	virtual RenderingDevice::DeviceType get_video_adapter_type() const = 0;
+	virtual String get_video_adapter_api_version() const = 0;
 
 	static RendererStorage *base_singleton;
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1254,6 +1254,7 @@ public:
 	virtual String get_device_vendor_name() const = 0;
 	virtual String get_device_name() const = 0;
 	virtual RenderingDevice::DeviceType get_device_type() const = 0;
+	virtual String get_device_api_version() const = 0;
 	virtual String get_device_pipeline_cache_uuid() const = 0;
 
 	virtual uint64_t get_driver_resource(DriverResource p_resource, RID p_rid = RID(), uint64_t p_index = 0) = 0;

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -265,6 +265,10 @@ RenderingDevice::DeviceType RenderingServerDefault::get_video_adapter_type() con
 	return RSG::storage->get_video_adapter_type();
 }
 
+String RenderingServerDefault::get_video_adapter_api_version() const {
+	return RSG::storage->get_video_adapter_api_version();
+}
+
 void RenderingServerDefault::set_frame_profiling_enabled(bool p_enable) {
 	RSG::storage->capturing_timestamps = p_enable;
 }

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -939,6 +939,7 @@ public:
 	virtual String get_video_adapter_name() const override;
 	virtual String get_video_adapter_vendor() const override;
 	virtual RenderingDevice::DeviceType get_video_adapter_type() const override;
+	virtual String get_video_adapter_api_version() const override;
 
 	virtual void set_frame_profiling_enabled(bool p_enable) override;
 	virtual Vector<FrameProfileArea> get_frame_profile() override;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2726,6 +2726,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_video_adapter_name"), &RenderingServer::get_video_adapter_name);
 	ClassDB::bind_method(D_METHOD("get_video_adapter_vendor"), &RenderingServer::get_video_adapter_vendor);
 	ClassDB::bind_method(D_METHOD("get_video_adapter_type"), &RenderingServer::get_video_adapter_type);
+	ClassDB::bind_method(D_METHOD("get_video_adapter_api_version"), &RenderingServer::get_video_adapter_api_version);
 
 	ClassDB::bind_method(D_METHOD("make_sphere_mesh", "latitudes", "longitudes", "radius"), &RenderingServer::make_sphere_mesh);
 	ClassDB::bind_method(D_METHOD("get_test_cube"), &RenderingServer::get_test_cube);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1487,6 +1487,7 @@ public:
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
 	virtual RenderingDevice::DeviceType get_video_adapter_type() const = 0;
+	virtual String get_video_adapter_api_version() const = 0;
 
 	struct FrameProfileArea {
 		String name;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/32126.

This method can be used to get the graphics API version currently in use (such as Vulkan). It can be used by projects for troubleshooting or statistical purposes.

## Preview

### Code

```gdscript
extends Node

func _ready():
	print(RenderingServer.get_video_adapter_name())
	print(RenderingServer.get_video_adapter_vendor())
	print(RenderingServer.get_video_adapter_api_version())
```

### Output

```
NVIDIA GeForce GTX 1080
NVIDIA
1.2.162
```