### PR TITLE
Use title case instead of uppercase for Vulkan Intel GPU detection

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -737,10 +737,11 @@ Error VulkanContext::_create_physical_device() {
 	} vendor_names[] = {
 		{ 0x1002, "AMD" },
 		{ 0x1010, "ImgTec" },
+		{ 0x106B, "Apple" },
 		{ 0x10DE, "NVIDIA" },
 		{ 0x13B5, "ARM" },
 		{ 0x5143, "Qualcomm" },
-		{ 0x8086, "INTEL" },
+		{ 0x8086, "Intel" },
 		{ 0, nullptr },
 	};
 	device_name = gpu_props.deviceName;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/51102 (can be merged independently).

This matches how the vendor name is displayed in most places.

The Apple GPU vendor was also added for the M1.