### PR TITLE
[3.x] Make action names translatable

### DIFF
--- a/editor/plugins/room_manager_editor_plugin.cpp
+++ b/editor/plugins/room_manager_editor_plugin.cpp
@@ -116,7 +116,7 @@ void RoomEditorPlugin::_generate_points() {
 
 		// allow the user to undo generating points, because it is
 		// frustrating to lose old data
-		undo_redo->create_action("generate_points");
+		undo_redo->create_action(TTR("Room Generate Points"));
 		undo_redo->add_do_property(_room, "points", pts);
 		undo_redo->add_undo_property(_room, "points", old_pts);
 		undo_redo->commit_action();

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -1339,8 +1339,14 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					}
 
 					if (_edit.mode != TRANSFORM_NONE) {
-						static const char *_transform_name[4] = { "None", "Rotate", "Translate", "Scale" };
-						undo_redo->create_action(_transform_name[_edit.mode]);
+						static const char *_transform_name[4] = {
+							TTRC("None"),
+							TTRC("Rotate"),
+							// TRANSLATORS: This refers to the movement that changes the position of an object.
+							TTRC("Translate"),
+							TTRC("Scale"),
+						};
+						undo_redo->create_action(TTRGET(_transform_name[_edit.mode]));
 
 						List<Node *> &selection = editor_selection->get_selected_node_list();
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -682,7 +682,7 @@ bool GridMapEditor::forward_spatial_input_event(Camera *p_camera, const Ref<Inpu
 			}
 
 			if (mb->get_button_index() == BUTTON_LEFT && input_action == INPUT_SELECT) {
-				undo_redo->create_action("GridMap Selection");
+				undo_redo->create_action(TTR("GridMap Selection"));
 				undo_redo->add_do_method(this, "_set_selection", selection.active, selection.begin, selection.end);
 				undo_redo->add_undo_method(this, "_set_selection", last_selection.active, last_selection.begin, last_selection.end);
 				undo_redo->commit_action();

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -974,7 +974,7 @@ void VisualScriptEditor::_change_port_type(int p_select, int p_id, int p_port, b
 		return;
 	}
 
-	undo_redo->create_action("Change Port Type");
+	undo_redo->create_action(TTR("Change Port Type"));
 	if (is_input) {
 		undo_redo->add_do_method(vsn.ptr(), "set_input_data_port_type", p_port, Variant::Type(p_select));
 		undo_redo->add_undo_method(vsn.ptr(), "set_input_data_port_type", p_port, vsn->get_input_value_port_info(p_port).type);
@@ -1007,7 +1007,7 @@ void VisualScriptEditor::_port_name_focus_out(const Node *p_name_box, int p_id, 
 		return;
 	}
 
-	undo_redo->create_action("Change Port Name");
+	undo_redo->create_action(TTR("Change Port Name"));
 	if (is_input) {
 		undo_redo->add_do_method(vsn.ptr(), "set_input_data_port_name", p_port, text);
 		undo_redo->add_undo_method(vsn.ptr(), "set_input_data_port_name", p_port, vsn->get_input_value_port_info(p_port).name);


### PR DESCRIPTION
The `3.x` version of #51105.

I also took the liberty of changing "generate_points" to "Room Generate Points" in order to be consistent with other action names.