### PR TITLE
Print a warning when the engine is started as `root`/superuser

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1596,6 +1596,13 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		rendering_server->set_print_gpu_profile(true);
 	}
 
+#ifdef UNIX_ENABLED
+	// Print warning after initializing the renderer but before initializing audio.
+	if (OS::get_singleton()->get_environment("USER") == "root" && !OS::get_singleton()->has_environment("GODOT_SILENCE_ROOT_WARNING")) {
+		WARN_PRINT("Started the engine as `root`/superuser. This is a security risk, and subsystems like audio may not work correctly.\nSet the environment variable `GODOT_SILENCE_ROOT_WARNING` to 1 to silence this warning.");
+	}
+#endif
+
 	OS::get_singleton()->initialize_joypads();
 
 	/* Initialize Audio Driver */


### PR DESCRIPTION
This is a security risk (especially when hosting a game server) [and can make audio non-functional on Linux](https://github.com/godotengine/godot/issues/24972#issuecomment-889970475).

Checking for administrator status on Windows may be more involved, so I didn't look into it yet. (Moreover, the amount of people hosting game servers on Windows is much lower and starting Godot as administrator doesn't break audio on Windows, so there's less of a need to do it).

## Preview

### Regular user

```
❯ bin/godot.linuxbsd.tools.64.llvm
Godot Engine v4.0.dev.custom_build.20d46c5b9 - https://godotengine.org
Vulkan API 1.2.162
Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080
- Vulkan multiview supported:
  max view count: 32
  max instances: 134217727
- Vulkan subgroup:
  size: 32
  stages: STAGE_VERTEX, STAGE_TESSELLATION_CONTROL, STAGE_TESSELLATION_EVALUATION, STAGE_GEOMETRY, STAGE_FRAGMENT, STAGE_COMPUTE, STAGE_RAYGEN_KHR, STAGE_ANY_HIT_KHR, STAGE_CLOSEST_HIT_KHR, STAGE_MISS_KHR, STAGE_INTERSECTION_KHR, STAGE_CALLABLE_KHR
  supported ops: FEATURE_BASIC, FEATURE_VOTE, FEATURE_ARITHMETIC, FEATURE_BALLOT, FEATURE_SHUFFLE, FEATURE_SHUFFLE_RELATIVE, FEATURE_CLUSTERED, FEATURE_QUAD, FEATURE_PARTITIONED_NV
  quad operations in all stages
```

### Superuser

```
❯ sudo bin/godot.linuxbsd.tools.64.llvm
Godot Engine v4.0.dev.custom_build.20d46c5b9 - https://godotengine.org
Vulkan API 1.2.162
Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080
- Vulkan multiview supported:
  max view count: 32
  max instances: 134217727
- Vulkan subgroup:
  size: 32
  stages: STAGE_VERTEX, STAGE_TESSELLATION_CONTROL, STAGE_TESSELLATION_EVALUATION, STAGE_GEOMETRY, STAGE_FRAGMENT, STAGE_COMPUTE, STAGE_RAYGEN_KHR, STAGE_ANY_HIT_KHR, STAGE_CLOSEST_HIT_KHR, STAGE_MISS_KHR, STAGE_INTERSECTION_KHR, STAGE_CALLABLE_KHR
  supported ops: FEATURE_BASIC, FEATURE_VOTE, FEATURE_ARITHMETIC, FEATURE_BALLOT, FEATURE_SHUFFLE, FEATURE_SHUFFLE_RELATIVE, FEATURE_CLUSTERED, FEATURE_QUAD, FEATURE_PARTITIONED_NV
  quad operations in all stages
WARNING: Started the engine as `root`/superuser. This is a security risk, and subsystems like audio may not work correctly.
Set the environment variable `GODOT_SILENCE_ROOT_WARNING` to 1 to silence this warning.
     at: setup2 (main/main.cpp:1602)
ERROR: Condition "status < 0" is true. Returning: ERR_CANT_OPEN
   at: init_device (drivers/alsa/audio_driver_alsa.cpp:89)
WARNING: All audio drivers failed, falling back to the dummy driver.
     at: initialize (servers/audio_server.cpp:222)
```

### Superuser, silence warning via environment variable

```
❯ sudo env GODOT_SILENCE_ROOT_WARNING=1 bin/godot.linuxbsd.tools.64.llvm
Godot Engine v4.0.dev.custom_build.20d46c5b9 - https://godotengine.org
Vulkan API 1.2.162
Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080
- Vulkan multiview supported:
  max view count: 32
  max instances: 134217727
- Vulkan subgroup:
  size: 32
  stages: STAGE_VERTEX, STAGE_TESSELLATION_CONTROL, STAGE_TESSELLATION_EVALUATION, STAGE_GEOMETRY, STAGE_FRAGMENT, STAGE_COMPUTE, STAGE_RAYGEN_KHR, STAGE_ANY_HIT_KHR, STAGE_CLOSEST_HIT_KHR, STAGE_MISS_KHR, STAGE_INTERSECTION_KHR, STAGE_CALLABLE_KHR
  supported ops: FEATURE_BASIC, FEATURE_VOTE, FEATURE_ARITHMETIC, FEATURE_BALLOT, FEATURE_SHUFFLE, FEATURE_SHUFFLE_RELATIVE, FEATURE_CLUSTERED, FEATURE_QUAD, FEATURE_PARTITIONED_NV
  quad operations in all stages
ERROR: Condition "status < 0" is true. Returning: ERR_CANT_OPEN
   at: init_device (drivers/alsa/audio_driver_alsa.cpp:89)
WARNING: All audio drivers failed, falling back to the dummy driver.
     at: initialize (servers/audio_server.cpp:222)
```