### PR TITLE
Move Vulkan debugging prints to verbose

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -577,26 +577,22 @@ Error VulkanContext::_check_capabilities() {
 			multiview_capabilities.max_view_count = multiviewProperties.maxMultiviewViewCount;
 			multiview_capabilities.max_instance_count = multiviewProperties.maxMultiviewInstanceIndex;
 
-#ifdef DEBUG_ENABLED
-			print_line("- Vulkan multiview supported:");
-			print_line("  max view count: " + itos(multiview_capabilities.max_view_count));
-			print_line("  max instances: " + itos(multiview_capabilities.max_instance_count));
+			print_verbose("- Vulkan multiview supported:");
+			print_verbose("  max view count: " + itos(multiview_capabilities.max_view_count));
+			print_verbose("  max instances: " + itos(multiview_capabilities.max_instance_count));
 		} else {
-			print_line("- Vulkan multiview not supported");
-#endif
+			print_verbose("- Vulkan multiview not supported");
 		}
 
-#ifdef DEBUG_ENABLED
-		print_line("- Vulkan subgroup:");
-		print_line("  size: " + itos(subgroup_capabilities.size));
-		print_line("  stages: " + subgroup_capabilities.supported_stages_desc());
-		print_line("  supported ops: " + subgroup_capabilities.supported_operations_desc());
+		print_verbose("- Vulkan subgroup:");
+		print_verbose("  size: " + itos(subgroup_capabilities.size));
+		print_verbose("  stages: " + subgroup_capabilities.supported_stages_desc());
+		print_verbose("  supported ops: " + subgroup_capabilities.supported_operations_desc());
 		if (subgroup_capabilities.quadOperationsInAllStages) {
-			print_line("  quad operations in all stages");
+			print_verbose("  quad operations in all stages");
 		}
 	} else {
-		print_line("- Couldn't call vkGetPhysicalDeviceProperties2");
-#endif
+		print_verbose("- Couldn't call vkGetPhysicalDeviceProperties2");
 	}
 
 	return OK;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/51099.

These messages can now be displayed in release builds if the `--verbose` command line argument is specified, which is useful for troubleshooting.