### PR TITLE
[3.x] Fix theming in the audio bus editor

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -62,7 +62,8 @@ void EditorAudioBus::_update_visible_channels() {
 
 void EditorAudioBus::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
 			for (int i = 0; i < CHANNELS_MAX; i++) {
 				channel[i].vu_l->set_under_texture(get_icon("BusVuEmpty", "EditorIcons"));
 				channel[i].vu_l->set_progress_texture(get_icon("BusVuFull", "EditorIcons"));
@@ -86,6 +87,12 @@ void EditorAudioBus::_notification(int p_what) {
 
 			bus_options->set_icon(get_icon("GuiTabMenuHl", "EditorIcons"));
 
+			audio_value_preview_label->add_color_override("font_color", get_color("font_color", "TooltipLabel"));
+			audio_value_preview_label->add_color_override("font_color_shadow", get_color("font_color_shadow", "TooltipLabel"));
+			audio_value_preview_box->add_style_override("panel", get_stylebox("panel", "TooltipPanel"));
+		} break;
+
+		case NOTIFICATION_READY: {
 			update_bus();
 			set_process(true);
 		} break;
@@ -157,26 +164,7 @@ void EditorAudioBus::_notification(int p_what) {
 
 			set_process(is_visible_in_tree());
 		} break;
-		case NOTIFICATION_THEME_CHANGED: {
-			for (int i = 0; i < CHANNELS_MAX; i++) {
-				channel[i].vu_l->set_under_texture(get_icon("BusVuEmpty", "EditorIcons"));
-				channel[i].vu_l->set_progress_texture(get_icon("BusVuFull", "EditorIcons"));
-				channel[i].vu_r->set_under_texture(get_icon("BusVuEmpty", "EditorIcons"));
-				channel[i].vu_r->set_progress_texture(get_icon("BusVuFull", "EditorIcons"));
-				channel[i].prev_active = true;
-			}
 
-			disabled_vu = get_icon("BusVuFrozen", "EditorIcons");
-
-			solo->set_icon(get_icon("AudioBusSolo", "EditorIcons"));
-			mute->set_icon(get_icon("AudioBusMute", "EditorIcons"));
-			bypass->set_icon(get_icon("AudioBusBypass", "EditorIcons"));
-
-			bus_options->set_icon(get_icon("GuiTabMenuHl", "EditorIcons"));
-
-			audio_value_preview_box->add_color_override("font_color", get_color("font_color", "TooltipLabel"));
-			audio_value_preview_box->add_style_override("panel", get_stylebox("panel", "TooltipPanel"));
-		} break;
 		case NOTIFICATION_MOUSE_EXIT:
 		case NOTIFICATION_DRAG_END: {
 			if (hovering_drop) {
@@ -855,6 +843,11 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	slider->set_clip_contents(false);
 
 	audio_value_preview_box = memnew(Panel);
+	slider->add_child(audio_value_preview_box);
+	audio_value_preview_box->set_as_toplevel(true);
+	audio_value_preview_box->set_mouse_filter(MOUSE_FILTER_PASS);
+	audio_value_preview_box->hide();
+
 	HBoxContainer *audioprev_hbc = memnew(HBoxContainer);
 	audioprev_hbc->set_v_size_flags(SIZE_EXPAND_FILL);
 	audioprev_hbc->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -865,15 +858,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	audio_value_preview_label->set_v_size_flags(SIZE_EXPAND_FILL);
 	audio_value_preview_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	audio_value_preview_label->set_mouse_filter(MOUSE_FILTER_PASS);
-	audio_value_preview_box->add_color_override("font_color", get_color("font_color", "TooltipLabel"));
-
 	audioprev_hbc->add_child(audio_value_preview_label);
-
-	slider->add_child(audio_value_preview_box);
-	audio_value_preview_box->set_as_toplevel(true);
-	audio_value_preview_box->add_style_override("panel", get_stylebox("panel", "TooltipPanel"));
-	audio_value_preview_box->set_mouse_filter(MOUSE_FILTER_PASS);
-	audio_value_preview_box->hide();
 
 	preview_timer = memnew(Timer);
 	preview_timer->set_wait_time(0.8f);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -381,6 +381,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color font_color = mono_color.linear_interpolate(base_color, 0.25);
 	const Color font_color_hl = mono_color.linear_interpolate(base_color, 0.15);
 	const Color font_color_disabled = Color(mono_color.r, mono_color.g, mono_color.b, 0.3);
+	const Color font_color_readonly = Color(mono_color.r, mono_color.g, mono_color.b, 0.65);
 	const Color font_color_selection = accent_color * Color(1, 1, 1, 0.4);
 	const Color color_disabled = mono_color.inverted().linear_interpolate(base_color, 0.7);
 	const Color color_disabled_bg = mono_color.inverted().linear_interpolate(base_color, 0.9);
@@ -957,6 +958,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("read_only", "LineEdit", font_color_disabled);
 	theme->set_color("font_color", "LineEdit", font_color);
 	theme->set_color("font_color_selected", "LineEdit", mono_color);
+	theme->set_color("font_color_uneditable", "LineEdit", font_color_readonly);
 	theme->set_color("cursor_color", "LineEdit", font_color);
 	theme->set_color("selection_color", "LineEdit", font_color_selection);
 	theme->set_color("clear_button_color", "LineEdit", font_color);


### PR DESCRIPTION
Proper remake of https://github.com/godotengine/godot/pull/50646. This correctly fixes the issue (it was but a typo with a font color override being applied to a wrong control), makes the readonly name of the `Master` bus more visible by introducing a new color instead of reusing the disabled color, and also cleans up the theme application in the audio bus editor (there likely were several other issues with it judging by the code).

**Light theme**

https://user-images.githubusercontent.com/11782833/127749662-ff7ff213-45d0-454c-b3a4-b07805ba7a35.mp4


**Dark theme**

https://user-images.githubusercontent.com/11782833/127749668-f430b65f-c258-4e7a-b62a-a6d57c51cf46.mp4

-----

I will look into the original PR for `master` because I think it also needs to be remade.