### PR TITLE
Move assignment of SSAO radius push constant

### DIFF
--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -1209,6 +1209,7 @@ void EffectsRD::generate_ssao(RID p_depth_buffer, RID p_normal_buffer, RID p_dep
 		ssao.gather_push_constant.half_screen_pixel_size_x025[0] = ssao.gather_push_constant.half_screen_pixel_size[0] * 0.25;
 		ssao.gather_push_constant.half_screen_pixel_size_x025[1] = ssao.gather_push_constant.half_screen_pixel_size[1] * 0.25;
 
+		ssao.gather_push_constant.radius = p_settings.radius;
 		float radius_near_limit = (p_settings.radius * 1.2f);
 		if (p_settings.quality <= RS::ENV_SSAO_QUALITY_LOW) {
 			radius_near_limit *= 1.50f;
@@ -1216,12 +1217,8 @@ void EffectsRD::generate_ssao(RID p_depth_buffer, RID p_normal_buffer, RID p_dep
 			if (p_settings.quality == RS::ENV_SSAO_QUALITY_VERY_LOW) {
 				ssao.gather_push_constant.radius *= 0.8f;
 			}
-			if (p_settings.half_size) {
-				ssao.gather_push_constant.radius *= 0.5f;
-			}
 		}
 		radius_near_limit /= tan_half_fov_y;
-		ssao.gather_push_constant.radius = p_settings.radius;
 		ssao.gather_push_constant.intensity = p_settings.intensity;
 		ssao.gather_push_constant.shadow_power = p_settings.power;
 		ssao.gather_push_constant.shadow_clamp = 0.98;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/50851

Assign ``ssao.gather_push_constant.radius`` before adjusting it based on quality. 

This results in a slight improvement when using the lowest quality setting. 

I removed the branch for half_size as that was an artifact from when I was adding the half resolution option. It is no longer needed and I didnt notice it was still there because it was always overwritten. 