### PR TITLE
Fix Xbox controllers in Bluetooth mode on macOS

### DIFF
--- a/platform/osx/joypad_osx.h
+++ b/platform/osx/joypad_osx.h
@@ -64,6 +64,7 @@ struct joypad {
 	Vector<rec_element> hat_elements;
 
 	int id = 0;
+	bool offset_hat = false;
 
 	io_service_t ffservice = 0; /* Interface for force feedback, 0 = no ff */
 	FFCONSTANTFORCE ff_constant_force;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51117.

This prevents the D-pad up arrow from being registered as pressed when it isn't, and pressing any direction from activating the next arrow clockwise of it.

Thanks @dsrw for providing this fix :slightly_smiling_face:

This closes https://github.com/godotengine/godot/issues/44721.