### PR TITLE
Fix Xbox controllers in Bluetooth mode on macOS (3.x)

### DIFF
--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -150,6 +150,8 @@ void joypad::add_hid_element(IOHIDElementRef p_element) {
 						switch (usage) {
 							case kHIDUsage_Sim_Rudder:
 							case kHIDUsage_Sim_Throttle:
+							case kHIDUsage_Sim_Accelerator:
+							case kHIDUsage_Sim_Brake:
 								if (!has_element(cookie, &axis_elements)) {
 									list = &axis_elements;
 								}
@@ -339,6 +341,13 @@ bool JoypadOSX::configure_joypad(IOHIDDeviceRef p_device_ref, joypad *p_joy) {
 		p_joy->add_hid_elements(array);
 		CFRelease(array);
 	}
+	// Xbox controller hat values start at 1 rather than 0.
+	p_joy->offset_hat = vendor == 0x45e &&
+						(product_id == 0x0b05 ||
+								product_id == 0x02e0 ||
+								product_id == 0x02fd ||
+								product_id == 0x0b13);
+
 	return true;
 }
 
@@ -395,12 +404,15 @@ bool joypad::check_ff_features() {
 	return false;
 }
 
-static int process_hat_value(int p_min, int p_max, int p_value) {
+static int process_hat_value(int p_min, int p_max, int p_value, bool p_offset_hat) {
 	int range = (p_max - p_min + 1);
 	int value = p_value - p_min;
 	int hat_value = InputDefault::HAT_MASK_CENTER;
 	if (range == 4) {
 		value *= 2;
+	}
+	if (p_offset_hat) {
+		value -= 1;
 	}
 
 	switch (value) {
@@ -475,7 +487,7 @@ void JoypadOSX::process_joypads() {
 		for (int j = 0; j < joy.hat_elements.size(); j++) {
 			rec_element &elem = joy.hat_elements.write[j];
 			int value = joy.get_hid_element_state(&elem);
-			int hat_value = process_hat_value(elem.min, elem.max, value);
+			int hat_value = process_hat_value(elem.min, elem.max, value, joy.offset_hat);
 			input->joy_hat(joy.id, hat_value);
 		}
 

--- a/platform/osx/joypad_osx.h
+++ b/platform/osx/joypad_osx.h
@@ -63,7 +63,8 @@ struct joypad {
 	Vector<rec_element> button_elements;
 	Vector<rec_element> hat_elements;
 
-	int id;
+	int id = 0;
+	bool offset_hat = false;
 
 	io_service_t ffservice; /* Interface for force feedback, 0 = no ff */
 	FFCONSTANTFORCE ff_constant_force;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/51116.

This prevents the D-pad up arrow from being registered as pressed when it isn't, and pressing any direction from activating the next arrow clockwise of it.

Thanks @dsrw for providing this fix :slightly_smiling_face: