### PR TITLE
Make the "View" menu in the 3D viewport stay open when selecting a checkbox

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7198,7 +7198,9 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(context_menu_container);
 	_update_context_menu_stylebox();
 
+	// Get the view menu popup and have it stay open when a checkable item is selected
 	p = view_menu->get_popup();
+	p->set_hide_on_checkable_item_selection(false);
 
 	accept = memnew(AcceptDialog);
 	editor->get_gui_base()->add_child(accept);


### PR DESCRIPTION
This pull request fixes an issue where the "View" menu in the 3D viewport would close when you selected either the "View Origin" or "View Grid" checkboxes. This was inconvenient and wasted time by making you have to reopen the menu in order to get to other settings anytime you changed this.

Resolves: #50602

https://user-images.githubusercontent.com/62965063/127752098-40954075-2a0d-4285-96de-283c66e37023.mp4

I find this to be a lot better and more consistent, as it allows you to edit/try many different settings without the menu constantly closing every time you change one of them. Often times you come into this menu and you want to change multiple things at the same time, so having it stay open while you make changes makes more sense.
