### PR TITLE
Link to the Random number generation tutorial in RandomNumberGenerator

### DIFF
--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -151,7 +151,7 @@
 			else:
 			    simulate_physics()
 			[/codeblock]
-			See [url=https://docs.godotengine.org/en/stable/tutorials/misc/running_code_in_the_editor.html]Running code in the editor[/url] in the documentation for more information.
+			See [url=https://docs.godotengine.org/en/3.3/tutorials/misc/running_code_in_the_editor.html]Running code in the editor[/url] in the documentation for more information.
 			[b]Note:[/b] To detect whether the script is run from an editor [i]build[/i] (e.g. when pressing [code]F5[/code]), use [method OS.has_feature] with the [code]"editor"[/code] argument instead. [code]OS.has_feature("editor")[/code] will evaluate to [code]true[/code] both when the code is running in the editor and when running the project from the editor, but it will evaluate to [code]false[/code] when the code is run from an exported project.
 		</member>
 		<member name="iterations_per_second" type="int" setter="set_iterations_per_second" getter="get_iterations_per_second" default="60">

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -16,6 +16,7 @@
 		[b]Note:[/b] The default values of [member seed] and [member state] properties are pseudo-random, and changes when calling [method randomize]. The [code]0[/code] value documented here is a placeholder, and not the actual default seed.
 	</description>
 	<tutorials>
+		<link title="Random number generation">https://docs.godotengine.org/en/3.3/tutorials/math/random_number_generation.html</link>
 	</tutorials>
 	<methods>
 		<method name="randf">

--- a/doc/classes/ResourceImporter.xml
+++ b/doc/classes/ResourceImporter.xml
@@ -7,7 +7,7 @@
 		This is the base class for the resource importers implemented in core. To implement your own resource importers using editor plugins, see [EditorImportPlugin].
 	</description>
 	<tutorials>
-		<link title="Import plugins">https://docs.godotengine.org/en/stable/tutorials/plugins/editor/import_plugins.html</link>
+		<link title="Import plugins">https://docs.godotengine.org/en/3.3/tutorials/plugins/editor/import_plugins.html</link>
 	</tutorials>
 	<methods>
 	</methods>


### PR DESCRIPTION
This was done in `master` already, but not in `3.x`.

PS: In the `3.x` branch, we should replace all 3.3 links with their 3.4 equivalent soon (or redo https://github.com/godotengine/godot/pull/47394 for `3.x`).