### PR TITLE
Docs: add more explanation for `Shape2D.custom_solver_bias`

### DIFF
--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -65,7 +65,7 @@
 	</methods>
 	<members>
 		<member name="custom_solver_bias" type="float" setter="set_custom_solver_bias" getter="get_custom_solver_bias" default="0.0">
-			The shape's custom solver bias.
+			The shape's custom solver bias. A solver bias is a factor controlling how much two objects "rebound", after violating a constraint, to avoid leaving them in that state because of numerical imprecision.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Copies the explanation what a solver bias is from the [PhysicsServer2D docs](https://github.com/godotengine/godot/blob/007b877cb73cd6b60c86eb7b02d4e6f1cee409ea/doc/classes/PhysicsServer2D.xml#L843) to the documentation for `Shape2D.custom_solver_bias` because it was ... very sparse.
