### PR TITLE
[3.x] Gltf2 Importer now takes '-loop' argument in animation names, but removes it from the final animation name

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4803,9 +4803,10 @@ Error GLTFDocument::_parse_animations(Ref<GLTFState> state) {
 		Array samplers = d["samplers"];
 
 		if (d.has("name")) {
-			const String name = d["name"];
-			if (name.begins_with("loop") || name.ends_with("loop") || name.begins_with("cycle") || name.ends_with("cycle")) {
+			String name = d["name"];
+			if (name.begins_with("loop") || name.ends_with("loop") || name.begins_with("cycle") || name.ends_with("cycle") || name.find(" -loop") > 0) {
 				animation->set_loop(true);
+				name = name.replace(" -loop", "");
 			}
 			if (state->use_legacy_names) {
 				animation->set_name(_sanitize_scene_name(state, name));


### PR DESCRIPTION
When importing animations from blender, i needed to add **loop** to the animation name to detect the animation, but that affected my naming convention, the argument ` -loop` will do the same with the advantage of also being removed (previous functionality is mantained)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
