### PR TITLE
[3.x] Support negative time scales inside the BlendTreeAnimationNode

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -86,15 +86,19 @@ float AnimationNodeAnimation::process(float p_time, bool p_seek) {
 
 	float step;
 
+	float anim_size = anim->get_length();
+
 	if (p_seek) {
 		time = p_time;
 		step = 0;
 	} else {
-		time = MAX(0, time + p_time);
+		if (p_time < 0 && Math::abs(p_time) > time) {
+			time = MAX(0, anim_size + time + p_time);
+		} else {
+			time = MAX(0, time + p_time);
+		}
 		step = p_time;
 	}
-
-	float anim_size = anim->get_length();
 
 	if (anim->has_loop()) {
 		if (anim_size) {
@@ -541,7 +545,7 @@ AnimationNodeBlend3::AnimationNodeBlend3() {
 /////////////////////////////////
 
 void AnimationNodeTimeScale::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::REAL, scale, PROPERTY_HINT_RANGE, "0,32,0.01,or_greater"));
+	r_list->push_back(PropertyInfo(Variant::REAL, scale, PROPERTY_HINT_RANGE, "-32,32,0.01,or_greater"));
 }
 Variant AnimationNodeTimeScale::get_parameter_default_value(const StringName &p_parameter) const {
 	return 1.0; //initial timescale


### PR DESCRIPTION
Negative time scales are usefull to add reverse walking cycles, but there's no way to introduce them to a StateMachineAnimationNode. Using a BlendTreeAnimationNode is easy to scale animation speeds, but up until now negative scales was not supported.

**Preview:**
https://gyazo.com/ef5b34cfa6d57346b8479b44e2acdaf6
**Blend Tree example:**
![image](https://user-images.githubusercontent.com/1776044/127756064-408d6b17-a718-4b05-b532-ea3780832221.png)


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
