### PR TITLE
Makes dictionary instead of string for visual shader version

### DIFF
--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -146,10 +146,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="engine_version" type="Dictionary" setter="set_engine_version" getter="get_engine_version" default="{}">
+			The Godot version this [VisualShader] was designed for, in the form of a [Dictionary] with [code]major[/code] and [code]minor[/code] keys with integer values. Example: [code]{"major": 4, "minor": 0}[/code]
+			This is used by the editor to convert visual shaders from older Godot versions.
+		</member>
 		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2(0, 0)">
 			The offset vector of the whole graph.
-		</member>
-		<member name="version" type="String" setter="set_version" getter="get_version" default="&quot;&quot;">
 		</member>
 	</members>
 	<constants>

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -35,7 +35,6 @@
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
 #include "core/os/keyboard.h"
-#include "core/version.h"
 #include "editor/editor_log.h"
 #include "editor/editor_properties.h"
 #include "editor/editor_scale.h"
@@ -995,9 +994,23 @@ void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
 			visual_shader->connect("changed", callable_mp(this, &VisualShaderEditor::_update_preview));
 		}
 #ifndef DISABLE_DEPRECATED
-		String version = VERSION_BRANCH;
-		if (visual_shader->get_version() != version) {
-			visual_shader->update_version(version);
+		Dictionary engine_version = Engine::get_singleton()->get_version_info();
+		static Array components;
+		if (components.is_empty()) {
+			components.push_back("major");
+			components.push_back("minor");
+		}
+		const Dictionary vs_version = visual_shader->get_engine_version();
+		if (!vs_version.has_all(components)) {
+			visual_shader->update_engine_version(engine_version);
+		} else {
+			for (int i = 0; i < components.size(); i++) {
+				if (vs_version[components[i]] != engine_version[components[i]]) {
+					visual_shader->update_engine_version(engine_version);
+					print_line(vformat(TTR("The shader (\"%s\") has been updated to correspond Godot %s.%s version."), visual_shader->get_path(), engine_version["major"], engine_version["minor"]));
+					break;
+				}
+			}
 		}
 #endif
 		visual_shader->set_graph_offset(graph->get_scroll_ofs() / EDSCALE);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -451,16 +451,21 @@ VisualShader::Type VisualShader::get_shader_type() const {
 	return current_type;
 }
 
-void VisualShader::set_version(const String &p_version) {
-	version = p_version;
+void VisualShader::set_engine_version(const Dictionary &p_engine_version) {
+	ERR_FAIL_COND(!p_engine_version.has("major"));
+	ERR_FAIL_COND(!p_engine_version.has("minor"));
+	engine_version["major"] = p_engine_version["major"];
+	engine_version["minor"] = p_engine_version["minor"];
 }
 
-String VisualShader::get_version() const {
-	return version;
+Dictionary VisualShader::get_engine_version() const {
+	return engine_version;
 }
 
-void VisualShader::update_version(const String &p_new_version) {
-	if (version == "") {
+#ifndef DISABLE_DEPRECATED
+
+void VisualShader::update_engine_version(const Dictionary &p_new_version) {
+	if (engine_version.is_empty()) { // before 4.0
 		for (int i = 0; i < TYPE_MAX; i++) {
 			for (Map<int, Node>::Element *E = graph[i].nodes.front(); E; E = E->next()) {
 				Ref<VisualShaderNodeExpression> expression = Object::cast_to<VisualShaderNodeExpression>(E->get().node.ptr());
@@ -491,8 +496,10 @@ void VisualShader::update_version(const String &p_new_version) {
 			}
 		}
 	}
-	set_version(p_new_version);
+	set_engine_version(p_new_version);
 }
+
+#endif /* DISABLE_DEPRECATED */
 
 void VisualShader::add_node(Type p_type, const Ref<VisualShaderNode> &p_node, const Vector2 &p_position, int p_id) {
 	ERR_FAIL_COND(p_node.is_null());
@@ -2007,8 +2014,8 @@ void VisualShader::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_node_connections", "type"), &VisualShader::_get_node_connections);
 
-	ClassDB::bind_method(D_METHOD("set_version", "version"), &VisualShader::set_version);
-	ClassDB::bind_method(D_METHOD("get_version"), &VisualShader::get_version);
+	ClassDB::bind_method(D_METHOD("set_engine_version", "version"), &VisualShader::set_engine_version);
+	ClassDB::bind_method(D_METHOD("get_engine_version"), &VisualShader::get_engine_version);
 
 	ClassDB::bind_method(D_METHOD("set_graph_offset", "offset"), &VisualShader::set_graph_offset);
 	ClassDB::bind_method(D_METHOD("get_graph_offset"), &VisualShader::get_graph_offset);
@@ -2016,7 +2023,7 @@ void VisualShader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_shader"), &VisualShader::_update_shader);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "graph_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_graph_offset", "get_graph_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "version", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_version", "get_version");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "engine_version", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_engine_version", "get_engine_version");
 
 	ADD_PROPERTY_DEFAULT("code", ""); // Inherited from Shader, prevents showing default code as override in docs.
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -44,7 +44,7 @@ class VisualShader : public Shader {
 
 	friend class VisualShaderNodeVersionChecker;
 
-	String version = "";
+	Dictionary engine_version;
 
 public:
 	enum Type {
@@ -137,10 +137,12 @@ public: // internal methods
 	Type get_shader_type() const;
 
 public:
-	void set_version(const String &p_version);
-	String get_version() const;
+	void set_engine_version(const Dictionary &p_version);
+	Dictionary get_engine_version() const;
 
-	void update_version(const String &p_new_version);
+#ifndef DISABLE_DEPRECATED
+	void update_engine_version(const Dictionary &p_new_version);
+#endif /* DISABLE_DEPRECATED */
 
 	enum {
 		NODE_ID_INVALID = -1,


### PR DESCRIPTION
Replaced a String with Dictionary with ["major"] and ["minor"] members, I think it's better for further usage and parsing + added a string to `update_shader` printed for every auto-changed shader like:

`The shader ("res://test.tres") has been updated to correspond Godot 4.0 version.`



