### PR TITLE
Portals - Improve UI and add shortcuts

### DIFF
--- a/editor/plugins/room_manager_editor_plugin.cpp
+++ b/editor/plugins/room_manager_editor_plugin.cpp
@@ -32,12 +32,6 @@
 
 #include "editor/spatial_editor_gizmos.h"
 
-void RoomManagerEditorPlugin::_rooms_convert() {
-	if (_room_manager) {
-		_room_manager->rooms_convert();
-	}
-}
-
 void RoomManagerEditorPlugin::_flip_portals() {
 	if (_room_manager) {
 		_room_manager->rooms_flip_portals();
@@ -59,16 +53,15 @@ bool RoomManagerEditorPlugin::handles(Object *p_object) const {
 
 void RoomManagerEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		button_rooms_convert->show();
 		button_flip_portals->show();
 	} else {
-		button_rooms_convert->hide();
 		button_flip_portals->hide();
 	}
+
+	SpatialEditor::get_singleton()->show_advanced_portal_tools(p_visible);
 }
 
 void RoomManagerEditorPlugin::_bind_methods() {
-	ClassDB::bind_method("_rooms_convert", &RoomManagerEditorPlugin::_rooms_convert);
 	ClassDB::bind_method("_flip_portals", &RoomManagerEditorPlugin::_flip_portals);
 }
 
@@ -81,13 +74,6 @@ RoomManagerEditorPlugin::RoomManagerEditorPlugin(EditorNode *p_node) {
 	button_flip_portals->hide();
 	button_flip_portals->connect("pressed", this, "_flip_portals");
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, button_flip_portals);
-
-	button_rooms_convert = memnew(ToolButton);
-	button_rooms_convert->set_icon(editor->get_gui_base()->get_icon("RoomGroup", "EditorIcons"));
-	button_rooms_convert->set_text(TTR("Convert Rooms"));
-	button_rooms_convert->hide();
-	button_rooms_convert->connect("pressed", this, "_rooms_convert");
-	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, button_rooms_convert);
 
 	_room_manager = nullptr;
 

--- a/editor/plugins/room_manager_editor_plugin.h
+++ b/editor/plugins/room_manager_editor_plugin.h
@@ -43,11 +43,9 @@ class RoomManagerEditorPlugin : public EditorPlugin {
 
 	RoomManager *_room_manager;
 
-	ToolButton *button_rooms_convert;
 	ToolButton *button_flip_portals;
 	EditorNode *editor;
 
-	void _rooms_convert();
 	void _flip_portals();
 
 protected:

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -207,7 +207,8 @@ class SpatialEditorViewport : public Control {
 		VIEW_DISPLAY_SHADELESS,
 		VIEW_LOCK_ROTATION,
 		VIEW_CINEMATIC_PREVIEW,
-		VIEW_AUTO_ORTHOGONAL
+		VIEW_AUTO_ORTHOGONAL,
+		VIEW_PORTAL_CULLING,
 	};
 
 public:
@@ -545,6 +546,7 @@ public:
 		TOOL_UNLOCK_SELECTED,
 		TOOL_GROUP_SELECTED,
 		TOOL_UNGROUP_SELECTED,
+		TOOL_CONVERT_ROOMS,
 		TOOL_MAX
 	};
 
@@ -624,6 +626,7 @@ private:
 		MENU_TOOL_LOCAL_COORDS,
 		MENU_TOOL_USE_SNAP,
 		MENU_TOOL_OVERRIDE_CAMERA,
+		MENU_TOOL_CONVERT_ROOMS,
 		MENU_TRANSFORM_CONFIGURE_SNAP,
 		MENU_TRANSFORM_DIALOG,
 		MENU_VIEW_USE_1_VIEWPORT,
@@ -634,6 +637,7 @@ private:
 		MENU_VIEW_USE_4_VIEWPORTS,
 		MENU_VIEW_ORIGIN,
 		MENU_VIEW_GRID,
+		MENU_VIEW_PORTAL_CULLING,
 		MENU_VIEW_GIZMOS_3D_ICONS,
 		MENU_VIEW_CAMERA_SETTINGS,
 		MENU_LOCK_SELECTED,
@@ -762,6 +766,8 @@ public:
 
 	void update_grid();
 	void update_transform_gizmo();
+	void update_portal_tools();
+	void show_advanced_portal_tools(bool p_show);
 	void update_all_gizmos(Node *p_node = nullptr);
 	void snap_selected_nodes_to_floor();
 	void select_gizmo_highlight_axis(int p_axis);

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -135,6 +135,12 @@ public:
 	// an easy way of grabbing the active room manager for tools purposes
 #ifdef TOOLS_ENABLED
 	static RoomManager *active_room_manager;
+
+	// static versions of functions for use from editor toolbars
+	static void static_rooms_set_active(bool p_active);
+	static bool static_rooms_get_active();
+	static bool static_rooms_get_active_and_loaded();
+	static void static_rooms_convert();
 #endif
 
 private:

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -159,6 +159,7 @@ public:
 	// for use in the editor only, to allow a cheap way of turning off portals
 	// if there has been a change, e.g. moving a room etc.
 	void rooms_unload() { _ensure_unloaded(); }
+	bool rooms_is_loaded() const { return _loaded; }
 
 	// debugging
 	void set_debug_sprawl(bool p_active) { _debug_sprawl = p_active; }

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -593,6 +593,9 @@ public:
 	BIND3(rooms_set_debug_feature, RID, RoomsDebugFeature, bool)
 	BIND2(rooms_update_gameplay_monitor, RID, const Vector<Vector3> &)
 
+	// don't use this in a game
+	BIND1RC(bool, rooms_is_loaded, RID)
+
 	// Callbacks
 	BIND1(callbacks_register, VisualServerCallbacks *)
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1308,6 +1308,12 @@ void VisualServerScene::rooms_update_gameplay_monitor(RID p_scenario, const Vect
 	scenario->_portal_renderer.rooms_update_gameplay_monitor(p_camera_positions);
 }
 
+bool VisualServerScene::rooms_is_loaded(RID p_scenario) const {
+	Scenario *scenario = scenario_owner.getornull(p_scenario);
+	ERR_FAIL_COND_V(!scenario, false);
+	return scenario->_portal_renderer.rooms_is_loaded();
+}
+
 Vector<ObjectID> VisualServerScene::instances_cull_aabb(const AABB &p_aabb, RID p_scenario) const {
 	Vector<ObjectID> instances;
 	Scenario *scenario = scenario_owner.get(p_scenario);

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -647,6 +647,9 @@ public:
 	virtual void rooms_set_debug_feature(RID p_scenario, VisualServer::RoomsDebugFeature p_feature, bool p_active);
 	virtual void rooms_update_gameplay_monitor(RID p_scenario, const Vector<Vector3> &p_camera_positions);
 
+	// don't use this in a game
+	virtual bool rooms_is_loaded(RID p_scenario) const;
+
 	virtual void callbacks_register(VisualServerCallbacks *p_callbacks);
 	VisualServerCallbacks *get_callbacks() const { return _visual_server_callbacks; }
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -516,6 +516,9 @@ public:
 	FUNC3(rooms_set_debug_feature, RID, RoomsDebugFeature, bool)
 	FUNC2(rooms_update_gameplay_monitor, RID, const Vector<Vector3> &)
 
+	// don't use this in a game
+	FUNC1RC(bool, rooms_is_loaded, RID)
+
 	// Callbacks
 	FUNC1(callbacks_register, VisualServerCallbacks *)
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -909,6 +909,9 @@ public:
 	virtual void rooms_set_debug_feature(RID p_scenario, RoomsDebugFeature p_feature, bool p_active) = 0;
 	virtual void rooms_update_gameplay_monitor(RID p_scenario, const Vector<Vector3> &p_camera_positions) = 0;
 
+	// don't use this in a game!
+	virtual bool rooms_is_loaded(RID p_scenario) const = 0;
+
 	// callbacks are used to send messages back from the visual server to scene tree in thread friendly manner
 	virtual void callbacks_register(VisualServerCallbacks *p_callbacks) = 0;
 


### PR DESCRIPTION
This PR makes the 'convert rooms' button permanently on the toolbar and accessible whichever node is selected, so you can convert rooms without having to select the RoomManager first.

It also adds a togglable item 'view portal culling' to the 'View' menu which is a simple way of setting the RoomManager 'active' setting without the RoomManager being the selected node.

Both of these have keyboard shortcuts, which should make it much faster to reconvert rooms and edit.

In addition there the string in the 'Perspective' Listbox is modified to show [portals active] when portal culling is operational, for visual feedback. This is updated when you change modes, and when the rooms are invalidated.

_The rooms convert button is to the right of the camera button. It disappears when there is no RoomManager in the scene.. it could alternatively be greyed out._
![portals_new_ui](https://user-images.githubusercontent.com/21999379/127780303-adc6e867-f367-4041-a2f6-14a5c1c3cc9e.png)

## Notes
* I've tried various places for these two buttons but this seems to make the most sense so far. I'd welcome other ideas though.
* The buttons need to be accessible continuously in the editor for the shortcuts to work. I did also try creating the 'convert rooms' button in the `room_manager_editor_plugin`, and simply not hiding it, but it didn't seem like it was easy to control the location on the toolbar unless I put it in the `spatial_editor_plugin`.
* One thing I'm not quite sure about, is that now the `convert rooms` button is permanently on the toolbar, it may not be so obvious to first time users because it doesn't have a big text label. Perhaps I could make a label appear when the RoomManager is selected? EDIT : Have done this.
* In most cases the [portals active] wording does react instantly when you change things, but there are a couple of instances where there is a delay until you click on that window. This doesn't seem serious but I'll see if I can track them down.
* When you change the `view_portal_culling` toggle, the `rooms_active` toggle in the RoomManager is also changed and the tick updated. The names aren't quite the same. Not sure how to improve the naming situation.
* I have no idea what the best shortcuts should be. So far I'd been using ALT+P to show and hide portal culling and ALT+C to convert the rooms. But I think there may be a conflict as when I press ALT+C in some Godot windows, it tries to select things.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
