### PR TITLE
Fix: UWP App crashes when managed_object->update_clipboard() is called

### DIFF
--- a/platform/uwp/app.cpp
+++ b/platform/uwp/app.cpp
@@ -98,6 +98,9 @@ void App::SetWindow(CoreWindow ^ p_window) {
 	window->VisibilityChanged +=
 			ref new TypedEventHandler<CoreWindow ^, VisibilityChangedEventArgs ^>(this, &App::OnVisibilityChanged);
 
+	window->Activated +=
+			ref new TypedEventHandler<CoreWindow ^, WindowActivatedEventArgs ^>(this, &App::OnWindowActivated);
+
 	window->Closed +=
 			ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &App::OnWindowClosed);
 
@@ -437,6 +440,10 @@ void App::OnActivated(CoreApplicationView ^ applicationView, IActivatedEventArgs
 // Window event handlers.
 void App::OnVisibilityChanged(CoreWindow ^ sender, VisibilityChangedEventArgs ^ args) {
 	mWindowVisible = args->Visible;
+}
+
+void App::OnWindowActivated(CoreWindow ^ sender, WindowActivatedEventArgs ^ args) {
+	os->update_clipboard();
 }
 
 void App::OnWindowClosed(CoreWindow ^ sender, CoreWindowEventArgs ^ args) {

--- a/platform/uwp/app.h
+++ b/platform/uwp/app.h
@@ -68,6 +68,7 @@ namespace GodotUWP
 		// Window event handlers.
 		void OnWindowSizeChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::WindowSizeChangedEventArgs^ args);
 		void OnVisibilityChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::VisibilityChangedEventArgs^ args);
+		void OnWindowActivated(CoreWindow ^ sender, WindowActivatedEventArgs ^ args);
 		void OnWindowClosed(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::CoreWindowEventArgs^ args);
 
 		void pointer_event(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::PointerEventArgs^ args, bool p_pressed, bool p_is_wheel = false);

--- a/platform/uwp/context_egl_uwp.cpp
+++ b/platform/uwp/context_egl_uwp.cpp
@@ -118,10 +118,12 @@ Error ContextEGL_UWP::initialize() {
 			EGL_PLATFORM_ANGLE_TYPE_ANGLE,
 			EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
 
+#ifdef EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER
 			// EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER is an optimization that can have large performance benefits on mobile devices.
 			// Its syntax is subject to change, though. Please update your Visual Studio templates if you experience compilation issues with it.
 			EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER,
 			EGL_TRUE,
+#endif
 
 			// EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE is an option that enables ANGLE to automatically call
 			// the IDXGIDevice3::Trim method on behalf of the application when it gets suspended.

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -245,8 +245,6 @@ Error OS_UWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	AudioDriverManager::initialize(p_audio_driver);
 
-	managed_object->update_clipboard();
-
 	Clipboard::ContentChanged += ref new EventHandler<Platform::Object ^>(managed_object, &ManagedType::on_clipboard_changed);
 
 	accelerometer = Accelerometer::GetDefault();
@@ -348,6 +346,12 @@ void OS_UWP::alert(const String &p_alert, const String &p_title) {
 	managed_object->alert_close_handle = true;
 
 	msg->ShowAsync();
+}
+
+void OS_UWP::update_clipboard() {
+
+	// See https://stackoverflow.com/questions/58660743/uwp-app-crashes-when-clipboard-getcontent-is-called-from-inside-onnavigatedto
+	managed_object->update_clipboard();
 }
 
 void OS_UWP::ManagedType::alert_close(IUICommand ^ command) {

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -224,6 +224,7 @@ public:
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
 
+        void update_clipboard();
 	void set_window(Windows::UI::Core::CoreWindow ^ p_window);
 	void screen_size_changed();
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Operating system and version: Windows 10 / UWP
Godot version: tested on 3.1.2
Device: x86_64
Steps to reproduce: this bug sometimes occurred when I tried to launch the application

Hello!
When I attempted to port our game to Xbox One I encountered a bug which was described here:
https://stackoverflow.com/questions/58660743/uwp-app-crashes-when-clipboard-getcontent-is-called-from-inside-onnavigatedto
I attempted to apply the fix described in the article and it worked, the application won't crash anymore.
Unfortunately, I don't remember well exactly under which circumstances the bug was reproduced (as far as I've remembered, it happened when I tried to launch the release version), but I hope it will be useful...
