### PR TITLE
Make some enhancements to the POT generation

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -921,7 +921,8 @@
 			Anchors the top edge of the node to the origin, the center or the end of its parent control. It changes how the top offset updates when the node moves or changes size. You can use one of the [enum Anchor] constants for convenience.
 		</member>
 		<member name="auto_translate" type="bool" setter="set_auto_translate" getter="is_auto_translating" default="true">
-			Toggles if any text should automatically change to its translated version depending on the current locale.
+			Toggles if any text should automatically change to its translated version depending on the current locale. Note that this will not affect any internal nodes (e.g. the popup of a [MenuButton]).
+			Also decides if the node's strings should be parsed for POT generation.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" enum="Control.FocusMode" default="0">
 			The focus access mode for the control (None, Click or All). Only one Control can be focused at the same time, and it will receive keyboard signals.

--- a/editor/plugins/packed_scene_translation_parser_plugin.h
+++ b/editor/plugins/packed_scene_translation_parser_plugin.h
@@ -37,7 +37,9 @@ class PackedSceneEditorTranslationParserPlugin : public EditorTranslationParserP
 	GDCLASS(PackedSceneEditorTranslationParserPlugin, EditorTranslationParserPlugin);
 
 	// Scene Node's properties that contain translation strings.
-	Set<String> lookup_properties;
+	Set<StringName> lookup_properties;
+	// Properties from specific Nodes that should be ignored.
+	Map<StringName, Vector<StringName>> exception_list;
 
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) override;

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -108,7 +108,6 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 	const String header =
 			"# LANGUAGE translation for " + project_name + " for the following files:\n" + extracted_files +
 			"#\n"
-			"#\n"
 			"# FIRST AUTHOR < EMAIL @ADDRESS>, YEAR.\n"
 			"#\n"
 			"#, fuzzy\n"
@@ -116,8 +115,9 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			"msgstr \"\"\n"
 			"\"Project-Id-Version: " +
 			project_name + "\\n\"\n"
+						   "\"MIME-Version: 1.0\\n\"\n"
 						   "\"Content-Type: text/plain; charset=UTF-8\\n\"\n"
-						   "\"Content-Transfer-Encoding: 8-bit\\n\"\n\n";
+						   "\"Content-Transfer-Encoding: 8-bit\\n\"\n";
 
 	file->store_string(header);
 
@@ -128,6 +128,9 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			String context = v_msgid_data[i].ctx;
 			String plural = v_msgid_data[i].plural;
 			const Set<String> &locations = v_msgid_data[i].locations;
+
+			// Put the blank line at the start, to avoid a double at the end when closing the file.
+			file->store_line("");
 
 			// Write file locations.
 			for (Set<String>::Element *E = locations.front(); E; E = E->next()) {
@@ -142,13 +145,13 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			// Write msgid.
 			_write_msgid(file, msgid, false);
 
-			// Write msgid_plural
+			// Write msgid_plural.
 			if (!plural.is_empty()) {
 				_write_msgid(file, plural, true);
 				file->store_line("msgstr[0] \"\"");
-				file->store_line("msgstr[1] \"\"\n");
+				file->store_line("msgstr[1] \"\"");
 			} else {
-				file->store_line("msgstr \"\"\n");
+				file->store_line("msgstr \"\"");
 			}
 		}
 	}

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -56,6 +56,10 @@ protected:
 	static void _bind_methods();
 
 public:
+	// ATTENTION: This is used by the POT generator's scene parser. If the number of properties returned by `_get_items()` ever changes,
+	// this value should be updated to reflect the new size.
+	static const int ITEM_PROPERTY_SIZE = 5;
+
 	void add_icon_item(const Ref<Texture2D> &p_icon, const String &p_label, int p_id = -1);
 	void add_item(const String &p_label, int p_id = -1);
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -144,6 +144,10 @@ protected:
 	static void _bind_methods();
 
 public:
+	// ATTENTION: This is used by the POT generator's scene parser. If the number of properties returned by `_get_items()` ever changes,
+	// this value should be updated to reflect the new size.
+	static const int ITEM_PROPERTY_SIZE = 10;
+
 	void add_item(const String &p_label, int p_id = -1, uint32_t p_accel = 0);
 	void add_icon_item(const Ref<Texture2D> &p_icon, const String &p_label, int p_id = -1, uint32_t p_accel = 0);
 	void add_check_item(const String &p_label, int p_id = -1, uint32_t p_accel = 0);


### PR DESCRIPTION
- Extract the menu items of `Menu`/`OptionButton` nodes.
- Ignore nodes that have `auto_translate` set to `false`.
- Ignore the `text` property of `Line`/`TextEdit` nodes.