### PR TITLE
Fixed gizmo forced implicit normalization and inconsistent rotation

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1111,9 +1111,9 @@ Transform3D Node3DEditorViewport::_compute_transform(TransformMode p_mode, const
 					local_motion.snap(Vector3(p_extra, p_extra, p_extra));
 				}
 
-				Vector3 local_scale = p_original_local.basis.get_scale() * (local_motion + Vector3(1, 1, 1));
-				Transform3D local_t = p_original_local;
-				local_t.basis.set_euler_scale(p_original_local.basis.get_rotation_euler(), local_scale);
+				Transform3D local_t;
+				local_t.basis = p_original_local.basis.scaled_local(local_motion + Vector3(1, 1, 1));
+				local_t.origin = p_original_local.origin;
 				return local_t;
 			} else {
 				Transform3D base = Transform3D(Basis(), _edit.center);
@@ -1121,9 +1121,9 @@ Transform3D Node3DEditorViewport::_compute_transform(TransformMode p_mode, const
 					p_motion.snap(Vector3(p_extra, p_extra, p_extra));
 				}
 
-				Transform3D r;
-				r.basis.scale(p_motion + Vector3(1, 1, 1));
-				return base * (r * (base.inverse() * p_original));
+				Transform3D global_t;
+				global_t.basis.scale(p_motion + Vector3(1, 1, 1));
+				return base * (global_t * (base.inverse() * p_original));
 			}
 		}
 		case TRANSFORM_TRANSLATE: {
@@ -1149,19 +1149,18 @@ Transform3D Node3DEditorViewport::_compute_transform(TransformMode p_mode, const
 		}
 		case TRANSFORM_ROTATE: {
 			if (p_local) {
-				Basis rot = Basis(p_motion, p_extra);
-
-				Vector3 scale = p_original_local.basis.get_scale();
-				Vector3 euler = (p_original_local.get_basis().orthonormalized() * rot).get_euler();
-				Transform3D t;
-				t.basis.set_euler_scale(euler, scale);
-				t.origin = p_original_local.origin;
-				return t;
+				Transform3D r;
+				Vector3 axis = p_original_local.basis.xform(p_motion);
+				r.basis = Basis(axis.normalized(), p_extra) * p_original_local.basis;
+				r.origin = p_original_local.origin;
+				return r;
 			} else {
 				Transform3D r;
-				r.basis.rotate(p_motion, p_extra);
-				Transform3D base = Transform3D(Basis(), _edit.center);
-				return base * r * base.inverse() * p_original;
+				Basis local = p_original.basis * p_original_local.basis.inverse();
+				Vector3 axis = local.xform_inv(p_motion);
+				r.basis = local * Basis(axis.normalized(), p_extra) * p_original_local.basis;
+				r.origin = Basis(p_motion, p_extra).xform(p_original.origin - _edit.center) + _edit.center;
+				return r;
 			}
 		}
 		default: {


### PR DESCRIPTION
Ref #18987.

The current behavior of Godot's Gizmo is inconsistent.

For example, if you do scaling in global transform mode and then rotate in local transform mode, implicit normalization will be done internally, resulting in an abbreviated transformation.

https://user-images.githubusercontent.com/61938263/127789631-23fe581d-4a18-4ea4-8ebd-caa546a8d29e.mov

Also, the rotation in the global transform and the rotation in the local transform perform completely different transformations. In a child node with a scaled parent node, rotation in global transform mode will rescale the node and cause an implicit skew.

https://user-images.githubusercontent.com/61938263/127789650-2a0444fb-007b-4d80-b5e0-aa93414ef636.mov

Correct rotation in a child node with a scaled parent node was considered to cause skew in the looks, ref: #32995.

With this PR, implicit normalization is no longer worked. So, skew will keep when transform, and matrix value will not change suddenly like first video. Moreover since the behavior of global and local transforms will be unified, I consider that it will be possible to implement something like auto-normalizing mode, keep-orthogonal mode (I think it will mainly be an option for the global transform scaling) for prevent to be generated local skew, and keep-looks mode for rotation #32995.
