### PR TITLE
Use Command+Drag in EditSpinSlider on macOS

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -32,12 +32,18 @@
 
 #include "core/input/input.h"
 #include "core/math/expression.h"
+#include "core/os/keyboard.h"
 #include "editor_node.h"
 #include "editor_scale.h"
 
 String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {
 	if (grabber->is_visible()) {
-		return TS->format_number(rtos(get_value())) + "\n\n" + TTR("Hold Ctrl to round to integers. Hold Shift for more precise changes.");
+#ifdef OSX_ENABLED
+		const int key = KEY_META;
+#else
+		const int key = KEY_CTRL;
+#endif
+		return TS->format_number(rtos(get_value())) + "\n\n" + vformat(TTR("Hold %s to round to integers. Hold Shift for more precise changes."), find_keycode_name(key));
 	}
 	return TS->format_number(rtos(get_value()));
 }
@@ -116,7 +122,7 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 					pre_grab_value = get_max();
 				}
 
-				if (mm->is_ctrl_pressed()) {
+				if (mm->is_command_pressed()) {
 					// If control was just pressed, don't make the value do a huge jump in magnitude.
 					if (grabbing_spinner_dist_cache != 0) {
 						pre_grab_value += grabbing_spinner_dist_cache * get_step();


### PR DESCRIPTION
Ctrl+LMB would be interpreted as a RMB click on macOS. So you wouldn't be able to start a Ctrl+Drag on an EditSpinSlider (although pressing Ctrl after the drag is started works).

`master` version of #51171.