### PR TITLE
Fix up property reversion

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -417,7 +417,7 @@ bool EditorPropertyRevert::may_node_be_in_instance(Node *p_node) {
 	return might_be; // or might not be
 }
 
-bool EditorPropertyRevert::get_instantiated_node_original_property(Node *p_node, const StringName &p_prop, Variant &value) {
+bool EditorPropertyRevert::get_instantiated_node_original_property(Node *p_node, const StringName &p_prop, Variant &value, bool p_check_class_default) {
 	Node *node = p_node;
 	Node *orig = node;
 
@@ -455,7 +455,7 @@ bool EditorPropertyRevert::get_instantiated_node_original_property(Node *p_node,
 		node = node->get_owner();
 	}
 
-	if (!found && p_node) {
+	if (p_check_class_default && !found && p_node) {
 		//if not found, try default class value
 		Variant attempt = ClassDB::class_get_default_property_value(p_node->get_class_name(), p_prop);
 		if (attempt.get_type() != Variant::NIL) {
@@ -548,7 +548,7 @@ Variant EditorPropertyRevert::get_property_revert_value(Object *p_object, const 
 		if (!ignore_parent) {
 			//check for difference including instantiation
 			Variant vorig;
-			if (EditorPropertyRevert::get_instantiated_node_original_property(node, p_property, vorig)) {
+			if (EditorPropertyRevert::get_instantiated_node_original_property(node, p_property, vorig, false)) {
 				return vorig;
 			}
 		}

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -40,7 +40,7 @@ class UndoRedo;
 class EditorPropertyRevert {
 public:
 	static bool may_node_be_in_instance(Node *p_node);
-	static bool get_instantiated_node_original_property(Node *p_node, const StringName &p_prop, Variant &value);
+	static bool get_instantiated_node_original_property(Node *p_node, const StringName &p_prop, Variant &value, bool p_check_class_default = true);
 	static bool is_node_property_different(Node *p_node, const Variant &p_current, const Variant &p_orig);
 	static bool is_property_value_different(const Variant &p_a, const Variant &p_b);
 	static Variant get_property_revert_value(Object *p_object, const StringName &p_property);


### PR DESCRIPTION
This is just a small correction to #46270 (the version of such PR for 3.x will already include the fix).

The idea is that `get_instantiated_node_original_property()`'s default behavior doesn't change (so other uses of it don't change) while also allowing opt-in to a behavior which is the most sensible one for property reversion: check default property value from builtin class only as the last resort.