### PR TITLE
Various text layout improvements (TextLine, TextParagraph, Label, TextServer)

### DIFF
--- a/doc/classes/TextLine.xml
+++ b/doc/classes/TextLine.xml
@@ -162,10 +162,28 @@
 		<member name="preserve_invalid" type="bool" setter="set_preserve_invalid" getter="get_preserve_invalid" default="true">
 			If set to [code]true[/code] text will display invalid characters.
 		</member>
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextLine.OverrunBehavior" default="3">
+			Sets the clipping behavior when the text exceeds the text line's set width. See [enum OverrunBehavior] for a description of all modes.
+		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="-1.0">
 			Text line width.
 		</member>
 	</members>
 	<constants>
+		<constant name="OVERRUN_NO_TRIMMING" value="0" enum="OverrunBehavior">
+			No text trimming is performed.
+		</constant>
+		<constant name="OVERRUN_TRIM_CHAR" value="1" enum="OverrunBehavior">
+			Trims the text per character.
+		</constant>
+		<constant name="OVERRUN_TRIM_WORD" value="2" enum="OverrunBehavior">
+			Trims the text per word.
+		</constant>
+		<constant name="OVERRUN_TRIM_ELLIPSIS" value="3" enum="OverrunBehavior">
+			Trims the text per character and adds an ellipsis to indicate that parts are hidden.
+		</constant>
+		<constant name="OVERRUN_TRIM_WORD_ELLIPSIS" value="4" enum="OverrunBehavior">
+			Trims the text per word and adds an ellipsis to indicate that parts are hidden.
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -284,6 +284,9 @@
 		<member name="flags" type="int" setter="set_flags" getter="get_flags" default="51">
 			Line breaking and alignment rules. For more info see [TextServer].
 		</member>
+		<member name="max_lines_visible" type="int" setter="set_max_lines_visible" getter="get_max_lines_visible" default="-1">
+			Limits the lines of text shown.
+		</member>
 		<member name="orientation" type="int" setter="set_orientation" getter="get_orientation" enum="TextServer.Orientation" default="0">
 			Text orientation.
 		</member>
@@ -293,10 +296,28 @@
 		<member name="preserve_invalid" type="bool" setter="set_preserve_invalid" getter="get_preserve_invalid" default="true">
 			If set to [code]true[/code] text will display invalid characters.
 		</member>
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextParagraph.OverrunBehavior" default="0">
+			Sets the clipping behavior when the text exceeds the paragraph's set width. See [enum OverrunBehavior] for a description of all modes.
+		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="-1.0">
 			Paragraph width.
 		</member>
 	</members>
 	<constants>
+		<constant name="OVERRUN_NO_TRIMMING" value="0" enum="OverrunBehavior">
+			No text trimming is performed.
+		</constant>
+		<constant name="OVERRUN_TRIM_CHAR" value="1" enum="OverrunBehavior">
+			Trims the text per character.
+		</constant>
+		<constant name="OVERRUN_TRIM_WORD" value="2" enum="OverrunBehavior">
+			Trims the text per word.
+		</constant>
+		<constant name="OVERRUN_TRIM_ELLIPSIS" value="3" enum="OverrunBehavior">
+			Trims the text per character and adds an ellipsis to indicate that parts are hidden.
+		</constant>
+		<constant name="OVERRUN_TRIM_WORD_ELLIPSIS" value="4" enum="OverrunBehavior">
+			Trims the text per word and adds an ellipsis to indicate that parts are hidden.
+		</constant>
 	</constants>
 </class>

--- a/modules/gdnative/text/text_server_gdnative.cpp
+++ b/modules/gdnative/text/text_server_gdnative.cpp
@@ -498,9 +498,9 @@ bool TextServerGDNative::shaped_text_update_justification_ops(RID p_shaped) {
 	return interface->shaped_text_update_justification_ops(data, (godot_rid *)&p_shaped);
 }
 
-void TextServerGDNative::shaped_text_overrun_trim_to_width(RID p_shaped_line, float p_width, uint8_t p_clip_flags) {
+void TextServerGDNative::shaped_text_overrun_trim_to_width(RID p_shaped_line, float p_width, uint8_t p_trim_flags) {
 	ERR_FAIL_COND(interface == nullptr);
-	interface->shaped_text_overrun_trim_to_width(data, (godot_rid *)&p_shaped_line, p_width, p_clip_flags);
+	interface->shaped_text_overrun_trim_to_width(data, (godot_rid *)&p_shaped_line, p_width, p_trim_flags);
 };
 
 bool TextServerGDNative::shaped_text_is_ready(RID p_shaped) const {

--- a/modules/gdnative/text/text_server_gdnative.h
+++ b/modules/gdnative/text/text_server_gdnative.h
@@ -167,7 +167,7 @@ public:
 	virtual bool shaped_text_update_breaks(RID p_shaped) override;
 	virtual bool shaped_text_update_justification_ops(RID p_shaped) override;
 
-	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint8_t p_clip_flags) override;
+	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint8_t p_trim_flags) override;
 
 	virtual bool shaped_text_is_ready(RID p_shaped) const override;
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -977,6 +977,7 @@ void TextServerAdvanced::invalidate(TextServerAdvanced::ShapedTextDataAdvanced *
 	p_shaped->sort_valid = false;
 	p_shaped->line_breaks_valid = false;
 	p_shaped->justification_ops_valid = false;
+	p_shaped->text_trimmed = false;
 	p_shaped->ascent = 0.f;
 	p_shaped->descent = 0.f;
 	p_shaped->width = 0.f;
@@ -984,6 +985,7 @@ void TextServerAdvanced::invalidate(TextServerAdvanced::ShapedTextDataAdvanced *
 	p_shaped->uthk = 0.f;
 	p_shaped->glyphs.clear();
 	p_shaped->glyphs_logical.clear();
+	p_shaped->overrun_trim_data = TrimData();
 	p_shaped->utf16 = Char16String();
 	if (p_shaped->script_iter != nullptr) {
 		memdelete(p_shaped->script_iter);
@@ -1363,7 +1365,7 @@ RID TextServerAdvanced::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 
 			ERR_FAIL_COND_V_MSG((start < 0 || end - start > new_sd->utf16.length()), RID(), "Invalid BiDi override range.");
 
-			//Create temporary line bidi & shape
+			// Create temporary line bidi & shape.
 			UBiDi *bidi_iter = ubidi_openSized(end - start, 0, &err);
 			ERR_FAIL_COND_V_MSG(U_FAILURE(err), RID(), u_errorName(err));
 			ubidi_setLine(sd->bidi_iter[ov], start, end, bidi_iter, &err);
@@ -1518,6 +1520,7 @@ float TextServerAdvanced::shaped_text_fit_to_width(RID p_shaped, float p_width, 
 		const_cast<TextServerAdvanced *>(this)->shaped_text_update_justification_ops(p_shaped);
 	}
 
+	sd->fit_width_minimum_reached = false;
 	int start_pos = 0;
 	int end_pos = sd->glyphs.size() - 1;
 
@@ -1546,14 +1549,26 @@ float TextServerAdvanced::shaped_text_fit_to_width(RID p_shaped, float p_width, 
 		}
 	}
 
+	float justification_width;
+	if ((p_jst_flags & JUSTIFICATION_CONSTRAIN_ELLIPSIS) == JUSTIFICATION_CONSTRAIN_ELLIPSIS) {
+		if (sd->overrun_trim_data.trim_pos >= 0) {
+			start_pos = sd->overrun_trim_data.trim_pos;
+			justification_width = sd->width_trimmed;
+		} else {
+			return sd->width;
+		}
+	} else {
+		justification_width = sd->width;
+	}
+
 	if ((p_jst_flags & JUSTIFICATION_TRIM_EDGE_SPACES) == JUSTIFICATION_TRIM_EDGE_SPACES) {
 		while ((start_pos < end_pos) && ((sd->glyphs[start_pos].flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE || (sd->glyphs[start_pos].flags & GRAPHEME_IS_BREAK_HARD) == GRAPHEME_IS_BREAK_HARD || (sd->glyphs[start_pos].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT)) {
-			sd->width -= sd->glyphs[start_pos].advance * sd->glyphs[start_pos].repeat;
+			justification_width -= sd->glyphs[start_pos].advance * sd->glyphs[start_pos].repeat;
 			sd->glyphs.write[start_pos].advance = 0;
 			start_pos += sd->glyphs[start_pos].count;
 		}
 		while ((start_pos < end_pos) && ((sd->glyphs[end_pos].flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE || (sd->glyphs[end_pos].flags & GRAPHEME_IS_BREAK_HARD) == GRAPHEME_IS_BREAK_HARD || (sd->glyphs[end_pos].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT)) {
-			sd->width -= sd->glyphs[end_pos].advance * sd->glyphs[end_pos].repeat;
+			justification_width -= sd->glyphs[end_pos].advance * sd->glyphs[end_pos].repeat;
 			sd->glyphs.write[end_pos].advance = 0;
 			end_pos -= sd->glyphs[end_pos].count;
 		}
@@ -1574,7 +1589,7 @@ float TextServerAdvanced::shaped_text_fit_to_width(RID p_shaped, float p_width, 
 	}
 
 	if ((elongation_count > 0) && ((p_jst_flags & JUSTIFICATION_KASHIDA) == JUSTIFICATION_KASHIDA)) {
-		float delta_width_per_kashida = (p_width - sd->width) / elongation_count;
+		float delta_width_per_kashida = (p_width - justification_width) / elongation_count;
 		for (int i = start_pos; i <= end_pos; i++) {
 			Glyph &gl = sd->glyphs.write[i];
 			if (gl.count > 0) {
@@ -1582,32 +1597,48 @@ float TextServerAdvanced::shaped_text_fit_to_width(RID p_shaped, float p_width, 
 					int count = delta_width_per_kashida / gl.advance;
 					int prev_count = gl.repeat;
 					if ((gl.flags & GRAPHEME_IS_VIRTUAL) == GRAPHEME_IS_VIRTUAL) {
-						gl.repeat = count;
-					} else {
-						gl.repeat = count + 1;
+						gl.repeat = MAX(count, 0);
 					}
-					sd->width += (gl.repeat - prev_count) * gl.advance;
+					justification_width += (gl.repeat - prev_count) * gl.advance;
 				}
 			}
 		}
 	}
-
+	float adv_remain = 0;
 	if ((space_count > 0) && ((p_jst_flags & JUSTIFICATION_WORD_BOUND) == JUSTIFICATION_WORD_BOUND)) {
-		float delta_width_per_space = (p_width - sd->width) / space_count;
+		float delta_width_per_space = (p_width - justification_width) / space_count;
 		for (int i = start_pos; i <= end_pos; i++) {
 			Glyph &gl = sd->glyphs.write[i];
 			if (gl.count > 0) {
 				if ((gl.flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE) {
 					float old_adv = gl.advance;
+					float new_advance;
 					if ((gl.flags & GRAPHEME_IS_VIRTUAL) == GRAPHEME_IS_VIRTUAL) {
-						gl.advance = Math::round(MAX(gl.advance + delta_width_per_space, 0.f));
+						new_advance = MAX(gl.advance + delta_width_per_space, 0.f);
 					} else {
-						gl.advance = Math::round(MAX(gl.advance + delta_width_per_space, 0.05 * gl.font_size));
+						new_advance = MAX(gl.advance + delta_width_per_space, 0.05 * gl.font_size);
 					}
-					sd->width += (gl.advance - old_adv);
+					gl.advance = new_advance;
+					adv_remain += (new_advance - gl.advance);
+					if (adv_remain >= 1.0) {
+						gl.advance++;
+						adv_remain -= 1.0;
+					} else if (adv_remain <= -1.0) {
+						gl.advance = MAX(gl.advance - 1, 0);
+						adv_remain -= 1.0;
+					}
+					justification_width += (gl.advance - old_adv);
 				}
 			}
 		}
+	}
+
+	if (Math::floor(p_width) < Math::floor(justification_width)) {
+		sd->fit_width_minimum_reached = true;
+	}
+
+	if ((p_jst_flags & JUSTIFICATION_CONSTRAIN_ELLIPSIS) != JUSTIFICATION_CONSTRAIN_ELLIPSIS) {
+		sd->width = justification_width;
 	}
 
 	return sd->width;
@@ -1662,7 +1693,7 @@ float TextServerAdvanced::shaped_text_tab_align(RID p_shaped, const Vector<float
 	return 0.f;
 }
 
-void TextServerAdvanced::shaped_text_overrun_trim_to_width(RID p_shaped_line, float p_width, uint8_t p_clip_flags) {
+void TextServerAdvanced::shaped_text_overrun_trim_to_width(RID p_shaped_line, float p_width, uint8_t p_trim_flags) {
 	_THREAD_SAFE_METHOD_
 	ShapedTextDataAdvanced *sd = shaped_owner.getornull(p_shaped_line);
 	ERR_FAIL_COND_MSG(!sd, "ShapedTextDataAdvanced invalid.");
@@ -1670,13 +1701,22 @@ void TextServerAdvanced::shaped_text_overrun_trim_to_width(RID p_shaped_line, fl
 		shaped_text_shape(p_shaped_line);
 	}
 
-	bool add_ellipsis = (p_clip_flags & OVERRUN_ADD_ELLIPSIS) == OVERRUN_ADD_ELLIPSIS;
-	bool cut_per_word = (p_clip_flags & OVERRUN_TRIM_WORD_ONLY) == OVERRUN_TRIM_WORD_ONLY;
-	bool enforce_ellipsis = (p_clip_flags & OVERRUN_ENFORCE_ELLIPSIS) == OVERRUN_ENFORCE_ELLIPSIS;
+	sd->overrun_trim_data.ellipsis_glyph_buf.clear();
+
+	bool add_ellipsis = (p_trim_flags & OVERRUN_ADD_ELLIPSIS) == OVERRUN_ADD_ELLIPSIS;
+	bool cut_per_word = (p_trim_flags & OVERRUN_TRIM_WORD_ONLY) == OVERRUN_TRIM_WORD_ONLY;
+	bool enforce_ellipsis = (p_trim_flags & OVERRUN_ENFORCE_ELLIPSIS) == OVERRUN_ENFORCE_ELLIPSIS;
+	bool justification_aware = (p_trim_flags & OVERRUN_JUSTIFICATION_AWARE) == OVERRUN_JUSTIFICATION_AWARE;
 
 	Glyph *sd_glyphs = sd->glyphs.ptrw();
 
-	if ((p_clip_flags & OVERRUN_TRIM) == OVERRUN_NO_TRIMMING || sd_glyphs == nullptr || p_width <= 0 || !(sd->width > p_width || enforce_ellipsis)) {
+	if ((p_trim_flags & OVERRUN_TRIM) == OVERRUN_NO_TRIMMING || sd_glyphs == nullptr || p_width <= 0 || !(sd->width > p_width || enforce_ellipsis)) {
+		sd->overrun_trim_data.trim_pos = -1;
+		sd->overrun_trim_data.ellipsis_pos = -1;
+		return;
+	}
+
+	if (justification_aware && !sd->fit_width_minimum_reached) {
 		return;
 	}
 
@@ -1688,9 +1728,9 @@ void TextServerAdvanced::shaped_text_overrun_trim_to_width(RID p_shaped_line, fl
 	uint32_t whitespace_gl_idx = font_get_glyph_index(last_gl_font_rid, ' ');
 	Vector2 whitespace_adv = font_get_glyph_advance(last_gl_font_rid, whitespace_gl_idx, last_gl_font_size);
 
-	int ellipsis_advance = 0;
+	int ellipsis_width = 0;
 	if (add_ellipsis) {
-		ellipsis_advance = 3 * dot_adv.x + font_get_spacing_glyph(last_gl_font_rid) + (cut_per_word ? whitespace_adv.x : 0);
+		ellipsis_width = 3 * dot_adv.x + font_get_spacing_glyph(last_gl_font_rid) + (cut_per_word ? whitespace_adv.x : 0);
 	}
 
 	int ell_min_characters = 6;
@@ -1710,12 +1750,12 @@ void TextServerAdvanced::shaped_text_overrun_trim_to_width(RID p_shaped_line, fl
 
 	for (int i = glyphs_from; i != glyphs_to; i += glyphs_delta) {
 		if (!is_rtl) {
-			width -= sd_glyphs[i].advance;
+			width -= sd_glyphs[i].advance * sd_glyphs[i].repeat;
 		}
 		if (sd_glyphs[i].count > 0) {
 			bool above_min_char_treshold = ((is_rtl) ? sd_size - 1 - i : i) >= ell_min_characters;
 
-			if (width + (((above_min_char_treshold && add_ellipsis) || enforce_ellipsis) ? ellipsis_advance : 0) <= p_width) {
+			if (width + (((above_min_char_treshold && add_ellipsis) || enforce_ellipsis) ? ellipsis_width : 0) <= p_width) {
 				if (cut_per_word && above_min_char_treshold) {
 					if ((sd_glyphs[i].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT) {
 						last_valid_cut = i;
@@ -1728,7 +1768,7 @@ void TextServerAdvanced::shaped_text_overrun_trim_to_width(RID p_shaped_line, fl
 				if (found) {
 					trim_pos = last_valid_cut;
 
-					if (above_min_char_treshold && width - ellipsis_advance <= p_width) {
+					if (add_ellipsis && (above_min_char_treshold || enforce_ellipsis) && width - ellipsis_width <= p_width) {
 						ellipsis_pos = trim_pos;
 					}
 					break;
@@ -1736,18 +1776,21 @@ void TextServerAdvanced::shaped_text_overrun_trim_to_width(RID p_shaped_line, fl
 			}
 		}
 		if (is_rtl) {
-			width -= sd_glyphs[i].advance;
+			width -= sd_glyphs[i].advance * sd_glyphs[i].repeat;
 		}
 	}
 
+	sd->overrun_trim_data.trim_pos = trim_pos;
+	sd->overrun_trim_data.ellipsis_pos = ellipsis_pos;
+	if (trim_pos == 0 && enforce_ellipsis && add_ellipsis) {
+		sd->overrun_trim_data.ellipsis_pos = 0;
+	}
+
 	if ((trim_pos >= 0 && sd->width > p_width) || enforce_ellipsis) {
-		int added_glyphs = 0;
 		if (add_ellipsis && (ellipsis_pos > 0 || enforce_ellipsis)) {
 			// Insert an additional space when cutting word bound for aesthetics.
 			if (cut_per_word && (ellipsis_pos > 0)) {
 				TextServer::Glyph gl;
-				gl.start = sd_glyphs[ellipsis_pos].start;
-				gl.end = sd_glyphs[ellipsis_pos].end;
 				gl.count = 1;
 				gl.advance = whitespace_adv.x;
 				gl.index = whitespace_gl_idx;
@@ -1755,66 +1798,31 @@ void TextServerAdvanced::shaped_text_overrun_trim_to_width(RID p_shaped_line, fl
 				gl.font_size = last_gl_font_size;
 				gl.flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_BREAK_SOFT | GRAPHEME_IS_VIRTUAL | (is_rtl ? GRAPHEME_IS_RTL : 0);
 
-				// Optimized glyph insertion by replacing a glyph whenever possible.
-				int glyph_idx = trim_pos + ((is_rtl) ? (-added_glyphs - 1) : added_glyphs);
-				if (is_rtl) {
-					if (glyph_idx < 0) {
-						sd->glyphs.insert(0, gl);
-					} else {
-						sd->glyphs.set(glyph_idx, gl);
-					}
-				} else {
-					if (glyph_idx > (sd_size - 1)) {
-						sd->glyphs.append(gl);
-					} else {
-						sd->glyphs.set(glyph_idx, gl);
-					}
-				}
-				added_glyphs++;
+				sd->overrun_trim_data.ellipsis_glyph_buf.append(gl);
 			}
 			// Add ellipsis dots.
-			for (int d = 0; d < 3; d++) {
-				TextServer::Glyph gl;
-				gl.start = sd_glyphs[ellipsis_pos].start;
-				gl.end = sd_glyphs[ellipsis_pos].end;
-				gl.count = 1;
-				gl.advance = dot_adv.x;
-				gl.index = dot_gl_idx;
-				gl.font_rid = last_gl_font_rid;
-				gl.font_size = last_gl_font_size;
-				gl.flags = GRAPHEME_IS_PUNCTUATION | GRAPHEME_IS_VIRTUAL | (is_rtl ? GRAPHEME_IS_RTL : 0);
+			TextServer::Glyph gl;
+			gl.count = 1;
+			gl.repeat = 3;
+			gl.advance = dot_adv.x;
+			gl.index = dot_gl_idx;
+			gl.font_rid = last_gl_font_rid;
+			gl.font_size = last_gl_font_size;
+			gl.flags = GRAPHEME_IS_PUNCTUATION | GRAPHEME_IS_VIRTUAL | (is_rtl ? GRAPHEME_IS_RTL : 0);
 
-				// Optimized glyph insertion by replacing a glyph whenever possible.
-				int glyph_idx = trim_pos + ((is_rtl) ? (-added_glyphs - 1) : added_glyphs);
-				if (is_rtl) {
-					if (glyph_idx < 0) {
-						sd->glyphs.insert(0, gl);
-					} else {
-						sd->glyphs.set(glyph_idx, gl);
-					}
-				} else {
-					if (glyph_idx > (sd_size - 1)) {
-						sd->glyphs.append(gl);
-					} else {
-						sd->glyphs.set(glyph_idx, gl);
-					}
-				}
-				added_glyphs++;
-			}
+			sd->overrun_trim_data.ellipsis_glyph_buf.append(gl);
 		}
 
-		// Cut the remaining glyphs off.
-		if (!is_rtl) {
-			sd->glyphs.resize(trim_pos + added_glyphs);
-		} else {
-			if (trim_pos - added_glyphs >= 0) {
-				sd->glyphs = sd->glyphs.subarray(trim_pos - added_glyphs, sd->glyphs.size() - 1);
-			}
-		}
-
-		// Update to correct width.
-		sd->width = width + ((ellipsis_pos != -1) ? ellipsis_advance : 0);
+		sd->text_trimmed = true;
+		sd->width_trimmed = width + ((ellipsis_pos != -1) ? ellipsis_width : 0);
 	}
+}
+
+TextServer::TrimData TextServerAdvanced::shaped_text_get_trim_data(RID p_shaped) const {
+	_THREAD_SAFE_METHOD_
+	ShapedTextDataAdvanced *sd = shaped_owner.getornull(p_shaped);
+	ERR_FAIL_COND_V_MSG(!sd, TrimData(), "ShapedTextDataAdvanced invalid.");
+	return sd->overrun_trim_data;
 }
 
 bool TextServerAdvanced::shaped_text_update_breaks(RID p_shaped) {
@@ -1843,7 +1851,7 @@ bool TextServerAdvanced::shaped_text_update_breaks(RID p_shaped) {
 		int r_end = sd->spans[i].end;
 		UBreakIterator *bi = ubrk_open(UBRK_LINE, language.ascii().get_data(), data + _convert_pos_inv(sd, r_start), _convert_pos_inv(sd, r_end - r_start), &err);
 		if (U_FAILURE(err)) {
-			//No data loaded - use fallback.
+			// No data loaded - use fallback.
 			for (int j = r_start; j < r_end; j++) {
 				char32_t c = sd->text[j - sd->start];
 				if (is_whitespace(c)) {
@@ -1907,7 +1915,7 @@ bool TextServerAdvanced::shaped_text_update_breaks(RID p_shaped) {
 						gl.font_rid = sd_glyphs[i].font_rid;
 						gl.font_size = sd_glyphs[i].font_size;
 						gl.flags = GRAPHEME_IS_BREAK_SOFT | GRAPHEME_IS_VIRTUAL;
-						sd->glyphs.insert(i + sd_glyphs[i].count, gl); // insert after
+						sd->glyphs.insert(i + sd_glyphs[i].count, gl); // Insert after.
 
 						// Update write pointer and size.
 						sd_size = sd->glyphs.size();
@@ -2027,7 +2035,7 @@ bool TextServerAdvanced::shaped_text_update_justification_ops(RID p_shaped) {
 	UErrorCode err = U_ZERO_ERROR;
 	UBreakIterator *bi = ubrk_open(UBRK_WORD, "", data, data_size, &err);
 	if (U_FAILURE(err)) {
-		// No data - use fallback
+		// No data - use fallback.
 		int limit = 0;
 		for (int i = 0; i < sd->text.length(); i++) {
 			if (is_whitespace(data[i])) {
@@ -2100,7 +2108,7 @@ bool TextServerAdvanced::shaped_text_update_justification_ops(RID p_shaped) {
 						gl.font_rid = sd->glyphs[i].font_rid;
 						gl.font_size = sd->glyphs[i].font_size;
 						gl.flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_VIRTUAL;
-						sd->glyphs.insert(i + sd->glyphs[i].count, gl); // insert after
+						sd->glyphs.insert(i + sd->glyphs[i].count, gl); // Insert after.
 						i += sd->glyphs[i].count;
 						continue;
 					}
@@ -2166,7 +2174,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 
 	int fs = p_sd->spans[p_span].font_size;
 	if (fd == nullptr) {
-		// Add fallback glyphs
+		// Add fallback glyphs.
 		for (int i = p_start; i < p_end; i++) {
 			if (p_sd->preserve_invalid || (p_sd->preserve_control && is_control(p_sd->text[i]))) {
 				TextServer::Glyph gl;
@@ -2309,7 +2317,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 			w[last_cluster_index].flags |= GRAPHEME_IS_VALID;
 		}
 
-		//Fallback.
+		// Fallback.
 		int failed_subrun_start = p_end + 1;
 		int failed_subrun_end = p_start;
 
@@ -2643,9 +2651,9 @@ Size2 TextServerAdvanced::shaped_text_get_size(RID p_shaped) const {
 		const_cast<TextServerAdvanced *>(this)->shaped_text_shape(p_shaped);
 	}
 	if (sd->orientation == TextServer::ORIENTATION_HORIZONTAL) {
-		return Size2(sd->width, sd->ascent + sd->descent);
+		return Size2((sd->text_trimmed ? sd->width_trimmed : sd->width), sd->ascent + sd->descent);
 	} else {
-		return Size2(sd->ascent + sd->descent, sd->width);
+		return Size2(sd->ascent + sd->descent, (sd->text_trimmed ? sd->width_trimmed : sd->width));
 	}
 }
 
@@ -2676,7 +2684,7 @@ float TextServerAdvanced::shaped_text_get_width(RID p_shaped) const {
 	if (!sd->valid) {
 		const_cast<TextServerAdvanced *>(this)->shaped_text_shape(p_shaped);
 	}
-	return sd->width;
+	return (sd->text_trimmed ? sd->width_trimmed : sd->width);
 }
 
 float TextServerAdvanced::shaped_text_get_underline_position(RID p_shaped) const {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -229,7 +229,8 @@ public:
 	virtual bool shaped_text_update_breaks(RID p_shaped) override;
 	virtual bool shaped_text_update_justification_ops(RID p_shaped) override;
 
-	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint8_t p_clip_flags) override;
+	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint8_t p_trim_flags) override;
+	virtual TrimData shaped_text_get_trim_data(RID p_shaped) const override;
 
 	virtual bool shaped_text_is_ready(RID p_shaped) const override;
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -570,7 +570,7 @@ void TextServerFallback::shaped_text_set_orientation(RID p_shaped, TextServer::O
 }
 
 void TextServerFallback::shaped_text_set_bidi_override(RID p_shaped, const Vector<Vector2i> &p_override) {
-	//No BiDi support, ignore.
+	// No BiDi support, ignore.
 }
 
 TextServer::Orientation TextServerFallback::shaped_text_get_orientation(RID p_shaped) const {
@@ -1148,7 +1148,7 @@ bool TextServerFallback::shaped_text_update_justification_ops(RID p_shaped) {
 	return true;
 }
 
-void TextServerFallback::shaped_text_overrun_trim_to_width(RID p_shaped_line, float p_width, uint8_t p_clip_flags) {
+void TextServerFallback::shaped_text_overrun_trim_to_width(RID p_shaped_line, float p_width, uint8_t p_trim_flags) {
 	_THREAD_SAFE_METHOD_
 	ShapedTextData *sd = shaped_owner.getornull(p_shaped_line);
 	ERR_FAIL_COND_MSG(!sd, "ShapedTextDataAdvanced invalid.");
@@ -1156,13 +1156,22 @@ void TextServerFallback::shaped_text_overrun_trim_to_width(RID p_shaped_line, fl
 		shaped_text_shape(p_shaped_line);
 	}
 
-	bool add_ellipsis = (p_clip_flags & OVERRUN_ADD_ELLIPSIS) == OVERRUN_ADD_ELLIPSIS;
-	bool cut_per_word = (p_clip_flags & OVERRUN_TRIM_WORD_ONLY) == OVERRUN_TRIM_WORD_ONLY;
-	bool enforce_ellipsis = (p_clip_flags & OVERRUN_ENFORCE_ELLIPSIS) == OVERRUN_ENFORCE_ELLIPSIS;
+	sd->overrun_trim_data.ellipsis_glyph_buf.clear();
+
+	bool add_ellipsis = (p_trim_flags & OVERRUN_ADD_ELLIPSIS) == OVERRUN_ADD_ELLIPSIS;
+	bool cut_per_word = (p_trim_flags & OVERRUN_TRIM_WORD_ONLY) == OVERRUN_TRIM_WORD_ONLY;
+	bool enforce_ellipsis = (p_trim_flags & OVERRUN_ENFORCE_ELLIPSIS) == OVERRUN_ENFORCE_ELLIPSIS;
+	bool justification_aware = (p_trim_flags & OVERRUN_JUSTIFICATION_AWARE) == OVERRUN_JUSTIFICATION_AWARE;
 
 	Glyph *sd_glyphs = sd->glyphs.ptrw();
 
-	if ((p_clip_flags & OVERRUN_TRIM) == OVERRUN_NO_TRIMMING || sd_glyphs == nullptr || p_width <= 0 || !(sd->width > p_width || enforce_ellipsis)) {
+	if ((p_trim_flags & OVERRUN_TRIM) == OVERRUN_NO_TRIMMING || sd_glyphs == nullptr || p_width <= 0 || !(sd->width > p_width || enforce_ellipsis)) {
+		sd->overrun_trim_data.trim_pos = -1;
+		sd->overrun_trim_data.ellipsis_pos = -1;
+		return;
+	}
+
+	if (justification_aware && !sd->fit_width_minimum_reached) {
 		return;
 	}
 
@@ -1174,34 +1183,27 @@ void TextServerFallback::shaped_text_overrun_trim_to_width(RID p_shaped_line, fl
 	uint32_t whitespace_gl_idx = font_get_glyph_index(last_gl_font_rid, ' ');
 	Vector2 whitespace_adv = font_get_glyph_advance(last_gl_font_rid, whitespace_gl_idx, last_gl_font_size);
 
-	int ellipsis_advance = 0;
+	int ellipsis_width = 0;
 	if (add_ellipsis) {
-		ellipsis_advance = 3 * dot_adv.x + font_get_spacing_glyph(last_gl_font_rid) + (cut_per_word ? whitespace_adv.x : 0);
+		ellipsis_width = 3 * dot_adv.x + font_get_spacing_glyph(last_gl_font_rid) + (cut_per_word ? whitespace_adv.x : 0);
 	}
 
 	int ell_min_characters = 6;
 	float width = sd->width;
 
-	bool is_rtl = sd->direction == DIRECTION_RTL || (sd->direction == DIRECTION_AUTO && sd->para_direction == DIRECTION_RTL);
-
-	int trim_pos = (is_rtl) ? sd_size : 0;
+	int trim_pos = 0;
 	int ellipsis_pos = (enforce_ellipsis) ? 0 : -1;
 
 	int last_valid_cut = 0;
 	bool found = false;
 
-	int glyphs_from = (is_rtl) ? 0 : sd_size - 1;
-	int glyphs_to = (is_rtl) ? sd_size - 1 : -1;
-	int glyphs_delta = (is_rtl) ? +1 : -1;
+	for (int i = sd_size - 1; i != -1; i--) {
+		width -= sd_glyphs[i].advance * sd_glyphs[i].repeat;
 
-	for (int i = glyphs_from; i != glyphs_to; i += glyphs_delta) {
-		if (!is_rtl) {
-			width -= sd_glyphs[i].advance;
-		}
 		if (sd_glyphs[i].count > 0) {
-			bool above_min_char_treshold = ((is_rtl) ? sd_size - 1 - i : i) >= ell_min_characters;
+			bool above_min_char_treshold = (i >= ell_min_characters);
 
-			if (width + (((above_min_char_treshold && add_ellipsis) || enforce_ellipsis) ? ellipsis_advance : 0) <= p_width) {
+			if (width + (((above_min_char_treshold && add_ellipsis) || enforce_ellipsis) ? ellipsis_width : 0) <= p_width) {
 				if (cut_per_word && above_min_char_treshold) {
 					if ((sd_glyphs[i].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT) {
 						last_valid_cut = i;
@@ -1214,93 +1216,58 @@ void TextServerFallback::shaped_text_overrun_trim_to_width(RID p_shaped_line, fl
 				if (found) {
 					trim_pos = last_valid_cut;
 
-					if (above_min_char_treshold && width - ellipsis_advance <= p_width) {
+					if (add_ellipsis && (above_min_char_treshold || enforce_ellipsis) && width - ellipsis_width <= p_width) {
 						ellipsis_pos = trim_pos;
 					}
 					break;
 				}
 			}
 		}
-		if (is_rtl) {
-			width -= sd_glyphs[i].advance;
-		}
+	}
+
+	sd->overrun_trim_data.trim_pos = trim_pos;
+	sd->overrun_trim_data.ellipsis_pos = ellipsis_pos;
+	if (trim_pos == 0 && enforce_ellipsis && add_ellipsis) {
+		sd->overrun_trim_data.ellipsis_pos = 0;
 	}
 
 	if ((trim_pos >= 0 && sd->width > p_width) || enforce_ellipsis) {
-		int added_glyphs = 0;
 		if (add_ellipsis && (ellipsis_pos > 0 || enforce_ellipsis)) {
 			// Insert an additional space when cutting word bound for aesthetics.
 			if (cut_per_word && (ellipsis_pos > 0)) {
 				TextServer::Glyph gl;
-				gl.start = sd_glyphs[ellipsis_pos].start;
-				gl.end = sd_glyphs[ellipsis_pos].end;
 				gl.count = 1;
 				gl.advance = whitespace_adv.x;
 				gl.index = whitespace_gl_idx;
 				gl.font_rid = last_gl_font_rid;
 				gl.font_size = last_gl_font_size;
-				gl.flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_BREAK_SOFT | GRAPHEME_IS_VIRTUAL | (is_rtl ? GRAPHEME_IS_RTL : 0);
+				gl.flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_BREAK_SOFT | GRAPHEME_IS_VIRTUAL;
 
-				// Optimized glyph insertion by replacing a glyph whenever possible.
-				int glyph_idx = trim_pos + ((is_rtl) ? -added_glyphs : added_glyphs);
-				if (is_rtl) {
-					if (glyph_idx < 0) {
-						sd->glyphs.insert(0, gl);
-					} else {
-						sd->glyphs.set(glyph_idx, gl);
-					}
-				} else {
-					if (glyph_idx > (sd_size - 1)) {
-						sd->glyphs.append(gl);
-					} else {
-						sd->glyphs.set(glyph_idx, gl);
-					}
-				}
-				added_glyphs++;
+				sd->overrun_trim_data.ellipsis_glyph_buf.append(gl);
 			}
 			// Add ellipsis dots.
-			for (int d = 0; d < 3; d++) {
-				TextServer::Glyph gl;
-				gl.start = sd_glyphs[ellipsis_pos].start;
-				gl.end = sd_glyphs[ellipsis_pos].end;
-				gl.count = 1;
-				gl.advance = dot_adv.x;
-				gl.index = dot_gl_idx;
-				gl.font_rid = last_gl_font_rid;
-				gl.font_size = last_gl_font_size;
-				gl.flags = GRAPHEME_IS_PUNCTUATION | GRAPHEME_IS_VIRTUAL | (is_rtl ? GRAPHEME_IS_RTL : 0);
+			TextServer::Glyph gl;
+			gl.count = 1;
+			gl.repeat = 3;
+			gl.advance = dot_adv.x;
+			gl.index = dot_gl_idx;
+			gl.font_rid = last_gl_font_rid;
+			gl.font_size = last_gl_font_size;
+			gl.flags = GRAPHEME_IS_PUNCTUATION | GRAPHEME_IS_VIRTUAL;
 
-				// Optimized glyph insertion by replacing a glyph whenever possible.
-				int glyph_idx = trim_pos + ((is_rtl) ? -added_glyphs : added_glyphs);
-				if (is_rtl) {
-					if (glyph_idx < 0) {
-						sd->glyphs.insert(0, gl);
-					} else {
-						sd->glyphs.set(glyph_idx, gl);
-					}
-				} else {
-					if (glyph_idx > (sd_size - 1)) {
-						sd->glyphs.append(gl);
-					} else {
-						sd->glyphs.set(glyph_idx, gl);
-					}
-				}
-				added_glyphs++;
-			}
+			sd->overrun_trim_data.ellipsis_glyph_buf.append(gl);
 		}
 
-		// Cut the remaining glyphs off.
-		if (!is_rtl) {
-			sd->glyphs.resize(trim_pos + added_glyphs);
-		} else {
-			for (int ridx = 0; ridx <= trim_pos - added_glyphs; ridx++) {
-				sd->glyphs.remove(0);
-			}
-		}
-
-		// Update to correct width.
-		sd->width = width + ((ellipsis_pos != -1) ? ellipsis_advance : 0);
+		sd->text_trimmed = true;
+		sd->width_trimmed = width + ((ellipsis_pos != -1) ? ellipsis_width : 0);
 	}
+}
+
+TextServer::TrimData TextServerFallback::shaped_text_get_trim_data(RID p_shaped) const {
+	_THREAD_SAFE_METHOD_
+	ShapedTextData *sd = shaped_owner.getornull(p_shaped);
+	ERR_FAIL_COND_V_MSG(!sd, TrimData(), "ShapedTextDataAdvanced invalid.");
+	return sd->overrun_trim_data;
 }
 
 bool TextServerFallback::shaped_text_shape(RID p_shaped) {

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -178,7 +178,8 @@ public:
 	virtual bool shaped_text_update_breaks(RID p_shaped) override;
 	virtual bool shaped_text_update_justification_ops(RID p_shaped) override;
 
-	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint8_t p_clip_flags) override;
+	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint8_t p_trim_flags) override;
+	virtual TrimData shaped_text_get_trim_data(RID p_shaped) const override;
 
 	virtual bool shaped_text_is_ready(RID p_shaped) const override;
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -95,7 +95,6 @@ void Label::_shape() {
 		lines_dirty = true;
 	}
 
-	uint8_t overrun_flags = TextServer::OVERRUN_NO_TRIMMING;
 	if (lines_dirty) {
 		for (int i = 0; i < lines_rid.size(); i++) {
 			TS->free(lines_rid[i]);
@@ -116,46 +115,11 @@ void Label::_shape() {
 			case AUTOWRAP_OFF:
 				break;
 		}
-		Vector<Vector2i> lines = TS->shaped_text_get_line_breaks(text_rid, width, 0, autowrap_flags);
+		Vector<Vector2i> line_breaks = TS->shaped_text_get_line_breaks(text_rid, width, 0, autowrap_flags);
 
-		for (int i = 0; i < lines.size(); i++) {
-			RID line = TS->shaped_text_substr(text_rid, lines[i].x, lines[i].y - lines[i].x);
-
-			switch (overrun_behavior) {
-				case OVERRUN_TRIM_WORD_ELLIPSIS:
-					overrun_flags |= TextServer::OVERRUN_TRIM;
-					overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
-					overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
-					break;
-				case OVERRUN_TRIM_ELLIPSIS:
-					overrun_flags |= TextServer::OVERRUN_TRIM;
-					overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
-					break;
-				case OVERRUN_TRIM_WORD:
-					overrun_flags |= TextServer::OVERRUN_TRIM;
-					overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
-					break;
-				case OVERRUN_TRIM_CHAR:
-					overrun_flags |= TextServer::OVERRUN_TRIM;
-					break;
-				case OVERRUN_NO_TRIMMING:
-					break;
-			}
-
-			if (autowrap_mode == AUTOWRAP_OFF && align != ALIGN_FILL && overrun_behavior != OVERRUN_NO_TRIMMING) {
-				TS->shaped_text_overrun_trim_to_width(line, width, overrun_flags);
-			}
-
+		for (int i = 0; i < line_breaks.size(); i++) {
+			RID line = TS->shaped_text_substr(text_rid, line_breaks[i].x, line_breaks[i].y - line_breaks[i].x);
 			lines_rid.push_back(line);
-		}
-
-		if (autowrap_mode != AUTOWRAP_OFF && overrun_behavior != OVERRUN_NO_TRIMMING) {
-			int visible_lines = get_visible_line_count();
-
-			if (visible_lines < lines_rid.size() && visible_lines > 0) {
-				overrun_flags |= TextServer::OVERRUN_ENFORCE_ELLIPSIS;
-				TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], width, overrun_flags);
-			}
 		}
 	}
 
@@ -163,6 +127,7 @@ void Label::_shape() {
 		minsize = Size2(1, get_line_height());
 		return;
 	}
+
 	if (autowrap_mode == AUTOWRAP_OFF) {
 		minsize.width = 0.0f;
 		for (int i = 0; i < lines_rid.size(); i++) {
@@ -173,19 +138,59 @@ void Label::_shape() {
 	}
 
 	if (lines_dirty) {
+		uint8_t overrun_flags = TextServer::OVERRUN_NO_TRIMMING;
+		switch (overrun_behavior) {
+			case OVERRUN_TRIM_WORD_ELLIPSIS:
+				overrun_flags |= TextServer::OVERRUN_TRIM;
+				overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
+				overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
+				break;
+			case OVERRUN_TRIM_ELLIPSIS:
+				overrun_flags |= TextServer::OVERRUN_TRIM;
+				overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
+				break;
+			case OVERRUN_TRIM_WORD:
+				overrun_flags |= TextServer::OVERRUN_TRIM;
+				overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
+				break;
+			case OVERRUN_TRIM_CHAR:
+				overrun_flags |= TextServer::OVERRUN_TRIM;
+				break;
+			case OVERRUN_NO_TRIMMING:
+				break;
+		}
+
 		// Fill after min_size calculation.
-		if (align == ALIGN_FILL) {
-			for (int i = 0; i < lines_rid.size(); i++) {
-				if (overrun_behavior != OVERRUN_NO_TRIMMING && autowrap_mode == AUTOWRAP_OFF) {
-					float line_unaltered_width = TS->shaped_text_get_width(lines_rid[i]);
-					TS->shaped_text_fit_to_width(lines_rid[i], width);
-					float new_line_width = TS->shaped_text_get_width(lines_rid[i]);
-					// Begin trimming when there is no space between words available anymore.
-					if (new_line_width < line_unaltered_width) {
-						TS->shaped_text_overrun_trim_to_width(lines_rid[i], width, overrun_flags);
+
+		if (autowrap_mode != AUTOWRAP_OFF) {
+			int visible_lines = get_visible_line_count();
+			bool lines_hidden = visible_lines > 0 && visible_lines < lines_rid.size();
+			if (lines_hidden) {
+				overrun_flags |= TextServer::OVERRUN_ENFORCE_ELLIPSIS;
+			}
+			if (align == ALIGN_FILL) {
+				for (int i = 0; i < lines_rid.size(); i++) {
+					if (i < visible_lines - 1 || lines_rid.size() == 1) {
+						TS->shaped_text_fit_to_width(lines_rid[i], width);
+					} else if (i == (visible_lines - 1)) {
+						TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], width, overrun_flags);
 					}
-				} else {
+				}
+
+			} else if (lines_hidden) {
+				TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], width, overrun_flags);
+			}
+
+		} else {
+			// Autowrap disabled.
+			for (int i = 0; i < lines_rid.size(); i++) {
+				if (align == ALIGN_FILL) {
 					TS->shaped_text_fit_to_width(lines_rid[i], width);
+					overrun_flags |= TextServer::OVERRUN_JUSTIFICATION_AWARE;
+					TS->shaped_text_overrun_trim_to_width(lines_rid[i], width, overrun_flags);
+					TS->shaped_text_fit_to_width(lines_rid[i], width, TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_CONSTRAIN_ELLIPSIS);
+				} else {
+					TS->shaped_text_overrun_trim_to_width(lines_rid[i], width, overrun_flags);
 				}
 			}
 		}
@@ -219,11 +224,30 @@ void Label::_update_visible() {
 	}
 }
 
+inline void draw_glyph(const TextServer::Glyph &p_gl, const RID &p_canvas, const Color &p_font_color, const Color &p_font_shadow_color, const Color &p_font_outline_color, const int &p_shadow_outline_size, const int &p_outline_size, const Vector2 &p_ofs, const Vector2 &shadow_ofs) {
+	if (p_gl.font_rid != RID()) {
+		if (p_font_shadow_color.a > 0) {
+			TS->font_draw_glyph(p_gl.font_rid, p_canvas, p_gl.font_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off) + shadow_ofs, p_gl.index, p_font_shadow_color);
+			if (p_shadow_outline_size > 0) {
+				TS->font_draw_glyph_outline(p_gl.font_rid, p_canvas, p_gl.font_size, p_shadow_outline_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off) + Vector2(-shadow_ofs.x, shadow_ofs.y), p_gl.index, p_font_shadow_color);
+				TS->font_draw_glyph_outline(p_gl.font_rid, p_canvas, p_gl.font_size, p_shadow_outline_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off) + Vector2(shadow_ofs.x, -shadow_ofs.y), p_gl.index, p_font_shadow_color);
+				TS->font_draw_glyph_outline(p_gl.font_rid, p_canvas, p_gl.font_size, p_shadow_outline_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off) + Vector2(-shadow_ofs.x, -shadow_ofs.y), p_gl.index, p_font_shadow_color);
+			}
+		}
+		if (p_font_outline_color.a != 0.0 && p_outline_size > 0) {
+			TS->font_draw_glyph_outline(p_gl.font_rid, p_canvas, p_gl.font_size, p_outline_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off), p_gl.index, p_font_outline_color);
+		}
+		TS->font_draw_glyph(p_gl.font_rid, p_canvas, p_gl.font_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off), p_gl.index, p_font_color);
+	} else {
+		TS->draw_hex_code_box(p_canvas, p_gl.font_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off), p_gl.index, p_font_color);
+	}
+}
+
 void Label::_notification(int p_what) {
 	if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 		String new_text = atr(text);
 		if (new_text == xl_text) {
-			return; //nothing new
+			return; // Nothing new.
 		}
 		xl_text = new_text;
 		dirty = true;
@@ -253,7 +277,7 @@ void Label::_notification(int p_what) {
 		Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
 		int outline_size = get_theme_constant(SNAME("outline_size"));
 		int shadow_outline_size = get_theme_constant(SNAME("shadow_outline_size"));
-		bool rtl = is_layout_rtl();
+		bool rtl = TS->shaped_text_get_direction(text_rid);
 
 		style->draw(ci, Rect2(Point2(0, 0), get_size()));
 
@@ -286,7 +310,7 @@ void Label::_notification(int p_what) {
 		if (lines_visible > 0) {
 			switch (valign) {
 				case VALIGN_TOP: {
-					//nothing
+					// Nothing.
 				} break;
 				case VALIGN_CENTER: {
 					vbegin = (size.y - (total_h - line_spacing)) / 2;
@@ -331,83 +355,84 @@ void Label::_notification(int p_what) {
 		Vector2 ofs;
 		ofs.y = style->get_offset().y + vbegin;
 		for (int i = lines_skipped; i < last_line; i++) {
+			Size2 line_size = TS->shaped_text_get_size(lines_rid[i]);
 			ofs.x = 0;
 			ofs.y += TS->shaped_text_get_ascent(lines_rid[i]) + font->get_spacing(Font::SPACING_TOP);
 			switch (align) {
 				case ALIGN_FILL:
-				case ALIGN_LEFT: {
-					if (rtl) {
-						ofs.x = int(size.width - style->get_margin(SIDE_RIGHT) - TS->shaped_text_get_size(lines_rid[i]).x);
+					if (rtl && autowrap_mode != AUTOWRAP_OFF) {
+						ofs.x = int(size.width - style->get_margin(SIDE_RIGHT) - line_size.width);
 					} else {
 						ofs.x = style->get_offset().x;
 					}
+					break;
+				case ALIGN_LEFT: {
+					ofs.x = style->get_offset().x;
 				} break;
 				case ALIGN_CENTER: {
-					ofs.x = int(size.width - TS->shaped_text_get_size(lines_rid[i]).x) / 2;
+					ofs.x = int(size.width - line_size.width) / 2;
 				} break;
 				case ALIGN_RIGHT: {
-					if (rtl) {
-						ofs.x = style->get_offset().x;
-					} else {
-						ofs.x = int(size.width - style->get_margin(SIDE_RIGHT) - TS->shaped_text_get_size(lines_rid[i]).x);
-					}
+					ofs.x = int(size.width - style->get_margin(SIDE_RIGHT) - line_size.width);
 				} break;
 			}
 
 			const Vector<TextServer::Glyph> visual = TS->shaped_text_get_glyphs(lines_rid[i]);
 			const TextServer::Glyph *glyphs = visual.ptr();
 			int gl_size = visual.size();
+			TextServer::TrimData trim_data = TS->shaped_text_get_trim_data(lines_rid[i]);
 
-			float x = ofs.x;
-			int outlines_drawn = glyhps_drawn;
+			// Draw RTL ellipsis string when necessary.
+			if (rtl && trim_data.ellipsis_pos >= 0) {
+				for (int gl_idx = trim_data.ellipsis_glyph_buf.size() - 1; gl_idx >= 0; gl_idx--) {
+					for (int j = 0; j < trim_data.ellipsis_glyph_buf[gl_idx].repeat; j++) {
+						//Draw glyph outlines and shadow.
+						draw_glyph(trim_data.ellipsis_glyph_buf[gl_idx], ci, font_color, font_shadow_color, font_outline_color, shadow_outline_size, outline_size, ofs, shadow_ofs);
+						ofs.x += trim_data.ellipsis_glyph_buf[gl_idx].advance;
+					}
+				}
+			}
+
+			// Draw main text.
 			for (int j = 0; j < gl_size; j++) {
 				for (int k = 0; k < glyphs[j].repeat; k++) {
-					if (glyphs[j].font_rid != RID()) {
-						if (font_shadow_color.a > 0) {
-							TS->font_draw_glyph(glyphs[j].font_rid, ci, glyphs[j].font_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + shadow_ofs, glyphs[j].index, font_shadow_color);
-							if (shadow_outline_size > 0) {
-								//draw shadow
-								TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, shadow_outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + Vector2(-shadow_ofs.x, shadow_ofs.y), glyphs[j].index, font_shadow_color);
-								TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, shadow_outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + Vector2(shadow_ofs.x, -shadow_ofs.y), glyphs[j].index, font_shadow_color);
-								TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, shadow_outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + Vector2(-shadow_ofs.x, -shadow_ofs.y), glyphs[j].index, font_shadow_color);
+					if (visible_glyphs != -1) {
+						if ((glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
+							if (glyhps_drawn >= visible_glyphs) {
+								return;
 							}
 						}
-						if (font_outline_color.a != 0.0 && outline_size > 0) {
-							TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off), glyphs[j].index, font_outline_color);
+					}
+
+					// Trim when necessary.
+					if (trim_data.trim_pos >= 0) {
+						if (rtl) {
+							if (j < trim_data.trim_pos && (glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
+								continue;
+							}
+						} else {
+							if (j >= trim_data.trim_pos && (glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
+								break;
+							}
 						}
 					}
+
+					// Draw glyph outlines and shadow.
+					draw_glyph(glyphs[j], ci, font_color, font_shadow_color, font_outline_color, shadow_outline_size, outline_size, ofs, shadow_ofs);
 					ofs.x += glyphs[j].advance;
+					glyhps_drawn++;
 				}
-				if (visible_glyphs != -1) {
-					if ((glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
-						outlines_drawn++;
-						if (outlines_drawn >= visible_glyphs) {
-							break;
-						}
+			}
+			// Draw LTR ellipsis string when necessary.
+			if (!rtl && trim_data.ellipsis_pos >= 0) {
+				for (int gl_idx = 0; gl_idx < trim_data.ellipsis_glyph_buf.size(); gl_idx++) {
+					for (int j = 0; j < trim_data.ellipsis_glyph_buf[gl_idx].repeat; j++) {
+						//Draw glyph outlines and shadow.
+						draw_glyph(trim_data.ellipsis_glyph_buf[gl_idx], ci, font_color, font_shadow_color, font_outline_color, shadow_outline_size, outline_size, ofs, shadow_ofs);
+						ofs.x += trim_data.ellipsis_glyph_buf[gl_idx].advance;
 					}
 				}
 			}
-			ofs.x = x;
-
-			for (int j = 0; j < gl_size; j++) {
-				for (int k = 0; k < glyphs[j].repeat; k++) {
-					if (glyphs[j].font_rid != RID()) {
-						TS->font_draw_glyph(glyphs[j].font_rid, ci, glyphs[j].font_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off), glyphs[j].index, font_color);
-					} else if ((glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
-						TS->draw_hex_code_box(ci, glyphs[j].font_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off), glyphs[j].index, font_color);
-					}
-					ofs.x += glyphs[j].advance;
-				}
-				if (visible_glyphs != -1) {
-					if ((glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
-						glyhps_drawn++;
-						if (glyhps_drawn >= visible_glyphs) {
-							return;
-						}
-					}
-				}
-			}
-
 			ofs.y += TS->shaped_text_get_descent(lines_rid[i]) + vsep + line_spacing + font->get_spacing(Font::SPACING_BOTTOM);
 		}
 	}
@@ -624,6 +649,9 @@ void Label::set_visible_characters(int p_amount) {
 	} else {
 		percent_visible = 1.0;
 	}
+	if (p_amount == -1) {
+		lines_dirty = true;
+	}
 	update();
 }
 
@@ -635,7 +663,7 @@ void Label::set_percent_visible(float p_percent) {
 	if (p_percent < 0 || p_percent >= 1) {
 		visible_chars = -1;
 		percent_visible = 1;
-
+		lines_dirty = true;
 	} else {
 		visible_chars = get_total_character_count() * p_percent;
 		percent_visible = p_percent;
@@ -793,7 +821,7 @@ void Label::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "valign", PROPERTY_HINT_ENUM, "Top,Center,Bottom,Fill"), "set_valign", "get_valign");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "autowrap_mode", PROPERTY_HINT_ENUM, "Off,Arbitrary,Word,Word (Smart)"), "set_autowrap_mode", "get_autowrap_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_text"), "set_clip_text", "is_clipping_text");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim nothing,Trim characters,Trim words,Ellipsis,Word ellipsis"), "set_text_overrun_behavior", "get_text_overrun_behavior");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim Nothing,Trim Characters,Trim Words,Ellipsis,Word Ellipsis"), "set_text_overrun_behavior", "get_text_overrun_behavior");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "uppercase"), "set_uppercase", "is_uppercase");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "visible_characters", PROPERTY_HINT_RANGE, "-1,128000,1", PROPERTY_USAGE_EDITOR), "set_visible_characters", "get_visible_characters");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "percent_visible", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_percent_visible", "get_percent_visible");

--- a/scene/resources/text_line.h
+++ b/scene/resources/text_line.h
@@ -39,6 +39,16 @@
 class TextLine : public RefCounted {
 	GDCLASS(TextLine, RefCounted);
 
+public:
+	enum OverrunBehavior {
+		OVERRUN_NO_TRIMMING,
+		OVERRUN_TRIM_CHAR,
+		OVERRUN_TRIM_WORD,
+		OVERRUN_TRIM_ELLIPSIS,
+		OVERRUN_TRIM_WORD_ELLIPSIS,
+	};
+
+private:
 	RID rid;
 	int spacing_top = 0;
 	int spacing_bottom = 0;
@@ -48,6 +58,7 @@ class TextLine : public RefCounted {
 	float width = -1.0;
 	uint8_t flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA;
 	HAlign align = HALIGN_LEFT;
+	OverrunBehavior overrun_behavior = OVERRUN_TRIM_ELLIPSIS;
 
 	Vector<float> tab_stops;
 
@@ -87,6 +98,9 @@ public:
 	void set_flags(uint8_t p_flags);
 	uint8_t get_flags() const;
 
+	void set_text_overrun_behavior(OverrunBehavior p_behavior);
+	OverrunBehavior get_text_overrun_behavior() const;
+
 	void set_width(float p_width);
 	float get_width() const;
 
@@ -112,5 +126,7 @@ public:
 	TextLine();
 	~TextLine();
 };
+
+VARIANT_ENUM_CAST(TextLine::OverrunBehavior);
 
 #endif // TEXT_LINE_H

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -74,6 +74,11 @@ void TextParagraph::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "flags", PROPERTY_HINT_FLAGS, "Kashida Justify,Word Justify,Trim Edge Spaces After Justify,Justify Only After Last Tab,Break Mandatory,Break Words,Break Graphemes"), "set_flags", "get_flags");
 
+	ClassDB::bind_method(D_METHOD("set_text_overrun_behavior", "overrun_behavior"), &TextParagraph::set_text_overrun_behavior);
+	ClassDB::bind_method(D_METHOD("get_text_overrun_behavior"), &TextParagraph::get_text_overrun_behavior);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim Nothing,Trim Characters,Trim Words,Ellipsis,Word Ellipsis"), "set_text_overrun_behavior", "get_text_overrun_behavior");
+
 	ClassDB::bind_method(D_METHOD("set_width", "width"), &TextParagraph::set_width);
 	ClassDB::bind_method(D_METHOD("get_width"), &TextParagraph::get_width);
 
@@ -87,6 +92,11 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_dropcap_rid"), &TextParagraph::get_dropcap_rid);
 
 	ClassDB::bind_method(D_METHOD("get_line_count"), &TextParagraph::get_line_count);
+
+	ClassDB::bind_method(D_METHOD("set_max_lines_visible", "max_lines_visible"), &TextParagraph::set_max_lines_visible);
+	ClassDB::bind_method(D_METHOD("get_max_lines_visible"), &TextParagraph::get_max_lines_visible);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_lines_visible"), "set_max_lines_visible", "get_max_lines_visible");
 
 	ClassDB::bind_method(D_METHOD("get_line_objects", "line"), &TextParagraph::get_line_objects);
 	ClassDB::bind_method(D_METHOD("get_line_object_rect", "line", "key"), &TextParagraph::get_line_object_rect);
@@ -114,14 +124,20 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_dropcap_outline", "canvas", "pos", "outline_size", "color"), &TextParagraph::draw_dropcap_outline, DEFVAL(1), DEFVAL(Color(1, 1, 1)));
 
 	ClassDB::bind_method(D_METHOD("hit_test", "coords"), &TextParagraph::hit_test);
+
+	BIND_ENUM_CONSTANT(OVERRUN_NO_TRIMMING);
+	BIND_ENUM_CONSTANT(OVERRUN_TRIM_CHAR);
+	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD);
+	BIND_ENUM_CONSTANT(OVERRUN_TRIM_ELLIPSIS);
+	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD_ELLIPSIS);
 }
 
 void TextParagraph::_shape_lines() {
-	if (dirty_lines) {
-		for (int i = 0; i < lines.size(); i++) {
-			TS->free(lines[i]);
+	if (lines_dirty) {
+		for (int i = 0; i < lines_rid.size(); i++) {
+			TS->free(lines_rid[i]);
 		}
-		lines.clear();
+		lines_rid.clear();
 
 		if (!tab_stops.is_empty()) {
 			TS->shaped_text_tab_align(rid, tab_stops);
@@ -153,13 +169,10 @@ void TextParagraph::_shape_lines() {
 				if (!tab_stops.is_empty()) {
 					TS->shaped_text_tab_align(line, tab_stops);
 				}
-				if (align == HALIGN_FILL && (line_breaks.size() == 1 || i < line_breaks.size() - 1)) {
-					TS->shaped_text_fit_to_width(line, width - h_offset, flags);
-				}
 				dropcap_lines++;
 				v_offset -= h;
 				start = line_breaks[i].y;
-				lines.push_back(line);
+				lines_rid.push_back(line);
 			}
 		}
 		// Use fixed for the rest of lines.
@@ -169,12 +182,69 @@ void TextParagraph::_shape_lines() {
 			if (!tab_stops.is_empty()) {
 				TS->shaped_text_tab_align(line, tab_stops);
 			}
-			if (align == HALIGN_FILL && (line_breaks.size() == 1 || i < line_breaks.size() - 1)) {
-				TS->shaped_text_fit_to_width(line, width, flags);
-			}
-			lines.push_back(line);
+			lines_rid.push_back(line);
 		}
-		dirty_lines = false;
+
+		uint8_t overrun_flags = TextServer::OVERRUN_NO_TRIMMING;
+		if (overrun_behavior != OVERRUN_NO_TRIMMING) {
+			switch (overrun_behavior) {
+				case OVERRUN_TRIM_WORD_ELLIPSIS:
+					overrun_flags |= TextServer::OVERRUN_TRIM;
+					overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
+					overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
+					break;
+				case OVERRUN_TRIM_ELLIPSIS:
+					overrun_flags |= TextServer::OVERRUN_TRIM;
+					overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
+					break;
+				case OVERRUN_TRIM_WORD:
+					overrun_flags |= TextServer::OVERRUN_TRIM;
+					overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
+					break;
+				case OVERRUN_TRIM_CHAR:
+					overrun_flags |= TextServer::OVERRUN_TRIM;
+					break;
+				case OVERRUN_NO_TRIMMING:
+					break;
+			}
+		}
+
+		bool autowrap_enabled = ((flags & TextServer::BREAK_WORD_BOUND) == TextServer::BREAK_WORD_BOUND) || ((flags & TextServer::BREAK_GRAPHEME_BOUND) == TextServer::BREAK_GRAPHEME_BOUND);
+
+		// Fill after min_size calculation.
+		if (autowrap_enabled) {
+			int visible_lines = (max_lines_visible >= 0) ? MIN(max_lines_visible, lines_rid.size()) : lines_rid.size();
+			bool lines_hidden = visible_lines > 0 && visible_lines < lines_rid.size();
+			if (lines_hidden) {
+				overrun_flags |= TextServer::OVERRUN_ENFORCE_ELLIPSIS;
+			}
+			if (align == HALIGN_FILL) {
+				for (int i = 0; i < lines_rid.size(); i++) {
+					if (i < visible_lines - 1 || lines_rid.size() == 1) {
+						TS->shaped_text_fit_to_width(lines_rid[i], width, flags);
+					} else if (i == (visible_lines - 1)) {
+						TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], width, overrun_flags);
+					}
+				}
+
+			} else if (lines_hidden) {
+				TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], width, overrun_flags);
+			}
+
+		} else {
+			// Autowrap disabled.
+			for (int i = 0; i < lines_rid.size(); i++) {
+				if (align == HALIGN_FILL) {
+					TS->shaped_text_fit_to_width(lines_rid[i], width, flags);
+					overrun_flags |= TextServer::OVERRUN_JUSTIFICATION_AWARE;
+					TS->shaped_text_overrun_trim_to_width(lines_rid[i], width, overrun_flags);
+					TS->shaped_text_fit_to_width(lines_rid[i], width, flags | TextServer::JUSTIFICATION_CONSTRAIN_ELLIPSIS);
+				} else {
+					TS->shaped_text_overrun_trim_to_width(lines_rid[i], width, overrun_flags);
+				}
+			}
+		}
+		lines_dirty = false;
 	}
 }
 
@@ -184,8 +254,8 @@ RID TextParagraph::get_rid() const {
 
 RID TextParagraph::get_line_rid(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), RID());
-	return lines[p_line];
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), RID());
+	return lines_rid[p_line];
 }
 
 RID TextParagraph::get_dropcap_rid() const {
@@ -195,10 +265,10 @@ RID TextParagraph::get_dropcap_rid() const {
 void TextParagraph::clear() {
 	spacing_top = 0;
 	spacing_bottom = 0;
-	for (int i = 0; i < lines.size(); i++) {
-		TS->free(lines[i]);
+	for (int i = 0; i < lines_rid.size(); i++) {
+		TS->free(lines_rid[i]);
 	}
-	lines.clear();
+	lines_rid.clear();
 	TS->shaped_text_clear(rid);
 	TS->shaped_text_clear(dropcap_rid);
 }
@@ -206,7 +276,7 @@ void TextParagraph::clear() {
 void TextParagraph::set_preserve_invalid(bool p_enabled) {
 	TS->shaped_text_set_preserve_invalid(rid, p_enabled);
 	TS->shaped_text_set_preserve_invalid(dropcap_rid, p_enabled);
-	dirty_lines = true;
+	lines_dirty = true;
 }
 
 bool TextParagraph::get_preserve_invalid() const {
@@ -216,7 +286,7 @@ bool TextParagraph::get_preserve_invalid() const {
 void TextParagraph::set_preserve_control(bool p_enabled) {
 	TS->shaped_text_set_preserve_control(rid, p_enabled);
 	TS->shaped_text_set_preserve_control(dropcap_rid, p_enabled);
-	dirty_lines = true;
+	lines_dirty = true;
 }
 
 bool TextParagraph::get_preserve_control() const {
@@ -226,7 +296,7 @@ bool TextParagraph::get_preserve_control() const {
 void TextParagraph::set_direction(TextServer::Direction p_direction) {
 	TS->shaped_text_set_direction(rid, p_direction);
 	TS->shaped_text_set_direction(dropcap_rid, p_direction);
-	dirty_lines = true;
+	lines_dirty = true;
 }
 
 TextServer::Direction TextParagraph::get_direction() const {
@@ -237,7 +307,7 @@ TextServer::Direction TextParagraph::get_direction() const {
 void TextParagraph::set_orientation(TextServer::Orientation p_orientation) {
 	TS->shaped_text_set_orientation(rid, p_orientation);
 	TS->shaped_text_set_orientation(dropcap_rid, p_orientation);
-	dirty_lines = true;
+	lines_dirty = true;
 }
 
 TextServer::Orientation TextParagraph::get_orientation() const {
@@ -250,14 +320,14 @@ bool TextParagraph::set_dropcap(const String &p_text, const Ref<Font> &p_fonts, 
 	TS->shaped_text_clear(dropcap_rid);
 	dropcap_margins = p_dropcap_margins;
 	bool res = TS->shaped_text_add_string(dropcap_rid, p_text, p_fonts->get_rids(), p_size, p_opentype_features, p_language);
-	dirty_lines = true;
+	lines_dirty = true;
 	return res;
 }
 
 void TextParagraph::clear_dropcap() {
 	dropcap_margins = Rect2();
 	TS->shaped_text_clear(dropcap_rid);
-	dirty_lines = true;
+	lines_dirty = true;
 }
 
 bool TextParagraph::add_string(const String &p_text, const Ref<Font> &p_fonts, int p_size, const Dictionary &p_opentype_features, const String &p_language) {
@@ -265,7 +335,7 @@ bool TextParagraph::add_string(const String &p_text, const Ref<Font> &p_fonts, i
 	bool res = TS->shaped_text_add_string(rid, p_text, p_fonts->get_rids(), p_size, p_opentype_features, p_language);
 	spacing_top = p_fonts->get_spacing(Font::SPACING_TOP);
 	spacing_bottom = p_fonts->get_spacing(Font::SPACING_BOTTOM);
-	dirty_lines = true;
+	lines_dirty = true;
 	return res;
 }
 
@@ -287,18 +357,18 @@ void TextParagraph::_set_bidi_override(const Array &p_override) {
 
 void TextParagraph::set_bidi_override(const Vector<Vector2i> &p_override) {
 	TS->shaped_text_set_bidi_override(rid, p_override);
-	dirty_lines = true;
+	lines_dirty = true;
 }
 
 bool TextParagraph::add_object(Variant p_key, const Size2 &p_size, VAlign p_inline_align, int p_length) {
 	bool res = TS->shaped_text_add_object(rid, p_key, p_size, p_inline_align, p_length);
-	dirty_lines = true;
+	lines_dirty = true;
 	return res;
 }
 
 bool TextParagraph::resize_object(Variant p_key, const Size2 &p_size, VAlign p_inline_align) {
 	bool res = TS->shaped_text_resize_object(rid, p_key, p_size, p_inline_align);
-	dirty_lines = true;
+	lines_dirty = true;
 	return res;
 }
 
@@ -306,7 +376,7 @@ void TextParagraph::set_align(HAlign p_align) {
 	if (align != p_align) {
 		if (align == HALIGN_FILL || p_align == HALIGN_FILL) {
 			align = p_align;
-			dirty_lines = true;
+			lines_dirty = true;
 		} else {
 			align = p_align;
 		}
@@ -319,13 +389,13 @@ HAlign TextParagraph::get_align() const {
 
 void TextParagraph::tab_align(const Vector<float> &p_tab_stops) {
 	tab_stops = p_tab_stops;
-	dirty_lines = true;
+	lines_dirty = true;
 }
 
 void TextParagraph::set_flags(uint8_t p_flags) {
 	if (flags != p_flags) {
 		flags = p_flags;
-		dirty_lines = true;
+		lines_dirty = true;
 	}
 }
 
@@ -333,10 +403,21 @@ uint8_t TextParagraph::get_flags() const {
 	return flags;
 }
 
+void TextParagraph::set_text_overrun_behavior(TextParagraph::OverrunBehavior p_behavior) {
+	if (overrun_behavior != p_behavior) {
+		overrun_behavior = p_behavior;
+		lines_dirty = true;
+	}
+}
+
+TextParagraph::OverrunBehavior TextParagraph::get_text_overrun_behavior() const {
+	return overrun_behavior;
+}
+
 void TextParagraph::set_width(float p_width) {
 	if (width != p_width) {
 		width = p_width;
-		dirty_lines = true;
+		lines_dirty = true;
 	}
 }
 
@@ -356,9 +437,9 @@ Size2 TextParagraph::get_non_wraped_size() const {
 Size2 TextParagraph::get_size() const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	Size2 size;
-	for (int i = 0; i < lines.size(); i++) {
-		Size2 lsize = TS->shaped_text_get_size(lines[i]);
-		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+	for (int i = 0; i < lines_rid.size(); i++) {
+		Size2 lsize = TS->shaped_text_get_size(lines_rid[i]);
+		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			size.x = MAX(size.x, lsize.x);
 			size.y += lsize.y + spacing_top + spacing_bottom;
 		} else {
@@ -371,22 +452,33 @@ Size2 TextParagraph::get_size() const {
 
 int TextParagraph::get_line_count() const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	return lines.size();
+	return lines_rid.size();
+}
+
+void TextParagraph::set_max_lines_visible(int p_lines) {
+	if (p_lines != max_lines_visible) {
+		max_lines_visible = p_lines;
+		lines_dirty = true;
+	}
+}
+
+int TextParagraph::get_max_lines_visible() const {
+	return max_lines_visible;
 }
 
 Array TextParagraph::get_line_objects(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), Array());
-	return TS->shaped_text_get_objects(lines[p_line]);
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), Array());
+	return TS->shaped_text_get_objects(lines_rid[p_line]);
 }
 
 Rect2 TextParagraph::get_line_object_rect(int p_line, Variant p_key) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), Rect2());
-	Rect2 xrect = TS->shaped_text_get_object_rect(lines[p_line], p_key);
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), Rect2());
+	Rect2 xrect = TS->shaped_text_get_object_rect(lines_rid[p_line], p_key);
 	for (int i = 0; i < p_line; i++) {
-		Size2 lsize = TS->shaped_text_get_size(lines[i]);
-		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+		Size2 lsize = TS->shaped_text_get_size(lines_rid[i]);
+		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			xrect.position.y += lsize.y + spacing_top + spacing_bottom;
 		} else {
 			xrect.position.x += lsize.x + spacing_top + spacing_bottom;
@@ -397,48 +489,48 @@ Rect2 TextParagraph::get_line_object_rect(int p_line, Variant p_key) const {
 
 Size2 TextParagraph::get_line_size(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), Size2());
-	if (TS->shaped_text_get_orientation(lines[p_line]) == TextServer::ORIENTATION_HORIZONTAL) {
-		return Size2(TS->shaped_text_get_size(lines[p_line]).x, TS->shaped_text_get_size(lines[p_line]).y + spacing_top + spacing_bottom);
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), Size2());
+	if (TS->shaped_text_get_orientation(lines_rid[p_line]) == TextServer::ORIENTATION_HORIZONTAL) {
+		return Size2(TS->shaped_text_get_size(lines_rid[p_line]).x, TS->shaped_text_get_size(lines_rid[p_line]).y + spacing_top + spacing_bottom);
 	} else {
-		return Size2(TS->shaped_text_get_size(lines[p_line]).x + spacing_top + spacing_bottom, TS->shaped_text_get_size(lines[p_line]).y);
+		return Size2(TS->shaped_text_get_size(lines_rid[p_line]).x + spacing_top + spacing_bottom, TS->shaped_text_get_size(lines_rid[p_line]).y);
 	}
 }
 
 Vector2i TextParagraph::get_line_range(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), Vector2i());
-	return TS->shaped_text_get_range(lines[p_line]);
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), Vector2i());
+	return TS->shaped_text_get_range(lines_rid[p_line]);
 }
 
 float TextParagraph::get_line_ascent(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), 0.f);
-	return TS->shaped_text_get_ascent(lines[p_line]) + spacing_top;
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), 0.f);
+	return TS->shaped_text_get_ascent(lines_rid[p_line]) + spacing_top;
 }
 
 float TextParagraph::get_line_descent(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), 0.f);
-	return TS->shaped_text_get_descent(lines[p_line]) + spacing_bottom;
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), 0.f);
+	return TS->shaped_text_get_descent(lines_rid[p_line]) + spacing_bottom;
 }
 
 float TextParagraph::get_line_width(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), 0.f);
-	return TS->shaped_text_get_width(lines[p_line]);
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), 0.f);
+	return TS->shaped_text_get_width(lines_rid[p_line]);
 }
 
 float TextParagraph::get_line_underline_position(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), 0.f);
-	return TS->shaped_text_get_underline_position(lines[p_line]);
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), 0.f);
+	return TS->shaped_text_get_underline_position(lines_rid[p_line]);
 }
 
 float TextParagraph::get_line_underline_thickness(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines.size(), 0.f);
-	return TS->shaped_text_get_underline_thickness(lines[p_line]);
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= lines_rid.size(), 0.f);
+	return TS->shaped_text_get_underline_thickness(lines_rid[p_line]);
 }
 
 Size2 TextParagraph::get_dropcap_size() const {
@@ -472,11 +564,13 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 		TS->shaped_text_draw(dropcap_rid, p_canvas, dc_off + Vector2(0, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.size.y + dropcap_margins.position.y / 2), -1, -1, p_dc_color);
 	}
 
-	for (int i = 0; i < lines.size(); i++) {
+	int lines_visible = (max_lines_visible >= 0) ? MIN(max_lines_visible, lines_rid.size()) : lines_rid.size();
+
+	for (int i = 0; i < lines_visible; i++) {
 		float l_width = width;
-		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			ofs.x = p_pos.x;
-			ofs.y += TS->shaped_text_get_ascent(lines[i]) + spacing_top;
+			ofs.y += TS->shaped_text_get_ascent(lines_rid[i]) + spacing_top;
 			if (i <= dropcap_lines) {
 				if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
 					ofs.x -= h_offset;
@@ -485,7 +579,7 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 			}
 		} else {
 			ofs.y = p_pos.y;
-			ofs.x += TS->shaped_text_get_ascent(lines[i]) + spacing_top;
+			ofs.x += TS->shaped_text_get_ascent(lines_rid[i]) + spacing_top;
 			if (i <= dropcap_lines) {
 				if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
 					ofs.x -= h_offset;
@@ -493,21 +587,29 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 				l_width -= h_offset;
 			}
 		}
-		float length = TS->shaped_text_get_width(lines[i]);
+		float length = TS->shaped_text_get_width(lines_rid[i]);
 		if (width > 0) {
 			switch (align) {
 				case HALIGN_FILL:
+					if (TS->shaped_text_get_direction(lines_rid[i]) == TextServer::DIRECTION_RTL) {
+						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+							ofs.x += l_width - length;
+						} else {
+							ofs.y += l_width - length;
+						}
+					}
+					break;
 				case HALIGN_LEFT:
 					break;
 				case HALIGN_CENTER: {
-					if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+					if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 						ofs.x += Math::floor((l_width - length) / 2.0);
 					} else {
 						ofs.y += Math::floor((l_width - length) / 2.0);
 					}
 				} break;
 				case HALIGN_RIGHT: {
-					if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+					if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 						ofs.x += l_width - length;
 					} else {
 						ofs.y += l_width - length;
@@ -516,18 +618,18 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 			}
 		}
 		float clip_l;
-		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			clip_l = MAX(0, p_pos.x - ofs.x);
 		} else {
 			clip_l = MAX(0, p_pos.y - ofs.y);
 		}
-		TS->shaped_text_draw(lines[i], p_canvas, ofs, clip_l, clip_l + l_width, p_color);
-		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+		TS->shaped_text_draw(lines_rid[i], p_canvas, ofs, clip_l, clip_l + l_width, p_color);
+		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			ofs.x = p_pos.x;
-			ofs.y += TS->shaped_text_get_descent(lines[i]) + spacing_bottom;
+			ofs.y += TS->shaped_text_get_descent(lines_rid[i]) + spacing_bottom;
 		} else {
 			ofs.y = p_pos.y;
-			ofs.x += TS->shaped_text_get_descent(lines[i]) + spacing_bottom;
+			ofs.x += TS->shaped_text_get_descent(lines_rid[i]) + spacing_bottom;
 		}
 	}
 }
@@ -556,11 +658,11 @@ void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outli
 		TS->shaped_text_draw_outline(dropcap_rid, p_canvas, dc_off + Vector2(dropcap_margins.position.x, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.position.y), -1, -1, p_outline_size, p_dc_color);
 	}
 
-	for (int i = 0; i < lines.size(); i++) {
+	for (int i = 0; i < lines_rid.size(); i++) {
 		float l_width = width;
-		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			ofs.x = p_pos.x;
-			ofs.y += TS->shaped_text_get_ascent(lines[i]) + spacing_top;
+			ofs.y += TS->shaped_text_get_ascent(lines_rid[i]) + spacing_top;
 			if (i <= dropcap_lines) {
 				if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
 					ofs.x -= h_offset;
@@ -569,7 +671,7 @@ void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outli
 			}
 		} else {
 			ofs.y = p_pos.y;
-			ofs.x += TS->shaped_text_get_ascent(lines[i]) + spacing_top;
+			ofs.x += TS->shaped_text_get_ascent(lines_rid[i]) + spacing_top;
 			if (i <= dropcap_lines) {
 				if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
 					ofs.x -= h_offset;
@@ -577,21 +679,29 @@ void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outli
 				l_width -= h_offset;
 			}
 		}
-		float length = TS->shaped_text_get_width(lines[i]);
+		float length = TS->shaped_text_get_width(lines_rid[i]);
 		if (width > 0) {
 			switch (align) {
 				case HALIGN_FILL:
+					if (TS->shaped_text_get_direction(lines_rid[i]) == TextServer::DIRECTION_RTL) {
+						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+							ofs.x += l_width - length;
+						} else {
+							ofs.y += l_width - length;
+						}
+					}
+					break;
 				case HALIGN_LEFT:
 					break;
 				case HALIGN_CENTER: {
-					if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+					if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 						ofs.x += Math::floor((l_width - length) / 2.0);
 					} else {
 						ofs.y += Math::floor((l_width - length) / 2.0);
 					}
 				} break;
 				case HALIGN_RIGHT: {
-					if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+					if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 						ofs.x += l_width - length;
 					} else {
 						ofs.y += l_width - length;
@@ -600,18 +710,18 @@ void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outli
 			}
 		}
 		float clip_l;
-		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			clip_l = MAX(0, p_pos.x - ofs.x);
 		} else {
 			clip_l = MAX(0, p_pos.y - ofs.y);
 		}
-		TS->shaped_text_draw_outline(lines[i], p_canvas, ofs, clip_l, clip_l + l_width, p_outline_size, p_color);
-		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+		TS->shaped_text_draw_outline(lines_rid[i], p_canvas, ofs, clip_l, clip_l + l_width, p_outline_size, p_color);
+		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			ofs.x = p_pos.x;
-			ofs.y += TS->shaped_text_get_descent(lines[i]) + spacing_bottom;
+			ofs.y += TS->shaped_text_get_descent(lines_rid[i]) + spacing_bottom;
 		} else {
 			ofs.y = p_pos.y;
-			ofs.x += TS->shaped_text_get_descent(lines[i]) + spacing_bottom;
+			ofs.x += TS->shaped_text_get_descent(lines_rid[i]) + spacing_bottom;
 		}
 	}
 }
@@ -628,17 +738,17 @@ int TextParagraph::hit_test(const Point2 &p_coords) const {
 			return 0;
 		}
 	}
-	for (int i = 0; i < lines.size(); i++) {
-		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-			if ((p_coords.y >= ofs.y) && (p_coords.y <= ofs.y + TS->shaped_text_get_size(lines[i]).y)) {
-				return TS->shaped_text_hit_test_position(lines[i], p_coords.x);
+	for (int i = 0; i < lines_rid.size(); i++) {
+		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+			if ((p_coords.y >= ofs.y) && (p_coords.y <= ofs.y + TS->shaped_text_get_size(lines_rid[i]).y)) {
+				return TS->shaped_text_hit_test_position(lines_rid[i], p_coords.x);
 			}
-			ofs.y += TS->shaped_text_get_size(lines[i]).y + spacing_bottom + spacing_top;
+			ofs.y += TS->shaped_text_get_size(lines_rid[i]).y + spacing_bottom + spacing_top;
 		} else {
-			if ((p_coords.x >= ofs.x) && (p_coords.x <= ofs.x + TS->shaped_text_get_size(lines[i]).x)) {
-				return TS->shaped_text_hit_test_position(lines[i], p_coords.y);
+			if ((p_coords.x >= ofs.x) && (p_coords.x <= ofs.x + TS->shaped_text_get_size(lines_rid[i]).x)) {
+				return TS->shaped_text_hit_test_position(lines_rid[i], p_coords.y);
 			}
-			ofs.y += TS->shaped_text_get_size(lines[i]).x + spacing_bottom + spacing_top;
+			ofs.y += TS->shaped_text_get_size(lines_rid[i]).x + spacing_bottom + spacing_top;
 		}
 	}
 	return TS->shaped_text_get_range(rid).y;
@@ -690,29 +800,29 @@ void TextParagraph::draw_dropcap_outline(RID p_canvas, const Vector2 &p_pos, int
 
 void TextParagraph::draw_line(RID p_canvas, const Vector2 &p_pos, int p_line, const Color &p_color) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND(p_line < 0 || p_line >= lines.size());
+	ERR_FAIL_COND(p_line < 0 || p_line >= lines_rid.size());
 
 	Vector2 ofs = p_pos;
 
-	if (TS->shaped_text_get_orientation(lines[p_line]) == TextServer::ORIENTATION_HORIZONTAL) {
-		ofs.y += TS->shaped_text_get_ascent(lines[p_line]) + spacing_top;
+	if (TS->shaped_text_get_orientation(lines_rid[p_line]) == TextServer::ORIENTATION_HORIZONTAL) {
+		ofs.y += TS->shaped_text_get_ascent(lines_rid[p_line]) + spacing_top;
 	} else {
-		ofs.x += TS->shaped_text_get_ascent(lines[p_line]) + spacing_top;
+		ofs.x += TS->shaped_text_get_ascent(lines_rid[p_line]) + spacing_top;
 	}
-	return TS->shaped_text_draw(lines[p_line], p_canvas, ofs, -1, -1, p_color);
+	return TS->shaped_text_draw(lines_rid[p_line], p_canvas, ofs, -1, -1, p_color);
 }
 
 void TextParagraph::draw_line_outline(RID p_canvas, const Vector2 &p_pos, int p_line, int p_outline_size, const Color &p_color) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	ERR_FAIL_COND(p_line < 0 || p_line >= lines.size());
+	ERR_FAIL_COND(p_line < 0 || p_line >= lines_rid.size());
 
 	Vector2 ofs = p_pos;
-	if (TS->shaped_text_get_orientation(lines[p_line]) == TextServer::ORIENTATION_HORIZONTAL) {
-		ofs.y += TS->shaped_text_get_ascent(lines[p_line]) + spacing_top;
+	if (TS->shaped_text_get_orientation(lines_rid[p_line]) == TextServer::ORIENTATION_HORIZONTAL) {
+		ofs.y += TS->shaped_text_get_ascent(lines_rid[p_line]) + spacing_top;
 	} else {
-		ofs.x += TS->shaped_text_get_ascent(lines[p_line]) + spacing_top;
+		ofs.x += TS->shaped_text_get_ascent(lines_rid[p_line]) + spacing_top;
 	}
-	return TS->shaped_text_draw_outline(lines[p_line], p_canvas, ofs, -1, -1, p_outline_size, p_color);
+	return TS->shaped_text_draw_outline(lines_rid[p_line], p_canvas, ofs, -1, -1, p_outline_size, p_color);
 }
 
 TextParagraph::TextParagraph(const String &p_text, const Ref<Font> &p_fonts, int p_size, const Dictionary &p_opentype_features, const String &p_language, float p_width, TextServer::Direction p_direction, TextServer::Orientation p_orientation) {
@@ -729,10 +839,10 @@ TextParagraph::TextParagraph() {
 }
 
 TextParagraph::~TextParagraph() {
-	for (int i = 0; i < lines.size(); i++) {
-		TS->free(lines[i]);
+	for (int i = 0; i < lines_rid.size(); i++) {
+		TS->free(lines_rid[i]);
 	}
-	lines.clear();
+	lines_rid.clear();
 	TS->free(rid);
 	TS->free(dropcap_rid);
 }

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -39,19 +39,33 @@
 class TextParagraph : public RefCounted {
 	GDCLASS(TextParagraph, RefCounted);
 
+public:
+	enum OverrunBehavior {
+		OVERRUN_NO_TRIMMING,
+		OVERRUN_TRIM_CHAR,
+		OVERRUN_TRIM_WORD,
+		OVERRUN_TRIM_ELLIPSIS,
+		OVERRUN_TRIM_WORD_ELLIPSIS,
+	};
+
+private:
 	RID dropcap_rid;
 	int dropcap_lines = 0;
 	Rect2 dropcap_margins;
 
 	RID rid;
-	Vector<RID> lines;
+	Vector<RID> lines_rid;
 	int spacing_top = 0;
 	int spacing_bottom = 0;
 
-	bool dirty_lines = true;
+	bool lines_dirty = true;
 
 	float width = -1.0;
+	int max_lines_visible = -1;
+
 	uint8_t flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND | TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA;
+	OverrunBehavior overrun_behavior = OVERRUN_NO_TRIMMING;
+
 	HAlign align = HALIGN_LEFT;
 
 	Vector<float> tab_stops;
@@ -97,8 +111,14 @@ public:
 	void set_flags(uint8_t p_flags);
 	uint8_t get_flags() const;
 
+	void set_text_overrun_behavior(OverrunBehavior p_behavior);
+	OverrunBehavior get_text_overrun_behavior() const;
+
 	void set_width(float p_width);
 	float get_width() const;
+
+	void set_max_lines_visible(int p_lines);
+	int get_max_lines_visible() const;
 
 	Size2 get_non_wraped_size() const;
 
@@ -139,5 +159,7 @@ public:
 	TextParagraph();
 	~TextParagraph();
 };
+
+VARIANT_ENUM_CAST(TextParagraph::OverrunBehavior);
 
 #endif // TEXT_PARAGRAPH_H

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -739,6 +739,11 @@ Vector<Vector2i> TextServer::shaped_text_get_word_breaks(RID p_shaped, int p_gra
 	return words;
 }
 
+TextServer::TrimData TextServer::shaped_text_get_trim_data(RID p_shaped) const {
+	WARN_PRINT("Getting overrun data not supported by this TextServer.");
+	return TrimData();
+}
+
 void TextServer::shaped_text_get_carets(RID p_shaped, int p_position, Rect2 &p_leading_caret, Direction &p_leading_dir, Rect2 &p_trailing_caret, Direction &p_trailing_dir) const {
 	Vector<Rect2> carets;
 	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
@@ -976,7 +981,7 @@ Vector<Vector2> TextServer::shaped_text_get_selection(RID p_shaped, int p_start,
 							ranges.push_back(Vector2(off + char_adv * (glyphs[i].end - start), off + advance));
 						}
 					}
-					// Selection range is within grapheme
+					// Selection range is within grapheme.
 					if (glyphs[i].start < start && glyphs[i].end > end) {
 						float advance = 0.f;
 						for (int j = 0; j < glyphs[i].count; j++) {
@@ -1137,10 +1142,26 @@ void TextServer::shaped_text_draw(RID p_shaped, RID p_canvas, const Vector2 &p_p
 	TextServer::Orientation orientation = shaped_text_get_orientation(p_shaped);
 	bool hex_codes = shaped_text_get_preserve_control(p_shaped) || shaped_text_get_preserve_invalid(p_shaped);
 
+	bool rtl = shaped_text_get_direction(p_shaped) == DIRECTION_RTL;
+	TrimData trim_data = shaped_text_get_trim_data(p_shaped);
+
 	int v_size = visual.size();
 	const Glyph *glyphs = visual.ptr();
 
 	Vector2 ofs = p_pos;
+	// Draw RTL ellipsis string when needed.
+	if (rtl && trim_data.ellipsis_pos >= 0) {
+		for (int i = trim_data.ellipsis_glyph_buf.size() - 1; i >= 0; i--) {
+			for (int j = 0; j < trim_data.ellipsis_glyph_buf[i].repeat; j++) {
+				font_draw_glyph(trim_data.ellipsis_glyph_buf[i].font_rid, p_canvas, trim_data.ellipsis_glyph_buf[i].font_size, ofs + Vector2(trim_data.ellipsis_glyph_buf[i].x_off, trim_data.ellipsis_glyph_buf[i].y_off), trim_data.ellipsis_glyph_buf[i].index, p_color);
+				if (orientation == ORIENTATION_HORIZONTAL) {
+					ofs.x += trim_data.ellipsis_glyph_buf[i].advance;
+				} else {
+					ofs.y += trim_data.ellipsis_glyph_buf[i].advance;
+				}
+			}
+		}
+	}
 	// Draw at the baseline.
 	for (int i = 0; i < v_size; i++) {
 		for (int j = 0; j < glyphs[i].repeat; j++) {
@@ -1170,6 +1191,18 @@ void TextServer::shaped_text_draw(RID p_shaped, RID p_canvas, const Vector2 &p_p
 					}
 				}
 			}
+			if (trim_data.trim_pos >= 0) {
+				if (rtl) {
+					if (i < trim_data.trim_pos && (glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
+						continue;
+					}
+				} else {
+					if (i >= trim_data.trim_pos && (glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
+						break;
+					}
+				}
+			}
+
 			if (glyphs[i].font_rid != RID()) {
 				font_draw_glyph(glyphs[i].font_rid, p_canvas, glyphs[i].font_size, ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, p_color);
 			} else if (hex_codes && ((glyphs[i].flags & GRAPHEME_IS_VIRTUAL) != GRAPHEME_IS_VIRTUAL)) {
@@ -1182,15 +1215,44 @@ void TextServer::shaped_text_draw(RID p_shaped, RID p_canvas, const Vector2 &p_p
 			}
 		}
 	}
+	// Draw LTR ellipsis string when needed.
+	if (!rtl && trim_data.ellipsis_pos >= 0) {
+		for (int i = 0; i < trim_data.ellipsis_glyph_buf.size(); i++) {
+			for (int j = 0; j < trim_data.ellipsis_glyph_buf[i].repeat; j++) {
+				font_draw_glyph(trim_data.ellipsis_glyph_buf[i].font_rid, p_canvas, trim_data.ellipsis_glyph_buf[i].font_size, ofs + Vector2(trim_data.ellipsis_glyph_buf[i].x_off, trim_data.ellipsis_glyph_buf[i].y_off), trim_data.ellipsis_glyph_buf[i].index, p_color);
+				if (orientation == ORIENTATION_HORIZONTAL) {
+					ofs.x += trim_data.ellipsis_glyph_buf[i].advance;
+				} else {
+					ofs.y += trim_data.ellipsis_glyph_buf[i].advance;
+				}
+			}
+		}
+	}
 }
 
 void TextServer::shaped_text_draw_outline(RID p_shaped, RID p_canvas, const Vector2 &p_pos, float p_clip_l, float p_clip_r, int p_outline_size, const Color &p_color) const {
 	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
 	TextServer::Orientation orientation = shaped_text_get_orientation(p_shaped);
 
+	bool rtl = (shaped_text_get_direction(p_shaped) == DIRECTION_RTL);
+	TrimData trim_data = shaped_text_get_trim_data(p_shaped);
+
 	int v_size = visual.size();
 	const Glyph *glyphs = visual.ptr();
 	Vector2 ofs = p_pos;
+	// Draw RTL ellipsis string when needed.
+	if (rtl && trim_data.ellipsis_pos >= 0) {
+		for (int i = trim_data.ellipsis_glyph_buf.size() - 1; i >= 0; i--) {
+			for (int j = 0; j < trim_data.ellipsis_glyph_buf[i].repeat; j++) {
+				font_draw_glyph(trim_data.ellipsis_glyph_buf[i].font_rid, p_canvas, trim_data.ellipsis_glyph_buf[i].font_size, ofs + Vector2(trim_data.ellipsis_glyph_buf[i].x_off, trim_data.ellipsis_glyph_buf[i].y_off), trim_data.ellipsis_glyph_buf[i].index, p_color);
+				if (orientation == ORIENTATION_HORIZONTAL) {
+					ofs.x += trim_data.ellipsis_glyph_buf[i].advance;
+				} else {
+					ofs.y += trim_data.ellipsis_glyph_buf[i].advance;
+				}
+			}
+		}
+	}
 	// Draw at the baseline.
 	for (int i = 0; i < v_size; i++) {
 		for (int j = 0; j < glyphs[i].repeat; j++) {
@@ -1220,6 +1282,17 @@ void TextServer::shaped_text_draw_outline(RID p_shaped, RID p_canvas, const Vect
 					}
 				}
 			}
+			if (trim_data.trim_pos >= 0) {
+				if (rtl) {
+					if (i < trim_data.trim_pos) {
+						continue;
+					}
+				} else {
+					if (i >= trim_data.trim_pos && (glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
+						break;
+					}
+				}
+			}
 			if (glyphs[i].font_rid != RID()) {
 				font_draw_glyph_outline(glyphs[i].font_rid, p_canvas, glyphs[i].font_size, p_outline_size, ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, p_color);
 			}
@@ -1227,6 +1300,19 @@ void TextServer::shaped_text_draw_outline(RID p_shaped, RID p_canvas, const Vect
 				ofs.x += glyphs[i].advance;
 			} else {
 				ofs.y += glyphs[i].advance;
+			}
+		}
+	}
+	// Draw LTR ellipsis string when needed.
+	if (!rtl && trim_data.ellipsis_pos >= 0) {
+		for (int i = 0; i < trim_data.ellipsis_glyph_buf.size(); i++) {
+			for (int j = 0; j < trim_data.ellipsis_glyph_buf[i].repeat; j++) {
+				font_draw_glyph(trim_data.ellipsis_glyph_buf[i].font_rid, p_canvas, trim_data.ellipsis_glyph_buf[i].font_size, ofs + Vector2(trim_data.ellipsis_glyph_buf[i].x_off, trim_data.ellipsis_glyph_buf[i].y_off), trim_data.ellipsis_glyph_buf[i].index, p_color);
+				if (orientation == ORIENTATION_HORIZONTAL) {
+					ofs.x += trim_data.ellipsis_glyph_buf[i].advance;
+				} else {
+					ofs.y += trim_data.ellipsis_glyph_buf[i].advance;
+				}
 			}
 		}
 	}

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -59,7 +59,8 @@ public:
 		JUSTIFICATION_KASHIDA = 1 << 0,
 		JUSTIFICATION_WORD_BOUND = 1 << 1,
 		JUSTIFICATION_TRIM_EDGE_SPACES = 1 << 2,
-		JUSTIFICATION_AFTER_LAST_TAB = 1 << 3
+		JUSTIFICATION_AFTER_LAST_TAB = 1 << 3,
+		JUSTIFICATION_CONSTRAIN_ELLIPSIS = 1 << 4,
 	};
 
 	enum LineBreakFlag {
@@ -67,7 +68,7 @@ public:
 		BREAK_MANDATORY = 1 << 4,
 		BREAK_WORD_BOUND = 1 << 5,
 		BREAK_GRAPHEME_BOUND = 1 << 6,
-		BREAK_WORD_BOUND_ADAPTIVE = 1 << 5 | 1 << 7
+		BREAK_WORD_BOUND_ADAPTIVE = 1 << 5 | 1 << 7,
 	};
 
 	enum TextOverrunFlag {
@@ -75,7 +76,8 @@ public:
 		OVERRUN_TRIM = 1 << 0,
 		OVERRUN_TRIM_WORD_ONLY = 1 << 1,
 		OVERRUN_ADD_ELLIPSIS = 1 << 2,
-		OVERRUN_ENFORCE_ELLIPSIS = 1 << 3
+		OVERRUN_ENFORCE_ELLIPSIS = 1 << 3,
+		OVERRUN_JUSTIFICATION_AWARE = 1 << 4,
 	};
 
 	enum GraphemeFlag {
@@ -154,6 +156,12 @@ public:
 		}
 	};
 
+	struct TrimData {
+		int trim_pos = -1;
+		int ellipsis_pos = -1;
+		Vector<TextServer::Glyph> ellipsis_glyph_buf;
+	};
+
 	struct ShapedTextData {
 		/* Source data */
 		RID parent; // Substring parent ShapedTextData.
@@ -192,6 +200,7 @@ public:
 		bool line_breaks_valid = false; // Line and word break flags are populated (and virtual zero width spaces inserted).
 		bool justification_ops_valid = false; // Virtual elongation glyphs are added to the string.
 		bool sort_valid = false;
+		bool text_trimmed = false;
 
 		bool preserve_invalid = true; // Draw hex code box instead of missing characters.
 		bool preserve_control = false; // Draw control characters.
@@ -199,9 +208,13 @@ public:
 		float ascent = 0.f; // Ascent for horizontal layout, 1/2 of width for vertical.
 		float descent = 0.f; // Descent for horizontal layout, 1/2 of width for vertical.
 		float width = 0.f; // Width for horizontal layout, height for vertical.
+		float width_trimmed = 0.f;
 
 		float upos = 0.f;
 		float uthk = 0.f;
+
+		TrimData overrun_trim_data;
+		bool fit_width_minimum_reached = false;
 
 		Vector<TextServer::Glyph> glyphs;
 		Vector<TextServer::Glyph> glyphs_logical;
@@ -357,7 +370,8 @@ public:
 	virtual Vector<Vector2i> shaped_text_get_line_breaks(RID p_shaped, float p_width, int p_start = 0, uint8_t /*TextBreakFlag*/ p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const;
 	virtual Vector<Vector2i> shaped_text_get_word_breaks(RID p_shaped, int p_grapheme_flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION) const;
 
-	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint8_t p_clip_flags) = 0;
+	virtual TrimData shaped_text_get_trim_data(RID p_shaped) const;
+	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint8_t p_trim_flags) = 0;
 	virtual Array shaped_text_get_objects(RID p_shaped) const = 0;
 	virtual Rect2 shaped_text_get_object_rect(RID p_shaped, Variant p_key) const = 0;
 


### PR DESCRIPTION
This PR aims to improve the text layout capabilities of the Label control, TextLine and TextParagraph as well as improve performance of text overrun trimming introduced with #50086. Implements godotengine/godot-proposals#2916 for TextLine and TextParagraph.

![main](https://user-images.githubusercontent.com/50084500/127862955-c39036d9-84b8-4510-be51-2216d55a90ef.gif)
*Correction: The texts of the TextParagraph/TextLine part is not representative of the align mode used.
Changes:
-	Text overrun trimming is now supported by the TextLine and TextParagraph resources
-	TextParagraph has now a max_lines_visible property, which can be useful for areas like in the EditorFileDialog(ItemList)
-	More accurate and smoother justification (most noticeable with RTL text) / fixed trimming:
CURRENT MASTER:
![label_just_old](https://user-images.githubusercontent.com/50084500/127859566-426202ac-3752-4083-b7cc-5ca5a1bb1c50.gif)
THIS PR:
![label_just_new](https://user-images.githubusercontent.com/50084500/127859965-d96e9bdf-b470-4555-837b-01011fd2bef5.gif)
-	Overrun text trimming is much faster now (trim position and ellipsis glyph buffer is calculated/created during the layout phase, actual trimming is performed during drawing). This way, the glyphs vector of ShapedTextData is no longer modified, so that `shaped_text_fit_to_width` and `shaped_text_trim_to_width` can be called subsequently without the need of calling `shaped_text_add_string/shaped_text_substring`
DEMO PROJECT (continuous resizing, 120 FPS before, now 340 FPS):
![labels_demo](https://user-images.githubusercontent.com/50084500/127861443-bb402a1b-778c-4e99-b1d0-19846c5486e5.gif)

-	Changed ALIGN_FILL behavior (when autowrap is enabled the last line is not fit to width of the bounding rectangle, which prevents weird looking, very long spaces and Kashidas; behavior matches other software): 
CURRENT MASTER:
![grafik](https://user-images.githubusercontent.com/50084500/127860420-679d297a-27de-4668-b792-5081e2c80f50.png) ![grafik](https://user-images.githubusercontent.com/50084500/127860710-a540571b-39f2-419b-b5c3-eb96ab946e6b.png)
THIS PR:
![grafik](https://user-images.githubusercontent.com/50084500/127860457-f1ec4722-65fb-4afa-a1ca-0162210d83ce.png) ![grafik](https://user-images.githubusercontent.com/50084500/127860815-2ad1bc31-d5f6-4e2f-a163-6d9a11da7994.png)

-	Fixed various small edge cases where text overrun trimming broke (there may be still some left:))
-	Renamed some of the variables in Label and TextParagraph to be more consistent and descriptive

Testing and feedback about these changes is always appreciated, concerning their behavior and implementation. 
As an alternative implementation of the text overrun trimming at draw-time I restructured the Label class to use the shaped_text_draw/shaped_text_draw_outline functions instead of the custom drawing logic to reduce and centralize the code, but in order to bring clipping by visible_chars/percent_visible to work, some hacky solutions were needed. This lead me to the decision to just add the necessary logic to the existing drawing code, as I didn’t want to add more parameters to the shaped_text_draw… functions. Or do you think that would be better?
Label, TextLine and TextParagraph currently have their own OverrunBehavior enum, which could be centralized by moving the enum to math_defs.h where HAlign and VAlign are located, but as it isn't really math related I left it there for now.
