### PR TITLE
Implement external texture support for XR plugins that require render…

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -547,6 +547,21 @@
 			<description>
 			</description>
 		</method>
+		<method name="texture_create_from_extension">
+			<return type="RID" />
+			<argument index="0" name="type" type="int" enum="RenderingDevice.TextureType" />
+			<argument index="1" name="format" type="int" enum="RenderingDevice.DataFormat" />
+			<argument index="2" name="samples" type="int" enum="RenderingDevice.TextureSamples" />
+			<argument index="3" name="flags" type="int" />
+			<argument index="4" name="image" type="int" />
+			<argument index="5" name="width" type="int" />
+			<argument index="6" name="height" type="int" />
+			<argument index="7" name="depth" type="int" />
+			<argument index="8" name="layers" type="int" />
+			<description>
+				Create a texture object based an image handle already created within an GDNative extension.
+			</description>
+		</method>
 		<method name="texture_create_shared">
 			<return type="RID" />
 			<argument index="0" name="view" type="RDTextureView" />

--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -36,6 +36,16 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_external_color_texture" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_external_depth_texture" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_name" qualifiers="virtual const">
 			<return type="StringName" />
 			<description>

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1256,10 +1256,11 @@ public:
 	void _set_current_render_target(RID p_render_target);
 
 	RID render_target_create() override;
+	void render_target_update(RID p_render_target) override;
 	void render_target_set_position(RID p_render_target, int p_x, int p_y) override;
 	void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) override;
 	RID render_target_get_texture(RID p_render_target) override;
-	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) override;
+	void render_target_set_external_textures(RID p_render_target, RID p_color, RID p_depth) override;
 
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) override;
 	bool render_target_was_used(RID p_render_target) override;

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -2170,6 +2170,124 @@ RID RenderingDeviceVulkan::texture_create_shared(const TextureView &p_view, RID 
 	return id;
 }
 
+RID RenderingDeviceVulkan::texture_create_from_extension(TextureType p_type, DataFormat p_format, TextureSamples p_samples, uint64_t p_flags, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers) {
+	_THREAD_SAFE_METHOD_
+
+	// This method creates a texture object using a VkImage created by an extension.
+	VkImage image = (VkImage)p_image;
+
+	Texture texture;
+	texture.image = image;
+	// if we leave texture.allocation as a nullptr, would that be enough to detect we don't "own" the image?
+	// also leave texture.allocation_info alone
+	// we'll set texture.view later on
+	texture.type = p_type;
+	texture.format = p_format;
+	texture.samples = p_samples;
+	texture.width = p_width;
+	texture.height = p_height;
+	texture.depth = p_depth;
+	texture.layers = p_layers;
+	texture.mipmaps = 0; // maybe make this settable too?
+	texture.usage_flags = p_flags;
+	texture.base_mipmap = 0;
+	texture.base_layer = 0;
+	texture.allowed_shared_formats.push_back(RD::DATA_FORMAT_R8G8B8A8_UNORM);
+	texture.allowed_shared_formats.push_back(RD::DATA_FORMAT_R8G8B8A8_SRGB);
+
+	// Do we need to do something with texture.layout ?
+
+	if (texture.usage_flags & TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+		texture.read_aspect_mask = VK_IMAGE_ASPECT_DEPTH_BIT;
+		texture.barrier_aspect_mask = VK_IMAGE_ASPECT_DEPTH_BIT;
+
+		// if (format_has_stencil(p_format.format)) {
+		// 	texture.barrier_aspect_mask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+		// }
+	} else {
+		texture.read_aspect_mask = VK_IMAGE_ASPECT_COLOR_BIT;
+		texture.barrier_aspect_mask = VK_IMAGE_ASPECT_COLOR_BIT;
+	}
+
+	// Create a view for us to use
+	VkImageViewCreateInfo image_view_create_info;
+	image_view_create_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+	image_view_create_info.pNext = nullptr;
+	image_view_create_info.flags = 0;
+	image_view_create_info.image = texture.image;
+
+	static const VkImageViewType view_types[TEXTURE_TYPE_MAX] = {
+		VK_IMAGE_VIEW_TYPE_1D,
+		VK_IMAGE_VIEW_TYPE_2D,
+		VK_IMAGE_VIEW_TYPE_3D,
+		VK_IMAGE_VIEW_TYPE_CUBE,
+		VK_IMAGE_VIEW_TYPE_1D_ARRAY,
+		VK_IMAGE_VIEW_TYPE_2D_ARRAY,
+		VK_IMAGE_VIEW_TYPE_CUBE_ARRAY,
+	};
+
+	image_view_create_info.viewType = view_types[texture.type];
+	image_view_create_info.format = vulkan_formats[texture.format];
+
+	static const VkComponentSwizzle component_swizzles[TEXTURE_SWIZZLE_MAX] = {
+		VK_COMPONENT_SWIZZLE_IDENTITY,
+		VK_COMPONENT_SWIZZLE_ZERO,
+		VK_COMPONENT_SWIZZLE_ONE,
+		VK_COMPONENT_SWIZZLE_R,
+		VK_COMPONENT_SWIZZLE_G,
+		VK_COMPONENT_SWIZZLE_B,
+		VK_COMPONENT_SWIZZLE_A
+	};
+
+	// hardcode for now, maybe make this settable from outside..
+	image_view_create_info.components.r = component_swizzles[TEXTURE_SWIZZLE_R];
+	image_view_create_info.components.g = component_swizzles[TEXTURE_SWIZZLE_G];
+	image_view_create_info.components.b = component_swizzles[TEXTURE_SWIZZLE_B];
+	image_view_create_info.components.a = component_swizzles[TEXTURE_SWIZZLE_A];
+
+	image_view_create_info.subresourceRange.baseMipLevel = 0;
+	image_view_create_info.subresourceRange.levelCount = texture.mipmaps;
+	image_view_create_info.subresourceRange.baseArrayLayer = 0;
+	image_view_create_info.subresourceRange.layerCount = texture.layers;
+	if (texture.usage_flags & TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+		image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+	} else {
+		image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	}
+
+	VkResult err = vkCreateImageView(device, &image_view_create_info, nullptr, &texture.view);
+
+	if (err) {
+		// vmaDestroyImage(allocator, texture.image, texture.allocation);
+		ERR_FAIL_V_MSG(RID(), "vkCreateImageView failed with error " + itos(err) + ".");
+	}
+
+	//barrier to set layout
+	{
+		VkImageMemoryBarrier image_memory_barrier;
+		image_memory_barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+		image_memory_barrier.pNext = nullptr;
+		image_memory_barrier.srcAccessMask = 0;
+		image_memory_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		image_memory_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+		image_memory_barrier.newLayout = texture.layout;
+		image_memory_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		image_memory_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		image_memory_barrier.image = texture.image;
+		image_memory_barrier.subresourceRange.aspectMask = texture.barrier_aspect_mask;
+		image_memory_barrier.subresourceRange.baseMipLevel = 0;
+		image_memory_barrier.subresourceRange.levelCount = texture.mipmaps;
+		image_memory_barrier.subresourceRange.baseArrayLayer = 0;
+		image_memory_barrier.subresourceRange.layerCount = texture.layers;
+
+		vkCmdPipelineBarrier(frames[frame].setup_command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &image_memory_barrier);
+	}
+
+	RID id = texture_owner.make_rid(texture);
+
+	return id;
+}
+
 RID RenderingDeviceVulkan::texture_create_shared_from_slice(const TextureView &p_view, RID p_with_texture, uint32_t p_layer, uint32_t p_mipmap, uint32_t p_mipmaps, TextureSliceType p_slice_type) {
 	_THREAD_SAFE_METHOD_
 
@@ -8720,7 +8838,7 @@ void RenderingDeviceVulkan::_free_pending_resources(int p_frame) {
 			WARN_PRINT("Deleted a texture while it was bound..");
 		}
 		vkDestroyImageView(device, texture->view, nullptr);
-		if (texture->owner.is_null()) {
+		if (texture->owner.is_null() && texture->allocation != nullptr) {
 			//actually owns the image and the allocation too
 			image_memory -= texture->allocation_info.size;
 			vmaDestroyImage(allocator, texture->image, texture->allocation);

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1036,6 +1036,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 public:
 	virtual RID texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t>> &p_data = Vector<Vector<uint8_t>>());
 	virtual RID texture_create_shared(const TextureView &p_view, RID p_with_texture);
+	virtual RID texture_create_from_extension(TextureType p_type, DataFormat p_format, TextureSamples p_samples, uint64_t p_flags, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers);
 
 	virtual RID texture_create_shared_from_slice(const TextureView &p_view, RID p_with_texture, uint32_t p_layer, uint32_t p_mipmap, uint32_t p_mipmaps = 1, TextureSliceType p_slice_type = TEXTURE_SLICE_2D);
 	virtual Error texture_update(RID p_texture, uint32_t p_layer, const Vector<uint8_t> &p_data, uint32_t p_post_barrier = BARRIER_MASK_ALL);

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -339,6 +339,7 @@ Error VulkanContext::_initialize_extensions() {
 			if (!strcmp(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, instance_extensions[i].extensionName)) {
 				extension_names[enabled_extension_count++] = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME;
 			}
+
 			if (enabled_extension_count >= MAX_EXTENSIONS) {
 				free(instance_extensions);
 				ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG");
@@ -801,6 +802,7 @@ Error VulkanContext::_create_physical_device() {
 				// if multiview is supported, enable it
 				extension_names[enabled_extension_count++] = VK_KHR_MULTIVIEW_EXTENSION_NAME;
 			}
+
 			if (enabled_extension_count >= MAX_EXTENSIONS) {
 				free(device_extensions);
 				ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG");

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -661,10 +661,11 @@ public:
 	/* RENDER TARGET */
 
 	RID render_target_create() override { return RID(); }
+	void render_target_update(RID p_render_target) override {}
 	void render_target_set_position(RID p_render_target, int p_x, int p_y) override {}
 	void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) override {}
 	RID render_target_get_texture(RID p_render_target) override { return RID(); }
-	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) override {}
+	void render_target_set_external_textures(RID p_render_target, RID p_color, RID p_depth) override {}
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) override {}
 	bool render_target_was_used(RID p_render_target) override { return false; }
 	void render_target_set_as_unused(RID p_render_target) override {}

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -1153,6 +1153,7 @@ private:
 	/* RENDER TARGET */
 
 	struct RenderTarget {
+		bool is_dirty = true;
 		Size2i size;
 		uint32_t view_count;
 		RID framebuffer;
@@ -1170,6 +1171,9 @@ private:
 		RID backbuffer; //used for effects
 		RID backbuffer_fb;
 		RID backbuffer_mipmap0;
+
+		RID external_color; // used for XR
+		RID external_depth;
 
 		struct BackbufferMipmap {
 			RID mipmap;
@@ -1201,6 +1205,7 @@ private:
 
 	mutable RID_Owner<RenderTarget> render_target_owner;
 
+	void _mark_render_target_dirty(RenderTarget *rt);
 	void _clear_render_target(RenderTarget *rt);
 	void _update_render_target(RenderTarget *rt);
 	void _create_render_target_backbuffer(RenderTarget *rt);
@@ -2334,10 +2339,11 @@ public:
 	/* RENDER TARGET API */
 
 	RID render_target_create();
+	void render_target_update(RID p_render_target);
 	void render_target_set_position(RID p_render_target, int p_x, int p_y);
 	void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count);
 	RID render_target_get_texture(RID p_render_target);
-	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id);
+	void render_target_set_external_textures(RID p_render_target, RID p_color, RID p_depth);
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value);
 	bool render_target_was_used(RID p_render_target);
 	void render_target_set_as_unused(RID p_render_target);

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -588,10 +588,11 @@ public:
 	};
 
 	virtual RID render_target_create() = 0;
+	virtual void render_target_update(RID p_render_target) = 0;
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y) = 0;
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) = 0;
 	virtual RID render_target_get_texture(RID p_render_target) = 0;
-	virtual void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) = 0;
+	virtual void render_target_set_external_textures(RID p_render_target, RID p_color, RID p_depth) = 0;
 	virtual void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) = 0;
 	virtual bool render_target_was_used(RID p_render_target) = 0;
 	virtual void render_target_set_as_unused(RID p_render_target) = 0;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -365,6 +365,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_create", "format", "view", "data"), &RenderingDevice::_texture_create, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("texture_create_shared", "view", "with_texture"), &RenderingDevice::_texture_create_shared);
 	ClassDB::bind_method(D_METHOD("texture_create_shared_from_slice", "view", "with_texture", "layer", "mipmap", "mipmaps", "slice_type"), &RenderingDevice::_texture_create_shared_from_slice, DEFVAL(1), DEFVAL(TEXTURE_SLICE_2D));
+	ClassDB::bind_method(D_METHOD("texture_create_from_extension", "type", "format", "samples", "flags", "image", "width", "height", "depth", "layers"), &RenderingDevice::texture_create_from_extension);
 
 	ClassDB::bind_method(D_METHOD("texture_update", "texture", "layer", "data", "post_barrier"), &RenderingDevice::texture_update, DEFVAL(BARRIER_MASK_ALL));
 	ClassDB::bind_method(D_METHOD("texture_get_data", "texture", "layer"), &RenderingDevice::texture_get_data);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -508,6 +508,7 @@ public:
 
 	virtual RID texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t>> &p_data = Vector<Vector<uint8_t>>()) = 0;
 	virtual RID texture_create_shared(const TextureView &p_view, RID p_with_texture) = 0;
+	virtual RID texture_create_from_extension(TextureType p_type, DataFormat p_format, TextureSamples p_samples, uint64_t p_flags, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers) = 0;
 
 	enum TextureSliceType {
 		TEXTURE_SLICE_2D,

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -137,7 +137,17 @@ PackedVector3Array XRInterface::get_play_area() const {
 	// Note implementation is responsible for applying our reference frame and world scale to the raw data.
 	// `play_area_changed` should be emitted if play area data is available and either the reference frame or world scale changes.
 	return PackedVector3Array();
-};
+}
+
+// optional render to external color texture which enhances performance on those platforms that require us to submit our end result into special textures.
+RID XRInterface::get_external_color_texture() {
+	return RID();
+}
+
+// optional render to external depth texture which enhances performance on those platforms that require us to submit our end result into special textures.
+RID XRInterface::get_external_depth_texture() {
+	return RID();
+}
 
 /** these will only be implemented on AR interfaces, so we want dummies for VR **/
 bool XRInterface::get_anchor_detection_is_enabled() const {

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -125,6 +125,8 @@ public:
 
 	// note, external color/depth/vrs texture support will be added here soon.
 
+	virtual RID get_external_color_texture(); /* if applicable return external color texture to render to */
+	virtual RID get_external_depth_texture(); /* if applicable return external depth texture to render to */
 	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) = 0; /* commit rendered views to the XR interface */
 
 	virtual void process() = 0;

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -52,6 +52,8 @@ void XRInterfaceExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_transform_for_view, "view", "cam_transform");
 	GDVIRTUAL_BIND(_get_projection_for_view, "view", "aspect", "z_near", "z_far");
 
+	GDVIRTUAL_BIND(_get_external_color_texture);
+	GDVIRTUAL_BIND(_get_external_depth_texture);
 	GDVIRTUAL_BIND(_commit_views, "render_target", "screen_rect");
 
 	GDVIRTUAL_BIND(_process);
@@ -333,3 +335,25 @@ RID XRInterfaceExtension::get_render_target_depth(RID p_render_target) {
 	return rd_scene->render_buffers_get_depth_texture(????????????);
 }
 */
+
+// optional render to external color texture which enhances performance on those platforms that require us to submit our end result into special textures.
+RID XRInterfaceExtension::get_external_color_texture() {
+	RID texture;
+
+	if (GDVIRTUAL_CALL(_get_external_color_texture, texture)) {
+		return texture;
+	}
+
+	return RID();
+};
+
+// optional render to external depth texture which enhances performance on those platforms that require us to submit our end result into special textures.
+RID XRInterfaceExtension::get_external_depth_texture() {
+	RID texture;
+
+	if (GDVIRTUAL_CALL(_get_external_depth_texture, texture)) {
+		return texture;
+	}
+
+	return RID();
+};

--- a/servers/xr/xr_interface_extension.h
+++ b/servers/xr/xr_interface_extension.h
@@ -108,8 +108,13 @@ public:
 	GDVIRTUAL2R(Transform3D, _get_transform_for_view, uint32_t, const Transform3D &);
 	GDVIRTUAL4R(PackedFloat64Array, _get_projection_for_view, uint32_t, double, double, double);
 
+	virtual RID get_external_color_texture() override; /* if applicable return external color texture to render to */
+	virtual RID get_external_depth_texture() override; /* if applicable return external depth texture to render to */
 	void add_blit(RID p_render_target, Rect2 p_src_rect, Rect2i p_dst_rect, bool p_use_layer = false, uint32_t p_layer = 0, bool p_apply_lens_distortion = false, Vector2 p_eye_center = Vector2(), double p_k1 = 0.0, double p_k2 = 0.0, double p_upscale = 1.0, double p_aspect_ratio = 1.0);
 	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) override;
+
+	GDVIRTUAL0R(RID, _get_external_color_texture);
+	GDVIRTUAL0R(RID, _get_external_depth_texture);
 	GDVIRTUAL2(_commit_views, RID, const Rect2 &);
 
 	virtual void process() override;


### PR DESCRIPTION
For a number of XR plugins (namely WebXR, Oculus and OpenXR) the XR runtime supplies us with textures that we need to render into. Especially on mobile platforms such as the Quest we'll want to do so as direct as possible.

This PR makes it possible to supply an external texture for the viewport, and an external depth texture for 3D rendering. In doing so Godots own texture objects are not created. 
Do note that there is still a copy involved as the 3D render buffer is still created by Godot however in combination with the new subpass logic this should handle things really nicely on a device like the Quest (or so we hope). This will require implementation of VRS to fully nullify the performance penalty as the render buffers we create do not support foveated rendering.

Also note that for WebXR we're actually not getting textures but we're getting an WebGL framebuffer and this is something we probably can't support until we have stereoscopic OpenGL/WebGL support in Godot 4 so this is not part of this PR.

With OpenXR, OpenXR has its own API for creating swapchains to render into that do not just setup the Vulkan `VkImage` to render into, but enables various other XR specific features. As a result it can't use images created by Godot.  
This now also applies for 2D viewports. OpenXR has a feature for compositing layers including 2D layers in 3D space. This bypasses the lens distortion used for the 3D render resulting in more legible text. I still need to add support in somehow to make it possible to set an alternative destination for this.

In many of these use cases, having Godot render into it's own framebuffers and then copying the end result will void most of the optimizations required for XR and is not a viable path forward.

There is one outstanding TODO in this PR, we're often using a swapchain managed by the XR runtime, meaning each frame is rendered into a different texture in a 1-2-3-1-2-3-etc style round ribbon approach. This means updating the framebuffers and recreating shared texture objects. This needs a better implementation by updating existing framebuffers and maybe adding a map so our shared texture objects once created for each texture, are re-used.