### PR TITLE
Validate TileData enum range before using it as index

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -3817,6 +3817,7 @@ int TileData::get_terrain_set() const {
 }
 
 void TileData::set_peering_bit_terrain(TileSet::CellNeighbor p_peering_bit, int p_terrain_index) {
+	ERR_FAIL_INDEX(p_peering_bit, TileSet::CellNeighbor::CELL_NEIGHBOR_MAX);
 	ERR_FAIL_COND(terrain_set < 0);
 	ERR_FAIL_COND(p_terrain_index < -1);
 	if (tile_set) {


### PR DESCRIPTION
Fixes #51183

The stack trace posted in that issue is a bit strange that shows it crashed inside `get_collision_polygons_count`, but it's actually inside `set_peering_bit_terrain`.