### PR TITLE
Portals - Fix UI default

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4319,28 +4319,31 @@ void SpatialEditor::show_advanced_portal_tools(bool p_show) {
 }
 
 void SpatialEditor::update_portal_tools() {
-	// the view portal culling toggle
-	int view_portal_item_index = view_menu->get_popup()->get_item_index(MENU_VIEW_PORTAL_CULLING);
-	if (RoomManager::active_room_manager) {
-		view_menu->get_popup()->set_item_disabled(view_portal_item_index, false);
+	// just some protection against calling null pointers, hopefully not needed
+	if (view_menu && view_menu->get_popup()) {
+		// the view portal culling toggle
+		int view_portal_item_index = view_menu->get_popup()->get_item_index(MENU_VIEW_PORTAL_CULLING);
+		if (RoomManager::active_room_manager) {
+			view_menu->get_popup()->set_item_disabled(view_portal_item_index, false);
 
-		bool active = RoomManager::static_rooms_get_active();
-		view_menu->get_popup()->set_item_checked(view_portal_item_index, active);
-	} else {
-		view_menu->get_popup()->set_item_disabled(view_portal_item_index, true);
-	}
+			bool active = RoomManager::static_rooms_get_active();
+			view_menu->get_popup()->set_item_checked(view_portal_item_index, active);
+		} else {
+			view_menu->get_popup()->set_item_disabled(view_portal_item_index, true);
+		}
 
-	// toolbar button
-	Button *const button = tool_button[TOOL_CONVERT_ROOMS];
+		// toolbar button
+		Button *const button = tool_button[TOOL_CONVERT_ROOMS];
 
-	if (RoomManager::active_room_manager) {
-		button->show();
-	} else {
-		button->hide();
-	}
+		if (RoomManager::active_room_manager) {
+			button->show();
+		} else {
+			button->hide();
+		}
 
-	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
-		viewports[i]->_update_name();
+		for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
+			viewports[i]->_update_name();
+		}
 	}
 }
 
@@ -6593,6 +6596,10 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	EDITOR_DEF("editors/3d/navigation/show_viewport_rotation_gizmo", true);
 
 	over_gizmo_handle = -1;
+
+	// make sure the portal tools are off by default
+	// (when no RoomManager is present)
+	update_portal_tools();
 }
 
 SpatialEditor::~SpatialEditor() {

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -652,7 +652,7 @@ private:
 
 	MenuButton *transform_menu;
 	PopupMenu *gizmos_menu;
-	MenuButton *view_menu;
+	MenuButton *view_menu = nullptr;
 
 	AcceptDialog *accept;
 


### PR DESCRIPTION
I had forgotten to add a call to update_portal_tools() at the end of the SpatialEditor constructors. This ensures that the portal UI is off by default in normal use without portals.

## Notes
* Sorry my bad, this was working during production but I must have removed this call at some point. This will have resulted in the 'convert rooms' button showing even if no RoomManager was present.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
