### PR TITLE
Fix crash when number of indices to optimize is not a multiple of 3

### DIFF
--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -1120,6 +1120,7 @@ SurfaceTool::CustomFormat SurfaceTool::get_custom_format(int p_index) const {
 void SurfaceTool::optimize_indices_for_cache() {
 	ERR_FAIL_COND(optimize_vertex_cache_func == nullptr);
 	ERR_FAIL_COND(index_array.size() == 0);
+	ERR_FAIL_COND(index_array.size() % 3 != 0);
 
 	LocalVector old_index_array = index_array;
 	memset(index_array.ptr(), 0, index_array.size() * sizeof(int));


### PR DESCRIPTION
Fixes #51184

The number of indices has to be a multiple of 3 (to form a triangle).