### PR TITLE
Validates VisualScript.add_node input node

### DIFF
--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -271,6 +271,7 @@ void VisualScript::_node_ports_changed(int p_id) {
 void VisualScript::add_node(int p_id, const Ref<VisualScriptNode> &p_node, const Point2 &p_pos) {
 	ERR_FAIL_COND(instances.size());
 	ERR_FAIL_COND(nodes.has(p_id)); // ID can exist only one in script.
+	ERR_FAIL_COND(p_node.is_null());
 
 	NodeData nd;
 	nd.node = p_node;


### PR DESCRIPTION
Fixes #51150

---

This fix also applies to the `3.x` branch. The reproduction script is slightly different:

```gdscript
extends SceneTree

func _init():
	var vs = VisualScript.new()
	vs.add_function("X")
	vs.add_node("X", -35, ClassDB.instance("GLTFState"), Vector2(39.6798973083496, 30.4844551086426))
	quit()
```