### PR TITLE
Validates set_sdfgi_cascades argument range

### DIFF
--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -449,6 +449,7 @@ bool Environment::is_sdfgi_enabled() const {
 }
 
 void Environment::set_sdfgi_cascades(SDFGICascades p_cascades) {
+	ERR_FAIL_INDEX(p_cascades, SDFGI_CASCADES_8 + 1);
 	sdfgi_cascades = p_cascades;
 	_update_sdfgi();
 }


### PR DESCRIPTION
Fixes #51182

The value will be used as an array index in `set_sdfgi_max_distance`.