### PR TITLE
memdelete the node in AnimationTreePlayer.remove_node

### DIFF
--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1314,6 +1314,7 @@ void AnimationTreePlayer::remove_node(const StringName &p_node) {
 		}
 	}
 
+	memdelete(node_map[p_node]);
 	node_map.erase(p_node);
 
 	_clear_cycle_test();


### PR DESCRIPTION
Fixes #51189

* The node is `memnew`ed inside `add_node` and kept in `node_map`
* Every pointer inside `node_map` will be `memdelete`d in the destructor of `AnimationTreePlayer`
* But calling `remove_node` only removes the pointer from `node_map` without deleting it.