### PR TITLE
Improve CodeEdit's callhint highlight visibility

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -225,8 +225,15 @@ void CodeEdit::_notification(int p_what) {
 					round_ofs = round_ofs.round();
 					draw_string(font, round_ofs, line.replace(String::chr(0xFFFF), ""), HALIGN_LEFT, -1, cache.font_size, font_color);
 					if (end > 0) {
-						Vector2 b = hint_ofs + sb->get_offset() + Vector2(begin, font_height + font_height * i + line_spacing - 1);
-						draw_line(b, b + Vector2(end - begin, 0), font_color);
+						// Draw an underline for the currently edited function parameter.
+						const Vector2 b = hint_ofs + sb->get_offset() + Vector2(begin, font_height + font_height * i + line_spacing);
+						draw_line(b, b + Vector2(end - begin, 0), font_color, 2);
+
+						// Draw a translucent text highlight as well.
+						const Rect2 highlight_rect = Rect2(
+								hint_ofs + sb->get_offset() + Vector2(begin, 0),
+								Vector2(end - begin, font_height));
+						draw_rect(highlight_rect, font_color * Color(1, 1, 1, 0.2));
 					}
 					line_spacing += cache.line_spacing;
 				}


### PR DESCRIPTION
This makes the currently edited parameter more visible in the script editor's code completion hint.

This can be remade for `3.x` if we agree on the design here.

This closes https://github.com/godotengine/godot-proposals/issues/3074.

## Preview

### Before

![2021-08-02_23 13 15](https://user-images.githubusercontent.com/180032/127925032-8acf19f5-4f77-4769-9a42-0453e17c0d5e.png)

### After

![2021-08-02_23 15 22](https://user-images.githubusercontent.com/180032/127925036-1b062804-d446-4340-ab28-c41df10c65f9.png)
