### PR TITLE
[3.x] Cache `EditorResourcePicker`'s allowed types

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3811,6 +3811,8 @@ void EditorNode::register_editor_types() {
 
 void EditorNode::unregister_editor_types() {
 	_init_callbacks.clear();
+
+	EditorResourcePicker::clear_caches();
 }
 
 void EditorNode::stop_child_process() {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -38,6 +38,12 @@
 #include "scene/main/viewport.h"
 #include "scene/resources/dynamic_font.h"
 
+HashMap<StringName, List<StringName>> EditorResourcePicker::allowed_types_cache;
+
+void EditorResourcePicker::clear_caches() {
+	allowed_types_cache.clear();
+}
+
 void EditorResourcePicker::_update_resource() {
 	preview_rect->set_texture(Ref<Texture>());
 	assign_button->set_custom_minimum_size(Size2(1, 1));
@@ -464,17 +470,31 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, Set<String> *
 		String base = allowed_types[i].strip_edges();
 		p_vector->insert(base);
 
-		List<StringName> inheriters;
-
-		ClassDB::get_inheriters_from_class(base, &inheriters);
-		for (List<StringName>::Element *E = inheriters.front(); E; E = E->next()) {
-			p_vector->insert(E->get());
-		}
-
-		for (List<StringName>::Element *E = global_classes.front(); E; E = E->next()) {
-			if (EditorNode::get_editor_data().script_class_is_parent(E->get(), base)) {
+		// If we hit a familiar base type, take all the data from cache.
+		if (allowed_types_cache.has(base)) {
+			List<StringName> allowed_subtypes = allowed_types_cache[base];
+			for (List<StringName>::Element *E = allowed_subtypes.front(); E; E = E->next()) {
 				p_vector->insert(E->get());
 			}
+		} else {
+			List<StringName> allowed_subtypes;
+
+			List<StringName> inheriters;
+			ClassDB::get_inheriters_from_class(base, &inheriters);
+			for (List<StringName>::Element *E = inheriters.front(); E; E = E->next()) {
+				p_vector->insert(E->get());
+				allowed_subtypes.push_back(E->get());
+			}
+
+			for (List<StringName>::Element *E = global_classes.front(); E; E = E->next()) {
+				if (EditorNode::get_editor_data().script_class_is_parent(E->get(), base)) {
+					p_vector->insert(E->get());
+					allowed_subtypes.push_back(E->get());
+				}
+			}
+
+			// Store the subtypes of the base type in the cache for future use.
+			allowed_types_cache[base] = allowed_subtypes;
 		}
 
 		if (p_with_convert) {
@@ -710,6 +730,10 @@ void EditorResourcePicker::set_base_type(const String &p_base_type) {
 			String class_str = (custom_class == StringName() ? edited_resource->get_class() : vformat("%s (%s)", custom_class, edited_resource->get_class()));
 			WARN_PRINT(vformat("Value mismatch between the new base type of this EditorResourcePicker, '%s', and the type of the value it already has, '%s'.", base_type, class_str));
 		}
+	} else {
+		// Call the method to build the cache immediately.
+		Set<String> allowed_types;
+		_get_allowed_types(false, &allowed_types);
 	}
 }
 

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -40,6 +40,8 @@
 class EditorResourcePicker : public HBoxContainer {
 	GDCLASS(EditorResourcePicker, HBoxContainer);
 
+	static HashMap<StringName, List<StringName>> allowed_types_cache;
+
 	String base_type;
 	RES edited_resource;
 
@@ -95,6 +97,8 @@ protected:
 	void _notification(int p_what);
 
 public:
+	static void clear_caches();
+
 	void set_base_type(const String &p_base_type);
 	String get_base_type() const;
 	Vector<String> get_allowed_types() const;


### PR DESCRIPTION
Mitigates https://github.com/godotengine/godot/issues/51188 by caching the types which the picker allows based on the base types. This means that the first time a new kind of node is selected, it will still hang, but from that point on there will be no freezes for a picker with the same type.

So for example, in a simple scene where you have a `Sprite` node and a `CPUParticles2D` node clicking on the particles will freeze for a bit, but then dragging and reselecting will work just fine. If you then select the sprite afterwards it won't freeze either, because it only has pickers for `Texture` resources, which would already be cached from clicking on `CPUParticles2D`. However, if upon loading the scene you click on the sprite first, and then on the particles, it will freeze a bit both times, as particles have other types of pickers too.

This doesn't solve the freezing completely, but it makes it less severe and more predictable. Unfortunately, as it stands, we need to do the run for each base type *at some point*, even to cache it. This cache is also valid for the entirety of the editor uptime — a restart is required to capture newly `class_name`d scripts. But this is already an existing limitation for some editor features so while not ideal doesn't introduce a new regression.

Ultimately, it's better to have support for custom types at least like that, because previously it was even more limited.

-----

I'll take a look if this should also be done in master in a bit.