### PR TITLE
Change the editor update spinner color when updating continuously

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -735,10 +735,25 @@ void EditorNode::_notification(int p_what) {
 void EditorNode::_update_update_spinner() {
 	update_spinner->set_visible(EditorSettings::get_singleton()->get("interface/editor/show_update_spinner"));
 
-	bool update_continuously = EditorSettings::get_singleton()->get("interface/editor/update_continuously");
+	const bool update_continuously = EditorSettings::get_singleton()->get("interface/editor/update_continuously");
 	PopupMenu *update_popup = update_spinner->get_popup();
 	update_popup->set_item_checked(update_popup->get_item_index(SETTINGS_UPDATE_CONTINUOUSLY), update_continuously);
 	update_popup->set_item_checked(update_popup->get_item_index(SETTINGS_UPDATE_WHEN_CHANGED), !update_continuously);
+
+	if (update_continuously) {
+		update_spinner->set_tooltip(TTR("Spins when the editor window redraws.\nUpdate Continuously is enabled, which can increase power usage. Click to disable it."));
+
+		// Use a different color for the update spinner when Update Continuously is enabled,
+		// as this feature should only be enabled for troubleshooting purposes.
+		// Make the icon modulate color overbright because icons are not completely white on a dark theme.
+		// On a light theme, icons are dark, so we need to modulate them with an even brighter color.
+		const bool dark_theme = EditorSettings::get_singleton()->is_dark_theme();
+		update_spinner->set_self_modulate(
+				gui_base->get_theme_color("error_color", "Editor") * (dark_theme ? Color(1.1, 1.1, 1.1) : Color(4.25, 4.25, 4.25)));
+	} else {
+		update_spinner->set_tooltip(TTR("Spins when the editor window redraws."));
+		update_spinner->set_self_modulate(Color(1, 1, 1));
+	}
 
 	OS::get_singleton()->set_low_processor_usage_mode(!update_continuously);
 }
@@ -6510,7 +6525,6 @@ EditorNode::EditorNode() {
 	layout_dialog->connect("name_confirmed", callable_mp(this, &EditorNode::_dialog_action));
 
 	update_spinner = memnew(MenuButton);
-	update_spinner->set_tooltip(TTR("Spins when the editor window redraws."));
 	right_menu_hb->add_child(update_spinner);
 	update_spinner->set_icon(gui_base->get_theme_icon(SNAME("Progress1"), SNAME("EditorIcons")));
 	update_spinner->get_popup()->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));


### PR DESCRIPTION
Updating continuously should only be enabled for troubleshooting purposes, as it uses a lot of CPU/GPU power.

The update spinner is now displayed in red when the Update Continuously editor setting is enabled.

I chose `error_color` instead of `warning_color` because the difference between the default color and `warning_color` is barely visible on a small icon.

## Preview

### Dark theme

| Update When Changed (default) | Update Continuously |
|-------------------------------|---------------------|
| ![image](https://user-images.githubusercontent.com/180032/128042527-7410c13a-2d81-4ada-8b8e-3732f83917d2.png) | ![2021-08-03_17 21 29](https://user-images.githubusercontent.com/180032/128042348-506017d6-0504-4b79-8eac-e109c10518d6.png) |

### Light theme

| Update When Changed (default) | Update Continuously |
|-------------------------------|---------------------|
| ![2021-08-03_17 22 26](https://user-images.githubusercontent.com/180032/128042352-c2264cff-ef24-43b0-92a5-956f4156c375.png) | ![2021-08-03_17 21 53](https://user-images.githubusercontent.com/180032/128042350-9c14bd47-b87e-4c58-8262-64a757bc9a23.png) |