### PR TITLE
Shortcut: Rename `shortcut` property to `event`

### DIFF
--- a/doc/classes/Shortcut.xml
+++ b/doc/classes/Shortcut.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		A shortcut for binding input.
-		Shortcuts are commonly used for interacting with a [Control] element from a [InputEvent].
+		Shortcuts are commonly used for interacting with a [Control] element from an [InputEvent] (also known as hotkeys).
 	</description>
 	<tutorials>
 	</tutorials>
@@ -16,24 +16,24 @@
 				Returns the shortcut's [InputEvent] as a [String].
 			</description>
 		</method>
-		<method name="is_shortcut" qualifiers="const">
+		<method name="has_valid_event" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether the shortcut has a valid [member event] assigned to it.
+			</description>
+		</method>
+		<method name="matches_event" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="event" type="InputEvent" />
 			<description>
-				Returns [code]true[/code] if the shortcut's [InputEvent] equals [code]event[/code].
-			</description>
-		</method>
-		<method name="is_valid" qualifiers="const">
-			<return type="bool" />
-			<description>
-				If [code]true[/code], this shortcut is valid.
+				Returns whether the shortcut's [member event] matches [code]event[/code].
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="shortcut" type="InputEvent" setter="set_shortcut" getter="get_shortcut">
+		<member name="event" type="InputEvent" setter="set_event" getter="get_event">
 			The shortcut's [InputEvent].
-			Generally the [InputEvent] is a keyboard key, though it can be any [InputEvent].
+			Generally the [InputEvent] is a keyboard key, though it can be any [InputEvent], including an [InputEventAction].
 		</member>
 	</members>
 	<constants>

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -605,12 +605,12 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	if (p_event->is_pressed()) {
-		if (ED_GET_SHORTCUT("animation_editor/duplicate_selection")->is_shortcut(p_event)) {
+		if (ED_GET_SHORTCUT("animation_editor/duplicate_selection")->matches_event(p_event)) {
 			duplicate_selection();
 			accept_event();
 		}
 
-		if (ED_GET_SHORTCUT("animation_editor/delete_selection")->is_shortcut(p_event)) {
+		if (ED_GET_SHORTCUT("animation_editor/delete_selection")->matches_event(p_event)) {
 			delete_selection();
 			accept_event();
 		}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2555,17 +2555,17 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	if (p_event->is_pressed()) {
-		if (ED_GET_SHORTCUT("animation_editor/duplicate_selection")->is_shortcut(p_event)) {
+		if (ED_GET_SHORTCUT("animation_editor/duplicate_selection")->matches_event(p_event)) {
 			emit_signal(SNAME("duplicate_request"));
 			accept_event();
 		}
 
-		if (ED_GET_SHORTCUT("animation_editor/duplicate_selection_transposed")->is_shortcut(p_event)) {
+		if (ED_GET_SHORTCUT("animation_editor/duplicate_selection_transposed")->matches_event(p_event)) {
 			emit_signal(SNAME("duplicate_transpose_request"));
 			accept_event();
 		}
 
-		if (ED_GET_SHORTCUT("animation_editor/delete_selection")->is_shortcut(p_event)) {
+		if (ED_GET_SHORTCUT("animation_editor/delete_selection")->matches_event(p_event)) {
 			emit_signal(SNAME("delete_request"));
 			accept_event();
 		}

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -80,7 +80,7 @@ bool EditorSettings::_set_only(const StringName &p_name, const Variant &p_value)
 
 			Ref<Shortcut> sc;
 			sc.instantiate();
-			sc->set_shortcut(shortcut);
+			sc->set_event(shortcut);
 			add_shortcut(name, sc);
 		}
 
@@ -153,13 +153,13 @@ bool EditorSettings::_get(const StringName &p_name, Variant &r_ret) const {
 				}
 
 				Ref<InputEvent> original = sc->get_meta("original");
-				if (sc->is_shortcut(original) || (original.is_null() && sc->get_shortcut().is_null())) {
+				if (sc->matches_event(original) || (original.is_null() && sc->get_event().is_null())) {
 					continue; //not changed from default, don't save
 				}
 			}
 
 			arr.push_back(E->key());
-			arr.push_back(sc->get_shortcut());
+			arr.push_back(sc->get_event());
 		}
 		r_ret = arr;
 		return true;
@@ -1457,7 +1457,7 @@ bool EditorSettings::is_shortcut(const String &p_name, const Ref<InputEvent> &p_
 	const Map<String, Ref<Shortcut>>::Element *E = shortcuts.find(p_name);
 	ERR_FAIL_COND_V_MSG(!E, false, "Unknown Shortcut: " + p_name + ".");
 
-	return E->get()->is_shortcut(p_event);
+	return E->get()->matches_event(p_event);
 }
 
 Ref<Shortcut> EditorSettings::get_shortcut(const String &p_name) const {
@@ -1473,7 +1473,7 @@ Ref<Shortcut> EditorSettings::get_shortcut(const String &p_name) const {
 	const Map<String, List<Ref<InputEvent>>>::Element *builtin_override = builtin_action_overrides.find(p_name);
 	if (builtin_override) {
 		sc.instantiate();
-		sc->set_shortcut(builtin_override->get().front()->get());
+		sc->set_event(builtin_override->get().front()->get());
 		sc->set_name(InputMap::get_singleton()->get_builtin_display_name(p_name));
 	}
 
@@ -1482,7 +1482,7 @@ Ref<Shortcut> EditorSettings::get_shortcut(const String &p_name) const {
 		const OrderedHashMap<String, List<Ref<InputEvent>>>::ConstElement builtin_default = InputMap::get_singleton()->get_builtins().find(p_name);
 		if (builtin_default) {
 			sc.instantiate();
-			sc->set_shortcut(builtin_default.get().front()->get());
+			sc->set_event(builtin_default.get().front()->get());
 			sc->set_name(InputMap::get_singleton()->get_builtin_display_name(p_name));
 		}
 	}
@@ -1538,7 +1538,7 @@ Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p
 		Ref<Shortcut> sc;
 		sc.instantiate();
 		sc->set_name(p_name);
-		sc->set_shortcut(ie);
+		sc->set_event(ie);
 		sc->set_meta("original", ie);
 		return sc;
 	}
@@ -1552,7 +1552,7 @@ Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p
 
 	sc.instantiate();
 	sc->set_name(p_name);
-	sc->set_shortcut(ie);
+	sc->set_event(ie);
 	sc->set_meta("original", ie); //to compare against changes
 	EditorSettings::get_singleton()->add_shortcut(p_path, sc);
 
@@ -1600,7 +1600,7 @@ void EditorSettings::set_builtin_action_override(const String &p_name, const Arr
 
 	// Update the shortcut (if it is used somewhere in the editor) to be the first event of the new list.
 	if (shortcuts.has(p_name)) {
-		shortcuts[p_name]->set_shortcut(event_list.front()->get());
+		shortcuts[p_name]->set_event(event_list.front()->get());
 	}
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -486,11 +486,11 @@ void CanvasItemEditor::_unhandled_key_input(const Ref<InputEvent> &p_ev) {
 		}
 
 		if (k->is_pressed() && !k->is_ctrl_pressed() && !k->is_echo()) {
-			if ((grid_snap_active || show_grid) && multiply_grid_step_shortcut.is_valid() && multiply_grid_step_shortcut->is_shortcut(p_ev)) {
+			if ((grid_snap_active || show_grid) && multiply_grid_step_shortcut.is_valid() && multiply_grid_step_shortcut->matches_event(p_ev)) {
 				// Multiply the grid size
 				grid_step_multiplier = MIN(grid_step_multiplier + 1, 12);
 				viewport->update();
-			} else if ((grid_snap_active || show_grid) && divide_grid_step_shortcut.is_valid() && divide_grid_step_shortcut->is_shortcut(p_ev)) {
+			} else if ((grid_snap_active || show_grid) && divide_grid_step_shortcut.is_valid() && divide_grid_step_shortcut->matches_event(p_ev)) {
 				// Divide the grid size
 				Point2 new_grid_step = grid_step * Math::pow(2.0, grid_step_multiplier - 1);
 				if (new_grid_step.x >= 1.0 && new_grid_step.y >= 1.0) {
@@ -1192,30 +1192,30 @@ bool CanvasItemEditor::_gui_input_zoom_or_pan(const Ref<InputEvent> &p_event, bo
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid()) {
 		if (k->is_pressed()) {
-			if (ED_GET_SHORTCUT("canvas_item_editor/zoom_3.125_percent")->is_shortcut(p_event)) {
+			if (ED_GET_SHORTCUT("canvas_item_editor/zoom_3.125_percent")->matches_event(p_event)) {
 				_update_zoom((1.0 / 32.0) * MAX(1, EDSCALE));
-			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_6.25_percent")->is_shortcut(p_event)) {
+			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_6.25_percent")->matches_event(p_event)) {
 				_update_zoom((1.0 / 16.0) * MAX(1, EDSCALE));
-			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_12.5_percent")->is_shortcut(p_event)) {
+			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_12.5_percent")->matches_event(p_event)) {
 				_update_zoom((1.0 / 8.0) * MAX(1, EDSCALE));
-			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_25_percent")->is_shortcut(p_event)) {
+			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_25_percent")->matches_event(p_event)) {
 				_update_zoom((1.0 / 4.0) * MAX(1, EDSCALE));
-			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_50_percent")->is_shortcut(p_event)) {
+			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_50_percent")->matches_event(p_event)) {
 				_update_zoom((1.0 / 2.0) * MAX(1, EDSCALE));
-			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_100_percent")->is_shortcut(p_event)) {
+			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_100_percent")->matches_event(p_event)) {
 				_update_zoom(1.0 * MAX(1, EDSCALE));
-			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_200_percent")->is_shortcut(p_event)) {
+			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_200_percent")->matches_event(p_event)) {
 				_update_zoom(2.0 * MAX(1, EDSCALE));
-			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_400_percent")->is_shortcut(p_event)) {
+			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_400_percent")->matches_event(p_event)) {
 				_update_zoom(4.0 * MAX(1, EDSCALE));
-			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_800_percent")->is_shortcut(p_event)) {
+			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_800_percent")->matches_event(p_event)) {
 				_update_zoom(8.0 * MAX(1, EDSCALE));
-			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_1600_percent")->is_shortcut(p_event)) {
+			} else if (ED_GET_SHORTCUT("canvas_item_editor/zoom_1600_percent")->matches_event(p_event)) {
 				_update_zoom(16.0 * MAX(1, EDSCALE));
 			}
 		}
 
-		bool is_pan_key = pan_view_shortcut.is_valid() && pan_view_shortcut->is_shortcut(p_event);
+		bool is_pan_key = pan_view_shortcut.is_valid() && pan_view_shortcut->matches_event(p_event);
 
 		if (is_pan_key && (EditorSettings::get_singleton()->get("editors/2d/simple_panning") || drag_type != DRAG_NONE)) {
 			if (!panning) {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2454,7 +2454,7 @@ static bool is_shortcut_pressed(const String &p_path) {
 	if (shortcut.is_null()) {
 		return false;
 	}
-	InputEventKey *k = Object::cast_to<InputEventKey>(shortcut->get_shortcut().ptr());
+	InputEventKey *k = Object::cast_to<InputEventKey>(shortcut->get_event().ptr());
 	if (k == nullptr) {
 		return false;
 	}

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -209,7 +209,7 @@ void EditorSettingsDialog::_event_config_confirmed() {
 
 		undo_redo->create_action(TTR("Change Shortcut") + " '" + shortcut_being_edited + "'");
 		undo_redo->add_do_method(current_sc.ptr(), "set_shortcut", k);
-		undo_redo->add_undo_method(current_sc.ptr(), "set_shortcut", current_sc->get_shortcut());
+		undo_redo->add_undo_method(current_sc.ptr(), "set_shortcut", current_sc->get_event());
 		undo_redo->add_do_method(this, "_update_shortcuts");
 		undo_redo->add_undo_method(this, "_update_shortcuts");
 		undo_redo->add_do_method(this, "_settings_changed");
@@ -361,7 +361,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 			item->set_text(0, sc->get_name());
 			item->set_text(1, sc->get_as_text());
 
-			if (!sc->is_shortcut(original) && !(sc->get_shortcut().is_null() && original.is_null())) {
+			if (!sc->matches_event(original) && !(sc->get_event().is_null() && original.is_null())) {
 				item->add_button(1, shortcuts->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")), 2);
 			}
 
@@ -444,7 +444,7 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 
 		switch (button_idx) {
 			case EditorSettingsDialog::SHORTCUT_EDIT:
-				shortcut_editor->popup_and_configure(sc->get_shortcut());
+				shortcut_editor->popup_and_configure(sc->get_event());
 				shortcut_being_edited = item;
 				break;
 			case EditorSettingsDialog::SHORTCUT_ERASE: {
@@ -454,7 +454,7 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 
 				undo_redo->create_action(TTR("Erase Shortcut"));
 				undo_redo->add_do_method(sc.ptr(), "set_shortcut", Ref<InputEvent>());
-				undo_redo->add_undo_method(sc.ptr(), "set_shortcut", sc->get_shortcut());
+				undo_redo->add_undo_method(sc.ptr(), "set_shortcut", sc->get_event());
 				undo_redo->add_do_method(this, "_update_shortcuts");
 				undo_redo->add_undo_method(this, "_update_shortcuts");
 				undo_redo->add_do_method(this, "_settings_changed");
@@ -470,7 +470,7 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 
 				undo_redo->create_action(TTR("Restore Shortcut"));
 				undo_redo->add_do_method(sc.ptr(), "set_shortcut", original);
-				undo_redo->add_undo_method(sc.ptr(), "set_shortcut", sc->get_shortcut());
+				undo_redo->add_undo_method(sc.ptr(), "set_shortcut", sc->get_event());
 				undo_redo->add_do_method(this, "_update_shortcuts");
 				undo_redo->add_undo_method(this, "_update_shortcuts");
 				undo_redo->add_do_method(this, "_settings_changed");

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -345,7 +345,7 @@ void BaseButton::_unhandled_key_input(Ref<InputEvent> p_event) {
 		return;
 	}
 
-	if (!is_disabled() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->is_shortcut(p_event)) {
+	if (!is_disabled() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
 		on_action_event(p_event);
 		accept_event();
 	}
@@ -353,7 +353,7 @@ void BaseButton::_unhandled_key_input(Ref<InputEvent> p_event) {
 
 String BaseButton::get_tooltip(const Point2 &p_pos) const {
 	String tooltip = Control::get_tooltip(p_pos);
-	if (shortcut_in_tooltip && shortcut.is_valid() && shortcut->is_valid()) {
+	if (shortcut_in_tooltip && shortcut.is_valid() && shortcut->has_valid_event()) {
 		String text = shortcut->get_name() + " (" + shortcut->get_as_text() + ")";
 		if (tooltip != String() && shortcut->get_name().nocasecmp_to(tooltip) != 0) {
 			text += "\n" + tooltip;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -74,7 +74,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 		size.width += items[i].text_buf->get_size().x;
 		size.height += vseparation;
 
-		if (items[i].accel || (items[i].shortcut.is_valid() && items[i].shortcut->is_valid())) {
+		if (items[i].accel || (items[i].shortcut.is_valid() && items[i].shortcut->has_valid_event())) {
 			int accel_w = hseparation * 2;
 			accel_w += items[i].accel_text_buf->get_size().x;
 			accel_max_w = MAX(accel_w, accel_max_w);
@@ -635,7 +635,7 @@ void PopupMenu::_draw_items() {
 		}
 
 		// Accelerator / Shortcut
-		if (items[i].accel || (items[i].shortcut.is_valid() && items[i].shortcut->is_valid())) {
+		if (items[i].accel || (items[i].shortcut.is_valid() && items[i].shortcut->has_valid_event())) {
 			if (rtl) {
 				item_ofs.x = scroll_width + style->get_margin(SIDE_LEFT) + item_end_padding;
 			} else {
@@ -1301,7 +1301,7 @@ bool PopupMenu::activate_item_by_event(const Ref<InputEvent> &p_event, bool p_fo
 			continue;
 		}
 
-		if (items[i].shortcut.is_valid() && items[i].shortcut->is_shortcut(p_event) && (items[i].shortcut_is_global || !p_for_global_only)) {
+		if (items[i].shortcut.is_valid() && items[i].shortcut->matches_event(p_event) && (items[i].shortcut_is_global || !p_for_global_only)) {
 			activate_item(i);
 			return true;
 		}

--- a/scene/gui/shortcut.cpp
+++ b/scene/gui/shortcut.cpp
@@ -32,42 +32,39 @@
 
 #include "core/os/keyboard.h"
 
-void Shortcut::set_shortcut(const Ref<InputEvent> &p_shortcut) {
-	shortcut = p_shortcut;
+void Shortcut::set_event(const Ref<InputEvent> &p_event) {
+	event = p_event;
 	emit_changed();
 }
 
-Ref<InputEvent> Shortcut::get_shortcut() const {
-	return shortcut;
+Ref<InputEvent> Shortcut::get_event() const {
+	return event;
 }
 
-bool Shortcut::is_shortcut(const Ref<InputEvent> &p_event) const {
-	return shortcut.is_valid() && shortcut->is_match(p_event, true);
+bool Shortcut::matches_event(const Ref<InputEvent> &p_event) const {
+	return event.is_valid() && event->is_match(p_event, true);
 }
 
 String Shortcut::get_as_text() const {
-	if (shortcut.is_valid()) {
-		return shortcut->as_text();
+	if (event.is_valid()) {
+		return event->as_text();
 	} else {
 		return "None";
 	}
 }
 
-bool Shortcut::is_valid() const {
-	return shortcut.is_valid();
+bool Shortcut::has_valid_event() const {
+	return event.is_valid();
 }
 
 void Shortcut::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_shortcut", "event"), &Shortcut::set_shortcut);
-	ClassDB::bind_method(D_METHOD("get_shortcut"), &Shortcut::get_shortcut);
+	ClassDB::bind_method(D_METHOD("set_event", "event"), &Shortcut::set_event);
+	ClassDB::bind_method(D_METHOD("get_event"), &Shortcut::get_event);
 
-	ClassDB::bind_method(D_METHOD("is_valid"), &Shortcut::is_valid);
+	ClassDB::bind_method(D_METHOD("has_valid_event"), &Shortcut::has_valid_event);
 
-	ClassDB::bind_method(D_METHOD("is_shortcut", "event"), &Shortcut::is_shortcut);
+	ClassDB::bind_method(D_METHOD("matches_event", "event"), &Shortcut::matches_event);
 	ClassDB::bind_method(D_METHOD("get_as_text"), &Shortcut::get_as_text);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), "set_shortcut", "get_shortcut");
-}
-
-Shortcut::Shortcut() {
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), "set_event", "get_event");
 }

--- a/scene/gui/shortcut.h
+++ b/scene/gui/shortcut.h
@@ -37,20 +37,18 @@
 class Shortcut : public Resource {
 	GDCLASS(Shortcut, Resource);
 
-	Ref<InputEvent> shortcut;
+	Ref<InputEvent> event;
 
 protected:
 	static void _bind_methods();
 
 public:
-	void set_shortcut(const Ref<InputEvent> &p_shortcut);
-	Ref<InputEvent> get_shortcut() const;
-	bool is_shortcut(const Ref<InputEvent> &p_event) const;
-	bool is_valid() const;
+	void set_event(const Ref<InputEvent> &p_shortcut);
+	Ref<InputEvent> get_event() const;
+	bool matches_event(const Ref<InputEvent> &p_event) const;
+	bool has_valid_event() const;
 
 	String get_as_text() const;
-
-	Shortcut();
 };
 
 #endif // SHORTCUT_H


### PR DESCRIPTION
Having a property which has the same name as its class leads to confusing
situations (e.g. `BaseButton` has a `shortcut` property of type `Shortcut`
which has a `shortcut` property of type `InputEvent`).

Also renames `is_event` to `matches_event`, and `is_valid` to `has_event`
to better reflect what the methods check.