### PR TITLE
[Headless] Add --headless switch (no rendering, no audio).

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -215,14 +215,6 @@ void OS::dump_resources_to_file(const char *p_file) {
 	ResourceCache::dump(p_file);
 }
 
-void OS::set_no_window_mode(bool p_enable) {
-	_no_window = p_enable;
-}
-
-bool OS::is_no_window_mode_enabled() const {
-	return _no_window;
-}
-
 int OS::get_exit_code() const {
 	return _exit_code;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -53,7 +53,6 @@ class OS {
 	bool _verbose_stdout = false;
 	bool _debug_stdout = false;
 	String _local_clipboard;
-	bool _no_window = false;
 	int _exit_code = EXIT_FAILURE; // unexpected exit is marked as failure
 	int _orientation;
 	bool _allow_hidpi = false;
@@ -268,9 +267,6 @@ public:
 	virtual String get_system_dir(SystemDir p_dir) const;
 
 	virtual Error move_to_trash(const String &p_path) { return FAILED; }
-
-	virtual void set_no_window_mode(bool p_enable);
-	virtual bool is_no_window_mode_enabled() const;
 
 	virtual void debug_break();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -326,9 +326,10 @@ void Main::print_help(const char *p_binary) {
 
 	OS::get_singleton()->print("  --text-driver <driver>                       Text driver (Fonts, BiDi, shaping)\n");
 
+	OS::get_singleton()->print("  --headless                                   Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script.\n");
+
 	OS::get_singleton()->print("\n");
 
-#ifndef SERVER_ENABLED
 	OS::get_singleton()->print("Display options:\n");
 	OS::get_singleton()->print("  -f, --fullscreen                             Request fullscreen mode.\n");
 	OS::get_singleton()->print("  -m, --maximized                              Request a maximized window.\n");
@@ -337,11 +338,9 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --resolution <W>x<H>                         Request window resolution.\n");
 	OS::get_singleton()->print("  --position <X>,<Y>                           Request window position.\n");
 	OS::get_singleton()->print("  --low-dpi                                    Force low-DPI mode (macOS and Windows only).\n");
-	OS::get_singleton()->print("  --no-window                                  Disable window creation (Windows only). Useful together with --script.\n");
 	OS::get_singleton()->print("  --single-window                              Use a single window (no separate subwindows).\n");
 	OS::get_singleton()->print("  --tablet-driver                              Pen tablet input driver.\n");
 	OS::get_singleton()->print("\n");
-#endif
 
 	OS::get_singleton()->print("Debug options:\n");
 	OS::get_singleton()->print("  -d, --debug                                  Debug (local stdout debugger).\n");
@@ -352,7 +351,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --gpu-abort                                  Abort on GPU errors (usually validation layer errors), may help see the problem if your system freezes.\n");
 #endif
 	OS::get_singleton()->print("  --remote-debug <uri>                         Remote debug (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007).\n");
-#if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
+#if defined(DEBUG_ENABLED)
 	OS::get_singleton()->print("  --debug-collisions                           Show collision shapes when running the scene.\n");
 	OS::get_singleton()->print("  --debug-navigation                           Show navigation polygons when running the scene.\n");
 #endif
@@ -728,7 +727,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing video driver argument, aborting.\n");
 				goto error;
 			}
-#ifndef SERVER_ENABLED
 		} else if (I->get() == "-f" || I->get() == "--fullscreen") { // force fullscreen
 
 			init_fullscreen = true;
@@ -818,10 +816,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "--low-dpi") { // force low DPI (macOS only)
 
 			force_lowdpi = true;
-		} else if (I->get() == "--no-window") { // disable window creation (Windows only)
+		} else if (I->get() == "--headless") { // enable headless mode (no audio, no rendering).
 
-			OS::get_singleton()->set_no_window_mode(true);
-#endif
+			audio_driver = "Dummy";
+			display_driver = "headless";
+
 		} else if (I->get() == "--profiling") { // enable profiling
 
 			use_debug_profiler = true;

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -50,7 +50,7 @@ _arguments \
   '--resolution[request window resolution]:resolution in WxH format' \
   '--position[request window position]:position in X,Y format' \
   '--low-dpi[force low-DPI mode (macOS and Windows only)]' \
-  '--no-window[disable window creation (Windows only), useful together with --script]' \
+  '--headless[enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script]' \
   '(-d --debug)'{-d,--debug}'[debug (local stdout debugger)]' \
   '(-b --breakpoints)'{-b,--breakpoints}'[specify the breakpoint list as source::line comma-separated pairs, no spaces (use %20 instead)]:breakpoint list' \
   '--profiling[enable profiling in the script debugger]' \

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -53,7 +53,7 @@ _complete_godot_options() {
 --resolution
 --position
 --low-dpi
---no-window
+--headless
 --debug
 --breakpoints
 --profiling

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -60,7 +60,7 @@ complete -c godot -s t -l always-on-top -d "Request an always-on-top window"
 complete -c godot -l resolution -d "Request window resolution" -x
 complete -c godot -l position -d "Request window position" -x
 complete -c godot -l low-dpi -d "Force low-DPI mode (macOS and Windows only)"
-complete -c godot -l no-window -d "Disable window creation (Windows only), useful together with --script"
+complete -c godot -l headless -d "Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script"
 
 # Debug options:
 complete -c godot -s d -l debug -d "Debug (local stdout debugger)"


### PR DESCRIPTION
Also remove now unused `--no-window` option, and relative OS getter and setter.