### PR TITLE
Fix various i18n failures

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3418,6 +3418,7 @@ void AnimationTrackEditor::_query_insert(const InsertData &p_id) {
 		if (bool(EDITOR_DEF("editors/animation/confirm_insert_track", true))) {
 			//potential new key, does not exist
 			if (num_tracks == 1) {
+				// TRANSLATORS: %s will be replaced by a phrase describing the target of track.
 				insert_confirm_text->set_text(vformat(TTR("Create new track for %s and insert key?"), p_id.query));
 			} else {
 				insert_confirm_text->set_text(vformat(TTR("Create %d new tracks and insert keys?"), num_tracks));
@@ -3525,7 +3526,8 @@ void AnimationTrackEditor::insert_transform_key(Node3D *p_node, const String &p_
 	id.track_idx = track_idx;
 	id.value = p_xform;
 	id.type = Animation::TYPE_TRANSFORM3D;
-	id.query = "node '" + p_node->get_name() + "'";
+	// TRANSLATORS: This describes the target of new animation track, will be inserted into another string.
+	id.query = vformat(TTR("node '%s'"), p_node->get_name());
 	id.advance = false;
 
 	//dialog insert
@@ -3547,7 +3549,8 @@ void AnimationTrackEditor::_insert_animation_key(NodePath p_path, const Variant 
 			id.track_idx = i;
 			id.value = p_value;
 			id.type = Animation::TYPE_ANIMATION;
-			id.query = "animation";
+			// TRANSLATORS: This describes the target of new animation track, will be inserted into another string.
+			id.query = TTR("animation");
 			id.advance = false;
 			//dialog insert
 			_query_insert(id);
@@ -3560,7 +3563,7 @@ void AnimationTrackEditor::_insert_animation_key(NodePath p_path, const Variant 
 	id.track_idx = -1;
 	id.value = p_value;
 	id.type = Animation::TYPE_ANIMATION;
-	id.query = "animation";
+	id.query = TTR("animation");
 	id.advance = false;
 	//dialog insert
 	_query_insert(id);
@@ -3609,7 +3612,8 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 			id.track_idx = i;
 			id.value = p_value;
 			id.type = Animation::TYPE_VALUE;
-			id.query = "property '" + p_property + "'";
+			// TRANSLATORS: This describes the target of new animation track, will be inserted into another string.
+			id.query = vformat(TTR("property '%s'"), p_property);
 			id.advance = false;
 			//dialog insert
 			_query_insert(id);
@@ -3639,7 +3643,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 			id.track_idx = i;
 			id.value = value;
 			id.type = Animation::TYPE_BEZIER;
-			id.query = "property '" + p_property + "'";
+			id.query = vformat(TTR("property '%s'"), p_property);
 			id.advance = false;
 			//dialog insert
 			_query_insert(id);
@@ -3655,7 +3659,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 	id.track_idx = -1;
 	id.value = p_value;
 	id.type = Animation::TYPE_VALUE;
-	id.query = "property '" + p_property + "'";
+	id.query = vformat(TTR("property '%s'"), p_property);
 	id.advance = false;
 	//dialog insert
 	_query_insert(id);
@@ -3708,7 +3712,7 @@ void AnimationTrackEditor::insert_value_key(const String &p_property, const Vari
 			id.track_idx = i;
 			id.value = p_value;
 			id.type = Animation::TYPE_VALUE;
-			id.query = "property '" + p_property + "'";
+			id.query = vformat(TTR("property '%s'"), p_property);
 			id.advance = p_advance;
 			//dialog insert
 			_query_insert(id);
@@ -3733,7 +3737,7 @@ void AnimationTrackEditor::insert_value_key(const String &p_property, const Vari
 			id.track_idx = i;
 			id.value = value;
 			id.type = Animation::TYPE_BEZIER;
-			id.query = "property '" + p_property + "'";
+			id.query = vformat(TTR("property '%s'"), p_property);
 			id.advance = p_advance;
 			//dialog insert
 			_query_insert(id);
@@ -3747,7 +3751,7 @@ void AnimationTrackEditor::insert_value_key(const String &p_property, const Vari
 		id.track_idx = -1;
 		id.value = p_value;
 		id.type = Animation::TYPE_VALUE;
-		id.query = "property '" + p_property + "'";
+		id.query = vformat(TTR("property '%s'"), p_property);
 		id.advance = p_advance;
 		//dialog insert
 		_query_insert(id);

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -563,7 +563,7 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 		int feature_id = md;
 		String feature_description = EditorFeatureProfile::get_feature_description(EditorFeatureProfile::Feature(feature_id));
 
-		description_bit->set_text(feature_description);
+		description_bit->set_text(TTRGET(feature_description));
 		return;
 	} else {
 		return;

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -889,8 +889,8 @@ ExportTemplateManager::ExportTemplateManager() {
 	request_mirrors->connect("request_completed", callable_mp(this, &ExportTemplateManager::_refresh_mirrors_completed));
 
 	mirror_options_button = memnew(MenuButton);
-	mirror_options_button->get_popup()->add_item("Open in Web Browser", VISIT_WEB_MIRROR);
-	mirror_options_button->get_popup()->add_item("Copy Mirror URL", COPY_MIRROR_URL);
+	mirror_options_button->get_popup()->add_item(TTR("Open in Web Browser"), VISIT_WEB_MIRROR);
+	mirror_options_button->get_popup()->add_item(TTR("Copy Mirror URL"), COPY_MIRROR_URL);
 	download_install_hb->add_child(mirror_options_button);
 	mirror_options_button->get_popup()->connect("id_pressed", callable_mp(this, &ExportTemplateManager::_mirror_options_button_cbk));
 


### PR DESCRIPTION
`master` version of #51218.

* `AnimationTrackEditor`: The phrase describing track target property / node / animation in prompt dialog was hardcoded.
* `ExportTemplateManager`: Two menu items were left hardcoded.
* `EditorFeatureProfileManager`: `TTRC` without `TTRGET`