### PR TITLE
[3.x] Fix various i18n failures

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3419,6 +3419,7 @@ void AnimationTrackEditor::_query_insert(const InsertData &p_id) {
 
 		if (bool(EDITOR_DEF("editors/animation/confirm_insert_track", true))) {
 			if (num_tracks == 1) {
+				// TRANSLATORS: %s will be replaced by a phrase describing the target of track.
 				insert_confirm_text->set_text(vformat(TTR("Create NEW track for %s and insert key?"), p_id.query));
 			} else {
 				insert_confirm_text->set_text(vformat(TTR("Create %d NEW tracks and insert keys?"), num_tracks));
@@ -3526,7 +3527,8 @@ void AnimationTrackEditor::insert_transform_key(Spatial *p_node, const String &p
 	id.track_idx = track_idx;
 	id.value = p_xform;
 	id.type = Animation::TYPE_TRANSFORM;
-	id.query = "node '" + p_node->get_name() + "'";
+	// TRANSLATORS: This describes the target of new animation track, will be inserted into another string.
+	id.query = vformat(TTR("node '%s'"), p_node->get_name());
 	id.advance = false;
 
 	//dialog insert
@@ -3548,7 +3550,8 @@ void AnimationTrackEditor::_insert_animation_key(NodePath p_path, const Variant 
 			id.track_idx = i;
 			id.value = p_value;
 			id.type = Animation::TYPE_ANIMATION;
-			id.query = "animation";
+			// TRANSLATORS: This describes the target of new animation track, will be inserted into another string.
+			id.query = TTR("animation");
 			id.advance = false;
 			//dialog insert
 			_query_insert(id);
@@ -3561,7 +3564,7 @@ void AnimationTrackEditor::_insert_animation_key(NodePath p_path, const Variant 
 	id.track_idx = -1;
 	id.value = p_value;
 	id.type = Animation::TYPE_ANIMATION;
-	id.query = "animation";
+	id.query = TTR("animation");
 	id.advance = false;
 	//dialog insert
 	_query_insert(id);
@@ -3610,7 +3613,8 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 			id.track_idx = i;
 			id.value = p_value;
 			id.type = Animation::TYPE_VALUE;
-			id.query = "property '" + p_property + "'";
+			// TRANSLATORS: This describes the target of new animation track, will be inserted into another string.
+			id.query = vformat(TTR("property '%s'"), p_property);
 			id.advance = false;
 			//dialog insert
 			_query_insert(id);
@@ -3640,7 +3644,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 			id.track_idx = i;
 			id.value = value;
 			id.type = Animation::TYPE_BEZIER;
-			id.query = "property '" + p_property + "'";
+			id.query = vformat(TTR("property '%s'"), p_property);
 			id.advance = false;
 			//dialog insert
 			_query_insert(id);
@@ -3656,7 +3660,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 	id.track_idx = -1;
 	id.value = p_value;
 	id.type = Animation::TYPE_VALUE;
-	id.query = "property '" + p_property + "'";
+	id.query = vformat(TTR("property '%s'"), p_property);
 	id.advance = false;
 	//dialog insert
 	_query_insert(id);
@@ -3709,7 +3713,7 @@ void AnimationTrackEditor::insert_value_key(const String &p_property, const Vari
 			id.track_idx = i;
 			id.value = p_value;
 			id.type = Animation::TYPE_VALUE;
-			id.query = "property '" + p_property + "'";
+			id.query = vformat(TTR("property '%s'"), p_property);
 			id.advance = p_advance;
 			//dialog insert
 			_query_insert(id);
@@ -3734,7 +3738,7 @@ void AnimationTrackEditor::insert_value_key(const String &p_property, const Vari
 			id.track_idx = i;
 			id.value = value;
 			id.type = Animation::TYPE_BEZIER;
-			id.query = "property '" + p_property + "'";
+			id.query = vformat(TTR("property '%s'"), p_property);
 			id.advance = p_advance;
 			//dialog insert
 			_query_insert(id);
@@ -3748,7 +3752,7 @@ void AnimationTrackEditor::insert_value_key(const String &p_property, const Vari
 		id.track_idx = -1;
 		id.value = p_value;
 		id.type = Animation::TYPE_VALUE;
-		id.query = "property '" + p_property + "'";
+		id.query = vformat(TTR("property '%s'"), p_property);
 		id.advance = p_advance;
 		//dialog insert
 		_query_insert(id);

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -566,7 +566,7 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 		int feature_id = md;
 		String feature_description = EditorFeatureProfile::get_feature_description(EditorFeatureProfile::Feature(feature_id));
 
-		description_bit->set_text(feature_description);
+		description_bit->set_text(TTRGET(feature_description));
 		return;
 	} else {
 		return;

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -910,8 +910,8 @@ ExportTemplateManager::ExportTemplateManager() {
 	request_mirrors->connect("request_completed", this, "_refresh_mirrors_completed");
 
 	mirror_options_button = memnew(MenuButton);
-	mirror_options_button->get_popup()->add_item("Open in Web Browser", VISIT_WEB_MIRROR);
-	mirror_options_button->get_popup()->add_item("Copy Mirror URL", COPY_MIRROR_URL);
+	mirror_options_button->get_popup()->add_item(TTR("Open in Web Browser"), VISIT_WEB_MIRROR);
+	mirror_options_button->get_popup()->add_item(TTR("Copy Mirror URL"), COPY_MIRROR_URL);
 	download_install_hb->add_child(mirror_options_button);
 	mirror_options_button->get_popup()->connect("id_pressed", this, "_mirror_options_button_cbk");
 

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -480,7 +480,7 @@ void RoomManager::show_warning(const String &p_string, const String &p_extra_str
 		WARN_PRINT(p_string + " " + p_extra_string);
 #ifdef TOOLS_ENABLED
 		if (p_alert && Engine::get_singleton()->is_editor_hint()) {
-			EditorNode::get_singleton()->show_warning(TTR(p_string + "\n" + p_extra_string));
+			EditorNode::get_singleton()->show_warning(TTRGET(p_string) + "\n" + TTRGET(p_extra_string));
 		}
 #endif
 	} else {
@@ -488,7 +488,7 @@ void RoomManager::show_warning(const String &p_string, const String &p_extra_str
 		// OS::get_singleton()->alert(p_string, p_title);
 #ifdef TOOLS_ENABLED
 		if (p_alert && Engine::get_singleton()->is_editor_hint()) {
-			EditorNode::get_singleton()->show_warning(TTR(p_string));
+			EditorNode::get_singleton()->show_warning(TTRGET(p_string));
 		}
 #endif
 	}
@@ -555,7 +555,7 @@ void RoomManager::rooms_flip_portals() {
 	_roomlist = _resolve_path<Spatial>(_settings_path_roomlist);
 	if (!_roomlist) {
 		WARN_PRINT("Cannot resolve nodepath");
-		show_warning("RoomList path is invalid.", "Please check the RoomList branch has been assigned in the RoomManager");
+		show_warning(TTRC("RoomList path is invalid."), TTRC("Please check the RoomList branch has been assigned in the RoomManager."));
 		return;
 	}
 
@@ -573,7 +573,7 @@ void RoomManager::rooms_convert() {
 	_roomlist = _resolve_path<Spatial>(_settings_path_roomlist);
 	if (!_roomlist) {
 		WARN_PRINT("Cannot resolve nodepath");
-		show_warning("RoomList path is invalid.", "Please check the RoomList branch has been assigned in the RoomManager");
+		show_warning(TTRC("RoomList path is invalid."), TTRC("Please check the RoomList branch has been assigned in the RoomManager."));
 		return;
 	}
 
@@ -600,7 +600,7 @@ void RoomManager::rooms_convert() {
 
 	if (!_rooms.size()) {
 		rooms_clear();
-		show_warning("RoomList contains no Rooms, aborting");
+		show_warning(TTRC("RoomList contains no Rooms, aborting."));
 		return;
 	}
 
@@ -660,20 +660,20 @@ void RoomManager::rooms_convert() {
 
 	// display error dialogs
 	if (_warning_misnamed_nodes_detected) {
-		show_warning("Misnamed nodes detected, check output log for details. Aborting.");
+		show_warning(TTRC("Misnamed nodes detected, check output log for details. Aborting."));
 		rooms_clear();
 	}
 
 	if (_warning_portal_link_room_not_found) {
-		show_warning("Portal link room not found, check output log for details.");
+		show_warning(TTRC("Portal link room not found, check output log for details."));
 	}
 
 	if (_warning_portal_autolink_failed) {
-		show_warning("Portal autolink failed, check output log for details.\nCheck the portal is facing outwards from the source room.");
+		show_warning(TTRC("Portal autolink failed, check output log for details.\nCheck the portal is facing outwards from the source room."));
 	}
 
 	if (_warning_room_overlap_detected) {
-		show_warning("Room overlap detected, cameras may work incorrectly in overlapping area.\nCheck output log for details..");
+		show_warning(TTRC("Room overlap detected, cameras may work incorrectly in overlapping area.\nCheck output log for details."));
 	}
 }
 
@@ -874,7 +874,7 @@ void RoomManager::_third_pass_rooms(const LocalVector<Portal *> &p_portals) {
 	}
 
 	if (found_errors) {
-		show_warning("ERROR calculating room bounds.", "Ensure all rooms contain geometry or manual bounds.");
+		show_warning(TTRC("ERROR calculating room bounds."), TTRC("Ensure all rooms contain geometry or manual bounds."));
 	}
 }
 


### PR DESCRIPTION
`3.x` version of #51217.

* `AnimationTrackEditor`: The phrase describing track target property / node / animation in prompt dialog was hardcoded.
* `ExportTemplateManager`: Two menu items were left hardcoded.
* `EditorFeatureProfileManager`: `TTRC` without `TTRGET`

---

This also changes `TTR(variable)` to `TTRC` & `TTRGET` in `RoomManager` and fixes some punctuations in the message.