### PR TITLE
Fix the editor theme application for the Mono build log

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -155,6 +155,7 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#8da5f3", "#3d64dd"); // 2D
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#4b70ea", "#1a3eac"); // 2D Dark
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#8eef97", "#2fa139"); // Control
+		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ffdd65", "#ca8a04"); // Node warning
 
 		// Rainbow
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ff4545", "#ff2929"); // Red
@@ -229,7 +230,6 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 		exceptions.insert("StatusError");
 		exceptions.insert("StatusSuccess");
 		exceptions.insert("StatusWarning");
-		exceptions.insert("NodeWarning");
 		exceptions.insert("OverbrightIndicator");
 	}
 
@@ -1045,6 +1045,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("tab", "TextEdit", theme->get_icon("GuiTab", "EditorIcons"));
 	theme->set_icon("space", "TextEdit", theme->get_icon("GuiSpace", "EditorIcons"));
 	theme->set_color("font_color", "TextEdit", font_color);
+	theme->set_color("font_readonly_color", "LineEdit", font_readonly_color);
 	theme->set_color("caret_color", "TextEdit", font_color);
 	theme->set_color("selection_color", "TextEdit", selection_color);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -11,6 +11,7 @@ namespace GodotTools.Build
     {
         public BuildOutputView BuildOutputView { get; private set; }
 
+        private MenuButton buildMenuBtn;
         private Button errorsBtn;
         private Button warningsBtn;
         private Button viewLogBtn;
@@ -131,7 +132,7 @@ namespace GodotTools.Build
             var toolBarHBox = new HBoxContainer {SizeFlagsHorizontal = (int)SizeFlags.ExpandFill};
             AddChild(toolBarHBox);
 
-            var buildMenuBtn = new MenuButton {Text = "Build", Icon = GetThemeIcon("Play", "EditorIcons")};
+            buildMenuBtn = new MenuButton {Text = "Build", Icon = GetThemeIcon("Play", "EditorIcons")};
             toolBarHBox.AddChild(buildMenuBtn);
 
             var buildMenu = buildMenuBtn.GetPopup();
@@ -176,6 +177,17 @@ namespace GodotTools.Build
 
             BuildOutputView = new BuildOutputView();
             AddChild(BuildOutputView);
+        }
+
+        public override void _Notification(int what)
+        {
+            base._Notification(what);
+
+            if (what == NotificationThemeChanged) {
+                buildMenuBtn.Icon = GetThemeIcon("Play", "EditorIcons");
+                errorsBtn.Icon = GetThemeIcon("StatusError", "EditorIcons");
+                warningsBtn.Icon = GetThemeIcon("NodeWarning", "EditorIcons");
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/45248.

The font color is now correct (we were missing one definition in the editor theme). I've also added the code necessary to correctly update the icons on the theme change, but the problem is those icons don't actually adjust with the editor theme for some reason. Their colors are not in the conversion table and they themselves are in fact in the list of exceptions. But why that's the case is unclear, as at least the node warning icon is clearly problematic in light themes.

So I've removed that icon from the exception list and added a special conversion rule for it:

![godot windows tools 64 mono_2021-08-03_21-21-46](https://user-images.githubusercontent.com/11782833/128073023-0fbb47a6-0cc2-412c-a1a7-9add42babc25.png)

![godot windows tools 64 mono_2021-08-03_22-08-34](https://user-images.githubusercontent.com/11782833/128073044-2b806a95-63f6-4aa9-9496-d2968cbd94ce.png)

Here's it in action in the Mono panel:


https://user-images.githubusercontent.com/11782833/128073196-dd9ef7c9-cf82-43c6-83ac-bdf09a3f27fd.mp4


And here's the output log (screenshot taken from the `3.x` build):

![godot windows tools 64 mono_2021-08-03_22-15-19](https://user-images.githubusercontent.com/11782833/128073230-57231102-4b8d-4c31-8d6d-febb8ad91b7c.png)