### PR TITLE
Removed useless semicolon in FileAccessWindows

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -265,7 +265,7 @@ uint64_t FileAccessWindows::get_buffer(uint8_t *p_dst, uint64_t p_length) const 
 	uint64_t read = fread(p_dst, 1, p_length, f);
 	check_errors();
 	return read;
-};
+}
 
 Error FileAccessWindows::get_error() const {
 	return last_error;


### PR DESCRIPTION
Removed wild useless(?) semicolon I noticed while working on something.

It exists in 3.x too.
