### PR TITLE
Various fixes to Tween code

### DIFF
--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -43,6 +43,7 @@ public:
 	virtual void set_tween(Ref<Tween> p_tween);
 	virtual void start() = 0;
 	virtual bool step(float &r_delta) = 0;
+	void clear_tween();
 
 protected:
 	static void _bind_methods();
@@ -111,7 +112,7 @@ private:
 	bool started = false;
 	bool running = true;
 	bool dead = false;
-	bool invalid = true;
+	bool valid = false;
 	bool default_parallel = false;
 	bool parallel_enabled = false;
 
@@ -128,7 +129,7 @@ public:
 	Ref<IntervalTweener> tween_interval(float p_time);
 	Ref<CallbackTweener> tween_callback(Callable p_callback);
 	Ref<MethodTweener> tween_method(Callable p_callback, float p_from, float p_to, float p_duration);
-	Ref<Tween> append(Ref<Tweener> p_tweener);
+	void append(Ref<Tweener> p_tweener);
 
 	bool custom_step(float p_delta);
 	void stop();
@@ -139,6 +140,7 @@ public:
 	bool is_running();
 	void set_valid(bool p_valid);
 	bool is_valid();
+	void clear();
 
 	Ref<Tween> bind_node(Node *p_node);
 	Ref<Tween> set_process_mode(TweenProcessMode p_mode);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -544,7 +544,7 @@ void SceneTree::process_tweens(float p_delta, bool p_physics) {
 		}
 
 		if (!E->get()->step(p_delta)) {
-			E->get()->set_valid(false);
+			E->get()->clear();
 			tweens.erase(E);
 		}
 		if (E == L) {


### PR DESCRIPTION
Attempt to fix #51231

The bug is caused by cyclic reference, but even though I clear everything, some of the Tweeners still don't get destroyed. Here's updated code from the issue's MRP, for testing:
```
extends Node2D

@onready var sprite := $Sprite2D

func _unhandled_input(event: InputEvent) -> void:
	if event.is_action_pressed("click"):
		move_node_to_click(get_global_mouse_position())
		get_tree().create_timer(2).timeout.connect(end)

func move_node_to_click(target_position: Vector2) -> void:
	print(target_position)
	var tween: Tween = get_tree().create_tween()
	tween.tween_interval(0.5)
	tween.tween_property(sprite, "position", target_position, 0.5)
#	tween.tween_callback(end)
	tween.tween_callback(test.bind("end?"))
	tween.tween_method(test, 0, 2, 0.01)

func test(v):
	print(v)

func end():
	print(get_tree().get_processed_tweens())
```
For whatever reason, only MethodTweener and PropertyTweener get properly destroyed. Tween, CallbackTweener and IntervalTweener still linger somewhere. What's more weird, when you change the callback in the code above to the commented out `end`, the callback tweener gets removed too (which makes me think that the issue is not related to Tweens).

Putting it as draft now. Also there are some debug prints for easier testing.

---

Aside from the above issue, I fixed broken `is_valid()` method. Also removed return value from `Tween.append()`, which was a leftover from a brief moment when it was exposed. There is also one error message I improved, but I'm not 100% if it's worded correctly.