### PR TITLE
Improve user communications in the theme editor

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1278,6 +1278,9 @@ void ThemeItemEditorDialog::_update_edit_types() {
 		edit_items_remove_class->set_disabled(false);
 		edit_items_remove_custom->set_disabled(false);
 		edit_items_remove_all->set_disabled(false);
+
+		edit_items_message->set_text("");
+		edit_items_message->hide();
 	} else {
 		edit_items_add_color->set_disabled(true);
 		edit_items_add_constant->set_disabled(true);
@@ -1289,6 +1292,9 @@ void ThemeItemEditorDialog::_update_edit_types() {
 		edit_items_remove_class->set_disabled(true);
 		edit_items_remove_custom->set_disabled(true);
 		edit_items_remove_all->set_disabled(true);
+
+		edit_items_message->set_text(TTR("Select a theme type from the list to edit its items.\nYou can add a custom type or import a type with its items from another theme."));
+		edit_items_message->show();
 	}
 	_update_edit_item_tree(selected_type);
 }
@@ -1305,6 +1311,7 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 	TreeItem *root = edit_items_tree->create_item();
 
 	List<StringName> names;
+	bool has_any_items = false;
 
 	{ // Colors.
 		names.clear();
@@ -1324,6 +1331,8 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
+
+			has_any_items = true;
 		}
 	}
 
@@ -1345,6 +1354,8 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
+
+			has_any_items = true;
 		}
 	}
 
@@ -1366,6 +1377,8 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
+
+			has_any_items = true;
 		}
 	}
 
@@ -1387,6 +1400,8 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
+
+			has_any_items = true;
 		}
 	}
 
@@ -1408,6 +1423,8 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
+
+			has_any_items = true;
 		}
 	}
 
@@ -1429,6 +1446,20 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 				item->add_button(0, get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), ITEMS_TREE_RENAME_ITEM, false, TTR("Rename Item"));
 				item->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ITEMS_TREE_REMOVE_ITEM, false, TTR("Remove Item"));
 			}
+
+			has_any_items = true;
+		}
+	}
+
+	// If some type is selected, but it doesn't seem to have any items, show a guiding message.
+	Vector<int> selected_ids = edit_type_list->get_selected_items();
+	if (selected_ids.size() > 0) {
+		if (!has_any_items) {
+			edit_items_message->set_text(TTR("This theme type is empty.\nAdd more items to it manually or by importing from another theme."));
+			edit_items_message->show();
+		} else {
+			edit_items_message->set_text("");
+			edit_items_message->hide();
 		}
 	}
 }
@@ -1872,6 +1903,14 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	edit_items_tree->set_columns(1);
 	edit_items_vb->add_child(edit_items_tree);
 	edit_items_tree->connect("button_pressed", callable_mp(this, &ThemeItemEditorDialog::_item_tree_button_pressed));
+
+	edit_items_message = memnew(Label);
+	edit_items_message->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
+	edit_items_message->set_mouse_filter(Control::MOUSE_FILTER_STOP);
+	edit_items_message->set_align(Label::ALIGN_CENTER);
+	edit_items_message->set_valign(Label::VALIGN_CENTER);
+	edit_items_message->set_autowrap_mode(Label::AUTOWRAP_WORD);
+	edit_items_tree->add_child(edit_items_message);
 
 	edit_theme_item_dialog = memnew(ConfirmationDialog);
 	edit_theme_item_dialog->set_title(TTR("Add Theme Item"));
@@ -2542,15 +2581,15 @@ void ThemeTypeEditor::_update_type_items() {
 	// Various type settings.
 	if (ClassDB::class_exists(edited_type)) {
 		type_variation_edit->set_editable(false);
-		type_variation_edit->set_tooltip(TTR("A type associated with a built-in class cannot be marked as a variation of another type."));
 		type_variation_edit->set_text("");
 		type_variation_button->hide();
+		type_variation_locked->show();
 	} else {
 		type_variation_edit->set_editable(true);
-		type_variation_edit->set_tooltip("");
 		type_variation_edit->set_text(edited_theme->get_type_variation_base(edited_type));
 		_add_focusable(type_variation_edit);
 		type_variation_button->show();
+		type_variation_locked->hide();
 	}
 }
 
@@ -3067,8 +3106,11 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	type_settings_list->set_h_size_flags(SIZE_EXPAND_FILL);
 	type_settings_sc->add_child(type_settings_list);
 
+	VBoxContainer *type_variation_vb = memnew(VBoxContainer);
+	type_settings_list->add_child(type_variation_vb);
+
 	HBoxContainer *type_variation_hb = memnew(HBoxContainer);
-	type_settings_list->add_child(type_variation_hb);
+	type_variation_vb->add_child(type_variation_hb);
 	Label *type_variation_label = memnew(Label);
 	type_variation_hb->add_child(type_variation_label);
 	type_variation_label->set_text(TTR("Base Type"));
@@ -3082,6 +3124,13 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	type_variation_hb->add_child(type_variation_button);
 	type_variation_button->set_tooltip(TTR("Select the variation base type from a list of available types."));
 	type_variation_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_add_type_variation_cbk));
+
+	type_variation_locked = memnew(Label);
+	type_variation_vb->add_child(type_variation_locked);
+	type_variation_locked->set_align(Label::ALIGN_CENTER);
+	type_variation_locked->set_autowrap_mode(Label::AUTOWRAP_WORD);
+	type_variation_locked->set_text(TTR("A type associated with a built-in class cannot be marked as a variation of another type."));
+	type_variation_locked->hide();
 
 	add_type_dialog = memnew(ThemeTypeDialog);
 	add_child(add_type_dialog);
@@ -3130,7 +3179,7 @@ void ThemeEditor::_theme_save_button_cbk(bool p_save_as) {
 }
 
 void ThemeEditor::_theme_edit_button_cbk() {
-	theme_edit_dialog->popup_centered(Size2(850, 760) * EDSCALE);
+	theme_edit_dialog->popup_centered(Size2(850, 700) * EDSCALE);
 }
 
 void ThemeEditor::_add_preview_button_cbk() {

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -197,6 +197,7 @@ class ThemeItemEditorDialog : public AcceptDialog {
 	Button *edit_items_remove_custom;
 	Button *edit_items_remove_all;
 	Tree *edit_items_tree;
+	Label *edit_items_message;
 
 	enum ItemsTreeAction {
 		ITEMS_TREE_RENAME_ITEM,
@@ -324,6 +325,7 @@ class ThemeTypeEditor : public MarginContainer {
 
 	LineEdit *type_variation_edit;
 	Button *type_variation_button;
+	Label *type_variation_locked;
 
 	enum TypeDialogMode {
 		ADD_THEME_TYPE,


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/49407. The theme management window has also been shrunk a bit vertically as some users reported it not fitting their screens.


https://user-images.githubusercontent.com/11782833/128209244-29a4f5b1-1dac-45cf-a0f2-f5ddc703c82a.mp4


Additionally, the message for when the type variation cannot be edited has been moved into a label so you don't need to hover over the line edit to see it (thanks to @EricEzaM for reporting it over RC).

![godot windows tools 64_2021-08-04_18-02-26](https://user-images.githubusercontent.com/11782833/128209297-d4ea7fcd-b6d8-437b-9298-ee81d453235b.png)
