### PR TITLE
Portals - add gizmo handles for editing portals and rooms

### DIFF
--- a/doc/classes/Portal.xml
+++ b/doc/classes/Portal.xml
@@ -12,6 +12,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="set_point">
+			<return type="void" />
+			<argument index="0" name="index" type="int" />
+			<argument index="1" name="position" type="Vector2" />
+			<description>
+				Sets individual points. Primarily for use by the editor.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="linked_room" type="NodePath" setter="set_linked_room" getter="get_linked_room" default="NodePath(&quot;&quot;)">

--- a/doc/classes/Room.xml
+++ b/doc/classes/Room.xml
@@ -13,6 +13,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="set_point">
+			<return type="void" />
+			<argument index="0" name="index" type="int" />
+			<argument index="1" name="position" type="Vector3" />
+			<description>
+				Sets individual points. Primarily for use by the editor.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="points" type="PoolVector3Array" setter="set_points" getter="get_points" default="PoolVector3Array(  )">

--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -429,6 +429,23 @@ public:
 	JointSpatialGizmoPlugin();
 };
 
+class Room;
+
+class RoomSpatialGizmo : public EditorSpatialGizmo {
+	GDCLASS(RoomSpatialGizmo, EditorSpatialGizmo);
+
+	Room *_room = nullptr;
+
+public:
+	virtual String get_handle_name(int p_idx) const;
+	virtual Variant get_handle_value(int p_idx);
+	virtual void set_handle(int p_idx, Camera *p_camera, const Point2 &p_point);
+	virtual void commit_handle(int p_idx, const Variant &p_restore, bool p_cancel = false);
+	virtual void redraw();
+
+	RoomSpatialGizmo(Room *p_room = nullptr);
+};
+
 class RoomGizmoPlugin : public EditorSpatialGizmoPlugin {
 	GDCLASS(RoomGizmoPlugin, EditorSpatialGizmoPlugin);
 
@@ -436,10 +453,29 @@ protected:
 	virtual bool has_gizmo(Spatial *p_spatial);
 	String get_name() const;
 	int get_priority() const;
-	void redraw(EditorSpatialGizmo *p_gizmo);
+	Ref<EditorSpatialGizmo> create_gizmo(Spatial *p_spatial);
 
 public:
 	RoomGizmoPlugin();
+};
+
+class Portal;
+
+class PortalSpatialGizmo : public EditorSpatialGizmo {
+	GDCLASS(PortalSpatialGizmo, EditorSpatialGizmo);
+
+	Portal *_portal = nullptr;
+	Color _color_portal_front;
+	Color _color_portal_back;
+
+public:
+	virtual String get_handle_name(int p_idx) const;
+	virtual Variant get_handle_value(int p_idx);
+	virtual void set_handle(int p_idx, Camera *p_camera, const Point2 &p_point);
+	virtual void commit_handle(int p_idx, const Variant &p_restore, bool p_cancel = false);
+	virtual void redraw();
+
+	PortalSpatialGizmo(Portal *p_portal = nullptr);
 };
 
 class PortalGizmoPlugin : public EditorSpatialGizmoPlugin {
@@ -449,11 +485,7 @@ protected:
 	virtual bool has_gizmo(Spatial *p_spatial);
 	String get_name() const;
 	int get_priority() const;
-	void redraw(EditorSpatialGizmo *p_gizmo);
-
-private:
-	Color _color_portal_front;
-	Color _color_portal_back;
+	Ref<EditorSpatialGizmo> create_gizmo(Spatial *p_spatial);
 
 public:
 	PortalGizmoPlugin();

--- a/scene/3d/portal.cpp
+++ b/scene/3d/portal.cpp
@@ -114,6 +114,16 @@ String Portal::get_configuration_warning() const {
 	return warning;
 }
 
+void Portal::set_point(int p_idx, const Vector2 &p_point) {
+	if (p_idx >= _pts_local_raw.size()) {
+		return;
+	}
+
+	_pts_local_raw.set(p_idx, p_point);
+	_sanitize_points();
+	update_gizmo();
+}
+
 void Portal::set_points(const PoolVector<Vector2> &p_points) {
 	_pts_local_raw = p_points;
 	_sanitize_points();
@@ -669,6 +679,8 @@ void Portal::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_points", "points"), &Portal::set_points);
 	ClassDB::bind_method(D_METHOD("get_points"), &Portal::get_points);
+
+	ClassDB::bind_method(D_METHOD("set_point", "index", "position"), &Portal::set_point);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "portal_active"), "set_portal_active", "get_portal_active");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "two_way"), "set_two_way", "is_two_way");

--- a/scene/3d/portal.h
+++ b/scene/3d/portal.h
@@ -47,6 +47,7 @@ class Portal : public Spatial {
 	friend class RoomManager;
 	friend class PortalGizmoPlugin;
 	friend class PortalEditorPlugin;
+	friend class PortalSpatialGizmo;
 
 public:
 	// ui interface .. will have no effect after room conversion
@@ -83,6 +84,9 @@ public:
 	void set_points(const PoolVector<Vector2> &p_points);
 	PoolVector<Vector2> get_points() const;
 
+	// primarily for the gizmo
+	void set_point(int p_idx, const Vector2 &p_point);
+
 	String get_configuration_warning() const;
 
 	Portal();
@@ -105,7 +109,7 @@ private:
 	void flip();
 	void _sanitize_points();
 	void _update_aabb();
-	Vector3 _vec2to3(const Vector2 &p_pt) const { return Vector3(p_pt.x, p_pt.y, 0.0); }
+	static Vector3 _vec2to3(const Vector2 &p_pt) { return Vector3(p_pt.x, p_pt.y, 0.0); }
 	void _sort_verts_clockwise(bool portal_plane_convention, Vector<Vector3> &r_verts);
 	Plane _plane_from_points_newell(const Vector<Vector3> &p_pts);
 	void resolve_links(const LocalVector<Room *, int32_t> &p_rooms, const RID &p_from_room_rid);

--- a/scene/3d/room.cpp
+++ b/scene/3d/room.cpp
@@ -130,6 +130,18 @@ void Room::set_use_default_simplify(bool p_use) {
 	_use_default_simplify = p_use;
 }
 
+void Room::set_point(int p_idx, const Vector3 &p_point) {
+	if (p_idx >= _bound_pts.size()) {
+		return;
+	}
+
+	_bound_pts.set(p_idx, p_point);
+
+#ifdef TOOLS_ENABLED
+	_changed(true);
+#endif
+}
+
 void Room::set_points(const PoolVector<Vector3> &p_points) {
 	_bound_pts = p_points;
 
@@ -272,6 +284,8 @@ void Room::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_points", "points"), &Room::set_points);
 	ClassDB::bind_method(D_METHOD("get_points"), &Room::get_points);
+
+	ClassDB::bind_method(D_METHOD("set_point", "index", "position"), &Room::set_point);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_default_simplify"), "set_use_default_simplify", "get_use_default_simplify");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "room_simplify", PROPERTY_HINT_RANGE, "0.0,1.0,0.005"), "set_room_simplify", "get_room_simplify");

--- a/scene/3d/room.h
+++ b/scene/3d/room.h
@@ -45,6 +45,7 @@ class Room : public Spatial {
 	friend class Portal;
 	friend class RoomGizmoPlugin;
 	friend class RoomEditorPlugin;
+	friend class RoomSpatialGizmo;
 
 	RID _room_rid;
 
@@ -70,6 +71,9 @@ public:
 
 	void set_points(const PoolVector<Vector3> &p_points);
 	PoolVector<Vector3> get_points() const;
+
+	// primarily for the gizmo
+	void set_point(int p_idx, const Vector3 &p_point);
 
 	// editor only
 	PoolVector<Vector3> generate_points();


### PR DESCRIPTION
Gizmo handles are added for much more user friendly editing of portals and room bounds.

![portal_handles](https://user-images.githubusercontent.com/21999379/128221749-b3607640-3dea-4239-b930-dee079fc267e.png)

![Screenshot from 2021-08-04 18-01-17](https://user-images.githubusercontent.com/21999379/128223340-1efb8a5a-6244-45ea-b135-8bfc27a14be9.png)

## N.B.
Room handles will only appear once you have clicked `Generate Points` to create a set of editable points (see the docs).

## Notes
* The portal handles are very easy to use, the portal is confined in 2d space.
* The room handles take a little more getting used to but they are very usable. Ideally in future I'd like to try JFons subgizmos if they support x/y/z handles per vertex.
* In order to have some kind of sensible transformation for the room vertices, the dragging is confined to the two axes that are furthest from the camera direction.
* The snapping works as is for the room vertices. For the portal vertices, they are defined in local space, and snapping to world space makes no sense (as they are confined to a 2d plane). So instead I've made the snapping snap within 2d space. This seems a good compromise (rather than not offering snapping at all), even though the scale may not match up to the world space scale.

## Edit
It turns out the problem I was getting with stutters in the editor when dragging the handles and the gizmos redrawing was due to #51256 a regression in the octahedral compression. Now that has been fixed I've re-enabled redrawing on mouse drag and it works fine. :+1: 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
