### PR TITLE
Add theme item descriptions to the online documentation

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -116,6 +116,17 @@ public:
 		}
 	};
 
+	struct ThemeItemDoc {
+		String name;
+		String type;
+		String data_type;
+		String description;
+		String default_value;
+		bool operator<(const ThemeItemDoc &p_theme_item) const {
+			return name < p_theme_item.name;
+		}
+	};
+
 	struct TutorialDoc {
 		String link;
 		String title;
@@ -133,7 +144,7 @@ public:
 		Vector<ConstantDoc> constants;
 		Map<String, String> enums;
 		Vector<PropertyDoc> properties;
-		Vector<PropertyDoc> theme_properties;
+		Vector<ThemeItemDoc> theme_properties;
 		bool is_script_doc = false;
 		String script_path;
 		bool operator<(const ClassDoc &p_class) const {

--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -93,7 +93,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			Panel that fills up the background of the window.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -104,64 +104,64 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [Button]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [Button].
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Text [Color] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="font_hover_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_hover_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [Button] is being hovered and pressed.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [Button].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [Button] is being pressed.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [Button]'s text.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="2">
+		<theme_item name="hseparation" data_type="constant" type="int" default="2">
 			The horizontal space between [Button]'s icon and text.
 		</theme_item>
-		<theme_item name="icon_disabled_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="icon_disabled_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="icon_hover_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="icon_hover_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="icon_hover_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="icon_hover_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being hovered and pressed.
 		</theme_item>
-		<theme_item name="icon_normal_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="icon_normal_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Default icon modulate [Color] of the [Button].
 		</theme_item>
-		<theme_item name="icon_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="icon_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being pressed.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [Button].
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is being pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -18,76 +18,76 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="check_vadjust" type="int" default="0">
+		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>
-		<theme_item name="checked" type="Texture2D">
+		<theme_item name="checked" data_type="icon" type="Texture2D">
 			The check icon to display when the [CheckBox] is checked.
 		</theme_item>
-		<theme_item name="checked_disabled" type="Texture2D">
+		<theme_item name="checked_disabled" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is focused.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			The [Font] to use for the [CheckBox] text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			The [CheckBox] text's font color.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			The [CheckBox] text's font color when it's disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			The [CheckBox] text's font color when it's hovered.
 		</theme_item>
-		<theme_item name="font_hover_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_hover_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckBox] text's font color when it's hovered and pressed.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [CheckBox].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckBox] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [CheckBox]'s text.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is hovered.
 		</theme_item>
-		<theme_item name="hover_pressed" type="StyleBox">
+		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is hovered and pressed.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The separation between the check icon and the text (in pixels).
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background.
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is pressed.
 		</theme_item>
-		<theme_item name="radio_checked" type="Texture2D">
+		<theme_item name="radio_checked" data_type="icon" type="Texture2D">
 			If the [CheckBox] is configured as a radio button, the icon to display when the [CheckBox] is checked.
 		</theme_item>
-		<theme_item name="radio_checked_disabled" type="Texture2D">
+		<theme_item name="radio_checked_disabled" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="radio_unchecked" type="Texture2D">
+		<theme_item name="radio_unchecked" data_type="icon" type="Texture2D">
 			If the [CheckBox] is configured as a radio button, the icon to display when the [CheckBox] is unchecked.
 		</theme_item>
-		<theme_item name="radio_unchecked_disabled" type="Texture2D">
+		<theme_item name="radio_unchecked_disabled" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="unchecked" type="Texture2D">
+		<theme_item name="unchecked" data_type="icon" type="Texture2D">
 			The check icon to display when the [CheckBox] is unchecked.
 		</theme_item>
-		<theme_item name="unchecked_disabled" type="Texture2D">
+		<theme_item name="unchecked_disabled" data_type="icon" type="Texture2D">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -18,79 +18,79 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="check_vadjust" type="int" default="0">
+		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is focused.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			The [Font] to use for the [CheckButton] text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			The [CheckButton] text's font color.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			The [CheckButton] text's font color when it's disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			The [CheckButton] text's font color when it's hovered.
 		</theme_item>
-		<theme_item name="font_hover_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_hover_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckButton] text's font color when it's hovered and pressed.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [CheckButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckButton] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [CheckButton]'s text.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is hovered.
 		</theme_item>
-		<theme_item name="hover_pressed" type="StyleBox">
+		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is hovered and pressed.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The separation between the toggle icon and the text (in pixels).
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background.
 		</theme_item>
-		<theme_item name="off" type="Texture2D">
+		<theme_item name="off" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is unchecked (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="off_disabled" type="Texture2D">
+		<theme_item name="off_disabled" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is unchecked and disabled (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="off_disabled_mirrored" type="Texture2D">
+		<theme_item name="off_disabled_mirrored" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is unchecked and disabled (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="off_mirrored" type="Texture2D">
+		<theme_item name="off_mirrored" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is unchecked (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="on" type="Texture2D">
+		<theme_item name="on" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is checked (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="on_disabled" type="Texture2D">
+		<theme_item name="on_disabled" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is checked and disabled (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="on_disabled_mirrored" type="Texture2D">
+		<theme_item name="on_disabled_mirrored" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is checked and disabled (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="on_mirrored" type="Texture2D">
+		<theme_item name="on_mirrored" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is checked (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -560,128 +560,128 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="background_color" type="Color" default="Color(0, 0, 0, 0)">
+		<theme_item name="background_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			Sets the background [Color].
 		</theme_item>
-		<theme_item name="bookmark" type="Texture2D">
+		<theme_item name="bookmark" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] to draw in the bookmark gutter for bookmarked lines.
 		</theme_item>
-		<theme_item name="bookmark_color" type="Color" default="Color(0.5, 0.64, 1, 0.8)">
+		<theme_item name="bookmark_color" data_type="color" type="Color" default="Color(0.5, 0.64, 1, 0.8)">
 			[Color] of the bookmark icon for bookmarked lines.
 		</theme_item>
-		<theme_item name="brace_mismatch_color" type="Color" default="Color(1, 0.2, 0.2, 1)">
+		<theme_item name="brace_mismatch_color" data_type="color" type="Color" default="Color(1, 0.2, 0.2, 1)">
 			[Color] of the text to highlight mismatched braces.
 		</theme_item>
-		<theme_item name="breakpoint" type="Texture2D">
+		<theme_item name="breakpoint" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] to draw in the breakpoint gutter for breakpointed lines.
 		</theme_item>
-		<theme_item name="breakpoint_color" type="Color" default="Color(0.9, 0.29, 0.3, 1)">
+		<theme_item name="breakpoint_color" data_type="color" type="Color" default="Color(0.9, 0.29, 0.3, 1)">
 			[Color] of the breakpoint icon for bookmarked lines.
 		</theme_item>
-		<theme_item name="can_fold" type="Texture2D">
+		<theme_item name="can_fold" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] to draw in the line folding gutter when a line can be folded.
 		</theme_item>
-		<theme_item name="caret_background_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="caret_background_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			[Color] of the text behind the caret when block caret is enabled.
 		</theme_item>
-		<theme_item name="caret_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="caret_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			[Color] of the caret.
 		</theme_item>
-		<theme_item name="code_folding_color" type="Color" default="Color(0.8, 0.8, 0.8, 0.8)">
+		<theme_item name="code_folding_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 0.8)">
 			[Color] for all icons related to line folding.
 		</theme_item>
-		<theme_item name="completion" type="StyleBox">
+		<theme_item name="completion" data_type="style" type="StyleBox">
 			[StyleBox] for the code completion popup.
 		</theme_item>
-		<theme_item name="completion_background_color" type="Color" default="Color(0.17, 0.16, 0.2, 1)">
+		<theme_item name="completion_background_color" data_type="color" type="Color" default="Color(0.17, 0.16, 0.2, 1)">
 			Sets the background [Color] for the code completion popup.
 		</theme_item>
-		<theme_item name="completion_existing_color" type="Color" default="Color(0.87, 0.87, 0.87, 0.13)">
+		<theme_item name="completion_existing_color" data_type="color" type="Color" default="Color(0.87, 0.87, 0.87, 0.13)">
 			Background highlight [Color] for matching text in code completion options.
 		</theme_item>
-		<theme_item name="completion_font_color" type="Color" default="Color(0.67, 0.67, 0.67, 1)">
+		<theme_item name="completion_font_color" data_type="color" type="Color" default="Color(0.67, 0.67, 0.67, 1)">
 			Font [Color] for the code completion popup.
 		</theme_item>
-		<theme_item name="completion_lines" type="int" default="7">
+		<theme_item name="completion_lines" data_type="constant" type="int" default="7">
 			Max number of options to display in the code completion popup at any one time.
 		</theme_item>
-		<theme_item name="completion_max_width" type="int" default="50">
+		<theme_item name="completion_max_width" data_type="constant" type="int" default="50">
 			Max width of options in the code completion popup. Options longer then this will be cut off.
 		</theme_item>
-		<theme_item name="completion_scroll_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="completion_scroll_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			[Color] of the scrollbar in the code completion popup.
 		</theme_item>
-		<theme_item name="completion_scroll_width" type="int" default="3">
+		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="3">
 			Width of the scrollbar in the code completion popup.
 		</theme_item>
-		<theme_item name="completion_selected_color" type="Color" default="Color(0.26, 0.26, 0.27, 1)">
+		<theme_item name="completion_selected_color" data_type="color" type="Color" default="Color(0.26, 0.26, 0.27, 1)">
 			Background highlight [Color] for the current selected option item in the code completion popup.
 		</theme_item>
-		<theme_item name="current_line_color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">
+		<theme_item name="current_line_color" data_type="color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">
 			Background [Color] of the line containing the caret.
 		</theme_item>
-		<theme_item name="executing_line" type="Texture2D">
+		<theme_item name="executing_line" data_type="icon" type="Texture2D">
 			Icon to draw in the executing gutter for executing lines.
 		</theme_item>
-		<theme_item name="executing_line_color" type="Color" default="Color(0.98, 0.89, 0.27, 1)">
+		<theme_item name="executing_line_color" data_type="color" type="Color" default="Color(0.98, 0.89, 0.27, 1)">
 			[Color] of the executing icon for executing lines.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			Sets the [StyleBox] when in focus.
 		</theme_item>
-		<theme_item name="folded" type="Texture2D">
+		<theme_item name="folded" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] to draw in the line folding gutter when a line is folded and can be unfolded.
 		</theme_item>
-		<theme_item name="folded_eol_icon" type="Texture2D">
+		<theme_item name="folded_eol_icon" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] to draw at the end of a folded line.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			Sets the default [Font].
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Sets the font [Color].
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [CodeEdit].
 		</theme_item>
-		<theme_item name="font_readonly_color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
-			Sets the font [Color] when [member readonly] is enabled.
+		<theme_item name="font_readonly_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
+			Sets the font [Color] when [member TextEdit.readonly] is enabled.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color(0, 0, 0, 1)">
-			Sets the [Color] of the selected text. [member override_selected_font_color] has to be enabled.
+		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+			Sets the [Color] of the selected text. [member TextEdit.override_selected_font_color] has to be enabled.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Sets default font size.
 		</theme_item>
-		<theme_item name="line_length_guideline_color" type="Color" default="Color(0.3, 0.5, 0.8, 0.1)">
+		<theme_item name="line_length_guideline_color" data_type="color" type="Color" default="Color(0.3, 0.5, 0.8, 0.1)">
 			[Color] of the main line length guideline, secondary guidelines will have 50% alpha applied.
 		</theme_item>
-		<theme_item name="line_number_color" type="Color" default="Color(0.67, 0.67, 0.67, 0.4)">
+		<theme_item name="line_number_color" data_type="color" type="Color" default="Color(0.67, 0.67, 0.67, 0.4)">
 			Sets the [Color] of line numbers.
 		</theme_item>
-		<theme_item name="line_spacing" type="int" default="4">
+		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
 			Sets the spacing between the lines.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Sets the [StyleBox].
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="read_only" type="StyleBox">
-			Sets the [StyleBox] when [member readonly] is enabled.
+		<theme_item name="read_only" data_type="style" type="StyleBox">
+			Sets the [StyleBox] when [member TextEdit.readonly] is enabled.
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 			Sets the highlight [Color] of text selections.
 		</theme_item>
-		<theme_item name="space" type="Texture2D">
+		<theme_item name="space" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for space text characters.
 		</theme_item>
-		<theme_item name="tab" type="Texture2D">
+		<theme_item name="tab" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for tab text characters.
 		</theme_item>
-		<theme_item name="word_highlighted_color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
-			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
+		<theme_item name="word_highlighted_color" data_type="color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
+			Sets the highlight [Color] of multiple occurrences. [member TextEdit.highlight_all_occurrences] has to be enabled.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -92,39 +92,39 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="add_preset" type="Texture2D">
+		<theme_item name="add_preset" data_type="icon" type="Texture2D">
 			The icon for the "Add Preset" button.
 		</theme_item>
-		<theme_item name="bar_arrow" type="Texture2D">
+		<theme_item name="bar_arrow" data_type="icon" type="Texture2D">
 			The texture for the arrow grabber.
 		</theme_item>
-		<theme_item name="color_hue" type="Texture2D">
+		<theme_item name="color_hue" data_type="icon" type="Texture2D">
 			Custom texture for the hue selection slider on the right.
 		</theme_item>
-		<theme_item name="color_sample" type="Texture2D">
+		<theme_item name="color_sample" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="h_width" type="int" default="30">
+		<theme_item name="h_width" data_type="constant" type="int" default="30">
 			The width of the hue selection slider.
 		</theme_item>
-		<theme_item name="label_width" type="int" default="10">
+		<theme_item name="label_width" data_type="constant" type="int" default="10">
 		</theme_item>
-		<theme_item name="margin" type="int" default="4">
+		<theme_item name="margin" data_type="constant" type="int" default="4">
 			The margin around the [ColorPicker].
 		</theme_item>
-		<theme_item name="overbright_indicator" type="Texture2D">
+		<theme_item name="overbright_indicator" data_type="icon" type="Texture2D">
 			The indicator used to signalize that the color value is outside the 0-1 range.
 		</theme_item>
-		<theme_item name="picker_cursor" type="Texture2D">
+		<theme_item name="picker_cursor" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="preset_bg" type="Texture2D">
+		<theme_item name="preset_bg" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="screen_picker" type="Texture2D">
+		<theme_item name="screen_picker" data_type="icon" type="Texture2D">
 			The icon for the screen color picker button.
 		</theme_item>
-		<theme_item name="sv_height" type="int" default="256">
+		<theme_item name="sv_height" data_type="constant" type="int" default="256">
 			The height of the saturation-value selection box.
 		</theme_item>
-		<theme_item name="sv_width" type="int" default="256">
+		<theme_item name="sv_width" data_type="constant" type="int" default="256">
 			The width of the saturation-value selection box.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -55,49 +55,49 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" type="Texture2D">
+		<theme_item name="bg" data_type="icon" type="Texture2D">
 			The background of the color preview rect on the button.
 		</theme_item>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [ColorPickerButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Default text [Color] of the [ColorPickerButton].
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.3)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.9, 0.9, 0.9, 0.3)">
 			Text [Color] used when the [ColorPickerButton] is disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [ColorPickerButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color(0.8, 0.8, 0.8, 1)">
+		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 1)">
 			Text [Color] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [ColorPickerButton]'s text.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="2">
+		<theme_item name="hseparation" data_type="constant" type="int" default="2">
 			The horizontal space between [ColorPickerButton]'s icon and text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [ColorPickerButton].
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -123,34 +123,34 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="back_folder" type="Texture2D">
+		<theme_item name="back_folder" data_type="icon" type="Texture2D">
 			Custom icon for the back arrow.
 		</theme_item>
-		<theme_item name="file" type="Texture2D">
+		<theme_item name="file" data_type="icon" type="Texture2D">
 			Custom icon for files.
 		</theme_item>
-		<theme_item name="file_icon_modulate" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="file_icon_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the file icon.
 		</theme_item>
-		<theme_item name="files_disabled" type="Color" default="Color(0, 0, 0, 0.7)">
+		<theme_item name="files_disabled" data_type="color" type="Color" default="Color(0, 0, 0, 0.7)">
 			The color tint for disabled files (when the [FileDialog] is used in open folder mode).
 		</theme_item>
-		<theme_item name="folder" type="Texture2D">
+		<theme_item name="folder" data_type="icon" type="Texture2D">
 			Custom icon for folders.
 		</theme_item>
-		<theme_item name="folder_icon_modulate" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="folder_icon_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the folder icon.
 		</theme_item>
-		<theme_item name="forward_folder" type="Texture2D">
+		<theme_item name="forward_folder" data_type="icon" type="Texture2D">
 			Custom icon for the forward arrow.
 		</theme_item>
-		<theme_item name="parent_folder" type="Texture2D">
+		<theme_item name="parent_folder" data_type="icon" type="Texture2D">
 			Custom icon for the parent folder arrow.
 		</theme_item>
-		<theme_item name="reload" type="Texture2D">
+		<theme_item name="reload" data_type="icon" type="Texture2D">
 			Custom icon for the reload button.
 		</theme_item>
-		<theme_item name="toggle_hidden" type="Texture2D">
+		<theme_item name="toggle_hidden" data_type="icon" type="Texture2D">
 			Custom icon for the toggle hidden button.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -268,45 +268,45 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="activity" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="activity" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 		</theme_item>
-		<theme_item name="bezier_len_neg" type="int" default="160">
+		<theme_item name="bezier_len_neg" data_type="constant" type="int" default="160">
 		</theme_item>
-		<theme_item name="bezier_len_pos" type="int" default="80">
+		<theme_item name="bezier_len_pos" data_type="constant" type="int" default="80">
 		</theme_item>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			The background drawn under the grid.
 		</theme_item>
-		<theme_item name="grid_major" type="Color" default="Color(1, 1, 1, 0.2)">
+		<theme_item name="grid_major" data_type="color" type="Color" default="Color(1, 1, 1, 0.2)">
 			Color of major grid lines.
 		</theme_item>
-		<theme_item name="grid_minor" type="Color" default="Color(1, 1, 1, 0.05)">
+		<theme_item name="grid_minor" data_type="color" type="Color" default="Color(1, 1, 1, 0.05)">
 			Color of minor grid lines.
 		</theme_item>
-		<theme_item name="minimap" type="Texture2D">
+		<theme_item name="minimap" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="minus" type="Texture2D">
+		<theme_item name="minus" data_type="icon" type="Texture2D">
 			The icon for the zoom out button.
 		</theme_item>
-		<theme_item name="more" type="Texture2D">
+		<theme_item name="more" data_type="icon" type="Texture2D">
 			The icon for the zoom in button.
 		</theme_item>
-		<theme_item name="port_grab_distance_horizontal" type="int" default="48">
+		<theme_item name="port_grab_distance_horizontal" data_type="constant" type="int" default="48">
 			The horizontal range within which a port can be grabbed (on both sides).
 		</theme_item>
-		<theme_item name="port_grab_distance_vertical" type="int" default="6">
+		<theme_item name="port_grab_distance_vertical" data_type="constant" type="int" default="6">
 			The vertical range within which a port can be grabbed (on both sides).
 		</theme_item>
-		<theme_item name="reset" type="Texture2D">
+		<theme_item name="reset" data_type="icon" type="Texture2D">
 			The icon for the zoom reset button.
 		</theme_item>
-		<theme_item name="selection_fill" type="Color" default="Color(1, 1, 1, 0.3)">
+		<theme_item name="selection_fill" data_type="color" type="Color" default="Color(1, 1, 1, 0.3)">
 			The fill color of the selection rectangle.
 		</theme_item>
-		<theme_item name="selection_stroke" type="Color" default="Color(1, 1, 1, 0.8)">
+		<theme_item name="selection_stroke" data_type="color" type="Color" default="Color(1, 1, 1, 0.8)">
 			The outline color of the selection rectangle.
 		</theme_item>
-		<theme_item name="snap" type="Texture2D">
+		<theme_item name="snap" data_type="icon" type="Texture2D">
 			The icon for the snap toggle button.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -292,59 +292,59 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="breakpoint" type="StyleBox">
+		<theme_item name="breakpoint" data_type="style" type="StyleBox">
 			The background used when [member overlay] is set to [constant OVERLAY_BREAKPOINT].
 		</theme_item>
-		<theme_item name="close" type="Texture2D">
+		<theme_item name="close" data_type="icon" type="Texture2D">
 			The icon for the close button, visible when [member show_close] is enabled.
 		</theme_item>
-		<theme_item name="close_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="close_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			The color modulation applied to the close button icon.
 		</theme_item>
-		<theme_item name="close_offset" type="int" default="18">
+		<theme_item name="close_offset" data_type="constant" type="int" default="18">
 			The vertical offset of the close button.
 		</theme_item>
-		<theme_item name="comment" type="StyleBox">
+		<theme_item name="comment" data_type="style" type="StyleBox">
 			The [StyleBox] used when [member comment] is enabled.
 		</theme_item>
-		<theme_item name="commentfocus" type="StyleBox">
+		<theme_item name="commentfocus" data_type="style" type="StyleBox">
 			The [StyleBox] used when [member comment] is enabled and the [GraphNode] is focused.
 		</theme_item>
-		<theme_item name="defaultfocus" type="StyleBox">
+		<theme_item name="defaultfocus" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="defaultframe" type="StyleBox">
+		<theme_item name="defaultframe" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="frame" type="StyleBox">
+		<theme_item name="frame" data_type="style" type="StyleBox">
 			The default background for [GraphNode].
 		</theme_item>
-		<theme_item name="port" type="Texture2D">
+		<theme_item name="port" data_type="icon" type="Texture2D">
 			The icon used for representing ports.
 		</theme_item>
-		<theme_item name="port_offset" type="int" default="3">
+		<theme_item name="port_offset" data_type="constant" type="int" default="3">
 			Horizontal offset for the ports.
 		</theme_item>
-		<theme_item name="position" type="StyleBox">
+		<theme_item name="position" data_type="style" type="StyleBox">
 			The background used when [member overlay] is set to [constant OVERLAY_POSITION].
 		</theme_item>
-		<theme_item name="resizer" type="Texture2D">
+		<theme_item name="resizer" data_type="icon" type="Texture2D">
 			The icon used for resizer, visible when [member resizable] is enabled.
 		</theme_item>
-		<theme_item name="resizer_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="resizer_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			The color modulation applied to the resizer icon.
 		</theme_item>
-		<theme_item name="selectedframe" type="StyleBox">
+		<theme_item name="selectedframe" data_type="style" type="StyleBox">
 			The background used when the [GraphNode] is selected.
 		</theme_item>
-		<theme_item name="separation" type="int" default="1">
+		<theme_item name="separation" data_type="constant" type="int" default="1">
 			The vertical distance between ports.
 		</theme_item>
-		<theme_item name="title_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="title_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			Color of the title text.
 		</theme_item>
-		<theme_item name="title_font" type="Font">
+		<theme_item name="title_font" data_type="font" type="Font">
 			Font used for the title text.
 		</theme_item>
-		<theme_item name="title_offset" type="int" default="20">
+		<theme_item name="title_offset" data_type="constant" type="int" default="20">
 			Vertical offset of the title text.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/GridContainer.xml
+++ b/doc/classes/GridContainer.xml
@@ -21,10 +21,10 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal separation of children nodes.
 		</theme_item>
-		<theme_item name="vseparation" type="int" default="4">
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
 			The vertical separation of children nodes.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HBoxContainer.xml
+++ b/doc/classes/HBoxContainer.xml
@@ -13,7 +13,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="separation" type="int" default="4">
+		<theme_item name="separation" data_type="constant" type="int" default="4">
 			The horizontal space between the [HBoxContainer]'s elements.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HScrollBar.xml
+++ b/doc/classes/HScrollBar.xml
@@ -13,31 +13,31 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="decrement" type="Texture2D">
+		<theme_item name="decrement" data_type="icon" type="Texture2D">
 			Icon used as a button to scroll the [ScrollBar] left. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
-		<theme_item name="decrement_highlight" type="Texture2D">
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
 			Displayed when the mouse cursor hovers over the decrement button.
 		</theme_item>
-		<theme_item name="grabber" type="StyleBox">
+		<theme_item name="grabber" data_type="style" type="StyleBox">
 			Used as texture for the grabber, the draggable element representing current scroll.
 		</theme_item>
-		<theme_item name="grabber_highlight" type="StyleBox">
+		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
 			Used when the mouse hovers over the grabber.
 		</theme_item>
-		<theme_item name="grabber_pressed" type="StyleBox">
+		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
 			Used when the grabber is being dragged.
 		</theme_item>
-		<theme_item name="increment" type="Texture2D">
+		<theme_item name="increment" data_type="icon" type="Texture2D">
 			Icon used as a button to scroll the [ScrollBar] right. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
-		<theme_item name="increment_highlight" type="Texture2D">
+		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Displayed when the mouse cursor hovers over the increment button.
 		</theme_item>
-		<theme_item name="scroll" type="StyleBox">
+		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].
 		</theme_item>
-		<theme_item name="scroll_focus" type="StyleBox">
+		<theme_item name="scroll_focus" data_type="style" type="StyleBox">
 			Used as background when the [ScrollBar] has the GUI focus.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HSeparator.xml
+++ b/doc/classes/HSeparator.xml
@@ -13,10 +13,10 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="separation" type="int" default="4">
+		<theme_item name="separation" data_type="constant" type="int" default="4">
 			The height of the area covered by the separator. Effectively works like a minimum height.
 		</theme_item>
-		<theme_item name="separator" type="StyleBox">
+		<theme_item name="separator" data_type="style" type="StyleBox">
 			The style for the separator line. Works best with [StyleBoxLine].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HSlider.xml
+++ b/doc/classes/HSlider.xml
@@ -14,24 +14,24 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="grabber" type="Texture2D">
+		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The texture for the grabber (the draggable element).
 		</theme_item>
-		<theme_item name="grabber_area" type="StyleBox">
+		<theme_item name="grabber_area" data_type="style" type="StyleBox">
 			The background of the area to the left of the grabber.
 		</theme_item>
-		<theme_item name="grabber_area_highlight" type="StyleBox">
+		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="grabber_disabled" type="Texture2D">
+		<theme_item name="grabber_disabled" data_type="icon" type="Texture2D">
 			The texture for the grabber when it's disabled.
 		</theme_item>
-		<theme_item name="grabber_highlight" type="Texture2D">
+		<theme_item name="grabber_highlight" data_type="icon" type="Texture2D">
 			The texture for the grabber when it's focused.
 		</theme_item>
-		<theme_item name="slider" type="StyleBox">
+		<theme_item name="slider" data_type="style" type="StyleBox">
 			The background for the whole slider. Determines the height of the [code]grabber_area[/code].
 		</theme_item>
-		<theme_item name="tick" type="Texture2D">
+		<theme_item name="tick" data_type="icon" type="Texture2D">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HSplitContainer.xml
+++ b/doc/classes/HSplitContainer.xml
@@ -13,15 +13,15 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="autohide" type="int" default="1">
+		<theme_item name="autohide" data_type="constant" type="int" default="1">
 			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
 		</theme_item>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="grabber" type="Texture2D">
+		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The icon used for the grabber drawn in the middle area.
 		</theme_item>
-		<theme_item name="separation" type="int" default="12">
+		<theme_item name="separation" data_type="constant" type="int" default="12">
 			The space between sides of the container.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -462,55 +462,55 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [ItemList], i.e. used when the control is not being focused.
 		</theme_item>
-		<theme_item name="bg_focus" type="StyleBox">
+		<theme_item name="bg_focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ItemList] is being focused.
 		</theme_item>
-		<theme_item name="cursor" type="StyleBox">
+		<theme_item name="cursor" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [ItemList] is being focused.
 		</theme_item>
-		<theme_item name="cursor_unfocused" type="StyleBox">
+		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [ItemList] is not being focused.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the item's text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.63, 0.63, 0.63, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.63, 0.63, 0.63, 1)">
 			Default text [Color] of the item.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the item.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the item is selected.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the item's text.
 		</theme_item>
-		<theme_item name="guide_color" type="Color" default="Color(0, 0, 0, 0.1)">
+		<theme_item name="guide_color" data_type="color" type="Color" default="Color(0, 0, 0, 0.1)">
 			[Color] of the guideline. The guideline is a line drawn between each row of items.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal spacing between items.
 		</theme_item>
-		<theme_item name="icon_margin" type="int" default="4">
+		<theme_item name="icon_margin" data_type="constant" type="int" default="4">
 			The spacing between item's icon and text.
 		</theme_item>
-		<theme_item name="line_separation" type="int" default="2">
+		<theme_item name="line_separation" data_type="constant" type="int" default="2">
 			The vertical spacing between each line of text.
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the item text outline.
 		</theme_item>
-		<theme_item name="selected" type="StyleBox">
+		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [ItemList] is not being focused.
 		</theme_item>
-		<theme_item name="selected_focus" type="StyleBox">
+		<theme_item name="selected_focus" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [ItemList] is being focused.
 		</theme_item>
-		<theme_item name="vseparation" type="int" default="2">
+		<theme_item name="vseparation" data_type="constant" type="int" default="2">
 			The vertical spacing between items.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -163,37 +163,37 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] used for the [Label]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Default text [Color] of the [Label].
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of [Font]'s outline.
 		</theme_item>
-		<theme_item name="font_shadow_color" type="Color" default="Color(0, 0, 0, 0)">
+		<theme_item name="font_shadow_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			[Color] of the text's shadow effect.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [Label]'s text.
 		</theme_item>
-		<theme_item name="line_spacing" type="int" default="3">
+		<theme_item name="line_spacing" data_type="constant" type="int" default="3">
 			Vertical space between lines in multiline [Label].
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Background [StyleBox] for the [Label].
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			Text outline size.
 		</theme_item>
-		<theme_item name="shadow_offset_x" type="int" default="1">
+		<theme_item name="shadow_offset_x" data_type="constant" type="int" default="1">
 			The horizontal offset of the text's shadow.
 		</theme_item>
-		<theme_item name="shadow_offset_y" type="int" default="1">
+		<theme_item name="shadow_offset_y" data_type="constant" type="int" default="1">
 			The vertical offset of the text's shadow.
 		</theme_item>
-		<theme_item name="shadow_outline_size" type="int" default="1">
+		<theme_item name="shadow_outline_size" data_type="constant" type="int" default="1">
 			Shadow outline size. If set to 1 or greater, the shadow will be displayed around the whole text as an outline.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -365,52 +365,52 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="caret_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="caret_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Color of the [LineEdit]'s caret (text cursor).
 		</theme_item>
-		<theme_item name="clear" type="Texture2D">
+		<theme_item name="clear" data_type="icon" type="Texture2D">
 			Texture for the clear button. See [member clear_button_enabled].
 		</theme_item>
-		<theme_item name="clear_button_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="clear_button_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Color used as default tint for the clear button.
 		</theme_item>
-		<theme_item name="clear_button_color_pressed" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="clear_button_color_pressed" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Color used for the clear button when it's pressed.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			Background used when [LineEdit] has GUI focus.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			Font used for the text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default font color.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [LineEdit].
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			Font color for selected text (inside the selection rectangle).
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [LineEdit]'s text.
 		</theme_item>
-		<theme_item name="font_uneditable_color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
+		<theme_item name="font_uneditable_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
 			Font color when editing is disabled.
 		</theme_item>
-		<theme_item name="minimum_character_width" type="int" default="4">
+		<theme_item name="minimum_character_width" data_type="constant" type="int" default="4">
 			Minimum horizontal space for the text (not counting the clear button and content margins). This value is measured in count of 'M' characters (i.e. this amount of 'M' characters can be displayed without scrolling).
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default background for the [LineEdit].
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="read_only" type="StyleBox">
+		<theme_item name="read_only" data_type="style" type="StyleBox">
 			Background used when [LineEdit] is in read-only mode ([member editable] is set to [code]false[/code]).
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 			Color of the selection rectangle.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -66,31 +66,31 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [LinkButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [LinkButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [LinkButton].
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] used when the [LinkButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [LinkButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [LinkButton] is being pressed.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [LinkButton]'s text.
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="underline_spacing" type="int" default="2">
+		<theme_item name="underline_spacing" data_type="constant" type="int" default="2">
 			The vertical space between the baseline of text and the underline.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/MarginContainer.xml
+++ b/doc/classes/MarginContainer.xml
@@ -32,16 +32,16 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="margin_bottom" type="int" default="0">
+		<theme_item name="margin_bottom" data_type="constant" type="int" default="0">
 			All direct children of [MarginContainer] will have a bottom margin of [code]margin_bottom[/code] pixels.
 		</theme_item>
-		<theme_item name="margin_left" type="int" default="0">
+		<theme_item name="margin_left" data_type="constant" type="int" default="0">
 			All direct children of [MarginContainer] will have a left margin of [code]margin_left[/code] pixels.
 		</theme_item>
-		<theme_item name="margin_right" type="int" default="0">
+		<theme_item name="margin_right" data_type="constant" type="int" default="0">
 			All direct children of [MarginContainer] will have a right margin of [code]margin_right[/code] pixels.
 		</theme_item>
-		<theme_item name="margin_top" type="int" default="0">
+		<theme_item name="margin_top" data_type="constant" type="int" default="0">
 			All direct children of [MarginContainer] will have a top margin of [code]margin_top[/code] pixels.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -44,46 +44,46 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [MenuButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [MenuButton].
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color(1, 1, 1, 0.3)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.3)">
 			Text [Color] used when the [MenuButton] is disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] used when the [MenuButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [MenuButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [MenuButton]'s text.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="3">
+		<theme_item name="hseparation" data_type="constant" type="int" default="3">
 			The horizontal space between [MenuButton]'s icon and text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [MenuButton].
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is being pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -186,64 +186,64 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="arrow" type="Texture2D">
+		<theme_item name="arrow" data_type="icon" type="Texture2D">
 			The arrow icon to be drawn on the right end of the button.
 		</theme_item>
-		<theme_item name="arrow_margin" type="int" default="2">
+		<theme_item name="arrow_margin" data_type="constant" type="int" default="2">
 			The horizontal space between the arrow icon and the right edge of the button.
 		</theme_item>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is disabled (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="disabled_mirrored" type="StyleBox">
+		<theme_item name="disabled_mirrored" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is disabled (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [OptionButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [OptionButton].
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Text [Color] used when the [OptionButton] is disabled.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] used when the [OptionButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [OptionButton].
 		</theme_item>
-		<theme_item name="font_pressed_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [OptionButton] is being pressed.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [OptionButton]'s text.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is being hovered (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="hover_mirrored" type="StyleBox">
+		<theme_item name="hover_mirrored" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is being hovered (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="2">
+		<theme_item name="hseparation" data_type="constant" type="int" default="2">
 			The horizontal space between [OptionButton]'s icon and text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [OptionButton] (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="normal_mirrored" type="StyleBox">
+		<theme_item name="normal_mirrored" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [OptionButton] (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is being pressed (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="pressed_mirrored" type="StyleBox">
+		<theme_item name="pressed_mirrored" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is being pressed (for right-to-left layouts).
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Panel.xml
+++ b/doc/classes/Panel.xml
@@ -24,10 +24,10 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style of this [Panel].
 		</theme_item>
-		<theme_item name="panel_fg" type="StyleBox">
+		<theme_item name="panel_fg" data_type="style" type="StyleBox">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/PanelContainer.xml
+++ b/doc/classes/PanelContainer.xml
@@ -17,7 +17,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style of [PanelContainer]'s background.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -538,77 +538,77 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="checked" type="Texture2D">
+		<theme_item name="checked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the checked checkbox items.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] used for the menu items.
 		</theme_item>
-		<theme_item name="font_accelerator_color" type="Color" default="Color(0.7, 0.7, 0.7, 0.8)">
+		<theme_item name="font_accelerator_color" data_type="color" type="Color" default="Color(0.7, 0.7, 0.7, 0.8)">
 			The text [Color] used for shortcuts and accelerators that show next to the menu item name when defined. See [method get_item_accelerator] for more info on accelerators.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			The default text [Color] for menu items' names.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color(0.4, 0.4, 0.4, 0.8)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.4, 0.4, 0.4, 0.8)">
 			[Color] used for disabled menu items' text.
 		</theme_item>
-		<theme_item name="font_hover_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			[Color] used for the hovered text.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the menu item.
 		</theme_item>
-		<theme_item name="font_separator_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_separator_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			[Color] used for labeled separators' text. See [method add_separator].
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the menu items.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] displayed when the [PopupMenu] item is hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal space between the item's name and the shortcut text/submenu arrow.
 		</theme_item>
-		<theme_item name="item_end_padding" type="int" default="2">
+		<theme_item name="item_end_padding" data_type="constant" type="int" default="2">
 		</theme_item>
-		<theme_item name="item_start_padding" type="int" default="2">
+		<theme_item name="item_start_padding" data_type="constant" type="int" default="2">
 		</theme_item>
-		<theme_item name="labeled_separator_left" type="StyleBox">
+		<theme_item name="labeled_separator_left" data_type="style" type="StyleBox">
 			[StyleBox] for the left side of labeled separator. See [method add_separator].
 		</theme_item>
-		<theme_item name="labeled_separator_right" type="StyleBox">
+		<theme_item name="labeled_separator_right" data_type="style" type="StyleBox">
 			[StyleBox] for the right side of labeled separator. See [method add_separator].
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the item text outline.
 		</theme_item>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			Default [StyleBox] of the [PopupMenu] items.
 		</theme_item>
-		<theme_item name="panel_disabled" type="StyleBox">
+		<theme_item name="panel_disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [PopupMenu] item is disabled.
 		</theme_item>
-		<theme_item name="radio_checked" type="Texture2D">
+		<theme_item name="radio_checked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the checked radio button items.
 		</theme_item>
-		<theme_item name="radio_unchecked" type="Texture2D">
+		<theme_item name="radio_unchecked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the unchecked radio button items.
 		</theme_item>
-		<theme_item name="separator" type="StyleBox">
+		<theme_item name="separator" data_type="style" type="StyleBox">
 			[StyleBox] used for the separators. See [method add_separator].
 		</theme_item>
-		<theme_item name="submenu" type="Texture2D">
+		<theme_item name="submenu" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the submenu arrow (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="submenu_mirrored" type="Texture2D">
+		<theme_item name="submenu_mirrored" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the submenu arrow (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="unchecked" type="Texture2D">
+		<theme_item name="unchecked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the unchecked checkbox items.
 		</theme_item>
-		<theme_item name="vseparation" type="int" default="4">
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
 			The vertical space between each menu item.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/PopupPanel.xml
+++ b/doc/classes/PopupPanel.xml
@@ -13,7 +13,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The background panel style of this [PopupPanel].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -20,28 +20,28 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			The style of the background.
 		</theme_item>
-		<theme_item name="fg" type="StyleBox">
+		<theme_item name="fg" data_type="style" type="StyleBox">
 			The style of the progress (i.e. the part that fills the bar).
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			Font used to draw the fill percentage if [member percent_visible] is [code]true[/code].
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			The color of the text.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [ProgressBar].
 		</theme_item>
-		<theme_item name="font_shadow_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="font_shadow_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			The color of the text's shadow.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size used to draw the fill percentage if [member percent_visible] is [code]true[/code].
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -522,85 +522,85 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="bold_font" type="Font">
+		<theme_item name="bold_font" data_type="font" type="Font">
 			The font used for bold text.
 		</theme_item>
-		<theme_item name="bold_font_size" type="int">
+		<theme_item name="bold_font_size" data_type="font_size" type="int">
 			The font size used for bold text.
 		</theme_item>
-		<theme_item name="bold_italics_font" type="Font">
+		<theme_item name="bold_italics_font" data_type="font" type="Font">
 			The font used for bold italics text.
 		</theme_item>
-		<theme_item name="bold_italics_font_size" type="int">
+		<theme_item name="bold_italics_font_size" data_type="font_size" type="int">
 			The font size used for bold italics text.
 		</theme_item>
-		<theme_item name="default_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="default_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The default text color.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			The background The background used when the [RichTextLabel] is focused.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The default tint of text outline.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			The color of selected text, used when [member selection_enabled] is [code]true[/code].
 		</theme_item>
-		<theme_item name="font_shadow_color" type="Color" default="Color(0, 0, 0, 0)">
+		<theme_item name="font_shadow_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			The color of the font's shadow.
 		</theme_item>
-		<theme_item name="italics_font" type="Font">
+		<theme_item name="italics_font" data_type="font" type="Font">
 			The font used for italics text.
 		</theme_item>
-		<theme_item name="italics_font_size" type="int">
+		<theme_item name="italics_font_size" data_type="font_size" type="int">
 			The font size used for italics text.
 		</theme_item>
-		<theme_item name="line_separation" type="int" default="1">
+		<theme_item name="line_separation" data_type="constant" type="int" default="1">
 			The vertical space between lines.
 		</theme_item>
-		<theme_item name="mono_font" type="Font">
+		<theme_item name="mono_font" data_type="font" type="Font">
 			The font used for monospace text.
 		</theme_item>
-		<theme_item name="mono_font_size" type="int">
+		<theme_item name="mono_font_size" data_type="font_size" type="int">
 			The font size used for monospace text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			The normal background for the [RichTextLabel].
 		</theme_item>
-		<theme_item name="normal_font" type="Font">
+		<theme_item name="normal_font" data_type="font" type="Font">
 			The default text font.
 		</theme_item>
-		<theme_item name="normal_font_size" type="int">
+		<theme_item name="normal_font_size" data_type="font_size" type="int">
 			The default text font size.
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color(0.1, 0.1, 1, 0.8)">
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.1, 0.1, 1, 0.8)">
 			The color of the selection box.
 		</theme_item>
-		<theme_item name="shadow_as_outline" type="int" default="0">
+		<theme_item name="shadow_as_outline" data_type="constant" type="int" default="0">
 			Boolean value. If 1 ([code]true[/code]), the shadow will be displayed around the whole text as an outline.
 		</theme_item>
-		<theme_item name="shadow_offset_x" type="int" default="1">
+		<theme_item name="shadow_offset_x" data_type="constant" type="int" default="1">
 			The horizontal offset of the font's shadow.
 		</theme_item>
-		<theme_item name="shadow_offset_y" type="int" default="1">
+		<theme_item name="shadow_offset_y" data_type="constant" type="int" default="1">
 			The vertical offset of the font's shadow.
 		</theme_item>
-		<theme_item name="table_border" type="Color" default="Color(0, 0, 0, 0)">
+		<theme_item name="table_border" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			The default cell border color.
 		</theme_item>
-		<theme_item name="table_even_row_bg" type="Color" default="Color(0, 0, 0, 0)">
+		<theme_item name="table_even_row_bg" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			The default background color for even rows.
 		</theme_item>
-		<theme_item name="table_hseparation" type="int" default="3">
+		<theme_item name="table_hseparation" data_type="constant" type="int" default="3">
 			The horizontal separation of elements in a table.
 		</theme_item>
-		<theme_item name="table_odd_row_bg" type="Color" default="Color(0, 0, 0, 0)">
+		<theme_item name="table_odd_row_bg" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			The default background color for odd rows.
 		</theme_item>
-		<theme_item name="table_vseparation" type="int" default="3">
+		<theme_item name="table_vseparation" data_type="constant" type="int" default="3">
 			The vertical separation of elements in a table.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -72,7 +72,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			The background [StyleBox] of the [ScrollContainer].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -59,7 +59,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="updown" type="Texture2D">
+		<theme_item name="updown" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for up and down arrows of the [SpinBox].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -161,61 +161,61 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="decrement" type="Texture2D">
+		<theme_item name="decrement" data_type="icon" type="Texture2D">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
 		</theme_item>
-		<theme_item name="decrement_highlight" type="Texture2D">
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Font color of disabled tabs.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the tab name.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Font color of the currently selected tab.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the tab names.
 		</theme_item>
-		<theme_item name="font_unselected_color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
+		<theme_item name="font_unselected_color" data_type="color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
 			Font color of the other, unselected tabs.
 		</theme_item>
-		<theme_item name="icon_separation" type="int" default="4">
+		<theme_item name="icon_separation" data_type="constant" type="int" default="4">
 			Space between tab's name and its icon.
 		</theme_item>
-		<theme_item name="increment" type="Texture2D">
+		<theme_item name="increment" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.
 		</theme_item>
-		<theme_item name="increment_highlight" type="Texture2D">
+		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="menu" type="Texture2D">
+		<theme_item name="menu" data_type="icon" type="Texture2D">
 			The icon for the menu button (see [method set_popup]).
 		</theme_item>
-		<theme_item name="menu_highlight" type="Texture2D">
+		<theme_item name="menu_highlight" data_type="icon" type="Texture2D">
 			The icon for the menu button (see [method set_popup]) when it's being hovered with the cursor.
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the tab text outline.
 		</theme_item>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style for the background fill.
 		</theme_item>
-		<theme_item name="side_margin" type="int" default="8">
+		<theme_item name="side_margin" data_type="constant" type="int" default="8">
 			The space at the left and right edges of the tab bar.
 		</theme_item>
-		<theme_item name="tab_disabled" type="StyleBox">
+		<theme_item name="tab_disabled" data_type="style" type="StyleBox">
 			The style of disabled tabs.
 		</theme_item>
-		<theme_item name="tab_selected" type="StyleBox">
+		<theme_item name="tab_selected" data_type="style" type="StyleBox">
 			The style of the currently selected tab.
 		</theme_item>
-		<theme_item name="tab_unselected" type="StyleBox">
+		<theme_item name="tab_unselected" data_type="style" type="StyleBox">
 			The style of the other, unselected tabs.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -282,58 +282,58 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="button" type="StyleBox">
+		<theme_item name="button" data_type="style" type="StyleBox">
 			Background of the close button when it's being hovered with the cursor.
 		</theme_item>
-		<theme_item name="button_pressed" type="StyleBox">
+		<theme_item name="button_pressed" data_type="style" type="StyleBox">
 			Background of the close button when it's being pressed.
 		</theme_item>
-		<theme_item name="close" type="Texture2D">
+		<theme_item name="close" data_type="icon" type="Texture2D">
 			The icon for the close button (see [member tab_close_display_policy]).
 		</theme_item>
-		<theme_item name="decrement" type="Texture2D">
+		<theme_item name="decrement" data_type="icon" type="Texture2D">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
 		</theme_item>
-		<theme_item name="decrement_highlight" type="Texture2D">
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>
-		<theme_item name="font_disabled_color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Font color of disabled tabs.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the tab name.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Font color of the currently selected tab.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the tab names.
 		</theme_item>
-		<theme_item name="font_unselected_color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
+		<theme_item name="font_unselected_color" data_type="color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
 			Font color of the other, unselected tabs.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal separation between the tabs.
 		</theme_item>
-		<theme_item name="increment" type="Texture2D">
+		<theme_item name="increment" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.
 		</theme_item>
-		<theme_item name="increment_highlight" type="Texture2D">
+		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the tab text outline.
 		</theme_item>
-		<theme_item name="tab_disabled" type="StyleBox">
+		<theme_item name="tab_disabled" data_type="style" type="StyleBox">
 			The style of disabled tabs.
 		</theme_item>
-		<theme_item name="tab_selected" type="StyleBox">
+		<theme_item name="tab_selected" data_type="style" type="StyleBox">
 			The style of the currently selected tab.
 		</theme_item>
-		<theme_item name="tab_unselected" type="StyleBox">
+		<theme_item name="tab_unselected" data_type="style" type="StyleBox">
 			The style of the other, unselected tabs.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -791,57 +791,61 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="background_color" type="Color" default="Color(0, 0, 0, 0)">
+		<theme_item name="background_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			Sets the background [Color] of this [TextEdit].
 		</theme_item>
-		<theme_item name="caret_background_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="caret_background_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+			[Color] of the text behind the caret when block caret is enabled.
 		</theme_item>
-		<theme_item name="caret_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="caret_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+			[Color] of the caret.
 		</theme_item>
-		<theme_item name="current_line_color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">
-			Sets the [Color] of the breakpoints. [member breakpoint_gutter] has to be enabled.
+		<theme_item name="current_line_color" data_type="color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">
+			Background [Color] of the line containing the caret.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			Sets the [StyleBox] when in focus.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			Sets the default [Font].
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Sets the font [Color].
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [TextEdit].
 		</theme_item>
-		<theme_item name="font_readonly_color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
+		<theme_item name="font_readonly_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
+			Sets the font [Color] when [member readonly] is enabled.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			Sets the [Color] of the selected text. [member override_selected_font_color] has to be enabled.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Sets default font size.
 		</theme_item>
-		<theme_item name="line_spacing" type="int" default="4">
+		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
 			Sets the spacing between the lines.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Sets the [StyleBox] of this [TextEdit].
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="read_only" type="StyleBox">
+		<theme_item name="read_only" data_type="style" type="StyleBox">
 			Sets the [StyleBox] of this [TextEdit] when [member readonly] is enabled.
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 			Sets the highlight [Color] of text selections.
 		</theme_item>
-		<theme_item name="space" type="Texture2D">
+		<theme_item name="space" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for space text characters.
 		</theme_item>
-		<theme_item name="tab" type="Texture2D">
+		<theme_item name="tab" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for tab text characters.
 		</theme_item>
-		<theme_item name="word_highlighted_color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
+		<theme_item name="word_highlighted_color" data_type="color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
 			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -474,142 +474,142 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="arrow" type="Texture2D">
+		<theme_item name="arrow" data_type="icon" type="Texture2D">
 			The arrow icon used when a foldable item is not collapsed.
 		</theme_item>
-		<theme_item name="arrow_collapsed" type="Texture2D">
+		<theme_item name="arrow_collapsed" data_type="icon" type="Texture2D">
 			The arrow icon used when a foldable item is collapsed (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="arrow_collapsed_mirrored" type="Texture2D">
+		<theme_item name="arrow_collapsed_mirrored" data_type="icon" type="Texture2D">
 			The arrow icon used when a foldable item is collapsed (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [Tree], i.e. used when the control is not being focused.
 		</theme_item>
-		<theme_item name="bg_focus" type="StyleBox">
+		<theme_item name="bg_focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Tree] is being focused.
 		</theme_item>
-		<theme_item name="button_margin" type="int" default="4">
+		<theme_item name="button_margin" data_type="constant" type="int" default="4">
 			The horizontal space between each button in a cell.
 		</theme_item>
-		<theme_item name="button_pressed" type="StyleBox">
+		<theme_item name="button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when a button in the tree is pressed.
 		</theme_item>
-		<theme_item name="checked" type="Texture2D">
+		<theme_item name="checked" data_type="icon" type="Texture2D">
 			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is checked.
 		</theme_item>
-		<theme_item name="children_hl_line_color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
+		<theme_item name="children_hl_line_color" data_type="color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
 			The [Color] of the relationship lines between the selected [TreeItem] and its children.
 		</theme_item>
-		<theme_item name="children_hl_line_width" type="int" default="1">
+		<theme_item name="children_hl_line_width" data_type="constant" type="int" default="1">
 			The width of the relationship lines between the selected [TreeItem] and its children.
 		</theme_item>
-		<theme_item name="cursor" type="StyleBox">
+		<theme_item name="cursor" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [Tree] is being focused.
 		</theme_item>
-		<theme_item name="cursor_unfocused" type="StyleBox">
+		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [Tree] is not being focused.
 		</theme_item>
-		<theme_item name="custom_button" type="StyleBox">
+		<theme_item name="custom_button" data_type="style" type="StyleBox">
 			Default [StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell.
 		</theme_item>
-		<theme_item name="custom_button_font_highlight" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
+		<theme_item name="custom_button_font_highlight" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
 		</theme_item>
-		<theme_item name="custom_button_hover" type="StyleBox">
+		<theme_item name="custom_button_hover" data_type="style" type="StyleBox">
 			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
 		</theme_item>
-		<theme_item name="custom_button_pressed" type="StyleBox">
+		<theme_item name="custom_button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's pressed.
 		</theme_item>
-		<theme_item name="draw_guides" type="int" default="1">
+		<theme_item name="draw_guides" data_type="constant" type="int" default="1">
 			Draws the guidelines if not zero, this acts as a boolean. The guideline is a horizontal line drawn at the bottom of each item.
 		</theme_item>
-		<theme_item name="draw_relationship_lines" type="int" default="0">
+		<theme_item name="draw_relationship_lines" data_type="constant" type="int" default="0">
 			Draws the relationship lines if not zero, this acts as a boolean. Relationship lines are drawn at the start of child items to show hierarchy.
 		</theme_item>
-		<theme_item name="drop_position_color" type="Color" default="Color(1, 0.3, 0.2, 1)">
+		<theme_item name="drop_position_color" data_type="color" type="Color" default="Color(1, 0.3, 0.2, 1)">
 			[Color] used to draw possible drop locations. See [enum DropModeFlags] constants for further description of drop locations.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the item's text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
 			Default text [Color] of the item.
 		</theme_item>
-		<theme_item name="font_outline_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the item.
 		</theme_item>
-		<theme_item name="font_selected_color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the item is selected.
 		</theme_item>
-		<theme_item name="font_size" type="int">
+		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the item's text.
 		</theme_item>
-		<theme_item name="guide_color" type="Color" default="Color(0, 0, 0, 0.1)">
+		<theme_item name="guide_color" data_type="color" type="Color" default="Color(0, 0, 0, 0.1)">
 			[Color] of the guideline.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal space between item cells. This is also used as the margin at the start of an item when folding is disabled.
 		</theme_item>
-		<theme_item name="item_margin" type="int" default="12">
+		<theme_item name="item_margin" data_type="constant" type="int" default="12">
 			The horizontal margin at the start of an item. This is used when folding is enabled for the item.
 		</theme_item>
-		<theme_item name="outline_size" type="int" default="0">
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="parent_hl_line_color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
+		<theme_item name="parent_hl_line_color" data_type="color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
 			The [Color] of the relationship lines between the selected [TreeItem] and its parents.
 		</theme_item>
-		<theme_item name="parent_hl_line_margin" type="int" default="0">
+		<theme_item name="parent_hl_line_margin" data_type="constant" type="int" default="0">
 			The space between the parent relationship lines for the selected [TreeItem] and the relationship lines to its siblings that are not selected.
 		</theme_item>
-		<theme_item name="parent_hl_line_width" type="int" default="1">
+		<theme_item name="parent_hl_line_width" data_type="constant" type="int" default="1">
 			The width of the relationship lines between the selected [TreeItem] and its parents.
 		</theme_item>
-		<theme_item name="relationship_line_color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
+		<theme_item name="relationship_line_color" data_type="color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
 			The default [Color] of the relationship lines.
 		</theme_item>
-		<theme_item name="relationship_line_width" type="int" default="1">
+		<theme_item name="relationship_line_width" data_type="constant" type="int" default="1">
 			The default width of the relationship lines.
 		</theme_item>
-		<theme_item name="scroll_border" type="int" default="4">
+		<theme_item name="scroll_border" data_type="constant" type="int" default="4">
 			The maximum distance between the mouse cursor and the control's border to trigger border scrolling when dragging.
 		</theme_item>
-		<theme_item name="scroll_speed" type="int" default="12">
+		<theme_item name="scroll_speed" data_type="constant" type="int" default="12">
 			The speed of border scrolling.
 		</theme_item>
-		<theme_item name="select_arrow" type="Texture2D">
+		<theme_item name="select_arrow" data_type="icon" type="Texture2D">
 			The arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
 		</theme_item>
-		<theme_item name="selected" type="StyleBox">
+		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is not being focused.
 		</theme_item>
-		<theme_item name="selected_focus" type="StyleBox">
+		<theme_item name="selected_focus" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is being focused.
 		</theme_item>
-		<theme_item name="title_button_color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+		<theme_item name="title_button_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the title button.
 		</theme_item>
-		<theme_item name="title_button_font" type="Font">
+		<theme_item name="title_button_font" data_type="font" type="Font">
 			[Font] of the title button's text.
 		</theme_item>
-		<theme_item name="title_button_hover" type="StyleBox">
+		<theme_item name="title_button_hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the title button is being hovered.
 		</theme_item>
-		<theme_item name="title_button_normal" type="StyleBox">
+		<theme_item name="title_button_normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the title button.
 		</theme_item>
-		<theme_item name="title_button_pressed" type="StyleBox">
+		<theme_item name="title_button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the title button is being pressed.
 		</theme_item>
-		<theme_item name="unchecked" type="Texture2D">
+		<theme_item name="unchecked" data_type="icon" type="Texture2D">
 			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is unchecked.
 		</theme_item>
-		<theme_item name="updown" type="Texture2D">
+		<theme_item name="updown" data_type="icon" type="Texture2D">
 			The updown arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
 		</theme_item>
-		<theme_item name="vseparation" type="int" default="4">
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
 			The vertical padding inside each item, i.e. the distance between the item's content and top/bottom border.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VBoxContainer.xml
+++ b/doc/classes/VBoxContainer.xml
@@ -14,7 +14,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="separation" type="int" default="4">
+		<theme_item name="separation" data_type="constant" type="int" default="4">
 			The vertical space between the [VBoxContainer]'s elements.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -17,31 +17,31 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="decrement" type="Texture2D">
+		<theme_item name="decrement" data_type="icon" type="Texture2D">
 			Icon used as a button to scroll the [ScrollBar] up. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
-		<theme_item name="decrement_highlight" type="Texture2D">
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
 			Displayed when the mouse cursor hovers over the decrement button.
 		</theme_item>
-		<theme_item name="grabber" type="StyleBox">
+		<theme_item name="grabber" data_type="style" type="StyleBox">
 			Used as texture for the grabber, the draggable element representing current scroll.
 		</theme_item>
-		<theme_item name="grabber_highlight" type="StyleBox">
+		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
 			Used when the mouse hovers over the grabber.
 		</theme_item>
-		<theme_item name="grabber_pressed" type="StyleBox">
+		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
 			Used when the grabber is being dragged.
 		</theme_item>
-		<theme_item name="increment" type="Texture2D">
+		<theme_item name="increment" data_type="icon" type="Texture2D">
 			Icon used as a button to scroll the [ScrollBar] down. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
-		<theme_item name="increment_highlight" type="Texture2D">
+		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Displayed when the mouse cursor hovers over the increment button.
 		</theme_item>
-		<theme_item name="scroll" type="StyleBox">
+		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].
 		</theme_item>
-		<theme_item name="scroll_focus" type="StyleBox">
+		<theme_item name="scroll_focus" data_type="style" type="StyleBox">
 			Used as background when the [ScrollBar] has the GUI focus.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VSeparator.xml
+++ b/doc/classes/VSeparator.xml
@@ -13,10 +13,10 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="separation" type="int" default="4">
+		<theme_item name="separation" data_type="constant" type="int" default="4">
 			The width of the area covered by the separator. Effectively works like a minimum width.
 		</theme_item>
-		<theme_item name="separator" type="StyleBox">
+		<theme_item name="separator" data_type="style" type="StyleBox">
 			The style for the separator line. Works best with [StyleBoxLine] (remember to enable [member StyleBoxLine.vertical]).
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VSlider.xml
+++ b/doc/classes/VSlider.xml
@@ -18,24 +18,24 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="grabber" type="Texture2D">
+		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The texture for the grabber (the draggable element).
 		</theme_item>
-		<theme_item name="grabber_area" type="StyleBox">
+		<theme_item name="grabber_area" data_type="style" type="StyleBox">
 			The background of the area below the grabber.
 		</theme_item>
-		<theme_item name="grabber_area_highlight" type="StyleBox">
+		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="grabber_disabled" type="Texture2D">
+		<theme_item name="grabber_disabled" data_type="icon" type="Texture2D">
 			The texture for the grabber when it's disabled.
 		</theme_item>
-		<theme_item name="grabber_highlight" type="Texture2D">
+		<theme_item name="grabber_highlight" data_type="icon" type="Texture2D">
 			The texture for the grabber when it's focused.
 		</theme_item>
-		<theme_item name="slider" type="StyleBox">
+		<theme_item name="slider" data_type="style" type="StyleBox">
 			The background for the whole slider. Determines the width of the [code]grabber_area[/code].
 		</theme_item>
-		<theme_item name="tick" type="Texture2D">
+		<theme_item name="tick" data_type="icon" type="Texture2D">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VSplitContainer.xml
+++ b/doc/classes/VSplitContainer.xml
@@ -13,15 +13,15 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="autohide" type="int" default="1">
+		<theme_item name="autohide" data_type="constant" type="int" default="1">
 			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
 		</theme_item>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="grabber" type="Texture2D">
+		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The icon used for the grabber drawn in the middle area.
 		</theme_item>
-		<theme_item name="separation" type="int" default="12">
+		<theme_item name="separation" data_type="constant" type="int" default="12">
 			The space between sides of the container.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -391,33 +391,33 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="close" type="Texture2D">
+		<theme_item name="close" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="close_h_ofs" type="int" default="18">
+		<theme_item name="close_h_ofs" data_type="constant" type="int" default="18">
 		</theme_item>
-		<theme_item name="close_pressed" type="Texture2D">
+		<theme_item name="close_pressed" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="close_v_ofs" type="int" default="18">
+		<theme_item name="close_v_ofs" data_type="constant" type="int" default="18">
 		</theme_item>
-		<theme_item name="embedded_border" type="StyleBox">
+		<theme_item name="embedded_border" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="resize_margin" type="int" default="4">
+		<theme_item name="resize_margin" data_type="constant" type="int" default="4">
 		</theme_item>
-		<theme_item name="scaleborder_size" type="int" default="4">
+		<theme_item name="scaleborder_size" data_type="constant" type="int" default="4">
 		</theme_item>
-		<theme_item name="title_color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="title_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 		</theme_item>
-		<theme_item name="title_font" type="Font">
+		<theme_item name="title_font" data_type="font" type="Font">
 		</theme_item>
-		<theme_item name="title_font_size" type="int">
+		<theme_item name="title_font_size" data_type="font_size" type="int">
 			The size of the title font.
 		</theme_item>
-		<theme_item name="title_height" type="int" default="20">
+		<theme_item name="title_height" data_type="constant" type="int" default="20">
 		</theme_item>
-		<theme_item name="title_outline_modulate" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="title_outline_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color of the title outline.
 		</theme_item>
-		<theme_item name="title_outline_size" type="int" default="0">
+		<theme_item name="title_outline_size" data_type="constant" type="int" default="0">
 			The size of the title outline.
 		</theme_item>
 	</theme_items>

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -145,15 +145,15 @@ void DocTools::merge_from(const DocTools &p_data) {
 		}
 
 		for (int i = 0; i < c.theme_properties.size(); i++) {
-			DocData::PropertyDoc &p = c.theme_properties.write[i];
+			DocData::ThemeItemDoc &ti = c.theme_properties.write[i];
 
 			for (int j = 0; j < cf.theme_properties.size(); j++) {
-				if (cf.theme_properties[j].name != p.name) {
+				if (cf.theme_properties[j].name != ti.name || cf.theme_properties[j].data_type != ti.data_type) {
 					continue;
 				}
-				const DocData::PropertyDoc &pf = cf.theme_properties[j];
+				const DocData::ThemeItemDoc &pf = cf.theme_properties[j];
 
-				p.description = pf.description;
+				ti.description = pf.description;
 				break;
 			}
 		}
@@ -464,60 +464,69 @@ void DocTools::generate(bool p_basic_types) {
 			c.constants.push_back(constant);
 		}
 
-		//theme stuff
-
+		// Theme items.
 		{
 			List<StringName> l;
-			Theme::get_default()->get_constant_list(cname, &l);
+
+			Theme::get_default()->get_color_list(cname, &l);
 			for (const StringName &E : l) {
-				DocData::PropertyDoc pd;
-				pd.name = E;
-				pd.type = "int";
-				pd.default_value = itos(Theme::get_default()->get_constant(E, cname));
-				c.theme_properties.push_back(pd);
+				DocData::ThemeItemDoc tid;
+				tid.name = E;
+				tid.type = "Color";
+				tid.data_type = "color";
+				tid.default_value = Variant(Theme::get_default()->get_color(E, cname)).get_construct_string();
+				c.theme_properties.push_back(tid);
 			}
 
 			l.clear();
-			Theme::get_default()->get_color_list(cname, &l);
+			Theme::get_default()->get_constant_list(cname, &l);
 			for (const StringName &E : l) {
-				DocData::PropertyDoc pd;
-				pd.name = E;
-				pd.type = "Color";
-				pd.default_value = Variant(Theme::get_default()->get_color(E, cname)).get_construct_string();
-				c.theme_properties.push_back(pd);
+				DocData::ThemeItemDoc tid;
+				tid.name = E;
+				tid.type = "int";
+				tid.data_type = "constant";
+				tid.default_value = itos(Theme::get_default()->get_constant(E, cname));
+				c.theme_properties.push_back(tid);
+			}
+
+			l.clear();
+			Theme::get_default()->get_font_list(cname, &l);
+			for (const StringName &E : l) {
+				DocData::ThemeItemDoc tid;
+				tid.name = E;
+				tid.type = "Font";
+				tid.data_type = "font";
+				c.theme_properties.push_back(tid);
+			}
+
+			l.clear();
+			Theme::get_default()->get_font_size_list(cname, &l);
+			for (const StringName &E : l) {
+				DocData::ThemeItemDoc tid;
+				tid.name = E;
+				tid.type = "int";
+				tid.data_type = "font_size";
+				c.theme_properties.push_back(tid);
 			}
 
 			l.clear();
 			Theme::get_default()->get_icon_list(cname, &l);
 			for (const StringName &E : l) {
-				DocData::PropertyDoc pd;
-				pd.name = E;
-				pd.type = "Texture2D";
-				c.theme_properties.push_back(pd);
+				DocData::ThemeItemDoc tid;
+				tid.name = E;
+				tid.type = "Texture2D";
+				tid.data_type = "icon";
+				c.theme_properties.push_back(tid);
 			}
-			l.clear();
-			Theme::get_default()->get_font_list(cname, &l);
-			for (const StringName &E : l) {
-				DocData::PropertyDoc pd;
-				pd.name = E;
-				pd.type = "Font";
-				c.theme_properties.push_back(pd);
-			}
-			l.clear();
-			Theme::get_default()->get_font_size_list(cname, &l);
-			for (const StringName &E : l) {
-				DocData::PropertyDoc pd;
-				pd.name = E;
-				pd.type = "int";
-				c.theme_properties.push_back(pd);
-			}
+
 			l.clear();
 			Theme::get_default()->get_stylebox_list(cname, &l);
 			for (const StringName &E : l) {
-				DocData::PropertyDoc pd;
-				pd.name = E;
-				pd.type = "StyleBox";
-				c.theme_properties.push_back(pd);
+				DocData::ThemeItemDoc tid;
+				tid.name = E;
+				tid.type = "StyleBox";
+				tid.data_type = "style";
+				c.theme_properties.push_back(tid);
 			}
 		}
 
@@ -1069,12 +1078,14 @@ Error DocTools::_load(Ref<XMLParser> parser) {
 							String name3 = parser->get_node_name();
 
 							if (name3 == "theme_item") {
-								DocData::PropertyDoc prop2;
+								DocData::ThemeItemDoc prop2;
 
 								ERR_FAIL_COND_V(!parser->has_attribute("name"), ERR_FILE_CORRUPT);
 								prop2.name = parser->get_attribute_value("name");
 								ERR_FAIL_COND_V(!parser->has_attribute("type"), ERR_FILE_CORRUPT);
 								prop2.type = parser->get_attribute_value("type");
+								ERR_FAIL_COND_V(!parser->has_attribute("data_type"), ERR_FILE_CORRUPT);
+								prop2.data_type = parser->get_attribute_value("data_type");
 								if (!parser->is_empty()) {
 									parser->read();
 									if (parser->get_node_type() == XMLParser::NODE_TEXT) {
@@ -1312,15 +1323,15 @@ Error DocTools::save_classes(const String &p_default_path, const Map<String, Str
 
 			_write_string(f, 1, "<theme_items>");
 			for (int i = 0; i < c.theme_properties.size(); i++) {
-				const DocData::PropertyDoc &p = c.theme_properties[i];
+				const DocData::ThemeItemDoc &ti = c.theme_properties[i];
 
-				if (p.default_value != "") {
-					_write_string(f, 2, "<theme_item name=\"" + p.name + "\" type=\"" + p.type + "\" default=\"" + p.default_value.xml_escape(true) + "\">");
+				if (ti.default_value != "") {
+					_write_string(f, 2, "<theme_item name=\"" + ti.name + "\" data_type=\"" + ti.data_type + "\" type=\"" + ti.type + "\" default=\"" + ti.default_value.xml_escape(true) + "\">");
 				} else {
-					_write_string(f, 2, "<theme_item name=\"" + p.name + "\" type=\"" + p.type + "\">");
+					_write_string(f, 2, "<theme_item name=\"" + ti.name + "\" data_type=\"" + ti.data_type + "\" type=\"" + ti.type + "\">");
 				}
 
-				_write_string(f, 3, p.description.strip_edges().xml_escape());
+				_write_string(f, 3, ti.description.strip_edges().xml_escape());
 
 				_write_string(f, 2, "</theme_item>");
 			}

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -758,8 +758,8 @@ void EditorHelp::_update_doc() {
 
 			if (cd.theme_properties[i].description != "") {
 				class_desc->push_font(doc_font);
-				class_desc->add_text("  ");
 				class_desc->push_color(comment_color);
+				class_desc->add_text(U" – ");
 				_add_text(DTR(cd.theme_properties[i].description));
 				class_desc->pop();
 				class_desc->pop();
@@ -941,8 +941,7 @@ void EditorHelp::_update_doc() {
 					if (enum_list[i].description != "") {
 						class_desc->push_font(doc_font);
 						class_desc->push_color(comment_color);
-						static const char32_t dash[6] = { ' ', ' ', 0x2013 /* en dash */, ' ', ' ', 0 };
-						class_desc->add_text(String(dash));
+						class_desc->add_text(U" – ");
 						_add_text(DTR(enum_list[i].description));
 						class_desc->pop();
 						class_desc->pop();
@@ -1011,8 +1010,7 @@ void EditorHelp::_update_doc() {
 				if (constants[i].description != "") {
 					class_desc->push_font(doc_font);
 					class_desc->push_color(comment_color);
-					static const char32_t dash[6] = { ' ', ' ', 0x2013 /* en dash */, ' ', ' ', 0 };
-					class_desc->add_text(String(dash));
+					class_desc->add_text(U" – ");
 					_add_text(DTR(constants[i].description));
 					class_desc->pop();
 					class_desc->pop();

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -367,7 +367,7 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 			if (search_flags & SEARCH_THEME_ITEMS) {
 				for (int i = 0; i < class_doc.theme_properties.size(); i++) {
 					if (_match_string(term, class_doc.theme_properties[i].name)) {
-						match.theme_properties.push_back(const_cast<DocData::PropertyDoc *>(&class_doc.theme_properties[i]));
+						match.theme_properties.push_back(const_cast<DocData::ThemeItemDoc *>(&class_doc.theme_properties[i]));
 					}
 				}
 			}
@@ -571,7 +571,7 @@ TreeItem *EditorHelpSearch::Runner::_create_property_item(TreeItem *p_parent, co
 	return _create_member_item(p_parent, p_class_doc->name, "MemberProperty", p_doc->name, p_doc->name, TTRC("Property"), "property", tooltip);
 }
 
-TreeItem *EditorHelpSearch::Runner::_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::PropertyDoc *p_doc) {
+TreeItem *EditorHelpSearch::Runner::_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ThemeItemDoc *p_doc) {
 	String tooltip = p_doc->type + " " + p_class_doc->name + "." + p_doc->name;
 	return _create_member_item(p_parent, p_class_doc->name, "MemberTheme", p_doc->name, p_doc->name, TTRC("Theme Property"), "theme_item", tooltip);
 }

--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -103,7 +103,7 @@ class EditorHelpSearch::Runner : public RefCounted {
 		Vector<DocData::MethodDoc *> signals;
 		Vector<DocData::ConstantDoc *> constants;
 		Vector<DocData::PropertyDoc *> properties;
-		Vector<DocData::PropertyDoc *> theme_properties;
+		Vector<DocData::ThemeItemDoc *> theme_properties;
 
 		bool required() {
 			return name || methods.size() || signals.size() || constants.size() || properties.size() || theme_properties.size();
@@ -145,7 +145,7 @@ class EditorHelpSearch::Runner : public RefCounted {
 	TreeItem *_create_signal_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::MethodDoc *p_doc);
 	TreeItem *_create_constant_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ConstantDoc *p_doc);
 	TreeItem *_create_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::PropertyDoc *p_doc);
-	TreeItem *_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::PropertyDoc *p_doc);
+	TreeItem *_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ThemeItemDoc *p_doc);
 	TreeItem *_create_member_item(TreeItem *p_parent, const String &p_class_name, const String &p_icon, const String &p_name, const String &p_text, const String &p_type, const String &p_metatype, const String &p_tooltip);
 
 public:

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -231,23 +231,29 @@ Error GDScriptWorkspace::initialize() {
 			class_symbol.children.push_back(symbol);
 		}
 
-		Vector<DocData::PropertyDoc> properties;
-		properties.append_array(class_data.properties);
-		const int theme_prop_start_idx = properties.size();
-		properties.append_array(class_data.theme_properties);
-
 		for (int i = 0; i < class_data.properties.size(); i++) {
 			const DocData::PropertyDoc &data = class_data.properties[i];
 			lsp::DocumentSymbol symbol;
 			symbol.name = data.name;
 			symbol.native_class = class_name;
 			symbol.kind = lsp::SymbolKind::Property;
-			symbol.detail = String(i >= theme_prop_start_idx ? "<Theme> var" : "var") + " " + class_name + "." + data.name;
+			symbol.detail = "var " + class_name + "." + data.name;
 			if (data.enumeration.length()) {
 				symbol.detail += ": " + data.enumeration;
 			} else {
 				symbol.detail += ": " + data.type;
 			}
+			symbol.documentation = data.description;
+			class_symbol.children.push_back(symbol);
+		}
+
+		for (int i = 0; i < class_data.theme_properties.size(); i++) {
+			const DocData::ThemeItemDoc &data = class_data.theme_properties[i];
+			lsp::DocumentSymbol symbol;
+			symbol.name = data.name;
+			symbol.native_class = class_name;
+			symbol.kind = lsp::SymbolKind::Property;
+			symbol.detail = "<Theme> var " + class_name + "." + data.name + ": " + data.type;
 			symbol.documentation = data.description;
 			class_symbol.children.push_back(symbol);
 		}


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/29868. This also improves on storing theme items in the XML as previously data types (color, icon, stylebox) weren't stored which could lead to conflicts. For online docs I've added theme items to the end of the descriptions, borrowing the look from class properties.

I've also added an en dash to the built-in docs to better separate the descriptions.

-----
Obviously not cherry-pickable and needs to be manually ported to 3.x.