### PR TITLE
Minor visual improvements to the view rotation gizmo

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -140,9 +140,11 @@ void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
 	}
 
 	if (front) {
-		String axis_name = direction == 0 ? "X" : (direction == 1 ? "Y" : "Z");
 		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS, c);
-		draw_char(get_theme_font(SNAME("rotation_control"), SNAME("EditorFonts")), p_axis.screen_point + Vector2i(-4, 5) * EDSCALE, axis_name, "", get_theme_font_size(SNAME("rotation_control_size"), SNAME("EditorFonts")), Color(0.3, 0.3, 0.3));
+		if (positive) {
+			String axis_name = direction == 0 ? "X" : (direction == 1 ? "Y" : "Z");
+			draw_char(get_theme_font(SNAME("rotation_control"), SNAME("EditorFonts")), p_axis.screen_point + Vector2i(-4, 5) * EDSCALE, axis_name, "", get_theme_font_size(SNAME("rotation_control_size"), SNAME("EditorFonts")), Color(0.0, 0.0, 0.0));
+		}
 	} else {
 		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS * (0.55 + (0.2 * (1.0 + p_axis.z_axis))), c);
 	}


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Before:
![image](https://user-images.githubusercontent.com/50304111/128242223-98afff79-271e-4589-a632-1636ad4ce5e6.png)

After:
![image](https://user-images.githubusercontent.com/50304111/128242023-f2702abe-f07f-4624-b2cd-af8957b37a2f.png)
(letters aren't drawn on negative axes)

Blender and Unity (for comparison):
![image](https://user-images.githubusercontent.com/50304111/128244348-e5404b52-9ad7-43b4-86c1-1c062103b9b4.png)
![image](https://user-images.githubusercontent.com/50304111/128244829-afcd0d79-5698-46dc-aaef-aec2ed289b5e.png)

As a side note, being able to draw anti-aliased circles would be nice, the blender and godot screenshots are at similar resolutions.

Closes https://github.com/godotengine/godot-proposals/issues/3089