### PR TITLE
Fix Bugs w/ Octahedral Compression Implementation

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2154,7 +2154,7 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 
 	glBindVertexArray(0);
 
-	state.scene_shader.remove_custom_define("#define ENABLE_OCTAHEDRAL_COMPRESSION\n");
+	state.scene_shader.set_conditional(SceneShaderGLES3::ENABLE_OCTAHEDRAL_COMPRESSION, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_INSTANCING, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_SKELETON, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_RADIANCE_MAP, false);

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1496,11 +1496,11 @@ Array VisualServer::_get_array_from_surface(uint32_t p_format, PoolVector<uint8_
 						for (int j = 0; j < p_vertex_len; j++) {
 							const int8_t *t = (const int8_t *)&r[j * total_elem_size + offsets[i]];
 							Vector2 enc(t[0] / 127.0f, t[1] / 127.0f);
-							Vector3 dec = oct_to_tangent(enc, &w[j * 3 + 2]);
+							Vector3 dec = oct_to_tangent(enc, &w[j * 4 + 3]);
 
-							w[j * 3 + 0] = dec.x;
-							w[j * 3 + 1] = dec.y;
-							w[j * 3 + 2] = dec.z;
+							w[j * 4 + 0] = dec.x;
+							w[j * 4 + 1] = dec.y;
+							w[j * 4 + 2] = dec.z;
 						}
 					} else {
 						PoolVector<float>::Write w = arr.write();
@@ -1508,11 +1508,11 @@ Array VisualServer::_get_array_from_surface(uint32_t p_format, PoolVector<uint8_
 						for (int j = 0; j < p_vertex_len; j++) {
 							const int16_t *t = (const int16_t *)&r[j * total_elem_size + offsets[i]];
 							Vector2 enc(t[0] / 32767.0f, t[1] / 32767.0f);
-							Vector3 dec = oct_to_tangent(enc, &w[j * 3 + 2]);
+							Vector3 dec = oct_to_tangent(enc, &w[j * 4 + 3]);
 
-							w[j * 3 + 0] = dec.x;
-							w[j * 3 + 1] = dec.y;
-							w[j * 3 + 2] = dec.z;
+							w[j * 4 + 0] = dec.x;
+							w[j * 4 + 1] = dec.y;
+							w[j * 4 + 2] = dec.z;
 						}
 					}
 				} else {


### PR DESCRIPTION
Initial octahedral compression incorrectly wrote tangent to the buffer
using an offset of 3 rather than 4, losing the sign of the tangent
vector needed for things like tangent space for texturing mapping

GLES3 renderer used remove_custom_define rather than set_conditional to
change back to the default conditional state the scene shader should be
in

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
