### PR TITLE
[3.x] Fixed crash on LSP content sync against files outside of res://

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -426,8 +426,10 @@ void GDScriptTextDocument::sync_script_content(const String &p_path, const Strin
 
 	EditorFileSystem::get_singleton()->update_file(path);
 	Ref<GDScript> script = ResourceLoader::load(path);
-	script->load_source_code(path);
-	script->reload(true);
+	Error err = script->load_source_code(path);
+	if (err == OK) {
+		script->reload(true);
+	}
 }
 
 void GDScriptTextDocument::show_native_symbol_in_editor(const String &p_symbol_id) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

When using an external editor to open files outside of `res://`, if the external editor is connected to the LSP server and the file is saved, then `GDScriptTextDocument::sync_script_content` will crash with a null pointer dereference.

Unable to reproduce bug on `master` branch. Only `3.x` seems affected.

Bug introduced by #48616
