### PR TITLE
Fix editor slowdown caused by editor grid mesh being compressed

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5725,7 +5725,7 @@ void SpatialEditor::_init_grid() {
 		d[VisualServer::ARRAY_VERTEX] = grid_points[c];
 		d[VisualServer::ARRAY_COLOR] = grid_colors[c];
 		d[VisualServer::ARRAY_NORMAL] = grid_normals[c];
-		VisualServer::get_singleton()->mesh_add_surface_from_arrays(grid[c], VisualServer::PRIMITIVE_LINES, d);
+		VisualServer::get_singleton()->mesh_add_surface_from_arrays(grid[c], VisualServer::PRIMITIVE_LINES, d, Array(), 0);
 		VisualServer::get_singleton()->mesh_surface_set_material(grid[c], 0, grid_mat[c]->get_rid());
 		grid_instance[c] = VisualServer::get_singleton()->instance_create2(grid[c], get_tree()->get_root()->get_world()->get_scenario());
 


### PR DESCRIPTION
This prevents the editor being slowed down, a runtime only mesh should not have compression as it will have heavy CPU load.

In my case it was consuming 36% of the thread. The fix is simple, disables the compression flags on the mesh so it generates a lot faster. 

Performance figure differences:

Before this fix:
<img width="702" alt="Screenshot 2021-08-03 at 18 06 07" src="https://user-images.githubusercontent.com/748770/128291186-794bcd0d-765a-413d-a087-cec3d07ee0ad.png">

After:
<img width="701" alt="Screenshot 2021-08-03 at 18 05 35" src="https://user-images.githubusercontent.com/748770/128291203-14189f94-079b-497a-945c-17d9a59d1e20.png">
