### PR TITLE
Portals - rooms_set_active needs Editor check

### DIFF
--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -510,7 +510,12 @@ void RoomManager::rooms_set_active(bool p_active) {
 		_active = p_active;
 
 #ifdef TOOLS_ENABLED
-		SpatialEditor::get_singleton()->update_portal_tools();
+		if (Engine::get_singleton()->is_editor_hint()) {
+			SpatialEditor *spatial_editor = SpatialEditor::get_singleton();
+			if (spatial_editor) {
+				spatial_editor->update_portal_tools();
+			}
+		}
 #endif
 	}
 }


### PR DESCRIPTION
Calling `rooms_set_active` with TOOLS_ENABLED from a running project resulted in a crash because the Spatial Editor is not available. Wrapped it in an `is_editor_hint`.

## Notes
* Must have missed this one as the other two calls have `is_editor_hint`checks.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
