### PR TITLE
Portals - fix showing debug collision shapes

### DIFF
--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -256,6 +256,7 @@ void CollisionObject::_update_debug_shapes() {
 				Ref<Mesh> mesh = s.shape->get_debug_mesh();
 				VS::get_singleton()->instance_set_base(s.debug_shape, mesh->get_rid());
 				VS::get_singleton()->instance_set_transform(s.debug_shape, get_global_transform() * shapedata.xform);
+				VS::get_singleton()->instance_set_portal_mode(s.debug_shape, VisualServer::INSTANCE_PORTAL_MODE_GLOBAL);
 			}
 		}
 	}


### PR DESCRIPTION
Set the portal_mode to GLOBAL on creation.

Fixes #51264

## Notes
* Another one of the debug gizmos that need to be set to GLOBAL to show when portals are active. See the discussion in #50999 for more info.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
