### PR TITLE
Fix get_used_rect() calculation

### DIFF
--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -213,8 +213,8 @@ private:
 	// Rect.
 	Rect2 rect_cache;
 	bool rect_cache_dirty = true;
-	Rect2 used_size_cache;
-	bool used_size_cache_dirty = true;
+	Rect2i used_rect_cache;
+	bool used_rect_cache_dirty = true;
 
 	// TileMap layers.
 	struct TileMapLayer {


### PR DESCRIPTION
Fixes #51253 (regression from #51004, but it was possibly broken before in different way; not sure why I wouldn't notice though)

The fixed algorithm starts from 0 size and expands to size - 1 and then adds one row and column. I tested with single rows, empty tilemap, different setups etc and seems to work fine.