### PR TITLE
Use doubles for time in many other places

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -46,14 +46,14 @@ int Engine::get_iterations_per_second() const {
 	return ips;
 }
 
-void Engine::set_physics_jitter_fix(float p_threshold) {
+void Engine::set_physics_jitter_fix(double p_threshold) {
 	if (p_threshold < 0) {
 		p_threshold = 0;
 	}
 	physics_jitter_fix = p_threshold;
 }
 
-float Engine::get_physics_jitter_fix() const {
+double Engine::get_physics_jitter_fix() const {
 	return physics_jitter_fix;
 }
 
@@ -77,11 +77,11 @@ uint32_t Engine::get_frame_delay() const {
 	return _frame_delay;
 }
 
-void Engine::set_time_scale(float p_scale) {
+void Engine::set_time_scale(double p_scale) {
 	_time_scale = p_scale;
 }
 
-float Engine::get_time_scale() const {
+double Engine::get_time_scale() const {
 	return _time_scale;
 }
 

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -51,15 +51,15 @@ private:
 	uint64_t frames_drawn = 0;
 	uint32_t _frame_delay = 0;
 	uint64_t _frame_ticks = 0;
-	float _process_step = 0;
+	double _process_step = 0;
 
 	int ips = 60;
-	float physics_jitter_fix = 0.5;
-	float _fps = 1;
+	double physics_jitter_fix = 0.5;
+	double _fps = 1;
 	int _target_fps = 0;
-	float _time_scale = 1.0;
+	double _time_scale = 1.0;
 	uint64_t _physics_frames = 0;
-	float _physics_interpolation_fraction = 0.0f;
+	double _physics_interpolation_fraction = 0.0f;
 	bool abort_on_gpu_errors = false;
 	bool use_validation_layers = false;
 
@@ -81,13 +81,13 @@ public:
 	virtual void set_iterations_per_second(int p_ips);
 	virtual int get_iterations_per_second() const;
 
-	void set_physics_jitter_fix(float p_threshold);
-	float get_physics_jitter_fix() const;
+	void set_physics_jitter_fix(double p_threshold);
+	double get_physics_jitter_fix() const;
 
 	virtual void set_target_fps(int p_fps);
 	virtual int get_target_fps() const;
 
-	virtual float get_frames_per_second() const { return _fps; }
+	virtual double get_frames_per_second() const { return _fps; }
 
 	uint64_t get_frames_drawn();
 
@@ -95,11 +95,11 @@ public:
 	uint64_t get_process_frames() const { return _process_frames; }
 	bool is_in_physics_frame() const { return _in_physics; }
 	uint64_t get_frame_ticks() const { return _frame_ticks; }
-	float get_process_step() const { return _process_step; }
-	float get_physics_interpolation_fraction() const { return _physics_interpolation_fraction; }
+	double get_process_step() const { return _process_step; }
+	double get_physics_interpolation_fraction() const { return _physics_interpolation_fraction; }
 
-	void set_time_scale(float p_scale);
-	float get_time_scale() const;
+	void set_time_scale(double p_scale);
+	double get_time_scale() const;
 
 	void set_print_error_messages(bool p_enabled);
 	bool is_printing_error_messages() const;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2085,15 +2085,15 @@ int _Engine::get_iterations_per_second() const {
 	return Engine::get_singleton()->get_iterations_per_second();
 }
 
-void _Engine::set_physics_jitter_fix(float p_threshold) {
+void _Engine::set_physics_jitter_fix(double p_threshold) {
 	Engine::get_singleton()->set_physics_jitter_fix(p_threshold);
 }
 
-float _Engine::get_physics_jitter_fix() const {
+double _Engine::get_physics_jitter_fix() const {
 	return Engine::get_singleton()->get_physics_jitter_fix();
 }
 
-float _Engine::get_physics_interpolation_fraction() const {
+double _Engine::get_physics_interpolation_fraction() const {
 	return Engine::get_singleton()->get_physics_interpolation_fraction();
 }
 
@@ -2105,7 +2105,7 @@ int _Engine::get_target_fps() const {
 	return Engine::get_singleton()->get_target_fps();
 }
 
-float _Engine::get_frames_per_second() const {
+double _Engine::get_frames_per_second() const {
 	return Engine::get_singleton()->get_frames_per_second();
 }
 
@@ -2117,11 +2117,11 @@ uint64_t _Engine::get_process_frames() const {
 	return Engine::get_singleton()->get_process_frames();
 }
 
-void _Engine::set_time_scale(float p_scale) {
+void _Engine::set_time_scale(double p_scale) {
 	Engine::get_singleton()->set_time_scale(p_scale);
 }
 
-float _Engine::get_time_scale() {
+double _Engine::get_time_scale() {
 	return Engine::get_singleton()->get_time_scale();
 }
 
@@ -2342,7 +2342,7 @@ void _EngineDebugger::call_add(void *p_user, const Array &p_data) {
 	ERR_FAIL_COND_MSG(err.error != Callable::CallError::CALL_OK, "Error calling 'add' to callable: " + Variant::get_callable_error_text(add, args, 1, err));
 }
 
-void _EngineDebugger::call_tick(void *p_user, float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+void _EngineDebugger::call_tick(void *p_user, double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
 	Callable &tick = ((ProfilerCallable *)p_user)->callable_tick;
 	if (tick.is_null()) {
 		return;

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -626,21 +626,21 @@ public:
 	void set_iterations_per_second(int p_ips);
 	int get_iterations_per_second() const;
 
-	void set_physics_jitter_fix(float p_threshold);
-	float get_physics_jitter_fix() const;
-	float get_physics_interpolation_fraction() const;
+	void set_physics_jitter_fix(double p_threshold);
+	double get_physics_jitter_fix() const;
+	double get_physics_interpolation_fraction() const;
 
 	void set_target_fps(int p_fps);
 	int get_target_fps() const;
 
-	float get_frames_per_second() const;
+	double get_frames_per_second() const;
 	uint64_t get_physics_frames() const;
 	uint64_t get_process_frames() const;
 
 	int get_frames_drawn();
 
-	void set_time_scale(float p_scale);
-	float get_time_scale();
+	void set_time_scale(double p_scale);
+	double get_time_scale();
 
 	MainLoop *get_main_loop() const;
 
@@ -712,7 +712,7 @@ public:
 
 	static void call_toggle(void *p_user, bool p_enable, const Array &p_opts);
 	static void call_add(void *p_user, const Array &p_data);
-	static void call_tick(void *p_user, float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time);
+	static void call_tick(void *p_user, double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time);
 	static Error call_capture(void *p_user, const String &p_cmd, const Array &p_data, bool &r_captured);
 
 	_EngineDebugger() { singleton = this; }

--- a/core/debugger/debugger_marshalls.h
+++ b/core/debugger/debugger_marshalls.h
@@ -83,14 +83,14 @@ struct DebuggerMarshalls {
 		StringName name;
 		int sig_id = -1;
 		int call_count = 0;
-		float self_time = 0;
-		float total_time = 0;
+		double self_time = 0;
+		double total_time = 0;
 	};
 
 	// Servers profiler
 	struct ServerFunctionInfo {
 		StringName name;
-		float time = 0;
+		double time = 0;
 	};
 
 	struct ServerInfo {
@@ -100,11 +100,11 @@ struct DebuggerMarshalls {
 
 	struct ServersProfilerFrame {
 		int frame_number = 0;
-		float frame_time = 0;
-		float idle_time = 0;
-		float physics_time = 0;
-		float physics_frame_time = 0;
-		float script_time = 0;
+		double frame_time = 0;
+		double idle_time = 0;
+		double physics_time = 0;
+		double physics_frame_time = 0;
+		double script_time = 0;
 		List<ServerInfo> servers;
 		Vector<ScriptFunctionInfo> script_functions;
 

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -117,7 +117,7 @@ void EngineDebugger::line_poll() {
 	poll_every++;
 }
 
-void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, float p_physics_frame_time) {
+void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, double p_physics_frame_time) {
 	frame_time = USEC_TO_SEC(p_frame_ticks);
 	process_time = USEC_TO_SEC(p_process_ticks);
 	physics_time = USEC_TO_SEC(p_physics_ticks);

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -44,7 +44,7 @@ class ScriptDebugger;
 class EngineDebugger {
 public:
 	typedef void (*ProfilingToggle)(void *p_user, bool p_enable, const Array &p_opts);
-	typedef void (*ProfilingTick)(void *p_user, float p_frame_time, float p_process_time, float p_physics_time, float p_physics_frame_time);
+	typedef void (*ProfilingTick)(void *p_user, double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time);
 	typedef void (*ProfilingAdd)(void *p_user, const Array &p_arr);
 
 	typedef Error (*CaptureFunc)(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);
@@ -85,10 +85,10 @@ public:
 	};
 
 private:
-	float frame_time = 0.0;
-	float process_time = 0.0;
-	float physics_time = 0.0;
-	float physics_frame_time = 0.0;
+	double frame_time = 0.0;
+	double process_time = 0.0;
+	double physics_time = 0.0;
+	double physics_frame_time = 0.0;
 
 	uint32_t poll_every = 0;
 
@@ -120,7 +120,7 @@ public:
 
 	static void register_uri_handler(const String &p_protocol, CreatePeerFunc p_func);
 
-	void iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, float p_physics_frame_time);
+	void iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, double p_physics_frame_time);
 	void profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts = Array());
 	Error capture_parse(const StringName &p_name, const String &p_msg, const Array &p_args, bool &r_captured);
 

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -41,7 +41,7 @@ struct LocalDebugger::ScriptsProfiler {
 		}
 	};
 
-	float frame_time = 0;
+	double frame_time = 0;
 	uint64_t idle_accum = 0;
 	Vector<ScriptLanguage::ProfilingInfo> pinfo;
 
@@ -61,7 +61,7 @@ struct LocalDebugger::ScriptsProfiler {
 		}
 	}
 
-	void tick(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
 		frame_time = p_frame_time;
 		_print_frame_data(false);
 	}
@@ -92,8 +92,8 @@ struct LocalDebugger::ScriptsProfiler {
 		for (int i = 0; i < ofs; i++) {
 			script_time_us += pinfo[i].self_time;
 		}
-		float script_time = USEC_TO_SEC(script_time_us);
-		float total_time = p_accumulated ? script_time : frame_time;
+		double script_time = USEC_TO_SEC(script_time_us);
+		double total_time = p_accumulated ? script_time : frame_time;
 
 		if (!p_accumulated) {
 			print_line("FRAME: total: " + rtos(total_time) + " script: " + rtos(script_time) + "/" + itos(script_time * 100 / total_time) + " %");
@@ -103,8 +103,8 @@ struct LocalDebugger::ScriptsProfiler {
 
 		for (int i = 0; i < ofs; i++) {
 			print_line(itos(i) + ":" + pinfo[i].signature);
-			float tt = USEC_TO_SEC(pinfo[i].total_time);
-			float st = USEC_TO_SEC(pinfo[i].self_time);
+			double tt = USEC_TO_SEC(pinfo[i].total_time);
+			double st = USEC_TO_SEC(pinfo[i].self_time);
 			print_line("\ttotal: " + rtos(tt) + "/" + itos(tt * 100 / total_time) + " % \tself: " + rtos(st) + "/" + itos(st * 100 / total_time) + " % tcalls: " + itos(pinfo[i].call_count));
 		}
 	}
@@ -373,7 +373,7 @@ LocalDebugger::LocalDebugger() {
 				((ScriptsProfiler *)p_user)->toggle(p_enable, p_opts);
 			},
 			nullptr,
-			[](void *p_user, float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+			[](void *p_user, double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
 				((ScriptsProfiler *)p_user)->tick(p_frame_time, p_idle_time, p_physics_time, p_physics_frame_time);
 			});
 	register_profiler("scripts", scr_prof);

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -50,7 +50,7 @@ void RemoteDebugger::_bind_profiler(const String &p_name, T *p_prof) {
 			[](void *p_user, const Array &p_data) {
 				((T *)p_user)->add(p_data);
 			},
-			[](void *p_user, float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+			[](void *p_user, double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
 				((T *)p_user)->tick(p_frame_time, p_idle_time, p_physics_time, p_physics_frame_time);
 			});
 	EngineDebugger::register_profiler(p_name, prof);
@@ -164,7 +164,7 @@ public:
 		}
 	}
 
-	void tick(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
 		uint64_t pt = OS::get_singleton()->get_ticks_msec();
 		if (pt - last_bandwidth_time > 200) {
 			last_bandwidth_time = pt;
@@ -278,10 +278,10 @@ struct RemoteDebugger::ServersProfiler {
 	Map<StringName, ServerInfo> server_data;
 	ScriptsProfiler scripts_profiler;
 
-	float frame_time = 0;
-	float idle_time = 0;
-	float physics_time = 0;
-	float physics_frame_time = 0;
+	double frame_time = 0;
+	double idle_time = 0;
+	double physics_time = 0;
+	double physics_frame_time = 0;
 
 	void toggle(bool p_enable, const Array &p_opts) {
 		skip_profile_frame = false;
@@ -308,7 +308,7 @@ struct RemoteDebugger::ServersProfiler {
 		srv.functions.push_back(fi);
 	}
 
-	void tick(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
 		frame_time = p_frame_time;
 		idle_time = p_idle_time;
 		physics_time = p_physics_time;
@@ -358,7 +358,7 @@ struct RemoteDebugger::VisualProfiler {
 
 	void add(const Array &p_data) {}
 
-	void tick(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
 		Vector<RS::FrameProfileArea> profile_areas = RS::get_singleton()->get_frame_profile();
 		DebuggerMarshalls::VisualProfilerFrame frame;
 		if (!profile_areas.size()) {
@@ -378,7 +378,7 @@ struct RemoteDebugger::PerformanceProfiler {
 
 	void toggle(bool p_enable, const Array &p_opts) {}
 	void add(const Array &p_data) {}
-	void tick(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
 		if (!performance) {
 			return;
 		}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4073,7 +4073,7 @@ void CanvasItemEditor::_popup_warning_depop(Control *p_control) {
 	info_overlay->set_offset(SIDE_LEFT, (show_rulers ? RULER_WIDTH : 0) + 10);
 }
 
-void CanvasItemEditor::_popup_warning_temporarily(Control *p_control, const float p_duration) {
+void CanvasItemEditor::_popup_warning_temporarily(Control *p_control, const double p_duration) {
 	Timer *timer;
 	if (!popup_temporarily_timers.has(p_control)) {
 		timer = memnew(Timer);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -540,7 +540,7 @@ private:
 	VSplitContainer *bottom_split;
 
 	void _update_context_menu_stylebox();
-	void _popup_warning_temporarily(Control *p_control, const float p_duration);
+	void _popup_warning_temporarily(Control *p_control, const double p_duration);
 	void _popup_warning_depop(Control *p_control);
 
 	void _set_owner_for_node_and_children(Node *p_node, Node *p_owner);

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -60,7 +60,7 @@ void GPUParticles2DEditorPlugin::_file_selected(const String &p_file) {
 void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 	switch (p_idx) {
 		case MENU_GENERATE_VISIBILITY_RECT: {
-			float gen_time = particles->get_lifetime();
+			double gen_time = particles->get_lifetime();
 			if (gen_time < 1.0) {
 				generate_seconds->set_value(1.0);
 			} else {
@@ -100,7 +100,7 @@ void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 }
 
 void GPUParticles2DEditorPlugin::_generate_visibility_rect() {
-	float time = generate_seconds->get_value();
+	double time = generate_seconds->get_value();
 
 	float running = 0.0;
 

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -282,9 +282,9 @@ void GPUParticles3DEditor::_menu_option(int p_option) {
 }
 
 void GPUParticles3DEditor::_generate_aabb() {
-	float time = generate_seconds->get_value();
+	double time = generate_seconds->get_value();
 
-	float running = 0.0;
+	double running = 0.0;
 
 	EditorProgress ep("gen_aabb", TTR("Generating AABB"), int(time));
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2735,7 +2735,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 		if (show_fps) {
 			cpu_time_history[cpu_time_history_index] = RS::get_singleton()->viewport_get_measured_render_time_cpu(viewport->get_viewport_rid());
 			cpu_time_history_index = (cpu_time_history_index + 1) % FRAME_TIME_HISTORY;
-			float cpu_time = 0.0;
+			double cpu_time = 0.0;
 			for (int i = 0; i < FRAME_TIME_HISTORY; i++) {
 				cpu_time += cpu_time_history[i];
 			}
@@ -2745,7 +2745,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 			gpu_time_history[gpu_time_history_index] = RS::get_singleton()->viewport_get_measured_render_time_gpu(viewport->get_viewport_rid());
 			gpu_time_history_index = (gpu_time_history_index + 1) % FRAME_TIME_HISTORY;
-			float gpu_time = 0.0;
+			double gpu_time = 0.0;
 			for (int i = 0; i < FRAME_TIME_HISTORY; i++) {
 				gpu_time += gpu_time_history[i];
 			}
@@ -2769,7 +2769,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 					frame_time_gradient->get_color_at_offset(
 							Math::range_lerp(gpu_time, 0, 30, 0, 1)));
 
-			const float fps = 1000.0 / gpu_time;
+			const double fps = 1000.0 / gpu_time;
 			fps_label->set_text(vformat(TTR("FPS: %d"), fps));
 			// Middle point is at 60 FPS.
 			fps_label->add_theme_color_override(

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -166,9 +166,9 @@ public:
 	};
 
 private:
-	float cpu_time_history[FRAME_TIME_HISTORY];
+	double cpu_time_history[FRAME_TIME_HISTORY];
 	int cpu_time_history_index;
-	float gpu_time_history[FRAME_TIME_HISTORY];
+	double gpu_time_history[FRAME_TIME_HISTORY];
 	int gpu_time_history_index;
 
 	int index;
@@ -336,7 +336,7 @@ private:
 
 	String last_message;
 	String message;
-	float message_time;
+	double message_time;
 
 	void set_message(String p_message, float p_time = 5);
 

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -93,7 +93,7 @@ String VisualScriptYield::get_text() const {
 class VisualScriptNodeInstanceYield : public VisualScriptNodeInstance {
 public:
 	VisualScriptYield::YieldMode mode;
-	float wait_time;
+	double wait_time;
 
 	virtual int get_working_memory_size() const { return 1; } //yield needs at least 1
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -159,7 +159,7 @@ VisualScriptYield::YieldMode VisualScriptYield::get_yield_mode() {
 	return yield_mode;
 }
 
-void VisualScriptYield::set_wait_time(float p_time) {
+void VisualScriptYield::set_wait_time(double p_time) {
 	if (wait_time == p_time) {
 		return;
 	}
@@ -167,7 +167,7 @@ void VisualScriptYield::set_wait_time(float p_time) {
 	ports_changed_notify();
 }
 
-float VisualScriptYield::get_wait_time() {
+double VisualScriptYield::get_wait_time() {
 	return wait_time;
 }
 

--- a/modules/visual_script/visual_script_yield_nodes.h
+++ b/modules/visual_script/visual_script_yield_nodes.h
@@ -47,7 +47,7 @@ public:
 
 private:
 	YieldMode yield_mode;
-	float wait_time;
+	double wait_time;
 
 protected:
 	virtual void _validate_property(PropertyInfo &property) const override;
@@ -73,8 +73,8 @@ public:
 	void set_yield_mode(YieldMode p_mode);
 	YieldMode get_yield_mode();
 
-	void set_wait_time(float p_time);
-	float get_wait_time();
+	void set_wait_time(double p_time);
+	double get_wait_time();
 
 	virtual VisualScriptNodeInstance *instantiate(VisualScriptInstance *p_instance) override;
 

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -159,12 +159,12 @@ void AnimatedSprite2D::_notification(int p_what) {
 				return;
 			}
 
-			float speed = frames->get_animation_speed(animation) * speed_scale;
+			double speed = frames->get_animation_speed(animation) * speed_scale;
 			if (speed == 0) {
 				return; //do nothing
 			}
 
-			float remaining = get_process_delta_time();
+			double remaining = get_process_delta_time();
 
 			while (remaining) {
 				if (timeout <= 0) {
@@ -205,7 +205,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 					emit_signal(SceneStringNames::get_singleton()->frame_changed);
 				}
 
-				float to_process = MIN(timeout, remaining);
+				double to_process = MIN(timeout, remaining);
 				remaining -= to_process;
 				timeout -= to_process;
 			}
@@ -310,8 +310,8 @@ int AnimatedSprite2D::get_frame() const {
 	return frame;
 }
 
-void AnimatedSprite2D::set_speed_scale(float p_speed_scale) {
-	float elapsed = _get_frame_duration() - timeout;
+void AnimatedSprite2D::set_speed_scale(double p_speed_scale) {
+	double elapsed = _get_frame_duration() - timeout;
 
 	speed_scale = MAX(p_speed_scale, 0.0f);
 
@@ -320,7 +320,7 @@ void AnimatedSprite2D::set_speed_scale(float p_speed_scale) {
 	timeout -= elapsed;
 }
 
-float AnimatedSprite2D::get_speed_scale() const {
+double AnimatedSprite2D::get_speed_scale() const {
 	return speed_scale;
 }
 
@@ -402,9 +402,9 @@ bool AnimatedSprite2D::is_playing() const {
 	return playing;
 }
 
-float AnimatedSprite2D::_get_frame_duration() {
+double AnimatedSprite2D::_get_frame_duration() {
 	if (frames.is_valid() && frames->has_animation(animation)) {
-		float speed = frames->get_animation_speed(animation) * speed_scale;
+		double speed = frames->get_animation_speed(animation) * speed_scale;
 		if (speed > 0) {
 			return 1.0 / speed;
 		}

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -56,7 +56,7 @@ class AnimatedSprite2D : public Node2D {
 
 	void _res_changed();
 
-	float _get_frame_duration();
+	double _get_frame_duration();
 	void _reset_timeout();
 	void _set_playing(bool p_playing);
 	bool _is_playing() const;
@@ -94,8 +94,8 @@ public:
 	void set_frame(int p_frame);
 	int get_frame() const;
 
-	void set_speed_scale(float p_speed_scale);
-	float get_speed_scale() const;
+	void set_speed_scale(double p_speed_scale);
+	double get_speed_scale() const;
 
 	void set_centered(bool p_center);
 	bool is_centered() const;

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -65,7 +65,7 @@ void CPUParticles2D::set_amount(int p_amount) {
 	particle_order.resize(p_amount);
 }
 
-void CPUParticles2D::set_lifetime(float p_lifetime) {
+void CPUParticles2D::set_lifetime(double p_lifetime) {
 	ERR_FAIL_COND_MSG(p_lifetime <= 0, "Particles lifetime must be greater than 0.");
 	lifetime = p_lifetime;
 }
@@ -74,7 +74,7 @@ void CPUParticles2D::set_one_shot(bool p_one_shot) {
 	one_shot = p_one_shot;
 }
 
-void CPUParticles2D::set_pre_process_time(float p_time) {
+void CPUParticles2D::set_pre_process_time(double p_time) {
 	pre_process_time = p_time;
 }
 
@@ -86,7 +86,7 @@ void CPUParticles2D::set_randomness_ratio(real_t p_ratio) {
 	randomness_ratio = p_ratio;
 }
 
-void CPUParticles2D::set_lifetime_randomness(float p_random) {
+void CPUParticles2D::set_lifetime_randomness(double p_random) {
 	lifetime_randomness = p_random;
 }
 
@@ -95,7 +95,7 @@ void CPUParticles2D::set_use_local_coordinates(bool p_enable) {
 	set_notify_transform(!p_enable);
 }
 
-void CPUParticles2D::set_speed_scale(real_t p_scale) {
+void CPUParticles2D::set_speed_scale(double p_scale) {
 	speed_scale = p_scale;
 }
 
@@ -107,7 +107,7 @@ int CPUParticles2D::get_amount() const {
 	return particles.size();
 }
 
-float CPUParticles2D::get_lifetime() const {
+double CPUParticles2D::get_lifetime() const {
 	return lifetime;
 }
 
@@ -115,7 +115,7 @@ bool CPUParticles2D::get_one_shot() const {
 	return one_shot;
 }
 
-float CPUParticles2D::get_pre_process_time() const {
+double CPUParticles2D::get_pre_process_time() const {
 	return pre_process_time;
 }
 
@@ -127,7 +127,7 @@ real_t CPUParticles2D::get_randomness_ratio() const {
 	return randomness_ratio;
 }
 
-float CPUParticles2D::get_lifetime_randomness() const {
+double CPUParticles2D::get_lifetime_randomness() const {
 	return lifetime_randomness;
 }
 
@@ -135,7 +135,7 @@ bool CPUParticles2D::get_use_local_coordinates() const {
 	return local_coords;
 }
 
-real_t CPUParticles2D::get_speed_scale() const {
+double CPUParticles2D::get_speed_scale() const {
 	return speed_scale;
 }
 
@@ -516,7 +516,7 @@ void CPUParticles2D::_update_internal() {
 		return;
 	}
 
-	float delta = get_process_delta_time();
+	double delta = get_process_delta_time();
 	if (emitting) {
 		inactive_time = 0;
 	} else {
@@ -536,14 +536,14 @@ void CPUParticles2D::_update_internal() {
 	_set_redraw(true);
 
 	if (time == 0 && pre_process_time > 0.0) {
-		float frame_time;
+		double frame_time;
 		if (fixed_fps > 0) {
 			frame_time = 1.0 / fixed_fps;
 		} else {
 			frame_time = 1.0 / 30.0;
 		}
 
-		float todo = pre_process_time;
+		double todo = pre_process_time;
 
 		while (todo >= 0) {
 			_particles_process(frame_time);
@@ -552,16 +552,16 @@ void CPUParticles2D::_update_internal() {
 	}
 
 	if (fixed_fps > 0) {
-		float frame_time = 1.0 / fixed_fps;
-		float decr = frame_time;
+		double frame_time = 1.0 / fixed_fps;
+		double decr = frame_time;
 
-		float ldelta = delta;
+		double ldelta = delta;
 		if (ldelta > 0.1) { //avoid recursive stalls if fps goes below 10
 			ldelta = 0.1;
 		} else if (ldelta <= 0.0) { //unlikely but..
 			ldelta = 0.001;
 		}
-		float todo = frame_remainder + ldelta;
+		double todo = frame_remainder + ldelta;
 
 		while (todo >= frame_time) {
 			_particles_process(frame_time);
@@ -577,7 +577,7 @@ void CPUParticles2D::_update_internal() {
 	_update_particle_data_buffer();
 }
 
-void CPUParticles2D::_particles_process(float p_delta) {
+void CPUParticles2D::_particles_process(double p_delta) {
 	p_delta *= speed_scale;
 
 	int pcount = particles.size();
@@ -585,7 +585,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 
 	Particle *parray = w;
 
-	float prev_time = time;
+	double prev_time = time;
 	time += p_delta;
 	if (time > lifetime) {
 		time = Math::fmod(time, lifetime);
@@ -604,7 +604,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 		velocity_xform[2] = Vector2();
 	}
 
-	float system_phase = time / lifetime;
+	double system_phase = time / lifetime;
 
 	for (int i = 0; i < pcount; i++) {
 		Particle &p = parray[i];
@@ -613,12 +613,12 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			continue;
 		}
 
-		float local_delta = p_delta;
+		double local_delta = p_delta;
 
 		// The phase is a ratio between 0 (birth) and 1 (end of life) for each particle.
 		// While we use time in tests later on, for randomness we use the phase as done in the
 		// original shader code, and we later multiply by lifetime to get the time.
-		real_t restart_phase = real_t(i) / real_t(pcount);
+		double restart_phase = double(i) / double(pcount);
 
 		if (randomness_ratio > 0.0) {
 			uint32_t seed = cycle;
@@ -627,12 +627,12 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			}
 			seed *= uint32_t(pcount);
 			seed += uint32_t(i);
-			real_t random = (idhash(seed) % uint32_t(65536)) / 65536.0;
-			restart_phase += randomness_ratio * random * 1.0 / pcount;
+			double random = double(idhash(seed) % uint32_t(65536)) / 65536.0;
+			restart_phase += randomness_ratio * random * 1.0 / double(pcount);
 		}
 
 		restart_phase *= (1.0 - explosiveness_ratio);
-		float restart_time = restart_phase * lifetime;
+		double restart_time = restart_phase * lifetime;
 		bool restart = false;
 
 		if (time > prev_time) {

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -91,16 +91,16 @@ private:
 		real_t scale_rand = 0.0;
 		real_t hue_rot_rand = 0.0;
 		real_t anim_offset_rand = 0.0;
-		float time = 0.0;
-		float lifetime = 0.0;
+		double time = 0.0;
+		double lifetime = 0.0;
 		Color base_color;
 
 		uint32_t seed = 0;
 	};
 
-	float time = 0.0;
-	float inactive_time = 0.0;
-	float frame_remainder = 0.0;
+	double time = 0.0;
+	double inactive_time = 0.0;
+	double frame_remainder = 0.0;
 	int cycle = 0;
 	bool redraw = false;
 
@@ -131,12 +131,12 @@ private:
 
 	bool one_shot = false;
 
-	float lifetime = 1.0;
-	float pre_process_time = 0.0;
+	double lifetime = 1.0;
+	double pre_process_time = 0.0;
 	real_t explosiveness_ratio = 0.0;
 	real_t randomness_ratio = 0.0;
-	real_t lifetime_randomness = 0.0;
-	real_t speed_scale = 1.0;
+	double lifetime_randomness = 0.0;
+	double speed_scale = 1.0;
 	bool local_coords;
 	int fixed_fps = 0;
 	bool fractional_delta = true;
@@ -172,7 +172,7 @@ private:
 	Vector2 gravity = Vector2(0, 980);
 
 	void _update_internal();
-	void _particles_process(float p_delta);
+	void _particles_process(double p_delta);
 	void _update_particle_data_buffer();
 
 	Mutex update_mutex;
@@ -193,27 +193,27 @@ protected:
 public:
 	void set_emitting(bool p_emitting);
 	void set_amount(int p_amount);
-	void set_lifetime(float p_lifetime);
+	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
-	void set_pre_process_time(float p_time);
+	void set_pre_process_time(double p_time);
 	void set_explosiveness_ratio(real_t p_ratio);
 	void set_randomness_ratio(real_t p_ratio);
-	void set_lifetime_randomness(float p_random);
+	void set_lifetime_randomness(double p_random);
 	void set_visibility_aabb(const Rect2 &p_aabb);
 	void set_use_local_coordinates(bool p_enable);
-	void set_speed_scale(real_t p_scale);
+	void set_speed_scale(double p_scale);
 
 	bool is_emitting() const;
 	int get_amount() const;
-	float get_lifetime() const;
+	double get_lifetime() const;
 	bool get_one_shot() const;
-	float get_pre_process_time() const;
+	double get_pre_process_time() const;
 	real_t get_explosiveness_ratio() const;
 	real_t get_randomness_ratio() const;
-	float get_lifetime_randomness() const;
+	double get_lifetime_randomness() const;
 	Rect2 get_visibility_aabb() const;
 	bool get_use_local_coordinates() const;
-	real_t get_speed_scale() const;
+	double get_speed_scale() const;
 
 	void set_fixed_fps(int p_count);
 	int get_fixed_fps() const;

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -54,7 +54,7 @@ void GPUParticles2D::set_amount(int p_amount) {
 	RS::get_singleton()->particles_set_amount(particles, amount);
 }
 
-void GPUParticles2D::set_lifetime(float p_lifetime) {
+void GPUParticles2D::set_lifetime(double p_lifetime) {
 	ERR_FAIL_COND_MSG(p_lifetime <= 0, "Particles lifetime must be greater than 0.");
 	lifetime = p_lifetime;
 	RS::get_singleton()->particles_set_lifetime(particles, lifetime);
@@ -76,7 +76,7 @@ void GPUParticles2D::set_one_shot(bool p_enable) {
 	}
 }
 
-void GPUParticles2D::set_pre_process_time(float p_time) {
+void GPUParticles2D::set_pre_process_time(double p_time) {
 	pre_process_time = p_time;
 	RS::get_singleton()->particles_set_pre_process_time(particles, pre_process_time);
 }
@@ -148,7 +148,8 @@ void GPUParticles2D::set_trail_enabled(bool p_enabled) {
 
 	RS::get_singleton()->particles_set_transform_align(particles, p_enabled ? RS::PARTICLES_TRANSFORM_ALIGN_Y_TO_VELOCITY : RS::PARTICLES_TRANSFORM_ALIGN_DISABLED);
 }
-void GPUParticles2D::set_trail_length(float p_seconds) {
+
+void GPUParticles2D::set_trail_length(double p_seconds) {
 	ERR_FAIL_COND(p_seconds < 0.001);
 	trail_length = p_seconds;
 	RS::get_singleton()->particles_set_trails(particles, trail_enabled, trail_length);
@@ -162,6 +163,7 @@ void GPUParticles2D::set_trail_sections(int p_sections) {
 	trail_sections = p_sections;
 	update();
 }
+
 void GPUParticles2D::set_trail_section_subdivisions(int p_subdivisions) {
 	ERR_FAIL_COND(trail_section_subdivisions < 1);
 	ERR_FAIL_COND(trail_section_subdivisions > 1024);
@@ -173,12 +175,13 @@ void GPUParticles2D::set_trail_section_subdivisions(int p_subdivisions) {
 bool GPUParticles2D::is_trail_enabled() const {
 	return trail_enabled;
 }
-float GPUParticles2D::get_trail_length() const {
+
+real_t GPUParticles2D::get_trail_length() const {
 	return trail_length;
 }
 
 void GPUParticles2D::_update_collision_size() {
-	float csize = collision_base_size;
+	real_t csize = collision_base_size;
 
 	if (texture.is_valid()) {
 		csize *= (texture->get_width() + texture->get_height()) / 4.0; //half size since its a radius
@@ -187,16 +190,16 @@ void GPUParticles2D::_update_collision_size() {
 	RS::get_singleton()->particles_set_collision_base_size(particles, csize);
 }
 
-void GPUParticles2D::set_collision_base_size(float p_size) {
+void GPUParticles2D::set_collision_base_size(real_t p_size) {
 	collision_base_size = p_size;
 	_update_collision_size();
 }
 
-float GPUParticles2D::get_collision_base_size() const {
+real_t GPUParticles2D::get_collision_base_size() const {
 	return collision_base_size;
 }
 
-void GPUParticles2D::set_speed_scale(float p_scale) {
+void GPUParticles2D::set_speed_scale(double p_scale) {
 	speed_scale = p_scale;
 	RS::get_singleton()->particles_set_speed_scale(particles, p_scale);
 }
@@ -209,7 +212,7 @@ int GPUParticles2D::get_amount() const {
 	return amount;
 }
 
-float GPUParticles2D::get_lifetime() const {
+double GPUParticles2D::get_lifetime() const {
 	return lifetime;
 }
 
@@ -224,7 +227,7 @@ bool GPUParticles2D::get_one_shot() const {
 	return one_shot;
 }
 
-float GPUParticles2D::get_pre_process_time() const {
+double GPUParticles2D::get_pre_process_time() const {
 	return pre_process_time;
 }
 
@@ -248,7 +251,7 @@ Ref<Material> GPUParticles2D::get_process_material() const {
 	return process_material;
 }
 
-float GPUParticles2D::get_speed_scale() const {
+double GPUParticles2D::get_speed_scale() const {
 	return speed_scale;
 }
 

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -51,11 +51,11 @@ private:
 
 	bool one_shot;
 	int amount;
-	float lifetime;
-	float pre_process_time;
+	double lifetime;
+	double pre_process_time;
 	float explosiveness_ratio;
 	float randomness_ratio;
-	float speed_scale;
+	double speed_scale;
 	Rect2 visibility_rect;
 	bool local_coords;
 	int fixed_fps;
@@ -89,32 +89,32 @@ protected:
 public:
 	void set_emitting(bool p_emitting);
 	void set_amount(int p_amount);
-	void set_lifetime(float p_lifetime);
+	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_enable);
-	void set_pre_process_time(float p_time);
+	void set_pre_process_time(double p_time);
 	void set_explosiveness_ratio(float p_ratio);
 	void set_randomness_ratio(float p_ratio);
 	void set_visibility_rect(const Rect2 &p_visibility_rect);
 	void set_use_local_coordinates(bool p_enable);
 	void set_process_material(const Ref<Material> &p_material);
-	void set_speed_scale(float p_scale);
-	void set_collision_base_size(float p_ratio);
+	void set_speed_scale(double p_scale);
+	void set_collision_base_size(real_t p_ratio);
 	void set_trail_enabled(bool p_enabled);
-	void set_trail_length(float p_seconds);
+	void set_trail_length(double p_seconds);
 	void set_trail_sections(int p_sections);
 	void set_trail_section_subdivisions(int p_subdivisions);
 
 	bool is_emitting() const;
 	int get_amount() const;
-	float get_lifetime() const;
+	double get_lifetime() const;
 	bool get_one_shot() const;
-	float get_pre_process_time() const;
+	double get_pre_process_time() const;
 	float get_explosiveness_ratio() const;
 	float get_randomness_ratio() const;
 	Rect2 get_visibility_rect() const;
 	bool get_use_local_coordinates() const;
 	Ref<Material> get_process_material() const;
-	float get_speed_scale() const;
+	double get_speed_scale() const;
 
 	float get_collision_base_size() const;
 	bool is_trail_enabled() const;

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -78,7 +78,7 @@ void CPUParticles3D::set_amount(int p_amount) {
 	particle_order.resize(p_amount);
 }
 
-void CPUParticles3D::set_lifetime(float p_lifetime) {
+void CPUParticles3D::set_lifetime(double p_lifetime) {
 	ERR_FAIL_COND_MSG(p_lifetime <= 0, "Particles lifetime must be greater than 0.");
 	lifetime = p_lifetime;
 }
@@ -87,7 +87,7 @@ void CPUParticles3D::set_one_shot(bool p_one_shot) {
 	one_shot = p_one_shot;
 }
 
-void CPUParticles3D::set_pre_process_time(float p_time) {
+void CPUParticles3D::set_pre_process_time(double p_time) {
 	pre_process_time = p_time;
 }
 
@@ -99,7 +99,7 @@ void CPUParticles3D::set_randomness_ratio(real_t p_ratio) {
 	randomness_ratio = p_ratio;
 }
 
-void CPUParticles3D::set_lifetime_randomness(float p_random) {
+void CPUParticles3D::set_lifetime_randomness(double p_random) {
 	lifetime_randomness = p_random;
 }
 
@@ -107,7 +107,7 @@ void CPUParticles3D::set_use_local_coordinates(bool p_enable) {
 	local_coords = p_enable;
 }
 
-void CPUParticles3D::set_speed_scale(real_t p_scale) {
+void CPUParticles3D::set_speed_scale(double p_scale) {
 	speed_scale = p_scale;
 }
 
@@ -119,7 +119,7 @@ int CPUParticles3D::get_amount() const {
 	return particles.size();
 }
 
-float CPUParticles3D::get_lifetime() const {
+double CPUParticles3D::get_lifetime() const {
 	return lifetime;
 }
 
@@ -127,7 +127,7 @@ bool CPUParticles3D::get_one_shot() const {
 	return one_shot;
 }
 
-float CPUParticles3D::get_pre_process_time() const {
+double CPUParticles3D::get_pre_process_time() const {
 	return pre_process_time;
 }
 
@@ -139,7 +139,7 @@ real_t CPUParticles3D::get_randomness_ratio() const {
 	return randomness_ratio;
 }
 
-float CPUParticles3D::get_lifetime_randomness() const {
+double CPUParticles3D::get_lifetime_randomness() const {
 	return lifetime_randomness;
 }
 
@@ -147,7 +147,7 @@ bool CPUParticles3D::get_use_local_coordinates() const {
 	return local_coords;
 }
 
-real_t CPUParticles3D::get_speed_scale() const {
+double CPUParticles3D::get_speed_scale() const {
 	return speed_scale;
 }
 
@@ -519,7 +519,7 @@ void CPUParticles3D::_update_internal() {
 		return;
 	}
 
-	float delta = get_process_delta_time();
+	double delta = get_process_delta_time();
 	if (emitting) {
 		inactive_time = 0;
 	} else {
@@ -541,14 +541,14 @@ void CPUParticles3D::_update_internal() {
 	bool processed = false;
 
 	if (time == 0 && pre_process_time > 0.0) {
-		float frame_time;
+		double frame_time;
 		if (fixed_fps > 0) {
 			frame_time = 1.0 / fixed_fps;
 		} else {
 			frame_time = 1.0 / 30.0;
 		}
 
-		float todo = pre_process_time;
+		double todo = pre_process_time;
 
 		while (todo >= 0) {
 			_particles_process(frame_time);
@@ -558,16 +558,16 @@ void CPUParticles3D::_update_internal() {
 	}
 
 	if (fixed_fps > 0) {
-		float frame_time = 1.0 / fixed_fps;
-		float decr = frame_time;
+		double frame_time = 1.0 / fixed_fps;
+		double decr = frame_time;
 
-		float ldelta = delta;
+		double ldelta = delta;
 		if (ldelta > 0.1) { //avoid recursive stalls if fps goes below 10
 			ldelta = 0.1;
 		} else if (ldelta <= 0.0) { //unlikely but..
 			ldelta = 0.001;
 		}
-		float todo = frame_remainder + ldelta;
+		double todo = frame_remainder + ldelta;
 
 		while (todo >= frame_time) {
 			_particles_process(frame_time);
@@ -587,7 +587,7 @@ void CPUParticles3D::_update_internal() {
 	}
 }
 
-void CPUParticles3D::_particles_process(float p_delta) {
+void CPUParticles3D::_particles_process(double p_delta) {
 	p_delta *= speed_scale;
 
 	int pcount = particles.size();
@@ -595,7 +595,7 @@ void CPUParticles3D::_particles_process(float p_delta) {
 
 	Particle *parray = w;
 
-	float prev_time = time;
+	double prev_time = time;
 	time += p_delta;
 	if (time > lifetime) {
 		time = Math::fmod(time, lifetime);
@@ -613,7 +613,7 @@ void CPUParticles3D::_particles_process(float p_delta) {
 		velocity_xform = emission_xform.basis;
 	}
 
-	float system_phase = time / lifetime;
+	double system_phase = time / lifetime;
 
 	for (int i = 0; i < pcount; i++) {
 		Particle &p = parray[i];
@@ -622,12 +622,12 @@ void CPUParticles3D::_particles_process(float p_delta) {
 			continue;
 		}
 
-		float local_delta = p_delta;
+		double local_delta = p_delta;
 
 		// The phase is a ratio between 0 (birth) and 1 (end of life) for each particle.
 		// While we use time in tests later on, for randomness we use the phase as done in the
 		// original shader code, and we later multiply by lifetime to get the time.
-		real_t restart_phase = real_t(i) / real_t(pcount);
+		double restart_phase = double(i) / double(pcount);
 
 		if (randomness_ratio > 0.0) {
 			uint32_t seed = cycle;
@@ -636,12 +636,12 @@ void CPUParticles3D::_particles_process(float p_delta) {
 			}
 			seed *= uint32_t(pcount);
 			seed += uint32_t(i);
-			real_t random = (idhash(seed) % uint32_t(65536)) / real_t(65536.0);
-			restart_phase += randomness_ratio * random * 1.0 / pcount;
+			double random = double(idhash(seed) % uint32_t(65536)) / 65536.0;
+			restart_phase += randomness_ratio * random * 1.0 / double(pcount);
 		}
 
 		restart_phase *= (1.0 - explosiveness_ratio);
-		float restart_time = restart_phase * lifetime;
+		double restart_time = restart_phase * lifetime;
 		bool restart = false;
 
 		if (time > prev_time) {

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -93,16 +93,16 @@ private:
 		real_t scale_rand = 0.0;
 		real_t hue_rot_rand = 0.0;
 		real_t anim_offset_rand = 0.0;
-		float time = 0.0;
-		float lifetime = 0.0;
+		double time = 0.0;
+		double lifetime = 0.0;
 		Color base_color;
 
 		uint32_t seed = 0;
 	};
 
-	float time = 0.0;
-	float inactive_time = 0.0;
-	float frame_remainder = 0.0;
+	double time = 0.0;
+	double inactive_time = 0.0;
+	double frame_remainder = 0.0;
 	int cycle = 0;
 	bool redraw = false;
 
@@ -132,12 +132,12 @@ private:
 
 	bool one_shot = false;
 
-	float lifetime = 1.0;
-	float pre_process_time = 0.0;
+	double lifetime = 1.0;
+	double pre_process_time = 0.0;
 	real_t explosiveness_ratio = 0.0;
 	real_t randomness_ratio = 0.0;
-	float lifetime_randomness = 0.0;
-	float speed_scale = 1.0;
+	double lifetime_randomness = 0.0;
+	double speed_scale = 1.0;
 	bool local_coords = true;
 	int fixed_fps = 0;
 	bool fractional_delta = true;
@@ -180,7 +180,7 @@ private:
 	Vector3 gravity = Vector3(0, -9.8, 0);
 
 	void _update_internal();
-	void _particles_process(float p_delta);
+	void _particles_process(double p_delta);
 	void _update_particle_data_buffer();
 
 	Mutex update_mutex;
@@ -200,27 +200,27 @@ public:
 
 	void set_emitting(bool p_emitting);
 	void set_amount(int p_amount);
-	void set_lifetime(float p_lifetime);
+	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
-	void set_pre_process_time(float p_time);
+	void set_pre_process_time(double p_time);
 	void set_explosiveness_ratio(real_t p_ratio);
 	void set_randomness_ratio(real_t p_ratio);
-	void set_lifetime_randomness(float p_random);
+	void set_lifetime_randomness(double p_random);
 	void set_visibility_aabb(const AABB &p_aabb);
 	void set_use_local_coordinates(bool p_enable);
-	void set_speed_scale(real_t p_scale);
+	void set_speed_scale(double p_scale);
 
 	bool is_emitting() const;
 	int get_amount() const;
-	float get_lifetime() const;
+	double get_lifetime() const;
 	bool get_one_shot() const;
-	float get_pre_process_time() const;
+	double get_pre_process_time() const;
 	real_t get_explosiveness_ratio() const;
 	real_t get_randomness_ratio() const;
-	float get_lifetime_randomness() const;
+	double get_lifetime_randomness() const;
 	AABB get_visibility_aabb() const;
 	bool get_use_local_coordinates() const;
-	real_t get_speed_scale() const;
+	double get_speed_scale() const;
 
 	void set_fixed_fps(int p_count);
 	int get_fixed_fps() const;

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -59,7 +59,7 @@ void GPUParticles3D::set_amount(int p_amount) {
 	RS::get_singleton()->particles_set_amount(particles, amount);
 }
 
-void GPUParticles3D::set_lifetime(float p_lifetime) {
+void GPUParticles3D::set_lifetime(double p_lifetime) {
 	ERR_FAIL_COND_MSG(p_lifetime <= 0, "Particles lifetime must be greater than 0.");
 	lifetime = p_lifetime;
 	RS::get_singleton()->particles_set_lifetime(particles, lifetime);
@@ -81,7 +81,7 @@ void GPUParticles3D::set_one_shot(bool p_one_shot) {
 	}
 }
 
-void GPUParticles3D::set_pre_process_time(float p_time) {
+void GPUParticles3D::set_pre_process_time(double p_time) {
 	pre_process_time = p_time;
 	RS::get_singleton()->particles_set_pre_process_time(particles, pre_process_time);
 }
@@ -118,7 +118,7 @@ void GPUParticles3D::set_process_material(const Ref<Material> &p_material) {
 	update_configuration_warnings();
 }
 
-void GPUParticles3D::set_speed_scale(float p_scale) {
+void GPUParticles3D::set_speed_scale(double p_scale) {
 	speed_scale = p_scale;
 	RS::get_singleton()->particles_set_speed_scale(particles, p_scale);
 }
@@ -136,7 +136,7 @@ int GPUParticles3D::get_amount() const {
 	return amount;
 }
 
-float GPUParticles3D::get_lifetime() const {
+double GPUParticles3D::get_lifetime() const {
 	return lifetime;
 }
 
@@ -144,7 +144,7 @@ bool GPUParticles3D::get_one_shot() const {
 	return one_shot;
 }
 
-float GPUParticles3D::get_pre_process_time() const {
+double GPUParticles3D::get_pre_process_time() const {
 	return pre_process_time;
 }
 
@@ -168,7 +168,7 @@ Ref<Material> GPUParticles3D::get_process_material() const {
 	return process_material;
 }
 
-float GPUParticles3D::get_speed_scale() const {
+double GPUParticles3D::get_speed_scale() const {
 	return speed_scale;
 }
 

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -64,11 +64,11 @@ private:
 
 	bool one_shot;
 	int amount;
-	float lifetime;
-	float pre_process_time;
+	double lifetime;
+	double pre_process_time;
 	float explosiveness_ratio;
 	float randomness_ratio;
-	float speed_scale;
+	double speed_scale;
 	AABB visibility_aabb;
 	bool local_coords;
 	int fixed_fps;
@@ -104,30 +104,30 @@ public:
 
 	void set_emitting(bool p_emitting);
 	void set_amount(int p_amount);
-	void set_lifetime(float p_lifetime);
+	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
-	void set_pre_process_time(float p_time);
+	void set_pre_process_time(double p_time);
 	void set_explosiveness_ratio(float p_ratio);
 	void set_randomness_ratio(float p_ratio);
 	void set_visibility_aabb(const AABB &p_aabb);
 	void set_use_local_coordinates(bool p_enable);
 	void set_process_material(const Ref<Material> &p_material);
-	void set_speed_scale(float p_scale);
+	void set_speed_scale(double p_scale);
 	void set_collision_base_size(float p_ratio);
 	void set_trail_enabled(bool p_enabled);
 	void set_trail_length(float p_seconds);
 
 	bool is_emitting() const;
 	int get_amount() const;
-	float get_lifetime() const;
+	double get_lifetime() const;
 	bool get_one_shot() const;
-	float get_pre_process_time() const;
+	double get_pre_process_time() const;
 	float get_explosiveness_ratio() const;
 	float get_randomness_ratio() const;
 	AABB get_visibility_aabb() const;
 	bool get_use_local_coordinates() const;
 	Ref<Material> get_process_material() const;
-	float get_speed_scale() const;
+	double get_speed_scale() const;
 	float get_collision_base_size() const;
 	bool is_trail_enabled() const;
 	float get_trail_length() const;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1037,7 +1037,7 @@ void AnimatedSprite3D::_notification(int p_what) {
 				return; //do nothing
 			}
 
-			float remaining = get_process_delta_time();
+			double remaining = get_process_delta_time();
 
 			while (remaining) {
 				if (timeout <= 0) {
@@ -1059,7 +1059,7 @@ void AnimatedSprite3D::_notification(int p_what) {
 					emit_signal(SceneStringNames::get_singleton()->frame_changed);
 				}
 
-				float to_process = MIN(timeout, remaining);
+				double to_process = MIN(timeout, remaining);
 				remaining -= to_process;
 				timeout -= to_process;
 			}

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -213,7 +213,7 @@ class AnimatedSprite3D : public SpriteBase3D {
 
 	bool centered = false;
 
-	float timeout = 0;
+	double timeout = 0.0;
 
 	void _res_changed();
 

--- a/scene/3d/velocity_tracker_3d.cpp
+++ b/scene/3d/velocity_tracker_3d.cpp
@@ -61,16 +61,16 @@ void VelocityTracker3D::update_position(const Vector3 &p_position) {
 Vector3 VelocityTracker3D::get_tracked_linear_velocity() const {
 	Vector3 linear_velocity;
 
-	float max_time = 1 / 5.0; //maximum time to interpolate a velocity
+	double max_time = 1 / 5.0; //maximum time to interpolate a velocity
 
 	Vector3 distance_accum;
-	float time_accum = 0.0;
-	float base_time = 0.0;
+	double time_accum = 0.0;
+	double base_time = 0.0;
 
 	if (position_history_len) {
 		if (physics_step) {
 			uint64_t base = Engine::get_singleton()->get_physics_frames();
-			base_time = float(base - position_history[0].frame) / Engine::get_singleton()->get_iterations_per_second();
+			base_time = double(base - position_history[0].frame) / Engine::get_singleton()->get_iterations_per_second();
 		} else {
 			uint64_t base = Engine::get_singleton()->get_frame_ticks();
 			base_time = double(base - position_history[0].frame) / 1000000.0;
@@ -78,12 +78,12 @@ Vector3 VelocityTracker3D::get_tracked_linear_velocity() const {
 	}
 
 	for (int i = 0; i < position_history_len - 1; i++) {
-		float delta = 0.0;
+		double delta = 0.0;
 		uint64_t diff = position_history[i].frame - position_history[i + 1].frame;
 		Vector3 distance = position_history[i].position - position_history[i + 1].position;
 
 		if (physics_step) {
-			delta = float(diff) / Engine::get_singleton()->get_iterations_per_second();
+			delta = double(diff) / Engine::get_singleton()->get_iterations_per_second();
 		} else {
 			delta = double(diff) / 1000000.0;
 		}

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -219,7 +219,7 @@ void AnimationNodeBlendSpace1D::_add_blend_point(int p_index, const Ref<Animatio
 	}
 }
 
-float AnimationNodeBlendSpace1D::process(float p_time, bool p_seek) {
+double AnimationNodeBlendSpace1D::process(double p_time, bool p_seek) {
 	if (blend_points_used == 0) {
 		return 0.0;
 	}
@@ -229,7 +229,7 @@ float AnimationNodeBlendSpace1D::process(float p_time, bool p_seek) {
 		return blend_node(blend_points[0].name, blend_points[0].node, p_time, p_seek, 1.0, FILTER_IGNORE, false);
 	}
 
-	float blend_pos = get_parameter(blend_position);
+	double blend_pos = get_parameter(blend_position);
 
 	float weights[MAX_BLEND_POINTS] = {};
 

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -93,7 +93,7 @@ public:
 	void set_value_label(const String &p_label);
 	String get_value_label() const;
 
-	float process(float p_time, bool p_seek) override;
+	double process(double p_time, bool p_seek) override;
 	String get_caption() const override;
 
 	Ref<AnimationNode> get_child_by_name(const StringName &p_name) override;

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -431,12 +431,12 @@ void AnimationNodeBlendSpace2D::_blend_triangle(const Vector2 &p_pos, const Vect
 	r_weights[2] = w;
 }
 
-float AnimationNodeBlendSpace2D::process(float p_time, bool p_seek) {
+double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek) {
 	_update_triangles();
 
 	Vector2 blend_pos = get_parameter(blend_position);
 	int closest = get_parameter(this->closest);
-	float length_internal = get_parameter(this->length_internal);
+	double length_internal = get_parameter(this->length_internal);
 	float mind = 0.0; //time of min distance point
 
 	if (blend_mode == BLEND_MODE_INTERPOLATED) {

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -126,7 +126,7 @@ public:
 	void set_y_label(const String &p_label);
 	String get_y_label() const;
 
-	virtual float process(float p_time, bool p_seek) override;
+	virtual double process(double p_time, bool p_seek) override;
 	virtual String get_caption() const override;
 
 	Vector2 get_closest_point(const Vector2 &p_point);

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -63,11 +63,11 @@ void AnimationNodeAnimation::_validate_property(PropertyInfo &property) const {
 	}
 }
 
-float AnimationNodeAnimation::process(float p_time, bool p_seek) {
+double AnimationNodeAnimation::process(double p_time, bool p_seek) {
 	AnimationPlayer *ap = state->player;
 	ERR_FAIL_COND_V(!ap, 0);
 
-	float time = get_parameter(this->time);
+	double time = get_parameter(this->time);
 
 	if (!ap->has_animation(animation)) {
 		AnimationNodeBlendTree *tree = Object::cast_to<AnimationNodeBlendTree>(parent);
@@ -84,7 +84,7 @@ float AnimationNodeAnimation::process(float p_time, bool p_seek) {
 
 	Ref<Animation> anim = ap->get_animation(animation);
 
-	float step;
+	double step;
 
 	if (p_seek) {
 		time = p_time;
@@ -94,7 +94,7 @@ float AnimationNodeAnimation::process(float p_time, bool p_seek) {
 		step = p_time;
 	}
 
-	float anim_size = anim->get_length();
+	double anim_size = anim->get_length();
 
 	if (anim->has_loop()) {
 		if (anim_size) {
@@ -202,12 +202,12 @@ bool AnimationNodeOneShot::has_filter() const {
 	return true;
 }
 
-float AnimationNodeOneShot::process(float p_time, bool p_seek) {
+double AnimationNodeOneShot::process(double p_time, bool p_seek) {
 	bool active = get_parameter(this->active);
 	bool prev_active = get_parameter(this->prev_active);
-	float time = get_parameter(this->time);
-	float remaining = get_parameter(this->remaining);
-	float time_to_restart = get_parameter(this->time_to_restart);
+	double time = get_parameter(this->time);
+	double remaining = get_parameter(this->remaining);
+	double time_to_restart = get_parameter(this->time_to_restart);
 
 	if (!active) {
 		//make it as if this node doesn't exist, pass input 0 by.
@@ -370,9 +370,9 @@ bool AnimationNodeAdd2::has_filter() const {
 	return true;
 }
 
-float AnimationNodeAdd2::process(float p_time, bool p_seek) {
-	float amount = get_parameter(add_amount);
-	float rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, !sync);
+double AnimationNodeAdd2::process(double p_time, bool p_seek) {
+	double amount = get_parameter(add_amount);
+	double rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, !sync);
 	blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync);
 
 	return rem0;
@@ -416,10 +416,10 @@ bool AnimationNodeAdd3::has_filter() const {
 	return true;
 }
 
-float AnimationNodeAdd3::process(float p_time, bool p_seek) {
-	float amount = get_parameter(add_amount);
+double AnimationNodeAdd3::process(double p_time, bool p_seek) {
+	double amount = get_parameter(add_amount);
 	blend_input(0, p_time, p_seek, MAX(0, -amount), FILTER_PASS, !sync);
-	float rem0 = blend_input(1, p_time, p_seek, 1.0, FILTER_IGNORE, !sync);
+	double rem0 = blend_input(1, p_time, p_seek, 1.0, FILTER_IGNORE, !sync);
 	blend_input(2, p_time, p_seek, MAX(0, amount), FILTER_PASS, !sync);
 
 	return rem0;
@@ -452,11 +452,11 @@ String AnimationNodeBlend2::get_caption() const {
 	return "Blend2";
 }
 
-float AnimationNodeBlend2::process(float p_time, bool p_seek) {
-	float amount = get_parameter(blend_amount);
+double AnimationNodeBlend2::process(double p_time, bool p_seek) {
+	double amount = get_parameter(blend_amount);
 
-	float rem0 = blend_input(0, p_time, p_seek, 1.0 - amount, FILTER_BLEND, !sync);
-	float rem1 = blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync);
+	double rem0 = blend_input(0, p_time, p_seek, 1.0 - amount, FILTER_BLEND, !sync);
+	double rem1 = blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync);
 
 	return amount > 0.5 ? rem1 : rem0; //hacky but good enough
 }
@@ -507,11 +507,11 @@ bool AnimationNodeBlend3::is_using_sync() const {
 	return sync;
 }
 
-float AnimationNodeBlend3::process(float p_time, bool p_seek) {
-	float amount = get_parameter(blend_amount);
-	float rem0 = blend_input(0, p_time, p_seek, MAX(0, -amount), FILTER_IGNORE, !sync);
-	float rem1 = blend_input(1, p_time, p_seek, 1.0 - ABS(amount), FILTER_IGNORE, !sync);
-	float rem2 = blend_input(2, p_time, p_seek, MAX(0, amount), FILTER_IGNORE, !sync);
+double AnimationNodeBlend3::process(double p_time, bool p_seek) {
+	double amount = get_parameter(blend_amount);
+	double rem0 = blend_input(0, p_time, p_seek, MAX(0, -amount), FILTER_IGNORE, !sync);
+	double rem1 = blend_input(1, p_time, p_seek, 1.0 - ABS(amount), FILTER_IGNORE, !sync);
+	double rem2 = blend_input(2, p_time, p_seek, MAX(0, amount), FILTER_IGNORE, !sync);
 
 	return amount > 0.5 ? rem2 : (amount < -0.5 ? rem0 : rem1); //hacky but good enough
 }
@@ -545,8 +545,8 @@ String AnimationNodeTimeScale::get_caption() const {
 	return "TimeScale";
 }
 
-float AnimationNodeTimeScale::process(float p_time, bool p_seek) {
-	float scale = get_parameter(this->scale);
+double AnimationNodeTimeScale::process(double p_time, bool p_seek) {
+	double scale = get_parameter(this->scale);
 	if (p_seek) {
 		return blend_input(0, p_time, true, 1.0, FILTER_IGNORE, false);
 	} else {
@@ -575,12 +575,12 @@ String AnimationNodeTimeSeek::get_caption() const {
 	return "Seek";
 }
 
-float AnimationNodeTimeSeek::process(float p_time, bool p_seek) {
-	float seek_pos = get_parameter(this->seek_pos);
+double AnimationNodeTimeSeek::process(double p_time, bool p_seek) {
+	double seek_pos = get_parameter(this->seek_pos);
 	if (p_seek) {
 		return blend_input(0, p_time, true, 1.0, FILTER_IGNORE, false);
 	} else if (seek_pos >= 0) {
-		float ret = blend_input(0, seek_pos, true, 1.0, FILTER_IGNORE, false);
+		double ret = blend_input(0, seek_pos, true, 1.0, FILTER_IGNORE, false);
 		set_parameter(this->seek_pos, -1.0); //reset
 		return ret;
 	} else {
@@ -676,13 +676,13 @@ float AnimationNodeTransition::get_cross_fade_time() const {
 	return xfade;
 }
 
-float AnimationNodeTransition::process(float p_time, bool p_seek) {
+double AnimationNodeTransition::process(double p_time, bool p_seek) {
 	int current = get_parameter(this->current);
 	int prev = get_parameter(this->prev);
 	int prev_current = get_parameter(this->prev_current);
 
-	float time = get_parameter(this->time);
-	float prev_xfading = get_parameter(this->prev_xfading);
+	double time = get_parameter(this->time);
+	double prev_xfading = get_parameter(this->prev_xfading);
 
 	bool switched = current != prev_current;
 
@@ -794,7 +794,7 @@ String AnimationNodeOutput::get_caption() const {
 	return "Output";
 }
 
-float AnimationNodeOutput::process(float p_time, bool p_seek) {
+double AnimationNodeOutput::process(double p_time, bool p_seek) {
 	return blend_input(0, p_time, p_seek, 1.0);
 }
 
@@ -1007,7 +1007,7 @@ String AnimationNodeBlendTree::get_caption() const {
 	return "BlendTree";
 }
 
-float AnimationNodeBlendTree::process(float p_time, bool p_seek) {
+double AnimationNodeBlendTree::process(double p_time, bool p_seek) {
 	Ref<AnimationNodeOutput> output = nodes[SceneStringNames::get_singleton()->output].node;
 	return _blend_node("output", nodes[SceneStringNames::get_singleton()->output].connections, this, output, p_time, p_seek, 1.0);
 }

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -53,7 +53,7 @@ public:
 	static Vector<String> (*get_editable_animation_list)();
 
 	virtual String get_caption() const override;
-	virtual float process(float p_time, bool p_seek) override;
+	virtual double process(double p_time, bool p_seek) override;
 
 	void set_animation(const StringName &p_name);
 	StringName get_animation() const;
@@ -122,7 +122,7 @@ public:
 	bool is_using_sync() const;
 
 	virtual bool has_filter() const override;
-	virtual float process(float p_time, bool p_seek) override;
+	virtual double process(double p_time, bool p_seek) override;
 
 	AnimationNodeOneShot();
 };
@@ -148,7 +148,7 @@ public:
 	bool is_using_sync() const;
 
 	virtual bool has_filter() const override;
-	virtual float process(float p_time, bool p_seek) override;
+	virtual double process(double p_time, bool p_seek) override;
 
 	AnimationNodeAdd2();
 };
@@ -172,7 +172,7 @@ public:
 	bool is_using_sync() const;
 
 	virtual bool has_filter() const override;
-	virtual float process(float p_time, bool p_seek) override;
+	virtual double process(double p_time, bool p_seek) override;
 
 	AnimationNodeAdd3();
 };
@@ -191,7 +191,7 @@ public:
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-	virtual float process(float p_time, bool p_seek) override;
+	virtual double process(double p_time, bool p_seek) override;
 
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
@@ -218,7 +218,7 @@ public:
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
 
-	float process(float p_time, bool p_seek) override;
+	double process(double p_time, bool p_seek) override;
 	AnimationNodeBlend3();
 };
 
@@ -236,7 +236,7 @@ public:
 
 	virtual String get_caption() const override;
 
-	float process(float p_time, bool p_seek) override;
+	double process(double p_time, bool p_seek) override;
 
 	AnimationNodeTimeScale();
 };
@@ -255,7 +255,7 @@ public:
 
 	virtual String get_caption() const override;
 
-	float process(float p_time, bool p_seek) override;
+	double process(double p_time, bool p_seek) override;
 
 	AnimationNodeTimeSeek();
 };
@@ -313,7 +313,7 @@ public:
 	void set_cross_fade_time(float p_fade);
 	float get_cross_fade_time() const;
 
-	float process(float p_time, bool p_seek) override;
+	double process(double p_time, bool p_seek) override;
 
 	AnimationNodeTransition();
 };
@@ -323,7 +323,7 @@ class AnimationNodeOutput : public AnimationNode {
 
 public:
 	virtual String get_caption() const override;
-	virtual float process(float p_time, bool p_seek) override;
+	virtual double process(double p_time, bool p_seek) override;
 	AnimationNodeOutput();
 };
 
@@ -390,7 +390,7 @@ public:
 	void get_node_connections(List<NodeConnection> *r_connections) const;
 
 	virtual String get_caption() const override;
-	virtual float process(float p_time, bool p_seek) override;
+	virtual double process(double p_time, bool p_seek) override;
 
 	void get_node_list(List<StringName> *r_list);
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -286,7 +286,7 @@ bool AnimationNodeStateMachinePlayback::_travel(AnimationNodeStateMachine *p_sta
 	return true;
 }
 
-float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_state_machine, float p_time, bool p_seek) {
+double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek) {
 	//if not playing and it can restart, then restart
 	if (!playing && start_request == StringName()) {
 		if (!stop_request && p_state_machine->start_node) {
@@ -790,7 +790,7 @@ Vector2 AnimationNodeStateMachine::get_graph_offset() const {
 	return graph_offset;
 }
 
-float AnimationNodeStateMachine::process(float p_time, bool p_seek) {
+double AnimationNodeStateMachine::process(double p_time, bool p_seek) {
 	Ref<AnimationNodeStateMachinePlayback> playback = get_parameter(this->playback);
 	ERR_FAIL_COND_V(playback.is_null(), 0.0);
 

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -114,7 +114,7 @@ class AnimationNodeStateMachinePlayback : public Resource {
 
 	bool _travel(AnimationNodeStateMachine *p_state_machine, const StringName &p_travel);
 
-	float process(AnimationNodeStateMachine *p_state_machine, float p_time, bool p_seek);
+	double process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek);
 
 protected:
 	static void _bind_methods();
@@ -210,7 +210,7 @@ public:
 	void set_graph_offset(const Vector2 &p_offset);
 	Vector2 get_graph_offset() const;
 
-	virtual float process(float p_time, bool p_seek) override;
+	virtual double process(double p_time, bool p_seek) override;
 	virtual String get_caption() const override;
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) override;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -341,7 +341,7 @@ void AnimationPlayer::_ensure_node_caches(AnimationData *p_anim, Node *p_root_ov
 	}
 }
 
-void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float p_time, float p_delta, float p_interp, bool p_is_current, bool p_seeked, bool p_started) {
+void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double p_time, double p_delta, float p_interp, bool p_is_current, bool p_seeked, bool p_started) {
 	_ensure_node_caches(p_anim);
 	ERR_FAIL_COND(p_anim->node_cache.size() != p_anim->animation->get_track_count());
 
@@ -723,7 +723,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 						continue;
 					}
 
-					float pos = a->track_get_key_time(i, idx);
+					double pos = a->track_get_key_time(i, idx);
 
 					StringName anim_name = a->animation_track_get_key_animation(i, idx);
 					if (String(anim_name) == "[stop]" || !player->has_animation(anim_name)) {
@@ -732,12 +732,12 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 
 					Ref<Animation> anim = player->get_animation(anim_name);
 
-					float at_anim_pos;
+					double at_anim_pos;
 
 					if (anim->has_loop()) {
-						at_anim_pos = Math::fposmod(p_time - pos, anim->get_length()); //seek to loop
+						at_anim_pos = Math::fposmod(p_time - pos, (double)anim->get_length()); //seek to loop
 					} else {
-						at_anim_pos = MAX(anim->get_length(), p_time - pos); //seek to end
+						at_anim_pos = MAX((double)anim->get_length(), p_time - pos); //seek to end
 					}
 
 					if (player->is_playing() || p_seeked) {
@@ -776,9 +776,9 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 	}
 }
 
-void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, float p_blend, bool p_seeked, bool p_started) {
-	float delta = p_delta * speed_scale * cd.speed_scale;
-	float next_pos = cd.pos + delta;
+void AnimationPlayer::_animation_process_data(PlaybackData &cd, double p_delta, float p_blend, bool p_seeked, bool p_started) {
+	double delta = p_delta * speed_scale * cd.speed_scale;
+	double next_pos = cd.pos + delta;
 
 	float len = cd.from->animation->get_length();
 	bool loop = cd.from->animation->has_loop();
@@ -808,7 +808,7 @@ void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, f
 		}
 
 	} else {
-		float looped_next_pos = Math::fposmod(next_pos, len);
+		double looped_next_pos = Math::fposmod(next_pos, (double)len);
 		if (looped_next_pos == 0 && next_pos != 0) {
 			// Loop multiples of the length to it, rather than 0
 			// so state at time=length is previewable in the editor
@@ -823,7 +823,7 @@ void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, f
 	_animation_process_animation(cd.from, cd.pos, delta, p_blend, &cd == &playback.current, p_seeked, p_started);
 }
 
-void AnimationPlayer::_animation_process2(float p_delta, bool p_started) {
+void AnimationPlayer::_animation_process2(double p_delta, bool p_started) {
 	Playback &c = playback;
 
 	accum_pass++;
@@ -927,7 +927,7 @@ void AnimationPlayer::_animation_update_transforms() {
 	cache_update_bezier_size = 0;
 }
 
-void AnimationPlayer::_animation_process(float p_delta) {
+void AnimationPlayer::_animation_process(double p_delta) {
 	if (playback.current.from) {
 		end_reached = false;
 		end_notify = false;
@@ -1283,7 +1283,7 @@ float AnimationPlayer::get_playing_speed() const {
 	return speed_scale * playback.current.speed_scale;
 }
 
-void AnimationPlayer::seek(float p_time, bool p_update) {
+void AnimationPlayer::seek(double p_time, bool p_update) {
 	if (!playback.current.from) {
 		if (playback.assigned) {
 			ERR_FAIL_COND(!animation_set.has(playback.assigned));
@@ -1299,7 +1299,7 @@ void AnimationPlayer::seek(float p_time, bool p_update) {
 	}
 }
 
-void AnimationPlayer::seek_delta(float p_time, float p_delta) {
+void AnimationPlayer::seek_delta(double p_time, float p_delta) {
 	if (!playback.current.from) {
 		if (playback.assigned) {
 			ERR_FAIL_COND(!animation_set.has(playback.assigned));

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -215,13 +215,13 @@ private:
 
 	NodePath root;
 
-	void _animation_process_animation(AnimationData *p_anim, float p_time, float p_delta, float p_interp, bool p_is_current = true, bool p_seeked = false, bool p_started = false);
+	void _animation_process_animation(AnimationData *p_anim, double p_time, double p_delta, float p_interp, bool p_is_current = true, bool p_seeked = false, bool p_started = false);
 
 	void _ensure_node_caches(AnimationData *p_anim, Node *p_root_override = nullptr);
-	void _animation_process_data(PlaybackData &cd, float p_delta, float p_blend, bool p_seeked, bool p_started);
-	void _animation_process2(float p_delta, bool p_started);
+	void _animation_process_data(PlaybackData &cd, double p_delta, float p_blend, bool p_seeked, bool p_started);
+	void _animation_process2(double p_delta, bool p_started);
 	void _animation_update_transforms();
-	void _animation_process(float p_delta);
+	void _animation_process(double p_delta);
 
 	void _node_removed(Node *p_node);
 	void _stop_playing_caches();
@@ -306,8 +306,8 @@ public:
 	void set_method_call_mode(AnimationMethodCallMode p_mode);
 	AnimationMethodCallMode get_method_call_mode() const;
 
-	void seek(float p_time, bool p_update = false);
-	void seek_delta(float p_time, float p_delta);
+	void seek(double p_time, bool p_update = false);
+	void seek_delta(double p_time, float p_delta);
 	float get_current_animation_position() const;
 	float get_current_animation_length() const;
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -328,7 +328,7 @@ void AnimationNode::remove_input(int p_index) {
 	emit_changed();
 }
 
-float AnimationNode::process(float p_time, bool p_seek) {
+double AnimationNode::process(double p_time, bool p_seek) {
 	if (get_script_instance()) {
 		return get_script_instance()->call("_process", p_time, p_seek);
 	}
@@ -818,8 +818,8 @@ void AnimationTree::_process_graph(float p_delta) {
 
 		for (const AnimationNode::AnimationState &as : state.animation_states) {
 			Ref<Animation> a = as.animation;
-			float time = as.time;
-			float delta = as.delta;
+			double time = as.time;
+			double delta = as.delta;
 			float weight = as.blend;
 			bool seeked = as.seeked;
 
@@ -1132,7 +1132,7 @@ void AnimationTree::_process_graph(float p_delta) {
 								continue;
 							}
 
-							float pos = a->track_get_key_time(i, idx);
+							double pos = a->track_get_key_time(i, idx);
 
 							StringName anim_name = a->animation_track_get_key_animation(i, idx);
 							if (String(anim_name) == "[stop]" || !player2->has_animation(anim_name)) {
@@ -1144,7 +1144,7 @@ void AnimationTree::_process_graph(float p_delta) {
 							float at_anim_pos;
 
 							if (anim->has_loop()) {
-								at_anim_pos = Math::fposmod(time - pos, anim->get_length()); //seek to loop
+								at_anim_pos = Math::fposmod(time - pos, (double)anim->get_length()); //seek to loop
 							} else {
 								at_anim_pos = MAX(anim->get_length(), time - pos); //seek to end
 							}

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -63,8 +63,8 @@ public:
 
 	struct AnimationState {
 		Ref<Animation> animation;
-		float time = 0.0;
-		float delta = 0.0;
+		double time = 0.0;
+		double delta = 0.0;
 		const Vector<float> *track_blends = nullptr;
 		float blend = 0.0;
 		bool seeked = false;
@@ -126,7 +126,7 @@ public:
 
 	virtual void get_child_nodes(List<ChildNode> *r_child_nodes);
 
-	virtual float process(float p_time, bool p_seek);
+	virtual double process(double p_time, bool p_seek);
 	virtual String get_caption() const;
 
 	int get_input_count() const;

--- a/scene/gui/rich_text_effect.h
+++ b/scene/gui/rich_text_effect.h
@@ -59,7 +59,7 @@ public:
 	bool outline = false;
 	Point2 offset;
 	Color color;
-	float elapsed_time = 0.0f;
+	double elapsed_time = 0.0f;
 	Dictionary environment;
 	uint32_t glpyh_index = 0;
 	RID font;
@@ -69,8 +69,8 @@ public:
 
 	Vector2i get_range() { return range; }
 	void set_range(const Vector2i &p_range) { range = p_range; }
-	float get_elapsed_time() { return elapsed_time; }
-	void set_elapsed_time(float p_elapsed_time) { elapsed_time = p_elapsed_time; }
+	double get_elapsed_time() { return elapsed_time; }
+	void set_elapsed_time(double p_elapsed_time) { elapsed_time = p_elapsed_time; }
 	bool is_visible() { return visibility; }
 	void set_visibility(bool p_visibility) { visibility = p_visibility; }
 	bool is_outline() { return outline; }

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1323,7 +1323,7 @@ void RichTextLabel::_update_scroll() {
 	}
 }
 
-void RichTextLabel::_update_fx(RichTextLabel::ItemFrame *p_frame, float p_delta_time) {
+void RichTextLabel::_update_fx(RichTextLabel::ItemFrame *p_frame, double p_delta_time) {
 	Item *it = p_frame;
 	while (it) {
 		ItemFX *ifx = nullptr;
@@ -1441,7 +1441,7 @@ void RichTextLabel::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (is_visible_in_tree()) {
-				float dt = get_process_delta_time();
+				double dt = get_process_delta_time();
 				_update_fx(main, dt);
 				update();
 			}

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -260,7 +260,7 @@ private:
 	};
 
 	struct ItemFX : public Item {
-		float elapsed_time = 0.f;
+		double elapsed_time = 0.f;
 	};
 
 	struct ItemShake : public ItemFX {
@@ -440,7 +440,7 @@ private:
 	void _fetch_item_fx_stack(Item *p_item, Vector<ItemFX *> &r_stack);
 
 	void _update_scroll();
-	void _update_fx(ItemFrame *p_frame, float p_delta_time);
+	void _update_fx(ItemFrame *p_frame, double p_delta_time);
 	void _scroll_changed(double);
 
 	void _gui_input(Ref<InputEvent> p_event);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -712,7 +712,7 @@ bool Node::is_enabled() const {
 	return _is_enabled();
 }
 
-float Node::get_physics_process_delta_time() const {
+double Node::get_physics_process_delta_time() const {
 	if (data.tree) {
 		return data.tree->get_physics_process_time();
 	} else {
@@ -720,7 +720,7 @@ float Node::get_physics_process_delta_time() const {
 	}
 }
 
-float Node::get_process_delta_time() const {
+double Node::get_process_delta_time() const {
 	if (data.tree) {
 		return data.tree->get_process_time();
 	} else {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -340,11 +340,11 @@ public:
 
 	/* PROCESSING */
 	void set_physics_process(bool p_process);
-	float get_physics_process_delta_time() const;
+	double get_physics_process_delta_time() const;
 	bool is_physics_processing() const;
 
 	void set_process(bool p_process);
-	float get_process_delta_time() const;
+	double get_process_delta_time() const;
 	bool is_processing() const;
 
 	void set_physics_process_internal(bool p_process_internal);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -375,7 +375,7 @@ private:
 		Variant drag_data;
 		ObjectID drag_preview_id;
 		Ref<SceneTreeTimer> tooltip_timer;
-		float tooltip_delay = 0.0;
+		double tooltip_delay = 0.0;
 		Transform2D focus_inv_xform;
 		bool roots_order_dirty = false;
 		List<Control *> roots;

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -722,7 +722,7 @@ bool Animation::track_get_interpolation_loop_wrap(int p_track) const {
 // transform
 /*
 template<class T>
-int Animation::_insert_pos(float p_time, T& p_keys) {
+int Animation::_insert_pos(double p_time, T& p_keys) {
 	// simple, linear time inset that should be fast enough in reality.
 
 	int idx=p_keys.size();
@@ -745,12 +745,12 @@ int Animation::_insert_pos(float p_time, T& p_keys) {
 
 */
 template <class T, class V>
-int Animation::_insert(float p_time, T &p_keys, const V &p_value) {
+int Animation::_insert(double p_time, T &p_keys, const V &p_value) {
 	int idx = p_keys.size();
 
 	while (true) {
 		// Condition for replacement.
-		if (idx > 0 && Math::is_equal_approx(p_keys[idx - 1].time, p_time)) {
+		if (idx > 0 && Math::is_equal_approx((double)p_keys[idx - 1].time, p_time)) {
 			float transition = p_keys[idx - 1].transition;
 			p_keys.write[idx - 1] = p_value;
 			p_keys.write[idx - 1].transition = transition;
@@ -794,7 +794,7 @@ Error Animation::transform_track_get_key(int p_track, int p_key, Vector3 *r_loc,
 	return OK;
 }
 
-int Animation::transform_track_insert_key(int p_track, float p_time, const Vector3 &p_loc, const Quaternion &p_rot, const Vector3 &p_scale) {
+int Animation::transform_track_insert_key(int p_track, double p_time, const Vector3 &p_loc, const Quaternion &p_rot, const Vector3 &p_scale) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_TRANSFORM3D, -1);
@@ -812,7 +812,7 @@ int Animation::transform_track_insert_key(int p_track, float p_time, const Vecto
 	return ret;
 }
 
-void Animation::track_remove_key_at_time(int p_track, float p_time) {
+void Animation::track_remove_key_at_time(int p_track, double p_time) {
 	int idx = track_find_key(p_track, p_time, true);
 	ERR_FAIL_COND(idx < 0);
 	track_remove_key(p_track, idx);
@@ -864,7 +864,7 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 	emit_changed();
 }
 
-int Animation::track_find_key(int p_track, float p_time, bool p_exact) const {
+int Animation::track_find_key(int p_track, double p_time, bool p_exact) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
@@ -946,7 +946,7 @@ int Animation::track_find_key(int p_track, float p_time, bool p_exact) const {
 	return -1;
 }
 
-void Animation::track_insert_key(int p_track, float p_time, const Variant &p_key, float p_transition) {
+void Animation::track_insert_key(int p_track, double p_time, const Variant &p_key, float p_transition) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 
@@ -1151,7 +1151,7 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 	ERR_FAIL_V(Variant());
 }
 
-float Animation::track_get_key_time(int p_track, int p_key_idx) const {
+double Animation::track_get_key_time(int p_track, int p_key_idx) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
@@ -1196,7 +1196,7 @@ float Animation::track_get_key_time(int p_track, int p_key_idx) const {
 	ERR_FAIL_V(-1);
 }
 
-void Animation::track_set_key_time(int p_track, int p_key_idx, float p_time) {
+void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 
@@ -1412,7 +1412,7 @@ void Animation::track_set_key_transition(int p_track, int p_key_idx, float p_tra
 }
 
 template <class K>
-int Animation::_find(const Vector<K> &p_keys, float p_time) const {
+int Animation::_find(const Vector<K> &p_keys, double p_time) const {
 	int len = p_keys.size();
 	if (len == 0) {
 		return -2;
@@ -1433,7 +1433,7 @@ int Animation::_find(const Vector<K> &p_keys, float p_time) const {
 	while (low <= high) {
 		middle = (low + high) / 2;
 
-		if (Math::is_equal_approx(p_time, keys[middle].time)) { //match
+		if (Math::is_equal_approx(p_time, (double)keys[middle].time)) { //match
 			return middle;
 		} else if (p_time < keys[middle].time) {
 			high = middle - 1; //search low end of array
@@ -1584,7 +1584,7 @@ float Animation::_cubic_interpolate(const float &p_pre_a, const float &p_a, cons
 }
 
 template <class T>
-T Animation::_interpolate(const Vector<TKey<T>> &p_keys, float p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const {
+T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const {
 	int len = _find(p_keys, length) + 1; // try to find last key (there may be more past the end)
 
 	if (len <= 0) {
@@ -1728,7 +1728,7 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, float p_time, Interpola
 	// do a barrel roll
 }
 
-Error Animation::transform_track_interpolate(int p_track, float p_time, Vector3 *r_loc, Quaternion *r_rot, Vector3 *r_scale) const {
+Error Animation::transform_track_interpolate(int p_track, double p_time, Vector3 *r_loc, Quaternion *r_rot, Vector3 *r_scale) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_TRANSFORM3D, ERR_INVALID_PARAMETER);
@@ -1758,7 +1758,7 @@ Error Animation::transform_track_interpolate(int p_track, float p_time, Vector3 
 	return OK;
 }
 
-Variant Animation::value_track_interpolate(int p_track, float p_time) const {
+Variant Animation::value_track_interpolate(int p_track, double p_time) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_VALUE, Variant());
@@ -1775,7 +1775,7 @@ Variant Animation::value_track_interpolate(int p_track, float p_time) const {
 	return Variant();
 }
 
-void Animation::_value_track_get_key_indices_in_range(const ValueTrack *vt, float from_time, float to_time, List<int> *p_indices) const {
+void Animation::_value_track_get_key_indices_in_range(const ValueTrack *vt, double from_time, double to_time, List<int> *p_indices) const {
 	if (from_time != length && to_time == length) {
 		to_time = length * 1.001; //include a little more if at the end
 	}
@@ -1812,15 +1812,15 @@ void Animation::_value_track_get_key_indices_in_range(const ValueTrack *vt, floa
 	}
 }
 
-void Animation::value_track_get_key_indices(int p_track, float p_time, float p_delta, List<int> *p_indices) const {
+void Animation::value_track_get_key_indices(int p_track, double p_time, double p_delta, List<int> *p_indices) const {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_VALUE);
 
 	ValueTrack *vt = static_cast<ValueTrack *>(t);
 
-	float from_time = p_time - p_delta;
-	float to_time = p_time;
+	double from_time = p_time - p_delta;
+	double to_time = p_time;
 
 	if (from_time > to_time) {
 		SWAP(from_time, to_time);
@@ -1875,7 +1875,7 @@ Animation::UpdateMode Animation::value_track_get_update_mode(int p_track) const 
 }
 
 template <class T>
-void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, float from_time, float to_time, List<int> *p_indices) const {
+void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices) const {
 	if (from_time != length && to_time == length) {
 		to_time = length * 1.01; //include a little more if at the end
 	}
@@ -1908,12 +1908,12 @@ void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, float 
 	}
 }
 
-void Animation::track_get_key_indices_in_range(int p_track, float p_time, float p_delta, List<int> *p_indices) const {
+void Animation::track_get_key_indices_in_range(int p_track, double p_time, double p_delta, List<int> *p_indices) const {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	const Track *t = tracks[p_track];
 
-	float from_time = p_time - p_delta;
-	float to_time = p_time;
+	double from_time = p_time - p_delta;
+	double to_time = p_time;
 
 	if (from_time > to_time) {
 		SWAP(from_time, to_time);
@@ -2021,7 +2021,7 @@ void Animation::track_get_key_indices_in_range(int p_track, float p_time, float 
 	}
 }
 
-void Animation::_method_track_get_key_indices_in_range(const MethodTrack *mt, float from_time, float to_time, List<int> *p_indices) const {
+void Animation::_method_track_get_key_indices_in_range(const MethodTrack *mt, double from_time, double to_time, List<int> *p_indices) const {
 	if (from_time != length && to_time == length) {
 		to_time = length * 1.01; //include a little more if at the end
 	}
@@ -2054,15 +2054,15 @@ void Animation::_method_track_get_key_indices_in_range(const MethodTrack *mt, fl
 	}
 }
 
-void Animation::method_track_get_key_indices(int p_track, float p_time, float p_delta, List<int> *p_indices) const {
+void Animation::method_track_get_key_indices(int p_track, double p_time, double p_delta, List<int> *p_indices) const {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_METHOD);
 
 	MethodTrack *mt = static_cast<MethodTrack *>(t);
 
-	float from_time = p_time - p_delta;
-	float to_time = p_time;
+	double from_time = p_time - p_delta;
+	double to_time = p_time;
 
 	if (from_time > to_time) {
 		SWAP(from_time, to_time);
@@ -2128,7 +2128,7 @@ StringName Animation::method_track_get_name(int p_track, int p_key_idx) const {
 	return pm->methods[p_key_idx].method;
 }
 
-int Animation::bezier_track_insert_key(int p_track, float p_time, float p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle) {
+int Animation::bezier_track_insert_key(int p_track, double p_time, float p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BEZIER, -1);
@@ -2246,7 +2246,7 @@ static _FORCE_INLINE_ Vector2 _bezier_interp(real_t t, const Vector2 &start, con
 	return start * omt3 + control_1 * omt2 * t * 3.0 + control_2 * omt * t2 * 3.0 + end * t3;
 }
 
-float Animation::bezier_track_interpolate(int p_track, float p_time) const {
+float Animation::bezier_track_interpolate(int p_track, double p_time) const {
 	//this uses a different interpolation scheme
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
 	Track *track = tracks[p_track];
@@ -2277,14 +2277,14 @@ float Animation::bezier_track_interpolate(int p_track, float p_time) const {
 		return bt->values[bt->values.size() - 1].value.value;
 	}
 
-	float t = p_time - bt->values[idx].time;
+	double t = p_time - bt->values[idx].time;
 
 	int iterations = 10;
 
-	float duration = bt->values[idx + 1].time - bt->values[idx].time; // time duration between our two keyframes
-	float low = 0.0; // 0% of the current animation segment
-	float high = 1.0; // 100% of the current animation segment
-	float middle;
+	real_t duration = bt->values[idx + 1].time - bt->values[idx].time; // time duration between our two keyframes
+	real_t low = 0.0; // 0% of the current animation segment
+	real_t high = 1.0; // 100% of the current animation segment
+	real_t middle;
 
 	Vector2 start(0, bt->values[idx].value.value);
 	Vector2 start_out = start + bt->values[idx].value.out_handle;
@@ -2307,12 +2307,12 @@ float Animation::bezier_track_interpolate(int p_track, float p_time) const {
 	//interpolate the result:
 	Vector2 low_pos = _bezier_interp(low, start, start_out, end_in, end);
 	Vector2 high_pos = _bezier_interp(high, start, start_out, end_in, end);
-	float c = (t - low_pos.x) / (high_pos.x - low_pos.x);
+	real_t c = (t - low_pos.x) / (high_pos.x - low_pos.x);
 
 	return low_pos.lerp(high_pos, c).y;
 }
 
-int Animation::audio_track_insert_key(int p_track, float p_time, const RES &p_stream, float p_start_offset, float p_end_offset) {
+int Animation::audio_track_insert_key(int p_track, double p_time, const RES &p_stream, float p_start_offset, float p_end_offset) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, -1);
@@ -2426,7 +2426,7 @@ float Animation::audio_track_get_key_end_offset(int p_track, int p_key) const {
 
 //
 
-int Animation::animation_track_insert_key(int p_track, float p_time, const StringName &p_animation) {
+int Animation::animation_track_insert_key(int p_track, double p_time, const StringName &p_animation) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, -1);
@@ -2727,9 +2727,9 @@ bool Animation::_transform_track_optimize_key(const TKey<TransformKey> &t0, cons
 
 		} else {
 			Vector3 pd = (v2 - v0);
-			float d0 = pd.dot(v0);
-			float d1 = pd.dot(v1);
-			float d2 = pd.dot(v2);
+			real_t d0 = pd.dot(v0);
+			real_t d1 = pd.dot(v1);
+			real_t d2 = pd.dot(v2);
 			if (d1 < d0 || d1 > d2) {
 				return false;
 			}
@@ -2817,9 +2817,9 @@ bool Animation::_transform_track_optimize_key(const TKey<TransformKey> &t0, cons
 
 		} else {
 			Vector3 pd = (v2 - v0);
-			float d0 = pd.dot(v0);
-			float d1 = pd.dot(v1);
-			float d2 = pd.dot(v2);
+			real_t d0 = pd.dot(v0);
+			real_t d1 = pd.dot(v1);
+			real_t d2 = pd.dot(v2);
 			if (d1 < d0 || d1 > d2) {
 				return false; //beyond segment range
 			}

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -172,16 +172,16 @@ private:
 
 	/*
 	template<class T>
-	int _insert_pos(float p_time, T& p_keys);*/
+	int _insert_pos(double p_time, T& p_keys);*/
 
 	template <class T>
 	void _clear(T &p_keys);
 
 	template <class T, class V>
-	int _insert(float p_time, T &p_keys, const V &p_value);
+	int _insert(double p_time, T &p_keys, const V &p_value);
 
 	template <class K>
-	inline int _find(const Vector<K> &p_keys, float p_time) const;
+	inline int _find(const Vector<K> &p_keys, double p_time) const;
 
 	_FORCE_INLINE_ Animation::TransformKey _interpolate(const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, float p_c) const;
 
@@ -197,21 +197,21 @@ private:
 	_FORCE_INLINE_ float _cubic_interpolate(const float &p_pre_a, const float &p_a, const float &p_b, const float &p_post_b, float p_c) const;
 
 	template <class T>
-	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T>> &p_keys, float p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const;
+	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const;
 
 	template <class T>
-	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, float from_time, float to_time, List<int> *p_indices) const;
+	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices) const;
 
-	_FORCE_INLINE_ void _value_track_get_key_indices_in_range(const ValueTrack *vt, float from_time, float to_time, List<int> *p_indices) const;
-	_FORCE_INLINE_ void _method_track_get_key_indices_in_range(const MethodTrack *mt, float from_time, float to_time, List<int> *p_indices) const;
+	_FORCE_INLINE_ void _value_track_get_key_indices_in_range(const ValueTrack *vt, double from_time, double to_time, List<int> *p_indices) const;
+	_FORCE_INLINE_ void _method_track_get_key_indices_in_range(const MethodTrack *mt, double from_time, double to_time, List<int> *p_indices) const;
 
-	float length = 1.0;
+	double length = 1.0;
 	float step = 0.1;
 	bool loop = false;
 
 	// bind helpers
 private:
-	Array _transform_track_interpolate(int p_track, float p_time) const {
+	Array _transform_track_interpolate(int p_track, double p_time) const {
 		Vector3 loc;
 		Quaternion rot;
 		Vector3 scale;
@@ -223,7 +223,7 @@ private:
 		return ret;
 	}
 
-	Vector<int> _value_track_get_key_indices(int p_track, float p_time, float p_delta) const {
+	Vector<int> _value_track_get_key_indices(int p_track, double p_time, double p_delta) const {
 		List<int> idxs;
 		value_track_get_key_indices(p_track, p_time, p_delta, &idxs);
 		Vector<int> idxr;
@@ -233,7 +233,7 @@ private:
 		}
 		return idxr;
 	}
-	Vector<int> _method_track_get_key_indices(int p_track, float p_time, float p_delta) const {
+	Vector<int> _method_track_get_key_indices(int p_track, double p_time, double p_delta) const {
 		List<int> idxs;
 		method_track_get_key_indices(p_track, p_time, p_delta, &idxs);
 		Vector<int> idxr;
@@ -279,24 +279,24 @@ public:
 	void track_set_enabled(int p_track, bool p_enabled);
 	bool track_is_enabled(int p_track) const;
 
-	void track_insert_key(int p_track, float p_time, const Variant &p_key, float p_transition = 1);
+	void track_insert_key(int p_track, double p_time, const Variant &p_key, float p_transition = 1);
 	void track_set_key_transition(int p_track, int p_key_idx, float p_transition);
 	void track_set_key_value(int p_track, int p_key_idx, const Variant &p_value);
-	void track_set_key_time(int p_track, int p_key_idx, float p_time);
-	int track_find_key(int p_track, float p_time, bool p_exact = false) const;
+	void track_set_key_time(int p_track, int p_key_idx, double p_time);
+	int track_find_key(int p_track, double p_time, bool p_exact = false) const;
 	void track_remove_key(int p_track, int p_idx);
-	void track_remove_key_at_time(int p_track, float p_time);
+	void track_remove_key_at_time(int p_track, double p_time);
 	int track_get_key_count(int p_track) const;
 	Variant track_get_key_value(int p_track, int p_key_idx) const;
-	float track_get_key_time(int p_track, int p_key_idx) const;
+	double track_get_key_time(int p_track, int p_key_idx) const;
 	float track_get_key_transition(int p_track, int p_key_idx) const;
 
-	int transform_track_insert_key(int p_track, float p_time, const Vector3 &p_loc, const Quaternion &p_rot = Quaternion(), const Vector3 &p_scale = Vector3());
+	int transform_track_insert_key(int p_track, double p_time, const Vector3 &p_loc, const Quaternion &p_rot = Quaternion(), const Vector3 &p_scale = Vector3());
 	Error transform_track_get_key(int p_track, int p_key, Vector3 *r_loc, Quaternion *r_rot, Vector3 *r_scale) const;
 	void track_set_interpolation_type(int p_track, InterpolationType p_interp);
 	InterpolationType track_get_interpolation_type(int p_track) const;
 
-	int bezier_track_insert_key(int p_track, float p_time, float p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle);
+	int bezier_track_insert_key(int p_track, double p_time, float p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle);
 	void bezier_track_set_key_value(int p_track, int p_index, float p_value);
 	void bezier_track_set_key_in_handle(int p_track, int p_index, const Vector2 &p_handle);
 	void bezier_track_set_key_out_handle(int p_track, int p_index, const Vector2 &p_handle);
@@ -304,9 +304,9 @@ public:
 	Vector2 bezier_track_get_key_in_handle(int p_track, int p_index) const;
 	Vector2 bezier_track_get_key_out_handle(int p_track, int p_index) const;
 
-	float bezier_track_interpolate(int p_track, float p_time) const;
+	float bezier_track_interpolate(int p_track, double p_time) const;
 
-	int audio_track_insert_key(int p_track, float p_time, const RES &p_stream, float p_start_offset = 0, float p_end_offset = 0);
+	int audio_track_insert_key(int p_track, double p_time, const RES &p_stream, float p_start_offset = 0, float p_end_offset = 0);
 	void audio_track_set_key_stream(int p_track, int p_key, const RES &p_stream);
 	void audio_track_set_key_start_offset(int p_track, int p_key, float p_offset);
 	void audio_track_set_key_end_offset(int p_track, int p_key, float p_offset);
@@ -314,27 +314,27 @@ public:
 	float audio_track_get_key_start_offset(int p_track, int p_key) const;
 	float audio_track_get_key_end_offset(int p_track, int p_key) const;
 
-	int animation_track_insert_key(int p_track, float p_time, const StringName &p_animation);
+	int animation_track_insert_key(int p_track, double p_time, const StringName &p_animation);
 	void animation_track_set_key_animation(int p_track, int p_key, const StringName &p_animation);
 	StringName animation_track_get_key_animation(int p_track, int p_key) const;
 
 	void track_set_interpolation_loop_wrap(int p_track, bool p_enable);
 	bool track_get_interpolation_loop_wrap(int p_track) const;
 
-	Error transform_track_interpolate(int p_track, float p_time, Vector3 *r_loc, Quaternion *r_rot, Vector3 *r_scale) const;
+	Error transform_track_interpolate(int p_track, double p_time, Vector3 *r_loc, Quaternion *r_rot, Vector3 *r_scale) const;
 
-	Variant value_track_interpolate(int p_track, float p_time) const;
-	void value_track_get_key_indices(int p_track, float p_time, float p_delta, List<int> *p_indices) const;
+	Variant value_track_interpolate(int p_track, double p_time) const;
+	void value_track_get_key_indices(int p_track, double p_time, double p_delta, List<int> *p_indices) const;
 	void value_track_set_update_mode(int p_track, UpdateMode p_mode);
 	UpdateMode value_track_get_update_mode(int p_track) const;
 
-	void method_track_get_key_indices(int p_track, float p_time, float p_delta, List<int> *p_indices) const;
+	void method_track_get_key_indices(int p_track, double p_time, double p_delta, List<int> *p_indices) const;
 	Vector<Variant> method_track_get_params(int p_track, int p_key_idx) const;
 	StringName method_track_get_name(int p_track, int p_key_idx) const;
 
 	void copy_track(int p_track, Ref<Animation> p_to_animation);
 
-	void track_get_key_indices_in_range(int p_track, float p_time, float p_delta, List<int> *p_indices) const;
+	void track_get_key_indices_in_range(int p_track, double p_time, double p_delta, List<int> *p_indices) const;
 
 	void set_length(float p_length);
 	float get_length() const;

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -122,14 +122,14 @@ Vector<String> SpriteFrames::get_animation_names() const {
 	return names;
 }
 
-void SpriteFrames::set_animation_speed(const StringName &p_anim, float p_fps) {
+void SpriteFrames::set_animation_speed(const StringName &p_anim, double p_fps) {
 	ERR_FAIL_COND_MSG(p_fps < 0, "Animation speed cannot be negative (" + itos(p_fps) + ").");
 	Map<StringName, Anim>::Element *E = animations.find(p_anim);
 	ERR_FAIL_COND_MSG(!E, "Animation '" + String(p_anim) + "' doesn't exist.");
 	E->get().speed = p_fps;
 }
 
-float SpriteFrames::get_animation_speed(const StringName &p_anim) const {
+double SpriteFrames::get_animation_speed(const StringName &p_anim) const {
 	const Map<StringName, Anim>::Element *E = animations.find(p_anim);
 	ERR_FAIL_COND_V_MSG(!E, 0, "Animation '" + String(p_anim) + "' doesn't exist.");
 	return E->get().speed;

--- a/scene/resources/sprite_frames.h
+++ b/scene/resources/sprite_frames.h
@@ -37,7 +37,7 @@ class SpriteFrames : public Resource {
 	GDCLASS(SpriteFrames, Resource);
 
 	struct Anim {
-		float speed = 5.0;
+		double speed = 5.0;
 		bool loop = true;
 		Vector<Ref<Texture2D>> frames;
 	};
@@ -64,8 +64,8 @@ public:
 	void get_animation_list(List<StringName> *r_animations) const;
 	Vector<String> get_animation_names() const;
 
-	void set_animation_speed(const StringName &p_anim, float p_fps);
-	float get_animation_speed(const StringName &p_anim) const;
+	void set_animation_speed(const StringName &p_anim, double p_fps);
+	double get_animation_speed(const StringName &p_anim) const;
 
 	void set_animation_loop(const StringName &p_anim, bool p_loop);
 	bool get_animation_loop(const StringName &p_anim) const;

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -540,13 +540,13 @@ public:
 	void particles_emit(RID p_particles, const Transform3D &p_transform, const Vector3 &p_velocity, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) override {}
 	void particles_set_emitting(RID p_particles, bool p_emitting) override {}
 	void particles_set_amount(RID p_particles, int p_amount) override {}
-	void particles_set_lifetime(RID p_particles, float p_lifetime) override {}
+	void particles_set_lifetime(RID p_particles, double p_lifetime) override {}
 	void particles_set_one_shot(RID p_particles, bool p_one_shot) override {}
-	void particles_set_pre_process_time(RID p_particles, float p_time) override {}
+	void particles_set_pre_process_time(RID p_particles, double p_time) override {}
 	void particles_set_explosiveness_ratio(RID p_particles, float p_ratio) override {}
 	void particles_set_randomness_ratio(RID p_particles, float p_ratio) override {}
 	void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) override {}
-	void particles_set_speed_scale(RID p_particles, float p_scale) override {}
+	void particles_set_speed_scale(RID p_particles, double p_scale) override {}
 	void particles_set_use_local_coordinates(RID p_particles, bool p_enable) override {}
 	void particles_set_process_material(RID p_particles, RID p_material) override {}
 	void particles_set_fixed_fps(RID p_particles, int p_fps) override {}
@@ -724,7 +724,7 @@ public:
 class RasterizerDummy : public RendererCompositor {
 private:
 	uint64_t frame = 1;
-	float delta = 0;
+	double delta = 0;
 
 protected:
 	RasterizerCanvasDummy canvas;
@@ -765,7 +765,7 @@ public:
 
 	bool is_low_end() const override { return true; }
 	uint64_t get_frame_number() const override { return frame; }
-	float get_frame_delta_time() const override { return delta; }
+	double get_frame_delta_time() const override { return delta; }
 
 	RasterizerDummy() {}
 	~RasterizerDummy() {}

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -85,7 +85,7 @@ public:
 	virtual void end_frame(bool p_swap_buffers) = 0;
 	virtual void finalize() = 0;
 	virtual uint64_t get_frame_number() const = 0;
-	virtual float get_frame_delta_time() const = 0;
+	virtual double get_frame_delta_time() const = 0;
 
 	virtual bool is_low_end() const = 0;
 	virtual bool is_xr_enabled() const;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -80,7 +80,7 @@ protected:
 	Map<RID, RID> render_target_descriptors;
 
 	double time;
-	float delta;
+	double delta;
 
 	static uint64_t frame;
 
@@ -100,7 +100,7 @@ public:
 	void finalize();
 
 	_ALWAYS_INLINE_ uint64_t get_frame_number() const { return frame; }
-	_ALWAYS_INLINE_ float get_frame_delta_time() const { return delta; }
+	_ALWAYS_INLINE_ double get_frame_delta_time() const { return delta; }
 	_ALWAYS_INLINE_ double get_total_time() const { return time; }
 
 	static Error is_viable() {

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -4091,7 +4091,7 @@ void RendererStorageRD::particles_set_amount(RID p_particles, int p_amount) {
 	particles->dependency.changed_notify(DEPENDENCY_CHANGED_PARTICLES);
 }
 
-void RendererStorageRD::particles_set_lifetime(RID p_particles, float p_lifetime) {
+void RendererStorageRD::particles_set_lifetime(RID p_particles, double p_lifetime) {
 	Particles *particles = particles_owner.getornull(p_particles);
 	ERR_FAIL_COND(!particles);
 	particles->lifetime = p_lifetime;
@@ -4103,7 +4103,7 @@ void RendererStorageRD::particles_set_one_shot(RID p_particles, bool p_one_shot)
 	particles->one_shot = p_one_shot;
 }
 
-void RendererStorageRD::particles_set_pre_process_time(RID p_particles, float p_time) {
+void RendererStorageRD::particles_set_pre_process_time(RID p_particles, double p_time) {
 	Particles *particles = particles_owner.getornull(p_particles);
 	ERR_FAIL_COND(!particles);
 	particles->pre_process_time = p_time;
@@ -4126,7 +4126,7 @@ void RendererStorageRD::particles_set_custom_aabb(RID p_particles, const AABB &p
 	particles->dependency.changed_notify(DEPENDENCY_CHANGED_AABB);
 }
 
-void RendererStorageRD::particles_set_speed_scale(RID p_particles, float p_scale) {
+void RendererStorageRD::particles_set_speed_scale(RID p_particles, double p_scale) {
 	Particles *particles = particles_owner.getornull(p_particles);
 	ERR_FAIL_COND(!particles);
 
@@ -4442,7 +4442,7 @@ void RendererStorageRD::particles_set_canvas_sdf_collision(RID p_particles, bool
 	particles->sdf_collision_texture = p_texture;
 }
 
-void RendererStorageRD::_particles_process(Particles *p_particles, float p_delta) {
+void RendererStorageRD::_particles_process(Particles *p_particles, double p_delta) {
 	if (p_particles->particles_material_uniform_set.is_null() || !RD::get_singleton()->uniform_set_is_valid(p_particles->particles_material_uniform_set)) {
 		Vector<RD::Uniform> uniforms;
 
@@ -4491,7 +4491,7 @@ void RendererStorageRD::_particles_process(Particles *p_particles, float p_delta
 		p_particles->particles_material_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, particles_shader.default_shader_rd, 1);
 	}
 
-	float new_phase = Math::fmod((float)p_particles->phase + (p_delta / p_particles->lifetime) * p_particles->speed_scale, (float)1.0);
+	double new_phase = Math::fmod((double)p_particles->phase + (p_delta / p_particles->lifetime) * p_particles->speed_scale, 1.0);
 
 	//move back history (if there is any)
 	for (uint32_t i = p_particles->frame_history.size() - 1; i > 0; i--) {
@@ -5131,14 +5131,14 @@ void RendererStorageRD::update_particles() {
 		bool zero_time_scale = Engine::get_singleton()->get_time_scale() <= 0.0;
 
 		if (particles->clear && particles->pre_process_time > 0.0) {
-			float frame_time;
+			double frame_time;
 			if (fixed_fps > 0) {
 				frame_time = 1.0 / fixed_fps;
 			} else {
 				frame_time = 1.0 / 30.0;
 			}
 
-			float todo = particles->pre_process_time;
+			double todo = particles->pre_process_time;
 
 			while (todo >= 0) {
 				_particles_process(particles, frame_time);
@@ -5147,8 +5147,8 @@ void RendererStorageRD::update_particles() {
 		}
 
 		if (fixed_fps > 0) {
-			float frame_time;
-			float decr;
+			double frame_time;
+			double decr;
 			if (zero_time_scale) {
 				frame_time = 0.0;
 				decr = 1.0 / fixed_fps;
@@ -5156,13 +5156,13 @@ void RendererStorageRD::update_particles() {
 				frame_time = 1.0 / fixed_fps;
 				decr = frame_time;
 			}
-			float delta = RendererCompositorRD::singleton->get_frame_delta_time();
+			double delta = RendererCompositorRD::singleton->get_frame_delta_time();
 			if (delta > 0.1) { //avoid recursive stalls if fps goes below 10
 				delta = 0.1;
 			} else if (delta <= 0.0) { //unlikely but..
 				delta = 0.001;
 			}
-			float todo = particles->frame_remainder + delta;
+			double todo = particles->frame_remainder + delta;
 
 			while (todo >= frame_time) {
 				_particles_process(particles, frame_time);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -715,12 +715,12 @@ private:
 	struct Particles {
 		RS::ParticlesMode mode = RS::PARTICLES_MODE_3D;
 		bool inactive = true;
-		float inactive_time = 0.0;
+		double inactive_time = 0.0;
 		bool emitting = false;
 		bool one_shot = false;
 		int amount = 0;
-		float lifetime = 1.0;
-		float pre_process_time = 0.0;
+		double lifetime = 1.0;
+		double pre_process_time = 0.0;
 		float explosiveness = 0.0;
 		float randomness = 0.0;
 		bool restart_request = false;
@@ -773,12 +773,12 @@ private:
 
 		uint32_t cycle_number = 0;
 
-		float speed_scale = 1.0;
+		double speed_scale = 1.0;
 
 		int fixed_fps = 30;
 		bool interpolate = true;
 		bool fractional_delta = false;
-		float frame_remainder = 0;
+		double frame_remainder = 0;
 		float collision_base_size = 0.01;
 
 		bool clear = true;
@@ -805,14 +805,14 @@ private:
 		}
 	};
 
-	void _particles_process(Particles *p_particles, float p_delta);
+	void _particles_process(Particles *p_particles, double p_delta);
 	void _particles_allocate_emission_buffer(Particles *particles);
 	void _particles_free_data(Particles *particles);
 	void _particles_update_buffers(Particles *particles);
 
 	struct ParticlesShader {
 		struct PushConstant {
-			float lifetime;
+			double lifetime;
 			uint32_t clear;
 			uint32_t total_particles;
 			uint32_t trail_size;
@@ -2144,13 +2144,13 @@ public:
 	void particles_set_mode(RID p_particles, RS::ParticlesMode p_mode);
 	void particles_set_emitting(RID p_particles, bool p_emitting);
 	void particles_set_amount(RID p_particles, int p_amount);
-	void particles_set_lifetime(RID p_particles, float p_lifetime);
+	void particles_set_lifetime(RID p_particles, double p_lifetime);
 	void particles_set_one_shot(RID p_particles, bool p_one_shot);
-	void particles_set_pre_process_time(RID p_particles, float p_time);
+	void particles_set_pre_process_time(RID p_particles, double p_time);
 	void particles_set_explosiveness_ratio(RID p_particles, float p_ratio);
 	void particles_set_randomness_ratio(RID p_particles, float p_ratio);
 	void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb);
-	void particles_set_speed_scale(RID p_particles, float p_scale);
+	void particles_set_speed_scale(RID p_particles, double p_scale);
 	void particles_set_use_local_coordinates(RID p_particles, bool p_enable);
 	void particles_set_process_material(RID p_particles, RID p_material);
 	void particles_set_fixed_fps(RID p_particles, int p_fps);

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -468,13 +468,13 @@ public:
 	virtual bool particles_get_emitting(RID p_particles) = 0;
 
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
-	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;
+	virtual void particles_set_lifetime(RID p_particles, double p_lifetime) = 0;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) = 0;
-	virtual void particles_set_pre_process_time(RID p_particles, float p_time) = 0;
+	virtual void particles_set_pre_process_time(RID p_particles, double p_time) = 0;
 	virtual void particles_set_explosiveness_ratio(RID p_particles, float p_ratio) = 0;
 	virtual void particles_set_randomness_ratio(RID p_particles, float p_ratio) = 0;
 	virtual void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) = 0;
-	virtual void particles_set_speed_scale(RID p_particles, float p_scale) = 0;
+	virtual void particles_set_speed_scale(RID p_particles, double p_scale) = 0;
 	virtual void particles_set_use_local_coordinates(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_process_material(RID p_particles, RID p_material) = 0;
 	virtual void particles_set_fixed_fps(RID p_particles, int p_fps) = 0;

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -134,8 +134,8 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 			}
 
 			if (RSG::storage->capturing_timestamps) {
-				new_profile.write[i].gpu_msec = float((time_gpu - base_gpu) / 1000) / 1000.0;
-				new_profile.write[i].cpu_msec = float(time_cpu - base_cpu) / 1000.0;
+				new_profile.write[i].gpu_msec = double((time_gpu - base_gpu) / 1000) / 1000.0;
+				new_profile.write[i].cpu_msec = double(time_cpu - base_cpu) / 1000.0;
 				new_profile.write[i].name = RSG::storage->get_captured_timestamp_name(i);
 			}
 		}
@@ -149,7 +149,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 		if (print_frame_profile_ticks_from == 0) {
 			print_frame_profile_ticks_from = OS::get_singleton()->get_ticks_usec();
 		}
-		float total_time = 0.0;
+		double total_time = 0.0;
 
 		for (int i = 0; i < frame_profile.size() - 1; i++) {
 			String name = frame_profile[i].name;
@@ -157,7 +157,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 				continue;
 			}
 
-			float time = frame_profile[i + 1].gpu_msec - frame_profile[i].gpu_msec;
+			double time = frame_profile[i + 1].gpu_msec - frame_profile[i].gpu_msec;
 
 			if (name[0] != '<' && name[0] != '>') {
 				if (print_gpu_profile_task_time.has(name)) {
@@ -179,7 +179,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 
 			float print_threshold = 0.01;
 			for (OrderedHashMap<String, float>::Element E = print_gpu_profile_task_time.front(); E; E = E.next()) {
-				float time = E.value() / float(print_frame_profile_frame_count);
+				double time = E.value() / double(print_frame_profile_frame_count);
 				if (time > print_threshold) {
 					print_line("\t-" + E.key() + ": " + rtos(time) + "ms");
 				}
@@ -193,7 +193,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	RSG::storage->update_memory_info();
 }
 
-float RenderingServerDefault::get_frame_setup_time_cpu() const {
+double RenderingServerDefault::get_frame_setup_time_cpu() const {
 	return frame_setup_time;
 }
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -71,7 +71,7 @@ class RenderingServerDefault : public RenderingServer {
 	uint64_t frame_profile_frame;
 	Vector<FrameProfileArea> frame_profile;
 
-	float frame_setup_time = 0;
+	double frame_setup_time = 0;
 
 	//for printing
 	bool print_gpu_profile = false;
@@ -440,13 +440,13 @@ public:
 	FUNC2(particles_set_emitting, RID, bool)
 	FUNC1R(bool, particles_get_emitting, RID)
 	FUNC2(particles_set_amount, RID, int)
-	FUNC2(particles_set_lifetime, RID, float)
+	FUNC2(particles_set_lifetime, RID, double)
 	FUNC2(particles_set_one_shot, RID, bool)
-	FUNC2(particles_set_pre_process_time, RID, float)
+	FUNC2(particles_set_pre_process_time, RID, double)
 	FUNC2(particles_set_explosiveness_ratio, RID, float)
 	FUNC2(particles_set_randomness_ratio, RID, float)
 	FUNC2(particles_set_custom_aabb, RID, const AABB &)
-	FUNC2(particles_set_speed_scale, RID, float)
+	FUNC2(particles_set_speed_scale, RID, double)
 	FUNC2(particles_set_use_local_coordinates, RID, bool)
 	FUNC2(particles_set_process_material, RID, RID)
 	FUNC2(particles_set_fixed_fps, RID, int)
@@ -574,8 +574,8 @@ public:
 	FUNC2(viewport_set_debug_draw, RID, ViewportDebugDraw)
 
 	FUNC2(viewport_set_measure_render_time, RID, bool)
-	FUNC1RC(float, viewport_get_measured_render_time_cpu, RID)
-	FUNC1RC(float, viewport_get_measured_render_time_gpu, RID)
+	FUNC1RC(double, viewport_get_measured_render_time_cpu, RID)
+	FUNC1RC(double, viewport_get_measured_render_time_gpu, RID)
 
 	FUNC2(call_set_vsync_mode, DisplayServer::VSyncMode, DisplayServer::WindowID)
 
@@ -890,7 +890,7 @@ public:
 
 	/* TESTING */
 
-	virtual float get_frame_setup_time_cpu() const override;
+	virtual double get_frame_setup_time_cpu() const override;
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) override;
 	virtual void set_default_clear_color(const Color &p_color) override;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -613,13 +613,13 @@ public:
 	virtual void particles_set_emitting(RID p_particles, bool p_enable) = 0;
 	virtual bool particles_get_emitting(RID p_particles) = 0;
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
-	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;
+	virtual void particles_set_lifetime(RID p_particles, double p_lifetime) = 0;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) = 0;
-	virtual void particles_set_pre_process_time(RID p_particles, float p_time) = 0;
+	virtual void particles_set_pre_process_time(RID p_particles, double p_time) = 0;
 	virtual void particles_set_explosiveness_ratio(RID p_particles, float p_ratio) = 0;
 	virtual void particles_set_randomness_ratio(RID p_particles, float p_ratio) = 0;
 	virtual void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) = 0;
-	virtual void particles_set_speed_scale(RID p_particles, float p_scale) = 0;
+	virtual void particles_set_speed_scale(RID p_particles, double p_scale) = 0;
 	virtual void particles_set_use_local_coordinates(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_process_material(RID p_particles, RID p_material) = 0;
 	virtual void particles_set_fixed_fps(RID p_particles, int p_fps) = 0;
@@ -900,8 +900,8 @@ public:
 	virtual void viewport_set_debug_draw(RID p_viewport, ViewportDebugDraw p_draw) = 0;
 
 	virtual void viewport_set_measure_render_time(RID p_viewport, bool p_enable) = 0;
-	virtual float viewport_get_measured_render_time_cpu(RID p_viewport) const = 0;
-	virtual float viewport_get_measured_render_time_gpu(RID p_viewport) const = 0;
+	virtual double viewport_get_measured_render_time_cpu(RID p_viewport) const = 0;
+	virtual double viewport_get_measured_render_time_gpu(RID p_viewport) const = 0;
 
 	/* SKY API */
 
@@ -1436,15 +1436,15 @@ public:
 
 	struct FrameProfileArea {
 		String name;
-		float gpu_msec;
-		float cpu_msec;
+		double gpu_msec;
+		double cpu_msec;
 	};
 
 	virtual void set_frame_profiling_enabled(bool p_enable) = 0;
 	virtual Vector<FrameProfileArea> get_frame_profile() = 0;
 	virtual uint64_t get_frame_profile_frame() = 0;
 
-	virtual float get_frame_setup_time_cpu() const = 0;
+	virtual double get_frame_setup_time_cpu() const = 0;
 
 	virtual void gi_set_use_half_resolution(bool p_enable) = 0;
 


### PR DESCRIPTION
Follow-up to #38880 and a subset of #21922 split into its own PR for easier reviewing.

Single-precision floats should never be used for time, because it fails after a few days as errors accumulate over time. With doubles, this code should work for about 4.7 million years before failing, assuming 60 FPS.

Unlike #38880 which aims to solve a specific problem (#38878), this PR is just broadly replacing `float` with `double` in time APIs. This should not impact performance on 64-bit systems (or extremely little), the main downside is slightly increased memory usage.

An alternative implementation would be to use `real_t`, in which case this code would only work for more than a few days if Godot was also using doubles for vectors, though I think it's better to use doubles for time always.
