### PR TITLE
Add support for modulating DynamicFont using a gradient

### DIFF
--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -309,6 +309,10 @@
 		<member name="force_autohinter" type="bool" setter="set_force_autohinter" getter="get_force_autohinter" default="false">
 			If [code]true[/code], default autohinter is used for font hinting.
 		</member>
+		<member name="gradient" type="Gradient" setter="set_gradient" getter="get_gradient">
+			If a [Gradient] resource is specified, modulates the DynamicFont's color and opacity by the gradient (applied from top to bottom). This applies to the font itself, but also the outline and shadow (if any).
+			[b]Note:[/b] This has no effect on bitmap fonts.
+		</member>
 		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="TextServer.Hinting" default="0">
 			The font hinting mode used by FreeType. See [enum TextServer.Hinting] for options.
 		</member>

--- a/modules/gdnative/include/text/godot_text.h
+++ b/modules/gdnative/include/text/godot_text.h
@@ -99,6 +99,8 @@ typedef struct {
 	godot_int (*font_get_hinting)(void *, godot_rid *);
 	void (*font_set_force_autohinter)(void *, godot_rid *, bool);
 	bool (*font_get_force_autohinter)(void *, godot_rid *);
+	void (*font_set_gradient)(void *, godot_rid *, const godot_object *);
+	godot_object *(*font_get_gradient)(void *, godot_rid *);
 	bool (*font_has_char)(void *, godot_rid *, char32_t);
 	godot_string (*font_get_supported_chars)(void *, godot_rid *);
 	bool (*font_has_outline)(void *, godot_rid *);

--- a/modules/gdnative/text/text_server_gdnative.cpp
+++ b/modules/gdnative/text/text_server_gdnative.cpp
@@ -247,6 +247,16 @@ bool TextServerGDNative::font_get_force_autohinter(RID p_font) const {
 	return interface->font_get_force_autohinter(data, (godot_rid *)&p_font);
 }
 
+void TextServerGDNative::font_set_gradient(RID p_font, const Ref<Gradient> &p_gradient) {
+	ERR_FAIL_COND(interface == nullptr);
+	interface->font_set_gradient(data, (godot_rid *)&p_font, (const godot_object *)p_gradient.ptr());
+}
+
+Ref<Gradient> TextServerGDNative::font_get_gradient(RID p_font) const {
+	ERR_FAIL_COND_V(interface == nullptr, nullptr);
+	return (Gradient *)interface->font_get_gradient(data, (godot_rid *)&p_font);
+}
+
 bool TextServerGDNative::font_has_char(RID p_font, char32_t p_char) const {
 	ERR_FAIL_COND_V(interface == nullptr, false);
 	return interface->font_has_char(data, (godot_rid *)&p_font, p_char);

--- a/modules/gdnative/text/text_server_gdnative.h
+++ b/modules/gdnative/text/text_server_gdnative.h
@@ -101,6 +101,9 @@ public:
 	virtual void font_set_force_autohinter(RID p_font, bool p_enabeld) override;
 	virtual bool font_get_force_autohinter(RID p_font) const override;
 
+	virtual void font_set_gradient(RID p_font, const Ref<Gradient> &p_gradient) override;
+	virtual Ref<Gradient> font_get_gradient(RID p_font) const override;
+
 	virtual bool font_has_char(RID p_font, char32_t p_char) const override;
 	virtual String font_get_supported_chars(RID p_font) const override;
 

--- a/modules/text_server_adv/bitmap_font_adv.h
+++ b/modules/text_server_adv/bitmap_font_adv.h
@@ -99,6 +99,9 @@ public:
 	virtual void set_force_autohinter(bool p_enabeld) override{};
 	virtual bool get_force_autohinter() const override { return false; };
 
+	virtual void set_gradient(const Ref<Gradient> &p_gradient) override{};
+	virtual Ref<Gradient> get_gradient() const override { return nullptr; };
+
 	virtual bool has_outline() const override { return false; };
 	virtual float get_base_size() const override;
 	virtual float get_font_scale(int p_size) const override;

--- a/modules/text_server_adv/dynamic_font_adv.h
+++ b/modules/text_server_adv/dynamic_font_adv.h
@@ -125,6 +125,7 @@ private:
 	float oversampling = 1.f;
 	bool antialiased = true;
 	bool force_autohinter = false;
+	Ref<Gradient> gradient;
 	TextServer::Hinting hinting = TextServer::HINTING_LIGHT;
 
 	Map<CacheID, DataAtSize *> size_cache;
@@ -167,6 +168,9 @@ public:
 
 	virtual void set_distance_field_hint(bool p_distance_field) override{};
 	virtual bool get_distance_field_hint() const override { return false; };
+
+	virtual void set_gradient(const Ref<Gradient> &p_gradient) override;
+	virtual Ref<Gradient> get_gradient() const override;
 
 	virtual bool has_outline() const override;
 	virtual float get_base_size() const override;

--- a/modules/text_server_adv/font_adv.h
+++ b/modules/text_server_adv/font_adv.h
@@ -89,6 +89,9 @@ struct FontDataAdvanced {
 	virtual void set_force_autohinter(bool p_enabeld) = 0;
 	virtual bool get_force_autohinter() const = 0;
 
+	virtual void set_gradient(const Ref<Gradient> &p_gradient) = 0;
+	virtual Ref<Gradient> get_gradient() const = 0;
+
 	virtual bool has_outline() const = 0;
 	virtual float get_base_size() const = 0;
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -754,6 +754,20 @@ bool TextServerAdvanced::font_get_force_autohinter(RID p_font) const {
 	return fd->get_force_autohinter();
 }
 
+void TextServerAdvanced::font_set_gradient(RID p_font, const Ref<Gradient> &p_gradient) {
+	_THREAD_SAFE_METHOD_
+	FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->set_gradient(p_gradient);
+}
+
+Ref<Gradient> TextServerAdvanced::font_get_gradient(RID p_font) const {
+	_THREAD_SAFE_METHOD_
+	const FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND_V(!fd, nullptr);
+	return fd->get_gradient();
+}
+
 bool TextServerAdvanced::font_has_char(RID p_font, char32_t p_char) const {
 	_THREAD_SAFE_METHOD_
 	const FontDataAdvanced *fd = font_owner.getornull(p_font);

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -163,6 +163,9 @@ public:
 	virtual void font_set_force_autohinter(RID p_font, bool p_enabeld) override;
 	virtual bool font_get_force_autohinter(RID p_font) const override;
 
+	virtual void font_set_gradient(RID p_font, const Ref<Gradient> &p_gradient) override;
+	virtual Ref<Gradient> font_get_gradient(RID p_font) const override;
+
 	virtual bool font_has_char(RID p_font, char32_t p_char) const override;
 	virtual String font_get_supported_chars(RID p_font) const override;
 

--- a/modules/text_server_fb/bitmap_font_fb.h
+++ b/modules/text_server_fb/bitmap_font_fb.h
@@ -95,6 +95,9 @@ public:
 	virtual void set_force_autohinter(bool p_enabeld) override{};
 	virtual bool get_force_autohinter() const override { return false; };
 
+	virtual void set_gradient(const Ref<Gradient> &p_gradient) override{};
+	virtual Ref<Gradient> get_gradient() const override { return nullptr; };
+
 	virtual bool has_outline() const override { return false; };
 	virtual float get_base_size() const override;
 

--- a/modules/text_server_fb/dynamic_font_fb.cpp
+++ b/modules/text_server_fb/dynamic_font_fb.cpp
@@ -557,6 +557,17 @@ TextServer::Hinting DynamicFontDataFallback::get_hinting() const {
 	return hinting;
 }
 
+void DynamicFontDataFallback::set_gradient(const Ref<Gradient> &p_gradient) {
+	if (gradient != p_gradient) {
+		clear_cache();
+		gradient = p_gradient;
+	}
+}
+
+Ref<Gradient> DynamicFontDataFallback::get_gradient() const {
+	return gradient;
+}
+
 bool DynamicFontDataFallback::has_outline() const {
 	return true;
 }

--- a/modules/text_server_fb/dynamic_font_fb.h
+++ b/modules/text_server_fb/dynamic_font_fb.h
@@ -114,6 +114,7 @@ private:
 	float oversampling = 1.f;
 	bool antialiased = true;
 	bool force_autohinter = false;
+	Ref<Gradient> gradient;
 	TextServer::Hinting hinting = TextServer::HINTING_LIGHT;
 
 	Map<CacheID, DataAtSize *> size_cache;
@@ -150,6 +151,9 @@ public:
 
 	virtual void set_distance_field_hint(bool p_distance_field) override{};
 	virtual bool get_distance_field_hint() const override { return false; };
+
+	virtual void set_gradient(const Ref<Gradient> &p_gradient) override;
+	virtual Ref<Gradient> get_gradient() const override;
 
 	virtual bool has_outline() const override;
 	virtual float get_base_size() const override;

--- a/modules/text_server_fb/font_fb.h
+++ b/modules/text_server_fb/font_fb.h
@@ -81,6 +81,9 @@ struct FontDataFallback {
 	virtual void set_force_autohinter(bool p_enabeld) = 0;
 	virtual bool get_force_autohinter() const = 0;
 
+	virtual void set_gradient(const Ref<Gradient> &p_gradient) = 0;
+	virtual Ref<Gradient> get_gradient() const = 0;
+
 	virtual bool has_outline() const = 0;
 	virtual float get_base_size() const = 0;
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -304,6 +304,20 @@ bool TextServerFallback::font_get_force_autohinter(RID p_font) const {
 	return fd->get_force_autohinter();
 }
 
+void TextServerFallback::font_set_gradient(RID p_font, const Ref<Gradient> &p_gradient) {
+	_THREAD_SAFE_METHOD_
+	FontDataFallback *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->set_gradient(p_gradient);
+}
+
+Ref<Gradient> TextServerFallback::font_get_gradient(RID p_font) const {
+	_THREAD_SAFE_METHOD_
+	const FontDataFallback *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND_V(!fd, nullptr);
+	return fd->get_gradient();
+}
+
 bool TextServerFallback::font_has_char(RID p_font, char32_t p_char) const {
 	_THREAD_SAFE_METHOD_
 	const FontDataFallback *fd = font_owner.getornull(p_font);

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -109,6 +109,9 @@ public:
 	virtual void font_set_force_autohinter(RID p_font, bool p_enabeld) override;
 	virtual bool font_get_force_autohinter(RID p_font) const override;
 
+	virtual void font_set_gradient(RID p_font, const Ref<Gradient> &p_gradient) override;
+	virtual Ref<Gradient> font_get_gradient(RID p_font) const override;
+
 	virtual bool font_has_char(RID p_font, char32_t p_char) const override;
 	virtual String font_get_supported_chars(RID p_font) const override;
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -75,6 +75,9 @@ void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_distance_field_hint", "distance_field"), &FontData::set_distance_field_hint);
 	ClassDB::bind_method(D_METHOD("get_distance_field_hint"), &FontData::get_distance_field_hint);
 
+	ClassDB::bind_method(D_METHOD("set_gradient", "gradient"), &FontData::set_gradient);
+	ClassDB::bind_method(D_METHOD("get_gradient"), &FontData::get_gradient);
+
 	ClassDB::bind_method(D_METHOD("has_char", "char"), &FontData::has_char);
 	ClassDB::bind_method(D_METHOD("get_supported_chars"), &FontData::get_supported_chars);
 
@@ -108,6 +111,7 @@ void FontData::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distance_field_hint"), "set_distance_field_hint", "get_distance_field_hint");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), "set_hinting", "get_hinting");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "gradient", PROPERTY_HINT_RESOURCE_TYPE, "Gradient"), "set_gradient", "get_gradient");
 
 	ADD_GROUP("Extra Spacing", "extra_spacing");
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "extra_spacing_glyph"), "set_spacing", "get_spacing", SPACING_GLYPH);
@@ -403,6 +407,19 @@ bool FontData::get_force_autohinter() const {
 		return false;
 	}
 	return TS->font_get_force_autohinter(rid);
+}
+
+void FontData::set_gradient(const Ref<Gradient> &p_gradient) {
+	ERR_FAIL_COND(rid == RID());
+	TS->font_set_gradient(rid, p_gradient);
+	emit_changed();
+}
+
+Ref<Gradient> FontData::get_gradient() const {
+	if (rid == RID()) {
+		return nullptr;
+	}
+	return TS->font_get_gradient(rid);
 }
 
 bool FontData::has_char(char32_t p_char) const {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -106,6 +106,9 @@ public:
 	void set_hinting(TextServer::Hinting p_hinting);
 	TextServer::Hinting get_hinting() const;
 
+	void set_gradient(const Ref<Gradient> &p_gradient);
+	Ref<Gradient> get_gradient() const;
+
 	bool has_char(char32_t p_char) const;
 	String get_supported_chars() const;
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -276,6 +276,9 @@ public:
 	virtual void font_set_force_autohinter(RID p_font, bool p_enabeld) = 0;
 	virtual bool font_get_force_autohinter(RID p_font) const = 0;
 
+	virtual void font_set_gradient(RID p_font, const Ref<Gradient> &p_gradient) = 0;
+	virtual Ref<Gradient> font_get_gradient(RID p_font) const = 0;
+
 	virtual bool font_has_char(RID p_font, char32_t p_char) const = 0;
 	virtual String font_get_supported_chars(RID p_font) const = 0;
 


### PR DESCRIPTION
This is useful to make DynamicFonts look better in certain scenarios, especially in pixel art games.

Also, this is done in the font itself, but in `master`, shadows/outlines are drawn on a per-font usage basis (e.g. with custom constants in Label). We should try to harmonize this in the future, so that gradients, shadows and outlines can be used in all Control nodes including RichTextLabel, Button, etc.

## TODO

- [ ] Update the font's glyphs when points in the gradient are changed. Right now, you need to reload the scene after editing the gradient for changes to be visible.
- [ ] Use font ascent/height instead of glyph height to apply the gradient. Otherwise, the gradient looks too sharp on small glyphs such as the `.` character.
- [ ] Use the gradient in the initial texture fill-in code to prevent artifacts from being visible when a filtered font is zoomed in. It's not very visible most of the time, so this can be done in future PR if it proves to be too difficult.

This partially addresses https://github.com/godotengine/godot-proposals/issues/2564.

## Preview

**Testing project:** [test_dynamicfont_gradient.zip](https://github.com/godotengine/godot/files/6942003/test_dynamicfont_gradient.zip)

![DynamicFont gradient](https://user-images.githubusercontent.com/180032/128429785-2341d5e0-3612-4313-8b29-e5d615416607.png)