### PR TITLE
Move mixing out of the AudioStreamPlayer* nodes

### DIFF
--- a/core/templates/safe_list.h
+++ b/core/templates/safe_list.h
@@ -1,0 +1,375 @@
+/*************************************************************************/
+/*  safe_list.h                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SAFE_LIST_H
+#define SAFE_LIST_H
+
+#include "core/os/memory.h"
+#include "core/typedefs.h"
+#include <functional>
+
+#if !defined(NO_THREADS)
+
+#include <atomic>
+#include <type_traits>
+
+// Design goals for these classes:
+// - Accessing this list with an iterator will never result in a use-after free,
+//   even if the element being accessed has been logically removed from the list on
+//   another thread.
+// - Logical deletion from the list will not result in deallocation at that time,
+//   instead the node will be deallocated at a later time when it is safe to do so.
+// - No blocking synchronization primitives will be used.
+
+// This is used in very specific areas of the engine where it's critical that these guarantees are held.
+
+template <class T, class A = DefaultAllocator>
+class SafeList {
+	struct SafeListNode {
+		std::atomic<SafeListNode *> next = nullptr;
+
+		// If the node is logically deleted, this pointer will typically point
+		// to the previous list item in time that was also logically deleted.
+		std::atomic<SafeListNode *> graveyard_next = nullptr;
+
+		std::function<void(T)> deletion_fn = [](T t) { return; };
+
+		T val;
+	};
+
+	static_assert(std::atomic<T>::is_always_lock_free);
+
+	std::atomic<SafeListNode *> head = nullptr;
+	std::atomic<SafeListNode *> graveyard_head = nullptr;
+
+	std::atomic_uint active_iterator_count = 0;
+
+public:
+	class Iterator {
+		friend class SafeList;
+
+		SafeListNode *cursor;
+		SafeList *list;
+
+		Iterator(SafeListNode *p_cursor, SafeList *p_list) :
+				cursor(p_cursor), list(p_list) {
+			list->active_iterator_count++;
+		}
+
+	public:
+		Iterator(const Iterator &p_other) :
+				cursor(p_other.cursor), list(p_other.list) {
+			list->active_iterator_count++;
+		}
+
+		~Iterator() {
+			list->active_iterator_count--;
+		}
+
+	public:
+		T &operator*() {
+			return cursor->val;
+		}
+
+		Iterator &operator++() {
+			cursor = cursor->next;
+			return *this;
+		}
+
+		// These two operators are mostly useful for comparisons to nullptr.
+		bool operator==(const void *p_other) const {
+			return cursor == p_other;
+		}
+
+		bool operator!=(const void *p_other) const {
+			return cursor != p_other;
+		}
+
+		// These two allow easy range-based for loops.
+		bool operator==(const Iterator &p_other) const {
+			return cursor == p_other.cursor;
+		}
+
+		bool operator!=(const Iterator &p_other) const {
+			return cursor != p_other.cursor;
+		}
+	};
+
+public:
+	// Calling this will cause an allocation.
+	void insert(T p_value) {
+		SafeListNode *new_node = memnew_allocator(SafeListNode, A);
+		new_node->val = p_value;
+		SafeListNode *expected_head = nullptr;
+		do {
+			expected_head = head.load();
+			new_node->next.store(expected_head);
+		} while (!head.compare_exchange_strong(/* expected= */ expected_head, /* new= */ new_node));
+	}
+
+	Iterator find(T p_value) {
+		for (Iterator it = begin(); it != end(); ++it) {
+			if (*it == p_value) {
+				return it;
+			}
+		}
+		return end();
+	}
+
+	void erase(T p_value, std::function<void(T)> p_deletion_fn) {
+		Iterator tmp = find(p_value);
+		erase(tmp, p_deletion_fn);
+	}
+
+	void erase(T p_value) {
+		Iterator tmp = find(p_value);
+		erase(tmp, [](T t) { return; });
+	}
+
+	void erase(Iterator &p_iterator, std::function<void(T)> p_deletion_fn) {
+		p_iterator.cursor->deletion_fn = p_deletion_fn;
+		erase(p_iterator);
+	}
+
+	void erase(Iterator &p_iterator) {
+		if (find(p_iterator.cursor->val) == nullptr) {
+			// Not in the list, nothing to do.
+			return;
+		}
+		// First, remove the node from the list.
+		while (true) {
+			Iterator prev = begin();
+			SafeListNode *expected_head = prev.cursor;
+			for (; prev != end(); ++prev) {
+				if (prev.cursor && prev.cursor->next == p_iterator.cursor) {
+					break;
+				}
+			}
+			if (prev != end()) {
+				// There exists a node before this.
+				prev.cursor->next.store(p_iterator.cursor->next.load());
+				// Done.
+				break;
+			} else {
+				if (head.compare_exchange_strong(/* expected= */ expected_head, /* new= */ p_iterator.cursor->next.load())) {
+					// Successfully reassigned the head pointer before another thread changed it to something else.
+					break;
+				}
+				// Fall through upon failure, try again.
+			}
+		}
+		// Then queue it for deletion by putting it in the node graveyard.
+		// Don't touch `next` because an iterator might still be pointing at this node.
+		SafeListNode *expected_head = nullptr;
+		do {
+			expected_head = graveyard_head.load();
+			p_iterator.cursor->graveyard_next.store(expected_head);
+		} while (!graveyard_head.compare_exchange_strong(/* expected= */ expected_head, /* new= */ p_iterator.cursor));
+	}
+
+	Iterator begin() {
+		return Iterator(head.load(), this);
+	}
+
+	Iterator end() {
+		return Iterator(nullptr, this);
+	}
+
+	// Calling this will cause zero to many deallocations.
+	void maybe_cleanup() {
+		SafeListNode *cursor = nullptr;
+		SafeListNode *new_graveyard_head = nullptr;
+		do {
+			// The access order here is theoretically important.
+			cursor = graveyard_head.load();
+			if (active_iterator_count.load() != 0) {
+				// It's not safe to clean up with an active iterator, because that iterator
+				// could be pointing to an element that we want to delete.
+				return;
+			}
+			// Any iterator created after this point will never point to a deleted node.
+			// Swap it out with the current graveyard head.
+		} while (!graveyard_head.compare_exchange_strong(/* expected= */ cursor, /* new= */ new_graveyard_head));
+		// Our graveyard list is now unreachable by any active iterators,
+		// detached from the main graveyard head and ready for deletion.
+		while (cursor) {
+			SafeListNode *tmp = cursor;
+			cursor = cursor->graveyard_next;
+			tmp->deletion_fn(tmp->val);
+			memdelete_allocator<SafeListNode, A>(tmp);
+		}
+	}
+};
+
+#else // NO_THREADS
+
+// Effectively the same structure without the atomics. It's probably possible to simplify it but the semantics shouldn't differ greatly.
+template <class T, class A = DefaultAllocator>
+class SafeList {
+	struct SafeListNode {
+		SafeListNode *next = nullptr;
+
+		// If the node is logically deleted, this pointer will typically point to the previous list item in time that was also logically deleted.
+		SafeListNode *graveyard_next = nullptr;
+
+		std::function<void(T)> deletion_fn = [](T t) { return; };
+
+		T val;
+	};
+
+	SafeListNode *head = nullptr;
+	SafeListNode *graveyard_head = nullptr;
+
+	unsigned int active_iterator_count = 0;
+
+public:
+	class Iterator {
+		friend class SafeList;
+
+		SafeListNode *cursor;
+		SafeList *list;
+
+	public:
+		Iterator(SafeListNode *p_cursor, SafeList *p_list) :
+				cursor(p_cursor), list(p_list) {
+			list->active_iterator_count++;
+		}
+
+		~Iterator() {
+			list->active_iterator_count--;
+		}
+
+		T &operator*() {
+			return cursor->val;
+		}
+
+		Iterator &operator++() {
+			cursor = cursor->next;
+			return *this;
+		}
+
+		// These two operators are mostly useful for comparisons to nullptr.
+		bool operator==(const void *p_other) const {
+			return cursor == p_other;
+		}
+
+		bool operator!=(const void *p_other) const {
+			return cursor != p_other;
+		}
+
+		// These two allow easy range-based for loops.
+		bool operator==(const Iterator &p_other) const {
+			return cursor == p_other.cursor;
+		}
+
+		bool operator!=(const Iterator &p_other) const {
+			return cursor != p_other.cursor;
+		}
+	};
+
+public:
+	// Calling this will cause an allocation.
+	void insert(T p_value) {
+		SafeListNode *new_node = memnew_allocator(SafeListNode, A);
+		new_node->val = p_value;
+		new_node->next = head;
+		head = new_node;
+	}
+
+	Iterator find(T p_value) {
+		for (Iterator it = begin(); it != end(); ++it) {
+			if (*it == p_value) {
+				return it;
+			}
+		}
+		return end();
+	}
+
+	void erase(T p_value, std::function<void(T)> p_deletion_fn) {
+		erase(find(p_value), p_deletion_fn);
+	}
+
+	void erase(T p_value) {
+		erase(find(p_value), [](T t) { return; });
+	}
+
+	void erase(Iterator p_iterator, std::function<void(T)> p_deletion_fn) {
+		p_iterator.cursor->deletion_fn = p_deletion_fn;
+		erase(p_iterator);
+	}
+
+	void erase(Iterator p_iterator) {
+		Iterator prev = begin();
+		for (; prev != end(); ++prev) {
+			if (prev.cursor && prev.cursor->next == p_iterator.cursor) {
+				break;
+			}
+		}
+		if (prev == end()) {
+			// Not in the list, nothing to do.
+			return;
+		}
+		// First, remove the node from the list.
+		prev.cursor->next = p_iterator.cursor->next;
+
+		// Then queue it for deletion by putting it in the node graveyard. Don't touch `next` because an iterator might still be pointing at this node.
+		p_iterator.cursor->graveyard_next = graveyard_head;
+		graveyard_head = p_iterator.cursor;
+	}
+
+	Iterator begin() {
+		return Iterator(head, this);
+	}
+
+	Iterator end() {
+		return Iterator(nullptr, this);
+	}
+
+	// Calling this will cause zero to many deallocations.
+	void maybe_cleanup() {
+		SafeListNode *cursor = graveyard_head;
+		if (active_iterator_count != 0) {
+			// It's not safe to clean up with an active iterator, because that iterator could be pointing to an element that we want to delete.
+			return;
+		}
+		graveyard_head = nullptr;
+		// Our graveyard list is now unreachable by any active iterators, detached from the main graveyard head and ready for deletion.
+		while (cursor) {
+			SafeListNode *tmp = cursor;
+			cursor = cursor->next;
+			tmp->deletion_fn(tmp->val);
+			memdelete_allocator<SafeListNode, A>(tmp);
+		}
+	}
+};
+
+#endif
+
+#endif // SAFE_LIST_H

--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -26,7 +26,7 @@
 			</description>
 		</method>
 		<method name="_mix" qualifiers="virtual">
-			<return type="void" />
+			<return type="int" />
 			<argument index="0" name="buffer" type="AudioFrame*" />
 			<argument index="1" name="rate_scale" type="float" />
 			<argument index="2" name="frames" type="int" />

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -37,10 +37,12 @@
 
 #include "core/io/file_access.h"
 
-void AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
-	ERR_FAIL_COND(!active);
+int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
+	ERR_FAIL_COND_V(!active, 0);
 
 	int todo = p_frames;
+
+	int frames_mixed_this_step = p_frames;
 
 	while (todo && active) {
 		mp3dec_frame_info_t frame_info;
@@ -60,6 +62,7 @@ void AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 				seek(mp3_stream->loop_offset);
 				loops++;
 			} else {
+				frames_mixed_this_step = p_frames - todo;
 				//fill remainder with silence
 				for (int i = p_frames - todo; i < p_frames; i++) {
 					p_buffer[i] = AudioFrame(0, 0);
@@ -69,6 +72,7 @@ void AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 			}
 		}
 	}
+	return frames_mixed_this_step;
 }
 
 float AudioStreamPlaybackMP3::get_stream_sampling_rate() {

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -51,7 +51,7 @@ class AudioStreamPlaybackMP3 : public AudioStreamPlaybackResampled {
 	Ref<AudioStreamMP3> mp3_stream;
 
 protected:
-	virtual void _mix_internal(AudioFrame *p_buffer, int p_frames) override;
+	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) override;
 	virtual float get_stream_sampling_rate() override;
 
 public:

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -32,12 +32,14 @@
 
 #include "core/io/file_access.h"
 
-void AudioStreamPlaybackOGGVorbis::_mix_internal(AudioFrame *p_buffer, int p_frames) {
-	ERR_FAIL_COND(!active);
+int AudioStreamPlaybackOGGVorbis::_mix_internal(AudioFrame *p_buffer, int p_frames) {
+	ERR_FAIL_COND_V(!active, 0);
 
 	int todo = p_frames;
 
 	int start_buffer = 0;
+
+	int frames_mixed_this_step = p_frames;
 
 	while (todo && active) {
 		float *buffer = (float *)p_buffer;
@@ -64,6 +66,7 @@ void AudioStreamPlaybackOGGVorbis::_mix_internal(AudioFrame *p_buffer, int p_fra
 				// we still have buffer to fill, start from this element in the next iteration.
 				start_buffer = p_frames - todo;
 			} else {
+				frames_mixed_this_step = p_frames - todo;
 				for (int i = p_frames - todo; i < p_frames; i++) {
 					p_buffer[i] = AudioFrame(0, 0);
 				}
@@ -72,6 +75,7 @@ void AudioStreamPlaybackOGGVorbis::_mix_internal(AudioFrame *p_buffer, int p_fra
 			}
 		}
 	}
+	return frames_mixed_this_step;
 }
 
 float AudioStreamPlaybackOGGVorbis::get_stream_sampling_rate() {

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.h
@@ -52,7 +52,7 @@ class AudioStreamPlaybackOGGVorbis : public AudioStreamPlaybackResampled {
 	Ref<AudioStreamOGGVorbis> vorbis_stream;
 
 protected:
-	virtual void _mix_internal(AudioFrame *p_buffer, int p_frames) override;
+	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) override;
 	virtual float get_stream_sampling_rate() override;
 
 public:

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -51,37 +51,29 @@ private:
 		Viewport *viewport = nullptr; //pointer only used for reference to previous mix
 	};
 
-	Output outputs[MAX_OUTPUTS];
-	SafeNumeric<int> output_count;
-	SafeFlag output_ready;
-
-	//these are used by audio thread to have a reference of previous volumes (for ramping volume and avoiding clicks)
-	Output prev_outputs[MAX_OUTPUTS];
-	int prev_output_count = 0;
-
 	Ref<AudioStreamPlayback> stream_playback;
 	Ref<AudioStream> stream;
-	Vector<AudioFrame> mix_buffer;
 
-	SafeNumeric<float> setseek{ -1.0 };
 	SafeFlag active;
 	SafeNumeric<float> setplay{ -1.0 };
+
+	Vector<AudioFrame> volume_vector;
+
+	uint64_t last_mix_count = -1;
 
 	float volume_db = 0.0;
 	float pitch_scale = 1.0;
 	bool autoplay = false;
-	bool stream_paused = false;
-	bool stream_paused_fade_in = false;
-	bool stream_paused_fade_out = false;
-	StringName bus;
-
-	void _mix_audio();
-	static void _mix_audios(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->_mix_audio(); }
+	StringName default_bus = "Master";
 
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
 
+	StringName _get_actual_bus();
+	void _update_panning();
 	void _bus_layout_changed();
+
+	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->_update_panning(); }
 
 	uint32_t area_mask = 1;
 

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -48,22 +48,13 @@ public:
 private:
 	Ref<AudioStreamPlayback> stream_playback;
 	Ref<AudioStream> stream;
-	Vector<AudioFrame> mix_buffer;
-	Vector<AudioFrame> fadeout_buffer;
-	bool use_fadeout = false;
 
-	SafeNumeric<float> setseek{ -1.0 };
 	SafeFlag active;
-	SafeFlag setstop;
-	SafeFlag stop_has_priority;
 
-	float mix_volume_db = 0.0;
 	float pitch_scale = 1.0;
 	float volume_db = 0.0;
 	bool autoplay = false;
-	bool stream_paused = false;
-	bool stream_paused_fade = false;
-	StringName bus;
+	StringName bus = "Master";
 
 	MixTarget mix_target = MIX_TARGET_STEREO;
 
@@ -76,6 +67,8 @@ private:
 
 	void _bus_layout_changed();
 	void _mix_to_bus(const AudioFrame *p_frames, int p_amount);
+
+	Vector<AudioFrame> _get_volume_vector();
 
 protected:
 	void _validate_property(PropertyInfo &property) const override;

--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -129,7 +129,7 @@ void VideoPlayer::_mix_audio() {
 void VideoPlayer::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_ENTER_TREE: {
-			AudioServer::get_singleton()->add_callback(_mix_audios, this);
+			AudioServer::get_singleton()->add_mix_callback(_mix_audios, this);
 
 			if (stream.is_valid() && autoplay && !Engine::get_singleton()->is_editor_hint()) {
 				play();
@@ -138,8 +138,7 @@ void VideoPlayer::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			AudioServer::get_singleton()->remove_callback(_mix_audios, this);
-
+			AudioServer::get_singleton()->remove_mix_callback(_mix_audios, this);
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -52,6 +52,7 @@
 #include "scene/resources/text_line.h"
 #include "scene/resources/world_2d.h"
 #include "scene/scene_string_names.h"
+#include "servers/audio_server.h"
 
 void ViewportTexture::setup_local_to_scene() {
 	if (vp) {
@@ -820,12 +821,7 @@ Rect2 Viewport::get_visible_rect() const {
 }
 
 void Viewport::_update_listener_2d() {
-	/*
-	if (is_inside_tree() && audio_listener_3d && (!get_parent() || (Object::cast_to<Control>(get_parent()) && Object::cast_to<Control>(get_parent())->is_visible_in_tree())))
-		SpatialSound2DServer::get_singleton()->listener_set_space(internal_listener_2d, find_world_2d()->get_sound_space());
-	else
-		SpatialSound2DServer::get_singleton()->listener_set_space(internal_listener_2d, RID());
-*/
+	AudioServer::get_singleton()->notify_listener_changed();
 }
 
 void Viewport::set_as_audio_listener_2d(bool p_enable) {
@@ -3072,6 +3068,7 @@ bool Viewport::is_audio_listener_3d() const {
 }
 
 void Viewport::_update_listener_3d() {
+	AudioServer::get_singleton()->notify_listener_changed();
 }
 
 void Viewport::_listener_transform_3d_changed_notify() {

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -221,12 +221,12 @@ void AudioStreamPlaybackSample::do_resample(const Depth *p_src, AudioFrame *p_ds
 	}
 }
 
-void AudioStreamPlaybackSample::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
+int AudioStreamPlaybackSample::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
 	if (!base->data || !active) {
 		for (int i = 0; i < p_frames; i++) {
 			p_buffer[i] = AudioFrame(0, 0);
 		}
-		return;
+		return 0;
 	}
 
 	int len = base->data_bytes;
@@ -395,12 +395,15 @@ void AudioStreamPlaybackSample::mix(AudioFrame *p_buffer, float p_rate_scale, in
 	}
 
 	if (todo) {
+		int mixed_frames = p_frames - todo;
 		//bit was missing from mix
 		int todo_ofs = p_frames - todo;
 		for (int i = todo_ofs; i < p_frames; i++) {
 			p_buffer[i] = AudioFrame(0, 0);
 		}
+		return mixed_frames;
 	}
+	return p_frames;
 }
 
 AudioStreamPlaybackSample::AudioStreamPlaybackSample() {}

--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -73,7 +73,7 @@ public:
 	virtual float get_playback_position() const override;
 	virtual void seek(float p_time) override;
 
-	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
+	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
 	AudioStreamPlaybackSample();
 };

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -51,7 +51,7 @@ protected:
 	GDVIRTUAL0RC(int, _get_loop_count)
 	GDVIRTUAL0RC(float, _get_playback_position)
 	GDVIRTUAL1(_seek, float)
-	GDVIRTUAL3(_mix, GDNativePtr<AudioFrame>, float, int)
+	GDVIRTUAL3R(int, _mix, GDNativePtr<AudioFrame>, float, int)
 public:
 	virtual void start(float p_from_pos = 0.0);
 	virtual void stop();
@@ -62,7 +62,7 @@ public:
 	virtual float get_playback_position() const;
 	virtual void seek(float p_time);
 
-	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
+	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
 };
 
 class AudioStreamPlaybackResampled : public AudioStreamPlayback {
@@ -77,15 +77,17 @@ class AudioStreamPlaybackResampled : public AudioStreamPlayback {
 	};
 
 	AudioFrame internal_buffer[INTERNAL_BUFFER_LEN + CUBIC_INTERP_HISTORY];
+	unsigned int internal_buffer_end = -1;
 	uint64_t mix_offset;
 
 protected:
 	void _begin_resample();
-	virtual void _mix_internal(AudioFrame *p_buffer, int p_frames) = 0;
+	// Returns the number of frames that were mixed.
+	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) = 0;
 	virtual float get_stream_sampling_rate() = 0;
 
 public:
-	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
+	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
 	AudioStreamPlaybackResampled() { mix_offset = 0; }
 };
@@ -140,11 +142,11 @@ class AudioStreamPlaybackMicrophone : public AudioStreamPlaybackResampled {
 	Ref<AudioStreamMicrophone> microphone;
 
 protected:
-	virtual void _mix_internal(AudioFrame *p_buffer, int p_frames) override;
+	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) override;
 	virtual float get_stream_sampling_rate() override;
 
 public:
-	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
+	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
 	virtual void start(float p_from_pos = 0.0) override;
 	virtual void stop() override;
@@ -208,7 +210,7 @@ public:
 	virtual float get_playback_position() const override;
 	virtual void seek(float p_time) override;
 
-	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
+	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
 	~AudioStreamPlaybackRandomPitch();
 };

--- a/servers/audio/effects/audio_stream_generator.cpp
+++ b/servers/audio/effects/audio_stream_generator.cpp
@@ -138,7 +138,7 @@ void AudioStreamGeneratorPlayback::clear_buffer() {
 	mixed = 0;
 }
 
-void AudioStreamGeneratorPlayback::_mix_internal(AudioFrame *p_buffer, int p_frames) {
+int AudioStreamGeneratorPlayback::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	int read_amount = buffer.data_left();
 	if (p_frames < read_amount) {
 		read_amount = p_frames;
@@ -156,6 +156,7 @@ void AudioStreamGeneratorPlayback::_mix_internal(AudioFrame *p_buffer, int p_fra
 	}
 
 	mixed += p_frames / generator->get_mix_rate();
+	return read_amount < p_frames ? read_amount : p_frames;
 }
 
 float AudioStreamGeneratorPlayback::get_stream_sampling_rate() {

--- a/servers/audio/effects/audio_stream_generator.h
+++ b/servers/audio/effects/audio_stream_generator.h
@@ -67,7 +67,7 @@ class AudioStreamGeneratorPlayback : public AudioStreamPlaybackResampled {
 	AudioStreamGenerator *generator;
 
 protected:
-	virtual void _mix_internal(AudioFrame *p_buffer, int p_frames) override;
+	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) override;
 	virtual float get_stream_sampling_rate() override;
 
 	static void _bind_methods();

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -32,12 +32,18 @@
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
+#include "core/error/error_macros.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/math/audio_frame.h"
 #include "core/os/os.h"
+#include "core/string/string_name.h"
+#include "core/templates/pair.h"
 #include "scene/resources/audio_stream_sample.h"
 #include "servers/audio/audio_driver_dummy.h"
 #include "servers/audio/effects/audio_effect_compressor.h"
+
+#include <cstring>
 
 #ifdef TOOLS_ENABLED
 #define MARK_EDITED set_edited(true);
@@ -234,6 +240,7 @@ AudioDriver *AudioDriverManager::get_driver(int p_driver) {
 //////////////////////////////////////////////
 
 void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
+	mix_count++;
 	int todo = p_frames;
 
 #ifdef DEBUG_ENABLED
@@ -331,10 +338,156 @@ void AudioServer::_mix_step() {
 			bus->soloed = false;
 		}
 	}
+	for (CallbackItem *ci : mix_callback_list) {
+		ci->callback(ci->userdata);
+	}
 
-	//make callbacks for mixing the audio
-	for (Set<CallbackItem>::Element *E = callbacks.front(); E; E = E->next()) {
-		E->get().callback(E->get().userdata);
+	for (AudioStreamPlaybackListNode *playback : playback_list) {
+		// Paused streams are no-ops. Don't even mix audio from the stream playback.
+		if (playback->state.load() == AudioStreamPlaybackListNode::PAUSED) {
+			continue;
+		}
+
+		bool fading_out = playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION || playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
+
+		AudioFrame *buf = mix_buffer.ptrw();
+
+		// Copy the lookeahead buffer into the mix buffer.
+		for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
+			buf[i] = playback->lookahead[i];
+		}
+
+		// Mix the audio stream
+		unsigned int mixed_frames = playback->stream_playback->mix(&buf[LOOKAHEAD_BUFFER_SIZE], playback->pitch_scale.get(), buffer_size);
+
+		if (mixed_frames != buffer_size) {
+			// We know we have at least the size of our lookahead buffer for fade-out purposes.
+
+			float fadeout_base = 0.87;
+			float fadeout_coefficient = 1;
+			static_assert(LOOKAHEAD_BUFFER_SIZE == 32, "Update fadeout_base and comment here if you change LOOKAHEAD_BUFFER_SIZE.");
+			// 0.87 ^ 32 = 0.0116. There might still be a pop but it'll be way better than if we didn't do this.
+			for (unsigned int idx = mixed_frames; idx < buffer_size; idx++) {
+				fadeout_coefficient *= fadeout_base;
+				buf[idx] *= fadeout_coefficient;
+			}
+			AudioStreamPlaybackListNode::PlaybackState new_state;
+			new_state = AudioStreamPlaybackListNode::AWAITING_DELETION;
+			playback->state.store(new_state);
+		} else {
+			// Move the last little bit of what we just mixed into our lookahead buffer.
+			for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
+				playback->lookahead[i] = buf[buffer_size + i];
+			}
+		}
+
+		ERR_FAIL_COND(playback->bus_details.load() == nullptr);
+		// By putting null into the bus details pointers, we're taking ownership of their memory for the duration of this mix.
+		AudioStreamPlaybackBusDetails *bus_details = nullptr;
+		{
+			std::atomic<AudioStreamPlaybackBusDetails *> bus_details_atomic = nullptr;
+			bus_details = playback->bus_details.exchange(bus_details_atomic);
+		}
+		ERR_FAIL_COND(bus_details == nullptr);
+		AudioStreamPlaybackBusDetails *prev_bus_details = playback->prev_bus_details;
+
+		// Mix to any active buses.
+		for (int idx = 0; idx < MAX_BUSES_PER_PLAYBACK; idx++) {
+			if (!bus_details->bus_active[idx]) {
+				continue;
+			}
+			int bus_idx = thread_find_bus_index(bus_details->bus[idx]);
+
+			int prev_bus_idx = -1;
+			for (int search_idx = 0; search_idx < MAX_BUSES_PER_PLAYBACK; search_idx++) {
+				if (!prev_bus_details->bus_active[search_idx]) {
+					continue;
+				}
+				if (prev_bus_details->bus[search_idx].hash() == bus_details->bus[idx].hash()) {
+					prev_bus_idx = search_idx;
+				}
+			}
+
+			for (int channel_idx = 0; channel_idx < channel_count; channel_idx++) {
+				AudioFrame *channel_buf = thread_get_channel_mix_buffer(bus_idx, channel_idx);
+				if (fading_out) {
+					bus_details->volume[idx][channel_idx] = AudioFrame(0, 0);
+				}
+				AudioFrame channel_vol = bus_details->volume[idx][channel_idx];
+
+				AudioFrame prev_channel_vol = AudioFrame(0, 0);
+				if (prev_bus_idx != -1) {
+					prev_channel_vol = prev_bus_details->volume[prev_bus_idx][channel_idx];
+				}
+				_mix_step_for_channel(channel_buf, buf, prev_channel_vol, channel_vol, playback->attenuation_filter_cutoff_hz.get(), playback->highshelf_gain.get(), &playback->filter_process[channel_idx * 2], &playback->filter_process[channel_idx * 2 + 1]);
+			}
+		}
+
+		// Now go through and fade-out any buses that were being played to previously that we missed by going through current data.
+		for (int idx = 0; idx < MAX_BUSES_PER_PLAYBACK; idx++) {
+			if (!prev_bus_details->bus_active[idx]) {
+				continue;
+			}
+			int bus_idx = thread_find_bus_index(prev_bus_details->bus[idx]);
+
+			int current_bus_idx = -1;
+			for (int search_idx = 0; search_idx < MAX_BUSES_PER_PLAYBACK; search_idx++) {
+				if (bus_details->bus[search_idx] == prev_bus_details->bus[idx]) {
+					current_bus_idx = search_idx;
+				}
+			}
+			if (current_bus_idx != -1) {
+				// If we found a corresponding bus in the current bus assignments, we've already mixed to this bus.
+				continue;
+			}
+
+			for (int channel_idx = 0; channel_idx < channel_count; channel_idx++) {
+				AudioFrame *channel_buf = thread_get_channel_mix_buffer(bus_idx, channel_idx);
+				AudioFrame prev_channel_vol = prev_bus_details->volume[idx][channel_idx];
+				// Fade out to silence
+				_mix_step_for_channel(channel_buf, buf, prev_channel_vol, AudioFrame(0, 0), playback->attenuation_filter_cutoff_hz.get(), playback->highshelf_gain.get(), &playback->filter_process[channel_idx * 2], &playback->filter_process[channel_idx * 2 + 1]);
+			}
+		}
+
+		// Copy the bus details we mixed with to the previous bus details to maintain volume ramps.
+		std::copy(std::begin(bus_details->bus_active), std::end(bus_details->bus_active), std::begin(prev_bus_details->bus_active));
+		std::copy(std::begin(bus_details->bus), std::end(bus_details->bus), std::begin(prev_bus_details->bus));
+		for (int bus_idx = 0; bus_idx < MAX_BUSES_PER_PLAYBACK; bus_idx++) {
+			std::copy(std::begin(bus_details->volume[bus_idx]), std::end(bus_details->volume[bus_idx]), std::begin(prev_bus_details->volume[bus_idx]));
+		}
+
+		AudioStreamPlaybackBusDetails *bus_details_expected = nullptr;
+		// Only put the bus details pointer back if it hasn't been updated already.
+		if (!playback->bus_details.compare_exchange_strong(/* expected= */ bus_details_expected, /* new= */ bus_details)) {
+			// If it *has* been updated already, queue the old one for deletion.
+			bus_details_graveyard.insert(bus_details);
+		}
+
+		switch (playback->state.load()) {
+			case AudioStreamPlaybackListNode::AWAITING_DELETION:
+			case AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION:
+				playback_list.erase(playback, [](AudioStreamPlaybackListNode *p) {
+					if (p->prev_bus_details)
+						delete p->prev_bus_details;
+					if (p->bus_details)
+						delete p->bus_details;
+					p->stream_playback.unref();
+					delete p;
+				});
+				break;
+			case AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE: {
+				// Pause the stream.
+				AudioStreamPlaybackListNode::PlaybackState old_state, new_state;
+				do {
+					old_state = playback->state.load();
+					new_state = AudioStreamPlaybackListNode::PAUSED;
+				} while (!playback->state.compare_exchange_strong(/* expected= */ old_state, new_state));
+			} break;
+			case AudioStreamPlaybackListNode::PLAYING:
+			case AudioStreamPlaybackListNode::PAUSED:
+				// No-op!
+				break;
+		}
 	}
 
 	for (int i = buses.size() - 1; i >= 0; i--) {
@@ -462,6 +615,53 @@ void AudioServer::_mix_step() {
 
 	mix_frames += buffer_size;
 	to_mix = buffer_size;
+}
+
+void AudioServer::_mix_step_for_channel(AudioFrame *p_out_buf, AudioFrame *p_source_buf, AudioFrame p_vol_start, AudioFrame p_vol_final, float p_attenuation_filter_cutoff_hz, float p_highshelf_gain, AudioFilterSW::Processor *p_processor_l, AudioFilterSW::Processor *p_processor_r) {
+	if (p_highshelf_gain != 0) {
+		AudioFilterSW filter;
+		filter.set_mode(AudioFilterSW::HIGHSHELF);
+		filter.set_sampling_rate(AudioServer::get_singleton()->get_mix_rate());
+		filter.set_cutoff(p_attenuation_filter_cutoff_hz);
+		filter.set_resonance(1);
+		filter.set_stages(1);
+		filter.set_gain(p_highshelf_gain);
+
+		ERR_FAIL_COND(p_processor_l == nullptr);
+		ERR_FAIL_COND(p_processor_r == nullptr);
+
+		bool is_just_started = p_vol_start.l == 0 && p_vol_start.r == 0;
+		p_processor_l->set_filter(&filter, /* clear_history= */ is_just_started);
+		p_processor_l->update_coeffs(buffer_size);
+		p_processor_r->set_filter(&filter, /* clear_history= */ is_just_started);
+		p_processor_r->update_coeffs(buffer_size);
+
+		for (unsigned int frame_idx = 0; frame_idx < buffer_size; frame_idx++) {
+			// Make this buffer size invariant if buffer_size ever becomes a project setting.
+			float lerp_param = (float)frame_idx / buffer_size;
+			AudioFrame vol = p_vol_final * lerp_param + (1 - lerp_param) * p_vol_start;
+			AudioFrame mixed = vol * p_source_buf[frame_idx];
+			p_processor_l->process_one_interp(mixed.l);
+			p_processor_r->process_one_interp(mixed.r);
+			p_out_buf[frame_idx] += mixed;
+		}
+
+	} else {
+		for (unsigned int frame_idx = 0; frame_idx < buffer_size; frame_idx++) {
+			// Make this buffer size invariant if buffer_size ever becomes a project setting.
+			float lerp_param = (float)frame_idx / buffer_size;
+			p_out_buf[frame_idx] += (p_vol_final * lerp_param + (1 - lerp_param) * p_vol_start) * p_source_buf[frame_idx];
+		}
+	}
+}
+
+AudioServer::AudioStreamPlaybackListNode *AudioServer::_find_playback_list_node(Ref<AudioStreamPlayback> p_playback) {
+	for (AudioStreamPlaybackListNode *playback_list_node : playback_list) {
+		if (playback_list_node->stream_playback == p_playback) {
+			return playback_list_node;
+		}
+	}
+	return nullptr;
 }
 
 bool AudioServer::thread_has_channel_mix_buffer(int p_bus, int p_buffer) const {
@@ -923,9 +1123,216 @@ float AudioServer::get_playback_speed_scale() const {
 	return playback_speed_scale;
 }
 
+void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, StringName p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time) {
+	ERR_FAIL_COND(p_playback.is_null());
+
+	Map<StringName, Vector<AudioFrame>> map;
+	map[p_bus] = p_volume_db_vector;
+
+	start_playback_stream(p_playback, map, p_start_time);
+}
+
+void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, Map<StringName, Vector<AudioFrame>> p_bus_volumes, float p_start_time) {
+	ERR_FAIL_COND(p_playback.is_null());
+
+	AudioStreamPlaybackListNode *playback_node = new AudioStreamPlaybackListNode();
+	playback_node->stream_playback = p_playback;
+	playback_node->stream_playback->start(p_start_time);
+
+	AudioStreamPlaybackBusDetails *new_bus_details = new AudioStreamPlaybackBusDetails();
+	int idx = 0;
+	for (KeyValue<StringName, Vector<AudioFrame>> pair : p_bus_volumes) {
+		ERR_FAIL_COND(pair.value.size() < channel_count);
+		ERR_FAIL_COND(pair.value.size() != MAX_CHANNELS_PER_BUS);
+
+		new_bus_details->bus_active[idx] = true;
+		new_bus_details->bus[idx] = pair.key;
+		for (int channel_idx = 0; channel_idx < MAX_CHANNELS_PER_BUS; channel_idx++) {
+			new_bus_details->volume[idx][channel_idx] = pair.value[channel_idx];
+		}
+	}
+	playback_node->bus_details = new_bus_details;
+	playback_node->prev_bus_details = new AudioStreamPlaybackBusDetails();
+
+	playback_node->setseek.set(-1);
+	playback_node->pitch_scale.set(1);
+	playback_node->highshelf_gain.set(0);
+	playback_node->attenuation_filter_cutoff_hz.set(0);
+
+	memset(playback_node->prev_bus_details->volume, 0, sizeof(playback_node->prev_bus_details->volume));
+
+	for (AudioFrame &frame : playback_node->lookahead) {
+		frame = AudioFrame(0, 0);
+	}
+
+	playback_node->state.store(AudioStreamPlaybackListNode::PLAYING);
+
+	playback_list.insert(playback_node);
+}
+
+void AudioServer::stop_playback_stream(Ref<AudioStreamPlayback> p_playback) {
+	ERR_FAIL_COND(p_playback.is_null());
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return;
+	}
+
+	AudioStreamPlaybackListNode::PlaybackState new_state, old_state;
+	do {
+		old_state = playback_node->state.load();
+		new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION;
+
+	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
+}
+
+void AudioServer::set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, StringName p_bus, Vector<AudioFrame> p_volumes) {
+	ERR_FAIL_COND(p_volumes.size() != MAX_CHANNELS_PER_BUS);
+
+	Map<StringName, Vector<AudioFrame>> map;
+	map[p_bus] = p_volumes;
+
+	set_playback_bus_volumes_linear(p_playback, map);
+}
+
+void AudioServer::set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Map<StringName, Vector<AudioFrame>> p_bus_volumes) {
+	ERR_FAIL_COND(p_bus_volumes.size() > MAX_BUSES_PER_PLAYBACK);
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return;
+	}
+	AudioStreamPlaybackBusDetails *old_bus_details, *new_bus_details = new AudioStreamPlaybackBusDetails();
+
+	int idx = 0;
+	for (KeyValue<StringName, Vector<AudioFrame>> pair : p_bus_volumes) {
+		ERR_FAIL_COND(pair.value.size() < channel_count);
+		ERR_FAIL_COND(pair.value.size() != MAX_CHANNELS_PER_BUS);
+
+		new_bus_details->bus_active[idx] = true;
+		new_bus_details->bus[idx] = pair.key;
+		for (int channel_idx = 0; channel_idx < MAX_CHANNELS_PER_BUS; channel_idx++) {
+			new_bus_details->volume[idx][channel_idx] = pair.value[channel_idx];
+		}
+	}
+
+	do {
+		old_bus_details = playback_node->bus_details.load();
+	} while (!playback_node->bus_details.compare_exchange_strong(old_bus_details, new_bus_details));
+
+	bus_details_graveyard.insert(old_bus_details);
+}
+
+void AudioServer::set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Vector<AudioFrame> p_volumes) {
+	ERR_FAIL_COND(p_playback.is_null());
+	ERR_FAIL_COND(p_volumes.size() != MAX_CHANNELS_PER_BUS);
+
+	Map<StringName, Vector<AudioFrame>> map;
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return;
+	}
+	for (int bus_idx = 0; bus_idx < MAX_BUSES_PER_PLAYBACK; bus_idx++) {
+		if (playback_node->bus_details.load()->bus_active[bus_idx]) {
+			map[playback_node->bus_details.load()->bus[bus_idx]] = p_volumes;
+		}
+	}
+
+	set_playback_bus_volumes_linear(p_playback, map);
+}
+
+void AudioServer::set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, float p_pitch_scale) {
+	ERR_FAIL_COND(p_playback.is_null());
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return;
+	}
+
+	playback_node->pitch_scale.set(p_pitch_scale);
+}
+
+void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused) {
+	ERR_FAIL_COND(p_playback.is_null());
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return;
+	}
+	if (!p_paused && playback_node->state == AudioStreamPlaybackListNode::PLAYING) {
+		return; // No-op.
+	}
+	if (p_paused && (playback_node->state == AudioStreamPlaybackListNode::PAUSED || playback_node->state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
+		return; // No-op.
+	}
+
+	AudioStreamPlaybackListNode::PlaybackState new_state, old_state;
+	do {
+		old_state = playback_node->state.load();
+		new_state = p_paused ? AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE : AudioStreamPlaybackListNode::PLAYING;
+	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
+}
+
+void AudioServer::set_playback_highshelf_params(Ref<AudioStreamPlayback> p_playback, float p_gain, float p_attenuation_cutoff_hz) {
+	ERR_FAIL_COND(p_playback.is_null());
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return;
+	}
+
+	playback_node->attenuation_filter_cutoff_hz.set(p_attenuation_cutoff_hz);
+	playback_node->highshelf_gain.set(p_gain);
+}
+
+bool AudioServer::is_playback_active(Ref<AudioStreamPlayback> p_playback) {
+	ERR_FAIL_COND_V(p_playback.is_null(), false);
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return false;
+	}
+
+	return playback_node->state.load() == AudioStreamPlaybackListNode::PLAYING;
+}
+
+float AudioServer::get_playback_position(Ref<AudioStreamPlayback> p_playback) {
+	ERR_FAIL_COND_V(p_playback.is_null(), 0);
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return 0;
+	}
+
+	return playback_node->stream_playback->get_playback_position();
+}
+
+bool AudioServer::is_playback_paused(Ref<AudioStreamPlayback> p_playback) {
+	ERR_FAIL_COND_V(p_playback.is_null(), false);
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return false;
+	}
+
+	return playback_node->state.load() == AudioStreamPlaybackListNode::PAUSED || playback_node->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
+}
+
+uint64_t AudioServer::get_mix_count() const {
+	return mix_count;
+}
+
+void AudioServer::notify_listener_changed() {
+	for (CallbackItem *ci : listener_changed_callback_list) {
+		ci->callback(ci->userdata);
+	}
+}
+
 void AudioServer::init_channels_and_buffers() {
 	channel_count = get_channel_count();
 	temp_buffer.resize(channel_count);
+	mix_buffer.resize(buffer_size + LOOKAHEAD_BUFFER_SIZE);
 
 	for (int i = 0; i < temp_buffer.size(); i++) {
 		temp_buffer.write[i].resize(buffer_size);
@@ -943,7 +1350,7 @@ void AudioServer::init() {
 	channel_disable_threshold_db = GLOBAL_DEF_RST("audio/buses/channel_disable_threshold_db", -60.0);
 	channel_disable_frames = float(GLOBAL_DEF_RST("audio/buses/channel_disable_time", 2.0)) * get_mix_rate();
 	ProjectSettings::get_singleton()->set_custom_property_info("audio/buses/channel_disable_time", PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
-	buffer_size = 1024; //hardcoded for now
+	buffer_size = 512; //hardcoded for now
 
 	init_channels_and_buffers();
 
@@ -1030,9 +1437,17 @@ void AudioServer::update() {
 	prof_time = 0;
 #endif
 
-	for (Set<CallbackItem>::Element *E = update_callbacks.front(); E; E = E->next()) {
-		E->get().callback(E->get().userdata);
+	for (CallbackItem *ci : update_callback_list) {
+		ci->callback(ci->userdata);
 	}
+	mix_callback_list.maybe_cleanup();
+	update_callback_list.maybe_cleanup();
+	listener_changed_callback_list.maybe_cleanup();
+	playback_list.maybe_cleanup();
+	for (AudioStreamPlaybackBusDetails *bus_details : bus_details_graveyard) {
+		bus_details_graveyard.erase(bus_details, [](AudioStreamPlaybackBusDetails *d) { delete d; });
+	}
+	bus_details_graveyard.maybe_cleanup();
 }
 
 void AudioServer::load_default_bus_layout() {
@@ -1098,40 +1513,49 @@ double AudioServer::get_time_since_last_mix() const {
 
 AudioServer *AudioServer::singleton = nullptr;
 
-void AudioServer::add_callback(AudioCallback p_callback, void *p_userdata) {
-	lock();
-	CallbackItem ci;
-	ci.callback = p_callback;
-	ci.userdata = p_userdata;
-	callbacks.insert(ci);
-	unlock();
-}
-
-void AudioServer::remove_callback(AudioCallback p_callback, void *p_userdata) {
-	lock();
-	CallbackItem ci;
-	ci.callback = p_callback;
-	ci.userdata = p_userdata;
-	callbacks.erase(ci);
-	unlock();
-}
-
 void AudioServer::add_update_callback(AudioCallback p_callback, void *p_userdata) {
-	lock();
-	CallbackItem ci;
-	ci.callback = p_callback;
-	ci.userdata = p_userdata;
-	update_callbacks.insert(ci);
-	unlock();
+	CallbackItem *ci = new CallbackItem();
+	ci->callback = p_callback;
+	ci->userdata = p_userdata;
+	update_callback_list.insert(ci);
 }
 
 void AudioServer::remove_update_callback(AudioCallback p_callback, void *p_userdata) {
-	lock();
-	CallbackItem ci;
-	ci.callback = p_callback;
-	ci.userdata = p_userdata;
-	update_callbacks.erase(ci);
-	unlock();
+	for (CallbackItem *ci : update_callback_list) {
+		if (ci->callback == p_callback && ci->userdata == p_userdata) {
+			update_callback_list.erase(ci, [](CallbackItem *c) { delete c; });
+		}
+	}
+}
+
+void AudioServer::add_mix_callback(AudioCallback p_callback, void *p_userdata) {
+	CallbackItem *ci = new CallbackItem();
+	ci->callback = p_callback;
+	ci->userdata = p_userdata;
+	mix_callback_list.insert(ci);
+}
+
+void AudioServer::remove_mix_callback(AudioCallback p_callback, void *p_userdata) {
+	for (CallbackItem *ci : mix_callback_list) {
+		if (ci->callback == p_callback && ci->userdata == p_userdata) {
+			mix_callback_list.erase(ci, [](CallbackItem *c) { delete c; });
+		}
+	}
+}
+
+void AudioServer::add_listener_changed_callback(AudioCallback p_callback, void *p_userdata) {
+	CallbackItem *ci = new CallbackItem();
+	ci->callback = p_callback;
+	ci->userdata = p_userdata;
+	listener_changed_callback_list.insert(ci);
+}
+
+void AudioServer::remove_listener_changed_callback(AudioCallback p_callback, void *p_userdata) {
+	for (CallbackItem *ci : listener_changed_callback_list) {
+		if (ci->callback == p_callback && ci->userdata == p_userdata) {
+			listener_changed_callback_list.erase(ci, [](CallbackItem *c) { delete c; });
+		}
+	}
 }
 
 void AudioServer::set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout) {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -34,12 +34,17 @@
 #include "core/math/audio_frame.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
+#include "core/templates/safe_list.h"
 #include "core/variant/variant.h"
 #include "servers/audio/audio_effect.h"
+#include "servers/audio/audio_filter_sw.h"
+
+#include <atomic>
 
 class AudioDriverDummy;
 class AudioStream;
 class AudioStreamSample;
+class AudioStreamPlayback;
 
 class AudioDriver {
 	static AudioDriver *singleton;
@@ -155,7 +160,10 @@ public:
 	};
 
 	enum {
-		AUDIO_DATA_INVALID_ID = -1
+		AUDIO_DATA_INVALID_ID = -1,
+		MAX_CHANNELS_PER_BUS = 4,
+		MAX_BUSES_PER_PLAYBACK = 6,
+		LOOKAHEAD_BUFFER_SIZE = 32,
 	};
 
 	typedef void (*AudioCallback)(void *p_userdata);
@@ -219,7 +227,43 @@ private:
 		int index_cache;
 	};
 
+	struct AudioStreamPlaybackBusDetails {
+		bool bus_active[MAX_BUSES_PER_PLAYBACK] = { false, false, false, false, false, false };
+		StringName bus[MAX_BUSES_PER_PLAYBACK];
+		AudioFrame volume[MAX_BUSES_PER_PLAYBACK][MAX_CHANNELS_PER_BUS];
+	};
+
+	struct AudioStreamPlaybackListNode {
+		enum PlaybackState {
+			PAUSED = 0, // Paused. Keep this stream playback around though so it can be restarted.
+			PLAYING = 1, // Playing. Fading may still be necessary if volume changes!
+			FADE_OUT_TO_PAUSE = 2, // About to pause.
+			FADE_OUT_TO_DELETION = 3, // About to stop.
+			AWAITING_DELETION = 4,
+		};
+		// If zero or positive, a place in the stream to seek to during the next mix.
+		SafeNumeric<float> setseek;
+		SafeNumeric<float> pitch_scale;
+		SafeNumeric<float> highshelf_gain;
+		SafeNumeric<float> attenuation_filter_cutoff_hz; // This isn't used unless highshelf_gain is nonzero.
+		AudioFilterSW::Processor filter_process[8];
+		// Updating this ref after the list node is created breaks consistency guarantees, don't do it!
+		Ref<AudioStreamPlayback> stream_playback;
+		// Playback state determines the fate of a particular AudioStreamListNode during the mix step. Must be atomically replaced.
+		std::atomic<PlaybackState> state = AWAITING_DELETION;
+		// This data should only ever be modified by an atomic replacement of the pointer.
+		std::atomic<AudioStreamPlaybackBusDetails *> bus_details = nullptr;
+		// Previous bus details should only be accessed on the audio thread.
+		AudioStreamPlaybackBusDetails *prev_bus_details = nullptr;
+		// The next few samples are stored here so we have some time to fade audio out if it ends abruptly at the beginning of the next mix.
+		AudioFrame lookahead[LOOKAHEAD_BUFFER_SIZE];
+	};
+
+	SafeList<AudioStreamPlaybackListNode *> playback_list;
+	SafeList<AudioStreamPlaybackBusDetails *> bus_details_graveyard;
+
 	Vector<Vector<AudioFrame>> temp_buffer; //temp_buffer for each level
+	Vector<AudioFrame> mix_buffer;
 	Vector<Bus *> buses;
 	Map<StringName, Bus *> bus_map;
 
@@ -230,18 +274,19 @@ private:
 	void init_channels_and_buffers();
 
 	void _mix_step();
+	void _mix_step_for_channel(AudioFrame *p_out_buf, AudioFrame *p_source_buf, AudioFrame p_vol_start, AudioFrame p_vol_final, float p_attenuation_filter_cutoff_hz, float p_highshelf_gain, AudioFilterSW::Processor *p_processor_l, AudioFilterSW::Processor *p_processor_r);
+
+	// Should only be called on the main thread.
+	AudioStreamPlaybackListNode *_find_playback_list_node(Ref<AudioStreamPlayback> p_playback);
 
 	struct CallbackItem {
 		AudioCallback callback;
 		void *userdata;
-
-		bool operator<(const CallbackItem &p_item) const {
-			return (callback == p_item.callback ? userdata < p_item.userdata : callback < p_item.callback);
-		}
 	};
 
-	Set<CallbackItem> callbacks;
-	Set<CallbackItem> update_callbacks;
+	SafeList<CallbackItem *> update_callback_list;
+	SafeList<CallbackItem *> mix_callback_list;
+	SafeList<CallbackItem *> listener_changed_callback_list;
 
 	friend class AudioDriver;
 	void _driver_process(int p_frames, int32_t *p_buffer);
@@ -319,6 +364,25 @@ public:
 	void set_playback_speed_scale(float p_scale);
 	float get_playback_speed_scale() const;
 
+	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, StringName p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time = 0);
+	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, Map<StringName, Vector<AudioFrame>> p_bus_volumes, float p_start_time = 0);
+	void stop_playback_stream(Ref<AudioStreamPlayback> p_playback);
+
+	void set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, StringName p_bus, Vector<AudioFrame> p_volumes);
+	void set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Map<StringName, Vector<AudioFrame>> p_bus_volumes);
+	void set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Vector<AudioFrame> p_volumes);
+	void set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, float p_pitch_scale);
+	void set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused);
+	void set_playback_highshelf_params(Ref<AudioStreamPlayback> p_playback, float p_gain, float p_attenuation_cutoff_hz);
+
+	bool is_playback_active(Ref<AudioStreamPlayback> p_playback);
+	float get_playback_position(Ref<AudioStreamPlayback> p_playback);
+	bool is_playback_paused(Ref<AudioStreamPlayback> p_playback);
+
+	uint64_t get_mix_count() const;
+
+	void notify_listener_changed();
+
 	virtual void init();
 	virtual void finish();
 	virtual void update();
@@ -340,11 +404,14 @@ public:
 	virtual double get_time_to_next_mix() const;
 	virtual double get_time_since_last_mix() const;
 
-	void add_callback(AudioCallback p_callback, void *p_userdata);
-	void remove_callback(AudioCallback p_callback, void *p_userdata);
+	void add_listener_changed_callback(AudioCallback p_callback, void *p_userdata);
+	void remove_listener_changed_callback(AudioCallback p_callback, void *p_userdata);
 
 	void add_update_callback(AudioCallback p_callback, void *p_userdata);
 	void remove_update_callback(AudioCallback p_callback, void *p_userdata);
+
+	void add_mix_callback(AudioCallback p_callback, void *p_userdata);
+	void remove_mix_callback(AudioCallback p_callback, void *p_userdata);
 
 	void set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout);
 	Ref<AudioBusLayout> generate_bus_layout() const;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #25087
Fixes #21312

Implements https://github.com/godotengine/godot-proposals/issues/2299

My focus here is parity with current `master`, not to add features, but it's still an enormous change. I can probably split off the individual commits into their own PRs if people would prefer that.

More detail is in the proposal above, but this basically moves all mixing into the audio server. Audio streams register their playback objects with the audio server and then update the volume during their panning or spatialization steps. This eliminates an entire class of bugs in which the player node's state is updated and it can't continue a volume ramp or fade out.

This also opens the door to lots of really exciting things! Now that we can crossfade across audio buses, we can have Area2D/Area3D based bus overrides that smoothly transition to the new bus. Imagine the mouth of a cave that slowly fades reverb in, or an area of a 2d platformer level that adds a distortion to audio. Before these things would cause pops and abrupt transitions, but with this change the pops are gone and it'll be fairly easy to add smooth transitions.

Another thing we can add back is polyphony, which I think users will appreciate. An audio stream player node can simply instance multiple playbacks for a stream and send them all to the audio server which will mix them independently. That's also not included in this change but should be simple to add.

A few notes:
* I changed the mix buffer size to 512, which I think is fine. It should probably be a project setting or at least influenced by the audio driver's buffer size, i.e. based on the latency project setting. It doesn't make sense for the audio server to have a bigger buffer than the audio driver.
* ~The NO_THREADS implementation of my SafeList data structure is probably broken, but I don't really know how to test it given that web exports aren't working in 4.0 right now, unless I'm mistaken on that.~
* This PR contains a mediocre workaround for #50958 that I put in for testing purposes only. I'm basically including the current viewport in the list of viewports to iterate through while looking for the active listener. It works for simple scenes but we should still address #50958 somehow.