### PR TITLE
Preserve original name in shader params cache

### DIFF
--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -76,8 +76,9 @@ void Shader::get_param_list(List<PropertyInfo> *p_params) const {
 		if (default_textures.has(pi.name)) { //do not show default textures
 			continue;
 		}
+		String original_name = pi.name;
 		pi.name = "shader_param/" + pi.name;
-		params_cache[pi.name] = pi.name;
+		params_cache[pi.name] = original_name;
 		if (p_params) {
 			//small little hack
 			if (pi.type == Variant::RID) {


### PR DESCRIPTION
Fixes #50936, which was a regression from #50511.