### PR TITLE
[Net] Fix ENetMultiplayerPeer status during connection.

### DIFF
--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -242,8 +242,8 @@ bool ENetMultiplayerPeer::_poll_client() {
 	}
 	switch (ret) {
 		case ENetConnection::EVENT_CONNECT: {
-			emit_signal(SNAME("peer_connected"), 1);
 			connection_status = CONNECTION_CONNECTED;
+			emit_signal(SNAME("peer_connected"), 1);
 			emit_signal(SNAME("connection_succeeded"));
 			return false;
 		}


### PR DESCRIPTION
While the client emitting "peer_connect" for the server, the status was
still set to CONNECTION_CONNECTING, causing bugs in the upper layer.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
