### PR TITLE
Improve implementation of builtin action overrides

### DIFF
--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -56,6 +56,7 @@ private:
 
 	mutable OrderedHashMap<StringName, Action> input_map;
 	OrderedHashMap<String, List<Ref<InputEvent>>> default_builtin_cache;
+	OrderedHashMap<String, List<Ref<InputEvent>>> default_builtin_with_overrides_cache;
 
 	List<Ref<InputEvent>>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool p_exact_match = false, bool *p_pressed = nullptr, float *p_strength = nullptr, float *p_raw_strength = nullptr) const;
 
@@ -93,6 +94,7 @@ public:
 	String get_builtin_display_name(const String &p_name) const;
 	// Use an Ordered Map so insertion order is preserved. We want the elements to be 'grouped' somewhat.
 	const OrderedHashMap<String, List<Ref<InputEvent>>> &get_builtins();
+	const OrderedHashMap<String, List<Ref<InputEvent>>> &get_builtins_with_feature_overrides_applied();
 
 	InputMap();
 	~InputMap();

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -268,7 +268,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 		Array events; // Need to get the list of events into an array so it can be set as metadata on the item.
 		Vector<String> event_strings;
 
-		List<Ref<InputEvent>> all_default_events = InputMap::get_singleton()->get_builtins().find(action_name).value();
+		List<Ref<InputEvent>> all_default_events = InputMap::get_singleton()->get_builtins_with_feature_overrides_applied().find(action_name).value();
 		List<Ref<InputEventKey>> key_default_events;
 		// Remove all non-key events from the defaults. Only check keys, since we are in the editor.
 		for (List<Ref<InputEvent>>::Element *I = all_default_events.front(); I; I = I->next()) {
@@ -404,7 +404,7 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 		switch (button_idx) {
 			case SHORTCUT_REVERT: {
 				Array events;
-				List<Ref<InputEvent>> defaults = InputMap::get_singleton()->get_builtins()[current_action];
+				List<Ref<InputEvent>> defaults = InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_action];
 
 				// Convert the list to an array, and only keep key events as this is for the editor.
 				for (const Ref<InputEvent> &k : defaults) {


### PR DESCRIPTION
Additional effort to #51280 to remove preprocessor defines and other hard-coded stuff.

This moves the "builtin actions" system to also use OS features just like the PR above. This means that such overrides can be specified for any OS now, not just macOS.

Solves an existing bug related to the determining whether to show the 'revert' button in the editor settings dialog. Introduces a new method, `get_builtins_with_feature_overrides_applied()`, which returns the builtin actions with any overrides applied. For example, if we had defined two separate sets of actions for `ui_select` and `ui_select.macOS`, calling `get_builtins_with_feature_overrides_applied()` would return a map with the key as `ui_select`, but with the actions defined in `ui_select.macOS`, if the executing operating system supported the `macOS` feature.

The method `get_builtins()` is still called in Project Settings, so that in the action editor there, all the builtins show up, including those which have overrides.