### PR TITLE
Fix vertical scroll/zoom for precision touchpad on windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2445,7 +2445,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					} else {
 						mb->set_button_index(MOUSE_BUTTON_WHEEL_DOWN);
 					}
-
+					mb->set_factor(fabs((double)motion / (double)WHEEL_DELTA));
 				} break;
 				case WM_MOUSEHWHEEL: {
 					mb->set_pressed(true);
@@ -2456,11 +2456,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 					if (motion < 0) {
 						mb->set_button_index(MOUSE_BUTTON_WHEEL_LEFT);
-						mb->set_factor(fabs((double)motion / (double)WHEEL_DELTA));
 					} else {
 						mb->set_button_index(MOUSE_BUTTON_WHEEL_RIGHT);
-						mb->set_factor(fabs((double)motion / (double)WHEEL_DELTA));
 					}
+					mb->set_factor(fabs((double)motion / (double)WHEEL_DELTA));
 				} break;
 				case WM_XBUTTONDOWN: {
 					mb->set_pressed(true);


### PR DESCRIPTION
This fix adds the factor data for the vertical mousewheel event, much like the horizontal mousewheel event, where this is already present.

With this fix, vertical scroll/zoom with a precision touchpad on windows is smooth and allows for fine grain control.
The code to support precision touchpad input is already present, but not used correctly.

Mousewheel events for other devices are not affected and are functioning as expected (tested with regular mouse).

It would be great if this could be cherrypicked for stable.

Fixes #51313 
