### PR TITLE
[3.x] Add theme item descriptions to the online documentation

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -58,37 +58,37 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [Button]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [Button].
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			Text [Color] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color_hover" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [Button] is being pressed.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="2">
+		<theme_item name="hseparation" data_type="constant" type="int" default="2">
 			The horizontal space between [Button]'s icon and text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [Button].
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is being pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -18,67 +18,67 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="check_vadjust" type="int" default="0">
+		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>
-		<theme_item name="checked" type="Texture">
+		<theme_item name="checked" data_type="icon" type="Texture">
 			The check icon to display when the [CheckBox] is checked.
 		</theme_item>
-		<theme_item name="checked_disabled" type="Texture">
+		<theme_item name="checked_disabled" data_type="icon" type="Texture">
 		</theme_item>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is focused.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			The [Font] to use for the [CheckBox] text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			The [CheckBox] text's font color.
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			The [CheckBox] text's font color when it's disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color_hover" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			The [CheckBox] text's font color when it's hovered.
 		</theme_item>
-		<theme_item name="font_color_hover_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_hover_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckBox] text's font color when it's hovered and pressed.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckBox] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is hovered.
 		</theme_item>
-		<theme_item name="hover_pressed" type="StyleBox">
+		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is hovered and pressed.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The separation between the check icon and the text (in pixels).
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background.
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is pressed.
 		</theme_item>
-		<theme_item name="radio_checked" type="Texture">
+		<theme_item name="radio_checked" data_type="icon" type="Texture">
 			If the [CheckBox] is configured as a radio button, the icon to display when the [CheckBox] is checked.
 		</theme_item>
-		<theme_item name="radio_checked_disabled" type="Texture">
+		<theme_item name="radio_checked_disabled" data_type="icon" type="Texture">
 		</theme_item>
-		<theme_item name="radio_unchecked" type="Texture">
+		<theme_item name="radio_unchecked" data_type="icon" type="Texture">
 			If the [CheckBox] is configured as a radio button, the icon to display when the [CheckBox] is unchecked.
 		</theme_item>
-		<theme_item name="radio_unchecked_disabled" type="Texture">
+		<theme_item name="radio_unchecked_disabled" data_type="icon" type="Texture">
 		</theme_item>
-		<theme_item name="unchecked" type="Texture">
+		<theme_item name="unchecked" data_type="icon" type="Texture">
 			The check icon to display when the [CheckBox] is unchecked.
 		</theme_item>
-		<theme_item name="unchecked_disabled" type="Texture">
+		<theme_item name="unchecked_disabled" data_type="icon" type="Texture">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -18,58 +18,58 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="check_vadjust" type="int" default="0">
+		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is focused.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			The [Font] to use for the [CheckButton] text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			The [CheckButton] text's font color.
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			The [CheckButton] text's font color when it's disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color_hover" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			The [CheckButton] text's font color when it's hovered.
 		</theme_item>
-		<theme_item name="font_color_hover_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_hover_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckButton] text's font color when it's hovered and pressed.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckButton] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is hovered.
 		</theme_item>
-		<theme_item name="hover_pressed" type="StyleBox">
+		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is hovered and pressed.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The separation between the toggle icon and the text (in pixels).
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background.
 		</theme_item>
-		<theme_item name="off" type="Texture">
+		<theme_item name="off" data_type="icon" type="Texture">
 			The icon to display when the [CheckButton] is unchecked.
 		</theme_item>
-		<theme_item name="off_disabled" type="Texture">
+		<theme_item name="off_disabled" data_type="icon" type="Texture">
 			The icon to display when the [CheckButton] is unchecked and disabled.
 		</theme_item>
-		<theme_item name="on" type="Texture">
+		<theme_item name="on" data_type="icon" type="Texture">
 			The icon to display when the [CheckButton] is checked.
 		</theme_item>
-		<theme_item name="on_disabled" type="Texture">
+		<theme_item name="on_disabled" data_type="icon" type="Texture">
 			The icon to display when the [CheckButton] is checked and disabled.
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -80,34 +80,34 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="add_preset" type="Texture">
+		<theme_item name="add_preset" data_type="icon" type="Texture">
 			The icon for the "Add Preset" button.
 		</theme_item>
-		<theme_item name="color_hue" type="Texture">
+		<theme_item name="color_hue" data_type="icon" type="Texture">
 			Custom texture for the hue selection slider on the right.
 		</theme_item>
-		<theme_item name="color_sample" type="Texture">
+		<theme_item name="color_sample" data_type="icon" type="Texture">
 		</theme_item>
-		<theme_item name="h_width" type="int" default="30">
+		<theme_item name="h_width" data_type="constant" type="int" default="30">
 			The width of the hue selection slider.
 		</theme_item>
-		<theme_item name="label_width" type="int" default="10">
+		<theme_item name="label_width" data_type="constant" type="int" default="10">
 		</theme_item>
-		<theme_item name="margin" type="int" default="4">
+		<theme_item name="margin" data_type="constant" type="int" default="4">
 			The margin around the [ColorPicker].
 		</theme_item>
-		<theme_item name="overbright_indicator" type="Texture">
+		<theme_item name="overbright_indicator" data_type="icon" type="Texture">
 			The indicator used to signalize that the color value is outside the 0-1 range.
 		</theme_item>
-		<theme_item name="preset_bg" type="Texture">
+		<theme_item name="preset_bg" data_type="icon" type="Texture">
 		</theme_item>
-		<theme_item name="screen_picker" type="Texture">
+		<theme_item name="screen_picker" data_type="icon" type="Texture">
 			The icon for the screen color picker button.
 		</theme_item>
-		<theme_item name="sv_height" type="int" default="256">
+		<theme_item name="sv_height" data_type="constant" type="int" default="256">
 			The height of the saturation-value selection box.
 		</theme_item>
-		<theme_item name="sv_width" type="int" default="256">
+		<theme_item name="sv_width" data_type="constant" type="int" default="256">
 			The width of the saturation-value selection box.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -55,40 +55,40 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" type="Texture">
+		<theme_item name="bg" data_type="icon" type="Texture">
 			The background of the color preview rect on the button.
 		</theme_item>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [ColorPickerButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Default text [Color] of the [ColorPickerButton].
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.3 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.3 )">
 			Text [Color] used when the [ColorPickerButton] is disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_hover" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 0.8, 0.8, 0.8, 1 )">
+		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 0.8, 0.8, 0.8, 1 )">
 			Text [Color] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="2">
+		<theme_item name="hseparation" data_type="constant" type="int" default="2">
 			The horizontal space between [ColorPickerButton]'s icon and text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [ColorPickerButton].
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -123,28 +123,28 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="file" type="Texture">
+		<theme_item name="file" data_type="icon" type="Texture">
 			Custom icon for files.
 		</theme_item>
-		<theme_item name="file_icon_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="file_icon_modulate" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The color modulation applied to the file icon.
 		</theme_item>
-		<theme_item name="files_disabled" type="Color" default="Color( 0, 0, 0, 0.7 )">
+		<theme_item name="files_disabled" data_type="color" type="Color" default="Color( 0, 0, 0, 0.7 )">
 			The color tint for disabled files (when the [FileDialog] is used in open folder mode).
 		</theme_item>
-		<theme_item name="folder" type="Texture">
+		<theme_item name="folder" data_type="icon" type="Texture">
 			Custom icon for folders.
 		</theme_item>
-		<theme_item name="folder_icon_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="folder_icon_modulate" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The color modulation applied to the folder icon.
 		</theme_item>
-		<theme_item name="parent_folder" type="Texture">
+		<theme_item name="parent_folder" data_type="icon" type="Texture">
 			Custom icon for the parent folder arrow.
 		</theme_item>
-		<theme_item name="reload" type="Texture">
+		<theme_item name="reload" data_type="icon" type="Texture">
 			Custom icon for the reload button.
 		</theme_item>
-		<theme_item name="toggle_hidden" type="Texture">
+		<theme_item name="toggle_hidden" data_type="icon" type="Texture">
 			Custom icon for the toggle hidden button.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -262,45 +262,45 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="activity" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="activity" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 		</theme_item>
-		<theme_item name="bezier_len_neg" type="int" default="160">
+		<theme_item name="bezier_len_neg" data_type="constant" type="int" default="160">
 		</theme_item>
-		<theme_item name="bezier_len_pos" type="int" default="80">
+		<theme_item name="bezier_len_pos" data_type="constant" type="int" default="80">
 		</theme_item>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			The background drawn under the grid.
 		</theme_item>
-		<theme_item name="grid_major" type="Color" default="Color( 1, 1, 1, 0.2 )">
+		<theme_item name="grid_major" data_type="color" type="Color" default="Color( 1, 1, 1, 0.2 )">
 			Color of major grid lines.
 		</theme_item>
-		<theme_item name="grid_minor" type="Color" default="Color( 1, 1, 1, 0.05 )">
+		<theme_item name="grid_minor" data_type="color" type="Color" default="Color( 1, 1, 1, 0.05 )">
 			Color of minor grid lines.
 		</theme_item>
-		<theme_item name="minimap" type="Texture">
+		<theme_item name="minimap" data_type="icon" type="Texture">
 		</theme_item>
-		<theme_item name="minus" type="Texture">
+		<theme_item name="minus" data_type="icon" type="Texture">
 			The icon for the zoom out button.
 		</theme_item>
-		<theme_item name="more" type="Texture">
+		<theme_item name="more" data_type="icon" type="Texture">
 			The icon for the zoom in button.
 		</theme_item>
-		<theme_item name="port_grab_distance_horizontal" type="int" default="48">
+		<theme_item name="port_grab_distance_horizontal" data_type="constant" type="int" default="48">
 			The horizontal range within which a port can be grabbed (on both sides).
 		</theme_item>
-		<theme_item name="port_grab_distance_vertical" type="int" default="6">
+		<theme_item name="port_grab_distance_vertical" data_type="constant" type="int" default="6">
 			The vertical range within which a port can be grabbed (on both sides).
 		</theme_item>
-		<theme_item name="reset" type="Texture">
+		<theme_item name="reset" data_type="icon" type="Texture">
 			The icon for the zoom reset button.
 		</theme_item>
-		<theme_item name="selection_fill" type="Color" default="Color( 1, 1, 1, 0.3 )">
+		<theme_item name="selection_fill" data_type="color" type="Color" default="Color( 1, 1, 1, 0.3 )">
 			The fill color of the selection rectangle.
 		</theme_item>
-		<theme_item name="selection_stroke" type="Color" default="Color( 1, 1, 1, 0.8 )">
+		<theme_item name="selection_stroke" data_type="color" type="Color" default="Color( 1, 1, 1, 0.8 )">
 			The outline color of the selection rectangle.
 		</theme_item>
-		<theme_item name="snap" type="Texture">
+		<theme_item name="snap" data_type="icon" type="Texture">
 			The icon for the snap toggle button.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -264,59 +264,59 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="breakpoint" type="StyleBox">
+		<theme_item name="breakpoint" data_type="style" type="StyleBox">
 			The background used when [member overlay] is set to [constant OVERLAY_BREAKPOINT].
 		</theme_item>
-		<theme_item name="close" type="Texture">
+		<theme_item name="close" data_type="icon" type="Texture">
 			The icon for the close button, visible when [member show_close] is enabled.
 		</theme_item>
-		<theme_item name="close_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="close_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
 			The color modulation applied to the close button icon.
 		</theme_item>
-		<theme_item name="close_offset" type="int" default="18">
+		<theme_item name="close_offset" data_type="constant" type="int" default="18">
 			The vertical offset of the close button.
 		</theme_item>
-		<theme_item name="comment" type="StyleBox">
+		<theme_item name="comment" data_type="style" type="StyleBox">
 			The [StyleBox] used when [member comment] is enabled.
 		</theme_item>
-		<theme_item name="commentfocus" type="StyleBox">
+		<theme_item name="commentfocus" data_type="style" type="StyleBox">
 			The [StyleBox] used when [member comment] is enabled and the [GraphNode] is focused.
 		</theme_item>
-		<theme_item name="defaultfocus" type="StyleBox">
+		<theme_item name="defaultfocus" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="defaultframe" type="StyleBox">
+		<theme_item name="defaultframe" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="frame" type="StyleBox">
+		<theme_item name="frame" data_type="style" type="StyleBox">
 			The default background for [GraphNode].
 		</theme_item>
-		<theme_item name="port" type="Texture">
+		<theme_item name="port" data_type="icon" type="Texture">
 			The icon used for representing ports.
 		</theme_item>
-		<theme_item name="port_offset" type="int" default="3">
+		<theme_item name="port_offset" data_type="constant" type="int" default="3">
 			Horizontal offset for the ports.
 		</theme_item>
-		<theme_item name="position" type="StyleBox">
+		<theme_item name="position" data_type="style" type="StyleBox">
 			The background used when [member overlay] is set to [constant OVERLAY_POSITION].
 		</theme_item>
-		<theme_item name="resizer" type="Texture">
+		<theme_item name="resizer" data_type="icon" type="Texture">
 			The icon used for resizer, visible when [member resizable] is enabled.
 		</theme_item>
-		<theme_item name="resizer_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="resizer_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
 			The color modulation applied to the resizer icon.
 		</theme_item>
-		<theme_item name="selectedframe" type="StyleBox">
+		<theme_item name="selectedframe" data_type="style" type="StyleBox">
 			The background used when the [GraphNode] is selected.
 		</theme_item>
-		<theme_item name="separation" type="int" default="1">
+		<theme_item name="separation" data_type="constant" type="int" default="1">
 			The vertical distance between ports.
 		</theme_item>
-		<theme_item name="title_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="title_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
 			Color of the title text.
 		</theme_item>
-		<theme_item name="title_font" type="Font">
+		<theme_item name="title_font" data_type="font" type="Font">
 			Font used for the title text.
 		</theme_item>
-		<theme_item name="title_offset" type="int" default="20">
+		<theme_item name="title_offset" data_type="constant" type="int" default="20">
 			Vertical offset of the title text.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/GridContainer.xml
+++ b/doc/classes/GridContainer.xml
@@ -22,10 +22,10 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal separation of children nodes.
 		</theme_item>
-		<theme_item name="vseparation" type="int" default="4">
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
 			The vertical separation of children nodes.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HBoxContainer.xml
+++ b/doc/classes/HBoxContainer.xml
@@ -13,7 +13,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="separation" type="int" default="4">
+		<theme_item name="separation" data_type="constant" type="int" default="4">
 			The horizontal space between the [HBoxContainer]'s elements.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HScrollBar.xml
+++ b/doc/classes/HScrollBar.xml
@@ -13,31 +13,31 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="decrement" type="Texture">
+		<theme_item name="decrement" data_type="icon" type="Texture">
 			Icon used as a button to scroll the [ScrollBar] left. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
-		<theme_item name="decrement_highlight" type="Texture">
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture">
 			Displayed when the mouse cursor hovers over the decrement button.
 		</theme_item>
-		<theme_item name="grabber" type="StyleBox">
+		<theme_item name="grabber" data_type="style" type="StyleBox">
 			Used as texture for the grabber, the draggable element representing current scroll.
 		</theme_item>
-		<theme_item name="grabber_highlight" type="StyleBox">
+		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
 			Used when the mouse hovers over the grabber.
 		</theme_item>
-		<theme_item name="grabber_pressed" type="StyleBox">
+		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
 			Used when the grabber is being dragged.
 		</theme_item>
-		<theme_item name="increment" type="Texture">
+		<theme_item name="increment" data_type="icon" type="Texture">
 			Icon used as a button to scroll the [ScrollBar] right. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
-		<theme_item name="increment_highlight" type="Texture">
+		<theme_item name="increment_highlight" data_type="icon" type="Texture">
 			Displayed when the mouse cursor hovers over the increment button.
 		</theme_item>
-		<theme_item name="scroll" type="StyleBox">
+		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].
 		</theme_item>
-		<theme_item name="scroll_focus" type="StyleBox">
+		<theme_item name="scroll_focus" data_type="style" type="StyleBox">
 			Used as background when the [ScrollBar] has the GUI focus.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HSeparator.xml
+++ b/doc/classes/HSeparator.xml
@@ -13,10 +13,10 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="separation" type="int" default="4">
+		<theme_item name="separation" data_type="constant" type="int" default="4">
 			The height of the area covered by the separator. Effectively works like a minimum height.
 		</theme_item>
-		<theme_item name="separator" type="StyleBox">
+		<theme_item name="separator" data_type="style" type="StyleBox">
 			The style for the separator line. Works best with [StyleBoxLine].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HSlider.xml
+++ b/doc/classes/HSlider.xml
@@ -14,24 +14,24 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="grabber" type="Texture">
+		<theme_item name="grabber" data_type="icon" type="Texture">
 			The texture for the grabber (the draggable element).
 		</theme_item>
-		<theme_item name="grabber_area" type="StyleBox">
+		<theme_item name="grabber_area" data_type="style" type="StyleBox">
 			The background of the area to the left of the grabber.
 		</theme_item>
-		<theme_item name="grabber_area_highlight" type="StyleBox">
+		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="grabber_disabled" type="Texture">
+		<theme_item name="grabber_disabled" data_type="icon" type="Texture">
 			The texture for the grabber when it's disabled.
 		</theme_item>
-		<theme_item name="grabber_highlight" type="Texture">
+		<theme_item name="grabber_highlight" data_type="icon" type="Texture">
 			The texture for the grabber when it's focused.
 		</theme_item>
-		<theme_item name="slider" type="StyleBox">
+		<theme_item name="slider" data_type="style" type="StyleBox">
 			The background for the whole slider. Determines the height of the [code]grabber_area[/code].
 		</theme_item>
-		<theme_item name="tick" type="Texture">
+		<theme_item name="tick" data_type="icon" type="Texture">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HSplitContainer.xml
+++ b/doc/classes/HSplitContainer.xml
@@ -13,15 +13,15 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="autohide" type="int" default="1">
+		<theme_item name="autohide" data_type="constant" type="int" default="1">
 			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
 		</theme_item>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="grabber" type="Texture">
+		<theme_item name="grabber" data_type="icon" type="Texture">
 			The icon used for the grabber drawn in the middle area.
 		</theme_item>
-		<theme_item name="separation" type="int" default="12">
+		<theme_item name="separation" data_type="constant" type="int" default="12">
 			The space between sides of the container.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -407,46 +407,46 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [ItemList], i.e. used when the control is not being focused.
 		</theme_item>
-		<theme_item name="bg_focus" type="StyleBox">
+		<theme_item name="bg_focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ItemList] is being focused.
 		</theme_item>
-		<theme_item name="cursor" type="StyleBox">
+		<theme_item name="cursor" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [ItemList] is being focused.
 		</theme_item>
-		<theme_item name="cursor_unfocused" type="StyleBox">
+		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [ItemList] is not being focused.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the item's text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.63, 0.63, 0.63, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.63, 0.63, 0.63, 1 )">
 			Default text [Color] of the item.
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_selected" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the item is selected.
 		</theme_item>
-		<theme_item name="guide_color" type="Color" default="Color( 0, 0, 0, 0.1 )">
+		<theme_item name="guide_color" data_type="color" type="Color" default="Color( 0, 0, 0, 0.1 )">
 			[Color] of the guideline. The guideline is a line drawn between each row of items.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal spacing between items.
 		</theme_item>
-		<theme_item name="icon_margin" type="int" default="4">
+		<theme_item name="icon_margin" data_type="constant" type="int" default="4">
 			The spacing between item's icon and text.
 		</theme_item>
-		<theme_item name="line_separation" type="int" default="2">
+		<theme_item name="line_separation" data_type="constant" type="int" default="2">
 			The vertical spacing between each line of text.
 		</theme_item>
-		<theme_item name="selected" type="StyleBox">
+		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [ItemList] is not being focused.
 		</theme_item>
-		<theme_item name="selected_focus" type="StyleBox">
+		<theme_item name="selected_focus" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [ItemList] is being focused.
 		</theme_item>
-		<theme_item name="vseparation" type="int" default="2">
+		<theme_item name="vseparation" data_type="constant" type="int" default="2">
 			The vertical spacing between items.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -97,31 +97,31 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] used for the [Label]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Default text [Color] of the [Label].
 		</theme_item>
-		<theme_item name="font_color_shadow" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="font_color_shadow" data_type="color" type="Color" default="Color( 0, 0, 0, 0 )">
 			[Color] of the text's shadow effect.
 		</theme_item>
-		<theme_item name="font_outline_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_modulate" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The tint of [Font]'s outline. See [member DynamicFont.outline_color].
 		</theme_item>
-		<theme_item name="line_spacing" type="int" default="3">
+		<theme_item name="line_spacing" data_type="constant" type="int" default="3">
 			Vertical space between lines in multiline [Label].
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Background [StyleBox] for the [Label].
 		</theme_item>
-		<theme_item name="shadow_as_outline" type="int" default="0">
+		<theme_item name="shadow_as_outline" data_type="constant" type="int" default="0">
 			Boolean value. If set to 1 ([code]true[/code]), the shadow will be displayed around the whole text as an outline.
 		</theme_item>
-		<theme_item name="shadow_offset_x" type="int" default="1">
+		<theme_item name="shadow_offset_x" data_type="constant" type="int" default="1">
 			The horizontal offset of the text's shadow.
 		</theme_item>
-		<theme_item name="shadow_offset_y" type="int" default="1">
+		<theme_item name="shadow_offset_y" data_type="constant" type="int" default="1">
 			The vertical offset of the text's shadow.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -231,43 +231,43 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="clear" type="Texture">
+		<theme_item name="clear" data_type="icon" type="Texture">
 			Texture for the clear button. See [member clear_button_enabled].
 		</theme_item>
-		<theme_item name="clear_button_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="clear_button_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Color used as default tint for the clear button.
 		</theme_item>
-		<theme_item name="clear_button_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="clear_button_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Color used for the clear button when it's pressed.
 		</theme_item>
-		<theme_item name="cursor_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="cursor_color" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Color of the [LineEdit]'s visual cursor (caret).
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			Background used when [LineEdit] has GUI focus.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			Font used for the text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default font color.
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_color_selected" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
 			Font color for selected text (inside the selection rectangle).
 		</theme_item>
-		<theme_item name="font_color_uneditable" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
+		<theme_item name="font_color_uneditable" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
 			Font color when editing is disabled.
 		</theme_item>
-		<theme_item name="minimum_spaces" type="int" default="12">
+		<theme_item name="minimum_spaces" data_type="constant" type="int" default="12">
 			Minimum horizontal space for the text (not counting the clear button and content margins). This value is measured in count of space characters (i.e. this amount of space characters can be displayed without scrolling).
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default background for the [LineEdit].
 		</theme_item>
-		<theme_item name="read_only" type="StyleBox">
+		<theme_item name="read_only" data_type="style" type="StyleBox">
 			Background used when [LineEdit] is in read-only mode ([member editable] is set to [code]false[/code]).
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
 			Color of the selection rectangle.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -33,22 +33,22 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [LinkButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [LinkButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [LinkButton].
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color_hover" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [LinkButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [LinkButton] is being pressed.
 		</theme_item>
-		<theme_item name="underline_spacing" type="int" default="2">
+		<theme_item name="underline_spacing" data_type="constant" type="int" default="2">
 			The vertical space between the baseline of text and the underline.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/MarginContainer.xml
+++ b/doc/classes/MarginContainer.xml
@@ -22,16 +22,16 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="margin_bottom" type="int" default="0">
+		<theme_item name="margin_bottom" data_type="constant" type="int" default="0">
 			All direct children of [MarginContainer] will have a bottom margin of [code]margin_bottom[/code] pixels.
 		</theme_item>
-		<theme_item name="margin_left" type="int" default="0">
+		<theme_item name="margin_left" data_type="constant" type="int" default="0">
 			All direct children of [MarginContainer] will have a left margin of [code]margin_left[/code] pixels.
 		</theme_item>
-		<theme_item name="margin_right" type="int" default="0">
+		<theme_item name="margin_right" data_type="constant" type="int" default="0">
 			All direct children of [MarginContainer] will have a right margin of [code]margin_right[/code] pixels.
 		</theme_item>
-		<theme_item name="margin_top" type="int" default="0">
+		<theme_item name="margin_top" data_type="constant" type="int" default="0">
 			All direct children of [MarginContainer] will have a top margin of [code]margin_top[/code] pixels.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -44,37 +44,37 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [MenuButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [MenuButton].
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 1, 1, 1, 0.3 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 1, 1, 1, 0.3 )">
 			Text [Color] used when the [MenuButton] is disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color_hover" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [MenuButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="3">
+		<theme_item name="hseparation" data_type="constant" type="int" default="3">
 			The horizontal space between [MenuButton]'s icon and text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [MenuButton].
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is being pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -186,43 +186,43 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="arrow" type="Texture">
+		<theme_item name="arrow" data_type="icon" type="Texture">
 			The arrow icon to be drawn on the right end of the button.
 		</theme_item>
-		<theme_item name="arrow_margin" type="int" default="2">
+		<theme_item name="arrow_margin" data_type="constant" type="int" default="2">
 			The horizontal space between the arrow icon and the right edge of the button.
 		</theme_item>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [OptionButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [OptionButton].
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			Text [Color] used when the [OptionButton] is disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color_hover" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [OptionButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [OptionButton] is being pressed.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="2">
+		<theme_item name="hseparation" data_type="constant" type="int" default="2">
 			The horizontal space between [OptionButton]'s icon and text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [OptionButton].
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is being pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Panel.xml
+++ b/doc/classes/Panel.xml
@@ -16,7 +16,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style of this [Panel].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/PanelContainer.xml
+++ b/doc/classes/PanelContainer.xml
@@ -14,7 +14,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style of [PanelContainer]'s background.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/PopupDialog.xml
+++ b/doc/classes/PopupDialog.xml
@@ -13,7 +13,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			Sets a custom [StyleBox] for the panel of the [PopupDialog].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -496,61 +496,61 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="checked" type="Texture">
+		<theme_item name="checked" data_type="icon" type="Texture">
 			[Texture] icon for the checked checkbox items.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] used for the menu items.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			The default text [Color] for menu items' names.
 		</theme_item>
-		<theme_item name="font_color_accel" type="Color" default="Color( 0.7, 0.7, 0.7, 0.8 )">
+		<theme_item name="font_color_accel" data_type="color" type="Color" default="Color( 0.7, 0.7, 0.7, 0.8 )">
 			The text [Color] used for shortcuts and accelerators that show next to the menu item name when defined. See [method get_item_accelerator] for more info on accelerators.
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.4, 0.4, 0.4, 0.8 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 0.4, 0.4, 0.4, 0.8 )">
 			[Color] used for disabled menu items' text.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color_hover" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			[Color] used for the hovered text.
 		</theme_item>
-		<theme_item name="font_color_separator" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color_separator" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			[Color] used for labeled separators' text. See [method add_separator].
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] displayed when the [PopupMenu] item is hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal space between the item's name and the shortcut text/submenu arrow.
 		</theme_item>
-		<theme_item name="labeled_separator_left" type="StyleBox">
+		<theme_item name="labeled_separator_left" data_type="style" type="StyleBox">
 			[StyleBox] for the left side of labeled separator. See [method add_separator].
 		</theme_item>
-		<theme_item name="labeled_separator_right" type="StyleBox">
+		<theme_item name="labeled_separator_right" data_type="style" type="StyleBox">
 			[StyleBox] for the right side of labeled separator. See [method add_separator].
 		</theme_item>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			Default [StyleBox] of the [PopupMenu] items.
 		</theme_item>
-		<theme_item name="panel_disabled" type="StyleBox">
+		<theme_item name="panel_disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [PopupMenu] item is disabled.
 		</theme_item>
-		<theme_item name="radio_checked" type="Texture">
+		<theme_item name="radio_checked" data_type="icon" type="Texture">
 			[Texture] icon for the checked radio button items.
 		</theme_item>
-		<theme_item name="radio_unchecked" type="Texture">
+		<theme_item name="radio_unchecked" data_type="icon" type="Texture">
 			[Texture] icon for the unchecked radio button items.
 		</theme_item>
-		<theme_item name="separator" type="StyleBox">
+		<theme_item name="separator" data_type="style" type="StyleBox">
 			[StyleBox] used for the separators. See [method add_separator].
 		</theme_item>
-		<theme_item name="submenu" type="Texture">
+		<theme_item name="submenu" data_type="icon" type="Texture">
 			[Texture] icon for the submenu arrow.
 		</theme_item>
-		<theme_item name="unchecked" type="Texture">
+		<theme_item name="unchecked" data_type="icon" type="Texture">
 			[Texture] icon for the unchecked checkbox items.
 		</theme_item>
-		<theme_item name="vseparation" type="int" default="4">
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
 			The vertical space between each menu item.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/PopupPanel.xml
+++ b/doc/classes/PopupPanel.xml
@@ -13,7 +13,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The background panel style of this [PopupPanel].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -20,19 +20,19 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			The style of the background.
 		</theme_item>
-		<theme_item name="fg" type="StyleBox">
+		<theme_item name="fg" data_type="style" type="StyleBox">
 			The style of the progress (i.e. the part that fills the bar).
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			Font used to draw the fill percentage if [member percent_visible] is [code]true[/code].
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			The color of the text.
 		</theme_item>
-		<theme_item name="font_color_shadow" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_color_shadow" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
 			The color of the text's shadow.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -364,55 +364,55 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="bold_font" type="Font">
+		<theme_item name="bold_font" data_type="font" type="Font">
 			The font used for bold text.
 		</theme_item>
-		<theme_item name="bold_italics_font" type="Font">
+		<theme_item name="bold_italics_font" data_type="font" type="Font">
 			The font used for bold italics text.
 		</theme_item>
-		<theme_item name="default_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="default_color" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The default text color.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			The background The background used when the [RichTextLabel] is focused.
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
+		<theme_item name="font_color_selected" data_type="color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
 			The color of selected text, used when [member selection_enabled] is [code]true[/code].
 		</theme_item>
-		<theme_item name="font_color_shadow" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="font_color_shadow" data_type="color" type="Color" default="Color( 0, 0, 0, 0 )">
 			The color of the font's shadow.
 		</theme_item>
-		<theme_item name="italics_font" type="Font">
+		<theme_item name="italics_font" data_type="font" type="Font">
 			The font used for italics text.
 		</theme_item>
-		<theme_item name="line_separation" type="int" default="1">
+		<theme_item name="line_separation" data_type="constant" type="int" default="1">
 			The vertical space between lines.
 		</theme_item>
-		<theme_item name="mono_font" type="Font">
+		<theme_item name="mono_font" data_type="font" type="Font">
 			The font used for monospace text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			The normal background for the [RichTextLabel].
 		</theme_item>
-		<theme_item name="normal_font" type="Font">
+		<theme_item name="normal_font" data_type="font" type="Font">
 			The default text font.
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color( 0.1, 0.1, 1, 0.8 )">
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color( 0.1, 0.1, 1, 0.8 )">
 			The color of the selection box.
 		</theme_item>
-		<theme_item name="shadow_as_outline" type="int" default="0">
+		<theme_item name="shadow_as_outline" data_type="constant" type="int" default="0">
 			Boolean value. If 1 ([code]true[/code]), the shadow will be displayed around the whole text as an outline.
 		</theme_item>
-		<theme_item name="shadow_offset_x" type="int" default="1">
+		<theme_item name="shadow_offset_x" data_type="constant" type="int" default="1">
 			The horizontal offset of the font's shadow.
 		</theme_item>
-		<theme_item name="shadow_offset_y" type="int" default="1">
+		<theme_item name="shadow_offset_y" data_type="constant" type="int" default="1">
 			The vertical offset of the font's shadow.
 		</theme_item>
-		<theme_item name="table_hseparation" type="int" default="3">
+		<theme_item name="table_hseparation" data_type="constant" type="int" default="3">
 			The horizontal separation of elements in a table.
 		</theme_item>
-		<theme_item name="table_vseparation" type="int" default="3">
+		<theme_item name="table_vseparation" data_type="constant" type="int" default="3">
 			The vertical separation of elements in a table.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -64,7 +64,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			The background [StyleBox] of the [ScrollContainer].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -50,7 +50,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="updown" type="Texture">
+		<theme_item name="updown" data_type="icon" type="Texture">
 			Sets a custom [Texture] for up and down arrows of the [SpinBox].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -161,59 +161,59 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="decrement" type="Texture">
+		<theme_item name="decrement" data_type="icon" type="Texture">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
 		</theme_item>
-		<theme_item name="decrement_highlight" type="Texture">
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>
-		<theme_item name="font_color_bg" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
+		<theme_item name="font_color_bg" data_type="color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
 			Font color of inactive tabs.
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			Font color of disabled tabs.
 		</theme_item>
-		<theme_item name="font_color_fg" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color_fg" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Font color of the currently selected tab.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			Horizontal separation between tabs.
 		</theme_item>
-		<theme_item name="increment" type="Texture">
+		<theme_item name="increment" data_type="icon" type="Texture">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.
 		</theme_item>
-		<theme_item name="increment_highlight" type="Texture">
+		<theme_item name="increment_highlight" data_type="icon" type="Texture">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="label_valign_bg" type="int" default="2">
+		<theme_item name="label_valign_bg" data_type="constant" type="int" default="2">
 		</theme_item>
-		<theme_item name="label_valign_fg" type="int" default="0">
+		<theme_item name="label_valign_fg" data_type="constant" type="int" default="0">
 		</theme_item>
-		<theme_item name="menu" type="Texture">
+		<theme_item name="menu" data_type="icon" type="Texture">
 			The icon for the menu button (see [method set_popup]).
 		</theme_item>
-		<theme_item name="menu_highlight" type="Texture">
+		<theme_item name="menu_highlight" data_type="icon" type="Texture">
 			The icon for the menu button (see [method set_popup]) when it's being hovered with the cursor.
 		</theme_item>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style for the background fill.
 		</theme_item>
-		<theme_item name="side_margin" type="int" default="8">
+		<theme_item name="side_margin" data_type="constant" type="int" default="8">
 			The space at the left and right edges of the tab bar.
 		</theme_item>
-		<theme_item name="tab_bg" type="StyleBox">
+		<theme_item name="tab_bg" data_type="style" type="StyleBox">
 			The style of inactive tabs.
 		</theme_item>
-		<theme_item name="tab_disabled" type="StyleBox">
+		<theme_item name="tab_disabled" data_type="style" type="StyleBox">
 			The style of disabled tabs.
 		</theme_item>
-		<theme_item name="tab_fg" type="StyleBox">
+		<theme_item name="tab_fg" data_type="style" type="StyleBox">
 			The style of the currently selected tab.
 		</theme_item>
-		<theme_item name="top_margin" type="int" default="24">
+		<theme_item name="top_margin" data_type="constant" type="int" default="24">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -225,56 +225,56 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="button" type="StyleBox">
+		<theme_item name="button" data_type="style" type="StyleBox">
 			Background of the close button when it's being hovered with the cursor.
 		</theme_item>
-		<theme_item name="button_pressed" type="StyleBox">
+		<theme_item name="button_pressed" data_type="style" type="StyleBox">
 			Background of the close button when it's being pressed.
 		</theme_item>
-		<theme_item name="close" type="Texture">
+		<theme_item name="close" data_type="icon" type="Texture">
 			The icon for the close button (see [member tab_close_display_policy]).
 		</theme_item>
-		<theme_item name="decrement" type="Texture">
+		<theme_item name="decrement" data_type="icon" type="Texture">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
 		</theme_item>
-		<theme_item name="decrement_highlight" type="Texture">
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>
-		<theme_item name="font_color_bg" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
+		<theme_item name="font_color_bg" data_type="color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
 			Font color of inactive tabs.
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			Font color of disabled tabs.
 		</theme_item>
-		<theme_item name="font_color_fg" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color_fg" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Font color of the currently selected tab.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal separation between the tabs.
 		</theme_item>
-		<theme_item name="increment" type="Texture">
+		<theme_item name="increment" data_type="icon" type="Texture">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.
 		</theme_item>
-		<theme_item name="increment_highlight" type="Texture">
+		<theme_item name="increment_highlight" data_type="icon" type="Texture">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="label_valign_bg" type="int" default="2">
+		<theme_item name="label_valign_bg" data_type="constant" type="int" default="2">
 		</theme_item>
-		<theme_item name="label_valign_fg" type="int" default="0">
+		<theme_item name="label_valign_fg" data_type="constant" type="int" default="0">
 		</theme_item>
-		<theme_item name="tab_bg" type="StyleBox">
+		<theme_item name="tab_bg" data_type="style" type="StyleBox">
 			The style of an inactive tab.
 		</theme_item>
-		<theme_item name="tab_disabled" type="StyleBox">
+		<theme_item name="tab_disabled" data_type="style" type="StyleBox">
 			The style of a disabled tab
 		</theme_item>
-		<theme_item name="tab_fg" type="StyleBox">
+		<theme_item name="tab_fg" data_type="style" type="StyleBox">
 			The style of the currently selected tab.
 		</theme_item>
-		<theme_item name="top_margin" type="int" default="24">
+		<theme_item name="top_margin" data_type="constant" type="int" default="24">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -536,97 +536,97 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="background_color" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="background_color" data_type="color" type="Color" default="Color( 0, 0, 0, 0 )">
 			Sets the background [Color] of this [TextEdit]. [member syntax_highlighting] has to be enabled.
 		</theme_item>
-		<theme_item name="bookmark_color" type="Color" default="Color( 0.08, 0.49, 0.98, 1 )">
+		<theme_item name="bookmark_color" data_type="color" type="Color" default="Color( 0.08, 0.49, 0.98, 1 )">
 			Sets the [Color] of the bookmark marker. [member syntax_highlighting] has to be enabled.
 		</theme_item>
-		<theme_item name="brace_mismatch_color" type="Color" default="Color( 1, 0.2, 0.2, 1 )">
+		<theme_item name="brace_mismatch_color" data_type="color" type="Color" default="Color( 1, 0.2, 0.2, 1 )">
 		</theme_item>
-		<theme_item name="breakpoint_color" type="Color" default="Color( 0.8, 0.8, 0.4, 0.2 )">
+		<theme_item name="breakpoint_color" data_type="color" type="Color" default="Color( 0.8, 0.8, 0.4, 0.2 )">
 			Sets the [Color] of the breakpoints. [member breakpoint_gutter] has to be enabled.
 		</theme_item>
-		<theme_item name="caret_background_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="caret_background_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
 		</theme_item>
-		<theme_item name="caret_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="caret_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 		</theme_item>
-		<theme_item name="code_folding_color" type="Color" default="Color( 0.8, 0.8, 0.8, 0.8 )">
+		<theme_item name="code_folding_color" data_type="color" type="Color" default="Color( 0.8, 0.8, 0.8, 0.8 )">
 		</theme_item>
-		<theme_item name="completion" type="StyleBox">
+		<theme_item name="completion" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="completion_background_color" type="Color" default="Color( 0.17, 0.16, 0.2, 1 )">
+		<theme_item name="completion_background_color" data_type="color" type="Color" default="Color( 0.17, 0.16, 0.2, 1 )">
 		</theme_item>
-		<theme_item name="completion_existing_color" type="Color" default="Color( 0.87, 0.87, 0.87, 0.13 )">
+		<theme_item name="completion_existing_color" data_type="color" type="Color" default="Color( 0.87, 0.87, 0.87, 0.13 )">
 		</theme_item>
-		<theme_item name="completion_font_color" type="Color" default="Color( 0.67, 0.67, 0.67, 1 )">
+		<theme_item name="completion_font_color" data_type="color" type="Color" default="Color( 0.67, 0.67, 0.67, 1 )">
 		</theme_item>
-		<theme_item name="completion_lines" type="int" default="7">
+		<theme_item name="completion_lines" data_type="constant" type="int" default="7">
 		</theme_item>
-		<theme_item name="completion_max_width" type="int" default="50">
+		<theme_item name="completion_max_width" data_type="constant" type="int" default="50">
 		</theme_item>
-		<theme_item name="completion_scroll_color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="completion_scroll_color" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 		</theme_item>
-		<theme_item name="completion_scroll_width" type="int" default="3">
+		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="3">
 		</theme_item>
-		<theme_item name="completion_selected_color" type="Color" default="Color( 0.26, 0.26, 0.27, 1 )">
+		<theme_item name="completion_selected_color" data_type="color" type="Color" default="Color( 0.26, 0.26, 0.27, 1 )">
 		</theme_item>
-		<theme_item name="current_line_color" type="Color" default="Color( 0.25, 0.25, 0.26, 0.8 )">
+		<theme_item name="current_line_color" data_type="color" type="Color" default="Color( 0.25, 0.25, 0.26, 0.8 )">
 			Sets the [Color] of the breakpoints. [member breakpoint_gutter] has to be enabled.
 		</theme_item>
-		<theme_item name="executing_line_color" type="Color" default="Color( 0.2, 0.8, 0.2, 0.4 )">
+		<theme_item name="executing_line_color" data_type="color" type="Color" default="Color( 0.2, 0.8, 0.2, 0.4 )">
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="fold" type="Texture">
+		<theme_item name="fold" data_type="icon" type="Texture">
 		</theme_item>
-		<theme_item name="folded" type="Texture">
+		<theme_item name="folded" data_type="icon" type="Texture">
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			Sets the default [Font].
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Sets the font [Color].
 		</theme_item>
-		<theme_item name="font_color_readonly" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
+		<theme_item name="font_color_readonly" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_color_selected" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
 			Sets the [Color] of the selected text. [member override_selected_font_color] has to be enabled.
 		</theme_item>
-		<theme_item name="function_color" type="Color" default="Color( 0.4, 0.64, 0.81, 1 )">
+		<theme_item name="function_color" data_type="color" type="Color" default="Color( 0.4, 0.64, 0.81, 1 )">
 		</theme_item>
-		<theme_item name="line_number_color" type="Color" default="Color( 0.67, 0.67, 0.67, 0.4 )">
+		<theme_item name="line_number_color" data_type="color" type="Color" default="Color( 0.67, 0.67, 0.67, 0.4 )">
 			Sets the [Color] of the line numbers. [member show_line_numbers] has to be enabled.
 		</theme_item>
-		<theme_item name="line_spacing" type="int" default="4">
+		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
 			Sets the spacing between the lines.
 		</theme_item>
-		<theme_item name="mark_color" type="Color" default="Color( 1, 0.4, 0.4, 0.4 )">
+		<theme_item name="mark_color" data_type="color" type="Color" default="Color( 1, 0.4, 0.4, 0.4 )">
 			Sets the [Color] of marked text.
 		</theme_item>
-		<theme_item name="member_variable_color" type="Color" default="Color( 0.9, 0.31, 0.35, 1 )">
+		<theme_item name="member_variable_color" data_type="color" type="Color" default="Color( 0.9, 0.31, 0.35, 1 )">
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Sets the [StyleBox] of this [TextEdit].
 		</theme_item>
-		<theme_item name="number_color" type="Color" default="Color( 0.92, 0.58, 0.2, 1 )">
+		<theme_item name="number_color" data_type="color" type="Color" default="Color( 0.92, 0.58, 0.2, 1 )">
 		</theme_item>
-		<theme_item name="read_only" type="StyleBox">
+		<theme_item name="read_only" data_type="style" type="StyleBox">
 			Sets the [StyleBox] of this [TextEdit] when [member readonly] is enabled.
 		</theme_item>
-		<theme_item name="safe_line_number_color" type="Color" default="Color( 0.67, 0.78, 0.67, 0.6 )">
+		<theme_item name="safe_line_number_color" data_type="color" type="Color" default="Color( 0.67, 0.78, 0.67, 0.6 )">
 		</theme_item>
-		<theme_item name="selection_color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
 			Sets the highlight [Color] of text selections.
 		</theme_item>
-		<theme_item name="space" type="Texture">
+		<theme_item name="space" data_type="icon" type="Texture">
 		</theme_item>
-		<theme_item name="symbol_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="symbol_color" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 		</theme_item>
-		<theme_item name="tab" type="Texture">
+		<theme_item name="tab" data_type="icon" type="Texture">
 			Sets a custom [Texture] for tab text characters.
 		</theme_item>
-		<theme_item name="word_highlighted_color" type="Color" default="Color( 0.8, 0.9, 0.9, 0.15 )">
+		<theme_item name="word_highlighted_color" data_type="color" type="Color" default="Color( 0.8, 0.9, 0.9, 0.15 )">
 			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ToolButton.xml
+++ b/doc/classes/ToolButton.xml
@@ -20,37 +20,37 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="disabled" type="StyleBox">
+		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ToolButton] is disabled.
 		</theme_item>
-		<theme_item name="focus" type="StyleBox">
+		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ToolButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the [ToolButton]'s text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [ToolButton].
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.95, 1, 0.3 )">
+		<theme_item name="font_color_disabled" data_type="color" type="Color" default="Color( 0.9, 0.95, 1, 0.3 )">
 			Text [Color] used when the [ToolButton] is disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_color_hover" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [ToolButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [ToolButton] is being pressed.
 		</theme_item>
-		<theme_item name="hover" type="StyleBox">
+		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ToolButton] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="3">
+		<theme_item name="hseparation" data_type="constant" type="int" default="3">
 			The horizontal space between [ToolButton]'s icon and text.
 		</theme_item>
-		<theme_item name="normal" type="StyleBox">
+		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [ToolButton].
 		</theme_item>
-		<theme_item name="pressed" type="StyleBox">
+		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ToolButton] is being pressed.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -355,112 +355,112 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="arrow" type="Texture">
+		<theme_item name="arrow" data_type="icon" type="Texture">
 			The arrow icon used when a foldable item is not collapsed.
 		</theme_item>
-		<theme_item name="arrow_collapsed" type="Texture">
+		<theme_item name="arrow_collapsed" data_type="icon" type="Texture">
 			The arrow icon used when a foldable item is collapsed.
 		</theme_item>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [Tree], i.e. used when the control is not being focused.
 		</theme_item>
-		<theme_item name="bg_focus" type="StyleBox">
+		<theme_item name="bg_focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Tree] is being focused.
 		</theme_item>
-		<theme_item name="button_margin" type="int" default="4">
+		<theme_item name="button_margin" data_type="constant" type="int" default="4">
 			The horizontal space between each button in a cell.
 		</theme_item>
-		<theme_item name="button_pressed" type="StyleBox">
+		<theme_item name="button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when a button in the tree is pressed.
 		</theme_item>
-		<theme_item name="checked" type="Texture">
+		<theme_item name="checked" data_type="icon" type="Texture">
 			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is checked.
 		</theme_item>
-		<theme_item name="cursor" type="StyleBox">
+		<theme_item name="cursor" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [Tree] is being focused.
 		</theme_item>
-		<theme_item name="cursor_unfocused" type="StyleBox">
+		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [Tree] is not being focused.
 		</theme_item>
-		<theme_item name="custom_button" type="StyleBox">
+		<theme_item name="custom_button" data_type="style" type="StyleBox">
 			Default [StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell.
 		</theme_item>
-		<theme_item name="custom_button_font_highlight" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="custom_button_font_highlight" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
 		</theme_item>
-		<theme_item name="custom_button_hover" type="StyleBox">
+		<theme_item name="custom_button_hover" data_type="style" type="StyleBox">
 			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
 		</theme_item>
-		<theme_item name="custom_button_pressed" type="StyleBox">
+		<theme_item name="custom_button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's pressed.
 		</theme_item>
-		<theme_item name="draw_guides" type="int" default="1">
+		<theme_item name="draw_guides" data_type="constant" type="int" default="1">
 			Draws the guidelines if not zero, this acts as a boolean. The guideline is a horizontal line drawn at the bottom of each item.
 		</theme_item>
-		<theme_item name="draw_relationship_lines" type="int" default="0">
+		<theme_item name="draw_relationship_lines" data_type="constant" type="int" default="0">
 			Draws the relationship lines if not zero, this acts as a boolean. Relationship lines are drawn at the start of child items to show hierarchy.
 		</theme_item>
-		<theme_item name="drop_position_color" type="Color" default="Color( 1, 0.3, 0.2, 1 )">
+		<theme_item name="drop_position_color" data_type="color" type="Color" default="Color( 1, 0.3, 0.2, 1 )">
 			[Color] used to draw possible drop locations. See [enum DropModeFlags] constants for further description of drop locations.
 		</theme_item>
-		<theme_item name="font" type="Font">
+		<theme_item name="font" data_type="font" type="Font">
 			[Font] of the item's text.
 		</theme_item>
-		<theme_item name="font_color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
 			Default text [Color] of the item.
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_color_selected" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the item is selected.
 		</theme_item>
-		<theme_item name="guide_color" type="Color" default="Color( 0, 0, 0, 0.1 )">
+		<theme_item name="guide_color" data_type="color" type="Color" default="Color( 0, 0, 0, 0.1 )">
 			[Color] of the guideline.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
+		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal space between item cells. This is also used as the margin at the start of an item when folding is disabled.
 		</theme_item>
-		<theme_item name="item_margin" type="int" default="12">
+		<theme_item name="item_margin" data_type="constant" type="int" default="12">
 			The horizontal margin at the start of an item. This is used when folding is enabled for the item.
 		</theme_item>
-		<theme_item name="relationship_line_color" type="Color" default="Color( 0.27, 0.27, 0.27, 1 )">
+		<theme_item name="relationship_line_color" data_type="color" type="Color" default="Color( 0.27, 0.27, 0.27, 1 )">
 			[Color] of the relationship lines.
 		</theme_item>
-		<theme_item name="scroll_border" type="int" default="4">
+		<theme_item name="scroll_border" data_type="constant" type="int" default="4">
 			The maximum distance between the mouse cursor and the control's border to trigger border scrolling when dragging.
 		</theme_item>
-		<theme_item name="scroll_speed" type="int" default="12">
+		<theme_item name="scroll_speed" data_type="constant" type="int" default="12">
 			The speed of border scrolling.
 		</theme_item>
-		<theme_item name="select_arrow" type="Texture">
+		<theme_item name="select_arrow" data_type="icon" type="Texture">
 			The arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
 		</theme_item>
-		<theme_item name="selected" type="StyleBox">
+		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is not being focused.
 		</theme_item>
-		<theme_item name="selected_focus" type="StyleBox">
+		<theme_item name="selected_focus" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is being focused.
 		</theme_item>
-		<theme_item name="title_button_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="title_button_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the title button.
 		</theme_item>
-		<theme_item name="title_button_font" type="Font">
+		<theme_item name="title_button_font" data_type="font" type="Font">
 			[Font] of the title button's text.
 		</theme_item>
-		<theme_item name="title_button_hover" type="StyleBox">
+		<theme_item name="title_button_hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the title button is being hovered.
 		</theme_item>
-		<theme_item name="title_button_normal" type="StyleBox">
+		<theme_item name="title_button_normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the title button.
 		</theme_item>
-		<theme_item name="title_button_pressed" type="StyleBox">
+		<theme_item name="title_button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the title button is being pressed.
 		</theme_item>
-		<theme_item name="unchecked" type="Texture">
+		<theme_item name="unchecked" data_type="icon" type="Texture">
 			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is unchecked.
 		</theme_item>
-		<theme_item name="updown" type="Texture">
+		<theme_item name="updown" data_type="icon" type="Texture">
 			The updown arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
 		</theme_item>
-		<theme_item name="vseparation" type="int" default="4">
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
 			The vertical padding inside each item, i.e. the distance between the item's content and top/bottom border.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VBoxContainer.xml
+++ b/doc/classes/VBoxContainer.xml
@@ -14,7 +14,7 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="separation" type="int" default="4">
+		<theme_item name="separation" data_type="constant" type="int" default="4">
 			The vertical space between the [VBoxContainer]'s elements.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -17,31 +17,31 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="decrement" type="Texture">
+		<theme_item name="decrement" data_type="icon" type="Texture">
 			Icon used as a button to scroll the [ScrollBar] up. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
-		<theme_item name="decrement_highlight" type="Texture">
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture">
 			Displayed when the mouse cursor hovers over the decrement button.
 		</theme_item>
-		<theme_item name="grabber" type="StyleBox">
+		<theme_item name="grabber" data_type="style" type="StyleBox">
 			Used as texture for the grabber, the draggable element representing current scroll.
 		</theme_item>
-		<theme_item name="grabber_highlight" type="StyleBox">
+		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
 			Used when the mouse hovers over the grabber.
 		</theme_item>
-		<theme_item name="grabber_pressed" type="StyleBox">
+		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
 			Used when the grabber is being dragged.
 		</theme_item>
-		<theme_item name="increment" type="Texture">
+		<theme_item name="increment" data_type="icon" type="Texture">
 			Icon used as a button to scroll the [ScrollBar] down. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
-		<theme_item name="increment_highlight" type="Texture">
+		<theme_item name="increment_highlight" data_type="icon" type="Texture">
 			Displayed when the mouse cursor hovers over the increment button.
 		</theme_item>
-		<theme_item name="scroll" type="StyleBox">
+		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].
 		</theme_item>
-		<theme_item name="scroll_focus" type="StyleBox">
+		<theme_item name="scroll_focus" data_type="style" type="StyleBox">
 			Used as background when the [ScrollBar] has the GUI focus.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VSeparator.xml
+++ b/doc/classes/VSeparator.xml
@@ -13,10 +13,10 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="separation" type="int" default="4">
+		<theme_item name="separation" data_type="constant" type="int" default="4">
 			The width of the area covered by the separator. Effectively works like a minimum width.
 		</theme_item>
-		<theme_item name="separator" type="StyleBox">
+		<theme_item name="separator" data_type="style" type="StyleBox">
 			The style for the separator line. Works best with [StyleBoxLine] (remember to enable [member StyleBoxLine.vertical]).
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VSlider.xml
+++ b/doc/classes/VSlider.xml
@@ -18,24 +18,24 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="grabber" type="Texture">
+		<theme_item name="grabber" data_type="icon" type="Texture">
 			The texture for the grabber (the draggable element).
 		</theme_item>
-		<theme_item name="grabber_area" type="StyleBox">
+		<theme_item name="grabber_area" data_type="style" type="StyleBox">
 			The background of the area below the grabber.
 		</theme_item>
-		<theme_item name="grabber_area_highlight" type="StyleBox">
+		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="grabber_disabled" type="Texture">
+		<theme_item name="grabber_disabled" data_type="icon" type="Texture">
 			The texture for the grabber when it's disabled.
 		</theme_item>
-		<theme_item name="grabber_highlight" type="Texture">
+		<theme_item name="grabber_highlight" data_type="icon" type="Texture">
 			The texture for the grabber when it's focused.
 		</theme_item>
-		<theme_item name="slider" type="StyleBox">
+		<theme_item name="slider" data_type="style" type="StyleBox">
 			The background for the whole slider. Determines the width of the [code]grabber_area[/code].
 		</theme_item>
-		<theme_item name="tick" type="Texture">
+		<theme_item name="tick" data_type="icon" type="Texture">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/VSplitContainer.xml
+++ b/doc/classes/VSplitContainer.xml
@@ -13,15 +13,15 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="autohide" type="int" default="1">
+		<theme_item name="autohide" data_type="constant" type="int" default="1">
 			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
 		</theme_item>
-		<theme_item name="bg" type="StyleBox">
+		<theme_item name="bg" data_type="style" type="StyleBox">
 		</theme_item>
-		<theme_item name="grabber" type="Texture">
+		<theme_item name="grabber" data_type="icon" type="Texture">
 			The icon used for the grabber drawn in the middle area.
 		</theme_item>
-		<theme_item name="separation" type="int" default="12">
+		<theme_item name="separation" data_type="constant" type="int" default="12">
 			The space between sides of the container.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/WindowDialog.xml
+++ b/doc/classes/WindowDialog.xml
@@ -27,31 +27,31 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="close" type="Texture">
+		<theme_item name="close" data_type="icon" type="Texture">
 			The icon for the close button.
 		</theme_item>
-		<theme_item name="close_h_ofs" type="int" default="18">
+		<theme_item name="close_h_ofs" data_type="constant" type="int" default="18">
 			The horizontal offset of the close button.
 		</theme_item>
-		<theme_item name="close_highlight" type="Texture">
+		<theme_item name="close_highlight" data_type="icon" type="Texture">
 			The icon used for the close button when it's hovered with the mouse cursor.
 		</theme_item>
-		<theme_item name="close_v_ofs" type="int" default="18">
+		<theme_item name="close_v_ofs" data_type="constant" type="int" default="18">
 			The vertical offset of the close button.
 		</theme_item>
-		<theme_item name="panel" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style for both the content background of the [WindowDialog] and the title bar. The title bar is created with a top border and an expand margin using the [code]panel[/code] stylebox.
 		</theme_item>
-		<theme_item name="scaleborder_size" type="int" default="4">
+		<theme_item name="scaleborder_size" data_type="constant" type="int" default="4">
 			The thickness of the border that can be dragged when scaling the window (if [member resizable] is enabled).
 		</theme_item>
-		<theme_item name="title_color" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="title_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
 			The color of the title text.
 		</theme_item>
-		<theme_item name="title_font" type="Font">
+		<theme_item name="title_font" data_type="font" type="Font">
 			The font used to draw the title.
 		</theme_item>
-		<theme_item name="title_height" type="int" default="20">
+		<theme_item name="title_height" data_type="constant" type="int" default="20">
 			The vertical offset of the title text.
 		</theme_item>
 	</theme_items>

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -90,9 +90,13 @@ class EnumDef:
 
 
 class ThemeItemDef:
-    def __init__(self, name, type_name, default_value):  # type: (str, TypeName, Optional[str]) -> None
+    def __init__(
+        self, name, type_name, data_name, text, default_value
+    ):  # type: (str, TypeName, str, Optional[str], Optional[str]) -> None
         self.name = name
         self.type_name = type_name
+        self.data_name = data_name
+        self.text = text
         self.default_value = default_value
 
 
@@ -104,10 +108,10 @@ class ClassDef:
         self.properties = OrderedDict()  # type: OrderedDict[str, PropertyDef]
         self.methods = OrderedDict()  # type: OrderedDict[str, List[MethodDef]]
         self.signals = OrderedDict()  # type: OrderedDict[str, SignalDef]
+        self.theme_items = OrderedDict()  # type: OrderedDict[str, ThemeItemDef]
         self.inherits = None  # type: Optional[str]
         self.brief_description = None  # type: Optional[str]
         self.description = None  # type: Optional[str]
-        self.theme_items = None  # type: Optional[OrderedDict[str, List[ThemeItemDef]]]
         self.tutorials = []  # type: List[Tuple[str, str]]
 
         # Used to match the class with XML source for output filtering purposes.
@@ -240,16 +244,33 @@ class State:
 
         theme_items = class_root.find("theme_items")
         if theme_items is not None:
-            class_def.theme_items = OrderedDict()
             for theme_item in theme_items:
                 assert theme_item.tag == "theme_item"
 
                 theme_item_name = theme_item.attrib["name"]
+                theme_item_data_name = theme_item.attrib["data_type"]
+                theme_item_id = "{}_{}".format(theme_item_data_name, theme_item_name)
+                if theme_item_id in class_def.theme_items:
+                    print_error(
+                        "Duplicate theme property '{}' of type '{}', file: {}".format(
+                            theme_item_name, theme_item_data_name, class_name
+                        ),
+                        self,
+                    )
+                    continue
+
                 default_value = theme_item.get("default") or None
-                theme_item_def = ThemeItemDef(theme_item_name, TypeName.from_element(theme_item), default_value)
-                if theme_item_name not in class_def.theme_items:
-                    class_def.theme_items[theme_item_name] = []
-                class_def.theme_items[theme_item_name].append(theme_item_def)
+                if default_value is not None:
+                    default_value = "``{}``".format(default_value)
+
+                theme_item_def = ThemeItemDef(
+                    theme_item_name,
+                    TypeName.from_element(theme_item),
+                    theme_item_data_name,
+                    theme_item.text,
+                    default_value,
+                )
+                class_def.theme_items[theme_item_id] = theme_item_def
 
         tutorials = class_root.find("tutorials")
         if tutorials is not None:
@@ -458,12 +479,14 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
         format_table(f, ml)
 
     # Theme properties
-    if class_def.theme_items is not None and len(class_def.theme_items) > 0:
+    if len(class_def.theme_items) > 0:
         f.write(make_heading("Theme Properties", "-"))
         pl = []
-        for theme_item_list in class_def.theme_items.values():
-            for theme_item in theme_item_list:
-                pl.append((theme_item.type_name.to_rst(state), theme_item.name, theme_item.default_value))
+        for theme_item_def in class_def.theme_items.values():
+            ref = ":ref:`{0}<class_{2}_theme_{1}_{0}>`".format(
+                theme_item_def.name, theme_item_def.data_name, class_name
+            )
+            pl.append((theme_item_def.type_name.to_rst(state), ref, theme_item_def.default_value))
         format_table(f, pl, True)
 
     # Signals
@@ -577,6 +600,30 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
                     f.write(rstize_text(m.description.strip(), state) + "\n\n")
 
                 index += 1
+
+    # Theme property descriptions
+    if len(class_def.theme_items) > 0:
+        f.write(make_heading("Theme Property Descriptions", "-"))
+        index = 0
+
+        for theme_item_def in class_def.theme_items.values():
+            if index != 0:
+                f.write("----\n\n")
+
+            f.write(".. _class_{}_theme_{}_{}:\n\n".format(class_name, theme_item_def.data_name, theme_item_def.name))
+            f.write("- {} **{}**\n\n".format(theme_item_def.type_name.to_rst(state), theme_item_def.name))
+
+            info = []
+            if theme_item_def.default_value is not None:
+                info.append(("*Default*", theme_item_def.default_value))
+
+            if len(info) > 0:
+                format_table(f, info)
+
+            if theme_item_def.text is not None and theme_item_def.text.strip() != "":
+                f.write(rstize_text(theme_item_def.text.strip(), state) + "\n\n")
+
+            index += 1
 
     f.write(make_footer())
 

--- a/editor/doc/doc_data.h
+++ b/editor/doc/doc_data.h
@@ -79,6 +79,17 @@ public:
 		}
 	};
 
+	struct ThemeItemDoc {
+		String name;
+		String type;
+		String data_type;
+		String description;
+		String default_value;
+		bool operator<(const ThemeItemDoc &p_theme_item) const {
+			return name < p_theme_item.name;
+		}
+	};
+
 	struct TutorialDoc {
 		String link;
 		String title;
@@ -95,7 +106,7 @@ public:
 		Vector<MethodDoc> signals;
 		Vector<ConstantDoc> constants;
 		Vector<PropertyDoc> properties;
-		Vector<PropertyDoc> theme_properties;
+		Vector<ThemeItemDoc> theme_properties;
 	};
 
 	String version;

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -365,7 +365,7 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 			if (search_flags & SEARCH_THEME_ITEMS) {
 				for (int i = 0; i < class_doc.theme_properties.size(); i++) {
 					if (_match_string(term, class_doc.theme_properties[i].name)) {
-						match.theme_properties.push_back(const_cast<DocData::PropertyDoc *>(&class_doc.theme_properties[i]));
+						match.theme_properties.push_back(const_cast<DocData::ThemeItemDoc *>(&class_doc.theme_properties[i]));
 					}
 				}
 			}
@@ -557,7 +557,7 @@ TreeItem *EditorHelpSearch::Runner::_create_property_item(TreeItem *p_parent, co
 	return _create_member_item(p_parent, p_class_doc->name, "MemberProperty", p_doc->name, TTRC("Property"), "property", tooltip);
 }
 
-TreeItem *EditorHelpSearch::Runner::_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::PropertyDoc *p_doc) {
+TreeItem *EditorHelpSearch::Runner::_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ThemeItemDoc *p_doc) {
 	String tooltip = p_doc->type + " " + p_class_doc->name + "." + p_doc->name;
 	return _create_member_item(p_parent, p_class_doc->name, "MemberTheme", p_doc->name, TTRC("Theme Property"), "theme_item", tooltip);
 }

--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -103,7 +103,7 @@ class EditorHelpSearch::Runner : public Reference {
 		Vector<DocData::MethodDoc *> signals;
 		Vector<DocData::ConstantDoc *> constants;
 		Vector<DocData::PropertyDoc *> properties;
-		Vector<DocData::PropertyDoc *> theme_properties;
+		Vector<DocData::ThemeItemDoc *> theme_properties;
 
 		bool required() {
 			return name || methods.size() || signals.size() || constants.size() || properties.size() || theme_properties.size();
@@ -145,7 +145,7 @@ class EditorHelpSearch::Runner : public Reference {
 	TreeItem *_create_signal_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::MethodDoc *p_doc);
 	TreeItem *_create_constant_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ConstantDoc *p_doc);
 	TreeItem *_create_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::PropertyDoc *p_doc);
-	TreeItem *_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::PropertyDoc *p_doc);
+	TreeItem *_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ThemeItemDoc *p_doc);
 	TreeItem *_create_member_item(TreeItem *p_parent, const String &p_class_name, const String &p_icon, const String &p_name, const String &p_type, const String &p_metatype, const String &p_tooltip);
 
 public:

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -261,23 +261,29 @@ Error GDScriptWorkspace::initialize() {
 			class_symbol.children.push_back(symbol);
 		}
 
-		Vector<DocData::PropertyDoc> properties;
-		properties.append_array(class_data.properties);
-		const int theme_prop_start_idx = properties.size();
-		properties.append_array(class_data.theme_properties);
-
 		for (int i = 0; i < class_data.properties.size(); i++) {
 			const DocData::PropertyDoc &data = class_data.properties[i];
 			lsp::DocumentSymbol symbol;
 			symbol.name = data.name;
 			symbol.native_class = class_name;
 			symbol.kind = lsp::SymbolKind::Property;
-			symbol.detail = String(i >= theme_prop_start_idx ? "<Theme> var" : "var") + " " + class_name + "." + data.name;
+			symbol.detail = "var " + class_name + "." + data.name;
 			if (data.enumeration.length()) {
 				symbol.detail += ": " + data.enumeration;
 			} else {
 				symbol.detail += ": " + data.type;
 			}
+			symbol.documentation = data.description;
+			class_symbol.children.push_back(symbol);
+		}
+
+		for (int i = 0; i < class_data.theme_properties.size(); i++) {
+			const DocData::ThemeItemDoc &data = class_data.theme_properties[i];
+			lsp::DocumentSymbol symbol;
+			symbol.name = data.name;
+			symbol.native_class = class_name;
+			symbol.kind = lsp::SymbolKind::Property;
+			symbol.detail = "<Theme> var " + class_name + "." + data.name + ": " + data.type;
 			symbol.documentation = data.description;
 			class_symbol.children.push_back(symbol);
 		}


### PR DESCRIPTION
The `3.x` version of https://github.com/godotengine/godot/pull/51247. Didn't do the en dashes as we don't use them in this version and `U" – "` was giving me an error, so I decided not to use it.