### PR TITLE
Ensure MSBuildPanel buttons are instantiated

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -73,7 +73,7 @@ namespace GodotTools.Build
                 GD.PushError("Failed to setup Godot NuGet Offline Packages: " + e.Message);
             }
 
-            if (!BuildManager.BuildProjectBlocking("Debug", targets: new[] {"Rebuild"}))
+            if (!BuildManager.BuildProjectBlocking("Debug", targets: new[] { "Rebuild" }))
                 return; // Build failed
 
             // Notify running game for hot-reload
@@ -92,7 +92,7 @@ namespace GodotTools.Build
             if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
                 return; // No solution to build
 
-            BuildManager.BuildProjectBlocking("Debug", targets: new[] {"Clean"});
+            BuildManager.BuildProjectBlocking("Debug", targets: new[] { "Clean" });
         }
 
         private void ViewLogToggled(bool pressed) => BuildOutputView.LogVisible = pressed;
@@ -129,10 +129,10 @@ namespace GodotTools.Build
             RectMinSize = new Vector2(0, 228) * EditorScale;
             SizeFlagsVertical = (int)SizeFlags.ExpandFill;
 
-            var toolBarHBox = new HBoxContainer {SizeFlagsHorizontal = (int)SizeFlags.ExpandFill};
+            var toolBarHBox = new HBoxContainer { SizeFlagsHorizontal = (int)SizeFlags.ExpandFill };
             AddChild(toolBarHBox);
 
-            buildMenuBtn = new MenuButton {Text = "Build", Icon = GetThemeIcon("Play", "EditorIcons")};
+            buildMenuBtn = new MenuButton { Text = "Build", Icon = GetThemeIcon("Play", "EditorIcons") };
             toolBarHBox.AddChild(buildMenuBtn);
 
             var buildMenu = buildMenuBtn.GetPopup();
@@ -183,10 +183,14 @@ namespace GodotTools.Build
         {
             base._Notification(what);
 
-            if (what == NotificationThemeChanged) {
-                buildMenuBtn.Icon = GetThemeIcon("Play", "EditorIcons");
-                errorsBtn.Icon = GetThemeIcon("StatusError", "EditorIcons");
-                warningsBtn.Icon = GetThemeIcon("NodeWarning", "EditorIcons");
+            if (what == NotificationThemeChanged)
+            {
+                if (buildMenuBtn != null)
+                    buildMenuBtn.Icon = GetThemeIcon("Play", "EditorIcons");
+                if (errorsBtn != null)
+                    errorsBtn.Icon = GetThemeIcon("StatusError", "EditorIcons");
+                if (warningsBtn != null)
+                    warningsBtn.Icon = GetThemeIcon("NodeWarning", "EditorIcons");
             }
         }
     }


### PR DESCRIPTION
After #51220, `MSBuildPanel` was throwing a `NullReferenceException` on the `_Notification` method since the method can get called before the `_Ready` method where the buttons are instantiated so it was trying to set the icon of a null button. This PR initializes the panel in the constructor instead of using the `_Ready` method to make sure the buttons are never null.

An alternative implementation would be to leave the initialization in the `_Ready` method and check if the buttons are null in the `_Notification` method, but it doesn't seem like we need to wait for `_Ready` to do any of the initialization that `MSBuildPanel` does so it can be done in the constructor.

*Bugsquad edit:* Fixes #51344.