### PR TITLE
[3.x] Ensure MSBuildPanel buttons are instantiated

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -57,7 +57,7 @@ namespace GodotTools.Build
 
             BuildManager.GenerateEditorScriptMetadata();
 
-            if (!BuildManager.BuildProjectBlocking("Debug", targets: new[] {"Rebuild"}))
+            if (!BuildManager.BuildProjectBlocking("Debug", targets: new[] { "Rebuild" }))
                 return; // Build failed
 
             // Notify running game for hot-reload
@@ -76,7 +76,7 @@ namespace GodotTools.Build
             if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
                 return; // No solution to build
 
-            BuildManager.BuildProjectBlocking("Debug", targets: new[] {"Clean"});
+            BuildManager.BuildProjectBlocking("Debug", targets: new[] { "Clean" });
         }
 
         private void ViewLogToggled(bool pressed) => BuildOutputView.LogVisible = pressed;
@@ -113,10 +113,10 @@ namespace GodotTools.Build
             RectMinSize = new Vector2(0, 228) * EditorScale;
             SizeFlagsVertical = (int)SizeFlags.ExpandFill;
 
-            var toolBarHBox = new HBoxContainer {SizeFlagsHorizontal = (int)SizeFlags.ExpandFill};
+            var toolBarHBox = new HBoxContainer { SizeFlagsHorizontal = (int)SizeFlags.ExpandFill };
             AddChild(toolBarHBox);
 
-            buildMenuBtn = new MenuButton {Text = "Build", Icon = GetIcon("Play", "EditorIcons")};
+            buildMenuBtn = new MenuButton { Text = "Build", Icon = GetIcon("Play", "EditorIcons") };
             toolBarHBox.AddChild(buildMenuBtn);
 
             var buildMenu = buildMenuBtn.GetPopup();
@@ -167,10 +167,14 @@ namespace GodotTools.Build
         {
             base._Notification(what);
 
-            if (what == NotificationThemeChanged) {
-                buildMenuBtn.Icon = GetIcon("Play", "EditorIcons");
-                errorsBtn.Icon = GetIcon("StatusError", "EditorIcons");
-                warningsBtn.Icon = GetIcon("NodeWarning", "EditorIcons");
+            if (what == NotificationThemeChanged)
+            {
+                if (buildMenuBtn != null)
+                    buildMenuBtn.Icon = GetIcon("Play", "EditorIcons");
+                if (errorsBtn != null)
+                    errorsBtn.Icon = GetIcon("StatusError", "EditorIcons");
+                if (warningsBtn != null)
+                    warningsBtn.Icon = GetIcon("NodeWarning", "EditorIcons");
             }
         }
     }


### PR DESCRIPTION
`3.x` version of #51322

*Bugsquad edit:* Fixes #51344.