### PR TITLE
[3.x] TileMap Fix trying to get data for tile not existing in attached TileSet

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -353,7 +353,7 @@ void TileMapEditor::_set_cell(const Point2i &p_pos, Vector<int> p_values, bool p
 		return;
 	}
 
-	if (manual_autotile || (p_value != -1 && node->get_tileset()->tile_get_tile_mode(p_value) == TileSet::ATLAS_TILE)) {
+	if (manual_autotile || (p_value != -1 && node->get_tileset()->has_tile(p_value) && node->get_tileset()->tile_get_tile_mode(p_value) == TileSet::ATLAS_TILE)) {
 		if (current != -1) {
 			node->set_cell_autotile_coord(p_pos.x, p_pos.y, position);
 		} else if (node->get_tileset()->tile_get_tile_mode(p_value) == TileSet::ATLAS_TILE && priority_atlastile) {
@@ -542,7 +542,7 @@ void TileMapEditor::_update_palette() {
 		sel_tile = palette->get_selected_items().get(0);
 	}
 
-	if (sel_tile != TileMap::INVALID_CELL && ((manual_autotile && tileset->tile_get_tile_mode(sel_tile) == TileSet::AUTO_TILE) || (!priority_atlastile && tileset->tile_get_tile_mode(sel_tile) == TileSet::ATLAS_TILE))) {
+	if (sel_tile != TileMap::INVALID_CELL && tileset->has_tile(sel_tile) && ((manual_autotile && tileset->tile_get_tile_mode(sel_tile) == TileSet::AUTO_TILE) || (!priority_atlastile && tileset->tile_get_tile_mode(sel_tile) == TileSet::ATLAS_TILE))) {
 		const Map<Vector2, uint32_t> &tiles2 = tileset->autotile_get_bitmask_map(sel_tile);
 
 		Vector<Vector2> entries2;
@@ -592,7 +592,7 @@ void TileMapEditor::_update_palette() {
 		manual_palette->show();
 	}
 
-	if (sel_tile != TileMap::INVALID_CELL && tileset->tile_get_tile_mode(sel_tile) == TileSet::AUTO_TILE) {
+	if (sel_tile != TileMap::INVALID_CELL && tileset->has_tile(sel_tile) && tileset->tile_get_tile_mode(sel_tile) == TileSet::AUTO_TILE) {
 		manual_button->show();
 		priority_button->hide();
 	} else {
@@ -604,7 +604,7 @@ void TileMapEditor::_update_palette() {
 void TileMapEditor::_pick_tile(const Point2 &p_pos) {
 	int id = node->get_cell(p_pos.x, p_pos.y);
 
-	if (id == TileMap::INVALID_CELL) {
+	if (id == TileMap::INVALID_CELL || !node->get_tileset()->has_tile(id)) {
 		return;
 	}
 
@@ -800,8 +800,11 @@ void TileMapEditor::_erase_selection() {
 }
 
 void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Point2i &p_autotile_coord, const Transform2D &p_xform) {
-	Ref<Texture> t = node->get_tileset()->tile_get_texture(p_cell);
+	if (!node->get_tileset()->has_tile(p_cell)) {
+		return;
+	}
 
+	Ref<Texture> t = node->get_tileset()->tile_get_texture(p_cell);
 	if (t.is_null()) {
 		return;
 	}

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -398,8 +398,7 @@ void TileMap::update_dirty_quadrants() {
 			Ref<ShaderMaterial> mat = tile_set->tile_get_material(c.id);
 			int z_index = tile_set->tile_get_z_index(c.id);
 
-			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE ||
-					tile_set->tile_get_tile_mode(c.id) == TileSet::ATLAS_TILE) {
+			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE || tile_set->tile_get_tile_mode(c.id) == TileSet::ATLAS_TILE) {
 				z_index += tile_set->autotile_get_z_index(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
 			}
 
@@ -939,6 +938,9 @@ void TileMap::update_cell_bitmask(int p_x, int p_y) {
 	Map<PosKey, Cell>::Element *E = tile_map.find(p);
 	if (E != nullptr) {
 		int id = get_cell(p_x, p_y);
+		if (!tile_set->has_tile(id)) {
+			return;
+		}
 		if (tile_set->tile_get_tile_mode(id) == TileSet::AUTO_TILE) {
 			uint16_t mask = 0;
 			if (tile_set->autotile_get_bitmask_mode(id) == TileSet::BITMASK_2X2) {


### PR DESCRIPTION
Probably fixes (not sure as there's no minimal reproduction projects there): #29715, #43306.

I assume it's `3.x` only because of the `TileMap` rework.
Cherry-pickable `3.3`.

Example of fixed error:
1. Initial setup:
![Godot_v3 4-beta2_win64_tamXhhVzG1](https://user-images.githubusercontent.com/9283098/128545502-8778337d-35a3-4f20-9cb4-93ee6a4aaea3.png)
2. After removing tile from `TileSet`:
![Godot_v3 4-beta2_win64_95UfIyusTa](https://user-images.githubusercontent.com/9283098/128545505-218700ac-8ea4-45bf-89b9-10446330eb55.png)

3. Painting a single cell next to a cell with tile id non-existant in attached `TileSet`:
- `3.4.beta2`:
![Godot_v3 4-beta2_win64_vlTXcfX8rq](https://user-images.githubusercontent.com/9283098/128545506-49f31a75-0953-477a-8926-51dc0fd202bb.png)
- this PR:
![O1bkjSk26K](https://user-images.githubusercontent.com/9283098/128546644-9fc44251-2b31-4f31-bb46-ffb26837b93d.png)