### PR TITLE
Fix LSP completion crashing on scene-less scripts

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -431,9 +431,13 @@ void GDScriptTextDocument::sync_script_content(const String &p_path, const Strin
 	GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_script(path, p_content);
 
 	EditorFileSystem::get_singleton()->update_file(path);
-	Ref<GDScript> script = ResourceLoader::load(path);
-	script->load_source_code(path);
-	script->reload(true);
+	Error error;
+	Ref<GDScript> script = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &error);
+	if (error == OK) {
+		if (script->load_source_code(path) == OK) {
+			script->reload(true);
+		}
+	}
 }
 
 void GDScriptTextDocument::show_native_symbol_in_editor(const String &p_symbol_id) {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -523,22 +523,24 @@ void GDScriptWorkspace::completion(const lsp::CompletionParams &p_params, List<S
 
 		Array stack;
 		Node *current = nullptr;
-		stack.push_back(owner_scene_node);
+		if (owner_scene_node != nullptr) {
+			stack.push_back(owner_scene_node);
 
-		while (!stack.is_empty()) {
-			current = stack.pop_back();
+			while (!stack.is_empty()) {
+				current = stack.pop_back();
+				Ref<GDScript> script = current->get_script();
+				if (script.is_valid() && script->get_path() == path) {
+					break;
+				}
+				for (int i = 0; i < current->get_child_count(); ++i) {
+					stack.push_back(current->get_child(i));
+				}
+			}
+
 			Ref<GDScript> script = current->get_script();
-			if (script.is_valid() && script->get_path() == path) {
-				break;
+			if (!script.is_valid() || script->get_path() != path) {
+				current = owner_scene_node;
 			}
-			for (int i = 0; i < current->get_child_count(); ++i) {
-				stack.push_back(current->get_child(i));
-			}
-		}
-
-		Ref<GDScript> script = current->get_script();
-		if (!script.is_valid() || script->get_path() != path) {
-			current = owner_scene_node;
 		}
 
 		String code = parser->get_text_for_completion(p_params.position);


### PR DESCRIPTION
Fixes #51331 . While the issue points to Godot 3.x, it's also there in 4.0, so I'm issuing this for 4.0 ~~and we can cherrypick it back into 3.x.~~ #51333 added for 3.x

Also adds checks to prevent crashes when the script cannot be loaded or is not part of the project.