### PR TITLE
[3.x] Fix LSP completion crashing on scene-less scripts

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -425,9 +425,13 @@ void GDScriptTextDocument::sync_script_content(const String &p_path, const Strin
 	GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_script(path, p_content);
 
 	EditorFileSystem::get_singleton()->update_file(path);
-	Ref<GDScript> script = ResourceLoader::load(path);
-	script->load_source_code(path);
-	script->reload(true);
+	Error error;
+	Ref<GDScript> script = ResourceLoader::load(path, "", false, &error);
+	if (error == OK) {
+		if (script->load_source_code(path) == OK) {
+			script->reload(true);
+		}
+	}
 }
 
 void GDScriptTextDocument::show_native_symbol_in_editor(const String &p_symbol_id) {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -517,22 +517,24 @@ void GDScriptWorkspace::completion(const lsp::CompletionParams &p_params, List<S
 
 		Array stack;
 		Node *current = nullptr;
-		stack.push_back(owner_scene_node);
 
-		while (!stack.empty()) {
-			current = stack.pop_back();
+		if (owner_scene_node) {
+			stack.push_back(owner_scene_node);
+			while (!stack.empty()) {
+				current = stack.pop_back();
+				Ref<GDScript> script = current->get_script();
+				if (script.is_valid() && script->get_path() == path) {
+					break;
+				}
+				for (int i = 0; i < current->get_child_count(); ++i) {
+					stack.push_back(current->get_child(i));
+				}
+			}
+
 			Ref<GDScript> script = current->get_script();
-			if (script.is_valid() && script->get_path() == path) {
-				break;
+			if (!script.is_valid() || script->get_path() != path) {
+				current = owner_scene_node;
 			}
-			for (int i = 0; i < current->get_child_count(); ++i) {
-				stack.push_back(current->get_child(i));
-			}
-		}
-
-		Ref<GDScript> script = current->get_script();
-		if (!script.is_valid() || script->get_path() != path) {
-			current = owner_scene_node;
 		}
 
 		String code = parser->get_text_for_completion(p_params.position);


### PR DESCRIPTION
Companion PR for #51332, since `ResourceLoader::load()` has a different interface from 4.0's version.

*Bugsquad edit:* Fixes regression from #51283.