### PR TITLE
[3.x] Improve `Control`'s theme item methods documentation

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -89,16 +89,14 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="color" type="Color" />
 			<description>
-				Overrides the [Color] with given [code]name[/code] in the [member theme] resource the control uses.
-				[b]Note:[/b] Unlike other theme overrides, there is no way to undo a color override without manually assigning the previous color.
+				Creates a local override for a theme [Color] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override cannot be removed, but it can be overridden with the corresponding default value.
+				See also [method get_color].
 				[b]Example of overriding a label's color and resetting it later:[/b]
 				[codeblock]
-				# Override the child node "MyLabel"'s font color to orange.
+				# Given the child Label node "MyLabel", override its font color with a custom value.
 				$MyLabel.add_color_override("font_color", Color(1, 0.5, 0))
-
-				# Reset the color by creating a new node to get the default value:
-				var default_label_color = Label.new().get_color("font_color")
-				$MyLabel.add_color_override("font_color", default_label_color)
+				# Reset the font color of the child label.
+				$MyLabel.add_color_override("font_color", get_color("font_color", "Label"))
 				[/codeblock]
 			</description>
 		</method>
@@ -107,7 +105,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="constant" type="int" />
 			<description>
-				Overrides an integer constant with given [code]name[/code] in the [member theme] resource the control uses. If the [code]constant[/code] is [code]0[/code], the override is cleared and the constant from assigned [Theme] is used.
+				Creates a local override for a theme constant with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override cannot be removed, but it can be overridden with the corresponding default value.
+				See also [method get_constant].
 			</description>
 		</method>
 		<method name="add_font_override">
@@ -115,7 +114,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="font" type="Font" />
 			<description>
-				Overrides the font with given [code]name[/code] in the [member theme] resource the control uses. If [code]font[/code] is [code]null[/code] or invalid, the override is cleared and the font from assigned [Theme] is used.
+				Creates a local override for a theme [Font] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed by assigning it a [code]null[/code] value.
+				See also [method get_font].
 			</description>
 		</method>
 		<method name="add_icon_override">
@@ -123,7 +123,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="texture" type="Texture" />
 			<description>
-				Overrides the icon with given [code]name[/code] in the [member theme] resource the control uses. If [code]icon[/code] is [code]null[/code] or invalid, the override is cleared and the icon from assigned [Theme] is used.
+				Creates a local override for a theme icon with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed by assigning it a [code]null[/code] value.
+				See also [method get_icon].
 			</description>
 		</method>
 		<method name="add_shader_override">
@@ -131,7 +132,7 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="shader" type="Shader" />
 			<description>
-				Overrides the [Shader] with given [code]name[/code] in the [member theme] resource the control uses. If [code]shader[/code] is [code]null[/code] or invalid, the override is cleared and the shader from assigned [Theme] is used.
+				Creates a local override for a theme shader with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed by assigning it a [code]null[/code] value.
 			</description>
 		</method>
 		<method name="add_stylebox_override">
@@ -139,7 +140,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="stylebox" type="StyleBox" />
 			<description>
-				Overrides the [StyleBox] with given [code]name[/code] in the [member theme] resource the control uses. If [code]stylebox[/code] is empty or invalid, the override is cleared and the [StyleBox] from assigned [Theme] is used.
+				Creates a local override for a theme [StyleBox] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed by assigning it a [code]null[/code] value.
+				See also [method get_stylebox].
 				[b]Example of modifying a property in a StyleBox by duplicating it:[/b]
 				[codeblock]
 				# The snippet below assumes the child node MyButton has a StyleBoxFlat assigned.
@@ -149,8 +151,7 @@
 				new_stylebox_normal.border_width_top = 3
 				new_stylebox_normal.border_color = Color(0, 1, 0.5)
 				$MyButton.add_stylebox_override("normal", new_stylebox_normal)
-
-				# Remove the stylebox override:
+				# Remove the stylebox override.
 				$MyButton.add_stylebox_override("normal", null)
 				[/codeblock]
 			</description>
@@ -222,12 +223,16 @@
 		<method name="get_color" qualifiers="const">
 			<return type="Color" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns a color from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
+				Returns a [Color] from the first matching [Theme] in the tree if that [Theme] has a color item with the specified [code]name[/code] and [code]theme_type[/code]. If [code]theme_type[/code] is omitted the class name of the current control is used as the type. If the type is a class name its parent classes are also checked, in order of inheritance.
+				For the current control its local overrides are considered first (see [method add_color_override]), then its assigned [member theme]. After the current control, each parent control and its assigned [member theme] are considered; controls without a [member theme] assigned are skipped. If no matching [Theme] is found in the tree, a custom project [Theme] (see [member ProjectSettings.gui/theme/custom]) and the default [Theme] are used.
 				[codeblock]
 				func _ready():
-				    modulate = get_color("font_color", "Button") #get the color defined for button fonts
+				    # Get the font color defined for the current Control's class, if it exists.
+				    modulate = get_color("font_color")
+				    # Get the font color defined for the Button class.
+				    modulate = get_color("font_color", "Button")
 				[/codeblock]
 			</description>
 		</method>
@@ -240,9 +245,10 @@
 		<method name="get_constant" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns a constant from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
+				Returns a constant from the first matching [Theme] in the tree if that [Theme] has a constant item with the specified [code]name[/code] and [code]theme_type[/code].
+				See [method get_color] for details.
 			</description>
 		</method>
 		<method name="get_cursor_shape" qualifiers="const">
@@ -288,9 +294,10 @@
 		<method name="get_font" qualifiers="const">
 			<return type="Font" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns a font from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
+				Returns a [Font] from the first matching [Theme] in the tree if that [Theme] has a font item with the specified [code]name[/code] and [code]theme_type[/code].
+				See [method get_color] for details.
 			</description>
 		</method>
 		<method name="get_global_rect" qualifiers="const">
@@ -302,9 +309,10 @@
 		<method name="get_icon" qualifiers="const">
 			<return type="Texture" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns an icon from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
+				Returns an icon from the first matching [Theme] in the tree if that [Theme] has an icon item with the specified [code]name[/code] and [code]theme_type[/code].
+				See [method get_color] for details.
 			</description>
 		</method>
 		<method name="get_margin" qualifiers="const">
@@ -347,9 +355,10 @@
 		<method name="get_stylebox" qualifiers="const">
 			<return type="StyleBox" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns a [StyleBox] from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
+				Returns a [StyleBox] from the first matching [Theme] in the tree if that [Theme] has a stylebox item with the specified [code]name[/code] and [code]theme_type[/code].
+				See [method get_color] for details.
 			</description>
 		</method>
 		<method name="get_tooltip" qualifiers="const">
@@ -378,31 +387,35 @@
 		<method name="has_color" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if [Color] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a color item with the specified [code]name[/code] and [code]theme_type[/code].
+				See [method get_color] for details.
 			</description>
 		</method>
 		<method name="has_color_override" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if [Color] with given [code]name[/code] has a valid override in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme [Color] with the specified [code]name[/code] in this [Control] node.
+				See [method add_color_override].
 			</description>
 		</method>
 		<method name="has_constant" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if constant with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a constant item with the specified [code]name[/code] and [code]theme_type[/code].
+				See [method get_color] for details.
 			</description>
 		</method>
 		<method name="has_constant_override" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if constant with given [code]name[/code] has a valid override in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme constant with the specified [code]name[/code] in this [Control] node.
+				See [method add_constant_override].
 			</description>
 		</method>
 		<method name="has_focus" qualifiers="const">
@@ -414,31 +427,35 @@
 		<method name="has_font" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if font with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a font item with the specified [code]name[/code] and [code]theme_type[/code].
+				See [method get_color] for details.
 			</description>
 		</method>
 		<method name="has_font_override" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if font with given [code]name[/code] has a valid override in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme [Font] with the specified [code]name[/code] in this [Control] node.
+				See [method add_font_override].
 			</description>
 		</method>
 		<method name="has_icon" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if icon with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has an icon item with the specified [code]name[/code] and [code]theme_type[/code].
+				See [method get_color] for details.
 			</description>
 		</method>
 		<method name="has_icon_override" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if icon with given [code]name[/code] has a valid override in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme icon with the specified [code]name[/code] in this [Control] node.
+				See [method add_icon_override].
 			</description>
 		</method>
 		<method name="has_point" qualifiers="virtual">
@@ -454,22 +471,25 @@
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if [Shader] with given [code]name[/code] has a valid override in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme shader with the specified [code]name[/code] in this [Control] node.
+				See [method add_shader_override].
 			</description>
 		</method>
 		<method name="has_stylebox" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="node_type" type="String" default="&quot;&quot;" />
+			<argument index="1" name="theme_type" type="String" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if [StyleBox] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a stylebox item with the specified [code]name[/code] and [code]theme_type[/code].
+				See [method get_color] for details.
 			</description>
 		</method>
 		<method name="has_stylebox_override" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if [StyleBox] with given [code]name[/code] has a valid override in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme [StyleBox] with the specified [code]name[/code] in this [Control] node.
+				See [method add_stylebox_override].
 			</description>
 		</method>
 		<method name="minimum_size_changed">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -785,15 +785,15 @@ Size2 Control::get_minimum_size() const {
 	return Size2();
 }
 
-Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		const Ref<Texture> *tex = data.icon_override.getptr(p_name);
 		if (tex) {
 			return *tex;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -827,15 +827,15 @@ Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_nod
 	return Theme::get_default()->get_icon(p_name, type);
 }
 
-Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		const Ref<Shader> *sdr = data.shader_override.getptr(p_name);
 		if (sdr) {
 			return *sdr;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -869,15 +869,15 @@ Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_no
 	return Theme::get_default()->get_shader(p_name, type);
 }
 
-Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		const Ref<StyleBox> *style = data.style_override.getptr(p_name);
 		if (style) {
 			return *style;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -917,15 +917,15 @@ Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &
 	}
 	return Theme::get_default()->get_stylebox(p_name, type);
 }
-Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		const Ref<Font> *font = data.font_override.getptr(p_name);
 		if (font) {
 			return *font;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -955,15 +955,15 @@ Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_node_t
 
 	return Theme::get_default()->get_font(p_name, type);
 }
-Color Control::get_color(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+Color Control::get_color(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		const Color *color = data.color_override.getptr(p_name);
 		if (color) {
 			return *color;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -996,15 +996,15 @@ Color Control::get_color(const StringName &p_name, const StringName &p_node_type
 	return Theme::get_default()->get_color(p_name, type);
 }
 
-int Control::get_constant(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+int Control::get_constant(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		const int *constant = data.constant_override.getptr(p_name);
 		if (constant) {
 			return *constant;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1067,14 +1067,14 @@ bool Control::has_constant_override(const StringName &p_name) const {
 	return constant != nullptr;
 }
 
-bool Control::has_icon(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+bool Control::has_icon(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		if (has_icon_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1106,14 +1106,14 @@ bool Control::has_icon(const StringName &p_name, const StringName &p_node_type) 
 	return Theme::get_default()->has_icon(p_name, type);
 }
 
-bool Control::has_shader(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+bool Control::has_shader(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		if (has_shader_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1144,14 +1144,14 @@ bool Control::has_shader(const StringName &p_name, const StringName &p_node_type
 	}
 	return Theme::get_default()->has_shader(p_name, type);
 }
-bool Control::has_stylebox(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+bool Control::has_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		if (has_stylebox_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1182,14 +1182,14 @@ bool Control::has_stylebox(const StringName &p_name, const StringName &p_node_ty
 	}
 	return Theme::get_default()->has_stylebox(p_name, type);
 }
-bool Control::has_font(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+bool Control::has_font(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		if (has_font_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1221,14 +1221,14 @@ bool Control::has_font(const StringName &p_name, const StringName &p_node_type) 
 	return Theme::get_default()->has_font(p_name, type);
 }
 
-bool Control::has_color(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+bool Control::has_color(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		if (has_color_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1260,14 +1260,14 @@ bool Control::has_color(const StringName &p_name, const StringName &p_node_type)
 	return Theme::get_default()->has_color(p_name, type);
 }
 
-bool Control::has_constant(const StringName &p_name, const StringName &p_node_type) const {
-	if (p_node_type == StringName() || p_node_type == get_class_name()) {
+bool Control::has_constant(const StringName &p_name, const StringName &p_theme_type) const {
+	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
 		if (has_constant_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_node_type ? p_node_type : get_class_name();
+	StringName type = p_theme_type ? p_theme_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -2774,11 +2774,11 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_color_override", "name", "color"), &Control::add_color_override);
 	ClassDB::bind_method(D_METHOD("add_constant_override", "name", "constant"), &Control::add_constant_override);
 
-	ClassDB::bind_method(D_METHOD("get_icon", "name", "node_type"), &Control::get_icon, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "node_type"), &Control::get_stylebox, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_font", "name", "node_type"), &Control::get_font, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_color", "name", "node_type"), &Control::get_color, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_constant", "name", "node_type"), &Control::get_constant, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_icon", "name", "theme_type"), &Control::get_icon, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "theme_type"), &Control::get_stylebox, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_font", "name", "theme_type"), &Control::get_font, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_color", "name", "theme_type"), &Control::get_color, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_constant", "name", "theme_type"), &Control::get_constant, DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("has_icon_override", "name"), &Control::has_icon_override);
 	ClassDB::bind_method(D_METHOD("has_shader_override", "name"), &Control::has_shader_override);
@@ -2787,11 +2787,11 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_color_override", "name"), &Control::has_color_override);
 	ClassDB::bind_method(D_METHOD("has_constant_override", "name"), &Control::has_constant_override);
 
-	ClassDB::bind_method(D_METHOD("has_icon", "name", "node_type"), &Control::has_icon, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "node_type"), &Control::has_stylebox, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("has_font", "name", "node_type"), &Control::has_font, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("has_color", "name", "node_type"), &Control::has_color, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("has_constant", "name", "node_type"), &Control::has_constant, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_icon", "name", "theme_type"), &Control::has_icon, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "theme_type"), &Control::has_stylebox, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_font", "name", "theme_type"), &Control::has_font, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_color", "name", "theme_type"), &Control::has_color, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_constant", "name", "theme_type"), &Control::has_constant, DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("get_parent_control"), &Control::get_parent_control);
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -425,12 +425,12 @@ public:
 	void add_color_override(const StringName &p_name, const Color &p_color);
 	void add_constant_override(const StringName &p_name, int p_constant);
 
-	Ref<Texture> get_icon(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	Ref<Font> get_font(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	Color get_color(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	int get_constant(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	Ref<Texture> get_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	Ref<Font> get_font(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	Color get_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	int get_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 
 	bool has_icon_override(const StringName &p_name) const;
 	bool has_shader_override(const StringName &p_name) const;
@@ -439,12 +439,12 @@ public:
 	bool has_color_override(const StringName &p_name) const;
 	bool has_constant_override(const StringName &p_name) const;
 
-	bool has_icon(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	bool has_shader(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	bool has_stylebox(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	bool has_font(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	bool has_color(const StringName &p_name, const StringName &p_node_type = StringName()) const;
-	bool has_constant(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	bool has_shader(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	bool has_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	bool has_font(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	bool has_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	bool has_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 
 	/* TOOLTIP */
 


### PR DESCRIPTION
An adapted backport of https://github.com/godotengine/godot/pull/50429. We don't have `remove_*_overrides` and as such some descriptions had to be adjusted.