### PR TITLE
Improvements to SpotLight3D and OmniLight3D's shadows

### DIFF
--- a/doc/classes/DirectionalLight3D.xml
+++ b/doc/classes/DirectionalLight3D.xml
@@ -36,7 +36,7 @@
 		<member name="directional_shadow_split_3" type="float" setter="set_param" getter="get_param" default="0.5">
 			The distance from shadow split 2 to split 3. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [code]SHADOW_PARALLEL_4_SPLITS[/code].
 		</member>
-		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" override="true" default="1.0" />
+		<member name="shadow_bias" type="float" setter="set_param" getter="get_param" override="true" default="0.1" />
 		<member name="use_in_sky_only" type="bool" setter="set_sky_only" getter="is_sky_only" default="false">
 			If [code]true[/code], this [DirectionalLight3D] will not be used for anything except sky shaders. Use this for lights that impact your sky shader that you may want to hide from affecting the rest of the scene. For example, you may want to enable this when the sun in your sky shader falls below the horizon.
 		</member>

--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -61,7 +61,7 @@
 		<member name="light_specular" type="float" setter="set_param" getter="get_param" default="0.5">
 			The intensity of the specular blob in objects affected by the light. At [code]0[/code], the light becomes a pure diffuse light. When not baking emission, this can be used to avoid unrealistic reflections when placing lights above an emissive surface.
 		</member>
-		<member name="shadow_bias" type="float" setter="set_param" getter="get_param" default="0.1">
+		<member name="shadow_bias" type="float" setter="set_param" getter="get_param" default="0.2">
 			Used to adjust shadow appearance. Too small a value results in self-shadowing ("shadow acne"), while too large a value causes shadows to separate from casters ("peter-panning"). Adjust as needed.
 		</member>
 		<member name="shadow_blur" type="float" setter="set_param" getter="get_param" default="1.0">
@@ -75,7 +75,7 @@
 		</member>
 		<member name="shadow_fog_fade" type="float" setter="set_param" getter="get_param" default="0.1">
 		</member>
-		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" default="2.0">
+		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" default="1.0">
 			Offsets the lookup into the shadow map by the object's normal. This can be used to reduce self-shadowing artifacts without using [member shadow_bias]. In practice, this value should be tweaked along with [member shadow_bias] to reduce artifacts as much as possible.
 		</member>
 		<member name="shadow_reverse_cull_face" type="bool" setter="set_shadow_reverse_cull_face" getter="get_shadow_reverse_cull_face" default="false">

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -212,10 +212,6 @@ void Light3D::_validate_property(PropertyInfo &property) const {
 		property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (get_light_type() == RS::LIGHT_SPOT && property.name == "shadow_normal_bias") {
-		property.usage = PROPERTY_USAGE_NONE;
-	}
-
 	if (get_light_type() == RS::LIGHT_DIRECTIONAL && property.name == "light_projector") {
 		property.usage = PROPERTY_USAGE_NONE;
 	}
@@ -425,9 +421,7 @@ DirectionalLight3D::DirectionalLight3D() :
 	set_param(PARAM_SHADOW_MAX_DISTANCE, 100);
 	set_param(PARAM_SHADOW_FADE_START, 0.8);
 	// Increase the default shadow bias to better suit most scenes.
-	// Leave normal bias untouched as it doesn't benefit DirectionalLight3D as much as OmniLight3D.
 	set_param(PARAM_SHADOW_BIAS, 0.1);
-	set_param(PARAM_SHADOW_NORMAL_BIAS, 1.0);
 	set_shadow_mode(SHADOW_PARALLEL_4_SPLITS);
 	blend_splits = false;
 }
@@ -468,8 +462,7 @@ OmniLight3D::OmniLight3D() :
 		Light3D(RenderingServer::LIGHT_OMNI) {
 	set_shadow_mode(SHADOW_CUBE);
 	// Increase the default shadow biases to better suit most scenes.
-	set_param(PARAM_SHADOW_BIAS, 0.1);
-	set_param(PARAM_SHADOW_NORMAL_BIAS, 2.0);
+	set_param(PARAM_SHADOW_BIAS, 0.2);
 }
 
 TypedArray<String> SpotLight3D::get_configuration_warnings() const {

--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -759,7 +759,7 @@ void EffectsRD::make_mipmap_raster(RID p_source_rd_texture, RID p_dest_framebuff
 	RD::get_singleton()->draw_list_end();
 }
 
-void EffectsRD::copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, float p_z_near, float p_z_far, bool p_dp_flip) {
+void EffectsRD::copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, float p_z_near, float p_z_far, bool p_dp_flip) {
 	CopyToDPPushConstant push_constant;
 	push_constant.screen_rect[0] = p_rect.position.x;
 	push_constant.screen_rect[1] = p_rect.position.y;
@@ -767,7 +767,9 @@ void EffectsRD::copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffe
 	push_constant.screen_rect[3] = p_rect.size.height;
 	push_constant.z_far = p_z_far;
 	push_constant.z_near = p_z_near;
-	push_constant.z_flip = p_dp_flip;
+	push_constant.texel_size[0] = 1.0f / p_dst_size.x;
+	push_constant.texel_size[1] = 1.0f / p_dst_size.y;
+	push_constant.texel_size[0] *= p_dp_flip ? -1.0f : 1.0f; // Encode dp flip as x size sign
 
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_dst_framebuffer, RD::INITIAL_ACTION_DROP, RD::FINAL_ACTION_DISCARD, RD::INITIAL_ACTION_KEEP, RD::FINAL_ACTION_READ);
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, cube_to_dp.pipeline.get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dst_framebuffer)));

--- a/servers/rendering/renderer_rd/effects_rd.h
+++ b/servers/rendering/renderer_rd/effects_rd.h
@@ -321,8 +321,7 @@ private:
 	struct CopyToDPPushConstant {
 		float z_far;
 		float z_near;
-		uint32_t z_flip;
-		uint32_t pad;
+		float texel_size[2];
 		float screen_rect[4];
 	};
 
@@ -770,7 +769,7 @@ public:
 	void cubemap_roughness_raster(RID p_source_rd_texture, RID p_dest_framebuffer, uint32_t p_face_id, uint32_t p_sample_count, float p_roughness, float p_size);
 	void make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const Size2i &p_size);
 	void make_mipmap_raster(RID p_source_rd_texture, RID p_dest_framebuffer, const Size2i &p_size);
-	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dest_texture, const Rect2 &p_rect, float p_z_near, float p_z_far, bool p_dp_flip);
+	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, float p_z_near, float p_z_far, bool p_dp_flip);
 	void luminance_reduction(RID p_source_texture, const Size2i p_source_size, const Vector<RID> p_reduce, RID p_prev_luminance, float p_min_luminance, float p_max_luminance, float p_adjust, bool p_set = false);
 	void luminance_reduction_raster(RID p_source_texture, const Size2i p_source_size, const Vector<RID> p_reduce, Vector<RID> p_fb, RID p_prev_luminance, float p_min_luminance, float p_max_luminance, float p_adjust, bool p_set = false);
 

--- a/servers/rendering/renderer_rd/shaders/cube_to_dp.glsl
+++ b/servers/rendering/renderer_rd/shaders/cube_to_dp.glsl
@@ -7,8 +7,7 @@
 layout(push_constant, binding = 1, std430) uniform Params {
 	float z_far;
 	float z_near;
-	bool z_flip;
-	uint pad;
+	vec2 texel_size;
 	vec4 screen_rect;
 }
 params;
@@ -35,22 +34,23 @@ layout(set = 0, binding = 0) uniform samplerCube source_cube;
 layout(push_constant, binding = 1, std430) uniform Params {
 	float z_far;
 	float z_near;
-	bool z_flip;
-	uint pad;
+	vec2 texel_size;
 	vec4 screen_rect;
 }
 params;
 
 void main() {
 	vec2 uv = uv_interp;
+	vec2 texel_size = abs(params.texel_size);
+
+	uv = clamp(uv * (1.0 + 2.0 * texel_size) - texel_size, vec2(0.0), vec2(1.0));
 
 	vec3 normal = vec3(uv * 2.0 - 1.0, 0.0);
-
-	normal.z = 0.5 - 0.5 * ((normal.x * normal.x) + (normal.y * normal.y));
+	normal.z = 0.5 * (1.0 - dot(normal.xy, normal.xy)); // z = 1/2 - 1/2 * (x^2 + y^2)
 	normal = normalize(normal);
 
 	normal.y = -normal.y; //needs to be flipped to match projection matrix
-	if (!params.z_flip) {
+	if (params.texel_size.x >= 0.0) { // Sign is used to encode Z flip
 		normal.z = -normal.z;
 	}
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -1601,7 +1601,7 @@ void main() {
 					continue; // Statically baked light and object uses lightmap, skip
 				}
 
-				float shadow = light_process_omni_shadow(light_index, vertex, view);
+				float shadow = light_process_omni_shadow(light_index, vertex, normal);
 
 				shadow = blur_shadow(shadow);
 
@@ -1677,7 +1677,7 @@ void main() {
 					continue; // Statically baked light and object uses lightmap, skip
 				}
 
-				float shadow = light_process_spot_shadow(light_index, vertex, view);
+				float shadow = light_process_spot_shadow(light_index, vertex, normal);
 
 				shadow = blur_shadow(shadow);
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -279,7 +279,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, float atte
 	}
 
 #ifdef USE_SHADOW_TO_OPACITY
-	alpha = min(alpha, clamp(1.0 - attenuation), 0.0, 1.0));
+	alpha = min(alpha, clamp(1.0 - attenuation, 0.0, 1.0));
 #endif
 
 #endif //defined(LIGHT_CODE_USED)
@@ -320,7 +320,7 @@ float sample_directional_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, ve
 	return avg * (1.0 / float(sc_directional_soft_shadow_samples));
 }
 
-float sample_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec4 coord) {
+float sample_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec3 coord) {
 	vec2 pos = coord.xy;
 	float depth = coord.z;
 
@@ -341,6 +341,49 @@ float sample_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec4 coord) {
 
 	for (uint i = 0; i < sc_soft_shadow_samples; i++) {
 		avg += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos + shadow_pixel_size * (disk_rotation * scene_data.soft_shadow_kernel[i].xy), depth, 1.0));
+	}
+
+	return avg * (1.0 / float(sc_soft_shadow_samples));
+}
+
+float sample_omni_pcf_shadow(texture2D shadow, float blur_scale, vec2 coord, vec4 uv_rect, vec2 flip_offset, float depth) {
+	//if only one sample is taken, take it from the center
+	if (sc_soft_shadow_samples == 1) {
+		vec2 pos = coord * 0.5 + 0.5;
+		pos = uv_rect.xy + pos * uv_rect.zw;
+		return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
+	}
+
+	mat2 disk_rotation;
+	{
+		float r = quick_hash(gl_FragCoord.xy) * 2.0 * M_PI;
+		float sr = sin(r);
+		float cr = cos(r);
+		disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
+	}
+
+	float avg = 0.0;
+	vec2 offset_scale = blur_scale * 2.0 * scene_data.shadow_atlas_pixel_size / uv_rect.zw;
+
+	for (uint i = 0; i < sc_soft_shadow_samples; i++) {
+		vec2 offset = offset_scale * (disk_rotation * scene_data.soft_shadow_kernel[i].xy);
+		vec2 sample_coord = coord + offset;
+
+		float sample_coord_length_sqaured = dot(sample_coord, sample_coord);
+		bool do_flip = sample_coord_length_sqaured > 1.0;
+
+		if (do_flip) {
+			float len = sqrt(sample_coord_length_sqaured);
+			sample_coord = sample_coord * (2.0 / len - 1.0);
+		}
+
+		sample_coord = sample_coord * 0.5 + 0.5;
+		sample_coord = uv_rect.xy + sample_coord * uv_rect.zw;
+
+		if (do_flip) {
+			sample_coord += flip_offset;
+		}
+		avg += textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(sample_coord, depth, 1.0));
 	}
 
 	return avg * (1.0 / float(sc_soft_shadow_samples));
@@ -403,15 +446,21 @@ float light_process_omni_shadow(uint idx, vec3 vertex, vec3 normal) {
 #ifndef USE_NO_SHADOWS
 	if (omni_lights.data[idx].shadow_enabled) {
 		// there is a shadowmap
+		vec2 texel_size = scene_data.shadow_atlas_pixel_size;
+		vec4 base_uv_rect = omni_lights.data[idx].atlas_rect;
+		base_uv_rect.xy += texel_size;
+		base_uv_rect.zw -= texel_size * 2.0;
 
-		vec3 light_rel_vec = omni_lights.data[idx].position - vertex;
-		float light_length = length(light_rel_vec);
+		// Omni lights use direction.xy to store to store the offset between the two paraboloid regions
+		vec2 flip_offset = omni_lights.data[idx].direction.xy;
 
-		vec4 v = vec4(vertex, 1.0);
+		vec3 local_vert = (omni_lights.data[idx].shadow_matrix * vec4(vertex, 1.0)).xyz;
 
-		vec4 splane = (omni_lights.data[idx].shadow_matrix * v);
+		float shadow_len = length(local_vert); //need to remember shadow len from here
+		vec3 shadow_dir = normalize(local_vert);
 
-		float shadow_len = length(splane.xyz); //need to remember shadow len from here
+		vec3 local_normal = normalize(mat3(omni_lights.data[idx].shadow_matrix) * normal);
+		vec3 normal_bias = local_normal * omni_lights.data[idx].shadow_normal_bias * (1.0 - abs(dot(local_normal, shadow_dir)));
 
 		float shadow;
 
@@ -431,10 +480,10 @@ float light_process_omni_shadow(uint idx, vec3 vertex, vec3 normal) {
 				disk_rotation = mat2(vec2(cr, -sr), vec2(sr, cr));
 			}
 
-			vec3 normal = normalize(splane.xyz);
-			vec3 v0 = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(0.0, 1.0, 0.0);
-			vec3 tangent = normalize(cross(v0, normal));
-			vec3 bitangent = normalize(cross(tangent, normal));
+			vec3 basis_normal = shadow_dir;
+			vec3 v0 = abs(basis_normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(0.0, 1.0, 0.0);
+			vec3 tangent = normalize(cross(v0, basis_normal));
+			vec3 bitangent = normalize(cross(tangent, basis_normal));
 			float z_norm = shadow_len * omni_lights.data[idx].inv_radius;
 
 			tangent *= omni_lights.data[idx].soft_shadow_size * omni_lights.data[idx].soft_shadow_scale;
@@ -443,18 +492,17 @@ float light_process_omni_shadow(uint idx, vec3 vertex, vec3 normal) {
 			for (uint i = 0; i < sc_penumbra_shadow_samples; i++) {
 				vec2 disk = disk_rotation * scene_data.penumbra_shadow_kernel[i].xy;
 
-				vec3 pos = splane.xyz + tangent * disk.x + bitangent * disk.y;
+				vec3 pos = local_vert + tangent * disk.x + bitangent * disk.y;
 
 				pos = normalize(pos);
-				vec4 uv_rect = omni_lights.data[idx].atlas_rect;
+
+				vec4 uv_rect = base_uv_rect;
 
 				if (pos.z >= 0.0) {
-					pos.z += 1.0;
-					uv_rect.y += uv_rect.w;
-				} else {
-					pos.z = 1.0 - pos.z;
+					uv_rect.xy += flip_offset;
 				}
 
+				pos.z = 1.0 + abs(pos.z);
 				pos.xy /= pos.z;
 
 				pos.xy = pos.xy * 0.5 + 0.5;
@@ -479,18 +527,18 @@ float light_process_omni_shadow(uint idx, vec3 vertex, vec3 normal) {
 				shadow = 0.0;
 				for (uint i = 0; i < sc_penumbra_shadow_samples; i++) {
 					vec2 disk = disk_rotation * scene_data.penumbra_shadow_kernel[i].xy;
-					vec3 pos = splane.xyz + tangent * disk.x + bitangent * disk.y;
+					vec3 pos = local_vert + tangent * disk.x + bitangent * disk.y;
 
 					pos = normalize(pos);
-					vec4 uv_rect = omni_lights.data[idx].atlas_rect;
+					pos = normalize(pos + normal_bias);
+
+					vec4 uv_rect = base_uv_rect;
 
 					if (pos.z >= 0.0) {
-						pos.z += 1.0;
-						uv_rect.y += uv_rect.w;
-					} else {
-						pos.z = 1.0 - pos.z;
+						uv_rect.xy += flip_offset;
 					}
 
+					pos.z = 1.0 + abs(pos.z);
 					pos.xy /= pos.z;
 
 					pos.xy = pos.xy * 0.5 + 0.5;
@@ -505,26 +553,19 @@ float light_process_omni_shadow(uint idx, vec3 vertex, vec3 normal) {
 				shadow = 1.0;
 			}
 		} else {
-			splane.xyz = normalize(splane.xyz);
-			vec4 clamp_rect = omni_lights.data[idx].atlas_rect;
+			vec4 uv_rect = base_uv_rect;
 
-			if (splane.z >= 0.0) {
-				splane.z += 1.0;
-
-				clamp_rect.y += clamp_rect.w;
-
-			} else {
-				splane.z = 1.0 - splane.z;
+			vec3 shadow_sample = normalize(shadow_dir + normal_bias);
+			if (shadow_sample.z >= 0.0) {
+				uv_rect.xy += flip_offset;
+				flip_offset *= -1.0;
 			}
 
-			splane.xy /= splane.z;
-
-			splane.xy = splane.xy * 0.5 + 0.5;
-			splane.z = shadow_len * omni_lights.data[idx].inv_radius;
-			splane.z -= omni_lights.data[idx].shadow_bias;
-			splane.xy = clamp_rect.xy + splane.xy * clamp_rect.zw;
-			splane.w = 1.0; //needed? i think it should be 1 already
-			shadow = sample_pcf_shadow(shadow_atlas, omni_lights.data[idx].soft_shadow_scale * scene_data.shadow_atlas_pixel_size, splane);
+			shadow_sample.z = 1.0 + abs(shadow_sample.z);
+			vec2 pos = shadow_sample.xy / shadow_sample.z;
+			float depth = shadow_len - omni_lights.data[idx].shadow_bias;
+			depth *= omni_lights.data[idx].inv_radius;
+			shadow = sample_omni_pcf_shadow(shadow_atlas, omni_lights.data[idx].soft_shadow_scale / shadow_sample.z, pos, uv_rect, flip_offset, depth);
 		}
 
 		return shadow;
@@ -608,12 +649,10 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 		vec4 atlas_rect = omni_lights.data[idx].projector_rect;
 
 		if (local_v.z >= 0.0) {
-			local_v.z += 1.0;
 			atlas_rect.y += atlas_rect.w;
-
-		} else {
-			local_v.z = 1.0 - local_v.z;
 		}
+
+		local_v.z = 1.0 + abs(local_v.z);
 
 		local_v.xy /= local_v.z;
 		local_v.xy = local_v.xy * 0.5 + 0.5;
@@ -694,15 +733,18 @@ float light_process_spot_shadow(uint idx, vec3 vertex, vec3 normal) {
 		vec3 light_rel_vec = spot_lights.data[idx].position - vertex;
 		float light_length = length(light_rel_vec);
 		vec3 spot_dir = spot_lights.data[idx].direction;
-		//there is a shadowmap
-		vec4 v = vec4(vertex, 1.0);
 
-		float shadow;
+		vec3 shadow_dir = light_rel_vec / light_length;
+		vec3 normal_bias = normal * light_length * spot_lights.data[idx].shadow_normal_bias * (1.0 - abs(dot(normal, shadow_dir)));
+
+		//there is a shadowmap
+		vec4 v = vec4(vertex + normal_bias, 1.0);
 
 		vec4 splane = (spot_lights.data[idx].shadow_matrix * v);
+		splane.z -= spot_lights.data[idx].shadow_bias / (light_length * spot_lights.data[idx].inv_radius);
 		splane /= splane.w;
-		splane.z -= spot_lights.data[idx].shadow_bias;
 
+		float shadow;
 		if (sc_use_light_soft_shadows && spot_lights.data[idx].soft_shadow_size > 0.0) {
 			//soft shadow
 
@@ -753,11 +795,9 @@ float light_process_spot_shadow(uint idx, vec3 vertex, vec3 normal) {
 				//no blockers found, so no shadow
 				shadow = 1.0;
 			}
-
 		} else {
 			//hard shadow
-			vec4 shadow_uv = vec4(splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy, splane.z, 1.0);
-
+			vec3 shadow_uv = vec3(splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy, splane.z);
 			shadow = sample_pcf_shadow(shadow_atlas, spot_lights.data[idx].soft_shadow_scale * scene_data.shadow_atlas_pixel_size, shadow_uv);
 		}
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -1387,7 +1387,7 @@ void main() {
 				break;
 			}
 
-			float shadow = light_process_omni_shadow(light_index, vertex, view);
+			float shadow = light_process_omni_shadow(light_index, vertex, normal);
 
 			shadow = blur_shadow(shadow);
 
@@ -1435,7 +1435,7 @@ void main() {
 				break;
 			}
 
-			float shadow = light_process_spot_shadow(light_index, vertex, view);
+			float shadow = light_process_spot_shadow(light_index, vertex, normal);
 
 			shadow = blur_shadow(shadow);
 

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2180,8 +2180,6 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 
 					p_scenario->indexers[Scenario::INDEXER_GEOMETRY].convex_query(planes.ptr(), planes.size(), points.ptr(), points.size(), cull_convex);
 
-					Plane near_plane(light_transform.origin, light_transform.basis.get_axis(2) * z);
-
 					RendererSceneRender::RenderShadowData &shadow_data = render_shadow_data[max_shadows_used++];
 
 					for (int j = 0; j < (int)instance_shadow_cull_result.size(); j++) {
@@ -2215,7 +2213,7 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 
 				real_t radius = RSG::storage->light_get_param(p_instance->base, RS::LIGHT_PARAM_RANGE);
 				CameraMatrix cm;
-				cm.set_perspective(90, 1, 0.01, radius);
+				cm.set_perspective(90, 1, radius * 0.005f, radius);
 
 				for (int i = 0; i < 6; i++) {
 					RENDER_TIMESTAMP("Culling Shadow Cube side" + itos(i));
@@ -2301,7 +2299,7 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 			real_t angle = RSG::storage->light_get_param(p_instance->base, RS::LIGHT_PARAM_SPOT_ANGLE);
 
 			CameraMatrix cm;
-			cm.set_perspective(angle * 2.0, 1.0, 0.01, radius);
+			cm.set_perspective(angle * 2.0, 1.0, 0.005f * radius, radius);
 
 			Vector<Plane> planes = cm.get_projection_planes(light_transform);
 
@@ -2794,12 +2792,9 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 	//rasterizer->set_camera(p_camera_data->main_transform, p_camera_data.main_projection, p_camera_data.is_ortogonal);
 
-	Vector<Plane> planes = p_camera_data->main_projection.get_projection_planes(p_camera_data->main_transform);
-
-	Plane near_plane(p_camera_data->main_transform.origin, -p_camera_data->main_transform.basis.get_axis(2).normalized());
-
 	/* STEP 2 - CULL */
 
+	Vector<Plane> planes = p_camera_data->main_projection.get_projection_planes(p_camera_data->main_transform);
 	cull.frustum = Frustum(planes);
 
 	Vector<RID> directional_lights;


### PR DESCRIPTION
Based on #51025, should be merged first.

Here's a quick comparison using the default bias values:

Before, current master:

https://user-images.githubusercontent.com/4402304/128563046-5bcdf91e-a11f-45a1-b37d-f07e4a1f2310.mp4

After:

https://user-images.githubusercontent.com/4402304/128563051-614a6dfd-e552-4e70-bfcc-06a5177afe32.mp4


### Fixed issues

#### Lack of precision in cube map mode
Cubemap shadows were using 0.01 as znear regardless of the light radius (zfar), so for large lights precision would go drastically down. I changed it so znear scales relative to the light's radius (0.005*radius) and acne cause by precision issues was gone. This means large lights can't be placed too close to shadow casters (i.e 0.5 meters for a 100 radius light) but dual paraboloid mode doesn't have this restriction, so users can go with that if needed. A probably better fix would be to use logarithmic depth or reverse Z buffer in order to keep a constant znear and still distribute precision evenly over the shadow map, but it can be done in a separate PR.

#### Squashed paraboloids
In order to fit both paraboloids on a single atlas square we were stacking them up in Y, resulting in two squashed 2:1 ratio paraboloids. This created aliasing and consequently acne in the shadows. I tried scaling the bias amount in the Y axis to compensate for that, but it didn't seem to work. The only solution I found was to use two square atlas regions, one for each paraboloid.

#### Shadowmap atlas bleeding
Since shadow atlas regions are adjacent to each other, and we use bilinear sampling, there's bleeding across them. I noticed this because sampling one paraboloid was picking data from the other. I added 1px padding to omni lights, but I think this will also be a problem for other light types, it needs to be looked into.

####  Shadow blur issues
Shadow blur had a couple of issues. The sampling radius was constant while the paraboloids have more pixel density near the Z axis, so it resulted in an inconsistent blurring size depending on the light's orientation. This was easy to fix by scaling the sampling radius according to the Z coordinates of the shadow ray. The other issue appeared because blur samples were not clamped inside the two circles that form the paraboloid, so with a large blur radius samples ended up outside the paraboloid regions and picked up invalid data. I added some code to detect such cases and move the sample point to the other paraboloid, and the issue is gone.

#### Biasing tweaks
With all the above issues fixed, I was able to tweak both regular bias and normal bias. I made sure they worked independently of the light's radius, and so far I haven't found any cases where I needed to change the default values.



### Remaining issues

#### Direct paraboloid mode
The acne issues weren't as severe in this mode, and some of the fixes I did also apply, but I didn't attempt to fix the artifacts that appear near the OmniLight's local Z plane, where the two paraboloids meet. There's also a lot of distortion in meshes that have long edges without subdivisions, but that's inherent to the way we render the paraboloids. That means this mode will be left as a faster but less accurate mode, it can be made to work in many situations, but it needs care when choosing the light's orientation and properly subdivided geometry.

#### Soft shadow darkening
This is a general issue for all light types. Increasing the radius of soft shadows (or shadow blur) results in a general darkening of the light. This happens because we take samples in a radius around the shaded surface point but then compare them all to the same depth, so samples that fall between the light and the shaded point are treated as shadowed even if they are not. In order to fix that, we should adjust the threshold depth of each sample. We can probably assume the surface to be flat, get the global position for each sample and recompute the depth threshold from there, but I haven't really tested it.


Edit: I fixed the shadow atlas allocation for omni lights, so now they correctly claim two atlas regions and avoid overlaps. I also went over the `SpotLight3D`s shadows. I added the same treatment to the znear distance to improve precision and fixed a couple of bugs regarding normal biasing. 