### PR TITLE
Improve editor grid performance

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5674,6 +5674,32 @@ void SpatialEditor::_init_grid() {
 		grid_mat[c]->set_shader_param("grid_size", grid_fade_size);
 		grid_mat[c]->set_shader_param("orthogonal", orthogonal);
 
+		// cache these so we don't have to re-access memory.
+		PoolVector<Vector3> &ref_grid = grid_points[c];
+		PoolVector<Vector3> &ref_grid_normals = grid_normals[c];
+		PoolVector<Color> &ref_grid_colors = grid_colors[c];
+
+		// count our elements same as code below it.
+		int expected_size = 0;
+		for (int i = -grid_size; i <= grid_size; i++) {
+			const real_t position_a = center_a + i * small_step_size;
+			const real_t position_b = center_b + i * small_step_size;
+
+			// Don't draw lines over the origin if it's enabled.
+			if (!(origin_enabled && Math::is_zero_approx(position_a))) {
+				expected_size += 2;
+			}
+
+			if (!(origin_enabled && Math::is_zero_approx(position_b))) {
+				expected_size += 2;
+			}
+		}
+
+		int idx = 0;
+		ref_grid.resize(expected_size);
+		ref_grid_normals.resize(expected_size);
+		ref_grid_colors.resize(expected_size);
+
 		// In each iteration of this loop, draw one line in each direction (so two lines per loop, in each if statement).
 		for (int i = -grid_size; i <= grid_size; i++) {
 			Color line_color;
@@ -5696,12 +5722,13 @@ void SpatialEditor::_init_grid() {
 				line_end[a] = position_a;
 				line_bgn[b] = bgn_b;
 				line_end[b] = end_b;
-				grid_points[c].push_back(line_bgn);
-				grid_points[c].push_back(line_end);
-				grid_colors[c].push_back(line_color);
-				grid_colors[c].push_back(line_color);
-				grid_normals[c].push_back(normal);
-				grid_normals[c].push_back(normal);
+				ref_grid.set(idx, line_bgn);
+				ref_grid.set(idx + 1, line_end);
+				ref_grid_colors.set(idx, line_color);
+				ref_grid_colors.set(idx + 1, line_color);
+				ref_grid_normals.set(idx, normal);
+				ref_grid_normals.set(idx + 1, normal);
+				idx += 2;
 			}
 
 			if (!(origin_enabled && Math::is_zero_approx(position_b))) {
@@ -5711,12 +5738,13 @@ void SpatialEditor::_init_grid() {
 				line_end[b] = position_b;
 				line_bgn[a] = bgn_a;
 				line_end[a] = end_a;
-				grid_points[c].push_back(line_bgn);
-				grid_points[c].push_back(line_end);
-				grid_colors[c].push_back(line_color);
-				grid_colors[c].push_back(line_color);
-				grid_normals[c].push_back(normal);
-				grid_normals[c].push_back(normal);
+				ref_grid.set(idx, line_bgn);
+				ref_grid.set(idx + 1, line_end);
+				ref_grid_colors.set(idx, line_color);
+				ref_grid_colors.set(idx + 1, line_color);
+				ref_grid_normals.set(idx, normal);
+				ref_grid_normals.set(idx + 1, normal);
+				idx += 2;
 			}
 		}
 


### PR DESCRIPTION
This was noticed in the MacOS profiler and will apply to other platforms too:

[optimized before]
<img width="940" alt="Screenshot 2021-08-06 at 23 51 19" src="https://user-images.githubusercontent.com/748770/128578207-9349c281-6a1d-44e8-8321-d7f3f9957ee0.png">

[optimized after]
<img width="922" alt="Screenshot 2021-08-06 at 23 52 49" src="https://user-images.githubusercontent.com/748770/128578227-39e6cea4-9d83-432c-9f76-7c00aee20d57.png">

[unoptimized before]
<img width="928" alt="Screenshot 2021-08-06 at 23 04 49" src="https://user-images.githubusercontent.com/748770/128578272-4ef35c42-db7d-4faf-a875-f7568ca35494.png">

[unoptimized after]
<img width="889" alt="Screenshot 2021-08-06 at 23 08 55" src="https://user-images.githubusercontent.com/748770/128578291-6d7fa159-a706-4877-b974-666cbacbee68.png">

Most of us are deving on debug so will be nice to not have this taking up a lot of CPU. 

