### PR TITLE
Suggest use of `ColorPickerButton` to show picker.

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Displays a color picker widget. Useful for selecting a color from an RGB/RGBA colorspace.
+		Note: You can use a [ColorPickerButton] to display a [ColorPicker] in a pop-up.
 	</description>
 	<tutorials>
 		<link title="Tween Demo">https://godotengine.org/asset-library/asset/146</link>


### PR DESCRIPTION
It's not obvious that the color picker "pop-up" behaviour (as seen in the Godot Editor) is implemented via a `ColorPickerButton` rather than use of a `ColorPicker` directly.

This adds a pointer to the `ColorPickerButton` in the docs for `ColorPicker`. (Which would've saved me a web search.)

(There's already a pointer to `ColorPicker` in the `ColorPickerButton` docs.)

[Feel free to edit wording to taste as I'm not currently checking/acting on GitHub notifications very regularly.]