### PR TITLE
Document workaround for non-visible `ColorPickerButton` color preview.

### DIFF
--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -6,6 +6,7 @@
 	<description>
 		Encapsulates a [ColorPicker] making it accessible by pressing a button. Pressing the button will toggle the [ColorPicker] visibility.
 		See also [BaseButton] which contains common properties and methods associated with this node.
+		Note: By default the button may not be wide enough for the color preview swatch to be visible. To workaround this issue you can type space characters into the [Text] property or change the value of the [rect_min_size] property.  
 	</description>
 	<tutorials>
 		<link title="GUI Drag And Drop Demo">https://godotengine.org/asset-library/asset/133</link>


### PR DESCRIPTION
This might be considered a bug but here's a workaround doc if that's useful. :)

This issue occurred for me with "Godot Engine v3.3.stable.official" on Linux/Elementary OS.

The button was inside a container which might also have contributed to the issue.

The default theme seems to set the button padding/margin to take up the entire default size/width of the default button size leaving no color preview visible. Which is very confusing. :)

[Feel free to edit wording to taste as I'm not currently checking/acting on GitHub notifications very regularly.]