### PR TITLE
Fix Path3D initial forward calculation

### DIFF
--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -120,7 +120,7 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 	// will be replaced by "Vector3(h_offset, v_offset, 0)" where it was formerly used
 
 	if (rotation_mode == ROTATION_ORIENTED) {
-		Vector3 forward = c->interpolate_baked(o_next, cubic);
+		Vector3 forward = c->interpolate_baked(o_next, cubic) - pos;
 
 		// Try with the previous position
 		if (forward.length_squared() < CMP_EPSILON2) {


### PR DESCRIPTION
Fixes #51342

---

PR #50986 introduced a regression calculation the forward vector because I forgot to substract the position, sorry about that :disappointed: 
