### PR TITLE
Expose soft body pin methods to GDScript

### DIFF
--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -42,6 +42,20 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_point_transform">
+			<return type="Vector3" />
+			<argument index="0" name="point_index" type="int" />
+			<description>
+				Returns local translation of a vertex in the surface array.
+			</description>
+		</method>
+		<method name="is_point_pinned" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="point_index" type="int" />
+			<description>
+				Returns [code]true[/code] if vertex is set to pinned.
+			</description>
+		</method>
 		<method name="remove_collision_exception_with">
 			<return type="void" />
 			<argument index="0" name="body" type="Node" />
@@ -63,6 +77,15 @@
 			<argument index="1" name="value" type="bool" />
 			<description>
 				Sets individual bits on the collision mask. Use this if you only need to change one layer's value.
+			</description>
+		</method>
+		<method name="set_point_pinned">
+			<return type="void" />
+			<argument index="0" name="point_index" type="int" />
+			<argument index="1" name="pinned" type="bool" />
+			<argument index="2" name="attachment_path" type="NodePath" default="NodePath(&quot;&quot;)" />
+			<description>
+				Sets the pinned state of a surface vertex. When set to [code]true[/code], the optional [code]attachment_path[/code] can define a [Node3D] the pinned vertex will be attached to.
 			</description>
 		</method>
 	</methods>

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -361,6 +361,11 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_drag_coefficient", "drag_coefficient"), &SoftBody3D::set_drag_coefficient);
 	ClassDB::bind_method(D_METHOD("get_drag_coefficient"), &SoftBody3D::get_drag_coefficient);
 
+	ClassDB::bind_method(D_METHOD("get_point_transform", "point_index"), &SoftBody3D::get_point_transform);
+
+	ClassDB::bind_method(D_METHOD("set_point_pinned", "point_index", "pinned", "attachment_path"), &SoftBody3D::pin_point, DEFVAL(NodePath()));
+	ClassDB::bind_method(D_METHOD("is_point_pinned", "point_index"), &SoftBody3D::is_point_pinned);
+
 	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &SoftBody3D::set_ray_pickable);
 	ClassDB::bind_method(D_METHOD("is_ray_pickable"), &SoftBody3D::is_ray_pickable);
 


### PR DESCRIPTION
Makes it easy to auto pin or unpin soft body points using vertex colours with a simple script and other like tools.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
