### PR TITLE
Fix PathFollow tests, Add PathFollow3D forward test

### DIFF
--- a/tests/scene/test_path_follow_2d.h
+++ b/tests/scene/test_path_follow_2d.h
@@ -32,205 +32,223 @@
 #define TEST_PATH_FOLLOW_2D_H
 
 #include "scene/2d/path_2d.h"
+#include "scene/main/window.h"
 
 #include "tests/test_macros.h"
 
 namespace TestPathFollow2D {
 
-TEST_CASE("[PathFollow2D] Sampling with progress ratio") {
-	const Ref<Curve2D> &curve = memnew(Curve2D());
+bool is_equal_approx(const Vector2 &p_a, const Vector2 &p_b) {
+	const real_t tolerance = 0.001;
+	return Math::is_equal_approx(p_a.x, p_b.x, tolerance) &&
+			Math::is_equal_approx(p_a.y, p_b.y, tolerance);
+}
+
+TEST_CASE("[SceneTree][PathFollow2D] Sampling with progress ratio") {
+	Ref<Curve2D> curve = memnew(Curve2D);
+	curve->set_bake_interval(1);
 	curve->add_point(Vector2(0, 0));
 	curve->add_point(Vector2(100, 0));
 	curve->add_point(Vector2(100, 100));
 	curve->add_point(Vector2(0, 100));
 	curve->add_point(Vector2(0, 0));
-	const Path2D *path = memnew(Path2D);
+	Path2D *path = memnew(Path2D);
 	path->set_curve(curve);
-	const PathFollow2D *path_follow_2d = memnew(PathFollow2D);
+	PathFollow2D *path_follow_2d = memnew(PathFollow2D);
+	path_follow_2d->set_loop(false);
 	path->add_child(path_follow_2d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_2d->set_progress_ratio(0);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(0, 0)));
+	CHECK(is_equal_approx(Vector2(0, 0), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress_ratio(0.125);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(50, 0)));
+	CHECK(is_equal_approx(Vector2(50, 0), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress_ratio(0.25);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(100, 0)));
+	CHECK(is_equal_approx(Vector2(100, 0), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress_ratio(0.375);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(100, 50)));
+	CHECK(is_equal_approx(Vector2(100, 50), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress_ratio(0.5);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(100, 100)));
+	CHECK(is_equal_approx(Vector2(100, 100), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress_ratio(0.625);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(50, 100)));
+	CHECK(is_equal_approx(Vector2(50, 100), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress_ratio(0.75);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(0, 100)));
+	CHECK(is_equal_approx(Vector2(0, 100), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress_ratio(0.875);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(0, 50)));
+	CHECK(is_equal_approx(Vector2(0, 50), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress_ratio(1);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(0, 0)));
+	CHECK(is_equal_approx(Vector2(0, 0), path_follow_2d->get_transform().get_origin()));
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow2D] Sampling with progress") {
-	const Ref<Curve2D> &curve = memnew(Curve2D());
+TEST_CASE("[SceneTree][PathFollow2D] Sampling with progress") {
+	Ref<Curve2D> curve = memnew(Curve2D);
+	curve->set_bake_interval(1);
 	curve->add_point(Vector2(0, 0));
 	curve->add_point(Vector2(100, 0));
 	curve->add_point(Vector2(100, 100));
 	curve->add_point(Vector2(0, 100));
 	curve->add_point(Vector2(0, 0));
-	const Path2D *path = memnew(Path2D);
+	Path2D *path = memnew(Path2D);
 	path->set_curve(curve);
-	const PathFollow2D *path_follow_2d = memnew(PathFollow2D);
+	PathFollow2D *path_follow_2d = memnew(PathFollow2D);
+	path_follow_2d->set_loop(false);
 	path->add_child(path_follow_2d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_2d->set_progress(0);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(0, 0)));
+	CHECK(is_equal_approx(Vector2(0, 0), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress(50);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(50, 0)));
+	CHECK(is_equal_approx(Vector2(50, 0), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress(100);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(100, 0)));
+	CHECK(is_equal_approx(Vector2(100, 0), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress(150);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(100, 50)));
+	CHECK(is_equal_approx(Vector2(100, 50), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress(200);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(100, 100)));
+	CHECK(is_equal_approx(Vector2(100, 100), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress(250);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(50, 100)));
+	CHECK(is_equal_approx(Vector2(50, 100), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress(300);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(0, 100)));
+	CHECK(is_equal_approx(Vector2(0, 100), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress(350);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(0, 50)));
+	CHECK(is_equal_approx(Vector2(0, 50), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_progress(400);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(0, 0)));
+	CHECK(is_equal_approx(Vector2(0, 0), path_follow_2d->get_transform().get_origin()));
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow2D] Removal of a point in curve") {
-	const Ref<Curve2D> &curve = memnew(Curve2D());
+TEST_CASE("[SceneTree][PathFollow2D] Removal of a point in curve") {
+	Ref<Curve2D> curve = memnew(Curve2D);
 	curve->add_point(Vector2(0, 0));
 	curve->add_point(Vector2(100, 0));
 	curve->add_point(Vector2(100, 100));
-	const Path2D *path = memnew(Path2D);
+	Path2D *path = memnew(Path2D);
 	path->set_curve(curve);
-	const PathFollow2D *path_follow_2d = memnew(PathFollow2D);
+	PathFollow2D *path_follow_2d = memnew(PathFollow2D);
 	path->add_child(path_follow_2d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_2d->set_progress_ratio(0.5);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(100, 0)));
+	CHECK(is_equal_approx(Vector2(100, 0), path_follow_2d->get_transform().get_origin()));
 
 	curve->remove_point(1);
 
+	path_follow_2d->set_progress_ratio(0.5);
 	CHECK_MESSAGE(
-			path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(50, 50)),
+			is_equal_approx(Vector2(50, 50), path_follow_2d->get_transform().get_origin()),
 			"Path follow's position should be updated after removing a point from the curve");
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow2D] Setting h_offset and v_offset") {
-	const Ref<Curve2D> &curve = memnew(Curve2D());
+TEST_CASE("[SceneTree][PathFollow2D] Setting h_offset and v_offset") {
+	Ref<Curve2D> curve = memnew(Curve2D);
 	curve->add_point(Vector2(0, 0));
 	curve->add_point(Vector2(100, 0));
-	const Path2D *path = memnew(Path2D);
+	Path2D *path = memnew(Path2D);
 	path->set_curve(curve);
-	const PathFollow2D *path_follow_2d = memnew(PathFollow2D);
+	PathFollow2D *path_follow_2d = memnew(PathFollow2D);
 	path->add_child(path_follow_2d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_2d->set_progress_ratio(0.5);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(50, 0)));
+	CHECK(is_equal_approx(Vector2(50, 0), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_h_offset(25);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(75, 0)));
+	CHECK(is_equal_approx(Vector2(75, 0), path_follow_2d->get_transform().get_origin()));
 
 	path_follow_2d->set_v_offset(25);
-	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(75, 25)));
+	CHECK(is_equal_approx(Vector2(75, 25), path_follow_2d->get_transform().get_origin()));
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow2D] Unit offset out of range") {
-	const Ref<Curve2D> &curve = memnew(Curve2D());
+TEST_CASE("[SceneTree][PathFollow2D] Progress ratio out of range") {
+	Ref<Curve2D> curve = memnew(Curve2D);
 	curve->add_point(Vector2(0, 0));
 	curve->add_point(Vector2(100, 0));
-	const Path2D *path = memnew(Path2D);
+	Path2D *path = memnew(Path2D);
 	path->set_curve(curve);
-	const PathFollow2D *path_follow_2d = memnew(PathFollow2D);
+	PathFollow2D *path_follow_2d = memnew(PathFollow2D);
 	path->add_child(path_follow_2d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_2d->set_loop(true);
 
 	path_follow_2d->set_progress_ratio(-0.3);
 	CHECK_MESSAGE(
-			path_follow_2d->get_progress_ratio() == 0.7,
+			Math::is_equal_approx(path_follow_2d->get_progress_ratio(), (real_t)0.7),
 			"Progress Ratio should loop back from the end in the opposite direction");
 
 	path_follow_2d->set_progress_ratio(1.3);
 	CHECK_MESSAGE(
-			path_follow_2d->get_progress_ratio() == 0.3,
+			Math::is_equal_approx(path_follow_2d->get_progress_ratio(), (real_t)0.3),
 			"Progress Ratio should loop back from the end in the opposite direction");
 
 	path_follow_2d->set_loop(false);
 
 	path_follow_2d->set_progress_ratio(-0.3);
 	CHECK_MESSAGE(
-			path_follow_2d->get_progress_ratio() == 0,
+			Math::is_equal_approx(path_follow_2d->get_progress_ratio(), 0),
 			"Progress Ratio should be clamped at 0");
 
 	path_follow_2d->set_progress_ratio(1.3);
 	CHECK_MESSAGE(
-			path_follow_2d->get_progress_ratio() == 1,
+			Math::is_equal_approx(path_follow_2d->get_progress_ratio(), 1),
 			"Progress Ratio should be clamped at 1");
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow2D] Progress out of range") {
-	const Ref<Curve2D> &curve = memnew(Curve2D());
+TEST_CASE("[SceneTree][PathFollow2D] Progress out of range") {
+	Ref<Curve2D> curve = memnew(Curve2D);
 	curve->add_point(Vector2(0, 0));
 	curve->add_point(Vector2(100, 0));
-	const Path2D *path = memnew(Path2D);
+	Path2D *path = memnew(Path2D);
 	path->set_curve(curve);
-	const PathFollow2D *path_follow_2d = memnew(PathFollow2D);
+	PathFollow2D *path_follow_2d = memnew(PathFollow2D);
 	path->add_child(path_follow_2d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_2d->set_loop(true);
 
 	path_follow_2d->set_progress(-50);
 	CHECK_MESSAGE(
-			path_follow_2d->get_progress() == 50,
+			Math::is_equal_approx(path_follow_2d->get_progress(), 50),
 			"Progress should loop back from the end in the opposite direction");
 
 	path_follow_2d->set_progress(150);
 	CHECK_MESSAGE(
-			path_follow_2d->get_progress() == 50,
+			Math::is_equal_approx(path_follow_2d->get_progress(), 50),
 			"Progress should loop back from the end in the opposite direction");
 
 	path_follow_2d->set_loop(false);
 
 	path_follow_2d->set_progress(-50);
 	CHECK_MESSAGE(
-			path_follow_2d->get_progress() == 0,
+			Math::is_equal_approx(path_follow_2d->get_progress(), 0),
 			"Progress should be clamped at 0");
 
 	path_follow_2d->set_progress(150);
 	CHECK_MESSAGE(
-			path_follow_2d->get_progress() == 100,
+			Math::is_equal_approx(path_follow_2d->get_progress(), 100),
 			"Progress should be clamped at 1");
 
 	memdelete(path);

--- a/tests/scene/test_path_follow_3d.h
+++ b/tests/scene/test_path_follow_3d.h
@@ -32,185 +32,286 @@
 #define TEST_PATH_FOLLOW_3D_H
 
 #include "scene/3d/path_3d.h"
+#include "scene/main/window.h"
 
 #include "tests/test_macros.h"
 
 namespace TestPathFollow3D {
 
-TEST_CASE("[PathFollow3D] Sampling with progress ratio") {
-	const Ref<Curve3D> &curve = memnew(Curve3D());
+bool is_equal_approx(const Vector3 &p_a, const Vector3 &p_b) {
+	const real_t tolerance = 0.001;
+	return Math::is_equal_approx(p_a.x, p_b.x, tolerance) &&
+			Math::is_equal_approx(p_a.y, p_b.y, tolerance) &&
+			Math::is_equal_approx(p_a.z, p_b.z, tolerance);
+}
+
+TEST_CASE("[SceneTree][PathFollow3D] Sampling with progress ratio") {
+	Ref<Curve3D> curve = memnew(Curve3D);
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
 	curve->add_point(Vector3(100, 100, 0));
 	curve->add_point(Vector3(100, 100, 100));
 	curve->add_point(Vector3(100, 0, 100));
-	const Path3D *path = memnew(Path3D);
+	Path3D *path = memnew(Path3D);
 	path->set_curve(curve);
-	const PathFollow3D *path_follow_3d = memnew(PathFollow3D);
+	PathFollow3D *path_follow_3d = memnew(PathFollow3D);
+	path_follow_3d->set_loop(false);
 	path->add_child(path_follow_3d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_3d->set_progress_ratio(0);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(0, 0, 0));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(0, 0, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress_ratio(0.125);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(50, 0, 0));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(50, 0, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress_ratio(0.25);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 0, 0);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 0, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress_ratio(0.375);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 50, 0)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 50, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress_ratio(0.5);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 100, 0)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 100, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress_ratio(0.625);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 100, 50)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 100, 50), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress_ratio(0.75);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 100, 100)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 100, 100), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress_ratio(0.875);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 50, 100)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 50, 100), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress_ratio(1);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 0, 100)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 0, 100), path_follow_3d->get_transform().get_origin()));
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow3D] Sampling with progress") {
-	const Ref<Curve3D> &curve = memnew(Curve3D());
+TEST_CASE("[SceneTree][PathFollow3D] Sampling with progress") {
+	Ref<Curve3D> curve = memnew(Curve3D);
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
 	curve->add_point(Vector3(100, 100, 0));
 	curve->add_point(Vector3(100, 100, 100));
 	curve->add_point(Vector3(100, 0, 100));
-	const Path3D *path = memnew(Path3D);
+	Path3D *path = memnew(Path3D);
 	path->set_curve(curve);
-	const PathFollow3D *path_follow_3d = memnew(PathFollow3D);
+	PathFollow3D *path_follow_3d = memnew(PathFollow3D);
+	path_follow_3d->set_loop(false);
 	path->add_child(path_follow_3d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_3d->set_progress(0);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(0, 0, 0));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(0, 0, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress(50);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(50, 0, 0));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(50, 0, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress(100);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 0, 0);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 0, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress(150);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 50, 0)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 50, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress(200);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 100, 0)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 100, 0), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress(250);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 100, 50)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 100, 50), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress(300);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 100, 100)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 100, 100), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress(350);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 50, 100)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 50, 100), path_follow_3d->get_transform().get_origin()));
 
 	path_follow_3d->set_progress(400);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector3(100, 0, 100)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 0, 100), path_follow_3d->get_transform().get_origin()));
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow3D] Removal of a point in curve") {
-	const Ref<Curve3D> &curve = memnew(Curve3D());
+TEST_CASE("[SceneTree][PathFollow3D] Removal of a point in curve") {
+	Ref<Curve3D> curve = memnew(Curve3D);
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
 	curve->add_point(Vector3(100, 100, 0));
-	const Path3D *path = memnew(Path3D);
+	Path3D *path = memnew(Path3D);
 	path->set_curve(curve);
-	const PathFollow3D *path_follow_3d = memnew(PathFollow3D);
+	PathFollow3D *path_follow_3d = memnew(PathFollow3D);
 	path->add_child(path_follow_3d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_3d->set_progress_ratio(0.5);
-	CHECK(path_follow_3d->get_transform().get_origin().is_equal_approx(Vector2(100, 0, 0)));
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(100, 0, 0), path_follow_3d->get_transform().get_origin()));
 
 	curve->remove_point(1);
 
+	path_follow_3d->set_progress_ratio(0.5);
+	path_follow_3d->update_transform(true);
 	CHECK_MESSAGE(
-			path_follow_3d->get_transform().get_origin().is_equal_approx(Vector2(50, 50, 0)),
+			is_equal_approx(Vector3(50, 50, 0), path_follow_3d->get_transform().get_origin()),
 			"Path follow's position should be updated after removing a point from the curve");
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow3D] Progress ratio out of range") {
-	const Ref<Curve3D> &curve = memnew(Curve3D());
+TEST_CASE("[SceneTree][PathFollow3D] Progress ratio out of range") {
+	Ref<Curve3D> curve = memnew(Curve3D);
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
-	const Path3D *path = memnew(Path3D);
+	Path3D *path = memnew(Path3D);
 	path->set_curve(curve);
-	const PathFollow3D *path_follow_3d = memnew(PathFollow3D);
+	PathFollow3D *path_follow_3d = memnew(PathFollow3D);
 	path->add_child(path_follow_3d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_3d->set_loop(true);
 
 	path_follow_3d->set_progress_ratio(-0.3);
 	CHECK_MESSAGE(
-			path_follow_3d->get_progress_ratio() == 0.7,
+			Math::is_equal_approx(path_follow_3d->get_progress_ratio(), (real_t)0.7),
 			"Progress Ratio should loop back from the end in the opposite direction");
 
 	path_follow_3d->set_progress_ratio(1.3);
 	CHECK_MESSAGE(
-			path_follow_3d->get_progress_ratio() == 0.3,
+			Math::is_equal_approx(path_follow_3d->get_progress_ratio(), (real_t)0.3),
 			"Progress Ratio should loop back from the end in the opposite direction");
 
 	path_follow_3d->set_loop(false);
 
 	path_follow_3d->set_progress_ratio(-0.3);
 	CHECK_MESSAGE(
-			path_follow_3d->get_progress_ratio() == 0,
+			Math::is_equal_approx(path_follow_3d->get_progress_ratio(), 0),
 			"Progress Ratio should be clamped at 0");
 
 	path_follow_3d->set_progress_ratio(1.3);
 	CHECK_MESSAGE(
-			path_follow_3d->get_progress_ratio() == 1,
+			Math::is_equal_approx(path_follow_3d->get_progress_ratio(), 1),
 			"Progress Ratio should be clamped at 1");
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow3D] Progress out of range") {
-	const Ref<Curve3D> &curve = memnew(Curve3D());
+TEST_CASE("[SceneTree][PathFollow3D] Progress out of range") {
+	Ref<Curve3D> curve = memnew(Curve3D);
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
-	const Path3D *path = memnew(Path3D);
+	Path3D *path = memnew(Path3D);
 	path->set_curve(curve);
-	const PathFollow3D *path_follow_3d = memnew(PathFollow3D);
+	PathFollow3D *path_follow_3d = memnew(PathFollow3D);
 	path->add_child(path_follow_3d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
 
 	path_follow_3d->set_loop(true);
 
 	path_follow_3d->set_progress(-50);
 	CHECK_MESSAGE(
-			path_follow_3d->get_progress() == 50,
+			Math::is_equal_approx(path_follow_3d->get_progress(), 50),
 			"Progress should loop back from the end in the opposite direction");
 
 	path_follow_3d->set_progress(150);
 	CHECK_MESSAGE(
-			path_follow_3d->get_progress() == 50,
+			Math::is_equal_approx(path_follow_3d->get_progress(), 50),
 			"Progress should loop back from the end in the opposite direction");
 
 	path_follow_3d->set_loop(false);
 
 	path_follow_3d->set_progress(-50);
 	CHECK_MESSAGE(
-			path_follow_3d->get_progress() == 0,
+			Math::is_equal_approx(path_follow_3d->get_progress(), 0),
 			"Progress should be clamped at 0");
 
 	path_follow_3d->set_progress(150);
 	CHECK_MESSAGE(
-			path_follow_3d->get_progress() == 100,
+			Math::is_equal_approx(path_follow_3d->get_progress(), 100),
 			"Progress should be clamped at max value of curve");
+
+	memdelete(path);
+}
+
+TEST_CASE("[SceneTree][PathFollow3D] Calculate forward vector") {
+	const real_t dist_cube_100 = 100 * Math::sqrt(3.0);
+	Ref<Curve3D> curve = memnew(Curve3D);
+	curve->add_point(Vector3(0, 0, 0));
+	curve->add_point(Vector3(100, 0, 0));
+	curve->add_point(Vector3(200, 100, -100));
+	curve->add_point(Vector3(200, 100, 200));
+	curve->add_point(Vector3(100, 0, 100));
+	curve->add_point(Vector3(0, 0, 100));
+	Path3D *path = memnew(Path3D);
+	path->set_curve(curve);
+	PathFollow3D *path_follow_3d = memnew(PathFollow3D);
+	path->add_child(path_follow_3d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
+
+	path_follow_3d->set_loop(false);
+	path_follow_3d->set_rotation_mode(PathFollow3D::RotationMode::ROTATION_ORIENTED);
+
+	path_follow_3d->set_progress(-50);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(-1, 0, 0), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(0);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(-1, 0, 0), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(50);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(-1, 0, 0), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(100);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(-1, 0, 0), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(100 + dist_cube_100 / 2);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(-0.577348, -0.577348, 0.577348), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(100 + dist_cube_100 - 0.01);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(-0.577348, -0.577348, 0.577348), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(250 + dist_cube_100);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(0, 0, -1), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(400 + dist_cube_100 - 0.01);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(0, 0, -1), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(400 + 1.5 * dist_cube_100);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(0.577348, 0.577348, 0.577348), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(400 + 2 * dist_cube_100 - 0.01);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(0.577348, 0.577348, 0.577348), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress(500 + 2 * dist_cube_100);
+	path_follow_3d->update_transform(true);
+	CHECK(is_equal_approx(Vector3(1, 0, 0), path_follow_3d->get_transform().get_basis().get_column(2)));
 
 	memdelete(path);
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -117,6 +117,7 @@
 #include "tests/scene/test_node_2d.h"
 #include "tests/scene/test_packed_scene.h"
 #include "tests/scene/test_path_2d.h"
+#include "tests/scene/test_path_follow_2d.h"
 #include "tests/scene/test_sprite_frames.h"
 #include "tests/scene/test_theme.h"
 #include "tests/scene/test_timer.h"
@@ -149,6 +150,7 @@
 #include "tests/scene/test_arraymesh.h"
 #include "tests/scene/test_camera_3d.h"
 #include "tests/scene/test_path_3d.h"
+#include "tests/scene/test_path_follow_3d.h"
 #include "tests/scene/test_primitives.h"
 #endif // _3D_DISABLED
 


### PR DESCRIPTION
- Fixes the tests for `PathFollow2D` and `PathFollow3D` so they compile and add them to `test_main.cpp` because they weren't being used before.
- Adds a test for the the forward direction of `PathFollow3D` to prevent regressions like #51342 in the future.

---

**NOTE:** I've marked this PR ready for review since the CI passes but I'd like to know what to do with the _remove point test_ and if the custom `is_equal_approx` is acceptable, then I'll squash the commits.