### PR TITLE
Fix action_get_events returning booleans instead of InputKey entries

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -196,7 +196,7 @@ Array InputMap::_action_get_events(const StringName &p_action) {
 	const List<Ref<InputEvent>> *al = action_get_events(p_action);
 	if (al) {
 		for (const List<Ref<InputEvent>>::Element *E = al->front(); E; E = E->next()) {
-			ret.push_back(E);
+			ret.push_back(E->get());
 		}
 	}
 


### PR DESCRIPTION
Closes #51374

I have only reverted the change made in InputMap::action_get_events in 4e6efd1b07f1c6d53d226977ddc729333b74306a.