### PR TITLE
Re-instance audio previews during resource re-import

### DIFF
--- a/editor/audio_stream_preview.h
+++ b/editor/audio_stream_preview.h
@@ -99,6 +99,8 @@ protected:
 public:
 	static AudioStreamPreviewGenerator *get_singleton() { return singleton; }
 
+	void _update_audio_streams();
+
 	Ref<AudioStreamPreview> generate_preview(const Ref<AudioStream> &p_stream);
 
 	AudioStreamPreviewGenerator();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

I think this fixes #27800 in most cases. It's not really a complete solution because if the audio stream preview is playing audio, it's still possible to get a use-after-free if the audio thread does a mix after `AudioStreamOGGVorbis::clear_data` and before `AudioStreamPreviewGenerator::_update_audio_streams`. I think I have a fix for #26964 that should at least prevent a crash in that situation, but it's still necessary for the preview window to re-instance all of its preview playbacks, so this PR will be necessary from a usability perspective.