### PR TITLE
Change in RenderingDevice decode api and docs

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1838,6 +1838,9 @@ static void _register_variant_builtin_methods() {
 	bind_function(PackedByteArray, to_int64_array, _VariantCall::func_PackedByteArray_decode_T_array<int64_t>, sarray(), varray());
 	bind_function(PackedByteArray, to_float32_array, _VariantCall::func_PackedByteArray_decode_T_array<float>, sarray(), varray());
 	bind_function(PackedByteArray, to_float64_array, _VariantCall::func_PackedByteArray_decode_T_array<double>, sarray(), varray());
+	bind_function(PackedByteArray, to_vector2_array, _VariantCall::func_PackedByteArray_decode_T_array<Vector2>, sarray(), varray());
+	bind_function(PackedByteArray, to_vector3_array, _VariantCall::func_PackedByteArray_decode_T_array<Vector3>, sarray(), varray());
+	bind_function(PackedByteArray, to_color_array, _VariantCall::func_PackedByteArray_decode_T_array<Color>, sarray(), varray());
 
 	bind_functionnc(PackedByteArray, encode_u8, _VariantCall::func_PackedByteArray_encode_u8, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_s8, _VariantCall::func_PackedByteArray_encode_s8, sarray("byte_offset", "value"), varray());

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -750,38 +750,12 @@ struct _VariantCall {
 		return 0;
 	}
 
-	static PackedInt32Array func_PackedByteArray_decode_s32_array(PackedByteArray *p_instance) {
+	template <typename T>
+	static Vector<T> func_PackedByteArray_decode_T_array(PackedByteArray *p_instance) {
 		uint64_t size = p_instance->size();
 		const uint8_t *r = p_instance->ptr();
-		PackedInt32Array dest;
-		dest.resize(size / sizeof(int32_t));
-		memcpy(dest.ptrw(), r, size);
-		return dest;
-	}
-
-	static PackedInt64Array func_PackedByteArray_decode_s64_array(PackedByteArray *p_instance) {
-		uint64_t size = p_instance->size();
-		const uint8_t *r = p_instance->ptr();
-		PackedInt64Array dest;
-		dest.resize(size / sizeof(int64_t));
-		memcpy(dest.ptrw(), r, size);
-		return dest;
-	}
-
-	static PackedFloat32Array func_PackedByteArray_decode_float_array(PackedByteArray *p_instance) {
-		uint64_t size = p_instance->size();
-		const uint8_t *r = p_instance->ptr();
-		PackedFloat32Array dest;
-		dest.resize(size / sizeof(float));
-		memcpy(dest.ptrw(), r, size);
-		return dest;
-	}
-
-	static PackedFloat64Array func_PackedByteArray_decode_double_array(PackedByteArray *p_instance) {
-		uint64_t size = p_instance->size();
-		const uint8_t *r = p_instance->ptr();
-		PackedFloat64Array dest;
-		dest.resize(size / sizeof(double));
+		Vector<T> dest;
+		dest.resize(size / sizeof(T));
 		memcpy(dest.ptrw(), r, size);
 		return dest;
 	}
@@ -1860,10 +1834,10 @@ static void _register_variant_builtin_methods() {
 	bind_function(PackedByteArray, decode_var, _VariantCall::func_PackedByteArray_decode_var, sarray("byte_offset", "allow_objects"), varray(false));
 	bind_function(PackedByteArray, decode_var_size, _VariantCall::func_PackedByteArray_decode_var_size, sarray("byte_offset", "allow_objects"), varray(false));
 
-	bind_function(PackedByteArray, to_int32_array, _VariantCall::func_PackedByteArray_decode_s32_array, sarray(), varray());
-	bind_function(PackedByteArray, to_int64_array, _VariantCall::func_PackedByteArray_decode_s64_array, sarray(), varray());
-	bind_function(PackedByteArray, to_float32_array, _VariantCall::func_PackedByteArray_decode_float_array, sarray(), varray());
-	bind_function(PackedByteArray, to_float64_array, _VariantCall::func_PackedByteArray_decode_double_array, sarray(), varray());
+	bind_function(PackedByteArray, to_int32_array, _VariantCall::func_PackedByteArray_decode_T_array<int32_t>, sarray(), varray());
+	bind_function(PackedByteArray, to_int64_array, _VariantCall::func_PackedByteArray_decode_T_array<int64_t>, sarray(), varray());
+	bind_function(PackedByteArray, to_float32_array, _VariantCall::func_PackedByteArray_decode_T_array<float>, sarray(), varray());
+	bind_function(PackedByteArray, to_float64_array, _VariantCall::func_PackedByteArray_decode_T_array<double>, sarray(), varray());
 
 	bind_functionnc(PackedByteArray, encode_u8, _VariantCall::func_PackedByteArray_encode_u8, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_s8, _VariantCall::func_PackedByteArray_encode_s8, sarray("byte_offset", "value"), varray());

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -393,6 +393,14 @@
 				Returns the slice of the [PackedByteArray] between indices (inclusive) as a new [PackedByteArray]. Any negative index is considered to be from the end of the array.
 			</description>
 		</method>
+		<method name="to_color_array" qualifiers="const">
+			<return type="PackedColorArray" />
+			<description>
+				Returns a copy of the data converted to a [PackedColorArray], where each block of 16 bytes has been converted to a [Color].
+				The size of the new array will be [code]byte_array.size() / 16[/code].
+				If the original data can't be converted to Colors, the resulting data is undefined.
+			</description>
+		</method>
 		<method name="to_float32_array" qualifiers="const">
 			<return type="PackedFloat32Array" />
 			<description>
@@ -423,6 +431,22 @@
 				Returns a copy of the data converted to a [PackedInt64Array], where each block of 4 bytes has been converted to a signed 64-bit integer (C++ [code]int64_t[/code], Godot [int]).
 				The size of the new array will be [code]byte_array.size() / 8[/code].
 				If the original data can't be converted to signed 64-bit integers, the resulting data is undefined.
+			</description>
+		</method>
+		<method name="to_vector2_array" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>
+				Returns a copy of the data converted to a [PackedVector2Array], where each block of 8 bytes has been converted to a [Vector2].
+				The size of the new array will be [code]byte_array.size() / 8[/code].
+				If the original data can't be converted to multiple Vector2, the resulting data is undefined.
+			</description>
+		</method>
+		<method name="to_vector3_array" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<description>
+				Returns a copy of the data converted to a [PackedVector3Array], where each block of 12 bytes has been converted to a [Color].
+				The size of the new array will be [code]byte_array.size() / 12[/code].
+				If the original data can't be converted to multiple Vector3, the resulting data is undefined.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -27,6 +27,18 @@
 			<return type="PackedByteArray" />
 			<argument index="0" name="buffer" type="RID" />
 			<description>
+				Fetch the data from the buffer as a [PackedByteArray].
+				The size of the new array will be of buffer's size.
+			</description>
+		</method>
+		<method name="buffer_get_data_generic">
+			<return type="Variant" />
+			<argument index="0" name="buffer" type="RID" />
+			<argument index="1" name="type" type="int" enum="Variant.Type" />
+			<description>
+				Fetch the data from the buffer as an array of type [code]type[/code].
+				The size of the new array will be of buffer's size (divided by the size of each element).
+				Valid [code]type[/code] are [PackedByteArray],[PackedInt32Array], [PackedInt64Array], [PackedFloat32Array], [PackedFloat64Array], [PackedVector2Array] and [PackedColorArray].
 			</description>
 		</method>
 		<method name="buffer_update">
@@ -37,6 +49,21 @@
 			<argument index="3" name="data" type="PackedByteArray" />
 			<argument index="4" name="post_barrier" type="int" default="7" />
 			<description>
+				Update the data in the buffer from position [code]offset[/code] to position [code]offset + size_bytes[/code] (excluded).
+				[code]data.size()[/code] must be &gt;= to [code]size_bytes[/code].
+			</description>
+		</method>
+		<method name="buffer_update_generic">
+			<return type="int" enum="Error" />
+			<argument index="0" name="buffer" type="RID" />
+			<argument index="1" name="index" type="int" />
+			<argument index="2" name="size" type="int" />
+			<argument index="3" name="data" type="Variant" />
+			<argument index="4" name="post_barrier" type="int" default="7" />
+			<description>
+				Update the data in the buffer from position [code]index[/code] to position [code]index + size[/code] (excluded).
+				[code]data.size()[/code] must be &gt;= to [code]size[/code].
+				Valid [code]data[/code] are of type [PackedByteArray],[PackedInt32Array], [PackedInt64Array], [PackedFloat32Array], [PackedFloat64Array], [PackedVector2Array] and [PackedColorArray].
 			</description>
 		</method>
 		<method name="capture_timestamp">
@@ -482,6 +509,17 @@
 			<argument index="1" name="data" type="PackedByteArray" default="PackedByteArray()" />
 			<argument index="2" name="usage" type="int" default="0" />
 			<description>
+				Create a storage buffer of size [code]size_bytes[/code].
+				If [code]data[/code] is not empty it must be of size [code]size_bytes[/code].
+			</description>
+		</method>
+		<method name="storage_buffer_create_generic">
+			<return type="RID" />
+			<argument index="0" name="data" type="Variant" />
+			<argument index="1" name="usage" type="int" default="0" />
+			<description>
+				Create a storage buffer initialized with values in [code]data[/code].
+				Valid [code]data[/code] are of type [PackedByteArray],[PackedInt32Array], [PackedInt64Array], [PackedFloat32Array], [PackedFloat64Array], [PackedVector2Array] and [PackedColorArray].
 			</description>
 		</method>
 		<method name="submit">
@@ -602,6 +640,16 @@
 			<argument index="0" name="size_bytes" type="int" />
 			<argument index="1" name="data" type="PackedByteArray" default="PackedByteArray()" />
 			<description>
+				Create a uniform buffer of size [code]size_bytes[/code].
+				If [code]data[/code] is not empty it must be of size [code]size_bytes[/code].
+			</description>
+		</method>
+		<method name="uniform_buffer_create_generic">
+			<return type="RID" />
+			<argument index="0" name="data" type="Variant" />
+			<description>
+				Create a uniform buffer initialized with values in [code]data[/code].
+				Valid [code]data[/code] are of type [PackedByteArray],[PackedInt32Array], [PackedInt64Array], [PackedFloat32Array], [PackedFloat64Array], [PackedVector2Array] and [PackedColorArray].
 			</description>
 		</method>
 		<method name="uniform_set_create">

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -744,6 +744,12 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 	RID_Owner<UniformSet, true> uniform_set_owner;
 
+	virtual RID _uniform_buffer_create(uint32_t p_size_bytes, const uint8_t *p_data = nullptr);
+	virtual RID _storage_buffer_create(uint32_t p_size_bytes, const uint8_t *p_data = nullptr, uint32_t p_usage = 0);
+
+	virtual uint64_t _buffer_get_size(RID p_buffer);
+	virtual void _buffer_get_data(RID p_buffer, uint8_t *p_mem); //this causes stall, only use to retrieve large buffers for saving
+
 	/*******************/
 	/**** PIPELINES ****/
 	/*******************/
@@ -1094,17 +1100,14 @@ public:
 	/**** UNIFORM ****/
 	/*****************/
 
-	virtual RID uniform_buffer_create(uint32_t p_size_bytes, const Vector<uint8_t> &p_data = Vector<uint8_t>());
-	virtual RID storage_buffer_create(uint32_t p_size_bytes, const Vector<uint8_t> &p_data = Vector<uint8_t>(), uint32_t p_usage = 0);
 	virtual RID texture_buffer_create(uint32_t p_size_elements, DataFormat p_format, const Vector<uint8_t> &p_data = Vector<uint8_t>());
 
 	virtual RID uniform_set_create(const Vector<Uniform> &p_uniforms, RID p_shader, uint32_t p_shader_set);
 	virtual bool uniform_set_is_valid(RID p_uniform_set);
 	virtual void uniform_set_set_invalidation_callback(RID p_uniform_set, UniformSetInvalidatedCallback p_callback, void *p_userdata);
 
-	virtual Error buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const void *p_data, uint32_t p_post_barrier = BARRIER_MASK_ALL); //works for any buffer
+	virtual Error buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size_bytes, const void *p_data, uint32_t p_post_barrier = BARRIER_MASK_ALL);
 	virtual Error buffer_clear(RID p_buffer, uint32_t p_offset, uint32_t p_size, uint32_t p_post_barrier = BARRIER_MASK_ALL);
-	virtual Vector<uint8_t> buffer_get_data(RID p_buffer);
 
 	/*************************/
 	/**** RENDER PIPELINE ****/


### PR DESCRIPTION
**My goal here is** to add some method on RenderingDevice for ease of use in godot script. As it is easy to push a structure in c++ on GPU it's not as easy in godot script so I just made some method to be able to push/retrieve a PackedVector2Array, a PackedColorArray, a PackedFloat32Array... I think it is useful and I am actually using it for compute shaders ;)

**RenderingDevice::buffer_update:**
It is now two template functions.
One to give an array of element and one to give only one element for ease of use.

Those two template functions are exposed as specialized functions in gdscript for the different type of array and their type T.

**PackedByteArray::to_XXX_array:**
Became a template function to avoid code duplication and then the content of this function have been moved to a Vector<T> ctor to make it more widely available.
Add three more specialization of this method for vector2, vector3 and color as it is commonly used type in shader.

Discussion started here but nobody seems to have something to say against it : https://github.com/godotengine/godot-proposals/issues/3042

Previous PR & godot-proposals linked to this issues :
https://github.com/godotengine/godot-proposals/issues/2993
https://github.com/godotengine/godot/pull/50535