### PR TITLE
Fix logic to allow default null thread argument

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1787,7 +1787,7 @@ void _Thread::_start_func(void *ud) {
 			target_param_count = method->get_argument_count();
 			target_default_arg_count = method->get_default_argument_count();
 		}
-		if (target_param_count >= 1 && target_default_arg_count == target_param_count) {
+		if (target_param_count >= 1 && target_default_arg_count < target_param_count) {
 			argc = 1;
 		}
 	}


### PR DESCRIPTION
Fixup of #51093.

Without this change, case 3 in the original PR is not really fixed. It would still fail.

I don't quite understand how the erroneous logic slipped into the commit.