### PR TITLE
Portals - Fix secondary PVS bug

### DIFF
--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -164,11 +164,6 @@ void RoomManager::_preview_camera_update() {
 			bool changed = false;
 			if (camera_pos != _godot_camera_pos) {
 				changed = true;
-
-				// update gameplay monitor
-				Vector<Vector3> camera_positions;
-				camera_positions.push_back(camera_pos);
-				VisualServer::get_singleton()->rooms_update_gameplay_monitor(scenario, camera_positions);
 			}
 			// check planes
 			if (!changed) {

--- a/servers/visual/portals/portal_gameplay_monitor.cpp
+++ b/servers/visual/portals/portal_gameplay_monitor.cpp
@@ -104,20 +104,23 @@ void PortalGameplayMonitor::update_gameplay(PortalRenderer &p_portal_renderer, c
 	for (int n = 0; n < p_num_source_rooms; n++) {
 		const VSRoom &source_room = p_portal_renderer.get_room(p_source_room_ids[n]);
 
-		int pvs_size = source_room._pvs_size;
-		int pvs_first = source_room._pvs_first;
 		if (_use_secondary_pvs) {
-			pvs_size = source_room._secondary_pvs_size;
-			pvs_first = source_room._secondary_pvs_first;
+			int pvs_size = source_room._secondary_pvs_size;
+			int pvs_first = source_room._secondary_pvs_first;
+
+			for (int r = 0; r < pvs_size; r++) {
+				int room_id = pvs.get_secondary_pvs_room_id(pvs_first + r);
+				_update_gameplay_room(p_portal_renderer, room_id, source_rooms_changed);
+			} // for r through the rooms hit in the pvs
+		} else {
+			int pvs_size = source_room._pvs_size;
+			int pvs_first = source_room._pvs_first;
+
+			for (int r = 0; r < pvs_size; r++) {
+				int room_id = pvs.get_pvs_room_id(pvs_first + r);
+				_update_gameplay_room(p_portal_renderer, room_id, source_rooms_changed);
+			} // for r through the rooms hit in the pvs
 		}
-
-		for (int r = 0; r < pvs_size; r++) {
-			int room_id = pvs.get_pvs_room_id(pvs_first + r);
-
-			_update_gameplay_room(p_portal_renderer, room_id, source_rooms_changed);
-
-		} // for r through the rooms hit in the pvs
-
 	} // for n through source rooms
 
 	// find any moving that were active last tick that are no longer active, and send notifications

--- a/servers/visual/portals/portal_pvs_builder.cpp
+++ b/servers/visual/portals/portal_pvs_builder.cpp
@@ -272,8 +272,8 @@ void PVSBuilder::calculate_pvs(PortalRenderer &p_portal_renderer, String p_filen
 
 		log("pvs from room : " + itos(n));
 
-		// trace_rooms_recursive_simple(0, n, n, -1, false, -1, dummy_planes, bf);
-		trace_rooms_recursive(0, n, n, -1, false, -1, dummy_planes, bf);
+		trace_rooms_recursive_simple(0, n, n, -1, false, -1, dummy_planes, bf);
+		// trace_rooms_recursive(0, n, n, -1, false, -1, dummy_planes, bf);
 
 		create_secondary_pvs(n, neighbors, bf);
 


### PR DESCRIPTION
Fixes a bug whereby it read from the primary PVS in the gameplay monitor, using the size from the secondary PVS. This would read out of bounds and crash.

Removed debug code to update the gameplay monitor from the preview camera - this is no longer required.

Temporarily revert to the simple PVS generation method, because I've noticed a bug in the complex version, and the simple version is safer while I fix this.

Fixes crash in #51386. (But not the Sprite3Ds yet)

## Notes
* I noticed a recursion loop in the new complex PVS method so I've temporarily turned it back to the simple version, just to be safe. This is not entirely surprising as the new method is a bit more convoluted and has to handle more cases.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
