### PR TITLE
Portals - fix crash when logging link room names

### DIFF
--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -848,7 +848,7 @@ void RoomManager::_third_pass_rooms(const LocalVector<Portal *> &p_portals) {
 				int linked_room_id = (portal_links_out) ? portal._linkedroom_ID[1] : portal._linkedroom_ID[0];
 
 				// this shouldn't be out of range, but just in case
-				if (linked_room_id < _rooms.size()) {
+				if ((linked_room_id >= 0) && (linked_room_id < _rooms.size())) {
 					Room *linked_room = _rooms[linked_room_id];
 
 					String portal_link_room_name = _find_name_before(linked_room, "-room", true);


### PR DESCRIPTION
The checking for link room IDs was checking for less than size(), but was not correctly checking for -1,
and therefore reading outside the array range. This PR fixes this.

Fixes #51390. (I hope!)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
