### PR TITLE
Portals - add support for Sprite3D

### DIFF
--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -41,6 +41,7 @@
 #include "room_group.h"
 #include "scene/3d/camera.h"
 #include "scene/3d/light.h"
+#include "scene/3d/sprite_3d.h"
 #include "visibility_notifier.h"
 
 #ifdef TOOLS_ENABLED
@@ -1728,11 +1729,11 @@ bool RoomManager::_bound_findpoints_geom_instance(GeometryInstance *p_gi, Vector
 
 			// convert to world space
 			for (int n = 0; n < vertices.size(); n++) {
-				Vector3 ptWorld = trans.xform(vertices[n]);
-				r_room_pts.push_back(ptWorld);
+				Vector3 pt_world = trans.xform(vertices[n]);
+				r_room_pts.push_back(pt_world);
 
 				// keep the bound up to date
-				r_aabb.expand_to(ptWorld);
+				r_aabb.expand_to(pt_world);
 			}
 
 		} // for through the surfaces
@@ -1788,13 +1789,34 @@ bool RoomManager::_bound_findpoints_geom_instance(GeometryInstance *p_gi, Vector
 			trans = mmi->get_global_transform() * trans;
 
 			for (int n = 0; n < local_verts.size(); n++) {
-				Vector3 ptWorld = trans.xform(local_verts[n]);
-				r_room_pts.push_back(ptWorld);
+				Vector3 pt_world = trans.xform(local_verts[n]);
+				r_room_pts.push_back(pt_world);
 
 				// keep the bound up to date
-				r_aabb.expand_to(ptWorld);
+				r_aabb.expand_to(pt_world);
 			}
 		}
+		return true;
+	}
+
+	// Sprite3D
+	SpriteBase3D *sprite = Object::cast_to<SpriteBase3D>(p_gi);
+	if (sprite) {
+		Ref<TriangleMesh> tmesh = sprite->generate_triangle_mesh();
+		PoolVector<Vector3> vertices = tmesh->get_vertices();
+
+		// for converting meshes to world space
+		Transform trans = p_gi->get_global_transform();
+
+		// convert to world space
+		for (int n = 0; n < vertices.size(); n++) {
+			Vector3 pt_world = trans.xform(vertices[n]);
+			r_room_pts.push_back(pt_world);
+
+			// keep the bound up to date
+			r_aabb.expand_to(pt_world);
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
Add support for Sprite3D and animated Sprite3D.

Fixes #51386 (with #51388)

## Notes
* I had simply forgotten these. Poor Sprite3D. :cry: 
* The animated version will probably need to be DYNAMIC rather than STATIC if the mesh moves. I'm not familiar with AnimatedSprite3D and whether this occurs, but if we can add it to the docs as similar to the situation with ParticleSystems which also need to be DYNAMIC or have an extra cull margin applied.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
