### PR TITLE
Portals - fix PVS generation and move settings

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1236,6 +1236,30 @@
 		<member name="rendering/mesh_storage/split_stream" type="bool" setter="" getter="" default="false">
 			On import, mesh vertex data will be split into two streams within a single vertex buffer, one for position data and the other for interleaved attributes data. Recommended to be enabled if targeting mobile devices. Requires manual reimport of meshes after toggling.
 		</member>
+		<member name="rendering/portals/advanced/flip_imported_portals" type="bool" setter="" getter="" default="false">
+			The default convention is for portal normals to point outward (face outward) from the source room.
+			If you accidentally build your level with portals facing the wrong way, this setting can fix the problem.
+			It will flip named portal meshes (i.e. [code]-portal[/code]) on the initial convertion to [Portal] nodes.
+		</member>
+		<member name="rendering/portals/debug/logging" type="bool" setter="" getter="" default="true">
+			Show conversion logs.
+			[b]Note:[/b] This will automatically be disabled in exports.
+		</member>
+		<member name="rendering/portals/gameplay/use_signals" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], gameplay callbacks will be sent as [code]signals[/code]. If [code]false[/code], they will be sent as [code]notifications[/code].
+		</member>
+		<member name="rendering/portals/optimize/remove_danglers" type="bool" setter="" getter="" default="true">
+			If enabled, while merging meshes, the system will also attempt to remove [Spatial] nodes that no longer have any children.
+			Reducing the number of [Node]s in the scene tree can make traversal more efficient, but can be switched off in case you wish to use empty [Spatial]s for markers or some other purpose.
+		</member>
+		<member name="rendering/portals/pvs/pvs_logging" type="bool" setter="" getter="" default="false">
+			Show logs during PVS generation.
+			[b]Note:[/b] This will automatically be disabled in exports.
+		</member>
+		<member name="rendering/portals/pvs/use_simple_pvs" type="bool" setter="" getter="" default="false">
+			Uses a simplified method of generating PVS (potentially visible set) data. The results may not be accurate where more than one portal join adjacent rooms.
+			[b]Note:[/b] Generally you should only use this option if you encounter bugs when it is set to [code]false[/code], i.e. there are problems with the default method.
+		</member>
 		<member name="rendering/quality/depth/hdr" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], allocates the main framebuffer with high dynamic range. High dynamic range allows the use of [Color] values greater than 1.
 			[b]Note:[/b] Only available on the GLES3 backend.

--- a/doc/classes/RoomManager.xml
+++ b/doc/classes/RoomManager.xml
@@ -48,9 +48,6 @@
 			Usually we don't want objects that only [b]just[/b] cross a boundary into an adjacent [Room] to sprawl into that room. To prevent this, each [Portal] has an extra margin, or tolerance zone where objects can enter without sprawling to a neighbouring room.
 			In most cases you can set this here for all portals. It is possible to override the margin for each portal.
 		</member>
-		<member name="flip_portal_meshes" type="bool" setter="set_flip_portal_meshes" getter="get_flip_portal_meshes" default="false">
-			The default convention is for portal normals to point outward (face outward) from the source room. If you accidentally build your level with portals facing the wrong way, this setting can fix the problem. It will flip named portal meshes (i.e. [code]Portal_[/code]) on the initial convertion to [Portal] nodes.
-		</member>
 		<member name="gameplay_monitor" type="bool" setter="set_gameplay_monitor_enabled" getter="get_gameplay_monitor_enabled" default="false">
 			When using a partial or full PVS, the gameplay monitor allows you to receive callbacks when roaming objects or rooms enter or exit the [b]gameplay area[/b]. The gameplay area is defined as either the primary, or secondary PVS.
 			These callbacks allow you to, for example, reduce processing for objects that are far from the player, or turn on and off AI.
@@ -78,10 +75,6 @@
 			Optionally during conversion the potentially visible set (PVS) of rooms that are potentially visible from each room can be calculated. This can be used either to aid in dynamic portal culling, or to totally replace portal culling.
 			In [code]Full[/code] PVS Mode, all objects within the potentially visible rooms will be frustum culled, and rendered if they are within the view frustum.
 		</member>
-		<member name="remove_danglers" type="bool" setter="set_remove_danglers" getter="get_remove_danglers" default="true">
-			If enabled, while merging meshes, the system will also attempt to remove [Spatial] nodes that no longer have any children.
-			Reducing the number of [Node]s in the scene tree can make traversal more efficient, but can be switched off in case you wish to use empty [Spatial]s for markers or some other purpose.
-		</member>
 		<member name="room_simplify" type="float" setter="set_room_simplify" getter="get_room_simplify" default="0.5">
 			During the conversion process, the geometry of objects within [Room]s, or a custom specified manual bound, are used to generate a [b]convex hull bound[/b].
 			This convex hull is [b]required[/b] in the visibility system, and is used for many purposes. Most importantly, it is used to decide whether the [Camera] (or an object) is within a [Room]. The convex hull generating algorithm is good, but occasionally it can create too many (or too few) planes to give a good representation of the room volume.
@@ -92,19 +85,12 @@
 		<member name="roomlist" type="NodePath" setter="set_roomlist_path" getter="get_roomlist_path" default="NodePath(&quot;&quot;)">
 			For the [Room] conversion process to succeed, you must point the [RoomManager] to the parent [Node] of your [Room]s and [RoomGroup]s, which we refer to as the [code]roomlist[/code] (the roomlist is not a special node type, it is normally just a [Spatial]).
 		</member>
-		<member name="show_debug" type="bool" setter="set_show_debug" getter="get_show_debug" default="true">
-			Show debugging information - including [Portal]s, and conversion logs.
-			[b]Note:[/b] This will automatically be disabled in exports.
-		</member>
 		<member name="show_margins" type="bool" setter="set_show_margins" getter="get_show_margins" default="true">
 			Shows the [Portal] margins when the portal gizmo is used in the editor.
 		</member>
 		<member name="use_secondary_pvs" type="bool" setter="set_use_secondary_pvs" getter="get_use_secondary_pvs" default="false">
 			When receiving gameplay callbacks when objects enter and exit gameplay, the [b]gameplay area[/b] can be defined by either the primary PVS (potentially visible set) of [Room]s, or the secondary PVS (the primary PVS and their neighbouring [Room]s).
 			Sometimes using the larger gameplay area of the secondary PVS may be preferable.
-		</member>
-		<member name="use_signals" type="bool" setter="set_use_signals" getter="get_use_signals" default="true">
-			Gameplay callbacks can either be sent as [code]signals[/code] or [code]notifications[/code].
 		</member>
 	</members>
 	<constants>

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -67,9 +67,6 @@ public:
 	void rooms_set_active(bool p_active);
 	bool rooms_get_active() const;
 
-	void set_show_debug(bool p_show);
-	bool get_show_debug() const;
-
 	void set_show_margins(bool p_show);
 	bool get_show_margins() const;
 
@@ -78,9 +75,6 @@ public:
 
 	void set_merge_meshes(bool p_enable);
 	bool get_merge_meshes() const;
-
-	void set_remove_danglers(bool p_enable);
-	bool get_remove_danglers() const;
 
 	void set_room_simplify(real_t p_value);
 	real_t get_room_simplify() const;
@@ -94,9 +88,6 @@ public:
 	void set_portal_depth_limit(int p_limit);
 	int get_portal_depth_limit() const { return _settings_portal_depth_limit; }
 
-	void set_flip_portal_meshes(bool p_flip);
-	bool get_flip_portal_meshes() const;
-
 	void set_pvs_mode(PVSMode p_mode);
 	PVSMode get_pvs_mode() const;
 
@@ -105,9 +96,6 @@ public:
 
 	void set_use_secondary_pvs(bool p_enable) { _settings_use_secondary_pvs = p_enable; }
 	bool get_use_secondary_pvs() const { return _settings_use_secondary_pvs; }
-
-	void set_use_signals(bool p_enable) { _settings_use_signals = p_enable; }
-	bool get_use_signals() const { return _settings_use_signals; }
 
 	void set_gameplay_monitor_enabled(bool p_enable) { _settings_gameplay_monitor_enabled = p_enable; }
 	bool get_gameplay_monitor_enabled() const { return _settings_gameplay_monitor_enabled; }
@@ -251,6 +239,9 @@ private:
 	PVSMode _pvs_mode = PVS_MODE_PARTIAL;
 	String _pvs_filename;
 	bool _settings_use_secondary_pvs = false;
+	bool _settings_use_simple_pvs = false;
+	bool _settings_log_pvs_generation = false;
+
 	bool _settings_use_signals = true;
 	bool _settings_gameplay_monitor_enabled = false;
 
@@ -277,6 +268,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	void _refresh_from_project_settings();
 };
 
 VARIANT_ENUM_CAST(RoomManager::PVSMode);

--- a/servers/visual/portals/portal_pvs_builder.h
+++ b/servers/visual/portals/portal_pvs_builder.h
@@ -46,7 +46,7 @@ class PVSBuilder {
 	};
 
 public:
-	void calculate_pvs(PortalRenderer &p_portal_renderer, String p_filename, int p_depth_limit);
+	void calculate_pvs(PortalRenderer &p_portal_renderer, String p_filename, int p_depth_limit, bool p_use_simple_pvs, bool p_log_pvs_generation);
 
 private:
 #ifdef GODOT_PVS_SUPPORT_SAVE_FILE

--- a/servers/visual/portals/portal_renderer.cpp
+++ b/servers/visual/portals/portal_renderer.cpp
@@ -653,7 +653,7 @@ void PortalRenderer::_rooms_add_portals_to_convex_hulls() {
 	}
 }
 
-void PortalRenderer::rooms_finalize(bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename) {
+void PortalRenderer::rooms_finalize(bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename, bool p_use_simple_pvs, bool p_log_pvs_generation) {
 	_gameplay_monitor.set_params(p_use_secondary_pvs, p_use_signals);
 
 	// portals should also bound the rooms, the room geometry may extend past the portal
@@ -687,7 +687,7 @@ void PortalRenderer::rooms_finalize(bool p_generate_pvs, bool p_cull_using_pvs, 
 	// calculate PVS
 	if (p_generate_pvs) {
 		PVSBuilder pvs;
-		pvs.calculate_pvs(*this, p_pvs_filename, _tracer.get_depth_limit());
+		pvs.calculate_pvs(*this, p_pvs_filename, _tracer.get_depth_limit(), p_use_simple_pvs, p_log_pvs_generation);
 		_cull_using_pvs = p_cull_using_pvs; // hard code to on for test
 	} else {
 		_cull_using_pvs = false;

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -149,7 +149,7 @@ public:
 	void room_set_bound(RoomHandle p_room, ObjectID p_room_object_id, const Vector<Plane> &p_convex, const AABB &p_aabb, const Vector<Vector3> &p_verts);
 	void room_prepare(RoomHandle p_room, int32_t p_priority);
 	void rooms_and_portals_clear();
-	void rooms_finalize(bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename);
+	void rooms_finalize(bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename, bool p_use_simple_pvs, bool p_log_pvs_generation);
 	void rooms_override_camera(bool p_override, const Vector3 &p_point, const Vector<Plane> *p_convex);
 	void rooms_set_active(bool p_active) { _active = p_active; }
 	void rooms_set_params(int p_portal_depth_limit) { _tracer.set_depth_limit(p_portal_depth_limit); }

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -586,7 +586,7 @@ public:
 	BIND2(room_prepare, RID, int32_t)
 	BIND1(rooms_and_portals_clear, RID)
 	BIND1(rooms_unload, RID)
-	BIND6(rooms_finalize, RID, bool, bool, bool, bool, String)
+	BIND8(rooms_finalize, RID, bool, bool, bool, bool, String, bool, bool)
 	BIND4(rooms_override_camera, RID, bool, const Vector3 &, const Vector<Plane> *)
 	BIND2(rooms_set_active, RID, bool)
 	BIND2(rooms_set_params, RID, int)

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1266,10 +1266,10 @@ void VisualServerScene::rooms_and_portals_clear(RID p_scenario) {
 	scenario->_portal_renderer.rooms_and_portals_clear();
 }
 
-void VisualServerScene::rooms_finalize(RID p_scenario, bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename) {
+void VisualServerScene::rooms_finalize(RID p_scenario, bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename, bool p_use_simple_pvs, bool p_log_pvs_generation) {
 	Scenario *scenario = scenario_owner.getornull(p_scenario);
 	ERR_FAIL_COND(!scenario);
-	scenario->_portal_renderer.rooms_finalize(p_generate_pvs, p_cull_using_pvs, p_use_secondary_pvs, p_use_signals, p_pvs_filename);
+	scenario->_portal_renderer.rooms_finalize(p_generate_pvs, p_cull_using_pvs, p_use_secondary_pvs, p_use_signals, p_pvs_filename, p_use_simple_pvs, p_log_pvs_generation);
 }
 
 void VisualServerScene::rooms_override_camera(RID p_scenario, bool p_override, const Vector3 &p_point, const Vector<Plane> *p_convex) {

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -640,7 +640,7 @@ public:
 	virtual void room_prepare(RID p_room, int32_t p_priority);
 	virtual void rooms_and_portals_clear(RID p_scenario);
 	virtual void rooms_unload(RID p_scenario);
-	virtual void rooms_finalize(RID p_scenario, bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename);
+	virtual void rooms_finalize(RID p_scenario, bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename, bool p_use_simple_pvs, bool p_log_pvs_generation);
 	virtual void rooms_override_camera(RID p_scenario, bool p_override, const Vector3 &p_point, const Vector<Plane> *p_convex);
 	virtual void rooms_set_active(RID p_scenario, bool p_active);
 	virtual void rooms_set_params(RID p_scenario, int p_portal_depth_limit);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -509,7 +509,7 @@ public:
 	FUNC2(room_prepare, RID, int32_t)
 	FUNC1(rooms_and_portals_clear, RID)
 	FUNC1(rooms_unload, RID)
-	FUNC6(rooms_finalize, RID, bool, bool, bool, bool, String)
+	FUNC8(rooms_finalize, RID, bool, bool, bool, bool, String, bool, bool)
 	FUNC4(rooms_override_camera, RID, bool, const Vector3 &, const Vector<Plane> *)
 	FUNC2(rooms_set_active, RID, bool)
 	FUNC2(rooms_set_params, RID, int)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2594,6 +2594,14 @@ VisualServer::VisualServer() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/batching/lights/max_join_items", PropertyInfo(Variant::INT, "rendering/batching/lights/max_join_items", PROPERTY_HINT_RANGE, "0,512"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/batching/parameters/item_reordering_lookahead", PropertyInfo(Variant::INT, "rendering/batching/parameters/item_reordering_lookahead", PROPERTY_HINT_RANGE, "0,256"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/batching/precision/uv_contract_amount", PropertyInfo(Variant::INT, "rendering/batching/precision/uv_contract_amount", PROPERTY_HINT_RANGE, "0,10000"));
+
+	// Portal rendering settings
+	GLOBAL_DEF("rendering/portals/pvs/use_simple_pvs", false);
+	GLOBAL_DEF("rendering/portals/pvs/pvs_logging", false);
+	GLOBAL_DEF("rendering/portals/gameplay/use_signals", true);
+	GLOBAL_DEF("rendering/portals/optimize/remove_danglers", true);
+	GLOBAL_DEF("rendering/portals/debug/logging", true);
+	GLOBAL_DEF("rendering/portals/advanced/flip_imported_portals", false);
 }
 
 VisualServer::~VisualServer() {

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -902,7 +902,7 @@ public:
 	virtual void room_prepare(RID p_room, int32_t p_priority) = 0;
 	virtual void rooms_and_portals_clear(RID p_scenario) = 0;
 	virtual void rooms_unload(RID p_scenario) = 0;
-	virtual void rooms_finalize(RID p_scenario, bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename) = 0;
+	virtual void rooms_finalize(RID p_scenario, bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename, bool p_use_simple_pvs, bool p_log_pvs_generation) = 0;
 	virtual void rooms_override_camera(RID p_scenario, bool p_override, const Vector3 &p_point, const Vector<Plane> *p_convex) = 0;
 	virtual void rooms_set_active(RID p_scenario, bool p_active) = 0;
 	virtual void rooms_set_params(RID p_scenario, int p_portal_depth_limit) = 0;


### PR DESCRIPTION
Fixed a bug in the complex PVS generation which was causing recursive loop, and changes the default method back to using this complex method.
Move some of the settings out of RoomManager into Project Settings.
Allow PVS generation method to be selected from Project Settings, and control PVS logging.

![room_manager_cutdown](https://user-images.githubusercontent.com/21999379/128643074-78f1a22c-b5c6-4de1-9fa3-146670f246d4.png)
![portals_project_settings](https://user-images.githubusercontent.com/21999379/128643078-fd3adbfa-b296-4426-92c5-c0da68e4d1a6.png)

## Notes
* While initially this was a bug fix for the complex PVS generation I decided at least for the betas it would be nice to expose choosing the PVS method, and whether PVS generation logs were displayed.
* I had another look at the properties of RoomManager and thought it might be better to move some of them (that are unlikely to change during runtime) into ProjectSettings in order to keep the RoomManager as simple as possible.
* In most cases, users won't need to tweak these ProjectSettings anyway, so it makes sense to keep them hidden.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
