### PR TITLE
Use range iterators for `Map` in most cases

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -252,15 +252,15 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	Set<_VCSort> vclist;
 
-	for (Map<StringName, VariantContainer>::Element *E = props.front(); E; E = E->next()) {
-		const VariantContainer *v = &E->get();
+	for (const KeyValue<StringName, VariantContainer> &E : props) {
+		const VariantContainer *v = &E.value;
 
 		if (v->hide_from_editor) {
 			continue;
 		}
 
 		_VCSort vc;
-		vc.name = E->key();
+		vc.name = E.key;
 		vc.order = v->order;
 		vc.type = v->variant.get_type();
 		if (vc.name.begins_with("input/") || vc.name.begins_with("import/") || vc.name.begins_with("export/") || vc.name.begins_with("/remap") || vc.name.begins_with("/locale") || vc.name.begins_with("/autoload")) {
@@ -318,14 +318,14 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 void ProjectSettings::_convert_to_last_version(int p_from_version) {
 	if (p_from_version <= 3) {
 		// Converts the actions from array to dictionary (array of events to dictionary with deadzone + events)
-		for (Map<StringName, ProjectSettings::VariantContainer>::Element *E = props.front(); E; E = E->next()) {
-			Variant value = E->get().variant;
-			if (String(E->key()).begins_with("input/") && value.get_type() == Variant::ARRAY) {
+		for (KeyValue<StringName, ProjectSettings::VariantContainer> &E : props) {
+			Variant value = E.value.variant;
+			if (String(E.key).begins_with("input/") && value.get_type() == Variant::ARRAY) {
 				Array array = value;
 				Dictionary action;
 				action["deadzone"] = Variant(0.5f);
 				action["events"] = array;
-				E->get().variant = action;
+				E.value.variant = action;
 			}
 		}
 	}
@@ -695,8 +695,8 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 
 	int count = 0;
 
-	for (Map<String, List<String>>::Element *E = props.front(); E; E = E->next()) {
-		count += E->get().size();
+	for (const KeyValue<String, List<String>> &E : props) {
+		count += E.value.size();
 	}
 
 	if (p_custom_features != String()) {
@@ -788,7 +788,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 	}
 	file->store_string("\n");
 
-	for (Map<String, List<String>>::Element *E = props.front(); E; E = E->next()) {
+	for (const Map<String, List<String>>::Element *E = props.front(); E; E = E->next()) {
 		if (E != props.front()) {
 			file->store_string("\n");
 		}
@@ -831,19 +831,19 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 	Set<_VCSort> vclist;
 
 	if (p_merge_with_current) {
-		for (Map<StringName, VariantContainer>::Element *G = props.front(); G; G = G->next()) {
-			const VariantContainer *v = &G->get();
+		for (const KeyValue<StringName, VariantContainer> &G : props) {
+			const VariantContainer *v = &G.value;
 
 			if (v->hide_from_editor) {
 				continue;
 			}
 
-			if (p_custom.has(G->key())) {
+			if (p_custom.has(G.key)) {
 				continue;
 			}
 
 			_VCSort vc;
-			vc.name = G->key(); //*k;
+			vc.name = G.key; //*k;
 			vc.order = v->order;
 			vc.type = v->variant.get_type();
 			vc.flags = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE;
@@ -855,14 +855,14 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		}
 	}
 
-	for (const Map<String, Variant>::Element *E = p_custom.front(); E; E = E->next()) {
+	for (const KeyValue<String, Variant> &E : p_custom) {
 		// Lookup global prop to store in the same order
-		Map<StringName, VariantContainer>::Element *global_prop = props.find(E->key());
+		Map<StringName, VariantContainer>::Element *global_prop = props.find(E.key);
 
 		_VCSort vc;
-		vc.name = E->key();
+		vc.name = E.key;
 		vc.order = global_prop ? global_prop->get().order : 0xFFFFFFF;
-		vc.type = E->get().get_type();
+		vc.type = E.value.get_type();
 		vc.flags = PROPERTY_USAGE_STORAGE;
 		vclist.insert(vc);
 	}

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2411,12 +2411,12 @@ Error EngineDebugger::call_capture(void *p_user, const String &p_cmd, const Arra
 }
 
 EngineDebugger::~EngineDebugger() {
-	for (Map<StringName, Callable>::Element *E = captures.front(); E; E = E->next()) {
-		::EngineDebugger::unregister_message_capture(E->key());
+	for (const KeyValue<StringName, Callable> &E : captures) {
+		::EngineDebugger::unregister_message_capture(E.key);
 	}
 	captures.clear();
-	for (Map<StringName, ProfilerCallable>::Element *E = profilers.front(); E; E = E->next()) {
-		::EngineDebugger::unregister_profiler(E->key());
+	for (const KeyValue<StringName, ProfilerCallable> &E : profilers) {
+		::EngineDebugger::unregister_profiler(E.key);
 	}
 	profilers.clear();
 }

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -123,8 +123,8 @@ void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks,
 	physics_time = USEC_TO_SEC(p_physics_ticks);
 	physics_frame_time = p_physics_frame_time;
 	// Notify tick to running profilers
-	for (Map<StringName, Profiler>::Element *E = profilers.front(); E; E = E->next()) {
-		Profiler &p = E->get();
+	for (KeyValue<StringName, Profiler> &E : profilers) {
+		Profiler &p = E.value;
 		if (!p.active || !p.tick) {
 			continue;
 		}
@@ -179,9 +179,9 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Ve
 void EngineDebugger::deinitialize() {
 	if (singleton) {
 		// Stop all profilers
-		for (Map<StringName, Profiler>::Element *E = profilers.front(); E; E = E->next()) {
-			if (E->get().active) {
-				singleton->profiler_enable(E->key(), false);
+		for (const KeyValue<StringName, Profiler> &E : profilers) {
+			if (E.value.active) {
+				singleton->profiler_enable(E.key, false);
 			}
 		}
 

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -166,8 +166,8 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 		} else if (line.begins_with("set")) {
 			if (line.get_slice_count(" ") == 1) {
-				for (Map<String, String>::Element *E = options.front(); E; E = E->next()) {
-					print_line("\t" + E->key() + "=" + E->value());
+				for (const KeyValue<String, String> &E : options) {
+					print_line("\t" + E.key + "=" + E.value);
 				}
 
 			} else {
@@ -249,8 +249,8 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				}
 
 				print_line("Breakpoint(s): " + itos(breakpoints.size()));
-				for (Map<int, Set<StringName>>::Element *E = breakpoints.front(); E; E = E->next()) {
-					print_line("\t" + String(E->value().front()->get()) + ":" + itos(E->key()));
+				for (const KeyValue<int, Set<StringName>> &E : breakpoints) {
+					print_line("\t" + String(E.value.front()->get()) + ":" + itos(E.key));
 				}
 
 			} else {

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -179,8 +179,8 @@ public:
 		if (pt - last_profile_time > 100) {
 			last_profile_time = pt;
 			DebuggerMarshalls::NetworkProfilerFrame frame;
-			for (Map<ObjectID, NodeInfo>::Element *E = multiplayer_node_data.front(); E; E = E->next()) {
-				frame.infos.push_back(E->get());
+			for (const KeyValue<ObjectID, NodeInfo> &E : multiplayer_node_data) {
+				frame.infos.push_back(E.value);
 			}
 			multiplayer_node_data.clear();
 			EngineDebugger::get_singleton()->send_message("network:profile_frame", frame.serialize());

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -353,11 +353,11 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 		api_dump["global_constants"] = constants;
 
 		Array enums;
-		for (Map<String, List<Pair<String, int>>>::Element *E = enum_list.front(); E; E = E->next()) {
+		for (const KeyValue<String, List<Pair<String, int>>> &E : enum_list) {
 			Dictionary d1;
-			d1["name"] = E->key();
+			d1["name"] = E.key;
 			Array values;
-			for (const Pair<String, int> &F : E->get()) {
+			for (const Pair<String, int> &F : E.value) {
 				Dictionary d2;
 				d2["name"] = F.first;
 				d2["value"] = F.second;

--- a/core/extension/native_extension_manager.cpp
+++ b/core/extension/native_extension_manager.cpp
@@ -84,8 +84,8 @@ bool NativeExtensionManager::is_extension_loaded(const String &p_path) const {
 
 Vector<String> NativeExtensionManager::get_loaded_extensions() const {
 	Vector<String> ret;
-	for (const Map<String, Ref<NativeExtension>>::Element *E = native_extension_map.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<String, Ref<NativeExtension>> &E : native_extension_map) {
+		ret.push_back(E.key);
 	}
 	return ret;
 }
@@ -97,16 +97,16 @@ Ref<NativeExtension> NativeExtensionManager::get_extension(const String &p_path)
 
 void NativeExtensionManager::initialize_extensions(NativeExtension::InitializationLevel p_level) {
 	ERR_FAIL_COND(int32_t(p_level) - 1 != level);
-	for (Map<String, Ref<NativeExtension>>::Element *E = native_extension_map.front(); E; E = E->next()) {
-		E->get()->initialize_library(p_level);
+	for (KeyValue<String, Ref<NativeExtension>> &E : native_extension_map) {
+		E.value->initialize_library(p_level);
 	}
 	level = p_level;
 }
 
 void NativeExtensionManager::deinitialize_extensions(NativeExtension::InitializationLevel p_level) {
 	ERR_FAIL_COND(int32_t(p_level) != level);
-	for (Map<String, Ref<NativeExtension>>::Element *E = native_extension_map.front(); E; E = E->next()) {
-		E->get()->deinitialize_library(p_level);
+	for (KeyValue<String, Ref<NativeExtension>> &E : native_extension_map) {
+		E.value->deinitialize_library(p_level);
 	}
 	level = int32_t(p_level) - 1;
 }

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -863,9 +863,9 @@ void Input::release_pressed_events() {
 	joy_buttons_pressed.clear();
 	_joy_axis.clear();
 
-	for (Map<StringName, Input::Action>::Element *E = action_state.front(); E; E = E->next()) {
-		if (E->get().pressed) {
-			action_release(E->key());
+	for (const KeyValue<StringName, Input::Action> &E : action_state) {
+		if (E.value.pressed) {
+			action_release(E.key);
 		}
 	}
 }
@@ -1322,8 +1322,8 @@ void Input::add_joy_mapping(String p_mapping, bool p_update_existing) {
 	if (p_update_existing) {
 		Vector<String> entry = p_mapping.split(",");
 		String uid = entry[0];
-		for (Map<int, Joypad>::Element *E = joy_names.front(); E; E = E->next()) {
-			Joypad &joy = E->get();
+		for (KeyValue<int, Joypad> &E : joy_names) {
+			Joypad &joy = E.value;
 			if (joy.uid == uid) {
 				joy.mapping = map_db.size() - 1;
 			}
@@ -1337,8 +1337,8 @@ void Input::remove_joy_mapping(String p_guid) {
 			map_db.remove(i);
 		}
 	}
-	for (Map<int, Joypad>::Element *E = joy_names.front(); E; E = E->next()) {
-		Joypad &joy = E->get();
+	for (KeyValue<int, Joypad> &E : joy_names) {
+		Joypad &joy = E.value;
 		if (joy.uid == p_guid) {
 			joy.mapping = -1;
 		}

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -110,8 +110,8 @@ PackedData::PackedData() {
 }
 
 void PackedData::_free_packed_dirs(PackedDir *p_dir) {
-	for (Map<String, PackedDir *>::Element *E = p_dir->subdirs.front(); E; E = E->next()) {
-		_free_packed_dirs(E->get());
+	for (const KeyValue<String, PackedDir *> &E : p_dir->subdirs) {
+		_free_packed_dirs(E.value);
 	}
 	memdelete(p_dir);
 }
@@ -395,8 +395,8 @@ Error DirAccessPack::list_dir_begin() {
 	list_dirs.clear();
 	list_files.clear();
 
-	for (Map<String, PackedData::PackedDir *>::Element *E = current->subdirs.front(); E; E = E->next()) {
-		list_dirs.push_back(E->key());
+	for (const KeyValue<String, PackedData::PackedDir *> &E : current->subdirs) {
+		list_dirs.push_back(E.key);
 	}
 
 	for (Set<String>::Element *E = current->files.front(); E; E = E->next()) {

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -288,8 +288,8 @@ Array IP::_get_local_interfaces() const {
 	Array results;
 	Map<String, Interface_Info> interfaces;
 	get_local_interfaces(&interfaces);
-	for (Map<String, Interface_Info>::Element *E = interfaces.front(); E; E = E->next()) {
-		Interface_Info &c = E->get();
+	for (KeyValue<String, Interface_Info> &E : interfaces) {
+		Interface_Info &c = E.value;
 		Dictionary rc;
 		rc["name"] = c.name;
 		rc["friendly"] = c.name_friendly;
@@ -310,8 +310,8 @@ Array IP::_get_local_interfaces() const {
 void IP::get_local_addresses(List<IPAddress> *r_addresses) const {
 	Map<String, Interface_Info> interfaces;
 	get_local_interfaces(&interfaces);
-	for (Map<String, Interface_Info>::Element *E = interfaces.front(); E; E = E->next()) {
-		for (const IPAddress &F : E->get().ip_addresses) {
+	for (const KeyValue<String, Interface_Info> &E : interfaces) {
+		for (const IPAddress &F : E.value.ip_addresses) {
 			r_addresses->push_front(F);
 		}
 	}

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -540,9 +540,9 @@ void ResourceCache::dump(const char *p_file, bool p_short) {
 		}
 	}
 
-	for (Map<String, int>::Element *E = type_count.front(); E; E = E->next()) {
+	for (const KeyValue<String, int> &E : type_count) {
 		if (f) {
-			f->store_line(E->key() + " count: " + itos(E->get()));
+			f->store_line(E.key + " count: " + itos(E.value));
 		}
 	}
 	if (f) {

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1960,8 +1960,8 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	Vector<RES> save_order;
 	save_order.resize(external_resources.size());
 
-	for (Map<RES, int>::Element *E = external_resources.front(); E; E = E->next()) {
-		save_order.write[E->get()] = E->key();
+	for (const KeyValue<RES, int> &E : external_resources) {
+		save_order.write[E.value] = E.key;
 	}
 
 	for (int i = 0; i < save_order.size(); i++) {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -156,8 +156,8 @@ void ResourceFormatLoader::get_dependencies(const String &p_path, List<String> *
 
 Error ResourceFormatLoader::rename_dependencies(const String &p_path, const Map<String, String> &p_map) {
 	Dictionary deps_dict;
-	for (Map<String, String>::Element *E = p_map.front(); E; E = E->next()) {
-		deps_dict[E->key()] = E->value();
+	for (KeyValue<String, String> E : p_map) {
+		deps_dict[E.key] = E.value;
 	}
 
 	int64_t err;

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -265,8 +265,8 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 		//create new faces from horizon edges
 		List<List<Face>::Element *> new_faces; //new faces
 
-		for (Map<Edge, FaceConnect>::Element *E = lit_edges.front(); E; E = E->next()) {
-			FaceConnect &fc = E->get();
+		for (KeyValue<Edge, FaceConnect> &E : lit_edges) {
+			FaceConnect &fc = E.value;
 			if (fc.left && fc.right) {
 				continue; //edge is uninteresting, not on horizon
 			}
@@ -275,8 +275,8 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 			Face face;
 			face.vertices[0] = f.points_over[next];
-			face.vertices[1] = E->key().vertices[0];
-			face.vertices[2] = E->key().vertices[1];
+			face.vertices[1] = E.key.vertices[0];
+			face.vertices[2] = E.key.vertices[1];
 
 			Plane p(p_points[face.vertices[0]], p_points[face.vertices[1]], p_points[face.vertices[2]]);
 
@@ -418,13 +418,13 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 				}
 
 				// remove all edge connections to this face
-				for (Map<Edge, RetFaceConnect>::Element *G = ret_edges.front(); G; G = G->next()) {
-					if (G->get().left == O) {
-						G->get().left = nullptr;
+				for (KeyValue<Edge, RetFaceConnect> &G : ret_edges) {
+					if (G.value.left == O) {
+						G.value.left = nullptr;
 					}
 
-					if (G->get().right == O) {
-						G->get().right = nullptr;
+					if (G.value.right == O) {
+						G.value.right = nullptr;
 					}
 				}
 
@@ -444,10 +444,10 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 	}
 	r_mesh.edges.resize(ret_edges.size());
 	idx = 0;
-	for (Map<Edge, RetFaceConnect>::Element *E = ret_edges.front(); E; E = E->next()) {
+	for (const KeyValue<Edge, RetFaceConnect> &E : ret_edges) {
 		Geometry3D::MeshData::Edge e;
-		e.a = E->key().vertices[0];
-		e.b = E->key().vertices[1];
+		e.a = E.key.vertices[0];
+		e.b = E.key.vertices[1];
 		r_mesh.edges.write[idx++] = e;
 	}
 

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -157,8 +157,8 @@ void TriangleMesh::create(const Vector<Vector3> &p_faces) {
 
 		vertices.resize(db.size());
 		Vector3 *vw = vertices.ptrw();
-		for (Map<Vector3, int>::Element *E = db.front(); E; E = E->next()) {
-			vw[E->get()] = E->key();
+		for (const KeyValue<Vector3, int> &E : db) {
+			vw[E.value] = E.key;
 		}
 	}
 

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -227,16 +227,16 @@ void MessageQueue::statistics() {
 	print_line("TOTAL BYTES: " + itos(buffer_end));
 	print_line("NULL count: " + itos(null_count));
 
-	for (Map<StringName, int>::Element *E = set_count.front(); E; E = E->next()) {
-		print_line("SET " + E->key() + ": " + itos(E->get()));
+	for (const KeyValue<StringName, int> &E : set_count) {
+		print_line("SET " + E.key + ": " + itos(E.value));
 	}
 
-	for (Map<Callable, int>::Element *E = call_count.front(); E; E = E->next()) {
-		print_line("CALL " + E->key() + ": " + itos(E->get()));
+	for (const KeyValue<Callable, int> &E : call_count) {
+		print_line("CALL " + E.key + ": " + itos(E.value));
 	}
 
-	for (Map<int, int>::Element *E = notify_count.front(); E; E = E->next()) {
-		print_line("NOTIFY " + itos(E->key()) + ": " + itos(E->get()));
+	for (const KeyValue<int, int> &E : notify_count) {
+		print_line("NOTIFY " + itos(E.key) + ": " + itos(E.value));
 	}
 }
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -93,8 +93,8 @@ Dictionary Script::_get_script_constant_map() {
 	Dictionary ret;
 	Map<StringName, Variant> map;
 	get_constants(&map);
-	for (Map<StringName, Variant>::Element *E = map.front(); E; E = E->next()) {
-		ret[E->key()] = E->value();
+	for (const KeyValue<StringName, Variant> &E : map) {
+		ret[E.key] = E.value;
 	}
 	return ret;
 }

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -162,11 +162,11 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		btw[btindex++] = t.size();
 		btw[btindex++] = hfunc_table[i];
 
-		for (Map<uint32_t, int>::Element *E = t.front(); E; E = E->next()) {
-			btw[btindex++] = E->key();
-			btw[btindex++] = compressed[E->get()].offset;
-			btw[btindex++] = compressed[E->get()].compressed.size();
-			btw[btindex++] = compressed[E->get()].orig_len;
+		for (const KeyValue<uint32_t, int> &E : t) {
+			btw[btindex++] = E.key;
+			btw[btindex++] = compressed[E.value].offset;
+			btw[btindex++] = compressed[E.value].compressed.size();
+			btw[btindex++] = compressed[E.value].orig_len;
 		}
 	}
 

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -820,8 +820,8 @@ static const char *locale_renames[][2] = {
 
 Dictionary Translation::_get_messages() const {
 	Dictionary d;
-	for (const Map<StringName, StringName>::Element *E = translation_map.front(); E; E = E->next()) {
-		d[E->key()] = E->value();
+	for (const KeyValue<StringName, StringName> &E : translation_map) {
+		d[E.key] = E.value;
 	}
 	return d;
 }
@@ -830,8 +830,8 @@ Vector<String> Translation::_get_message_list() const {
 	Vector<String> msgs;
 	msgs.resize(translation_map.size());
 	int idx = 0;
-	for (const Map<StringName, StringName>::Element *E = translation_map.front(); E; E = E->next()) {
-		msgs.set(idx, E->key());
+	for (const KeyValue<StringName, StringName> &E : translation_map) {
+		msgs.set(idx, E.key);
 		idx += 1;
 	}
 
@@ -911,8 +911,8 @@ void Translation::erase_message(const StringName &p_src_text, const StringName &
 }
 
 void Translation::get_message_list(List<StringName> *r_messages) const {
-	for (const Map<StringName, StringName>::Element *E = translation_map.front(); E; E = E->next()) {
-		r_messages->push_back(E->key());
+	for (const KeyValue<StringName, StringName> &E : translation_map) {
+		r_messages->push_back(E.key);
 	}
 }
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1241,8 +1241,8 @@ void Variant::get_constants_for_type(Variant::Type p_type, List<StringName> *p_c
 	for (List<StringName>::Element *E = cd.value_ordered.front(); E; E = E->next()) {
 		p_constants->push_back(E->get());
 #else
-	for (Map<StringName, int>::Element *E = cd.value.front(); E; E = E->next()) {
-		p_constants->push_back(E->key());
+	for (const KeyValue<StringName, int> &E : cd.value) {
+		p_constants->push_back(E.key);
 #endif
 	}
 
@@ -1250,8 +1250,8 @@ void Variant::get_constants_for_type(Variant::Type p_type, List<StringName> *p_c
 	for (List<StringName>::Element *E = cd.variant_value_ordered.front(); E; E = E->next()) {
 		p_constants->push_back(E->get());
 #else
-	for (Map<StringName, Variant>::Element *E = cd.variant_value.front(); E; E = E->next()) {
-		p_constants->push_back(E->key());
+	for (const KeyValue<StringName, Variant> &E : cd.variant_value) {
+		p_constants->push_back(E.key);
 #endif
 	}
 }

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -258,8 +258,8 @@ _FORCE_INLINE_ Error NetSocketPosix::_change_multicast_group(IPAddress p_ip, Str
 	uint32_t if_v6id = 0;
 	Map<String, IP::Interface_Info> if_info;
 	IP::get_singleton()->get_local_interfaces(&if_info);
-	for (Map<String, IP::Interface_Info>::Element *E = if_info.front(); E; E = E->next()) {
-		IP::Interface_Info &c = E->get();
+	for (KeyValue<String, IP::Interface_Info> &E : if_info) {
+		IP::Interface_Info &c = E.value;
 		if (c.name != p_if_name) {
 			continue;
 		}

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8688,10 +8688,10 @@ void RenderingDeviceVulkan::_free_pending_resources(int p_frame) {
 	while (frames[p_frame].framebuffers_to_dispose_of.front()) {
 		Framebuffer *framebuffer = &frames[p_frame].framebuffers_to_dispose_of.front()->get();
 
-		for (Map<Framebuffer::VersionKey, Framebuffer::Version>::Element *E = framebuffer->framebuffers.front(); E; E = E->next()) {
+		for (const KeyValue<Framebuffer::VersionKey, Framebuffer::Version> &E : framebuffer->framebuffers) {
 			//first framebuffer, then render pass because it depends on it
-			vkDestroyFramebuffer(device, E->get().framebuffer, nullptr);
-			vkDestroyRenderPass(device, E->get().render_pass, nullptr);
+			vkDestroyFramebuffer(device, E.value.framebuffer, nullptr);
+			vkDestroyRenderPass(device, E.value.render_pass, nullptr);
 		}
 
 		frames[p_frame].framebuffers_to_dispose_of.pop_front();

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -1755,8 +1755,8 @@ Error VulkanContext::prepare_buffers() {
 	vkWaitForFences(device, 1, &fences[frame_index], VK_TRUE, UINT64_MAX);
 	vkResetFences(device, 1, &fences[frame_index]);
 
-	for (Map<int, Window>::Element *E = windows.front(); E; E = E->next()) {
-		Window *w = &E->get();
+	for (KeyValue<int, Window> &E : windows) {
+		Window *w = &E.value;
 
 		w->semaphore_acquired = false;
 
@@ -1837,8 +1837,8 @@ Error VulkanContext::swap_buffers() {
 	VkSemaphore *semaphores_to_acquire = (VkSemaphore *)alloca(windows.size() * sizeof(VkSemaphore));
 	uint32_t semaphores_to_acquire_count = 0;
 
-	for (Map<int, Window>::Element *E = windows.front(); E; E = E->next()) {
-		Window *w = &E->get();
+	for (KeyValue<int, Window> &E : windows) {
+		Window *w = &E.value;
 
 		if (w->semaphore_acquired) {
 			semaphores_to_acquire[semaphores_to_acquire_count++] = w->image_acquired_semaphores[frame_index];
@@ -1876,8 +1876,8 @@ Error VulkanContext::swap_buffers() {
 		VkCommandBuffer *cmdbufptr = (VkCommandBuffer *)alloca(sizeof(VkCommandBuffer *) * windows.size());
 		submit_info.pCommandBuffers = cmdbufptr;
 
-		for (Map<int, Window>::Element *E = windows.front(); E; E = E->next()) {
-			Window *w = &E->get();
+		for (KeyValue<int, Window> &E : windows) {
+			Window *w = &E.value;
 
 			if (w->swapchain == VK_NULL_HANDLE) {
 				continue;
@@ -1911,8 +1911,8 @@ Error VulkanContext::swap_buffers() {
 	present.pSwapchains = pSwapchains;
 	present.pImageIndices = pImageIndices;
 
-	for (Map<int, Window>::Element *E = windows.front(); E; E = E->next()) {
-		Window *w = &E->get();
+	for (KeyValue<int, Window> &E : windows) {
+		Window *w = &E.value;
 
 		if (w->swapchain == VK_NULL_HANDLE) {
 			continue;

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -398,17 +398,17 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 
 			float scale = timeline->get_zoom_scale();
 			Ref<Texture2D> point = get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons"));
-			for (Map<int, Color>::Element *E = subtrack_colors.front(); E; E = E->next()) {
-				_draw_track(E->key(), E->get());
+			for (const KeyValue<int, Color> &E : subtrack_colors) {
+				_draw_track(E.key, E.value);
 
-				for (int i = 0; i < animation->track_get_key_count(E->key()); i++) {
-					float offset = animation->track_get_key_time(E->key(), i);
-					float value = animation->bezier_track_get_key_value(E->key(), i);
+				for (int i = 0; i < animation->track_get_key_count(E.key); i++) {
+					float offset = animation->track_get_key_time(E.key, i);
+					float value = animation->bezier_track_get_key_value(E.key, i);
 
 					Vector2 pos((offset - timeline->get_value()) * scale + limit, _bezier_h_to_pixel(value));
 
 					if (pos.x >= limit && pos.x <= right_limit) {
-						draw_texture(point, pos - point->get_size() / 2, E->get());
+						draw_texture(point, pos - point->get_size() / 2, E.value);
 					}
 				}
 			}
@@ -680,9 +680,9 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			emit_signal(SNAME("close_request"));
 			return;
 		}
-		for (Map<int, Rect2>::Element *E = subtracks.front(); E; E = E->next()) {
-			if (E->get().has_point(mb->get_position())) {
-				set_animation_and_track(animation, E->key());
+		for (const KeyValue<int, Rect2> &E : subtracks) {
+			if (E.value.has_point(mb->get_position())) {
+				set_animation_and_track(animation, E.key);
 				_clear_selection();
 				return;
 			}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -702,8 +702,7 @@ public:
 
 		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 			int key = 0;
-			for (float &F : E->value()) {
-				float key_ofs = F;
+			for (const float &key_ofs : E->value()) {
 				if (from != key_ofs) {
 					key++;
 					continue;
@@ -728,8 +727,7 @@ public:
 		bool change_notify_deserved = false;
 		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 			int track = E->key();
-			for (float &F : E->value()) {
-				float key_ofs = F;
+			for (const float &key_ofs : E->value()) {
 				int key = animation->track_find_key(track, key_ofs, true);
 				ERR_FAIL_COND_V(key == -1, false);
 
@@ -986,8 +984,7 @@ public:
 	bool _get(const StringName &p_name, Variant &r_ret) const {
 		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 			int track = E->key();
-			for (float &F : E->value()) {
-				float key_ofs = F;
+			for (const float &key_ofs : E->value()) {
 				int key = animation->track_find_key(track, key_ofs, true);
 				ERR_CONTINUE(key == -1);
 
@@ -1137,7 +1134,7 @@ public:
 					same_key_type = false;
 				}
 
-				for (float &F : E->value()) {
+				for (const float &F : E->value()) {
 					int key = animation->track_find_key(track, F, true);
 					ERR_FAIL_COND(key == -1);
 					if (first_key < 0) {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -700,15 +700,15 @@ public:
 			return;
 		}
 
-		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
+		for (const KeyValue<int, List<float>> &E : key_ofs_map) {
 			int key = 0;
-			for (const float &key_ofs : E->value()) {
+			for (const float &key_ofs : E.value) {
 				if (from != key_ofs) {
 					key++;
 					continue;
 				}
 
-				int track = E->key();
+				int track = E.key;
 				key_ofs_map[track][key] = to;
 
 				if (setting) {
@@ -725,9 +725,9 @@ public:
 	bool _set(const StringName &p_name, const Variant &p_value) {
 		bool update_obj = false;
 		bool change_notify_deserved = false;
-		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
-			int track = E->key();
-			for (const float &key_ofs : E->value()) {
+		for (const KeyValue<int, List<float>> &E : key_ofs_map) {
+			int track = E.key;
+			for (const float &key_ofs : E.value) {
 				int key = animation->track_find_key(track, key_ofs, true);
 				ERR_FAIL_COND_V(key == -1, false);
 
@@ -982,9 +982,9 @@ public:
 	}
 
 	bool _get(const StringName &p_name, Variant &r_ret) const {
-		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
-			int track = E->key();
-			for (const float &key_ofs : E->value()) {
+		for (const KeyValue<int, List<float>> &E : key_ofs_map) {
+			int track = E.key;
+			for (const float &key_ofs : E.value) {
 				int key = animation->track_find_key(track, key_ofs, true);
 				ERR_CONTINUE(key == -1);
 
@@ -1116,15 +1116,15 @@ public:
 		bool show_time = true;
 		bool same_track_type = true;
 		bool same_key_type = true;
-		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
-			int track = E->key();
+		for (const KeyValue<int, List<float>> &E : key_ofs_map) {
+			int track = E.key;
 			ERR_FAIL_INDEX(track, animation->get_track_count());
 
 			if (first_track < 0) {
 				first_track = track;
 			}
 
-			if (show_time && E->value().size() > 1) {
+			if (show_time && E.value.size() > 1) {
 				show_time = false;
 			}
 
@@ -1134,7 +1134,7 @@ public:
 					same_key_type = false;
 				}
 
-				for (const float &F : E->value()) {
+				for (const float &F : E.value) {
 					int key = animation->track_find_key(track, F, true);
 					ERR_FAIL_COND(key == -1);
 					if (first_key < 0) {
@@ -4828,8 +4828,8 @@ void AnimationTrackEditor::_update_key_edit() {
 		Map<int, List<float>> key_ofs_map;
 		Map<int, NodePath> base_map;
 		int first_track = -1;
-		for (Map<SelectedKey, KeyInfo>::Element *E = selection.front(); E; E = E->next()) {
-			int track = E->key().track;
+		for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
+			int track = E.key.track;
 			if (first_track < 0) {
 				first_track = track;
 			}
@@ -4839,7 +4839,7 @@ void AnimationTrackEditor::_update_key_edit() {
 				base_map[track] = NodePath();
 			}
 
-			key_ofs_map[track].push_back(animation->track_get_key_time(track, E->key().key));
+			key_ofs_map[track].push_back(animation->track_get_key_time(track, E.key.key));
 		}
 		multi_key_edit->key_ofs_map = key_ofs_map;
 		multi_key_edit->base_map = base_map;
@@ -5383,8 +5383,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			float len = -1e20;
 			float pivot = 0;
 
-			for (Map<SelectedKey, KeyInfo>::Element *E = selection.front(); E; E = E->next()) {
-				float t = animation->track_get_key_time(E->key().track, E->key().key);
+			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
+				float t = animation->track_get_key_time(E.key.track, E.key.key);
 				if (t < from_t) {
 					from_t = t;
 				}

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -216,15 +216,15 @@ AudioStreamPreviewGenerator *AudioStreamPreviewGenerator::singleton = nullptr;
 void AudioStreamPreviewGenerator::_notification(int p_what) {
 	if (p_what == NOTIFICATION_PROCESS) {
 		List<ObjectID> to_erase;
-		for (Map<ObjectID, Preview>::Element *E = previews.front(); E; E = E->next()) {
-			if (!E->get().generating.is_set()) {
-				if (E->get().thread) {
-					E->get().thread->wait_to_finish();
-					memdelete(E->get().thread);
-					E->get().thread = nullptr;
+		for (KeyValue<ObjectID, Preview> &E : previews) {
+			if (!E.value.generating.is_set()) {
+				if (E.value.thread) {
+					E.value.thread->wait_to_finish();
+					memdelete(E.value.thread);
+					E.value.thread = nullptr;
 				}
-				if (!ObjectDB::get_instance(E->key())) { //no longer in use, get rid of preview
-					to_erase.push_back(E->key());
+				if (!ObjectDB::get_instance(E.key)) { //no longer in use, get rid of preview
+					to_erase.push_back(E.key);
 				}
 			}
 		}

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -306,8 +306,8 @@ Dictionary DebugAdapterParser::req_stackTrace(const Dictionary &p_params) const 
 
 	Array arr;
 	DebugAdapterProtocol *dap = DebugAdapterProtocol::get_singleton();
-	for (Map<DAP::StackFrame, List<int>>::Element *E = dap->stackframe_list.front(); E; E = E->next()) {
-		DAP::StackFrame sf = E->key();
+	for (const KeyValue<DAP::StackFrame, List<int>> &E : dap->stackframe_list) {
+		DAP::StackFrame sf = E.key;
 		if (!lines_at_one) {
 			sf.line--;
 		}

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -200,12 +200,12 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 }
 
 void EditorDebuggerInspector::clear_cache() {
-	for (Map<ObjectID, EditorDebuggerRemoteObject *>::Element *E = remote_objects.front(); E; E = E->next()) {
+	for (const KeyValue<ObjectID, EditorDebuggerRemoteObject *> &E : remote_objects) {
 		EditorNode *editor = EditorNode::get_singleton();
-		if (editor->get_editor_history()->get_current() == E->value()->get_instance_id()) {
+		if (editor->get_editor_history()->get_current() == E.value->get_instance_id()) {
 			editor->push_item(nullptr);
 		}
-		memdelete(E->value());
+		memdelete(E.value);
 	}
 	remote_objects.clear();
 	remote_dependencies.clear();

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -328,9 +328,9 @@ void EditorDebuggerNode::_notification(int p_what) {
 		debugger->set_editor_remote_tree(remote_scene_tree);
 		debugger->start(server->take_connection());
 		// Send breakpoints.
-		for (Map<Breakpoint, bool>::Element *E = breakpoints.front(); E; E = E->next()) {
-			const Breakpoint &bp = E->key();
-			debugger->set_breakpoint(bp.source, bp.line, E->get());
+		for (const KeyValue<Breakpoint, bool> &E : breakpoints) {
+			const Breakpoint &bp = E.key;
+			debugger->set_breakpoint(bp.source, bp.line, E.value);
 		} // Will arrive too late, how does the regular run work?
 
 		debugger->update_live_edit_root();
@@ -497,8 +497,8 @@ void EditorDebuggerNode::set_breakpoints(const String &p_path, Array p_lines) {
 		set_breakpoint(p_path, p_lines[i], true);
 	}
 
-	for (Map<Breakpoint, bool>::Element *E = breakpoints.front(); E; E = E->next()) {
-		Breakpoint b = E->key();
+	for (const KeyValue<Breakpoint, bool> &E : breakpoints) {
+		Breakpoint b = E.key;
 		if (b.source == p_path && !p_lines.has(b.line)) {
 			set_breakpoint(p_path, b.line, false);
 		}

--- a/editor/debugger/editor_network_profiler.cpp
+++ b/editor/debugger/editor_network_profiler.cpp
@@ -56,18 +56,18 @@ void EditorNetworkProfiler::_update_frame() {
 
 	TreeItem *root = counters_display->create_item();
 
-	for (Map<ObjectID, DebuggerMarshalls::MultiplayerNodeInfo>::Element *E = nodes_data.front(); E; E = E->next()) {
+	for (const KeyValue<ObjectID, DebuggerMarshalls::MultiplayerNodeInfo> &E : nodes_data) {
 		TreeItem *node = counters_display->create_item(root);
 
 		for (int j = 0; j < counters_display->get_columns(); ++j) {
 			node->set_text_align(j, j > 0 ? TreeItem::ALIGN_RIGHT : TreeItem::ALIGN_LEFT);
 		}
 
-		node->set_text(0, E->get().node_path);
-		node->set_text(1, E->get().incoming_rpc == 0 ? "-" : itos(E->get().incoming_rpc));
-		node->set_text(2, E->get().incoming_rset == 0 ? "-" : itos(E->get().incoming_rset));
-		node->set_text(3, E->get().outgoing_rpc == 0 ? "-" : itos(E->get().outgoing_rpc));
-		node->set_text(4, E->get().outgoing_rset == 0 ? "-" : itos(E->get().outgoing_rset));
+		node->set_text(0, E.value.node_path);
+		node->set_text(1, E.value.incoming_rpc == 0 ? "-" : itos(E.value.incoming_rpc));
+		node->set_text(2, E.value.incoming_rset == 0 ? "-" : itos(E.value.incoming_rset));
+		node->set_text(3, E.value.outgoing_rpc == 0 ? "-" : itos(E.value.outgoing_rpc));
+		node->set_text(4, E.value.outgoing_rset == 0 ? "-" : itos(E.value.outgoing_rset));
 	}
 }
 

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -515,11 +515,11 @@ Vector<Vector<String>> EditorProfiler::get_data_as_csv() const {
 		if (!m.valid) {
 			continue;
 		}
-		for (Map<StringName, Metric::Category *>::Element *E = m.category_ptrs.front(); E; E = E->next()) {
-			possible_signatures.insert(E->key());
+		for (const KeyValue<StringName, Metric::Category *> &E : m.category_ptrs) {
+			possible_signatures.insert(E.key);
 		}
-		for (Map<StringName, Metric::Category::Item *>::Element *E = m.item_ptrs.front(); E; E = E->next()) {
-			possible_signatures.insert(E->key());
+		for (const KeyValue<StringName, Metric::Category::Item *> &E : m.item_ptrs) {
+			possible_signatures.insert(E.key);
 		}
 	}
 
@@ -557,11 +557,11 @@ Vector<Vector<String>> EditorProfiler::get_data_as_csv() const {
 		values.clear();
 		values.resize(possible_signatures.size());
 
-		for (Map<StringName, Metric::Category *>::Element *E = m.category_ptrs.front(); E; E = E->next()) {
-			values.write[sig_map[E->key()]] = String::num_real(E->value()->total_time);
+		for (const KeyValue<StringName, Metric::Category *> &E : m.category_ptrs) {
+			values.write[sig_map[E.key]] = String::num_real(E.value->total_time);
 		}
-		for (Map<StringName, Metric::Category::Item *>::Element *E = m.item_ptrs.front(); E; E = E->next()) {
-			values.write[sig_map[E->key()]] = String::num_real(E->value()->total);
+		for (const KeyValue<StringName, Metric::Category::Item *> &E : m.item_ptrs) {
+			values.write[sig_map[E.key]] = String::num_real(E.value->total);
 		}
 
 		res.push_back(values);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -74,16 +74,16 @@ void DependencyEditor::_fix_and_find(EditorFileSystemDirectory *efsd, Map<String
 
 		String path = efsd->get_file_path(i);
 
-		for (Map<String, String>::Element *E = candidates[file].front(); E; E = E->next()) {
-			if (E->get() == String()) {
-				E->get() = path;
+		for (KeyValue<String, String> &E : candidates[file]) {
+			if (E.value == String()) {
+				E.value = path;
 				continue;
 			}
 
 			//must match the best, using subdirs
-			String existing = E->get().replace_first("res://", "");
+			String existing = E.value.replace_first("res://", "");
 			String current = path.replace_first("res://", "");
-			String lost = E->key().replace_first("res://", "");
+			String lost = E.key.replace_first("res://", "");
 
 			Vector<String> existingv = existing.split("/");
 			existingv.reverse();
@@ -107,7 +107,7 @@ void DependencyEditor::_fix_and_find(EditorFileSystemDirectory *efsd, Map<String
 			if (current_score > existing_score) {
 				//if it was the same, could track distance to new path but..
 
-				E->get() = path; //replace by more accurate
+				E.value = path; //replace by more accurate
 			}
 		}
 	}
@@ -133,10 +133,10 @@ void DependencyEditor::_fix_all() {
 
 	Map<String, String> remaps;
 
-	for (Map<String, Map<String, String>>::Element *E = candidates.front(); E; E = E->next()) {
-		for (Map<String, String>::Element *F = E->get().front(); F; F = F->next()) {
-			if (F->get() != String()) {
-				remaps[F->key()] = F->get();
+	for (KeyValue<String, Map<String, String>> &E : candidates) {
+		for (const KeyValue<String, String> &F : E.value) {
+			if (F.value != String()) {
+				remaps[F.key] = F.value;
 			}
 		}
 	}

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -44,8 +44,8 @@
 #include "modules/modules_enabled.gen.h"
 
 void DocTools::merge_from(const DocTools &p_data) {
-	for (Map<String, DocData::ClassDoc>::Element *E = class_list.front(); E; E = E->next()) {
-		DocData::ClassDoc &c = E->get();
+	for (KeyValue<String, DocData::ClassDoc> &E : class_list) {
+		DocData::ClassDoc &c = E.value;
 
 		if (!p_data.class_list.has(c.name)) {
 			continue;
@@ -185,9 +185,9 @@ void DocTools::merge_from(const DocTools &p_data) {
 }
 
 void DocTools::remove_from(const DocTools &p_data) {
-	for (Map<String, DocData::ClassDoc>::Element *E = p_data.class_list.front(); E; E = E->next()) {
-		if (class_list.has(E->key())) {
-			class_list.erase(E->key());
+	for (const KeyValue<String, DocData::ClassDoc> &E : p_data.class_list) {
+		if (class_list.has(E.key)) {
+			class_list.erase(E.key);
 		}
 	}
 }
@@ -1227,8 +1227,8 @@ static void _write_method_doc(FileAccess *f, const String &p_name, Vector<DocDat
 }
 
 Error DocTools::save_classes(const String &p_default_path, const Map<String, String> &p_class_path) {
-	for (Map<String, DocData::ClassDoc>::Element *E = class_list.front(); E; E = E->next()) {
-		DocData::ClassDoc &c = E->get();
+	for (KeyValue<String, DocData::ClassDoc> &E : class_list) {
+		DocData::ClassDoc &c = E.value;
 
 		String save_path;
 		if (p_class_path.has(c.name)) {

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -473,8 +473,8 @@ void EditorAutoloadSettings::update_autoload() {
 	}
 
 	// Remove deleted/changed autoloads
-	for (Map<String, AutoLoadInfo>::Element *E = to_remove.front(); E; E = E->next()) {
-		AutoLoadInfo &info = E->get();
+	for (KeyValue<String, AutoLoadInfo> &E : to_remove) {
+		AutoLoadInfo &info = E.value;
 		if (info.is_singleton) {
 			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 				ScriptServer::get_language(i)->remove_named_global_constant(info.name);

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1105,8 +1105,8 @@ Array EditorSelection::_get_transformable_selected_nodes() {
 TypedArray<Node> EditorSelection::get_selected_nodes() {
 	TypedArray<Node> ret;
 
-	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<Node *, Object *> &E : selection) {
+		ret.push_back(E.key);
 	}
 
 	return ret;
@@ -1133,8 +1133,8 @@ void EditorSelection::_update_nl() {
 
 	selected_node_list.clear();
 
-	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-		Node *parent = E->key();
+	for (const KeyValue<Node *, Object *> &E : selection) {
+		Node *parent = E.key;
 		parent = parent->get_parent();
 		bool skip = false;
 		while (parent) {
@@ -1148,7 +1148,7 @@ void EditorSelection::_update_nl() {
 		if (skip) {
 			continue;
 		}
-		selected_node_list.push_back(E->key());
+		selected_node_list.push_back(E.key);
 	}
 
 	nl_changed = true;
@@ -1183,8 +1183,8 @@ List<Node *> &EditorSelection::get_selected_node_list() {
 
 List<Node *> EditorSelection::get_full_selected_node_list() {
 	List<Node *> node_list;
-	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-		node_list.push_back(E->key());
+	for (const KeyValue<Node *, Object *> &E : selection) {
+		node_list.push_back(E.key);
 	}
 
 	return node_list;

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1817,9 +1817,9 @@ bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset,
 
 List<String> EditorExportPlatformPC::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
 	List<String> list;
-	for (Map<String, String>::Element *E = extensions.front(); E; E = E->next()) {
-		if (p_preset->get(E->key())) {
-			list.push_back(extensions[E->key()]);
+	for (const KeyValue<String, String> &E : extensions) {
+		if (p_preset->get(E.key)) {
+			list.push_back(extensions[E.key]);
 			return list;
 		}
 	}

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -179,9 +179,9 @@ Error EditorFeatureProfile::save_to_file(const String &p_path) {
 
 	Array dis_props;
 
-	for (Map<StringName, Set<StringName>>::Element *E = disabled_properties.front(); E; E = E->next()) {
-		for (Set<StringName>::Element *F = E->get().front(); F; F = F->next()) {
-			dis_props.push_back(String(E->key()) + ":" + String(F->get()));
+	for (KeyValue<StringName, Set<StringName>> &E : disabled_properties) {
+		for (Set<StringName>::Element *F = E.value.front(); F; F = F->next()) {
+			dis_props.push_back(String(E.key) + ":" + String(F->get()));
 		}
 	}
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1663,8 +1663,8 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 	Error err = importer->import_group_file(p_group_file, source_file_options, base_paths);
 
 	//all went well, overwrite config files with proper remaps and md5s
-	for (Map<String, Map<StringName, Variant>>::Element *E = source_file_options.front(); E; E = E->next()) {
-		const String &file = E->key();
+	for (const KeyValue<String, Map<StringName, Variant>> &E : source_file_options) {
+		const String &file = E.key;
 		String base_path = ResourceFormatImporter::get_singleton()->get_import_base_path(file);
 		FileAccessRef f = FileAccess::open(file + ".import", FileAccess::WRITE);
 		ERR_FAIL_COND_V_MSG(!f, ERR_FILE_CANT_OPEN, "Cannot open import file '" + file + ".import'.");
@@ -2133,10 +2133,10 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 	if (groups_to_reimport.size()) {
 		Map<String, Vector<String>> group_files;
 		_find_group_files(filesystem, group_files, groups_to_reimport);
-		for (Map<String, Vector<String>>::Element *E = group_files.front(); E; E = E->next()) {
-			Error err = _reimport_group(E->key(), E->get());
+		for (const KeyValue<String, Vector<String>> &E : group_files) {
+			Error err = _reimport_group(E.key, E.value);
 			if (err == OK) {
-				_reimport_file(E->key());
+				_reimport_file(E.key);
 			}
 		}
 	}

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -394,8 +394,8 @@ void EditorHelp::_update_doc() {
 		bool prev = false;
 
 		class_desc->push_font(doc_font);
-		for (Map<String, DocData::ClassDoc>::Element *E = doc->class_list.front(); E; E = E->next()) {
-			if (E->get().inherits == cd.name) {
+		for (const KeyValue<String, DocData::ClassDoc> &E : doc->class_list) {
+			if (E.value.inherits == cd.name) {
 				if (!found) {
 					class_desc->push_color(title_color);
 					class_desc->add_text(TTR("Inherited by:") + " ");
@@ -406,7 +406,7 @@ void EditorHelp::_update_doc() {
 					class_desc->add_text(" , ");
 				}
 
-				_add_type(E->get().name);
+				_add_type(E.value.name);
 				prev = true;
 			}
 		}
@@ -876,14 +876,14 @@ void EditorHelp::_update_doc() {
 
 			class_desc->add_newline();
 
-			for (Map<String, Vector<DocData::ConstantDoc>>::Element *E = enums.front(); E; E = E->next()) {
-				enum_line[E->key()] = class_desc->get_line_count() - 2;
+			for (KeyValue<String, Vector<DocData::ConstantDoc>> &E : enums) {
+				enum_line[E.key] = class_desc->get_line_count() - 2;
 
 				class_desc->push_font(doc_code_font);
 				class_desc->push_color(title_color);
 				class_desc->add_text("enum  ");
 				class_desc->pop();
-				String e = E->key();
+				String e = E.key;
 				if ((e.get_slice_count(".") > 1) && (e.get_slice(".", 0) == edited_class)) {
 					e = e.get_slice(".", 1);
 				}
@@ -913,10 +913,10 @@ void EditorHelp::_update_doc() {
 				}
 
 				class_desc->push_indent(1);
-				Vector<DocData::ConstantDoc> enum_list = E->get();
+				Vector<DocData::ConstantDoc> enum_list = E.value;
 
 				Map<String, int> enumValuesContainer;
-				int enumStartingLine = enum_line[E->key()];
+				int enumStartingLine = enum_line[E.key];
 
 				for (int i = 0; i < enum_list.size(); i++) {
 					if (cd.name == "@GlobalScope") {
@@ -955,7 +955,7 @@ void EditorHelp::_update_doc() {
 				}
 
 				if (cd.name == "@GlobalScope") {
-					enum_values_line[E->key()] = enumValuesContainer;
+					enum_values_line[E.key] = enumValuesContainer;
 				}
 
 				class_desc->pop();

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -842,10 +842,10 @@ void EditorProperty::set_bottom_editor(Control *p_control) {
 
 bool EditorProperty::is_cache_valid() const {
 	if (object) {
-		for (Map<StringName, Variant>::Element *E = cache.front(); E; E = E->next()) {
+		for (const KeyValue<StringName, Variant> &E : cache) {
 			bool valid;
-			Variant value = object->get(E->key(), &valid);
-			if (!valid || value != E->get()) {
+			Variant value = object->get(E.key, &valid);
+			if (!valid || value != E.value) {
 				return false;
 			}
 		}
@@ -3029,8 +3029,8 @@ void EditorInspector::collapse_all_folding() {
 		E->fold();
 	}
 
-	for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
-		for (EditorProperty *E : F->get()) {
+	for (const KeyValue<StringName, List<EditorProperty *>> &F : editor_property_map) {
+		for (EditorProperty *E : F.value) {
 			E->collapse_all_folding();
 		}
 	}
@@ -3040,8 +3040,8 @@ void EditorInspector::expand_all_folding() {
 	for (EditorInspectorSection *E : sections) {
 		E->unfold();
 	}
-	for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
-		for (EditorProperty *E : F->get()) {
+	for (const KeyValue<StringName, List<EditorProperty *>> &F : editor_property_map) {
+		for (EditorProperty *E : F.value) {
 			E->expand_all_folding();
 		}
 	}
@@ -3306,11 +3306,11 @@ void EditorInspector::_property_selected(const String &p_path, int p_focusable) 
 	property_selected = p_path;
 	property_focusable = p_focusable;
 	//deselect the others
-	for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
-		if (F->key() == property_selected) {
+	for (const KeyValue<StringName, List<EditorProperty *>> &F : editor_property_map) {
+		if (F.key == property_selected) {
 			continue;
 		}
-		for (EditorProperty *E : F->get()) {
+		for (EditorProperty *E : F.value) {
 			if (E->is_selected()) {
 				E->deselect();
 			}
@@ -3368,8 +3368,8 @@ void EditorInspector::_notification(int p_what) {
 		if (refresh_countdown > 0) {
 			refresh_countdown -= get_process_delta_time();
 			if (refresh_countdown <= 0) {
-				for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
-					for (EditorProperty *E : F->get()) {
+				for (const KeyValue<StringName, List<EditorProperty *>> &F : editor_property_map) {
+					for (EditorProperty *E : F.value) {
 						if (!E->is_cache_valid()) {
 							E->update_property();
 							E->update_reload_status();

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -116,8 +116,8 @@ void EditorLog::_save_state() {
 	config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 
 	const String section = "editor_log";
-	for (Map<MessageType, LogFilter *>::Element *E = type_filter_map.front(); E; E = E->next()) {
-		config->set_value(section, "log_filter_" + itos(E->key()), E->get()->is_active());
+	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
+		config->set_value(section, "log_filter_" + itos(E.key), E.value->is_active());
 	}
 
 	config->set_value(section, "collapse", collapse);
@@ -135,8 +135,8 @@ void EditorLog::_load_state() {
 
 	// Run the below code even if config->load returns an error, since we want the defaults to be set even if the file does not exist yet.
 	const String section = "editor_log";
-	for (Map<MessageType, LogFilter *>::Element *E = type_filter_map.front(); E; E = E->next()) {
-		E->get()->set_active(config->get_value(section, "log_filter_" + itos(E->key()), true));
+	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
+		E.value->set_active(config->get_value(section, "log_filter_" + itos(E.key), true));
 	}
 
 	collapse = config->get_value(section, "collapse", false);
@@ -306,8 +306,8 @@ void EditorLog::_search_changed(const String &p_text) {
 }
 
 void EditorLog::_reset_message_counts() {
-	for (Map<MessageType, LogFilter *>::Element *E = type_filter_map.front(); E; E = E->next()) {
-		E->value()->set_message_count(0);
+	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
+		E.value->set_message_count(0);
 	}
 }
 
@@ -441,7 +441,7 @@ void EditorLog::deinit() {
 }
 
 EditorLog::~EditorLog() {
-	for (Map<MessageType, LogFilter *>::Element *E = type_filter_map.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
+		memdelete(E.value);
 	}
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3202,8 +3202,8 @@ void EditorNode::_update_addon_config() {
 
 	Vector<String> enabled_addons;
 
-	for (Map<String, EditorPlugin *>::Element *E = plugin_addons.front(); E; E = E->next()) {
-		enabled_addons.push_back(E->key());
+	for (const KeyValue<String, EditorPlugin *> &E : plugin_addons) {
+		enabled_addons.push_back(E.key);
 	}
 
 	if (enabled_addons.size() == 0) {
@@ -3585,9 +3585,9 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	dependency_errors.erase(lpath); //at least not self path
 
-	for (Map<String, Set<String>>::Element *E = dependency_errors.front(); E; E = E->next()) {
-		String txt = vformat(TTR("Scene '%s' has broken dependencies:"), E->key()) + "\n";
-		for (Set<String>::Element *F = E->get().front(); F; F = F->next()) {
+	for (KeyValue<String, Set<String>> &E : dependency_errors) {
+		String txt = vformat(TTR("Scene '%s' has broken dependencies:"), E.key) + "\n";
+		for (Set<String>::Element *F = E.value.front(); F; F = F->next()) {
 			txt += "\t" + F->get() + "\n";
 		}
 		add_io_error(txt);
@@ -4050,8 +4050,8 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 	}
 
 	const Map<String, Vector<EditorData::CustomType>> &p_map = EditorNode::get_editor_data().get_custom_types();
-	for (const Map<String, Vector<EditorData::CustomType>>::Element *E = p_map.front(); E; E = E->next()) {
-		const Vector<EditorData::CustomType> &ct = E->value();
+	for (const KeyValue<String, Vector<EditorData::CustomType>> &E : p_map) {
+		const Vector<EditorData::CustomType> &ct = E.value;
 		for (int i = 0; i < ct.size(); ++i) {
 			if (ct[i].name == p_class) {
 				if (ct[i].icon.is_valid()) {

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -66,9 +66,9 @@ void EditorRunNative::_notification(int p_what) {
 		bool changed = EditorExport::get_singleton()->poll_export_platforms() || first;
 
 		if (changed) {
-			for (Map<int, MenuButton *>::Element *E = menus.front(); E; E = E->next()) {
-				Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(E->key());
-				MenuButton *mb = E->get();
+			for (KeyValue<int, MenuButton *> &E : menus) {
+				Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(E.key);
+				MenuButton *mb = E.value;
 				int dc = eep->get_options_count();
 
 				if (dc == 0) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -139,10 +139,10 @@ bool EditorSettings::_get(const StringName &p_name, Variant &r_ret) const {
 
 	if (p_name == "shortcuts") {
 		Array arr;
-		for (const Map<String, Ref<Shortcut>>::Element *E = shortcuts.front(); E; E = E->next()) {
-			Ref<Shortcut> sc = E->get();
+		for (const KeyValue<String, Ref<Shortcut>> &E : shortcuts) {
+			Ref<Shortcut> sc = E.value;
 
-			if (builtin_action_overrides.has(E->key())) {
+			if (builtin_action_overrides.has(E.key)) {
 				// This shortcut was auto-generated from built in actions: don't save.
 				continue;
 			}
@@ -158,19 +158,19 @@ bool EditorSettings::_get(const StringName &p_name, Variant &r_ret) const {
 				}
 			}
 
-			arr.push_back(E->key());
+			arr.push_back(E.key);
 			arr.push_back(sc->get_event());
 		}
 		r_ret = arr;
 		return true;
 	} else if (p_name == "builtin_action_overrides") {
 		Array actions_arr;
-		for (Map<String, List<Ref<InputEvent>>>::Element *E = builtin_action_overrides.front(); E; E = E->next()) {
-			List<Ref<InputEvent>> events = E->get();
+		for (const KeyValue<String, List<Ref<InputEvent>>> &E : builtin_action_overrides) {
+			List<Ref<InputEvent>> events = E.value;
 
 			// TODO: skip actions which are the same as the builtin.
 			Dictionary action_dict;
-			action_dict["name"] = E->key();
+			action_dict["name"] = E.key;
 
 			Array events_arr;
 			for (List<Ref<InputEvent>>::Element *I = events.front(); I; I = I->next()) {
@@ -1429,8 +1429,8 @@ Ref<Shortcut> EditorSettings::get_shortcut(const String &p_name) const {
 }
 
 void EditorSettings::get_shortcut_list(List<String> *r_shortcuts) {
-	for (const Map<String, Ref<Shortcut>>::Element *E = shortcuts.front(); E; E = E->next()) {
-		r_shortcuts->push_back(E->key());
+	for (const KeyValue<String, Ref<Shortcut>> &E : shortcuts) {
+		r_shortcuts->push_back(E.key);
 	}
 }
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1301,11 +1301,11 @@ void FileSystemDock::_update_dependencies_after_move(const Map<String, String> &
 void FileSystemDock::_update_project_settings_after_move(const Map<String, String> &p_renames) const {
 	// Find all project settings of type FILE and replace them if needed.
 	const Map<StringName, PropertyInfo> prop_info = ProjectSettings::get_singleton()->get_custom_property_info();
-	for (const Map<StringName, PropertyInfo>::Element *E = prop_info.front(); E; E = E->next()) {
-		if (E->get().hint == PROPERTY_HINT_FILE) {
-			String old_path = GLOBAL_GET(E->key());
+	for (const KeyValue<StringName, PropertyInfo> &E : prop_info) {
+		if (E.value.hint == PROPERTY_HINT_FILE) {
+			String old_path = GLOBAL_GET(E.key);
 			if (p_renames.has(old_path)) {
-				ProjectSettings::get_singleton()->set_setting(E->key(), p_renames[old_path]);
+				ProjectSettings::get_singleton()->set_setting(E.key, p_renames[old_path]);
 			}
 		};
 	}

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -840,8 +840,8 @@ void FindInFilesPanel::_on_replace_all_clicked() {
 
 	PackedStringArray modified_files;
 
-	for (Map<String, TreeItem *>::Element *E = _file_items.front(); E; E = E->next()) {
-		TreeItem *file_item = E->value();
+	for (KeyValue<String, TreeItem *> &E : _file_items) {
+		TreeItem *file_item = E.value;
 		String fpath = file_item->get_metadata(0);
 
 		Vector<Result> locations;

--- a/editor/import/collada.cpp
+++ b/editor/import/collada.cpp
@@ -2095,19 +2095,19 @@ void Collada::_merge_skeletons(VisualScene *p_vscene, Node *p_node) {
 }
 
 void Collada::_merge_skeletons2(VisualScene *p_vscene) {
-	for (Map<String, SkinControllerData>::Element *E = state.skin_controller_data_map.front(); E; E = E->next()) {
-		SkinControllerData &cd = E->get();
+	for (KeyValue<String, SkinControllerData> &E : state.skin_controller_data_map) {
+		SkinControllerData &cd = E.value;
 
 		NodeSkeleton *skeleton = nullptr;
 
-		for (Map<String, Transform3D>::Element *F = cd.bone_rest_map.front(); F; F = F->next()) {
+		for (const KeyValue<String, Transform3D> &F : cd.bone_rest_map) {
 			String name;
 
-			if (!state.sid_to_node_map.has(F->key())) {
+			if (!state.sid_to_node_map.has(F.key)) {
 				continue;
 			}
 
-			name = state.sid_to_node_map[F->key()];
+			name = state.sid_to_node_map[F.key];
 
 			ERR_CONTINUE(!state.scene_map.has(name));
 
@@ -2248,9 +2248,9 @@ bool Collada::_move_geometry_to_skeletons(VisualScene *p_vscene, Node *p_node, L
 			p_node->default_transform = skel_inv * (skin.bind_shape /* p_node->get_global_transform()*/); // i honestly have no idea what to do with a previous model xform.. most exporters ignore it
 
 			//make rests relative to the skeleton (they seem to be always relative to world)
-			for (Map<String, Transform3D>::Element *E = skin.bone_rest_map.front(); E; E = E->next()) {
-				E->get() = skel_inv * E->get(); //make the bone rest local to the skeleton
-				state.bone_rest_map[E->key()] = E->get(); // make it remember where the bone is globally, now that it's relative
+			for (KeyValue<String, Transform3D> &E : skin.bone_rest_map) {
+				E.value = skel_inv * E.value; //make the bone rest local to the skeleton
+				state.bone_rest_map[E.key] = E.value; // make it remember where the bone is globally, now that it's relative
 			}
 
 			//but most exporters seem to work only if i do this..
@@ -2302,8 +2302,8 @@ void Collada::_find_morph_nodes(VisualScene *p_vscene, Node *p_node) {
 }
 
 void Collada::_optimize() {
-	for (Map<String, VisualScene>::Element *E = state.visual_scene_map.front(); E; E = E->next()) {
-		VisualScene &vs = E->get();
+	for (KeyValue<String, VisualScene> &E : state.visual_scene_map) {
+		VisualScene &vs = E.value;
 		for (int i = 0; i < vs.root_nodes.size(); i++) {
 			_create_skeletons(&vs.root_nodes.write[i]);
 		}

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1314,8 +1314,8 @@ Error ColladaImport::load(const String &p_path, int p_flags, bool p_force_make_t
 }
 
 void ColladaImport::_fix_param_animation_tracks() {
-	for (Map<String, Collada::Node *>::Element *E = collada.state.scene_map.front(); E; E = E->next()) {
-		Collada::Node *n = E->get();
+	for (KeyValue<String, Collada::Node *> &E : collada.state.scene_map) {
+		Collada::Node *n = E.value;
 		switch (n->type) {
 			case Collada::Node::TYPE_NODE: {
 				// ? do nothing
@@ -1363,7 +1363,7 @@ void ColladaImport::_fix_param_animation_tracks() {
 										for (int rti = 0; rti < rt.size(); rti++) {
 											Collada::AnimationTrack *at = &collada.state.animation_tracks.write[rt[rti]];
 
-											at->target = E->key();
+											at->target = E.key;
 											at->param = "morph/" + collada.state.mesh_name_map[mesh_name];
 											at->property = true;
 											//at->param
@@ -1431,11 +1431,11 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 		animation->set_name(collada.state.animation_clips[p_clip].name);
 	}
 
-	for (Map<String, NodeMap>::Element *E = node_map.front(); E; E = E->next()) {
-		if (E->get().bone < 0) {
+	for (const KeyValue<String, NodeMap> &E : node_map) {
+		if (E.value.bone < 0) {
 			continue;
 		}
-		bones_with_animation[E->key()] = false;
+		bones_with_animation[E.key] = false;
 	}
 	//store and validate tracks
 
@@ -1626,19 +1626,19 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 
 	if (p_make_tracks_in_all_bones) {
 		//some bones may lack animation, but since we don't store pose as a property, we must add keyframes!
-		for (Map<String, bool>::Element *E = bones_with_animation.front(); E; E = E->next()) {
-			if (E->get()) {
+		for (const KeyValue<String, bool> &E : bones_with_animation) {
+			if (E.value) {
 				continue;
 			}
 
-			NodeMap &nm = node_map[E->key()];
+			NodeMap &nm = node_map[E.key];
 			String path = scene->get_path_to(nm.node);
 			ERR_CONTINUE(nm.bone < 0);
 			Skeleton3D *sk = static_cast<Skeleton3D *>(nm.node);
 			String name = sk->get_bone_name(nm.bone);
 			path = path + ":" + name;
 
-			Collada::Node *cn = collada.state.scene_map[E->key()];
+			Collada::Node *cn = collada.state.scene_map[E.key];
 			if (cn->ignore_anim) {
 				WARN_PRINT("Collada: Ignoring animation on node: " + path);
 				continue;

--- a/editor/import/editor_importer_bake_reset.cpp
+++ b/editor/import/editor_importer_bake_reset.cpp
@@ -122,14 +122,14 @@ void BakeReset::_align_animations(AnimationPlayer *p_ap, const Map<StringName, B
 	for (List<StringName>::Element *anim_i = anim_names.front(); anim_i; anim_i = anim_i->next()) {
 		Ref<Animation> a = p_ap->get_animation(anim_i->get());
 		ERR_CONTINUE(a.is_null());
-		for (Map<StringName, BakeResetRestBone>::Element *rest_bone_i = r_rest_bones.front(); rest_bone_i; rest_bone_i = rest_bone_i->next()) {
-			int track = a->find_track(NodePath(rest_bone_i->key()));
+		for (const KeyValue<StringName, BakeResetRestBone> &rest_bone_i : r_rest_bones) {
+			int track = a->find_track(NodePath(rest_bone_i.key));
 			if (track == -1) {
 				continue;
 			}
 			int new_track = a->add_track(Animation::TYPE_TRANSFORM3D);
-			NodePath new_path = NodePath(rest_bone_i->key());
-			BakeResetRestBone rest_bone = rest_bone_i->get();
+			NodePath new_path = NodePath(rest_bone_i.key);
+			const BakeResetRestBone rest_bone = rest_bone_i.value;
 			a->track_set_path(new_track, new_path);
 			for (int key_i = 0; key_i < a->track_get_key_count(track); key_i++) {
 				Vector3 loc;

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -86,28 +86,28 @@ void ResourceImporterTexture::update_imports() {
 			return;
 		}
 
-		for (Map<StringName, MakeInfo>::Element *E = make_flags.front(); E; E = E->next()) {
+		for (const KeyValue<StringName, MakeInfo> &E : make_flags) {
 			Ref<ConfigFile> cf;
 			cf.instantiate();
-			String src_path = String(E->key()) + ".import";
+			String src_path = String(E.key) + ".import";
 
 			Error err = cf->load(src_path);
 			ERR_CONTINUE(err != OK);
 
 			bool changed = false;
 
-			if (E->get().flags & MAKE_NORMAL_FLAG && int(cf->get_value("params", "compress/normal_map")) == 0) {
+			if (E.value.flags & MAKE_NORMAL_FLAG && int(cf->get_value("params", "compress/normal_map")) == 0) {
 				cf->set_value("params", "compress/normal_map", 1);
 				changed = true;
 			}
 
-			if (E->get().flags & MAKE_ROUGHNESS_FLAG && int(cf->get_value("params", "roughness/mode")) == 0) {
-				cf->set_value("params", "roughness/mode", E->get().channel_for_roughness + 2);
-				cf->set_value("params", "roughness/src_normal", E->get().normal_path_for_roughness);
+			if (E.value.flags & MAKE_ROUGHNESS_FLAG && int(cf->get_value("params", "roughness/mode")) == 0) {
+				cf->set_value("params", "roughness/mode", E.value.channel_for_roughness + 2);
+				cf->set_value("params", "roughness/src_normal", E.value.normal_path_for_roughness);
 				changed = true;
 			}
 
-			if (E->get().flags & MAKE_3D_FLAG && bool(cf->get_value("params", "detect_3d/compress_to"))) {
+			if (E.value.flags & MAKE_3D_FLAG && bool(cf->get_value("params", "detect_3d/compress_to"))) {
 				int compress_to = cf->get_value("params", "detect_3d/compress_to");
 				cf->set_value("params", "detect_3d/compress_to", 0);
 				if (compress_to == 1) {
@@ -121,7 +121,7 @@ void ResourceImporterTexture::update_imports() {
 
 			if (changed) {
 				cf->save(src_path);
-				to_reimport.push_back(E->key());
+				to_reimport.push_back(E.key);
 			}
 		}
 

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -771,52 +771,52 @@ void SceneImportSettings::_re_import() {
 
 	Dictionary subresources;
 
-	for (Map<String, NodeData>::Element *E = node_map.front(); E; E = E->next()) {
-		if (E->get().settings.size()) {
+	for (KeyValue<String, NodeData> &E : node_map) {
+		if (E.value.settings.size()) {
 			Dictionary d;
-			for (Map<StringName, Variant>::Element *F = E->get().settings.front(); F; F = F->next()) {
-				d[String(F->key())] = F->get();
+			for (const KeyValue<StringName, Variant> &F : E.value.settings) {
+				d[String(F.key)] = F.value;
 			}
-			nodes[E->key()] = d;
+			nodes[E.key] = d;
 		}
 	}
 	if (nodes.size()) {
 		subresources["nodes"] = nodes;
 	}
 
-	for (Map<String, MaterialData>::Element *E = material_map.front(); E; E = E->next()) {
-		if (E->get().settings.size()) {
+	for (KeyValue<String, MaterialData> &E : material_map) {
+		if (E.value.settings.size()) {
 			Dictionary d;
-			for (Map<StringName, Variant>::Element *F = E->get().settings.front(); F; F = F->next()) {
-				d[String(F->key())] = F->get();
+			for (const KeyValue<StringName, Variant> &F : E.value.settings) {
+				d[String(F.key)] = F.value;
 			}
-			materials[E->key()] = d;
+			materials[E.key] = d;
 		}
 	}
 	if (materials.size()) {
 		subresources["materials"] = materials;
 	}
 
-	for (Map<String, MeshData>::Element *E = mesh_map.front(); E; E = E->next()) {
-		if (E->get().settings.size()) {
+	for (KeyValue<String, MeshData> &E : mesh_map) {
+		if (E.value.settings.size()) {
 			Dictionary d;
-			for (Map<StringName, Variant>::Element *F = E->get().settings.front(); F; F = F->next()) {
-				d[String(F->key())] = F->get();
+			for (const KeyValue<StringName, Variant> &F : E.value.settings) {
+				d[String(F.key)] = F.value;
 			}
-			meshes[E->key()] = d;
+			meshes[E.key] = d;
 		}
 	}
 	if (meshes.size()) {
 		subresources["meshes"] = meshes;
 	}
 
-	for (Map<String, AnimationData>::Element *E = animation_map.front(); E; E = E->next()) {
-		if (E->get().settings.size()) {
+	for (KeyValue<String, AnimationData> &E : animation_map) {
+		if (E.value.settings.size()) {
 			Dictionary d;
-			for (Map<StringName, Variant>::Element *F = E->get().settings.front(); F; F = F->next()) {
-				d[String(F->key())] = F->get();
+			for (const KeyValue<StringName, Variant> &F : E.value.settings) {
+				d[String(F.key)] = F.value;
 			}
-			animations[E->key()] = d;
+			animations[E.key] = d;
 		}
 	}
 	if (animations.size()) {
@@ -889,8 +889,8 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 
 	switch (current_action) {
 		case ACTION_EXTRACT_MATERIALS: {
-			for (Map<String, MaterialData>::Element *E = material_map.front(); E; E = E->next()) {
-				MaterialData &md = material_map[E->key()];
+			for (const KeyValue<String, MaterialData> &E : material_map) {
+				MaterialData &md = material_map[E.key];
 
 				TreeItem *item = external_path_tree->create_item(root);
 
@@ -905,7 +905,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 						item->set_text(2, "Already External");
 						item->set_tooltip(2, TTR("This material already references an external file, no action will be taken.\nDisable the external property for it to be extracted again."));
 					} else {
-						item->set_metadata(0, E->key());
+						item->set_metadata(0, E.key);
 						item->set_editable(0, true);
 						item->set_checked(0, true);
 						String path = p_path.plus_file(name);
@@ -942,8 +942,8 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 			external_paths->get_ok_button()->set_text(TTR("Extract"));
 		} break;
 		case ACTION_CHOOSE_MESH_SAVE_PATHS: {
-			for (Map<String, MeshData>::Element *E = mesh_map.front(); E; E = E->next()) {
-				MeshData &md = mesh_map[E->key()];
+			for (const KeyValue<String, MeshData> &E : mesh_map) {
+				MeshData &md = mesh_map[E.key];
 
 				TreeItem *item = external_path_tree->create_item(root);
 
@@ -958,7 +958,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 						item->set_text(2, "Already Saving");
 						item->set_tooltip(2, TTR("This mesh already saves to an external resource, no action will be taken."));
 					} else {
-						item->set_metadata(0, E->key());
+						item->set_metadata(0, E.key);
 						item->set_editable(0, true);
 						item->set_checked(0, true);
 						String path = p_path.plus_file(name);
@@ -995,8 +995,8 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 			external_paths->get_ok_button()->set_text(TTR("Set Paths"));
 		} break;
 		case ACTION_CHOOSE_ANIMATION_SAVE_PATHS: {
-			for (Map<String, AnimationData>::Element *E = animation_map.front(); E; E = E->next()) {
-				AnimationData &ad = animation_map[E->key()];
+			for (const KeyValue<String, AnimationData> &E : animation_map) {
+				AnimationData &ad = animation_map[E.key];
 
 				TreeItem *item = external_path_tree->create_item(root);
 
@@ -1010,7 +1010,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 					item->set_text(2, "Already Saving");
 					item->set_tooltip(2, TTR("This animation already saves to an external resource, no action will be taken."));
 				} else {
-					item->set_metadata(0, E->key());
+					item->set_metadata(0, E.key);
 					item->set_editable(0, true);
 					item->set_checked(0, true);
 					String path = p_path.plus_file(name);

--- a/editor/import/scene_importer_mesh.cpp
+++ b/editor/import/scene_importer_mesh.cpp
@@ -966,8 +966,8 @@ Ref<NavigationMesh> EditorSceneImporterMesh::create_navigation_mesh() {
 
 	Vector<Vector3> vertices;
 	vertices.resize(unique_vertices.size());
-	for (Map<Vector3, int>::Element *E = unique_vertices.front(); E; E = E->next()) {
-		vertices.write[E->get()] = E->key();
+	for (const KeyValue<Vector3, int> &E : unique_vertices) {
+		vertices.write[E.value] = E.key;
 	}
 
 	Ref<NavigationMesh> nm;

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -86,9 +86,9 @@ void ImportDefaultsEditor::_save() {
 	if (settings->importer.is_valid()) {
 		Dictionary modified;
 
-		for (Map<StringName, Variant>::Element *E = settings->values.front(); E; E = E->next()) {
-			if (E->get() != settings->default_values[E->key()]) {
-				modified[E->key()] = E->get();
+		for (const KeyValue<StringName, Variant> &E : settings->values) {
+			if (E.value != settings->default_values[E.key]) {
+				modified[E.key] = E.value;
 			}
 		}
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -776,16 +776,16 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 		}
 
 		if (player) {
-			for (Map<StringName, ProgressBar *>::Element *E = animations.front(); E; E = E->next()) {
-				Ref<AnimationNodeAnimation> an = blend_tree->get_node(E->key());
+			for (const KeyValue<StringName, ProgressBar *> &E : animations) {
+				Ref<AnimationNodeAnimation> an = blend_tree->get_node(E.key);
 				if (an.is_valid()) {
 					if (player->has_animation(an->get_animation())) {
 						Ref<Animation> anim = player->get_animation(an->get_animation());
 						if (anim.is_valid()) {
-							E->get()->set_max(anim->get_length());
+							E.value->set_max(anim->get_length());
 							//StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + E.input_node;
-							StringName time_path = AnimationTreeEditor::get_singleton()->get_base_path() + String(E->key()) + "/time";
-							E->get()->set_value(AnimationTreeEditor::get_singleton()->get_tree()->get(time_path));
+							StringName time_path = AnimationTreeEditor::get_singleton()->get_base_path() + String(E.key) + "/time";
+							E.value->set_value(AnimationTreeEditor::get_singleton()->get_tree()->get(time_path));
 						}
 					}
 				}

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -830,9 +830,9 @@ void EditorAssetLibrary::_update_image_queue() {
 	int current_images = 0;
 
 	List<int> to_delete;
-	for (Map<int, ImageQueue>::Element *E = image_queue.front(); E; E = E->next()) {
-		if (!E->get().active && current_images < max_images) {
-			String cache_filename_base = EditorPaths::get_singleton()->get_cache_dir().plus_file("assetimage_" + E->get().image_url.md5_text());
+	for (KeyValue<int, ImageQueue> &E : image_queue) {
+		if (!E.value.active && current_images < max_images) {
+			String cache_filename_base = EditorPaths::get_singleton()->get_cache_dir().plus_file("assetimage_" + E.value.image_url.md5_text());
 			Vector<String> headers;
 
 			if (FileAccess::exists(cache_filename_base + ".etag") && FileAccess::exists(cache_filename_base + ".data")) {
@@ -844,14 +844,14 @@ void EditorAssetLibrary::_update_image_queue() {
 				}
 			}
 
-			Error err = E->get().request->request(E->get().image_url, headers);
+			Error err = E.value.request->request(E.value.image_url, headers);
 			if (err != OK) {
-				to_delete.push_back(E->key());
+				to_delete.push_back(E.key);
 			} else {
-				E->get().active = true;
+				E.value.active = true;
 			}
 			current_images++;
-		} else if (E->get().active) {
+		} else if (E.value.active) {
 			current_images++;
 		}
 	}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -748,8 +748,8 @@ bool CanvasItemEditor::_select_click_on_item(CanvasItem *item, Point2 p_click_po
 
 List<CanvasItem *> CanvasItemEditor::_get_edited_canvas_items(bool retreive_locked, bool remove_canvas_item_if_parent_in_selection) {
 	List<CanvasItem *> selection;
-	for (Map<Node *, Object *>::Element *E = editor_selection->get_selection().front(); E; E = E->next()) {
-		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
+	for (const KeyValue<Node *, Object *> &E : editor_selection->get_selection()) {
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E.key);
 		if (canvas_item && canvas_item->is_visible_in_tree() && canvas_item->get_viewport() == EditorNode::get_singleton()->get_scene_root() && (retreive_locked || !_is_node_locked(canvas_item))) {
 			CanvasItemEditorSelectedItem *se = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(canvas_item);
 			if (se) {
@@ -3782,8 +3782,8 @@ void CanvasItemEditor::_notification(int p_what) {
 		}
 
 		// Update the viewport if bones changes
-		for (Map<BoneKey, BoneList>::Element *E = bone_list.front(); E; E = E->next()) {
-			Object *b = ObjectDB::get_instance(E->key().from);
+		for (KeyValue<BoneKey, BoneList> &E : bone_list) {
+			Object *b = ObjectDB::get_instance(E.key.from);
 			if (!b) {
 				viewport->update();
 				break;
@@ -3796,14 +3796,14 @@ void CanvasItemEditor::_notification(int p_what) {
 
 			Transform2D global_xform = b2->get_global_transform();
 
-			if (global_xform != E->get().xform) {
-				E->get().xform = global_xform;
+			if (global_xform != E.value.xform) {
+				E.value.xform = global_xform;
 				viewport->update();
 			}
 
 			Bone2D *bone = Object::cast_to<Bone2D>(b);
-			if (bone && bone->get_length() != E->get().length) {
-				E->get().length = bone->get_length();
+			if (bone && bone->get_length() != E.value.length) {
+				E.value.length = bone->get_length();
 				viewport->update();
 			}
 		}
@@ -4263,8 +4263,8 @@ void CanvasItemEditor::_button_tool_select(int p_index) {
 void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, bool p_scale, bool p_on_existing) {
 	Map<Node *, Object *> &selection = editor_selection->get_selection();
 
-	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
+	for (const KeyValue<Node *, Object *> &E : selection) {
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E.key);
 		if (!canvas_item || !canvas_item->is_visible_in_tree()) {
 			continue;
 		}
@@ -4695,8 +4695,8 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			Map<Node *, Object *> &selection = editor_selection->get_selection();
 
-			for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
+			for (const KeyValue<Node *, Object *> &E : selection) {
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E.key);
 				if (!canvas_item || !canvas_item->is_visible_in_tree()) {
 					continue;
 				}
@@ -4741,8 +4741,8 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 		case ANIM_CLEAR_POSE: {
 			Map<Node *, Object *> &selection = editor_selection->get_selection();
 
-			for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
+			for (const KeyValue<Node *, Object *> &E : selection) {
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E.key);
 				if (!canvas_item || !canvas_item->is_visible_in_tree()) {
 					continue;
 				}
@@ -4816,8 +4816,8 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			Node *editor_root = EditorNode::get_singleton()->get_edited_scene()->get_tree()->get_edited_scene_root();
 
 			undo_redo->create_action(TTR("Create Custom Bone2D(s) from Node(s)"));
-			for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-				Node2D *n2d = Object::cast_to<Node2D>(E->key());
+			for (const KeyValue<Node *, Object *> &E : selection) {
+				Node2D *n2d = Object::cast_to<Node2D>(E.key);
 
 				Bone2D *new_bone = memnew(Bone2D);
 				String new_bone_name = n2d->get_name();
@@ -4861,8 +4861,8 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 	int count = 0;
 
 	Map<Node *, Object *> &selection = editor_selection->get_selection();
-	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
+	for (const KeyValue<Node *, Object *> &E : selection) {
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E.key);
 		if (!canvas_item) {
 			continue;
 		}

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -4773,10 +4773,10 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 	Vector<Vector3> lines;
 
-	for (Map<_EdgeKey, bool>::Element *E = edge_map.front(); E; E = E->next()) {
-		if (E->get()) {
-			lines.push_back(E->key().from);
-			lines.push_back(E->key().to);
+	for (const KeyValue<_EdgeKey, bool> &E : edge_map) {
+		if (E.value) {
+			lines.push_back(E.key.from);
+			lines.push_back(E.key.to);
 		}
 	}
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -357,8 +357,8 @@ int Node3DEditorViewport::get_selected_count() const {
 
 	int count = 0;
 
-	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-		Node3D *sp = Object::cast_to<Node3D>(E->key());
+	for (const KeyValue<Node *, Object *> &E : selection) {
+		Node3D *sp = Object::cast_to<Node3D>(E.key);
 		if (!sp) {
 			continue;
 		}
@@ -864,8 +864,8 @@ void Node3DEditorViewport::_compute_edit(const Point2 &p_point) {
 	Node3DEditorSelectedItem *se = selected ? editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(selected) : nullptr;
 
 	if (se && se->gizmo.is_valid()) {
-		for (Map<int, Transform3D>::Element *E = se->subgizmos.front(); E; E = E->next()) {
-			int subgizmo_id = E->key();
+		for (const KeyValue<int, Transform3D> &E : se->subgizmos) {
+			int subgizmo_id = E.key;
 			se->subgizmos[subgizmo_id] = se->gizmo->get_subgizmo_transform(subgizmo_id);
 		}
 		se->original_local = selected->get_transform();
@@ -1374,9 +1374,9 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							Vector<int> ids;
 							Vector<Transform3D> restore;
 
-							for (Map<int, Transform3D>::Element *GE = se->subgizmos.front(); GE; GE = GE->next()) {
-								ids.push_back(GE->key());
-								restore.push_back(GE->value());
+							for (const KeyValue<int, Transform3D> &GE : se->subgizmos) {
+								ids.push_back(GE.key);
+								restore.push_back(GE.value);
 							}
 
 							se->gizmo->commit_subgizmos(ids, restore, true);
@@ -1612,9 +1612,9 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							Vector<int> ids;
 							Vector<Transform3D> restore;
 
-							for (Map<int, Transform3D>::Element *GE = se->subgizmos.front(); GE; GE = GE->next()) {
-								ids.push_back(GE->key());
-								restore.push_back(GE->value());
+							for (const KeyValue<int, Transform3D> &GE : se->subgizmos) {
+								ids.push_back(GE.key);
+								restore.push_back(GE.value);
 							}
 
 							se->gizmo->commit_subgizmos(ids, restore, false);
@@ -1845,13 +1845,13 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							}
 
 							if (se->gizmo.is_valid()) {
-								for (Map<int, Transform3D>::Element *GE = se->subgizmos.front(); GE; GE = GE->next()) {
-									Transform3D xform = GE->get();
+								for (KeyValue<int, Transform3D> &GE : se->subgizmos) {
+									Transform3D xform = GE.value;
 									Transform3D new_xform = _compute_transform(TRANSFORM_SCALE, se->original * xform, xform, motion, snap, local_coords);
 									if (!local_coords) {
 										new_xform = se->original.affine_inverse() * new_xform;
 									}
-									se->gizmo->set_subgizmo_transform(GE->key(), new_xform);
+									se->gizmo->set_subgizmo_transform(GE.key, new_xform);
 								}
 							} else {
 								Transform3D new_xform = _compute_transform(TRANSFORM_SCALE, se->original, se->original_local, motion, snap, local_coords);
@@ -1944,11 +1944,11 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							}
 
 							if (se->gizmo.is_valid()) {
-								for (Map<int, Transform3D>::Element *GE = se->subgizmos.front(); GE; GE = GE->next()) {
-									Transform3D xform = GE->get();
+								for (KeyValue<int, Transform3D> &GE : se->subgizmos) {
+									Transform3D xform = GE.value;
 									Transform3D new_xform = _compute_transform(TRANSFORM_TRANSLATE, se->original * xform, xform, motion, snap, local_coords);
 									new_xform = se->original.affine_inverse() * new_xform;
-									se->gizmo->set_subgizmo_transform(GE->key(), new_xform);
+									se->gizmo->set_subgizmo_transform(GE.key, new_xform);
 								}
 							} else {
 								Transform3D new_xform = _compute_transform(TRANSFORM_TRANSLATE, se->original, se->original_local, motion, snap, local_coords);
@@ -2030,14 +2030,14 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 							Vector3 compute_axis = local_coords ? axis : plane.normal;
 							if (se->gizmo.is_valid()) {
-								for (Map<int, Transform3D>::Element *GE = se->subgizmos.front(); GE; GE = GE->next()) {
-									Transform3D xform = GE->get();
+								for (KeyValue<int, Transform3D> &GE : se->subgizmos) {
+									Transform3D xform = GE.value;
 
 									Transform3D new_xform = _compute_transform(TRANSFORM_ROTATE, se->original * xform, xform, compute_axis, angle, local_coords);
 									if (!local_coords) {
 										new_xform = se->original.affine_inverse() * new_xform;
 									}
-									se->gizmo->set_subgizmo_transform(GE->key(), new_xform);
+									se->gizmo->set_subgizmo_transform(GE.key, new_xform);
 								}
 							} else {
 								Transform3D new_xform = _compute_transform(TRANSFORM_ROTATE, se->original, se->original_local, compute_axis, angle, local_coords);
@@ -2666,8 +2666,8 @@ void Node3DEditorViewport::_notification(int p_what) {
 		bool changed = false;
 		bool exist = false;
 
-		for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-			Node3D *sp = Object::cast_to<Node3D>(E->key());
+		for (const KeyValue<Node *, Object *> &E : selection) {
+			Node3D *sp = Object::cast_to<Node3D>(E.key);
 			if (!sp) {
 				continue;
 			}
@@ -3809,8 +3809,8 @@ void Node3DEditorViewport::focus_selection() {
 		}
 
 		if (se->gizmo.is_valid()) {
-			for (Map<int, Transform3D>::Element *GE = se->subgizmos.front(); GE; GE = GE->next()) {
-				center += se->gizmo->get_subgizmo_transform(GE->key()).origin;
+			for (const KeyValue<int, Transform3D> &GE : se->subgizmos) {
+				center += se->gizmo->get_subgizmo_transform(GE.key).origin;
 				count++;
 			}
 		}
@@ -4750,8 +4750,8 @@ void Node3DEditor::update_transform_gizmo() {
 	Node3DEditorSelectedItem *se = selected ? editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(selected) : nullptr;
 
 	if (se && se->gizmo.is_valid()) {
-		for (Map<int, Transform3D>::Element *E = se->subgizmos.front(); E; E = E->next()) {
-			Transform3D xf = se->sp->get_global_transform() * se->gizmo->get_subgizmo_transform(E->key());
+		for (const KeyValue<int, Transform3D> &E : se->subgizmos) {
+			Transform3D xf = se->sp->get_global_transform() * se->gizmo->get_subgizmo_transform(E.key);
 			gizmo_center += xf.origin;
 			if (count == 0 && local_gizmo_coords) {
 				gizmo_basis = xf.basis;
@@ -6677,8 +6677,8 @@ Vector<int> Node3DEditor::get_subgizmo_selection() {
 
 	Vector<int> ret;
 	if (se) {
-		for (Map<int, Transform3D>::Element *E = se->subgizmos.front(); E; E = E->next()) {
-			ret.push_back(E->key());
+		for (const KeyValue<int, Transform3D> &E : se->subgizmos) {
+			ret.push_back(E.key);
 		}
 	}
 	return ret;

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -131,9 +131,9 @@ void ShaderTextEditor::_load_theme_settings() {
 
 	List<String> built_ins;
 	if (shader.is_valid()) {
-		for (const Map<StringName, ShaderLanguage::FunctionInfo>::Element *E = ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(shader->get_mode())).front(); E; E = E->next()) {
-			for (const Map<StringName, ShaderLanguage::BuiltInInfo>::Element *F = E->get().built_ins.front(); F; F = F->next()) {
-				built_ins.push_back(F->key());
+		for (const KeyValue<StringName, ShaderLanguage::FunctionInfo> &E : ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(shader->get_mode()))) {
+			for (const KeyValue<StringName, ShaderLanguage::BuiltInInfo> &F : E.value.built_ins) {
+				built_ins.push_back(F.key);
 			}
 		}
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -437,8 +437,8 @@ void ThemeItemImportTree::_update_total_selected(Theme::DataType p_data_type) {
 	}
 
 	int count = 0;
-	for (Map<ThemeItem, ItemCheckedState>::Element *E = selected_items.front(); E; E = E->next()) {
-		ThemeItem ti = E->key();
+	for (const KeyValue<ThemeItem, ItemCheckedState> &E : selected_items) {
+		ThemeItem ti = E.key;
 		if (ti.data_type == p_data_type) {
 			count++;
 		}
@@ -759,7 +759,7 @@ void ThemeItemImportTree::_import_selected() {
 	ProgressDialog::get_singleton()->add_task("import_theme_items", TTR("Importing Theme Items"), selected_items.size() + 2);
 
 	int idx = 0;
-	for (Map<ThemeItem, ItemCheckedState>::Element *E = selected_items.front(); E; E = E->next()) {
+	for (KeyValue<ThemeItem, ItemCheckedState> &E : selected_items) {
 		// Arbitrary number of items to skip from reporting.
 		// Reduces the number of UI updates that this causes when copying large themes.
 		if (idx % 10 == 0) {
@@ -769,8 +769,8 @@ void ThemeItemImportTree::_import_selected() {
 			ProgressDialog::get_singleton()->task_step("import_theme_items", TTR("Importing items {n}/{n}").format(arr, "{n}"), idx);
 		}
 
-		ItemCheckedState cs = E->get();
-		ThemeItem ti = E->key();
+		ItemCheckedState cs = E.value;
+		ThemeItem ti = E.key;
 
 		if (cs == SELECT_IMPORT_DEFINITION || cs == SELECT_IMPORT_FULL) {
 			Variant item_value = Variant();

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -522,10 +522,10 @@ void TileAtlasView::_update_alternative_tiles_rect_cache() {
 }
 
 Vector3i TileAtlasView::get_alternative_tile_at_pos(const Vector2 p_pos) const {
-	for (Map<Vector2, Map<int, Rect2i>>::Element *E_coords = alternative_tiles_rect_cache.front(); E_coords; E_coords = E_coords->next()) {
-		for (Map<int, Rect2i>::Element *E_alternative = E_coords->value().front(); E_alternative; E_alternative = E_alternative->next()) {
-			if (E_alternative->value().has_point(p_pos)) {
-				return Vector3i(E_coords->key().x, E_coords->key().y, E_alternative->key());
+	for (const KeyValue<Vector2, Map<int, Rect2i>> &E_coords : alternative_tiles_rect_cache) {
+		for (const KeyValue<int, Rect2i> &E_alternative : E_coords.value) {
+			if (E_alternative.value.has_point(p_pos)) {
+				return Vector3i(E_coords.key.x, E_coords.key.y, E_alternative.key);
 			}
 		}
 	}

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -756,10 +756,10 @@ Variant TileDataDefaultEditor::_get_value(TileSetAtlasSource *p_tile_set_atlas_s
 }
 
 void TileDataDefaultEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, Map<TileMapCell, Variant> p_previous_values, Variant p_new_value) {
-	for (Map<TileMapCell, Variant>::Element *E = p_previous_values.front(); E; E = E->next()) {
-		Vector2i coords = E->key().get_atlas_coords();
-		undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/%s", coords.x, coords.y, E->key().alternative_tile, property), E->get());
-		undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/%s", coords.x, coords.y, E->key().alternative_tile, property), p_new_value);
+	for (const KeyValue<TileMapCell, Variant> &E : p_previous_values) {
+		Vector2i coords = E.key.get_atlas_coords();
+		undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/%s", coords.x, coords.y, E.key.alternative_tile, property), E.value);
+		undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/%s", coords.x, coords.y, E.key.alternative_tile, property), p_new_value);
 	}
 }
 
@@ -1191,10 +1191,10 @@ Variant TileDataOcclusionShapeEditor::_get_value(TileSetAtlasSource *p_tile_set_
 }
 
 void TileDataOcclusionShapeEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, Map<TileMapCell, Variant> p_previous_values, Variant p_new_value) {
-	for (Map<TileMapCell, Variant>::Element *E = p_previous_values.front(); E; E = E->next()) {
-		Vector2i coords = E->key().get_atlas_coords();
-		undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/occlusion_layer_%d/polygon", coords.x, coords.y, E->key().alternative_tile, occlusion_layer), E->get());
-		undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/occlusion_layer_%d/polygon", coords.x, coords.y, E->key().alternative_tile, occlusion_layer), p_new_value);
+	for (const KeyValue<TileMapCell, Variant> &E : p_previous_values) {
+		Vector2i coords = E.key.get_atlas_coords();
+		undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/occlusion_layer_%d/polygon", coords.x, coords.y, E.key.alternative_tile, occlusion_layer), E.value);
+		undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/occlusion_layer_%d/polygon", coords.x, coords.y, E.key.alternative_tile, occlusion_layer), p_new_value);
 	}
 }
 
@@ -1312,8 +1312,8 @@ void TileDataCollisionEditor::_set_painted_value(TileSetAtlasSource *p_tile_set_
 		dummy_object->set(vformat("polygon_%d_one_way", i), tile_data->is_collision_polygon_one_way(physics_layer, i));
 		dummy_object->set(vformat("polygon_%d_one_way_margin", i), tile_data->get_collision_polygon_one_way_margin(physics_layer, i));
 	}
-	for (Map<StringName, EditorProperty *>::Element *E = property_editors.front(); E; E = E->next()) {
-		E->get()->update_property();
+	for (const KeyValue<StringName, EditorProperty *> &E : property_editors) {
+		E.value->update_property();
 	}
 
 	polygon_editor->set_background(p_tile_set_atlas_source->get_texture(), p_tile_set_atlas_source->get_tile_texture_region(p_coords), p_tile_set_atlas_source->get_tile_effective_texture_offset(p_coords, p_alternative_tile), tile_data->get_flip_h(), tile_data->get_flip_v(), tile_data->get_transpose(), tile_data->get_modulate());
@@ -1359,24 +1359,24 @@ Variant TileDataCollisionEditor::_get_value(TileSetAtlasSource *p_tile_set_atlas
 
 void TileDataCollisionEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, Map<TileMapCell, Variant> p_previous_values, Variant p_new_value) {
 	Array new_array = p_new_value;
-	for (Map<TileMapCell, Variant>::Element *E = p_previous_values.front(); E; E = E->next()) {
-		Array old_array = E->get();
+	for (KeyValue<TileMapCell, Variant> &E : p_previous_values) {
+		Array old_array = E.value;
 
-		Vector2i coords = E->key().get_atlas_coords();
-		undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygons_count", coords.x, coords.y, E->key().alternative_tile, physics_layer), old_array.size());
+		Vector2i coords = E.key.get_atlas_coords();
+		undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygons_count", coords.x, coords.y, E.key.alternative_tile, physics_layer), old_array.size());
 		for (int i = 0; i < old_array.size(); i++) {
 			Dictionary dict = old_array[i];
-			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/points", coords.x, coords.y, E->key().alternative_tile, physics_layer, i), dict["points"]);
-			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way", coords.x, coords.y, E->key().alternative_tile, physics_layer, i), dict["one_way"]);
-			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way_margin", coords.x, coords.y, E->key().alternative_tile, physics_layer, i), dict["one_way_margin"]);
+			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/points", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), dict["points"]);
+			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), dict["one_way"]);
+			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way_margin", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), dict["one_way_margin"]);
 		}
 
-		undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygons_count", coords.x, coords.y, E->key().alternative_tile, physics_layer), new_array.size());
+		undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygons_count", coords.x, coords.y, E.key.alternative_tile, physics_layer), new_array.size());
 		for (int i = 0; i < new_array.size(); i++) {
 			Dictionary dict = new_array[i];
-			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/points", coords.x, coords.y, E->key().alternative_tile, physics_layer, i), dict["points"]);
-			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way", coords.x, coords.y, E->key().alternative_tile, physics_layer, i), dict["one_way"]);
-			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way_margin", coords.x, coords.y, E->key().alternative_tile, physics_layer, i), dict["one_way_margin"]);
+			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/points", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), dict["points"]);
+			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), dict["one_way"]);
+			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way_margin", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), dict["one_way_margin"]);
 		}
 	}
 }
@@ -2021,16 +2021,16 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 					drag_type = DRAG_TYPE_NONE;
 				} else if (drag_type == DRAG_TYPE_PAINT_TERRAIN_SET) {
 					undo_redo->create_action(TTR("Painting Terrain Set"));
-					for (Map<TileMapCell, Variant>::Element *E = drag_modified.front(); E; E = E->next()) {
-						Dictionary dict = E->get();
-						Vector2i coords = E->key().get_atlas_coords();
-						undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrain_set", coords.x, coords.y, E->key().alternative_tile), drag_painted_value);
-						undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrain_set", coords.x, coords.y, E->key().alternative_tile), dict["terrain_set"]);
+					for (KeyValue<TileMapCell, Variant> &E : drag_modified) {
+						Dictionary dict = E.value;
+						Vector2i coords = E.key.get_atlas_coords();
+						undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrain_set", coords.x, coords.y, E.key.alternative_tile), drag_painted_value);
+						undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrain_set", coords.x, coords.y, E.key.alternative_tile), dict["terrain_set"]);
 						Array array = dict["terrain_peering_bits"];
 						for (int i = 0; i < array.size(); i++) {
 							TileSet::CellNeighbor bit = TileSet::CellNeighbor(i);
 							if (tile_set->is_valid_peering_bit_terrain(dict["terrain_set"], bit)) {
-								undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E->key().alternative_tile), array[i]);
+								undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E.key.alternative_tile), array[i]);
 							}
 						}
 					}
@@ -2041,17 +2041,17 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 					int terrain_set = int(painted["terrain_set"]);
 					int terrain = int(painted["terrain"]);
 					undo_redo->create_action(TTR("Painting Terrain"));
-					for (Map<TileMapCell, Variant>::Element *E = drag_modified.front(); E; E = E->next()) {
-						Dictionary dict = E->get();
-						Vector2i coords = E->key().get_atlas_coords();
+					for (KeyValue<TileMapCell, Variant> &E : drag_modified) {
+						Dictionary dict = E.value;
+						Vector2i coords = E.key.get_atlas_coords();
 						Array array = dict["terrain_peering_bits"];
 						for (int i = 0; i < array.size(); i++) {
 							TileSet::CellNeighbor bit = TileSet::CellNeighbor(i);
 							if (tile_set->is_valid_peering_bit_terrain(terrain_set, bit)) {
-								undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E->key().alternative_tile), terrain);
+								undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E.key.alternative_tile), terrain);
 							}
 							if (tile_set->is_valid_peering_bit_terrain(dict["terrain_set"], bit)) {
-								undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E->key().alternative_tile), array[i]);
+								undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E.key.alternative_tile), array[i]);
 							}
 						}
 					}
@@ -2304,14 +2304,14 @@ void TileDataTerrainsEditor::forward_painting_alternatives_gui_input(TileAtlasVi
 			} else {
 				if (drag_type == DRAG_TYPE_PAINT_TERRAIN_SET) {
 					undo_redo->create_action(TTR("Painting Tiles Property"));
-					for (Map<TileMapCell, Variant>::Element *E = drag_modified.front(); E; E = E->next()) {
-						Dictionary dict = E->get();
-						Vector2i coords = E->key().get_atlas_coords();
-						undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrain_set", coords.x, coords.y, E->key().alternative_tile), dict["terrain_set"]);
-						undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrain_set", coords.x, coords.y, E->key().alternative_tile), drag_painted_value);
+					for (KeyValue<TileMapCell, Variant> &E : drag_modified) {
+						Dictionary dict = E.value;
+						Vector2i coords = E.key.get_atlas_coords();
+						undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrain_set", coords.x, coords.y, E.key.alternative_tile), dict["terrain_set"]);
+						undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrain_set", coords.x, coords.y, E.key.alternative_tile), drag_painted_value);
 						Array array = dict["terrain_peering_bits"];
 						for (int i = 0; i < array.size(); i++) {
-							undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E->key().alternative_tile), array[i]);
+							undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E.key.alternative_tile), array[i]);
 						}
 					}
 					undo_redo->commit_action(false);
@@ -2321,17 +2321,17 @@ void TileDataTerrainsEditor::forward_painting_alternatives_gui_input(TileAtlasVi
 					int terrain_set = int(painted["terrain_set"]);
 					int terrain = int(painted["terrain"]);
 					undo_redo->create_action(TTR("Painting Terrain"));
-					for (Map<TileMapCell, Variant>::Element *E = drag_modified.front(); E; E = E->next()) {
-						Dictionary dict = E->get();
-						Vector2i coords = E->key().get_atlas_coords();
+					for (KeyValue<TileMapCell, Variant> &E : drag_modified) {
+						Dictionary dict = E.value;
+						Vector2i coords = E.key.get_atlas_coords();
 						Array array = dict["terrain_peering_bits"];
 						for (int i = 0; i < array.size(); i++) {
 							TileSet::CellNeighbor bit = TileSet::CellNeighbor(i);
 							if (tile_set->is_valid_peering_bit_terrain(terrain_set, bit)) {
-								undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E->key().alternative_tile), terrain);
+								undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E.key.alternative_tile), terrain);
 							}
 							if (tile_set->is_valid_peering_bit_terrain(dict["terrain_set"], bit)) {
-								undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E->key().alternative_tile), array[i]);
+								undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[i]), coords.x, coords.y, E.key.alternative_tile), array[i]);
 							}
 						}
 					}
@@ -2443,10 +2443,10 @@ Variant TileDataNavigationEditor::_get_value(TileSetAtlasSource *p_tile_set_atla
 }
 
 void TileDataNavigationEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, Map<TileMapCell, Variant> p_previous_values, Variant p_new_value) {
-	for (Map<TileMapCell, Variant>::Element *E = p_previous_values.front(); E; E = E->next()) {
-		Vector2i coords = E->key().get_atlas_coords();
-		undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/navigation_layer_%d/polygon", coords.x, coords.y, E->key().alternative_tile, navigation_layer), E->get());
-		undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/navigation_layer_%d/polygon", coords.x, coords.y, E->key().alternative_tile, navigation_layer), p_new_value);
+	for (const KeyValue<TileMapCell, Variant> &E : p_previous_values) {
+		Vector2i coords = E.key.get_atlas_coords();
+		undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/navigation_layer_%d/polygon", coords.x, coords.y, E.key.alternative_tile, navigation_layer), E.value);
+		undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/navigation_layer_%d/polygon", coords.x, coords.y, E.key.alternative_tile, navigation_layer), p_new_value);
 	}
 }
 

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -455,15 +455,15 @@ bool TileMapEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p
 		switch (drag_type) {
 			case DRAG_TYPE_PAINT: {
 				Map<Vector2i, TileMapCell> to_draw = _draw_line(drag_start_mouse_pos, drag_last_mouse_pos, mpos);
-				for (Map<Vector2i, TileMapCell>::Element *E = to_draw.front(); E; E = E->next()) {
-					if (!erase_button->is_pressed() && E->get().source_id == TileSet::INVALID_SOURCE) {
+				for (const KeyValue<Vector2i, TileMapCell> &E : to_draw) {
+					if (!erase_button->is_pressed() && E.value.source_id == TileSet::INVALID_SOURCE) {
 						continue;
 					}
-					Vector2i coords = E->key();
+					Vector2i coords = E.key;
 					if (!drag_modified.has(coords)) {
 						drag_modified.insert(coords, tile_map->get_cell(tile_map_layer, coords));
 					}
-					tile_map->set_cell(tile_map_layer, coords, E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+					tile_map->set_cell(tile_map_layer, coords, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 				}
 			} break;
 			case DRAG_TYPE_BUCKET: {
@@ -471,15 +471,15 @@ bool TileMapEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p
 				for (int i = 0; i < line.size(); i++) {
 					if (!drag_modified.has(line[i])) {
 						Map<Vector2i, TileMapCell> to_draw = _draw_bucket_fill(line[i], bucket_continuous_checkbox->is_pressed());
-						for (Map<Vector2i, TileMapCell>::Element *E = to_draw.front(); E; E = E->next()) {
-							if (!erase_button->is_pressed() && E->get().source_id == TileSet::INVALID_SOURCE) {
+						for (const KeyValue<Vector2i, TileMapCell> &E : to_draw) {
+							if (!erase_button->is_pressed() && E.value.source_id == TileSet::INVALID_SOURCE) {
 								continue;
 							}
-							Vector2i coords = E->key();
+							Vector2i coords = E.key;
 							if (!drag_modified.has(coords)) {
 								drag_modified.insert(coords, tile_map->get_cell(tile_map_layer, coords));
 							}
-							tile_map->set_cell(tile_map_layer, coords, E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+							tile_map->set_cell(tile_map_layer, coords, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 						}
 					}
 				}
@@ -531,15 +531,15 @@ bool TileMapEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p
 							drag_start_mouse_pos = mpos;
 							drag_modified.clear();
 							Map<Vector2i, TileMapCell> to_draw = _draw_line(drag_start_mouse_pos, mpos, mpos);
-							for (Map<Vector2i, TileMapCell>::Element *E = to_draw.front(); E; E = E->next()) {
-								if (!erase_button->is_pressed() && E->get().source_id == TileSet::INVALID_SOURCE) {
+							for (const KeyValue<Vector2i, TileMapCell> &E : to_draw) {
+								if (!erase_button->is_pressed() && E.value.source_id == TileSet::INVALID_SOURCE) {
 									continue;
 								}
-								Vector2i coords = E->key();
+								Vector2i coords = E.key;
 								if (!drag_modified.has(coords)) {
 									drag_modified.insert(coords, tile_map->get_cell(tile_map_layer, coords));
 								}
-								tile_map->set_cell(tile_map_layer, coords, E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+								tile_map->set_cell(tile_map_layer, coords, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 							}
 						} else if (tool_buttons_group->get_pressed_button() == line_tool_button) {
 							drag_type = DRAG_TYPE_LINE;
@@ -557,15 +557,15 @@ bool TileMapEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p
 							for (int i = 0; i < line.size(); i++) {
 								if (!drag_modified.has(line[i])) {
 									Map<Vector2i, TileMapCell> to_draw = _draw_bucket_fill(line[i], bucket_continuous_checkbox->is_pressed());
-									for (Map<Vector2i, TileMapCell>::Element *E = to_draw.front(); E; E = E->next()) {
-										if (!erase_button->is_pressed() && E->get().source_id == TileSet::INVALID_SOURCE) {
+									for (const KeyValue<Vector2i, TileMapCell> &E : to_draw) {
+										if (!erase_button->is_pressed() && E.value.source_id == TileSet::INVALID_SOURCE) {
 											continue;
 										}
-										Vector2i coords = E->key();
+										Vector2i coords = E.key;
 										if (!drag_modified.has(coords)) {
 											drag_modified.insert(coords, tile_map->get_cell(tile_map_layer, coords));
 										}
-										tile_map->set_cell(tile_map_layer, coords, E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+										tile_map->set_cell(tile_map_layer, coords, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 									}
 								}
 							}
@@ -710,8 +710,8 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 			// Expand the grid if needed
 			if (expand_grid && !preview.is_empty()) {
 				drawn_grid_rect = Rect2i(preview.front()->key(), Vector2i(1, 1));
-				for (Map<Vector2i, TileMapCell>::Element *E = preview.front(); E; E = E->next()) {
-					drawn_grid_rect.expand_to(E->key());
+				for (const KeyValue<Vector2i, TileMapCell> &E : preview) {
+					drawn_grid_rect.expand_to(E.key);
 				}
 			}
 		}
@@ -748,23 +748,23 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 			}
 
 			// Draw the preview.
-			for (Map<Vector2i, TileMapCell>::Element *E = preview.front(); E; E = E->next()) {
+			for (const KeyValue<Vector2i, TileMapCell> &E : preview) {
 				Transform2D tile_xform;
-				tile_xform.set_origin(tile_map->map_to_world(E->key()));
+				tile_xform.set_origin(tile_map->map_to_world(E.key));
 				tile_xform.set_scale(tile_set->get_tile_size());
 				if (!erase_button->is_pressed() && random_tile_checkbox->is_pressed()) {
 					tile_set->draw_tile_shape(p_overlay, xform * tile_xform, Color(1.0, 1.0, 1.0, 0.5), true);
 				} else {
-					if (tile_set->has_source(E->get().source_id)) {
-						TileSetSource *source = *tile_set->get_source(E->get().source_id);
+					if (tile_set->has_source(E.value.source_id)) {
+						TileSetSource *source = *tile_set->get_source(E.value.source_id);
 						TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
 						if (atlas_source) {
 							// Get tile data.
-							TileData *tile_data = Object::cast_to<TileData>(atlas_source->get_tile_data(E->get().get_atlas_coords(), E->get().alternative_tile));
+							TileData *tile_data = Object::cast_to<TileData>(atlas_source->get_tile_data(E.value.get_atlas_coords(), E.value.alternative_tile));
 
 							// Compute the offset
-							Rect2i source_rect = atlas_source->get_tile_texture_region(E->get().get_atlas_coords());
-							Vector2i tile_offset = atlas_source->get_tile_effective_texture_offset(E->get().get_atlas_coords(), E->get().alternative_tile);
+							Rect2i source_rect = atlas_source->get_tile_texture_region(E.value.get_atlas_coords());
+							Vector2i tile_offset = atlas_source->get_tile_effective_texture_offset(E.value.get_atlas_coords(), E.value.alternative_tile);
 
 							// Compute the destination rectangle in the CanvasItem.
 							Rect2 dest_rect;
@@ -772,9 +772,9 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 
 							bool transpose = tile_data->get_transpose();
 							if (transpose) {
-								dest_rect.position = (tile_map->map_to_world(E->key()) - Vector2(dest_rect.size.y, dest_rect.size.x) / 2 - tile_offset);
+								dest_rect.position = (tile_map->map_to_world(E.key) - Vector2(dest_rect.size.y, dest_rect.size.x) / 2 - tile_offset);
 							} else {
-								dest_rect.position = (tile_map->map_to_world(E->key()) - dest_rect.size / 2 - tile_offset);
+								dest_rect.position = (tile_map->map_to_world(E.key) - dest_rect.size / 2 - tile_offset);
 							}
 
 							dest_rect = xform.xform(dest_rect);
@@ -1165,11 +1165,11 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 			}
 			undo_redo->create_action(TTR("Move tiles"));
 			// Move the tiles.
-			for (Map<Vector2i, TileMapCell>::Element *E = cells_do.front(); E; E = E->next()) {
-				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+			for (const KeyValue<Vector2i, TileMapCell> &E : cells_do) {
+				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E.key, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 			}
-			for (Map<Vector2i, TileMapCell>::Element *E = cells_undo.front(); E; E = E->next()) {
-				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+			for (const KeyValue<Vector2i, TileMapCell> &E : cells_undo) {
+				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E.key, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 			}
 
 			// Update the selection.
@@ -1205,41 +1205,41 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 		} break;
 		case DRAG_TYPE_PAINT: {
 			undo_redo->create_action(TTR("Paint tiles"));
-			for (Map<Vector2i, TileMapCell>::Element *E = drag_modified.front(); E; E = E->next()) {
-				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E->key(), tile_map->get_cell_source_id(tile_map_layer, E->key()), tile_map->get_cell_atlas_coords(tile_map_layer, E->key()), tile_map->get_cell_alternative_tile(tile_map_layer, E->key()));
-				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+			for (const KeyValue<Vector2i, TileMapCell> &E : drag_modified) {
+				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E.key, tile_map->get_cell_source_id(tile_map_layer, E.key), tile_map->get_cell_atlas_coords(tile_map_layer, E.key), tile_map->get_cell_alternative_tile(tile_map_layer, E.key));
+				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E.key, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 			}
 			undo_redo->commit_action(false);
 		} break;
 		case DRAG_TYPE_LINE: {
 			Map<Vector2i, TileMapCell> to_draw = _draw_line(drag_start_mouse_pos, drag_start_mouse_pos, mpos);
 			undo_redo->create_action(TTR("Paint tiles"));
-			for (Map<Vector2i, TileMapCell>::Element *E = to_draw.front(); E; E = E->next()) {
-				if (!erase_button->is_pressed() && E->get().source_id == TileSet::INVALID_SOURCE) {
+			for (const KeyValue<Vector2i, TileMapCell> &E : to_draw) {
+				if (!erase_button->is_pressed() && E.value.source_id == TileSet::INVALID_SOURCE) {
 					continue;
 				}
-				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
-				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E->key(), tile_map->get_cell_source_id(tile_map_layer, E->key()), tile_map->get_cell_atlas_coords(tile_map_layer, E->key()), tile_map->get_cell_alternative_tile(tile_map_layer, E->key()));
+				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E.key, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
+				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E.key, tile_map->get_cell_source_id(tile_map_layer, E.key), tile_map->get_cell_atlas_coords(tile_map_layer, E.key), tile_map->get_cell_alternative_tile(tile_map_layer, E.key));
 			}
 			undo_redo->commit_action();
 		} break;
 		case DRAG_TYPE_RECT: {
 			Map<Vector2i, TileMapCell> to_draw = _draw_rect(tile_map->world_to_map(drag_start_mouse_pos), tile_map->world_to_map(mpos));
 			undo_redo->create_action(TTR("Paint tiles"));
-			for (Map<Vector2i, TileMapCell>::Element *E = to_draw.front(); E; E = E->next()) {
-				if (!erase_button->is_pressed() && E->get().source_id == TileSet::INVALID_SOURCE) {
+			for (const KeyValue<Vector2i, TileMapCell> &E : to_draw) {
+				if (!erase_button->is_pressed() && E.value.source_id == TileSet::INVALID_SOURCE) {
 					continue;
 				}
-				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
-				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E->key(), tile_map->get_cell_source_id(tile_map_layer, E->key()), tile_map->get_cell_atlas_coords(tile_map_layer, E->key()), tile_map->get_cell_alternative_tile(tile_map_layer, E->key()));
+				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E.key, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
+				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E.key, tile_map->get_cell_source_id(tile_map_layer, E.key), tile_map->get_cell_atlas_coords(tile_map_layer, E.key), tile_map->get_cell_alternative_tile(tile_map_layer, E.key));
 			}
 			undo_redo->commit_action();
 		} break;
 		case DRAG_TYPE_BUCKET: {
 			undo_redo->create_action(TTR("Paint tiles"));
-			for (Map<Vector2i, TileMapCell>::Element *E = drag_modified.front(); E; E = E->next()) {
-				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E->key(), tile_map->get_cell_source_id(tile_map_layer, E->key()), tile_map->get_cell_atlas_coords(tile_map_layer, E->key()), tile_map->get_cell_alternative_tile(tile_map_layer, E->key()));
-				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+			for (const KeyValue<Vector2i, TileMapCell> &E : drag_modified) {
+				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E.key, tile_map->get_cell_source_id(tile_map_layer, E.key), tile_map->get_cell_atlas_coords(tile_map_layer, E.key), tile_map->get_cell_alternative_tile(tile_map_layer, E.key));
+				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E.key, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 			}
 			undo_redo->commit_action(false);
 		} break;
@@ -1364,17 +1364,17 @@ void TileMapEditorTilesPlugin::_update_selection_pattern_from_tileset_selection(
 	}
 
 	int vertical_offset = 0;
-	for (Map<int, List<const TileMapCell *>>::Element *E_source = per_source.front(); E_source; E_source = E_source->next()) {
+	for (const KeyValue<int, List<const TileMapCell *>> &E_source : per_source) {
 		// Per source.
 		List<const TileMapCell *> unorganized;
 		Rect2i encompassing_rect_coords;
 		Map<Vector2i, const TileMapCell *> organized_pattern;
 
-		TileSetSource *source = *tile_set->get_source(E_source->key());
+		TileSetSource *source = *tile_set->get_source(E_source.key);
 		TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
 		if (atlas_source) {
 			// Organize using coordinates.
-			for (const TileMapCell *current : E_source->get()) {
+			for (const TileMapCell *current : E_source.value) {
 				if (current->alternative_tile == 0) {
 					organized_pattern[current->get_atlas_coords()] = current;
 				} else {
@@ -1393,14 +1393,14 @@ void TileMapEditorTilesPlugin::_update_selection_pattern_from_tileset_selection(
 			}
 		} else {
 			// Add everything unorganized.
-			for (const TileMapCell *cell : E_source->get()) {
+			for (const TileMapCell *cell : E_source.value) {
 				unorganized.push_back(cell);
 			}
 		}
 
 		// Now add everything to the output pattern.
-		for (Map<Vector2i, const TileMapCell *>::Element *E_cell = organized_pattern.front(); E_cell; E_cell = E_cell->next()) {
-			selection_pattern->set_cell(E_cell->key() - encompassing_rect_coords.position + Vector2i(0, vertical_offset), E_cell->get()->source_id, E_cell->get()->get_atlas_coords(), E_cell->get()->alternative_tile);
+		for (const KeyValue<Vector2i, const TileMapCell *> &E_cell : organized_pattern) {
+			selection_pattern->set_cell(E_cell.key - encompassing_rect_coords.position + Vector2i(0, vertical_offset), E_cell.value->source_id, E_cell.value->get_atlas_coords(), E_cell.value->alternative_tile);
 		}
 		Vector2i organized_size = selection_pattern->get_size();
 		int unorganized_index = 0;
@@ -2308,14 +2308,14 @@ Set<TileMapEditorTerrainsPlugin::TerrainsTilePattern> TileMapEditorTerrainsPlugi
 
 	// Returns all tiles compatible with the given constraints.
 	Set<TerrainsTilePattern> compatible_terrain_tile_patterns;
-	for (Map<TerrainsTilePattern, Set<TileMapCell>>::Element *E = per_terrain_terrains_tile_patterns_tiles[p_terrain_set].front(); E; E = E->next()) {
+	for (const KeyValue<TerrainsTilePattern, Set<TileMapCell>> &E : per_terrain_terrains_tile_patterns_tiles[p_terrain_set]) {
 		int valid = true;
 		int in_pattern_count = 0;
 		for (int i = 0; i < TileSet::CELL_NEIGHBOR_MAX; i++) {
 			TileSet::CellNeighbor bit = TileSet::CellNeighbor(i);
 			if (tile_set->is_valid_peering_bit_terrain(p_terrain_set, bit)) {
 				// Check if the bit is compatible with the constraints.
-				Constraint terrain_bit_constraint = Constraint(tile_map, p_position, bit, E->key()[in_pattern_count]);
+				Constraint terrain_bit_constraint = Constraint(tile_map, p_position, bit, E.key[in_pattern_count]);
 
 				Set<Constraint>::Element *in_set_constraint_element = p_constraints.find(terrain_bit_constraint);
 				if (in_set_constraint_element && in_set_constraint_element->get().get_terrain() != terrain_bit_constraint.get_terrain()) {
@@ -2327,7 +2327,7 @@ Set<TileMapEditorTerrainsPlugin::TerrainsTilePattern> TileMapEditorTerrainsPlugi
 		}
 
 		if (valid) {
-			compatible_terrain_tile_patterns.insert(E->key());
+			compatible_terrain_tile_patterns.insert(E.key);
 		}
 	}
 
@@ -2368,15 +2368,15 @@ Set<TileMapEditorTerrainsPlugin::Constraint> TileMapEditorTerrainsPlugin::_get_c
 
 		// Count the number of occurrences per terrain.
 		Map<Vector2i, TileSet::CellNeighbor> overlapping_terrain_bits = c.get_overlapping_coords_and_peering_bits();
-		for (Map<Vector2i, TileSet::CellNeighbor>::Element *E_overlapping = overlapping_terrain_bits.front(); E_overlapping; E_overlapping = E_overlapping->next()) {
-			if (!p_to_replace.has(E_overlapping->key())) {
-				TileMapCell neighbor_cell = tile_map->get_cell(tile_map_layer, E_overlapping->key());
+		for (const KeyValue<Vector2i, TileSet::CellNeighbor> &E_overlapping : overlapping_terrain_bits) {
+			if (!p_to_replace.has(E_overlapping.key)) {
+				TileMapCell neighbor_cell = tile_map->get_cell(tile_map_layer, E_overlapping.key);
 				TileData *neighbor_tile_data = nullptr;
 				if (terrain_tiles.has(neighbor_cell) && terrain_tiles[neighbor_cell]->get_terrain_set() == p_terrain_set) {
 					neighbor_tile_data = terrain_tiles[neighbor_cell];
 				}
 
-				int terrain = neighbor_tile_data ? neighbor_tile_data->get_peering_bit_terrain(TileSet::CellNeighbor(E_overlapping->get())) : -1;
+				int terrain = neighbor_tile_data ? neighbor_tile_data->get_peering_bit_terrain(TileSet::CellNeighbor(E_overlapping.value)) : -1;
 				if (terrain_count.has(terrain)) {
 					terrain_count[terrain] = 0;
 				}
@@ -2387,10 +2387,10 @@ Set<TileMapEditorTerrainsPlugin::Constraint> TileMapEditorTerrainsPlugin::_get_c
 		// Get the terrain with the max number of occurrences.
 		int max = 0;
 		int max_terrain = -1;
-		for (Map<int, int>::Element *E_terrain_count = terrain_count.front(); E_terrain_count; E_terrain_count = E_terrain_count->next()) {
-			if (E_terrain_count->get() > max) {
-				max = E_terrain_count->get();
-				max_terrain = E_terrain_count->key();
+		for (const KeyValue<int, int> &E_terrain_count : terrain_count) {
+			if (E_terrain_count.value > max) {
+				max = E_terrain_count.value;
+				max_terrain = E_terrain_count.key;
 			}
 		}
 
@@ -2458,15 +2458,15 @@ Map<Vector2i, TileMapEditorTerrainsPlugin::TerrainsTilePattern> TileMapEditorTer
 	while (!to_replace.is_empty()) {
 		// Compute the minimum number of tile possibilities for each cell.
 		int min_nb_possibilities = 100000000;
-		for (Map<Vector2i, Set<TerrainsTilePattern>>::Element *E = per_cell_acceptable_tiles.front(); E; E = E->next()) {
-			min_nb_possibilities = MIN(min_nb_possibilities, E->get().size());
+		for (const KeyValue<Vector2i, Set<TerrainsTilePattern>> &E : per_cell_acceptable_tiles) {
+			min_nb_possibilities = MIN(min_nb_possibilities, E.value.size());
 		}
 
 		// Get the set of possible cells to fill.
 		LocalVector<Vector2i> to_choose_from;
-		for (Map<Vector2i, Set<TerrainsTilePattern>>::Element *E = per_cell_acceptable_tiles.front(); E; E = E->next()) {
-			if (E->get().size() == min_nb_possibilities) {
-				to_choose_from.push_back(E->key());
+		for (const KeyValue<Vector2i, Set<TerrainsTilePattern>> &E : per_cell_acceptable_tiles) {
+			if (E.value.size() == min_nb_possibilities) {
+				to_choose_from.push_back(E.key);
 			}
 		}
 
@@ -2584,9 +2584,9 @@ Map<Vector2i, TileMapCell> TileMapEditorTerrainsPlugin::_draw_terrains(const Map
 
 	// Add the constraints from the added tiles.
 	Set<TileMapEditorTerrainsPlugin::Constraint> added_tiles_constraints_set;
-	for (Map<Vector2i, TerrainsTilePattern>::Element *E_to_paint = p_to_paint.front(); E_to_paint; E_to_paint = E_to_paint->next()) {
-		Vector2i coords = E_to_paint->key();
-		TerrainsTilePattern terrains_tile_pattern = E_to_paint->get();
+	for (const KeyValue<Vector2i, TerrainsTilePattern> &E_to_paint : p_to_paint) {
+		Vector2i coords = E_to_paint.key;
+		TerrainsTilePattern terrains_tile_pattern = E_to_paint.value;
 
 		Set<TileMapEditorTerrainsPlugin::Constraint> cell_constraints = _get_constraints_from_added_tile(coords, p_terrain_set, terrains_tile_pattern);
 		for (Set<TileMapEditorTerrainsPlugin::Constraint>::Element *E = cell_constraints.front(); E; E = E->next()) {
@@ -2596,8 +2596,8 @@ Map<Vector2i, TileMapCell> TileMapEditorTerrainsPlugin::_draw_terrains(const Map
 
 	// Build the list of potential tiles to replace.
 	Set<Vector2i> potential_to_replace;
-	for (Map<Vector2i, TerrainsTilePattern>::Element *E_to_paint = p_to_paint.front(); E_to_paint; E_to_paint = E_to_paint->next()) {
-		Vector2i coords = E_to_paint->key();
+	for (const KeyValue<Vector2i, TerrainsTilePattern> &E_to_paint : p_to_paint) {
+		Vector2i coords = E_to_paint.key;
 		for (int i = 0; i < TileSet::CELL_NEIGHBOR_MAX; i++) {
 			if (tile_map->is_existing_neighbor(TileSet::CellNeighbor(i))) {
 				Vector2i neighbor = tile_map->get_neighbor_cell(coords, TileSet::CellNeighbor(i));
@@ -2612,8 +2612,8 @@ Map<Vector2i, TileMapCell> TileMapEditorTerrainsPlugin::_draw_terrains(const Map
 	Set<Vector2i> to_replace;
 
 	// Add the central tiles to the one to replace. TODO: maybe change that.
-	for (Map<Vector2i, TerrainsTilePattern>::Element *E_to_paint = p_to_paint.front(); E_to_paint; E_to_paint = E_to_paint->next()) {
-		to_replace.insert(E_to_paint->key());
+	for (const KeyValue<Vector2i, TerrainsTilePattern> &E_to_paint : p_to_paint) {
+		to_replace.insert(E_to_paint.key);
 	}
 
 	// Add the constraints from the surroundings of the modified areas.
@@ -2627,9 +2627,9 @@ Map<Vector2i, TileMapCell> TileMapEditorTerrainsPlugin::_draw_terrains(const Map
 		Map<Constraint, Set<Vector2i>> source_tiles_of_constraint;
 		for (Set<Constraint>::Element *E = removed_cells_constraints_set.front(); E; E = E->next()) {
 			Map<Vector2i, TileSet::CellNeighbor> sources_of_constraint = E->get().get_overlapping_coords_and_peering_bits();
-			for (Map<Vector2i, TileSet::CellNeighbor>::Element *E_source_tile_of_constraint = sources_of_constraint.front(); E_source_tile_of_constraint; E_source_tile_of_constraint = E_source_tile_of_constraint->next()) {
-				if (potential_to_replace.has(E_source_tile_of_constraint->key())) {
-					source_tiles_of_constraint[E->get()].insert(E_source_tile_of_constraint->key());
+			for (const KeyValue<Vector2i, TileSet::CellNeighbor> &E_source_tile_of_constraint : sources_of_constraint) {
+				if (potential_to_replace.has(E_source_tile_of_constraint.key)) {
+					source_tiles_of_constraint[E->get()].insert(E_source_tile_of_constraint.key);
 				}
 			}
 		}
@@ -2646,8 +2646,8 @@ Map<Vector2i, TileMapCell> TileMapEditorTerrainsPlugin::_draw_terrains(const Map
 					potential_to_replace.erase(to_add_to_remove);
 					to_replace.insert(to_add_to_remove);
 					to_replace_modified = true;
-					for (Map<Constraint, Set<Vector2i>>::Element *E_source_tiles_of_constraint = source_tiles_of_constraint.front(); E_source_tiles_of_constraint; E_source_tiles_of_constraint = E_source_tiles_of_constraint->next()) {
-						E_source_tiles_of_constraint->get().erase(to_add_to_remove);
+					for (KeyValue<Constraint, Set<Vector2i>> &E_source_tiles_of_constraint : source_tiles_of_constraint) {
+						E_source_tiles_of_constraint.value.erase(to_add_to_remove);
 					}
 					break;
 				}
@@ -2665,13 +2665,13 @@ Map<Vector2i, TileMapCell> TileMapEditorTerrainsPlugin::_draw_terrains(const Map
 	Map<Vector2i, TerrainsTilePattern> wfc_output = _wave_function_collapse(to_replace, p_terrain_set, constraints);
 
 	// Use the WFC run for the output.
-	for (Map<Vector2i, TerrainsTilePattern>::Element *E = wfc_output.front(); E; E = E->next()) {
-		output[E->key()] = _get_random_tile_from_pattern(p_terrain_set, E->get());
+	for (const KeyValue<Vector2i, TerrainsTilePattern> &E : wfc_output) {
+		output[E.key] = _get_random_tile_from_pattern(p_terrain_set, E.value);
 	}
 
 	// Override the WFC results to make sure at least the painted tiles are actually painted.
-	for (Map<Vector2i, TerrainsTilePattern>::Element *E_to_paint = p_to_paint.front(); E_to_paint; E_to_paint = E_to_paint->next()) {
-		output[E_to_paint->key()] = _get_random_tile_from_pattern(p_terrain_set, E_to_paint->get());
+	for (const KeyValue<Vector2i, TerrainsTilePattern> &E_to_paint : p_to_paint) {
+		output[E_to_paint.key] = _get_random_tile_from_pattern(p_terrain_set, E_to_paint.value);
 	}
 
 	return output;
@@ -2749,9 +2749,9 @@ void TileMapEditorTerrainsPlugin::_stop_dragging() {
 		} break;
 		case DRAG_TYPE_PAINT: {
 			undo_redo->create_action(TTR("Paint terrain"));
-			for (Map<Vector2i, TileMapCell>::Element *E = drag_modified.front(); E; E = E->next()) {
-				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E->key(), tile_map->get_cell_source_id(tile_map_layer, E->key()), tile_map->get_cell_atlas_coords(tile_map_layer, E->key()), tile_map->get_cell_alternative_tile(tile_map_layer, E->key()));
-				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+			for (const KeyValue<Vector2i, TileMapCell> &E : drag_modified) {
+				undo_redo->add_do_method(tile_map, "set_cell", tile_map_layer, E.key, tile_map->get_cell_source_id(tile_map_layer, E.key), tile_map->get_cell_atlas_coords(tile_map_layer, E.key), tile_map->get_cell_alternative_tile(tile_map_layer, E.key));
+				undo_redo->add_undo_method(tile_map, "set_cell", tile_map_layer, E.key, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 			}
 			undo_redo->commit_action(false);
 		} break;
@@ -2825,11 +2825,11 @@ bool TileMapEditorTerrainsPlugin::forward_canvas_gui_input(const Ref<InputEvent>
 						to_draw[line[i]] = selected_terrains_tile_pattern;
 					}
 					Map<Vector2i, TileMapCell> modified = _draw_terrains(to_draw, selected_terrain_set);
-					for (Map<Vector2i, TileMapCell>::Element *E = modified.front(); E; E = E->next()) {
-						if (!drag_modified.has(E->key())) {
-							drag_modified[E->key()] = tile_map->get_cell(tile_map_layer, E->key());
+					for (const KeyValue<Vector2i, TileMapCell> &E : modified) {
+						if (!drag_modified.has(E.key)) {
+							drag_modified[E.key] = tile_map->get_cell(tile_map_layer, E.key);
 						}
-						tile_map->set_cell(tile_map_layer, E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+						tile_map->set_cell(tile_map_layer, E.key, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 					}
 				}
 			} break;
@@ -2864,9 +2864,9 @@ bool TileMapEditorTerrainsPlugin::forward_canvas_gui_input(const Ref<InputEvent>
 						terrains_to_draw[tile_map->world_to_map(mpos)] = selected_terrains_tile_pattern;
 
 						Map<Vector2i, TileMapCell> to_draw = _draw_terrains(terrains_to_draw, selected_terrain_set);
-						for (Map<Vector2i, TileMapCell>::Element *E = to_draw.front(); E; E = E->next()) {
-							drag_modified[E->key()] = tile_map->get_cell(tile_map_layer, E->key());
-							tile_map->set_cell(tile_map_layer, E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
+						for (const KeyValue<Vector2i, TileMapCell> &E : to_draw) {
+							drag_modified[E.key] = tile_map->get_cell(tile_map_layer, E.key);
+							tile_map->set_cell(tile_map_layer, E.key, E.value.source_id, E.value.get_atlas_coords(), E.value.alternative_tile);
 						}
 					}
 				}

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -674,9 +674,9 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 #undef ADD_TILE_DATA_EDITOR
 
 	// Add tile data editors as children.
-	for (Map<String, TileDataEditor *>::Element *E = tile_data_editors.front(); E; E = E->next()) {
+	for (KeyValue<String, TileDataEditor *> &E : tile_data_editors) {
 		// Tile Data Editor.
-		TileDataEditor *tile_data_editor = E->get();
+		TileDataEditor *tile_data_editor = E.value;
 		if (!tile_data_editor->is_inside_tree()) {
 			tile_data_painting_editor_container->add_child(tile_data_editor);
 		}
@@ -716,9 +716,9 @@ void TileSetAtlasSourceEditor::_update_current_tile_data_editor() {
 	}
 
 	// Hide all editors but the current one.
-	for (Map<String, TileDataEditor *>::Element *E = tile_data_editors.front(); E; E = E->next()) {
-		E->get()->hide();
-		E->get()->get_toolbar()->hide();
+	for (const KeyValue<String, TileDataEditor *> &E : tile_data_editors) {
+		E.value->hide();
+		E.value->get_toolbar()->hide();
 	}
 	if (tile_data_editors.has(property)) {
 		current_tile_data_editor = tile_data_editors[property];

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -123,9 +123,9 @@ void VisualShaderGraphPlugin::set_connections(List<VisualShader::Connection> &p_
 
 void VisualShaderGraphPlugin::show_port_preview(VisualShader::Type p_type, int p_node_id, int p_port_id) {
 	if (visual_shader->get_shader_type() == p_type && links.has(p_node_id) && links[p_node_id].output_ports.has(p_port_id)) {
-		for (Map<int, Port>::Element *E = links[p_node_id].output_ports.front(); E; E = E->next()) {
-			if (E->value().preview_button != nullptr) {
-				E->value().preview_button->set_pressed(false);
+		for (const KeyValue<int, Port> &E : links[p_node_id].output_ports) {
+			if (E.value.preview_button != nullptr) {
+				E.value.preview_button->set_pressed(false);
 			}
 		}
 
@@ -264,11 +264,11 @@ void VisualShaderGraphPlugin::register_curve_editor(int p_node_id, int p_index, 
 }
 
 void VisualShaderGraphPlugin::update_uniform_refs() {
-	for (Map<int, Link>::Element *E = links.front(); E; E = E->next()) {
-		VisualShaderNodeUniformRef *ref = Object::cast_to<VisualShaderNodeUniformRef>(E->get().visual_node);
+	for (KeyValue<int, Link> &E : links) {
+		VisualShaderNodeUniformRef *ref = Object::cast_to<VisualShaderNodeUniformRef>(E.value.visual_node);
 		if (ref) {
-			remove_node(E->get().type, E->key());
-			add_node(E->get().type, E->key());
+			remove_node(E.value.type, E.key);
+			add_node(E.value.type, E.key);
 		}
 	}
 }

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -63,9 +63,9 @@ void BackgroundProgress::_add_task(const String &p_task, const String &p_label, 
 void BackgroundProgress::_update() {
 	_THREAD_SAFE_METHOD_
 
-	for (Map<String, int>::Element *E = updates.front(); E; E = E->next()) {
-		if (tasks.has(E->key())) {
-			_task_step(E->key(), E->get());
+	for (const KeyValue<String, int> &E : updates) {
+		if (tasks.has(E.key)) {
+			_task_step(E.key, E.value);
 		}
 	}
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -517,8 +517,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				editor_data->get_undo_redo().add_do_method(paste_parent, "add_child", dup);
 
-				for (Map<const Node *, Node *>::Element *E2 = duplimap.front(); E2; E2 = E2->next()) {
-					Node *d = E2->value();
+				for (KeyValue<const Node *, Node *> &E2 : duplimap) {
+					Node *d = E2.value;
 					editor_data->get_undo_redo().add_do_method(d, "set_owner", owner);
 				}
 
@@ -848,8 +848,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 			Ref<MultiNodeEdit> mne = memnew(MultiNodeEdit);
-			for (const Map<Node *, Object *>::Element *E = editor_selection->get_selection().front(); E; E = E->next()) {
-				mne->add_node(root->get_path_to(E->key()));
+			for (const KeyValue<Node *, Object *> &E : editor_selection->get_selection()) {
+				mne->add_node(root->get_path_to(E.key));
 			}
 
 			EditorNode::get_singleton()->push_item(mne.ptr());

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -425,8 +425,8 @@ void ScriptCreateDialog::_lang_changed(int l) {
 			templates[i].id = new_id;
 		}
 		// Disable overridden
-		for (Map<String, Vector<int>>::Element *E = template_overrides.front(); E; E = E->next()) {
-			const Vector<int> &overrides = E->get();
+		for (const KeyValue<String, Vector<int>> &E : template_overrides) {
+			const Vector<int> &overrides = E.value;
 
 			if (overrides.size() == 1) {
 				continue; // doesn't override anything

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -382,8 +382,8 @@ void EditorSettingsDialog::_update_shortcuts() {
 	}
 
 	// remove sections with no shortcuts
-	for (Map<String, TreeItem *>::Element *E = sections.front(); E; E = E->next()) {
-		TreeItem *section = E->get();
+	for (KeyValue<String, TreeItem *> &E : sections) {
+		TreeItem *section = E.value;
 		if (section->get_first_child() == nullptr) {
 			root->remove_child(section);
 		}

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -1404,8 +1404,8 @@ void BulletPhysicsServer3D::free(RID p_rid) {
 		ShapeBullet *shape = shape_owner.get_or_null(p_rid);
 
 		// Notify the shape is configured
-		for (Map<ShapeOwnerBullet *, int>::Element *element = shape->get_owners().front(); element; element = element->next()) {
-			static_cast<ShapeOwnerBullet *>(element->key())->remove_shape_full(shape);
+		for (const KeyValue<ShapeOwnerBullet *, int> &element : shape->get_owners()) {
+			static_cast<ShapeOwnerBullet *>(element.key)->remove_shape_full(shape);
 		}
 
 		shape_owner.free(p_rid);

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -63,8 +63,8 @@ btCollisionShape *ShapeBullet::prepare(btCollisionShape *p_btShape) const {
 }
 
 void ShapeBullet::notifyShapeChanged() {
-	for (Map<ShapeOwnerBullet *, int>::Element *E = owners.front(); E; E = E->next()) {
-		ShapeOwnerBullet *owner = static_cast<ShapeOwnerBullet *>(E->key());
+	for (const KeyValue<ShapeOwnerBullet *, int> &E : owners) {
+		ShapeOwnerBullet *owner = static_cast<ShapeOwnerBullet *>(E.key);
 		owner->shape_changed(owner->find_shape(this));
 	}
 }

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -258,8 +258,8 @@ void CSGBrush::build_from_faces(const Vector<Vector3> &p_vertices, const Vector<
 	}
 
 	materials.resize(material_map.size());
-	for (Map<Ref<Material>, int>::Element *E = material_map.front(); E; E = E->next()) {
-		materials.write[E->get()] = E->key();
+	for (const KeyValue<Ref<Material>, int> &E : material_map) {
+		materials.write[E.value] = E.key;
 	}
 
 	_regen_face_aabbs();
@@ -457,8 +457,8 @@ void CSGBrushOperation::merge_brushes(Operation p_operation, const CSGBrush &p_b
 
 	// Update the list of materials.
 	r_merged_brush.materials.resize(mesh_merge.materials.size());
-	for (const Map<Ref<Material>, int>::Element *E = mesh_merge.materials.front(); E; E = E->next()) {
-		r_merged_brush.materials.write[E->get()] = E->key();
+	for (const KeyValue<Ref<Material>, int> &E : mesh_merge.materials) {
+		r_merged_brush.materials.write[E.value] = E.key;
 	}
 }
 

--- a/modules/fbx/data/fbx_skeleton.cpp
+++ b/modules/fbx/data/fbx_skeleton.cpp
@@ -98,9 +98,9 @@ void FBXSkeleton::init_skeleton(const ImportState &state) {
 
 	ERR_FAIL_COND_MSG(skeleton->get_bone_count() != bone_count, "Not all bones got added, is the file corrupted?");
 
-	for (Map<int, Ref<FBXBone>>::Element *bone_element = bone_map.front(); bone_element; bone_element = bone_element->next()) {
-		const Ref<FBXBone> bone = bone_element->value();
-		int bone_index = bone_element->key();
+	for (const KeyValue<int, Ref<FBXBone>> &bone_element : bone_map) {
+		const Ref<FBXBone> bone = bone_element.value;
+		int bone_index = bone_element.key;
 		print_verbose("working on bone: " + itos(bone_index) + " bone name:" + bone->bone_name);
 
 		skeleton->set_bone_rest(bone->godot_bone_id, get_unscaled_transform(bone->node->pivot_transform->LocalTransform, state.scale));

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -567,8 +567,8 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 		// this means that the nodes from maya kLocators will be preserved as bones
 		// in the same rig without having to match this across skeletons and merge by detection
 		// we can just merge and undo any parent transforms
-		for (Map<uint64_t, Ref<FBXBone>>::Element *bone_element = state.fbx_bone_map.front(); bone_element; bone_element = bone_element->next()) {
-			Ref<FBXBone> bone = bone_element->value();
+		for (KeyValue<uint64_t, Ref<FBXBone>> &bone_element : state.fbx_bone_map) {
+			Ref<FBXBone> bone = bone_element.value;
 			Ref<FBXSkeleton> fbx_skeleton_inst;
 
 			uint64_t armature_id = bone->armature_id;
@@ -609,8 +609,8 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 		}
 
 		// setup skeleton instances if required :)
-		for (Map<uint64_t, Ref<FBXSkeleton>>::Element *skeleton_node = state.skeleton_map.front(); skeleton_node; skeleton_node = skeleton_node->next()) {
-			Ref<FBXSkeleton> &skeleton = skeleton_node->value();
+		for (KeyValue<uint64_t, Ref<FBXSkeleton>> &skeleton_node : state.skeleton_map) {
+			Ref<FBXSkeleton> &skeleton = skeleton_node.value;
 			skeleton->init_skeleton(state);
 
 			ERR_CONTINUE_MSG(skeleton->fbx_node.is_null(), "invalid fbx target map, missing skeleton");
@@ -699,9 +699,9 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 		}
 	}
 
-	for (Map<uint64_t, Ref<FBXMeshData>>::Element *mesh_data = state.renderer_mesh_data.front(); mesh_data; mesh_data = mesh_data->next()) {
-		const uint64_t mesh_id = mesh_data->key();
-		Ref<FBXMeshData> mesh = mesh_data->value();
+	for (KeyValue<uint64_t, Ref<FBXMeshData>> &mesh_data : state.renderer_mesh_data) {
+		const uint64_t mesh_id = mesh_data.key;
+		Ref<FBXMeshData> mesh = mesh_data.value;
 
 		const FBXDocParser::MeshGeometry *mesh_geometry = p_document->GetObject(mesh_id)->Get<FBXDocParser::MeshGeometry>();
 
@@ -765,9 +765,9 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 	}
 
 	// mesh data iteration for populating skeleton mapping
-	for (Map<uint64_t, Ref<FBXMeshData>>::Element *mesh_data = state.renderer_mesh_data.front(); mesh_data; mesh_data = mesh_data->next()) {
-		Ref<FBXMeshData> mesh = mesh_data->value();
-		const uint64_t mesh_id = mesh_data->key();
+	for (KeyValue<uint64_t, Ref<FBXMeshData>> &mesh_data : state.renderer_mesh_data) {
+		Ref<FBXMeshData> mesh = mesh_data.value;
+		const uint64_t mesh_id = mesh_data.key;
 		EditorSceneImporterMeshNode3D *mesh_instance = mesh->godot_mesh_instance;
 		const int mesh_weights = mesh->max_weight_count;
 		Ref<FBXSkeleton> skeleton;
@@ -1004,13 +1004,13 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 
 					// target id, [ track name, [time index, vector] ]
 					//std::map<uint64_t, std::map<StringName, FBXTrack > > AnimCurveNodes;
-					for (Map<uint64_t, Map<StringName, FBXTrack>>::Element *track = AnimCurveNodes.front(); track; track = track->next()) {
+					for (KeyValue<uint64_t, Map<StringName, FBXTrack>> &track : AnimCurveNodes) {
 						// 5 tracks
 						// current track index
 						// track count is 5
 						// track count is 5.
 						// next track id is 5.
-						const uint64_t target_id = track->key();
+						const uint64_t target_id = track.key;
 						int track_idx = animation->add_track(Animation::TYPE_TRANSFORM3D);
 
 						// animation->track_set_path(track_idx, node_path);
@@ -1072,7 +1072,7 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 						const FBXDocParser::Model *model = target_node->fbx_model;
 						const FBXDocParser::PropertyTable *props = dynamic_cast<const FBXDocParser::PropertyTable *>(model);
 
-						Map<StringName, FBXTrack> &track_data = track->value();
+						Map<StringName, FBXTrack> &track_data = track.value;
 						FBXTrack &translation_keys = track_data[StringName("T")];
 						FBXTrack &rotation_keys = track_data[StringName("R")];
 						FBXTrack &scale_keys = track_data[StringName("S")];
@@ -1259,15 +1259,15 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 	state.fbx_target_map.clear();
 	state.fbx_node_list.clear();
 
-	for (Map<uint64_t, Ref<FBXBone>>::Element *element = state.fbx_bone_map.front(); element; element = element->next()) {
-		Ref<FBXBone> bone = element->value();
+	for (KeyValue<uint64_t, Ref<FBXBone>> &element : state.fbx_bone_map) {
+		Ref<FBXBone> bone = element.value;
 		bone->parent_bone.unref();
 		bone->node.unref();
 		bone->fbx_skeleton.unref();
 	}
 
-	for (Map<uint64_t, Ref<FBXSkeleton>>::Element *element = state.skeleton_map.front(); element; element = element->next()) {
-		Ref<FBXSkeleton> skel = element->value();
+	for (KeyValue<uint64_t, Ref<FBXSkeleton>> &element : state.skeleton_map) {
+		Ref<FBXSkeleton> skel = element.value;
 		skel->fbx_node.unref();
 		skel->skeleton_bones.clear();
 	}

--- a/modules/fbx/tools/validation_tools.h
+++ b/modules/fbx/tools/validation_tools.h
@@ -53,9 +53,9 @@ protected:
 			String csv_header = "file_path, error message, extra data\n";
 			massive_log_file += csv_header;
 
-			for (Map<String, LocalVector<String>>::Element *element = validation_entries.front(); element; element = element->next()) {
-				for (unsigned int x = 0; x < element->value().size(); x++) {
-					const String &line_entry = element->key() + ", " + element->value()[x].c_escape() + "\n";
+			for (const KeyValue<String, LocalVector<String>> &element : validation_entries) {
+				for (unsigned int x = 0; x < element.value.size(); x++) {
+					const String &line_entry = element.key + ", " + element.value[x].c_escape() + "\n";
 					massive_log_file += line_entry;
 				}
 			}

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -38,9 +38,9 @@ void GDNativeLibraryEditor::edit(Ref<GDNativeLibrary> p_library) {
 	library = p_library;
 	Ref<ConfigFile> config = p_library->get_config_file();
 
-	for (Map<String, NativePlatformConfig>::Element *E = platforms.front(); E; E = E->next()) {
-		for (List<String>::Element *it = E->value().entries.front(); it; it = it->next()) {
-			String target = E->key() + "." + it->get();
+	for (KeyValue<String, NativePlatformConfig> &E : platforms) {
+		for (List<String>::Element *it = E.value.entries.front(); it; it = it->next()) {
+			String target = E.key + "." + it->get();
 			TargetConfig ecfg;
 			ecfg.library = config->get_value("entry", target, "");
 			ecfg.dependencies = config->get_value("dependencies", target, Array());
@@ -245,9 +245,9 @@ void GDNativeLibraryEditor::_translate_to_config_file() {
 		config->erase_section("entry");
 		config->erase_section("dependencies");
 
-		for (Map<String, NativePlatformConfig>::Element *E = platforms.front(); E; E = E->next()) {
-			for (List<String>::Element *it = E->value().entries.front(); it; it = it->next()) {
-				String target = E->key() + "." + it->get();
+		for (KeyValue<String, NativePlatformConfig> &E : platforms) {
+			for (List<String>::Element *it = E.value.entries.front(); it; it = it->next()) {
+				String target = E.key + "." + it->get();
 				if (entry_configs[target].library.is_empty() && entry_configs[target].dependencies.is_empty()) {
 					continue;
 				}
@@ -341,9 +341,9 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 	filter_list->set_hide_on_checkable_item_selection(false);
 
 	int idx = 0;
-	for (Map<String, NativePlatformConfig>::Element *E = platforms.front(); E; E = E->next()) {
-		filter_list->add_check_item(E->get().name, idx);
-		filter_list->set_item_metadata(idx, E->key());
+	for (const KeyValue<String, NativePlatformConfig> &E : platforms) {
+		filter_list->add_check_item(E.value.name, idx);
+		filter_list->set_item_metadata(idx, E.key);
 		filter_list->set_item_checked(idx, true);
 		idx += 1;
 	}

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -223,8 +223,8 @@ List<ClassAPI> generate_c_api_classes() {
 				enum_api_map[enum_name] = enum_api;
 			}
 		}
-		for (const Map<StringName, EnumAPI>::Element *E = enum_api_map.front(); E; E = E->next()) {
-			global_constants_api.enums.push_back(E->get());
+		for (const KeyValue<StringName, EnumAPI> &E : enum_api_map) {
+			global_constants_api.enums.push_back(E.value);
 		}
 		global_constants_api.constants.sort_custom<ConstantAPIComparator>();
 		api.push_back(global_constants_api);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -122,8 +122,8 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	instance->owner_id = p_owner->get_instance_id();
 #ifdef DEBUG_ENABLED
 	//needed for hot reloading
-	for (Map<StringName, MemberInfo>::Element *E = member_indices.front(); E; E = E->next()) {
-		instance->member_indices_cache[E->key()] = E->get().index;
+	for (const KeyValue<StringName, MemberInfo> &E : member_indices) {
+		instance->member_indices_cache[E.key] = E.value.index;
 	}
 #endif
 	instance->owner->set_script_instance(instance);
@@ -253,10 +253,10 @@ void GDScript::_placeholder_erased(PlaceHolderScriptInstance *p_placeholder) {
 void GDScript::_get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const {
 	const GDScript *current = this;
 	while (current) {
-		for (const Map<StringName, GDScriptFunction *>::Element *E = current->member_functions.front(); E; E = E->next()) {
-			GDScriptFunction *func = E->get();
+		for (const KeyValue<StringName, GDScriptFunction *> &E : current->member_functions) {
+			GDScriptFunction *func = E.value;
 			MethodInfo mi;
-			mi.name = E->key();
+			mi.name = E.key;
 			for (int i = 0; i < func->get_argument_count(); i++) {
 				PropertyInfo arginfo = func->get_argument_type(i);
 #ifdef TOOLS_ENABLED
@@ -286,11 +286,11 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 
 	while (sptr) {
 		Vector<_GDScriptMemberSort> msort;
-		for (Map<StringName, PropertyInfo>::Element *E = sptr->member_info.front(); E; E = E->next()) {
+		for (const KeyValue<StringName, PropertyInfo> &E : sptr->member_info) {
 			_GDScriptMemberSort ms;
-			ERR_CONTINUE(!sptr->member_indices.has(E->key()));
-			ms.index = sptr->member_indices[E->key()].index;
-			ms.name = E->key();
+			ERR_CONTINUE(!sptr->member_indices.has(E.key));
+			ms.index = sptr->member_indices[E.key].index;
+			ms.name = E.key;
 			msort.push_back(ms);
 		}
 
@@ -412,8 +412,8 @@ void GDScript::_update_exports_values(Map<StringName, Variant> &values, List<Pro
 		base_cache->_update_exports_values(values, propnames);
 	}
 
-	for (Map<StringName, Variant>::Element *E = member_default_values_cache.front(); E; E = E->next()) {
-		values[E->key()] = E->get();
+	for (const KeyValue<StringName, Variant> &E : member_default_values_cache) {
+		values[E.key] = E.value;
 	}
 
 	for (const PropertyInfo &E : members_cache) {
@@ -471,9 +471,9 @@ void GDScript::_update_doc() {
 	doc.description = doc_description;
 	doc.tutorials = doc_tutorials;
 
-	for (Map<String, DocData::EnumDoc>::Element *E = doc_enums.front(); E; E = E->next()) {
-		if (E->value().description != "") {
-			doc.enums[E->key()] = E->value().description;
+	for (const KeyValue<String, DocData::EnumDoc> &E : doc_enums) {
+		if (E.value.description != "") {
+			doc.enums[E.key] = E.value.description;
 		}
 	}
 
@@ -552,29 +552,29 @@ void GDScript::_update_doc() {
 		doc.signals.push_back(signal_doc);
 	}
 
-	for (Map<StringName, Variant>::Element *E = constants.front(); E; E = E->next()) {
-		if (subclasses.has(E->key())) {
+	for (const KeyValue<StringName, Variant> &E : constants) {
+		if (subclasses.has(E.key)) {
 			continue;
 		}
 
 		// Enums.
 		bool is_enum = false;
-		if (E->value().get_type() == Variant::DICTIONARY) {
-			if (doc_enums.has(E->key())) {
+		if (E.value.get_type() == Variant::DICTIONARY) {
+			if (doc_enums.has(E.key)) {
 				is_enum = true;
-				for (int i = 0; i < doc_enums[E->key()].values.size(); i++) {
-					doc_enums[E->key()].values.write[i].enumeration = E->key();
-					doc.constants.push_back(doc_enums[E->key()].values[i]);
+				for (int i = 0; i < doc_enums[E.key].values.size(); i++) {
+					doc_enums[E.key].values.write[i].enumeration = E.key;
+					doc.constants.push_back(doc_enums[E.key].values[i]);
 				}
 			}
 		}
 		if (!is_enum && doc_enums.has("@unnamed_enums")) {
 			for (int i = 0; i < doc_enums["@unnamed_enums"].values.size(); i++) {
-				if (E->key() == doc_enums["@unnamed_enums"].values[i].name) {
+				if (E.key == doc_enums["@unnamed_enums"].values[i].name) {
 					is_enum = true;
 					DocData::ConstantDoc constant_doc;
 					constant_doc.enumeration = "@unnamed_enums";
-					DocData::constant_doc_from_variant(constant_doc, E->key(), E->value(), doc_enums["@unnamed_enums"].values[i].description);
+					DocData::constant_doc_from_variant(constant_doc, E.key, E.value, doc_enums["@unnamed_enums"].values[i].description);
 					doc.constants.push_back(constant_doc);
 					break;
 				}
@@ -583,16 +583,16 @@ void GDScript::_update_doc() {
 		if (!is_enum) {
 			DocData::ConstantDoc constant_doc;
 			String doc_description;
-			if (doc_constants.has(E->key())) {
-				doc_description = doc_constants[E->key()];
+			if (doc_constants.has(E.key)) {
+				doc_description = doc_constants[E.key];
 			}
-			DocData::constant_doc_from_variant(constant_doc, E->key(), E->value(), doc_description);
+			DocData::constant_doc_from_variant(constant_doc, E.key, E.value, doc_description);
 			doc.constants.push_back(constant_doc);
 		}
 	}
 
-	for (Map<StringName, Ref<GDScript>>::Element *E = subclasses.front(); E; E = E->next()) {
-		E->get()->_update_doc();
+	for (KeyValue<StringName, Ref<GDScript>> &E : subclasses) {
+		E.value->_update_doc();
 	}
 
 	_add_doc(doc);
@@ -784,8 +784,8 @@ void GDScript::update_exports() {
 
 void GDScript::_set_subclass_path(Ref<GDScript> &p_sc, const String &p_path) {
 	p_sc->path = p_path;
-	for (Map<StringName, Ref<GDScript>>::Element *E = p_sc->subclasses.front(); E; E = E->next()) {
-		_set_subclass_path(E->get(), p_path);
+	for (KeyValue<StringName, Ref<GDScript>> &E : p_sc->subclasses) {
+		_set_subclass_path(E.value, p_path);
 	}
 }
 
@@ -886,8 +886,8 @@ Error GDScript::reload(bool p_keep_state) {
 
 	valid = true;
 
-	for (Map<StringName, Ref<GDScript>>::Element *E = subclasses.front(); E; E = E->next()) {
-		_set_subclass_path(E->get(), path);
+	for (KeyValue<StringName, Ref<GDScript>> &E : subclasses) {
+		_set_subclass_path(E.value, path);
 	}
 
 	_init_rpc_methods_properties();
@@ -901,8 +901,8 @@ ScriptLanguage *GDScript::get_language() const {
 
 void GDScript::get_constants(Map<StringName, Variant> *p_constants) {
 	if (p_constants) {
-		for (Map<StringName, Variant>::Element *E = constants.front(); E; E = E->next()) {
-			(*p_constants)[E->key()] = E->value();
+		for (const KeyValue<StringName, Variant> &E : constants) {
+			(*p_constants)[E.key] = E.value;
 		}
 	}
 }
@@ -1032,9 +1032,9 @@ const Map<StringName, GDScriptFunction *> &GDScript::debug_get_member_functions(
 }
 
 StringName GDScript::debug_get_member_by_index(int p_idx) const {
-	for (const Map<StringName, MemberInfo>::Element *E = member_indices.front(); E; E = E->next()) {
-		if (E->get().index == p_idx) {
-			return E->key();
+	for (const KeyValue<StringName, MemberInfo> &E : member_indices) {
+		if (E.value.index == p_idx) {
+			return E.key;
 		}
 	}
 
@@ -1079,12 +1079,12 @@ bool GDScript::has_script_signal(const StringName &p_signal) const {
 }
 
 void GDScript::_get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base) const {
-	for (const Map<StringName, Vector<StringName>>::Element *E = _signals.front(); E; E = E->next()) {
+	for (const KeyValue<StringName, Vector<StringName>> &E : _signals) {
 		MethodInfo mi;
-		mi.name = E->key();
-		for (int i = 0; i < E->get().size(); i++) {
+		mi.name = E.key;
+		for (int i = 0; i < E.value.size(); i++) {
 			PropertyInfo arg;
-			arg.name = E->get()[i];
+			arg.name = E.value[i];
 			mi.arguments.push_back(arg);
 		}
 		r_list->push_back(mi);
@@ -1142,11 +1142,11 @@ void GDScript::_save_orphaned_subclasses() {
 	};
 	Vector<ClassRefWithName> weak_subclasses;
 	// collect subclasses ObjectID and name
-	for (Map<StringName, Ref<GDScript>>::Element *E = subclasses.front(); E; E = E->next()) {
-		E->get()->_owner = nullptr; //bye, you are no longer owned cause I died
+	for (KeyValue<StringName, Ref<GDScript>> &E : subclasses) {
+		E.value->_owner = nullptr; //bye, you are no longer owned cause I died
 		ClassRefWithName subclass;
-		subclass.id = E->get()->get_instance_id();
-		subclass.fully_qualified_name = E->get()->fully_qualified_name;
+		subclass.id = E.value->get_instance_id();
+		subclass.fully_qualified_name = E.value->fully_qualified_name;
 		weak_subclasses.push_back(subclass);
 	}
 
@@ -1178,10 +1178,10 @@ void GDScript::_init_rpc_methods_properties() {
 	Map<StringName, Ref<GDScript>>::Element *sub_E = subclasses.front();
 	while (cscript) {
 		// RPC Methods
-		for (Map<StringName, GDScriptFunction *>::Element *E = cscript->member_functions.front(); E; E = E->next()) {
-			Multiplayer::RPCConfig config = E->get()->get_rpc_config();
+		for (KeyValue<StringName, GDScriptFunction *> &E : cscript->member_functions) {
+			Multiplayer::RPCConfig config = E.value->get_rpc_config();
 			if (config.rpc_mode != Multiplayer::RPC_MODE_DISABLED) {
-				config.name = E->get()->get_name();
+				config.name = E.value->get_name();
 				if (rpc_functions.find(config) == -1) {
 					rpc_functions.push_back(config);
 				}
@@ -1215,8 +1215,8 @@ GDScript::~GDScript() {
 		}
 	}
 
-	for (Map<StringName, GDScriptFunction *>::Element *E = member_functions.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<StringName, GDScriptFunction *> &E : member_functions) {
+		memdelete(E.value);
 	}
 
 	if (GDScriptCache::singleton) { // Cache may have been already destroyed at engine shutdown.
@@ -1442,11 +1442,11 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 		//instance a fake script for editing the values
 
 		Vector<_GDScriptMemberSort> msort;
-		for (Map<StringName, PropertyInfo>::Element *F = sptr->member_info.front(); F; F = F->next()) {
+		for (const KeyValue<StringName, PropertyInfo> &F : sptr->member_info) {
 			_GDScriptMemberSort ms;
-			ERR_CONTINUE(!sptr->member_indices.has(F->key()));
-			ms.index = sptr->member_indices[F->key()].index;
-			ms.name = F->key();
+			ERR_CONTINUE(!sptr->member_indices.has(F.key));
+			ms.index = sptr->member_indices[F.key].index;
+			ms.name = F.key;
 			msort.push_back(ms);
 		}
 
@@ -1467,11 +1467,11 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 void GDScriptInstance::get_method_list(List<MethodInfo> *p_list) const {
 	const GDScript *sptr = script.ptr();
 	while (sptr) {
-		for (Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.front(); E; E = E->next()) {
+		for (const KeyValue<StringName, GDScriptFunction *> &E : sptr->member_functions) {
 			MethodInfo mi;
-			mi.name = E->key();
+			mi.name = E.key;
 			mi.flags |= METHOD_FLAG_FROM_SCRIPT;
-			for (int i = 0; i < E->get()->get_argument_count(); i++) {
+			for (int i = 0; i < E.value->get_argument_count(); i++) {
 				mi.arguments.push_back(PropertyInfo(Variant::NIL, "arg" + itos(i)));
 			}
 			p_list->push_back(mi);
@@ -1569,10 +1569,10 @@ void GDScriptInstance::reload_members() {
 	new_members.resize(script->member_indices.size());
 
 	//pass the values to the new indices
-	for (Map<StringName, GDScript::MemberInfo>::Element *E = script->member_indices.front(); E; E = E->next()) {
-		if (member_indices_cache.has(E->key())) {
-			Variant value = members[member_indices_cache[E->key()]];
-			new_members.write[E->get().index] = value;
+	for (KeyValue<StringName, GDScript::MemberInfo> &E : script->member_indices) {
+		if (member_indices_cache.has(E.key)) {
+			Variant value = members[member_indices_cache[E.key]];
+			new_members.write[E.value.index] = value;
 		}
 	}
 
@@ -1581,8 +1581,8 @@ void GDScriptInstance::reload_members() {
 
 	//pass the values to the new indices
 	member_indices_cache.clear();
-	for (Map<StringName, GDScript::MemberInfo>::Element *E = script->member_indices.front(); E; E = E->next()) {
-		member_indices_cache[E->key()] = E->get().index;
+	for (const KeyValue<StringName, GDScript::MemberInfo> &E : script->member_indices) {
+		member_indices_cache[E.key] = E.value.index;
 	}
 
 #endif
@@ -1890,21 +1890,21 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 
 #endif
 
-			for (Map<ObjectID, List<Pair<StringName, Variant>>>::Element *F = script->pending_reload_state.front(); F; F = F->next()) {
-				map[F->key()] = F->get(); //pending to reload, use this one instead
+			for (const KeyValue<ObjectID, List<Pair<StringName, Variant>>> &F : script->pending_reload_state) {
+				map[F.key] = F.value; //pending to reload, use this one instead
 			}
 		}
 	}
 
-	for (Map<Ref<GDScript>, Map<ObjectID, List<Pair<StringName, Variant>>>>::Element *E = to_reload.front(); E; E = E->next()) {
-		Ref<GDScript> scr = E->key();
+	for (KeyValue<Ref<GDScript>, Map<ObjectID, List<Pair<StringName, Variant>>>> &E : to_reload) {
+		Ref<GDScript> scr = E.key;
 		scr->reload(p_soft_reload);
 
 		//restore state if saved
-		for (Map<ObjectID, List<Pair<StringName, Variant>>>::Element *F = E->get().front(); F; F = F->next()) {
-			List<Pair<StringName, Variant>> &saved_state = F->get();
+		for (KeyValue<ObjectID, List<Pair<StringName, Variant>>> &F : E.value) {
+			List<Pair<StringName, Variant>> &saved_state = F.value;
 
-			Object *obj = ObjectDB::get_instance(F->key());
+			Object *obj = ObjectDB::get_instance(F.key);
 			if (!obj) {
 				continue;
 			}
@@ -2210,15 +2210,15 @@ GDScriptLanguage::~GDScriptLanguage() {
 		// is not the same as before).
 		script->reference();
 
-		for (Map<StringName, GDScriptFunction *>::Element *E = script->member_functions.front(); E; E = E->next()) {
-			GDScriptFunction *func = E->get();
+		for (KeyValue<StringName, GDScriptFunction *> &E : script->member_functions) {
+			GDScriptFunction *func = E.value;
 			for (int i = 0; i < func->argument_types.size(); i++) {
 				func->argument_types.write[i].script_type_ref = Ref<Script>();
 			}
 			func->return_type.script_type_ref = Ref<Script>();
 		}
-		for (Map<StringName, GDScript::MemberInfo>::Element *E = script->member_indices.front(); E; E = E->next()) {
-			E->get().data_type.script_type_ref = Ref<Script>();
+		for (KeyValue<StringName, GDScript::MemberInfo> &E : script->member_indices) {
+			E.value.data_type.script_type_ref = Ref<Script>();
 		}
 
 		s = s->next();

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2270,10 +2270,10 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool is_awa
 
 	if (get_function_signature(p_call, base_type, p_call->function_name, return_type, par_types, default_arg_count, is_static, is_vararg)) {
 		// If the function require typed arrays we must make literals be typed.
-		for (Map<int, GDScriptParser::ArrayNode *>::Element *E = arrays.front(); E; E = E->next()) {
-			int index = E->key();
+		for (const KeyValue<int, GDScriptParser::ArrayNode *> &E : arrays) {
+			int index = E.key;
 			if (index < par_types.size() && par_types[index].has_container_element_type()) {
-				update_array_literal_element_type(par_types[index], E->get());
+				update_array_literal_element_type(par_types[index], E.value);
 			}
 		}
 		validate_call_arg(par_types, default_arg_count, is_vararg, p_call);

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -209,8 +209,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 	if (name_map.size()) {
 		function->global_names.resize(name_map.size());
 		function->_global_names_ptr = &function->global_names[0];
-		for (Map<StringName, int>::Element *E = name_map.front(); E; E = E->next()) {
-			function->global_names.write[E->get()] = E->key();
+		for (const KeyValue<StringName, int> &E : name_map) {
+			function->global_names.write[E.value] = E.key;
 		}
 		function->_global_names_count = function->global_names.size();
 
@@ -241,8 +241,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->operator_funcs.resize(operator_func_map.size());
 		function->_operator_funcs_count = function->operator_funcs.size();
 		function->_operator_funcs_ptr = function->operator_funcs.ptr();
-		for (const Map<Variant::ValidatedOperatorEvaluator, int>::Element *E = operator_func_map.front(); E; E = E->next()) {
-			function->operator_funcs.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedOperatorEvaluator, int> &E : operator_func_map) {
+			function->operator_funcs.write[E.value] = E.key;
 		}
 	} else {
 		function->_operator_funcs_count = 0;
@@ -253,8 +253,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->setters.resize(setters_map.size());
 		function->_setters_count = function->setters.size();
 		function->_setters_ptr = function->setters.ptr();
-		for (const Map<Variant::ValidatedSetter, int>::Element *E = setters_map.front(); E; E = E->next()) {
-			function->setters.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedSetter, int> &E : setters_map) {
+			function->setters.write[E.value] = E.key;
 		}
 	} else {
 		function->_setters_count = 0;
@@ -265,8 +265,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->getters.resize(getters_map.size());
 		function->_getters_count = function->getters.size();
 		function->_getters_ptr = function->getters.ptr();
-		for (const Map<Variant::ValidatedGetter, int>::Element *E = getters_map.front(); E; E = E->next()) {
-			function->getters.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedGetter, int> &E : getters_map) {
+			function->getters.write[E.value] = E.key;
 		}
 	} else {
 		function->_getters_count = 0;
@@ -277,8 +277,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->keyed_setters.resize(keyed_setters_map.size());
 		function->_keyed_setters_count = function->keyed_setters.size();
 		function->_keyed_setters_ptr = function->keyed_setters.ptr();
-		for (const Map<Variant::ValidatedKeyedSetter, int>::Element *E = keyed_setters_map.front(); E; E = E->next()) {
-			function->keyed_setters.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedKeyedSetter, int> &E : keyed_setters_map) {
+			function->keyed_setters.write[E.value] = E.key;
 		}
 	} else {
 		function->_keyed_setters_count = 0;
@@ -289,8 +289,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->keyed_getters.resize(keyed_getters_map.size());
 		function->_keyed_getters_count = function->keyed_getters.size();
 		function->_keyed_getters_ptr = function->keyed_getters.ptr();
-		for (const Map<Variant::ValidatedKeyedGetter, int>::Element *E = keyed_getters_map.front(); E; E = E->next()) {
-			function->keyed_getters.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedKeyedGetter, int> &E : keyed_getters_map) {
+			function->keyed_getters.write[E.value] = E.key;
 		}
 	} else {
 		function->_keyed_getters_count = 0;
@@ -301,8 +301,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->indexed_setters.resize(indexed_setters_map.size());
 		function->_indexed_setters_count = function->indexed_setters.size();
 		function->_indexed_setters_ptr = function->indexed_setters.ptr();
-		for (const Map<Variant::ValidatedIndexedSetter, int>::Element *E = indexed_setters_map.front(); E; E = E->next()) {
-			function->indexed_setters.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedIndexedSetter, int> &E : indexed_setters_map) {
+			function->indexed_setters.write[E.value] = E.key;
 		}
 	} else {
 		function->_indexed_setters_count = 0;
@@ -313,8 +313,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->indexed_getters.resize(indexed_getters_map.size());
 		function->_indexed_getters_count = function->indexed_getters.size();
 		function->_indexed_getters_ptr = function->indexed_getters.ptr();
-		for (const Map<Variant::ValidatedIndexedGetter, int>::Element *E = indexed_getters_map.front(); E; E = E->next()) {
-			function->indexed_getters.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedIndexedGetter, int> &E : indexed_getters_map) {
+			function->indexed_getters.write[E.value] = E.key;
 		}
 	} else {
 		function->_indexed_getters_count = 0;
@@ -325,8 +325,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->builtin_methods.resize(builtin_method_map.size());
 		function->_builtin_methods_ptr = function->builtin_methods.ptr();
 		function->_builtin_methods_count = builtin_method_map.size();
-		for (const Map<Variant::ValidatedBuiltInMethod, int>::Element *E = builtin_method_map.front(); E; E = E->next()) {
-			function->builtin_methods.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedBuiltInMethod, int> &E : builtin_method_map) {
+			function->builtin_methods.write[E.value] = E.key;
 		}
 	} else {
 		function->_builtin_methods_ptr = nullptr;
@@ -337,8 +337,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->constructors.resize(constructors_map.size());
 		function->_constructors_ptr = function->constructors.ptr();
 		function->_constructors_count = constructors_map.size();
-		for (const Map<Variant::ValidatedConstructor, int>::Element *E = constructors_map.front(); E; E = E->next()) {
-			function->constructors.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedConstructor, int> &E : constructors_map) {
+			function->constructors.write[E.value] = E.key;
 		}
 	} else {
 		function->_constructors_ptr = nullptr;
@@ -349,8 +349,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->utilities.resize(utilities_map.size());
 		function->_utilities_ptr = function->utilities.ptr();
 		function->_utilities_count = utilities_map.size();
-		for (const Map<Variant::ValidatedUtilityFunction, int>::Element *E = utilities_map.front(); E; E = E->next()) {
-			function->utilities.write[E->get()] = E->key();
+		for (const KeyValue<Variant::ValidatedUtilityFunction, int> &E : utilities_map) {
+			function->utilities.write[E.value] = E.key;
 		}
 	} else {
 		function->_utilities_ptr = nullptr;
@@ -361,8 +361,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->gds_utilities.resize(gds_utilities_map.size());
 		function->_gds_utilities_ptr = function->gds_utilities.ptr();
 		function->_gds_utilities_count = gds_utilities_map.size();
-		for (const Map<GDScriptUtilityFunctions::FunctionPtr, int>::Element *E = gds_utilities_map.front(); E; E = E->next()) {
-			function->gds_utilities.write[E->get()] = E->key();
+		for (const KeyValue<GDScriptUtilityFunctions::FunctionPtr, int> &E : gds_utilities_map) {
+			function->gds_utilities.write[E.value] = E.key;
 		}
 	} else {
 		function->_gds_utilities_ptr = nullptr;
@@ -373,8 +373,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->methods.resize(method_bind_map.size());
 		function->_methods_ptr = function->methods.ptrw();
 		function->_methods_count = method_bind_map.size();
-		for (const Map<MethodBind *, int>::Element *E = method_bind_map.front(); E; E = E->next()) {
-			function->methods.write[E->get()] = E->key();
+		for (const KeyValue<MethodBind *, int> &E : method_bind_map) {
+			function->methods.write[E.value] = E.key;
 		}
 	} else {
 		function->_methods_ptr = nullptr;
@@ -385,8 +385,8 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->lambdas.resize(lambdas_map.size());
 		function->_lambdas_ptr = function->lambdas.ptrw();
 		function->_lambdas_count = lambdas_map.size();
-		for (const Map<GDScriptFunction *, int>::Element *E = lambdas_map.front(); E; E = E->next()) {
-			function->lambdas.write[E->get()] = E->key();
+		for (const KeyValue<GDScriptFunction *, int> &E : lambdas_map) {
+			function->lambdas.write[E.value] = E.key;
 		}
 	} else {
 		function->_lambdas_ptr = nullptr;

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -153,12 +153,12 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 #endif
 		locals.resize(current_locals);
 		if (debug_stack) {
-			for (Map<StringName, int>::Element *E = block_identifiers.front(); E; E = E->next()) {
+			for (const KeyValue<StringName, int> &E : block_identifiers) {
 				GDScriptFunction::StackDebug sd;
 				sd.added = false;
-				sd.identifier = E->key();
+				sd.identifier = E.key;
 				sd.line = current_line;
-				sd.pos = E->get();
+				sd.pos = E.value;
 				stack_debug.push_back(sd);
 			}
 			block_identifiers = block_identifier_stack.back()->get();

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2193,8 +2193,8 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 	p_script->_base = nullptr;
 	p_script->members.clear();
 	p_script->constants.clear();
-	for (Map<StringName, GDScriptFunction *>::Element *E = p_script->member_functions.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<StringName, GDScriptFunction *> &E : p_script->member_functions) {
+		memdelete(E.value);
 	}
 	p_script->member_functions.clear();
 	p_script->member_indices.clear();
@@ -2519,8 +2519,8 @@ Error GDScriptCompiler::_parse_class_blocks(GDScript *p_script, const GDScriptPa
 					instance->owner = E->get();
 
 					//needed for hot reloading
-					for (Map<StringName, GDScript::MemberInfo>::Element *F = p_script->member_indices.front(); F; F = F->next()) {
-						instance->member_indices_cache[F->key()] = F->get().index;
+					for (const KeyValue<StringName, GDScript::MemberInfo> &F : p_script->member_indices) {
+						instance->member_indices_cache[F.key] = F.value.index;
 					}
 					instance->owner->set_script_instance(instance);
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -173,8 +173,8 @@ bool GDScriptLanguage::validate(const String &p_script, const String &p_path, Li
 
 		get_function_names_recursively(cl, "", funcs);
 
-		for (Map<int, String>::Element *E = funcs.front(); E; E = E->next()) {
-			r_functions->push_back(E->get() + ":" + itos(E->key()));
+		for (const KeyValue<int, String> &E : funcs) {
+			r_functions->push_back(E.value + ":" + itos(E.key));
 		}
 	}
 
@@ -344,9 +344,9 @@ void GDScriptLanguage::debug_get_stack_level_members(int p_level, List<String> *
 
 	const Map<StringName, GDScript::MemberInfo> &mi = script->debug_get_member_indices();
 
-	for (const Map<StringName, GDScript::MemberInfo>::Element *E = mi.front(); E; E = E->next()) {
-		p_members->push_back(E->key());
-		p_values->push_back(instance->debug_get_member_by_index(E->get().index));
+	for (const KeyValue<StringName, GDScript::MemberInfo> &E : mi) {
+		p_members->push_back(E.key);
+		p_values->push_back(instance->debug_get_member_by_index(E.value.index));
 	}
 }
 
@@ -370,14 +370,14 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 	List<Pair<String, Variant>> cinfo;
 	get_public_constants(&cinfo);
 
-	for (const Map<StringName, int>::Element *E = name_idx.front(); E; E = E->next()) {
-		if (ClassDB::class_exists(E->key()) || Engine::get_singleton()->has_singleton(E->key())) {
+	for (const KeyValue<StringName, int> &E : name_idx) {
+		if (ClassDB::class_exists(E.key) || Engine::get_singleton()->has_singleton(E.key)) {
 			continue;
 		}
 
 		bool is_script_constant = false;
 		for (List<Pair<String, Variant>>::Element *CE = cinfo.front(); CE; CE = CE->next()) {
-			if (CE->get().first == E->key()) {
+			if (CE->get().first == E.key) {
 				is_script_constant = true;
 				break;
 			}
@@ -386,7 +386,7 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 			continue;
 		}
 
-		const Variant &var = globals[E->value()];
+		const Variant &var = globals[E.value];
 		if (Object *obj = var) {
 			if (Object::cast_to<GDScriptNativeClass>(obj)) {
 				continue;
@@ -395,7 +395,7 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 
 		bool skip = false;
 		for (int i = 0; i < CoreConstants::get_global_constant_count(); i++) {
-			if (E->key() == CoreConstants::get_global_constant_name(i)) {
+			if (E.key == CoreConstants::get_global_constant_name(i)) {
 				skip = true;
 				break;
 			}
@@ -404,7 +404,7 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 			continue;
 		}
 
-		p_globals->push_back(E->key());
+		p_globals->push_back(E.key);
 		p_values->push_back(var);
 	}
 }
@@ -875,8 +875,8 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						}
 						Map<StringName, Variant> constants;
 						scr->get_constants(&constants);
-						for (Map<StringName, Variant>::Element *E = constants.front(); E; E = E->next()) {
-							ScriptCodeCompletionOption option(E->key().operator String(), ScriptCodeCompletionOption::KIND_CONSTANT);
+						for (const KeyValue<StringName, Variant> &E : constants) {
+							ScriptCodeCompletionOption option(E.key.operator String(), ScriptCodeCompletionOption::KIND_CONSTANT);
 							r_result.insert(option.display, option);
 						}
 
@@ -1099,12 +1099,12 @@ static void _find_identifiers(GDScriptParser::CompletionContext &p_context, bool
 	}
 
 	// Native classes and global constants.
-	for (const Map<StringName, int>::Element *E = GDScriptLanguage::get_singleton()->get_global_map().front(); E; E = E->next()) {
+	for (const KeyValue<StringName, int> &E : GDScriptLanguage::get_singleton()->get_global_map()) {
 		ScriptCodeCompletionOption option;
-		if (ClassDB::class_exists(E->key()) || Engine::get_singleton()->has_singleton(E->key())) {
-			option = ScriptCodeCompletionOption(E->key().operator String(), ScriptCodeCompletionOption::KIND_CLASS);
+		if (ClassDB::class_exists(E.key) || Engine::get_singleton()->has_singleton(E.key)) {
+			option = ScriptCodeCompletionOption(E.key.operator String(), ScriptCodeCompletionOption::KIND_CLASS);
 		} else {
-			option = ScriptCodeCompletionOption(E->key().operator String(), ScriptCodeCompletionOption::KIND_CONSTANT);
+			option = ScriptCodeCompletionOption(E.key.operator String(), ScriptCodeCompletionOption::KIND_CONSTANT);
 		}
 		r_result.insert(option.display, option);
 	}
@@ -2680,8 +2680,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 		} break;
 	}
 
-	for (Map<String, ScriptCodeCompletionOption>::Element *E = options.front(); E; E = E->next()) {
-		r_options->push_back(E->get());
+	for (const KeyValue<String, ScriptCodeCompletionOption> &E : options) {
+		r_options->push_back(E.value);
 	}
 
 	return OK;

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -120,11 +120,11 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 	}
 
 	List<_GDFKCS> stackpositions;
-	for (Map<StringName, _GDFKC>::Element *E = sdmap.front(); E; E = E->next()) {
+	for (const KeyValue<StringName, _GDFKC> &E : sdmap) {
 		_GDFKCS spp;
-		spp.id = E->key();
-		spp.order = E->get().order;
-		spp.pos = E->get().pos.back()->get();
+		spp.id = E.key;
+		spp.order = E.value.order;
+		spp.pos = E.value.pos.back()->get();
 		stackpositions.push_back(spp);
 	}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -582,9 +582,9 @@ void GDScriptParser::parse_program() {
 	parse_class_body(true);
 
 #ifdef TOOLS_ENABLED
-	for (Map<int, GDScriptTokenizer::CommentData>::Element *E = tokenizer.get_comments().front(); E; E = E->next()) {
-		if (E->get().new_line && E->get().comment.begins_with("##")) {
-			class_doc_line = MIN(class_doc_line, E->key());
+	for (const KeyValue<int, GDScriptTokenizer::CommentData> &E : tokenizer.get_comments()) {
+		if (E.value.new_line && E.value.comment.begins_with("##")) {
+			class_doc_line = MIN(class_doc_line, E.key);
 		}
 	}
 	if (has_comment(class_doc_line)) {

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -317,9 +317,9 @@ struct GDScriptUtilityFunctionsDefinitions {
 				d["@subpath"] = cp;
 				d["@path"] = p->get_path();
 
-				for (Map<StringName, GDScript::MemberInfo>::Element *E = base->member_indices.front(); E; E = E->next()) {
-					if (!d.has(E->key())) {
-						d[E->key()] = ins->members[E->get().index];
+				for (const KeyValue<StringName, GDScript::MemberInfo> &E : base->member_indices) {
+					if (!d.has(E.key)) {
+						d[E.key] = ins->members[E.value.index];
 					}
 				}
 				*r_ret = d;
@@ -396,9 +396,9 @@ struct GDScriptUtilityFunctionsDefinitions {
 		GDScriptInstance *ins = static_cast<GDScriptInstance *>(static_cast<Object *>(*r_ret)->get_script_instance());
 		Ref<GDScript> gd_ref = ins->get_script();
 
-		for (Map<StringName, GDScript::MemberInfo>::Element *E = gd_ref->member_indices.front(); E; E = E->next()) {
-			if (d.has(E->key())) {
-				ins->members.write[E->get().index] = d[E->key()];
+		for (KeyValue<StringName, GDScript::MemberInfo> &E : gd_ref->member_indices) {
+			if (d.has(E.key)) {
+				ins->members.write[E.value.index] = d[E.key];
 			}
 		}
 	}

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -531,8 +531,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 	memnew_placement(&stack[ADDR_STACK_CLASS], Variant(script));
 
-	for (const Map<int, Variant::Type>::Element *E = temporary_slots.front(); E; E = E->next()) {
-		type_init_function_table[E->get()](&stack[E->key()]);
+	for (const KeyValue<int, Variant::Type> &E : temporary_slots) {
+		type_init_function_table[E.value](&stack[E.key]);
 	}
 
 	String err_text;

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -212,11 +212,11 @@ void GDScriptLanguageProtocol::initialized(const Variant &p_params) {
 	lsp::GodotCapabilities capabilities;
 
 	DocTools *doc = EditorHelp::get_doc_data();
-	for (Map<String, DocData::ClassDoc>::Element *E = doc->class_list.front(); E; E = E->next()) {
+	for (const KeyValue<String, DocData::ClassDoc> &E : doc->class_list) {
 		lsp::GodotNativeClassInfo gdclass;
-		gdclass.name = E->get().name;
-		gdclass.class_doc = &(E->get());
-		if (ClassDB::ClassInfo *ptr = ClassDB::classes.getptr(StringName(E->get().name))) {
+		gdclass.name = E.value.name;
+		gdclass.class_doc = &(E.value);
+		if (ClassDB::ClassInfo *ptr = ClassDB::classes.getptr(StringName(E.value.name))) {
 			gdclass.class_info = ptr;
 		}
 		capabilities.native_classes.push_back(gdclass);

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -217,8 +217,8 @@ Array GDScriptTextDocument::completion(const Dictionary &p_params) {
 	} else if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
 		arr = native_member_completions.duplicate();
 
-		for (Map<String, ExtendGDScriptParser *>::Element *E = GDScriptLanguageProtocol::get_singleton()->get_workspace()->scripts.front(); E; E = E->next()) {
-			ExtendGDScriptParser *script = E->get();
+		for (KeyValue<String, ExtendGDScriptParser *> &E : GDScriptLanguageProtocol::get_singleton()->get_workspace()->scripts) {
+			ExtendGDScriptParser *script = E.value;
 			const Array &items = script->get_member_completions();
 
 			const int start_size = arr.size();

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -261,9 +261,9 @@ Array GDScriptWorkspace::symbol(const Dictionary &p_params) {
 	String query = p_params["query"];
 	Array arr;
 	if (!query.is_empty()) {
-		for (Map<String, ExtendGDScriptParser *>::Element *E = scripts.front(); E; E = E->next()) {
+		for (const KeyValue<String, ExtendGDScriptParser *> &E : scripts) {
 			Vector<lsp::DocumentedSymbolInformation> script_symbols;
-			E->get()->get_symbols().symbol_tree_as_list(E->key(), script_symbols);
+			E.value->get_symbols().symbol_tree_as_list(E.key, script_symbols);
 			for (int i = 0; i < script_symbols.size(); ++i) {
 				if (query.is_subsequence_ofi(script_symbols[i].name)) {
 					lsp::DocumentedSymbolInformation symbol = script_symbols[i];
@@ -282,10 +282,10 @@ Error GDScriptWorkspace::initialize() {
 	}
 
 	DocTools *doc = EditorHelp::get_doc_data();
-	for (Map<String, DocData::ClassDoc>::Element *E = doc->class_list.front(); E; E = E->next()) {
-		const DocData::ClassDoc &class_data = E->value();
+	for (const KeyValue<String, DocData::ClassDoc> &E : doc->class_list) {
+		const DocData::ClassDoc &class_data = E.value;
 		lsp::DocumentSymbol class_symbol;
-		String class_name = E->key();
+		String class_name = E.key;
 		class_symbol.name = class_name;
 		class_symbol.native_class = class_name;
 		class_symbol.kind = lsp::SymbolKind::Class;
@@ -393,19 +393,19 @@ Error GDScriptWorkspace::initialize() {
 	reload_all_workspace_scripts();
 
 	if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
-		for (Map<StringName, lsp::DocumentSymbol>::Element *E = native_symbols.front(); E; E = E->next()) {
+		for (const KeyValue<StringName, lsp::DocumentSymbol> &E : native_symbols) {
 			ClassMembers members;
-			const lsp::DocumentSymbol &class_symbol = E->get();
+			const lsp::DocumentSymbol &class_symbol = E.value;
 			for (int i = 0; i < class_symbol.children.size(); i++) {
 				const lsp::DocumentSymbol &symbol = class_symbol.children[i];
 				members.set(symbol.name, &symbol);
 			}
-			native_members.set(E->key(), members);
+			native_members.set(E.key, members);
 		}
 
 		// cache member completions
-		for (Map<String, ExtendGDScriptParser *>::Element *S = scripts.front(); S; S = S->next()) {
-			S->get()->get_member_completions();
+		for (const KeyValue<String, ExtendGDScriptParser *> &S : scripts) {
+			S.value->get_member_completions();
 		}
 	}
 
@@ -685,8 +685,8 @@ void GDScriptWorkspace::resolve_related_symbols(const lsp::TextDocumentPositionP
 			class_ptr = native_members.next(class_ptr);
 		}
 
-		for (Map<String, ExtendGDScriptParser *>::Element *E = scripts.front(); E; E = E->next()) {
-			const ExtendGDScriptParser *script = E->get();
+		for (const KeyValue<String, ExtendGDScriptParser *> &E : scripts) {
+			const ExtendGDScriptParser *script = E.value;
 			const ClassMembers &members = script->get_members();
 			if (const lsp::DocumentSymbol *const *symbol = members.getptr(symbol_identifier)) {
 				r_list.push_back(*symbol);
@@ -786,12 +786,12 @@ GDScriptWorkspace::GDScriptWorkspace() {
 GDScriptWorkspace::~GDScriptWorkspace() {
 	Set<String> cached_parsers;
 
-	for (Map<String, ExtendGDScriptParser *>::Element *E = parse_results.front(); E; E = E->next()) {
-		cached_parsers.insert(E->key());
+	for (const KeyValue<String, ExtendGDScriptParser *> &E : parse_results) {
+		cached_parsers.insert(E.key);
 	}
 
-	for (Map<String, ExtendGDScriptParser *>::Element *E = scripts.front(); E; E = E->next()) {
-		cached_parsers.insert(E->key());
+	for (const KeyValue<String, ExtendGDScriptParser *> &E : scripts) {
+		cached_parsers.insert(E.key);
 	}
 
 	for (Set<String>::Element *E = cached_parsers.front(); E; E = E->next()) {

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -277,15 +277,15 @@ struct WorkspaceEdit {
 		Dictionary dict;
 
 		Dictionary out_changes;
-		for (Map<String, Vector<TextEdit>>::Element *E = changes.front(); E; E = E->next()) {
+		for (const KeyValue<String, Vector<TextEdit>> &E : changes) {
 			Array edits;
-			for (int i = 0; i < E->get().size(); ++i) {
+			for (int i = 0; i < E.value.size(); ++i) {
 				Dictionary text_edit;
-				text_edit["range"] = E->get()[i].range.to_json();
-				text_edit["newText"] = E->get()[i].newText;
+				text_edit["range"] = E.value[i].range.to_json();
+				text_edit["newText"] = E.value[i].newText;
 				edits.push_back(text_edit);
 			}
-			out_changes[E->key()] = edits;
+			out_changes[E.key] = edits;
 		}
 		dict["changes"] = out_changes;
 

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -172,8 +172,8 @@ static void test_compiler(const String &p_code, const String &p_script_path, con
 		return;
 	}
 
-	for (const Map<StringName, GDScriptFunction *>::Element *E = script->get_member_functions().front(); E; E = E->next()) {
-		const GDScriptFunction *func = E->value();
+	for (const KeyValue<StringName, GDScriptFunction *> &E : script->get_member_functions()) {
+		const GDScriptFunction *func = E.value;
 
 		String signature = "Disassembling " + func->get_name().operator String() + "(";
 		for (int i = 0; i < func->get_argument_count(); i++) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4673,8 +4673,8 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 		Array channels;
 		Array samplers;
 
-		for (Map<int, GLTFAnimation::Track>::Element *track_i = gltf_animation->get_tracks().front(); track_i; track_i = track_i->next()) {
-			GLTFAnimation::Track track = track_i->get();
+		for (KeyValue<int, GLTFAnimation::Track> &track_i : gltf_animation->get_tracks()) {
+			GLTFAnimation::Track track = track_i.value;
 			if (track.position_track.times.size()) {
 				Dictionary t;
 				t["sampler"] = samplers.size();
@@ -4690,7 +4690,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 
 				Dictionary target;
 				target["path"] = "translation";
-				target["node"] = track_i->key();
+				target["node"] = track_i.key;
 
 				t["target"] = target;
 				channels.push_back(t);
@@ -4710,7 +4710,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 
 				Dictionary target;
 				target["path"] = "rotation";
-				target["node"] = track_i->key();
+				target["node"] = track_i.key;
 
 				t["target"] = target;
 				channels.push_back(t);
@@ -4730,7 +4730,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 
 				Dictionary target;
 				target["path"] = "scale";
-				target["node"] = track_i->key();
+				target["node"] = track_i.key;
 
 				t["target"] = target;
 				channels.push_back(t);
@@ -4809,7 +4809,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 
 				Dictionary target;
 				target["path"] = "weights";
-				target["node"] = track_i->key();
+				target["node"] = track_i.key;
 
 				t["target"] = target;
 				channels.push_back(t);
@@ -5800,16 +5800,16 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 
 	float length = 0.0;
 
-	for (Map<int, GLTFAnimation::Track>::Element *track_i = anim->get_tracks().front(); track_i; track_i = track_i->next()) {
-		const GLTFAnimation::Track &track = track_i->get();
+	for (const KeyValue<int, GLTFAnimation::Track> &track_i : anim->get_tracks()) {
+		const GLTFAnimation::Track &track = track_i.value;
 		//need to find the path: for skeletons, weight tracks will affect the mesh
 		NodePath node_path;
 		//for skeletons, transform tracks always affect bones
 		NodePath transform_node_path;
 
-		GLTFNodeIndex node_index = track_i->key();
+		GLTFNodeIndex node_index = track_i.key;
 
-		const Ref<GLTFNode> gltf_node = state->nodes[track_i->key()];
+		const Ref<GLTFNode> gltf_node = state->nodes[track_i.key];
 
 		Node *root = ap->get_parent();
 		ERR_FAIL_COND(root == nullptr);
@@ -5861,15 +5861,15 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 			Vector3 base_scale = Vector3(1, 1, 1);
 
 			if (!track.rotation_track.values.size()) {
-				base_rot = state->nodes[track_i->key()]->rotation.normalized();
+				base_rot = state->nodes[track_i.key]->rotation.normalized();
 			}
 
 			if (!track.position_track.values.size()) {
-				base_pos = state->nodes[track_i->key()]->position;
+				base_pos = state->nodes[track_i.key]->position;
 			}
 
 			if (!track.scale_track.values.size()) {
-				base_scale = state->nodes[track_i->key()]->scale;
+				base_scale = state->nodes[track_i.key]->scale;
 			}
 
 			bool last = false;
@@ -6322,9 +6322,9 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			const Vector<String> node_suffix = String(orig_track_path).split(":position");
 			const NodePath path = node_suffix[0];
 			const Node *node = ap->get_parent()->get_node_or_null(path);
-			for (Map<GLTFNodeIndex, Node *>::Element *position_scene_node_i = state->scene_nodes.front(); position_scene_node_i; position_scene_node_i = position_scene_node_i->next()) {
-				if (position_scene_node_i->get() == node) {
-					GLTFNodeIndex node_index = position_scene_node_i->key();
+			for (const KeyValue<GLTFNodeIndex, Node *> &position_scene_node_i : state->scene_nodes) {
+				if (position_scene_node_i.value == node) {
+					GLTFNodeIndex node_index = position_scene_node_i.key;
 					Map<int, GLTFAnimation::Track>::Element *position_track_i = gltf_animation->get_tracks().find(node_index);
 					GLTFAnimation::Track track;
 					if (position_track_i) {
@@ -6338,9 +6338,9 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			const Vector<String> node_suffix = String(orig_track_path).split(":rotation_degrees");
 			const NodePath path = node_suffix[0];
 			const Node *node = ap->get_parent()->get_node_or_null(path);
-			for (Map<GLTFNodeIndex, Node *>::Element *rotation_degree_scene_node_i = state->scene_nodes.front(); rotation_degree_scene_node_i; rotation_degree_scene_node_i = rotation_degree_scene_node_i->next()) {
-				if (rotation_degree_scene_node_i->get() == node) {
-					GLTFNodeIndex node_index = rotation_degree_scene_node_i->key();
+			for (const KeyValue<GLTFNodeIndex, Node *> &rotation_degree_scene_node_i : state->scene_nodes) {
+				if (rotation_degree_scene_node_i.value == node) {
+					GLTFNodeIndex node_index = rotation_degree_scene_node_i.key;
 					Map<int, GLTFAnimation::Track>::Element *rotation_degree_track_i = gltf_animation->get_tracks().find(node_index);
 					GLTFAnimation::Track track;
 					if (rotation_degree_track_i) {
@@ -6354,9 +6354,9 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			const Vector<String> node_suffix = String(orig_track_path).split(":scale");
 			const NodePath path = node_suffix[0];
 			const Node *node = ap->get_parent()->get_node_or_null(path);
-			for (Map<GLTFNodeIndex, Node *>::Element *scale_scene_node_i = state->scene_nodes.front(); scale_scene_node_i; scale_scene_node_i = scale_scene_node_i->next()) {
-				if (scale_scene_node_i->get() == node) {
-					GLTFNodeIndex node_index = scale_scene_node_i->key();
+			for (const KeyValue<GLTFNodeIndex, Node *> &scale_scene_node_i : state->scene_nodes) {
+				if (scale_scene_node_i.value == node) {
+					GLTFNodeIndex node_index = scale_scene_node_i.key;
 					Map<int, GLTFAnimation::Track>::Element *scale_track_i = gltf_animation->get_tracks().find(node_index);
 					GLTFAnimation::Track track;
 					if (scale_track_i) {
@@ -6370,11 +6370,11 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			const Vector<String> node_suffix = String(orig_track_path).split(":transform");
 			const NodePath path = node_suffix[0];
 			const Node *node = ap->get_parent()->get_node_or_null(path);
-			for (Map<GLTFNodeIndex, Node *>::Element *transform_track_i = state->scene_nodes.front(); transform_track_i; transform_track_i = transform_track_i->next()) {
-				if (transform_track_i->get() == node) {
+			for (const KeyValue<GLTFNodeIndex, Node *> &transform_track_i : state->scene_nodes) {
+				if (transform_track_i.value == node) {
 					GLTFAnimation::Track track;
-					track = _convert_animation_track(state, track, animation, Transform3D(), track_i, transform_track_i->key());
-					gltf_animation->get_tracks().insert(transform_track_i->key(), track);
+					track = _convert_animation_track(state, track, animation, Transform3D(), track_i, transform_track_i.key);
+					gltf_animation->get_tracks().insert(transform_track_i.key, track);
 				}
 			}
 		} else if (String(orig_track_path).find(":blend_shapes/") != -1) {
@@ -6386,9 +6386,9 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			Ref<Mesh> mesh = mi->get_mesh();
 			ERR_CONTINUE(mesh.is_null());
 			int32_t mesh_index = -1;
-			for (Map<GLTFNodeIndex, Node *>::Element *mesh_track_i = state->scene_nodes.front(); mesh_track_i; mesh_track_i = mesh_track_i->next()) {
-				if (mesh_track_i->get() == node) {
-					mesh_index = mesh_track_i->key();
+			for (const KeyValue<GLTFNodeIndex, Node *> &mesh_track_i : state->scene_nodes) {
+				if (mesh_track_i.value == node) {
+					mesh_index = mesh_track_i.key;
 				}
 			}
 			ERR_CONTINUE(mesh_index == -1);
@@ -6469,9 +6469,9 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			for (int32_t node_i = 0; node_i < ap->get_parent()->get_child_count(); node_i++) {
 				const Node *child = ap->get_parent()->get_child(node_i);
 				const Node *node = child->get_node_or_null(orig_track_path);
-				for (Map<GLTFNodeIndex, Node *>::Element *scene_node_i = state->scene_nodes.front(); scene_node_i; scene_node_i = scene_node_i->next()) {
-					if (scene_node_i->get() == node) {
-						GLTFNodeIndex node_index = scene_node_i->key();
+				for (const KeyValue<GLTFNodeIndex, Node *> &scene_node_i : state->scene_nodes) {
+					if (scene_node_i.value == node) {
+						GLTFNodeIndex node_index = scene_node_i.key;
 						Map<int, GLTFAnimation::Track>::Element *node_track_i = gltf_animation->get_tracks().find(node_index);
 						GLTFAnimation::Track track;
 						if (node_track_i) {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -420,8 +420,8 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	}
 
 	//erase navigation
-	for (Map<IndexKey, Octant::NavMesh>::Element *E = g.navmesh_ids.front(); E; E = E->next()) {
-		NavigationServer3D::get_singleton()->free(E->get().region);
+	for (const KeyValue<IndexKey, Octant::NavMesh> &E : g.navmesh_ids) {
+		NavigationServer3D::get_singleton()->free(E.value.region);
 	}
 	g.navmesh_ids.clear();
 
@@ -512,15 +512,15 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 	//update multimeshes, only if not baked
 	if (baked_meshes.size() == 0) {
-		for (Map<int, List<Pair<Transform3D, IndexKey>>>::Element *E = multimesh_items.front(); E; E = E->next()) {
+		for (const KeyValue<int, List<Pair<Transform3D, IndexKey>>> &E : multimesh_items) {
 			Octant::MultimeshInstance mmi;
 
 			RID mm = RS::get_singleton()->multimesh_create();
-			RS::get_singleton()->multimesh_allocate_data(mm, E->get().size(), RS::MULTIMESH_TRANSFORM_3D);
-			RS::get_singleton()->multimesh_set_mesh(mm, mesh_library->get_item_mesh(E->key())->get_rid());
+			RS::get_singleton()->multimesh_allocate_data(mm, E.value.size(), RS::MULTIMESH_TRANSFORM_3D);
+			RS::get_singleton()->multimesh_set_mesh(mm, mesh_library->get_item_mesh(E.key)->get_rid());
 
 			int idx = 0;
-			for (const Pair<Transform3D, IndexKey> &F : E->get()) {
+			for (const Pair<Transform3D, IndexKey> &F : E.value) {
 				RS::get_singleton()->multimesh_instance_set_transform(mm, idx, F.first);
 #ifdef TOOLS_ENABLED
 
@@ -567,9 +567,9 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 }
 
 void GridMap::_reset_physic_bodies_collision_filters() {
-	for (Map<OctantKey, Octant *>::Element *E = octant_map.front(); E; E = E->next()) {
-		PhysicsServer3D::get_singleton()->body_set_collision_layer(E->get()->static_body, collision_layer);
-		PhysicsServer3D::get_singleton()->body_set_collision_mask(E->get()->static_body, collision_mask);
+	for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
+		PhysicsServer3D::get_singleton()->body_set_collision_layer(E.value->static_body, collision_layer);
+		PhysicsServer3D::get_singleton()->body_set_collision_mask(E.value->static_body, collision_mask);
 	}
 }
 
@@ -590,17 +590,17 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 	}
 
 	if (bake_navigation && mesh_library.is_valid()) {
-		for (Map<IndexKey, Octant::NavMesh>::Element *F = g.navmesh_ids.front(); F; F = F->next()) {
-			if (cell_map.has(F->key()) && F->get().region.is_valid() == false) {
-				Ref<NavigationMesh> nm = mesh_library->get_item_navmesh(cell_map[F->key()].item);
+		for (KeyValue<IndexKey, Octant::NavMesh> &F : g.navmesh_ids) {
+			if (cell_map.has(F.key) && F.value.region.is_valid() == false) {
+				Ref<NavigationMesh> nm = mesh_library->get_item_navmesh(cell_map[F.key].item);
 				if (nm.is_valid()) {
 					RID region = NavigationServer3D::get_singleton()->region_create();
 					NavigationServer3D::get_singleton()->region_set_layers(region, navigation_layers);
 					NavigationServer3D::get_singleton()->region_set_navmesh(region, nm);
-					NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * F->get().xform);
+					NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * F.value.xform);
 					NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
 
-					F->get().region = region;
+					F.value.region = region;
 				}
 			}
 		}
@@ -621,10 +621,10 @@ void GridMap::_octant_exit_world(const OctantKey &p_key) {
 		RS::get_singleton()->instance_set_scenario(g.multimesh_instances[i].instance, RID());
 	}
 
-	for (Map<IndexKey, Octant::NavMesh>::Element *F = g.navmesh_ids.front(); F; F = F->next()) {
-		if (F->get().region.is_valid()) {
-			NavigationServer3D::get_singleton()->free(F->get().region);
-			F->get().region = RID();
+	for (KeyValue<IndexKey, Octant::NavMesh> &F : g.navmesh_ids) {
+		if (F.value.region.is_valid()) {
+			NavigationServer3D::get_singleton()->free(F.value.region);
+			F.value.region = RID();
 		}
 	}
 }
@@ -643,8 +643,8 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 	PhysicsServer3D::get_singleton()->free(g.static_body);
 
 	// Erase navigation
-	for (Map<IndexKey, Octant::NavMesh>::Element *E = g.navmesh_ids.front(); E; E = E->next()) {
-		NavigationServer3D::get_singleton()->free(E->get().region);
+	for (const KeyValue<IndexKey, Octant::NavMesh> &E : g.navmesh_ids) {
+		NavigationServer3D::get_singleton()->free(E.value.region);
 	}
 	g.navmesh_ids.clear();
 
@@ -662,8 +662,8 @@ void GridMap::_notification(int p_what) {
 		case NOTIFICATION_ENTER_WORLD: {
 			last_transform = get_global_transform();
 
-			for (Map<OctantKey, Octant *>::Element *E = octant_map.front(); E; E = E->next()) {
-				_octant_enter_world(E->key());
+			for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
+				_octant_enter_world(E.key);
 			}
 
 			for (int i = 0; i < baked_meshes.size(); i++) {
@@ -678,8 +678,8 @@ void GridMap::_notification(int p_what) {
 				break;
 			}
 			//update run
-			for (Map<OctantKey, Octant *>::Element *E = octant_map.front(); E; E = E->next()) {
-				_octant_transform(E->key());
+			for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
+				_octant_transform(E.key);
 			}
 
 			last_transform = new_xform;
@@ -689,8 +689,8 @@ void GridMap::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {
-			for (Map<OctantKey, Octant *>::Element *E = octant_map.front(); E; E = E->next()) {
-				_octant_exit_world(E->key());
+			for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
+				_octant_exit_world(E.key);
 			}
 
 			//_queue_octants_dirty(MAP_DIRTY_INSTANCES|MAP_DIRTY_TRANSFORMS);
@@ -712,8 +712,8 @@ void GridMap::_update_visibility() {
 		return;
 	}
 
-	for (Map<OctantKey, Octant *>::Element *e = octant_map.front(); e; e = e->next()) {
-		Octant *octant = e->value();
+	for (KeyValue<OctantKey, Octant *> &e : octant_map) {
+		Octant *octant = e.value;
 		for (int i = 0; i < octant->multimesh_instances.size(); i++) {
 			const Octant::MultimeshInstance &mi = octant->multimesh_instances[i];
 			RS::get_singleton()->instance_set_visible(mi.instance, is_visible_in_tree());
@@ -738,20 +738,20 @@ void GridMap::_recreate_octant_data() {
 	recreating_octants = true;
 	Map<IndexKey, Cell> cell_copy = cell_map;
 	_clear_internal();
-	for (Map<IndexKey, Cell>::Element *E = cell_copy.front(); E; E = E->next()) {
-		set_cell_item(Vector3i(E->key()), E->get().item, E->get().rot);
+	for (const KeyValue<IndexKey, Cell> &E : cell_copy) {
+		set_cell_item(Vector3i(E.key), E.value.item, E.value.rot);
 	}
 	recreating_octants = false;
 }
 
 void GridMap::_clear_internal() {
-	for (Map<OctantKey, Octant *>::Element *E = octant_map.front(); E; E = E->next()) {
+	for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
 		if (is_inside_world()) {
-			_octant_exit_world(E->key());
+			_octant_exit_world(E.key);
 		}
 
-		_octant_clean_up(E->key());
-		memdelete(E->get());
+		_octant_clean_up(E.key);
+		memdelete(E.value);
 	}
 
 	octant_map.clear();
@@ -773,9 +773,9 @@ void GridMap::_update_octants_callback() {
 	}
 
 	List<OctantKey> to_delete;
-	for (Map<OctantKey, Octant *>::Element *E = octant_map.front(); E; E = E->next()) {
-		if (_octant_update(E->key())) {
-			to_delete.push_back(E->key());
+	for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
+		if (_octant_update(E.key)) {
+			to_delete.push_back(E.key);
 		}
 	}
 
@@ -883,8 +883,8 @@ void GridMap::set_clip(bool p_enabled, bool p_clip_above, int p_floor, Vector3::
 	clip_above = p_clip_above;
 
 	//make it all update
-	for (Map<OctantKey, Octant *>::Element *E = octant_map.front(); E; E = E->next()) {
-		Octant *g = E->get();
+	for (KeyValue<OctantKey, Octant *> &E : octant_map) {
+		Octant *g = E.value;
 		g->dirty = true;
 	}
 	awaiting_update = true;
@@ -904,8 +904,8 @@ Array GridMap::get_used_cells() const {
 	Array a;
 	a.resize(cell_map.size());
 	int i = 0;
-	for (Map<IndexKey, Cell>::Element *E = cell_map.front(); E; E = E->next()) {
-		Vector3 p(E->key().x, E->key().y, E->key().z);
+	for (const KeyValue<IndexKey, Cell> &E : cell_map) {
+		Vector3 p(E.key.x, E.key.y, E.key.z);
 		a[i++] = p;
 	}
 
@@ -920,8 +920,8 @@ Array GridMap::get_meshes() {
 	Vector3 ofs = _get_offset();
 	Array meshes;
 
-	for (Map<IndexKey, Cell>::Element *E = cell_map.front(); E; E = E->next()) {
-		int id = E->get().item;
+	for (KeyValue<IndexKey, Cell> &E : cell_map) {
+		int id = E.value.item;
 		if (!mesh_library->has_item(id)) {
 			continue;
 		}
@@ -930,13 +930,13 @@ Array GridMap::get_meshes() {
 			continue;
 		}
 
-		IndexKey ik = E->key();
+		IndexKey ik = E.key;
 
 		Vector3 cellpos = Vector3(ik.x, ik.y, ik.z);
 
 		Transform3D xform;
 
-		xform.basis.set_orthogonal_index(E->get().rot);
+		xform.basis.set_orthogonal_index(E.value.rot);
 
 		xform.set_origin(cellpos * cell_size + ofs);
 		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
@@ -972,10 +972,10 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 	//generate
 	Map<OctantKey, Map<Ref<Material>, Ref<SurfaceTool>>> surface_map;
 
-	for (Map<IndexKey, Cell>::Element *E = cell_map.front(); E; E = E->next()) {
-		IndexKey key = E->key();
+	for (KeyValue<IndexKey, Cell> &E : cell_map) {
+		IndexKey key = E.key;
 
-		int item = E->get().item;
+		int item = E.value.item;
 		if (!mesh_library->has_item(item)) {
 			continue;
 		}
@@ -990,7 +990,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 
 		Transform3D xform;
 
-		xform.basis.set_orthogonal_index(E->get().rot);
+		xform.basis.set_orthogonal_index(E.value.rot);
 		xform.set_origin(cellpos * cell_size + ofs);
 		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
 
@@ -1023,11 +1023,11 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		}
 	}
 
-	for (Map<OctantKey, Map<Ref<Material>, Ref<SurfaceTool>>>::Element *E = surface_map.front(); E; E = E->next()) {
+	for (KeyValue<OctantKey, Map<Ref<Material>, Ref<SurfaceTool>>> &E : surface_map) {
 		Ref<ArrayMesh> mesh;
 		mesh.instantiate();
-		for (Map<Ref<Material>, Ref<SurfaceTool>>::Element *F = E->get().front(); F; F = F->next()) {
-			F->get()->commit(mesh);
+		for (KeyValue<Ref<Material>, Ref<SurfaceTool>> &F : E.value) {
+			F.value->commit(mesh);
 		}
 
 		BakedMesh bm;

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -613,17 +613,17 @@ void NavMap::sync() {
 		}
 
 		Vector<gd::Edge::Connection> free_edges;
-		for (Map<gd::EdgeKey, Vector<gd::Edge::Connection>>::Element *E = connections.front(); E; E = E->next()) {
-			if (E->get().size() == 2) {
+		for (KeyValue<gd::EdgeKey, Vector<gd::Edge::Connection>> &E : connections) {
+			if (E.value.size() == 2) {
 				// Connect edge that are shared in different polygons.
-				gd::Edge::Connection &c1 = E->get().write[0];
-				gd::Edge::Connection &c2 = E->get().write[1];
+				gd::Edge::Connection &c1 = E.value.write[0];
+				gd::Edge::Connection &c2 = E.value.write[1];
 				c1.polygon->edges[c1.edge].connections.push_back(c2);
 				c2.polygon->edges[c2.edge].connections.push_back(c1);
 				// Note: The pathway_start/end are full for those connection and do not need to be modified.
 			} else {
-				CRASH_COND_MSG(E->get().size() != 1, vformat("Number of connection != 1. Found: %d", E->get().size()));
-				free_edges.push_back(E->get()[0]);
+				CRASH_COND_MSG(E.value.size() != 1, vformat("Number of connection != 1. Found: %d", E.value.size()));
+				free_edges.push_back(E.value[0]);
 			}
 		}
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1585,8 +1585,8 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 }
 
 _FORCE_INLINE_ void TextServerAdvanced::_font_clear_cache(FontDataAdvanced *p_font_data) {
-	for (const Map<Vector2i, FontDataForSizeAdvanced *>::Element *E = p_font_data->cache.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<Vector2i, FontDataForSizeAdvanced *> &E : p_font_data->cache) {
+		memdelete(E.value);
 	}
 	p_font_data->cache.clear();
 	p_font_data->face_init = false;
@@ -1822,8 +1822,8 @@ void TextServerAdvanced::font_clear_size_cache(RID p_font_rid) {
 	ERR_FAIL_COND(!fd);
 
 	MutexLock lock(fd->mutex);
-	for (const Map<Vector2i, FontDataForSizeAdvanced *>::Element *E = fd->cache.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<Vector2i, FontDataForSizeAdvanced *> &E : fd->cache) {
+		memdelete(E.value);
 	}
 	fd->cache.clear();
 }
@@ -2678,8 +2678,8 @@ Vector<String> TextServerAdvanced::font_get_language_support_overrides(RID p_fon
 
 	MutexLock lock(fd->mutex);
 	Vector<String> out;
-	for (const Map<String, bool>::Element *E = fd->language_support_overrides.front(); E; E = E->next()) {
-		out.push_back(E->key());
+	for (const KeyValue<String, bool> &E : fd->language_support_overrides) {
+		out.push_back(E.key);
 	}
 	return out;
 }
@@ -2839,9 +2839,9 @@ void TextServerAdvanced::invalidate(TextServerAdvanced::ShapedTextDataAdvanced *
 void TextServerAdvanced::full_copy(ShapedTextDataAdvanced *p_shaped) {
 	ShapedTextDataAdvanced *parent = shaped_owner.get_or_null(p_shaped->parent);
 
-	for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = parent->objects.front(); E; E = E->next()) {
-		if (E->get().pos >= p_shaped->start && E->get().pos < p_shaped->end) {
-			p_shaped->objects[E->key()] = E->get();
+	for (const KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : parent->objects) {
+		if (E.value.pos >= p_shaped->start && E.value.pos < p_shaped->end) {
+			p_shaped->objects[E.key] = E.value;
 		}
 	}
 
@@ -3065,9 +3065,9 @@ bool TextServerAdvanced::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 			Glyph gl = sd->glyphs[i];
 			Variant key;
 			if (gl.count == 1) {
-				for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
-					if (E->get().pos == gl.start) {
-						key = E->key();
+				for (const KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
+					if (E.value.pos == gl.start) {
+						key = E.key;
 						break;
 					}
 				}
@@ -3110,64 +3110,64 @@ bool TextServerAdvanced::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 		// Align embedded objects to baseline.
 		real_t full_ascent = sd->ascent;
 		real_t full_descent = sd->descent;
-		for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
-			if ((E->get().pos >= sd->start) && (E->get().pos < sd->end)) {
+		for (KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
+			if ((E.value.pos >= sd->start) && (E.value.pos < sd->end)) {
 				if (sd->orientation == ORIENTATION_HORIZONTAL) {
-					switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 						case INLINE_ALIGN_TO_TOP: {
-							E->get().rect.position.y = -sd->ascent;
+							E.value.rect.position.y = -sd->ascent;
 						} break;
 						case INLINE_ALIGN_TO_CENTER: {
-							E->get().rect.position.y = (-sd->ascent + sd->descent) / 2;
+							E.value.rect.position.y = (-sd->ascent + sd->descent) / 2;
 						} break;
 						case INLINE_ALIGN_TO_BASELINE: {
-							E->get().rect.position.y = 0;
+							E.value.rect.position.y = 0;
 						} break;
 						case INLINE_ALIGN_TO_BOTTOM: {
-							E->get().rect.position.y = sd->descent;
+							E.value.rect.position.y = sd->descent;
 						} break;
 					}
-					switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 						case INLINE_ALIGN_BOTTOM_TO: {
-							E->get().rect.position.y -= E->get().rect.size.y;
+							E.value.rect.position.y -= E.value.rect.size.y;
 						} break;
 						case INLINE_ALIGN_CENTER_TO: {
-							E->get().rect.position.y -= E->get().rect.size.y / 2;
+							E.value.rect.position.y -= E.value.rect.size.y / 2;
 						} break;
 						case INLINE_ALIGN_TOP_TO: {
 							//NOP
 						} break;
 					}
-					full_ascent = MAX(full_ascent, -E->get().rect.position.y);
-					full_descent = MAX(full_descent, E->get().rect.position.y + E->get().rect.size.y);
+					full_ascent = MAX(full_ascent, -E.value.rect.position.y);
+					full_descent = MAX(full_descent, E.value.rect.position.y + E.value.rect.size.y);
 				} else {
-					switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 						case INLINE_ALIGN_TO_TOP: {
-							E->get().rect.position.x = -sd->ascent;
+							E.value.rect.position.x = -sd->ascent;
 						} break;
 						case INLINE_ALIGN_TO_CENTER: {
-							E->get().rect.position.x = (-sd->ascent + sd->descent) / 2;
+							E.value.rect.position.x = (-sd->ascent + sd->descent) / 2;
 						} break;
 						case INLINE_ALIGN_TO_BASELINE: {
-							E->get().rect.position.x = 0;
+							E.value.rect.position.x = 0;
 						} break;
 						case INLINE_ALIGN_TO_BOTTOM: {
-							E->get().rect.position.x = sd->descent;
+							E.value.rect.position.x = sd->descent;
 						} break;
 					}
-					switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 						case INLINE_ALIGN_BOTTOM_TO: {
-							E->get().rect.position.x -= E->get().rect.size.x;
+							E.value.rect.position.x -= E.value.rect.size.x;
 						} break;
 						case INLINE_ALIGN_CENTER_TO: {
-							E->get().rect.position.x -= E->get().rect.size.x / 2;
+							E.value.rect.position.x -= E.value.rect.size.x / 2;
 						} break;
 						case INLINE_ALIGN_TOP_TO: {
 							//NOP
 						} break;
 					}
-					full_ascent = MAX(full_ascent, -E->get().rect.position.x);
-					full_descent = MAX(full_descent, E->get().rect.position.x + E->get().rect.size.x);
+					full_ascent = MAX(full_ascent, -E.value.rect.position.x);
+					full_descent = MAX(full_descent, E.value.rect.position.x + E.value.rect.size.x);
 				}
 			}
 		}
@@ -3254,11 +3254,11 @@ RID TextServerAdvanced::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 						Variant key;
 						bool find_embedded = false;
 						if (gl.count == 1) {
-							for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
-								if (E->get().pos == gl.start) {
+							for (const KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
+								if (E.value.pos == gl.start) {
 									find_embedded = true;
-									key = E->key();
-									new_sd->objects[key] = E->get();
+									key = E.key;
+									new_sd->objects[key] = E.value;
 									break;
 								}
 							}
@@ -3301,64 +3301,64 @@ RID TextServerAdvanced::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 		// Align embedded objects to baseline.
 		real_t full_ascent = new_sd->ascent;
 		real_t full_descent = new_sd->descent;
-		for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = new_sd->objects.front(); E; E = E->next()) {
-			if ((E->get().pos >= new_sd->start) && (E->get().pos < new_sd->end)) {
+		for (KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : new_sd->objects) {
+			if ((E.value.pos >= new_sd->start) && (E.value.pos < new_sd->end)) {
 				if (sd->orientation == ORIENTATION_HORIZONTAL) {
-					switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 						case INLINE_ALIGN_TO_TOP: {
-							E->get().rect.position.y = -new_sd->ascent;
+							E.value.rect.position.y = -new_sd->ascent;
 						} break;
 						case INLINE_ALIGN_TO_CENTER: {
-							E->get().rect.position.y = (-new_sd->ascent + new_sd->descent) / 2;
+							E.value.rect.position.y = (-new_sd->ascent + new_sd->descent) / 2;
 						} break;
 						case INLINE_ALIGN_TO_BASELINE: {
-							E->get().rect.position.y = 0;
+							E.value.rect.position.y = 0;
 						} break;
 						case INLINE_ALIGN_TO_BOTTOM: {
-							E->get().rect.position.y = new_sd->descent;
+							E.value.rect.position.y = new_sd->descent;
 						} break;
 					}
-					switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 						case INLINE_ALIGN_BOTTOM_TO: {
-							E->get().rect.position.y -= E->get().rect.size.y;
+							E.value.rect.position.y -= E.value.rect.size.y;
 						} break;
 						case INLINE_ALIGN_CENTER_TO: {
-							E->get().rect.position.y -= E->get().rect.size.y / 2;
+							E.value.rect.position.y -= E.value.rect.size.y / 2;
 						} break;
 						case INLINE_ALIGN_TOP_TO: {
 							//NOP
 						} break;
 					}
-					full_ascent = MAX(full_ascent, -E->get().rect.position.y);
-					full_descent = MAX(full_descent, E->get().rect.position.y + E->get().rect.size.y);
+					full_ascent = MAX(full_ascent, -E.value.rect.position.y);
+					full_descent = MAX(full_descent, E.value.rect.position.y + E.value.rect.size.y);
 				} else {
-					switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 						case INLINE_ALIGN_TO_TOP: {
-							E->get().rect.position.x = -new_sd->ascent;
+							E.value.rect.position.x = -new_sd->ascent;
 						} break;
 						case INLINE_ALIGN_TO_CENTER: {
-							E->get().rect.position.x = (-new_sd->ascent + new_sd->descent) / 2;
+							E.value.rect.position.x = (-new_sd->ascent + new_sd->descent) / 2;
 						} break;
 						case INLINE_ALIGN_TO_BASELINE: {
-							E->get().rect.position.x = 0;
+							E.value.rect.position.x = 0;
 						} break;
 						case INLINE_ALIGN_TO_BOTTOM: {
-							E->get().rect.position.x = new_sd->descent;
+							E.value.rect.position.x = new_sd->descent;
 						} break;
 					}
-					switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 						case INLINE_ALIGN_BOTTOM_TO: {
-							E->get().rect.position.x -= E->get().rect.size.x;
+							E.value.rect.position.x -= E.value.rect.size.x;
 						} break;
 						case INLINE_ALIGN_CENTER_TO: {
-							E->get().rect.position.x -= E->get().rect.size.x / 2;
+							E.value.rect.position.x -= E.value.rect.size.x / 2;
 						} break;
 						case INLINE_ALIGN_TOP_TO: {
 							//NOP
 						} break;
 					}
-					full_ascent = MAX(full_ascent, -E->get().rect.position.x);
-					full_descent = MAX(full_descent, E->get().rect.position.x + E->get().rect.size.x);
+					full_ascent = MAX(full_ascent, -E.value.rect.position.x);
+					full_descent = MAX(full_descent, E.value.rect.position.x + E.value.rect.size.x);
 				}
 			}
 		}
@@ -4413,63 +4413,63 @@ bool TextServerAdvanced::shaped_text_shape(RID p_shaped) {
 	// Align embedded objects to baseline.
 	real_t full_ascent = sd->ascent;
 	real_t full_descent = sd->descent;
-	for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
+	for (KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
 		if (sd->orientation == ORIENTATION_HORIZONTAL) {
-			switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+			switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 				case INLINE_ALIGN_TO_TOP: {
-					E->get().rect.position.y = -sd->ascent;
+					E.value.rect.position.y = -sd->ascent;
 				} break;
 				case INLINE_ALIGN_TO_CENTER: {
-					E->get().rect.position.y = (-sd->ascent + sd->descent) / 2;
+					E.value.rect.position.y = (-sd->ascent + sd->descent) / 2;
 				} break;
 				case INLINE_ALIGN_TO_BASELINE: {
-					E->get().rect.position.y = 0;
+					E.value.rect.position.y = 0;
 				} break;
 				case INLINE_ALIGN_TO_BOTTOM: {
-					E->get().rect.position.y = sd->descent;
+					E.value.rect.position.y = sd->descent;
 				} break;
 			}
-			switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+			switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 				case INLINE_ALIGN_BOTTOM_TO: {
-					E->get().rect.position.y -= E->get().rect.size.y;
+					E.value.rect.position.y -= E.value.rect.size.y;
 				} break;
 				case INLINE_ALIGN_CENTER_TO: {
-					E->get().rect.position.y -= E->get().rect.size.y / 2;
+					E.value.rect.position.y -= E.value.rect.size.y / 2;
 				} break;
 				case INLINE_ALIGN_TOP_TO: {
 					//NOP
 				} break;
 			}
-			full_ascent = MAX(full_ascent, -E->get().rect.position.y);
-			full_descent = MAX(full_descent, E->get().rect.position.y + E->get().rect.size.y);
+			full_ascent = MAX(full_ascent, -E.value.rect.position.y);
+			full_descent = MAX(full_descent, E.value.rect.position.y + E.value.rect.size.y);
 		} else {
-			switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+			switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 				case INLINE_ALIGN_TO_TOP: {
-					E->get().rect.position.x = -sd->ascent;
+					E.value.rect.position.x = -sd->ascent;
 				} break;
 				case INLINE_ALIGN_TO_CENTER: {
-					E->get().rect.position.x = (-sd->ascent + sd->descent) / 2;
+					E.value.rect.position.x = (-sd->ascent + sd->descent) / 2;
 				} break;
 				case INLINE_ALIGN_TO_BASELINE: {
-					E->get().rect.position.x = 0;
+					E.value.rect.position.x = 0;
 				} break;
 				case INLINE_ALIGN_TO_BOTTOM: {
-					E->get().rect.position.x = sd->descent;
+					E.value.rect.position.x = sd->descent;
 				} break;
 			}
-			switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+			switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 				case INLINE_ALIGN_BOTTOM_TO: {
-					E->get().rect.position.x -= E->get().rect.size.x;
+					E.value.rect.position.x -= E.value.rect.size.x;
 				} break;
 				case INLINE_ALIGN_CENTER_TO: {
-					E->get().rect.position.x -= E->get().rect.size.x / 2;
+					E.value.rect.position.x -= E.value.rect.size.x / 2;
 				} break;
 				case INLINE_ALIGN_TOP_TO: {
 					//NOP
 				} break;
 			}
-			full_ascent = MAX(full_ascent, -E->get().rect.position.x);
-			full_descent = MAX(full_descent, E->get().rect.position.x + E->get().rect.size.x);
+			full_ascent = MAX(full_ascent, -E.value.rect.position.x);
+			full_descent = MAX(full_descent, E.value.rect.position.x + E.value.rect.size.x);
 		}
 	}
 	sd->ascent = full_ascent;
@@ -4529,8 +4529,8 @@ Array TextServerAdvanced::shaped_text_get_objects(RID p_shaped) const {
 	ERR_FAIL_COND_V(!sd, ret);
 
 	MutexLock lock(sd->mutex);
-	for (const Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
+		ret.push_back(E.key);
 	}
 
 	return ret;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -795,8 +795,8 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontDataFallback 
 }
 
 _FORCE_INLINE_ void TextServerFallback::_font_clear_cache(FontDataFallback *p_font_data) {
-	for (const Map<Vector2i, FontDataForSizeFallback *>::Element *E = p_font_data->cache.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<Vector2i, FontDataForSizeFallback *> &E : p_font_data->cache) {
+		memdelete(E.value);
 	}
 
 	p_font_data->cache.clear();
@@ -1008,8 +1008,8 @@ Array TextServerFallback::font_get_size_cache_list(RID p_font_rid) const {
 
 	MutexLock lock(fd->mutex);
 	Array ret;
-	for (const Map<Vector2i, FontDataForSizeFallback *>::Element *E = fd->cache.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<Vector2i, FontDataForSizeFallback *> &E : fd->cache) {
+		ret.push_back(E.key);
 	}
 	return ret;
 }
@@ -1019,8 +1019,8 @@ void TextServerFallback::font_clear_size_cache(RID p_font_rid) {
 	ERR_FAIL_COND(!fd);
 
 	MutexLock lock(fd->mutex);
-	for (const Map<Vector2i, FontDataForSizeFallback *>::Element *E = fd->cache.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<Vector2i, FontDataForSizeFallback *> &E : fd->cache) {
+		memdelete(E.value);
 	}
 	fd->cache.clear();
 }
@@ -1578,8 +1578,8 @@ Array TextServerFallback::font_get_kerning_list(RID p_font_rid, int p_size) cons
 	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Array());
 
 	Array ret;
-	for (const Map<Vector2i, Vector2>::Element *E = fd->cache[size]->kerning_map.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<Vector2i, Vector2> &E : fd->cache[size]->kerning_map) {
+		ret.push_back(E.key);
 	}
 	return ret;
 }
@@ -1852,8 +1852,8 @@ Vector<String> TextServerFallback::font_get_language_support_overrides(RID p_fon
 
 	MutexLock lock(fd->mutex);
 	Vector<String> out;
-	for (const Map<String, bool>::Element *E = fd->language_support_overrides.front(); E; E = E->next()) {
-		out.push_back(E->key());
+	for (const KeyValue<String, bool> &E : fd->language_support_overrides) {
+		out.push_back(E.key);
 	}
 	return out;
 }
@@ -1902,8 +1902,8 @@ Vector<String> TextServerFallback::font_get_script_support_overrides(RID p_font_
 
 	MutexLock lock(fd->mutex);
 	Vector<String> out;
-	for (const Map<String, bool>::Element *E = fd->script_support_overrides.front(); E; E = E->next()) {
-		out.push_back(E->key());
+	for (const KeyValue<String, bool> &E : fd->script_support_overrides) {
+		out.push_back(E.key);
 	}
 	return out;
 }
@@ -1971,9 +1971,9 @@ void TextServerFallback::invalidate(ShapedTextData *p_shaped) {
 void TextServerFallback::full_copy(ShapedTextData *p_shaped) {
 	ShapedTextData *parent = shaped_owner.get_or_null(p_shaped->parent);
 
-	for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = parent->objects.front(); E; E = E->next()) {
-		if (E->get().pos >= p_shaped->start && E->get().pos < p_shaped->end) {
-			p_shaped->objects[E->key()] = E->get();
+	for (const KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : parent->objects) {
+		if (E.value.pos >= p_shaped->start && E.value.pos < p_shaped->end) {
+			p_shaped->objects[E.key] = E.value;
 		}
 	}
 
@@ -2192,9 +2192,9 @@ bool TextServerFallback::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 			Glyph gl = sd->glyphs[i];
 			Variant key;
 			if (gl.count == 1) {
-				for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
-					if (E->get().pos == gl.start) {
-						key = E->key();
+				for (const KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
+					if (E.value.pos == gl.start) {
+						key = E.key;
 						break;
 					}
 				}
@@ -2237,64 +2237,64 @@ bool TextServerFallback::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 		// Align embedded objects to baseline.
 		real_t full_ascent = sd->ascent;
 		real_t full_descent = sd->descent;
-		for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
-			if ((E->get().pos >= sd->start) && (E->get().pos < sd->end)) {
+		for (KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
+			if ((E.value.pos >= sd->start) && (E.value.pos < sd->end)) {
 				if (sd->orientation == ORIENTATION_HORIZONTAL) {
-					switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 						case INLINE_ALIGN_TO_TOP: {
-							E->get().rect.position.y = -sd->ascent;
+							E.value.rect.position.y = -sd->ascent;
 						} break;
 						case INLINE_ALIGN_TO_CENTER: {
-							E->get().rect.position.y = (-sd->ascent + sd->descent) / 2;
+							E.value.rect.position.y = (-sd->ascent + sd->descent) / 2;
 						} break;
 						case INLINE_ALIGN_TO_BASELINE: {
-							E->get().rect.position.y = 0;
+							E.value.rect.position.y = 0;
 						} break;
 						case INLINE_ALIGN_TO_BOTTOM: {
-							E->get().rect.position.y = sd->descent;
+							E.value.rect.position.y = sd->descent;
 						} break;
 					}
-					switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 						case INLINE_ALIGN_BOTTOM_TO: {
-							E->get().rect.position.y -= E->get().rect.size.y;
+							E.value.rect.position.y -= E.value.rect.size.y;
 						} break;
 						case INLINE_ALIGN_CENTER_TO: {
-							E->get().rect.position.y -= E->get().rect.size.y / 2;
+							E.value.rect.position.y -= E.value.rect.size.y / 2;
 						} break;
 						case INLINE_ALIGN_TOP_TO: {
 							//NOP
 						} break;
 					}
-					full_ascent = MAX(full_ascent, -E->get().rect.position.y);
-					full_descent = MAX(full_descent, E->get().rect.position.y + E->get().rect.size.y);
+					full_ascent = MAX(full_ascent, -E.value.rect.position.y);
+					full_descent = MAX(full_descent, E.value.rect.position.y + E.value.rect.size.y);
 				} else {
-					switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 						case INLINE_ALIGN_TO_TOP: {
-							E->get().rect.position.x = -sd->ascent;
+							E.value.rect.position.x = -sd->ascent;
 						} break;
 						case INLINE_ALIGN_TO_CENTER: {
-							E->get().rect.position.x = (-sd->ascent + sd->descent) / 2;
+							E.value.rect.position.x = (-sd->ascent + sd->descent) / 2;
 						} break;
 						case INLINE_ALIGN_TO_BASELINE: {
-							E->get().rect.position.x = 0;
+							E.value.rect.position.x = 0;
 						} break;
 						case INLINE_ALIGN_TO_BOTTOM: {
-							E->get().rect.position.x = sd->descent;
+							E.value.rect.position.x = sd->descent;
 						} break;
 					}
-					switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 						case INLINE_ALIGN_BOTTOM_TO: {
-							E->get().rect.position.x -= E->get().rect.size.x;
+							E.value.rect.position.x -= E.value.rect.size.x;
 						} break;
 						case INLINE_ALIGN_CENTER_TO: {
-							E->get().rect.position.x -= E->get().rect.size.x / 2;
+							E.value.rect.position.x -= E.value.rect.size.x / 2;
 						} break;
 						case INLINE_ALIGN_TOP_TO: {
 							//NOP
 						} break;
 					}
-					full_ascent = MAX(full_ascent, -E->get().rect.position.x);
-					full_descent = MAX(full_descent, E->get().rect.position.x + E->get().rect.size.x);
+					full_ascent = MAX(full_ascent, -E.value.rect.position.x);
+					full_descent = MAX(full_descent, E.value.rect.position.x + E.value.rect.size.x);
 				}
 			}
 		}
@@ -2344,11 +2344,11 @@ RID TextServerFallback::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 				Variant key;
 				bool find_embedded = false;
 				if (gl.count == 1) {
-					for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
-						if (E->get().pos == gl.start) {
+					for (const KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
+						if (E.value.pos == gl.start) {
 							find_embedded = true;
-							key = E->key();
-							new_sd->objects[key] = E->get();
+							key = E.key;
+							new_sd->objects[key] = E.value;
 							break;
 						}
 					}
@@ -2389,64 +2389,64 @@ RID TextServerFallback::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 		// Align embedded objects to baseline.
 		real_t full_ascent = new_sd->ascent;
 		real_t full_descent = new_sd->descent;
-		for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = new_sd->objects.front(); E; E = E->next()) {
-			if ((E->get().pos >= new_sd->start) && (E->get().pos < new_sd->end)) {
+		for (KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : new_sd->objects) {
+			if ((E.value.pos >= new_sd->start) && (E.value.pos < new_sd->end)) {
 				if (sd->orientation == ORIENTATION_HORIZONTAL) {
-					switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 						case INLINE_ALIGN_TO_TOP: {
-							E->get().rect.position.y = -new_sd->ascent;
+							E.value.rect.position.y = -new_sd->ascent;
 						} break;
 						case INLINE_ALIGN_TO_CENTER: {
-							E->get().rect.position.y = (-new_sd->ascent + new_sd->descent) / 2;
+							E.value.rect.position.y = (-new_sd->ascent + new_sd->descent) / 2;
 						} break;
 						case INLINE_ALIGN_TO_BASELINE: {
-							E->get().rect.position.y = 0;
+							E.value.rect.position.y = 0;
 						} break;
 						case INLINE_ALIGN_TO_BOTTOM: {
-							E->get().rect.position.y = new_sd->descent;
+							E.value.rect.position.y = new_sd->descent;
 						} break;
 					}
-					switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 						case INLINE_ALIGN_BOTTOM_TO: {
-							E->get().rect.position.y -= E->get().rect.size.y;
+							E.value.rect.position.y -= E.value.rect.size.y;
 						} break;
 						case INLINE_ALIGN_CENTER_TO: {
-							E->get().rect.position.y -= E->get().rect.size.y / 2;
+							E.value.rect.position.y -= E.value.rect.size.y / 2;
 						} break;
 						case INLINE_ALIGN_TOP_TO: {
 							//NOP
 						} break;
 					}
-					full_ascent = MAX(full_ascent, -E->get().rect.position.y);
-					full_descent = MAX(full_descent, E->get().rect.position.y + E->get().rect.size.y);
+					full_ascent = MAX(full_ascent, -E.value.rect.position.y);
+					full_descent = MAX(full_descent, E.value.rect.position.y + E.value.rect.size.y);
 				} else {
-					switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 						case INLINE_ALIGN_TO_TOP: {
-							E->get().rect.position.x = -new_sd->ascent;
+							E.value.rect.position.x = -new_sd->ascent;
 						} break;
 						case INLINE_ALIGN_TO_CENTER: {
-							E->get().rect.position.x = (-new_sd->ascent + new_sd->descent) / 2;
+							E.value.rect.position.x = (-new_sd->ascent + new_sd->descent) / 2;
 						} break;
 						case INLINE_ALIGN_TO_BASELINE: {
-							E->get().rect.position.x = 0;
+							E.value.rect.position.x = 0;
 						} break;
 						case INLINE_ALIGN_TO_BOTTOM: {
-							E->get().rect.position.x = new_sd->descent;
+							E.value.rect.position.x = new_sd->descent;
 						} break;
 					}
-					switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+					switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 						case INLINE_ALIGN_BOTTOM_TO: {
-							E->get().rect.position.x -= E->get().rect.size.x;
+							E.value.rect.position.x -= E.value.rect.size.x;
 						} break;
 						case INLINE_ALIGN_CENTER_TO: {
-							E->get().rect.position.x -= E->get().rect.size.x / 2;
+							E.value.rect.position.x -= E.value.rect.size.x / 2;
 						} break;
 						case INLINE_ALIGN_TOP_TO: {
 							//NOP
 						} break;
 					}
-					full_ascent = MAX(full_ascent, -E->get().rect.position.x);
-					full_descent = MAX(full_descent, E->get().rect.position.x + E->get().rect.size.x);
+					full_ascent = MAX(full_ascent, -E.value.rect.position.x);
+					full_descent = MAX(full_descent, E.value.rect.position.x + E.value.rect.size.x);
 				}
 			}
 		}
@@ -2907,63 +2907,63 @@ bool TextServerFallback::shaped_text_shape(RID p_shaped) {
 	// Align embedded objects to baseline.
 	real_t full_ascent = sd->ascent;
 	real_t full_descent = sd->descent;
-	for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
+	for (KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
 		if (sd->orientation == ORIENTATION_HORIZONTAL) {
-			switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+			switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 				case INLINE_ALIGN_TO_TOP: {
-					E->get().rect.position.y = -sd->ascent;
+					E.value.rect.position.y = -sd->ascent;
 				} break;
 				case INLINE_ALIGN_TO_CENTER: {
-					E->get().rect.position.y = (-sd->ascent + sd->descent) / 2;
+					E.value.rect.position.y = (-sd->ascent + sd->descent) / 2;
 				} break;
 				case INLINE_ALIGN_TO_BASELINE: {
-					E->get().rect.position.y = 0;
+					E.value.rect.position.y = 0;
 				} break;
 				case INLINE_ALIGN_TO_BOTTOM: {
-					E->get().rect.position.y = sd->descent;
+					E.value.rect.position.y = sd->descent;
 				} break;
 			}
-			switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+			switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 				case INLINE_ALIGN_BOTTOM_TO: {
-					E->get().rect.position.y -= E->get().rect.size.y;
+					E.value.rect.position.y -= E.value.rect.size.y;
 				} break;
 				case INLINE_ALIGN_CENTER_TO: {
-					E->get().rect.position.y -= E->get().rect.size.y / 2;
+					E.value.rect.position.y -= E.value.rect.size.y / 2;
 				} break;
 				case INLINE_ALIGN_TOP_TO: {
 					//NOP
 				} break;
 			}
-			full_ascent = MAX(full_ascent, -E->get().rect.position.y);
-			full_descent = MAX(full_descent, E->get().rect.position.y + E->get().rect.size.y);
+			full_ascent = MAX(full_ascent, -E.value.rect.position.y);
+			full_descent = MAX(full_descent, E.value.rect.position.y + E.value.rect.size.y);
 		} else {
-			switch (E->get().inline_align & INLINE_ALIGN_TEXT_MASK) {
+			switch (E.value.inline_align & INLINE_ALIGN_TEXT_MASK) {
 				case INLINE_ALIGN_TO_TOP: {
-					E->get().rect.position.x = -sd->ascent;
+					E.value.rect.position.x = -sd->ascent;
 				} break;
 				case INLINE_ALIGN_TO_CENTER: {
-					E->get().rect.position.x = (-sd->ascent + sd->descent) / 2;
+					E.value.rect.position.x = (-sd->ascent + sd->descent) / 2;
 				} break;
 				case INLINE_ALIGN_TO_BASELINE: {
-					E->get().rect.position.x = 0;
+					E.value.rect.position.x = 0;
 				} break;
 				case INLINE_ALIGN_TO_BOTTOM: {
-					E->get().rect.position.x = sd->descent;
+					E.value.rect.position.x = sd->descent;
 				} break;
 			}
-			switch (E->get().inline_align & INLINE_ALIGN_IMAGE_MASK) {
+			switch (E.value.inline_align & INLINE_ALIGN_IMAGE_MASK) {
 				case INLINE_ALIGN_BOTTOM_TO: {
-					E->get().rect.position.x -= E->get().rect.size.x;
+					E.value.rect.position.x -= E.value.rect.size.x;
 				} break;
 				case INLINE_ALIGN_CENTER_TO: {
-					E->get().rect.position.x -= E->get().rect.size.x / 2;
+					E.value.rect.position.x -= E.value.rect.size.x / 2;
 				} break;
 				case INLINE_ALIGN_TOP_TO: {
 					//NOP
 				} break;
 			}
-			full_ascent = MAX(full_ascent, -E->get().rect.position.x);
-			full_descent = MAX(full_descent, E->get().rect.position.x + E->get().rect.size.x);
+			full_ascent = MAX(full_ascent, -E.value.rect.position.x);
+			full_descent = MAX(full_descent, E.value.rect.position.x + E.value.rect.size.x);
 		}
 	}
 	sd->ascent = full_ascent;
@@ -3017,8 +3017,8 @@ Array TextServerFallback::shaped_text_get_objects(RID p_shaped) const {
 	ERR_FAIL_COND_V(!sd, ret);
 
 	MutexLock lock(sd->mutex);
-	for (const Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = sd->objects.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<Variant, ShapedTextData::EmbeddedObject> &E : sd->objects) {
+		ret.push_back(E.key);
 	}
 
 	return ret;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -702,8 +702,8 @@ void VisualScript::rename_custom_signal(const StringName &p_name, const StringNa
 }
 
 void VisualScript::get_custom_signal_list(List<StringName> *r_custom_signals) const {
-	for (const Map<StringName, Vector<Argument>>::Element *E = custom_signals.front(); E; E = E->next()) {
-		r_custom_signals->push_back(E->key());
+	for (const KeyValue<StringName, Vector<Argument>> &E : custom_signals) {
+		r_custom_signals->push_back(E.key);
 	}
 
 	r_custom_signals->sort_custom<StringName::AlphCompare>();
@@ -848,13 +848,13 @@ bool VisualScript::has_script_signal(const StringName &p_signal) const {
 }
 
 void VisualScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	for (const Map<StringName, Vector<Argument>>::Element *E = custom_signals.front(); E; E = E->next()) {
+	for (const KeyValue<StringName, Vector<Argument>> &E : custom_signals) {
 		MethodInfo mi;
-		mi.name = E->key();
-		for (int i = 0; i < E->get().size(); i++) {
+		mi.name = E.key;
+		for (int i = 0; i < E.value.size(); i++) {
 			PropertyInfo arg;
-			arg.type = E->get()[i].type;
-			arg.name = E->get()[i].name;
+			arg.type = E.value[i].type;
+			arg.name = E.value[i].name;
 			mi.arguments.push_back(arg);
 		}
 
@@ -1056,13 +1056,13 @@ Dictionary VisualScript::_get_data() const {
 	d["variables"] = vars;
 
 	Array sigs;
-	for (const Map<StringName, Vector<Argument>>::Element *E = custom_signals.front(); E; E = E->next()) {
+	for (const KeyValue<StringName, Vector<Argument>> &E : custom_signals) {
 		Dictionary cs;
-		cs["name"] = E->key();
+		cs["name"] = E.key;
 		Array args;
-		for (int i = 0; i < E->get().size(); i++) {
-			args.push_back(E->get()[i].name);
-			args.push_back(E->get()[i].type);
+		for (int i = 0; i < E.value.size(); i++) {
+			args.push_back(E.value[i].name);
+			args.push_back(E.value[i].type);
 		}
 		cs["arguments"] = args;
 
@@ -2093,8 +2093,8 @@ VisualScriptInstance::~VisualScriptInstance() {
 		script->instances.erase(owner);
 	}
 
-	for (Map<int, VisualScriptNodeInstance *>::Element *E = instances.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<int, VisualScriptNodeInstance *> &E : instances) {
+		memdelete(E.value);
 	}
 }
 
@@ -2516,8 +2516,8 @@ Ref<VisualScriptNode> VisualScriptLanguage::create_node_from_name(const String &
 }
 
 void VisualScriptLanguage::get_registered_node_names(List<String> *r_names) {
-	for (Map<String, VisualScriptNodeRegisterFunc>::Element *E = register_funcs.front(); E; E = E->next()) {
-		r_names->push_back(E->key());
+	for (const KeyValue<String, VisualScriptNodeRegisterFunc> &E : register_funcs) {
+		r_names->push_back(E.key);
 	}
 }
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3632,17 +3632,17 @@ void VisualScriptEditor::_notification(int p_what) {
 				node_colors["constants"] = Color(0.94, 0.18, 0.49);
 			}
 
-			for (Map<StringName, Color>::Element *E = node_colors.front(); E; E = E->next()) {
+			for (const KeyValue<StringName, Color> &E : node_colors) {
 				const Ref<StyleBoxFlat> sb = tm->get_stylebox(SNAME("frame"), SNAME("GraphNode"));
 
 				if (!sb.is_null()) {
 					Ref<StyleBoxFlat> frame_style = sb->duplicate();
 					// Adjust the border color to be close to the GraphNode's background color.
 					// This keeps the node's title area from being too distracting.
-					Color color = dark_theme ? E->get().darkened(0.75) : E->get().lightened(0.75);
+					Color color = dark_theme ? E.value.darkened(0.75) : E.value.lightened(0.75);
 					color.a = 0.9;
 					frame_style->set_border_color(color);
-					node_styles[E->key()] = frame_style;
+					node_styles[E.key] = frame_style;
 				}
 			}
 
@@ -3813,15 +3813,15 @@ void VisualScriptEditor::_menu_option(int p_what) {
 				}
 			}
 
-			for (Map<int, Ref<VisualScriptNode>>::Element *E = clipboard->nodes.front(); E; E = E->next()) {
-				Ref<VisualScriptNode> node = E->get()->duplicate();
+			for (KeyValue<int, Ref<VisualScriptNode>> &E : clipboard->nodes) {
+				Ref<VisualScriptNode> node = E.value->duplicate();
 
 				int new_id = idc++;
 				to_select.insert(new_id);
 
-				remap[E->key()] = new_id;
+				remap[E.key] = new_id;
 
-				Vector2 paste_pos = clipboard->nodes_positions[E->key()];
+				Vector2 paste_pos = clipboard->nodes_positions[E.key];
 
 				while (existing_positions.has(paste_pos.snapped(Vector2(2, 2)))) {
 					paste_pos += Vector2(20, 20) * EDSCALE;
@@ -3906,16 +3906,16 @@ void VisualScriptEditor::_menu_option(int p_what) {
 					// the user wants to connect the nodes.
 					int top_nd = -1;
 					Vector2 top;
-					for (Map<int, Ref<VisualScriptNode>>::Element *E = nodes.front(); E; E = E->next()) {
-						Ref<VisualScriptNode> nd = script->get_node(E->key());
+					for (const KeyValue<int, Ref<VisualScriptNode>> &E : nodes) {
+						Ref<VisualScriptNode> nd = script->get_node(E.key);
 						if (nd.is_valid() && nd->has_input_sequence_port()) {
 							if (top_nd < 0) {
-								top_nd = E->key();
+								top_nd = E.key;
 								top = script->get_node_position(top_nd);
 							}
-							Vector2 pos = script->get_node_position(E->key());
+							Vector2 pos = script->get_node_position(E.key);
 							if (top.y > pos.y) {
-								top_nd = E->key();
+								top_nd = E.key;
 								top = pos;
 							}
 						}

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -148,8 +148,8 @@ void WebSocketMultiplayerPeer::_send_add(int32_t p_peer_id) {
 	// Then send the server peer (which will trigger connection_succeded in client)
 	_send_sys(get_peer(p_peer_id), SYS_ADD, 1);
 
-	for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
-		int32_t id = E->key();
+	for (const KeyValue<int, Ref<WebSocketPeer>> &E : _peer_map) {
+		int32_t id = E.key;
 		if (p_peer_id == id) {
 			continue; // Skip the newly added peer (already confirmed)
 		}
@@ -162,8 +162,8 @@ void WebSocketMultiplayerPeer::_send_add(int32_t p_peer_id) {
 }
 
 void WebSocketMultiplayerPeer::_send_del(int32_t p_peer_id) {
-	for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
-		int32_t id = E->key();
+	for (const KeyValue<int, Ref<WebSocketPeer>> &E : _peer_map) {
+		int32_t id = E.key;
 		if (p_peer_id != id) {
 			_send_sys(get_peer(id), SYS_DEL, p_peer_id);
 		}
@@ -186,17 +186,17 @@ Error WebSocketMultiplayerPeer::_server_relay(int32_t p_from, int32_t p_to, cons
 		return OK; // Will not send to self
 
 	} else if (p_to == 0) {
-		for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
-			if (E->key() != p_from) {
-				E->get()->put_packet(p_buffer, p_buffer_size);
+		for (KeyValue<int, Ref<WebSocketPeer>> &E : _peer_map) {
+			if (E.key != p_from) {
+				E.value->put_packet(p_buffer, p_buffer_size);
 			}
 		}
 		return OK; // Sent to all but sender
 
 	} else if (p_to < 0) {
-		for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
-			if (E->key() != p_from && E->key() != -p_to) {
-				E->get()->put_packet(p_buffer, p_buffer_size);
+		for (KeyValue<int, Ref<WebSocketPeer>> &E : _peer_map) {
+			if (E.key != p_from && E.key != -p_to) {
+				E.value->put_packet(p_buffer, p_buffer_size);
 			}
 		}
 		return OK; // Sent to all but sender and excluded

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -182,12 +182,12 @@ Error WSLServer::listen(int p_port, const Vector<String> p_protocols, bool gd_mp
 
 void WSLServer::poll() {
 	List<int> remove_ids;
-	for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
-		Ref<WSLPeer> peer = (WSLPeer *)E->get().ptr();
+	for (const KeyValue<int, Ref<WebSocketPeer>> &E : _peer_map) {
+		Ref<WSLPeer> peer = (WSLPeer *)E.value.ptr();
 		peer->poll();
 		if (!peer->is_connected_to_host()) {
-			_on_disconnect(E->key(), peer->close_code != -1);
-			remove_ids.push_back(E->key());
+			_on_disconnect(E.key, peer->close_code != -1);
+			remove_ids.push_back(E.key);
 		}
 	}
 	for (int &E : remove_ids) {
@@ -265,8 +265,8 @@ int WSLServer::get_max_packet_size() const {
 
 void WSLServer::stop() {
 	_server->stop();
-	for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
-		Ref<WSLPeer> peer = (WSLPeer *)E->get().ptr();
+	for (const KeyValue<int, Ref<WebSocketPeer>> &E : _peer_map) {
+		Ref<WSLPeer> peer = (WSLPeer *)E.value.ptr();
 		peer->close_now();
 	}
 	_pending.clear();

--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -99,8 +99,8 @@ void EditorExportPlatformJavaScript::_replace_strings(Map<String, String> p_repl
 	Vector<String> lines = str_template.split("\n");
 	for (int i = 0; i < lines.size(); i++) {
 		String current_line = lines[i];
-		for (Map<String, String>::Element *E = p_replaces.front(); E; E = E->next()) {
-			current_line = current_line.replace(E->key(), E->get());
+		for (const KeyValue<String, String> &E : p_replaces) {
+			current_line = current_line.replace(E.key, E.value);
 		}
 		out += current_line + "\n";
 	}

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -306,11 +306,11 @@ void DisplayServerX11::mouse_set_mode(MouseMode p_mode) {
 	// The only modes that show a cursor are VISIBLE and CONFINED
 	bool showCursor = (p_mode == MOUSE_MODE_VISIBLE || p_mode == MOUSE_MODE_CONFINED);
 
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
 		if (showCursor) {
-			XDefineCursor(x11_display, E->get().x11_window, cursors[current_cursor]); // show cursor
+			XDefineCursor(x11_display, E.value.x11_window, cursors[current_cursor]); // show cursor
 		} else {
-			XDefineCursor(x11_display, E->get().x11_window, null_cursor); // hide cursor
+			XDefineCursor(x11_display, E.value.x11_window, null_cursor); // hide cursor
 		}
 	}
 	mouse_mode = p_mode;
@@ -785,8 +785,8 @@ Vector<DisplayServer::WindowID> DisplayServerX11::get_window_list() const {
 	_THREAD_SAFE_METHOD_
 
 	Vector<int> ret;
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
+		ret.push_back(E.key);
 	}
 	return ret;
 }
@@ -864,8 +864,8 @@ DisplayServerX11::WindowID DisplayServerX11::get_window_at_screen_position(const
 	WindowID found_window = INVALID_WINDOW_ID;
 	WindowID parent_window = INVALID_WINDOW_ID;
 	unsigned int focus_order = 0;
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		const WindowData &wd = E->get();
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
+		const WindowData &wd = E.value;
 
 		// Discard windows with no focus.
 		if (wd.focus_order == 0) {
@@ -873,7 +873,7 @@ DisplayServerX11::WindowID DisplayServerX11::get_window_at_screen_position(const
 		}
 
 		// Find topmost window which contains the given position.
-		WindowID window_id = E->key();
+		WindowID window_id = E.key;
 		Rect2i win_rect = Rect2i(window_get_position(window_id), window_get_size(window_id));
 		if (win_rect.has_point(p_position)) {
 			// For siblings, pick the window which was focused last.
@@ -1768,8 +1768,8 @@ bool DisplayServerX11::window_can_draw(WindowID p_window) const {
 bool DisplayServerX11::can_any_window_draw() const {
 	_THREAD_SAFE_METHOD_
 
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		if (window_get_mode(E->key()) != WINDOW_MODE_MINIMIZED) {
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
+		if (window_get_mode(E.key) != WINDOW_MODE_MINIMIZED) {
 			return true;
 		}
 	}
@@ -1841,12 +1841,12 @@ void DisplayServerX11::cursor_set_shape(CursorShape p_shape) {
 
 	if (mouse_mode == MOUSE_MODE_VISIBLE || mouse_mode == MOUSE_MODE_CONFINED) {
 		if (cursors[p_shape] != None) {
-			for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-				XDefineCursor(x11_display, E->get().x11_window, cursors[p_shape]);
+			for (const KeyValue<WindowID, WindowData> &E : windows) {
+				XDefineCursor(x11_display, E.value.x11_window, cursors[p_shape]);
 			}
 		} else if (cursors[CURSOR_ARROW] != None) {
-			for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-				XDefineCursor(x11_display, E->get().x11_window, cursors[CURSOR_ARROW]);
+			for (const KeyValue<WindowID, WindowData> &E : windows) {
+				XDefineCursor(x11_display, E.value.x11_window, cursors[CURSOR_ARROW]);
 			}
 		}
 	}
@@ -1944,8 +1944,8 @@ void DisplayServerX11::cursor_set_custom_image(const RES &p_cursor, CursorShape 
 
 		if (p_shape == current_cursor) {
 			if (mouse_mode == MOUSE_MODE_VISIBLE || mouse_mode == MOUSE_MODE_CONFINED) {
-				for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-					XDefineCursor(x11_display, E->get().x11_window, cursors[p_shape]);
+				for (const KeyValue<WindowID, WindowData> &E : windows) {
+					XDefineCursor(x11_display, E.value.x11_window, cursors[p_shape]);
 				}
 			}
 		}
@@ -2517,8 +2517,8 @@ void DisplayServerX11::_xim_destroy_callback(::XIM im, ::XPointer client_data,
 	DisplayServerX11 *ds = reinterpret_cast<DisplayServerX11 *>(client_data);
 	ds->xim = nullptr;
 
-	for (Map<WindowID, WindowData>::Element *E = ds->windows.front(); E; E = E->next()) {
-		E->get().xic = nullptr;
+	for (KeyValue<WindowID, WindowData> &E : ds->windows) {
+		E.value.xic = nullptr;
 	}
 }
 
@@ -2526,9 +2526,9 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 	WindowID window_id = MAIN_WINDOW_ID;
 
 	// Assign the event to the relevant window
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		if (event->xany.window == E->get().x11_window) {
-			window_id = E->key();
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
+		if (event->xany.window == E.value.x11_window) {
+			window_id = E.key;
 			break;
 		}
 	}
@@ -2602,8 +2602,8 @@ void DisplayServerX11::_dispatch_input_event(const Ref<InputEvent> &p_event) {
 		callable.call((const Variant **)&evp, 1, ret, ce);
 	} else {
 		//send to all windows
-		for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-			Callable callable = E->get().input_event_callback;
+		for (KeyValue<WindowID, WindowData> &E : windows) {
+			Callable callable = E.value.input_event_callback;
 			if (callable.is_null()) {
 				continue;
 			}
@@ -2703,8 +2703,8 @@ void DisplayServerX11::process_events() {
 	if (app_focused) {
 		//verify that one of the windows has focus, else send focus out notification
 		bool focus_found = false;
-		for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-			if (E->get().focused) {
+		for (const KeyValue<WindowID, WindowData> &E : windows) {
+			if (E.value.focused) {
 				focus_found = true;
 				break;
 			}
@@ -2749,9 +2749,9 @@ void DisplayServerX11::process_events() {
 		WindowID window_id = MAIN_WINDOW_ID;
 
 		// Assign the event to the relevant window
-		for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-			if (event.xany.window == E->get().x11_window) {
-				window_id = E->key();
+		for (const KeyValue<WindowID, WindowData> &E : windows) {
+			if (event.xany.window == E.value.x11_window) {
+				window_id = E.key;
 				break;
 			}
 		}
@@ -2990,17 +2990,17 @@ void DisplayServerX11::process_events() {
 				if (mouse_mode_grab) {
 					// Show and update the cursor if confined and the window regained focus.
 
-					for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
+					for (const KeyValue<WindowID, WindowData> &E : windows) {
 						if (mouse_mode == MOUSE_MODE_CONFINED) {
-							XUndefineCursor(x11_display, E->get().x11_window);
+							XUndefineCursor(x11_display, E.value.x11_window);
 						} else if (mouse_mode == MOUSE_MODE_CAPTURED || mouse_mode == MOUSE_MODE_CONFINED_HIDDEN) { // Or re-hide it.
-							XDefineCursor(x11_display, E->get().x11_window, null_cursor);
+							XDefineCursor(x11_display, E.value.x11_window, null_cursor);
 						}
 
 						XGrabPointer(
-								x11_display, E->get().x11_window, True,
+								x11_display, E.value.x11_window, True,
 								ButtonPressMask | ButtonReleaseMask | PointerMotionMask,
-								GrabModeAsync, GrabModeAsync, E->get().x11_window, None, CurrentTime);
+								GrabModeAsync, GrabModeAsync, E.value.x11_window, None, CurrentTime);
 					}
 				}
 #ifdef TOUCH_ENABLED
@@ -3036,11 +3036,11 @@ void DisplayServerX11::process_events() {
 				_send_window_event(wd, WINDOW_EVENT_FOCUS_OUT);
 
 				if (mouse_mode_grab) {
-					for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
+					for (const KeyValue<WindowID, WindowData> &E : windows) {
 						//dear X11, I try, I really try, but you never work, you do whathever you want.
 						if (mouse_mode == MOUSE_MODE_CAPTURED) {
 							// Show the cursor if we're in captured mode so it doesn't look weird.
-							XUndefineCursor(x11_display, E->get().x11_window);
+							XUndefineCursor(x11_display, E.value.x11_window);
 						}
 					}
 					XUngrabPointer(x11_display, CurrentTime);
@@ -3052,12 +3052,12 @@ void DisplayServerX11::process_events() {
 				}*/
 
 				// Release every pointer to avoid sticky points
-				for (Map<int, Vector2>::Element *E = xi.state.front(); E; E = E->next()) {
+				for (const KeyValue<int, Vector2> &E : xi.state) {
 					Ref<InputEventScreenTouch> st;
 					st.instantiate();
-					st->set_index(E->key());
+					st->set_index(E.key);
 					st->set_window_id(window_id);
-					st->set_position(E->get());
+					st->set_position(E.value);
 					Input::get_singleton()->parse_input_event(st);
 				}
 				xi.state.clear();
@@ -3144,9 +3144,9 @@ void DisplayServerX11::process_events() {
 						// Note: This is needed for drag & drop to work between windows,
 						// because the engine expects events to keep being processed
 						// on the same window dragging started.
-						for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-							const WindowData &wd_other = E->get();
-							WindowID window_id_other = E->key();
+						for (const KeyValue<WindowID, WindowData> &E : windows) {
+							const WindowData &wd_other = E.value;
+							WindowID window_id_other = E.key;
 							if (wd_other.focused) {
 								if (window_id_other != window_id) {
 									int x, y;
@@ -3287,8 +3287,8 @@ void DisplayServerX11::process_events() {
 					// Note: This is needed for drag & drop to work between windows,
 					// because the engine expects events to keep being processed
 					// on the same window dragging started.
-					for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-						const WindowData &wd_other = E->get();
+					for (const KeyValue<WindowID, WindowData> &E : windows) {
+						const WindowData &wd_other = E.value;
 						if (wd_other.focused) {
 							int x, y;
 							Window child;
@@ -3296,7 +3296,7 @@ void DisplayServerX11::process_events() {
 
 							Point2i pos_focused(x, y);
 
-							mm->set_window_id(E->key());
+							mm->set_window_id(E.key);
 							mm->set_position(pos_focused);
 							mm->set_global_position(pos_focused);
 							mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
@@ -3487,8 +3487,8 @@ void DisplayServerX11::set_context(Context p_context) {
 
 	context = p_context;
 
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		_update_context(E->get());
+	for (KeyValue<WindowID, WindowData> &E : windows) {
+		_update_context(E.value);
 	}
 }
 
@@ -4268,14 +4268,14 @@ DisplayServerX11::~DisplayServerX11() {
 	events_thread.wait_to_finish();
 
 	//destroy all windows
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
+	for (KeyValue<WindowID, WindowData> &E : windows) {
 #ifdef VULKAN_ENABLED
 		if (rendering_driver == "vulkan") {
-			context_vulkan->window_destroy(E->key());
+			context_vulkan->window_destroy(E.key);
 		}
 #endif
 
-		WindowData &wd = E->get();
+		WindowData &wd = E.value;
 		if (wd.xic) {
 			XDestroyIC(wd.xic);
 			wd.xic = nullptr;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -454,8 +454,8 @@ Vector<DisplayServer::WindowID> DisplayServerWindows::get_window_list() const {
 	_THREAD_SAFE_METHOD_
 
 	Vector<DisplayServer::WindowID> ret;
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
+		ret.push_back(E.key);
 	}
 	return ret;
 }
@@ -465,9 +465,9 @@ DisplayServer::WindowID DisplayServerWindows::get_window_at_screen_position(cons
 	p.x = p_position.x;
 	p.y = p_position.y;
 	HWND hwnd = WindowFromPoint(p);
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		if (E->get().hWnd == hwnd) {
-			return E->key();
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
+		if (E.value.hWnd == hwnd) {
+			return E.key;
 		}
 	}
 
@@ -1131,8 +1131,8 @@ bool DisplayServerWindows::window_can_draw(WindowID p_window) const {
 bool DisplayServerWindows::can_any_window_draw() const {
 	_THREAD_SAFE_METHOD_
 
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		if (!E->get().minimized) {
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
+		if (!E.value.minimized) {
 			return true;
 		}
 	}
@@ -1816,8 +1816,8 @@ void DisplayServerWindows::_dispatch_input_event(const Ref<InputEvent> &p_event)
 		callable.call((const Variant **)&evp, 1, ret, ce);
 	} else {
 		// Send to all windows.
-		for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-			Callable callable = E->get().input_event_callback;
+		for (const KeyValue<WindowID, WindowData> &E : windows) {
+			const Callable callable = E.value.input_event_callback;
 			if (callable.is_null()) {
 				continue;
 			}
@@ -1844,9 +1844,9 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 	bool window_created = false;
 
 	// Check whether window exists.
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		if (E->get().hWnd == hWnd) {
-			window_id = E->key();
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
+		if (E.value.hWnd == hWnd) {
+			window_id = E.key;
 			window_created = true;
 			break;
 		}
@@ -1882,8 +1882,8 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			ReleaseCapture();
 
 			// Release every touch to avoid sticky points.
-			for (Map<int, Vector2>::Element *E = touch_state.front(); E; E = E->next()) {
-				_touch_event(window_id, false, E->get().x, E->get().y, E->key());
+			for (const KeyValue<int, Vector2> &E : touch_state) {
+				_touch_event(window_id, false, E.value.x, E.value.y, E.key);
 			}
 			touch_state.clear();
 
@@ -2943,8 +2943,8 @@ void DisplayServerWindows::_process_key_events() {
 }
 
 void DisplayServerWindows::_update_tablet_ctx(const String &p_old_driver, const String &p_new_driver) {
-	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
-		WindowData &wd = E->get();
+	for (KeyValue<WindowID, WindowData> &E : windows) {
+		WindowData &wd = E.value;
 		wd.block_mm = false;
 		if ((p_old_driver == "wintab") && wintab_available && wd.wtctx) {
 			wintab_WTEnable(wd.wtctx, false);

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -300,8 +300,8 @@ void Area2D::_clear_monitoring() {
 		body_map.clear();
 		//disconnect all monitored stuff
 
-		for (Map<ObjectID, BodyState>::Element *E = bmcopy.front(); E; E = E->next()) {
-			Object *obj = ObjectDB::get_instance(E->key());
+		for (const KeyValue<ObjectID, BodyState> &E : bmcopy) {
+			Object *obj = ObjectDB::get_instance(E.key);
 			Node *node = Object::cast_to<Node>(obj);
 
 			if (!node) { //node may have been deleted in previous frame or at other legitimate point
@@ -311,12 +311,12 @@ void Area2D::_clear_monitoring() {
 			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_body_enter_tree));
 			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_body_exit_tree));
 
-			if (!E->get().in_tree) {
+			if (!E.value.in_tree) {
 				continue;
 			}
 
-			for (int i = 0; i < E->get().shapes.size(); i++) {
-				emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E->get().rid, node, E->get().shapes[i].body_shape, E->get().shapes[i].area_shape);
+			for (int i = 0; i < E.value.shapes.size(); i++) {
+				emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E.value.rid, node, E.value.shapes[i].body_shape, E.value.shapes[i].area_shape);
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
@@ -328,8 +328,8 @@ void Area2D::_clear_monitoring() {
 		area_map.clear();
 		//disconnect all monitored stuff
 
-		for (Map<ObjectID, AreaState>::Element *E = bmcopy.front(); E; E = E->next()) {
-			Object *obj = ObjectDB::get_instance(E->key());
+		for (const KeyValue<ObjectID, AreaState> &E : bmcopy) {
+			Object *obj = ObjectDB::get_instance(E.key);
 			Node *node = Object::cast_to<Node>(obj);
 
 			if (!node) { //node may have been deleted in previous frame or at other legitimate point
@@ -339,12 +339,12 @@ void Area2D::_clear_monitoring() {
 			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_area_enter_tree));
 			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_area_exit_tree));
 
-			if (!E->get().in_tree) {
+			if (!E.value.in_tree) {
 				continue;
 			}
 
-			for (int i = 0; i < E->get().shapes.size(); i++) {
-				emit_signal(SceneStringNames::get_singleton()->area_shape_exited, E->get().rid, node, E->get().shapes[i].area_shape, E->get().shapes[i].self_shape);
+			for (int i = 0; i < E.value.shapes.size(); i++) {
+				emit_signal(SceneStringNames::get_singleton()->area_shape_exited, E.value.rid, node, E.value.shapes[i].area_shape, E.value.shapes[i].self_shape);
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
@@ -404,8 +404,8 @@ TypedArray<Node2D> Area2D::get_overlapping_bodies() const {
 	TypedArray<Node2D> ret;
 	ret.resize(body_map.size());
 	int idx = 0;
-	for (const Map<ObjectID, BodyState>::Element *E = body_map.front(); E; E = E->next()) {
-		Object *obj = ObjectDB::get_instance(E->key());
+	for (const KeyValue<ObjectID, BodyState> &E : body_map) {
+		Object *obj = ObjectDB::get_instance(E.key);
 		if (!obj) {
 			ret.resize(ret.size() - 1); //ops
 		} else {
@@ -421,8 +421,8 @@ TypedArray<Area2D> Area2D::get_overlapping_areas() const {
 	TypedArray<Area2D> ret;
 	ret.resize(area_map.size());
 	int idx = 0;
-	for (const Map<ObjectID, AreaState>::Element *E = area_map.front(); E; E = E->next()) {
-		Object *obj = ObjectDB::get_instance(E->key());
+	for (const KeyValue<ObjectID, AreaState> &E : area_map) {
+		Object *obj = ObjectDB::get_instance(E.key);
 		if (!obj) {
 			ret.resize(ret.size() - 1); //ops
 		} else {

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -342,15 +342,15 @@ real_t CollisionObject2D::get_shape_owner_one_way_collision_margin(uint32_t p_ow
 }
 
 void CollisionObject2D::get_shape_owners(List<uint32_t> *r_owners) {
-	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		r_owners->push_back(E->key());
+	for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
+		r_owners->push_back(E.key);
 	}
 }
 
 Array CollisionObject2D::_get_shape_owners() {
 	Array ret;
-	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
+		ret.push_back(E.key);
 	}
 
 	return ret;
@@ -434,10 +434,10 @@ void CollisionObject2D::shape_owner_remove_shape(uint32_t p_owner, int p_shape) 
 
 	shapes[p_owner].shapes.remove(p_shape);
 
-	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		for (int i = 0; i < E->get().shapes.size(); i++) {
-			if (E->get().shapes[i].index > index_to_remove) {
-				E->get().shapes.write[i].index -= 1;
+	for (KeyValue<uint32_t, ShapeData> &E : shapes) {
+		for (int i = 0; i < E.value.shapes.size(); i++) {
+			if (E.value.shapes[i].index > index_to_remove) {
+				E.value.shapes.write[i].index -= 1;
 			}
 		}
 	}
@@ -456,10 +456,10 @@ void CollisionObject2D::shape_owner_clear_shapes(uint32_t p_owner) {
 uint32_t CollisionObject2D::shape_find_owner(int p_shape_index) const {
 	ERR_FAIL_INDEX_V(p_shape_index, total_subshapes, 0);
 
-	for (const Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		for (int i = 0; i < E->get().shapes.size(); i++) {
-			if (E->get().shapes[i].index == p_shape_index) {
-				return E->key();
+	for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
+		for (int i = 0; i < E.value.shapes.size(); i++) {
+			if (E.value.shapes[i].index == p_shape_index) {
+				return E.key;
 			}
 		}
 	}

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -462,9 +462,9 @@ void RigidDynamicBody2D::_body_state_changed(PhysicsDirectBodyState2D *p_state) 
 
 		//untag all
 		int rc = 0;
-		for (Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
-			for (int i = 0; i < E->get().shapes.size(); i++) {
-				E->get().shapes[i].tagged = false;
+		for (KeyValue<ObjectID, BodyState> &E : contact_monitor->body_map) {
+			for (int i = 0; i < E.value.shapes.size(); i++) {
+				E.value.shapes[i].tagged = false;
 				rc++;
 			}
 		}
@@ -508,12 +508,12 @@ void RigidDynamicBody2D::_body_state_changed(PhysicsDirectBodyState2D *p_state) 
 
 		//put the ones to remove
 
-		for (Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
-			for (int i = 0; i < E->get().shapes.size(); i++) {
-				if (!E->get().shapes[i].tagged) {
-					toremove[toremove_count].rid = E->get().rid;
-					toremove[toremove_count].body_id = E->key();
-					toremove[toremove_count].pair = E->get().shapes[i];
+		for (const KeyValue<ObjectID, BodyState> &E : contact_monitor->body_map) {
+			for (int i = 0; i < E.value.shapes.size(); i++) {
+				if (!E.value.shapes[i].tagged) {
+					toremove[toremove_count].rid = E.value.rid;
+					toremove[toremove_count].body_id = E.key;
+					toremove[toremove_count].pair = E.value.shapes[i];
 					toremove_count++;
 				}
 			}
@@ -820,8 +820,8 @@ TypedArray<Node2D> RigidDynamicBody2D::get_colliding_bodies() const {
 	TypedArray<Node2D> ret;
 	ret.resize(contact_monitor->body_map.size());
 	int idx = 0;
-	for (const Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
-		Object *obj = ObjectDB::get_instance(E->key());
+	for (const KeyValue<ObjectID, BodyState> &E : contact_monitor->body_map) {
+		Object *obj = ObjectDB::get_instance(E.key);
 		if (!obj) {
 			ret.resize(ret.size() - 1); //ops
 		} else {
@@ -840,9 +840,9 @@ void RigidDynamicBody2D::set_contact_monitor(bool p_enabled) {
 	if (!p_enabled) {
 		ERR_FAIL_COND_MSG(contact_monitor->locked, "Can't disable contact monitoring during in/out callback. Use call_deferred(\"set_contact_monitor\", false) instead.");
 
-		for (Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
+		for (const KeyValue<ObjectID, BodyState> &E : contact_monitor->body_map) {
 			//clean up mess
-			Object *obj = ObjectDB::get_instance(E->key());
+			Object *obj = ObjectDB::get_instance(E.key);
 			Node *node = Object::cast_to<Node>(obj);
 
 			if (node) {

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -262,8 +262,8 @@ void Area3D::_clear_monitoring() {
 		body_map.clear();
 		//disconnect all monitored stuff
 
-		for (Map<ObjectID, BodyState>::Element *E = bmcopy.front(); E; E = E->next()) {
-			Object *obj = ObjectDB::get_instance(E->key());
+		for (const KeyValue<ObjectID, BodyState> &E : bmcopy) {
+			Object *obj = ObjectDB::get_instance(E.key);
 			Node *node = Object::cast_to<Node>(obj);
 
 			if (!node) { //node may have been deleted in previous frame or at other legitimate point
@@ -274,12 +274,12 @@ void Area3D::_clear_monitoring() {
 			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_body_enter_tree));
 			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_body_exit_tree));
 
-			if (!E->get().in_tree) {
+			if (!E.value.in_tree) {
 				continue;
 			}
 
-			for (int i = 0; i < E->get().shapes.size(); i++) {
-				emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E->get().rid, node, E->get().shapes[i].body_shape, E->get().shapes[i].area_shape);
+			for (int i = 0; i < E.value.shapes.size(); i++) {
+				emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E.value.rid, node, E.value.shapes[i].body_shape, E.value.shapes[i].area_shape);
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->body_exited, node);
@@ -291,8 +291,8 @@ void Area3D::_clear_monitoring() {
 		area_map.clear();
 		//disconnect all monitored stuff
 
-		for (Map<ObjectID, AreaState>::Element *E = bmcopy.front(); E; E = E->next()) {
-			Object *obj = ObjectDB::get_instance(E->key());
+		for (const KeyValue<ObjectID, AreaState> &E : bmcopy) {
+			Object *obj = ObjectDB::get_instance(E.key);
 			Node *node = Object::cast_to<Node>(obj);
 
 			if (!node) { //node may have been deleted in previous frame or at other legitimate point
@@ -303,12 +303,12 @@ void Area3D::_clear_monitoring() {
 			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_area_enter_tree));
 			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_area_exit_tree));
 
-			if (!E->get().in_tree) {
+			if (!E.value.in_tree) {
 				continue;
 			}
 
-			for (int i = 0; i < E->get().shapes.size(); i++) {
-				emit_signal(SceneStringNames::get_singleton()->area_shape_exited, E->get().rid, node, E->get().shapes[i].area_shape, E->get().shapes[i].self_shape);
+			for (int i = 0; i < E.value.shapes.size(); i++) {
+				emit_signal(SceneStringNames::get_singleton()->area_shape_exited, E.value.rid, node, E.value.shapes[i].area_shape, E.value.shapes[i].self_shape);
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
@@ -446,8 +446,8 @@ TypedArray<Node3D> Area3D::get_overlapping_bodies() const {
 	Array ret;
 	ret.resize(body_map.size());
 	int idx = 0;
-	for (const Map<ObjectID, BodyState>::Element *E = body_map.front(); E; E = E->next()) {
-		Object *obj = ObjectDB::get_instance(E->key());
+	for (const KeyValue<ObjectID, BodyState> &E : body_map) {
+		Object *obj = ObjectDB::get_instance(E.key);
 		if (!obj) {
 			ret.resize(ret.size() - 1); //ops
 		} else {
@@ -479,8 +479,8 @@ TypedArray<Area3D> Area3D::get_overlapping_areas() const {
 	Array ret;
 	ret.resize(area_map.size());
 	int idx = 0;
-	for (const Map<ObjectID, AreaState>::Element *E = area_map.front(); E; E = E->next()) {
-		Object *obj = ObjectDB::get_instance(E->key());
+	for (const KeyValue<ObjectID, AreaState> &E : area_map) {
+		Object *obj = ObjectDB::get_instance(E.key);
 		if (!obj) {
 			ret.resize(ret.size() - 1); //ops
 		} else {

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -37,8 +37,8 @@ void CollisionObject3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (_are_collision_shapes_visible()) {
 				debug_shape_old_transform = get_global_transform();
-				for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-					debug_shapes_to_update.insert(E->key());
+				for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
+					debug_shapes_to_update.insert(E.key);
 				}
 				_update_debug_shapes();
 			}
@@ -324,8 +324,8 @@ void CollisionObject3D::_update_shape_data(uint32_t p_owner) {
 }
 
 void CollisionObject3D::_shape_changed(const Ref<Shape3D> &p_shape) {
-	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		ShapeData &shapedata = E->get();
+	for (KeyValue<uint32_t, ShapeData> &E : shapes) {
+		ShapeData &shapedata = E.value;
 		ShapeData::ShapeBase *shapes = shapedata.shapes.ptrw();
 		for (int i = 0; i < shapedata.shapes.size(); i++) {
 			ShapeData::ShapeBase &s = shapes[i];
@@ -380,8 +380,8 @@ void CollisionObject3D::_update_debug_shapes() {
 }
 
 void CollisionObject3D::_clear_debug_shapes() {
-	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		ShapeData &shapedata = E->get();
+	for (KeyValue<uint32_t, ShapeData> &E : shapes) {
+		ShapeData &shapedata = E.value;
 		ShapeData::ShapeBase *shapes = shapedata.shapes.ptrw();
 		for (int i = 0; i < shapedata.shapes.size(); i++) {
 			ShapeData::ShapeBase &s = shapes[i];
@@ -400,8 +400,8 @@ void CollisionObject3D::_clear_debug_shapes() {
 void CollisionObject3D::_on_transform_changed() {
 	if (debug_shapes_count > 0 && !debug_shape_old_transform.is_equal_approx(get_global_transform())) {
 		debug_shape_old_transform = get_global_transform();
-		for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-			ShapeData &shapedata = E->get();
+		for (KeyValue<uint32_t, ShapeData> &E : shapes) {
+			ShapeData &shapedata = E.value;
 			const ShapeData::ShapeBase *shapes = shapedata.shapes.ptr();
 			for (int i = 0; i < shapedata.shapes.size(); i++) {
 				RS::get_singleton()->instance_set_transform(shapes[i].debug_shape, debug_shape_old_transform * shapedata.xform);
@@ -523,15 +523,15 @@ bool CollisionObject3D::is_shape_owner_disabled(uint32_t p_owner) const {
 }
 
 void CollisionObject3D::get_shape_owners(List<uint32_t> *r_owners) {
-	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		r_owners->push_back(E->key());
+	for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
+		r_owners->push_back(E.key);
 	}
 }
 
 Array CollisionObject3D::_get_shape_owners() {
 	Array ret;
-	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		ret.push_back(E->key());
+	for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
+		ret.push_back(E.key);
 	}
 
 	return ret;
@@ -628,10 +628,10 @@ void CollisionObject3D::shape_owner_remove_shape(uint32_t p_owner, int p_shape) 
 
 	shapes[p_owner].shapes.remove(p_shape);
 
-	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		for (int i = 0; i < E->get().shapes.size(); i++) {
-			if (E->get().shapes[i].index > index_to_remove) {
-				E->get().shapes.write[i].index -= 1;
+	for (KeyValue<uint32_t, ShapeData> &E : shapes) {
+		for (int i = 0; i < E.value.shapes.size(); i++) {
+			if (E.value.shapes[i].index > index_to_remove) {
+				E.value.shapes.write[i].index -= 1;
 			}
 		}
 	}
@@ -650,10 +650,10 @@ void CollisionObject3D::shape_owner_clear_shapes(uint32_t p_owner) {
 uint32_t CollisionObject3D::shape_find_owner(int p_shape_index) const {
 	ERR_FAIL_INDEX_V(p_shape_index, total_subshapes, 0);
 
-	for (const Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
-		for (int i = 0; i < E->get().shapes.size(); i++) {
-			if (E->get().shapes[i].index == p_shape_index) {
-				return E->key();
+	for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
+		for (int i = 0; i < E.value.shapes.size(); i++) {
+			if (E.value.shapes[i].index == p_shape_index) {
+				return E.key;
 			}
 		}
 	}

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -86,8 +86,8 @@ bool MeshInstance3D::_get(const StringName &p_name, Variant &r_ret) const {
 
 void MeshInstance3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<String> ls;
-	for (const Map<StringName, BlendShapeTrack>::Element *E = blend_shape_tracks.front(); E; E = E->next()) {
-		ls.push_back(E->key());
+	for (const KeyValue<StringName, BlendShapeTrack> &E : blend_shape_tracks) {
+		ls.push_back(E.key);
 	}
 
 	ls.sort();

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -516,9 +516,9 @@ void RigidDynamicBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) 
 
 		//untag all
 		int rc = 0;
-		for (Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
-			for (int i = 0; i < E->get().shapes.size(); i++) {
-				E->get().shapes[i].tagged = false;
+		for (KeyValue<ObjectID, BodyState> &E : contact_monitor->body_map) {
+			for (int i = 0; i < E.value.shapes.size(); i++) {
+				E.value.shapes[i].tagged = false;
 				rc++;
 			}
 		}
@@ -564,12 +564,12 @@ void RigidDynamicBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) 
 
 		//put the ones to remove
 
-		for (Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
-			for (int i = 0; i < E->get().shapes.size(); i++) {
-				if (!E->get().shapes[i].tagged) {
-					toremove[toremove_count].rid = E->get().rid;
-					toremove[toremove_count].body_id = E->key();
-					toremove[toremove_count].pair = E->get().shapes[i];
+		for (const KeyValue<ObjectID, BodyState> &E : contact_monitor->body_map) {
+			for (int i = 0; i < E.value.shapes.size(); i++) {
+				if (!E.value.shapes[i].tagged) {
+					toremove[toremove_count].rid = E.value.rid;
+					toremove[toremove_count].body_id = E.key;
+					toremove[toremove_count].pair = E.value.shapes[i];
 					toremove_count++;
 				}
 			}
@@ -889,9 +889,9 @@ void RigidDynamicBody3D::set_contact_monitor(bool p_enabled) {
 	if (!p_enabled) {
 		ERR_FAIL_COND_MSG(contact_monitor->locked, "Can't disable contact monitoring during in/out callback. Use call_deferred(\"set_contact_monitor\", false) instead.");
 
-		for (Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
+		for (const KeyValue<ObjectID, BodyState> &E : contact_monitor->body_map) {
 			//clean up mess
-			Object *obj = ObjectDB::get_instance(E->key());
+			Object *obj = ObjectDB::get_instance(E.key);
 			Node *node = Object::cast_to<Node>(obj);
 
 			if (node) {
@@ -918,8 +918,8 @@ Array RigidDynamicBody3D::get_colliding_bodies() const {
 	Array ret;
 	ret.resize(contact_monitor->body_map.size());
 	int idx = 0;
-	for (const Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.front(); E; E = E->next()) {
-		Object *obj = ObjectDB::get_instance(E->key());
+	for (const KeyValue<ObjectID, BodyState> &E : contact_monitor->body_map) {
+		Object *obj = ObjectDB::get_instance(E.key);
 		if (!obj) {
 			ret.resize(ret.size() - 1); //ops
 		} else {

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -828,9 +828,9 @@ Ref<AnimationNode> AnimationNodeBlendTree::get_node(const StringName &p_name) co
 }
 
 StringName AnimationNodeBlendTree::get_node_name(const Ref<AnimationNode> &p_node) const {
-	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
-		if (E->get().node == p_node) {
-			return E->key();
+	for (const KeyValue<StringName, Node> &E : nodes) {
+		if (E.value.node == p_node) {
+			return E.key;
 		}
 	}
 
@@ -850,8 +850,8 @@ Vector2 AnimationNodeBlendTree::get_node_position(const StringName &p_node) cons
 void AnimationNodeBlendTree::get_child_nodes(List<ChildNode> *r_child_nodes) {
 	Vector<StringName> ns;
 
-	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
-		ns.push_back(E->key());
+	for (const KeyValue<StringName, Node> &E : nodes) {
+		ns.push_back(E.key);
 	}
 
 	ns.sort_custom<StringName::AlphCompare>();
@@ -886,10 +886,10 @@ void AnimationNodeBlendTree::remove_node(const StringName &p_name) {
 	nodes.erase(p_name);
 
 	//erase connections to name
-	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
-		for (int i = 0; i < E->get().connections.size(); i++) {
-			if (E->get().connections[i] == p_name) {
-				E->get().connections.write[i] = StringName();
+	for (KeyValue<StringName, Node> &E : nodes) {
+		for (int i = 0; i < E.value.connections.size(); i++) {
+			if (E.value.connections[i] == p_name) {
+				E.value.connections.write[i] = StringName();
 			}
 		}
 	}
@@ -910,10 +910,10 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 	nodes.erase(p_name);
 
 	//rename connections
-	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
-		for (int i = 0; i < E->get().connections.size(); i++) {
-			if (E->get().connections[i] == p_name) {
-				E->get().connections.write[i] = p_new_name;
+	for (KeyValue<StringName, Node> &E : nodes) {
+		for (int i = 0; i < E.value.connections.size(); i++) {
+			if (E.value.connections[i] == p_name) {
+				E.value.connections.write[i] = p_new_name;
 			}
 		}
 	}
@@ -932,9 +932,9 @@ void AnimationNodeBlendTree::connect_node(const StringName &p_input_node, int p_
 	Ref<AnimationNode> input = nodes[p_input_node].node;
 	ERR_FAIL_INDEX(p_input_index, nodes[p_input_node].connections.size());
 
-	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
-		for (int i = 0; i < E->get().connections.size(); i++) {
-			StringName output = E->get().connections[i];
+	for (KeyValue<StringName, Node> &E : nodes) {
+		for (int i = 0; i < E.value.connections.size(); i++) {
+			StringName output = E.value.connections[i];
 			ERR_FAIL_COND(output == p_output_node);
 		}
 	}
@@ -976,9 +976,9 @@ AnimationNodeBlendTree::ConnectionError AnimationNodeBlendTree::can_connect_node
 		return CONNECTION_ERROR_CONNECTION_EXISTS;
 	}
 
-	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
-		for (int i = 0; i < E->get().connections.size(); i++) {
-			const StringName output = E->get().connections[i];
+	for (const KeyValue<StringName, Node> &E : nodes) {
+		for (int i = 0; i < E.value.connections.size(); i++) {
+			const StringName output = E.value.connections[i];
 			if (output == p_output_node) {
 				return CONNECTION_ERROR_CONNECTION_EXISTS;
 			}
@@ -988,12 +988,12 @@ AnimationNodeBlendTree::ConnectionError AnimationNodeBlendTree::can_connect_node
 }
 
 void AnimationNodeBlendTree::get_node_connections(List<NodeConnection> *r_connections) const {
-	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
-		for (int i = 0; i < E->get().connections.size(); i++) {
-			const StringName output = E->get().connections[i];
+	for (const KeyValue<StringName, Node> &E : nodes) {
+		for (int i = 0; i < E.value.connections.size(); i++) {
+			const StringName output = E.value.connections[i];
 			if (output != StringName()) {
 				NodeConnection nc;
-				nc.input_node = E->key();
+				nc.input_node = E.key;
 				nc.input_index = i;
 				nc.output_node = output;
 				r_connections->push_back(nc);
@@ -1012,8 +1012,8 @@ double AnimationNodeBlendTree::process(double p_time, bool p_seek) {
 }
 
 void AnimationNodeBlendTree::get_node_list(List<StringName> *r_list) {
-	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
-		r_list->push_back(E->key());
+	for (const KeyValue<StringName, Node> &E : nodes) {
+		r_list->push_back(E.key);
 	}
 }
 
@@ -1104,8 +1104,8 @@ bool AnimationNodeBlendTree::_get(const StringName &p_name, Variant &r_ret) cons
 
 void AnimationNodeBlendTree::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<StringName> names;
-	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
-		names.push_back(E->key());
+	for (const KeyValue<StringName, Node> &E : nodes) {
+		names.push_back(E.key);
 	}
 	names.sort_custom<StringName::AlphCompare>();
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -978,7 +978,7 @@ AnimationNodeBlendTree::ConnectionError AnimationNodeBlendTree::can_connect_node
 
 	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
 		for (int i = 0; i < E->get().connections.size(); i++) {
-			StringName output = E->get().connections[i];
+			const StringName output = E->get().connections[i];
 			if (output == p_output_node) {
 				return CONNECTION_ERROR_CONNECTION_EXISTS;
 			}
@@ -990,7 +990,7 @@ AnimationNodeBlendTree::ConnectionError AnimationNodeBlendTree::can_connect_node
 void AnimationNodeBlendTree::get_node_connections(List<NodeConnection> *r_connections) const {
 	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
 		for (int i = 0; i < E->get().connections.size(); i++) {
-			StringName output = E->get().connections[i];
+			const StringName output = E->get().connections[i];
 			if (output != StringName()) {
 				NodeConnection nc;
 				nc.input_node = E->key();

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -571,9 +571,9 @@ Ref<AnimationNode> AnimationNodeStateMachine::get_node(const StringName &p_name)
 }
 
 StringName AnimationNodeStateMachine::get_node_name(const Ref<AnimationNode> &p_node) const {
-	for (Map<StringName, State>::Element *E = states.front(); E; E = E->next()) {
-		if (E->get().node == p_node) {
-			return E->key();
+	for (const KeyValue<StringName, State> &E : states) {
+		if (E.value.node == p_node) {
+			return E.key;
 		}
 	}
 
@@ -583,8 +583,8 @@ StringName AnimationNodeStateMachine::get_node_name(const Ref<AnimationNode> &p_
 void AnimationNodeStateMachine::get_child_nodes(List<ChildNode> *r_child_nodes) {
 	Vector<StringName> nodes;
 
-	for (Map<StringName, State>::Element *E = states.front(); E; E = E->next()) {
-		nodes.push_back(E->key());
+	for (const KeyValue<StringName, State> &E : states) {
+		nodes.push_back(E.key);
 	}
 
 	nodes.sort_custom<StringName::AlphCompare>();
@@ -674,8 +674,8 @@ void AnimationNodeStateMachine::rename_node(const StringName &p_name, const Stri
 
 void AnimationNodeStateMachine::get_node_list(List<StringName> *r_nodes) const {
 	List<StringName> nodes;
-	for (Map<StringName, State>::Element *E = states.front(); E; E = E->next()) {
-		nodes.push_back(E->key());
+	for (const KeyValue<StringName, State> &E : states) {
+		nodes.push_back(E.key);
 	}
 	nodes.sort_custom<StringName::AlphCompare>();
 
@@ -897,8 +897,8 @@ bool AnimationNodeStateMachine::_get(const StringName &p_name, Variant &r_ret) c
 
 void AnimationNodeStateMachine::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<StringName> names;
-	for (Map<StringName, State>::Element *E = states.front(); E; E = E->next()) {
-		names.push_back(E->key());
+	for (const KeyValue<StringName, State> &E : states) {
+		names.push_back(E.key);
 	}
 	names.sort_custom<StringName::AlphCompare>();
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -124,8 +124,8 @@ bool AnimationPlayer::_get(const StringName &p_name, Variant &r_ret) const {
 
 	} else if (name == "blend_times") {
 		Vector<BlendKey> keys;
-		for (Map<BlendKey, float>::Element *E = blend_times.front(); E; E = E->next()) {
-			keys.ordered_insert(E->key());
+		for (const KeyValue<BlendKey, float> &E : blend_times) {
+			keys.ordered_insert(E.key);
 		}
 
 		Array array;
@@ -147,8 +147,8 @@ void AnimationPlayer::_validate_property(PropertyInfo &property) const {
 	if (property.name == "current_animation") {
 		List<String> names;
 
-		for (Map<StringName, AnimationData>::Element *E = animation_set.front(); E; E = E->next()) {
-			names.push_back(E->key());
+		for (const KeyValue<StringName, AnimationData> &E : animation_set) {
+			names.push_back(E.key);
 		}
 		names.sort();
 		names.push_front("[stop]");
@@ -167,10 +167,10 @@ void AnimationPlayer::_validate_property(PropertyInfo &property) const {
 void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<PropertyInfo> anim_names;
 
-	for (Map<StringName, AnimationData>::Element *E = animation_set.front(); E; E = E->next()) {
-		anim_names.push_back(PropertyInfo(Variant::OBJECT, "anims/" + String(E->key()), PROPERTY_HINT_RESOURCE_TYPE, "Animation", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE));
-		if (E->get().next != StringName()) {
-			anim_names.push_back(PropertyInfo(Variant::STRING, "next/" + String(E->key()), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
+		anim_names.push_back(PropertyInfo(Variant::OBJECT, "anims/" + String(E.key), PROPERTY_HINT_RESOURCE_TYPE, "Animation", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE));
+		if (E.value.next != StringName()) {
+			anim_names.push_back(PropertyInfo(Variant::STRING, "next/" + String(E.key), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 		}
 	}
 
@@ -1019,8 +1019,8 @@ void AnimationPlayer::rename_animation(const StringName &p_name, const StringNam
 
 	List<BlendKey> to_erase;
 	Map<BlendKey, float> to_insert;
-	for (Map<BlendKey, float>::Element *E = blend_times.front(); E; E = E->next()) {
-		BlendKey bk = E->key();
+	for (const KeyValue<BlendKey, float> &E : blend_times) {
+		BlendKey bk = E.key;
 		BlendKey new_bk = bk;
 		bool erase = false;
 		if (bk.from == p_name) {
@@ -1034,7 +1034,7 @@ void AnimationPlayer::rename_animation(const StringName &p_name, const StringNam
 
 		if (erase) {
 			to_erase.push_back(bk);
-			to_insert[new_bk] = E->get();
+			to_insert[new_bk] = E.value;
 		}
 	}
 
@@ -1071,8 +1071,8 @@ Ref<Animation> AnimationPlayer::get_animation(const StringName &p_name) const {
 void AnimationPlayer::get_animation_list(List<StringName> *p_animations) const {
 	List<String> anims;
 
-	for (Map<StringName, AnimationData>::Element *E = animation_set.front(); E; E = E->next()) {
-		anims.push_back(E->key());
+	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
+		anims.push_back(E.key);
 	}
 
 	anims.sort();
@@ -1365,8 +1365,8 @@ void AnimationPlayer::clear_caches() {
 
 	node_cache_map.clear();
 
-	for (Map<StringName, AnimationData>::Element *E = animation_set.front(); E; E = E->next()) {
-		E->get().node_cache.clear();
+	for (KeyValue<StringName, AnimationData> &E : animation_set) {
+		E.value.node_cache.clear();
 	}
 
 	cache_update_size = 0;
@@ -1388,9 +1388,9 @@ bool AnimationPlayer::is_active() const {
 }
 
 StringName AnimationPlayer::find_animation(const Ref<Animation> &p_animation) const {
-	for (Map<StringName, AnimationData>::Element *E = animation_set.front(); E; E = E->next()) {
-		if (E->get().animation == p_animation) {
-			return E->key();
+	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
+		if (E.value.animation == p_animation) {
+			return E.key;
 		}
 	}
 
@@ -1545,12 +1545,12 @@ Ref<AnimatedValuesBackup> AnimationPlayer::backup_animated_values(Node *p_root_o
 				entry.bone_idx = -1;
 				backup->entries.push_back(entry);
 			} else {
-				for (Map<StringName, TrackNodeCache::PropertyAnim>::Element *E = nc->property_anim.front(); E; E = E->next()) {
+				for (const KeyValue<StringName, TrackNodeCache::PropertyAnim> &E : nc->property_anim) {
 					AnimatedValuesBackup::Entry entry;
-					entry.object = E->value().object;
-					entry.subpath = E->value().subpath;
+					entry.object = E.value.object;
+					entry.subpath = E.value.subpath;
 					bool valid;
-					entry.value = E->value().object->get_indexed(E->value().subpath, &valid);
+					entry.value = E.value.object->get_indexed(E.value.subpath, &valid);
 					entry.bone_idx = -1;
 					if (valid) {
 						backup->entries.push_back(entry);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -249,8 +249,8 @@ void SceneDebugger::remove_from_cache(const String &p_filename, Node *p_node) {
 	Map<Node *, Map<ObjectID, Node *>> &remove_list = debugger->live_edit_remove_list;
 	Map<Node *, Map<ObjectID, Node *>>::Element *F = remove_list.find(p_node);
 	if (F) {
-		for (Map<ObjectID, Node *>::Element *G = F->get().front(); G; G = G->next()) {
-			memdelete(G->get());
+		for (const KeyValue<ObjectID, Node *> &G : F->get()) {
+			memdelete(G.value);
 		}
 		remove_list.erase(F);
 	}
@@ -339,15 +339,15 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 	}
 	// Constants
 	for (ScriptConstantsMap::Element *sc = constants.front(); sc; sc = sc->next()) {
-		for (Map<StringName, Variant>::Element *E = sc->get().front(); E; E = E->next()) {
+		for (const KeyValue<StringName, Variant> &E : sc->get()) {
 			String script_path = sc->key() == p_script ? "" : sc->key()->get_path().get_file() + "/";
-			if (E->value().get_type() == Variant::OBJECT) {
-				Variant id = ((Object *)E->value())->get_instance_id();
-				PropertyInfo pi(id.get_type(), "Constants/" + E->key(), PROPERTY_HINT_OBJECT_ID, "Object");
+			if (E.value.get_type() == Variant::OBJECT) {
+				Variant id = ((Object *)E.value)->get_instance_id();
+				PropertyInfo pi(id.get_type(), "Constants/" + E.key, PROPERTY_HINT_OBJECT_ID, "Object");
 				properties.push_back(SceneDebuggerProperty(pi, id));
 			} else {
-				PropertyInfo pi(E->value().get_type(), "Constants/" + script_path + E->key());
-				properties.push_back(SceneDebuggerProperty(pi, E->value()));
+				PropertyInfo pi(E.value.get_type(), "Constants/" + script_path + E.key);
+				properties.push_back(SceneDebuggerProperty(pi, E.value));
 			}
 		}
 	}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1620,12 +1620,12 @@ Point2 CodeEdit::get_delimiter_start_position(int p_line, int p_column) const {
 	bool in_region = ((p_line <= 0 || delimiter_cache[p_line - 1].size() < 1) ? -1 : delimiter_cache[p_line - 1].back()->value()) != -1;
 
 	/* Check the keys for this line. */
-	for (Map<int, int>::Element *E = delimiter_cache[p_line].front(); E; E = E->next()) {
-		if (E->key() > p_column) {
+	for (const KeyValue<int, int> &E : delimiter_cache[p_line]) {
+		if (E.key > p_column) {
 			break;
 		}
-		in_region = E->value() != -1;
-		start_position.x = in_region ? E->key() : -1;
+		in_region = E.value != -1;
+		start_position.x = in_region ? E.key : -1;
 	}
 
 	/* Region was found on this line and is not a multiline continuation. */
@@ -1671,12 +1671,12 @@ Point2 CodeEdit::get_delimiter_end_position(int p_line, int p_column) const {
 	int region = (p_line <= 0 || delimiter_cache[p_line - 1].size() < 1) ? -1 : delimiter_cache[p_line - 1].back()->value();
 
 	/* Check the keys for this line. */
-	for (Map<int, int>::Element *E = delimiter_cache[p_line].front(); E; E = E->next()) {
-		end_position.x = (E->value() == -1) ? E->key() : -1;
-		if (E->key() > p_column) {
+	for (const KeyValue<int, int> &E : delimiter_cache[p_line]) {
+		end_position.x = (E.value == -1) ? E.key : -1;
+		if (E.key > p_column) {
 			break;
 		}
-		region = E->value();
+		region = E.value;
 	}
 
 	/* Region was found on this line and is not a multiline continuation. */

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -403,28 +403,28 @@ void GraphNode::_notification(int p_what) {
 				close_rect = Rect2();
 			}
 
-			for (Map<int, Slot>::Element *E = slot_info.front(); E; E = E->next()) {
-				if (E->key() < 0 || E->key() >= cache_y.size()) {
+			for (const KeyValue<int, Slot> &E : slot_info) {
+				if (E.key < 0 || E.key >= cache_y.size()) {
 					continue;
 				}
-				if (!slot_info.has(E->key())) {
+				if (!slot_info.has(E.key)) {
 					continue;
 				}
-				const Slot &s = slot_info[E->key()];
+				const Slot &s = slot_info[E.key];
 				//left
 				if (s.enable_left) {
 					Ref<Texture2D> p = port;
 					if (s.custom_slot_left.is_valid()) {
 						p = s.custom_slot_left;
 					}
-					p->draw(get_canvas_item(), icofs + Point2(edgeofs, cache_y[E->key()]), s.color_left);
+					p->draw(get_canvas_item(), icofs + Point2(edgeofs, cache_y[E.key]), s.color_left);
 				}
 				if (s.enable_right) {
 					Ref<Texture2D> p = port;
 					if (s.custom_slot_right.is_valid()) {
 						p = s.custom_slot_right;
 					}
-					p->draw(get_canvas_item(), icofs + Point2(get_size().x - edgeofs, cache_y[E->key()]), s.color_right);
+					p->draw(get_canvas_item(), icofs + Point2(get_size().x - edgeofs, cache_y[E.key]), s.color_right);
 				}
 			}
 

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -82,15 +82,15 @@ void GridContainer::_notification(int p_what) {
 
 			// Evaluate the remaining space for expanded columns/rows.
 			Size2 remaining_space = get_size();
-			for (Map<int, int>::Element *E = col_minw.front(); E; E = E->next()) {
-				if (!col_expanded.has(E->key())) {
-					remaining_space.width -= E->get();
+			for (const KeyValue<int, int> &E : col_minw) {
+				if (!col_expanded.has(E.key)) {
+					remaining_space.width -= E.value;
 				}
 			}
 
-			for (Map<int, int>::Element *E = row_minh.front(); E; E = E->next()) {
-				if (!row_expanded.has(E->key())) {
-					remaining_space.height -= E->get();
+			for (const KeyValue<int, int> &E : row_minh) {
+				if (!row_expanded.has(E.key)) {
+					remaining_space.height -= E.value;
 				}
 			}
 			remaining_space.height -= vsep * MAX(max_row - 1, 0);
@@ -247,12 +247,12 @@ Size2 GridContainer::get_minimum_size() const {
 
 	Size2 ms;
 
-	for (Map<int, int>::Element *E = col_minw.front(); E; E = E->next()) {
-		ms.width += E->get();
+	for (const KeyValue<int, int> &E : col_minw) {
+		ms.width += E.value;
 	}
 
-	for (Map<int, int>::Element *E = row_minh.front(); E; E = E->next()) {
-		ms.height += E->get();
+	for (const KeyValue<int, int> &E : row_minh) {
+		ms.height += E.value;
 	}
 
 	ms.height += vsep * max_row;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -211,8 +211,8 @@ void Node::_propagate_enter_tree() {
 
 	data.inside_tree = true;
 
-	for (Map<StringName, GroupData>::Element *E = data.grouped.front(); E; E = E->next()) {
-		E->get().group = data.tree->add_to_group(E->key(), this);
+	for (KeyValue<StringName, GroupData> &E : data.grouped) {
+		E.value.group = data.tree->add_to_group(E.key, this);
 	}
 
 	notification(NOTIFICATION_ENTER_TREE);
@@ -274,9 +274,9 @@ void Node::_propagate_exit_tree() {
 
 	// exit groups
 
-	for (Map<StringName, GroupData>::Element *E = data.grouped.front(); E; E = E->next()) {
-		data.tree->remove_from_group(E->key(), this);
-		E->get().group = nullptr;
+	for (KeyValue<StringName, GroupData> &E : data.grouped) {
+		data.tree->remove_from_group(E.key, this);
+		E.value.group = nullptr;
 	}
 
 	data.viewport = nullptr;
@@ -353,9 +353,9 @@ void Node::_move_child(Node *p_child, int p_pos, bool p_ignore_end) {
 	for (int i = motion_from; i <= motion_to; i++) {
 		data.children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
 	}
-	for (const Map<StringName, GroupData>::Element *E = p_child->data.grouped.front(); E; E = E->next()) {
-		if (E->get().group) {
-			E->get().group->changed = true;
+	for (const KeyValue<StringName, GroupData> &E : p_child->data.grouped) {
+		if (E.value.group) {
+			E.value.group->changed = true;
 		}
 	}
 
@@ -1678,10 +1678,10 @@ Array Node::_get_groups() const {
 }
 
 void Node::get_groups(List<GroupInfo> *p_groups) const {
-	for (const Map<StringName, GroupData>::Element *E = data.grouped.front(); E; E = E->next()) {
+	for (const KeyValue<StringName, GroupData> &E : data.grouped) {
 		GroupInfo gi;
-		gi.name = E->key();
-		gi.persistent = E->get().persistent;
+		gi.name = E.key;
+		gi.persistent = E.value.persistent;
 		p_groups->push_back(gi);
 	}
 }
@@ -1689,8 +1689,8 @@ void Node::get_groups(List<GroupInfo> *p_groups) const {
 int Node::get_persistent_group_count() const {
 	int count = 0;
 
-	for (const Map<StringName, GroupData>::Element *E = data.grouped.front(); E; E = E->next()) {
-		if (E->get().persistent) {
+	for (const KeyValue<StringName, GroupData> &E : data.grouped) {
+		if (E.value.persistent) {
 			count += 1;
 		}
 	}

--- a/scene/main/resource_preloader.cpp
+++ b/scene/main/resource_preloader.cpp
@@ -57,8 +57,8 @@ Array ResourcePreloader::_get_resources() const {
 
 	Set<String> sorted_names;
 
-	for (Map<StringName, RES>::Element *E = resources.front(); E; E = E->next()) {
-		sorted_names.insert(E->key());
+	for (const KeyValue<StringName, RES> &E : resources) {
+		sorted_names.insert(E.key);
 	}
 
 	int i = 0;
@@ -131,8 +131,8 @@ Vector<String> ResourcePreloader::_get_resource_list() const {
 }
 
 void ResourcePreloader::get_resource_list(List<StringName> *p_list) {
-	for (Map<StringName, RES>::Element *E = resources.front(); E; E = E->next()) {
-		p_list->push_back(E->key());
+	for (const KeyValue<StringName, RES> &E : resources) {
+		p_list->push_back(E.key);
 	}
 }
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -966,9 +966,9 @@ PackedVector2Array Curve2D::tessellate(int p_max_stages, float p_tolerance) cons
 	int pidx = 0;
 
 	for (int i = 0; i < points.size() - 1; i++) {
-		for (Map<float, Vector2>::Element *E = midpoints[i].front(); E; E = E->next()) {
+		for (const KeyValue<float, Vector2> &E : midpoints[i]) {
 			pidx++;
-			bpw[pidx] = E->get();
+			bpw[pidx] = E.value;
 		}
 
 		pidx++;
@@ -1652,9 +1652,9 @@ PackedVector3Array Curve3D::tessellate(int p_max_stages, float p_tolerance) cons
 	int pidx = 0;
 
 	for (int i = 0; i < points.size() - 1; i++) {
-		for (Map<float, Vector3>::Element *E = midpoints[i].front(); E; E = E->next()) {
+		for (const KeyValue<float, Vector3> &E : midpoints[i]) {
 			pidx++;
-			bpw[pidx] = E->get();
+			bpw[pidx] = E.value;
 		}
 
 		pidx++;

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -373,8 +373,8 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 
 		//normalize
 
-		for (Map<Vector3, Vector3>::Element *E = normal_accum.front(); E; E = E->next()) {
-			E->get().normalize();
+		for (KeyValue<Vector3, Vector3> &E : normal_accum) {
+			E.value.normalize();
 		}
 
 		//displace normals

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -97,8 +97,8 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
-	for (Map<int, Item>::Element *E = item_map.front(); E; E = E->next()) {
-		String name = "item/" + itos(E->key()) + "/";
+	for (const KeyValue<int, Item> &E : item_map) {
+		String name = "item/" + itos(E.key) + "/";
 		p_list->push_back(PropertyInfo(Variant::STRING, name + "name"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, name + "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, name + "mesh_transform"));
@@ -230,17 +230,17 @@ Vector<int> MeshLibrary::get_item_list() const {
 	Vector<int> ret;
 	ret.resize(item_map.size());
 	int idx = 0;
-	for (Map<int, Item>::Element *E = item_map.front(); E; E = E->next()) {
-		ret.write[idx++] = E->key();
+	for (const KeyValue<int, Item> &E : item_map) {
+		ret.write[idx++] = E.key;
 	}
 
 	return ret;
 }
 
 int MeshLibrary::find_item_by_name(const String &p_name) const {
-	for (Map<int, Item>::Element *E = item_map.front(); E; E = E->next()) {
-		if (E->get().name == p_name) {
-			return E->key();
+	for (const KeyValue<int, Item> &E : item_map) {
+		if (E.value.name == p_name) {
+			return E.key;
 		}
 	}
 	return -1;

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -367,10 +367,10 @@ Ref<Mesh> NavigationMesh::get_debug_mesh() {
 	}
 	List<Vector3> lines;
 
-	for (Map<_EdgeKey, bool>::Element *E = edge_map.front(); E; E = E->next()) {
-		if (E->get()) {
-			lines.push_back(E->key().from);
-			lines.push_back(E->key().to);
+	for (const KeyValue<_EdgeKey, bool> &E : edge_map) {
+		if (E.value) {
+			lines.push_back(E.key.from);
+			lines.push_back(E.key.to);
 		}
 	}
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -299,8 +299,8 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 		}
 	}
 
-	for (Map<Ref<Resource>, Ref<Resource>>::Element *E = resources_local_to_scene.front(); E; E = E->next()) {
-		E->get()->setup_local_to_scene();
+	for (KeyValue<Ref<Resource>, Ref<Resource>> &E : resources_local_to_scene) {
+		E.value->setup_local_to_scene();
 	}
 
 	//do connections
@@ -887,8 +887,8 @@ Error SceneState::pack(Node *p_scene) {
 
 	names.resize(name_map.size());
 
-	for (Map<StringName, int>::Element *E = name_map.front(); E; E = E->next()) {
-		names.write[E->get()] = E->key();
+	for (const KeyValue<StringName, int> &E : name_map) {
+		names.write[E.value] = E.key;
 	}
 
 	variants.resize(variant_map.size());
@@ -899,14 +899,14 @@ Error SceneState::pack(Node *p_scene) {
 	}
 
 	node_paths.resize(nodepath_map.size());
-	for (Map<Node *, int>::Element *E = nodepath_map.front(); E; E = E->next()) {
-		node_paths.write[E->get()] = scene->get_path_to(E->key());
+	for (const KeyValue<Node *, int> &E : nodepath_map) {
+		node_paths.write[E.value] = scene->get_path_to(E.key);
 	}
 
 	if (Engine::get_singleton()->is_editor_hint()) {
 		// Build node path cache
-		for (Map<Node *, int>::Element *E = node_map.front(); E; E = E->next()) {
-			node_path_cache[scene->get_path_to(E->key())] = E->get();
+		for (const KeyValue<Node *, int> &E : node_map) {
+			node_path_cache[scene->get_path_to(E.key)] = E.value;
 		}
 	}
 
@@ -977,9 +977,9 @@ int SceneState::find_node_by_path(const NodePath &p_node) const {
 }
 
 int SceneState::_find_base_scene_node_remap_key(int p_idx) const {
-	for (Map<int, int>::Element *E = base_scene_node_remap.front(); E; E = E->next()) {
-		if (E->value() == p_idx) {
-			return E->key();
+	for (const KeyValue<int, int> &E : base_scene_node_remap) {
+		if (E.value == p_idx) {
+			return E.key;
 		}
 	}
 	return -1;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1653,55 +1653,55 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 #ifdef TOOLS_ENABLED
 	// Keep order from cached ids.
 	Set<String> cached_ids_found;
-	for (Map<RES, String>::Element *E = external_resources.front(); E; E = E->next()) {
-		String cached_id = E->key()->get_id_for_path(local_path);
+	for (KeyValue<RES, String> &E : external_resources) {
+		String cached_id = E.key->get_id_for_path(local_path);
 		if (cached_id == "" || cached_ids_found.has(cached_id)) {
-			int sep_pos = E->get().find("_");
+			int sep_pos = E.value.find("_");
 			if (sep_pos != -1) {
-				E->get() = E->get().substr(0, sep_pos + 1); // Keep the order found, for improved thread loading performance.
+				E.value = E.value.substr(0, sep_pos + 1); // Keep the order found, for improved thread loading performance.
 			} else {
-				E->get() = "";
+				E.value = "";
 			}
 
 		} else {
-			E->get() = cached_id;
+			E.value = cached_id;
 			cached_ids_found.insert(cached_id);
 		}
 	}
 	// Create IDs for non cached resources.
-	for (Map<RES, String>::Element *E = external_resources.front(); E; E = E->next()) {
-		if (cached_ids_found.has(E->get())) { // Already cached, go on.
+	for (KeyValue<RES, String> &E : external_resources) {
+		if (cached_ids_found.has(E.value)) { // Already cached, go on.
 			continue;
 		}
 
 		String attempt;
 		while (true) {
-			attempt = E->get() + Resource::generate_scene_unique_id();
+			attempt = E.value + Resource::generate_scene_unique_id();
 			if (!cached_ids_found.has(attempt)) {
 				break;
 			}
 		}
 
 		cached_ids_found.insert(attempt);
-		E->get() = attempt;
+		E.value = attempt;
 		// Update also in resource.
-		Ref<Resource> res = E->key();
+		Ref<Resource> res = E.key;
 		res->set_id_for_path(local_path, attempt);
 	}
 #else
 	// Make sure to start from one, as it makes format more readable.
 	int counter = 1;
-	for (Map<RES, String>::Element *E = external_resources.front(); E; E = E->next()) {
-		E->get() = itos(counter++);
+	for (KeyValue<RES, String> &E : external_resources) {
+		E.value = itos(counter++);
 	}
 #endif
 
 	Vector<ResourceSort> sorted_er;
 
-	for (Map<RES, String>::Element *E = external_resources.front(); E; E = E->next()) {
+	for (const KeyValue<RES, String> &E : external_resources) {
 		ResourceSort rs;
-		rs.resource = E->key();
-		rs.id = E->get();
+		rs.resource = E.key;
+		rs.id = E.value;
 		sorted_er.push_back(rs);
 	}
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -116,8 +116,8 @@ Ref<Texture2D> Shader::get_default_texture_param(const StringName &p_param) cons
 }
 
 void Shader::get_default_texture_param_list(List<StringName> *r_textures) const {
-	for (const Map<StringName, Ref<Texture2D>>::Element *E = default_textures.front(); E; E = E->next()) {
-		r_textures->push_back(E->key());
+	for (const KeyValue<StringName, Ref<Texture2D>> &E : default_textures) {
+		r_textures->push_back(E.key);
 	}
 }
 

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -108,15 +108,15 @@ Vector<String> SpriteFrames::_get_animation_list() const {
 }
 
 void SpriteFrames::get_animation_list(List<StringName> *r_animations) const {
-	for (const Map<StringName, Anim>::Element *E = animations.front(); E; E = E->next()) {
-		r_animations->push_back(E->key());
+	for (const KeyValue<StringName, Anim> &E : animations) {
+		r_animations->push_back(E.key);
 	}
 }
 
 Vector<String> SpriteFrames::get_animation_names() const {
 	Vector<String> names;
-	for (const Map<StringName, Anim>::Element *E = animations.front(); E; E = E->next()) {
-		names.push_back(E->key());
+	for (const KeyValue<StringName, Anim> &E : animations) {
+		names.push_back(E.key);
 	}
 	names.sort();
 	return names;
@@ -164,14 +164,14 @@ Array SpriteFrames::_get_frames() const {
 
 Array SpriteFrames::_get_animations() const {
 	Array anims;
-	for (Map<StringName, Anim>::Element *E = animations.front(); E; E = E->next()) {
+	for (const KeyValue<StringName, Anim> &E : animations) {
 		Dictionary d;
-		d["name"] = E->key();
-		d["speed"] = E->get().speed;
-		d["loop"] = E->get().loop;
+		d["name"] = E.key;
+		d["speed"] = E.value.speed;
+		d["loop"] = E.value.loop;
 		Array frames;
-		for (int i = 0; i < E->get().frames.size(); i++) {
-			frames.push_back(E->get().frames[i]);
+		for (int i = 0; i < E.value.frames.size(); i++) {
+			frames.push_back(E.value.frames[i]);
 		}
 		d["frames"] = frames;
 		anims.push_back(d);

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -66,8 +66,8 @@ const char *TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[] = {
 void TileSet::set_tile_shape(TileSet::TileShape p_shape) {
 	tile_shape = p_shape;
 
-	for (Map<int, Ref<TileSetSource>>::Element *E_source = sources.front(); E_source; E_source = E_source->next()) {
-		E_source->get()->notify_tile_data_properties_should_change();
+	for (KeyValue<int, Ref<TileSetSource>> &E_source : sources) {
+		E_source.value->notify_tile_data_properties_should_change();
 	}
 
 	terrain_bits_meshes_dirty = true;
@@ -89,8 +89,8 @@ TileSet::TileLayout TileSet::get_tile_layout() const {
 void TileSet::set_tile_offset_axis(TileSet::TileOffsetAxis p_alignment) {
 	tile_offset_axis = p_alignment;
 
-	for (Map<int, Ref<TileSetSource>>::Element *E_source = sources.front(); E_source; E_source = E_source->next()) {
-		E_source->get()->notify_tile_data_properties_should_change();
+	for (KeyValue<int, Ref<TileSetSource>> &E_source : sources) {
+		E_source.value->notify_tile_data_properties_should_change();
 	}
 
 	terrain_bits_meshes_dirty = true;
@@ -386,8 +386,8 @@ void TileSet::remove_terrain_set(int p_index) {
 void TileSet::set_terrain_set_mode(int p_terrain_set, TerrainMode p_terrain_mode) {
 	ERR_FAIL_INDEX(p_terrain_set, terrain_sets.size());
 	terrain_sets.write[p_terrain_set].mode = p_terrain_mode;
-	for (Map<int, Ref<TileSetSource>>::Element *E_source = sources.front(); E_source; E_source = E_source->next()) {
-		E_source->get()->notify_tile_data_properties_should_change();
+	for (KeyValue<int, Ref<TileSetSource>> &E_source : sources) {
+		E_source.value->notify_tile_data_properties_should_change();
 	}
 
 	notify_property_list_changed();
@@ -719,8 +719,8 @@ void TileSet::set_custom_data_type(int p_layer_id, Variant::Type p_value) {
 	ERR_FAIL_INDEX(p_layer_id, custom_data_layers.size());
 	custom_data_layers.write[p_layer_id].type = p_value;
 
-	for (Map<int, Ref<TileSetSource>>::Element *E_source = sources.front(); E_source; E_source = E_source->next()) {
-		E_source->get()->notify_tile_data_properties_should_change();
+	for (KeyValue<int, Ref<TileSetSource>> &E_source : sources) {
+		E_source.value->notify_tile_data_properties_should_change();
 	}
 
 	emit_changed();
@@ -858,10 +858,10 @@ void TileSet::remove_alternative_level_tile_proxy(int p_source_from, Vector2i p_
 
 Array TileSet::get_source_level_tile_proxies() const {
 	Array output;
-	for (Map<int, int>::Element *E = source_level_proxies.front(); E; E = E->next()) {
+	for (const KeyValue<int, int> &E : source_level_proxies) {
 		Array proxy;
-		proxy.push_back(E->key());
-		proxy.push_back(E->get());
+		proxy.push_back(E.key);
+		proxy.push_back(E.value);
 		output.push_back(proxy);
 	}
 	return output;
@@ -869,10 +869,10 @@ Array TileSet::get_source_level_tile_proxies() const {
 
 Array TileSet::get_coords_level_tile_proxies() const {
 	Array output;
-	for (Map<Array, Array>::Element *E = coords_level_proxies.front(); E; E = E->next()) {
+	for (const KeyValue<Array, Array> &E : coords_level_proxies) {
 		Array proxy;
-		proxy.append_array(E->key());
-		proxy.append_array(E->get());
+		proxy.append_array(E.key);
+		proxy.append_array(E.value);
 		output.push_back(proxy);
 	}
 	return output;
@@ -880,10 +880,10 @@ Array TileSet::get_coords_level_tile_proxies() const {
 
 Array TileSet::get_alternative_level_tile_proxies() const {
 	Array output;
-	for (Map<Array, Array>::Element *E = alternative_level_proxies.front(); E; E = E->next()) {
+	for (const KeyValue<Array, Array> &E : alternative_level_proxies) {
 		Array proxy;
-		proxy.append_array(E->key());
-		proxy.append_array(E->get());
+		proxy.append_array(E.key);
+		proxy.append_array(E.value);
 		output.push_back(proxy);
 	}
 	return output;
@@ -935,9 +935,9 @@ Array TileSet::map_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_a
 void TileSet::cleanup_invalid_tile_proxies() {
 	// Source level.
 	Vector<int> source_to_remove;
-	for (Map<int, int>::Element *E = source_level_proxies.front(); E; E = E->next()) {
-		if (has_source(E->key())) {
-			source_to_remove.append(E->key());
+	for (const KeyValue<int, int> &E : source_level_proxies) {
+		if (has_source(E.key)) {
+			source_to_remove.append(E.key);
 		}
 	}
 	for (int i = 0; i < source_to_remove.size(); i++) {
@@ -946,8 +946,8 @@ void TileSet::cleanup_invalid_tile_proxies() {
 
 	// Coords level.
 	Vector<Array> coords_to_remove;
-	for (Map<Array, Array>::Element *E = coords_level_proxies.front(); E; E = E->next()) {
-		Array a = E->key();
+	for (const KeyValue<Array, Array> &E : coords_level_proxies) {
+		Array a = E.key;
 		if (has_source(a[0]) && get_source(a[0])->has_tile(a[1])) {
 			coords_to_remove.append(a);
 		}
@@ -959,8 +959,8 @@ void TileSet::cleanup_invalid_tile_proxies() {
 
 	// Alternative level.
 	Vector<Array> alternative_to_remove;
-	for (Map<Array, Array>::Element *E = alternative_level_proxies.front(); E; E = E->next()) {
-		Array a = E->key();
+	for (const KeyValue<Array, Array> &E : alternative_level_proxies) {
+		Array a = E.key;
 		if (has_source(a[0]) && get_source(a[0])->has_tile(a[1]) && get_source(a[0])->has_alternative_tile(a[1], a[2])) {
 			alternative_to_remove.append(a);
 		}
@@ -1911,8 +1911,8 @@ const int TileSetSource::INVALID_TILE_ALTERNATIVE = -1;
 
 #ifndef DISABLE_DEPRECATED
 void TileSet::_compatibility_conversion() {
-	for (Map<int, CompatibilityTileData *>::Element *E = compatibility_data.front(); E; E = E->next()) {
-		CompatibilityTileData *ctd = E->value();
+	for (KeyValue<int, CompatibilityTileData *> &E : compatibility_data) {
+		CompatibilityTileData *ctd = E.value;
 
 		// Add the texture
 		TileSetAtlasSource *atlas_source = memnew(TileSetAtlasSource);
@@ -1950,11 +1950,11 @@ void TileSet::_compatibility_conversion() {
 					value_array.push_back(coords);
 					value_array.push_back(alternative_tile);
 
-					if (!compatibility_tilemap_mapping.has(E->key())) {
-						compatibility_tilemap_mapping[E->key()] = Map<Array, Array>();
+					if (!compatibility_tilemap_mapping.has(E.key)) {
+						compatibility_tilemap_mapping[E.key] = Map<Array, Array>();
 					}
-					compatibility_tilemap_mapping[E->key()][key_array] = value_array;
-					compatibility_tilemap_mapping_tile_modes[E->key()] = COMPATIBILITY_TILE_MODE_SINGLE_TILE;
+					compatibility_tilemap_mapping[E.key][key_array] = value_array;
+					compatibility_tilemap_mapping_tile_modes[E.key] = COMPATIBILITY_TILE_MODE_SINGLE_TILE;
 
 					TileData *tile_data = Object::cast_to<TileData>(atlas_source->get_tile_data(coords, alternative_tile));
 
@@ -2042,11 +2042,11 @@ void TileSet::_compatibility_conversion() {
 							value_array.push_back(coords);
 							value_array.push_back(alternative_tile);
 
-							if (!compatibility_tilemap_mapping.has(E->key())) {
-								compatibility_tilemap_mapping[E->key()] = Map<Array, Array>();
+							if (!compatibility_tilemap_mapping.has(E.key)) {
+								compatibility_tilemap_mapping[E.key] = Map<Array, Array>();
 							}
-							compatibility_tilemap_mapping[E->key()][key_array] = value_array;
-							compatibility_tilemap_mapping_tile_modes[E->key()] = COMPATIBILITY_TILE_MODE_ATLAS_TILE;
+							compatibility_tilemap_mapping[E.key][key_array] = value_array;
+							compatibility_tilemap_mapping_tile_modes[E.key] = COMPATIBILITY_TILE_MODE_ATLAS_TILE;
 
 							TileData *tile_data = Object::cast_to<TileData>(atlas_source->get_tile_data(coords, alternative_tile));
 
@@ -2128,8 +2128,8 @@ void TileSet::_compatibility_conversion() {
 	}
 
 	// Reset compatibility data
-	for (Map<int, CompatibilityTileData *>::Element *E = compatibility_data.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<int, CompatibilityTileData *> &E : compatibility_data) {
+		memdelete(E.value);
 	}
 	compatibility_data = Map<int, CompatibilityTileData *>();
 }
@@ -2579,25 +2579,25 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (components.size() == 2 && components[0] == "tile_proxies") {
 		if (components[1] == "source_level") {
 			Array a;
-			for (Map<int, int>::Element *E = source_level_proxies.front(); E; E = E->next()) {
-				a.push_back(E->key());
-				a.push_back(E->get());
+			for (const KeyValue<int, int> &E : source_level_proxies) {
+				a.push_back(E.key);
+				a.push_back(E.value);
 			}
 			r_ret = a;
 			return true;
 		} else if (components[1] == "coords_level") {
 			Array a;
-			for (Map<Array, Array>::Element *E = coords_level_proxies.front(); E; E = E->next()) {
-				a.push_back(E->key());
-				a.push_back(E->get());
+			for (const KeyValue<Array, Array> &E : coords_level_proxies) {
+				a.push_back(E.key);
+				a.push_back(E.value);
 			}
 			r_ret = a;
 			return true;
 		} else if (components[1] == "alternative_level") {
 			Array a;
-			for (Map<Array, Array>::Element *E = alternative_level_proxies.front(); E; E = E->next()) {
-				a.push_back(E->key());
-				a.push_back(E->get());
+			for (const KeyValue<Array, Array> &E : alternative_level_proxies) {
+				a.push_back(E.key);
+				a.push_back(E.value);
 			}
 			r_ret = a;
 			return true;
@@ -2673,8 +2673,8 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	// Sources.
 	// Note: sources have to be listed in at the end as some TileData rely on the TileSet properties being initialized first.
-	for (Map<int, Ref<TileSetSource>>::Element *E_source = sources.front(); E_source; E_source = E_source->next()) {
-		p_list->push_back(PropertyInfo(Variant::INT, vformat("sources/%d", E_source->key()), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+	for (const KeyValue<int, Ref<TileSetSource>> &E_source : sources) {
+		p_list->push_back(PropertyInfo(Variant::INT, vformat("sources/%d", E_source.key), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	}
 
 	// Tile Proxies.
@@ -2850,8 +2850,8 @@ TileSet::TileSet() {
 
 TileSet::~TileSet() {
 #ifndef DISABLE_DEPRECATED
-	for (Map<int, CompatibilityTileData *>::Element *E = compatibility_data.front(); E; E = E->next()) {
-		memdelete(E->get());
+	for (const KeyValue<int, CompatibilityTileData *> &E : compatibility_data) {
+		memdelete(E.value);
 	}
 #endif // DISABLE_DEPRECATED
 	while (!source_ids.is_empty()) {
@@ -2883,18 +2883,18 @@ void TileSetAtlasSource::set_tile_set(const TileSet *p_tile_set) {
 	tile_set = p_tile_set;
 
 	// Set the TileSet on all TileData.
-	for (Map<Vector2i, TileAlternativesData>::Element *E_tile = tiles.front(); E_tile; E_tile = E_tile->next()) {
-		for (Map<int, TileData *>::Element *E_alternative = E_tile->get().alternatives.front(); E_alternative; E_alternative = E_alternative->next()) {
-			E_alternative->get()->set_tile_set(tile_set);
+	for (KeyValue<Vector2i, TileAlternativesData> &E_tile : tiles) {
+		for (KeyValue<int, TileData *> &E_alternative : E_tile.value.alternatives) {
+			E_alternative.value->set_tile_set(tile_set);
 		}
 	}
 }
 
 void TileSetAtlasSource::notify_tile_data_properties_should_change() {
 	// Set the TileSet on all TileData.
-	for (Map<Vector2i, TileAlternativesData>::Element *E_tile = tiles.front(); E_tile; E_tile = E_tile->next()) {
-		for (Map<int, TileData *>::Element *E_alternative = E_tile->get().alternatives.front(); E_alternative; E_alternative = E_alternative->next()) {
-			E_alternative->get()->notify_tile_data_properties_should_change();
+	for (KeyValue<Vector2i, TileAlternativesData> &E_tile : tiles) {
+		for (KeyValue<int, TileData *> &E_alternative : E_tile.value.alternatives) {
+			E_alternative.value->notify_tile_data_properties_should_change();
 		}
 	}
 }
@@ -3045,9 +3045,9 @@ void TileSetAtlasSource::remove_custom_data_layer(int p_index) {
 
 void TileSetAtlasSource::reset_state() {
 	// Reset all TileData.
-	for (Map<Vector2i, TileAlternativesData>::Element *E_tile = tiles.front(); E_tile; E_tile = E_tile->next()) {
-		for (Map<int, TileData *>::Element *E_alternative = E_tile->get().alternatives.front(); E_alternative; E_alternative = E_alternative->next()) {
-			E_alternative->get()->reset_state();
+	for (KeyValue<Vector2i, TileAlternativesData> &E_tile : tiles) {
+		for (KeyValue<int, TileData *> &E_alternative : E_tile.value.alternatives) {
+			E_alternative.value->reset_state();
 		}
 	}
 }
@@ -3260,40 +3260,40 @@ bool TileSetAtlasSource::_get(const StringName &p_name, Variant &r_ret) const {
 void TileSetAtlasSource::_get_property_list(List<PropertyInfo> *p_list) const {
 	// Atlases data.
 	PropertyInfo property_info;
-	for (Map<Vector2i, TileAlternativesData>::Element *E_tile = tiles.front(); E_tile; E_tile = E_tile->next()) {
+	for (const KeyValue<Vector2i, TileAlternativesData> &E_tile : tiles) {
 		List<PropertyInfo> tile_property_list;
 
 		// size_in_atlas
 		property_info = PropertyInfo(Variant::VECTOR2I, "size_in_atlas", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR);
-		if (E_tile->get().size_in_atlas == Vector2i(1, 1)) {
+		if (E_tile.value.size_in_atlas == Vector2i(1, 1)) {
 			property_info.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 		tile_property_list.push_back(property_info);
 
 		// next_alternative_id
 		property_info = PropertyInfo(Variant::INT, "next_alternative_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR);
-		if (E_tile->get().next_alternative_id == 1) {
+		if (E_tile.value.next_alternative_id == 1) {
 			property_info.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 		tile_property_list.push_back(property_info);
 
 		// animation_columns.
 		property_info = PropertyInfo(Variant::INT, "animation_columns", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR);
-		if (E_tile->get().animation_columns == 0) {
+		if (E_tile.value.animation_columns == 0) {
 			property_info.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 		tile_property_list.push_back(property_info);
 
 		// animation_separation.
 		property_info = PropertyInfo(Variant::INT, "animation_separation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR);
-		if (E_tile->get().animation_separation == Vector2i()) {
+		if (E_tile.value.animation_separation == Vector2i()) {
 			property_info.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 		tile_property_list.push_back(property_info);
 
 		// animation_speed.
 		property_info = PropertyInfo(Variant::FLOAT, "animation_speed", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR);
-		if (E_tile->get().animation_speed == 1.0) {
+		if (E_tile.value.animation_speed == 1.0) {
 			property_info.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 		tile_property_list.push_back(property_info);
@@ -3302,8 +3302,8 @@ void TileSetAtlasSource::_get_property_list(List<PropertyInfo> *p_list) const {
 		tile_property_list.push_back(PropertyInfo(Variant::INT, "animation_frames_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NETWORK));
 
 		// animation_frame_*.
-		bool store_durations = tiles[E_tile->key()].animation_frames_durations.size() >= 2;
-		for (int i = 0; i < (int)tiles[E_tile->key()].animation_frames_durations.size(); i++) {
+		bool store_durations = tiles[E_tile.key].animation_frames_durations.size() >= 2;
+		for (int i = 0; i < (int)tiles[E_tile.key].animation_frames_durations.size(); i++) {
 			property_info = PropertyInfo(Variant::FLOAT, vformat("animation_frame_%d/duration", i), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR);
 			if (!store_durations) {
 				property_info.usage ^= PROPERTY_USAGE_STORAGE;
@@ -3311,27 +3311,27 @@ void TileSetAtlasSource::_get_property_list(List<PropertyInfo> *p_list) const {
 			tile_property_list.push_back(property_info);
 		}
 
-		for (Map<int, TileData *>::Element *E_alternative = E_tile->get().alternatives.front(); E_alternative; E_alternative = E_alternative->next()) {
+		for (const KeyValue<int, TileData *> &E_alternative : E_tile.value.alternatives) {
 			// Add a dummy property to show the alternative exists.
-			tile_property_list.push_back(PropertyInfo(Variant::INT, vformat("%d", E_alternative->key()), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+			tile_property_list.push_back(PropertyInfo(Variant::INT, vformat("%d", E_alternative.key), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 
 			// Get the alternative tile's properties and append them to the list of properties.
 			List<PropertyInfo> alternative_property_list;
-			E_alternative->get()->get_property_list(&alternative_property_list);
+			E_alternative.value->get_property_list(&alternative_property_list);
 			for (PropertyInfo &alternative_property_info : alternative_property_list) {
 				Variant default_value = ClassDB::class_get_default_property_value("TileData", alternative_property_info.name);
-				Variant value = E_alternative->get()->get(alternative_property_info.name);
+				Variant value = E_alternative.value->get(alternative_property_info.name);
 				if (default_value.get_type() != Variant::NIL && bool(Variant::evaluate(Variant::OP_EQUAL, value, default_value))) {
 					alternative_property_info.usage ^= PROPERTY_USAGE_STORAGE;
 				}
-				alternative_property_info.name = vformat("%s/%s", vformat("%d", E_alternative->key()), alternative_property_info.name);
+				alternative_property_info.name = vformat("%s/%s", vformat("%d", E_alternative.key), alternative_property_info.name);
 				tile_property_list.push_back(alternative_property_info);
 			}
 		}
 
 		// Add all alternative.
 		for (PropertyInfo &tile_property_info : tile_property_list) {
-			tile_property_info.name = vformat("%s/%s", vformat("%d:%d", E_tile->key().x, E_tile->key().y), tile_property_info.name);
+			tile_property_info.name = vformat("%s/%s", vformat("%d:%d", E_tile.key.x, E_tile.key.y), tile_property_info.name);
 			p_list->push_back(tile_property_info);
 		}
 	}
@@ -3373,8 +3373,8 @@ void TileSetAtlasSource::remove_tile(Vector2i p_atlas_coords) {
 	_clear_coords_mapping_cache(p_atlas_coords);
 
 	// Free tile data.
-	for (Map<int, TileData *>::Element *E_tile_data = tiles[p_atlas_coords].alternatives.front(); E_tile_data; E_tile_data = E_tile_data->next()) {
-		memdelete(E_tile_data->get());
+	for (const KeyValue<int, TileData *> &E_tile_data : tiles[p_atlas_coords].alternatives) {
+		memdelete(E_tile_data.value);
 	}
 
 	// Delete the tile
@@ -3619,8 +3619,8 @@ bool TileSetAtlasSource::has_tiles_outside_texture() {
 	Vector2i grid_size = get_atlas_grid_size();
 	Vector<Vector2i> to_remove;
 
-	for (Map<Vector2i, TileSetAtlasSource::TileAlternativesData>::Element *E = tiles.front(); E; E = E->next()) {
-		if (E->key().x >= grid_size.x || E->key().y >= grid_size.y) {
+	for (const KeyValue<Vector2i, TileSetAtlasSource::TileAlternativesData> &E : tiles) {
+		if (E.key.x >= grid_size.x || E.key.y >= grid_size.y) {
 			return true;
 		}
 	}
@@ -3632,9 +3632,9 @@ void TileSetAtlasSource::clear_tiles_outside_texture() {
 	Vector2i grid_size = get_atlas_grid_size();
 	Vector<Vector2i> to_remove;
 
-	for (Map<Vector2i, TileSetAtlasSource::TileAlternativesData>::Element *E = tiles.front(); E; E = E->next()) {
-		if (E->key().x >= grid_size.x || E->key().y >= grid_size.y) {
-			to_remove.append(E->key());
+	for (const KeyValue<Vector2i, TileSetAtlasSource::TileAlternativesData> &E : tiles) {
+		if (E.key.x >= grid_size.x || E.key.y >= grid_size.y) {
+			to_remove.append(E.key);
 		}
 	}
 
@@ -3775,9 +3775,9 @@ void TileSetAtlasSource::_bind_methods() {
 
 TileSetAtlasSource::~TileSetAtlasSource() {
 	// Free everything needed.
-	for (Map<Vector2i, TileAlternativesData>::Element *E_alternatives = tiles.front(); E_alternatives; E_alternatives = E_alternatives->next()) {
-		for (Map<int, TileData *>::Element *E_tile_data = E_alternatives->get().alternatives.front(); E_tile_data; E_tile_data = E_tile_data->next()) {
-			memdelete(E_tile_data->get());
+	for (KeyValue<Vector2i, TileAlternativesData> &E_alternatives : tiles) {
+		for (KeyValue<int, TileData *> &E_tile_data : E_alternatives.value.alternatives) {
+			memdelete(E_tile_data.value);
 		}
 	}
 }

--- a/servers/physics_2d/shape_2d_sw.cpp
+++ b/servers/physics_2d/shape_2d_sw.cpp
@@ -36,8 +36,8 @@
 void Shape2DSW::configure(const Rect2 &p_aabb) {
 	aabb = p_aabb;
 	configured = true;
-	for (Map<ShapeOwner2DSW *, int>::Element *E = owners.front(); E; E = E->next()) {
-		ShapeOwner2DSW *co = (ShapeOwner2DSW *)E->key();
+	for (const KeyValue<ShapeOwner2DSW *, int> &E : owners) {
+		ShapeOwner2DSW *co = (ShapeOwner2DSW *)E.key;
 		co->_shape_changed();
 	}
 }
@@ -875,9 +875,9 @@ void ConcavePolygonShape2DSW::set_data(const Variant &p_data) {
 
 		points.resize(pointmap.size());
 		aabb.position = pointmap.front()->key();
-		for (Map<Point2, int>::Element *E = pointmap.front(); E; E = E->next()) {
-			aabb.expand_to(E->key());
-			points.write[E->get()] = E->key();
+		for (const KeyValue<Point2, int> &E : pointmap) {
+			aabb.expand_to(E.key);
+			points.write[E.value] = E.key;
 		}
 
 		Vector<BVH> main_vbh;

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -688,13 +688,13 @@ void BodySW::simulate_motion(const Transform3D& p_xform,real_t p_step) {
 */
 
 void Body3DSW::wakeup_neighbours() {
-	for (Map<Constraint3DSW *, int>::Element *E = constraint_map.front(); E; E = E->next()) {
-		const Constraint3DSW *c = E->key();
+	for (const KeyValue<Constraint3DSW *, int> &E : constraint_map) {
+		const Constraint3DSW *c = E.key;
 		Body3DSW **n = c->get_body_ptr();
 		int bc = c->get_body_count();
 
 		for (int i = 0; i < bc; i++) {
-			if (i == E->get()) {
+			if (i == E.value) {
 				continue;
 			}
 			Body3DSW *b = n[i];

--- a/servers/physics_3d/shape_3d_sw.cpp
+++ b/servers/physics_3d/shape_3d_sw.cpp
@@ -61,8 +61,8 @@ subject to the following restrictions:
 void Shape3DSW::configure(const AABB &p_aabb) {
 	aabb = p_aabb;
 	configured = true;
-	for (Map<ShapeOwner3DSW *, int>::Element *E = owners.front(); E; E = E->next()) {
-		ShapeOwner3DSW *co = (ShapeOwner3DSW *)E->key();
+	for (const KeyValue<ShapeOwner3DSW *, int> &E : owners) {
+		ShapeOwner3DSW *co = (ShapeOwner3DSW *)E.key;
 		co->_shape_changed();
 	}
 }

--- a/servers/physics_3d/step_3d_sw.cpp
+++ b/servers/physics_3d/step_3d_sw.cpp
@@ -47,8 +47,8 @@ void Step3DSW::_populate_island(Body3DSW *p_body, LocalVector<Body3DSW *> &p_bod
 		p_body_island.push_back(p_body);
 	}
 
-	for (Map<Constraint3DSW *, int>::Element *E = p_body->get_constraint_map().front(); E; E = E->next()) {
-		Constraint3DSW *constraint = (Constraint3DSW *)E->key();
+	for (const KeyValue<Constraint3DSW *, int> &E : p_body->get_constraint_map()) {
+		Constraint3DSW *constraint = (Constraint3DSW *)E.key;
 		if (constraint->get_island_step() == _step) {
 			continue; // Already processed.
 		}
@@ -59,7 +59,7 @@ void Step3DSW::_populate_island(Body3DSW *p_body, LocalVector<Body3DSW *> &p_bod
 
 		// Find connected rigid bodies.
 		for (int i = 0; i < constraint->get_body_count(); i++) {
-			if (i == E->get()) {
+			if (i == E.value) {
 				continue;
 			}
 			Body3DSW *other_body = constraint->get_body_ptr()[i];

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -344,36 +344,36 @@ void SceneShaderForwardClustered::ShaderData::set_default_texture_param(const St
 void SceneShaderForwardClustered::ShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
 	Map<int, StringName> order;
 
-	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
-		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_LOCAL) {
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_LOCAL) {
 			continue;
 		}
 
-		if (E->get().texture_order >= 0) {
-			order[E->get().texture_order + 100000] = E->key();
+		if (E.value.texture_order >= 0) {
+			order[E.value.texture_order + 100000] = E.key;
 		} else {
-			order[E->get().order] = E->key();
+			order[E.value.order] = E.key;
 		}
 	}
 
-	for (Map<int, StringName>::Element *E = order.front(); E; E = E->next()) {
-		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E->get()]);
-		pi.name = E->get();
+	for (const KeyValue<int, StringName> &E : order) {
+		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E.value]);
+		pi.name = E.value;
 		p_param_list->push_back(pi);
 	}
 }
 
 void SceneShaderForwardClustered::ShaderData::get_instance_param_list(List<RendererStorage::InstanceShaderParam> *p_param_list) const {
-	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
-		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
 			continue;
 		}
 
 		RendererStorage::InstanceShaderParam p;
-		p.info = ShaderLanguage::uniform_to_property_info(E->get());
-		p.info.name = E->key(); //supply name
-		p.index = E->get().instance_index;
-		p.default_value = ShaderLanguage::constant_value_to_variant(E->get().default_value, E->get().type, E->get().hint);
+		p.info = ShaderLanguage::uniform_to_property_info(E.value);
+		p.info.name = E.key; //supply name
+		p.index = E.value.instance_index;
+		p.default_value = ShaderLanguage::constant_value_to_variant(E.value.default_value, E.value.type, E.value.hint);
 		p_param_list->push_back(p);
 	}
 }

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -336,36 +336,36 @@ void SceneShaderForwardMobile::ShaderData::set_default_texture_param(const Strin
 void SceneShaderForwardMobile::ShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
 	Map<int, StringName> order;
 
-	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
-		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_LOCAL) {
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_LOCAL) {
 			continue;
 		}
 
-		if (E->get().texture_order >= 0) {
-			order[E->get().texture_order + 100000] = E->key();
+		if (E.value.texture_order >= 0) {
+			order[E.value.texture_order + 100000] = E.key;
 		} else {
-			order[E->get().order] = E->key();
+			order[E.value.order] = E.key;
 		}
 	}
 
-	for (Map<int, StringName>::Element *E = order.front(); E; E = E->next()) {
-		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E->get()]);
-		pi.name = E->get();
+	for (const KeyValue<int, StringName> &E : order) {
+		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E.value]);
+		pi.name = E.value;
 		p_param_list->push_back(pi);
 	}
 }
 
 void SceneShaderForwardMobile::ShaderData::get_instance_param_list(List<RendererStorage::InstanceShaderParam> *p_param_list) const {
-	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
-		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
 			continue;
 		}
 
 		RendererStorage::InstanceShaderParam p;
-		p.info = ShaderLanguage::uniform_to_property_info(E->get());
-		p.info.name = E->key(); //supply name
-		p.index = E->get().instance_index;
-		p.default_value = ShaderLanguage::constant_value_to_variant(E->get().default_value, E->get().type, E->get().hint);
+		p.info = ShaderLanguage::uniform_to_property_info(E.value);
+		p.info.name = E.key; //supply name
+		p.index = E.value.instance_index;
+		p.default_value = ShaderLanguage::constant_value_to_variant(E.value.default_value, E.value.type, E.value.hint);
 		p_param_list->push_back(p);
 	}
 }

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2133,35 +2133,35 @@ void RendererCanvasRenderRD::ShaderData::set_default_texture_param(const StringN
 void RendererCanvasRenderRD::ShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
 	Map<int, StringName> order;
 
-	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
-		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_LOCAL) {
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_LOCAL) {
 			continue;
 		}
-		if (E->get().texture_order >= 0) {
-			order[E->get().texture_order + 100000] = E->key();
+		if (E.value.texture_order >= 0) {
+			order[E.value.texture_order + 100000] = E.key;
 		} else {
-			order[E->get().order] = E->key();
+			order[E.value.order] = E.key;
 		}
 	}
 
-	for (Map<int, StringName>::Element *E = order.front(); E; E = E->next()) {
-		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E->get()]);
-		pi.name = E->get();
+	for (const KeyValue<int, StringName> &E : order) {
+		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E.value]);
+		pi.name = E.value;
 		p_param_list->push_back(pi);
 	}
 }
 
 void RendererCanvasRenderRD::ShaderData::get_instance_param_list(List<RendererStorage::InstanceShaderParam> *p_param_list) const {
-	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
-		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
 			continue;
 		}
 
 		RendererStorage::InstanceShaderParam p;
-		p.info = ShaderLanguage::uniform_to_property_info(E->get());
-		p.info.name = E->key(); //supply name
-		p.index = E->get().instance_index;
-		p.default_value = ShaderLanguage::constant_value_to_variant(E->get().default_value, E->get().type, E->get().hint);
+		p.info = ShaderLanguage::uniform_to_property_info(E.value);
+		p.info.name = E.key; //supply name
+		p.index = E.value.instance_index;
+		p.default_value = ShaderLanguage::constant_value_to_variant(E.value.default_value, E.value.type, E.value.hint);
 		p_param_list->push_back(p);
 	}
 }

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -850,8 +850,8 @@ void RendererSceneRenderRD::shadow_atlas_set_size(RID p_atlas, int p_size, bool 
 	}
 
 	//erase shadow atlas reference from lights
-	for (Map<RID, uint32_t>::Element *E = shadow_atlas->shadow_owners.front(); E; E = E->next()) {
-		LightInstance *li = light_instance_owner.get_or_null(E->key());
+	for (const KeyValue<RID, uint32_t> &E : shadow_atlas->shadow_owners) {
+		LightInstance *li = light_instance_owner.get_or_null(E.key);
 		ERR_CONTINUE(!li);
 		li->shadow_atlases.erase(p_atlas);
 	}
@@ -4801,8 +4801,8 @@ void RendererSceneRenderRD::init() {
 }
 
 RendererSceneRenderRD::~RendererSceneRenderRD() {
-	for (Map<int, ShadowCubemap>::Element *E = shadow_cubemaps.front(); E; E = E->next()) {
-		RD::get_singleton()->free(E->get().cubemap);
+	for (const KeyValue<int, ShadowCubemap> &E : shadow_cubemaps) {
+		RD::get_singleton()->free(E.value.cubemap);
 	}
 
 	if (sky.sky_scene_state.uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(sky.sky_scene_state.uniform_set)) {

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -148,36 +148,36 @@ void RendererSceneSkyRD::SkyShaderData::set_default_texture_param(const StringNa
 void RendererSceneSkyRD::SkyShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
 	Map<int, StringName> order;
 
-	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
-		if (E->get().scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_GLOBAL || E->get().scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_GLOBAL || E.value.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
 			continue;
 		}
 
-		if (E->get().texture_order >= 0) {
-			order[E->get().texture_order + 100000] = E->key();
+		if (E.value.texture_order >= 0) {
+			order[E.value.texture_order + 100000] = E.key;
 		} else {
-			order[E->get().order] = E->key();
+			order[E.value.order] = E.key;
 		}
 	}
 
-	for (Map<int, StringName>::Element *E = order.front(); E; E = E->next()) {
-		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E->get()]);
-		pi.name = E->get();
+	for (const KeyValue<int, StringName> &E : order) {
+		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E.value]);
+		pi.name = E.value;
 		p_param_list->push_back(pi);
 	}
 }
 
 void RendererSceneSkyRD::SkyShaderData::get_instance_param_list(List<RendererStorage::InstanceShaderParam> *p_param_list) const {
-	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
-		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
 			continue;
 		}
 
 		RendererStorage::InstanceShaderParam p;
-		p.info = ShaderLanguage::uniform_to_property_info(E->get());
-		p.info.name = E->key(); //supply name
-		p.index = E->get().instance_index;
-		p.default_value = ShaderLanguage::constant_value_to_variant(E->get().default_value, E->get().type, E->get().hint);
+		p.info = ShaderLanguage::uniform_to_property_info(E.value);
+		p.info.name = E.key; //supply name
+		p.index = E.value.instance_index;
+		p.default_value = ShaderLanguage::constant_value_to_variant(E.value.default_value, E.value.type, E.value.hint);
 		p_param_list->push_back(p);
 	}
 }

--- a/servers/rendering/renderer_rd/shader_compiler_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_compiler_rd.cpp
@@ -566,11 +566,11 @@ String ShaderCompilerRD::_dump_node_code(const SL::Node *p_node, int p_level, Ge
 			int max_texture_uniforms = 0;
 			int max_uniforms = 0;
 
-			for (Map<StringName, SL::ShaderNode::Uniform>::Element *E = pnode->uniforms.front(); E; E = E->next()) {
-				if (SL::is_sampler_type(E->get().type)) {
+			for (const KeyValue<StringName, SL::ShaderNode::Uniform> &E : pnode->uniforms) {
+				if (SL::is_sampler_type(E.value.type)) {
 					max_texture_uniforms++;
 				} else {
-					if (E->get().scope == SL::ShaderNode::Uniform::SCOPE_INSTANCE) {
+					if (E.value.scope == SL::ShaderNode::Uniform::SCOPE_INSTANCE) {
 						continue; // Instances are indexed directly, don't need index uniforms.
 					}
 
@@ -590,8 +590,8 @@ String ShaderCompilerRD::_dump_node_code(const SL::Node *p_node, int p_level, Ge
 
 			Vector<StringName> uniform_names;
 
-			for (Map<StringName, SL::ShaderNode::Uniform>::Element *E = pnode->uniforms.front(); E; E = E->next()) {
-				uniform_names.push_back(E->key());
+			for (const KeyValue<StringName, SL::ShaderNode::Uniform> &E : pnode->uniforms) {
+				uniform_names.push_back(E.key);
 			}
 
 			uniform_names.sort_custom<StringName::AlphCompare>(); //ensure order is deterministic so the same shader is always produced
@@ -724,8 +724,8 @@ String ShaderCompilerRD::_dump_node_code(const SL::Node *p_node, int p_level, Ge
 
 			Vector<StringName> varying_names;
 
-			for (Map<StringName, SL::ShaderNode::Varying>::Element *E = pnode->varyings.front(); E; E = E->next()) {
-				varying_names.push_back(E->key());
+			for (const KeyValue<StringName, SL::ShaderNode::Varying> &E : pnode->varyings) {
+				varying_names.push_back(E.key);
 			}
 
 			varying_names.sort_custom<StringName::AlphCompare>(); //ensure order is deterministic so the same shader is always produced

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -174,8 +174,8 @@ void ShaderRD::_build_variant_code(StringBuilder &builder, uint32_t p_variant, c
 				if (p_version->uniforms.size()) {
 					builder.append("#define MATERIAL_UNIFORMS_USED\n");
 				}
-				for (Map<StringName, CharString>::Element *E = p_version->code_sections.front(); E; E = E->next()) {
-					builder.append(String("#define ") + String(E->key()) + "_CODE_USED\n");
+				for (const KeyValue<StringName, CharString> &E : p_version->code_sections) {
+					builder.append(String("#define ") + String(E.key) + "_CODE_USED\n");
 				}
 			} break;
 			case StageTemplate::Chunk::TYPE_MATERIAL_UNIFORMS: {
@@ -355,8 +355,8 @@ String ShaderRD::_version_get_sha1(Version *p_version) const {
 	hash_build.append(p_version->compute_globals.get_data());
 
 	Vector<StringName> code_sections;
-	for (Map<StringName, CharString>::Element *E = p_version->code_sections.front(); E; E = E->next()) {
-		code_sections.push_back(E->key());
+	for (const KeyValue<StringName, CharString> &E : p_version->code_sections) {
+		code_sections.push_back(E.key);
 	}
 	code_sections.sort_custom<StringName::AlphCompare>();
 
@@ -530,8 +530,8 @@ void ShaderRD::version_set_code(RID p_version, const Map<String, String> &p_code
 	version->fragment_globals = p_fragment_globals.utf8();
 	version->uniforms = p_uniforms.utf8();
 	version->code_sections.clear();
-	for (Map<String, String>::Element *E = p_code.front(); E; E = E->next()) {
-		version->code_sections[StringName(E->key().to_upper())] = E->get().utf8();
+	for (const KeyValue<String, String> &E : p_code) {
+		version->code_sections[StringName(E.key.to_upper())] = E.value.utf8();
 	}
 
 	version->custom_defines.clear();
@@ -556,8 +556,8 @@ void ShaderRD::version_set_compute_code(RID p_version, const Map<String, String>
 	version->uniforms = p_uniforms.utf8();
 
 	version->code_sections.clear();
-	for (Map<String, String>::Element *E = p_code.front(); E; E = E->next()) {
-		version->code_sections[StringName(E->key().to_upper())] = E->get().utf8();
+	for (const KeyValue<String, String> &E : p_code) {
+		version->code_sections[StringName(E.key.to_upper())] = E.value.utf8();
 	}
 
 	version->custom_defines.clear();

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1403,8 +1403,8 @@ void RendererSceneCull::instance_geometry_get_shader_parameter_list(RID p_instan
 	const_cast<RendererSceneCull *>(this)->update_dirty_instances();
 
 	Vector<StringName> names;
-	for (Map<StringName, Instance::InstanceShaderParameter>::Element *E = instance->instance_shader_parameters.front(); E; E = E->next()) {
-		names.push_back(E->key());
+	for (const KeyValue<StringName, Instance::InstanceShaderParameter> &E : instance->instance_shader_parameters) {
+		names.push_back(E.key);
 	}
 	names.sort_custom<StringName::AlphCompare>();
 	for (int i = 0; i < names.size(); i++) {
@@ -3688,9 +3688,9 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
 					p_instance->instance_allocated_shader_parameters_offset = RSG::storage->global_variables_instance_allocate(p_instance->self);
 					scene_render->geometry_instance_set_instance_shader_parameters_offset(geom->geometry_instance, p_instance->instance_allocated_shader_parameters_offset);
 
-					for (Map<StringName, Instance::InstanceShaderParameter>::Element *E = p_instance->instance_shader_parameters.front(); E; E = E->next()) {
-						if (E->get().value.get_type() != Variant::NIL) {
-							RSG::storage->global_variables_instance_update(p_instance->self, E->get().index, E->get().value);
+					for (const KeyValue<StringName, Instance::InstanceShaderParameter> &E : p_instance->instance_shader_parameters) {
+						if (E.value.value.get_type() != Variant::NIL) {
+							RSG::storage->global_variables_instance_update(p_instance->self, E.value.index, E.value.value);
 						}
 					}
 				} else {

--- a/servers/rendering/renderer_storage.cpp
+++ b/servers/rendering/renderer_storage.cpp
@@ -33,21 +33,21 @@
 RendererStorage *RendererStorage::base_singleton = nullptr;
 
 void RendererStorage::Dependency::changed_notify(DependencyChangedNotification p_notification) {
-	for (Map<DependencyTracker *, uint32_t>::Element *E = instances.front(); E; E = E->next()) {
-		if (E->key()->changed_callback) {
-			E->key()->changed_callback(p_notification, E->key());
+	for (const KeyValue<DependencyTracker *, uint32_t> &E : instances) {
+		if (E.key->changed_callback) {
+			E.key->changed_callback(p_notification, E.key);
 		}
 	}
 }
 
 void RendererStorage::Dependency::deleted_notify(const RID &p_rid) {
-	for (Map<DependencyTracker *, uint32_t>::Element *E = instances.front(); E; E = E->next()) {
-		if (E->key()->deleted_callback) {
-			E->key()->deleted_callback(p_rid, E->key());
+	for (const KeyValue<DependencyTracker *, uint32_t> &E : instances) {
+		if (E.key->deleted_callback) {
+			E.key->deleted_callback(p_rid, E.key);
 		}
 	}
-	for (Map<DependencyTracker *, uint32_t>::Element *E = instances.front(); E; E = E->next()) {
-		E->key()->dependencies.erase(this);
+	for (const KeyValue<DependencyTracker *, uint32_t> &E : instances) {
+		E.key->dependencies.erase(this);
 	}
 	instances.clear();
 }
@@ -56,8 +56,8 @@ RendererStorage::Dependency::~Dependency() {
 #ifdef DEBUG_ENABLED
 	if (instances.size()) {
 		WARN_PRINT("Leaked instance dependency: Bug - did not call instance_notify_deleted when freeing.");
-		for (Map<DependencyTracker *, uint32_t>::Element *E = instances.front(); E; E = E->next()) {
-			E->key()->dependencies.erase(this);
+		for (const KeyValue<DependencyTracker *, uint32_t> &E : instances) {
+			E.key->dependencies.erase(this);
 		}
 	}
 #endif

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -210,9 +210,9 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			RendererCanvasRender::LightOccluderInstance *occluders = nullptr;
 
 			//make list of occluders
-			for (Map<RID, Viewport::CanvasData>::Element *E = p_viewport->canvas_map.front(); E; E = E->next()) {
-				RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E->get().canvas);
-				Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E->get(), clip_rect.size);
+			for (KeyValue<RID, Viewport::CanvasData> &E : p_viewport->canvas_map) {
+				RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value.canvas);
+				Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E.value, clip_rect.size);
 
 				for (Set<RendererCanvasRender::LightOccluderInstance *>::Element *F = canvas->occluders.front(); F; F = F->next()) {
 					if (!F->get()->enabled) {
@@ -242,10 +242,10 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		int directional_light_count = 0;
 
 		RENDER_TIMESTAMP("Cull Canvas Lights");
-		for (Map<RID, Viewport::CanvasData>::Element *E = p_viewport->canvas_map.front(); E; E = E->next()) {
-			RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E->get().canvas);
+		for (KeyValue<RID, Viewport::CanvasData> &E : p_viewport->canvas_map) {
+			RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value.canvas);
 
-			Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E->get(), clip_rect.size);
+			Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E.value, clip_rect.size);
 
 			//find lights in canvas
 
@@ -307,7 +307,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 				}
 			}
 
-			canvas_map[Viewport::CanvasKey(E->key(), E->get().layer, E->get().sublayer)] = &E->get();
+			canvas_map[Viewport::CanvasKey(E.key, E.value.layer, E.value.sublayer)] = &E.value;
 		}
 
 		if (lights_with_shadow) {
@@ -319,9 +319,9 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			RENDER_TIMESTAMP("Cull Occluders");
 
 			//make list of occluders
-			for (Map<RID, Viewport::CanvasData>::Element *E = p_viewport->canvas_map.front(); E; E = E->next()) {
-				RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E->get().canvas);
-				Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E->get(), clip_rect.size);
+			for (KeyValue<RID, Viewport::CanvasData> &E : p_viewport->canvas_map) {
+				RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value.canvas);
+				Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E.value, clip_rect.size);
 
 				for (Set<RendererCanvasRender::LightOccluderInstance *>::Element *F = canvas->occluders.front(); F; F = F->next()) {
 					if (!F->get()->enabled) {
@@ -400,9 +400,9 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 
 				//make list of occluders
 				int occ_cullded = 0;
-				for (Map<RID, Viewport::CanvasData>::Element *E = p_viewport->canvas_map.front(); E; E = E->next()) {
-					RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E->get().canvas);
-					Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E->get(), clip_rect.size);
+				for (KeyValue<RID, Viewport::CanvasData> &E : p_viewport->canvas_map) {
+					RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value.canvas);
+					Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E.value, clip_rect.size);
 
 					for (Set<RendererCanvasRender::LightOccluderInstance *>::Element *F = canvas->occluders.front(); F; F = F->next()) {
 						if (!F->get()->enabled) {
@@ -439,17 +439,17 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			scenario_draw_canvas_bg = false;
 		}
 
-		for (Map<Viewport::CanvasKey, Viewport::CanvasData *>::Element *E = canvas_map.front(); E; E = E->next()) {
-			RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E->get()->canvas);
+		for (const KeyValue<Viewport::CanvasKey, Viewport::CanvasData *> &E : canvas_map) {
+			RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value->canvas);
 
-			Transform2D xform = _canvas_get_transform(p_viewport, canvas, E->get(), clip_rect.size);
+			Transform2D xform = _canvas_get_transform(p_viewport, canvas, E.value, clip_rect.size);
 
 			RendererCanvasRender::Light *canvas_lights = nullptr;
 			RendererCanvasRender::Light *canvas_directional_lights = nullptr;
 
 			RendererCanvasRender::Light *ptr = lights;
 			while (ptr) {
-				if (E->get()->layer >= ptr->layer_min && E->get()->layer <= ptr->layer_max) {
+				if (E.value->layer >= ptr->layer_min && E.value->layer <= ptr->layer_max) {
 					ptr->next_ptr = canvas_lights;
 					canvas_lights = ptr;
 				}
@@ -458,7 +458,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 
 			ptr = directional_lights;
 			while (ptr) {
-				if (E->get()->layer >= ptr->layer_min && E->get()->layer <= ptr->layer_max) {
+				if (E.value->layer >= ptr->layer_min && E.value->layer <= ptr->layer_max) {
 					ptr->next_ptr = canvas_directional_lights;
 					canvas_directional_lights = ptr;
 				}
@@ -471,7 +471,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			}
 			i++;
 
-			if (scenario_draw_canvas_bg && E->key().get_layer() >= scenario_canvas_max_layer) {
+			if (scenario_draw_canvas_bg && E.key.get_layer() >= scenario_canvas_max_layer) {
 				if (!can_draw_3d) {
 					RSG::scene->render_empty_scene(p_viewport->render_buffers, p_viewport->scenario, p_viewport->shadow_atlas);
 				} else {
@@ -660,8 +660,8 @@ void RendererViewport::draw_viewports() {
 	//this needs to be called to make screen swapping more efficient
 	RSG::rasterizer->prepare_for_blitting_render_targets();
 
-	for (Map<int, Vector<BlitToScreen>>::Element *E = blit_to_screen_list.front(); E; E = E->next()) {
-		RSG::rasterizer->blit_render_targets_to_screen(E->key(), E->get().ptr(), E->get().size());
+	for (const KeyValue<int, Vector<BlitToScreen>> &E : blit_to_screen_list) {
+		RSG::rasterizer->blit_render_targets_to_screen(E.key, E.value.ptr(), E.value.size());
 	}
 }
 

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -171,7 +171,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 
 		/* STEP 2, Compile the versions, add to shader file */
 
-		for (Map<StringName, String>::Element *E = version_texts.front(); E; E = E->next()) {
+		for (const KeyValue<StringName, String> &E : version_texts) {
 			Ref<RDShaderSPIRV> bytecode;
 			bytecode.instantiate();
 
@@ -180,7 +180,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 				if (code == String()) {
 					continue;
 				}
-				code = code.replace("VERSION_DEFINES", E->get());
+				code = code.replace("VERSION_DEFINES", E.value);
 				String error;
 				Vector<uint8_t> spirv = RenderingDevice::get_singleton()->shader_compile_spirv_from_source(RD::ShaderStage(i), code, RD::SHADER_LANGUAGE_GLSL, &error, false);
 				bytecode->set_stage_bytecode(RD::ShaderStage(i), spirv);
@@ -195,7 +195,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 				bytecode->set_stage_compile_error(RD::ShaderStage(i), error);
 			}
 
-			set_bytecode(bytecode, E->key());
+			set_bytecode(bytecode, E.key);
 		}
 
 		return errors_found ? ERR_PARSE_ERROR : OK;

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -351,8 +351,8 @@ public:
 
 	Vector<StringName> get_version_list() const {
 		Vector<StringName> vnames;
-		for (Map<StringName, Ref<RDShaderSPIRV>>::Element *E = versions.front(); E; E = E->next()) {
-			vnames.push_back(E->key());
+		for (const KeyValue<StringName, Ref<RDShaderSPIRV>> &E : versions) {
+			vnames.push_back(E.key);
 		}
 		vnames.sort_custom<StringName::AlphCompare>();
 		return vnames;
@@ -371,9 +371,9 @@ public:
 		if (base_error != "") {
 			ERR_PRINT("Error parsing shader '" + p_file + "':\n\n" + base_error);
 		} else {
-			for (Map<StringName, Ref<RDShaderSPIRV>>::Element *E = versions.front(); E; E = E->next()) {
+			for (KeyValue<StringName, Ref<RDShaderSPIRV>> &E : versions) {
 				for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
-					String error = E->get()->get_stage_compile_error(RD::ShaderStage(i));
+					String error = E.value->get_stage_compile_error(RD::ShaderStage(i));
 					if (error != String()) {
 						static const char *stage_str[RD::SHADER_STAGE_MAX] = {
 							"vertex",
@@ -383,7 +383,7 @@ public:
 							"compute"
 						};
 
-						ERR_PRINT("Error parsing shader '" + p_file + "', version '" + String(E->key()) + "', stage '" + stage_str[i] + "':\n\n" + error);
+						ERR_PRINT("Error parsing shader '" + p_file + "', version '" + String(E.key) + "', stage '" + stage_str[i] + "':\n\n" + error);
 					}
 				}
 			}

--- a/servers/rendering/shader_warnings.cpp
+++ b/servers/rendering/shader_warnings.cpp
@@ -119,10 +119,10 @@ ShaderWarning::CodeFlags ShaderWarning::get_flags_from_codemap(const Map<Code, b
 		init_code_to_flags_map();
 	}
 
-	for (Map<Code, bool>::Element *E = p_map.front(); E; E = E->next()) {
-		if (E->get()) {
-			ERR_FAIL_COND_V(!code_to_flags_map->has((int)E->key()), ShaderWarning::NONE_FLAG);
-			result |= (*code_to_flags_map)[(int)E->key()];
+	for (const KeyValue<Code, bool> &E : p_map) {
+		if (E.value) {
+			ERR_FAIL_COND_V(!code_to_flags_map->has((int)E.key), ShaderWarning::NONE_FLAG);
+			result |= (*code_to_flags_map)[(int)E.key];
 		}
 	}
 	return (CodeFlags)result;

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -296,8 +296,8 @@ public:
 				if (tk == TK_IDENTIFIER) {
 					String name = value;
 					if (use_next_class || p_known_class_name == name) {
-						for (Map<int, String>::Element *E = namespace_stack.front(); E; E = E->next()) {
-							class_name += E->get() + ".";
+						for (const KeyValue<int, String> &E : namespace_stack) {
+							class_name += E.value + ".";
 						}
 						class_name += String(value);
 						break;

--- a/tests/test_shader_lang.cpp
+++ b/tests/test_shader_lang.cpp
@@ -120,14 +120,14 @@ static String dump_node_code(SL::Node *p_node, int p_level) {
 		case SL::Node::TYPE_SHADER: {
 			SL::ShaderNode *pnode = (SL::ShaderNode *)p_node;
 
-			for (Map<StringName, SL::ShaderNode::Uniform>::Element *E = pnode->uniforms.front(); E; E = E->next()) {
+			for (const KeyValue<StringName, SL::ShaderNode::Uniform> &E : pnode->uniforms) {
 				String ucode = "uniform ";
-				ucode += _prestr(E->get().precision);
-				ucode += _typestr(E->get().type);
-				ucode += " " + String(E->key());
+				ucode += _prestr(E.value.precision);
+				ucode += _typestr(E.value.type);
+				ucode += " " + String(E.key);
 
-				if (E->get().default_value.size()) {
-					ucode += " = " + get_constant_text(E->get().type, E->get().default_value);
+				if (E.value.default_value.size()) {
+					ucode += " = " + get_constant_text(E.value.type, E.value.default_value);
 				}
 
 				static const char *hint_name[SL::ShaderNode::Uniform::HINT_MAX] = {
@@ -140,18 +140,18 @@ static String dump_node_code(SL::Node *p_node, int p_level) {
 					"white"
 				};
 
-				if (E->get().hint) {
-					ucode += " : " + String(hint_name[E->get().hint]);
+				if (E.value.hint) {
+					ucode += " : " + String(hint_name[E.value.hint]);
 				}
 
 				code += ucode + "\n";
 			}
 
-			for (Map<StringName, SL::ShaderNode::Varying>::Element *E = pnode->varyings.front(); E; E = E->next()) {
+			for (const KeyValue<StringName, SL::ShaderNode::Varying> &E : pnode->varyings) {
 				String vcode = "varying ";
-				vcode += _prestr(E->get().precision);
-				vcode += _typestr(E->get().type);
-				vcode += " " + String(E->key());
+				vcode += _prestr(E.value.precision);
+				vcode += _typestr(E.value.type);
+				vcode += " " + String(E.key);
 
 				code += vcode + "\n";
 			}
@@ -183,8 +183,8 @@ static String dump_node_code(SL::Node *p_node, int p_level) {
 
 			//variables
 			code += _mktab(p_level - 1) + "{\n";
-			for (Map<StringName, SL::BlockNode::Variable>::Element *E = bnode->variables.front(); E; E = E->next()) {
-				code += _mktab(p_level) + _prestr(E->get().precision) + _typestr(E->get().type) + " " + E->key() + ";\n";
+			for (const KeyValue<StringName, SL::BlockNode::Variable> &E : bnode->variables) {
+				code += _mktab(p_level) + _prestr(E.value.precision) + _typestr(E.value.type) + " " + E.key + ";\n";
 			}
 
 			for (int i = 0; i < bnode->statements.size(); i++) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
See https://github.com/godotengine/godot/pull/50284
Tries to convert iterators to be `const` whenever possible.

*Bugsquad edit: Follow-up to https://github.com/godotengine/godot/pull/50511.*

<details>
<summary>Python script used, although I've made some manual fixup changes too.</summary>

```py
import os
import re


def const_only_usage() -> bool:
	assigned_to_regex = r"[^\s]+? [&*]?[_a-zA-Z][_a-zA-Z0-9]* = &?(Object::cast_to<.+?>\()?" + re.escape(iterator_name) + r"\.value(((\.|->).+?)+)?;"
	iterated_through_regex = r"\([^\s]+? &[_a-zA-Z][_a-zA-Z0-9]* : " + re.escape(iterator_name) + r"\.value\)"
	
	# Assigned to a constant value, must be constant.
	if re.search(f"const {assigned_to_regex}", slice) != None:
		return True
	if re.search(f"const {iterated_through_regex}", slice) != None:
		return True

	# Regexes to check.
	const_checks = [
		# Value or sub-value assigned.
		re.compile(iterator_name + r"\.value(((\.|->).+?)+)?(\[.+?\])? = .+?;"),
		# Assigned to non-const value.
		re.compile(assigned_to_regex),
		re.compile(iterated_through_regex),
		# Non-const method called on value or sub-value.
		re.compile(iterator_name + r".value(((\.|->).+?)+)?(->|\.)((push_packet|put_packet|commit|notify_tile_data_properties_should_change|_update_doc|clear|normalize|setup_local_to_scene|remove)\(|(write)\[)"),
		# Value passed as a non-const argument.
		re.compile(r"(_update_context|_set_subclass_path)\(" + re.escape(iterator_name) + r".value"),
		re.compile(r"(to_erase\.push_back|dirty_quadrant_list\.add)\(&?" + iterator_name)
	]

	for const_check in const_checks:
		if const_check.search(slice) != None:
			return False
	return True


directory = "C:/Users/Aaron/Projects/GodotSource/godot"
types = ("cpp", "h", "hpp")

os.chdir(directory)

# Get a list of files to modify.
grabbed_files = []
for root, dirs, files in os.walk(directory, topdown=True):
	dirs[:] = [d for d in dirs if d not in (".git", "thirdparty")]
	for file in files:
		if not file.endswith(types) or ".gen" in file:
			continue

		grabbed_files.append(os.path.join(root, file))


map_iter_re = re.compile(r"for ?\((const )?Map<(.+?), (.+?)>::Element \*(.+?) = (.+?)\.front\(\); \4; \4 = \4->next\(\)\) \{")
for grabbed_file in grabbed_files:
	# Read in the file.
	with open(grabbed_file, 'r', encoding="utf-8", newline="\n") as file:
		file_data = file.read()

	pos = 0
	while True:
		result = map_iter_re.search(file_data, pos)
		if not result:
			# Next file.
			break
		
		pos = result.end(0)

		is_const = result[1] != None
		key_type = result[2]
		value_type = result[3]
		iterator_name = result[4]
		container_name = result[5]

		# Discard custom comparators.
		if value_type.count(",") > value_type.count(">"):
			value_type = value_type[:value_type.rfind(",")]

		# Workaround for weird cases.
		if container_name in ("state.MeshNodes", "physics_2d_mouseover", "physics_2d_shape_mouseover"):
			# Should state.MeshNodes be deleted? It's an empty loop.
			continue

		# Get closing bracket position.
		bracket_count = 1
		bracket_pos = result.end(0)
		while bracket_count > 0:
			if file_data[bracket_pos] == "{":
				bracket_count += 1
			elif file_data[bracket_pos] == "}":
				bracket_count -= 1
			
			bracket_pos += 1
	
		slice = file_data[result.end(0):bracket_pos]
		if re.search(r"\b" + re.escape(iterator_name) + r"->next\(\)", slice):
			# Skip iterators that make use of `->next()`.
			continue
		if re.search(r"\b" + re.escape(container_name) + r"(->|\.)erase\(", slice):
			# Container is modified, I'm not sure how this is handeled.
			continue
		if f"_make_quadrant_dirty({iterator_name})" in slice:
			# See tile_map.cpp
			continue
		if "Object::cast_to<VisualShaderNodeGlobalExpression>(E->get().node.ptr())" in slice:
			# Not sure how to handle.
			continue

		replace_with = {"get": "value", "value": "value", "key": "key"}
		for key, value in replace_with.items():
			slice = re.sub(
				r"(?<=\b)" + re.escape(iterator_name) + r"->" + re.escape(key) + r"\(\)",
				iterator_name + "." + value,
				slice
			)
		# Convert iterators that weren't previously const to const if possible.
		if not is_const:
			is_const = const_only_usage()

		file_data = file_data[:result.end(0)] + slice + file_data[bracket_pos:]

		slice = file_data[result.start(0):result.end(0)]
		const = "const " if is_const else ""
		slice = f"for ({const}KeyValue<{key_type}, {value_type}> &{iterator_name} : {container_name}) {{"
		file_data = file_data[:result.start(0)] + slice + file_data[result.end(0):]

	# Write the file out again.
	with open(grabbed_file, 'w', encoding="utf-8", newline="\n") as file:
		file.write(file_data)

```
</details>