### PR TITLE
[3.x] Make blinn and phong specular consider albedo and specular amount

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -225,12 +225,12 @@ void light_compute(vec3 N, vec3 L, vec3 V, vec3 light_color, float roughness, in
 		vec3 H = normalize(V + L);
 		float cNdotH = max(dot(N, H), 0.0);
 		float shininess = exp2(15.0 * (1.0 - roughness) + 1.0) * 0.25;
-		float blinn = pow(cNdotH, shininess) * cNdotL;
-		blinn *= (shininess + 8.0) * (1.0 / (8.0 * M_PI));
+		float blinn = pow(cNdotH, shininess);
+		blinn *= (shininess + 2.0) * (1.0 / (8.0 * M_PI));
 		specular_brdf_NL = blinn;
 #endif
 
-		specular += specular_brdf_NL * light_color * (1.0 / M_PI);
+		specular += specular_brdf_NL * light_color;
 	}
 }
 
@@ -1122,11 +1122,11 @@ LIGHT_SHADER_CODE
 
 		//normalized blinn
 		float shininess = exp2(15.0 * (1.0 - roughness) + 1.0) * 0.25;
-		float blinn = pow(cNdotH, shininess) * cNdotL;
-		blinn *= (shininess + 8.0) * (1.0 / (8.0 * M_PI));
+		float blinn = pow(cNdotH, shininess);
+		blinn *= (shininess + 2.0) * (1.0 / (8.0 * M_PI)); // Normalized NDF and Geometric term
 		float intensity = blinn;
 
-		specular_light += light_color * intensity * specular_blob_intensity * attenuation;
+		specular_light += light_color * intensity * specular_blob_intensity * attenuation * diffuse_color * specular;
 
 #elif defined(SPECULAR_PHONG)
 
@@ -1134,10 +1134,10 @@ LIGHT_SHADER_CODE
 		float cRdotV = max(0.0, dot(R, V));
 		float shininess = exp2(15.0 * (1.0 - roughness) + 1.0) * 0.25;
 		float phong = pow(cRdotV, shininess);
-		phong *= (shininess + 8.0) * (1.0 / (8.0 * M_PI));
-		float intensity = (phong) / max(4.0 * cNdotV * cNdotL, 0.75);
+		phong *= (shininess + 1.0) * (1.0 / (8.0 * M_PI)); // Normalized NDF and Geometric term
+		float intensity = phong;
 
-		specular_light += light_color * intensity * specular_blob_intensity * attenuation;
+		specular_light += light_color * intensity * specular_blob_intensity * attenuation * diffuse_color * specular;
 
 #elif defined(SPECULAR_TOON)
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/50455 and fixes https://github.com/godotengine/godot/issues/34257

4.0 version: https://github.com/godotengine/godot/pull/51411

This PR adds in the ``specular`` amount and ``albedo`` into the calculation of specular lighting for Blinn and Phong modes. This is not physically based, however, it comes close to mirroring the old Specular/Diffuse lighting that was around before PBR. In discussions with other contributors it is clear that we want to maintain the Blinn and Phong modes for performance reasons and for compatibility with older workflows. The main difference between this and the old Specular/Diffuse lighting model is that this only provides one albedo colour. The older workflow always specified a specular colour and a diffuse colour, here we use albedo for specular and diffuse. Essentially we have gone from:
```
diffuse_color = albedo;
specular_color = vec3(1,1,1);
```
to:
```
diffuse_color = specular_color = albedo;
```
This PR should be slightly improve performance in theory. But in practice there will be a negligible difference. 

**Visual comparison**

All comparisons use the same layout. GGX in the upper right, Blinn in the lower left, and Phong in the lower right

<details><summary>Smooth metal</summary>

_old_
![smooth-old](https://user-images.githubusercontent.com/16521339/128647074-1677abbe-7b6c-41b8-8fcb-f5d561f1f736.png)


_new: note the color around the specular highlight_
![smooth-newnew](https://user-images.githubusercontent.com/16521339/128806966-fc9f1262-4cd2-4168-bb8c-57b3337f429d.png)


</details>

<details><summary>0.5 rough metal</summary>

_old_
![mid-old](https://user-images.githubusercontent.com/16521339/128647077-ab3a7335-cdc0-4423-a99d-31eb422cf404.png)


_new: note the colored specular highlight_
![mid-newnew](https://user-images.githubusercontent.com/16521339/128806973-620139ad-5bf4-4cf0-8d49-6b27603ed0b0.png)


</details>

<details><summary>rough metal</summary>

_old_
![rough-old](https://user-images.githubusercontent.com/16521339/128647081-c70709c3-f18d-4cf2-a156-ded9b9ac72a5.png)


_new_
![rough-newnew](https://user-images.githubusercontent.com/16521339/128806980-51aee9e6-92d0-4646-8e97-b0021cb5d9f6.png)


</details>

This PR should result in as little change as possible for existing materials while allowing more cohesiveness when using Blinn and Phong. Users that appreciated having the overblown specular on darker materials can still achieve the same look by boosting specular with the ``specular`` property.

<details><summary>Old notes</summary>
This PR adds a Fresnel term and geometric term to both the Blinn and Phong specular modes. The Fresnel term scales the specular intensity quite strongly and removes the overbright specular reflections when roughness is high. 

By way of background, BRDF's typically share 3 terms D (normalized density function) G (geometric term) F (Fresnel term). The Blinn BRDF is ``D*G*F / 4 * NdotL * nDotV`` (see https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf) . Godot has been using a more simplified model which ignored the G and F terms (and had a mistake in the D term): ``D` / 4 * NdotL * nDotV``. This simplified model is naturally simpler to compute, but was totally broken (hence https://github.com/godotengine/godot/pull/33836 which didn't actually fully fix Blinn).

This PR restores the G and F terms. The G term for Blinn-Phong is equal to ``NdotL * nDotV`` and so it cancels out the ``NdotL * nDotV`` in the BRDF. We are left with ``D * F / 4`` which is what this PR uses.

**Visual comparison**

All comparisons use the same layout. GGX in the upper right, Blinn in the lower left, and Phong in the lower right

<details><summary>Smooth metal</summary>

_old_
![smooth-old](https://user-images.githubusercontent.com/16521339/128647074-1677abbe-7b6c-41b8-8fcb-f5d561f1f736.png)


_new: note the color around the specular highlight_
![smooth-new](https://user-images.githubusercontent.com/16521339/128647076-ba130a5f-5d65-42af-ad4f-3e0013d90104.png)


</details>

<details><summary>0.5 rough metal</summary>

_old_
![mid-old](https://user-images.githubusercontent.com/16521339/128647077-ab3a7335-cdc0-4423-a99d-31eb422cf404.png)


_new: note the colored specular highlight_
![mid-new](https://user-images.githubusercontent.com/16521339/128647078-c29bc499-2d0e-4521-9a1f-551fb05845a6.png)


</details>

<details><summary>rough metal</summary>

_old_
![rough-old](https://user-images.githubusercontent.com/16521339/128647081-c70709c3-f18d-4cf2-a156-ded9b9ac72a5.png)


_new_
![rough-new](https://user-images.githubusercontent.com/16521339/128647082-3123d087-4515-494b-83a8-2f9b2425d119.png)


</details>
</details>

_edit: references for future reference_
http://www.thetenthplanet.de/archives/255
https://seblagarde.wordpress.com/2011/08/17/hello-world/
https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf
https://slideplayer.com/slide/1507561/