### PR TITLE
[3.x] Add horizon specular occlusion

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1686,6 +1686,8 @@ FRAGMENT_SHADER_CODE
 	ref_vec.z *= -1.0;
 
 	specular_light = textureCubeLod(radiance_map, ref_vec, roughness * RADIANCE_MAX_LOD).xyz * bg_energy;
+	float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
+	specular_light *= horizon * horizon;
 #ifndef USE_LIGHTMAP
 	{
 		vec3 ambient_dir = normalize((radiance_inverse_xform * vec4(normal, 0.0)).xyz);

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1882,6 +1882,8 @@ FRAGMENT_SHADER_CODE
 			ref_vec = normalize((radiance_inverse_xform * vec4(ref_vec, 0.0)).xyz);
 			vec3 radiance = textureDualParaboloid(radiance_map, ref_vec, roughness) * bg_energy;
 			env_reflection_light = radiance;
+			float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
+			env_reflection_light *= horizon * horizon;
 		}
 	}
 #ifndef USE_LIGHTMAP


### PR DESCRIPTION
Implements horizon specular occlusion. This helps reduce artifacts where you see the sky on the edges of e.g. tiles bricks etc.

_before: GLES3_
![Screenshot (197)](https://user-images.githubusercontent.com/16521339/128655039-e6d96011-985f-4f88-ad96-c48771275af9.png)

_after: GLES3_
![Screenshot (198)](https://user-images.githubusercontent.com/16521339/128655042-72d09fd2-3b74-4c54-8e95-924d59548643.png)

_before: GLES2_
![Screenshot (201)](https://user-images.githubusercontent.com/16521339/128655044-0dd00b2a-0616-4d53-bce3-61dc3b0b9e97.png)

_after: GLES2_
![Screenshot (200)](https://user-images.githubusercontent.com/16521339/128655046-677069c6-760d-4a66-a0e9-5cc57b723072.png)

Note: for some reason GLES2 suffers much less from this particular artifact. With horizon specular occlusion it looks almost perfect. At some point it may be worth exploring what is going on to see if we can improve GLES3 similarly.