### PR TITLE
automatically detect openbsd as platform=linuxbsd

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -196,7 +196,13 @@ elif env_base["p"] != "":
     selected_platform = env_base["p"]
 else:
     # Missing `platform` argument, try to detect platform automatically
-    if sys.platform.startswith("linux"):
+    if (
+        sys.platform.startswith("linux")
+        or sys.platform.startswith("dragonfly")
+        or sys.platform.startswith("freebsd")
+        or sys.platform.startswith("netbsd")
+        or sys.platform.startswith("openbsd")
+    ):
         selected_platform = "linuxbsd"
     elif sys.platform == "darwin":
         selected_platform = "osx"


### PR DESCRIPTION
as per title, like the bit for linux, this automatically matches openbsd as platform=linuxbsd