### PR TITLE
Fix Windows platform file access to allow file sharing with external programs

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -113,10 +113,10 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 		path = path + ".tmp";
 	}
 
-	errno_t errcode = _wfopen_s(&f, (LPCWSTR)(path.utf16().get_data()), mode_string);
+	f = _wfsopen((LPCWSTR)(path.utf16().get_data()), mode_string, _SH_DENYNO);
 
 	if (f == nullptr) {
-		switch (errcode) {
+		switch (errno) {
 			case ENOENT: {
 				last_error = ERR_FILE_NOT_FOUND;
 			} break;
@@ -307,10 +307,8 @@ void FileAccessWindows::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 }
 
 bool FileAccessWindows::file_exists(const String &p_name) {
-	FILE *g;
-	//printf("opening file %s\n", p_fname.utf8().get_data());
 	String filename = fix_path(p_name);
-	_wfopen_s(&g, (LPCWSTR)(filename.utf16().get_data()), L"rb");
+	FILE *g = _wfsopen((LPCWSTR)(filename.utf16().get_data()), L"rb", _SH_DENYNO);
 	if (g == nullptr) {
 		return false;
 	} else {

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -77,8 +77,8 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 		return ERR_INVALID_PARAMETER;
 	}
 
-	/* pretty much every implementation that uses fopen as primary
-	   backend supports utf8 encoding */
+	/* Pretty much every implementation that uses fopen as primary
+	   backend supports utf8 encoding. */
 
 	struct _stat st;
 	if (_wstat((LPCWSTR)(path.utf16().get_data()), &st) == 0) {
@@ -157,10 +157,10 @@ void FileAccessWindows::close() {
 #else
 			if (!PathFileExistsW((LPCWSTR)(save_path.utf16().get_data()))) {
 #endif
-				//creating new file
+				// Creating new file
 				rename_error = _wrename((LPCWSTR)((save_path + ".tmp").utf16().get_data()), (LPCWSTR)(save_path.utf16().get_data())) != 0;
 			} else {
-				//atomic replace for existing file
+				// Atomic replace for existing file
 				rename_error = !ReplaceFileW((LPCWSTR)(save_path.utf16().get_data()), (LPCWSTR)((save_path + ".tmp").utf16().get_data()), nullptr, 2 | 4, nullptr, nullptr);
 			}
 			if (rename_error) {
@@ -205,6 +205,7 @@ void FileAccessWindows::seek(uint64_t p_position) {
 
 void FileAccessWindows::seek_end(int64_t p_position) {
 	ERR_FAIL_COND(!f);
+
 	if (_fseeki64(f, p_position, SEEK_END)) {
 		check_errors();
 	}
@@ -237,6 +238,7 @@ bool FileAccessWindows::eof_reached() const {
 
 uint8_t FileAccessWindows::get_8() const {
 	ERR_FAIL_COND_V(!f, 0);
+
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == WRITE) {
 			fflush(f);
@@ -273,6 +275,7 @@ Error FileAccessWindows::get_error() const {
 
 void FileAccessWindows::flush() {
 	ERR_FAIL_COND(!f);
+
 	fflush(f);
 	if (prev_op == WRITE) {
 		prev_op = 0;
@@ -281,6 +284,7 @@ void FileAccessWindows::flush() {
 
 void FileAccessWindows::store_8(uint8_t p_dest) {
 	ERR_FAIL_COND(!f);
+
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == READ) {
 			if (last_error != ERR_FILE_EOF) {
@@ -295,6 +299,7 @@ void FileAccessWindows::store_8(uint8_t p_dest) {
 void FileAccessWindows::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND(!f);
 	ERR_FAIL_COND(!p_src && p_length > 0);
+
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == READ) {
 			if (last_error != ERR_FILE_EOF) {


### PR DESCRIPTION
This restores Windows platform file handling back to open files non-exlusively by default, as was the case before October 2018. (See https://github.com/godotengine/godot/commit/b902a2f2a7438810cdcb053568ed5c27089b1e8a)

It seems back then it was unintentionally changed while fixing warnings.

This is fixed by changing the open call from `_wfopen_s()` to `_wfsopen()`, thus being able to set the file sharing constant to `_SH_DENYNO` while still preserving security features of `_wfopen_s()`, like parameter validation, meaning the warning stays fixed.

Fixes #28036.

I tested this change on Windows as extensively as I could and found no issues.

---

<details>
  <summary>Details</summary>
  
Back then, while fixing warnings for *MSVC*, the function used for opening files was changed from `_wfopen()` to `_wfopen_s()` as suggested by the warning `C4996`. (`"This function may be unsafe, consider using _wfopen_s instead."`)

This new function
1. did parameter validation and thus avoided some possible security issues due to nil pointers or wrongly terminated strings
2. it also changed the default file sharing for opened files from `_SH_DENYNO` (which was the implicit default for the previous `_wfopen()`) to `_SH_SECURE`.

`_SH_DENYNO` means every opened file could be opened by other calls (like is the default on other operating systems).
`_SH_SECURE` means if the file is opened with READ access, others can still read the same file (but not write to it), but if it is opened with WRITE access, others can't open it at all, not even to read.

As this file sharing access is implied as default, not a parameter for either function, it seems this change was neither intended nor noticed.

This led to rarely occuring bugs on Windows, i.e. due to random access by Antivirus processes, or Godot/Windows not closing a file handle fast enough while trying to open it again elsewhere (i.e. `project.godot`, instead showing the Project Manager, or saving shaders/debugging the game).

What this PR does is change the file access to a third method, `_wfsopen()`. This is still secure, doing parameter validation and thus avoids the warning, but it allows us to actually SET the file sharing parameter. And we set it to `_SH_DENYNO`, as it was implicitely before the change. (And as it currently is on all non-Windows platforms, where file sharing restrictions don't exist by default.)

Warning `C4996` should really have been pointing this out. It should've been `_wfsopen()` all along. Let's hope this banishes those annoying, rare errors for all eternity.

The only interesting lines are 116 and 316, changing the function used for opening in `FileAccessWindows::_open()` and `FileAccessWindows::file_exists()` respectively, everything else are formatting fixes.

Links:
[_wfopen() docs ](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-160)
[_wfopen_s() docs](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-s-wfopen-s?view=msvc-160)
[_wfsopen() docs](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fsopen-wfsopen?view=msvc-160)
</details>