### PR TITLE
Improve the appearance of simple parallax in SpatialMaterial

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -776,7 +776,9 @@ void SpatialMaterial::_update_shader() {
 
 		} else {
 			code += "\t\tfloat depth = texture(texture_depth, base_uv).r;\n";
-			code += "\t\tvec2 ofs = base_uv - view_dir.xy / view_dir.z * (depth * depth_scale);\n";
+			// Use offset limiting to improve the appearance of non-deep parallax.
+			// This reduces the impression of depth, but avoids visible warping in the distance.
+			code += "\t\tvec2 ofs = base_uv - view_dir.xy * depth * depth_scale;\n";
 		}
 
 		code += "\t\tbase_uv=ofs;\n";


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50383.

This uses offset limiting to avoid distortion in the distance, and makes simple (non-deep) parallax more usable overall.

**Testing project:** https://github.com/Calinou/godot-parallax-test-4.0/tree/3.x

## Preview

| Before | After
|-|-|
| ![2021-11-07_00 57 40](https://user-images.githubusercontent.com/180032/140627285-54db0b0f-ca21-4edf-a572-de896a4cca5f.png) | ![2021-11-07_00 57 25](https://user-images.githubusercontent.com/180032/140627284-2fc53689-9503-49a5-bd38-3f76caa1a951.png) |