### PR TITLE
[Net] Add "dtls_hostname" property to ENet.

### DIFF
--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -118,6 +118,10 @@
 		<member name="compression_mode" type="int" setter="set_compression_mode" getter="get_compression_mode" enum="NetworkedMultiplayerENet.CompressionMode" default="0">
 			The compression method used for network packets. These have different tradeoffs of compression speed versus bandwidth, you may need to test which one works best for your use case if you use compression at all.
 		</member>
+		<member name="dtls_hostname" type="String" setter="set_dtls_hostname" getter="get_dtls_hostname" default="&quot;&quot;">
+			The hostname used for DTLS verification, to be compared against the "CN" value in the certificate provided by the server.
+			When set to an empty string, the [code]address[/code] parameter passed to [method create_client] is used instead.
+		</member>
 		<member name="dtls_verify" type="bool" setter="set_dtls_verify_enabled" getter="is_dtls_verify_enabled" default="true">
 			Enable or disable certificate verification when [member use_dtls] [code]true[/code].
 		</member>

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -157,7 +157,7 @@ Error NetworkedMultiplayerENet::create_client(const String &p_address, int p_por
 	ERR_FAIL_COND_V_MSG(!host, ERR_CANT_CREATE, "Couldn't create the ENet client host.");
 #ifdef GODOT_ENET
 	if (dtls_enabled) {
-		enet_host_dtls_client_setup(host, dtls_cert.ptr(), dtls_verify, p_address.utf8().get_data());
+		enet_host_dtls_client_setup(host, dtls_cert.ptr(), dtls_verify, dtls_hostname.empty() ? p_address.utf8().get_data() : dtls_hostname.utf8().get_data());
 	}
 	enet_host_refuse_new_connections(host, refuse_connections);
 #endif
@@ -851,6 +851,8 @@ void NetworkedMultiplayerENet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_dtls_certificate", "certificate"), &NetworkedMultiplayerENet::set_dtls_certificate);
 	ClassDB::bind_method(D_METHOD("set_dtls_verify_enabled", "enabled"), &NetworkedMultiplayerENet::set_dtls_verify_enabled);
 	ClassDB::bind_method(D_METHOD("is_dtls_verify_enabled"), &NetworkedMultiplayerENet::is_dtls_verify_enabled);
+	ClassDB::bind_method(D_METHOD("set_dtls_hostname", "hostname"), &NetworkedMultiplayerENet::set_dtls_hostname);
+	ClassDB::bind_method(D_METHOD("get_dtls_hostname"), &NetworkedMultiplayerENet::get_dtls_hostname);
 	ClassDB::bind_method(D_METHOD("get_peer_address", "id"), &NetworkedMultiplayerENet::get_peer_address);
 	ClassDB::bind_method(D_METHOD("get_peer_port", "id"), &NetworkedMultiplayerENet::get_peer_port);
 	ClassDB::bind_method(D_METHOD("set_peer_timeout", "id", "timeout_limit", "timeout_min", "timeout_max"), &NetworkedMultiplayerENet::set_peer_timeout);
@@ -872,6 +874,7 @@ void NetworkedMultiplayerENet::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "always_ordered"), "set_always_ordered", "is_always_ordered");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "server_relay"), "set_server_relay_enabled", "is_server_relay_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dtls_verify"), "set_dtls_verify_enabled", "is_dtls_verify_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "dtls_hostname"), "set_dtls_hostname", "get_dtls_hostname");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_dtls"), "set_dtls_enabled", "is_dtls_enabled");
 
 	BIND_ENUM_CONSTANT(COMPRESS_NONE);
@@ -946,4 +949,13 @@ void NetworkedMultiplayerENet::set_dtls_key(Ref<CryptoKey> p_key) {
 void NetworkedMultiplayerENet::set_dtls_certificate(Ref<X509Certificate> p_cert) {
 	ERR_FAIL_COND(active);
 	dtls_cert = p_cert;
+}
+
+void NetworkedMultiplayerENet::set_dtls_hostname(const String &p_hostname) {
+	ERR_FAIL_COND(active);
+	dtls_hostname = p_hostname;
+}
+
+String NetworkedMultiplayerENet::get_dtls_hostname() const {
+	return dtls_hostname;
 }

--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -114,6 +114,7 @@ private:
 	Ref<CryptoKey> dtls_key;
 	Ref<X509Certificate> dtls_cert;
 	bool dtls_verify;
+	String dtls_hostname;
 
 protected:
 	static void _bind_methods();
@@ -177,6 +178,8 @@ public:
 	bool is_dtls_verify_enabled() const;
 	void set_dtls_key(Ref<CryptoKey> p_key);
 	void set_dtls_certificate(Ref<X509Certificate> p_cert);
+	void set_dtls_hostname(const String &p_hostname);
+	String get_dtls_hostname() const;
 };
 
 VARIANT_ENUM_CAST(NetworkedMultiplayerENet::CompressionMode);


### PR DESCRIPTION
Used to specify the expected "CN" in the server certificate if different from the server address.

Closes godotengine/godot-proposals#1993
This PR is on `3.x` directly because the issue in `master` is addressed via #50710.