### PR TITLE
Clamp negative colors regardless of the tonemapper to avoid artifacts

### DIFF
--- a/servers/rendering/renderer_rd/shaders/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/tonemap.glsl
@@ -184,10 +184,6 @@ vec3 tonemap_aces(vec3 color, float white) {
 }
 
 vec3 tonemap_reinhard(vec3 color, float white) {
-	// Ensure color values are positive.
-	// They can be negative in the case of negative lights, which leads to undesired behavior.
-	color = max(vec3(0.0), color);
-
 	return (white * color + color) / (color * white + white);
 }
 
@@ -211,7 +207,7 @@ vec3 apply_tonemapping(vec3 color, float white) { // inputs are LINEAR, always o
 		return tonemap_reinhard(color, white);
 	} else if (params.tonemapper == TONEMAPPER_FILMIC) {
 		return tonemap_filmic(color, white);
-	} else { //aces
+	} else { // TONEMAPPER_ACES
 		return tonemap_aces(color, white);
 	}
 }
@@ -405,7 +401,9 @@ void main() {
 		color += screen_space_dither(gl_FragCoord.xy);
 	}
 
-	color = apply_tonemapping(color, params.white);
+	// Ensure color values passed to tonemappers are positive.
+	// They can be negative in the case of negative lights, which leads to undesired behavior.
+	color = apply_tonemapping(max(vec3(0.0), color), params.white);
 
 	color = linear_to_srgb(color); // regular linear -> SRGB conversion
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51439.

Color artifacts could be visible when using negative lights with the Filmic and ACES tonemapping operators, as these did not clamp negative colors.

**Question:** Should we clamp in each tonemapper individually, do it for all tonemappers separately, or do it for all tonemappers except Linear? I'm not sure if it makes a difference.

## Preview

### Linear

| Before | After |
|-|-|
| ![2021-08-09_17 00 15](https://user-images.githubusercontent.com/180032/128728333-2cebdff8-32ad-4899-9ca6-1b2d35c07519.png) | ![2021-08-09_16 59 16](https://user-images.githubusercontent.com/180032/128728348-16fa2d98-8834-4aee-b992-9a669d2b6aa7.png) |

### Reinhard (already clamped before this PR)

| Before | After |
|-|-|
| ![2021-08-09_17 00 22](https://user-images.githubusercontent.com/180032/128728374-009175d6-3797-43cf-8ee9-5c8119f6e326.png) | ![2021-08-09_16 59 23](https://user-images.githubusercontent.com/180032/128728392-f4923d8f-7c88-4653-8590-c6f5214946ee.png) |

### Filmic

| Before | After |
|-|-|
| ![2021-08-09_17 00 28](https://user-images.githubusercontent.com/180032/128728406-12a10973-4afb-4035-9319-ae87d32209ba.png) | ![2021-08-09_16 59 31](https://user-images.githubusercontent.com/180032/128728429-d01519aa-8059-4a51-8d61-b25fb8ec2d76.png) |

### ACES

| Before | After |
|-|-|
| ![2021-08-09_17 00 36](https://user-images.githubusercontent.com/180032/128728448-38982856-f2d2-4b38-8a6a-f8441e41ff63.png) | ![2021-08-09_16 59 37](https://user-images.githubusercontent.com/180032/128728487-e6e4bfda-e918-41c2-8cd0-86bc62194cb3.png) |