### PR TITLE
Clamp negative colors regardless of the tonemapper to avoid artifacts

### DIFF
--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -160,10 +160,6 @@ vec3 tonemap_aces(vec3 color, float white) {
 }
 
 vec3 tonemap_reinhard(vec3 color, float white) {
-	// Ensure color values are positive.
-	// They can be negative in the case of negative lights, which leads to undesired behavior.
-	color = max(vec3(0.0), color);
-
 	return clamp((white * color + color) / (color * white + white), vec3(0.0f), vec3(1.0f));
 }
 
@@ -347,8 +343,9 @@ void main() {
 #endif
 
 	// Early Tonemap & SRGB Conversion; note that Linear tonemapping does not clamp to [0, 1]; some operations below expect a [0, 1] range and will clamp
-
-	color = apply_tonemapping(color, white);
+	// Ensure color values are positive.
+	// They can be negative in the case of negative lights, which leads to undesired behavior.
+	color = apply_tonemapping(max(vec3(0.0), color), white);
 
 #ifdef KEEP_3D_LINEAR
 	// leave color as is (-> don't convert to SRGB)


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/51436.

Color artifacts could be visible when using negative lights with the Filmic and ACES tonemapping operators, as these did not clamp negative colors.

## Preview

### Linear

| Before | After |
|-|-|
| ![2021-08-09_17 06 02](https://user-images.githubusercontent.com/180032/128730678-352ff745-5dae-4823-ad29-0b9f53dfbed5.png) | ![2021-08-09_17 15 30](https://user-images.githubusercontent.com/180032/128730686-d2df6822-fea2-4882-bed2-44f77062cae9.png) |

### Reinhard (already clamped before this PR)

| Before | After |
|-|-|
| ![2021-08-09_17 06 18](https://user-images.githubusercontent.com/180032/128730682-09dcc874-8efc-49f1-b113-90e1e1430e9b.png) | ![2021-08-09_17 15 36](https://user-images.githubusercontent.com/180032/128730689-f7d95e2e-9ad1-4123-aca4-836fd9ffeaa6.png) |

### Filmic

| Before | After |
|-|-|
| ![2021-08-09_17 06 22](https://user-images.githubusercontent.com/180032/128730683-b562abdc-e561-46fc-a9e4-10d3bc7eef3b.png) | ![2021-08-09_17 15 41](https://user-images.githubusercontent.com/180032/128730693-13cb5819-90ac-47fb-aa0a-7c73014560f4.png) |

### ACES

| Before | After |
|-|-|
| ![2021-08-09_17 06 27](https://user-images.githubusercontent.com/180032/128730685-54d62909-ca2c-491d-8fe6-3d98015dfd71.png) | ![2021-08-09_17 15 47](https://user-images.githubusercontent.com/180032/128730696-1d4fd998-9690-4c4c-83ab-9adbc498a3db.png) |