### PR TITLE
[Net] [Editor] Network scenes configuration.

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -1293,6 +1293,25 @@ void MultiplayerAPI::_bind_methods() {
 
 MultiplayerAPI::MultiplayerAPI() {
 	clear();
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		// Load default spawnables
+		List<PropertyInfo> props;
+		ProjectSettings::get_singleton()->get_property_list(&props);
+		for (const PropertyInfo &pi : props) {
+			if (!pi.name.begins_with("spawnables/")) {
+				continue;
+			}
+
+			String name = pi.name.get_slice("/", 1);
+			int mode = ProjectSettings::get_singleton()->get(pi.name);
+
+			if (mode != MultiplayerAPI::SPAWN_MODE_SERVER && mode != MultiplayerAPI::SPAWN_MODE_CUSTOM) {
+				continue;
+			}
+			ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id("uid://" + name);
+			spawnable_config(uid, (SpawnMode)mode);
+		}
+	}
 }
 
 MultiplayerAPI::~MultiplayerAPI() {

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -165,6 +165,11 @@ StringName EditorFileSystemDirectory::get_file_type(int p_idx) const {
 	return files[p_idx]->type;
 }
 
+ResourceUID::ID EditorFileSystemDirectory::get_file_uid(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, files.size(), ResourceUID::INVALID_ID);
+	return files[p_idx]->uid;
+}
+
 String EditorFileSystemDirectory::get_name() {
 	return name;
 }

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -91,6 +91,7 @@ public:
 	String get_file(int p_idx) const;
 	String get_file_path(int p_idx) const;
 	StringName get_file_type(int p_idx) const;
+	ResourceUID::ID get_file_uid(int p_idx) const;
 	Vector<String> get_file_deps(int p_idx) const;
 	bool get_file_import_is_valid(int p_idx) const;
 	uint64_t get_file_modified_time(int p_idx) const;

--- a/editor/editor_spawnable_settings.cpp
+++ b/editor/editor_spawnable_settings.cpp
@@ -1,0 +1,167 @@
+/*************************************************************************/
+/*  editor_spawnable_settings.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor_spawnable_settings.h"
+
+#include "core/config/project_settings.h"
+#include "editor/editor_file_system.h"
+#include "editor/editor_node.h"
+#include "scene/gui/tree.h"
+
+void EditorSpawnableSettings::_item_edited() {
+	TreeItem *ti = tree->get_selected();
+	if (!ti || !ti->is_editable(0)) {
+		return;
+	}
+	updating = true;
+
+	ResourceUID::ID uid = ti->get_metadata(0);
+	if (ProjectSettings::get_singleton()->has_setting(_get_prop(uid))) {
+		spawnable_remove(uid);
+	} else {
+		spawnable_add(uid, MultiplayerAPI::SPAWN_MODE_SERVER);
+	}
+	updating = false;
+}
+
+void EditorSpawnableSettings::update_spawnables() {
+	if (updating) {
+		return;
+	}
+	updating = true;
+	tree->clear();
+	TreeItem *root = tree->create_item();
+	_fill_tree(EditorFileSystem::get_singleton()->get_filesystem(), root);
+	updating = false;
+}
+
+bool EditorSpawnableSettings::spawnable_add(const ResourceUID::ID p_id, MultiplayerAPI::SpawnMode p_mode) {
+	const String name = _get_prop(p_id);
+
+	UndoRedo *undo_redo = EditorNode::get_undo_redo();
+
+	undo_redo->create_action(TTR("Add Spawnable"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, p_mode);
+
+	if (ProjectSettings::get_singleton()->has_setting(name)) {
+		undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, ProjectSettings::get_singleton()->get(name));
+	} else {
+		undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, Variant());
+	}
+
+	undo_redo->add_do_method(this, "update_spawnables");
+	undo_redo->add_undo_method(this, "update_spawnables");
+
+	undo_redo->add_do_method(this, "emit_signal", spawnable_changed);
+	undo_redo->add_undo_method(this, "emit_signal", spawnable_changed);
+
+	undo_redo->commit_action();
+	return true;
+}
+
+void EditorSpawnableSettings::spawnable_remove(const ResourceUID::ID p_id) {
+	const String name = _get_prop(p_id);
+
+	UndoRedo *undo_redo = EditorNode::get_undo_redo();
+
+	undo_redo->create_action(TTR("Remove Spawnable"));
+
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, Variant());
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, ProjectSettings::get_singleton()->get(name));
+
+	undo_redo->add_do_method(this, "update_spawnables");
+	undo_redo->add_undo_method(this, "update_spawnables");
+
+	undo_redo->add_do_method(this, "emit_signal", spawnable_changed);
+	undo_redo->add_undo_method(this, "emit_signal", spawnable_changed);
+
+	undo_redo->commit_action();
+}
+
+bool EditorSpawnableSettings::_fill_tree(EditorFileSystemDirectory *p_dir, TreeItem *p_item) {
+	p_item->set_cell_mode(0, TreeItem::CELL_MODE_CUSTOM);
+	p_item->set_icon(0, get_theme_icon(SNAME("folder"), SNAME("FileDialog")));
+	p_item->set_text(0, p_dir->get_name().is_empty() ? "res://" : p_dir->get_name() + "/");
+	p_item->set_editable(0, false);
+	p_item->set_metadata(0, p_dir->get_path());
+
+	bool used = false;
+	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
+		TreeItem *subdir = tree->create_item(p_item);
+		if (_fill_tree(p_dir->get_subdir(i), subdir)) {
+			used = true;
+		} else {
+			memdelete(subdir);
+		}
+	}
+
+	for (int i = 0; i < p_dir->get_file_count(); i++) {
+		String type = p_dir->get_file_type(i);
+		if (type != "PackedScene") {
+			continue;
+		}
+
+		TreeItem *file = tree->create_item(p_item);
+		file->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+		file->set_text(0, p_dir->get_file(i));
+
+		ResourceUID::ID uid = p_dir->get_file_uid(i);
+
+		file->set_icon(0, EditorNode::get_singleton()->get_class_icon(type));
+		file->set_editable(0, true);
+		file->set_checked(0, ProjectSettings::get_singleton()->has_setting(_get_prop(uid)));
+		file->set_metadata(0, uid);
+
+		used = true;
+	}
+
+	return used;
+}
+
+void EditorSpawnableSettings::_bind_methods() {
+	ClassDB::bind_method("update_spawnables", &EditorSpawnableSettings::update_spawnables);
+	ClassDB::bind_method("spawnable_add", &EditorSpawnableSettings::spawnable_add);
+	ClassDB::bind_method("spawnable_remove", &EditorSpawnableSettings::spawnable_remove);
+
+	ADD_SIGNAL(MethodInfo("spawnable_changed"));
+}
+
+EditorSpawnableSettings::EditorSpawnableSettings() {
+	spawnable_changed = "spawnable_changed";
+
+	Label *label = memnew(Label);
+	label->set_text(TTR("Select the scenes you wish to be automatically replicated by the server over the network.\nSee the MultiplayerAPI documentation for more information."));
+	add_child(label, true);
+
+	tree = memnew(Tree);
+	tree->set_v_size_flags(SIZE_EXPAND_FILL);
+	tree->connect("item_edited", callable_mp(this, &EditorSpawnableSettings::_item_edited));
+	add_child(tree, true);
+}

--- a/editor/editor_spawnable_settings.h
+++ b/editor/editor_spawnable_settings.h
@@ -1,0 +1,64 @@
+/*************************************************************************/
+/*  editor_spawnable_settings.h                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef EDITOR_SPAWNABLE_SETTINGS_H
+#define EDITOR_SPAWNABLE_SETTINGS_H
+
+#include "core/io/resource_uid.h"
+#include "scene/gui/box_container.h"
+
+class Tree;
+class TreeItem;
+class EditorFileSystemDirectory;
+
+class EditorSpawnableSettings : public VBoxContainer {
+	GDCLASS(EditorSpawnableSettings, VBoxContainer);
+
+	bool updating = false;
+	StringName spawnable_changed;
+	Tree *tree;
+
+	bool _fill_tree(EditorFileSystemDirectory *p_dir, TreeItem *p_item);
+
+	void _item_edited();
+	String _get_prop(const ResourceUID::ID p_id) const { return "spawnables/" + ResourceUID::get_singleton()->id_to_text(p_id).right(-6); }
+
+protected:
+	static void _bind_methods();
+
+public:
+	void update_spawnables();
+	bool spawnable_add(const ResourceUID::ID p_id, MultiplayerAPI::SpawnMode p_mode);
+	void spawnable_remove(const ResourceUID::ID p_id);
+
+	EditorSpawnableSettings();
+};
+
+#endif

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -51,6 +51,7 @@ void ProjectSettingsEditor::popup_project_settings() {
 
 	localization_editor->update_translations();
 	autoload_settings->update_autoload();
+	spawnable_settings->update_spawnables();
 	plugin_settings->update_plugins();
 	import_defaults_editor->clear();
 }
@@ -628,6 +629,11 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	autoload_settings->set_name(TTR("AutoLoad"));
 	autoload_settings->connect("autoload_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
 	tab_container->add_child(autoload_settings);
+
+	spawnable_settings = memnew(EditorSpawnableSettings);
+	spawnable_settings->set_name(TTR("Network Scenes"));
+	spawnable_settings->connect("spawnable_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
+	tab_container->add_child(spawnable_settings);
 
 	shaders_global_variables_editor = memnew(ShaderGlobalsEditor);
 	shaders_global_variables_editor->set_name(TTR("Shader Globals"));

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -33,13 +33,14 @@
 
 #include "core/object/undo_redo.h"
 #include "editor/action_map_editor.h"
+#include "editor/editor_autoload_settings.h"
 #include "editor/editor_data.h"
 #include "editor/editor_plugin_settings.h"
 #include "editor/editor_sectioned_inspector.h"
+#include "editor/editor_spawnable_settings.h"
 #include "editor/import_defaults_editor.h"
 #include "editor/localization_editor.h"
 #include "editor/shader_globals_editor.h"
-#include "editor_autoload_settings.h"
 #include "scene/gui/tab_container.h"
 
 class ProjectSettingsEditor : public AcceptDialog {
@@ -54,6 +55,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	ActionMapEditor *action_map;
 	LocalizationEditor *localization_editor;
 	EditorAutoloadSettings *autoload_settings;
+	EditorSpawnableSettings *spawnable_settings;
 	ShaderGlobalsEditor *shaders_global_variables_editor;
 	EditorPluginSettings *plugin_settings;
 


### PR DESCRIPTION
Add and remove "spawnables" (#51097) from project settings via the editor.
"SPAWN_MODE_SERVER" only, since for custom mode you'll end up with your own registration logic anyway.

![Network Scenes settings editor](https://user-images.githubusercontent.com/1687918/128750638-9c7c478a-3dad-4f65-bce8-ce1db3300163.png)
