### PR TITLE
Allocate unique `track_blends` vector for animation states

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -116,7 +116,7 @@ void AnimationNode::blend_animation(const StringName &p_animation, double p_time
 
 	AnimationState anim_state;
 	anim_state.blend = p_blend;
-	anim_state.track_blends = &blends;
+	anim_state.track_blends = blends;
 	anim_state.delta = p_delta;
 	anim_state.time = p_time;
 	anim_state.animation = animation;
@@ -1124,7 +1124,7 @@ void AnimationTree::_process_graph(double p_delta) {
 				ERR_CONTINUE(!state.track_map.has(path));
 				int blend_idx = state.track_map[path];
 				ERR_CONTINUE(blend_idx < 0 || blend_idx >= state.track_count);
-				real_t blend = (*as.track_blends)[blend_idx] * weight;
+				real_t blend = (as.track_blends)[blend_idx] * weight;
 
 				Animation::TrackType ttype = a->track_get_type(i);
 				if (ttype != Animation::TYPE_POSITION_3D && ttype != Animation::TYPE_ROTATION_3D && ttype != Animation::TYPE_SCALE_3D && track->type != ttype) {

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -68,7 +68,7 @@ public:
 		Ref<Animation> animation;
 		double time = 0.0;
 		double delta = 0.0;
-		const Vector<real_t> *track_blends = nullptr;
+		Vector<real_t> track_blends;
 		real_t blend = 0.0;
 		bool seeked = false;
 		bool is_external_seeking = false;


### PR DESCRIPTION
This is a fix for the bug logged here (https://github.com/godotengine/godot/issues/51408). The only downside is that the fix introduces an extra memory allocation since it know longer uses the pointers to AnimationNode blends directly in order to prevent memory being overwritten on instanced animation state machines. There are ways this could be cached, so requesting feedback for profiling and alternative suggestions on how to fix.

*Bugsquad edit:* Fixes #51408.