### PR TITLE
Increase djb2 hash quality by using xor instead of add.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2673,7 +2673,7 @@ uint32_t String::hash(const char *p_cstr) {
 	uint32_t c;
 
 	while ((c = *p_cstr++)) {
-		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		hashv = ((hashv << 5) + hashv) ^ c; /* hash * 33 ^ c */
 	}
 
 	return hashv;
@@ -2682,7 +2682,7 @@ uint32_t String::hash(const char *p_cstr) {
 uint32_t String::hash(const char *p_cstr, int p_len) {
 	uint32_t hashv = 5381;
 	for (int i = 0; i < p_len; i++) {
-		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
+		hashv = ((hashv << 5) + hashv) ^ p_cstr[i]; /* hash * 33 ^ c */
 	}
 
 	return hashv;
@@ -2691,7 +2691,7 @@ uint32_t String::hash(const char *p_cstr, int p_len) {
 uint32_t String::hash(const wchar_t *p_cstr, int p_len) {
 	uint32_t hashv = 5381;
 	for (int i = 0; i < p_len; i++) {
-		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
+		hashv = ((hashv << 5) + hashv) ^ p_cstr[i]; /* hash * 33 ^ c */
 	}
 
 	return hashv;
@@ -2702,7 +2702,7 @@ uint32_t String::hash(const wchar_t *p_cstr) {
 	uint32_t c;
 
 	while ((c = *p_cstr++)) {
-		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		hashv = ((hashv << 5) + hashv) ^ c; /* hash * 33 ^ c */
 	}
 
 	return hashv;
@@ -2711,7 +2711,7 @@ uint32_t String::hash(const wchar_t *p_cstr) {
 uint32_t String::hash(const char32_t *p_cstr, int p_len) {
 	uint32_t hashv = 5381;
 	for (int i = 0; i < p_len; i++) {
-		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
+		hashv = ((hashv << 5) + hashv) ^ p_cstr[i]; /* hash * 33 ^ c */
 	}
 
 	return hashv;
@@ -2722,7 +2722,7 @@ uint32_t String::hash(const char32_t *p_cstr) {
 	uint32_t c;
 
 	while ((c = *p_cstr++)) {
-		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		hashv = ((hashv << 5) + hashv) ^ c; /* hash * 33 ^ c */
 	}
 
 	return hashv;
@@ -2736,7 +2736,7 @@ uint32_t String::hash() const {
 	uint32_t c;
 
 	while ((c = *chr++)) {
-		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		hashv = ((hashv << 5) + hashv) ^ c; /* hash * 33 ^ c */
 	}
 
 	return hashv;
@@ -2750,7 +2750,7 @@ uint64_t String::hash64() const {
 	uint64_t c;
 
 	while ((c = *chr++)) {
-		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		hashv = ((hashv << 5) + hashv) ^ c; /* hash * 33 ^ c */
 	}
 
 	return hashv;

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -54,7 +54,7 @@ static inline uint32_t hash_djb2(const char *p_cstr) {
 	uint32_t c;
 
 	while ((c = *chr++)) {
-		hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+		hash = ((hash << 5) + hash) ^ c; /* hash * 33 ^ c */
 	}
 
 	return hash;
@@ -64,14 +64,14 @@ static inline uint32_t hash_djb2_buffer(const uint8_t *p_buff, int p_len, uint32
 	uint32_t hash = p_prev;
 
 	for (int i = 0; i < p_len; i++) {
-		hash = ((hash << 5) + hash) + p_buff[i]; /* hash * 33 + c */
+		hash = ((hash << 5) + hash) ^ p_buff[i]; /* hash * 33 ^ c */
 	}
 
 	return hash;
 }
 
 static inline uint32_t hash_djb2_one_32(uint32_t p_in, uint32_t p_prev = 5381) {
-	return ((p_prev << 5) + p_prev) + p_in;
+	return ((p_prev << 5) + p_prev) ^ p_in;
 }
 
 static inline uint32_t hash_one_uint64(const uint64_t p_int) {
@@ -100,7 +100,7 @@ static inline uint32_t hash_djb2_one_float(double p_in, uint32_t p_prev = 5381) 
 		u.d = p_in;
 	}
 
-	return ((p_prev << 5) + p_prev) + hash_one_uint64(u.i);
+	return ((p_prev << 5) + p_prev) ^ hash_one_uint64(u.i);
 }
 
 template <class T>
@@ -129,11 +129,11 @@ static inline uint64_t hash_djb2_one_float_64(double p_in, uint64_t p_prev = 538
 		u.d = p_in;
 	}
 
-	return ((p_prev << 5) + p_prev) + u.i;
+	return ((p_prev << 5) + p_prev) ^ u.i;
 }
 
 static inline uint64_t hash_djb2_one_64(uint64_t p_in, uint64_t p_prev = 5381) {
-	return ((p_prev << 5) + p_prev) + p_in;
+	return ((p_prev << 5) + p_prev) ^ p_in;
 }
 
 template <class T>


### PR DESCRIPTION
Using xor somewhat increases hash quality and deals with the pathological case identified in the issue #51023

I've seen this djb2 variant being called djb2a. I don't think it is an official name though. So I didn't change function names.

I have no idea if this change has any side effects as this is my first time working with Godot code.