### PR TITLE
Fix crashing autoloaded singleton from calling another autoloaded in _ready

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -191,6 +191,12 @@ bool ScriptServer::is_reload_scripts_on_save_enabled() {
 	return reload_scripts_on_save;
 }
 
+void ScriptServer::reload_all_scripts() {
+	for (int i = 0; i < _language_count; i++) {
+		_languages[i]->reload_all_scripts();
+	}
+}
+
 void ScriptServer::thread_enter() {
 	for (int i = 0; i < _language_count; i++) {
 		_languages[i]->thread_enter();

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -70,6 +70,8 @@ public:
 	static void register_language(ScriptLanguage *p_language);
 	static void unregister_language(ScriptLanguage *p_language);
 
+	static void reload_all_scripts();
+
 	static void set_reload_scripts_on_save(bool p_enable);
 	static bool is_reload_scripts_on_save_enabled();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2177,6 +2177,8 @@ bool Main::start() {
 					}
 				}
 
+				ScriptServer::reload_all_scripts();
+
 				for (Node *E : to_add) {
 					sml->get_root()->add_child(E);
 				}


### PR DESCRIPTION
Work in progress fix for this issue (https://github.com/godotengine/godot/issues/50471). Prevents the crashing, but not a complete solution yet since it still prints errors and requires loading the autoload singletons twice.