### PR TITLE
Fix infinite loop when creating a newly inherited GDScript file

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -107,7 +107,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 			// Locate class by constructing the path to it and following that path
 			GDScriptParser::ClassNode *class_type = p_datatype.class_type;
 			if (class_type) {
-				if (class_type->fqcn.begins_with(main_script->path) || (!main_script->name.is_empty() && class_type->fqcn.begins_with(main_script->name))) {
+				if ((!main_script->path.is_empty() && class_type->fqcn.begins_with(main_script->path)) || (!main_script->name.is_empty() && class_type->fqcn.begins_with(main_script->name))) {
 					// Local class.
 					List<StringName> names;
 					while (class_type->outer) {


### PR DESCRIPTION
Closes #50681

When creating a new script inheriting another script (see screenshot for example), the base type is wrongly set to itself, creating a loop.
The root cause is that on creation, its path (=main_script->path) is empty, and in gscript_compiler.cpp, the condition `class_type->fqcn.begins_with(main_script->path))` is always true, whatever is the parent path.

![image](https://user-images.githubusercontent.com/440909/128779757-31e0fdcd-abc2-48f4-adb7-8f0a71852def.png)
