### PR TITLE
Allow unclamped colors in Sprite3D

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -404,7 +404,7 @@ SpriteBase3D::SpriteBase3D() {
 	mesh_array[VS::ARRAY_COLOR] = mesh_colors;
 	mesh_array[VS::ARRAY_TEX_UV] = mesh_uvs;
 
-	VS::get_singleton()->mesh_add_surface_from_arrays(mesh, VS::PRIMITIVE_TRIANGLE_FAN, mesh_array, Array(), VS::ARRAY_COMPRESS_DEFAULT & ~VS::ARRAY_COMPRESS_TEX_UV);
+	VS::get_singleton()->mesh_add_surface_from_arrays(mesh, VS::PRIMITIVE_TRIANGLE_FAN, mesh_array, Array(), (VS::ARRAY_COMPRESS_DEFAULT & ~VS::ARRAY_COMPRESS_TEX_UV) & ~VS::ARRAY_COMPRESS_COLOR);
 	const int surface_vertex_len = VS::get_singleton()->mesh_surface_get_array_len(mesh, 0);
 	const int surface_index_len = VS::get_singleton()->mesh_surface_get_array_index_len(mesh, 0);
 
@@ -531,7 +531,7 @@ void Sprite3D::_draw() {
 
 	AABB aabb;
 
-	// Everything except position and UV is compressed
+	// Everything except position, color, and UV is compressed
 	PoolVector<uint8_t>::Write write_buffer = mesh_buffer.write();
 
 	Vector2 normal_oct = VisualServer::get_singleton()->norm_to_oct(normal);
@@ -544,13 +544,6 @@ void Sprite3D::_draw() {
 	int8_t v_tangent[2] = {
 		(int8_t)CLAMP(tangent_oct.x * 127, -128, 127),
 		(int8_t)CLAMP(tangent_oct.y * 127, -128, 127),
-	};
-
-	uint8_t v_color[4] = {
-		(uint8_t)CLAMP(int(color.r * 255.0), 0, 255),
-		(uint8_t)CLAMP(int(color.g * 255.0), 0, 255),
-		(uint8_t)CLAMP(int(color.b * 255.0), 0, 255),
-		(uint8_t)CLAMP(int(color.a * 255.0), 0, 255)
 	};
 
 	for (int i = 0; i < 4; i++) {
@@ -571,7 +564,7 @@ void Sprite3D::_draw() {
 		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
 		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_NORMAL]], v_normal, 2);
 		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TANGENT]], v_tangent, 2);
-		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_COLOR]], v_color, 4);
+		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_COLOR]], color.components, 4 * 4);
 	}
 
 	write_buffer.release();
@@ -883,7 +876,7 @@ void AnimatedSprite3D::_draw() {
 
 	AABB aabb;
 
-	// Everything except position and UV is compressed
+	// Everything except position, color, and UV is compressed
 	PoolVector<uint8_t>::Write write_buffer = mesh_buffer.write();
 
 	Vector2 normal_oct = VisualServer::get_singleton()->norm_to_oct(normal);
@@ -896,13 +889,6 @@ void AnimatedSprite3D::_draw() {
 	int8_t v_tangent[2] = {
 		(int8_t)CLAMP(tangent_oct.x * 127, -128, 127),
 		(int8_t)CLAMP(tangent_oct.y * 127, -128, 127),
-	};
-
-	uint8_t v_color[4] = {
-		(uint8_t)CLAMP(int(color.r * 255.0), 0, 255),
-		(uint8_t)CLAMP(int(color.g * 255.0), 0, 255),
-		(uint8_t)CLAMP(int(color.b * 255.0), 0, 255),
-		(uint8_t)CLAMP(int(color.a * 255.0), 0, 255)
 	};
 
 	for (int i = 0; i < 4; i++) {
@@ -923,7 +909,7 @@ void AnimatedSprite3D::_draw() {
 		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
 		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_NORMAL]], v_normal, 2);
 		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TANGENT]], v_tangent, 2);
-		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_COLOR]], v_color, 4);
+		memcpy(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_COLOR]], color.components, 4 * 4);
 	}
 
 	write_buffer.release();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/51460

This was another regression from the big Sprite3D overhaul. I was using compressed colors as that was the default setting for meshes, but that clamps values to the 0-1 range. This uses uncompressed colors, but allows any range of values. 
