### PR TITLE
[Net] [RFC] Add initial state replication to spawnables.

### DIFF
--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -122,9 +122,9 @@ protected:
 
 	Error _encode_and_compress_variant(const Variant &p_variant, uint8_t *p_buffer, int &r_len);
 	Error _decode_and_decompress_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len);
-	Error _encode_spawn_state(const SpawnableConfig &p_cfg, const Object *p_obj, uint8_t *p_buffer, int &r_len);
-	Error _decode_spawn_state(const SpawnableConfig &p_cfg, Object *p_obj, const uint8_t *p_buffer, int p_len, int &r_len);
-	Error _send_spawn_despawn(int p_peer_id, const ResourceUID::ID &p_scene_id, const NodePath &p_path, const Variant &p_state, bool p_spawn);
+	Error _encode_spawn_state(const SpawnableConfig &p_cfg, const Object *p_obj, uint8_t *p_buffer, int &r_len, bool *r_raw = nullptr);
+	Error _decode_spawn_state(const SpawnableConfig &p_cfg, Object *p_obj, const uint8_t *p_buffer, int p_len, int &r_len, bool p_raw = false);
+	Error _send_spawn_despawn(int p_peer_id, const ResourceUID::ID &p_scene_id, const NodePath &p_path, const Variant &p_state, bool p_spawn, bool p_optmize_objects);
 
 public:
 	enum NetworkCommands {

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -90,8 +90,29 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="scene_id" type="int" />
 			<argument index="1" name="spawn_mode" type="int" enum="MultiplayerAPI.SpawnMode" />
+			<argument index="2" name="properties" type="StringName[]" default="[]" />
 			<description>
-				Configures the MultiplayerAPI to track instances of the [PackedScene] idenfied by [code]scene_id[/code] (see [method ResourceLoader.get_resource_uid]) for the purpose of network replication. See [enum SpawnMode] for the possible configurations.
+				Configures the MultiplayerAPI to track instances of the [PackedScene] identified by [code]scene_id[/code] (see [method ResourceLoader.get_resource_uid]) for the purpose of network replication. When [code]mode[/code] is [constant SPAWN_MODE_SERVER], the specified [code]properties[/code] will also be replicated to clients during the initial spawn.
+				Tip: You can use a custom property in the scene main script to return a customly optimized state representation.
+			</description>
+		</method>
+		<method name="spawnable_decode_state">
+			<return type="int" enum="Error" />
+			<argument index="0" name="scene_id" type="int" />
+			<argument index="1" name="object" type="Object" />
+			<argument index="2" name="data" type="PackedByteArray" />
+			<description>
+				Decode the given [code]data[/code] representing a spawnable state into [code]object[/code] using the configuration associated with the provided [code]scene_id[/code]. This function is called automatically when a client receives a server spawn for a scene with [constant SPAWN_MODE_SERVER]. See [method spawnable_config].
+				Tip: You may find this function useful in servers when parsing spawn requests from clients, or when implementing your own logic with [constant SPAWN_MODE_CUSTOM].
+			</description>
+		</method>
+		<method name="spawnable_encode_state">
+			<return type="PackedByteArray" />
+			<argument index="0" name="scene_id" type="int" />
+			<argument index="1" name="object" type="Object" />
+			<description>
+				Encode the given [code]object[/code] using the configuration associated with the provided [code]scene_id[/code]. This function is called automatically when the server spawns scenes with [constant SPAWN_MODE_SERVER]. See [method spawnable_config].
+				Tip: You may find this function useful when requesting spawns from clients to server, or when implementing your own logic with [constant SPAWN_MODE_CUSTOM].
 			</description>
 		</method>
 	</methods>
@@ -123,10 +144,8 @@
 			</description>
 		</signal>
 		<signal name="network_despawn">
-			<argument index="0" name="id" type="int" />
-			<argument index="1" name="scene_id" type="int" />
-			<argument index="2" name="node" type="Node" />
-			<argument index="3" name="data" type="PackedByteArray" />
+			<argument index="0" name="scene_id" type="int" />
+			<argument index="1" name="node" type="Node" />
 			<description>
 				Emitted on a client before deleting a local Node upon receiving a despawn request from the server.
 			</description>
@@ -161,10 +180,8 @@
 			</description>
 		</signal>
 		<signal name="network_spawn">
-			<argument index="0" name="id" type="int" />
-			<argument index="1" name="scene_id" type="int" />
-			<argument index="2" name="node" type="Node" />
-			<argument index="3" name="data" type="PackedByteArray" />
+			<argument index="0" name="scene_id" type="int" />
+			<argument index="1" name="node" type="Node" />
 			<description>
 				Emitted on a client after a new Node is instantiated locally and added to the SceneTree upon receiving a spawn request from the server.
 			</description>


### PR DESCRIPTION
Only automatic in SERVER mode.

Only synchronize specified properties passed to `spawnable_config`.

You can use script properties to optimize the state representation. send_spawn and send_despawn now accept a variant. Only NIL, OBJECT, and PACKED_BYTE_ARRAY are allowed.

If the passed variant is an object the state will be serialized according to `spawnable_config` rules. No automatic decoding is performed except in SERVER mode when synchronizing from server to client.

You can use `spawnable_decode_state` to decode the state.

Example:
```
# Configure the given scene to replicate the initial position and linear_velocity
multiplayer.spawnable_config(id, MultiplayerAPI.SPAWN_MODE_SERVER, [&"position", &"linear_velocity"])
```

You can attach a script to the main node, and use it to optimize the initial state:
```gdscript
# Configure the given scene to replicate your own state
multiplayer.spawnable_config(id, MultiplayerAPI.SPAWN_MODE_SERVER, [&"state"])

# In your player script
# Optimized state representation
var state:
	get:
		var buf = PackedByteArray()
		buf.resize(8)
		buf.encode_half(0, position.x)
		buf.encode_half(2, position.y)
		buf.encode_half(4, linear_velocity.x)
		buf.encode_half(6, linear_velocity.y)
		return buf

	set(value):
		if typeof(value) != TYPE_RAW_ARRAY or value.size() != 8:
			return
		position = Vector2(value.decode_half(0), value.decode_half(2))
		linear_velocity = Vector2(value.decode_half(4), value.decode_half(6))
```

In SERVER mode, when sending a state that has only one property and that property is a PoolByteArray, that property is automatically optimized to skip encoding (second commit).

When manually calling `send_spawn` you can pass a `PackedByteArray` to receive the same result.

Feedback's welcome.
GUI (#51443) will likely need update after this to let you select base node and script properties to sync.