### PR TITLE
[Net] Enet optimizations and fixes for sending unreliable enet traffic larger than enets 1400 byte MTU

### DIFF
--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -34,6 +34,16 @@
 #include "core/io/ip.h"
 #include "core/reference.h"
 
+typedef struct {
+#ifdef WINDOWS_ENABLED
+	size_t dataLength;
+	void *data;
+#else
+	void *data;
+	size_t dataLength;
+#endif
+} NetSocketBuffer;
+
 class NetSocket : public Reference {
 protected:
 	static NetSocket *(*_create)();
@@ -63,6 +73,7 @@ public:
 	virtual Error recvfrom(uint8_t *p_buffer, int p_len, int &r_read, IP_Address &r_ip, uint16_t &r_port, bool p_peek = false) = 0;
 	virtual Error send(const uint8_t *p_buffer, int p_len, int &r_sent) = 0;
 	virtual Error sendto(const uint8_t *p_buffer, int p_len, int &r_sent, IP_Address p_ip, uint16_t p_port) = 0;
+	virtual Error sendmsg(const NetSocketBuffer *p_buffers, int p_len, int &r_sent, IP_Address p_ip, uint16_t p_port) = 0;
 	virtual Ref<NetSocket> accept(IP_Address &r_ip, uint16_t &r_port) = 0;
 
 	virtual bool is_open() const = 0;

--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -83,6 +83,7 @@ public:
 	virtual Error recvfrom(uint8_t *p_buffer, int p_len, int &r_read, IP_Address &r_ip, uint16_t &r_port, bool p_peek = false);
 	virtual Error send(const uint8_t *p_buffer, int p_len, int &r_sent);
 	virtual Error sendto(const uint8_t *p_buffer, int p_len, int &r_sent, IP_Address p_ip, uint16_t p_port);
+	virtual Error sendmsg(const NetSocketBuffer *p_buffers, int p_len, int &r_sent, IP_Address p_ip, uint16_t p_port);
 	virtual Ref<NetSocket> accept(IP_Address &r_ip, uint16_t &r_port);
 
 	virtual bool is_open() const;

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -217,20 +217,23 @@ void NetworkedMultiplayerENet::poll() {
 
 	_pop_current_packet();
 
+	if (!host || !active) { // Might be disconnected
+		return;
+	}
+
 	ENetEvent event;
-	/* Keep servicing until there are no available events left in queue. */
-	while (true) {
-		if (!host || !active) { // Might have been disconnected while emitting a notification
+	int ret = enet_host_service(host, &event, 0);
+
+	if (ret < 0) {
+		ERR_FAIL_MSG("Enet host service error");
+	} else if (ret == 0) {
+		return; // No events
+	}
+
+	/* Keep servicing until there are no available events left in the queue. */
+	do {
+		if (!host || !active) { // Check again after every event
 			return;
-		}
-
-		int ret = enet_host_service(host, &event, 0);
-
-		if (ret < 0) {
-			// Error, do something?
-			break;
-		} else if (ret == 0) {
-			break;
 		}
 
 		switch (event.type) {
@@ -436,7 +439,7 @@ void NetworkedMultiplayerENet::poll() {
 				// Do nothing
 			} break;
 		}
-	}
+	} while (enet_host_check_events(host, &event) > 0);
 }
 
 bool NetworkedMultiplayerENet::is_server() const {
@@ -544,9 +547,10 @@ Error NetworkedMultiplayerENet::put_packet(const uint8_t *p_buffer, int p_buffer
 				packet_flags = ENET_PACKET_FLAG_UNSEQUENCED;
 			}
 			channel = SYSCH_UNRELIABLE;
+			packet_flags |= ENET_PACKET_FLAG_UNRELIABLE_FRAGMENT;
 		} break;
 		case TRANSFER_MODE_UNRELIABLE_ORDERED: {
-			packet_flags = 0;
+			packet_flags = ENET_PACKET_FLAG_UNRELIABLE_FRAGMENT;
 			channel = SYSCH_UNRELIABLE;
 		} break;
 		case TRANSFER_MODE_RELIABLE: {

--- a/thirdparty/enet/enet/godot.h
+++ b/thirdparty/enet/enet/godot.h
@@ -59,8 +59,13 @@ typedef void *ENetSocket;
 
 typedef struct
 {
+#ifdef WINDOWS_ENABLED
+	size_t dataLength;
+	void *data;
+#else
 	void *data;
 	size_t dataLength;
+#endif
 } ENetBuffer;
 
 #define ENET_CALLBACK


### PR DESCRIPTION
This PR includes some of the enet optimizations and fixes we have been using on our private godot fork.

This PR address the following:

 * Current NetworkedMultiplayerEnet does not set the flag `ENET_PACKET_FLAG_UNRELIABLE_FRAGMENT` when sending data on the unreliable enet transport.    Enet's internal MTU is configured to be 1400 bytes.  **If you do not set this flag, Enet will deliver messages that are larger than 1400 bytes RELIABLY**.  The following is output from a gameserver with `ENET_DEBUG` defined in enet's `protocol.c` source.  This was really surprising to us to see enet queue up outgoing packets even though our godot application was sending everything unreliably.  Unless the `ENET_PACKET_FLAG_UNRELIABLE_FRAGMENT` flag is set (https://github.com/lsalzman/enet/blob/74cea7abf52ddd355146aeb0a4077d2b95368122/include/enet/enet.h#L115), Enet will deliver unreliable messages over 1400 bytes reliably as enet by default will attempt to re-assemble fragments.  
```
"peer 0: 0.000000%+-0.000000% packet loss, 16+-4 ms round trip time, 1.000000% throttle, 0 outgoing, 0/0 incoming\r\n"
"peer 0: 0.000000%+-0.000000% packet loss, 19+-4 ms round trip time, 1.000000% throttle, 0 outgoing, 0/0 incoming\r\n"
"peer 0: 0.000229%+-0.000458% packet loss, 16+-3 ms round trip time, 1.000000% throttle, 0 outgoing, 0/0 incoming\r\n"
"peer 0: 0.000839%+-0.001678% packet loss, 18+-4 ms round trip time, 1.000000% throttle, 0 outgoing, 0/0 incoming\r\n"
"peer 0: 0.000626%+-0.001160% packet loss, 20+-4 ms round trip time, 1.000000% throttle, 0 outgoing, 0/0 incoming\r\n"
"peer 0: 0.002182%+-0.003952% packet loss, 20+-4 ms round trip time, 1.000000% throttle, 9 outgoing, 0/0 incoming\r\n"
"peer 0: 0.000885%+-0.001404% packet loss, 23+-7 ms round trip time, 1.000000% throttle, 0 outgoing, 0/0 incoming\r\n"
"peer 0: 0.001907%+-0.003510% packet loss, 23+-7 ms round trip time, 1.000000% throttle, 0 outgoing, 0/0 incoming\r\n"
"peer 0: 0.002213%+-0.002319% packet loss, 94+-75 ms round trip time, 0.000000% throttle, 2404 outgoing, 0/0 incoming\r\n"
"peer 0: 0.002472%+-0.002274% packet loss, 394+-93 ms round trip time, 0.000000% throttle, 7114 outgoing, 0/0 incoming\r\n"
"peer 0: 0.029907%+-0.056595% packet loss, 639+-161 ms round trip time, 0.062500% throttle, 10664 outgoing, 0/0 incoming\r\n"
"peer 0: 0.063278%+-0.109177% packet loss, 824+-7 ms round trip time, 1.000000% throttle, 13068 outgoing, 0/0 incoming\r\n"
"peer 0: 0.093979%+-0.143295% packet loss, 1006+-7 ms round trip time, 1.000000% throttle, 15179 outgoing, 0/0 incoming\r\n"
```

* The current implementation of `enet_socket_send` in godot (`godot.cpp`), makes a surperflous copy of outbound data before sending it out on the socket.   https://github.com/godotengine/godot/pull/7985/files#diff-4b4db5dcc81b5bff9d43a2bf9b6193316d1b822fe8a310f34b324f0a9e451d3dR143-R148   This is due mainly to the fact that enet wants to to send data via `sendmsg` on posix platforms, and `WSASendTo` on windows (in `win23.c` and `unix.c` within the enet library).  Both these platform functions allow an application to send a list of packets ( A packet being a data pointer and length).  `Netsocket` does not expose a similar interface, so a copy has to be made from each of outgoing packets within `enet_socket_send`.    This PR adds `sendmsg` type support to `Netsocket` which allows godot to send a list of packets implemented with `sendmsg` and `WSASendTo` on supported godot platforms.  Supporting this api in `Netsocket` allows this PR to remove the superfluous memcopy in `enet_socket_send` in `godot.cpp`.

* Lastly, an improvement is made to how enet is serviced in `NetworkedMultiplayerENet::poll`.  The current implementation is to loop on `enet_host_service()`.  This method of servicing enet has a potential starvation issue that we encountered, which can lead to unexpected durations of how long the godot main thread is spending in `NetworkedMultiplayerENet::poll`.  This is especially not wanted, if you are polling enet on the main thread of a game engine (there is no guarantee the loop will ever stop).  If you have clients that send data fast enough, enet will continue to service these messages, and it can be tough to break out of the loop and lead to starvation issues.  A solution by the enet library developer was to add `enet_host_check_events()`.  This can be used to process all the events queued up for processing by a single call to `enet_host_service()`.  This is somewhat described in this response here: https://github.com/lsalzman/enet/issues/126#issuecomment-802652587    A single call to`enet_host_service()` will hit the socket, and queue all incoming messages for processing in enet.    Repeatedly calling `enet_host_check_events()` doesn't touch the socket at all, and will process all queued messages until there are none left.  This technique is described the enet library's developer here: https://www.mail-archive.com/enet-discuss@cubik.org/msg00947.html and http://lists.cubik.org/pipermail/enet-discuss/2013-September/002238.html.

* Of note - I have NOT been able to test `NetSocketPosix::sendmsg` on windows.  `NetSocketPosix::sendmsg` does have an `#ifdef` for the windows platform here but I believe it's a good tradeoff here to support this api, as it allows a lot of efficiencies especially when specifically working with the enet api.  The spec for `WSASendTo` seems reasonably straight forward (https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendto) however I currently don't have a machine to test this path.

This change can be cherry picked to 4.0 master as well.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
