### PR TITLE
Fix incorrect border width of antialiased lines

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -639,17 +639,19 @@ void RendererCanvasCull::canvas_item_add_polyline(RID p_item, const Vector<Point
 
 			j2 = j + 1;
 
-			Vector2 tangent = ((t + prev_t).normalized()) * p_width * 0.5;
+			Vector2 dir = (t + prev_t).normalized();
+			Vector2 tangent = dir * p_width * 0.5;
+			Vector2 border = dir * 2.0;
 			Vector2 pos = p_points[i];
 
 			points_ptr[j] = pos + tangent;
 			points_ptr[j2] = pos - tangent;
 
-			points_top_ptr[j] = pos + tangent + tangent;
+			points_top_ptr[j] = pos + tangent + border;
 			points_top_ptr[j2] = pos + tangent;
 
 			points_bottom_ptr[j] = pos - tangent;
-			points_bottom_ptr[j2] = pos - tangent - tangent;
+			points_bottom_ptr[j2] = pos - tangent - border;
 
 			if (i < p_colors.size()) {
 				color = p_colors[i];


### PR DESCRIPTION
I think currently AA is looking incorrect when the width is large:

![image](https://user-images.githubusercontent.com/3036176/128816743-53d821fd-3089-4664-972b-8ee913ae8da3.png)

This is not how AA lines looks in 3.x with the same code.

I fixed it so now it looks like:

![image](https://user-images.githubusercontent.com/3036176/128816883-c55e668e-e7b7-4a3f-9b5e-51db6d564172.png)
