### PR TITLE
Quickhull - reduce warning spam and make hideable

### DIFF
--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -364,6 +364,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_me
 	bool warning_f = false;
 	bool warning_o_equal_e = false;
 	bool warning_o = false;
+	bool warning_not_f2 = false;
 
 	for (List<Geometry::MeshData::Face>::Element *E = ret_faces.front(); E; E = E->next()) {
 		Geometry::MeshData::Face &f = E->get();
@@ -413,7 +414,12 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_me
 							Edge e2(idx, idxn);
 
 							Map<Edge, RetFaceConnect>::Element *F2 = ret_edges.find(e2);
-							ERR_CONTINUE(!F2);
+
+							if (unlikely(!F2)) {
+								warning_not_f2 = true;
+								continue;
+							}
+
 							//change faceconnect, point to this face instead
 							if (F2->get().left == O) {
 								F2->get().left = E;
@@ -452,6 +458,9 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_me
 		}
 		if (warning_o) {
 			WARN_PRINT("QuickHull : O == nullptr");
+		}
+		if (warning_not_f2) {
+			WARN_PRINT("QuickHull : !F2");
 		}
 	}
 


### PR DESCRIPTION
Added one more warning to the hideable warnings. These seem to be benign warnings and are hidden during use in rooms and portals. When used from other areas, only one warning is displayed per run, instead of for every occurrence.

Fixes warning reported by @timothyqiu 

## Notes
* I just missed one of the warnings when doing this originally (this warning occurs more rarely).

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
