### PR TITLE
Fix crash when parsing Dictionary

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2480,7 +2480,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 			switch (dictionary->style) {
 				case DictionaryNode::LUA_TABLE:
 					if (key != nullptr && key->type != Node::IDENTIFIER) {
-						push_error("Expected identifier as dictionary key.");
+						push_error("Expected identifier as LUA-style dictionary key.");
+						advance();
+						break;
 					}
 					if (!match(GDScriptTokenizer::Token::EQUAL)) {
 						if (match(GDScriptTokenizer::Token::COLON)) {


### PR DESCRIPTION
So I got this crash when opening project (I don't know what code exactly caused it):
```
CrashHandlerException: Program crashed
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[0] std::_Atomic_storage<unsigned int,4>::load (C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29333\include\atomic:922)
[1] SafeNumeric<unsigned int>::conditional_increment (C:\Users\Tomek\Desktop\Godot\godot\core\templates\safe_refcount.h:122)
[2] SafeRefCount::ref (C:\Users\Tomek\Desktop\Godot\godot\core\templates\safe_refcount.h:169)
[3] StringName::StringName (C:\Users\Tomek\Desktop\Godot\godot\core\string\string_name.cpp:180)
[4] Variant::Variant (C:\Users\Tomek\Desktop\Godot\godot\core\variant\variant.cpp:2418)
[5] GDScriptParser::parse_dictionary (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_parser.cpp:2494)
[6] GDScriptParser::parse_precedence (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_parser.cpp:2009)
[7] GDScriptParser::parse_expression (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_parser.cpp:2035)
[8] GDScriptParser::parse_constant (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_parser.cpp:1024)
[9] GDScriptParser::parse_class_member<GDScriptParser::ConstantNode> (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_parser.cpp:719)
[10] GDScriptParser::parse_class_body (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_parser.cpp:776)
[11] GDScriptParser::parse_program (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_parser.cpp:603)
[12] GDScriptParser::parse (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_parser.cpp:383)
[14] GDScriptCache::get_full_script (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_cache.cpp:211)
[15] ResourceFormatLoaderGDScript::load (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript.cpp:2247)
[16] ResourceLoader::_load (C:\Users\Tomek\Desktop\Godot\godot\core\io\resource_loader.cpp:201)
[17] ResourceLoader::_thread_load_function (C:\Users\Tomek\Desktop\Godot\godot\core\io\resource_loader.cpp:228)
[18] ResourceLoader::load (C:\Users\Tomek\Desktop\Godot\godot\core\io\resource_loader.cpp:575)
[19] EditorAutoloadSettings::_create_autoload (C:\Users\Tomek\Desktop\Godot\godot\editor\editor_autoload_settings.cpp:346)
[20] EditorAutoloadSettings::EditorAutoloadSettings (C:\Users\Tomek\Desktop\Godot\godot\editor\editor_autoload_settings.cpp:795)
[21] ProjectSettingsEditor::ProjectSettingsEditor (C:\Users\Tomek\Desktop\Godot\godot\editor\project_settings_editor.cpp:627)
[22] EditorNode::EditorNode (C:\Users\Tomek\Desktop\Godot\godot\editor\editor_node.cpp:6205)
[23] Main::start (C:\Users\Tomek\Desktop\Godot\godot\main\main.cpp:2189)
[24] widechar_main (C:\Users\Tomek\Desktop\Godot\godot\platform\windows\godot_windows.cpp:161)
[25] _main (C:\Users\Tomek\Desktop\Godot\godot\platform\windows\godot_windows.cpp:185)
[26] main (C:\Users\Tomek\Desktop\Godot\godot\platform\windows\godot_windows.cpp:199)
[27] __scrt_common_main_seh (d:\agent\_work\63\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[28] BaseThreadInitThunk
-- END OF BACKTRACE --
```
Looking at the code, when key is not identifier the parser shows an error, but it does continue and later tries to cast it to identifier anyway, which results in null dereference. Not sure if this is the proper way to handle it, but it should definitely stop at this point.

EDIT:
Seems like this is the crash part of #44977

EDIT2:
Pushed a better fix.