### PR TITLE
Organize methods in Viewport and explicitly name 3D methods with 3D

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -169,7 +169,7 @@
 		<member name="audio_listener_enable_2d" type="bool" setter="set_as_audio_listener_2d" getter="is_audio_listener_2d" default="false">
 			If [code]true[/code], the viewport will process 2D audio streams.
 		</member>
-		<member name="audio_listener_enable_3d" type="bool" setter="set_as_audio_listener" getter="is_audio_listener" default="false">
+		<member name="audio_listener_enable_3d" type="bool" setter="set_as_audio_listener_3d" getter="is_audio_listener_3d" default="false">
 			If [code]true[/code], the viewport will process 3D audio streams.
 		</member>
 		<member name="canvas_item_default_texture_filter" type="int" setter="set_default_canvas_item_texture_filter" getter="get_default_canvas_item_texture_filter" enum="Viewport.DefaultCanvasItemTextureFilter" default="1">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -565,7 +565,7 @@ void EditorNode::_notification(int p_what) {
 			Engine::get_singleton()->set_editor_hint(true);
 
 			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(EDITOR_GET("interface/editor/low_processor_mode_sleep_usec")));
-			get_tree()->get_root()->set_as_audio_listener(false);
+			get_tree()->get_root()->set_as_audio_listener_3d(false);
 			get_tree()->get_root()->set_as_audio_listener_2d(false);
 			get_tree()->get_root()->set_snap_2d_transforms_to_pixel(false);
 			get_tree()->get_root()->set_snap_2d_vertices_to_pixel(false);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3187,7 +3187,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			int idx = view_menu->get_popup()->get_item_index(VIEW_AUDIO_LISTENER);
 			bool current = view_menu->get_popup()->is_item_checked(idx);
 			current = !current;
-			viewport->set_as_audio_listener(current);
+			viewport->set_as_audio_listener_3d(current);
 			view_menu->get_popup()->set_item_checked(idx, current);
 
 		} break;
@@ -3634,7 +3634,7 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 		bool listener = p_state["listener"];
 
 		int idx = view_menu->get_popup()->get_item_index(VIEW_AUDIO_LISTENER);
-		viewport->set_as_audio_listener(listener);
+		viewport->set_as_audio_listener_3d(listener);
 		view_menu->get_popup()->set_item_checked(idx, listener);
 	}
 	if (p_state.has("doppler")) {
@@ -3718,7 +3718,7 @@ Dictionary Node3DEditorViewport::get_state() const {
 	} else if (view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_DISPLAY_SHADELESS))) {
 		d["display_mode"] = VIEW_DISPLAY_SHADELESS;
 	}
-	d["listener"] = viewport->is_audio_listener();
+	d["listener"] = viewport->is_audio_listener_3d();
 	d["doppler"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_AUDIO_DOPPLER));
 	d["gizmos"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_GIZMOS));
 	d["information"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_INFORMATION));
@@ -4363,7 +4363,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 
 	if (p_index == 0) {
 		view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_AUDIO_LISTENER), true);
-		viewport->set_as_audio_listener(true);
+		viewport->set_as_audio_listener_3d(true);
 	}
 
 	name = "";
@@ -6820,7 +6820,7 @@ void Node3DEditor::clear() {
 
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
 		viewports[i]->view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(Node3DEditorViewport::VIEW_AUDIO_LISTENER), i == 0);
-		viewports[i]->viewport->set_as_audio_listener(i == 0);
+		viewports[i]->viewport->set_as_audio_listener_3d(i == 0);
 	}
 
 	view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(MENU_VIEW_GRID), true);

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -407,14 +407,14 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 			for (const Set<Camera3D *>::Element *E = world_3d->get_cameras().front(); E; E = E->next()) {
 				Camera3D *camera = E->get();
 				Viewport *vp = camera->get_viewport();
-				if (!vp->is_audio_listener()) {
+				if (!vp->is_audio_listener_3d()) {
 					continue;
 				}
 
 				bool listener_is_camera = true;
 				Node3D *listener_node = camera;
 
-				Listener3D *listener = vp->get_listener();
+				Listener3D *listener = vp->get_listener_3d();
 				if (listener) {
 					listener_node = listener;
 					listener_is_camera = false;

--- a/scene/3d/listener_3d.cpp
+++ b/scene/3d/listener_3d.cpp
@@ -73,14 +73,14 @@ void Listener3D::_get_property_list(List<PropertyInfo> *p_list) const {
 
 void Listener3D::_update_listener() {
 	if (is_inside_tree() && is_current()) {
-		get_viewport()->_listener_transform_changed_notify();
+		get_viewport()->_listener_transform_3d_changed_notify();
 	}
 }
 
 void Listener3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_WORLD: {
-			bool first_listener = get_viewport()->_listener_add(this);
+			bool first_listener = get_viewport()->_listener_3d_add(this);
 			if (!get_tree()->is_node_being_edited(this) && (current || first_listener)) {
 				make_current();
 			}
@@ -99,7 +99,7 @@ void Listener3D::_notification(int p_what) {
 				}
 			}
 
-			get_viewport()->_listener_remove(this);
+			get_viewport()->_listener_3d_remove(this);
 
 		} break;
 	}
@@ -116,7 +116,7 @@ void Listener3D::make_current() {
 		return;
 	}
 
-	get_viewport()->_listener_set(this);
+	get_viewport()->_listener_3d_set(this);
 }
 
 void Listener3D::clear_current() {
@@ -125,15 +125,15 @@ void Listener3D::clear_current() {
 		return;
 	}
 
-	if (get_viewport()->get_listener() == this) {
-		get_viewport()->_listener_set(nullptr);
-		get_viewport()->_listener_make_next_current(this);
+	if (get_viewport()->get_listener_3d() == this) {
+		get_viewport()->_listener_3d_set(nullptr);
+		get_viewport()->_listener_3d_make_next_current(this);
 	}
 }
 
 bool Listener3D::is_current() const {
 	if (is_inside_tree() && !get_tree()->is_node_being_edited(this)) {
-		return get_viewport()->get_listener() == this;
+		return get_viewport()->get_listener_3d() == this;
 	} else {
 		return current;
 	}

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -94,7 +94,7 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 	} else if (p_msg == "override_camera_3D:set") {
 		ERR_FAIL_COND_V(p_args.size() < 1, ERR_INVALID_DATA);
 		bool enable = p_args[0];
-		scene_tree->get_root()->enable_camera_override(enable);
+		scene_tree->get_root()->enable_camera_3d_override(enable);
 
 	} else if (p_msg == "override_camera_3D:transform") {
 		ERR_FAIL_COND_V(p_args.size() < 5, ERR_INVALID_DATA);
@@ -104,11 +104,11 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 		float near = p_args[3];
 		float far = p_args[4];
 		if (is_perspective) {
-			scene_tree->get_root()->set_camera_override_perspective(size_or_fov, near, far);
+			scene_tree->get_root()->set_camera_3d_override_perspective(size_or_fov, near, far);
 		} else {
-			scene_tree->get_root()->set_camera_override_orthogonal(size_or_fov, near, far);
+			scene_tree->get_root()->set_camera_3d_override_orthogonal(size_or_fov, near, far);
 		}
-		scene_tree->get_root()->set_camera_override_transform(transform);
+		scene_tree->get_root()->set_camera_3d_override_transform(transform);
 
 	} else if (p_msg == "set_object_property") {
 		ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1341,7 +1341,7 @@ SceneTree::SceneTree() {
 	set_multiplayer(Ref<MultiplayerAPI>(memnew(MultiplayerAPI)));
 
 	//root->set_world_2d( Ref<World2D>( memnew( World2D )));
-	root->set_as_audio_listener(true);
+	root->set_as_audio_listener_3d(true);
 	root->set_as_audio_listener_2d(true);
 	current_scene = nullptr;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -184,24 +184,6 @@ public:
 
 /////////////////////////////////////
 
-void Viewport::_collision_object_input_event(CollisionObject3D *p_object, Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape) {
-	Transform3D object_transform = p_object->get_global_transform();
-	Transform3D camera_transform = p_camera->get_global_transform();
-	ObjectID id = p_object->get_instance_id();
-
-	//avoid sending the fake event unnecessarily if nothing really changed in the context
-	if (object_transform == physics_last_object_transform && camera_transform == physics_last_camera_transform && physics_last_id == id) {
-		Ref<InputEventMouseMotion> mm = p_input_event;
-		if (mm.is_valid() && mm->get_device() == InputEvent::DEVICE_ID_INTERNAL) {
-			return; //discarded
-		}
-	}
-	p_object->_input_event(camera_3d, p_input_event, p_pos, p_normal, p_shape);
-	physics_last_object_transform = object_transform;
-	physics_last_camera_transform = camera_transform;
-	physics_last_id = id;
-}
-
 void Viewport::_sub_window_update_order() {
 	for (int i = 0; i < gui.sub_windows.size(); i++) {
 		RS::get_singleton()->canvas_item_set_draw_index(gui.sub_windows[i].canvas_item, i);
@@ -388,27 +370,6 @@ void Viewport::_sub_window_remove(Window *p_window) {
 	RenderingServer::get_singleton()->viewport_set_parent_viewport(p_window->viewport, p_window->parent ? p_window->parent->viewport : RID());
 }
 
-void Viewport::_own_world_3d_changed() {
-	ERR_FAIL_COND(world_3d.is_null());
-	ERR_FAIL_COND(own_world_3d.is_null());
-
-	if (is_inside_tree()) {
-		_propagate_exit_world(this);
-	}
-
-	own_world_3d = world_3d->duplicate();
-
-	if (is_inside_tree()) {
-		_propagate_enter_world(this);
-	}
-
-	if (is_inside_tree()) {
-		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
-	}
-
-	_update_listener();
-}
-
 void Viewport::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -422,19 +383,16 @@ void Viewport::_notification(int p_what) {
 			}
 
 			current_canvas = find_world_2d()->get_canvas();
-			RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
 			RenderingServer::get_singleton()->viewport_attach_canvas(viewport, current_canvas);
-
-			_update_listener();
 			_update_listener_2d();
+			RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
+			_update_listener_3d();
 
 			add_to_group("_viewports");
 			if (get_tree()->is_debugging_collisions_hint()) {
-				//2D
 				PhysicsServer2D::get_singleton()->space_set_debug_contacts(find_world_2d()->get_space(), get_tree()->get_collision_debug_contact_count());
 				contact_2d_debug = RenderingServer::get_singleton()->canvas_item_create();
 				RenderingServer::get_singleton()->canvas_item_set_parent(contact_2d_debug, find_world_2d()->get_canvas());
-				//3D
 				PhysicsServer3D::get_singleton()->space_set_debug_contacts(find_world_3d()->get_space(), get_tree()->get_collision_debug_contact_count());
 				contact_3d_debug_multimesh = RenderingServer::get_singleton()->multimesh_create();
 				RenderingServer::get_singleton()->multimesh_allocate_data(contact_3d_debug_multimesh, get_tree()->get_collision_debug_contact_count(), RS::MULTIMESH_TRANSFORM_3D, true);
@@ -444,15 +402,13 @@ void Viewport::_notification(int p_what) {
 				RenderingServer::get_singleton()->instance_set_base(contact_3d_debug_instance, contact_3d_debug_multimesh);
 				RenderingServer::get_singleton()->instance_set_scenario(contact_3d_debug_instance, find_world_3d()->get_scenario());
 				//RenderingServer::get_singleton()->instance_geometry_set_flag(contact_3d_debug_instance, RS::INSTANCE_FLAG_VISIBLE_IN_ALL_ROOMS, true);
-				set_physics_process_internal(true);
 			}
 
 		} break;
 		case NOTIFICATION_READY: {
-#ifndef _3D_DISABLED
-			if (listeners.size() && !listener) {
+			if (listener_3d_set.size() && !listener_3d) {
 				Listener3D *first = nullptr;
-				for (Set<Listener3D *>::Element *E = listeners.front(); E; E = E->next()) {
+				for (Set<Listener3D *>::Element *E = listener_3d_set.front(); E; E = E->next()) {
 					if (first == nullptr || first->is_greater_than(E->get())) {
 						first = E->get();
 					}
@@ -463,10 +419,10 @@ void Viewport::_notification(int p_what) {
 				}
 			}
 
-			if (cameras.size() && !camera_3d) {
+			if (camera_3d_set.size() && !camera_3d) {
 				//there are cameras but no current camera, pick first in tree and make it current
 				Camera3D *first = nullptr;
-				for (Set<Camera3D *>::Element *E = cameras.front(); E; E = E->next()) {
+				for (Set<Camera3D *>::Element *E = camera_3d_set.front(); E; E = E->next()) {
 					if (first == nullptr || first->is_greater_than(E->get())) {
 						first = E->get();
 					}
@@ -476,7 +432,6 @@ void Viewport::_notification(int p_what) {
 					first->make_current();
 				}
 			}
-#endif
 
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
@@ -515,7 +470,6 @@ void Viewport::_notification(int p_what) {
 					RenderingServer::get_singleton()->canvas_item_add_rect(contact_2d_debug, Rect2(points[i] - Vector2(2, 2), Vector2(5, 5)), ccol);
 				}
 			}
-
 			if (get_tree()->is_debugging_collisions_hint() && contact_3d_debug_multimesh.is_valid()) {
 				Vector<Vector3> points = PhysicsServer3D::get_singleton()->space_get_contacts(find_world_3d()->get_space());
 				int point_count = PhysicsServer3D::get_singleton()->space_get_contact_count(find_world_3d()->get_space());
@@ -560,11 +514,9 @@ void Viewport::_process_picking() {
 
 	_drop_physics_mouseover(true);
 
-#ifndef _3D_DISABLED
 	Vector2 last_pos(1e20, 1e20);
 	CollisionObject3D *last_object = nullptr;
 	ObjectID last_id;
-#endif
 	PhysicsDirectSpaceState3D::RayResult result;
 	PhysicsDirectSpaceState2D *ss2d = PhysicsServer2D::get_singleton()->space_get_direct_state(find_world_2d()->get_space());
 
@@ -725,13 +677,12 @@ void Viewport::_process_picking() {
 			}
 		}
 
-#ifndef _3D_DISABLED
 		bool captured = false;
 
 		if (physics_object_capture.is_valid()) {
 			CollisionObject3D *co = Object::cast_to<CollisionObject3D>(ObjectDB::get_instance(physics_object_capture));
 			if (co && camera_3d) {
-				_collision_object_input_event(co, camera_3d, ev, Vector3(), Vector3(), 0);
+				_collision_object_3d_input_event(co, camera_3d, ev, Vector3(), Vector3(), 0);
 				captured = true;
 				if (mb.is_valid() && mb->get_button_index() == 1 && !mb->is_pressed()) {
 					physics_object_capture = ObjectID();
@@ -748,7 +699,7 @@ void Viewport::_process_picking() {
 			if (last_id.is_valid()) {
 				if (ObjectDB::get_instance(last_id) && last_object) {
 					//good, exists
-					_collision_object_input_event(last_object, camera_3d, ev, result.position, result.normal, result.shape);
+					_collision_object_3d_input_event(last_object, camera_3d, ev, result.position, result.normal, result.shape);
 					if (last_object->get_capture_input_on_drag() && mb.is_valid() && mb->get_button_index() == 1 && mb->is_pressed()) {
 						physics_object_capture = last_id;
 					}
@@ -765,8 +716,8 @@ void Viewport::_process_picking() {
 					ObjectID new_collider;
 					if (col) {
 						CollisionObject3D *co = Object::cast_to<CollisionObject3D>(result.collider);
-						if (co) {
-							_collision_object_input_event(co, camera_3d, ev, result.position, result.normal, result.shape);
+						if (co && co->can_process()) {
+							_collision_object_3d_input_event(co, camera_3d, ev, result.position, result.normal, result.shape);
 							last_object = co;
 							last_id = result.collider_id;
 							new_collider = last_id;
@@ -798,7 +749,6 @@ void Viewport::_process_picking() {
 				last_pos = pos;
 			}
 		}
-#endif
 	}
 }
 
@@ -865,29 +815,13 @@ Rect2 Viewport::get_visible_rect() const {
 	return r;
 }
 
-void Viewport::_update_listener() {
-}
-
 void Viewport::_update_listener_2d() {
 	/*
-	if (is_inside_tree() && audio_listener && (!get_parent() || (Object::cast_to<Control>(get_parent()) && Object::cast_to<Control>(get_parent())->is_visible_in_tree())))
+	if (is_inside_tree() && audio_listener_3d && (!get_parent() || (Object::cast_to<Control>(get_parent()) && Object::cast_to<Control>(get_parent())->is_visible_in_tree())))
 		SpatialSound2DServer::get_singleton()->listener_set_space(internal_listener_2d, find_world_2d()->get_sound_space());
 	else
 		SpatialSound2DServer::get_singleton()->listener_set_space(internal_listener_2d, RID());
 */
-}
-
-void Viewport::set_as_audio_listener(bool p_enable) {
-	if (p_enable == audio_listener) {
-		return;
-	}
-
-	audio_listener = p_enable;
-	_update_listener();
-}
-
-bool Viewport::is_audio_listener() const {
-	return audio_listener;
 }
 
 void Viewport::set_as_audio_listener_2d(bool p_enable) {
@@ -902,15 +836,6 @@ void Viewport::set_as_audio_listener_2d(bool p_enable) {
 
 bool Viewport::is_audio_listener_2d() const {
 	return audio_listener_2d;
-}
-
-void Viewport::set_disable_3d(bool p_disable) {
-	disable_3d = p_disable;
-	RenderingServer::get_singleton()->viewport_set_disable_3d(viewport, disable_3d);
-}
-
-bool Viewport::is_3d_disabled() const {
-	return disable_3d;
 }
 
 void Viewport::enable_canvas_transform_override(bool p_enable) {
@@ -973,130 +898,9 @@ Transform2D Viewport::get_global_canvas_transform() const {
 	return global_canvas_transform;
 }
 
-void Viewport::_listener_transform_changed_notify() {
-}
-
-void Viewport::_listener_set(Listener3D *p_listener) {
-#ifndef _3D_DISABLED
-
-	if (listener == p_listener) {
-		return;
-	}
-
-	listener = p_listener;
-
-	_update_listener();
-	_listener_transform_changed_notify();
-#endif
-}
-
-bool Viewport::_listener_add(Listener3D *p_listener) {
-	listeners.insert(p_listener);
-	return listeners.size() == 1;
-}
-
-void Viewport::_listener_remove(Listener3D *p_listener) {
-	listeners.erase(p_listener);
-	if (listener == p_listener) {
-		listener = nullptr;
-	}
-}
-
-#ifndef _3D_DISABLED
-void Viewport::_listener_make_next_current(Listener3D *p_exclude) {
-	if (listeners.size() > 0) {
-		for (Set<Listener3D *>::Element *E = listeners.front(); E; E = E->next()) {
-			if (p_exclude == E->get()) {
-				continue;
-			}
-			if (!E->get()->is_inside_tree()) {
-				continue;
-			}
-			if (listener != nullptr) {
-				return;
-			}
-
-			E->get()->make_current();
-		}
-	} else {
-		// Attempt to reset listener to the camera position
-		if (camera_3d != nullptr) {
-			_update_listener();
-			_camera_3d_transform_changed_notify();
-		}
-	}
-}
-#endif
-
-void Viewport::_camera_3d_transform_changed_notify() {
-#ifndef _3D_DISABLED
-#endif
-}
-
-void Viewport::_camera_3d_set(Camera3D *p_camera) {
-#ifndef _3D_DISABLED
-
-	if (camera_3d == p_camera) {
-		return;
-	}
-
-	if (camera_3d) {
-		camera_3d->notification(Camera3D::NOTIFICATION_LOST_CURRENT);
-	}
-
-	camera_3d = p_camera;
-
-	if (!camera_override) {
-		if (camera_3d) {
-			RenderingServer::get_singleton()->viewport_attach_camera(viewport, camera_3d->get_camera());
-		} else {
-			RenderingServer::get_singleton()->viewport_attach_camera(viewport, RID());
-		}
-	}
-
-	if (camera_3d) {
-		camera_3d->notification(Camera3D::NOTIFICATION_BECAME_CURRENT);
-	}
-
-	_update_listener();
-	_camera_3d_transform_changed_notify();
-#endif
-}
-
 void Viewport::_camera_2d_set(Camera2D *p_camera_2d) {
 	camera_2d = p_camera_2d;
 }
-
-bool Viewport::_camera_3d_add(Camera3D *p_camera) {
-	cameras.insert(p_camera);
-	return cameras.size() == 1;
-}
-
-void Viewport::_camera_3d_remove(Camera3D *p_camera) {
-	cameras.erase(p_camera);
-	if (camera_3d == p_camera) {
-		camera_3d->notification(Camera3D::NOTIFICATION_LOST_CURRENT);
-		camera_3d = nullptr;
-	}
-}
-
-#ifndef _3D_DISABLED
-void Viewport::_camera_3d_make_next_current(Camera3D *p_exclude) {
-	for (Set<Camera3D *>::Element *E = cameras.front(); E; E = E->next()) {
-		if (p_exclude == E->get()) {
-			continue;
-		}
-		if (!E->get()->is_inside_tree()) {
-			continue;
-		}
-		if (camera_3d != nullptr) {
-			return;
-		}
-
-		E->get()->make_current();
-	}
-}
-#endif
 
 void Viewport::_canvas_layer_add(CanvasLayer *p_canvas_layer) {
 	canvas_layers.insert(p_canvas_layer);
@@ -1121,7 +925,7 @@ void Viewport::set_world_2d(const Ref<World2D> &p_world_2d) {
 	}
 
 	if (parent && parent->find_world_2d() == p_world_2d) {
-		WARN_PRINT("Unable to use parent world_3d as world_2d");
+		WARN_PRINT("Unable to use parent world_2d as world_2d");
 		return;
 	}
 
@@ -1154,33 +958,6 @@ Ref<World2D> Viewport::find_world_2d() const {
 	}
 }
 
-void Viewport::_propagate_enter_world(Node *p_node) {
-	if (p_node != this) {
-		if (!p_node->is_inside_tree()) { //may not have entered scene yet
-			return;
-		}
-
-#ifndef _3D_DISABLED
-		if (Object::cast_to<Node3D>(p_node) || Object::cast_to<WorldEnvironment>(p_node)) {
-			p_node->notification(Node3D::NOTIFICATION_ENTER_WORLD);
-		} else {
-#endif
-			Viewport *v = Object::cast_to<Viewport>(p_node);
-			if (v) {
-				if (v->world_3d.is_valid() || v->own_world_3d.is_valid()) {
-					return;
-				}
-			}
-#ifndef _3D_DISABLED
-		}
-#endif
-	}
-
-	for (int i = 0; i < p_node->get_child_count(); i++) {
-		_propagate_enter_world(p_node->get_child(i));
-	}
-}
-
 void Viewport::_propagate_viewport_notification(Node *p_node, int p_what) {
 	p_node->notification(p_what);
 	for (int i = 0; i < p_node->get_child_count(); i++) {
@@ -1192,172 +969,12 @@ void Viewport::_propagate_viewport_notification(Node *p_node, int p_what) {
 	}
 }
 
-void Viewport::_propagate_exit_world(Node *p_node) {
-	if (p_node != this) {
-		if (!p_node->is_inside_tree()) { //may have exited scene already
-			return;
-		}
-
-#ifndef _3D_DISABLED
-		if (Object::cast_to<Node3D>(p_node) || Object::cast_to<WorldEnvironment>(p_node)) {
-			p_node->notification(Node3D::NOTIFICATION_EXIT_WORLD);
-		} else {
-#endif
-			Viewport *v = Object::cast_to<Viewport>(p_node);
-			if (v) {
-				if (v->world_3d.is_valid() || v->own_world_3d.is_valid()) {
-					return;
-				}
-			}
-#ifndef _3D_DISABLED
-		}
-#endif
-	}
-
-	for (int i = 0; i < p_node->get_child_count(); i++) {
-		_propagate_exit_world(p_node->get_child(i));
-	}
-}
-
-void Viewport::set_world_3d(const Ref<World3D> &p_world_3d) {
-	if (world_3d == p_world_3d) {
-		return;
-	}
-
-	if (is_inside_tree()) {
-		_propagate_exit_world(this);
-	}
-
-	if (own_world_3d.is_valid() && world_3d.is_valid()) {
-		world_3d->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
-	}
-
-	world_3d = p_world_3d;
-
-	if (own_world_3d.is_valid()) {
-		if (world_3d.is_valid()) {
-			own_world_3d = world_3d->duplicate();
-			world_3d->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
-		} else {
-			own_world_3d = Ref<World3D>(memnew(World3D));
-		}
-	}
-
-	if (is_inside_tree()) {
-		_propagate_enter_world(this);
-	}
-
-	if (is_inside_tree()) {
-		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
-	}
-
-	_update_listener();
-}
-
-Ref<World3D> Viewport::get_world_3d() const {
-	return world_3d;
-}
-
 Ref<World2D> Viewport::get_world_2d() const {
 	return world_2d;
 }
 
-Ref<World3D> Viewport::find_world_3d() const {
-	if (own_world_3d.is_valid()) {
-		return own_world_3d;
-	} else if (world_3d.is_valid()) {
-		return world_3d;
-	} else if (parent) {
-		return parent->find_world_3d();
-	} else {
-		return Ref<World3D>();
-	}
-}
-
-Listener3D *Viewport::get_listener() const {
-	return listener;
-}
-
-Camera3D *Viewport::get_camera_3d() const {
-	return camera_3d;
-}
-
 Camera2D *Viewport::get_camera_2d() const {
 	return camera_2d;
-}
-
-void Viewport::enable_camera_override(bool p_enable) {
-#ifndef _3D_DISABLED
-	if (p_enable == camera_override) {
-		return;
-	}
-
-	if (p_enable) {
-		camera_override.rid = RenderingServer::get_singleton()->camera_create();
-	} else {
-		RenderingServer::get_singleton()->free(camera_override.rid);
-		camera_override.rid = RID();
-	}
-
-	if (p_enable) {
-		RenderingServer::get_singleton()->viewport_attach_camera(viewport, camera_override.rid);
-	} else if (camera_3d) {
-		RenderingServer::get_singleton()->viewport_attach_camera(viewport, camera_3d->get_camera());
-	} else {
-		RenderingServer::get_singleton()->viewport_attach_camera(viewport, RID());
-	}
-#endif
-}
-
-bool Viewport::is_camera_override_enabled() const {
-	return camera_override;
-}
-
-void Viewport::set_camera_override_transform(const Transform3D &p_transform) {
-	if (camera_override) {
-		camera_override.transform = p_transform;
-		RenderingServer::get_singleton()->camera_set_transform(camera_override.rid, p_transform);
-	}
-}
-
-Transform3D Viewport::get_camera_override_transform() const {
-	if (camera_override) {
-		return camera_override.transform;
-	}
-
-	return Transform3D();
-}
-
-void Viewport::set_camera_override_perspective(float p_fovy_degrees, float p_z_near, float p_z_far) {
-	if (camera_override) {
-		if (camera_override.fov == p_fovy_degrees && camera_override.z_near == p_z_near &&
-				camera_override.z_far == p_z_far && camera_override.projection == CameraOverrideData::PROJECTION_PERSPECTIVE) {
-			return;
-		}
-
-		camera_override.fov = p_fovy_degrees;
-		camera_override.z_near = p_z_near;
-		camera_override.z_far = p_z_far;
-		camera_override.projection = CameraOverrideData::PROJECTION_PERSPECTIVE;
-
-		RenderingServer::get_singleton()->camera_set_perspective(camera_override.rid, camera_override.fov, camera_override.z_near, camera_override.z_far);
-	}
-}
-
-void Viewport::set_camera_override_orthogonal(float p_size, float p_z_near, float p_z_far) {
-	if (camera_override) {
-		if (camera_override.size == p_size && camera_override.z_near == p_z_near &&
-				camera_override.z_far == p_z_far && camera_override.projection == CameraOverrideData::PROJECTION_ORTHOGONAL) {
-			return;
-		}
-
-		camera_override.size = p_size;
-		camera_override.z_near = p_z_near;
-		camera_override.z_far = p_z_far;
-		camera_override.projection = CameraOverrideData::PROJECTION_ORTHOGONAL;
-
-		RenderingServer::get_singleton()->camera_set_orthogonal(camera_override.rid, camera_override.size, camera_override.z_near, camera_override.z_far);
-	}
 }
 
 Transform2D Viewport::get_final_transform() const {
@@ -1382,16 +999,6 @@ void Viewport::_update_canvas_items(Node *p_node) {
 	for (int i = 0; i < cc; i++) {
 		_update_canvas_items(p_node->get_child(i));
 	}
-}
-
-void Viewport::set_use_xr(bool p_use_xr) {
-	use_xr = p_use_xr;
-
-	RS::get_singleton()->viewport_set_use_xr(viewport, use_xr);
-}
-
-bool Viewport::is_using_xr() {
-	return use_xr;
 }
 
 Ref<ViewportTexture> Viewport::get_texture() const {
@@ -2605,7 +2212,6 @@ void Viewport::_drop_physics_mouseover(bool p_paused_only) {
 
 	_cleanup_mouseover_colliders(true, p_paused_only);
 
-#ifndef _3D_DISABLED
 	if (physics_object_over.is_valid()) {
 		CollisionObject3D *co = Object::cast_to<CollisionObject3D>(ObjectDB::get_instance(physics_object_over));
 		if (co) {
@@ -2616,7 +2222,6 @@ void Viewport::_drop_physics_mouseover(bool p_paused_only) {
 			}
 		}
 	}
-#endif
 }
 
 void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paused_only, uint64_t p_frame_reference) {
@@ -3137,44 +2742,6 @@ void Viewport::unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coor
 	}
 }
 
-void Viewport::set_use_own_world_3d(bool p_world_3d) {
-	if (p_world_3d == own_world_3d.is_valid()) {
-		return;
-	}
-
-	if (is_inside_tree()) {
-		_propagate_exit_world(this);
-	}
-
-	if (!p_world_3d) {
-		own_world_3d = Ref<World3D>();
-		if (world_3d.is_valid()) {
-			world_3d->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
-		}
-	} else {
-		if (world_3d.is_valid()) {
-			own_world_3d = world_3d->duplicate();
-			world_3d->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
-		} else {
-			own_world_3d = Ref<World3D>(memnew(World3D));
-		}
-	}
-
-	if (is_inside_tree()) {
-		_propagate_enter_world(this);
-	}
-
-	if (is_inside_tree()) {
-		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
-	}
-
-	_update_listener();
-}
-
-bool Viewport::is_using_own_world_3d() const {
-	return own_world_3d.is_valid();
-}
-
 void Viewport::set_physics_object_picking(bool p_enable) {
 	physics_object_picking = p_enable;
 	if (physics_object_picking) {
@@ -3275,6 +2842,7 @@ void Viewport::set_lod_threshold(float p_pixels) {
 	lod_threshold = p_pixels;
 	RS::get_singleton()->viewport_set_lod_threshold(viewport, lod_threshold);
 }
+
 float Viewport::get_lod_threshold() const {
 	return lod_threshold;
 }
@@ -3487,6 +3055,7 @@ void Viewport::set_sdf_oversize(SDFOversize p_sdf_oversize) {
 	sdf_oversize = p_sdf_oversize;
 	RS::get_singleton()->viewport_set_sdf_oversize_and_scale(viewport, RS::ViewportSDFOversize(sdf_oversize), RS::ViewportSDFScale(sdf_scale));
 }
+
 Viewport::SDFOversize Viewport::get_sdf_oversize() const {
 	return sdf_oversize;
 }
@@ -3496,17 +3065,413 @@ void Viewport::set_sdf_scale(SDFScale p_sdf_scale) {
 	sdf_scale = p_sdf_scale;
 	RS::get_singleton()->viewport_set_sdf_oversize_and_scale(viewport, RS::ViewportSDFOversize(sdf_oversize), RS::ViewportSDFScale(sdf_scale));
 }
+
 Viewport::SDFScale Viewport::get_sdf_scale() const {
 	return sdf_scale;
+}
+
+Listener3D *Viewport::get_listener_3d() const {
+	return listener_3d;
+}
+
+void Viewport::set_as_audio_listener_3d(bool p_enable) {
+	if (p_enable == audio_listener_3d) {
+		return;
+	}
+
+	audio_listener_3d = p_enable;
+	_update_listener_3d();
+}
+
+bool Viewport::is_audio_listener_3d() const {
+	return audio_listener_3d;
+}
+
+void Viewport::_update_listener_3d() {
+}
+
+void Viewport::_listener_transform_3d_changed_notify() {
+}
+
+void Viewport::_listener_3d_set(Listener3D *p_listener) {
+	if (listener_3d == p_listener) {
+		return;
+	}
+
+	listener_3d = p_listener;
+
+	_update_listener_3d();
+	_listener_transform_3d_changed_notify();
+}
+
+bool Viewport::_listener_3d_add(Listener3D *p_listener) {
+	listener_3d_set.insert(p_listener);
+	return listener_3d_set.size() == 1;
+}
+
+void Viewport::_listener_3d_remove(Listener3D *p_listener) {
+	listener_3d_set.erase(p_listener);
+	if (listener_3d == p_listener) {
+		listener_3d = nullptr;
+	}
+}
+
+void Viewport::_listener_3d_make_next_current(Listener3D *p_exclude) {
+	if (listener_3d_set.size() > 0) {
+		for (Set<Listener3D *>::Element *E = listener_3d_set.front(); E; E = E->next()) {
+			if (p_exclude == E->get()) {
+				continue;
+			}
+			if (!E->get()->is_inside_tree()) {
+				continue;
+			}
+			if (listener_3d != nullptr) {
+				return;
+			}
+
+			E->get()->make_current();
+		}
+	} else {
+		// Attempt to reset listener to the camera position
+		if (camera_3d != nullptr) {
+			_update_listener_3d();
+			_camera_3d_transform_changed_notify();
+		}
+	}
+}
+
+void Viewport::_collision_object_3d_input_event(CollisionObject3D *p_object, Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape) {
+	Transform3D object_transform = p_object->get_global_transform();
+	Transform3D camera_transform = p_camera->get_global_transform();
+	ObjectID id = p_object->get_instance_id();
+
+	//avoid sending the fake event unnecessarily if nothing really changed in the context
+	if (object_transform == physics_last_object_transform && camera_transform == physics_last_camera_transform && physics_last_id == id) {
+		Ref<InputEventMouseMotion> mm = p_input_event;
+		if (mm.is_valid() && mm->get_device() == InputEvent::DEVICE_ID_INTERNAL) {
+			return; //discarded
+		}
+	}
+	p_object->_input_event(camera_3d, p_input_event, p_pos, p_normal, p_shape);
+	physics_last_object_transform = object_transform;
+	physics_last_camera_transform = camera_transform;
+	physics_last_id = id;
+}
+
+Camera3D *Viewport::get_camera_3d() const {
+	return camera_3d;
+}
+
+void Viewport::_camera_3d_transform_changed_notify() {
+}
+
+void Viewport::_camera_3d_set(Camera3D *p_camera) {
+	if (camera_3d == p_camera) {
+		return;
+	}
+
+	if (camera_3d) {
+		camera_3d->notification(Camera3D::NOTIFICATION_LOST_CURRENT);
+	}
+
+	camera_3d = p_camera;
+
+	if (!camera_3d_override) {
+		if (camera_3d) {
+			RenderingServer::get_singleton()->viewport_attach_camera(viewport, camera_3d->get_camera());
+		} else {
+			RenderingServer::get_singleton()->viewport_attach_camera(viewport, RID());
+		}
+	}
+
+	if (camera_3d) {
+		camera_3d->notification(Camera3D::NOTIFICATION_BECAME_CURRENT);
+	}
+
+	_update_listener_3d();
+	_camera_3d_transform_changed_notify();
+}
+
+bool Viewport::_camera_3d_add(Camera3D *p_camera) {
+	camera_3d_set.insert(p_camera);
+	return camera_3d_set.size() == 1;
+}
+
+void Viewport::_camera_3d_remove(Camera3D *p_camera) {
+	camera_3d_set.erase(p_camera);
+	if (camera_3d == p_camera) {
+		camera_3d->notification(Camera3D::NOTIFICATION_LOST_CURRENT);
+		camera_3d = nullptr;
+	}
+}
+
+void Viewport::_camera_3d_make_next_current(Camera3D *p_exclude) {
+	for (Set<Camera3D *>::Element *E = camera_3d_set.front(); E; E = E->next()) {
+		if (p_exclude == E->get()) {
+			continue;
+		}
+		if (!E->get()->is_inside_tree()) {
+			continue;
+		}
+		if (camera_3d != nullptr) {
+			return;
+		}
+
+		E->get()->make_current();
+	}
+}
+
+void Viewport::enable_camera_3d_override(bool p_enable) {
+	if (p_enable == camera_3d_override) {
+		return;
+	}
+
+	if (p_enable) {
+		camera_3d_override.rid = RenderingServer::get_singleton()->camera_create();
+	} else {
+		RenderingServer::get_singleton()->free(camera_3d_override.rid);
+		camera_3d_override.rid = RID();
+	}
+
+	if (p_enable) {
+		RenderingServer::get_singleton()->viewport_attach_camera(viewport, camera_3d_override.rid);
+	} else if (camera_3d) {
+		RenderingServer::get_singleton()->viewport_attach_camera(viewport, camera_3d->get_camera());
+	} else {
+		RenderingServer::get_singleton()->viewport_attach_camera(viewport, RID());
+	}
+}
+
+void Viewport::set_camera_3d_override_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far) {
+	if (camera_3d_override) {
+		if (camera_3d_override.fov == p_fovy_degrees && camera_3d_override.z_near == p_z_near &&
+				camera_3d_override.z_far == p_z_far && camera_3d_override.projection == Camera3DOverrideData::PROJECTION_PERSPECTIVE) {
+			return;
+		}
+
+		camera_3d_override.fov = p_fovy_degrees;
+		camera_3d_override.z_near = p_z_near;
+		camera_3d_override.z_far = p_z_far;
+		camera_3d_override.projection = Camera3DOverrideData::PROJECTION_PERSPECTIVE;
+
+		RenderingServer::get_singleton()->camera_set_perspective(camera_3d_override.rid, camera_3d_override.fov, camera_3d_override.z_near, camera_3d_override.z_far);
+	}
+}
+
+void Viewport::set_camera_3d_override_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far) {
+	if (camera_3d_override) {
+		if (camera_3d_override.size == p_size && camera_3d_override.z_near == p_z_near &&
+				camera_3d_override.z_far == p_z_far && camera_3d_override.projection == Camera3DOverrideData::PROJECTION_ORTHOGONAL) {
+			return;
+		}
+
+		camera_3d_override.size = p_size;
+		camera_3d_override.z_near = p_z_near;
+		camera_3d_override.z_far = p_z_far;
+		camera_3d_override.projection = Camera3DOverrideData::PROJECTION_ORTHOGONAL;
+
+		RenderingServer::get_singleton()->camera_set_orthogonal(camera_3d_override.rid, camera_3d_override.size, camera_3d_override.z_near, camera_3d_override.z_far);
+	}
+}
+
+void Viewport::set_disable_3d(bool p_disable) {
+	disable_3d = p_disable;
+	RenderingServer::get_singleton()->viewport_set_disable_3d(viewport, disable_3d);
+}
+
+bool Viewport::is_3d_disabled() const {
+	return disable_3d;
+}
+
+bool Viewport::is_camera_3d_override_enabled() const {
+	return camera_3d_override;
+}
+
+void Viewport::set_camera_3d_override_transform(const Transform3D &p_transform) {
+	if (camera_3d_override) {
+		camera_3d_override.transform = p_transform;
+		RenderingServer::get_singleton()->camera_set_transform(camera_3d_override.rid, p_transform);
+	}
+}
+
+Transform3D Viewport::get_camera_3d_override_transform() const {
+	if (camera_3d_override) {
+		return camera_3d_override.transform;
+	}
+
+	return Transform3D();
+}
+
+Ref<World3D> Viewport::get_world_3d() const {
+	return world_3d;
+}
+
+Ref<World3D> Viewport::find_world_3d() const {
+	if (own_world_3d.is_valid()) {
+		return own_world_3d;
+	} else if (world_3d.is_valid()) {
+		return world_3d;
+	} else if (parent) {
+		return parent->find_world_3d();
+	} else {
+		return Ref<World3D>();
+	}
+}
+
+void Viewport::set_world_3d(const Ref<World3D> &p_world_3d) {
+	if (world_3d == p_world_3d) {
+		return;
+	}
+
+	if (is_inside_tree()) {
+		_propagate_exit_world_3d(this);
+	}
+
+	if (own_world_3d.is_valid() && world_3d.is_valid()) {
+		world_3d->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
+	}
+
+	world_3d = p_world_3d;
+
+	if (own_world_3d.is_valid()) {
+		if (world_3d.is_valid()) {
+			own_world_3d = world_3d->duplicate();
+			world_3d->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
+		} else {
+			own_world_3d = Ref<World3D>(memnew(World3D));
+		}
+	}
+
+	if (is_inside_tree()) {
+		_propagate_enter_world_3d(this);
+	}
+
+	if (is_inside_tree()) {
+		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
+	}
+
+	_update_listener_3d();
+}
+
+void Viewport::_own_world_3d_changed() {
+	ERR_FAIL_COND(world_3d.is_null());
+	ERR_FAIL_COND(own_world_3d.is_null());
+
+	if (is_inside_tree()) {
+		_propagate_exit_world_3d(this);
+	}
+
+	own_world_3d = world_3d->duplicate();
+
+	if (is_inside_tree()) {
+		_propagate_enter_world_3d(this);
+	}
+
+	if (is_inside_tree()) {
+		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
+	}
+
+	_update_listener_3d();
+}
+
+void Viewport::set_use_own_world_3d(bool p_world_3d) {
+	if (p_world_3d == own_world_3d.is_valid()) {
+		return;
+	}
+
+	if (is_inside_tree()) {
+		_propagate_exit_world_3d(this);
+	}
+
+	if (!p_world_3d) {
+		own_world_3d = Ref<World3D>();
+		if (world_3d.is_valid()) {
+			world_3d->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
+		}
+	} else {
+		if (world_3d.is_valid()) {
+			own_world_3d = world_3d->duplicate();
+			world_3d->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
+		} else {
+			own_world_3d = Ref<World3D>(memnew(World3D));
+		}
+	}
+
+	if (is_inside_tree()) {
+		_propagate_enter_world_3d(this);
+	}
+
+	if (is_inside_tree()) {
+		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
+	}
+
+	_update_listener_3d();
+}
+
+bool Viewport::is_using_own_world_3d() const {
+	return own_world_3d.is_valid();
+}
+
+void Viewport::_propagate_enter_world_3d(Node *p_node) {
+	if (p_node != this) {
+		if (!p_node->is_inside_tree()) { //may not have entered scene yet
+			return;
+		}
+
+		if (Object::cast_to<Node3D>(p_node) || Object::cast_to<WorldEnvironment>(p_node)) {
+			p_node->notification(Node3D::NOTIFICATION_ENTER_WORLD);
+		} else {
+			Viewport *v = Object::cast_to<Viewport>(p_node);
+			if (v) {
+				if (v->world_3d.is_valid() || v->own_world_3d.is_valid()) {
+					return;
+				}
+			}
+		}
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_propagate_enter_world_3d(p_node->get_child(i));
+	}
+}
+
+void Viewport::_propagate_exit_world_3d(Node *p_node) {
+	if (p_node != this) {
+		if (!p_node->is_inside_tree()) { //may have exited scene already
+			return;
+		}
+
+		if (Object::cast_to<Node3D>(p_node) || Object::cast_to<WorldEnvironment>(p_node)) {
+			p_node->notification(Node3D::NOTIFICATION_EXIT_WORLD);
+		} else {
+			Viewport *v = Object::cast_to<Viewport>(p_node);
+			if (v) {
+				if (v->world_3d.is_valid() || v->own_world_3d.is_valid()) {
+					return;
+				}
+			}
+		}
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_propagate_exit_world_3d(p_node->get_child(i));
+	}
+}
+
+void Viewport::set_use_xr(bool p_use_xr) {
+	use_xr = p_use_xr;
+
+	RS::get_singleton()->viewport_set_use_xr(viewport, use_xr);
+}
+
+bool Viewport::is_using_xr() {
+	return use_xr;
 }
 
 void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_world_2d", "world_2d"), &Viewport::set_world_2d);
 	ClassDB::bind_method(D_METHOD("get_world_2d"), &Viewport::get_world_2d);
 	ClassDB::bind_method(D_METHOD("find_world_2d"), &Viewport::find_world_2d);
-	ClassDB::bind_method(D_METHOD("set_world_3d", "world_3d"), &Viewport::set_world_3d);
-	ClassDB::bind_method(D_METHOD("get_world_3d"), &Viewport::get_world_3d);
-	ClassDB::bind_method(D_METHOD("find_world_3d"), &Viewport::find_world_3d);
 
 	ClassDB::bind_method(D_METHOD("set_canvas_transform", "xform"), &Viewport::set_canvas_transform);
 	ClassDB::bind_method(D_METHOD("get_canvas_transform"), &Viewport::get_canvas_transform);
@@ -3536,9 +3501,6 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_render_info", "type", "info"), &Viewport::get_render_info);
 
-	ClassDB::bind_method(D_METHOD("set_use_xr", "use"), &Viewport::set_use_xr);
-	ClassDB::bind_method(D_METHOD("is_using_xr"), &Viewport::is_using_xr);
-
 	ClassDB::bind_method(D_METHOD("get_texture"), &Viewport::get_texture);
 
 	ClassDB::bind_method(D_METHOD("set_physics_object_picking", "enable"), &Viewport::set_physics_object_picking);
@@ -3549,20 +3511,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("input", "event", "in_local_coords"), &Viewport::input, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("unhandled_input", "event", "in_local_coords"), &Viewport::unhandled_input, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("set_use_own_world_3d", "enable"), &Viewport::set_use_own_world_3d);
-	ClassDB::bind_method(D_METHOD("is_using_own_world_3d"), &Viewport::is_using_own_world_3d);
-
-	ClassDB::bind_method(D_METHOD("get_camera_3d"), &Viewport::get_camera_3d);
 	ClassDB::bind_method(D_METHOD("get_camera_2d"), &Viewport::get_camera_2d);
-
-	ClassDB::bind_method(D_METHOD("set_as_audio_listener", "enable"), &Viewport::set_as_audio_listener);
-	ClassDB::bind_method(D_METHOD("is_audio_listener"), &Viewport::is_audio_listener);
-
 	ClassDB::bind_method(D_METHOD("set_as_audio_listener_2d", "enable"), &Viewport::set_as_audio_listener_2d);
 	ClassDB::bind_method(D_METHOD("is_audio_listener_2d"), &Viewport::is_audio_listener_2d);
-
-	ClassDB::bind_method(D_METHOD("set_disable_3d", "disable"), &Viewport::set_disable_3d);
-	ClassDB::bind_method(D_METHOD("is_3d_disabled"), &Viewport::is_3d_disabled);
 
 	ClassDB::bind_method(D_METHOD("get_mouse_position"), &Viewport::get_mouse_position);
 	ClassDB::bind_method(D_METHOD("warp_mouse", "to_position"), &Viewport::warp_mouse);
@@ -3621,7 +3572,26 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_process_picking"), &Viewport::_process_picking);
 
+	ClassDB::bind_method(D_METHOD("set_world_3d", "world_3d"), &Viewport::set_world_3d);
+	ClassDB::bind_method(D_METHOD("get_world_3d"), &Viewport::get_world_3d);
+	ClassDB::bind_method(D_METHOD("find_world_3d"), &Viewport::find_world_3d);
+
+	ClassDB::bind_method(D_METHOD("set_use_own_world_3d", "enable"), &Viewport::set_use_own_world_3d);
+	ClassDB::bind_method(D_METHOD("is_using_own_world_3d"), &Viewport::is_using_own_world_3d);
+
+	ClassDB::bind_method(D_METHOD("get_camera_3d"), &Viewport::get_camera_3d);
+	ClassDB::bind_method(D_METHOD("set_as_audio_listener_3d", "enable"), &Viewport::set_as_audio_listener_3d);
+	ClassDB::bind_method(D_METHOD("is_audio_listener_3d"), &Viewport::is_audio_listener_3d);
+
+	ClassDB::bind_method(D_METHOD("set_disable_3d", "disable"), &Viewport::set_disable_3d);
+	ClassDB::bind_method(D_METHOD("is_3d_disabled"), &Viewport::is_3d_disabled);
+
+	ClassDB::bind_method(D_METHOD("set_use_xr", "use"), &Viewport::set_use_xr);
+	ClassDB::bind_method(D_METHOD("is_using_xr"), &Viewport::is_using_xr);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_3d"), "set_disable_3d", "is_3d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_xr"), "set_use_xr", "is_using_xr");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_listener_enable_3d"), "set_as_audio_listener_3d", "is_audio_listener_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "own_world_3d"), "set_use_own_world_3d", "is_using_own_world_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_3d", PROPERTY_HINT_RESOURCE_TYPE, "World3D"), "set_world_3d", "get_world_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_2d", PROPERTY_HINT_RESOURCE_TYPE, "World2D", PROPERTY_USAGE_NONE), "set_world_2d", "get_world_2d");
@@ -3630,7 +3600,6 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snap_2d_transforms_to_pixel"), "set_snap_2d_transforms_to_pixel", "is_snap_2d_transforms_to_pixel_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snap_2d_vertices_to_pixel"), "set_snap_2d_vertices_to_pixel", "is_snap_2d_vertices_to_pixel_enabled");
 	ADD_GROUP("Rendering", "");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_3d"), "set_disable_3d", "is_3d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "msaa", PROPERTY_HINT_ENUM, "Disabled (Fastest),2x (Fast),4x (Average),8x (Slow),16x (Slower)"), "set_msaa", "get_msaa");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "screen_space_aa", PROPERTY_HINT_ENUM, "Disabled (Fastest),FXAA (Fast)"), "set_screen_space_aa", "get_screen_space_aa");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_debanding"), "set_use_debanding", "is_using_debanding");
@@ -3642,7 +3611,6 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "canvas_item_default_texture_repeat", PROPERTY_HINT_ENUM, "Disabled,Enabled,Mirror"), "set_default_canvas_item_texture_repeat", "get_default_canvas_item_texture_repeat");
 	ADD_GROUP("Audio Listener", "audio_listener_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_listener_enable_2d"), "set_as_audio_listener_2d", "is_audio_listener_2d");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_listener_enable_3d"), "set_as_audio_listener", "is_audio_listener");
 	ADD_GROUP("Physics", "physics_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_object_picking"), "set_physics_object_picking", "get_physics_object_picking");
 	ADD_GROUP("GUI", "gui_");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -194,38 +194,12 @@ private:
 
 	Viewport *parent = nullptr;
 
-	Listener3D *listener = nullptr;
-	Set<Listener3D *> listeners;
-
-	struct CameraOverrideData {
-		Transform3D transform;
-		enum Projection {
-			PROJECTION_PERSPECTIVE,
-			PROJECTION_ORTHOGONAL
-		};
-		Projection projection = Projection::PROJECTION_PERSPECTIVE;
-		float fov = 0.0;
-		float size = 0.0;
-		float z_near = 0.0;
-		float z_far = 0.0;
-		RID rid;
-
-		operator bool() const {
-			return rid != RID();
-		}
-	} camera_override;
-
-	Camera3D *camera_3d = nullptr;
 	Camera2D *camera_2d = nullptr;
-	Set<Camera3D *> cameras;
 	Set<CanvasLayer *> canvas_layers;
 
 	RID viewport;
 	RID current_canvas;
 	RID subwindow_canvas;
-
-	bool audio_listener = false;
-	RID internal_listener;
 
 	bool audio_listener_2d = false;
 	RID internal_listener_2d;
@@ -240,7 +214,6 @@ private:
 	Size2i size = Size2i(512, 512);
 	Size2i size_2d_override;
 	bool size_allocated = false;
-	bool use_xr = false;
 
 	RID contact_2d_debug;
 	RID contact_3d_debug_multimesh;
@@ -274,8 +247,6 @@ private:
 
 	} physics_last_mouse_state;
 
-	void _collision_object_input_event(CollisionObject3D *p_object, Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);
-
 	bool handle_input_locally = true;
 	bool local_input_handled = false;
 
@@ -287,8 +258,6 @@ private:
 	void _cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paused_only, uint64_t p_frame_reference = 0);
 
 	Ref<World2D> world_2d;
-	Ref<World3D> world_3d;
-	Ref<World3D> own_world_3d;
 
 	Rect2i to_screen_rect;
 	StringName input_group;
@@ -296,13 +265,10 @@ private:
 	StringName unhandled_input_group;
 	StringName unhandled_key_input_group;
 
-	void _update_listener();
 	void _update_listener_2d();
 
 	bool disable_3d = false;
 
-	void _propagate_enter_world(Node *p_node);
-	void _propagate_exit_world(Node *p_node);
 	void _propagate_viewport_notification(Node *p_node, int p_what);
 
 	void _update_global_transform();
@@ -443,20 +409,6 @@ private:
 
 	bool _gui_drop(Control *p_at_control, Point2 p_at_pos, bool p_just_check);
 
-	friend class Listener3D;
-	void _listener_transform_changed_notify();
-	void _listener_set(Listener3D *p_listener);
-	bool _listener_add(Listener3D *p_listener); //true if first
-	void _listener_remove(Listener3D *p_listener);
-	void _listener_make_next_current(Listener3D *p_exclude);
-
-	friend class Camera3D;
-	void _camera_3d_transform_changed_notify();
-	void _camera_3d_set(Camera3D *p_camera);
-	bool _camera_3d_add(Camera3D *p_camera); //true if first
-	void _camera_3d_remove(Camera3D *p_camera);
-	void _camera_3d_make_next_current(Camera3D *p_exclude);
-
 	friend class Camera2D;
 	void _camera_2d_set(Camera2D *p_camera_2d);
 
@@ -470,8 +422,6 @@ private:
 	void _update_canvas_items(Node *p_node);
 
 	void _gui_set_root_order_dirty();
-
-	void _own_world_3d_changed();
 
 	friend class Window;
 
@@ -500,38 +450,16 @@ protected:
 public:
 	uint64_t get_processed_events_count() const { return event_count; }
 
-	Listener3D *get_listener() const;
-	Camera3D *get_camera_3d() const;
 	Camera2D *get_camera_2d() const;
-
-	void enable_camera_override(bool p_enable);
-	bool is_camera_override_enabled() const;
-
-	void set_camera_override_transform(const Transform3D &p_transform);
-	Transform3D get_camera_override_transform() const;
-
-	void set_camera_override_perspective(float p_fovy_degrees, float p_z_near, float p_z_far);
-	void set_camera_override_orthogonal(float p_size, float p_z_near, float p_z_far);
-
-	void set_as_audio_listener(bool p_enable);
-	bool is_audio_listener() const;
-
 	void set_as_audio_listener_2d(bool p_enable);
 	bool is_audio_listener_2d() const;
-
-	void set_disable_3d(bool p_disable);
-	bool is_3d_disabled() const;
 
 	void update_canvas_items();
 
 	Rect2 get_visible_rect() const;
 	RID get_viewport_rid() const;
 
-	void set_world_3d(const Ref<World3D> &p_world_3d);
 	void set_world_2d(const Ref<World2D> &p_world_2d);
-	Ref<World3D> get_world_3d() const;
-	Ref<World3D> find_world_3d() const;
-
 	Ref<World2D> get_world_2d() const;
 	Ref<World2D> find_world_2d() const;
 
@@ -551,9 +479,6 @@ public:
 
 	void set_transparent_background(bool p_enable);
 	bool has_transparent_background() const;
-
-	void set_use_xr(bool p_use_xr);
-	bool is_using_xr();
 
 	Ref<ViewportTexture> get_texture() const;
 
@@ -583,9 +508,6 @@ public:
 
 	Vector2 get_camera_coords(const Vector2 &p_viewport_coords) const;
 	Vector2 get_camera_rect_size() const;
-
-	void set_use_own_world_3d(bool p_world_3d);
-	bool is_using_own_world_3d() const;
 
 	void input_text(const String &p_text);
 	void input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
@@ -653,6 +575,78 @@ public:
 	Window *get_base_window() const;
 
 	void pass_mouse_focus_to(Viewport *p_viewport, Control *p_control);
+
+	bool use_xr = false;
+	friend class Listener3D;
+	Listener3D *listener_3d = nullptr;
+	Set<Listener3D *> listener_3d_set;
+	bool audio_listener_3d = false;
+	RID internal_listener_3d;
+	Listener3D *get_listener_3d() const;
+	void set_as_audio_listener_3d(bool p_enable);
+	bool is_audio_listener_3d() const;
+	void _update_listener_3d();
+	void _listener_transform_3d_changed_notify();
+	void _listener_3d_set(Listener3D *p_listener);
+	bool _listener_3d_add(Listener3D *p_listener); //true if first
+	void _listener_3d_remove(Listener3D *p_listener);
+	void _listener_3d_make_next_current(Listener3D *p_exclude);
+
+	void _collision_object_3d_input_event(CollisionObject3D *p_object, Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);
+
+	struct Camera3DOverrideData {
+		Transform3D transform;
+		enum Projection {
+			PROJECTION_PERSPECTIVE,
+			PROJECTION_ORTHOGONAL
+		};
+		Projection projection = Projection::PROJECTION_PERSPECTIVE;
+		real_t fov = 0.0;
+		real_t size = 0.0;
+		real_t z_near = 0.0;
+		real_t z_far = 0.0;
+		RID rid;
+
+		operator bool() const {
+			return rid != RID();
+		}
+	} camera_3d_override;
+
+	friend class Camera3D;
+	Camera3D *camera_3d = nullptr;
+	Set<Camera3D *> camera_3d_set;
+	Camera3D *get_camera_3d() const;
+	void _camera_3d_transform_changed_notify();
+	void _camera_3d_set(Camera3D *p_camera);
+	bool _camera_3d_add(Camera3D *p_camera); //true if first
+	void _camera_3d_remove(Camera3D *p_camera);
+	void _camera_3d_make_next_current(Camera3D *p_exclude);
+
+	void enable_camera_3d_override(bool p_enable);
+	bool is_camera_3d_override_enabled() const;
+
+	void set_camera_3d_override_transform(const Transform3D &p_transform);
+	Transform3D get_camera_3d_override_transform() const;
+
+	void set_camera_3d_override_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far);
+	void set_camera_3d_override_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far);
+
+	void set_disable_3d(bool p_disable);
+	bool is_3d_disabled() const;
+
+	Ref<World3D> world_3d;
+	Ref<World3D> own_world_3d;
+	void set_world_3d(const Ref<World3D> &p_world_3d);
+	Ref<World3D> get_world_3d() const;
+	Ref<World3D> find_world_3d() const;
+	void _own_world_3d_changed();
+	void set_use_own_world_3d(bool p_world_3d);
+	bool is_using_own_world_3d() const;
+	void _propagate_enter_world_3d(Node *p_node);
+	void _propagate_exit_world_3d(Node *p_node);
+
+	void set_use_xr(bool p_use_xr);
+	bool is_using_xr();
 
 	Viewport();
 	~Viewport();


### PR DESCRIPTION
This is a subset of #50147, split into its own PR for easy reviewing.

This PR does two things:

* Organize methods in Viewport so that all 3D methods are next to each other. This makes it easy to disable them with #50147.

* Explicitly name 3D methods with a 3D suffix.
