### PR TITLE
Streamline the project import workflow.

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -264,6 +264,8 @@ void EditorFileDialog::update_dir() {
 	}
 	dir->set_text(dir_access->get_current_dir(false));
 
+	file->set_text("");
+
 	// Disable "Open" button only when selecting file(s) mode.
 	get_ok_button()->set_disabled(_is_open_should_be_disabled());
 	switch (mode) {
@@ -271,10 +273,10 @@ void EditorFileDialog::update_dir() {
 		case FILE_MODE_OPEN_FILES:
 			set_ok_button_text(TTR("Open"));
 			break;
+		case FILE_MODE_OPEN_ANY:
 		case FILE_MODE_OPEN_DIR:
 			set_ok_button_text(TTR("Select Current Folder"));
 			break;
-		case FILE_MODE_OPEN_ANY:
 		case FILE_MODE_SAVE_FILE:
 			// FIXME: Implement, or refactor to avoid duplication with set_mode
 			break;
@@ -522,7 +524,11 @@ void EditorFileDialog::_item_selected(int p_item) {
 	if (!d["dir"]) {
 		file->set_text(d["name"]);
 		_request_single_thumbnail(get_current_dir().path_join(get_current_file()));
-	} else if (mode == FILE_MODE_OPEN_DIR) {
+
+		// FILE_MODE_OPEN_ANY can alternate this text depending on what's selected.
+		set_ok_button_text(TTR("Open"));
+	} else if (mode == FILE_MODE_OPEN_DIR || mode == FILE_MODE_OPEN_ANY) {
+		file->set_text("");
 		set_ok_button_text(TTR("Select This Folder"));
 	}
 
@@ -560,12 +566,13 @@ void EditorFileDialog::_items_clear_selection(const Vector2 &p_pos, MouseButton 
 			get_ok_button()->set_disabled(!item_list->is_anything_selected());
 			break;
 
+		case FILE_MODE_OPEN_ANY:
 		case FILE_MODE_OPEN_DIR:
+			file->set_text("");
 			get_ok_button()->set_disabled(false);
 			set_ok_button_text(TTR("Select Current Folder"));
 			break;
 
-		case FILE_MODE_OPEN_ANY:
 		case FILE_MODE_SAVE_FILE:
 			// FIXME: Implement, or refactor to avoid duplication with set_mode
 			break;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -208,7 +208,7 @@ String ProjectDialog::_test_path() {
 				}
 
 			} else {
-				_set_message(TTR("Please choose a \"project.godot\" or \".zip\" file."), MESSAGE_ERROR);
+				_set_message(TTR("Please choose a \"project.godot\", a directory with it, or a \".zip\" file."), MESSAGE_ERROR);
 				install_path_container->hide();
 				get_ok_button()->set_disabled(true);
 				return "";
@@ -283,6 +283,9 @@ void ProjectDialog::_path_text_changed(const String &p_path) {
 }
 
 void ProjectDialog::_file_selected(const String &p_path) {
+	// If not already shown.
+	show_dialog();
+
 	String p = p_path;
 	if (mode == MODE_IMPORT) {
 		if (p.ends_with("project.godot")) {
@@ -311,6 +314,9 @@ void ProjectDialog::_file_selected(const String &p_path) {
 }
 
 void ProjectDialog::_path_selected(const String &p_path) {
+	// If not already shown.
+	show_dialog();
+
 	String sp = p_path.simplify_path();
 	project_path->set_text(sp);
 	_path_text_changed(sp);
@@ -328,7 +334,7 @@ void ProjectDialog::_browse_path() {
 	fdialog->set_current_dir(project_path->get_text());
 
 	if (mode == MODE_IMPORT) {
-		fdialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
+		fdialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_ANY);
 		fdialog->clear_filters();
 		fdialog->add_filter("project.godot", vformat("%s %s", VERSION_NAME, TTR("Project")));
 		fdialog->add_filter("*.zip", TTR("ZIP File"));
@@ -664,6 +670,14 @@ void ProjectDialog::set_mode(Mode p_mode) {
 
 void ProjectDialog::set_project_path(const String &p_path) {
 	project_path->set_text(p_path);
+}
+
+void ProjectDialog::ask_for_path_and_show() {
+	// Workaround: for the file selection dialog content to be rendered we need to show its parent dialog.
+	show_dialog();
+	_set_message("");
+
+	_browse_path();
 }
 
 void ProjectDialog::show_dialog() {
@@ -2448,7 +2462,7 @@ void ProjectManager::_new_project() {
 
 void ProjectManager::_import_project() {
 	npdialog->set_mode(ProjectDialog::MODE_IMPORT);
-	npdialog->show_dialog();
+	npdialog->ask_for_path_and_show();
 }
 
 void ProjectManager::_rename_project() {

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -131,6 +131,7 @@ public:
 	void set_mode(Mode p_mode);
 	void set_project_path(const String &p_path);
 
+	void ask_for_path_and_show();
 	void show_dialog();
 
 	ProjectDialog();


### PR DESCRIPTION
The goal of this PR is to ease the steps required to import a project.

![Screenshot 2023-07-30 at 17 17 55](https://github.com/godotengine/godot/assets/11571820/8668e389-0e4a-4bce-82e2-87822a7bf488)

After clicking Import, the file selection dialog is immediately shown (previously one needed an extra button click).

The project file selection dialog now also supports selecting a directory, similar to Scan mode. Changes to Any mode of the selection dialog are because I wanted it to offer full functionality of both File and Directory selection modes.

Notes:
1) I had to still show the original dialog together in the background of file selection dialog, because otherwise the content of file selection dialog isn't rendered. The drawback is that when hitting Cancel in the file selection dialog, we see the original dialog, while ideally it shouldn't be shown on the first Cancel after clicking Import.

Maybe we should change the hierarchy of the dialogs to be siblings?

2) I was going to also merge Import and Scan, but not sure about the best approach to show Scan option in the UI of Import. Maybe it's for after this PR is merged.

3) The lines below are because in the original PR there was no issue described in 1). If we decide to ignore 1), then I think they can be removed:

```
// if not already shown
show_dialog();
```

Relaled: https://github.com/godotengine/godot-proposals/issues/2483