### PR TITLE
Fix 3D character snap on moving platforms

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1176,11 +1176,6 @@ bool CharacterBody3D::move_and_slide() {
 		}
 	}
 
-	if (!on_floor && !on_wall) {
-		// Add last platform velocity when just left a moving platform.
-		linear_velocity += current_floor_velocity;
-	}
-
 	if (was_on_floor && snap != Vector3()) {
 		// Apply snap.
 		Transform3D gt = get_global_transform();
@@ -1211,6 +1206,11 @@ bool CharacterBody3D::move_and_slide() {
 				set_global_transform(gt);
 			}
 		}
+	}
+
+	if (!on_floor && !on_wall) {
+		// Add last platform velocity when just left a moving platform.
+		linear_velocity += current_floor_velocity;
 	}
 
 	return motion_results.size() > 0;


### PR DESCRIPTION
Fixes the first point from https://github.com/godotengine/godot/issues/50732#issuecomment-896292908 (regression from #51457).
CC @TokageItLab
CC @fabriceci

Applying the platform velocity when leaving the platform floor should be done after snapping to keep things consistent, like it's done in 2D.

This issue also affects the 3.x version, so I'll make a separate PR for 3.x.
