### PR TITLE
Use f0 instead of albedo in blinn and phong

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -211,7 +211,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, float atte
 		float blinn = pow(cNdotH, shininess);
 		blinn *= (shininess + 2.0) * (1.0 / (8.0 * M_PI));
 
-		specular_light += light_color * attenuation * specular_amount * blinn * albedo * unpackUnorm4x8(orms).w;
+		specular_light += light_color * attenuation * specular_amount * blinn * f0 * unpackUnorm4x8(orms).w;
 
 #elif defined(SPECULAR_PHONG)
 
@@ -221,7 +221,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, float atte
 		float phong = pow(cRdotV, shininess);
 		phong *= (shininess + 1.0) * (1.0 / (8.0 * M_PI));
 
-		specular_light += light_color * attenuation * specular_amount * phong * albedo * unpackUnorm4x8(orms).w;
+		specular_light += light_color * attenuation * specular_amount * phong * f0 * unpackUnorm4x8(orms).w;
 
 #elif defined(SPECULAR_TOON)
 


### PR DESCRIPTION
Turns out there is a good reason why https://github.com/godotengine/godot/pull/51411 was marked as draft. 

It wasn't production ready code. ``albedo`` isn't defined in that function so using Blinn or Specular causes a compile error. This instead uses ``f0`` which is equal to albedo for metallic materials and equal to ``0.16 * specular * specular`` for dialectrics. Which should still look fine (technically this makes Blinn and Phong closer to PBR than in 3,x) In practice the difference is quite small. 