### PR TITLE
Delta smoothing - fix overflow for long frames

### DIFF
--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -48,11 +48,11 @@ class MainTimerSync {
 	class DeltaSmoother {
 	public:
 		// pass the recorded delta, returns a smoothed delta
-		int smooth_delta(int p_delta);
+		int64_t smooth_delta(int64_t p_delta);
 
 	private:
-		void update_refresh_rate_estimator(int p_delta);
-		bool fps_allows_smoothing(int p_delta);
+		void update_refresh_rate_estimator(int64_t p_delta);
+		bool fps_allows_smoothing(int64_t p_delta);
 
 		// estimated vsync delta (monitor refresh rate)
 		int64_t _vsync_delta = 16666;
@@ -75,19 +75,19 @@ class MainTimerSync {
 
 		// we can estimate the fps by growing it on condition
 		// that a large proportion of frames are higher than the current estimate.
-		int _estimated_fps = 0;
-		int _hits_at_estimated = 0;
-		int _hits_above_estimated = 0;
-		int _hits_below_estimated = 0;
-		int _hits_one_above_estimated = 0;
-		int _hits_one_below_estimated = 0;
+		int32_t _estimated_fps = 0;
+		int32_t _hits_at_estimated = 0;
+		int32_t _hits_above_estimated = 0;
+		int32_t _hits_below_estimated = 0;
+		int32_t _hits_one_above_estimated = 0;
+		int32_t _hits_one_below_estimated = 0;
 		bool _estimate_complete = false;
 		bool _estimate_locked = false;
 
 		// data for averaging the delta over a second or so
 		// to prevent spurious values
-		int _estimator_total_delta = 0;
-		int _estimator_delta_readings = 0;
+		int64_t _estimator_total_delta = 0;
+		int32_t _estimator_delta_readings = 0;
 
 		void made_new_estimate() {
 			_hits_above_estimated = 0;


### PR DESCRIPTION
Extremely long frames caused by suspending and resuming the machine could result in an overflow in the delta smoothing because it uses 32 bit math on delta values measured in nanoseconds.

This PR puts a cap of a second as the maximum frame delta that will be processed by the smoothing, otherwise it returns the frame delta 64 bit value unaltered.

I've also converted all internal math to use 64 bit explicitly (except counters). This is probably overkill but it might help avoid any future bugs, and it's not a bottleneck area so there's no real downside.

Fixes #51482 (untested, but looks like the source of the bug)

## Notes
* There are a number of ways of fixing this, we could for instance just cap the maximum delta, however that could make programs that depend on 'real time' go out of sync with long frames.
* Not processing long frames in the delta smoothing is equivalent to turning it off for one frame. As it is based on deltas, it should recover perfectly on the next frame, as if the long frame had never happened.
* We could alternatively use 64 bit math throughout the smoothing, but this is not necessary, smoothing is going to turn off anyway with such long frame times.
* Rather confusingly the bug occurs even when smoothing is off. This is because the `smooth` function is called _before_ it checks for the off condition, and the conversion to int32_t occurs in the function call.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
