### PR TITLE
Fix incorrect position of the created VisualShader nodes on zoomed graph

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2361,6 +2361,7 @@ void VisualShaderEditor::_add_node(int p_idx, int p_op_idx, String p_resource_pa
 		position += graph->get_size() * 0.5;
 		position /= EDSCALE;
 	}
+	position /= graph->get_zoom();
 	saved_node_pos_dirty = false;
 
 	int id_to_use = visual_shader->get_valid_node_id(type);


### PR DESCRIPTION
Fix
<details>
<summary>Detalis</summary>

![vs_addnode_fix](https://user-images.githubusercontent.com/3036176/128991486-069538a5-799e-4323-8601-01343fa54bbc.gif)

</details>

