### PR TITLE
Move cursor to edge of selection when moving caret left/right

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1584,6 +1584,12 @@ void TextEdit::_move_cursor_left(bool p_select, bool p_move_by_word) {
 	// Handle selection
 	if (p_select) {
 		_pre_shift_selection();
+	} else if (selection.active && !p_move_by_word) {
+		// If a selection is active, move cursor to start of selection
+		cursor_set_line(selection.from_line);
+		cursor_set_column(selection.from_column);
+		deselect();
+		return;
 	} else {
 		deselect();
 	}
@@ -1629,6 +1635,12 @@ void TextEdit::_move_cursor_right(bool p_select, bool p_move_by_word) {
 	// Handle selection
 	if (p_select) {
 		_pre_shift_selection();
+	} else if (selection.active && !p_move_by_word) {
+		// If a selection is active, move cursor to end of selection
+		cursor_set_line(selection.to_line);
+		cursor_set_column(selection.to_column);
+		deselect();
+		return;
 	} else {
 		deselect();
 	}


### PR DESCRIPTION
This is to mimic the behavior of many third party text editors. The reason it's not doing it when moving by word is due to that behavior being mostly the same on other editors.

The below example gifs show the change - pressing left arrow when there is a selection should move the caret to the start of the selection, and pressing right arrow should move it to the end of the selection. This also works when selecting multiple lines.

**Wrong behavior in Godot:**
![f517bfb3-ebae-4f86-8bf2-d64597743a68](https://user-images.githubusercontent.com/136534/128999401-3a370414-dc0f-4a0c-95aa-006fb07625a3.gif)

**Expected behavior in VSCode:**
![b6c9c313-f726-4deb-a321-026960fc3e9a](https://user-images.githubusercontent.com/136534/128999471-de830511-5c17-47d8-908f-67bc28139fcb.gif)
