### PR TITLE
command palette improvements

### DIFF
--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -60,7 +60,6 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 	commands.get_key_list(&command_keys);
 	ERR_FAIL_COND(command_keys.is_empty());
 
-	const bool empty_search = search_text.is_empty();
 	Map<String, TreeItem *> sections;
 	TreeItem *first_section = nullptr;
 
@@ -71,7 +70,7 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 		r.key_name = command_keys[i];
 		r.display_name = commands[r.key_name].name;
 		r.shortcut_text = commands[r.key_name].shortcut;
-		if (!empty_search && search_text.is_subsequence_ofi(r.display_name)) {
+		if (search_text.is_subsequence_ofi(r.display_name)) {
 			r.score = _score_path(search_text, r.display_name.to_lower());
 			entries.push_back(r);
 		}
@@ -83,7 +82,7 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 	root->clear_children();
 
 	if (entries.size() > 0) {
-		if (!empty_search) {
+		if (!search_text.is_empty()) {
 			SortArray<CommandEntry, CommandEntryComparator> sorter;
 			sorter.sort(entries.ptrw(), entries.size());
 		}
@@ -128,7 +127,7 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 		get_ok_button()->set_disabled(false);
 	} else {
 		TreeItem *ti = search_options->create_item(root);
-		ti->set_text(0, TTR("No Matching Command"));
+		ti->set_text(0, TTR("No matching commands found"));
 		ti->set_metadata(0, "");
 		Color c = Color(0.5, 0.5, 0.5, 0.5);
 		ti->set_custom_color(0, c);
@@ -179,35 +178,35 @@ void EditorCommandPalette::get_actions_list(List<String> *p_list) const {
 }
 
 void EditorCommandPalette::remove_command(String p_key_name) {
-	ERR_FAIL_COND_MSG(!commands.has(p_key_name), "The EditorAction '" + String(p_key_name) + "' Doesn't exists. Unable to remove it.");
+	ERR_FAIL_COND_MSG(!commands.has(p_key_name), "The Command '" + String(p_key_name) + "' doesn't exists. Unable to remove it.");
 
 	commands.erase(p_key_name);
 }
 
 void EditorCommandPalette::add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, String p_shortcut_text) {
-	ERR_FAIL_COND_MSG(commands.has(p_key_name), "The EditorAction '" + String(p_command_name) + "' already exists. Unable to add it.");
+	ERR_FAIL_COND_MSG(commands.has(p_key_name), "The Command '" + String(p_command_name) + "' already exists. Unable to add it.");
 
 	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * arguments.size());
 	for (int i = 0; i < arguments.size(); i++) {
 		argptrs[i] = &arguments[i];
 	}
-	Command p_command;
-	p_command.name = p_command_name;
-	p_command.callable = p_action.bind(argptrs, arguments.size());
-	p_command.shortcut = p_shortcut_text;
+	Command command;
+	command.name = p_command_name;
+	command.callable = p_action.bind(argptrs, arguments.size());
+	command.shortcut = p_shortcut_text;
 
-	commands[p_key_name] = p_command;
+	commands[p_key_name] = command;
 }
 
 void EditorCommandPalette::_add_command(String p_command_name, String p_key_name, Callable p_binded_action, String p_shortcut_text) {
-	ERR_FAIL_COND_MSG(commands.has(p_key_name), "The EditorAction '" + String(p_command_name) + "' already exists. Unable to add it.");
+	ERR_FAIL_COND_MSG(commands.has(p_key_name), "The Command '" + String(p_command_name) + "' already exists. Unable to add it.");
 
-	Command p_command;
-	p_command.name = p_command_name;
-	p_command.callable = p_binded_action;
-	p_command.shortcut = p_shortcut_text;
+	Command command;
+	command.name = p_command_name;
+	command.callable = p_binded_action;
+	command.shortcut = p_shortcut_text;
 
-	commands[p_key_name] = p_command;
+	commands[p_key_name] = command;
 }
 
 void EditorCommandPalette::execute_command(String &p_command_key) {
@@ -216,17 +215,17 @@ void EditorCommandPalette::execute_command(String &p_command_key) {
 }
 
 void EditorCommandPalette::register_shortcuts_as_command() {
-	const String *p_key = nullptr;
-	p_key = unregistered_shortcuts.next(p_key);
-	while (p_key != nullptr) {
-		String command_name = unregistered_shortcuts[*p_key].first;
-		Ref<Shortcut> p_shortcut = unregistered_shortcuts[*p_key].second;
+	const String *key = nullptr;
+	key = unregistered_shortcuts.next(key);
+	while (key != nullptr) {
+		String command_name = unregistered_shortcuts[*key].first;
+		Ref<Shortcut> shortcut = unregistered_shortcuts[*key].second;
 		Ref<InputEventShortcut> ev;
 		ev.instantiate();
-		ev->set_shortcut(p_shortcut);
-		String shortcut_text = String(p_shortcut->get_as_text());
-		add_command(command_name, *p_key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::unhandled_input), varray(ev, false), shortcut_text);
-		p_key = unregistered_shortcuts.next(p_key);
+		ev->set_shortcut(shortcut);
+		String shortcut_text = String(shortcut->get_as_text());
+		add_command(command_name, *key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::unhandled_input), varray(ev, false), shortcut_text);
+		key = unregistered_shortcuts.next(key);
 	}
 	unregistered_shortcuts.clear();
 }
@@ -241,8 +240,8 @@ Ref<Shortcut> EditorCommandPalette::add_shortcut_command(const String &p_command
 	} else {
 		const String key_name = String(p_key);
 		const String command_name = String(p_command);
-		Pair p_pair = Pair(command_name, p_shortcut);
-		unregistered_shortcuts[key_name] = p_pair;
+		Pair pair = Pair(command_name, p_shortcut);
+		unregistered_shortcuts[key_name] = pair;
 	}
 	return p_shortcut;
 }
@@ -264,12 +263,11 @@ EditorCommandPalette::EditorCommandPalette() {
 	add_child(vbc);
 
 	command_search_box = memnew(LineEdit);
-	command_search_box->set_placeholder("search for a command");
-	command_search_box->set_placeholder_alpha(0.5);
+	command_search_box->set_placeholder(TTR("Filter commands"));
 	command_search_box->connect("gui_input", callable_mp(this, &EditorCommandPalette::_sbox_input));
 	command_search_box->connect("text_changed", callable_mp(this, &EditorCommandPalette::_update_command_search));
-	command_search_box->connect("text_submitted", callable_mp(this, &EditorCommandPalette::_confirmed).unbind(1));
 	command_search_box->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	command_search_box->set_clear_button_enabled(true);
 	MarginContainer *margin_container_csb = memnew(MarginContainer);
 	margin_container_csb->add_child(command_search_box);
 	vbc->add_child(margin_container_csb);
@@ -285,9 +283,9 @@ EditorCommandPalette::EditorCommandPalette() {
 	search_options->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	search_options->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search_options->set_column_custom_minimum_width(0, int(8 * EDSCALE));
-
 	vbc->add_child(search_options, true);
 
+	connect("confirmed", callable_mp(this, &EditorCommandPalette::_confirmed));
 	set_hide_on_ok(false);
 }
 
@@ -296,7 +294,7 @@ Ref<Shortcut> ED_SHORTCUT_AND_COMMAND(const String &p_path, const String &p_name
 		p_command_name = p_name;
 	}
 
-	Ref<Shortcut> p_shortcut = ED_SHORTCUT(p_path, p_name, p_keycode);
-	EditorCommandPalette::get_singleton()->add_shortcut_command(p_command_name, p_path, p_shortcut);
-	return p_shortcut;
+	Ref<Shortcut> shortcut = ED_SHORTCUT(p_path, p_name, p_keycode);
+	EditorCommandPalette::get_singleton()->add_shortcut_command(p_command_name, p_path, shortcut);
+	return shortcut;
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6367,6 +6367,7 @@ EditorNode::EditorNode() {
 #else
 	p->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/editor_settings", TTR("Editor Settings...")), SETTINGS_PREFERENCES);
 #endif
+	p->add_shortcut(ED_SHORTCUT("editor/command_palette", TTR("Command Palette..."), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_P), HELP_COMMAND_PALETTE);
 	p->add_separator();
 
 	editor_layouts = memnew(PopupMenu);
@@ -6680,7 +6681,7 @@ EditorNode::EditorNode() {
 	bottom_panel_raise->set_flat(true);
 	bottom_panel_raise->set_icon(gui_base->get_theme_icon(SNAME("ExpandBottomDock"), SNAME("EditorIcons")));
 
-	bottom_panel_raise->set_shortcut(ED_SHORTCUT("editor/bottom_panel_expand", TTR("Expand Bottom Panel"), KEY_MASK_SHIFT | KEY_F12));
+	bottom_panel_raise->set_shortcut(ED_SHORTCUT_AND_COMMAND("editor/bottom_panel_expand", TTR("Expand Bottom Panel"), KEY_MASK_SHIFT | KEY_F12));
 
 	bottom_panel_hb->add_child(bottom_panel_raise);
 	bottom_panel_raise->hide();
@@ -7045,14 +7046,12 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_AND_COMMAND("editor/editor_3d", TTR("Open 3D Editor"), KEY_MASK_ALT | KEY_2);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_script", TTR("Open Script Editor"), KEY_MASK_ALT | KEY_3);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_assetlib", TTR("Open Asset Library"), KEY_MASK_ALT | KEY_4);
-	ED_SHORTCUT("editor/command_palette", TTR("Open Command Palette"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_P);
 #else
 	// Use the Ctrl modifier so F2 can be used to rename nodes in the scene tree dock.
 	ED_SHORTCUT_AND_COMMAND("editor/editor_2d", TTR("Open 2D Editor"), KEY_MASK_CTRL | KEY_F1);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_3d", TTR("Open 3D Editor"), KEY_MASK_CTRL | KEY_F2);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_script", TTR("Open Script Editor"), KEY_MASK_CTRL | KEY_F3);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_assetlib", TTR("Open Asset Library"), KEY_MASK_CTRL | KEY_F4);
-	ED_SHORTCUT("editor/command_palette", TTR("Open Command Palette"), KEY_MASK_CTRL | KEY_MASK_SHIFT | KEY_P);
 #endif
 	ED_SHORTCUT_AND_COMMAND("editor/editor_next", TTR("Open the next Editor"));
 	ED_SHORTCUT_AND_COMMAND("editor/editor_prev", TTR("Open the previous Editor"));

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -708,7 +708,6 @@ public:
 	EditorInspector *get_inspector() { return inspector_dock->get_inspector(); }
 	Container *get_inspector_dock_addon_area() { return inspector_dock->get_addon_area(); }
 	ScriptCreateDialog *get_script_create_dialog() { return scene_tree_dock->get_script_create_dialog(); }
-	EditorCommandPalette *get_editor_command_palette() { return command_palette; }
 
 	ProjectSettingsEditor *get_project_settings() { return project_settings; }
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -311,7 +311,7 @@ bool EditorInterface::is_distraction_free_mode_enabled() const {
 }
 
 EditorCommandPalette *EditorInterface::get_command_palette() const {
-	return EditorNode::get_singleton()->get_editor_command_palette();
+	return EditorCommandPalette::get_singleton();
 }
 
 EditorInterface *EditorInterface::singleton = nullptr;

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -145,10 +145,11 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 
 	if (status.press_attempt && status.pressing_inside) {
 		if (toggle_mode) {
+			bool is_pressed = p_event->is_pressed();
 			if (Object::cast_to<InputEventShortcut>(*p_event)) {
-				action_mode = ACTION_MODE_BUTTON_PRESS; // HACK.
+				is_pressed = false;
 			}
-			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
+			if ((is_pressed && action_mode == ACTION_MODE_BUTTON_PRESS) || (!is_pressed && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
 				if (action_mode == ACTION_MODE_BUTTON_PRESS) {
 					status.press_attempt = false;
 					status.pressing_inside = false;

--- a/scene/gui/shortcut.cpp
+++ b/scene/gui/shortcut.cpp
@@ -43,7 +43,7 @@ Ref<InputEvent> Shortcut::get_event() const {
 
 bool Shortcut::matches_event(const Ref<InputEvent> &p_event) const {
 	Ref<InputEventShortcut> ies = p_event;
-	if (ies != nullptr) {
+	if (ies.is_valid()) {
 		if (ies->get_shortcut().ptr() == this) {
 			return true;
 		}


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This PR [fixes](https://github.com/godotengine/godot/pull/49417#pullrequestreview-726900118): 

1. Adding Command Palette as a Menu option.
2. Empty search shows all the available commands.
3. ok button of the command palette works.
4. other code fixes.
