### PR TITLE
Better port handling connection for `GraphEdit`

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -299,7 +299,7 @@
 		<theme_item name="more" data_type="icon" type="Texture2D">
 			The icon for the zoom in button.
 		</theme_item>
-		<theme_item name="port_grab_distance_horizontal" data_type="constant" type="int" default="48">
+		<theme_item name="port_grab_distance_horizontal" data_type="constant" type="int" default="24">
 			The horizontal range within which a port can be grabbed (on both sides).
 		</theme_item>
 		<theme_item name="port_grab_distance_vertical" data_type="constant" type="int" default="6">

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -186,7 +186,7 @@ private:
 	GraphEditMinimap *minimap;
 	void _top_layer_input(const Ref<InputEvent> &p_ev);
 
-	bool is_in_hot_zone(const Vector2 &pos, const Vector2 &p_mouse_pos);
+	bool is_in_hot_zone(const Vector2 &pos, const Vector2 &p_mouse_pos, const Vector2i &p_port_size, bool p_left);
 
 	void _top_layer_draw();
 	void _connections_layer_draw();

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -967,7 +967,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// Visual Node Ports
 
-	theme->set_constant("port_grab_distance_horizontal", "GraphEdit", 48 * scale);
+	theme->set_constant("port_grab_distance_horizontal", "GraphEdit", 24 * scale);
 	theme->set_constant("port_grab_distance_vertical", "GraphEdit", 6 * scale);
 
 	theme->set_stylebox("bg", "GraphEditMinimap", make_flat_stylebox(Color(0.24, 0.24, 0.24), 0, 0, 0, 0));


### PR DESCRIPTION
This PR changes the hot zones of the `GraphEdit` ports.

Currently, the hot zone is expanded to both sizes equally which overlaps the controls like the preview button in shaders, it should expand only to the required edge. 

And this PR will make it extended to the side which depended on whether it is output or input. It would also correctly been handled when the zoom is changed:

![vs_ports](https://user-images.githubusercontent.com/3036176/129050973-635bf2b1-8b43-46e0-8ab5-03705c649e72.gif)

Note: these yellow rectangles are just for demo only, the final PR does not contain the rendering them.

I've also decreased the `port_grab_distance_horizontal` in EditorTheme by half to reflect this change. 
Fix #47288 