### PR TITLE
Enable range coder compression by default in NetworkedMultiplayerENet (3.x)

### DIFF
--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -115,8 +115,9 @@
 		<member name="channel_count" type="int" setter="set_channel_count" getter="get_channel_count" default="3">
 			The number of channels to be used by ENet. Channels are used to separate different kinds of data. In reliable or ordered mode, for example, the packet delivery order is ensured on a per-channel basis. This is done to combat latency and reduces ordering restrictions on packets. The delivery status of a packet in one channel won't stall the delivery of other packets in another channel.
 		</member>
-		<member name="compression_mode" type="int" setter="set_compression_mode" getter="get_compression_mode" enum="NetworkedMultiplayerENet.CompressionMode" default="0">
+		<member name="compression_mode" type="int" setter="set_compression_mode" getter="get_compression_mode" enum="NetworkedMultiplayerENet.CompressionMode" default="1">
 			The compression method used for network packets. These have different tradeoffs of compression speed versus bandwidth, you may need to test which one works best for your use case if you use compression at all.
+			[b]Note:[/b] Most games' network design involve sending many small packets frequently (smaller than 4 KB each). If in doubt, it is recommended to keep the default compression algorithm as it works best on these small packets.
 		</member>
 		<member name="dtls_hostname" type="String" setter="set_dtls_hostname" getter="get_dtls_hostname" default="&quot;&quot;">
 			The hostname used for DTLS verification, to be compared against the "CN" value in the certificate provided by the server.
@@ -140,16 +141,16 @@
 	</members>
 	<constants>
 		<constant name="COMPRESS_NONE" value="0" enum="CompressionMode">
-			No compression. This uses the most bandwidth, but has the upside of requiring the fewest CPU resources.
+			No compression. This uses the most bandwidth, but has the upside of requiring the fewest CPU resources. This option may also be used to make network debugging using tools like Wireshark easier.
 		</constant>
 		<constant name="COMPRESS_RANGE_CODER" value="1" enum="CompressionMode">
-			ENet's built-in range encoding.
+			ENet's built-in range encoding. Works well on small packets, but is not the most efficient algorithm on packets larger than 4 KB.
 		</constant>
 		<constant name="COMPRESS_FASTLZ" value="2" enum="CompressionMode">
 			[url=http://fastlz.org/]FastLZ[/url] compression. This option uses less CPU resources compared to [constant COMPRESS_ZLIB], at the expense of using more bandwidth.
 		</constant>
 		<constant name="COMPRESS_ZLIB" value="3" enum="CompressionMode">
-			[url=https://www.zlib.net/]Zlib[/url] compression. This option uses less bandwidth compared to [constant COMPRESS_FASTLZ], at the expense of using more CPU resources.
+			[url=https://www.zlib.net/]Zlib[/url] compression. This option uses less bandwidth compared to [constant COMPRESS_FASTLZ], at the expense of using more CPU resources. Note that this algorithm is not very efficient on packets smaller than 4 KB. Therefore, it's recommended to use other compression algorithms in most cases.
 		</constant>
 		<constant name="COMPRESS_ZSTD" value="4" enum="CompressionMode">
 			[url=https://facebook.github.io/zstd/]Zstandard[/url] compression.

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -897,7 +897,7 @@ NetworkedMultiplayerENet::NetworkedMultiplayerENet() {
 	transfer_channel = -1;
 	always_ordered = false;
 	connection_status = CONNECTION_DISCONNECTED;
-	compression_mode = COMPRESS_NONE;
+	compression_mode = COMPRESS_RANGE_CODER;
 	enet_compressor.context = this;
 	enet_compressor.compress = enet_compress;
 	enet_compressor.decompress = enet_decompress;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/38313. This shouldn't break compatibility with existing projects, as behavior doesn't rely on compression being enabled or not.

From empirical testing, this seems to provide the best compression compared to other compression algorithms when used in the Multiplayer Bomber demo.

Other algorithms may provide better compression ratios for more complex games, but some compression is probably better than no compression.

Zstandard was also not very efficient in my testing, so I added a note in the documentation.