### PR TITLE
Set looping on OGGVorbis default import options to false

### DIFF
--- a/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
@@ -67,7 +67,7 @@ String ResourceImporterOGGVorbis::get_preset_name(int p_idx) const {
 }
 
 void ResourceImporterOGGVorbis::get_import_options(List<ImportOption> *r_options, int p_preset) const {
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop"), true));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "loop_offset"), 0));
 }
 


### PR DESCRIPTION
This was a cause of confusion for me when I was participating in a game jam.
Although I had disabled looping on the AudioStreamPlayer2D node, this change had no effect.

I discovered that the OGG import settings where to blame which have looping turned on by default.

First off all, this option shouldn't even exist. Looping should be controlled by the AudioStreamPlayer only and not be inherent to a resource.
Me and according to google many others had encountered a "bug" where a sound, that shouldn't be looping was looping despite looping being turned of in the Node.

Instead of removing it outright right now, maybe it should be turned off by default to not break any projects.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/3120.*