### PR TITLE
Use nearest mipmaps for both minification and magnification

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -9129,7 +9129,7 @@ RendererStorageRD::RendererStorageRD() {
 				} break;
 				case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS: {
 					sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;
-					sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
+					sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
 					if (GLOBAL_GET("rendering/textures/default_filters/use_nearest_mipmap_filter")) {
 						sampler_state.mip_filter = RD::SAMPLER_FILTER_NEAREST;
 					} else {
@@ -9148,7 +9148,7 @@ RendererStorageRD::RendererStorageRD() {
 				} break;
 				case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC: {
 					sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;
-					sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
+					sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
 					if (GLOBAL_GET("rendering/textures/default_filters/use_nearest_mipmap_filter")) {
 						sampler_state.mip_filter = RD::SAMPLER_FILTER_NEAREST;
 					} else {


### PR DESCRIPTION
Port of https://github.com/godotengine/godot/pull/40523 to `master`. Follow-up to https://github.com/godotengine/godot/pull/51533 and https://github.com/godotengine/godot/pull/51531.

This is generally the expected behavior when using a nearest + mipmaps mode, as it's often used for pixel art games.

This closes https://github.com/godotengine/godot-proposals/issues/1222.

## Preview

*The floor texture uses the Nearest Mipmap filter mode. Click to view at full size, as the difference isn't really noticeable on the preview.*

### Before

![Before](https://user-images.githubusercontent.com/180032/129122835-c47db1d8-8e8f-4f0e-8424-f7047529d8d3.png)

### After

![After](https://user-images.githubusercontent.com/180032/129122832-089aac91-ed39-42e3-82fe-601afc688dca.png)