### PR TITLE
Fixes crash when AnimationPlayer reset on save

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1606,7 +1606,9 @@ static void _reset_animation_players(Node *p_node, List<Ref<AnimatedValuesBackup
 		AnimationPlayer *player = Object::cast_to<AnimationPlayer>(p_node->get_child(i));
 		if (player && player->is_reset_on_save_enabled() && player->can_apply_reset()) {
 			Ref<AnimatedValuesBackup> old_values = player->apply_reset();
-			r_anim_backups->push_back(old_values);
+			if (old_values.is_valid()) {
+				r_anim_backups->push_back(old_values);
+			}
 		}
 		_reset_animation_players(p_node->get_child(i), r_anim_backups);
 	}


### PR DESCRIPTION
`AnimationPlayer::apply_reset()` may return an invalid reference on error. This situation was not handled, so later access to the invalid `Ref` crashed the editor.

To reproduce the crash:

1. Animate any node property with RESET track created.
2. Clear the AnimationPlayer's Root Node property.
3. Save the scene, and the editor crashes when the progress bar reaches the end.