### PR TITLE
Add 'child_manipulation_disabled' property to Container

### DIFF
--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -20,15 +20,21 @@
 		</method>
 		<method name="queue_sort">
 			<return type="void" />
+			<argument index="0" name="ignore_sort_disabled" type="bool"/>
 			<description>
-				Queue resort of the contained children. This is called automatically anyway, but can be called upon request.
+				Queue resort of the contained children. This is called automatically anyway, but can be called upon request. If [code]sort_disabled[/code] is [code]true[/code], the resort will not be queued unless [code]ignore_sort_disabled[/code] is also [code]true[/code].
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="sort_disabled" type="bool" setter="set_sort_disabled" getter"is_sort_disabled" default="false">
+			If [code]true[/code], the container will not manipulate the position, scale, or size of its children.
+		</member>
+	</members>
 	<signals>
 		<signal name="sort_children">
 			<description>
-				Emitted when sorting the children is needed.
+				Emitted when sorting the children is needed, regardless of whether [code]sort_disabled[/code] is set to true.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -20,15 +20,21 @@
 		</method>
 		<method name="queue_sort">
 			<return type="void" />
+			<argument index="0" name="ignore_sort_disabled" type="bool" default="false" />
 			<description>
-				Queue resort of the contained children. This is called automatically anyway, but can be called upon request.
+				Queue resort of the contained children. This is called automatically anyway, but can be called upon request. If [code]sort_disabled[/code] is [code]true[/code], the resort will not be queued unless [code]ignore_sort_disabled[/code] is also [code]true[/code].
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="sort_disabled" type="bool" setter="set_sort_disabled" getter="is_sort_disabled" default="false">
+			If [code]true[/code], the container will not manipulate the position, scale, or size of its children.
+		</member>
+	</members>
 	<signals>
 		<signal name="sort_children">
 			<description>
-				Emitted when sorting the children is needed.
+				Emitted when sorting the children is needed, regardless of whether [code]sort_disabled[/code] is set to true.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -20,21 +20,21 @@
 		</method>
 		<method name="queue_sort">
 			<return type="void" />
-			<argument index="0" name="ignore_sort_disabled" type="bool" default="false" />
+			<argument index="0" name="ignore_child_manipulation_disabled" type="bool" default="false" />
 			<description>
-				Queue resort of the contained children. This is called automatically anyway, but can be called upon request. If [code]sort_disabled[/code] is [code]true[/code], the resort will not be queued unless [code]ignore_sort_disabled[/code] is also [code]true[/code].
+				Queue resort of the contained children. This is called automatically anyway, but can be called upon request. If [code]child_manipulation_disabled[/code] is [code]true[/code], the resort will not be queued unless [code]ignore_child_manipulation_disabled[/code] is also [code]true[/code].
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="sort_disabled" type="bool" setter="set_sort_disabled" getter="is_sort_disabled" default="false">
+		<member name="child_manipulation_disabled" type="bool" setter="set_child_manipulation_disabled" getter="is_child_manipulation_disabled" default="false">
 			If [code]true[/code], the container will not manipulate the position, scale, or size of its children.
 		</member>
 	</members>
 	<signals>
 		<signal name="sort_children">
 			<description>
-				Emitted when sorting the children is needed, regardless of whether [code]sort_disabled[/code] is set to true.
+				Emitted when sorting the children is needed, regardless of whether [code]child_manipulation_disabled[/code] is set to [code]true[/code].
 			</description>
 		</signal>
 	</signals>

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -134,7 +134,7 @@ void Container::fit_child_in_rect(Control *p_child, const Rect2 &p_rect) {
 	p_child->set_scale(Vector2(1, 1));
 }
 
-void Container::queue_sort(bool p_ignore_sort_disabled) {
+void Container::queue_sort(bool p_ignore_child_manipulation_disabled) {
 	if (!is_inside_tree()) {
 		return;
 	}
@@ -143,7 +143,7 @@ void Container::queue_sort(bool p_ignore_sort_disabled) {
 		return;
 	}
 
-	MessageQueue::get_singleton()->push_call(this, "_sort_children", sort_disabled && !p_ignore_sort_disabled);
+	MessageQueue::get_singleton()->push_call(this, "_sort_children", child_manipulation_disabled && !p_ignore_child_manipulation_disabled);
 	pending_sort = true;
 }
 
@@ -179,23 +179,23 @@ String Container::get_configuration_warning() const {
 	return warning;
 }
 
-void Container::set_sort_disabled(bool p_disabled) {
-	sort_disabled = p_disabled;
+void Container::set_child_manipulation_disabled(bool p_disabled) {
+	child_manipulation_disabled = p_disabled;
 }
 
-bool Container::is_sort_disabled() const {
-	return sort_disabled;
+bool Container::is_child_manipulation_disabled() const {
+	return child_manipulation_disabled;
 }
 
 void Container::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_sort_children"), &Container::_sort_children);
 	ClassDB::bind_method(D_METHOD("_child_minsize_changed"), &Container::_child_minsize_changed);
-	ClassDB::bind_method(D_METHOD("queue_sort", "ignore_sort_disabled"), &Container::queue_sort, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("queue_sort", "ignore_child_manipulation_disabled"), &Container::queue_sort, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("fit_child_in_rect", "child", "rect"), &Container::fit_child_in_rect);
-	ClassDB::bind_method(D_METHOD("set_sort_disabled", "disabled"), &Container::set_sort_disabled);
-	ClassDB::bind_method(D_METHOD("is_sort_disabled"), &Container::is_sort_disabled);
+	ClassDB::bind_method(D_METHOD("set_child_manipulation_disabled", "disabled"), &Container::set_child_manipulation_disabled);
+	ClassDB::bind_method(D_METHOD("is_child_manipulation_disabled"), &Container::is_child_manipulation_disabled);
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sort_disabled"), "set_sort_disabled", "is_sort_disabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "child_manipulation_disabled"), "set_child_manipulation_disabled", "is_child_manipulation_disabled");
 
 	BIND_CONSTANT(NOTIFICATION_SORT_CHILDREN);
 	ADD_SIGNAL(MethodInfo("sort_children"));
@@ -203,5 +203,5 @@ void Container::_bind_methods() {
 
 Container::Container() {
 	pending_sort = false;
-	sort_disabled = false;
+	child_manipulation_disabled = false;
 }

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -82,12 +82,15 @@ void Container::remove_child_notify(Node *p_child) {
 	queue_sort();
 }
 
-void Container::_sort_children() {
+void Container::_sort_children(bool p_sort_disabled) {
 	if (!is_inside_tree()) {
 		return;
 	}
 
-	notification(NOTIFICATION_SORT_CHILDREN);
+	if (!p_sort_disabled) {
+		notification(NOTIFICATION_SORT_CHILDREN);
+	}
+
 	emit_signal(SceneStringNames::get_singleton()->sort_children);
 	pending_sort = false;
 }
@@ -131,7 +134,7 @@ void Container::fit_child_in_rect(Control *p_child, const Rect2 &p_rect) {
 	p_child->set_scale(Vector2(1, 1));
 }
 
-void Container::queue_sort() {
+void Container::queue_sort(bool p_ignore_sort_disabled) {
 	if (!is_inside_tree()) {
 		return;
 	}
@@ -140,7 +143,7 @@ void Container::queue_sort() {
 		return;
 	}
 
-	MessageQueue::get_singleton()->push_call(this, "_sort_children");
+	MessageQueue::get_singleton()->push_call(this, "_sort_children", sort_disabled && !p_ignore_sort_disabled);
 	pending_sort = true;
 }
 
@@ -176,12 +179,23 @@ String Container::get_configuration_warning() const {
 	return warning;
 }
 
+void Container::set_sort_disabled(bool p_disabled) {
+	sort_disabled = p_disabled;
+}
+
+bool Container::is_sort_disabled() const {
+	return sort_disabled;
+}
+
 void Container::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_sort_children"), &Container::_sort_children);
 	ClassDB::bind_method(D_METHOD("_child_minsize_changed"), &Container::_child_minsize_changed);
-
-	ClassDB::bind_method(D_METHOD("queue_sort"), &Container::queue_sort);
+	ClassDB::bind_method(D_METHOD("queue_sort", "ignore_sort_disabled"), &Container::queue_sort, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("fit_child_in_rect", "child", "rect"), &Container::fit_child_in_rect);
+	ClassDB::bind_method(D_METHOD("set_sort_disabled", "disabled"), &Container::set_sort_disabled);
+	ClassDB::bind_method(D_METHOD("is_sort_disabled"), &Container::is_sort_disabled);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sort_disabled"), "set_sort_disabled", "is_sort_disabled");
 
 	BIND_CONSTANT(NOTIFICATION_SORT_CHILDREN);
 	ADD_SIGNAL(MethodInfo("sort_children"));
@@ -189,4 +203,5 @@ void Container::_bind_methods() {
 
 Container::Container() {
 	pending_sort = false;
+	sort_disabled = false;
 }

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -37,11 +37,11 @@ class Container : public Control {
 	GDCLASS(Container, Control);
 
 	bool pending_sort;
-	void _sort_children();
+	void _sort_children(bool p_sort_disabled);
 	void _child_minsize_changed();
 
 protected:
-	void queue_sort();
+	void queue_sort(bool p_ignore_sort_disabled = false);
 	virtual void add_child_notify(Node *p_child);
 	virtual void move_child_notify(Node *p_child);
 	virtual void remove_child_notify(Node *p_child);
@@ -49,6 +49,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+private:
+	bool sort_disabled = false;
 public:
 	enum {
 		NOTIFICATION_SORT_CHILDREN = 50
@@ -57,6 +59,9 @@ public:
 	void fit_child_in_rect(Control *p_child, const Rect2 &p_rect);
 
 	virtual String get_configuration_warning() const;
+
+	void set_sort_disabled(bool p_disabled);
+	bool is_sort_disabled() const;
 
 	Container();
 };

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -41,7 +41,7 @@ class Container : public Control {
 	void _child_minsize_changed();
 
 protected:
-	void queue_sort(bool p_ignore_sort_disabled = false);
+	void queue_sort(bool p_ignore_child_manipulation_disabled = false);
 	virtual void add_child_notify(Node *p_child);
 	virtual void move_child_notify(Node *p_child);
 	virtual void remove_child_notify(Node *p_child);
@@ -50,7 +50,7 @@ protected:
 	static void _bind_methods();
 
 private:
-	bool sort_disabled = false;
+	bool child_manipulation_disabled = false;
 
 public:
 	enum {
@@ -61,8 +61,8 @@ public:
 
 	virtual String get_configuration_warning() const;
 
-	void set_sort_disabled(bool p_disabled);
-	bool is_sort_disabled() const;
+	void set_child_manipulation_disabled(bool p_disabled);
+	bool is_child_manipulation_disabled() const;
 
 	Container();
 };

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -37,17 +37,20 @@ class Container : public Control {
 	GDCLASS(Container, Control);
 
 	bool pending_sort;
-	void _sort_children();
+	void _sort_children(bool p_sort_disabled);
 	void _child_minsize_changed();
 
 protected:
-	void queue_sort();
+	void queue_sort(bool p_ignore_sort_disabled = false);
 	virtual void add_child_notify(Node *p_child);
 	virtual void move_child_notify(Node *p_child);
 	virtual void remove_child_notify(Node *p_child);
 
 	void _notification(int p_what);
 	static void _bind_methods();
+
+private:
+	bool sort_disabled = false;
 
 public:
 	enum {
@@ -57,6 +60,9 @@ public:
 	void fit_child_in_rect(Control *p_child, const Rect2 &p_rect);
 
 	virtual String get_configuration_warning() const;
+
+	void set_sort_disabled(bool p_disabled);
+	bool is_sort_disabled() const;
 
 	Container();
 };


### PR DESCRIPTION
Added the `child_manipulation_disabled` property to the Container class, which stops `queue_sort()` from queueing the sort unless overridden via the `ignore_child_manipulation_disabled` argument.

This allows users to use Containers such as BoxContainers and PanelContainers to place children initially, but then directly control the properties of the children in a script without having to worry about the Container overriding them when the size changes. The issue can somewhat be worked around by setting properties of the children after the Container has sorted them, but this introduces a noticeable flicker.

Example of implementation:
[Without `child_manipulation_disabled`](https://user-images.githubusercontent.com/44363049/129152654-905b689f-f861-422a-88ea-70915723e3f8.mp4)
[With `child_manipulation_disabled`](https://user-images.githubusercontent.com/44363049/129152658-e5f94f55-4e37-44bb-a9ce-22df8d1900f1.mp4)

Master implementation does not work due to https://github.com/godotengine/godot/issues/51543

Edit: Godot improvement proposal [here](https://github.com/godotengine/godot-proposals/issues/3123)
Edit: Renamed property name from `sort_disabled` to `child_manipulation_disabled`

*Bugsquad edit: Closes https://github.com/godotengine/godot-proposals/issues/3123 for `3.x`*