### PR TITLE
Removes an internal error report if shader fails compile

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -131,8 +131,9 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	SceneShaderForwardClustered *shader_singleton = (SceneShaderForwardClustered *)SceneShaderForwardClustered::singleton;
 	Error err = shader_singleton->compiler.compile(RS::SHADER_SPATIAL, code, &actions, path, gen_code);
-
-	ERR_FAIL_COND(err != OK);
+	if (err != OK) {
+		return;
+	}
 
 	if (version.is_null()) {
 		version = shader_singleton->shader.version_create();

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -142,7 +142,9 @@ public:
 		ERR_FAIL_COND_V(!variants_enabled[p_variant], RID());
 
 		Version *version = version_owner.getornull(p_version);
-		ERR_FAIL_COND_V(!version, RID());
+		if (!version) {
+			return RID();
+		}
 
 		if (version->dirty) {
 			_compile_version(version);


### PR DESCRIPTION
I don't think the user should need to know where in the code internals failed if the shader contains errors:

![image](https://user-images.githubusercontent.com/3036176/129153305-ffebaf45-8588-440b-bb68-ec265a395536.png)

Note: in the 3.x it does not report it either