### PR TITLE
[3.x] Fix loading mipmaps, if the mipmap levels have different formats.

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -566,6 +566,10 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &tw_
 				ERR_FAIL_COND_V(img.is_null() || img->empty(), ERR_FILE_CORRUPT);
 			}
 
+			if (i != 0) {
+				img->convert(mipmap_images[0]->get_format()); // ensure the same format for all mipmaps
+			}
+
 			total_size += img->get_data().size();
 
 			mipmap_images.push_back(img);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/50647

This fix does not apply to master, since it already works there.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
