### PR TITLE
Resource: Remove unused `_use_builtin_script()` virtual method

### DIFF
--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -62,8 +62,6 @@ private:
 	String path_cache;
 	String scene_unique_id;
 
-	virtual bool _use_builtin_script() const { return true; }
-
 #ifdef TOOLS_ENABLED
 	uint64_t last_modified_time = 0;
 	uint64_t import_last_modified_time = 0;

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2323,10 +2323,6 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				pset.instantiate();
 				pset->set_call_mode(VisualScriptPropertySet::CALL_MODE_INSTANCE);
 				pset->set_base_type(obj->get_class());
-				/*if (use_value) {
-						pset->set_use_builtin_value(true);
-						pset->set_builtin_value(d["value"]);
-					}*/
 				vnode = pset;
 			} else {
 				Ref<VisualScriptPropertyGet> pget;


### PR DESCRIPTION
And another piece of dead code found while searching for "use_builtin".