### PR TITLE
Properly finish Godot's Android activity when destroyed by the system

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -842,6 +842,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	}
 
 	private void forceQuit() {
+		getActivity().finish();
 		System.exit(0);
 	}
 


### PR DESCRIPTION
Godot got stuck in an endless loop when started while the system destroyed it (after a couple of hours in the background). 

This happend since #42186 got merged. Before this PR `forceQuite()` was called directly in the `FragmentActivity`, but that changed and now it's in a `Fragment`. That means we also have to call `finish()` on the parent Activity. Otherwise `onDestory() `will not get called in the Activity and the app will be in a weird state, where it enters an endless loop of callbacks (see the linked issue below).

Fixes #51021