### PR TITLE
[DRAFT] Add error_name(), add error name to error_string()

### DIFF
--- a/core/error/error_list.cpp
+++ b/core/error/error_list.cpp
@@ -31,8 +31,60 @@
 #include "error_list.h"
 
 const char *error_names[] = {
-	"No error",
-	"Generic error",
+	"OK",
+	"FAILED",
+	"ERR_UNAVAILABLE",
+	"ERR_UNCONFIGURED",
+	"ERR_UNAUTHORIZED",
+	"ERR_PARAMETER_RANGE_ERROR",
+	"ERR_OUT_OF_MEMORY",
+	"ERR_FILE_NOT_FOUND",
+	"ERR_FILE_BAD_DRIVE",
+	"ERR_FILE_BAD_PATH",
+	"ERR_FILE_NO_PERMISSION",
+	"ERR_FILE_ALREADY_IN_USE",
+	"ERR_FILE_CANT_OPEN",
+	"ERR_FILE_CANT_WRITE",
+	"ERR_FILE_CANT_READ",
+	"ERR_FILE_UNRECOGNIZED",
+	"ERR_FILE_CORRUPT",
+	"ERR_FILE_MISSING_DEPENDENCIES",
+	"ERR_FILE_EOF",
+	"ERR_CANT_OPEN",
+	"ERR_CANT_CREATE",
+	"ERR_QUERY_FAILED",
+	"ERR_ALREADY_IN_USE",
+	"ERR_LOCKED",
+	"ERR_TIMEOUT",
+	"ERR_CANT_CONNECT",
+	"ERR_CANT_RESOLVE",
+	"ERR_CONNECTION_ERROR",
+	"ERR_CANT_ACQUIRE_RESOURCE",
+	"ERR_CANT_FORK",
+	"ERR_INVALID_DATA",
+	"ERR_INVALID_PARAMETER",
+	"ERR_ALREADY_EXISTS",
+	"ERR_DOES_NOT_EXIST",
+	"ERR_DATABASE_CANT_READ",
+	"ERR_DATABASE_CANT_WRITE",
+	"ERR_COMPILATION_FAILED",
+	"ERR_METHOD_NOT_FOUND",
+	"ERR_LINK_FAILED",
+	"ERR_SCRIPT_FAILED",
+	"ERR_CYCLIC_LINK",
+	"ERR_INVALID_DECLARATION",
+	"ERR_DUPLICATE_SYMBOL",
+	"ERR_PARSE_ERROR",
+	"ERR_BUSY",
+	"ERR_SKIP",
+	"ERR_HELP",
+	"ERR_BUG",
+	"ERR_PRINTER_ON_FIRE",
+};
+
+const char *error_names_readable[] = {
+	"OK", // OK
+	"Generic error", // FAILED
 	"Requested operation is unsupported/unavailable",
 	"The object hasn't been set up properly",
 	"Missing credentials for requested resource",
@@ -83,3 +135,4 @@ const char *error_names[] = {
 };
 
 static_assert(sizeof(error_names) / sizeof(*error_names) == ERR_MAX);
+static_assert(sizeof(error_names_readable) / sizeof(*error_names_readable) == ERR_MAX);

--- a/core/error/error_list.h
+++ b/core/error/error_list.h
@@ -92,5 +92,6 @@ enum Error {
 };
 
 extern const char *error_names[];
+extern const char *error_names_readable[];
 
 #endif // ERROR_LIST_H

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -489,6 +489,14 @@ struct VariantUtilityFunctions {
 			return String("(invalid error code)");
 		}
 
+		return String(error_names_readable[error]) + " (" + String(error_names[error]) + ")";
+	}
+
+	static inline String error_name(Error error) {
+		if (error < 0 || error >= ERR_MAX) {
+			return String("(invalid error code)");
+		}
+
 		return String(error_names[error]);
 	}
 
@@ -1243,6 +1251,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(_typeof, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGS(str, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(error_string, sarray("error"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(error_name, sarray("error"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(print, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(printerr, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(printt, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -212,11 +212,18 @@
 				Easing function, based on exponent. The curve values are: 0 is constant, 1 is linear, 0 to 1 is ease-in, 1+ is ease out. Negative values are in-out/out in.
 			</description>
 		</method>
+		<method name="error_name">
+			<return type="String" />
+			<argument index="0" name="error" type="int" />
+			<description>
+				Returns the error name for the given error code.
+			</description>
+		</method>
 		<method name="error_string">
 			<return type="String" />
 			<argument index="0" name="error" type="int" />
 			<description>
-				Returns a human-readable name for the given error code.
+				Returns a human-readable description for the given error code, including the error name.
 			</description>
 		</method>
 		<method name="exp">


### PR DESCRIPTION
**Behaviour before this PR:**
`error_string(ERR_UNAVAILABLE)` -> `"Requested operation is unsupported/unavailable"`

**Behaviour after this PR:**
`error_string(ERR_UNAVAILABLE)` -> `"Requested operation is unsupported/unavailable (ERR_UNAVAILABLE)"`
`error_name(ERR_UNAVAILABLE)` -> `"ERR_UNAVAILABLE"`

`error_name()` is useful in cases where we (Godot) or the user/gamedev want to log the error that occured, where currently one would log the actual `int` value, which is ill-advised as it is an implementation detail that may change (and its also annoying to look up a `int` val in the struct manually).

Improves upon https://github.com/godotengine/godot/pull/38992.