### PR TITLE
Fix AnimationTree function call track loop

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -67,7 +67,7 @@ double AnimationNodeAnimation::process(double p_time, bool p_seek) {
 	AnimationPlayer *ap = state->player;
 	ERR_FAIL_COND_V(!ap, 0);
 
-	double time = get_parameter(this->time);
+	const double current_time = get_parameter(this->time);
 
 	if (!ap->has_animation(animation)) {
 		AnimationNodeBlendTree *tree = Object::cast_to<AnimationNodeBlendTree>(parent);
@@ -84,6 +84,7 @@ double AnimationNodeAnimation::process(double p_time, bool p_seek) {
 
 	Ref<Animation> anim = ap->get_animation(animation);
 
+	double time = current_time;
 	double step;
 
 	if (p_seek) {
@@ -100,9 +101,9 @@ double AnimationNodeAnimation::process(double p_time, bool p_seek) {
 		if (anim_size) {
 			time = Math::fposmod(time, anim_size);
 		}
-
 	} else if (time > anim_size) {
 		time = anim_size;
+		step = anim_size - current_time;
 	}
 
 	blend_animation(animation, time, step, p_seek, 1.0);


### PR DESCRIPTION
Fixes #50636.

If the animation does not loop, delta time should be set to zero if we're already at the end of the animation.

I'm pretty sure this fixes the cause of the issue. But I'm not 100% sure there is no other code that depends on the old behavior, it's odd that a stopped animation would revisit a method call keyframe repeatedly though. 

For `3.x`, this is basically the same except that time uses `float` instead of `double`.