### PR TITLE
Fix incorrect descriptions for EditorFileSystem's `get_file_type()`

### DIFF
--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -14,7 +14,7 @@
 			<return type="String" />
 			<argument index="0" name="path" type="String" />
 			<description>
-				Gets the type of the file, given the full path.
+				Returns the resource type of the file, given the full path. This returns a string such as [code]"Resource"[/code] or [code]"GDScript"[/code], [i]not[/i] a file extension such as [code]".gd"[/code].
 			</description>
 		</method>
 		<method name="get_filesystem">

--- a/doc/classes/EditorFileSystemDirectory.xml
+++ b/doc/classes/EditorFileSystemDirectory.xml
@@ -68,7 +68,7 @@
 			<return type="StringName" />
 			<argument index="0" name="idx" type="int" />
 			<description>
-				Returns the file extension of the file at index [code]idx[/code].
+				Returns the resource type of the file at index [code]idx[/code]. This returns a string such as [code]"Resource"[/code] or [code]"GDScript"[/code], [i]not[/i] a file extension such as [code]".gd"[/code].
 			</description>
 		</method>
 		<method name="get_name">


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-docs/issues/4331.