### PR TITLE
Port camera feed to the new RenderingServer API.

### DIFF
--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -10,7 +10,60 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_datatype" qualifiers="const">
+			<return type="int" enum="CameraFeed.FeedDataType" />
+			<description>
+				Returns feed image data type.
+			</description>
+		</method>
+		<method name="get_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the unique ID for this feed.
+			</description>
+		</method>
+		<method name="get_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the camera's name.
+			</description>
+		</method>
+		<method name="get_position" qualifiers="const">
+			<return type="int" enum="CameraFeed.FeedPosition" />
+			<description>
+				Returns the position of camera on the device.
+			</description>
+		</method>
 	</methods>
+	<members>
+		<member name="feed_is_active" type="bool" setter="set_active" getter="is_active" default="false">
+			If [code]true[/code], the feed is active.
+		</member>
+		<member name="feed_transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D(1, 0, 0, -1, 0, 1)">
+			The transform applied to the camera's image.
+		</member>
+	</members>
 	<constants>
+		<constant name="FEED_NOIMAGE" value="0" enum="FeedDataType">
+			No image set for the feed.
+		</constant>
+		<constant name="FEED_RGB" value="1" enum="FeedDataType">
+			Feed supplies RGB images.
+		</constant>
+		<constant name="FEED_YCBCR" value="2" enum="FeedDataType">
+			Feed supplies YCbCr images that need to be converted to RGB.
+		</constant>
+		<constant name="FEED_YCBCR_SEP" value="3" enum="FeedDataType">
+			Feed supplies separate Y and CbCr images that need to be combined and converted to RGB.
+		</constant>
+		<constant name="FEED_UNSPECIFIED" value="0" enum="FeedPosition">
+			Unspecified position.
+		</constant>
+		<constant name="FEED_FRONT" value="1" enum="FeedPosition">
+			Camera is mounted at the front of the device.
+		</constant>
+		<constant name="FEED_BACK" value="2" enum="FeedPosition">
+			Camera is mounted at the back of the device.
+		</constant>
 	</constants>
 </class>

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -33,17 +33,16 @@
 #include "servers/rendering_server.h"
 
 void CameraFeed::_bind_methods() {
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
 	// The setters prefixed with _ are only exposed so we can have feeds through GDNative!
 	// They should not be called by the end user.
 
 	ClassDB::bind_method(D_METHOD("get_id"), &CameraFeed::get_id);
-	ClassDB::bind_method(D_METHOD("get_name"), &CameraFeed::get_name);
-	ClassDB::bind_method(D_METHOD("_set_name", "name"), &CameraFeed::set_name);
 
 	ClassDB::bind_method(D_METHOD("is_active"), &CameraFeed::is_active);
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &CameraFeed::set_active);
+
+	ClassDB::bind_method(D_METHOD("get_name"), &CameraFeed::get_name);
+	ClassDB::bind_method(D_METHOD("_set_name", "name"), &CameraFeed::set_name);
 
 	ClassDB::bind_method(D_METHOD("get_position"), &CameraFeed::get_position);
 	ClassDB::bind_method(D_METHOD("_set_position", "position"), &CameraFeed::set_position);
@@ -54,7 +53,8 @@ void CameraFeed::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_RGB_img", "rgb_img"), &CameraFeed::set_RGB_img);
 	ClassDB::bind_method(D_METHOD("_set_YCbCr_img", "ycbcr_img"), &CameraFeed::set_YCbCr_img);
-	ClassDB::bind_method(D_METHOD("_allocate_texture", "width", "height", "format", "texture_type", "data_type"), &CameraFeed::allocate_texture);
+
+	ClassDB::bind_method(D_METHOD("get_datatype"), &CameraFeed::get_datatype);
 
 	ADD_GROUP("Feed", "feed_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "feed_is_active"), "set_active", "is_active");
@@ -68,7 +68,6 @@ void CameraFeed::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEED_UNSPECIFIED);
 	BIND_ENUM_CONSTANT(FEED_FRONT);
 	BIND_ENUM_CONSTANT(FEED_BACK);
-#endif
 }
 
 int CameraFeed::get_id() const {
@@ -144,14 +143,6 @@ CameraFeed::CameraFeed() {
 	datatype = CameraFeed::FEED_RGB;
 	position = CameraFeed::FEED_UNSPECIFIED;
 	transform = Transform2D(1.0, 0.0, 0.0, -1.0, 0.0, 1.0);
-
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
-	// create a texture object
-	RenderingServer *vs = RenderingServer::get_singleton();
-	texture[CameraServer::FEED_Y_IMAGE] = vs->texture_create(); // also used for RGBA
-	texture[CameraServer::FEED_CBCR_IMAGE] = vs->texture_create();
-#endif
 }
 
 CameraFeed::CameraFeed(String p_name, FeedPosition p_position) {
@@ -164,33 +155,21 @@ CameraFeed::CameraFeed(String p_name, FeedPosition p_position) {
 	datatype = CameraFeed::FEED_NOIMAGE;
 	position = p_position;
 	transform = Transform2D(1.0, 0.0, 0.0, -1.0, 0.0, 1.0);
-
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
-	// create a texture object
-	RenderingServer *vs = RenderingServer::get_singleton();
-	texture[CameraServer::FEED_Y_IMAGE] = vs->texture_create(); // also used for RGBA
-	texture[CameraServer::FEED_CBCR_IMAGE] = vs->texture_create();
-#endif
 }
 
 CameraFeed::~CameraFeed() {
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
 	// Free our textures
-	RenderingServer *vs = RenderingServer::get_singleton();
-	vs->free(texture[CameraServer::FEED_Y_IMAGE]);
-	vs->free(texture[CameraServer::FEED_CBCR_IMAGE]);
-#endif
+	if (texture[CameraServer::FEED_Y_IMAGE].is_valid()) {
+		RenderingServer::get_singleton()->free(texture[CameraServer::FEED_Y_IMAGE]);
+	}
+	if (texture[CameraServer::FEED_CBCR_IMAGE].is_valid()) {
+		RenderingServer::get_singleton()->free(texture[CameraServer::FEED_CBCR_IMAGE]);
+	}
 }
 
 void CameraFeed::set_RGB_img(const Ref<Image> &p_rgb_img) {
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
 	ERR_FAIL_COND(p_rgb_img.is_null());
 	if (active) {
-		RenderingServer *vs = RenderingServer::get_singleton();
-
 		int new_width = p_rgb_img->get_width();
 		int new_height = p_rgb_img->get_height();
 
@@ -198,23 +177,23 @@ void CameraFeed::set_RGB_img(const Ref<Image> &p_rgb_img) {
 			// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 			base_width = new_width;
 			base_height = new_height;
-
-			vs->texture_allocate(texture[CameraServer::FEED_RGBA_IMAGE], new_width, new_height, 0, Image::FORMAT_RGB8, RS::TEXTURE_TYPE_2D, RS::TEXTURE_FLAGS_DEFAULT);
+			if (texture[CameraServer::FEED_RGBA_IMAGE].is_null()) {
+				texture[CameraServer::FEED_RGBA_IMAGE] = RenderingServer::get_singleton()->texture_2d_create(p_rgb_img);
+			} else {
+				RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_rgb_img);
+				RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_RGBA_IMAGE], new_texture);
+			}
+		} else {
+			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_RGBA_IMAGE], p_rgb_img);
 		}
 
-		vs->texture_set_data(texture[CameraServer::FEED_RGBA_IMAGE], p_rgb_img);
 		datatype = CameraFeed::FEED_RGB;
 	}
-#endif
 }
 
 void CameraFeed::set_YCbCr_img(const Ref<Image> &p_ycbcr_img) {
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
 	ERR_FAIL_COND(p_ycbcr_img.is_null());
 	if (active) {
-		RenderingServer *vs = RenderingServer::get_singleton();
-
 		int new_width = p_ycbcr_img->get_width();
 		int new_height = p_ycbcr_img->get_height();
 
@@ -222,67 +201,56 @@ void CameraFeed::set_YCbCr_img(const Ref<Image> &p_ycbcr_img) {
 			// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 			base_width = new_width;
 			base_height = new_height;
-
-			vs->texture_allocate(texture[CameraServer::FEED_RGBA_IMAGE], new_width, new_height, 0, Image::FORMAT_RGB8, RS::TEXTURE_TYPE_2D, RS::TEXTURE_FLAGS_DEFAULT);
+			if (texture[CameraServer::FEED_RGBA_IMAGE].is_null()) {
+				texture[CameraServer::FEED_RGBA_IMAGE] = RenderingServer::get_singleton()->texture_2d_create(p_ycbcr_img);
+			} else {
+				RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_ycbcr_img);
+				RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_RGBA_IMAGE], new_texture);
+			}
+		} else {
+			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_RGBA_IMAGE], p_ycbcr_img);
 		}
 
-		vs->texture_set_data(texture[CameraServer::FEED_RGBA_IMAGE], p_ycbcr_img);
 		datatype = CameraFeed::FEED_YCBCR;
 	}
-#endif
 }
 
 void CameraFeed::set_YCbCr_imgs(const Ref<Image> &p_y_img, const Ref<Image> &p_cbcr_img) {
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
 	ERR_FAIL_COND(p_y_img.is_null());
 	ERR_FAIL_COND(p_cbcr_img.is_null());
 	if (active) {
-		RenderingServer *vs = RenderingServer::get_singleton();
-
 		///@TODO investigate whether we can use thirdparty/misc/yuv2rgb.h here to convert our YUV data to RGB, our shader approach is potentially faster though..
 		// Wondering about including that into multiple projects, may cause issues.
 		// That said, if we convert to RGB, we could enable using texture resources again...
 
 		int new_y_width = p_y_img->get_width();
 		int new_y_height = p_y_img->get_height();
-		int new_cbcr_width = p_cbcr_img->get_width();
-		int new_cbcr_height = p_cbcr_img->get_height();
 
 		if ((base_width != new_y_width) || (base_height != new_y_height)) {
 			// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 			base_width = new_y_width;
 			base_height = new_y_height;
+			if (texture[CameraServer::FEED_Y_IMAGE].is_null()) {
+				texture[CameraServer::FEED_Y_IMAGE] = RenderingServer::get_singleton()->texture_2d_create(p_y_img);
+			} else {
+				RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_y_img);
+				RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_Y_IMAGE], new_texture);
+			}
 
-			vs->texture_allocate(texture[CameraServer::FEED_Y_IMAGE], new_y_width, new_y_height, 0, Image::FORMAT_R8, RS::TEXTURE_TYPE_2D, RS::TEXTURE_FLAG_USED_FOR_STREAMING);
-
-			///@TODO GLES2 doesn't support FORMAT_RG8, need to do some form of conversion
-			vs->texture_allocate(texture[CameraServer::FEED_CBCR_IMAGE], new_cbcr_width, new_cbcr_height, 0, Image::FORMAT_RG8, RS::TEXTURE_TYPE_2D, RS::TEXTURE_FLAG_USED_FOR_STREAMING);
+			if (texture[CameraServer::FEED_CBCR_IMAGE].is_null()) {
+				texture[CameraServer::FEED_CBCR_IMAGE] = RenderingServer::get_singleton()->texture_2d_create(p_cbcr_img);
+			} else {
+				RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_cbcr_img);
+				RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_CBCR_IMAGE], new_texture);
+			}
+		} else {
+			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_Y_IMAGE], p_y_img);
+			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_CBCR_IMAGE], p_cbcr_img);
 		}
 
-		vs->texture_set_data(texture[CameraServer::FEED_Y_IMAGE], p_y_img);
-		vs->texture_set_data(texture[CameraServer::FEED_CBCR_IMAGE], p_cbcr_img);
 		datatype = CameraFeed::FEED_YCBCR_SEP;
 	}
-#endif
 }
-
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
-void CameraFeed::allocate_texture(int p_width, int p_height, Image::Format p_format, RenderingServer::TextureType p_texture_type, FeedDataType p_data_type) {
-	RenderingServer *vs = RenderingServer::get_singleton();
-
-	if ((base_width != p_width) || (base_height != p_height)) {
-		// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
-		base_width = p_width;
-		base_height = p_height;
-
-		vs->texture_allocate(texture[0], p_width, p_height, 0, p_format, p_texture_type, RS::TEXTURE_FLAGS_DEFAULT);
-	}
-
-	datatype = p_data_type;
-}
-#endif
 
 bool CameraFeed::activate_feed() {
 	// nothing to do here

--- a/servers/camera/camera_feed.h
+++ b/servers/camera/camera_feed.h
@@ -103,10 +103,6 @@ public:
 	void set_RGB_img(const Ref<Image> &p_rgb_img);
 	void set_YCbCr_img(const Ref<Image> &p_ycbcr_img);
 	void set_YCbCr_imgs(const Ref<Image> &p_y_img, const Ref<Image> &p_cbcr_img);
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
-	void allocate_texture(int p_width, int p_height, Image::Format p_format, RenderingServer::TextureType p_texture_type, FeedDataType p_data_type);
-#endif
 
 	virtual bool activate_feed();
 	virtual void deactivate_feed();


### PR DESCRIPTION
Implements CameraFeed texture creation/update with the API. Original CameraFeed code was commented out after Vulkan transition.

Test project:
[camera_test.zip](https://github.com/godotengine/godot/files/6977464/camera_test.zip)
