### PR TITLE
Optimise TextEdit theme loading

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -306,6 +306,18 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="begin_bulk_theme_override">
+			<return type="void" />
+			<description>
+				Prevents [code]*_theme_*_override[/code] methods from emitting [constant NOTIFICATION_THEME_CHANGED] until [method end_bulk_theme_override] is called.
+			</description>
+		</method>
+		<method name="end_bulk_theme_override">
+			<return type="void" />
+			<description>
+				Ends a bulk theme override update. See [method begin_bulk_theme_override].
+			</description>
+		</method>
 		<method name="find_next_valid_focus" qualifiers="const">
 			<return type="Control" />
 			<description>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1520,40 +1520,12 @@ void CodeTextEditor::goto_error() {
 }
 
 void CodeTextEditor::_update_text_editor_theme() {
-	text_editor->add_theme_color_override("background_color", EDITOR_GET("text_editor/highlighting/background_color"));
-	text_editor->add_theme_color_override("completion_background_color", EDITOR_GET("text_editor/highlighting/completion_background_color"));
-	text_editor->add_theme_color_override("completion_selected_color", EDITOR_GET("text_editor/highlighting/completion_selected_color"));
-	text_editor->add_theme_color_override("completion_existing_color", EDITOR_GET("text_editor/highlighting/completion_existing_color"));
-	text_editor->add_theme_color_override("completion_scroll_color", EDITOR_GET("text_editor/highlighting/completion_scroll_color"));
-	text_editor->add_theme_color_override("completion_font_color", EDITOR_GET("text_editor/highlighting/completion_font_color"));
-	text_editor->add_theme_color_override("font_color", EDITOR_GET("text_editor/highlighting/text_color"));
-	text_editor->add_theme_color_override("line_number_color", EDITOR_GET("text_editor/highlighting/line_number_color"));
-	text_editor->add_theme_color_override("caret_color", EDITOR_GET("text_editor/highlighting/caret_color"));
-	text_editor->add_theme_color_override("caret_background_color", EDITOR_GET("text_editor/highlighting/caret_background_color"));
-	text_editor->add_theme_color_override("font_selected_color", EDITOR_GET("text_editor/highlighting/text_selected_color"));
-	text_editor->add_theme_color_override("selection_color", EDITOR_GET("text_editor/highlighting/selection_color"));
-	text_editor->add_theme_color_override("brace_mismatch_color", EDITOR_GET("text_editor/highlighting/brace_mismatch_color"));
-	text_editor->add_theme_color_override("current_line_color", EDITOR_GET("text_editor/highlighting/current_line_color"));
-	text_editor->add_theme_color_override("line_length_guideline_color", EDITOR_GET("text_editor/highlighting/line_length_guideline_color"));
-	text_editor->add_theme_color_override("word_highlighted_color", EDITOR_GET("text_editor/highlighting/word_highlighted_color"));
-	text_editor->add_theme_color_override("bookmark_color", EDITOR_GET("text_editor/highlighting/bookmark_color"));
-	text_editor->add_theme_color_override("breakpoint_color", EDITOR_GET("text_editor/highlighting/breakpoint_color"));
-	text_editor->add_theme_color_override("executing_line_color", EDITOR_GET("text_editor/highlighting/executing_line_color"));
-	text_editor->add_theme_color_override("code_folding_color", EDITOR_GET("text_editor/highlighting/code_folding_color"));
-	text_editor->add_theme_color_override("search_result_color", EDITOR_GET("text_editor/highlighting/search_result_color"));
-	text_editor->add_theme_color_override("search_result_border_color", EDITOR_GET("text_editor/highlighting/search_result_border_color"));
-	text_editor->add_theme_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 6));
 	emit_signal(SNAME("load_theme_settings"));
-	_load_theme_settings();
-}
 
-void CodeTextEditor::_update_font() {
-	text_editor->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
-	text_editor->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts")));
-
-	error->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-	error->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
-	error->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	error->begin_bulk_theme_override();
+	error->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	error->add_theme_font_size_override(SNAME("font_size"), get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+	error->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
 	Ref<Font> status_bar_font = get_theme_font(SNAME("status_source"), SNAME("EditorFonts"));
 	int status_bar_font_size = get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts"));
@@ -1567,6 +1539,7 @@ void CodeTextEditor::_update_font() {
 			n->add_theme_font_size_override("font_size", status_bar_font_size);
 		}
 	}
+	error->end_bulk_theme_override();
 }
 
 void CodeTextEditor::_on_settings_change() {
@@ -1582,7 +1555,6 @@ void CodeTextEditor::_apply_settings_change() {
 	settings_changed = false;
 
 	_update_text_editor_theme();
-	_update_font();
 
 	font_size = EditorSettings::get_singleton()->get("interface/editor/code_font_size");
 
@@ -1668,7 +1640,6 @@ void CodeTextEditor::_notification(int p_what) {
 				update_toggle_scripts_button();
 			}
 			_update_text_editor_theme();
-			_update_font();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 			error_button->set_icon(get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -168,7 +168,6 @@ class CodeTextEditor : public VBoxContainer {
 	void _apply_settings_change();
 
 	void _update_text_editor_theme();
-	void _update_font();
 	void _complete_request();
 	Ref<Texture2D> _get_completion_icon(const ScriptCodeCompletionOption &p_option);
 	void _font_resize_timeout();

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1051,19 +1051,17 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
 
 	// CodeEdit
+	theme->set_font("font", "CodeEdit", theme->get_font("source", "EditorFonts"));
+	theme->set_font_size("font_size", "CodeEdit", theme->get_font_size("source_size", "EditorFonts"));
 	theme->set_stylebox("normal", "CodeEdit", style_widget);
 	theme->set_stylebox("focus", "CodeEdit", style_widget_hover);
 	theme->set_stylebox("read_only", "CodeEdit", style_widget_disabled);
-	theme->set_constant("side_margin", "TabContainer", 0);
 	theme->set_icon("tab", "CodeEdit", theme->get_icon("GuiTab", "EditorIcons"));
 	theme->set_icon("space", "CodeEdit", theme->get_icon("GuiSpace", "EditorIcons"));
 	theme->set_icon("folded", "CodeEdit", theme->get_icon("GuiTreeArrowRight", "EditorIcons"));
 	theme->set_icon("can_fold", "CodeEdit", theme->get_icon("GuiTreeArrowDown", "EditorIcons"));
 	theme->set_icon("executing_line", "CodeEdit", theme->get_icon("MainPlay", "EditorIcons"));
-	theme->set_color("font_color", "CodeEdit", font_color);
-	theme->set_color("caret_color", "CodeEdit", font_color);
-	theme->set_color("selection_color", "CodeEdit", selection_color);
-	theme->set_constant("line_spacing", "CodeEdit", 4 * EDSCALE);
+	theme->set_constant("line_spacing", "CodeEdit", EDITOR_DEF("text_editor/theme/line_spacing", 6));
 
 	// H/VSplitContainer
 	theme->set_stylebox("bg", "VSplitContainer", make_stylebox(theme->get_icon("GuiVsplitBg", "EditorIcons"), 1, 1, 1, 1));
@@ -1473,6 +1471,29 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	} else if (text_editor_color_theme == "Godot 2") {
 		setting->load_text_editor_theme();
 	}
+
+	// Now theme is loaded, apply it to CodeEdit.
+	theme->set_color("background_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/background_color"));
+	theme->set_color("completion_background_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/completion_background_color"));
+	theme->set_color("completion_selected_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/completion_selected_color"));
+	theme->set_color("completion_existing_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/completion_existing_color"));
+	theme->set_color("completion_scroll_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/completion_scroll_color"));
+	theme->set_color("completion_font_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/completion_font_color"));
+	theme->set_color("font_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/text_color"));
+	theme->set_color("line_number_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/line_number_color"));
+	theme->set_color("caret_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/caret_color"));
+	theme->set_color("font_selected_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/text_selected_color"));
+	theme->set_color("selection_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/selection_color"));
+	theme->set_color("brace_mismatch_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/brace_mismatch_color"));
+	theme->set_color("current_line_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/current_line_color"));
+	theme->set_color("line_length_guideline_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/line_length_guideline_color"));
+	theme->set_color("word_highlighted_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/word_highlighted_color"));
+	theme->set_color("bookmark_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/bookmark_color"));
+	theme->set_color("breakpoint_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/breakpoint_color"));
+	theme->set_color("executing_line_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/executing_line_color"));
+	theme->set_color("code_folding_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/code_folding_color"));
+	theme->set_color("search_result_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/search_result_color"));
+	theme->set_color("search_result_border_color", "CodeEdit", EDITOR_GET("text_editor/highlighting/search_result_border_color"));
 
 	return theme;
 }

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2906,7 +2906,10 @@ void CodeEdit::_text_changed() {
 	while (lc /= 10) {
 		line_number_digits++;
 	}
-	set_gutter_width(line_number_gutter, (line_number_digits + 1) * font->get_char_size('0', 0, font_size).width);
+
+	if (font.is_valid()) {
+		set_gutter_width(line_number_gutter, (line_number_digits + 1) * font->get_char_size('0', 0, font_size).width);
+	}
 
 	lc = get_line_count();
 	int line_change_size = (lines_edited_to - lines_edited_from);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1686,6 +1686,17 @@ Rect2 Control::get_anchorable_rect() const {
 	return Rect2(Point2(), get_size());
 }
 
+void Control::begin_bulk_theme_override() {
+	data.bulk_theme_override = true;
+}
+
+void Control::end_bulk_theme_override() {
+	ERR_FAIL_COND(!data.bulk_theme_override);
+
+	data.bulk_theme_override = false;
+	_notify_theme_changed();
+}
+
 void Control::add_theme_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon) {
 	ERR_FAIL_COND(!p_icon.is_valid());
 
@@ -1695,7 +1706,7 @@ void Control::add_theme_icon_override(const StringName &p_name, const Ref<Textur
 
 	data.icon_override[p_name] = p_icon;
 	data.icon_override[p_name]->connect("changed", callable_mp(this, &Control::_override_changed), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::add_theme_style_override(const StringName &p_name, const Ref<StyleBox> &p_style) {
@@ -1707,7 +1718,7 @@ void Control::add_theme_style_override(const StringName &p_name, const Ref<Style
 
 	data.style_override[p_name] = p_style;
 	data.style_override[p_name]->connect("changed", callable_mp(this, &Control::_override_changed), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::add_theme_font_override(const StringName &p_name, const Ref<Font> &p_font) {
@@ -1719,22 +1730,22 @@ void Control::add_theme_font_override(const StringName &p_name, const Ref<Font> 
 
 	data.font_override[p_name] = p_font;
 	data.font_override[p_name]->connect("changed", callable_mp(this, &Control::_override_changed), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::add_theme_font_size_override(const StringName &p_name, int p_font_size) {
 	data.font_size_override[p_name] = p_font_size;
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::add_theme_color_override(const StringName &p_name, const Color &p_color) {
 	data.color_override[p_name] = p_color;
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::add_theme_constant_override(const StringName &p_name, int p_constant) {
 	data.constant_override[p_name] = p_constant;
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::remove_theme_icon_override(const StringName &p_name) {
@@ -1743,7 +1754,7 @@ void Control::remove_theme_icon_override(const StringName &p_name) {
 	}
 
 	data.icon_override.erase(p_name);
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::remove_theme_style_override(const StringName &p_name) {
@@ -1752,7 +1763,7 @@ void Control::remove_theme_style_override(const StringName &p_name) {
 	}
 
 	data.style_override.erase(p_name);
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::remove_theme_font_override(const StringName &p_name) {
@@ -1761,22 +1772,22 @@ void Control::remove_theme_font_override(const StringName &p_name) {
 	}
 
 	data.font_override.erase(p_name);
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::remove_theme_font_size_override(const StringName &p_name) {
 	data.font_size_override.erase(p_name);
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::remove_theme_color_override(const StringName &p_name) {
 	data.color_override.erase(p_name);
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::remove_theme_constant_override(const StringName &p_name) {
 	data.constant_override.erase(p_name);
-	notification(NOTIFICATION_THEME_CHANGED);
+	_notify_theme_changed();
 }
 
 void Control::set_focus_mode(FocusMode p_focus_mode) {
@@ -2047,6 +2058,12 @@ void Control::_propagate_theme_changed(Node *p_at, Control *p_owner, Window *p_o
 
 void Control::_theme_changed() {
 	_propagate_theme_changed(this, this, nullptr, false);
+}
+
+void Control::_notify_theme_changed() {
+	if (!data.bulk_theme_override) {
+		notification(NOTIFICATION_THEME_CHANGED);
+	}
 }
 
 void Control::set_theme(const Ref<Theme> &p_theme) {
@@ -2718,6 +2735,9 @@ void Control::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_theme_type_variation", "theme_type"), &Control::set_theme_type_variation);
 	ClassDB::bind_method(D_METHOD("get_theme_type_variation"), &Control::get_theme_type_variation);
+
+	ClassDB::bind_method(D_METHOD("begin_bulk_theme_override"), &Control::begin_bulk_theme_override);
+	ClassDB::bind_method(D_METHOD("end_bulk_theme_override"), &Control::end_bulk_theme_override);
 
 	ClassDB::bind_method(D_METHOD("add_theme_icon_override", "name", "texture"), &Control::add_theme_icon_override);
 	ClassDB::bind_method(D_METHOD("add_theme_stylebox_override", "name", "stylebox"), &Control::add_theme_style_override);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -220,6 +220,7 @@ private:
 		NodePath focus_next;
 		NodePath focus_prev;
 
+		bool bulk_theme_override = false;
 		HashMap<StringName, Ref<Texture2D>> icon_override;
 		HashMap<StringName, Ref<StyleBox>> style_override;
 		HashMap<StringName, Ref<Font>> font_override;
@@ -241,6 +242,7 @@ private:
 	void _set_size(const Size2 &p_size);
 
 	void _theme_changed();
+	void _notify_theme_changed();
 
 	void _update_minimum_size();
 
@@ -451,6 +453,9 @@ public:
 	MouseFilter get_mouse_filter() const;
 
 	/* SKINNING */
+
+	void begin_bulk_theme_override();
+	void end_bulk_theme_override();
 
 	void add_theme_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon);
 	void add_theme_style_override(const StringName &p_name, const Ref<StyleBox> &p_style);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -62,11 +62,19 @@ static bool _is_char(char32_t c) {
 ///////////////////////////////////////////////////////////////////////////////
 
 void TextEdit::Text::set_font(const Ref<Font> &p_font) {
+	if (font == p_font) {
+		return;
+	}
 	font = p_font;
+	is_dirty = true;
 }
 
 void TextEdit::Text::set_font_size(int p_font_size) {
+	if (font_size == p_font_size) {
+		return;
+	}
 	font_size = p_font_size;
+	is_dirty = true;
 }
 
 void TextEdit::Text::set_tab_size(int p_tab_size) {
@@ -78,16 +86,28 @@ int TextEdit::Text::get_tab_size() const {
 }
 
 void TextEdit::Text::set_font_features(const Dictionary &p_features) {
+	if (opentype_features.hash() == p_features.hash()) {
+		return;
+	}
 	opentype_features = p_features;
+	is_dirty = true;
 }
 
 void TextEdit::Text::set_direction_and_language(TextServer::Direction p_direction, const String &p_language) {
+	if (direction == p_direction && language == p_language) {
+		return;
+	}
 	direction = p_direction;
 	language = p_language;
+	is_dirty = true;
 }
 
 void TextEdit::Text::set_draw_control_chars(bool p_draw_control_chars) {
+	if (draw_control_chars == p_draw_control_chars) {
+		return;
+	}
 	draw_control_chars = p_draw_control_chars;
+	is_dirty = true;
 }
 
 int TextEdit::Text::get_line_width(int p_line, int p_wrap_index) const {
@@ -176,9 +196,14 @@ void TextEdit::Text::invalidate_all_lines() {
 }
 
 void TextEdit::Text::invalidate_all() {
+	if (!is_dirty) {
+		return;
+	}
+
 	for (int i = 0; i < text.size(); i++) {
 		invalidate_cache(i);
 	}
+	is_dirty = false;
 }
 
 void TextEdit::Text::clear() {
@@ -4748,7 +4773,6 @@ bool TextEdit::_set(const StringName &p_name, const Variant &p_value) {
 				opentype_features[tag] = value;
 				text.set_font_features(opentype_features);
 				text.invalidate_all();
-				;
 				update();
 			}
 		}

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -151,6 +151,8 @@ private:
 		};
 
 	private:
+		bool is_dirty = false;
+
 		mutable Vector<Line> text;
 		Ref<Font> font;
 		int font_size = -1;


### PR DESCRIPTION
During editor load and when switching between scripts tabs, `TextEdit` was updating its cache for no reason, this was quite slow.

This PR adds two new methods to `Control`. `begin_bulk_theme_override`, which will prevent `*_theme_*_override` methods from causing a theme update, until `end_bulk_theme_override` is called.

Secondly, since we now have a dedicated code editing node `CodeEdit`, unlike before with `TextEdit`, we had to override most items to turn it into the code editor. Now there is no longer a need to do so, the theme overrides have been moved into the default editor theme.

Finally, `TextEdits` internal `text` class, now has a `is_dirty` flag to prevent invalidating the cache when not needed.

Overall, this has increased performance for a large script on load from `450ms` to `30ms`, and switching script tabs, from `1.3 seconds`  to `80ms`.

Seems to alleviate some of the issues seen in #51349