### PR TITLE
Explicit 2D naming and some organization in texture region editor plugin

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -63,16 +63,16 @@ void draw_margin_line(Control *edit_draw, Vector2 from, Vector2 to) {
 
 void TextureRegionEditor::_region_draw() {
 	Ref<Texture2D> base_tex = nullptr;
-	if (node_sprite) {
-		base_tex = node_sprite->get_texture();
+	if (atlas_tex.is_valid()) {
+		base_tex = atlas_tex->get_atlas();
+	} else if (node_sprite_2d) {
+		base_tex = node_sprite_2d->get_texture();
 	} else if (node_sprite_3d) {
 		base_tex = node_sprite_3d->get_texture();
 	} else if (node_ninepatch) {
 		base_tex = node_ninepatch->get_texture();
 	} else if (obj_styleBox.is_valid()) {
 		base_tex = obj_styleBox->get_texture();
-	} else if (atlas_tex.is_valid()) {
-		base_tex = atlas_tex->get_atlas();
 	}
 
 	if (base_tex.is_null()) {
@@ -332,24 +332,27 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 							rect = E;
 							if (Input::get_singleton()->is_key_pressed(KEY_CTRL) && !(Input::get_singleton()->is_key_pressed(Key(KEY_SHIFT | KEY_ALT)))) {
 								Rect2 r;
-								if (node_sprite) {
-									r = node_sprite->get_region_rect();
+								if (atlas_tex.is_valid()) {
+									r = atlas_tex->get_region();
+								} else if (node_sprite_2d) {
+									r = node_sprite_2d->get_region_rect();
 								} else if (node_sprite_3d) {
 									r = node_sprite_3d->get_region_rect();
 								} else if (node_ninepatch) {
 									r = node_ninepatch->get_region_rect();
 								} else if (obj_styleBox.is_valid()) {
 									r = obj_styleBox->get_region_rect();
-								} else if (atlas_tex.is_valid()) {
-									r = atlas_tex->get_region();
 								}
 								rect.expand_to(r.position);
 								rect.expand_to(r.position + r.size);
 							}
 							undo_redo->create_action(TTR("Set Region Rect"));
-							if (node_sprite) {
-								undo_redo->add_do_method(node_sprite, "set_region_rect", rect);
-								undo_redo->add_undo_method(node_sprite, "set_region_rect", node_sprite->get_region_rect());
+							if (atlas_tex.is_valid()) {
+								undo_redo->add_do_method(atlas_tex.ptr(), "set_region", rect);
+								undo_redo->add_undo_method(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
+							} else if (node_sprite_2d) {
+								undo_redo->add_do_method(node_sprite_2d, "set_region_rect", rect);
+								undo_redo->add_undo_method(node_sprite_2d, "set_region_rect", node_sprite_2d->get_region_rect());
 							} else if (node_sprite_3d) {
 								undo_redo->add_do_method(node_sprite_3d, "set_region_rect", rect);
 								undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
@@ -359,9 +362,6 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 							} else if (obj_styleBox.is_valid()) {
 								undo_redo->add_do_method(obj_styleBox.ptr(), "set_region_rect", rect);
 								undo_redo->add_undo_method(obj_styleBox.ptr(), "set_region_rect", obj_styleBox->get_region_rect());
-							} else if (atlas_tex.is_valid()) {
-								undo_redo->add_do_method(atlas_tex.ptr(), "set_region", rect);
-								undo_redo->add_undo_method(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
 							}
 							undo_redo->add_do_method(this, "_update_rect");
 							undo_redo->add_undo_method(this, "_update_rect");
@@ -379,16 +379,16 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 						drag_from = snap_point(drag_from);
 					}
 					drag = true;
-					if (node_sprite) {
-						rect_prev = node_sprite->get_region_rect();
+					if (atlas_tex.is_valid()) {
+						rect_prev = atlas_tex->get_region();
+					} else if (node_sprite_2d) {
+						rect_prev = node_sprite_2d->get_region_rect();
 					} else if (node_sprite_3d) {
 						rect_prev = node_sprite_3d->get_region_rect();
 					} else if (node_ninepatch) {
 						rect_prev = node_ninepatch->get_region_rect();
 					} else if (obj_styleBox.is_valid()) {
 						rect_prev = obj_styleBox->get_region_rect();
-					} else if (atlas_tex.is_valid()) {
-						rect_prev = atlas_tex->get_region();
 					}
 
 					for (int i = 0; i < 8; i++) {
@@ -419,15 +419,15 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					edited_margin = -1;
 				} else {
 					undo_redo->create_action(TTR("Set Region Rect"));
-					if (node_sprite) {
-						undo_redo->add_do_method(node_sprite, "set_region_rect", node_sprite->get_region_rect());
-						undo_redo->add_undo_method(node_sprite, "set_region_rect", rect_prev);
+					if (atlas_tex.is_valid()) {
+						undo_redo->add_do_method(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
+						undo_redo->add_undo_method(atlas_tex.ptr(), "set_region", rect_prev);
+					} else if (node_sprite_2d) {
+						undo_redo->add_do_method(node_sprite_2d, "set_region_rect", node_sprite_2d->get_region_rect());
+						undo_redo->add_undo_method(node_sprite_2d, "set_region_rect", rect_prev);
 					} else if (node_sprite_3d) {
 						undo_redo->add_do_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
 						undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", rect_prev);
-					} else if (atlas_tex.is_valid()) {
-						undo_redo->add_do_method(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
-						undo_redo->add_undo_method(atlas_tex.ptr(), "set_region", rect_prev);
 					} else if (node_ninepatch) {
 						undo_redo->add_do_method(node_ninepatch, "set_region_rect", node_ninepatch->get_region_rect());
 						undo_redo->add_undo_method(node_ninepatch, "set_region_rect", rect_prev);
@@ -693,22 +693,24 @@ void TextureRegionEditor::_zoom_out() {
 }
 
 void TextureRegionEditor::apply_rect(const Rect2 &p_rect) {
-	if (node_sprite) {
-		node_sprite->set_region_rect(p_rect);
+	if (atlas_tex.is_valid()) {
+		atlas_tex->set_region(p_rect);
+	} else if (node_sprite_2d) {
+		node_sprite_2d->set_region_rect(p_rect);
 	} else if (node_sprite_3d) {
 		node_sprite_3d->set_region_rect(p_rect);
 	} else if (node_ninepatch) {
 		node_ninepatch->set_region_rect(p_rect);
 	} else if (obj_styleBox.is_valid()) {
 		obj_styleBox->set_region_rect(p_rect);
-	} else if (atlas_tex.is_valid()) {
-		atlas_tex->set_region(p_rect);
 	}
 }
 
 void TextureRegionEditor::_update_rect() {
-	if (node_sprite) {
-		rect = node_sprite->get_region_rect();
+	if (atlas_tex.is_valid()) {
+		rect = atlas_tex->get_region();
+	} else if (node_sprite_2d) {
+		rect = node_sprite_2d->get_region_rect();
 	} else if (node_sprite_3d) {
 		rect = node_sprite_3d->get_region_rect();
 	} else if (node_ninepatch) {
@@ -718,8 +720,6 @@ void TextureRegionEditor::_update_rect() {
 		}
 	} else if (obj_styleBox.is_valid()) {
 		rect = obj_styleBox->get_region_rect();
-	} else if (atlas_tex.is_valid()) {
-		rect = atlas_tex->get_region();
 	}
 }
 
@@ -728,16 +728,16 @@ void TextureRegionEditor::_update_autoslice() {
 	autoslice_cache.clear();
 
 	Ref<Texture2D> texture = nullptr;
-	if (node_sprite) {
-		texture = node_sprite->get_texture();
+	if (atlas_tex.is_valid()) {
+		texture = atlas_tex->get_atlas();
+	} else if (node_sprite_2d) {
+		texture = node_sprite_2d->get_texture();
 	} else if (node_sprite_3d) {
 		texture = node_sprite_3d->get_texture();
 	} else if (node_ninepatch) {
 		texture = node_ninepatch->get_texture();
 	} else if (obj_styleBox.is_valid()) {
 		texture = obj_styleBox->get_texture();
-	} else if (atlas_tex.is_valid()) {
-		texture = atlas_tex->get_atlas();
 	}
 
 	if (texture.is_null()) {
@@ -823,8 +823,8 @@ void TextureRegionEditor::_notification(int p_what) {
 }
 
 void TextureRegionEditor::_node_removed(Object *p_obj) {
-	if (p_obj == node_sprite || p_obj == node_sprite_3d || p_obj == node_ninepatch || p_obj == obj_styleBox.ptr() || p_obj == atlas_tex.ptr()) {
-		node_sprite = nullptr;
+	if (p_obj == node_sprite_2d || p_obj == node_sprite_3d || p_obj == node_ninepatch || p_obj == obj_styleBox.ptr() || p_obj == atlas_tex.ptr()) {
+		node_sprite_2d = nullptr;
 		node_sprite_3d = nullptr;
 		node_ninepatch = nullptr;
 		obj_styleBox = Ref<StyleBox>(nullptr);
@@ -852,17 +852,17 @@ bool TextureRegionEditor::is_ninepatch() {
 	return node_ninepatch != nullptr;
 }
 
+Sprite2D *TextureRegionEditor::get_sprite_2d() {
+	return node_sprite_2d;
+}
+
 Sprite3D *TextureRegionEditor::get_sprite_3d() {
 	return node_sprite_3d;
 }
 
-Sprite2D *TextureRegionEditor::get_sprite() {
-	return node_sprite;
-}
-
 void TextureRegionEditor::edit(Object *p_obj) {
-	if (node_sprite) {
-		node_sprite->disconnect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+	if (node_sprite_2d) {
+		node_sprite_2d->disconnect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (node_sprite_3d) {
 		node_sprite_3d->disconnect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
@@ -877,7 +877,7 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		atlas_tex->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (p_obj) {
-		node_sprite = Object::cast_to<Sprite2D>(p_obj);
+		node_sprite_2d = Object::cast_to<Sprite2D>(p_obj);
 		node_sprite_3d = Object::cast_to<Sprite3D>(p_obj);
 		node_ninepatch = Object::cast_to<NinePatchRect>(p_obj);
 
@@ -898,14 +898,14 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		}
 		_edit_region();
 	} else {
-		node_sprite = nullptr;
+		node_sprite_2d = nullptr;
 		node_sprite_3d = nullptr;
 		node_ninepatch = nullptr;
 		obj_styleBox = Ref<StyleBoxTexture>(nullptr);
 		atlas_tex = Ref<AtlasTexture>(nullptr);
 	}
 	edit_draw->update();
-	if ((node_sprite && !node_sprite->is_region_enabled()) || (node_sprite_3d && !node_sprite_3d->is_region_enabled())) {
+	if ((node_sprite_2d && !node_sprite_2d->is_region_enabled()) || (node_sprite_3d && !node_sprite_3d->is_region_enabled())) {
 		set_process(true);
 	}
 	if (!p_obj) {
@@ -922,16 +922,16 @@ void TextureRegionEditor::_texture_changed() {
 
 void TextureRegionEditor::_edit_region() {
 	Ref<Texture2D> texture = nullptr;
-	if (node_sprite) {
-		texture = node_sprite->get_texture();
+	if (atlas_tex.is_valid()) {
+		texture = atlas_tex->get_atlas();
+	} else if (node_sprite_2d) {
+		texture = node_sprite_2d->get_texture();
 	} else if (node_sprite_3d) {
 		texture = node_sprite_3d->get_texture();
 	} else if (node_ninepatch) {
 		texture = node_ninepatch->get_texture();
 	} else if (obj_styleBox.is_valid()) {
 		texture = obj_styleBox->get_texture();
-	} else if (atlas_tex.is_valid()) {
-		texture = atlas_tex->get_atlas();
 	}
 
 	if (texture.is_null()) {
@@ -967,7 +967,7 @@ Vector2 TextureRegionEditor::snap_point(Vector2 p_target) const {
 }
 
 TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
-	node_sprite = nullptr;
+	node_sprite_2d = nullptr;
 	node_sprite_3d = nullptr;
 	node_ninepatch = nullptr;
 	obj_styleBox = Ref<StyleBoxTexture>(nullptr);
@@ -1122,7 +1122,9 @@ void TextureRegionEditorPlugin::_editor_visiblity_changed() {
 void TextureRegionEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		texture_region_button->show();
-		bool is_node_configured = region_editor->is_stylebox() || region_editor->is_atlas_texture() || region_editor->is_ninepatch() || (region_editor->get_sprite() && region_editor->get_sprite()->is_region_enabled()) || (region_editor->get_sprite_3d() && region_editor->get_sprite_3d()->is_region_enabled());
+		bool is_node_configured = region_editor->is_stylebox() || region_editor->is_atlas_texture() || region_editor->is_ninepatch();
+		is_node_configured |= region_editor->get_sprite_2d() && region_editor->get_sprite_2d()->is_region_enabled();
+		is_node_configured |= region_editor->get_sprite_3d() && region_editor->get_sprite_3d()->is_region_enabled();
 		if ((is_node_configured && !manually_hidden) || texture_region_button->is_pressed()) {
 			editor->make_bottom_panel_item_visible(region_editor);
 		}

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -83,7 +83,7 @@ class TextureRegionEditor : public VBoxContainer {
 	Vector2 snap_step;
 	Vector2 snap_separation;
 
-	Sprite2D *node_sprite;
+	Sprite2D *node_sprite_2d;
 	Sprite3D *node_sprite_3d;
 	NinePatchRect *node_ninepatch;
 	Ref<StyleBoxTexture> obj_styleBox;
@@ -134,8 +134,8 @@ public:
 	bool is_stylebox();
 	bool is_atlas_texture();
 	bool is_ninepatch();
+	Sprite2D *get_sprite_2d();
 	Sprite3D *get_sprite_3d();
-	Sprite2D *get_sprite();
 
 	void edit(Object *p_obj);
 	TextureRegionEditor(EditorNode *p_editor);


### PR DESCRIPTION
This PR does two things:

* Rename Sprite2D code to be explicitly named with 2D: `node_sprite_2d` and `get_sprite_2d`.
* Organize the `if` statements to have the atlas stuff first so that the 2D and 3D stuff are both on `} else if (` lines. This change makes it so that the Sprite2D and Sprite3D code is lined up for slightly easier readability.
  * This also makes it easier to disable these lines of code in the event that someone compiles the editor without Sprite2D or Sprite3D (though that's not possible at the moment).

This code is not exposed, it's only used by the editor. This PR shouldn't change the behavior.