### PR TITLE
Android: Use volk instead of NDK Vulkan headers

### DIFF
--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -6,23 +6,12 @@ thirdparty_obj = []
 thirdparty_dir = "#thirdparty/vulkan"
 thirdparty_volk_dir = "#thirdparty/volk"
 
+# Use bundled Vulkan headers
+env.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "/include"])
+
 if env["use_volk"]:
     env.AppendUnique(CPPDEFINES=["USE_VOLK"])
     env.Prepend(CPPPATH=[thirdparty_volk_dir])
-
-if env["platform"] == "android" and not env["use_volk"]:
-    # Use NDK Vulkan headers
-    ndk_vulkan_dir = env["ANDROID_NDK_ROOT"] + "/sources/third_party/vulkan/src"
-    thirdparty_includes = [
-        ndk_vulkan_dir,
-        ndk_vulkan_dir + "/include",
-        ndk_vulkan_dir + "/layers",
-        ndk_vulkan_dir + "/layers/generated",
-    ]
-    env.Prepend(CPPPATH=thirdparty_includes)
-else:
-    # Use bundled Vulkan headers
-    env.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "/include"])
 
 if env["platform"] == "android":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_ANDROID_KHR"])

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -54,7 +54,6 @@ def get_android_ndk_root():
 def get_flags():
     return [
         ("tools", False),
-        ("use_volk", False),
     ]
 
 


### PR DESCRIPTION
We no longer build the Vulkan loader, and volk lets us load it dynamically.
Roblox uses volk on Android so it should work well for us too.

Follow-up to #51516.