### PR TITLE
Make `get_position` and `get_global_position` part of CanvasItem

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -337,6 +337,12 @@
 				Returns the global position of the mouse.
 			</description>
 		</method>
+		<method name="get_global_position" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the global position of this [CanvasItem]. This is the same as the origin of the global transformation matrix.
+			</description>
+		</method>
 		<method name="get_global_transform" qualifiers="const">
 			<return type="Transform2D" />
 			<description>
@@ -353,6 +359,12 @@
 			<return type="Vector2" />
 			<description>
 				Returns the mouse position relative to this item's position.
+			</description>
+		</method>
+		<method name="get_position" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the position of this [CanvasItem]. This is the same as the origin of the transformation matrix.
 			</description>
 		</method>
 		<method name="get_transform" qualifiers="const">

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -377,7 +377,6 @@ void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skew", "radians"), &Node2D::set_skew);
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &Node2D::set_scale);
 
-	ClassDB::bind_method(D_METHOD("get_position"), &Node2D::get_position);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &Node2D::get_rotation);
 	ClassDB::bind_method(D_METHOD("get_skew"), &Node2D::get_skew);
 	ClassDB::bind_method(D_METHOD("get_scale"), &Node2D::get_scale);
@@ -390,7 +389,6 @@ void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_scale", "ratio"), &Node2D::apply_scale);
 
 	ClassDB::bind_method(D_METHOD("set_global_position", "position"), &Node2D::set_global_position);
-	ClassDB::bind_method(D_METHOD("get_global_position"), &Node2D::get_global_position);
 	ClassDB::bind_method(D_METHOD("set_global_rotation", "radians"), &Node2D::set_global_rotation);
 	ClassDB::bind_method(D_METHOD("get_global_rotation"), &Node2D::get_global_rotation);
 	ClassDB::bind_method(D_METHOD("set_global_scale", "scale"), &Node2D::set_global_scale);

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -85,12 +85,12 @@ public:
 	void global_translate(const Vector2 &p_amount);
 	void apply_scale(const Size2 &p_amount);
 
-	Point2 get_position() const;
+	virtual Point2 get_position() const override;
 	real_t get_rotation() const;
 	real_t get_skew() const;
 	Size2 get_scale() const;
 
-	Point2 get_global_position() const;
+	virtual Point2 get_global_position() const override;
 	real_t get_global_rotation() const;
 	Size2 get_global_scale() const;
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2860,14 +2860,12 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_offset", "offset"), &Control::get_offset);
 	ClassDB::bind_method(D_METHOD("get_begin"), &Control::get_begin);
 	ClassDB::bind_method(D_METHOD("get_end"), &Control::get_end);
-	ClassDB::bind_method(D_METHOD("get_position"), &Control::get_position);
 	ClassDB::bind_method(D_METHOD("get_size"), &Control::get_size);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &Control::get_rotation);
 	ClassDB::bind_method(D_METHOD("get_scale"), &Control::get_scale);
 	ClassDB::bind_method(D_METHOD("get_pivot_offset"), &Control::get_pivot_offset);
 	ClassDB::bind_method(D_METHOD("get_custom_minimum_size"), &Control::get_custom_minimum_size);
 	ClassDB::bind_method(D_METHOD("get_parent_area_size"), &Control::get_parent_area_size);
-	ClassDB::bind_method(D_METHOD("get_global_position"), &Control::get_global_position);
 	ClassDB::bind_method(D_METHOD("get_rect"), &Control::get_rect);
 	ClassDB::bind_method(D_METHOD("get_global_rect"), &Control::get_global_rect);
 	ClassDB::bind_method(D_METHOD("set_focus_mode", "mode"), &Control::set_focus_mode);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -395,8 +395,8 @@ public:
 
 	void set_position(const Point2 &p_point, bool p_keep_offsets = false);
 	void set_global_position(const Point2 &p_point, bool p_keep_offsets = false);
-	Point2 get_position() const;
-	Point2 get_global_position() const;
+	virtual Point2 get_position() const override;
+	virtual Point2 get_global_position() const override;
 	Point2 get_screen_position() const;
 
 	void set_size(const Size2 &p_size, bool p_keep_offsets = false);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -902,6 +902,8 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_set_transform_matrix", "xform"), &CanvasItem::draw_set_transform_matrix);
 	ClassDB::bind_method(D_METHOD("draw_animation_slice", "animation_length", "slice_begin", "slice_end", "offset"), &CanvasItem::draw_animation_slice, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("draw_end_animation"), &CanvasItem::draw_end_animation);
+	ClassDB::bind_method(D_METHOD("get_position"), &CanvasItem::get_position);
+	ClassDB::bind_method(D_METHOD("get_global_position"), &CanvasItem::get_global_position);
 	ClassDB::bind_method(D_METHOD("get_transform"), &CanvasItem::get_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &CanvasItem::get_global_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform_with_canvas"), &CanvasItem::get_global_transform_with_canvas);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -256,6 +256,8 @@ public:
 
 	CanvasItem *get_parent_item() const;
 
+	virtual Point2 get_position() const = 0;
+	virtual Point2 get_global_position() const = 0;
 	virtual Transform2D get_transform() const = 0;
 
 	virtual Transform2D get_global_transform() const;


### PR DESCRIPTION
The existence of `get_position()` on CanvasItem is implied by the existence of `get_transform()`, since you can do `get_transform().origin`. Same with `get_global_position()` and `get_global_transform().origin`.

This PR does not change anything else such as `set_position`. We could, since both Control and Node2D have this ability, however I'm not sure that would be good idea since theoretically someone could make third custom class that inherits CanvasItem that doesn't have this ability (yet *getting* the position and transform is always implied since the node needs to be rendered etc).