### PR TITLE
Optimize device calls when using Volk

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -682,7 +682,7 @@ Error VulkanContext::_create_physical_device() {
 	inst_initialized = true;
 
 #ifdef USE_VOLK
-	volkLoadInstance(inst);
+	volkLoadInstanceOnly(inst);
 #endif
 
 	/* Make initial call to query gpu_count, then second call for gpu info*/
@@ -1009,6 +1009,10 @@ Error VulkanContext::_create_device() {
 #endif
 
 	err = vkCreateDevice(gpu, &sdevice, nullptr, &device);
+#ifdef USE_VOLK
+	volkLoadDevice(device);
+#endif
+
 	ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 
 	return OK;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/51516.

There are some issues with my current proof of concept implementation:

- This won't work with local RenderingDevices as the [device table approach](https://github.com/zeux/volk#optimizing-device-calls) is not used. I started looking into doing this, but ran into an issue with the Vulkan memory allocator.

<details>
<summary>Diff of my attempt to use VolkDeviceTable</summary>

```diff
diff --git a/drivers/vulkan/rendering_device_vulkan.cpp b/drivers/vulkan/rendering_device_vulkan.cpp
index f6677e2da4..b0debbfd42 100644
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8778,6 +8778,10 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 
 	context = p_context;
 	device = p_context->get_device();
+#ifdef USE_VOLK
+	device_table = p_context->get_device_table();
+#endif
+
 	if (p_local_device) {
 		frame_count = 1;
 		local_device = p_context->local_device_create();
@@ -8793,7 +8797,11 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 		VmaAllocatorCreateInfo allocatorInfo;
 		memset(&allocatorInfo, 0, sizeof(VmaAllocatorCreateInfo));
 		allocatorInfo.physicalDevice = p_context->get_physical_device();
+#ifdef USE_VOLK
+		allocatorInfo.device = device_table;
+#else
 		allocatorInfo.device = device;
+#endif
 		vmaCreateAllocator(&allocatorInfo, &allocator);
 	}
 
diff --git a/drivers/vulkan/rendering_device_vulkan.h b/drivers/vulkan/rendering_device_vulkan.h
index 6175369285..a4589100c5 100644
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -100,6 +100,9 @@ class RenderingDeviceVulkan : public RenderingDevice {
 	};
 
 	VkDevice device = VK_NULL_HANDLE;
+#ifdef USE_VOLK
+	VolkDeviceTable device_table;
+#endif
 
 	Map<RID, Set<RID>> dependency_map; //IDs to IDs that depend on it
 	Map<RID, Set<RID>> reverse_dependency_map; //same as above, but in reverse
diff --git a/drivers/vulkan/vulkan_context.cpp b/drivers/vulkan/vulkan_context.cpp
index 87749450c4..b41a36f23f 100644
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -682,7 +682,16 @@ Error VulkanContext::_create_physical_device() {
 	inst_initialized = true;
 
 #ifdef USE_VOLK
-	volkLoadInstance(inst);
+	// Godot supports using multiple Vulkan devices at the same time (local RenderingDevices),
+	// so we have to use the device table approach.
+	//
+	// "Since volkLoadDevice overwrites some function pointers with device-specific versions,
+	// you can choose to use volkLoadInstanceOnly instead of volkLoadInstance;
+	// when using table-based interface this can also help enforce the usage
+	// of the function tables as volkLoadInstanceOnly will leave device-specific functions as NULL."
+	//
+	// https://github.com/zeux/volk#optimizing-device-calls
+	volkLoadInstanceOnly(inst);
 #endif
 
 	/* Make initial call to query gpu_count, then second call for gpu info*/
@@ -1011,6 +1020,10 @@ Error VulkanContext::_create_device() {
 	err = vkCreateDevice(gpu, &sdevice, nullptr, &device);
 	ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 
+#ifdef USE_VOLK
+	volkLoadDeviceTable(&device_table, device);
+#endif
+
 	return OK;
 }
 
@@ -1082,7 +1095,7 @@ Error VulkanContext::_initialize_queues(VkSurfaceKHR p_surface) {
 		GET_DEVICE_PROC_ADDR(device, GetPastPresentationTimingGOOGLE);
 	}
 
-	vkGetDeviceQueue(device, graphics_queue_family_index, 0, &graphics_queue);
+	device_table.vkGetDeviceQueue(device, graphics_queue_family_index, 0, &graphics_queue);
 
 	if (!separate_present_queue) {
 		present_queue = graphics_queue;
@@ -1167,14 +1180,14 @@ Error VulkanContext::_create_semaphores() {
 		/*flags*/ VK_FENCE_CREATE_SIGNALED_BIT
 	};
 	for (uint32_t i = 0; i < FRAME_LAG; i++) {
-		err = vkCreateFence(device, &fence_ci, nullptr, &fences[i]);
+		err = device_table.vkCreateFence(device, &fence_ci, nullptr, &fences[i]);
 		ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 
-		err = vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &draw_complete_semaphores[i]);
+		err = device_table.vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &draw_complete_semaphores[i]);
 		ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 
 		if (separate_present_queue) {
-			err = vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &image_ownership_semaphores[i]);
+			err = device_table.vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &image_ownership_semaphores[i]);
 			ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 		}
 	}
@@ -1229,7 +1242,7 @@ Error VulkanContext::_window_create(DisplayServer::WindowID p_window_id, Display
 	};
 
 	for (uint32_t i = 0; i < FRAME_LAG; i++) {
-		VkResult vkerr = vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &window.image_acquired_semaphores[i]);
+		VkResult vkerr = device_table.vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &window.image_acquired_semaphores[i]);
 		ERR_FAIL_COND_V(vkerr, ERR_CANT_CREATE);
 	}
 
@@ -1540,7 +1553,7 @@ Error VulkanContext::_update_swap_chain(Window *window) {
 
 		color_image_view.image = window->swapchain_image_resources[i].image;
 
-		err = vkCreateImageView(device, &color_image_view, nullptr, &window->swapchain_image_resources[i].view);
+		err = device_table.vkCreateImageView(device, &color_image_view, nullptr, &window->swapchain_image_resources[i].view);
 		if (err) {
 			free(swapchainImages);
 			ERR_FAIL_V(ERR_CANT_CREATE);
@@ -1593,7 +1606,7 @@ Error VulkanContext::_update_swap_chain(Window *window) {
 			/*pDependencies*/ nullptr,
 		};
 
-		err = vkCreateRenderPass(device, &rp_info, nullptr, &window->render_pass);
+		err = device_table.vkCreateRenderPass(device, &rp_info, nullptr, &window->render_pass);
 		ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 
 		for (uint32_t i = 0; i < swapchainImageCount; i++) {
@@ -1609,7 +1622,7 @@ Error VulkanContext::_update_swap_chain(Window *window) {
 				/*layers*/ 1,
 			};
 
-			err = vkCreateFramebuffer(device, &fb_info, nullptr, &window->swapchain_image_resources[i].framebuffer);
+			err = device_table.vkCreateFramebuffer(device, &fb_info, nullptr, &window->swapchain_image_resources[i].framebuffer);
 			ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 		}
 	}
@@ -1623,7 +1636,7 @@ Error VulkanContext::_update_swap_chain(Window *window) {
 			/*flags*/ 0,
 			/*queueFamilyIndex*/ present_queue_family_index,
 		};
-		err = vkCreateCommandPool(device, &present_cmd_pool_info, nullptr, &window->present_cmd_pool);
+		err = device_table.vkCreateCommandPool(device, &present_cmd_pool_info, nullptr, &window->present_cmd_pool);
 		ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 		const VkCommandBufferAllocateInfo present_cmd_info = {
 			/*sType*/ VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
@@ -1633,7 +1646,7 @@ Error VulkanContext::_update_swap_chain(Window *window) {
 			/*commandBufferCount*/ 1,
 		};
 		for (uint32_t i = 0; i < swapchainImageCount; i++) {
-			err = vkAllocateCommandBuffers(device, &present_cmd_info,
+			err = device_table.vkAllocateCommandBuffers(device, &present_cmd_info,
 					&window->swapchain_image_resources[i].graphics_to_present_cmd);
 			ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 
@@ -1643,7 +1656,7 @@ Error VulkanContext::_update_swap_chain(Window *window) {
 				/*flags*/ VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT,
 				/*pInheritanceInfo*/ nullptr,
 			};
-			err = vkBeginCommandBuffer(window->swapchain_image_resources[i].graphics_to_present_cmd, &cmd_buf_info);
+			err = device_table.vkBeginCommandBuffer(window->swapchain_image_resources[i].graphics_to_present_cmd, &cmd_buf_info);
 			ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 
 			VkImageMemoryBarrier image_ownership_barrier = {
@@ -1659,9 +1672,9 @@ Error VulkanContext::_update_swap_chain(Window *window) {
 				/*subresourceRange*/ { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }
 			};
 
-			vkCmdPipelineBarrier(window->swapchain_image_resources[i].graphics_to_present_cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+			device_table.vkCmdPipelineBarrier(window->swapchain_image_resources[i].graphics_to_present_cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 					VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, nullptr, 0, nullptr, 1, &image_ownership_barrier);
-			err = vkEndCommandBuffer(window->swapchain_image_resources[i].graphics_to_present_cmd);
+			err = device_table.vkEndCommandBuffer(window->swapchain_image_resources[i].graphics_to_present_cmd);
 			ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
 		}
 	}
@@ -2018,11 +2031,17 @@ Error VulkanContext::swap_buffers() {
 void VulkanContext::resize_notify() {
 }
 
-VkDevice VulkanContext::get_device() {
+VkDevice VulkanContext::get_device() const {
 	return device;
 }
 
-VkPhysicalDevice VulkanContext::get_physical_device() {
+#ifdef USE_VOLK
+VolkDeviceTable VulkanContext::get_device_table() const {
+	return device_table;
+}
+#endif
+
+VkPhysicalDevice VulkanContext::get_physical_device() const {
 	return gpu;
 }
 
diff --git a/drivers/vulkan/vulkan_context.h b/drivers/vulkan/vulkan_context.h
index 1690b853e3..5660d7cb39 100644
--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -79,6 +79,8 @@ private:
 	uint32_t queue_family_count = 0;
 	VkQueueFamilyProperties *queue_props = nullptr;
 	VkDevice device = VK_NULL_HANDLE;
+	// See <https://github.com/zeux/volk#optimizing-device-calls> for the `device_table`'s purpose.
+	VolkDeviceTable device_table;
 	bool device_initialized = false;
 	bool inst_initialized = false;
 
@@ -136,6 +138,8 @@ private:
 	struct LocalDevice {
 		bool waiting = false;
 		VkDevice device = VK_NULL_HANDLE;
+		// See <https://github.com/zeux/volk#optimizing-device-calls> for the `device_table`'s purpose.
+		VolkDeviceTable device_table;
 		VkQueue queue = VK_NULL_HANDLE;
 	};
 
@@ -243,8 +247,11 @@ public:
 	SubgroupCapabilities get_subgroup_capabilities() const { return subgroup_capabilities; };
 	MultiviewCapabilities get_multiview_capabilities() const { return multiview_capabilities; };
 
-	VkDevice get_device();
-	VkPhysicalDevice get_physical_device();
+	VkDevice get_device() const;
+#ifdef USE_VOLK
+	VolkDeviceTable get_device_table() const;
+#endif
+	VkPhysicalDevice get_physical_device() const;
 	int get_swapchain_image_count() const;
 	uint32_t get_graphics_queue() const;
 
```
</details>

- I could not notice any performance difference in two simple testing projects (one with just a cube, [another with a few spheres and SDFGI enabled](https://github.com/godotengine/godot/files/6979093/d.zip)).

### With optimized device calls

#### Run 1

```
❯ bin/godot.linuxbsd.tools.64.llvm --fullscreen --path /tmp/d/ --print-fps
Godot Engine v4.0.dev.custom_build.29d18c8cf - https://godotengine.org
Vulkan API 1.2.162
Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080

Project FPS: 2 (500.0 mspf)
Project FPS: 267 (3.7 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 339 (2.9 mspf)
Project FPS: 341 (2.9 mspf)
Project FPS: 341 (2.9 mspf)
Project FPS: 336 (2.9 mspf)
Project FPS: 339 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 339 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
```

#### Run 2

```
❯ bin/godot.linuxbsd.tools.64.llvm --fullscreen --path /tmp/d/ --print-fps
Godot Engine v4.0.dev.custom_build.29d18c8cf - https://godotengine.org
Vulkan API 1.2.162
Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080

Project FPS: 2 (500.0 mspf)
Project FPS: 275 (3.6 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 339 (2.9 mspf)
Project FPS: 339 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 337 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
```

### Without optimized device calls

#### Run 1

```
❯ bin/godot.linuxbsd.tools.64.llvm.vanilla --fullscreen --path /tmp/d/ --print-fps
Godot Engine v4.0.dev.custom_build.a98589a44 - https://godotengine.org
Vulkan API 1.2.162
Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080

Project FPS: 1 (1000.0 mspf)
Project FPS: 63 (15.8 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 339 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 339 (2.9 mspf)
```

#### Run 2

```
❯ bin/godot.linuxbsd.tools.64.llvm.vanilla --fullscreen --path /tmp/d/ --print-fps
Godot Engine v4.0.dev.custom_build.a98589a44 - https://godotengine.org
Vulkan API 1.2.162
Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080

Project FPS: 2 (500.0 mspf)
Project FPS: 275 (3.6 mspf)
Project FPS: 339 (2.9 mspf)
Project FPS: 337 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 340 (2.9 mspf)
Project FPS: 339 (2.9 mspf)
Project FPS: 338 (2.9 mspf)
Project FPS: 337 (2.9 mspf)
Project FPS: 339 (2.9 mspf)
Project FPS: 338 (2.9 mspf)
```