### PR TITLE
[3.x] Add support for prompting the user to retain app data on uninstall.

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -904,6 +904,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 		bool backup_allowed = p_preset->get("user_data_backup/allow");
 		bool classify_as_game = p_preset->get("package/classify_as_game");
+		bool retain_data_on_uninstall = p_preset->get("package/retain_data_on_uninstall");
 
 		Vector<String> perms;
 		// Write permissions into the perms variable.
@@ -1009,6 +1010,10 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 						if (tname == "application" && attrname == "isGame") {
 							encode_uint32(classify_as_game, &p_manifest.write[iofs + 16]);
+						}
+
+						if (tname == "application" && attrname == "hasFragileUserData") {
+							encode_uint32(retain_data_on_uninstall, &p_manifest.write[iofs + 16]);
 						}
 
 						if (tname == "instrumentation" && attrname == "targetPackage") {
@@ -1764,6 +1769,7 @@ public:
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name [default if blank]"), ""));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/signed"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/classify_as_game"), true));
+		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/retain_data_on_uninstall"), false));
 
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_icon_option, PROPERTY_HINT_FILE, "*.png"), ""));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_adaptive_icon_foreground_option, PROPERTY_HINT_FILE, "*.png"), ""));

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -265,13 +265,15 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
 			"        android:allowBackup=\"%s\"\n"
 			"        android:isGame=\"%s\"\n"
+			"        android:hasFragileUserData=\"%s\"\n"
 			"        android:requestLegacyExternalStorage=\"%s\"\n"
-			"        tools:replace=\"android:allowBackup,android:isGame,android:requestLegacyExternalStorage\"\n"
+			"        tools:replace=\"android:allowBackup,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n"
 			"        tools:ignore=\"GoogleAppIndexingWarning\"\n"
 			"        android:icon=\"@mipmap/icon\" >\n\n"
 			"        <meta-data tools:node=\"remove\" android:name=\"xr_mode_metadata_name\" />\n",
 			bool_to_string(p_preset->get("user_data_backup/allow")),
 			bool_to_string(p_preset->get("package/classify_as_game")),
+			bool_to_string(p_preset->get("package/retain_data_on_uninstall")),
 			bool_to_string(p_has_storage_permission));
 
 	if (uses_xr) {

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -28,7 +28,7 @@
     <!-- If you want to add tags manually, do before it. -->
     <!-- WARNING: This should stay on a single line until the parsing code is improved. See GH-32414. -->
     <!-- TODO: Remove the 'requestLegacyExternalStorage' attribute when https://github.com/godotengine/godot/issues/38913 is resolved -->
-    <application android:label="@string/godot_project_name_string" android:allowBackup="false" android:isGame="true" android:requestLegacyExternalStorage="false" tools:ignore="GoogleAppIndexingWarning" android:icon="@mipmap/icon" >
+    <application android:label="@string/godot_project_name_string" android:allowBackup="false" android:isGame="true" android:hasFragileUserData="false" android:requestLegacyExternalStorage="false" tools:ignore="GoogleAppIndexingWarning" android:icon="@mipmap/icon" >
 
         <!-- Records the version of the Godot editor used for building -->
         <meta-data


### PR DESCRIPTION
As specified in the [documentation](https://developer.android.com/guide/topics/manifest/application-element#fragileuserdata):
```
When the user uninstalls an app, whether or not to show the user a prompt to keep the app's data. 
```

Supported on Android 10 and higher.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
