### PR TITLE
Add support for prompting the user to retain app data on uninstall.

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -819,6 +819,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 
 	bool backup_allowed = p_preset->get("user_data_backup/allow");
 	bool classify_as_game = p_preset->get("package/classify_as_game");
+	bool retain_data_on_uninstall = p_preset->get("package/retain_data_on_uninstall");
 
 	Vector<String> perms;
 	// Write permissions into the perms variable.
@@ -918,6 +919,10 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 
 					if (tname == "application" && attrname == "isGame") {
 						encode_uint32(classify_as_game, &p_manifest.write[iofs + 16]);
+					}
+
+					if (tname == "application" && attrname == "hasFragileUserData") {
+						encode_uint32(retain_data_on_uninstall, &p_manifest.write[iofs + 16]);
 					}
 
 					if (tname == "instrumentation" && attrname == "targetPackage") {
@@ -1635,6 +1640,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name [default if blank]"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/signed"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/classify_as_game"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/retain_data_on_uninstall"), false));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_icon_option, PROPERTY_HINT_FILE, "*.png"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_adaptive_icon_foreground_option, PROPERTY_HINT_FILE, "*.png"), ""));

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -241,10 +241,12 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset) {
 			"        android:allowBackup=\"%s\"\n"
 			"        android:icon=\"@mipmap/icon\"\n"
 			"        android:isGame=\"%s\"\n"
-			"        tools:replace=\"android:allowBackup,android:isGame\"\n"
+			"        android:hasFragileUserData=\"%s\"\n"
+			"        tools:replace=\"android:allowBackup,android:isGame,android:hasFragileUserData\"\n"
 			"        tools:ignore=\"GoogleAppIndexingWarning\">\n\n",
 			bool_to_string(p_preset->get("user_data_backup/allow")),
-			bool_to_string(p_preset->get("package/classify_as_game")));
+			bool_to_string(p_preset->get("package/classify_as_game")),
+			bool_to_string(p_preset->get("package/retain_data_on_uninstall")));
 
 	manifest_application_text += _get_activity_tag(p_preset);
 	manifest_application_text += "    </application>\n";

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/icon"
         android:isGame="true"
+        android:hasFragileUserData="false"
         tools:ignore="GoogleAppIndexingWarning" >
 
         <!-- Records the version of the Godot editor used for building -->


### PR DESCRIPTION
As specified in the [documentation](https://developer.android.com/guide/topics/manifest/application-element#fragileuserdata):
```
When the user uninstalls an app, whether or not to show the user a prompt to keep the app's data. 
```

Supported on Android 10 and higher.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
