### PR TITLE
Fix incorrect word block colors in the inspector tooltip

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -887,7 +887,7 @@ Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 				text += "\n" + property_doc;
 			}
 		}
-		help_bit->set_text(text);
+		help_bit->call_deferred(SNAME("set_text"), text); //hack so it uses proper theme once inside scene
 	}
 
 	return help_bit;
@@ -1102,7 +1102,7 @@ Control *EditorInspectorCategory::make_custom_tooltip(const String &p_text) cons
 				text += "\n" + property_doc;
 			}
 		}
-		help_bit->set_text(text); //hack so it uses proper theme once inside scene
+		help_bit->call_deferred(SNAME("set_text"), text); //hack so it uses proper theme once inside scene
 	}
 
 	return help_bit;


### PR DESCRIPTION
By setting up a theme to this tooltip at its creation.

Before:
![image](https://user-images.githubusercontent.com/3036176/129346295-f21794d2-df65-48a5-b743-ef16e71ca784.png)


After:

![image](https://user-images.githubusercontent.com/3036176/129346085-823f9931-1f71-4593-9e7f-c95c62123ebb.png)

*Bugsquad edit:* Fixes #51561.