### PR TITLE
Namespaces instead of underscore prefix for binds, remove cruft

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -41,39 +41,41 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 
-////// _ResourceLoader //////
+namespace core_bind {
 
-_ResourceLoader *_ResourceLoader::singleton = nullptr;
+////// ResourceLoader //////
 
-Error _ResourceLoader::load_threaded_request(const String &p_path, const String &p_type_hint, bool p_use_sub_threads) {
-	return ResourceLoader::load_threaded_request(p_path, p_type_hint, p_use_sub_threads);
+ResourceLoader *ResourceLoader::singleton = nullptr;
+
+Error ResourceLoader::load_threaded_request(const String &p_path, const String &p_type_hint, bool p_use_sub_threads) {
+	return ::ResourceLoader::load_threaded_request(p_path, p_type_hint, p_use_sub_threads);
 }
 
-_ResourceLoader::ThreadLoadStatus _ResourceLoader::load_threaded_get_status(const String &p_path, Array r_progress) {
+ResourceLoader::ThreadLoadStatus ResourceLoader::load_threaded_get_status(const String &p_path, Array r_progress) {
 	float progress = 0;
-	ResourceLoader::ThreadLoadStatus tls = ResourceLoader::load_threaded_get_status(p_path, &progress);
+	::ResourceLoader::ThreadLoadStatus tls = ::ResourceLoader::load_threaded_get_status(p_path, &progress);
 	r_progress.resize(1);
 	r_progress[0] = progress;
 	return (ThreadLoadStatus)tls;
 }
 
-RES _ResourceLoader::load_threaded_get(const String &p_path) {
+RES ResourceLoader::load_threaded_get(const String &p_path) {
 	Error error;
-	RES res = ResourceLoader::load_threaded_get(p_path, &error);
+	RES res = ::ResourceLoader::load_threaded_get(p_path, &error);
 	return res;
 }
 
-RES _ResourceLoader::load(const String &p_path, const String &p_type_hint, CacheMode p_cache_mode) {
+RES ResourceLoader::load(const String &p_path, const String &p_type_hint, CacheMode p_cache_mode) {
 	Error err = OK;
-	RES ret = ResourceLoader::load(p_path, p_type_hint, ResourceFormatLoader::CacheMode(p_cache_mode), &err);
+	RES ret = ::ResourceLoader::load(p_path, p_type_hint, ResourceFormatLoader::CacheMode(p_cache_mode), &err);
 
 	ERR_FAIL_COND_V_MSG(err != OK, ret, "Error loading resource: '" + p_path + "'.");
 	return ret;
 }
 
-Vector<String> _ResourceLoader::get_recognized_extensions_for_type(const String &p_type) {
+Vector<String> ResourceLoader::get_recognized_extensions_for_type(const String &p_type) {
 	List<String> exts;
-	ResourceLoader::get_recognized_extensions_for_type(p_type, &exts);
+	::ResourceLoader::get_recognized_extensions_for_type(p_type, &exts);
 	Vector<String> ret;
 	for (const String &E : exts) {
 		ret.push_back(E);
@@ -82,13 +84,13 @@ Vector<String> _ResourceLoader::get_recognized_extensions_for_type(const String 
 	return ret;
 }
 
-void _ResourceLoader::set_abort_on_missing_resources(bool p_abort) {
-	ResourceLoader::set_abort_on_missing_resources(p_abort);
+void ResourceLoader::set_abort_on_missing_resources(bool p_abort) {
+	::ResourceLoader::set_abort_on_missing_resources(p_abort);
 }
 
-PackedStringArray _ResourceLoader::get_dependencies(const String &p_path) {
+PackedStringArray ResourceLoader::get_dependencies(const String &p_path) {
 	List<String> deps;
-	ResourceLoader::get_dependencies(p_path, &deps);
+	::ResourceLoader::get_dependencies(p_path, &deps);
 
 	PackedStringArray ret;
 	for (const String &E : deps) {
@@ -98,31 +100,31 @@ PackedStringArray _ResourceLoader::get_dependencies(const String &p_path) {
 	return ret;
 }
 
-bool _ResourceLoader::has_cached(const String &p_path) {
+bool ResourceLoader::has_cached(const String &p_path) {
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	return ResourceCache::has(local_path);
 }
 
-bool _ResourceLoader::exists(const String &p_path, const String &p_type_hint) {
-	return ResourceLoader::exists(p_path, p_type_hint);
+bool ResourceLoader::exists(const String &p_path, const String &p_type_hint) {
+	return ::ResourceLoader::exists(p_path, p_type_hint);
 }
 
-ResourceUID::ID _ResourceLoader::get_resource_uid(const String &p_path) {
-	return ResourceLoader::get_resource_uid(p_path);
+ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {
+	return ::ResourceLoader::get_resource_uid(p_path);
 }
 
-void _ResourceLoader::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads"), &_ResourceLoader::load_threaded_request, DEFVAL(""), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("load_threaded_get_status", "path", "progress"), &_ResourceLoader::load_threaded_get_status, DEFVAL(Array()));
-	ClassDB::bind_method(D_METHOD("load_threaded_get", "path"), &_ResourceLoader::load_threaded_get);
+void ResourceLoader::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads"), &ResourceLoader::load_threaded_request, DEFVAL(""), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("load_threaded_get_status", "path", "progress"), &ResourceLoader::load_threaded_get_status, DEFVAL(Array()));
+	ClassDB::bind_method(D_METHOD("load_threaded_get", "path"), &ResourceLoader::load_threaded_get);
 
-	ClassDB::bind_method(D_METHOD("load", "path", "type_hint", "cache_mode"), &_ResourceLoader::load, DEFVAL(""), DEFVAL(CACHE_MODE_REUSE));
-	ClassDB::bind_method(D_METHOD("get_recognized_extensions_for_type", "type"), &_ResourceLoader::get_recognized_extensions_for_type);
-	ClassDB::bind_method(D_METHOD("set_abort_on_missing_resources", "abort"), &_ResourceLoader::set_abort_on_missing_resources);
-	ClassDB::bind_method(D_METHOD("get_dependencies", "path"), &_ResourceLoader::get_dependencies);
-	ClassDB::bind_method(D_METHOD("has_cached", "path"), &_ResourceLoader::has_cached);
-	ClassDB::bind_method(D_METHOD("exists", "path", "type_hint"), &_ResourceLoader::exists, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_resource_uid", "path"), &_ResourceLoader::get_resource_uid);
+	ClassDB::bind_method(D_METHOD("load", "path", "type_hint", "cache_mode"), &ResourceLoader::load, DEFVAL(""), DEFVAL(CACHE_MODE_REUSE));
+	ClassDB::bind_method(D_METHOD("get_recognized_extensions_for_type", "type"), &ResourceLoader::get_recognized_extensions_for_type);
+	ClassDB::bind_method(D_METHOD("set_abort_on_missing_resources", "abort"), &ResourceLoader::set_abort_on_missing_resources);
+	ClassDB::bind_method(D_METHOD("get_dependencies", "path"), &ResourceLoader::get_dependencies);
+	ClassDB::bind_method(D_METHOD("has_cached", "path"), &ResourceLoader::has_cached);
+	ClassDB::bind_method(D_METHOD("exists", "path", "type_hint"), &ResourceLoader::exists, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_resource_uid", "path"), &ResourceLoader::get_resource_uid);
 
 	BIND_ENUM_CONSTANT(THREAD_LOAD_INVALID_RESOURCE);
 	BIND_ENUM_CONSTANT(THREAD_LOAD_IN_PROGRESS);
@@ -134,17 +136,17 @@ void _ResourceLoader::_bind_methods() {
 	BIND_ENUM_CONSTANT(CACHE_MODE_REPLACE);
 }
 
-////// _ResourceSaver //////
+////// ResourceSaver //////
 
-Error _ResourceSaver::save(const String &p_path, const RES &p_resource, SaverFlags p_flags) {
+Error ResourceSaver::save(const String &p_path, const RES &p_resource, SaverFlags p_flags) {
 	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, "Can't save empty resource to path '" + String(p_path) + "'.");
-	return ResourceSaver::save(p_path, p_resource, p_flags);
+	return ::ResourceSaver::save(p_path, p_resource, p_flags);
 }
 
-Vector<String> _ResourceSaver::get_recognized_extensions(const RES &p_resource) {
+Vector<String> ResourceSaver::get_recognized_extensions(const RES &p_resource) {
 	ERR_FAIL_COND_V_MSG(p_resource.is_null(), Vector<String>(), "It's not a reference to a valid Resource object.");
 	List<String> exts;
-	ResourceSaver::get_recognized_extensions(p_resource, &exts);
+	::ResourceSaver::get_recognized_extensions(p_resource, &exts);
 	Vector<String> ret;
 	for (const String &E : exts) {
 		ret.push_back(E);
@@ -152,11 +154,11 @@ Vector<String> _ResourceSaver::get_recognized_extensions(const RES &p_resource) 
 	return ret;
 }
 
-_ResourceSaver *_ResourceSaver::singleton = nullptr;
+ResourceSaver *ResourceSaver::singleton = nullptr;
 
-void _ResourceSaver::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("save", "path", "resource", "flags"), &_ResourceSaver::save, DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("get_recognized_extensions", "type"), &_ResourceSaver::get_recognized_extensions);
+void ResourceSaver::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("save", "path", "resource", "flags"), &ResourceSaver::save, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_recognized_extensions", "type"), &ResourceSaver::get_recognized_extensions);
 
 	BIND_ENUM_CONSTANT(FLAG_RELATIVE_PATHS);
 	BIND_ENUM_CONSTANT(FLAG_BUNDLE_RESOURCES);
@@ -167,65 +169,65 @@ void _ResourceSaver::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_REPLACE_SUBRESOURCE_PATHS);
 }
 
-////// _OS //////
+////// OS //////
 
-PackedStringArray _OS::get_connected_midi_inputs() {
-	return OS::get_singleton()->get_connected_midi_inputs();
+PackedStringArray OS::get_connected_midi_inputs() {
+	return ::OS::get_singleton()->get_connected_midi_inputs();
 }
 
-void _OS::open_midi_inputs() {
-	OS::get_singleton()->open_midi_inputs();
+void OS::open_midi_inputs() {
+	::OS::get_singleton()->open_midi_inputs();
 }
 
-void _OS::close_midi_inputs() {
-	OS::get_singleton()->close_midi_inputs();
+void OS::close_midi_inputs() {
+	::OS::get_singleton()->close_midi_inputs();
 }
 
-void _OS::set_use_file_access_save_and_swap(bool p_enable) {
+void OS::set_use_file_access_save_and_swap(bool p_enable) {
 	FileAccess::set_backup_save(p_enable);
 }
 
-void _OS::set_low_processor_usage_mode(bool p_enabled) {
-	OS::get_singleton()->set_low_processor_usage_mode(p_enabled);
+void OS::set_low_processor_usage_mode(bool p_enabled) {
+	::OS::get_singleton()->set_low_processor_usage_mode(p_enabled);
 }
 
-bool _OS::is_in_low_processor_usage_mode() const {
-	return OS::get_singleton()->is_in_low_processor_usage_mode();
+bool OS::is_in_low_processor_usage_mode() const {
+	return ::OS::get_singleton()->is_in_low_processor_usage_mode();
 }
 
-void _OS::set_low_processor_usage_mode_sleep_usec(int p_usec) {
-	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(p_usec);
+void OS::set_low_processor_usage_mode_sleep_usec(int p_usec) {
+	::OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(p_usec);
 }
 
-int _OS::get_low_processor_usage_mode_sleep_usec() const {
-	return OS::get_singleton()->get_low_processor_usage_mode_sleep_usec();
+int OS::get_low_processor_usage_mode_sleep_usec() const {
+	return ::OS::get_singleton()->get_low_processor_usage_mode_sleep_usec();
 }
 
-void _OS::alert(const String &p_alert, const String &p_title) {
-	OS::get_singleton()->alert(p_alert, p_title);
+void OS::alert(const String &p_alert, const String &p_title) {
+	::OS::get_singleton()->alert(p_alert, p_title);
 }
 
-String _OS::get_executable_path() const {
-	return OS::get_singleton()->get_executable_path();
+String OS::get_executable_path() const {
+	return ::OS::get_singleton()->get_executable_path();
 }
 
-Error _OS::shell_open(String p_uri) {
+Error OS::shell_open(String p_uri) {
 	if (p_uri.begins_with("res://")) {
 		WARN_PRINT("Attempting to open an URL with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_open()`.");
 	} else if (p_uri.begins_with("user://")) {
 		WARN_PRINT("Attempting to open an URL with the \"user://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_open()`.");
 	}
-	return OS::get_singleton()->shell_open(p_uri);
+	return ::OS::get_singleton()->shell_open(p_uri);
 }
 
-int _OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r_output, bool p_read_stderr) {
+int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r_output, bool p_read_stderr) {
 	List<String> args;
 	for (int i = 0; i < p_arguments.size(); i++) {
 		args.push_back(p_arguments[i]);
 	}
 	String pipe;
 	int exitcode = 0;
-	Error err = OS::get_singleton()->execute(p_path, args, &pipe, &exitcode, p_read_stderr);
+	Error err = ::OS::get_singleton()->execute(p_path, args, &pipe, &exitcode, p_read_stderr);
 	r_output.push_back(pipe);
 	if (err != OK) {
 		return -1;
@@ -233,45 +235,45 @@ int _OS::execute(const String &p_path, const Vector<String> &p_arguments, Array 
 	return exitcode;
 }
 
-int _OS::create_process(const String &p_path, const Vector<String> &p_arguments) {
+int OS::create_process(const String &p_path, const Vector<String> &p_arguments) {
 	List<String> args;
 	for (int i = 0; i < p_arguments.size(); i++) {
 		args.push_back(p_arguments[i]);
 	}
-	OS::ProcessID pid = 0;
-	Error err = OS::get_singleton()->create_process(p_path, args, &pid);
+	::OS::ProcessID pid = 0;
+	Error err = ::OS::get_singleton()->create_process(p_path, args, &pid);
 	if (err != OK) {
 		return -1;
 	}
 	return pid;
 }
 
-Error _OS::kill(int p_pid) {
-	return OS::get_singleton()->kill(p_pid);
+Error OS::kill(int p_pid) {
+	return ::OS::get_singleton()->kill(p_pid);
 }
 
-int _OS::get_process_id() const {
-	return OS::get_singleton()->get_process_id();
+int OS::get_process_id() const {
+	return ::OS::get_singleton()->get_process_id();
 }
 
-bool _OS::has_environment(const String &p_var) const {
-	return OS::get_singleton()->has_environment(p_var);
+bool OS::has_environment(const String &p_var) const {
+	return ::OS::get_singleton()->has_environment(p_var);
 }
 
-String _OS::get_environment(const String &p_var) const {
-	return OS::get_singleton()->get_environment(p_var);
+String OS::get_environment(const String &p_var) const {
+	return ::OS::get_singleton()->get_environment(p_var);
 }
 
-bool _OS::set_environment(const String &p_var, const String &p_value) const {
-	return OS::get_singleton()->set_environment(p_var, p_value);
+bool OS::set_environment(const String &p_var, const String &p_value) const {
+	return ::OS::get_singleton()->set_environment(p_var, p_value);
 }
 
-String _OS::get_name() const {
-	return OS::get_singleton()->get_name();
+String OS::get_name() const {
+	return ::OS::get_singleton()->get_name();
 }
 
-Vector<String> _OS::get_cmdline_args() {
-	List<String> cmdline = OS::get_singleton()->get_cmdline_args();
+Vector<String> OS::get_cmdline_args() {
+	List<String> cmdline = ::OS::get_singleton()->get_cmdline_args();
 	Vector<String> cmdlinev;
 	for (const String &E : cmdline) {
 		cmdlinev.push_back(E);
@@ -280,81 +282,81 @@ Vector<String> _OS::get_cmdline_args() {
 	return cmdlinev;
 }
 
-String _OS::get_locale() const {
-	return OS::get_singleton()->get_locale();
+String OS::get_locale() const {
+	return ::OS::get_singleton()->get_locale();
 }
 
-String _OS::get_model_name() const {
-	return OS::get_singleton()->get_model_name();
+String OS::get_model_name() const {
+	return ::OS::get_singleton()->get_model_name();
 }
 
-Error _OS::set_thread_name(const String &p_name) {
-	return Thread::set_name(p_name);
+Error OS::set_thread_name(const String &p_name) {
+	return ::Thread::set_name(p_name);
 }
 
-Thread::ID _OS::get_thread_caller_id() const {
-	return Thread::get_caller_id();
+::Thread::ID OS::get_thread_caller_id() const {
+	return ::Thread::get_caller_id();
 };
 
-bool _OS::has_feature(const String &p_feature) const {
-	return OS::get_singleton()->has_feature(p_feature);
+bool OS::has_feature(const String &p_feature) const {
+	return ::OS::get_singleton()->has_feature(p_feature);
 }
 
-uint64_t _OS::get_static_memory_usage() const {
-	return OS::get_singleton()->get_static_memory_usage();
+uint64_t OS::get_static_memory_usage() const {
+	return ::OS::get_singleton()->get_static_memory_usage();
 }
 
-uint64_t _OS::get_static_memory_peak_usage() const {
-	return OS::get_singleton()->get_static_memory_peak_usage();
+uint64_t OS::get_static_memory_peak_usage() const {
+	return ::OS::get_singleton()->get_static_memory_peak_usage();
 }
 
 /** This method uses a signed argument for better error reporting as it's used from the scripting API. */
-void _OS::delay_usec(int p_usec) const {
+void OS::delay_usec(int p_usec) const {
 	ERR_FAIL_COND_MSG(
 			p_usec < 0,
 			vformat("Can't sleep for %d microseconds. The delay provided must be greater than or equal to 0 microseconds.", p_usec));
-	OS::get_singleton()->delay_usec(p_usec);
+	::OS::get_singleton()->delay_usec(p_usec);
 }
 
 /** This method uses a signed argument for better error reporting as it's used from the scripting API. */
-void _OS::delay_msec(int p_msec) const {
+void OS::delay_msec(int p_msec) const {
 	ERR_FAIL_COND_MSG(
 			p_msec < 0,
 			vformat("Can't sleep for %d milliseconds. The delay provided must be greater than or equal to 0 milliseconds.", p_msec));
-	OS::get_singleton()->delay_usec(int64_t(p_msec) * 1000);
+	::OS::get_singleton()->delay_usec(int64_t(p_msec) * 1000);
 }
 
-bool _OS::can_use_threads() const {
-	return OS::get_singleton()->can_use_threads();
+bool OS::can_use_threads() const {
+	return ::OS::get_singleton()->can_use_threads();
 }
 
-bool _OS::is_userfs_persistent() const {
-	return OS::get_singleton()->is_userfs_persistent();
+bool OS::is_userfs_persistent() const {
+	return ::OS::get_singleton()->is_userfs_persistent();
 }
 
-int _OS::get_processor_count() const {
-	return OS::get_singleton()->get_processor_count();
+int OS::get_processor_count() const {
+	return ::OS::get_singleton()->get_processor_count();
 }
 
-bool _OS::is_stdout_verbose() const {
-	return OS::get_singleton()->is_stdout_verbose();
+bool OS::is_stdout_verbose() const {
+	return ::OS::get_singleton()->is_stdout_verbose();
 }
 
-void _OS::dump_memory_to_file(const String &p_file) {
-	OS::get_singleton()->dump_memory_to_file(p_file.utf8().get_data());
+void OS::dump_memory_to_file(const String &p_file) {
+	::OS::get_singleton()->dump_memory_to_file(p_file.utf8().get_data());
 }
 
-struct _OSCoreBindImg {
+struct OSCoreBindImg {
 	String path;
 	Size2 size;
 	int fmt = 0;
 	ObjectID id;
 	int vram = 0;
-	bool operator<(const _OSCoreBindImg &p_img) const { return vram == p_img.vram ? id < p_img.id : vram > p_img.vram; }
+	bool operator<(const OSCoreBindImg &p_img) const { return vram == p_img.vram ? id < p_img.id : vram > p_img.vram; }
 };
 
-void _OS::print_all_textures_by_size() {
-	List<_OSCoreBindImg> imgs;
+void OS::print_all_textures_by_size() {
+	List<OSCoreBindImg> imgs;
 	uint64_t total = 0;
 	{
 		List<Ref<Resource>> rsrc;
@@ -368,7 +370,7 @@ void _OS::print_all_textures_by_size() {
 			Size2 size = res->call("get_size");
 			int fmt = res->call("get_format");
 
-			_OSCoreBindImg img;
+			OSCoreBindImg img;
 			img.size = size;
 			img.fmt = fmt;
 			img.path = res->get_path();
@@ -388,7 +390,7 @@ void _OS::print_all_textures_by_size() {
 				   "Path - VRAM usage (Dimensions)");
 	}
 
-	for (const _OSCoreBindImg &img : imgs) {
+	for (const OSCoreBindImg &img : imgs) {
 		print_line(vformat("%s - %s %s",
 				img.path,
 				String::humanize_size(img.vram),
@@ -398,7 +400,7 @@ void _OS::print_all_textures_by_size() {
 	print_line(vformat("Total VRAM usage: %s.", String::humanize_size(total)));
 }
 
-void _OS::print_resources_by_type(const Vector<String> &p_types) {
+void OS::print_resources_by_type(const Vector<String> &p_types) {
 	ERR_FAIL_COND_MSG(p_types.size() == 0,
 			"At least one type should be provided to print resources by type.");
 
@@ -440,38 +442,38 @@ void _OS::print_resources_by_type(const Vector<String> &p_types) {
 	}
 }
 
-void _OS::print_all_resources(const String &p_to_file) {
-	OS::get_singleton()->print_all_resources(p_to_file);
+void OS::print_all_resources(const String &p_to_file) {
+	::OS::get_singleton()->print_all_resources(p_to_file);
 }
 
-void _OS::print_resources_in_use(bool p_short) {
-	OS::get_singleton()->print_resources_in_use(p_short);
+void OS::print_resources_in_use(bool p_short) {
+	::OS::get_singleton()->print_resources_in_use(p_short);
 }
 
-void _OS::dump_resources_to_file(const String &p_file) {
-	OS::get_singleton()->dump_resources_to_file(p_file.utf8().get_data());
+void OS::dump_resources_to_file(const String &p_file) {
+	::OS::get_singleton()->dump_resources_to_file(p_file.utf8().get_data());
 }
 
-String _OS::get_user_data_dir() const {
-	return OS::get_singleton()->get_user_data_dir();
+String OS::get_user_data_dir() const {
+	return ::OS::get_singleton()->get_user_data_dir();
 }
 
-String _OS::get_config_dir() const {
+String OS::get_config_dir() const {
 	// Exposed as `get_config_dir()` instead of `get_config_path()` for consistency with other exposed OS methods.
-	return OS::get_singleton()->get_config_path();
+	return ::OS::get_singleton()->get_config_path();
 }
 
-String _OS::get_data_dir() const {
+String OS::get_data_dir() const {
 	// Exposed as `get_data_dir()` instead of `get_data_path()` for consistency with other exposed OS methods.
-	return OS::get_singleton()->get_data_path();
+	return ::OS::get_singleton()->get_data_path();
 }
 
-String _OS::get_cache_dir() const {
+String OS::get_cache_dir() const {
 	// Exposed as `get_cache_dir()` instead of `get_cache_path()` for consistency with other exposed OS methods.
-	return OS::get_singleton()->get_cache_path();
+	return ::OS::get_singleton()->get_cache_path();
 }
 
-bool _OS::is_debug_build() const {
+bool OS::is_debug_build() const {
 #ifdef DEBUG_ENABLED
 	return true;
 #else
@@ -479,113 +481,113 @@ bool _OS::is_debug_build() const {
 #endif
 }
 
-String _OS::get_system_dir(SystemDir p_dir, bool p_shared_storage) const {
-	return OS::get_singleton()->get_system_dir(OS::SystemDir(p_dir), p_shared_storage);
+String OS::get_system_dir(SystemDir p_dir, bool p_shared_storage) const {
+	return ::OS::get_singleton()->get_system_dir(::OS::SystemDir(p_dir), p_shared_storage);
 }
 
-String _OS::get_keycode_string(uint32_t p_code) const {
-	return keycode_get_string(p_code);
+String OS::get_keycode_string(uint32_t p_code) const {
+	return ::keycode_get_string(p_code);
 }
 
-bool _OS::is_keycode_unicode(uint32_t p_unicode) const {
-	return keycode_has_unicode(p_unicode);
+bool OS::is_keycode_unicode(uint32_t p_unicode) const {
+	return ::keycode_has_unicode(p_unicode);
 }
 
-int _OS::find_keycode_from_string(const String &p_code) const {
+int OS::find_keycode_from_string(const String &p_code) const {
 	return find_keycode(p_code);
 }
 
-bool _OS::request_permission(const String &p_name) {
-	return OS::get_singleton()->request_permission(p_name);
+bool OS::request_permission(const String &p_name) {
+	return ::OS::get_singleton()->request_permission(p_name);
 }
 
-bool _OS::request_permissions() {
-	return OS::get_singleton()->request_permissions();
+bool OS::request_permissions() {
+	return ::OS::get_singleton()->request_permissions();
 }
 
-Vector<String> _OS::get_granted_permissions() const {
-	return OS::get_singleton()->get_granted_permissions();
+Vector<String> OS::get_granted_permissions() const {
+	return ::OS::get_singleton()->get_granted_permissions();
 }
 
-String _OS::get_unique_id() const {
-	return OS::get_singleton()->get_unique_id();
+String OS::get_unique_id() const {
+	return ::OS::get_singleton()->get_unique_id();
 }
 
-_OS *_OS::singleton = nullptr;
+OS *OS::singleton = nullptr;
 
-void _OS::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_connected_midi_inputs"), &_OS::get_connected_midi_inputs);
-	ClassDB::bind_method(D_METHOD("open_midi_inputs"), &_OS::open_midi_inputs);
-	ClassDB::bind_method(D_METHOD("close_midi_inputs"), &_OS::close_midi_inputs);
+void OS::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_connected_midi_inputs"), &OS::get_connected_midi_inputs);
+	ClassDB::bind_method(D_METHOD("open_midi_inputs"), &OS::open_midi_inputs);
+	ClassDB::bind_method(D_METHOD("close_midi_inputs"), &OS::close_midi_inputs);
 
-	ClassDB::bind_method(D_METHOD("alert", "text", "title"), &_OS::alert, DEFVAL("Alert!"));
+	ClassDB::bind_method(D_METHOD("alert", "text", "title"), &OS::alert, DEFVAL("Alert!"));
 
-	ClassDB::bind_method(D_METHOD("set_low_processor_usage_mode", "enable"), &_OS::set_low_processor_usage_mode);
-	ClassDB::bind_method(D_METHOD("is_in_low_processor_usage_mode"), &_OS::is_in_low_processor_usage_mode);
+	ClassDB::bind_method(D_METHOD("set_low_processor_usage_mode", "enable"), &OS::set_low_processor_usage_mode);
+	ClassDB::bind_method(D_METHOD("is_in_low_processor_usage_mode"), &OS::is_in_low_processor_usage_mode);
 
-	ClassDB::bind_method(D_METHOD("set_low_processor_usage_mode_sleep_usec", "usec"), &_OS::set_low_processor_usage_mode_sleep_usec);
-	ClassDB::bind_method(D_METHOD("get_low_processor_usage_mode_sleep_usec"), &_OS::get_low_processor_usage_mode_sleep_usec);
+	ClassDB::bind_method(D_METHOD("set_low_processor_usage_mode_sleep_usec", "usec"), &OS::set_low_processor_usage_mode_sleep_usec);
+	ClassDB::bind_method(D_METHOD("get_low_processor_usage_mode_sleep_usec"), &OS::get_low_processor_usage_mode_sleep_usec);
 
-	ClassDB::bind_method(D_METHOD("get_processor_count"), &_OS::get_processor_count);
+	ClassDB::bind_method(D_METHOD("get_processor_count"), &OS::get_processor_count);
 
-	ClassDB::bind_method(D_METHOD("get_executable_path"), &_OS::get_executable_path);
-	ClassDB::bind_method(D_METHOD("execute", "path", "arguments", "output", "read_stderr"), &_OS::execute, DEFVAL(Array()), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("create_process", "path", "arguments"), &_OS::create_process);
-	ClassDB::bind_method(D_METHOD("kill", "pid"), &_OS::kill);
-	ClassDB::bind_method(D_METHOD("shell_open", "uri"), &_OS::shell_open);
-	ClassDB::bind_method(D_METHOD("get_process_id"), &_OS::get_process_id);
+	ClassDB::bind_method(D_METHOD("get_executable_path"), &OS::get_executable_path);
+	ClassDB::bind_method(D_METHOD("execute", "path", "arguments", "output", "read_stderr"), &OS::execute, DEFVAL(Array()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("create_process", "path", "arguments"), &OS::create_process);
+	ClassDB::bind_method(D_METHOD("kill", "pid"), &OS::kill);
+	ClassDB::bind_method(D_METHOD("shell_open", "uri"), &OS::shell_open);
+	ClassDB::bind_method(D_METHOD("get_process_id"), &OS::get_process_id);
 
-	ClassDB::bind_method(D_METHOD("get_environment", "variable"), &_OS::get_environment);
-	ClassDB::bind_method(D_METHOD("set_environment", "variable", "value"), &_OS::set_environment);
-	ClassDB::bind_method(D_METHOD("has_environment", "variable"), &_OS::has_environment);
+	ClassDB::bind_method(D_METHOD("get_environment", "variable"), &OS::get_environment);
+	ClassDB::bind_method(D_METHOD("set_environment", "variable", "value"), &OS::set_environment);
+	ClassDB::bind_method(D_METHOD("has_environment", "variable"), &OS::has_environment);
 
-	ClassDB::bind_method(D_METHOD("get_name"), &_OS::get_name);
-	ClassDB::bind_method(D_METHOD("get_cmdline_args"), &_OS::get_cmdline_args);
+	ClassDB::bind_method(D_METHOD("get_name"), &OS::get_name);
+	ClassDB::bind_method(D_METHOD("get_cmdline_args"), &OS::get_cmdline_args);
 
-	ClassDB::bind_method(D_METHOD("delay_usec", "usec"), &_OS::delay_usec);
-	ClassDB::bind_method(D_METHOD("delay_msec", "msec"), &_OS::delay_msec);
-	ClassDB::bind_method(D_METHOD("get_locale"), &_OS::get_locale);
-	ClassDB::bind_method(D_METHOD("get_model_name"), &_OS::get_model_name);
+	ClassDB::bind_method(D_METHOD("delay_usec", "usec"), &OS::delay_usec);
+	ClassDB::bind_method(D_METHOD("delay_msec", "msec"), &OS::delay_msec);
+	ClassDB::bind_method(D_METHOD("get_locale"), &OS::get_locale);
+	ClassDB::bind_method(D_METHOD("get_model_name"), &OS::get_model_name);
 
-	ClassDB::bind_method(D_METHOD("is_userfs_persistent"), &_OS::is_userfs_persistent);
-	ClassDB::bind_method(D_METHOD("is_stdout_verbose"), &_OS::is_stdout_verbose);
+	ClassDB::bind_method(D_METHOD("is_userfs_persistent"), &OS::is_userfs_persistent);
+	ClassDB::bind_method(D_METHOD("is_stdout_verbose"), &OS::is_stdout_verbose);
 
-	ClassDB::bind_method(D_METHOD("can_use_threads"), &_OS::can_use_threads);
+	ClassDB::bind_method(D_METHOD("can_use_threads"), &OS::can_use_threads);
 
-	ClassDB::bind_method(D_METHOD("is_debug_build"), &_OS::is_debug_build);
+	ClassDB::bind_method(D_METHOD("is_debug_build"), &OS::is_debug_build);
 
-	ClassDB::bind_method(D_METHOD("dump_memory_to_file", "file"), &_OS::dump_memory_to_file);
-	ClassDB::bind_method(D_METHOD("dump_resources_to_file", "file"), &_OS::dump_resources_to_file);
-	ClassDB::bind_method(D_METHOD("print_resources_in_use", "short"), &_OS::print_resources_in_use, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("print_all_resources", "tofile"), &_OS::print_all_resources, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("dump_memory_to_file", "file"), &OS::dump_memory_to_file);
+	ClassDB::bind_method(D_METHOD("dump_resources_to_file", "file"), &OS::dump_resources_to_file);
+	ClassDB::bind_method(D_METHOD("print_resources_in_use", "short"), &OS::print_resources_in_use, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("print_all_resources", "tofile"), &OS::print_all_resources, DEFVAL(""));
 
-	ClassDB::bind_method(D_METHOD("get_static_memory_usage"), &_OS::get_static_memory_usage);
-	ClassDB::bind_method(D_METHOD("get_static_memory_peak_usage"), &_OS::get_static_memory_peak_usage);
+	ClassDB::bind_method(D_METHOD("get_static_memory_usage"), &OS::get_static_memory_usage);
+	ClassDB::bind_method(D_METHOD("get_static_memory_peak_usage"), &OS::get_static_memory_peak_usage);
 
-	ClassDB::bind_method(D_METHOD("get_user_data_dir"), &_OS::get_user_data_dir);
-	ClassDB::bind_method(D_METHOD("get_system_dir", "dir", "shared_storage"), &_OS::get_system_dir, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("get_config_dir"), &_OS::get_config_dir);
-	ClassDB::bind_method(D_METHOD("get_data_dir"), &_OS::get_data_dir);
-	ClassDB::bind_method(D_METHOD("get_cache_dir"), &_OS::get_cache_dir);
-	ClassDB::bind_method(D_METHOD("get_unique_id"), &_OS::get_unique_id);
+	ClassDB::bind_method(D_METHOD("get_user_data_dir"), &OS::get_user_data_dir);
+	ClassDB::bind_method(D_METHOD("get_system_dir", "dir", "shared_storage"), &OS::get_system_dir, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_config_dir"), &OS::get_config_dir);
+	ClassDB::bind_method(D_METHOD("get_data_dir"), &OS::get_data_dir);
+	ClassDB::bind_method(D_METHOD("get_cache_dir"), &OS::get_cache_dir);
+	ClassDB::bind_method(D_METHOD("get_unique_id"), &OS::get_unique_id);
 
-	ClassDB::bind_method(D_METHOD("print_all_textures_by_size"), &_OS::print_all_textures_by_size);
-	ClassDB::bind_method(D_METHOD("print_resources_by_type", "types"), &_OS::print_resources_by_type);
+	ClassDB::bind_method(D_METHOD("print_all_textures_by_size"), &OS::print_all_textures_by_size);
+	ClassDB::bind_method(D_METHOD("print_resources_by_type", "types"), &OS::print_resources_by_type);
 
-	ClassDB::bind_method(D_METHOD("get_keycode_string", "code"), &_OS::get_keycode_string);
-	ClassDB::bind_method(D_METHOD("is_keycode_unicode", "code"), &_OS::is_keycode_unicode);
-	ClassDB::bind_method(D_METHOD("find_keycode_from_string", "string"), &_OS::find_keycode_from_string);
+	ClassDB::bind_method(D_METHOD("get_keycode_string", "code"), &OS::get_keycode_string);
+	ClassDB::bind_method(D_METHOD("is_keycode_unicode", "code"), &OS::is_keycode_unicode);
+	ClassDB::bind_method(D_METHOD("find_keycode_from_string", "string"), &OS::find_keycode_from_string);
 
-	ClassDB::bind_method(D_METHOD("set_use_file_access_save_and_swap", "enabled"), &_OS::set_use_file_access_save_and_swap);
+	ClassDB::bind_method(D_METHOD("set_use_file_access_save_and_swap", "enabled"), &OS::set_use_file_access_save_and_swap);
 
-	ClassDB::bind_method(D_METHOD("set_thread_name", "name"), &_OS::set_thread_name);
-	ClassDB::bind_method(D_METHOD("get_thread_caller_id"), &_OS::get_thread_caller_id);
+	ClassDB::bind_method(D_METHOD("set_thread_name", "name"), &OS::set_thread_name);
+	ClassDB::bind_method(D_METHOD("get_thread_caller_id"), &OS::get_thread_caller_id);
 
-	ClassDB::bind_method(D_METHOD("has_feature", "tag_name"), &_OS::has_feature);
+	ClassDB::bind_method(D_METHOD("has_feature", "tag_name"), &OS::has_feature);
 
-	ClassDB::bind_method(D_METHOD("request_permission", "name"), &_OS::request_permission);
-	ClassDB::bind_method(D_METHOD("request_permissions"), &_OS::request_permissions);
-	ClassDB::bind_method(D_METHOD("get_granted_permissions"), &_OS::get_granted_permissions);
+	ClassDB::bind_method(D_METHOD("request_permission", "name"), &OS::request_permission);
+	ClassDB::bind_method(D_METHOD("request_permissions"), &OS::request_permissions);
+	ClassDB::bind_method(D_METHOD("get_granted_permissions"), &OS::get_granted_permissions);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "low_processor_usage_mode"), "set_low_processor_usage_mode", "is_in_low_processor_usage_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "low_processor_usage_mode_sleep_usec"), "set_low_processor_usage_mode_sleep_usec", "get_low_processor_usage_mode_sleep_usec");
@@ -630,43 +632,43 @@ void _OS::_bind_methods() {
 	BIND_ENUM_CONSTANT(SYSTEM_DIR_RINGTONES);
 }
 
-////// _Geometry2D //////
+////// Geometry2D //////
 
-_Geometry2D *_Geometry2D::singleton = nullptr;
+Geometry2D *Geometry2D::singleton = nullptr;
 
-_Geometry2D *_Geometry2D::get_singleton() {
+Geometry2D *Geometry2D::get_singleton() {
 	return singleton;
 }
 
-bool _Geometry2D::is_point_in_circle(const Vector2 &p_point, const Vector2 &p_circle_pos, real_t p_circle_radius) {
-	return Geometry2D::is_point_in_circle(p_point, p_circle_pos, p_circle_radius);
+bool Geometry2D::is_point_in_circle(const Vector2 &p_point, const Vector2 &p_circle_pos, real_t p_circle_radius) {
+	return ::Geometry2D::is_point_in_circle(p_point, p_circle_pos, p_circle_radius);
 }
 
-real_t _Geometry2D::segment_intersects_circle(const Vector2 &p_from, const Vector2 &p_to, const Vector2 &p_circle_pos, real_t p_circle_radius) {
-	return Geometry2D::segment_intersects_circle(p_from, p_to, p_circle_pos, p_circle_radius);
+real_t Geometry2D::segment_intersects_circle(const Vector2 &p_from, const Vector2 &p_to, const Vector2 &p_circle_pos, real_t p_circle_radius) {
+	return ::Geometry2D::segment_intersects_circle(p_from, p_to, p_circle_pos, p_circle_radius);
 }
 
-Variant _Geometry2D::segment_intersects_segment(const Vector2 &p_from_a, const Vector2 &p_to_a, const Vector2 &p_from_b, const Vector2 &p_to_b) {
+Variant Geometry2D::segment_intersects_segment(const Vector2 &p_from_a, const Vector2 &p_to_a, const Vector2 &p_from_b, const Vector2 &p_to_b) {
 	Vector2 result;
-	if (Geometry2D::segment_intersects_segment(p_from_a, p_to_a, p_from_b, p_to_b, &result)) {
+	if (::Geometry2D::segment_intersects_segment(p_from_a, p_to_a, p_from_b, p_to_b, &result)) {
 		return result;
 	} else {
 		return Variant();
 	}
 }
 
-Variant _Geometry2D::line_intersects_line(const Vector2 &p_from_a, const Vector2 &p_dir_a, const Vector2 &p_from_b, const Vector2 &p_dir_b) {
+Variant Geometry2D::line_intersects_line(const Vector2 &p_from_a, const Vector2 &p_dir_a, const Vector2 &p_from_b, const Vector2 &p_dir_b) {
 	Vector2 result;
-	if (Geometry2D::line_intersects_line(p_from_a, p_dir_a, p_from_b, p_dir_b, result)) {
+	if (::Geometry2D::line_intersects_line(p_from_a, p_dir_a, p_from_b, p_dir_b, result)) {
 		return result;
 	} else {
 		return Variant();
 	}
 }
 
-Vector<Vector2> _Geometry2D::get_closest_points_between_segments(const Vector2 &p1, const Vector2 &q1, const Vector2 &p2, const Vector2 &q2) {
+Vector<Vector2> Geometry2D::get_closest_points_between_segments(const Vector2 &p1, const Vector2 &q1, const Vector2 &p2, const Vector2 &q2) {
 	Vector2 r1, r2;
-	Geometry2D::get_closest_points_between_segments(p1, q1, p2, q2, r1, r2);
+	::Geometry2D::get_closest_points_between_segments(p1, q1, p2, q2, r1, r2);
 	Vector<Vector2> r;
 	r.resize(2);
 	r.set(0, r1);
@@ -674,42 +676,42 @@ Vector<Vector2> _Geometry2D::get_closest_points_between_segments(const Vector2 &
 	return r;
 }
 
-Vector2 _Geometry2D::get_closest_point_to_segment(const Vector2 &p_point, const Vector2 &p_a, const Vector2 &p_b) {
+Vector2 Geometry2D::get_closest_point_to_segment(const Vector2 &p_point, const Vector2 &p_a, const Vector2 &p_b) {
 	Vector2 s[2] = { p_a, p_b };
-	return Geometry2D::get_closest_point_to_segment(p_point, s);
+	return ::Geometry2D::get_closest_point_to_segment(p_point, s);
 }
 
-Vector2 _Geometry2D::get_closest_point_to_segment_uncapped(const Vector2 &p_point, const Vector2 &p_a, const Vector2 &p_b) {
+Vector2 Geometry2D::get_closest_point_to_segment_uncapped(const Vector2 &p_point, const Vector2 &p_a, const Vector2 &p_b) {
 	Vector2 s[2] = { p_a, p_b };
-	return Geometry2D::get_closest_point_to_segment_uncapped(p_point, s);
+	return ::Geometry2D::get_closest_point_to_segment_uncapped(p_point, s);
 }
 
-bool _Geometry2D::point_is_inside_triangle(const Vector2 &s, const Vector2 &a, const Vector2 &b, const Vector2 &c) const {
-	return Geometry2D::is_point_in_triangle(s, a, b, c);
+bool Geometry2D::point_is_inside_triangle(const Vector2 &s, const Vector2 &a, const Vector2 &b, const Vector2 &c) const {
+	return ::Geometry2D::is_point_in_triangle(s, a, b, c);
 }
 
-bool _Geometry2D::is_polygon_clockwise(const Vector<Vector2> &p_polygon) {
-	return Geometry2D::is_polygon_clockwise(p_polygon);
+bool Geometry2D::is_polygon_clockwise(const Vector<Vector2> &p_polygon) {
+	return ::Geometry2D::is_polygon_clockwise(p_polygon);
 }
 
-bool _Geometry2D::is_point_in_polygon(const Point2 &p_point, const Vector<Vector2> &p_polygon) {
-	return Geometry2D::is_point_in_polygon(p_point, p_polygon);
+bool Geometry2D::is_point_in_polygon(const Point2 &p_point, const Vector<Vector2> &p_polygon) {
+	return ::Geometry2D::is_point_in_polygon(p_point, p_polygon);
 }
 
-Vector<int> _Geometry2D::triangulate_polygon(const Vector<Vector2> &p_polygon) {
-	return Geometry2D::triangulate_polygon(p_polygon);
+Vector<int> Geometry2D::triangulate_polygon(const Vector<Vector2> &p_polygon) {
+	return ::Geometry2D::triangulate_polygon(p_polygon);
 }
 
-Vector<int> _Geometry2D::triangulate_delaunay(const Vector<Vector2> &p_points) {
-	return Geometry2D::triangulate_delaunay(p_points);
+Vector<int> Geometry2D::triangulate_delaunay(const Vector<Vector2> &p_points) {
+	return ::Geometry2D::triangulate_delaunay(p_points);
 }
 
-Vector<Point2> _Geometry2D::convex_hull(const Vector<Point2> &p_points) {
-	return Geometry2D::convex_hull(p_points);
+Vector<Point2> Geometry2D::convex_hull(const Vector<Point2> &p_points) {
+	return ::Geometry2D::convex_hull(p_points);
 }
 
-Array _Geometry2D::merge_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = Geometry2D::merge_polygons(p_polygon_a, p_polygon_b);
+Array Geometry2D::merge_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::merge_polygons(p_polygon_a, p_polygon_b);
 
 	Array ret;
 
@@ -719,8 +721,8 @@ Array _Geometry2D::merge_polygons(const Vector<Vector2> &p_polygon_a, const Vect
 	return ret;
 }
 
-Array _Geometry2D::clip_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = Geometry2D::clip_polygons(p_polygon_a, p_polygon_b);
+Array Geometry2D::clip_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polygons(p_polygon_a, p_polygon_b);
 
 	Array ret;
 
@@ -730,8 +732,8 @@ Array _Geometry2D::clip_polygons(const Vector<Vector2> &p_polygon_a, const Vecto
 	return ret;
 }
 
-Array _Geometry2D::intersect_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = Geometry2D::intersect_polygons(p_polygon_a, p_polygon_b);
+Array Geometry2D::intersect_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polygons(p_polygon_a, p_polygon_b);
 
 	Array ret;
 
@@ -741,8 +743,8 @@ Array _Geometry2D::intersect_polygons(const Vector<Vector2> &p_polygon_a, const 
 	return ret;
 }
 
-Array _Geometry2D::exclude_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = Geometry2D::exclude_polygons(p_polygon_a, p_polygon_b);
+Array Geometry2D::exclude_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::exclude_polygons(p_polygon_a, p_polygon_b);
 
 	Array ret;
 
@@ -752,8 +754,8 @@ Array _Geometry2D::exclude_polygons(const Vector<Vector2> &p_polygon_a, const Ve
 	return ret;
 }
 
-Array _Geometry2D::clip_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-	Vector<Vector<Point2>> polys = Geometry2D::clip_polyline_with_polygon(p_polyline, p_polygon);
+Array Geometry2D::clip_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polyline_with_polygon(p_polyline, p_polygon);
 
 	Array ret;
 
@@ -763,8 +765,8 @@ Array _Geometry2D::clip_polyline_with_polygon(const Vector<Vector2> &p_polyline,
 	return ret;
 }
 
-Array _Geometry2D::intersect_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-	Vector<Vector<Point2>> polys = Geometry2D::intersect_polyline_with_polygon(p_polyline, p_polygon);
+Array Geometry2D::intersect_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polyline_with_polygon(p_polyline, p_polygon);
 
 	Array ret;
 
@@ -774,8 +776,8 @@ Array _Geometry2D::intersect_polyline_with_polygon(const Vector<Vector2> &p_poly
 	return ret;
 }
 
-Array _Geometry2D::offset_polygon(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
-	Vector<Vector<Point2>> polys = Geometry2D::offset_polygon(p_polygon, p_delta, Geometry2D::PolyJoinType(p_join_type));
+Array Geometry2D::offset_polygon(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::offset_polygon(p_polygon, p_delta, ::Geometry2D::PolyJoinType(p_join_type));
 
 	Array ret;
 
@@ -785,8 +787,8 @@ Array _Geometry2D::offset_polygon(const Vector<Vector2> &p_polygon, real_t p_del
 	return ret;
 }
 
-Array _Geometry2D::offset_polyline(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
-	Vector<Vector<Point2>> polys = Geometry2D::offset_polyline(p_polygon, p_delta, Geometry2D::PolyJoinType(p_join_type), Geometry2D::PolyEndType(p_end_type));
+Array Geometry2D::offset_polyline(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::offset_polyline(p_polygon, p_delta, ::Geometry2D::PolyJoinType(p_join_type), ::Geometry2D::PolyEndType(p_end_type));
 
 	Array ret;
 
@@ -796,7 +798,7 @@ Array _Geometry2D::offset_polyline(const Vector<Vector2> &p_polygon, real_t p_de
 	return ret;
 }
 
-Dictionary _Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
+Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	Dictionary ret;
 
 	Vector<Size2i> rects;
@@ -807,7 +809,7 @@ Dictionary _Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	Vector<Point2i> result;
 	Size2i size;
 
-	Geometry2D::make_atlas(rects, result, size);
+	::Geometry2D::make_atlas(rects, result, size);
 
 	Size2 r_size = size;
 	Vector<Point2> r_result;
@@ -821,37 +823,37 @@ Dictionary _Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	return ret;
 }
 
-void _Geometry2D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("is_point_in_circle", "point", "circle_position", "circle_radius"), &_Geometry2D::is_point_in_circle);
-	ClassDB::bind_method(D_METHOD("segment_intersects_segment", "from_a", "to_a", "from_b", "to_b"), &_Geometry2D::segment_intersects_segment);
-	ClassDB::bind_method(D_METHOD("line_intersects_line", "from_a", "dir_a", "from_b", "dir_b"), &_Geometry2D::line_intersects_line);
+void Geometry2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_point_in_circle", "point", "circle_position", "circle_radius"), &Geometry2D::is_point_in_circle);
+	ClassDB::bind_method(D_METHOD("segment_intersects_segment", "from_a", "to_a", "from_b", "to_b"), &Geometry2D::segment_intersects_segment);
+	ClassDB::bind_method(D_METHOD("line_intersects_line", "from_a", "dir_a", "from_b", "dir_b"), &Geometry2D::line_intersects_line);
 
-	ClassDB::bind_method(D_METHOD("get_closest_points_between_segments", "p1", "q1", "p2", "q2"), &_Geometry2D::get_closest_points_between_segments);
+	ClassDB::bind_method(D_METHOD("get_closest_points_between_segments", "p1", "q1", "p2", "q2"), &Geometry2D::get_closest_points_between_segments);
 
-	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment", "point", "s1", "s2"), &_Geometry2D::get_closest_point_to_segment);
+	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment", "point", "s1", "s2"), &Geometry2D::get_closest_point_to_segment);
 
-	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment_uncapped", "point", "s1", "s2"), &_Geometry2D::get_closest_point_to_segment_uncapped);
+	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment_uncapped", "point", "s1", "s2"), &Geometry2D::get_closest_point_to_segment_uncapped);
 
-	ClassDB::bind_method(D_METHOD("point_is_inside_triangle", "point", "a", "b", "c"), &_Geometry2D::point_is_inside_triangle);
+	ClassDB::bind_method(D_METHOD("point_is_inside_triangle", "point", "a", "b", "c"), &Geometry2D::point_is_inside_triangle);
 
-	ClassDB::bind_method(D_METHOD("is_polygon_clockwise", "polygon"), &_Geometry2D::is_polygon_clockwise);
-	ClassDB::bind_method(D_METHOD("is_point_in_polygon", "point", "polygon"), &_Geometry2D::is_point_in_polygon);
-	ClassDB::bind_method(D_METHOD("triangulate_polygon", "polygon"), &_Geometry2D::triangulate_polygon);
-	ClassDB::bind_method(D_METHOD("triangulate_delaunay", "points"), &_Geometry2D::triangulate_delaunay);
-	ClassDB::bind_method(D_METHOD("convex_hull", "points"), &_Geometry2D::convex_hull);
+	ClassDB::bind_method(D_METHOD("is_polygon_clockwise", "polygon"), &Geometry2D::is_polygon_clockwise);
+	ClassDB::bind_method(D_METHOD("is_point_in_polygon", "point", "polygon"), &Geometry2D::is_point_in_polygon);
+	ClassDB::bind_method(D_METHOD("triangulate_polygon", "polygon"), &Geometry2D::triangulate_polygon);
+	ClassDB::bind_method(D_METHOD("triangulate_delaunay", "points"), &Geometry2D::triangulate_delaunay);
+	ClassDB::bind_method(D_METHOD("convex_hull", "points"), &Geometry2D::convex_hull);
 
-	ClassDB::bind_method(D_METHOD("merge_polygons", "polygon_a", "polygon_b"), &_Geometry2D::merge_polygons);
-	ClassDB::bind_method(D_METHOD("clip_polygons", "polygon_a", "polygon_b"), &_Geometry2D::clip_polygons);
-	ClassDB::bind_method(D_METHOD("intersect_polygons", "polygon_a", "polygon_b"), &_Geometry2D::intersect_polygons);
-	ClassDB::bind_method(D_METHOD("exclude_polygons", "polygon_a", "polygon_b"), &_Geometry2D::exclude_polygons);
+	ClassDB::bind_method(D_METHOD("merge_polygons", "polygon_a", "polygon_b"), &Geometry2D::merge_polygons);
+	ClassDB::bind_method(D_METHOD("clip_polygons", "polygon_a", "polygon_b"), &Geometry2D::clip_polygons);
+	ClassDB::bind_method(D_METHOD("intersect_polygons", "polygon_a", "polygon_b"), &Geometry2D::intersect_polygons);
+	ClassDB::bind_method(D_METHOD("exclude_polygons", "polygon_a", "polygon_b"), &Geometry2D::exclude_polygons);
 
-	ClassDB::bind_method(D_METHOD("clip_polyline_with_polygon", "polyline", "polygon"), &_Geometry2D::clip_polyline_with_polygon);
-	ClassDB::bind_method(D_METHOD("intersect_polyline_with_polygon", "polyline", "polygon"), &_Geometry2D::intersect_polyline_with_polygon);
+	ClassDB::bind_method(D_METHOD("clip_polyline_with_polygon", "polyline", "polygon"), &Geometry2D::clip_polyline_with_polygon);
+	ClassDB::bind_method(D_METHOD("intersect_polyline_with_polygon", "polyline", "polygon"), &Geometry2D::intersect_polyline_with_polygon);
 
-	ClassDB::bind_method(D_METHOD("offset_polygon", "polygon", "delta", "join_type"), &_Geometry2D::offset_polygon, DEFVAL(JOIN_SQUARE));
-	ClassDB::bind_method(D_METHOD("offset_polyline", "polyline", "delta", "join_type", "end_type"), &_Geometry2D::offset_polyline, DEFVAL(JOIN_SQUARE), DEFVAL(END_SQUARE));
+	ClassDB::bind_method(D_METHOD("offset_polygon", "polygon", "delta", "join_type"), &Geometry2D::offset_polygon, DEFVAL(JOIN_SQUARE));
+	ClassDB::bind_method(D_METHOD("offset_polyline", "polyline", "delta", "join_type", "end_type"), &Geometry2D::offset_polyline, DEFVAL(JOIN_SQUARE), DEFVAL(END_SQUARE));
 
-	ClassDB::bind_method(D_METHOD("make_atlas", "sizes"), &_Geometry2D::make_atlas);
+	ClassDB::bind_method(D_METHOD("make_atlas", "sizes"), &Geometry2D::make_atlas);
 
 	BIND_ENUM_CONSTANT(OPERATION_UNION);
 	BIND_ENUM_CONSTANT(OPERATION_DIFFERENCE);
@@ -869,29 +871,29 @@ void _Geometry2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(END_ROUND);
 }
 
-////// _Geometry3D //////
+////// Geometry3D //////
 
-_Geometry3D *_Geometry3D::singleton = nullptr;
+Geometry3D *Geometry3D::singleton = nullptr;
 
-_Geometry3D *_Geometry3D::get_singleton() {
+Geometry3D *Geometry3D::get_singleton() {
 	return singleton;
 }
 
-Vector<Plane> _Geometry3D::build_box_planes(const Vector3 &p_extents) {
-	return Geometry3D::build_box_planes(p_extents);
+Vector<Plane> Geometry3D::build_box_planes(const Vector3 &p_extents) {
+	return ::Geometry3D::build_box_planes(p_extents);
 }
 
-Vector<Plane> _Geometry3D::build_cylinder_planes(float p_radius, float p_height, int p_sides, Vector3::Axis p_axis) {
-	return Geometry3D::build_cylinder_planes(p_radius, p_height, p_sides, p_axis);
+Vector<Plane> Geometry3D::build_cylinder_planes(float p_radius, float p_height, int p_sides, Vector3::Axis p_axis) {
+	return ::Geometry3D::build_cylinder_planes(p_radius, p_height, p_sides, p_axis);
 }
 
-Vector<Plane> _Geometry3D::build_capsule_planes(float p_radius, float p_height, int p_sides, int p_lats, Vector3::Axis p_axis) {
-	return Geometry3D::build_capsule_planes(p_radius, p_height, p_sides, p_lats, p_axis);
+Vector<Plane> Geometry3D::build_capsule_planes(float p_radius, float p_height, int p_sides, int p_lats, Vector3::Axis p_axis) {
+	return ::Geometry3D::build_capsule_planes(p_radius, p_height, p_sides, p_lats, p_axis);
 }
 
-Vector<Vector3> _Geometry3D::get_closest_points_between_segments(const Vector3 &p1, const Vector3 &p2, const Vector3 &q1, const Vector3 &q2) {
+Vector<Vector3> Geometry3D::get_closest_points_between_segments(const Vector3 &p1, const Vector3 &p2, const Vector3 &q1, const Vector3 &q2) {
 	Vector3 r1, r2;
-	Geometry3D::get_closest_points_between_segments(p1, p2, q1, q2, r1, r2);
+	::Geometry3D::get_closest_points_between_segments(p1, p2, q1, q2, r1, r2);
 	Vector<Vector3> r;
 	r.resize(2);
 	r.set(0, r1);
@@ -899,38 +901,38 @@ Vector<Vector3> _Geometry3D::get_closest_points_between_segments(const Vector3 &
 	return r;
 }
 
-Vector3 _Geometry3D::get_closest_point_to_segment(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b) {
+Vector3 Geometry3D::get_closest_point_to_segment(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b) {
 	Vector3 s[2] = { p_a, p_b };
-	return Geometry3D::get_closest_point_to_segment(p_point, s);
+	return ::Geometry3D::get_closest_point_to_segment(p_point, s);
 }
 
-Vector3 _Geometry3D::get_closest_point_to_segment_uncapped(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b) {
+Vector3 Geometry3D::get_closest_point_to_segment_uncapped(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b) {
 	Vector3 s[2] = { p_a, p_b };
-	return Geometry3D::get_closest_point_to_segment_uncapped(p_point, s);
+	return ::Geometry3D::get_closest_point_to_segment_uncapped(p_point, s);
 }
 
-Variant _Geometry3D::ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2) {
+Variant Geometry3D::ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2) {
 	Vector3 res;
-	if (Geometry3D::ray_intersects_triangle(p_from, p_dir, p_v0, p_v1, p_v2, &res)) {
+	if (::Geometry3D::ray_intersects_triangle(p_from, p_dir, p_v0, p_v1, p_v2, &res)) {
 		return res;
 	} else {
 		return Variant();
 	}
 }
 
-Variant _Geometry3D::segment_intersects_triangle(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2) {
+Variant Geometry3D::segment_intersects_triangle(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2) {
 	Vector3 res;
-	if (Geometry3D::segment_intersects_triangle(p_from, p_to, p_v0, p_v1, p_v2, &res)) {
+	if (::Geometry3D::segment_intersects_triangle(p_from, p_to, p_v0, p_v1, p_v2, &res)) {
 		return res;
 	} else {
 		return Variant();
 	}
 }
 
-Vector<Vector3> _Geometry3D::segment_intersects_sphere(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_sphere_pos, real_t p_sphere_radius) {
+Vector<Vector3> Geometry3D::segment_intersects_sphere(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_sphere_pos, real_t p_sphere_radius) {
 	Vector<Vector3> r;
 	Vector3 res, norm;
-	if (!Geometry3D::segment_intersects_sphere(p_from, p_to, p_sphere_pos, p_sphere_radius, &res, &norm)) {
+	if (!::Geometry3D::segment_intersects_sphere(p_from, p_to, p_sphere_pos, p_sphere_radius, &res, &norm)) {
 		return r;
 	}
 
@@ -940,10 +942,10 @@ Vector<Vector3> _Geometry3D::segment_intersects_sphere(const Vector3 &p_from, co
 	return r;
 }
 
-Vector<Vector3> _Geometry3D::segment_intersects_cylinder(const Vector3 &p_from, const Vector3 &p_to, float p_height, float p_radius) {
+Vector<Vector3> Geometry3D::segment_intersects_cylinder(const Vector3 &p_from, const Vector3 &p_to, float p_height, float p_radius) {
 	Vector<Vector3> r;
 	Vector3 res, norm;
-	if (!Geometry3D::segment_intersects_cylinder(p_from, p_to, p_height, p_radius, &res, &norm)) {
+	if (!::Geometry3D::segment_intersects_cylinder(p_from, p_to, p_height, p_radius, &res, &norm)) {
 		return r;
 	}
 
@@ -953,10 +955,10 @@ Vector<Vector3> _Geometry3D::segment_intersects_cylinder(const Vector3 &p_from, 
 	return r;
 }
 
-Vector<Vector3> _Geometry3D::segment_intersects_convex(const Vector3 &p_from, const Vector3 &p_to, const Vector<Plane> &p_planes) {
+Vector<Vector3> Geometry3D::segment_intersects_convex(const Vector3 &p_from, const Vector3 &p_to, const Vector<Plane> &p_planes) {
 	Vector<Vector3> r;
 	Vector3 res, norm;
-	if (!Geometry3D::segment_intersects_convex(p_from, p_to, p_planes.ptr(), p_planes.size(), &res, &norm)) {
+	if (!::Geometry3D::segment_intersects_convex(p_from, p_to, p_planes.ptr(), p_planes.size(), &res, &norm)) {
 		return r;
 	}
 
@@ -966,33 +968,33 @@ Vector<Vector3> _Geometry3D::segment_intersects_convex(const Vector3 &p_from, co
 	return r;
 }
 
-Vector<Vector3> _Geometry3D::clip_polygon(const Vector<Vector3> &p_points, const Plane &p_plane) {
-	return Geometry3D::clip_polygon(p_points, p_plane);
+Vector<Vector3> Geometry3D::clip_polygon(const Vector<Vector3> &p_points, const Plane &p_plane) {
+	return ::Geometry3D::clip_polygon(p_points, p_plane);
 }
 
-void _Geometry3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("build_box_planes", "extents"), &_Geometry3D::build_box_planes);
-	ClassDB::bind_method(D_METHOD("build_cylinder_planes", "radius", "height", "sides", "axis"), &_Geometry3D::build_cylinder_planes, DEFVAL(Vector3::AXIS_Z));
-	ClassDB::bind_method(D_METHOD("build_capsule_planes", "radius", "height", "sides", "lats", "axis"), &_Geometry3D::build_capsule_planes, DEFVAL(Vector3::AXIS_Z));
+void Geometry3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("build_box_planes", "extents"), &Geometry3D::build_box_planes);
+	ClassDB::bind_method(D_METHOD("build_cylinder_planes", "radius", "height", "sides", "axis"), &Geometry3D::build_cylinder_planes, DEFVAL(Vector3::AXIS_Z));
+	ClassDB::bind_method(D_METHOD("build_capsule_planes", "radius", "height", "sides", "lats", "axis"), &Geometry3D::build_capsule_planes, DEFVAL(Vector3::AXIS_Z));
 
-	ClassDB::bind_method(D_METHOD("get_closest_points_between_segments", "p1", "p2", "q1", "q2"), &_Geometry3D::get_closest_points_between_segments);
+	ClassDB::bind_method(D_METHOD("get_closest_points_between_segments", "p1", "p2", "q1", "q2"), &Geometry3D::get_closest_points_between_segments);
 
-	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment", "point", "s1", "s2"), &_Geometry3D::get_closest_point_to_segment);
+	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment", "point", "s1", "s2"), &Geometry3D::get_closest_point_to_segment);
 
-	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment_uncapped", "point", "s1", "s2"), &_Geometry3D::get_closest_point_to_segment_uncapped);
+	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment_uncapped", "point", "s1", "s2"), &Geometry3D::get_closest_point_to_segment_uncapped);
 
-	ClassDB::bind_method(D_METHOD("ray_intersects_triangle", "from", "dir", "a", "b", "c"), &_Geometry3D::ray_intersects_triangle);
-	ClassDB::bind_method(D_METHOD("segment_intersects_triangle", "from", "to", "a", "b", "c"), &_Geometry3D::segment_intersects_triangle);
-	ClassDB::bind_method(D_METHOD("segment_intersects_sphere", "from", "to", "sphere_position", "sphere_radius"), &_Geometry3D::segment_intersects_sphere);
-	ClassDB::bind_method(D_METHOD("segment_intersects_cylinder", "from", "to", "height", "radius"), &_Geometry3D::segment_intersects_cylinder);
-	ClassDB::bind_method(D_METHOD("segment_intersects_convex", "from", "to", "planes"), &_Geometry3D::segment_intersects_convex);
+	ClassDB::bind_method(D_METHOD("ray_intersects_triangle", "from", "dir", "a", "b", "c"), &Geometry3D::ray_intersects_triangle);
+	ClassDB::bind_method(D_METHOD("segment_intersects_triangle", "from", "to", "a", "b", "c"), &Geometry3D::segment_intersects_triangle);
+	ClassDB::bind_method(D_METHOD("segment_intersects_sphere", "from", "to", "sphere_position", "sphere_radius"), &Geometry3D::segment_intersects_sphere);
+	ClassDB::bind_method(D_METHOD("segment_intersects_cylinder", "from", "to", "height", "radius"), &Geometry3D::segment_intersects_cylinder);
+	ClassDB::bind_method(D_METHOD("segment_intersects_convex", "from", "to", "planes"), &Geometry3D::segment_intersects_convex);
 
-	ClassDB::bind_method(D_METHOD("clip_polygon", "points", "plane"), &_Geometry3D::clip_polygon);
+	ClassDB::bind_method(D_METHOD("clip_polygon", "points", "plane"), &Geometry3D::clip_polygon);
 }
 
-////// _File //////
+////// File //////
 
-Error _File::open_encrypted(const String &p_path, ModeFlags p_mode_flags, const Vector<uint8_t> &p_key) {
+Error File::open_encrypted(const String &p_path, ModeFlags p_mode_flags, const Vector<uint8_t> &p_key) {
 	Error err = open(p_path, p_mode_flags);
 	if (err) {
 		return err;
@@ -1009,7 +1011,7 @@ Error _File::open_encrypted(const String &p_path, ModeFlags p_mode_flags, const 
 	return OK;
 }
 
-Error _File::open_encrypted_pass(const String &p_path, ModeFlags p_mode_flags, const String &p_pass) {
+Error File::open_encrypted_pass(const String &p_path, ModeFlags p_mode_flags, const String &p_pass) {
 	Error err = open(p_path, p_mode_flags);
 	if (err) {
 		return err;
@@ -1027,7 +1029,7 @@ Error _File::open_encrypted_pass(const String &p_path, ModeFlags p_mode_flags, c
 	return OK;
 }
 
-Error _File::open_compressed(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode) {
+Error File::open_compressed(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode) {
 	FileAccessCompressed *fac = memnew(FileAccessCompressed);
 
 	fac->configure("GCPF", (Compression::Mode)p_compress_mode);
@@ -1043,7 +1045,7 @@ Error _File::open_compressed(const String &p_path, ModeFlags p_mode_flags, Compr
 	return OK;
 }
 
-Error _File::open(const String &p_path, ModeFlags p_mode_flags) {
+Error File::open(const String &p_path, ModeFlags p_mode_flags) {
 	close();
 	Error err;
 	f = FileAccess::open(p_path, p_mode_flags, &err);
@@ -1053,94 +1055,94 @@ Error _File::open(const String &p_path, ModeFlags p_mode_flags) {
 	return err;
 }
 
-void _File::flush() {
+void File::flush() {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before flushing.");
 	f->flush();
 }
 
-void _File::close() {
+void File::close() {
 	if (f) {
 		memdelete(f);
 	}
 	f = nullptr;
 }
 
-bool _File::is_open() const {
+bool File::is_open() const {
 	return f != nullptr;
 }
 
-String _File::get_path() const {
+String File::get_path() const {
 	ERR_FAIL_COND_V_MSG(!f, "", "File must be opened before use.");
 	return f->get_path();
 }
 
-String _File::get_path_absolute() const {
+String File::get_path_absolute() const {
 	ERR_FAIL_COND_V_MSG(!f, "", "File must be opened before use.");
 	return f->get_path_absolute();
 }
 
-void _File::seek(int64_t p_position) {
+void File::seek(int64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	ERR_FAIL_COND_MSG(p_position < 0, "Seek position must be a positive integer.");
 	f->seek(p_position);
 }
 
-void _File::seek_end(int64_t p_position) {
+void File::seek_end(int64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	f->seek_end(p_position);
 }
 
-uint64_t _File::get_position() const {
+uint64_t File::get_position() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_position();
 }
 
-uint64_t _File::get_length() const {
+uint64_t File::get_length() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_length();
 }
 
-bool _File::eof_reached() const {
+bool File::eof_reached() const {
 	ERR_FAIL_COND_V_MSG(!f, false, "File must be opened before use.");
 	return f->eof_reached();
 }
 
-uint8_t _File::get_8() const {
+uint8_t File::get_8() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_8();
 }
 
-uint16_t _File::get_16() const {
+uint16_t File::get_16() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_16();
 }
 
-uint32_t _File::get_32() const {
+uint32_t File::get_32() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_32();
 }
 
-uint64_t _File::get_64() const {
+uint64_t File::get_64() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_64();
 }
 
-float _File::get_float() const {
+float File::get_float() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_float();
 }
 
-double _File::get_double() const {
+double File::get_double() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_double();
 }
 
-real_t _File::get_real() const {
+real_t File::get_real() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_real();
 }
 
-Vector<uint8_t> _File::get_buffer(int64_t p_length) const {
+Vector<uint8_t> File::get_buffer(int64_t p_length) const {
 	Vector<uint8_t> data;
 	ERR_FAIL_COND_V_MSG(!f, data, "File must be opened before use.");
 
@@ -1162,7 +1164,7 @@ Vector<uint8_t> _File::get_buffer(int64_t p_length) const {
 	return data;
 }
 
-String _File::get_as_text() const {
+String File::get_as_text() const {
 	ERR_FAIL_COND_V_MSG(!f, String(), "File must be opened before use.");
 
 	String text;
@@ -1181,20 +1183,20 @@ String _File::get_as_text() const {
 	return text;
 }
 
-String _File::get_md5(const String &p_path) const {
+String File::get_md5(const String &p_path) const {
 	return FileAccess::get_md5(p_path);
 }
 
-String _File::get_sha256(const String &p_path) const {
+String File::get_sha256(const String &p_path) const {
 	return FileAccess::get_sha256(p_path);
 }
 
-String _File::get_line() const {
+String File::get_line() const {
 	ERR_FAIL_COND_V_MSG(!f, String(), "File must be opened before use.");
 	return f->get_line();
 }
 
-Vector<String> _File::get_csv_line(const String &p_delim) const {
+Vector<String> File::get_csv_line(const String &p_delim) const {
 	ERR_FAIL_COND_V_MSG(!f, Vector<String>(), "File must be opened before use.");
 	return f->get_csv_line(p_delim);
 }
@@ -1204,95 +1206,95 @@ Vector<String> _File::get_csv_line(const String &p_delim) const {
  * These flags get reset to false (little endian) on each open
  */
 
-void _File::set_big_endian(bool p_big_endian) {
+void File::set_big_endian(bool p_big_endian) {
 	big_endian = p_big_endian;
 	if (f) {
 		f->set_big_endian(p_big_endian);
 	}
 }
 
-bool _File::is_big_endian() {
+bool File::is_big_endian() {
 	return big_endian;
 }
 
-Error _File::get_error() const {
+Error File::get_error() const {
 	if (!f) {
 		return ERR_UNCONFIGURED;
 	}
 	return f->get_error();
 }
 
-void _File::store_8(uint8_t p_dest) {
+void File::store_8(uint8_t p_dest) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_8(p_dest);
 }
 
-void _File::store_16(uint16_t p_dest) {
+void File::store_16(uint16_t p_dest) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_16(p_dest);
 }
 
-void _File::store_32(uint32_t p_dest) {
+void File::store_32(uint32_t p_dest) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_32(p_dest);
 }
 
-void _File::store_64(uint64_t p_dest) {
+void File::store_64(uint64_t p_dest) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_64(p_dest);
 }
 
-void _File::store_float(float p_dest) {
+void File::store_float(float p_dest) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_float(p_dest);
 }
 
-void _File::store_double(double p_dest) {
+void File::store_double(double p_dest) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_double(p_dest);
 }
 
-void _File::store_real(real_t p_real) {
+void File::store_real(real_t p_real) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_real(p_real);
 }
 
-void _File::store_string(const String &p_string) {
+void File::store_string(const String &p_string) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_string(p_string);
 }
 
-void _File::store_pascal_string(const String &p_string) {
+void File::store_pascal_string(const String &p_string) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_pascal_string(p_string);
 }
 
-String _File::get_pascal_string() {
+String File::get_pascal_string() {
 	ERR_FAIL_COND_V_MSG(!f, "", "File must be opened before use.");
 
 	return f->get_pascal_string();
 }
 
-void _File::store_line(const String &p_string) {
+void File::store_line(const String &p_string) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	f->store_line(p_string);
 }
 
-void _File::store_csv_line(const Vector<String> &p_values, const String &p_delim) {
+void File::store_csv_line(const Vector<String> &p_values, const String &p_delim) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	f->store_csv_line(p_values, p_delim);
 }
 
-void _File::store_buffer(const Vector<uint8_t> &p_buffer) {
+void File::store_buffer(const Vector<uint8_t> &p_buffer) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	uint64_t len = p_buffer.size();
@@ -1305,11 +1307,11 @@ void _File::store_buffer(const Vector<uint8_t> &p_buffer) {
 	f->store_buffer(&r[0], len);
 }
 
-bool _File::file_exists(const String &p_name) const {
+bool File::file_exists(const String &p_name) const {
 	return FileAccess::exists(p_name);
 }
 
-void _File::store_var(const Variant &p_var, bool p_full_objects) {
+void File::store_var(const Variant &p_var, bool p_full_objects) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	int len;
 	Error err = encode_variant(p_var, nullptr, len, p_full_objects);
@@ -1326,7 +1328,7 @@ void _File::store_var(const Variant &p_var, bool p_full_objects) {
 	store_buffer(buff);
 }
 
-Variant _File::get_var(bool p_allow_objects) const {
+Variant File::get_var(bool p_allow_objects) const {
 	ERR_FAIL_COND_V_MSG(!f, Variant(), "File must be opened before use.");
 	uint32_t len = get_32();
 	Vector<uint8_t> buff = get_buffer(len);
@@ -1341,62 +1343,62 @@ Variant _File::get_var(bool p_allow_objects) const {
 	return v;
 }
 
-uint64_t _File::get_modified_time(const String &p_file) const {
+uint64_t File::get_modified_time(const String &p_file) const {
 	return FileAccess::get_modified_time(p_file);
 }
 
-void _File::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("open_encrypted", "path", "mode_flags", "key"), &_File::open_encrypted);
-	ClassDB::bind_method(D_METHOD("open_encrypted_with_pass", "path", "mode_flags", "pass"), &_File::open_encrypted_pass);
-	ClassDB::bind_method(D_METHOD("open_compressed", "path", "mode_flags", "compression_mode"), &_File::open_compressed, DEFVAL(0));
+void File::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("open_encrypted", "path", "mode_flags", "key"), &File::open_encrypted);
+	ClassDB::bind_method(D_METHOD("open_encrypted_with_pass", "path", "mode_flags", "pass"), &File::open_encrypted_pass);
+	ClassDB::bind_method(D_METHOD("open_compressed", "path", "mode_flags", "compression_mode"), &File::open_compressed, DEFVAL(0));
 
-	ClassDB::bind_method(D_METHOD("open", "path", "flags"), &_File::open);
-	ClassDB::bind_method(D_METHOD("flush"), &_File::flush);
-	ClassDB::bind_method(D_METHOD("close"), &_File::close);
-	ClassDB::bind_method(D_METHOD("get_path"), &_File::get_path);
-	ClassDB::bind_method(D_METHOD("get_path_absolute"), &_File::get_path_absolute);
-	ClassDB::bind_method(D_METHOD("is_open"), &_File::is_open);
-	ClassDB::bind_method(D_METHOD("seek", "position"), &_File::seek);
-	ClassDB::bind_method(D_METHOD("seek_end", "position"), &_File::seek_end, DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("get_position"), &_File::get_position);
-	ClassDB::bind_method(D_METHOD("get_length"), &_File::get_length);
-	ClassDB::bind_method(D_METHOD("eof_reached"), &_File::eof_reached);
-	ClassDB::bind_method(D_METHOD("get_8"), &_File::get_8);
-	ClassDB::bind_method(D_METHOD("get_16"), &_File::get_16);
-	ClassDB::bind_method(D_METHOD("get_32"), &_File::get_32);
-	ClassDB::bind_method(D_METHOD("get_64"), &_File::get_64);
-	ClassDB::bind_method(D_METHOD("get_float"), &_File::get_float);
-	ClassDB::bind_method(D_METHOD("get_double"), &_File::get_double);
-	ClassDB::bind_method(D_METHOD("get_real"), &_File::get_real);
-	ClassDB::bind_method(D_METHOD("get_buffer", "length"), &_File::get_buffer);
-	ClassDB::bind_method(D_METHOD("get_line"), &_File::get_line);
-	ClassDB::bind_method(D_METHOD("get_csv_line", "delim"), &_File::get_csv_line, DEFVAL(","));
-	ClassDB::bind_method(D_METHOD("get_as_text"), &_File::get_as_text);
-	ClassDB::bind_method(D_METHOD("get_md5", "path"), &_File::get_md5);
-	ClassDB::bind_method(D_METHOD("get_sha256", "path"), &_File::get_sha256);
-	ClassDB::bind_method(D_METHOD("is_big_endian"), &_File::is_big_endian);
-	ClassDB::bind_method(D_METHOD("set_big_endian", "big_endian"), &_File::set_big_endian);
-	ClassDB::bind_method(D_METHOD("get_error"), &_File::get_error);
-	ClassDB::bind_method(D_METHOD("get_var", "allow_objects"), &_File::get_var, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("open", "path", "flags"), &File::open);
+	ClassDB::bind_method(D_METHOD("flush"), &File::flush);
+	ClassDB::bind_method(D_METHOD("close"), &File::close);
+	ClassDB::bind_method(D_METHOD("get_path"), &File::get_path);
+	ClassDB::bind_method(D_METHOD("get_path_absolute"), &File::get_path_absolute);
+	ClassDB::bind_method(D_METHOD("is_open"), &File::is_open);
+	ClassDB::bind_method(D_METHOD("seek", "position"), &File::seek);
+	ClassDB::bind_method(D_METHOD("seek_end", "position"), &File::seek_end, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_position"), &File::get_position);
+	ClassDB::bind_method(D_METHOD("get_length"), &File::get_length);
+	ClassDB::bind_method(D_METHOD("eof_reached"), &File::eof_reached);
+	ClassDB::bind_method(D_METHOD("get_8"), &File::get_8);
+	ClassDB::bind_method(D_METHOD("get_16"), &File::get_16);
+	ClassDB::bind_method(D_METHOD("get_32"), &File::get_32);
+	ClassDB::bind_method(D_METHOD("get_64"), &File::get_64);
+	ClassDB::bind_method(D_METHOD("get_float"), &File::get_float);
+	ClassDB::bind_method(D_METHOD("get_double"), &File::get_double);
+	ClassDB::bind_method(D_METHOD("get_real"), &File::get_real);
+	ClassDB::bind_method(D_METHOD("get_buffer", "length"), &File::get_buffer);
+	ClassDB::bind_method(D_METHOD("get_line"), &File::get_line);
+	ClassDB::bind_method(D_METHOD("get_csv_line", "delim"), &File::get_csv_line, DEFVAL(","));
+	ClassDB::bind_method(D_METHOD("get_as_text"), &File::get_as_text);
+	ClassDB::bind_method(D_METHOD("get_md5", "path"), &File::get_md5);
+	ClassDB::bind_method(D_METHOD("get_sha256", "path"), &File::get_sha256);
+	ClassDB::bind_method(D_METHOD("is_big_endian"), &File::is_big_endian);
+	ClassDB::bind_method(D_METHOD("set_big_endian", "big_endian"), &File::set_big_endian);
+	ClassDB::bind_method(D_METHOD("get_error"), &File::get_error);
+	ClassDB::bind_method(D_METHOD("get_var", "allow_objects"), &File::get_var, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("store_8", "value"), &_File::store_8);
-	ClassDB::bind_method(D_METHOD("store_16", "value"), &_File::store_16);
-	ClassDB::bind_method(D_METHOD("store_32", "value"), &_File::store_32);
-	ClassDB::bind_method(D_METHOD("store_64", "value"), &_File::store_64);
-	ClassDB::bind_method(D_METHOD("store_float", "value"), &_File::store_float);
-	ClassDB::bind_method(D_METHOD("store_double", "value"), &_File::store_double);
-	ClassDB::bind_method(D_METHOD("store_real", "value"), &_File::store_real);
-	ClassDB::bind_method(D_METHOD("store_buffer", "buffer"), &_File::store_buffer);
-	ClassDB::bind_method(D_METHOD("store_line", "line"), &_File::store_line);
-	ClassDB::bind_method(D_METHOD("store_csv_line", "values", "delim"), &_File::store_csv_line, DEFVAL(","));
-	ClassDB::bind_method(D_METHOD("store_string", "string"), &_File::store_string);
-	ClassDB::bind_method(D_METHOD("store_var", "value", "full_objects"), &_File::store_var, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("store_8", "value"), &File::store_8);
+	ClassDB::bind_method(D_METHOD("store_16", "value"), &File::store_16);
+	ClassDB::bind_method(D_METHOD("store_32", "value"), &File::store_32);
+	ClassDB::bind_method(D_METHOD("store_64", "value"), &File::store_64);
+	ClassDB::bind_method(D_METHOD("store_float", "value"), &File::store_float);
+	ClassDB::bind_method(D_METHOD("store_double", "value"), &File::store_double);
+	ClassDB::bind_method(D_METHOD("store_real", "value"), &File::store_real);
+	ClassDB::bind_method(D_METHOD("store_buffer", "buffer"), &File::store_buffer);
+	ClassDB::bind_method(D_METHOD("store_line", "line"), &File::store_line);
+	ClassDB::bind_method(D_METHOD("store_csv_line", "values", "delim"), &File::store_csv_line, DEFVAL(","));
+	ClassDB::bind_method(D_METHOD("store_string", "string"), &File::store_string);
+	ClassDB::bind_method(D_METHOD("store_var", "value", "full_objects"), &File::store_var, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("store_pascal_string", "string"), &_File::store_pascal_string);
-	ClassDB::bind_method(D_METHOD("get_pascal_string"), &_File::get_pascal_string);
+	ClassDB::bind_method(D_METHOD("store_pascal_string", "string"), &File::store_pascal_string);
+	ClassDB::bind_method(D_METHOD("get_pascal_string"), &File::get_pascal_string);
 
-	ClassDB::bind_method(D_METHOD("file_exists", "path"), &_File::file_exists);
-	ClassDB::bind_method(D_METHOD("get_modified_time", "file"), &_File::get_modified_time);
+	ClassDB::bind_method(D_METHOD("file_exists", "path"), &File::file_exists);
+	ClassDB::bind_method(D_METHOD("get_modified_time", "file"), &File::get_modified_time);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "big_endian"), "set_big_endian", "is_big_endian");
 
@@ -1411,15 +1413,15 @@ void _File::_bind_methods() {
 	BIND_ENUM_CONSTANT(COMPRESSION_GZIP);
 }
 
-_File::~_File() {
+File::~File() {
 	if (f) {
 		memdelete(f);
 	}
 }
 
-////// _Directory //////
+////// Directory //////
 
-Error _Directory::open(const String &p_path) {
+Error Directory::open(const String &p_path) {
 	Error err;
 	DirAccess *alt = DirAccess::open(p_path, &err);
 
@@ -1435,11 +1437,11 @@ Error _Directory::open(const String &p_path) {
 	return OK;
 }
 
-bool _Directory::is_open() const {
+bool Directory::is_open() const {
 	return d && dir_open;
 }
 
-Error _Directory::list_dir_begin(bool p_show_navigational, bool p_show_hidden) {
+Error Directory::list_dir_begin(bool p_show_navigational, bool p_show_hidden) {
 	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 
 	_list_skip_navigational = !p_show_navigational;
@@ -1448,7 +1450,7 @@ Error _Directory::list_dir_begin(bool p_show_navigational, bool p_show_hidden) {
 	return d->list_dir_begin();
 }
 
-String _Directory::get_next() {
+String Directory::get_next() {
 	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
 
 	String next = d->get_next();
@@ -1458,32 +1460,32 @@ String _Directory::get_next() {
 	return next;
 }
 
-bool _Directory::current_is_dir() const {
+bool Directory::current_is_dir() const {
 	ERR_FAIL_COND_V_MSG(!is_open(), false, "Directory must be opened before use.");
 	return d->current_is_dir();
 }
 
-void _Directory::list_dir_end() {
+void Directory::list_dir_end() {
 	ERR_FAIL_COND_MSG(!is_open(), "Directory must be opened before use.");
 	d->list_dir_end();
 }
 
-int _Directory::get_drive_count() {
+int Directory::get_drive_count() {
 	ERR_FAIL_COND_V_MSG(!is_open(), 0, "Directory must be opened before use.");
 	return d->get_drive_count();
 }
 
-String _Directory::get_drive(int p_drive) {
+String Directory::get_drive(int p_drive) {
 	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
 	return d->get_drive(p_drive);
 }
 
-int _Directory::get_current_drive() {
+int Directory::get_current_drive() {
 	ERR_FAIL_COND_V_MSG(!is_open(), 0, "Directory must be opened before use.");
 	return d->get_current_drive();
 }
 
-Error _Directory::change_dir(String p_dir) {
+Error Directory::change_dir(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
 	Error err = d->change_dir(p_dir);
 
@@ -1495,12 +1497,12 @@ Error _Directory::change_dir(String p_dir) {
 	return OK;
 }
 
-String _Directory::get_current_dir() {
+String Directory::get_current_dir() {
 	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
 	return d->get_current_dir();
 }
 
-Error _Directory::make_dir(String p_dir) {
+Error Directory::make_dir(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
@@ -1511,7 +1513,7 @@ Error _Directory::make_dir(String p_dir) {
 	return d->make_dir(p_dir);
 }
 
-Error _Directory::make_dir_recursive(String p_dir) {
+Error Directory::make_dir_recursive(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
@@ -1522,7 +1524,7 @@ Error _Directory::make_dir_recursive(String p_dir) {
 	return d->make_dir_recursive(p_dir);
 }
 
-bool _Directory::file_exists(String p_file) {
+bool Directory::file_exists(String p_file) {
 	ERR_FAIL_COND_V_MSG(!d, false, "Directory is not configured properly.");
 	if (!p_file.is_rel_path()) {
 		return FileAccess::exists(p_file);
@@ -1531,7 +1533,7 @@ bool _Directory::file_exists(String p_file) {
 	return d->file_exists(p_file);
 }
 
-bool _Directory::dir_exists(String p_dir) {
+bool Directory::dir_exists(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, false, "Directory is not configured properly.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
@@ -1543,17 +1545,17 @@ bool _Directory::dir_exists(String p_dir) {
 	return d->dir_exists(p_dir);
 }
 
-uint64_t _Directory::get_space_left() {
+uint64_t Directory::get_space_left() {
 	ERR_FAIL_COND_V_MSG(!d, 0, "Directory must be opened before use.");
 	return d->get_space_left() / 1024 * 1024; // Truncate to closest MiB.
 }
 
-Error _Directory::copy(String p_from, String p_to) {
+Error Directory::copy(String p_from, String p_to) {
 	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	return d->copy(p_from, p_to);
 }
 
-Error _Directory::rename(String p_from, String p_to) {
+Error Directory::rename(String p_from, String p_to) {
 	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_from.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_from);
@@ -1567,7 +1569,7 @@ Error _Directory::rename(String p_from, String p_to) {
 	return d->rename(p_from, p_to);
 }
 
-Error _Directory::remove(String p_name) {
+Error Directory::remove(String p_name) {
 	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_name.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_name);
@@ -1579,47 +1581,47 @@ Error _Directory::remove(String p_name) {
 	return d->remove(p_name);
 }
 
-void _Directory::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("open", "path"), &_Directory::open);
-	ClassDB::bind_method(D_METHOD("list_dir_begin", "show_navigational", "show_hidden"), &_Directory::list_dir_begin, DEFVAL(false), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("get_next"), &_Directory::get_next);
-	ClassDB::bind_method(D_METHOD("current_is_dir"), &_Directory::current_is_dir);
-	ClassDB::bind_method(D_METHOD("list_dir_end"), &_Directory::list_dir_end);
-	ClassDB::bind_method(D_METHOD("get_drive_count"), &_Directory::get_drive_count);
-	ClassDB::bind_method(D_METHOD("get_drive", "idx"), &_Directory::get_drive);
-	ClassDB::bind_method(D_METHOD("get_current_drive"), &_Directory::get_current_drive);
-	ClassDB::bind_method(D_METHOD("change_dir", "todir"), &_Directory::change_dir);
-	ClassDB::bind_method(D_METHOD("get_current_dir"), &_Directory::get_current_dir);
-	ClassDB::bind_method(D_METHOD("make_dir", "path"), &_Directory::make_dir);
-	ClassDB::bind_method(D_METHOD("make_dir_recursive", "path"), &_Directory::make_dir_recursive);
-	ClassDB::bind_method(D_METHOD("file_exists", "path"), &_Directory::file_exists);
-	ClassDB::bind_method(D_METHOD("dir_exists", "path"), &_Directory::dir_exists);
-	//ClassDB::bind_method(D_METHOD("get_modified_time","file"),&_Directory::get_modified_time);
-	ClassDB::bind_method(D_METHOD("get_space_left"), &_Directory::get_space_left);
-	ClassDB::bind_method(D_METHOD("copy", "from", "to"), &_Directory::copy);
-	ClassDB::bind_method(D_METHOD("rename", "from", "to"), &_Directory::rename);
-	ClassDB::bind_method(D_METHOD("remove", "path"), &_Directory::remove);
+void Directory::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("open", "path"), &Directory::open);
+	ClassDB::bind_method(D_METHOD("list_dir_begin", "show_navigational", "show_hidden"), &Directory::list_dir_begin, DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_next"), &Directory::get_next);
+	ClassDB::bind_method(D_METHOD("current_is_dir"), &Directory::current_is_dir);
+	ClassDB::bind_method(D_METHOD("list_dir_end"), &Directory::list_dir_end);
+	ClassDB::bind_method(D_METHOD("get_drive_count"), &Directory::get_drive_count);
+	ClassDB::bind_method(D_METHOD("get_drive", "idx"), &Directory::get_drive);
+	ClassDB::bind_method(D_METHOD("get_current_drive"), &Directory::get_current_drive);
+	ClassDB::bind_method(D_METHOD("change_dir", "todir"), &Directory::change_dir);
+	ClassDB::bind_method(D_METHOD("get_current_dir"), &Directory::get_current_dir);
+	ClassDB::bind_method(D_METHOD("make_dir", "path"), &Directory::make_dir);
+	ClassDB::bind_method(D_METHOD("make_dir_recursive", "path"), &Directory::make_dir_recursive);
+	ClassDB::bind_method(D_METHOD("file_exists", "path"), &Directory::file_exists);
+	ClassDB::bind_method(D_METHOD("dir_exists", "path"), &Directory::dir_exists);
+	//ClassDB::bind_method(D_METHOD("get_modified_time","file"),&Directory::get_modified_time);
+	ClassDB::bind_method(D_METHOD("get_space_left"), &Directory::get_space_left);
+	ClassDB::bind_method(D_METHOD("copy", "from", "to"), &Directory::copy);
+	ClassDB::bind_method(D_METHOD("rename", "from", "to"), &Directory::rename);
+	ClassDB::bind_method(D_METHOD("remove", "path"), &Directory::remove);
 }
 
-_Directory::_Directory() {
+Directory::Directory() {
 	d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 }
 
-_Directory::~_Directory() {
+Directory::~Directory() {
 	if (d) {
 		memdelete(d);
 	}
 }
 
-////// _Marshalls //////
+////// Marshalls //////
 
-_Marshalls *_Marshalls::singleton = nullptr;
+Marshalls *Marshalls::singleton = nullptr;
 
-_Marshalls *_Marshalls::get_singleton() {
+Marshalls *Marshalls::get_singleton() {
 	return singleton;
 }
 
-String _Marshalls::variant_to_base64(const Variant &p_var, bool p_full_objects) {
+String Marshalls::variant_to_base64(const Variant &p_var, bool p_full_objects) {
 	int len;
 	Error err = encode_variant(p_var, nullptr, len, p_full_objects);
 	ERR_FAIL_COND_V_MSG(err != OK, "", "Error when trying to encode Variant.");
@@ -1637,7 +1639,7 @@ String _Marshalls::variant_to_base64(const Variant &p_var, bool p_full_objects) 
 	return ret;
 }
 
-Variant _Marshalls::base64_to_variant(const String &p_str, bool p_allow_objects) {
+Variant Marshalls::base64_to_variant(const String &p_str, bool p_allow_objects) {
 	int strlen = p_str.length();
 	CharString cstr = p_str.ascii();
 
@@ -1655,13 +1657,13 @@ Variant _Marshalls::base64_to_variant(const String &p_str, bool p_allow_objects)
 	return v;
 }
 
-String _Marshalls::raw_to_base64(const Vector<uint8_t> &p_arr) {
+String Marshalls::raw_to_base64(const Vector<uint8_t> &p_arr) {
 	String ret = CryptoCore::b64_encode_str(p_arr.ptr(), p_arr.size());
 	ERR_FAIL_COND_V(ret == "", ret);
 	return ret;
 }
 
-Vector<uint8_t> _Marshalls::base64_to_raw(const String &p_str) {
+Vector<uint8_t> Marshalls::base64_to_raw(const String &p_str) {
 	int strlen = p_str.length();
 	CharString cstr = p_str.ascii();
 
@@ -1678,14 +1680,14 @@ Vector<uint8_t> _Marshalls::base64_to_raw(const String &p_str) {
 	return buf;
 }
 
-String _Marshalls::utf8_to_base64(const String &p_str) {
+String Marshalls::utf8_to_base64(const String &p_str) {
 	CharString cstr = p_str.utf8();
 	String ret = CryptoCore::b64_encode_str((unsigned char *)cstr.get_data(), cstr.length());
 	ERR_FAIL_COND_V(ret == "", ret);
 	return ret;
 }
 
-String _Marshalls::base64_to_utf8(const String &p_str) {
+String Marshalls::base64_to_utf8(const String &p_str) {
 	int strlen = p_str.length();
 	CharString cstr = p_str.ascii();
 
@@ -1702,62 +1704,62 @@ String _Marshalls::base64_to_utf8(const String &p_str) {
 	return ret;
 }
 
-void _Marshalls::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("variant_to_base64", "variant", "full_objects"), &_Marshalls::variant_to_base64, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("base64_to_variant", "base64_str", "allow_objects"), &_Marshalls::base64_to_variant, DEFVAL(false));
+void Marshalls::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("variant_to_base64", "variant", "full_objects"), &Marshalls::variant_to_base64, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("base64_to_variant", "base64_str", "allow_objects"), &Marshalls::base64_to_variant, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("raw_to_base64", "array"), &_Marshalls::raw_to_base64);
-	ClassDB::bind_method(D_METHOD("base64_to_raw", "base64_str"), &_Marshalls::base64_to_raw);
+	ClassDB::bind_method(D_METHOD("raw_to_base64", "array"), &Marshalls::raw_to_base64);
+	ClassDB::bind_method(D_METHOD("base64_to_raw", "base64_str"), &Marshalls::base64_to_raw);
 
-	ClassDB::bind_method(D_METHOD("utf8_to_base64", "utf8_str"), &_Marshalls::utf8_to_base64);
-	ClassDB::bind_method(D_METHOD("base64_to_utf8", "base64_str"), &_Marshalls::base64_to_utf8);
+	ClassDB::bind_method(D_METHOD("utf8_to_base64", "utf8_str"), &Marshalls::utf8_to_base64);
+	ClassDB::bind_method(D_METHOD("base64_to_utf8", "base64_str"), &Marshalls::base64_to_utf8);
 }
 
-////// _Semaphore //////
+////// Semaphore //////
 
-void _Semaphore::wait() {
+void Semaphore::wait() {
 	semaphore.wait();
 }
 
-Error _Semaphore::try_wait() {
+Error Semaphore::try_wait() {
 	return semaphore.try_wait() ? OK : ERR_BUSY;
 }
 
-void _Semaphore::post() {
+void Semaphore::post() {
 	semaphore.post();
 }
 
-void _Semaphore::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("wait"), &_Semaphore::wait);
-	ClassDB::bind_method(D_METHOD("try_wait"), &_Semaphore::try_wait);
-	ClassDB::bind_method(D_METHOD("post"), &_Semaphore::post);
+void Semaphore::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("wait"), &Semaphore::wait);
+	ClassDB::bind_method(D_METHOD("try_wait"), &Semaphore::try_wait);
+	ClassDB::bind_method(D_METHOD("post"), &Semaphore::post);
 }
 
-////// _Mutex //////
+////// Mutex //////
 
-void _Mutex::lock() {
+void Mutex::lock() {
 	mutex.lock();
 }
 
-Error _Mutex::try_lock() {
+Error Mutex::try_lock() {
 	return mutex.try_lock();
 }
 
-void _Mutex::unlock() {
+void Mutex::unlock() {
 	mutex.unlock();
 }
 
-void _Mutex::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("lock"), &_Mutex::lock);
-	ClassDB::bind_method(D_METHOD("try_lock"), &_Mutex::try_lock);
-	ClassDB::bind_method(D_METHOD("unlock"), &_Mutex::unlock);
+void Mutex::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("lock"), &Mutex::lock);
+	ClassDB::bind_method(D_METHOD("try_lock"), &Mutex::try_lock);
+	ClassDB::bind_method(D_METHOD("unlock"), &Mutex::unlock);
 }
 
-////// _Thread //////
+////// Thread //////
 
-void _Thread::_start_func(void *ud) {
-	Ref<_Thread> *tud = (Ref<_Thread> *)ud;
-	Ref<_Thread> t = *tud;
+void Thread::_start_func(void *ud) {
+	Ref<Thread> *tud = (Ref<Thread> *)ud;
+	Ref<Thread> t = *tud;
 	memdelete(tud);
 	Callable::CallError ce;
 	const Variant *arg[1] = { &t->userdata };
@@ -1792,7 +1794,7 @@ void _Thread::_start_func(void *ud) {
 		}
 	}
 
-	Thread::set_name(t->target_method);
+	::Thread::set_name(t->target_method);
 
 	t->ret = t->target_instance->call(t->target_method, arg, argc, ce);
 	if (ce.error != Callable::CallError::CALL_OK) {
@@ -1818,7 +1820,7 @@ void _Thread::_start_func(void *ud) {
 	}
 }
 
-Error _Thread::start(Object *p_instance, const StringName &p_method, const Variant &p_userdata, Priority p_priority) {
+Error Thread::start(Object *p_instance, const StringName &p_method, const Variant &p_userdata, Priority p_priority) {
 	ERR_FAIL_COND_V_MSG(active.is_set(), ERR_ALREADY_IN_USE, "Thread already started.");
 	ERR_FAIL_COND_V(!p_instance, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_method == StringName(), ERR_INVALID_PARAMETER);
@@ -1830,24 +1832,24 @@ Error _Thread::start(Object *p_instance, const StringName &p_method, const Varia
 	userdata = p_userdata;
 	active.set();
 
-	Ref<_Thread> *ud = memnew(Ref<_Thread>(this));
+	Ref<Thread> *ud = memnew(Ref<Thread>(this));
 
-	Thread::Settings s;
-	s.priority = (Thread::Priority)p_priority;
+	::Thread::Settings s;
+	s.priority = (::Thread::Priority)p_priority;
 	thread.start(_start_func, ud, s);
 
 	return OK;
 }
 
-String _Thread::get_id() const {
+String Thread::get_id() const {
 	return itos(thread.get_id());
 }
 
-bool _Thread::is_active() const {
+bool Thread::is_active() const {
 	return active.is_set();
 }
 
-Variant _Thread::wait_to_finish() {
+Variant Thread::wait_to_finish() {
 	ERR_FAIL_COND_V_MSG(!active.is_set(), Variant(), "Thread must be active to wait for its completion.");
 	thread.wait_to_finish();
 	Variant r = ret;
@@ -1859,22 +1861,24 @@ Variant _Thread::wait_to_finish() {
 	return r;
 }
 
-void _Thread::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("start", "instance", "method", "userdata", "priority"), &_Thread::start, DEFVAL(Variant()), DEFVAL(PRIORITY_NORMAL));
-	ClassDB::bind_method(D_METHOD("get_id"), &_Thread::get_id);
-	ClassDB::bind_method(D_METHOD("is_active"), &_Thread::is_active);
-	ClassDB::bind_method(D_METHOD("wait_to_finish"), &_Thread::wait_to_finish);
+void Thread::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("start", "instance", "method", "userdata", "priority"), &Thread::start, DEFVAL(Variant()), DEFVAL(PRIORITY_NORMAL));
+	ClassDB::bind_method(D_METHOD("get_id"), &Thread::get_id);
+	ClassDB::bind_method(D_METHOD("is_active"), &Thread::is_active);
+	ClassDB::bind_method(D_METHOD("wait_to_finish"), &Thread::wait_to_finish);
 
 	BIND_ENUM_CONSTANT(PRIORITY_LOW);
 	BIND_ENUM_CONSTANT(PRIORITY_NORMAL);
 	BIND_ENUM_CONSTANT(PRIORITY_HIGH);
 }
 
-////// _ClassDB //////
+namespace special {
 
-PackedStringArray _ClassDB::get_class_list() const {
+////// ClassDB //////
+
+PackedStringArray ClassDB::get_class_list() const {
 	List<StringName> classes;
-	ClassDB::get_class_list(&classes);
+	::ClassDB::get_class_list(&classes);
 
 	PackedStringArray ret;
 	ret.resize(classes.size());
@@ -1886,9 +1890,9 @@ PackedStringArray _ClassDB::get_class_list() const {
 	return ret;
 }
 
-PackedStringArray _ClassDB::get_inheriters_from_class(const StringName &p_class) const {
+PackedStringArray ClassDB::get_inheriters_from_class(const StringName &p_class) const {
 	List<StringName> classes;
-	ClassDB::get_inheriters_from_class(p_class, &classes);
+	::ClassDB::get_inheriters_from_class(p_class, &classes);
 
 	PackedStringArray ret;
 	ret.resize(classes.size());
@@ -1900,24 +1904,24 @@ PackedStringArray _ClassDB::get_inheriters_from_class(const StringName &p_class)
 	return ret;
 }
 
-StringName _ClassDB::get_parent_class(const StringName &p_class) const {
-	return ClassDB::get_parent_class(p_class);
+StringName ClassDB::get_parent_class(const StringName &p_class) const {
+	return ::ClassDB::get_parent_class(p_class);
 }
 
-bool _ClassDB::class_exists(const StringName &p_class) const {
-	return ClassDB::class_exists(p_class);
+bool ClassDB::class_exists(const StringName &p_class) const {
+	return ::ClassDB::class_exists(p_class);
 }
 
-bool _ClassDB::is_parent_class(const StringName &p_class, const StringName &p_inherits) const {
-	return ClassDB::is_parent_class(p_class, p_inherits);
+bool ClassDB::is_parent_class(const StringName &p_class, const StringName &p_inherits) const {
+	return ::ClassDB::is_parent_class(p_class, p_inherits);
 }
 
-bool _ClassDB::can_instantiate(const StringName &p_class) const {
-	return ClassDB::can_instantiate(p_class);
+bool ClassDB::can_instantiate(const StringName &p_class) const {
+	return ::ClassDB::can_instantiate(p_class);
 }
 
-Variant _ClassDB::instantiate(const StringName &p_class) const {
-	Object *obj = ClassDB::instantiate(p_class);
+Variant ClassDB::instantiate(const StringName &p_class) const {
+	Object *obj = ::ClassDB::instantiate(p_class);
 	if (!obj) {
 		return Variant();
 	}
@@ -1930,22 +1934,22 @@ Variant _ClassDB::instantiate(const StringName &p_class) const {
 	}
 }
 
-bool _ClassDB::has_signal(StringName p_class, StringName p_signal) const {
-	return ClassDB::has_signal(p_class, p_signal);
+bool ClassDB::has_signal(StringName p_class, StringName p_signal) const {
+	return ::ClassDB::has_signal(p_class, p_signal);
 }
 
-Dictionary _ClassDB::get_signal(StringName p_class, StringName p_signal) const {
+Dictionary ClassDB::get_signal(StringName p_class, StringName p_signal) const {
 	MethodInfo signal;
-	if (ClassDB::get_signal(p_class, p_signal, &signal)) {
+	if (::ClassDB::get_signal(p_class, p_signal, &signal)) {
 		return signal.operator Dictionary();
 	} else {
 		return Dictionary();
 	}
 }
 
-Array _ClassDB::get_signal_list(StringName p_class, bool p_no_inheritance) const {
+Array ClassDB::get_signal_list(StringName p_class, bool p_no_inheritance) const {
 	List<MethodInfo> signals;
-	ClassDB::get_signal_list(p_class, &signals, p_no_inheritance);
+	::ClassDB::get_signal_list(p_class, &signals, p_no_inheritance);
 	Array ret;
 
 	for (const MethodInfo &E : signals) {
@@ -1955,9 +1959,9 @@ Array _ClassDB::get_signal_list(StringName p_class, bool p_no_inheritance) const
 	return ret;
 }
 
-Array _ClassDB::get_property_list(StringName p_class, bool p_no_inheritance) const {
+Array ClassDB::get_property_list(StringName p_class, bool p_no_inheritance) const {
 	List<PropertyInfo> plist;
-	ClassDB::get_property_list(p_class, &plist, p_no_inheritance);
+	::ClassDB::get_property_list(p_class, &plist, p_no_inheritance);
 	Array ret;
 	for (const PropertyInfo &E : plist) {
 		ret.push_back(E.operator Dictionary());
@@ -1966,16 +1970,16 @@ Array _ClassDB::get_property_list(StringName p_class, bool p_no_inheritance) con
 	return ret;
 }
 
-Variant _ClassDB::get_property(Object *p_object, const StringName &p_property) const {
+Variant ClassDB::get_property(Object *p_object, const StringName &p_property) const {
 	Variant ret;
-	ClassDB::get_property(p_object, p_property, ret);
+	::ClassDB::get_property(p_object, p_property, ret);
 	return ret;
 }
 
-Error _ClassDB::set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const {
+Error ClassDB::set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const {
 	Variant ret;
 	bool valid;
-	if (!ClassDB::set_property(p_object, p_property, p_value, &valid)) {
+	if (!::ClassDB::set_property(p_object, p_property, p_value, &valid)) {
 		return ERR_UNAVAILABLE;
 	} else if (!valid) {
 		return ERR_INVALID_DATA;
@@ -1983,13 +1987,13 @@ Error _ClassDB::set_property(Object *p_object, const StringName &p_property, con
 	return OK;
 }
 
-bool _ClassDB::has_method(StringName p_class, StringName p_method, bool p_no_inheritance) const {
-	return ClassDB::has_method(p_class, p_method, p_no_inheritance);
+bool ClassDB::has_method(StringName p_class, StringName p_method, bool p_no_inheritance) const {
+	return ::ClassDB::has_method(p_class, p_method, p_no_inheritance);
 }
 
-Array _ClassDB::get_method_list(StringName p_class, bool p_no_inheritance) const {
+Array ClassDB::get_method_list(StringName p_class, bool p_no_inheritance) const {
 	List<MethodInfo> methods;
-	ClassDB::get_method_list(p_class, &methods, p_no_inheritance);
+	::ClassDB::get_method_list(p_class, &methods, p_no_inheritance);
 	Array ret;
 
 	for (const MethodInfo &E : methods) {
@@ -2005,9 +2009,9 @@ Array _ClassDB::get_method_list(StringName p_class, bool p_no_inheritance) const
 	return ret;
 }
 
-PackedStringArray _ClassDB::get_integer_constant_list(const StringName &p_class, bool p_no_inheritance) const {
+PackedStringArray ClassDB::get_integer_constant_list(const StringName &p_class, bool p_no_inheritance) const {
 	List<String> constants;
-	ClassDB::get_integer_constant_list(p_class, &constants, p_no_inheritance);
+	::ClassDB::get_integer_constant_list(p_class, &constants, p_no_inheritance);
 
 	PackedStringArray ret;
 	ret.resize(constants.size());
@@ -2019,204 +2023,206 @@ PackedStringArray _ClassDB::get_integer_constant_list(const StringName &p_class,
 	return ret;
 }
 
-bool _ClassDB::has_integer_constant(const StringName &p_class, const StringName &p_name) const {
+bool ClassDB::has_integer_constant(const StringName &p_class, const StringName &p_name) const {
 	bool success;
-	ClassDB::get_integer_constant(p_class, p_name, &success);
+	::ClassDB::get_integer_constant(p_class, p_name, &success);
 	return success;
 }
 
-int _ClassDB::get_integer_constant(const StringName &p_class, const StringName &p_name) const {
+int ClassDB::get_integer_constant(const StringName &p_class, const StringName &p_name) const {
 	bool found;
-	int c = ClassDB::get_integer_constant(p_class, p_name, &found);
+	int c = ::ClassDB::get_integer_constant(p_class, p_name, &found);
 	ERR_FAIL_COND_V(!found, 0);
 	return c;
 }
 
-StringName _ClassDB::get_category(const StringName &p_node) const {
-	return ClassDB::get_category(p_node);
+StringName ClassDB::get_category(const StringName &p_node) const {
+	return ::ClassDB::get_category(p_node);
 }
 
-bool _ClassDB::is_class_enabled(StringName p_class) const {
-	return ClassDB::is_class_enabled(p_class);
+bool ClassDB::is_class_enabled(StringName p_class) const {
+	return ::ClassDB::is_class_enabled(p_class);
 }
 
-void _ClassDB::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_class_list"), &_ClassDB::get_class_list);
-	ClassDB::bind_method(D_METHOD("get_inheriters_from_class", "class"), &_ClassDB::get_inheriters_from_class);
-	ClassDB::bind_method(D_METHOD("get_parent_class", "class"), &_ClassDB::get_parent_class);
-	ClassDB::bind_method(D_METHOD("class_exists", "class"), &_ClassDB::class_exists);
-	ClassDB::bind_method(D_METHOD("is_parent_class", "class", "inherits"), &_ClassDB::is_parent_class);
-	ClassDB::bind_method(D_METHOD("can_instantiate", "class"), &_ClassDB::can_instantiate);
-	ClassDB::bind_method(D_METHOD("instantiate", "class"), &_ClassDB::instantiate);
+void ClassDB::_bind_methods() {
+	::ClassDB::bind_method(D_METHOD("get_class_list"), &ClassDB::get_class_list);
+	::ClassDB::bind_method(D_METHOD("get_inheriters_from_class", "class"), &ClassDB::get_inheriters_from_class);
+	::ClassDB::bind_method(D_METHOD("get_parent_class", "class"), &ClassDB::get_parent_class);
+	::ClassDB::bind_method(D_METHOD("class_exists", "class"), &ClassDB::class_exists);
+	::ClassDB::bind_method(D_METHOD("is_parent_class", "class", "inherits"), &ClassDB::is_parent_class);
+	::ClassDB::bind_method(D_METHOD("can_instantiate", "class"), &ClassDB::can_instantiate);
+	::ClassDB::bind_method(D_METHOD("instantiate", "class"), &ClassDB::instantiate);
 
-	ClassDB::bind_method(D_METHOD("class_has_signal", "class", "signal"), &_ClassDB::has_signal);
-	ClassDB::bind_method(D_METHOD("class_get_signal", "class", "signal"), &_ClassDB::get_signal);
-	ClassDB::bind_method(D_METHOD("class_get_signal_list", "class", "no_inheritance"), &_ClassDB::get_signal_list, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_has_signal", "class", "signal"), &ClassDB::has_signal);
+	::ClassDB::bind_method(D_METHOD("class_get_signal", "class", "signal"), &ClassDB::get_signal);
+	::ClassDB::bind_method(D_METHOD("class_get_signal_list", "class", "no_inheritance"), &ClassDB::get_signal_list, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("class_get_property_list", "class", "no_inheritance"), &_ClassDB::get_property_list, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("class_get_property", "object", "property"), &_ClassDB::get_property);
-	ClassDB::bind_method(D_METHOD("class_set_property", "object", "property", "value"), &_ClassDB::set_property);
+	::ClassDB::bind_method(D_METHOD("class_get_property_list", "class", "no_inheritance"), &ClassDB::get_property_list, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_get_property", "object", "property"), &ClassDB::get_property);
+	::ClassDB::bind_method(D_METHOD("class_set_property", "object", "property", "value"), &ClassDB::set_property);
 
-	ClassDB::bind_method(D_METHOD("class_has_method", "class", "method", "no_inheritance"), &_ClassDB::has_method, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_has_method", "class", "method", "no_inheritance"), &ClassDB::has_method, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("class_get_method_list", "class", "no_inheritance"), &_ClassDB::get_method_list, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_get_method_list", "class", "no_inheritance"), &ClassDB::get_method_list, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("class_get_integer_constant_list", "class", "no_inheritance"), &_ClassDB::get_integer_constant_list, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_get_integer_constant_list", "class", "no_inheritance"), &ClassDB::get_integer_constant_list, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("class_has_integer_constant", "class", "name"), &_ClassDB::has_integer_constant);
-	ClassDB::bind_method(D_METHOD("class_get_integer_constant", "class", "name"), &_ClassDB::get_integer_constant);
+	::ClassDB::bind_method(D_METHOD("class_has_integer_constant", "class", "name"), &ClassDB::has_integer_constant);
+	::ClassDB::bind_method(D_METHOD("class_get_integer_constant", "class", "name"), &ClassDB::get_integer_constant);
 
-	ClassDB::bind_method(D_METHOD("class_get_category", "class"), &_ClassDB::get_category);
-	ClassDB::bind_method(D_METHOD("is_class_enabled", "class"), &_ClassDB::is_class_enabled);
+	::ClassDB::bind_method(D_METHOD("class_get_category", "class"), &ClassDB::get_category);
+	::ClassDB::bind_method(D_METHOD("is_class_enabled", "class"), &ClassDB::is_class_enabled);
 }
 
-////// _Engine //////
+} // namespace special
 
-void _Engine::set_physics_ticks_per_second(int p_ips) {
-	Engine::get_singleton()->set_physics_ticks_per_second(p_ips);
+////// Engine //////
+
+void Engine::set_physics_ticks_per_second(int p_ips) {
+	::Engine::get_singleton()->set_physics_ticks_per_second(p_ips);
 }
 
-int _Engine::get_physics_ticks_per_second() const {
-	return Engine::get_singleton()->get_physics_ticks_per_second();
+int Engine::get_physics_ticks_per_second() const {
+	return ::Engine::get_singleton()->get_physics_ticks_per_second();
 }
 
-void _Engine::set_physics_jitter_fix(double p_threshold) {
-	Engine::get_singleton()->set_physics_jitter_fix(p_threshold);
+void Engine::set_physics_jitter_fix(double p_threshold) {
+	::Engine::get_singleton()->set_physics_jitter_fix(p_threshold);
 }
 
-double _Engine::get_physics_jitter_fix() const {
-	return Engine::get_singleton()->get_physics_jitter_fix();
+double Engine::get_physics_jitter_fix() const {
+	return ::Engine::get_singleton()->get_physics_jitter_fix();
 }
 
-double _Engine::get_physics_interpolation_fraction() const {
-	return Engine::get_singleton()->get_physics_interpolation_fraction();
+double Engine::get_physics_interpolation_fraction() const {
+	return ::Engine::get_singleton()->get_physics_interpolation_fraction();
 }
 
-void _Engine::set_target_fps(int p_fps) {
-	Engine::get_singleton()->set_target_fps(p_fps);
+void Engine::set_target_fps(int p_fps) {
+	::Engine::get_singleton()->set_target_fps(p_fps);
 }
 
-int _Engine::get_target_fps() const {
-	return Engine::get_singleton()->get_target_fps();
+int Engine::get_target_fps() const {
+	return ::Engine::get_singleton()->get_target_fps();
 }
 
-double _Engine::get_frames_per_second() const {
-	return Engine::get_singleton()->get_frames_per_second();
+double Engine::get_frames_per_second() const {
+	return ::Engine::get_singleton()->get_frames_per_second();
 }
 
-uint64_t _Engine::get_physics_frames() const {
-	return Engine::get_singleton()->get_physics_frames();
+uint64_t Engine::get_physics_frames() const {
+	return ::Engine::get_singleton()->get_physics_frames();
 }
 
-uint64_t _Engine::get_process_frames() const {
-	return Engine::get_singleton()->get_process_frames();
+uint64_t Engine::get_process_frames() const {
+	return ::Engine::get_singleton()->get_process_frames();
 }
 
-void _Engine::set_time_scale(double p_scale) {
-	Engine::get_singleton()->set_time_scale(p_scale);
+void Engine::set_time_scale(double p_scale) {
+	::Engine::get_singleton()->set_time_scale(p_scale);
 }
 
-double _Engine::get_time_scale() {
-	return Engine::get_singleton()->get_time_scale();
+double Engine::get_time_scale() {
+	return ::Engine::get_singleton()->get_time_scale();
 }
 
-int _Engine::get_frames_drawn() {
-	return Engine::get_singleton()->get_frames_drawn();
+int Engine::get_frames_drawn() {
+	return ::Engine::get_singleton()->get_frames_drawn();
 }
 
-MainLoop *_Engine::get_main_loop() const {
-	//needs to remain in OS, since it's actually OS that interacts with it, but it's better exposed here
-	return OS::get_singleton()->get_main_loop();
+MainLoop *Engine::get_main_loop() const {
+	// Needs to remain in OS, since it's actually OS that interacts with it, but it's better exposed here
+	return ::OS::get_singleton()->get_main_loop();
 }
 
-Dictionary _Engine::get_version_info() const {
-	return Engine::get_singleton()->get_version_info();
+Dictionary Engine::get_version_info() const {
+	return ::Engine::get_singleton()->get_version_info();
 }
 
-Dictionary _Engine::get_author_info() const {
-	return Engine::get_singleton()->get_author_info();
+Dictionary Engine::get_author_info() const {
+	return ::Engine::get_singleton()->get_author_info();
 }
 
-Array _Engine::get_copyright_info() const {
-	return Engine::get_singleton()->get_copyright_info();
+Array Engine::get_copyright_info() const {
+	return ::Engine::get_singleton()->get_copyright_info();
 }
 
-Dictionary _Engine::get_donor_info() const {
-	return Engine::get_singleton()->get_donor_info();
+Dictionary Engine::get_donor_info() const {
+	return ::Engine::get_singleton()->get_donor_info();
 }
 
-Dictionary _Engine::get_license_info() const {
-	return Engine::get_singleton()->get_license_info();
+Dictionary Engine::get_license_info() const {
+	return ::Engine::get_singleton()->get_license_info();
 }
 
-String _Engine::get_license_text() const {
-	return Engine::get_singleton()->get_license_text();
+String Engine::get_license_text() const {
+	return ::Engine::get_singleton()->get_license_text();
 }
 
-bool _Engine::is_in_physics_frame() const {
-	return Engine::get_singleton()->is_in_physics_frame();
+bool Engine::is_in_physics_frame() const {
+	return ::Engine::get_singleton()->is_in_physics_frame();
 }
 
-bool _Engine::has_singleton(const String &p_name) const {
-	return Engine::get_singleton()->has_singleton(p_name);
+bool Engine::has_singleton(const String &p_name) const {
+	return ::Engine::get_singleton()->has_singleton(p_name);
 }
 
-Object *_Engine::get_singleton_object(const String &p_name) const {
-	return Engine::get_singleton()->get_singleton_object(p_name);
+Object *Engine::get_singleton_object(const String &p_name) const {
+	return ::Engine::get_singleton()->get_singleton_object(p_name);
 }
 
-void _Engine::set_editor_hint(bool p_enabled) {
-	Engine::get_singleton()->set_editor_hint(p_enabled);
+void Engine::set_editor_hint(bool p_enabled) {
+	::Engine::get_singleton()->set_editor_hint(p_enabled);
 }
 
-bool _Engine::is_editor_hint() const {
-	return Engine::get_singleton()->is_editor_hint();
+bool Engine::is_editor_hint() const {
+	return ::Engine::get_singleton()->is_editor_hint();
 }
 
-void _Engine::set_print_error_messages(bool p_enabled) {
-	Engine::get_singleton()->set_print_error_messages(p_enabled);
+void Engine::set_print_error_messages(bool p_enabled) {
+	::Engine::get_singleton()->set_print_error_messages(p_enabled);
 }
 
-bool _Engine::is_printing_error_messages() const {
-	return Engine::get_singleton()->is_printing_error_messages();
+bool Engine::is_printing_error_messages() const {
+	return ::Engine::get_singleton()->is_printing_error_messages();
 }
 
-void _Engine::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_physics_ticks_per_second", "physics_ticks_per_second"), &_Engine::set_physics_ticks_per_second);
-	ClassDB::bind_method(D_METHOD("get_physics_ticks_per_second"), &_Engine::get_physics_ticks_per_second);
-	ClassDB::bind_method(D_METHOD("set_physics_jitter_fix", "physics_jitter_fix"), &_Engine::set_physics_jitter_fix);
-	ClassDB::bind_method(D_METHOD("get_physics_jitter_fix"), &_Engine::get_physics_jitter_fix);
-	ClassDB::bind_method(D_METHOD("get_physics_interpolation_fraction"), &_Engine::get_physics_interpolation_fraction);
-	ClassDB::bind_method(D_METHOD("set_target_fps", "target_fps"), &_Engine::set_target_fps);
-	ClassDB::bind_method(D_METHOD("get_target_fps"), &_Engine::get_target_fps);
+void Engine::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_physics_ticks_per_second", "physics_ticks_per_second"), &Engine::set_physics_ticks_per_second);
+	ClassDB::bind_method(D_METHOD("get_physics_ticks_per_second"), &Engine::get_physics_ticks_per_second);
+	ClassDB::bind_method(D_METHOD("set_physics_jitter_fix", "physics_jitter_fix"), &Engine::set_physics_jitter_fix);
+	ClassDB::bind_method(D_METHOD("get_physics_jitter_fix"), &Engine::get_physics_jitter_fix);
+	ClassDB::bind_method(D_METHOD("get_physics_interpolation_fraction"), &Engine::get_physics_interpolation_fraction);
+	ClassDB::bind_method(D_METHOD("set_target_fps", "target_fps"), &Engine::set_target_fps);
+	ClassDB::bind_method(D_METHOD("get_target_fps"), &Engine::get_target_fps);
 
-	ClassDB::bind_method(D_METHOD("set_time_scale", "time_scale"), &_Engine::set_time_scale);
-	ClassDB::bind_method(D_METHOD("get_time_scale"), &_Engine::get_time_scale);
+	ClassDB::bind_method(D_METHOD("set_time_scale", "time_scale"), &Engine::set_time_scale);
+	ClassDB::bind_method(D_METHOD("get_time_scale"), &Engine::get_time_scale);
 
-	ClassDB::bind_method(D_METHOD("get_frames_drawn"), &_Engine::get_frames_drawn);
-	ClassDB::bind_method(D_METHOD("get_frames_per_second"), &_Engine::get_frames_per_second);
-	ClassDB::bind_method(D_METHOD("get_physics_frames"), &_Engine::get_physics_frames);
-	ClassDB::bind_method(D_METHOD("get_process_frames"), &_Engine::get_process_frames);
+	ClassDB::bind_method(D_METHOD("get_frames_drawn"), &Engine::get_frames_drawn);
+	ClassDB::bind_method(D_METHOD("get_frames_per_second"), &Engine::get_frames_per_second);
+	ClassDB::bind_method(D_METHOD("get_physics_frames"), &Engine::get_physics_frames);
+	ClassDB::bind_method(D_METHOD("get_process_frames"), &Engine::get_process_frames);
 
-	ClassDB::bind_method(D_METHOD("get_main_loop"), &_Engine::get_main_loop);
+	ClassDB::bind_method(D_METHOD("get_main_loop"), &Engine::get_main_loop);
 
-	ClassDB::bind_method(D_METHOD("get_version_info"), &_Engine::get_version_info);
-	ClassDB::bind_method(D_METHOD("get_author_info"), &_Engine::get_author_info);
-	ClassDB::bind_method(D_METHOD("get_copyright_info"), &_Engine::get_copyright_info);
-	ClassDB::bind_method(D_METHOD("get_donor_info"), &_Engine::get_donor_info);
-	ClassDB::bind_method(D_METHOD("get_license_info"), &_Engine::get_license_info);
-	ClassDB::bind_method(D_METHOD("get_license_text"), &_Engine::get_license_text);
+	ClassDB::bind_method(D_METHOD("get_version_info"), &Engine::get_version_info);
+	ClassDB::bind_method(D_METHOD("get_author_info"), &Engine::get_author_info);
+	ClassDB::bind_method(D_METHOD("get_copyright_info"), &Engine::get_copyright_info);
+	ClassDB::bind_method(D_METHOD("get_donor_info"), &Engine::get_donor_info);
+	ClassDB::bind_method(D_METHOD("get_license_info"), &Engine::get_license_info);
+	ClassDB::bind_method(D_METHOD("get_license_text"), &Engine::get_license_text);
 
-	ClassDB::bind_method(D_METHOD("is_in_physics_frame"), &_Engine::is_in_physics_frame);
+	ClassDB::bind_method(D_METHOD("is_in_physics_frame"), &Engine::is_in_physics_frame);
 
-	ClassDB::bind_method(D_METHOD("has_singleton", "name"), &_Engine::has_singleton);
-	ClassDB::bind_method(D_METHOD("get_singleton", "name"), &_Engine::get_singleton_object);
+	ClassDB::bind_method(D_METHOD("has_singleton", "name"), &Engine::has_singleton);
+	ClassDB::bind_method(D_METHOD("get_singleton", "name"), &Engine::get_singleton_object);
 
-	ClassDB::bind_method(D_METHOD("set_editor_hint", "enabled"), &_Engine::set_editor_hint);
-	ClassDB::bind_method(D_METHOD("is_editor_hint"), &_Engine::is_editor_hint);
+	ClassDB::bind_method(D_METHOD("set_editor_hint", "enabled"), &Engine::set_editor_hint);
+	ClassDB::bind_method(D_METHOD("is_editor_hint"), &Engine::is_editor_hint);
 
-	ClassDB::bind_method(D_METHOD("set_print_error_messages", "enabled"), &_Engine::set_print_error_messages);
-	ClassDB::bind_method(D_METHOD("is_printing_error_messages"), &_Engine::is_printing_error_messages);
+	ClassDB::bind_method(D_METHOD("set_print_error_messages", "enabled"), &Engine::set_print_error_messages);
+	ClassDB::bind_method(D_METHOD("is_printing_error_messages"), &Engine::is_printing_error_messages);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editor_hint"), "set_editor_hint", "is_editor_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "print_error_messages"), "set_print_error_messages", "is_printing_error_messages");
@@ -2226,92 +2232,74 @@ void _Engine::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "physics_jitter_fix"), "set_physics_jitter_fix", "get_physics_jitter_fix");
 }
 
-_Engine *_Engine::singleton = nullptr;
+Engine *Engine::singleton = nullptr;
 
-////// _EngineDebugger //////
+////// EngineDebugger //////
 
-void _EngineDebugger::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("is_active"), &_EngineDebugger::is_active);
-
-	ClassDB::bind_method(D_METHOD("register_profiler", "name", "toggle", "add", "tick"), &_EngineDebugger::register_profiler);
-	ClassDB::bind_method(D_METHOD("unregister_profiler", "name"), &_EngineDebugger::unregister_profiler);
-	ClassDB::bind_method(D_METHOD("is_profiling", "name"), &_EngineDebugger::is_profiling);
-	ClassDB::bind_method(D_METHOD("has_profiler", "name"), &_EngineDebugger::has_profiler);
-
-	ClassDB::bind_method(D_METHOD("profiler_add_frame_data", "name", "data"), &_EngineDebugger::profiler_add_frame_data);
-	ClassDB::bind_method(D_METHOD("profiler_enable", "name", "enable", "arguments"), &_EngineDebugger::profiler_enable, DEFVAL(Array()));
-
-	ClassDB::bind_method(D_METHOD("register_message_capture", "name", "callable"), &_EngineDebugger::register_message_capture);
-	ClassDB::bind_method(D_METHOD("unregister_message_capture", "name"), &_EngineDebugger::unregister_message_capture);
-	ClassDB::bind_method(D_METHOD("has_capture", "name"), &_EngineDebugger::has_capture);
-
-	ClassDB::bind_method(D_METHOD("send_message", "message", "data"), &_EngineDebugger::send_message);
+bool EngineDebugger::is_active() {
+	return ::EngineDebugger::is_active();
 }
 
-bool _EngineDebugger::is_active() {
-	return EngineDebugger::is_active();
-}
-
-void _EngineDebugger::register_profiler(const StringName &p_name, const Callable &p_toggle, const Callable &p_add, const Callable &p_tick) {
+void EngineDebugger::register_profiler(const StringName &p_name, const Callable &p_toggle, const Callable &p_add, const Callable &p_tick) {
 	ERR_FAIL_COND_MSG(profilers.has(p_name) || has_profiler(p_name), "Profiler already registered: " + p_name);
 	profilers.insert(p_name, ProfilerCallable(p_toggle, p_add, p_tick));
 	ProfilerCallable &p = profilers[p_name];
-	EngineDebugger::Profiler profiler(
+	::EngineDebugger::Profiler profiler(
 			&p,
-			&_EngineDebugger::call_toggle,
-			&_EngineDebugger::call_add,
-			&_EngineDebugger::call_tick);
-	EngineDebugger::register_profiler(p_name, profiler);
+			&EngineDebugger::call_toggle,
+			&EngineDebugger::call_add,
+			&EngineDebugger::call_tick);
+	::EngineDebugger::register_profiler(p_name, profiler);
 }
 
-void _EngineDebugger::unregister_profiler(const StringName &p_name) {
+void EngineDebugger::unregister_profiler(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(!profilers.has(p_name), "Profiler not registered: " + p_name);
-	EngineDebugger::unregister_profiler(p_name);
+	::EngineDebugger::unregister_profiler(p_name);
 	profilers.erase(p_name);
 }
 
-bool _EngineDebugger::_EngineDebugger::is_profiling(const StringName &p_name) {
-	return EngineDebugger::is_profiling(p_name);
+bool EngineDebugger::is_profiling(const StringName &p_name) {
+	return ::EngineDebugger::is_profiling(p_name);
 }
 
-bool _EngineDebugger::has_profiler(const StringName &p_name) {
-	return EngineDebugger::has_profiler(p_name);
+bool EngineDebugger::has_profiler(const StringName &p_name) {
+	return ::EngineDebugger::has_profiler(p_name);
 }
 
-void _EngineDebugger::profiler_add_frame_data(const StringName &p_name, const Array &p_data) {
-	EngineDebugger::profiler_add_frame_data(p_name, p_data);
+void EngineDebugger::profiler_add_frame_data(const StringName &p_name, const Array &p_data) {
+	::EngineDebugger::profiler_add_frame_data(p_name, p_data);
 }
 
-void _EngineDebugger::profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts) {
-	if (EngineDebugger::get_singleton()) {
-		EngineDebugger::get_singleton()->profiler_enable(p_name, p_enabled, p_opts);
+void EngineDebugger::profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts) {
+	if (::EngineDebugger::get_singleton()) {
+		::EngineDebugger::get_singleton()->profiler_enable(p_name, p_enabled, p_opts);
 	}
 }
 
-void _EngineDebugger::register_message_capture(const StringName &p_name, const Callable &p_callable) {
+void EngineDebugger::register_message_capture(const StringName &p_name, const Callable &p_callable) {
 	ERR_FAIL_COND_MSG(captures.has(p_name) || has_capture(p_name), "Capture already registered: " + p_name);
 	captures.insert(p_name, p_callable);
 	Callable &c = captures[p_name];
-	EngineDebugger::Capture capture(&c, &_EngineDebugger::call_capture);
-	EngineDebugger::register_message_capture(p_name, capture);
+	::EngineDebugger::Capture capture(&c, &EngineDebugger::call_capture);
+	::EngineDebugger::register_message_capture(p_name, capture);
 }
 
-void _EngineDebugger::unregister_message_capture(const StringName &p_name) {
+void EngineDebugger::unregister_message_capture(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(!captures.has(p_name), "Capture not registered: " + p_name);
-	EngineDebugger::unregister_message_capture(p_name);
+	::EngineDebugger::unregister_message_capture(p_name);
 	captures.erase(p_name);
 }
 
-bool _EngineDebugger::has_capture(const StringName &p_name) {
-	return EngineDebugger::has_capture(p_name);
+bool EngineDebugger::has_capture(const StringName &p_name) {
+	return ::EngineDebugger::has_capture(p_name);
 }
 
-void _EngineDebugger::send_message(const String &p_msg, const Array &p_data) {
-	ERR_FAIL_COND_MSG(!EngineDebugger::is_active(), "Can't send message. No active debugger");
-	EngineDebugger::get_singleton()->send_message(p_msg, p_data);
+void EngineDebugger::send_message(const String &p_msg, const Array &p_data) {
+	ERR_FAIL_COND_MSG(!::EngineDebugger::is_active(), "Can't send message. No active debugger");
+	::EngineDebugger::get_singleton()->send_message(p_msg, p_data);
 }
 
-void _EngineDebugger::call_toggle(void *p_user, bool p_enable, const Array &p_opts) {
+void EngineDebugger::call_toggle(void *p_user, bool p_enable, const Array &p_opts) {
 	Callable &toggle = ((ProfilerCallable *)p_user)->callable_toggle;
 	if (toggle.is_null()) {
 		return;
@@ -2324,7 +2312,7 @@ void _EngineDebugger::call_toggle(void *p_user, bool p_enable, const Array &p_op
 	ERR_FAIL_COND_MSG(err.error != Callable::CallError::CALL_OK, "Error calling 'toggle' to callable: " + Variant::get_callable_error_text(toggle, args, 2, err));
 }
 
-void _EngineDebugger::call_add(void *p_user, const Array &p_data) {
+void EngineDebugger::call_add(void *p_user, const Array &p_data) {
 	Callable &add = ((ProfilerCallable *)p_user)->callable_add;
 	if (add.is_null()) {
 		return;
@@ -2337,7 +2325,7 @@ void _EngineDebugger::call_add(void *p_user, const Array &p_data) {
 	ERR_FAIL_COND_MSG(err.error != Callable::CallError::CALL_OK, "Error calling 'add' to callable: " + Variant::get_callable_error_text(add, args, 1, err));
 }
 
-void _EngineDebugger::call_tick(void *p_user, double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
+void EngineDebugger::call_tick(void *p_user, double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
 	Callable &tick = ((ProfilerCallable *)p_user)->callable_tick;
 	if (tick.is_null()) {
 		return;
@@ -2350,7 +2338,7 @@ void _EngineDebugger::call_tick(void *p_user, double p_frame_time, double p_idle
 	ERR_FAIL_COND_MSG(err.error != Callable::CallError::CALL_OK, "Error calling 'tick' to callable: " + Variant::get_callable_error_text(tick, args, 4, err));
 }
 
-Error _EngineDebugger::call_capture(void *p_user, const String &p_cmd, const Array &p_data, bool &r_captured) {
+Error EngineDebugger::call_capture(void *p_user, const String &p_cmd, const Array &p_data, bool &r_captured) {
 	Callable &capture = *(Callable *)p_user;
 	if (capture.is_null()) {
 		return FAILED;
@@ -2366,15 +2354,35 @@ Error _EngineDebugger::call_capture(void *p_user, const String &p_cmd, const Arr
 	return OK;
 }
 
-_EngineDebugger::~_EngineDebugger() {
+EngineDebugger::~EngineDebugger() {
 	for (Map<StringName, Callable>::Element *E = captures.front(); E; E = E->next()) {
-		EngineDebugger::unregister_message_capture(E->key());
+		::EngineDebugger::unregister_message_capture(E->key());
 	}
 	captures.clear();
 	for (Map<StringName, ProfilerCallable>::Element *E = profilers.front(); E; E = E->next()) {
-		EngineDebugger::unregister_profiler(E->key());
+		::EngineDebugger::unregister_profiler(E->key());
 	}
 	profilers.clear();
 }
 
-_EngineDebugger *_EngineDebugger::singleton = nullptr;
+EngineDebugger *EngineDebugger::singleton = nullptr;
+
+void EngineDebugger::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_active"), &EngineDebugger::is_active);
+
+	ClassDB::bind_method(D_METHOD("register_profiler", "name", "toggle", "add", "tick"), &EngineDebugger::register_profiler);
+	ClassDB::bind_method(D_METHOD("unregister_profiler", "name"), &EngineDebugger::unregister_profiler);
+	ClassDB::bind_method(D_METHOD("is_profiling", "name"), &EngineDebugger::is_profiling);
+	ClassDB::bind_method(D_METHOD("has_profiler", "name"), &EngineDebugger::has_profiler);
+
+	ClassDB::bind_method(D_METHOD("profiler_add_frame_data", "name", "data"), &EngineDebugger::profiler_add_frame_data);
+	ClassDB::bind_method(D_METHOD("profiler_enable", "name", "enable", "arguments"), &EngineDebugger::profiler_enable, DEFVAL(Array()));
+
+	ClassDB::bind_method(D_METHOD("register_message_capture", "name", "callable"), &EngineDebugger::register_message_capture);
+	ClassDB::bind_method(D_METHOD("unregister_message_capture", "name"), &EngineDebugger::unregister_message_capture);
+	ClassDB::bind_method(D_METHOD("has_capture", "name"), &EngineDebugger::has_capture);
+
+	ClassDB::bind_method(D_METHOD("send_message", "message", "data"), &EngineDebugger::send_message);
+}
+
+} // namespace core_bind

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -42,12 +42,16 @@
 #include "core/os/thread.h"
 #include "core/templates/safe_refcount.h"
 
-class _ResourceLoader : public Object {
-	GDCLASS(_ResourceLoader, Object);
+class MainLoop;
+
+namespace core_bind {
+
+class ResourceLoader : public Object {
+	GDCLASS(ResourceLoader, Object);
 
 protected:
 	static void _bind_methods();
-	static _ResourceLoader *singleton;
+	static ResourceLoader *singleton;
 
 public:
 	enum ThreadLoadStatus {
@@ -63,7 +67,7 @@ public:
 		CACHE_MODE_REPLACE, // Resource and subresource use path cache, but replace existing loaded resources when available with information from disk.
 	};
 
-	static _ResourceLoader *get_singleton() { return singleton; }
+	static ResourceLoader *get_singleton() { return singleton; }
 
 	Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false);
 	ThreadLoadStatus load_threaded_get_status(const String &p_path, Array r_progress = Array());
@@ -77,18 +81,15 @@ public:
 	bool exists(const String &p_path, const String &p_type_hint = "");
 	ResourceUID::ID get_resource_uid(const String &p_path);
 
-	_ResourceLoader() { singleton = this; }
+	ResourceLoader() { singleton = this; }
 };
 
-VARIANT_ENUM_CAST(_ResourceLoader::ThreadLoadStatus);
-VARIANT_ENUM_CAST(_ResourceLoader::CacheMode);
-
-class _ResourceSaver : public Object {
-	GDCLASS(_ResourceSaver, Object);
+class ResourceSaver : public Object {
+	GDCLASS(ResourceSaver, Object);
 
 protected:
 	static void _bind_methods();
-	static _ResourceSaver *singleton;
+	static ResourceSaver *singleton;
 
 public:
 	enum SaverFlags {
@@ -101,24 +102,20 @@ public:
 		FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
 	};
 
-	static _ResourceSaver *get_singleton() { return singleton; }
+	static ResourceSaver *get_singleton() { return singleton; }
 
 	Error save(const String &p_path, const RES &p_resource, SaverFlags p_flags);
 	Vector<String> get_recognized_extensions(const RES &p_resource);
 
-	_ResourceSaver() { singleton = this; }
+	ResourceSaver() { singleton = this; }
 };
 
-VARIANT_ENUM_CAST(_ResourceSaver::SaverFlags);
-
-class MainLoop;
-
-class _OS : public Object {
-	GDCLASS(_OS, Object);
+class OS : public Object {
+	GDCLASS(OS, Object);
 
 protected:
 	static void _bind_methods();
-	static _OS *singleton;
+	static OS *singleton;
 
 public:
 	enum VideoDriver {
@@ -245,26 +242,21 @@ public:
 	bool request_permissions();
 	Vector<String> get_granted_permissions() const;
 
-	static _OS *get_singleton() { return singleton; }
+	static OS *get_singleton() { return singleton; }
 
-	_OS() { singleton = this; }
+	OS() { singleton = this; }
 };
 
-VARIANT_ENUM_CAST(_OS::VideoDriver);
-VARIANT_ENUM_CAST(_OS::Weekday);
-VARIANT_ENUM_CAST(_OS::Month);
-VARIANT_ENUM_CAST(_OS::SystemDir);
+class Geometry2D : public Object {
+	GDCLASS(Geometry2D, Object);
 
-class _Geometry2D : public Object {
-	GDCLASS(_Geometry2D, Object);
-
-	static _Geometry2D *singleton;
+	static Geometry2D *singleton;
 
 protected:
 	static void _bind_methods();
 
 public:
-	static _Geometry2D *get_singleton();
+	static Geometry2D *get_singleton();
 	Variant segment_intersects_segment(const Vector2 &p_from_a, const Vector2 &p_to_a, const Vector2 &p_from_b, const Vector2 &p_to_b);
 	Variant line_intersects_line(const Vector2 &p_from_a, const Vector2 &p_dir_a, const Vector2 &p_from_b, const Vector2 &p_dir_b);
 	Vector<Vector2> get_closest_points_between_segments(const Vector2 &p1, const Vector2 &q1, const Vector2 &p2, const Vector2 &q2);
@@ -315,23 +307,19 @@ public:
 
 	Dictionary make_atlas(const Vector<Size2> &p_rects);
 
-	_Geometry2D() { singleton = this; }
+	Geometry2D() { singleton = this; }
 };
 
-VARIANT_ENUM_CAST(_Geometry2D::PolyBooleanOperation);
-VARIANT_ENUM_CAST(_Geometry2D::PolyJoinType);
-VARIANT_ENUM_CAST(_Geometry2D::PolyEndType);
+class Geometry3D : public Object {
+	GDCLASS(Geometry3D, Object);
 
-class _Geometry3D : public Object {
-	GDCLASS(_Geometry3D, Object);
-
-	static _Geometry3D *singleton;
+	static Geometry3D *singleton;
 
 protected:
 	static void _bind_methods();
 
 public:
-	static _Geometry3D *get_singleton();
+	static Geometry3D *get_singleton();
 	Vector<Plane> build_box_planes(const Vector3 &p_extents);
 	Vector<Plane> build_cylinder_planes(float p_radius, float p_height, int p_sides, Vector3::Axis p_axis = Vector3::AXIS_Z);
 	Vector<Plane> build_capsule_planes(float p_radius, float p_height, int p_sides, int p_lats, Vector3::Axis p_axis = Vector3::AXIS_Z);
@@ -347,11 +335,11 @@ public:
 
 	Vector<Vector3> clip_polygon(const Vector<Vector3> &p_points, const Plane &p_plane);
 
-	_Geometry3D() { singleton = this; }
+	Geometry3D() { singleton = this; }
 };
 
-class _File : public RefCounted {
-	GDCLASS(_File, RefCounted);
+class File : public RefCounted {
+	GDCLASS(File, RefCounted);
 
 	FileAccess *f = nullptr;
 	bool big_endian = false;
@@ -445,15 +433,12 @@ public:
 
 	uint64_t get_modified_time(const String &p_file) const;
 
-	_File() {}
-	virtual ~_File();
+	File() {}
+	virtual ~File();
 };
 
-VARIANT_ENUM_CAST(_File::ModeFlags);
-VARIANT_ENUM_CAST(_File::CompressionMode);
-
-class _Directory : public RefCounted {
-	GDCLASS(_Directory, RefCounted);
+class Directory : public RefCounted {
+	GDCLASS(Directory, RefCounted);
 	DirAccess *d;
 	bool dir_open = false;
 
@@ -490,24 +475,24 @@ public:
 	Error rename(String p_from, String p_to);
 	Error remove(String p_name);
 
-	_Directory();
-	virtual ~_Directory();
+	Directory();
+	virtual ~Directory();
 
 private:
 	bool _list_skip_navigational = false;
 	bool _list_skip_hidden = false;
 };
 
-class _Marshalls : public Object {
-	GDCLASS(_Marshalls, Object);
+class Marshalls : public Object {
+	GDCLASS(Marshalls, Object);
 
-	static _Marshalls *singleton;
+	static Marshalls *singleton;
 
 protected:
 	static void _bind_methods();
 
 public:
-	static _Marshalls *get_singleton();
+	static Marshalls *get_singleton();
 
 	String variant_to_base64(const Variant &p_var, bool p_full_objects = false);
 	Variant base64_to_variant(const String &p_str, bool p_allow_objects = false);
@@ -518,13 +503,13 @@ public:
 	String utf8_to_base64(const String &p_str);
 	String base64_to_utf8(const String &p_str);
 
-	_Marshalls() { singleton = this; }
-	~_Marshalls() { singleton = nullptr; }
+	Marshalls() { singleton = this; }
+	~Marshalls() { singleton = nullptr; }
 };
 
-class _Mutex : public RefCounted {
-	GDCLASS(_Mutex, RefCounted);
-	Mutex mutex;
+class Mutex : public RefCounted {
+	GDCLASS(Mutex, RefCounted);
+	::Mutex mutex;
 
 	static void _bind_methods();
 
@@ -534,9 +519,9 @@ public:
 	void unlock();
 };
 
-class _Semaphore : public RefCounted {
-	GDCLASS(_Semaphore, RefCounted);
-	Semaphore semaphore;
+class Semaphore : public RefCounted {
+	GDCLASS(Semaphore, RefCounted);
+	::Semaphore semaphore;
 
 	static void _bind_methods();
 
@@ -546,8 +531,8 @@ public:
 	void post();
 };
 
-class _Thread : public RefCounted {
-	GDCLASS(_Thread, RefCounted);
+class Thread : public RefCounted {
+	GDCLASS(Thread, RefCounted);
 
 protected:
 	Variant ret;
@@ -555,7 +540,7 @@ protected:
 	SafeFlag active;
 	Object *target_instance = nullptr;
 	StringName target_method;
-	Thread thread;
+	::Thread thread;
 	static void _bind_methods();
 	static void _start_func(void *ud);
 
@@ -573,10 +558,10 @@ public:
 	Variant wait_to_finish();
 };
 
-VARIANT_ENUM_CAST(_Thread::Priority);
+namespace special {
 
-class _ClassDB : public Object {
-	GDCLASS(_ClassDB, Object);
+class ClassDB : public Object {
+	GDCLASS(ClassDB, Object);
 
 protected:
 	static void _bind_methods();
@@ -609,19 +594,21 @@ public:
 
 	bool is_class_enabled(StringName p_class) const;
 
-	_ClassDB() {}
-	~_ClassDB() {}
+	ClassDB() {}
+	~ClassDB() {}
 };
 
-class _Engine : public Object {
-	GDCLASS(_Engine, Object);
+} // namespace special
+
+class Engine : public Object {
+	GDCLASS(Engine, Object);
 
 protected:
 	static void _bind_methods();
-	static _Engine *singleton;
+	static Engine *singleton;
 
 public:
-	static _Engine *get_singleton() { return singleton; }
+	static Engine *get_singleton() { return singleton; }
 	void set_physics_ticks_per_second(int p_ips);
 	int get_physics_ticks_per_second() const;
 
@@ -661,14 +648,14 @@ public:
 	void set_print_error_messages(bool p_enabled);
 	bool is_printing_error_messages() const;
 
-	_Engine() { singleton = this; }
+	Engine() { singleton = this; }
 };
 
-class _EngineDebugger : public Object {
-	GDCLASS(_EngineDebugger, Object);
+class EngineDebugger : public Object {
+	GDCLASS(EngineDebugger, Object);
 
 	class ProfilerCallable {
-		friend class _EngineDebugger;
+		friend class EngineDebugger;
 
 		Callable callable_toggle;
 		Callable callable_add;
@@ -689,10 +676,10 @@ class _EngineDebugger : public Object {
 
 protected:
 	static void _bind_methods();
-	static _EngineDebugger *singleton;
+	static EngineDebugger *singleton;
 
 public:
-	static _EngineDebugger *get_singleton() { return singleton; }
+	static EngineDebugger *get_singleton() { return singleton; }
 
 	bool is_active();
 
@@ -714,8 +701,29 @@ public:
 	static void call_tick(void *p_user, double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time);
 	static Error call_capture(void *p_user, const String &p_cmd, const Array &p_data, bool &r_captured);
 
-	_EngineDebugger() { singleton = this; }
-	~_EngineDebugger();
+	EngineDebugger() { singleton = this; }
+	~EngineDebugger();
 };
+
+} // namespace core_bind
+
+VARIANT_ENUM_CAST(core_bind::ResourceLoader::ThreadLoadStatus);
+VARIANT_ENUM_CAST(core_bind::ResourceLoader::CacheMode);
+
+VARIANT_ENUM_CAST(core_bind::ResourceSaver::SaverFlags);
+
+VARIANT_ENUM_CAST(core_bind::OS::VideoDriver);
+VARIANT_ENUM_CAST(core_bind::OS::Weekday);
+VARIANT_ENUM_CAST(core_bind::OS::Month);
+VARIANT_ENUM_CAST(core_bind::OS::SystemDir);
+
+VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyBooleanOperation);
+VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyJoinType);
+VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyEndType);
+
+VARIANT_ENUM_CAST(core_bind::File::ModeFlags);
+VARIANT_ENUM_CAST(core_bind::File::CompressionMode);
+
+VARIANT_ENUM_CAST(core_bind::Thread::Priority);
 
 #endif // CORE_BIND_H

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -330,7 +330,7 @@ public:
 
 		if (type->method_map.has(p_name)) {
 			memdelete(bind);
-			// overloading not supported
+			// Overloading not supported
 			ERR_FAIL_V_MSG(nullptr, "Method already bound: " + instance_type + "::" + p_name + ".");
 		}
 		type->method_map[p_name] = bind;
@@ -409,25 +409,25 @@ public:
 #ifdef DEBUG_METHODS_ENABLED
 
 #define BIND_CONSTANT(m_constant) \
-	ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
+	::ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
 
 #define BIND_ENUM_CONSTANT(m_constant) \
-	ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant, #m_constant), #m_constant, m_constant);
+	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant, #m_constant), #m_constant, m_constant);
 
 #else
 
 #define BIND_CONSTANT(m_constant) \
-	ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
+	::ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
 
 #define BIND_ENUM_CONSTANT(m_constant) \
-	ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
+	::ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
 
 #endif
 
 #ifdef TOOLS_ENABLED
 
 #define BIND_VMETHOD(m_method) \
-	ClassDB::add_virtual_method(get_class_static(), m_method);
+	::ClassDB::add_virtual_method(get_class_static(), m_method);
 
 #else
 
@@ -437,11 +437,11 @@ public:
 
 #define GDREGISTER_CLASS(m_class)                    \
 	if (!GD_IS_DEFINED(ClassDB_Disable_##m_class)) { \
-		ClassDB::register_class<m_class>();          \
+		::ClassDB::register_class<m_class>();        \
 	}
-#define GDREGISTER_VIRTUAL_CLASS(m_class)            \
-	if (!GD_IS_DEFINED(ClassDB_Disable_##m_class)) { \
-		ClassDB::register_virtual_class<m_class>();  \
+#define GDREGISTER_VIRTUAL_CLASS(m_class)             \
+	if (!GD_IS_DEFINED(ClassDB_Disable_##m_class)) {  \
+		::ClassDB::register_virtual_class<m_class>(); \
 	}
 
 #include "core/disabled_classes.gen.h"

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -137,17 +137,17 @@ enum PropertyUsageFlags {
 	PROPERTY_USAGE_NOEDITOR = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_NETWORK,
 };
 
-#define ADD_SIGNAL(m_signal) ClassDB::add_signal(get_class_static(), m_signal)
-#define ADD_PROPERTY(m_property, m_setter, m_getter) ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter))
-#define ADD_PROPERTYI(m_property, m_setter, m_getter, m_index) ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter), m_index)
-#define ADD_PROPERTY_DEFAULT(m_property, m_default) ClassDB::set_property_default_value(get_class_static(), m_property, m_default)
-#define ADD_GROUP(m_name, m_prefix) ClassDB::add_property_group(get_class_static(), m_name, m_prefix)
-#define ADD_SUBGROUP(m_name, m_prefix) ClassDB::add_property_subgroup(get_class_static(), m_name, m_prefix)
+#define ADD_SIGNAL(m_signal) ::ClassDB::add_signal(get_class_static(), m_signal)
+#define ADD_PROPERTY(m_property, m_setter, m_getter) ::ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter))
+#define ADD_PROPERTYI(m_property, m_setter, m_getter, m_index) ::ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter), m_index)
+#define ADD_PROPERTY_DEFAULT(m_property, m_default) ::ClassDB::set_property_default_value(get_class_static(), m_property, m_default)
+#define ADD_GROUP(m_name, m_prefix) ::ClassDB::add_property_group(get_class_static(), m_name, m_prefix)
+#define ADD_SUBGROUP(m_name, m_prefix) ::ClassDB::add_property_subgroup(get_class_static(), m_name, m_prefix)
 
 struct PropertyInfo {
 	Variant::Type type = Variant::NIL;
 	String name;
-	StringName class_name; //for classes
+	StringName class_name; // For classes
 	PropertyHint hint = PROPERTY_HINT_NONE;
 	String hint_string;
 	uint32_t usage = PROPERTY_USAGE_DEFAULT;
@@ -277,7 +277,7 @@ struct ObjectNativeExtension {
 };
 
 #define GDVIRTUAL_CALL(m_name, ...) _gdvirtual_##m_name##_call(__VA_ARGS__)
-#define GDVIRTUAL_BIND(m_name) ClassDB::add_virtual_method(get_class_static(), _gdvirtual_##m_name##_get_method_info());
+#define GDVIRTUAL_BIND(m_name) ::ClassDB::add_virtual_method(get_class_static(), _gdvirtual_##m_name##_get_method_info());
 
 /*
    the following is an incomprehensible blob of hacks and workarounds to compensate for many of the fallencies in C++. As a plus, this macro pretty much alone defines the object model.
@@ -299,7 +299,7 @@ private:
 private:                                                                                                                                         \
 	void operator=(const m_class &p_rval) {}                                                                                                     \
 	mutable StringName _class_name;                                                                                                              \
-	friend class ClassDB;                                                                                                                        \
+	friend class ::ClassDB;                                                                                                                      \
                                                                                                                                                  \
 public:                                                                                                                                          \
 	virtual String get_class() const override {                                                                                                  \
@@ -372,7 +372,7 @@ public:                                                                         
 			return;                                                                                                                              \
 		}                                                                                                                                        \
 		m_inherits::initialize_class();                                                                                                          \
-		ClassDB::_add_class<m_class>();                                                                                                          \
+		::ClassDB::_add_class<m_class>();                                                                                                        \
 		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) {                                                                   \
 			_bind_methods();                                                                                                                     \
 		}                                                                                                                                        \
@@ -415,13 +415,13 @@ protected:                                                                      
 		}                                                                                                                                        \
 		p_list->push_back(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));                \
 		if (!_is_gpl_reversed()) {                                                                                                               \
-			ClassDB::get_property_list(#m_class, p_list, true, this);                                                                            \
+			::ClassDB::get_property_list(#m_class, p_list, true, this);                                                                          \
 		}                                                                                                                                        \
 		if (m_class::_get_get_property_list() != m_inherits::_get_get_property_list()) {                                                         \
 			_get_property_list(p_list);                                                                                                          \
 		}                                                                                                                                        \
 		if (_is_gpl_reversed()) {                                                                                                                \
-			ClassDB::get_property_list(#m_class, p_list, true, this);                                                                            \
+			::ClassDB::get_property_list(#m_class, p_list, true, this);                                                                          \
 		}                                                                                                                                        \
 		if (p_reversed) {                                                                                                                        \
 			m_inherits::_get_property_listv(p_list, p_reversed);                                                                                 \

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -84,18 +84,18 @@ static Ref<ResourceFormatSaverCrypto> resource_format_saver_crypto;
 static Ref<ResourceFormatLoaderCrypto> resource_format_loader_crypto;
 static Ref<NativeExtensionResourceLoader> resource_loader_native_extension;
 
-static _ResourceLoader *_resource_loader = nullptr;
-static _ResourceSaver *_resource_saver = nullptr;
-static _OS *_os = nullptr;
-static _Engine *_engine = nullptr;
-static _ClassDB *_classdb = nullptr;
-static _Marshalls *_marshalls = nullptr;
-static _EngineDebugger *_engine_debugger = nullptr;
+static core_bind::ResourceLoader *_resource_loader = nullptr;
+static core_bind::ResourceSaver *_resource_saver = nullptr;
+static core_bind::OS *_os = nullptr;
+static core_bind::Engine *_engine = nullptr;
+static core_bind::special::ClassDB *_classdb = nullptr;
+static core_bind::Marshalls *_marshalls = nullptr;
+static core_bind::EngineDebugger *_engine_debugger = nullptr;
 
 static IP *ip = nullptr;
 
-static _Geometry2D *_geometry_2d = nullptr;
-static _Geometry3D *_geometry_3d = nullptr;
+static core_bind::Geometry2D *_geometry_2d = nullptr;
+static core_bind::Geometry3D *_geometry_3d = nullptr;
 
 extern Mutex _global_mutex;
 
@@ -203,11 +203,11 @@ void register_core_types() {
 	GDREGISTER_CLASS(ResourceFormatLoader);
 	GDREGISTER_CLASS(ResourceFormatSaver);
 
-	GDREGISTER_CLASS(_File);
-	GDREGISTER_CLASS(_Directory);
-	GDREGISTER_CLASS(_Thread);
-	GDREGISTER_CLASS(_Mutex);
-	GDREGISTER_CLASS(_Semaphore);
+	GDREGISTER_CLASS(core_bind::File);
+	GDREGISTER_CLASS(core_bind::Directory);
+	GDREGISTER_CLASS(core_bind::Thread);
+	GDREGISTER_CLASS(core_bind::Mutex);
+	GDREGISTER_CLASS(core_bind::Semaphore);
 
 	GDREGISTER_CLASS(XMLParser);
 	GDREGISTER_CLASS(JSON);
@@ -240,16 +240,16 @@ void register_core_types() {
 
 	ip = IP::create();
 
-	_geometry_2d = memnew(_Geometry2D);
-	_geometry_3d = memnew(_Geometry3D);
+	_geometry_2d = memnew(core_bind::Geometry2D);
+	_geometry_3d = memnew(core_bind::Geometry3D);
 
-	_resource_loader = memnew(_ResourceLoader);
-	_resource_saver = memnew(_ResourceSaver);
-	_os = memnew(_OS);
-	_engine = memnew(_Engine);
-	_classdb = memnew(_ClassDB);
-	_marshalls = memnew(_Marshalls);
-	_engine_debugger = memnew(_EngineDebugger);
+	_resource_loader = memnew(core_bind::ResourceLoader);
+	_resource_saver = memnew(core_bind::ResourceSaver);
+	_os = memnew(core_bind::OS);
+	_engine = memnew(core_bind::Engine);
+	_classdb = memnew(core_bind::special::ClassDB);
+	_marshalls = memnew(core_bind::Marshalls);
+	_engine_debugger = memnew(core_bind::EngineDebugger);
 }
 
 void register_core_settings() {
@@ -266,35 +266,35 @@ void register_core_settings() {
 void register_core_singletons() {
 	GDREGISTER_CLASS(ProjectSettings);
 	GDREGISTER_VIRTUAL_CLASS(IP);
-	GDREGISTER_CLASS(_Geometry2D);
-	GDREGISTER_CLASS(_Geometry3D);
-	GDREGISTER_CLASS(_ResourceLoader);
-	GDREGISTER_CLASS(_ResourceSaver);
-	GDREGISTER_CLASS(_OS);
-	GDREGISTER_CLASS(_Engine);
-	GDREGISTER_CLASS(_ClassDB);
-	GDREGISTER_CLASS(_Marshalls);
+	GDREGISTER_CLASS(core_bind::Geometry2D);
+	GDREGISTER_CLASS(core_bind::Geometry3D);
+	GDREGISTER_CLASS(core_bind::ResourceLoader);
+	GDREGISTER_CLASS(core_bind::ResourceSaver);
+	GDREGISTER_CLASS(core_bind::OS);
+	GDREGISTER_CLASS(core_bind::Engine);
+	GDREGISTER_CLASS(core_bind::special::ClassDB);
+	GDREGISTER_CLASS(core_bind::Marshalls);
 	GDREGISTER_CLASS(TranslationServer);
 	GDREGISTER_VIRTUAL_CLASS(Input);
 	GDREGISTER_CLASS(InputMap);
 	GDREGISTER_CLASS(Expression);
-	GDREGISTER_CLASS(_EngineDebugger);
+	GDREGISTER_CLASS(core_bind::EngineDebugger);
 	GDREGISTER_CLASS(Time);
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("IP", IP::get_singleton(), "IP"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry2D", _Geometry2D::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry3D", _Geometry3D::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceLoader", _ResourceLoader::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceSaver", _ResourceSaver::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("OS", _OS::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Engine", _Engine::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry2D", core_bind::Geometry2D::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry3D", core_bind::Geometry3D::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceLoader", core_bind::ResourceLoader::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceSaver", core_bind::ResourceSaver::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("OS", core_bind::OS::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Engine", core_bind::Engine::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ClassDB", _classdb));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Marshalls", _Marshalls::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Marshalls", core_bind::Marshalls::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TranslationServer", TranslationServer::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", Input::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("EngineDebugger", _EngineDebugger::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("EngineDebugger", core_bind::EngineDebugger::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Time", Time::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NativeExtensionManager", NativeExtensionManager::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceUID", ResourceUID::get_singleton()));

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -241,14 +241,27 @@ struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>:
 	}
 };
 
-#define TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_impl)                                                                                                                                 \
-	template <>                                                                                                                                                                   \
-	struct GetTypeInfo<m_impl> {                                                                                                                                                  \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                                                   \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                                                             \
-		static inline PropertyInfo get_class_info() {                                                                                                                             \
-			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, String(#m_enum).replace("::", ".")); \
-		}                                                                                                                                                                         \
+namespace godot {
+namespace details {
+inline String enum_qualified_name_to_class_info_name(const String &p_qualified_name) {
+	Vector<String> parts = p_qualified_name.split("::", false);
+	if (parts.size() <= 2)
+		return String(".").join(parts);
+	// Contains namespace. We only want the class and enum names.
+	return parts[parts.size() - 2] + "." + parts[parts.size() - 1];
+}
+} // namespace details
+} // namespace godot
+
+#define TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_impl)                                                                                            \
+	template <>                                                                                                                              \
+	struct GetTypeInfo<m_impl> {                                                                                                             \
+		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
+		static inline PropertyInfo get_class_info() {                                                                                        \
+			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, \
+					godot::details::enum_qualified_name_to_class_info_name(String(#m_enum)));                                                \
+		}                                                                                                                                    \
 	};
 
 #define MAKE_ENUM_TYPE_INFO(m_enum)                 \

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -1031,9 +1031,6 @@ def make_enum(t, state):  # type: (str, State) -> str
         if c in state.classes and e not in state.classes[c].enums:
             c = "@GlobalScope"
 
-    if not c in state.classes and c.startswith("_"):
-        c = c[1:]  # Remove the underscore prefix
-
     if c in state.classes and e in state.classes[c].enums:
         return ":ref:`{0}<enum_{1}_{0}>`".format(e, c)
 

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -245,9 +245,6 @@ void DocTools::generate(bool p_basic_types) {
 		}
 
 		String cname = name;
-		if (cname.begins_with("_")) { //proxy class
-			cname = cname.substr(1, name.length());
-		}
 
 		class_list[cname] = DocData::ClassDoc();
 		DocData::ClassDoc &c = class_list[cname];
@@ -739,9 +736,6 @@ void DocTools::generate(bool p_basic_types) {
 			pd.type = s.ptr->get_class();
 			while (String(ClassDB::get_parent_class(pd.type)) != "Object") {
 				pd.type = ClassDB::get_parent_class(pd.type);
-			}
-			if (pd.type.begins_with("_")) {
-				pd.type = pd.type.substr(1, pd.type.length());
 			}
 			c.properties.push_back(pd);
 		}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -104,11 +104,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 	List<StringName> types;
 	ClassDB::get_class_list(&types);
 	for (const StringName &E : types) {
-		String n = E;
-		if (n.begins_with("_")) {
-			n = n.substr(1, n.length());
-		}
-		highlighter->add_keyword_color(n, type_color);
+		highlighter->add_keyword_color(E, type_color);
 	}
 
 	/* User types. */

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -756,8 +756,6 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 	} else if (script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_symbol_lookup(), p_symbol, script->get_path(), base, result) == OK) {
 		_goto_line(p_row);
 
-		result.class_name = result.class_name.trim_prefix("_");
-
 		switch (result.type) {
 			case ScriptLanguage::LookupResult::RESULT_SCRIPT_LOCATION: {
 				if (result.script.is_valid()) {

--- a/modules/fbx/data/fbx_material.cpp
+++ b/modules/fbx/data/fbx_material.cpp
@@ -31,7 +31,7 @@
 #include "fbx_material.h"
 
 // FIXME: Shouldn't depend on core_bind.h! Use DirAccessRef like the rest of
-// the engine instead of _Directory.
+// the engine instead of core_bind::Directory.
 #include "core/core_bind.h"
 #include "scene/resources/material.h"
 #include "scene/resources/texture.h"
@@ -55,7 +55,7 @@ void FBXMaterial::add_search_string(String p_filename, String p_current_director
 }
 
 String find_file(const String &p_base, const String &p_file_to_find) {
-	_Directory dir;
+	core_bind::Directory dir;
 	dir.open(p_base);
 
 	dir.list_dir_begin();
@@ -84,7 +84,7 @@ String find_file(const String &p_base, const String &p_file_to_find) {
 // fbx will not give us good path information and let's not regex them to fix them
 // no relative paths are in fbx generally they have a rel field but it's populated incorrectly by the SDK.
 String FBXMaterial::find_texture_path_by_filename(const String p_filename, const String p_current_directory) {
-	_Directory dir;
+	core_bind::Directory dir;
 	Vector<String> paths;
 	add_search_string(p_filename, p_current_directory, "", paths);
 	add_search_string(p_filename, p_current_directory, "texture", paths);

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -242,13 +242,9 @@ List<ClassAPI> generate_c_api_classes() {
 		class_api.class_name = class_name;
 		class_api.super_class_name = ClassDB::get_parent_class(class_name);
 		{
-			String name = class_name;
-			if (name.begins_with("_")) {
-				name.remove(0);
-			}
-			class_api.is_singleton = Engine::get_singleton()->has_singleton(name);
+			class_api.is_singleton = Engine::get_singleton()->has_singleton(class_name);
 			if (class_api.is_singleton) {
-				class_api.singleton_name = name;
+				class_api.singleton_name = class_name;
 			}
 		}
 		class_api.is_instantiable = !class_api.is_singleton && ClassDB::can_instantiate(class_name);

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -459,11 +459,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	List<StringName> types;
 	ClassDB::get_class_list(&types);
 	for (const StringName &E : types) {
-		String n = E;
-		if (n.begins_with("_")) {
-			n = n.substr(1, n.length());
-		}
-		keywords[n] = types_color;
+		keywords[E] = types_color;
 	}
 
 	/* User types. */

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1644,16 +1644,11 @@ void GDScriptLanguage::init() {
 	List<StringName> class_list;
 	ClassDB::get_class_list(&class_list);
 	for (const StringName &n : class_list) {
-		String s = String(n);
-		if (s.begins_with("_")) {
-			s = s.substr(1, s.length());
-		}
-
-		if (globals.has(s)) {
+		if (globals.has(n)) {
 			continue;
 		}
 		Ref<GDScriptNativeClass> nc = memnew(GDScriptNativeClass(n));
-		_add_global(s, nc);
+		_add_global(n, nc);
 	}
 
 	//populate singletons

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -111,11 +111,7 @@ public:
 				}
 
 				if (!ClassDB::is_parent_class(obj->get_class_name(), native_type)) {
-					// Try with underscore prefix
-					StringName underscore_native_type = "_" + native_type;
-					if (!ClassDB::is_parent_class(obj->get_class_name(), underscore_native_type)) {
-						return false;
-					}
+					return false;
 				}
 				return true;
 			} break;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -94,43 +94,8 @@ Variant::Type GDScriptParser::get_builtin_type(const StringName &p_type) {
 	return Variant::VARIANT_MAX;
 }
 
-// TODO: Move this to a central location (maybe core?).
-static HashMap<StringName, StringName> underscore_map;
-static const char *underscore_classes[] = {
-	"ClassDB",
-	"Directory",
-	"Engine",
-	"File",
-	"Geometry",
-	"GodotSharp",
-	"JSON",
-	"Marshalls",
-	"Mutex",
-	"OS",
-	"ResourceLoader",
-	"ResourceSaver",
-	"Semaphore",
-	"Thread",
-	"VisualScriptEditor",
-	nullptr,
-};
-StringName GDScriptParser::get_real_class_name(const StringName &p_source) {
-	if (underscore_map.is_empty()) {
-		const char **class_name = underscore_classes;
-		while (*class_name != nullptr) {
-			underscore_map[*class_name] = String("_") + *class_name;
-			class_name++;
-		}
-	}
-	if (underscore_map.has(p_source)) {
-		return underscore_map[p_source];
-	}
-	return p_source;
-}
-
 void GDScriptParser::cleanup() {
 	builtin_types.clear();
-	underscore_map.clear();
 }
 
 void GDScriptParser::get_annotation_list(List<MethodInfo> *r_annotations) const {
@@ -3363,10 +3328,10 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 				variable->export_info.hint_string = Variant::get_type_name(export_type.builtin_type);
 				break;
 			case GDScriptParser::DataType::NATIVE:
-				if (ClassDB::is_parent_class(get_real_class_name(export_type.native_type), "Resource")) {
+				if (ClassDB::is_parent_class(export_type.native_type, "Resource")) {
 					variable->export_info.type = Variant::OBJECT;
 					variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
-					variable->export_info.hint_string = get_real_class_name(export_type.native_type);
+					variable->export_info.hint_string = export_type.native_type;
 				} else {
 					push_error(R"(Export type can only be built-in, a resource, or an enum.)", variable);
 					return false;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1399,7 +1399,6 @@ public:
 	ClassNode *get_tree() const { return head; }
 	bool is_tool() const { return _is_tool; }
 	static Variant::Type get_builtin_type(const StringName &p_type);
-	static StringName get_real_class_name(const StringName &p_source);
 
 	CompletionContext get_completion_context() const { return completion_context; }
 	CompletionCall get_completion_call() const { return completion_call; }

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -241,7 +241,7 @@ MonoBoolean godot_icall_Internal_IsAssembliesReloadingNeeded() {
 
 void godot_icall_Internal_ReloadAssemblies(MonoBoolean p_soft_reload) {
 #ifdef GD_MONO_HOT_RELOAD
-	_GodotSharp::get_singleton()->call_deferred(SNAME("_reload_assemblies"), (bool)p_soft_reload);
+	mono_bind::GodotSharp::get_singleton()->call_deferred(SNAME("_reload_assemblies"), (bool)p_soft_reload);
 #endif
 }
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -73,7 +73,7 @@
 #endif
 
 // TODO:
-// This has turn into a gigantic mess. There's too much going on here. Too much #ifdef as well.
+// This has turned into a gigantic mess. There's too much going on here. Too much #ifdef as well.
 // It's just painful to read... It needs to be re-structured. Please, clean this up, future me.
 
 GDMono *GDMono::singleton = nullptr;
@@ -1335,23 +1335,25 @@ GDMono::~GDMono() {
 	singleton = nullptr;
 }
 
-_GodotSharp *_GodotSharp::singleton = nullptr;
+namespace mono_bind {
 
-void _GodotSharp::attach_thread() {
+GodotSharp *GodotSharp::singleton = nullptr;
+
+void GodotSharp::attach_thread() {
 	GDMonoUtils::attach_current_thread();
 }
 
-void _GodotSharp::detach_thread() {
+void GodotSharp::detach_thread() {
 	GDMonoUtils::detach_current_thread();
 }
 
-int32_t _GodotSharp::get_domain_id() {
+int32_t GodotSharp::get_domain_id() {
 	MonoDomain *domain = mono_domain_get();
 	ERR_FAIL_NULL_V(domain, -1);
 	return mono_domain_get_id(domain);
 }
 
-int32_t _GodotSharp::get_scripts_domain_id() {
+int32_t GodotSharp::get_scripts_domain_id() {
 	ERR_FAIL_NULL_V_MSG(GDMono::get_singleton(),
 			-1, "The Mono runtime is not initialized");
 	MonoDomain *domain = GDMono::get_singleton()->get_scripts_domain();
@@ -1359,21 +1361,21 @@ int32_t _GodotSharp::get_scripts_domain_id() {
 	return mono_domain_get_id(domain);
 }
 
-bool _GodotSharp::is_scripts_domain_loaded() {
+bool GodotSharp::is_scripts_domain_loaded() {
 	return GDMono::get_singleton() != nullptr &&
 		   GDMono::get_singleton()->is_runtime_initialized() &&
 		   GDMono::get_singleton()->get_scripts_domain() != nullptr;
 }
 
-bool _GodotSharp::_is_domain_finalizing_for_unload(int32_t p_domain_id) {
+bool GodotSharp::_is_domain_finalizing_for_unload(int32_t p_domain_id) {
 	return is_domain_finalizing_for_unload(p_domain_id);
 }
 
-bool _GodotSharp::is_domain_finalizing_for_unload(int32_t p_domain_id) {
+bool GodotSharp::is_domain_finalizing_for_unload(int32_t p_domain_id) {
 	return is_domain_finalizing_for_unload(mono_domain_get_by_id(p_domain_id));
 }
 
-bool _GodotSharp::is_domain_finalizing_for_unload(MonoDomain *p_domain) {
+bool GodotSharp::is_domain_finalizing_for_unload(MonoDomain *p_domain) {
 	GDMono *gd_mono = GDMono::get_singleton();
 
 	ERR_FAIL_COND_V_MSG(!gd_mono || !gd_mono->is_runtime_initialized(),
@@ -1388,15 +1390,15 @@ bool _GodotSharp::is_domain_finalizing_for_unload(MonoDomain *p_domain) {
 	return mono_domain_is_unloading(p_domain);
 }
 
-bool _GodotSharp::is_runtime_shutting_down() {
+bool GodotSharp::is_runtime_shutting_down() {
 	return mono_runtime_is_shutting_down();
 }
 
-bool _GodotSharp::is_runtime_initialized() {
+bool GodotSharp::is_runtime_initialized() {
 	return GDMono::get_singleton() != nullptr && GDMono::get_singleton()->is_runtime_initialized();
 }
 
-void _GodotSharp::_reload_assemblies(bool p_soft_reload) {
+void GodotSharp::_reload_assemblies(bool p_soft_reload) {
 #ifdef GD_MONO_HOT_RELOAD
 	CRASH_COND(CSharpLanguage::get_singleton() == nullptr);
 	// This method may be called more than once with `call_deferred`, so we need to check
@@ -1407,24 +1409,26 @@ void _GodotSharp::_reload_assemblies(bool p_soft_reload) {
 #endif
 }
 
-void _GodotSharp::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("attach_thread"), &_GodotSharp::attach_thread);
-	ClassDB::bind_method(D_METHOD("detach_thread"), &_GodotSharp::detach_thread);
+void GodotSharp::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("attach_thread"), &GodotSharp::attach_thread);
+	ClassDB::bind_method(D_METHOD("detach_thread"), &GodotSharp::detach_thread);
 
-	ClassDB::bind_method(D_METHOD("get_domain_id"), &_GodotSharp::get_domain_id);
-	ClassDB::bind_method(D_METHOD("get_scripts_domain_id"), &_GodotSharp::get_scripts_domain_id);
-	ClassDB::bind_method(D_METHOD("is_scripts_domain_loaded"), &_GodotSharp::is_scripts_domain_loaded);
-	ClassDB::bind_method(D_METHOD("is_domain_finalizing_for_unload", "domain_id"), &_GodotSharp::_is_domain_finalizing_for_unload);
+	ClassDB::bind_method(D_METHOD("get_domain_id"), &GodotSharp::get_domain_id);
+	ClassDB::bind_method(D_METHOD("get_scripts_domain_id"), &GodotSharp::get_scripts_domain_id);
+	ClassDB::bind_method(D_METHOD("is_scripts_domain_loaded"), &GodotSharp::is_scripts_domain_loaded);
+	ClassDB::bind_method(D_METHOD("is_domain_finalizing_for_unload", "domain_id"), &GodotSharp::_is_domain_finalizing_for_unload);
 
-	ClassDB::bind_method(D_METHOD("is_runtime_shutting_down"), &_GodotSharp::is_runtime_shutting_down);
-	ClassDB::bind_method(D_METHOD("is_runtime_initialized"), &_GodotSharp::is_runtime_initialized);
-	ClassDB::bind_method(D_METHOD("_reload_assemblies"), &_GodotSharp::_reload_assemblies);
+	ClassDB::bind_method(D_METHOD("is_runtime_shutting_down"), &GodotSharp::is_runtime_shutting_down);
+	ClassDB::bind_method(D_METHOD("is_runtime_initialized"), &GodotSharp::is_runtime_initialized);
+	ClassDB::bind_method(D_METHOD("_reload_assemblies"), &GodotSharp::_reload_assemblies);
 }
 
-_GodotSharp::_GodotSharp() {
+GodotSharp::GodotSharp() {
 	singleton = this;
 }
 
-_GodotSharp::~_GodotSharp() {
+GodotSharp::~GodotSharp() {
 	singleton = nullptr;
 }
+
+} // namespace mono_bind

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -293,8 +293,10 @@ public:
 	gdmono::ScopeExitDomainUnload __gdmono__scope__exit__domain__unload__(m_mono_domain); \
 	(void)__gdmono__scope__exit__domain__unload__;
 
-class _GodotSharp : public Object {
-	GDCLASS(_GodotSharp, Object);
+namespace mono_bind {
+
+class GodotSharp : public Object {
+	GDCLASS(GodotSharp, Object);
 
 	friend class GDMono;
 
@@ -303,11 +305,11 @@ class _GodotSharp : public Object {
 	void _reload_assemblies(bool p_soft_reload);
 
 protected:
-	static _GodotSharp *singleton;
+	static GodotSharp *singleton;
 	static void _bind_methods();
 
 public:
-	static _GodotSharp *get_singleton() { return singleton; }
+	static GodotSharp *get_singleton() { return singleton; }
 
 	void attach_thread();
 	void detach_thread();
@@ -323,8 +325,10 @@ public:
 	bool is_runtime_shutting_down();
 	bool is_runtime_initialized();
 
-	_GodotSharp();
-	~_GodotSharp();
+	GodotSharp();
+	~GodotSharp();
 };
+
+} // namespace mono_bind
 
 #endif // GD_MONO_H

--- a/modules/mono/register_types.cpp
+++ b/modules/mono/register_types.cpp
@@ -38,15 +38,15 @@ CSharpLanguage *script_language_cs = nullptr;
 Ref<ResourceFormatLoaderCSharpScript> resource_loader_cs;
 Ref<ResourceFormatSaverCSharpScript> resource_saver_cs;
 
-_GodotSharp *_godotsharp = nullptr;
+mono_bind::GodotSharp *_godotsharp = nullptr;
 
 void register_mono_types() {
 	GDREGISTER_CLASS(CSharpScript);
 
-	_godotsharp = memnew(_GodotSharp);
+	_godotsharp = memnew(mono_bind::GodotSharp);
 
-	GDREGISTER_CLASS(_GodotSharp);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("GodotSharp", _GodotSharp::get_singleton()));
+	GDREGISTER_CLASS(mono_bind::GodotSharp);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("GodotSharp", mono_bind::GodotSharp::get_singleton()));
 
 	script_language_cs = memnew(CSharpLanguage);
 	script_language_cs->set_language_index(ScriptServer::get_language_count());

--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -43,7 +43,7 @@
 
 VisualScriptLanguage *visual_script_language = nullptr;
 #ifdef TOOLS_ENABLED
-static _VisualScriptEditor *vs_editor_singleton = nullptr;
+static vs_bind::VisualScriptEditor *vs_editor_singleton = nullptr;
 #endif
 
 void register_visual_script_types() {
@@ -114,10 +114,10 @@ void register_visual_script_types() {
 
 #ifdef TOOLS_ENABLED
 	ClassDB::set_current_api(ClassDB::API_EDITOR);
-	GDREGISTER_CLASS(_VisualScriptEditor);
+	GDREGISTER_CLASS(vs_bind::VisualScriptEditor);
 	ClassDB::set_current_api(ClassDB::API_CORE);
-	vs_editor_singleton = memnew(_VisualScriptEditor);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("VisualScriptEditor", _VisualScriptEditor::get_singleton()));
+	vs_editor_singleton = memnew(vs_bind::VisualScriptEditor);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("VisualScriptEditor", vs_bind::VisualScriptEditor::get_singleton()));
 
 	VisualScriptEditor::register_editor();
 #endif

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -4521,44 +4521,49 @@ void VisualScriptEditor::register_editor() {
 	EditorNode::add_plugin_init_callback(register_editor_callback);
 }
 
-Ref<VisualScriptNode> _VisualScriptEditor::create_node_custom(const String &p_name) {
+void VisualScriptEditor::validate() {
+}
+
+namespace vs_bind {
+
+Ref<VisualScriptNode> VisualScriptEditor::create_node_custom(const String &p_name) {
 	Ref<VisualScriptCustomNode> node;
 	node.instantiate();
 	node->set_script(singleton->custom_nodes[p_name]);
 	return node;
 }
 
-_VisualScriptEditor *_VisualScriptEditor::singleton = nullptr;
-Map<String, REF> _VisualScriptEditor::custom_nodes;
+VisualScriptEditor *VisualScriptEditor::singleton = nullptr;
+Map<String, REF> VisualScriptEditor::custom_nodes;
 
-_VisualScriptEditor::_VisualScriptEditor() {
+VisualScriptEditor::VisualScriptEditor() {
 	singleton = this;
 }
 
-_VisualScriptEditor::~_VisualScriptEditor() {
+VisualScriptEditor::~VisualScriptEditor() {
 	custom_nodes.clear();
 }
 
-void _VisualScriptEditor::add_custom_node(const String &p_name, const String &p_category, const Ref<Script> &p_script) {
+void VisualScriptEditor::add_custom_node(const String &p_name, const String &p_category, const Ref<Script> &p_script) {
 	String node_name = "custom/" + p_category + "/" + p_name;
 	custom_nodes.insert(node_name, p_script);
-	VisualScriptLanguage::singleton->add_register_func(node_name, &_VisualScriptEditor::create_node_custom);
+	VisualScriptLanguage::singleton->add_register_func(node_name, &VisualScriptEditor::create_node_custom);
 	emit_signal(SNAME("custom_nodes_updated"));
 }
 
-void _VisualScriptEditor::remove_custom_node(const String &p_name, const String &p_category) {
+void VisualScriptEditor::remove_custom_node(const String &p_name, const String &p_category) {
 	String node_name = "custom/" + p_category + "/" + p_name;
 	custom_nodes.erase(node_name);
 	VisualScriptLanguage::singleton->remove_register_func(node_name);
 	emit_signal(SNAME("custom_nodes_updated"));
 }
 
-void _VisualScriptEditor::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_custom_node", "name", "category", "script"), &_VisualScriptEditor::add_custom_node);
-	ClassDB::bind_method(D_METHOD("remove_custom_node", "name", "category"), &_VisualScriptEditor::remove_custom_node);
+void VisualScriptEditor::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_custom_node", "name", "category", "script"), &VisualScriptEditor::add_custom_node);
+	ClassDB::bind_method(D_METHOD("remove_custom_node", "name", "category"), &VisualScriptEditor::remove_custom_node);
 	ADD_SIGNAL(MethodInfo("custom_nodes_updated"));
 }
 
-void VisualScriptEditor::validate() {
-}
+} // namespace vs_bind
+
 #endif

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -332,28 +332,33 @@ public:
 	~VisualScriptEditor();
 };
 
+namespace vs_bind {
+
 // Singleton
-class _VisualScriptEditor : public Object {
-	GDCLASS(_VisualScriptEditor, Object);
+class VisualScriptEditor : public Object {
+	GDCLASS(VisualScriptEditor, Object);
 
 	friend class VisualScriptLanguage;
 
 protected:
 	static void _bind_methods();
-	static _VisualScriptEditor *singleton;
+	static VisualScriptEditor *singleton;
 
 	static Map<String, REF> custom_nodes;
 	static Ref<VisualScriptNode> create_node_custom(const String &p_name);
 
 public:
-	static _VisualScriptEditor *get_singleton() { return singleton; }
+	static VisualScriptEditor *get_singleton() { return singleton; }
 
 	void add_custom_node(const String &p_name, const String &p_category, const Ref<Script> &p_script);
 	void remove_custom_node(const String &p_name, const String &p_category);
 
-	_VisualScriptEditor();
-	~_VisualScriptEditor();
+	VisualScriptEditor();
+	~VisualScriptEditor();
 };
+
+} // namespace vs_bind
+
 #endif
 
 #endif // VISUALSCRIPT_EDITOR_H


### PR DESCRIPTION
Redoing https://github.com/godotengine/godot/pull/26990/ for current master.

**This is now fully working and tested :)**

The first commit moves underscored classes to namespaces,
the second removes a lot of hacks/cruft checking for underscores on classes, which we now no longer need to do.

I recommend reviewing both commits sperately.

Note: This currently means that for namespaced classes, the macros will check for defines like `ClassDB_Disable_core_bind::Directory` instead of `ClassDB_Disable_Directory`. (In the `GDREGISTER_CLASS` macro).
(Used when passing `disabled_classes` to SCons.)
This only affects the small handful of classes that were previously underscored:
- ClassDB
- Directory
- Engine
- File
- Geometry2D
- Geometry3D
- GodotSharp
- Marshalls
- Mutex
- OS
- ResourceLoader
- ResourceSaver
- Semaphore
- Thread
- VisualScriptEditor

Getting rid of the current special casing for all those underscore classes seems prudent, as even while working on this PR I found various bugs related to it - cases where underscores were checked in some cases, in some not, or were applied inconsistently; sometimes classes were displayed with underscores in Godot UI, sometimes not. The list of `underscore_classes` this removes even exhibits a few errors: `JSON` is no longer current, and `Geometry` has become `Geometry2D` and `Geometry3D`.