### PR TITLE
Implement more advanced features for DAP

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -44,7 +44,7 @@ class DebugAdapterParser : public Object {
 private:
 	friend DebugAdapterProtocol;
 
-	_FORCE_INLINE_ bool is_valid_path(const String &p_path) {
+	_FORCE_INLINE_ bool is_valid_path(const String &p_path) const {
 		return p_path.begins_with(ProjectSettings::get_singleton()->get_resource_path());
 	}
 
@@ -60,17 +60,23 @@ protected:
 public:
 	// Requests
 	Dictionary req_initialize(const Dictionary &p_params) const;
-	Dictionary req_launch(const Dictionary &p_params);
+	Dictionary req_launch(const Dictionary &p_params) const;
+	Dictionary req_disconnect(const Dictionary &p_params) const;
+	Dictionary req_attach(const Dictionary &p_params) const;
+	Dictionary req_restart(const Dictionary &p_params) const;
 	Dictionary req_terminate(const Dictionary &p_params) const;
 	Dictionary req_pause(const Dictionary &p_params) const;
 	Dictionary req_continue(const Dictionary &p_params) const;
 	Dictionary req_threads(const Dictionary &p_params) const;
 	Dictionary req_stackTrace(const Dictionary &p_params) const;
-	Dictionary req_setBreakpoints(const Dictionary &p_params);
-	Dictionary req_scopes(const Dictionary &p_params);
+	Dictionary req_setBreakpoints(const Dictionary &p_params) const;
+	Dictionary req_breakpointLocations(const Dictionary &p_params) const;
+	Dictionary req_scopes(const Dictionary &p_params) const;
 	Dictionary req_variables(const Dictionary &p_params) const;
 	Dictionary req_next(const Dictionary &p_params) const;
 	Dictionary req_stepIn(const Dictionary &p_params) const;
+	Dictionary req_evaluate(const Dictionary &p_params) const;
+	Dictionary req_godot_put_msg(const Dictionary &p_params) const;
 
 	// Events
 	Dictionary ev_initialized() const;
@@ -83,6 +89,8 @@ public:
 	Dictionary ev_stopped_step() const;
 	Dictionary ev_continued() const;
 	Dictionary ev_output(const String &p_message) const;
+	Dictionary ev_custom_data(const String &p_msg, const Array &p_data) const;
+	Dictionary ev_breakpoint(const DAP::Breakpoint &p_breakpoint, const bool &p_enabled) const;
 };
 
 #endif

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -94,11 +94,17 @@ Error DAPeer::handle_data() {
 		String msg;
 		msg.parse_utf8((const char *)req_buf, req_pos);
 
+		// Apply a timestamp if it there's none yet
+		if (!timestamp) {
+			timestamp = OS::get_singleton()->get_ticks_msec();
+		}
+
 		// Response
 		if (DebugAdapterProtocol::get_singleton()->process_message(msg)) {
 			// Reset to read again
 			req_pos = 0;
 			has_header = false;
+			timestamp = 0;
 		}
 	}
 	return OK;
@@ -180,11 +186,459 @@ void DebugAdapterProtocol::reset_stack_info() {
 	variable_list.clear();
 }
 
+int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
+	switch (p_var.get_type()) {
+		case Variant::VECTOR2:
+		case Variant::VECTOR2I: {
+			int id = variable_id++;
+			Vector2 vec = p_var;
+			DAP::Variable x, y;
+			x.name = "x";
+			y.name = "y";
+			x.type = y.type = Variant::get_type_name(p_var.get_type() == Variant::VECTOR2 ? Variant::FLOAT : Variant::INT);
+			x.value = rtos(vec.x);
+			y.value = rtos(vec.y);
+
+			Array arr;
+			arr.push_back(x.to_json());
+			arr.push_back(y.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::RECT2:
+		case Variant::RECT2I: {
+			int id = variable_id++;
+			Rect2 rect = p_var;
+			DAP::Variable x, y, w, h;
+			x.name = "x";
+			y.name = "y";
+			w.name = "w";
+			h.name = "h";
+			x.type = y.type = w.type = h.type = Variant::get_type_name(p_var.get_type() == Variant::RECT2 ? Variant::FLOAT : Variant::INT);
+			x.value = rtos(rect.position.x);
+			y.value = rtos(rect.position.y);
+			w.value = rtos(rect.size.x);
+			h.value = rtos(rect.size.y);
+
+			Array arr;
+			arr.push_back(x.to_json());
+			arr.push_back(y.to_json());
+			arr.push_back(w.to_json());
+			arr.push_back(h.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::VECTOR3:
+		case Variant::VECTOR3I: {
+			int id = variable_id++;
+			Vector3 vec = p_var;
+			DAP::Variable x, y, z;
+			x.name = "x";
+			y.name = "y";
+			z.name = "z";
+			x.type = y.type = z.type = Variant::get_type_name(p_var.get_type() == Variant::VECTOR3 ? Variant::FLOAT : Variant::INT);
+			x.value = rtos(vec.x);
+			y.value = rtos(vec.y);
+			z.value = rtos(vec.z);
+
+			Array arr;
+			arr.push_back(x.to_json());
+			arr.push_back(y.to_json());
+			arr.push_back(z.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::TRANSFORM2D: {
+			int id = variable_id++;
+			Transform2D transform = p_var;
+			DAP::Variable x, y, origin;
+			x.name = "x";
+			y.name = "y";
+			origin.name = "origin";
+			x.type = y.type = origin.type = Variant::get_type_name(Variant::VECTOR2);
+			x.value = transform.elements[0];
+			y.value = transform.elements[1];
+			origin.value = transform.elements[2];
+			x.variablesReference = parse_variant(transform.elements[0]);
+			y.variablesReference = parse_variant(transform.elements[1]);
+			origin.variablesReference = parse_variant(transform.elements[2]);
+
+			Array arr;
+			arr.push_back(x.to_json());
+			arr.push_back(y.to_json());
+			arr.push_back(origin.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PLANE: {
+			int id = variable_id++;
+			Plane plane = p_var;
+			DAP::Variable d, normal;
+			d.name = "d";
+			normal.name = "normal";
+			d.type = Variant::get_type_name(Variant::FLOAT);
+			normal.type = Variant::get_type_name(Variant::VECTOR3);
+			d.value = rtos(plane.d);
+			normal.value = plane.normal;
+			normal.variablesReference = parse_variant(plane.normal);
+
+			Array arr;
+			arr.push_back(d.to_json());
+			arr.push_back(normal.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::QUATERNION: {
+			int id = variable_id++;
+			Quaternion quat = p_var;
+			DAP::Variable x, y, z, w;
+			x.name = "x";
+			y.name = "y";
+			z.name = "z";
+			w.name = "w";
+			x.type = y.type = z.type = w.type = Variant::get_type_name(Variant::FLOAT);
+			x.value = rtos(quat.x);
+			y.value = rtos(quat.y);
+			z.value = rtos(quat.z);
+			w.value = rtos(quat.w);
+
+			Array arr;
+			arr.push_back(x.to_json());
+			arr.push_back(y.to_json());
+			arr.push_back(z.to_json());
+			arr.push_back(w.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::AABB: {
+			int id = variable_id++;
+			AABB aabb = p_var;
+			DAP::Variable position, size;
+			position.name = "position";
+			size.name = "size";
+			position.type = size.type = Variant::get_type_name(Variant::VECTOR3);
+			position.value = aabb.position;
+			size.value = aabb.size;
+			position.variablesReference = parse_variant(aabb.position);
+			size.variablesReference = parse_variant(aabb.size);
+
+			Array arr;
+			arr.push_back(position.to_json());
+			arr.push_back(size.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::BASIS: {
+			int id = variable_id++;
+			Basis basis = p_var;
+			DAP::Variable x, y, z;
+			x.name = "x";
+			y.name = "y";
+			z.name = "z";
+			x.type = y.type = z.type = Variant::get_type_name(Variant::VECTOR2);
+			x.value = basis.elements[0];
+			y.value = basis.elements[1];
+			z.value = basis.elements[2];
+			x.variablesReference = parse_variant(basis.elements[0]);
+			y.variablesReference = parse_variant(basis.elements[1]);
+			z.variablesReference = parse_variant(basis.elements[2]);
+
+			Array arr;
+			arr.push_back(x.to_json());
+			arr.push_back(y.to_json());
+			arr.push_back(z.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::TRANSFORM3D: {
+			int id = variable_id++;
+			Transform3D transform = p_var;
+			DAP::Variable basis, origin;
+			basis.name = "basis";
+			origin.name = "origin";
+			basis.type = Variant::get_type_name(Variant::BASIS);
+			origin.type = Variant::get_type_name(Variant::VECTOR3);
+			basis.value = transform.basis;
+			origin.value = transform.origin;
+			basis.variablesReference = parse_variant(transform.basis);
+			origin.variablesReference = parse_variant(transform.origin);
+
+			Array arr;
+			arr.push_back(basis.to_json());
+			arr.push_back(origin.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::COLOR: {
+			int id = variable_id++;
+			Color color = p_var;
+			DAP::Variable r, g, b, a;
+			r.name = "r";
+			g.name = "g";
+			b.name = "b";
+			a.name = "a";
+			r.type = g.type = b.type = a.type = Variant::get_type_name(Variant::FLOAT);
+			r.value = rtos(color.r);
+			g.value = rtos(color.g);
+			b.value = rtos(color.b);
+			a.value = rtos(color.a);
+
+			Array arr;
+			arr.push_back(r.to_json());
+			arr.push_back(g.to_json());
+			arr.push_back(b.to_json());
+			arr.push_back(a.to_json());
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::ARRAY: {
+			int id = variable_id++;
+			Array array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = Variant::get_type_name(array[i].get_type());
+				var.value = array[i];
+				var.variablesReference = parse_variant(array[i]);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::DICTIONARY: {
+			int id = variable_id++;
+			Dictionary dictionary = p_var;
+			Array arr;
+
+			for (int i = 0; i < dictionary.size(); i++) {
+				DAP::Variable var;
+				var.name = dictionary.get_key_at_index(i);
+				Variant value = dictionary.get_value_at_index(i);
+				var.type = Variant::get_type_name(value.get_type());
+				var.value = value;
+				var.variablesReference = parse_variant(value);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PACKED_BYTE_ARRAY: {
+			int id = variable_id++;
+			PackedByteArray array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = "byte";
+				var.value = itos(array[i]);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PACKED_INT32_ARRAY: {
+			int id = variable_id++;
+			PackedInt32Array array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = "int";
+				var.value = itos(array[i]);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PACKED_INT64_ARRAY: {
+			int id = variable_id++;
+			PackedInt64Array array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = "long";
+				var.value = itos(array[i]);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PACKED_FLOAT32_ARRAY: {
+			int id = variable_id++;
+			PackedFloat32Array array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = "float";
+				var.value = rtos(array[i]);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PACKED_FLOAT64_ARRAY: {
+			int id = variable_id++;
+			PackedFloat64Array array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = "double";
+				var.value = rtos(array[i]);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PACKED_STRING_ARRAY: {
+			int id = variable_id++;
+			PackedStringArray array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = Variant::get_type_name(Variant::STRING);
+				var.value = array[i];
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PACKED_VECTOR2_ARRAY: {
+			int id = variable_id++;
+			PackedVector2Array array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = Variant::get_type_name(Variant::VECTOR2);
+				var.value = array[i];
+				var.variablesReference = parse_variant(array[i]);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PACKED_VECTOR3_ARRAY: {
+			int id = variable_id++;
+			PackedVector2Array array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = Variant::get_type_name(Variant::VECTOR3);
+				var.value = array[i];
+				var.variablesReference = parse_variant(array[i]);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		case Variant::PACKED_COLOR_ARRAY: {
+			int id = variable_id++;
+			PackedColorArray array = p_var;
+			DAP::Variable size;
+			size.name = "size";
+			size.type = Variant::get_type_name(Variant::INT);
+			size.value = itos(array.size());
+
+			Array arr;
+			arr.push_back(size.to_json());
+
+			for (int i = 0; i < array.size(); i++) {
+				DAP::Variable var;
+				var.name = itos(i);
+				var.type = Variant::get_type_name(Variant::COLOR);
+				var.value = array[i];
+				var.variablesReference = parse_variant(array[i]);
+				arr.push_back(var.to_json());
+			}
+			variable_list.insert(id, arr);
+			return id;
+		}
+		default:
+			// Simple atomic stuff, or too complex to be manipulated
+			return 0;
+	}
+}
+
 bool DebugAdapterProtocol::process_message(const String &p_text) {
 	JSON json;
 	ERR_FAIL_COND_V_MSG(json.parse(p_text) != OK, true, "Mal-formed message!");
 	Dictionary params = json.get_data();
 	bool completed = true;
+
+	if (OS::get_singleton()->get_ticks_msec() - _current_peer->timestamp > _request_timeout) {
+		Dictionary response = parser->prepare_error_response(params, DAP::ErrorType::TIMEOUT);
+		_current_peer->res_queue.push_front(response);
+		return true;
+	}
 
 	// Append "req_" to any command received; prevents name clash with existing functions, and possibly exploiting
 	String command = "req_" + (String)params["command"];
@@ -211,7 +665,7 @@ void DebugAdapterProtocol::notify_initialized() {
 }
 
 void DebugAdapterProtocol::notify_process() {
-	String launch_mode = _current_request.is_empty() ? "launch" : _current_request;
+	String launch_mode = _current_peer->attached ? "attach" : "launch";
 
 	Dictionary event = parser->ev_process(launch_mode);
 	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
@@ -222,7 +676,7 @@ void DebugAdapterProtocol::notify_process() {
 void DebugAdapterProtocol::notify_terminated() {
 	Dictionary event = parser->ev_terminated();
 	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		if (_current_request == "launch" && _current_peer == E->get()) {
+		if ((_current_request == "launch" || _current_request == "restart") && _current_peer == E->get()) {
 			continue;
 		}
 		E->get()->res_queue.push_back(event);
@@ -232,7 +686,7 @@ void DebugAdapterProtocol::notify_terminated() {
 void DebugAdapterProtocol::notify_exited(const int &p_exitcode) {
 	Dictionary event = parser->ev_exited(p_exitcode);
 	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		if (_current_request == "launch" && _current_peer == E->get()) {
+		if ((_current_request == "launch" || _current_request == "restart") && _current_peer == E->get()) {
 			continue;
 		}
 		E->get()->res_queue.push_back(event);
@@ -286,25 +740,46 @@ void DebugAdapterProtocol::notify_output(const String &p_message) {
 	}
 }
 
+void DebugAdapterProtocol::notify_custom_data(const String &p_msg, const Array &p_data) {
+	Dictionary event = parser->ev_custom_data(p_msg, p_data);
+	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
+		Ref<DAPeer> peer = E->get();
+		if (peer->supportsCustomData) {
+			peer->res_queue.push_back(event);
+		}
+	}
+}
+
+void DebugAdapterProtocol::notify_breakpoint(const DAP::Breakpoint &p_breakpoint, const bool &p_enabled) {
+	Dictionary event = parser->ev_breakpoint(p_breakpoint, p_enabled);
+	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
+		if (_current_request == "setBreakpoints" && E->get() == _current_peer) {
+			continue;
+		}
+		E->get()->res_queue.push_back(event);
+	}
+}
+
 Array DebugAdapterProtocol::update_breakpoints(const String &p_path, const Array &p_lines) {
 	Array updated_breakpoints;
 
+	// Add breakpoints
 	for (int i = 0; i < p_lines.size(); i++) {
+		EditorDebuggerNode::get_singleton()->get_default_debugger()->_set_breakpoint(p_path, p_lines[i], true);
 		DAP::Breakpoint breakpoint;
-		breakpoint.verified = true;
-		breakpoint.source.path = p_path;
-		breakpoint.source.compute_checksums();
 		breakpoint.line = p_lines[i];
+		breakpoint.source.path = p_path;
 
-		List<DAP::Breakpoint>::Element *E = breakpoint_list.find(breakpoint);
-		if (E) {
-			breakpoint.id = E->get().id;
-		} else {
-			breakpoint.id = breakpoint_id++;
-			breakpoint_list.push_back(breakpoint);
+		ERR_FAIL_COND_V(!breakpoint_list.find(breakpoint), Array());
+		updated_breakpoints.push_back(breakpoint_list.find(breakpoint)->get().to_json());
+	}
+
+	// Remove breakpoints
+	for (List<DAP::Breakpoint>::Element *E = breakpoint_list.front(); E; E = E->next()) {
+		DAP::Breakpoint b = E->get();
+		if (b.source.path == p_path && !p_lines.has(b.line)) {
+			EditorDebuggerNode::get_singleton()->get_default_debugger()->_set_breakpoint(p_path, b.line, false);
 		}
-
-		updated_breakpoints.push_back(breakpoint.to_json());
 	}
 
 	return updated_breakpoints;
@@ -345,6 +820,29 @@ void DebugAdapterProtocol::on_debug_breaked(const bool &p_reallydid, const bool 
 	}
 
 	_processing_stackdump = p_has_stackdump;
+}
+
+void DebugAdapterProtocol::on_debug_breakpoint_toggled(const String &p_path, const int &p_line, const bool &p_enabled) {
+	DAP::Breakpoint breakpoint;
+	breakpoint.verified = true;
+	breakpoint.source.path = ProjectSettings::get_singleton()->globalize_path(p_path);
+	breakpoint.source.compute_checksums();
+	breakpoint.line = p_line;
+
+	if (p_enabled) {
+		// Add the breakpoint
+		breakpoint.id = breakpoint_id++;
+		breakpoint_list.push_back(breakpoint);
+	} else {
+		// Remove the breakpoint
+		List<DAP::Breakpoint>::Element *E = breakpoint_list.find(breakpoint);
+		if (E) {
+			breakpoint.id = E->get().id;
+			breakpoint_list.erase(E);
+		}
+	}
+
+	notify_breakpoint(breakpoint, p_enabled);
 }
 
 void DebugAdapterProtocol::on_debug_stack_dump(const Array &p_stack_dump) {
@@ -424,9 +922,19 @@ void DebugAdapterProtocol::on_debug_stack_frame_var(const Array &p_data) {
 	variable.name = stack_var.name;
 	variable.value = stack_var.value;
 	variable.type = Variant::get_type_name(stack_var.value.get_type());
+	variable.variablesReference = parse_variant(stack_var.value);
 
 	variable_list.find(variable_id)->value().push_back(variable.to_json());
 	_remaining_vars--;
+}
+
+void DebugAdapterProtocol::on_debug_data(const String &p_msg, const Array &p_data) {
+	// Ignore data that is already handled by DAP
+	if (p_msg == "debug_enter" || p_msg == "debug_exit" || p_msg == "stack_dump" || p_msg == "stack_frame_vars" || p_msg == "stack_frame_var" || p_msg == "output" || p_msg == "request_quit") {
+		return;
+	}
+
+	notify_custom_data(p_msg, p_data);
 }
 
 void DebugAdapterProtocol::poll() {
@@ -459,6 +967,8 @@ void DebugAdapterProtocol::poll() {
 }
 
 Error DebugAdapterProtocol::start(int p_port, const IPAddress &p_bind_ip) {
+	_request_timeout = (uint64_t)_EDITOR_GET("network/debug_adapter/request_timeout");
+	_sync_breakpoints = (bool)_EDITOR_GET("network/debug_adapter/sync_breakpoints");
 	_initialized = true;
 	return server->listen(p_port, p_bind_ip);
 }
@@ -484,12 +994,15 @@ DebugAdapterProtocol::DebugAdapterProtocol() {
 	node->get_pause_button()->connect("pressed", callable_mp(this, &DebugAdapterProtocol::on_debug_paused));
 
 	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	debugger_node->connect("breakpoint_toggled", callable_mp(this, &DebugAdapterProtocol::on_debug_breakpoint_toggled));
+
 	debugger_node->get_default_debugger()->connect("stopped", callable_mp(this, &DebugAdapterProtocol::on_debug_stopped));
 	debugger_node->get_default_debugger()->connect("output", callable_mp(this, &DebugAdapterProtocol::on_debug_output));
 	debugger_node->get_default_debugger()->connect("breaked", callable_mp(this, &DebugAdapterProtocol::on_debug_breaked));
 	debugger_node->get_default_debugger()->connect("stack_dump", callable_mp(this, &DebugAdapterProtocol::on_debug_stack_dump));
 	debugger_node->get_default_debugger()->connect("stack_frame_vars", callable_mp(this, &DebugAdapterProtocol::on_debug_stack_frame_vars));
 	debugger_node->get_default_debugger()->connect("stack_frame_var", callable_mp(this, &DebugAdapterProtocol::on_debug_stack_frame_var));
+	debugger_node->get_default_debugger()->connect("debug_data", callable_mp(this, &DebugAdapterProtocol::on_debug_data));
 }
 
 DebugAdapterProtocol::~DebugAdapterProtocol() {

--- a/editor/debugger/debug_adapter/debug_adapter_server.h
+++ b/editor/debugger/debug_adapter/debug_adapter_server.h
@@ -39,11 +39,9 @@ class DebugAdapterServer : public EditorPlugin {
 
 	DebugAdapterProtocol protocol;
 
-	Thread thread;
 	int remote_port = 6006;
 	bool thread_running = false;
 	bool started = false;
-	bool use_thread = false;
 	bool polling = false;
 	static void thread_func(void *p_userdata);
 

--- a/editor/debugger/debug_adapter/debug_adapter_types.h
+++ b/editor/debugger/debug_adapter/debug_adapter_types.h
@@ -38,7 +38,11 @@ namespace DAP {
 
 enum ErrorType {
 	UNKNOWN,
-	WRONG_PATH
+	WRONG_PATH,
+	NOT_RUNNING,
+	TIMEOUT,
+	UNKNOWN_PLATFORM,
+	MISSING_DEVICE
 };
 
 struct Checksum {
@@ -118,10 +122,14 @@ struct Breakpoint {
 
 struct BreakpointLocation {
 	int line;
+	int endLine = -1;
 
 	_FORCE_INLINE_ Dictionary to_json() const {
 		Dictionary dict;
 		dict["line"] = line;
+		if (endLine >= 0) {
+			dict["endLine"] = endLine;
+		}
 
 		return dict;
 	}

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -164,6 +164,7 @@ void EditorDebuggerNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("set_execution", PropertyInfo("script"), PropertyInfo(Variant::INT, "line")));
 	ADD_SIGNAL(MethodInfo("clear_execution", PropertyInfo("script")));
 	ADD_SIGNAL(MethodInfo("breaked", PropertyInfo(Variant::BOOL, "reallydid"), PropertyInfo(Variant::BOOL, "can_debug")));
+	ADD_SIGNAL(MethodInfo("breakpoint_toggled", PropertyInfo(Variant::STRING, "path"), PropertyInfo(Variant::INT, "line"), PropertyInfo(Variant::BOOL, "enabled")));
 }
 
 EditorDebuggerRemoteObject *EditorDebuggerNode::get_inspected_remote_object() {
@@ -487,6 +488,8 @@ void EditorDebuggerNode::set_breakpoint(const String &p_path, int p_line, bool p
 	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
 		dbg->set_breakpoint(p_path, p_line, p_enabled);
 	});
+
+	emit_signal("breakpoint_toggled", p_path, p_line, p_enabled);
 }
 
 void EditorDebuggerNode::set_breakpoints(const String &p_path, Array p_lines) {

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -296,6 +296,7 @@ Size2 ScriptEditorDebugger::get_minimum_size() const {
 }
 
 void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_data) {
+	emit_signal(SNAME("debug_data"), p_msg, p_data);
 	if (p_msg == "debug_enter") {
 		_put_msg("get_stack_dump", Array());
 
@@ -870,6 +871,16 @@ void ScriptEditorDebugger::_clear_execution() {
 	stack_script.unref();
 	stack_dump->clear();
 	inspector->clear_stack_variables();
+}
+
+void ScriptEditorDebugger::_set_breakpoint(const String &p_file, const int &p_line, const bool &p_enabled) {
+	Ref<Script> script = ResourceLoader::load(p_file);
+	emit_signal("set_breakpoint", script, p_line - 1, p_enabled);
+	script.unref();
+}
+
+void ScriptEditorDebugger::_clear_breakpoints() {
+	emit_signal("clear_breakpoints");
 }
 
 void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
@@ -1503,6 +1514,9 @@ void ScriptEditorDebugger::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("stack_dump", PropertyInfo(Variant::ARRAY, "stack_dump")));
 	ADD_SIGNAL(MethodInfo("stack_frame_vars", PropertyInfo(Variant::INT, "num_vars")));
 	ADD_SIGNAL(MethodInfo("stack_frame_var", PropertyInfo(Variant::ARRAY, "data")));
+	ADD_SIGNAL(MethodInfo("debug_data", PropertyInfo(Variant::STRING, "msg"), PropertyInfo(Variant::ARRAY, "data")));
+	ADD_SIGNAL(MethodInfo("set_breakpoint", PropertyInfo("script"), PropertyInfo(Variant::INT, "line"), PropertyInfo(Variant::BOOL, "enabled")));
+	ADD_SIGNAL(MethodInfo("clear_breakpoints"));
 }
 
 void ScriptEditorDebugger::add_debugger_plugin(const Ref<Script> &p_script) {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -205,6 +205,9 @@ private:
 	void _clear_execution();
 	void _stop_and_notify();
 
+	void _set_breakpoint(const String &p_path, const int &p_line, const bool &p_enabled);
+	void _clear_breakpoints();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4759,6 +4759,10 @@ bool EditorNode::ensure_main_scene(bool p_from_native) {
 	return true;
 }
 
+Error EditorNode::run_play_native(int p_idx, int p_platform) {
+	return run_native->run_native(p_idx, p_platform);
+}
+
 void EditorNode::run_play() {
 	_menu_option_confirm(RUN_STOP, true);
 	_run(false);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -893,6 +893,7 @@ public:
 
 	bool ensure_main_scene(bool p_from_native);
 
+	Error run_play_native(int p_idx, int p_platform);
 	void run_play();
 	void run_play_current();
 	void run_play_custom(const String &p_custom);

--- a/editor/editor_run_native.h
+++ b/editor/editor_run_native.h
@@ -43,13 +43,12 @@ class EditorRunNative : public HBoxContainer {
 	int resume_idx;
 	int resume_platform;
 
-	void _run_native(int p_idx, int p_platform);
-
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
 public:
+	Error run_native(int p_idx, int p_platform);
 	bool is_deploy_debug_remote_enabled() const;
 
 	void resume_run_native();

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -37,6 +37,7 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_node.h"
 #include "editor/editor_run_script.h"
 #include "editor/editor_scale.h"
@@ -482,6 +483,29 @@ void ScriptEditor::_clear_execution(REF p_script) {
 			if ((script != nullptr && se->get_edited_resource() == p_script) || se->get_edited_resource()->get_path() == script->get_path()) {
 				se->clear_executing_line();
 			}
+		}
+	}
+}
+
+void ScriptEditor::_set_breakpoint(REF p_script, int p_line, bool p_enabled) {
+	Ref<Script> script = Object::cast_to<Script>(*p_script);
+	if (script.is_valid() && (script->has_source_code() || script->get_path().is_resource_file())) {
+		if (edit(p_script, p_line, 0, false)) {
+			editor->push_item(p_script.ptr());
+
+			ScriptEditorBase *se = _get_current_editor();
+			if (se) {
+				se->set_breakpoint(p_line, p_enabled);
+			}
+		}
+	}
+}
+
+void ScriptEditor::_clear_breakpoints() {
+	for (int i = 0; i < tab_container->get_child_count(); i++) {
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
+		if (se) {
+			se->clear_breakpoints();
 		}
 	}
 }
@@ -3488,6 +3512,8 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	debugger->connect("set_execution", callable_mp(this, &ScriptEditor::_set_execution));
 	debugger->connect("clear_execution", callable_mp(this, &ScriptEditor::_clear_execution));
 	debugger->connect("breaked", callable_mp(this, &ScriptEditor::_breaked));
+	debugger->get_default_debugger()->connect("set_breakpoint", callable_mp(this, &ScriptEditor::_set_breakpoint));
+	debugger->get_default_debugger()->connect("clear_breakpoints", callable_mp(this, &ScriptEditor::_clear_breakpoints));
 
 	menu_hb->add_spacer();
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -152,6 +152,8 @@ public:
 	virtual void tag_saved_version() = 0;
 	virtual void reload(bool p_soft) {}
 	virtual Array get_breakpoints() = 0;
+	virtual void set_breakpoint(int p_line, bool p_enabled) = 0;
+	virtual void clear_breakpoints() = 0;
 	virtual void add_callback(const String &p_function, PackedStringArray p_args) = 0;
 	virtual void update_settings() = 0;
 	virtual void set_debugger_active(bool p_active) = 0;
@@ -370,6 +372,8 @@ class ScriptEditor : public PanelContainer {
 	void _breaked(bool p_breaked, bool p_can_debug);
 	void _update_window_menu();
 	void _script_created(Ref<Script> p_script);
+	void _set_breakpoint(REF p_scrpt, int p_line, bool p_enabled);
+	void _clear_breakpoints();
 
 	ScriptEditorBase *_get_current_editor() const;
 	Array _get_open_script_editors() const;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1370,6 +1370,14 @@ Array ScriptTextEditor::get_breakpoints() {
 	return code_editor->get_text_editor()->get_breakpointed_lines();
 }
 
+void ScriptTextEditor::set_breakpoint(int p_line, bool p_enabled) {
+	code_editor->get_text_editor()->set_line_as_breakpoint(p_line, p_enabled);
+}
+
+void ScriptTextEditor::clear_breakpoints() {
+	code_editor->get_text_editor()->clear_breakpointed_lines();
+}
+
 void ScriptTextEditor::set_tooltip_request_func(String p_method, Object *p_obj) {
 	code_editor->get_text_editor()->set_tooltip_request_func(p_obj, p_method, this);
 }

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -224,6 +224,8 @@ public:
 
 	virtual void reload(bool p_soft) override;
 	virtual Array get_breakpoints() override;
+	virtual void set_breakpoint(int p_line, bool p_enabled) override;
+	virtual void clear_breakpoints() override;
 
 	virtual void add_callback(const String &p_function, PackedStringArray p_args) override;
 	virtual void update_settings() override;

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -120,6 +120,8 @@ public:
 	virtual void set_edit_state(const Variant &p_state) override;
 	virtual Vector<String> get_functions() override;
 	virtual Array get_breakpoints() override;
+	virtual void set_breakpoint(int p_line, bool p_enabled) override{};
+	virtual void clear_breakpoints() override{};
 	virtual void goto_line(int p_line, bool p_with_error = false) override;
 	void goto_line_selection(int p_line, int p_begin, int p_end);
 	virtual void set_executing_line(int p_line) override;

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -311,6 +311,8 @@ public:
 	virtual void tag_saved_version() override;
 	virtual void reload(bool p_soft) override;
 	virtual Array get_breakpoints() override;
+	virtual void set_breakpoint(int p_line, bool p_enable) override{};
+	virtual void clear_breakpoints() override{};
 	virtual void add_callback(const String &p_function, PackedStringArray p_args) override;
 	virtual void update_settings() override;
 	virtual bool show_members_overview() override;


### PR DESCRIPTION
*(for [GSoC DAP project](https://summerofcode.withgoogle.com/projects/#6389461815918592), and [godot-proposals#2494](https://github.com/godotengine/godot-proposals/issues/2494))*

This PR implements a few more advanced features for DAP:

- Added support for more requests:
	- `attach` *(attaching to an already running project instance)*
	- `evaluate` *(hovering over a variable to query it's current value)*

- Added support for some internal requests:
	- `breakpointLocations`
	- `restart`

- Implemented a *(configurable)* timeout for requests to prevent infinite dangling requests. Defaults to 1000msecs *(1 second)*
- Removed option to run the DAP interpreter as a separate thread; this only caused problems and random segfaults, and also has no real reason to exist anyways.
- Added a *(configurable)* toggle to sync breakpoints from the editor to any DAP connection.
	- ***Note:** This feature is disabled by default as it's not 100% reliable due to the nature of DAP's specification, as well as DAP client implementations. Use it only if it's working well under your environment, as it might delete breakpoints and/or report non-existent ones.*
![Peek 2021-08-13 19-08](https://user-images.githubusercontent.com/6501975/129401446-54168f8b-f218-4715-a5a6-3d5319d18c37.gif)

- Implemented forwarding of Godot's internal communication between game and editor through the DAP.
	- This is useful for developing specialized plugins for debugging Godot projects with it's unique debugging features *(eg. inspecting live scene tree, reloading scripts, registering custom profilling monitors, etc...)*
	- The following properties must be present on a `launch` request to use this:
	```
	interface LaunchRequest extends Request {
		...

		/**
		 * If Godot's custom communication should be forwarded. Defaults to false.
		 * Note: some events aren't forwarded, as they're already handled by other DAP requests/events.
		 */
		godot/custom_data?: boolean;
	}
	```
	- Clients will then receive a new event type:
	```
	interface GodotCustomDataEvent extends Event {
		event: 'godot/custom_data'

		body: {
			/**
			 * The message string.
			 */
			message: string;

			/**
			 * Any extra data that may exist.
			 */
			data: any[];
		}
	}
	```
	- A DAP client can also send messages as well through a new request. This is equivalent to a raw `_put_msg()` call on `ScriptEditorDebugger`:
	```
	interface GodotPutMsg extends Request {
		command: 'godot/put_msg'

		arguments: GodotPutMsgArguments;
	}
	```
	```
	interface GodotPutMsgArguments {
		/**
		 * Message to pass to the debugee.
		 */
		message: string;

		/**
		 * Extra data needed. Supply an empty array if there's none.
		 */
		data: any[];
	}
	```
	The response is just an empty ACK body:
	```
	interface GodotPutMsgResponse extends Response {
	}
	```
- Implemented inspection of Godot Variant types:
![Clipboard - August 2, 2021 11_38 AM](https://user-images.githubusercontent.com/6501975/129401647-07af013f-a6ae-4a7b-b440-2989cbab0e6a.png)

- Added support for debugging native platforms as well *(aka Android and/or Web)*
	- The following properties must be present on a `launch` request to use this:
	```
	interface LaunchRequest extends Request {
		...

		/**
		 * Platform for debugging. Defaults to 'host'
		 * Values:
		 * 'host': Same platform the editor is running under (Windows/macOS/Linux)
		 * 'android': Android devices
		 * 'web': Web platform
		 */
		platform?: 'host' | 'android' | 'web';

		/**
		 * Device index to use if there is more than one. Only used for Android platforms. Defaults to 0.
		 */
		device?: number;
	}
	```

- A few more bug-fixing and code cleanups here and there