### PR TITLE
API improvement on the physics (CharacterBody and related classes)

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -15,10 +15,23 @@
 		<link title="2D Platformer Demo">https://godotengine.org/asset-library/asset/120</link>
 	</tutorials>
 	<methods>
+		<method name="get_floor_angle" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="up_direction" type="Vector2" default="Vector2(0, -1)" />
+			<description>
+				Returns the floor's collision angle at the last collision point according to [code]up_direction[/code], which is [code]Vector2.UP[/code] by default. This value is always positive and only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
+			</description>
+		</method>
 		<method name="get_floor_normal" qualifiers="const">
 			<return type="Vector2" />
 			<description>
 				Returns the surface normal of the floor at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
+			</description>
+		</method>
+		<method name="get_last_slide_collision">
+			<return type="KinematicCollision2D" />
+			<description>
+				Returns a [KinematicCollision2D], which contains information about the latest collision that occurred during the last call to [method move_and_slide].
 			</description>
 		</method>
 		<method name="get_platform_velocity" qualifiers="const">
@@ -31,11 +44,11 @@
 			<return type="KinematicCollision2D" />
 			<argument index="0" name="slide_idx" type="int" />
 			<description>
-				Returns a [KinematicCollision2D], which contains information about a collision that occurred during the last call to [method move_and_slide]. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_count] - 1).
+				Returns a [KinematicCollision2D], which contains information about a collision that occurred during the last call to [method move_and_slide]. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_collision_count] - 1).
 				[b]Example usage:[/b]
 				[codeblocks]
 				[gdscript]
-				for i in get_slide_count():
+				for i in get_slide_collision_count():
 				var collision = get_slide_collision(i)
 				print("Collided with: ", collision.collider.name)
 				[/gdscript]
@@ -49,7 +62,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="get_slide_count" qualifiers="const">
+		<method name="get_slide_collision_count" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the number of times the body collided and changed direction during the last call to [method move_and_slide].
@@ -92,12 +105,13 @@
 			</description>
 		</method>
 		<method name="move_and_slide">
-			<return type="void" />
+			<return type="bool" />
 			<description>
-				Moves the body based on [member linear_velocity]. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [CharacterBody2D] or [RigidBody2D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
+				Moves the body based on [member linear_velocity]. If the body collides with another, it will slide along the other body (by default only on floor) rather than stop immediately. If the other body is a [CharacterBody2D] or [RigidBody2D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
 				This method should be used in [method Node._physics_process] (or in a method called by [method Node._physics_process]), as it uses the physics step's [code]delta[/code] value automatically in calculations. Otherwise, the simulation will run at an incorrect speed.
-				Modifies [member linear_velocity] if a slide collision occurred. To get detailed information about collisions that occurred, use [method get_slide_collision].
+				Modifies [member linear_velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for detailed information about collisions that occurred, use [method get_slide_collision].
 				When the body touches a moving platform, the platform's velocity is automatically added to the body motion. If a collision occurs due to the platform's motion, it will always be first in the slide collisions.
+				Returns [code]true[/code] if the body collided, otherwise, returns [code]false[/code].
 			</description>
 		</method>
 	</methods>
@@ -108,12 +122,12 @@
 			A higher value means it's more flexible for detecting collision, which helps with consistently detecting walls and floors.
 			A lower value forces the collision algorithm to use more exact detection, so it can be used in cases that specifically require precision, e.g at very low scale to avoid visible jittering, or for stability with a stack of character bodies.
 		</member>
-		<member name="constant_speed_on_floor" type="bool" setter="set_constant_speed_on_floor_enabled" getter="is_constant_speed_on_floor_enabled" default="false">
+		<member name="floor_block_on_wall" type="bool" setter="set_floor_block_on_wall_enabled" getter="is_floor_block_on_wall_enabled" default="true">
+			If [code]true[/code], the body will be able to move on the floor only. This option avoids to be able to walk on walls, it will however allow to slide down along them.
+		</member>
+		<member name="floor_constant_speed" type="bool" setter="set_floor_constant_speed_enabled" getter="is_floor_constant_speed_enabled" default="false">
 			If [code]false[/code] (by default), the body will move faster on downward slopes and slower on upward slopes.
 			If [code]true[/code], the body will always move at the same speed on the ground no matter the slope. Note that you need to use [member floor_snap_length] to stick along a downward slope at constant speed.
-		</member>
-		<member name="exclude_body_layers" type="int" setter="set_exclude_body_layers" getter="get_exclude_body_layers" default="0">
-			Collision layers that will be excluded for detecting bodies that will act as moving platforms to be followed by the [CharacterBody2D]. By default, all touching bodies are detected and propagate their velocity. You can add excluded layers to ignore bodies that are contained in these layers.
 		</member>
 		<member name="floor_max_angle" type="float" setter="set_floor_max_angle" getter="get_floor_max_angle" default="0.785398">
 			Maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. The default value equals 45 degrees.
@@ -122,20 +136,20 @@
 			Sets a snapping distance. When set to a value different from [code]0.0[/code], the body is kept attached to slopes when calling [method move_and_slide]. The snapping vector is determined by the given distance along the opposite direction of the [member up_direction].
 			As long as the snapping vector is in contact with the ground and the body moves against `up_direction`, the body will remain attached to the surface. Snapping is not applied if the body moves along `up_direction`, so it will be able to detach from the ground when jumping.
 		</member>
+		<member name="floor_stop_on_slope" type="bool" setter="set_floor_stop_on_slope_enabled" getter="is_floor_stop_on_slope_enabled" default="false">
+			If [code]true[/code], the body will not slide on floor's slopes when you include gravity in [code]linear_velocity[/code] when calling [method move_and_slide] and the body is standing still.
+		</member>
 		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2(0, 0)">
 			Current velocity vector in pixels per second, used and modified during calls to [method move_and_slide].
 		</member>
 		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="4">
 			Maximum number of times the body can change direction before it stops when calling [method move_and_slide].
 		</member>
-		<member name="move_on_floor_only" type="bool" setter="set_move_on_floor_only_enabled" getter="is_move_on_floor_only_enabled" default="true">
-			If [code]true[/code], the body will be able to move on the floor only, this option avoids to be able to walk on walls, it will however allow to slide down along them.
+		<member name="moving_platform_ignore_layers" type="int" setter="set_moving_platform_ignore_layers" getter="get_moving_platform_ignore_layers" default="0">
+			Collision layers that will be excluded for detecting bodies that will act as moving platforms to be followed by the [CharacterBody2D]. By default, all touching bodies are detected and propagate their velocity. You can add excluded layers to ignore bodies that are contained in these layers.
 		</member>
 		<member name="slide_on_ceiling" type="bool" setter="set_slide_on_ceiling_enabled" getter="is_slide_on_ceiling_enabled" default="true">
 			If [code]true[/code], during a jump against the ceiling, the body will slide, if [code]false[/code] it will be stopped and will fall vertically.
-		</member>
-		<member name="stop_on_slope" type="bool" setter="set_stop_on_slope_enabled" getter="is_stop_on_slope_enabled" default="false">
-			If [code]true[/code], the body will not slide on slopes when you include gravity in [code]linear_velocity[/code] when calling [method move_and_slide] and the body is standing still.
 		</member>
 		<member name="up_direction" type="Vector2" setter="set_up_direction" getter="get_up_direction" default="Vector2(0, -1)">
 			Direction vector used to determine what is a wall and what is a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. Defaults to [code]Vector2.UP[/code]. If set to [code]Vector2(0, 0)[/code], everything is considered a wall. This is useful for topdown games.

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -16,13 +16,26 @@
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
 	<methods>
+		<method name="get_floor_angle" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="up_direction" type="Vector3" default="Vector3(0, 1, 0)" />
+			<description>
+				Returns the floor's collision angle at the last collision point according to [code]up_direction[/code], which is [code]Vector3.UP[/code] by default. This value is always positive and only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
+			</description>
+		</method>
 		<method name="get_floor_normal" qualifiers="const">
 			<return type="Vector3" />
 			<description>
 				Returns the surface normal of the floor at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
-		<method name="get_floor_velocity" qualifiers="const">
+		<method name="get_last_slide_collision">
+			<return type="KinematicCollision3D" />
+			<description>
+				Returns a [KinematicCollision3D], which contains information about the latest collision that occurred during the last call to [method move_and_slide].
+			</description>
+		</method>
+		<method name="get_platform_velocity" qualifiers="const">
 			<return type="Vector3" />
 			<description>
 				Returns the linear velocity of the floor at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
@@ -32,10 +45,10 @@
 			<return type="KinematicCollision3D" />
 			<argument index="0" name="slide_idx" type="int" />
 			<description>
-				Returns a [KinematicCollision3D], which contains information about a collision that occurred during the last call to [method move_and_slide]. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_count] - 1).
+				Returns a [KinematicCollision3D], which contains information about a collision that occurred during the last call to [method move_and_slide]. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_collision_count] - 1).
 			</description>
 		</method>
-		<method name="get_slide_count" qualifiers="const">
+		<method name="get_slide_collision_count" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the number of times the body collided and changed direction during the last call to [method move_and_slide].
@@ -47,10 +60,22 @@
 				Returns [code]true[/code] if the body collided with the ceiling on the last call of [method move_and_slide]. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
+		<method name="is_on_ceiling_only" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the body collided only with the ceiling on the last call of [method move_and_slide]. Otherwise, returns [code]false[/code].
+			</description>
+		</method>
 		<method name="is_on_floor" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the body collided with the floor on the last call of [method move_and_slide]. Otherwise, returns [code]false[/code].
+			</description>
+		</method>
+		<method name="is_on_floor_only" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the body collided only with the floor on the last call of [method move_and_slide]. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="is_on_wall" qualifiers="const">
@@ -59,13 +84,20 @@
 				Returns [code]true[/code] if the body collided with a wall on the last call of [method move_and_slide]. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
+		<method name="is_on_wall_only" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the body collided only with a wall on the last call of [method move_and_slide]. Otherwise, returns [code]false[/code].
+			</description>
+		</method>
 		<method name="move_and_slide">
-			<return type="void" />
+			<return type="bool" />
 			<description>
 				Moves the body based on [member linear_velocity]. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [CharacterBody3D] or [RigidBody3D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
 				This method should be used in [method Node._physics_process] (or in a method called by [method Node._physics_process]), as it uses the physics step's [code]delta[/code] value automatically in calculations. Otherwise, the simulation will run at an incorrect speed.
-				Modifies [member linear_velocity] if a slide collision occurred. To get detailed information about collisions that occurred, use [method get_slide_collision].
+				Modifies [member linear_velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for more detailed information about collisions that occurred, use [method get_slide_collision].
 				When the body touches a moving platform, the platform's velocity is automatically added to the body motion. If a collision occurs due to the platform's motion, it will always be first in the slide collisions.
+				Returns [code]true[/code] if the body collided, otherwise, returns [code]false[/code].
 			</description>
 		</method>
 	</methods>
@@ -79,6 +111,9 @@
 		<member name="floor_max_angle" type="float" setter="set_floor_max_angle" getter="get_floor_max_angle" default="0.785398">
 			Maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. The default value equals 45 degrees.
 		</member>
+		<member name="floor_stop_on_slope" type="bool" setter="set_floor_stop_on_slope_enabled" getter="is_floor_stop_on_slope_enabled" default="false">
+			If [code]true[/code], the body will not slide on slopes when you include gravity in [code]linear_velocity[/code] when calling [method move_and_slide] and the body is standing still.
+		</member>
 		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3(0, 0, 0)">
 			Current velocity vector (typically meters per second), used and modified during calls to [method move_and_slide].
 		</member>
@@ -88,9 +123,6 @@
 		<member name="snap" type="Vector3" setter="set_snap" getter="get_snap" default="Vector3(0, 0, 0)">
 			When set to a value different from [code]Vector3(0, 0, 0)[/code], the body is kept attached to slopes when calling [method move_and_slide].
 			As long as the [code]snap[/code] vector is in contact with the ground, the body will remain attached to the surface. This means you must disable snap in order to jump, for example. You can do this by setting [code]snap[/code] to [code]Vector3(0, 0, 0)[/code].
-		</member>
-		<member name="stop_on_slope" type="bool" setter="set_stop_on_slope_enabled" getter="is_stop_on_slope_enabled" default="false">
-			If [code]true[/code], the body will not slide on slopes when you include gravity in [code]linear_velocity[/code] when calling [method move_and_slide] and the body is standing still.
 		</member>
 		<member name="up_direction" type="Vector3" setter="set_up_direction" getter="get_up_direction" default="Vector3(0, 1, 0)">
 			Direction vector used to determine what is a wall and what is a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. Defaults to [code]Vector3.UP[/code]. If set to [code]Vector3(0, 0, 0)[/code], everything is considered a wall. This is useful for topdown games.

--- a/doc/classes/KinematicCollision2D.xml
+++ b/doc/classes/KinematicCollision2D.xml
@@ -10,6 +10,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_angle" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="up_direction" type="Vector2" default="Vector2(0, -1)" />
+			<description>
+				The collision angle according to [code]up_direction[/code], which is [code]Vector2.UP[/code] by default. This value is always positive.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="collider" type="Object" setter="" getter="get_collider">

--- a/doc/classes/KinematicCollision3D.xml
+++ b/doc/classes/KinematicCollision3D.xml
@@ -10,6 +10,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_angle" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="up_direction" type="Vector3" default="Vector3(0, 1, 0)" />
+			<description>
+				The collision angle according to [code]up_direction[/code], which is [code]Vector3.UP[/code] by default. This value is always positive.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="collider" type="Object" setter="" getter="get_collider">

--- a/doc/classes/PhysicsTestMotionResult2D.xml
+++ b/doc/classes/PhysicsTestMotionResult2D.xml
@@ -29,9 +29,9 @@
 		</member>
 		<member name="collision_unsafe_fraction" type="float" setter="" getter="get_collision_unsafe_fraction" default="0.0">
 		</member>
-		<member name="motion" type="Vector2" setter="" getter="get_motion" default="Vector2(0, 0)">
+		<member name="remainder" type="Vector2" setter="" getter="get_remainder" default="Vector2(0, 0)">
 		</member>
-		<member name="motion_remainder" type="Vector2" setter="" getter="get_motion_remainder" default="Vector2(0, 0)">
+		<member name="travel" type="Vector2" setter="" getter="get_travel" default="Vector2(0, 0)">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/PhysicsTestMotionResult3D.xml
+++ b/doc/classes/PhysicsTestMotionResult3D.xml
@@ -29,9 +29,9 @@
 		</member>
 		<member name="collision_unsafe_fraction" type="float" setter="" getter="get_collision_unsafe_fraction" default="0.0">
 		</member>
-		<member name="motion" type="Vector3" setter="" getter="get_motion" default="Vector3(0, 0, 0)">
+		<member name="remainder" type="Vector3" setter="" getter="get_remainder" default="Vector3(0, 0, 0)">
 		</member>
-		<member name="motion_remainder" type="Vector3" setter="" getter="get_motion_remainder" default="Vector3(0, 0, 0)">
+		<member name="travel" type="Vector3" setter="" getter="get_travel" default="Vector3(0, 0, 0)">
 		</member>
 	</members>
 	<constants>

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -271,16 +271,16 @@ class CharacterBody2D : public PhysicsBody2D {
 private:
 	real_t margin = 0.08;
 
-	bool stop_on_slope = false;
-	bool constant_speed_on_floor = false;
-	bool move_on_floor_only = true;
+	bool floor_stop_on_slope = false;
+	bool floor_constant_speed = false;
+	bool floor_block_on_wall = true;
 	bool slide_on_ceiling = true;
 	int max_slides = 4;
 	int platform_layer;
 	real_t floor_max_angle = Math::deg2rad((real_t)45.0);
 	float floor_snap_length = 0;
 	Vector2 up_direction = Vector2(0.0, -1.0);
-	uint32_t exclude_body_layers = 0;
+	uint32_t moving_platform_ignore_layers = 0;
 	Vector2 linear_velocity;
 
 	Vector2 floor_normal;
@@ -296,14 +296,14 @@ private:
 	void set_safe_margin(real_t p_margin);
 	real_t get_safe_margin() const;
 
-	bool is_stop_on_slope_enabled() const;
-	void set_stop_on_slope_enabled(bool p_enabled);
+	bool is_floor_stop_on_slope_enabled() const;
+	void set_floor_stop_on_slope_enabled(bool p_enabled);
 
-	bool is_constant_speed_on_floor_enabled() const;
-	void set_constant_speed_on_floor_enabled(bool p_enabled);
+	bool is_floor_constant_speed_enabled() const;
+	void set_floor_constant_speed_enabled(bool p_enabled);
 
-	bool is_move_on_floor_only_enabled() const;
-	void set_move_on_floor_only_enabled(bool p_enabled);
+	bool is_floor_block_on_wall_enabled() const;
+	void set_floor_block_on_wall_enabled(bool p_enabled);
 
 	bool is_slide_on_ceiling_enabled() const;
 	void set_slide_on_ceiling_enabled(bool p_enabled);
@@ -317,10 +317,11 @@ private:
 	real_t get_floor_snap_length();
 	void set_floor_snap_length(real_t p_floor_snap_length);
 
-	uint32_t get_exclude_body_layers() const;
-	void set_exclude_body_layers(const uint32_t p_exclude_layer);
+	uint32_t get_moving_platform_ignore_layers() const;
+	void set_moving_platform_ignore_layers(const uint32_t p_exclude_layer);
 
 	Ref<KinematicCollision2D> _get_slide_collision(int p_bounce);
+	Ref<KinematicCollision2D> _get_last_slide_collision();
 	const Vector2 &get_up_direction() const;
 	bool _on_floor_if_snapped(bool was_on_floor, bool vel_dir_facing_up);
 	void set_up_direction(const Vector2 &p_up_direction);
@@ -333,7 +334,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void move_and_slide();
+	bool move_and_slide();
 
 	const Vector2 &get_linear_velocity() const;
 	void set_linear_velocity(const Vector2 &p_velocity);
@@ -345,9 +346,10 @@ public:
 	bool is_on_ceiling() const;
 	bool is_on_ceiling_only() const;
 	Vector2 get_floor_normal() const;
+	real_t get_floor_angle(const Vector2 &p_up_direction = Vector2(0.0, -1.0)) const;
 	Vector2 get_platform_velocity() const;
 
-	int get_slide_count() const;
+	int get_slide_collision_count() const;
 	PhysicsServer2D::MotionResult get_slide_collision(int p_bounce) const;
 
 	CharacterBody2D();
@@ -370,6 +372,7 @@ public:
 	Vector2 get_normal() const;
 	Vector2 get_travel() const;
 	Vector2 get_remainder() const;
+	real_t get_angle(const Vector2 &p_up_direction = Vector2(0.0, -1.0)) const;
 	Object *get_local_shape() const;
 	Object *get_collider() const;
 	ObjectID get_collider_id() const;

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -278,7 +278,7 @@ class CharacterBody3D : public PhysicsBody3D {
 private:
 	real_t margin = 0.001;
 
-	bool stop_on_slope = false;
+	bool floor_stop_on_slope = false;
 	int max_slides = 4;
 	real_t floor_max_angle = Math::deg2rad((real_t)45.0);
 	Vector3 snap;
@@ -296,14 +296,15 @@ private:
 	Vector<Ref<KinematicCollision3D>> slide_colliders;
 
 	Ref<KinematicCollision3D> _get_slide_collision(int p_bounce);
+	Ref<KinematicCollision3D> _get_last_slide_collision();
 
 	void _set_collision_direction(const PhysicsServer3D::MotionResult &p_result);
 
 	void set_safe_margin(real_t p_margin);
 	real_t get_safe_margin() const;
 
-	bool is_stop_on_slope_enabled() const;
-	void set_stop_on_slope_enabled(bool p_enabled);
+	bool is_floor_stop_on_slope_enabled() const;
+	void set_floor_stop_on_slope_enabled(bool p_enabled);
 
 	int get_max_slides() const;
 	void set_max_slides(int p_max_slides);
@@ -322,18 +323,22 @@ protected:
 	static void _bind_methods();
 
 public:
-	void move_and_slide();
+	bool move_and_slide();
 
 	virtual Vector3 get_linear_velocity() const override;
 	void set_linear_velocity(const Vector3 &p_velocity);
 
 	bool is_on_floor() const;
+	bool is_on_floor_only() const;
 	bool is_on_wall() const;
+	bool is_on_wall_only() const;
 	bool is_on_ceiling() const;
+	bool is_on_ceiling_only() const;
 	Vector3 get_floor_normal() const;
-	Vector3 get_floor_velocity() const;
+	real_t get_floor_angle(const Vector3 &p_up_direction = Vector3(0.0, 1.0, 0.0)) const;
+	Vector3 get_platform_velocity() const;
 
-	int get_slide_count() const;
+	int get_slide_collision_count() const;
 	PhysicsServer3D::MotionResult get_slide_collision(int p_bounce) const;
 
 	CharacterBody3D();
@@ -356,6 +361,7 @@ public:
 	Vector3 get_normal() const;
 	Vector3 get_travel() const;
 	Vector3 get_remainder() const;
+	real_t get_angle(const Vector3 &p_up_direction = Vector3(0.0, 1.0, 0.0)) const;
 	Object *get_local_shape() const;
 	Object *get_collider() const;
 	ObjectID get_collider_id() const;

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -560,7 +560,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 	if (!shapes_found) {
 		if (r_result) {
 			*r_result = PhysicsServer2D::MotionResult();
-			r_result->motion = p_motion;
+			r_result->travel = p_motion;
 		}
 		return false;
 	}
@@ -954,9 +954,9 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 				Vector2 rel_vec = r_result->collision_point - body->get_transform().get_origin();
 				r_result->collider_velocity = Vector2(-body->get_angular_velocity() * rel_vec.y, body->get_angular_velocity() * rel_vec.x) + body->get_linear_velocity();
 
-				r_result->motion = safe * p_motion;
+				r_result->travel = safe * p_motion;
 				r_result->remainder = p_motion - safe * p_motion;
-				r_result->motion += (body_transform.get_origin() - p_from.get_origin());
+				r_result->travel += (body_transform.get_origin() - p_from.get_origin());
 			}
 
 			collided = true;
@@ -964,9 +964,9 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 	}
 
 	if (!collided && r_result) {
-		r_result->motion = p_motion;
+		r_result->travel = p_motion;
 		r_result->remainder = Vector2();
-		r_result->motion += (body_transform.get_origin() - p_from.get_origin());
+		r_result->travel += (body_transform.get_origin() - p_from.get_origin());
 	}
 
 	return collided;

--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -600,7 +600,7 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform3D &p_from, co
 	if (!shapes_found) {
 		if (r_result) {
 			*r_result = PhysicsServer3D::MotionResult();
-			r_result->motion = p_motion;
+			r_result->travel = p_motion;
 		}
 
 		return false;
@@ -879,9 +879,9 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform3D &p_from, co
 				Vector3 rel_vec = rcd.best_contact - (body->get_transform().origin + body->get_center_of_mass());
 				r_result->collider_velocity = body->get_linear_velocity() + (body->get_angular_velocity()).cross(rel_vec);
 
-				r_result->motion = safe * p_motion;
+				r_result->travel = safe * p_motion;
 				r_result->remainder = p_motion - safe * p_motion;
-				r_result->motion += (body_transform.get_origin() - p_from.get_origin());
+				r_result->travel += (body_transform.get_origin() - p_from.get_origin());
 			}
 
 			collided = true;
@@ -889,9 +889,9 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform3D &p_from, co
 	}
 
 	if (!collided && r_result) {
-		r_result->motion = p_motion;
+		r_result->travel = p_motion;
 		r_result->remainder = Vector3();
-		r_result->motion += (body_transform.get_origin() - p_from.get_origin());
+		r_result->travel += (body_transform.get_origin() - p_from.get_origin());
 	}
 
 	return collided;

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -422,11 +422,11 @@ void PhysicsDirectSpaceState2D::_bind_methods() {
 
 ///////////////////////////////
 
-Vector2 PhysicsTestMotionResult2D::get_motion() const {
-	return result.motion;
+Vector2 PhysicsTestMotionResult2D::get_travel() const {
+	return result.travel;
 }
 
-Vector2 PhysicsTestMotionResult2D::get_motion_remainder() const {
+Vector2 PhysicsTestMotionResult2D::get_remainder() const {
 	return result.remainder;
 }
 
@@ -471,8 +471,8 @@ real_t PhysicsTestMotionResult2D::get_collision_unsafe_fraction() const {
 }
 
 void PhysicsTestMotionResult2D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_motion"), &PhysicsTestMotionResult2D::get_motion);
-	ClassDB::bind_method(D_METHOD("get_motion_remainder"), &PhysicsTestMotionResult2D::get_motion_remainder);
+	ClassDB::bind_method(D_METHOD("get_travel"), &PhysicsTestMotionResult2D::get_travel);
+	ClassDB::bind_method(D_METHOD("get_remainder"), &PhysicsTestMotionResult2D::get_remainder);
 	ClassDB::bind_method(D_METHOD("get_collision_point"), &PhysicsTestMotionResult2D::get_collision_point);
 	ClassDB::bind_method(D_METHOD("get_collision_normal"), &PhysicsTestMotionResult2D::get_collision_normal);
 	ClassDB::bind_method(D_METHOD("get_collider_velocity"), &PhysicsTestMotionResult2D::get_collider_velocity);
@@ -484,8 +484,8 @@ void PhysicsTestMotionResult2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_collision_safe_fraction"), &PhysicsTestMotionResult2D::get_collision_safe_fraction);
 	ClassDB::bind_method(D_METHOD("get_collision_unsafe_fraction"), &PhysicsTestMotionResult2D::get_collision_unsafe_fraction);
 
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "motion"), "", "get_motion");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "motion_remainder"), "", "get_motion_remainder");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "travel"), "", "get_travel");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "remainder"), "", "get_remainder");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "collision_point"), "", "get_collision_point");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "collision_normal"), "", "get_collision_normal");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "collider_velocity"), "", "get_collider_velocity");

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -465,7 +465,7 @@ public:
 	virtual PhysicsDirectBodyState2D *body_get_direct_state(RID p_body) = 0;
 
 	struct MotionResult {
-		Vector2 motion;
+		Vector2 travel;
 		Vector2 remainder;
 
 		Vector2 collision_point;
@@ -479,6 +479,10 @@ public:
 		RID collider;
 		int collider_shape = 0;
 		Variant collider_metadata;
+
+		real_t get_angle(Vector2 p_up_direction) const {
+			return Math::acos(collision_normal.dot(p_up_direction));
+		}
 	};
 
 	virtual bool body_test_motion(RID p_body, const Transform2D &p_from, const Vector2 &p_motion, real_t p_margin = 0.08, MotionResult *r_result = nullptr, const Set<RID> &p_exclude = Set<RID>()) = 0;
@@ -588,8 +592,8 @@ protected:
 public:
 	PhysicsServer2D::MotionResult *get_result_ptr() const { return const_cast<PhysicsServer2D::MotionResult *>(&result); }
 
-	Vector2 get_motion() const;
-	Vector2 get_motion_remainder() const;
+	Vector2 get_travel() const;
+	Vector2 get_remainder() const;
 
 	Vector2 get_collision_point() const;
 	Vector2 get_collision_normal() const;

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -369,11 +369,11 @@ void PhysicsDirectSpaceState3D::_bind_methods() {
 
 ///////////////////////////////
 
-Vector3 PhysicsTestMotionResult3D::get_motion() const {
-	return result.motion;
+Vector3 PhysicsTestMotionResult3D::get_travel() const {
+	return result.travel;
 }
 
-Vector3 PhysicsTestMotionResult3D::get_motion_remainder() const {
+Vector3 PhysicsTestMotionResult3D::get_remainder() const {
 	return result.remainder;
 }
 
@@ -418,8 +418,8 @@ real_t PhysicsTestMotionResult3D::get_collision_unsafe_fraction() const {
 }
 
 void PhysicsTestMotionResult3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_motion"), &PhysicsTestMotionResult3D::get_motion);
-	ClassDB::bind_method(D_METHOD("get_motion_remainder"), &PhysicsTestMotionResult3D::get_motion_remainder);
+	ClassDB::bind_method(D_METHOD("get_travel"), &PhysicsTestMotionResult3D::get_travel);
+	ClassDB::bind_method(D_METHOD("get_remainder"), &PhysicsTestMotionResult3D::get_remainder);
 	ClassDB::bind_method(D_METHOD("get_collision_point"), &PhysicsTestMotionResult3D::get_collision_point);
 	ClassDB::bind_method(D_METHOD("get_collision_normal"), &PhysicsTestMotionResult3D::get_collision_normal);
 	ClassDB::bind_method(D_METHOD("get_collider_velocity"), &PhysicsTestMotionResult3D::get_collider_velocity);
@@ -431,8 +431,8 @@ void PhysicsTestMotionResult3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_collision_safe_fraction"), &PhysicsTestMotionResult3D::get_collision_safe_fraction);
 	ClassDB::bind_method(D_METHOD("get_collision_unsafe_fraction"), &PhysicsTestMotionResult3D::get_collision_unsafe_fraction);
 
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "motion"), "", "get_motion");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "motion_remainder"), "", "get_motion_remainder");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "travel"), "", "get_travel");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "remainder"), "", "get_remainder");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collision_point"), "", "get_collision_point");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collision_normal"), "", "get_collision_normal");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collider_velocity"), "", "get_collider_velocity");

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -473,7 +473,7 @@ public:
 	virtual PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) = 0;
 
 	struct MotionResult {
-		Vector3 motion;
+		Vector3 travel;
 		Vector3 remainder;
 
 		Vector3 collision_point;
@@ -487,6 +487,10 @@ public:
 		RID collider;
 		int collider_shape = 0;
 		Variant collider_metadata;
+
+		real_t get_angle(Vector3 p_up_direction) const {
+			return Math::acos(collision_normal.dot(p_up_direction));
+		}
 	};
 
 	virtual bool body_test_motion(RID p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin = 0.001, MotionResult *r_result = nullptr, const Set<RID> &p_exclude = Set<RID>()) = 0;
@@ -752,8 +756,8 @@ protected:
 public:
 	PhysicsServer3D::MotionResult *get_result_ptr() const { return const_cast<PhysicsServer3D::MotionResult *>(&result); }
 
-	Vector3 get_motion() const;
-	Vector3 get_motion_remainder() const;
+	Vector3 get_travel() const;
+	Vector3 get_remainder() const;
 
 	Vector3 get_collision_point() const;
 	Vector3 get_collision_normal() const;


### PR DESCRIPTION
This PR makes changes in the API according chat's discussions and aims to steer the API to his final form for 4.0 alpha.

Changes:

- Rename few methods/property and group them in the editor when it's possible
- Improvement on the CharacterBody docs.
- Make MotionResult internal API consistency with `KinematicCollision`
- Return a boolean in `move_and_slide` if there was a collision
- New methods:
  - `get_floor_angle` on `CharacterBody` to get the floor angle.
  - `get_angle` on `KinematicCollision` to get the collision angle.
  - `get_last_slide_collision` to quickly get the latest collision of `move_and_slide`.
  