### PR TITLE
[3.x] Make sure stylebox is valid in `EditorSpinSlider` before using it

### DIFF
--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -77,6 +77,8 @@ class EditorSpinSlider : public Range {
 
 	void _evaluate_input_text();
 
+	void _draw_spin_slider();
+
 protected:
 	void _notification(int p_what);
 	void _gui_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
This should fix the crash reported by @timothyqiu in https://github.com/godotengine/godot/issues/51003#issuecomment-894907434.

I am unsure if this crash is related to https://github.com/godotengine/godot/issues/51414 though, but it might be. The main problem in https://github.com/godotengine/godot/issues/51414 is that the custom editor theme cannot be a partial theme, and I think I have a better solution for this problem that I'll post in another PR (https://github.com/godotengine/godot/pull/51648).

-----

This PR also *switches* `EditorSpinSlider`'s `notification` to a switch statement, as our best practices dictate (hence why it is so big, the actual fix is in a single line related to the stylebox).