### PR TITLE
[3.x] Add support for partial custom editor themes

### DIFF
--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -275,6 +275,14 @@
 				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
+		<method name="merge_with">
+			<return type="void" />
+			<argument index="0" name="other" type="Theme" />
+			<description>
+				Adds missing and overrides existing definitions with values from the [code]other[/code] [Theme].
+				[b]Note:[/b] This modifies the current theme. If you want to merge two themes together without modifying either one, create a new empty theme and merge the other two into it one after another.
+			</description>
+		</method>
 		<method name="rename_color">
 			<return type="void" />
 			<argument index="0" name="old_name" type="String" />

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -571,6 +571,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("panel", "PanelContainer", style_menu);
 	theme->set_stylebox("MenuPanel", "EditorStyles", style_menu);
 
+	// CanvasItem Editor
+	Ref<StyleBoxFlat> style_canvas_editor_info = make_flat_stylebox(Color(0.0, 0.0, 0.0, 0.2));
+	style_canvas_editor_info->set_expand_margin_size_all(4 * EDSCALE);
+	theme->set_stylebox("CanvasItemInfoOverlay", "EditorStyles", style_canvas_editor_info);
+
 	// Script Editor
 	theme->set_stylebox("ScriptEditorPanel", "EditorStyles", make_empty_stylebox(default_margin_size, 0, default_margin_size, default_margin_size));
 	theme->set_stylebox("ScriptEditor", "EditorStyles", make_empty_stylebox(0, 0, 0, 0));
@@ -1376,15 +1381,14 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 }
 
 Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
-	Ref<Theme> theme;
+	Ref<Theme> theme = create_editor_theme(p_theme);
 
-	const String custom_theme = EditorSettings::get_singleton()->get("interface/theme/custom_theme");
-	if (custom_theme != "") {
-		theme = ResourceLoader::load(custom_theme);
-	}
-
-	if (!theme.is_valid()) {
-		theme = create_editor_theme(p_theme);
+	const String custom_theme_path = EditorSettings::get_singleton()->get("interface/theme/custom_theme");
+	if (custom_theme_path != "") {
+		Ref<Theme> custom_theme = ResourceLoader::load(custom_theme_path);
+		if (custom_theme.is_valid()) {
+			theme->merge_with(custom_theme);
+		}
 	}
 
 	return theme;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4198,6 +4198,10 @@ void CanvasItemEditor::_notification(int p_what) {
 		font->set_outline_color(Color(0, 0, 0));
 		zoom_reset->add_font_override("font", font);
 		zoom_reset->add_color_override("font_color", Color(1, 1, 1));
+
+		info_overlay->get_theme()->set_stylebox("normal", "Label", get_stylebox("CanvasItemInfoOverlay", "EditorStyles"));
+		warning_child_of_container->add_color_override("font_color", get_color("warning_color", "Editor"));
+		warning_child_of_container->add_font_override("font", get_font("main", "EditorFonts"));
 	}
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
@@ -5778,20 +5782,13 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	info_overlay->add_constant_override("separation", 10);
 	viewport_scrollable->add_child(info_overlay);
 
+	// Make sure all labels inside of the container are styled the same.
 	Theme *info_overlay_theme = memnew(Theme);
-	info_overlay_theme->copy_default_theme();
 	info_overlay->set_theme(info_overlay_theme);
-
-	StyleBoxFlat *info_overlay_label_stylebox = memnew(StyleBoxFlat);
-	info_overlay_label_stylebox->set_bg_color(Color(0.0, 0.0, 0.0, 0.2));
-	info_overlay_label_stylebox->set_expand_margin_size_all(4);
-	info_overlay_theme->set_stylebox("normal", "Label", info_overlay_label_stylebox);
 
 	warning_child_of_container = memnew(Label);
 	warning_child_of_container->hide();
 	warning_child_of_container->set_text(TTR("Warning: Children of a container get their position and size determined only by their parent."));
-	warning_child_of_container->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("warning_color", "Editor"));
-	warning_child_of_container->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("main", "EditorFonts"));
 	add_control_to_info_overlay(warning_child_of_container);
 
 	h_scroll = memnew(HScrollBar);

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -1182,6 +1182,82 @@ void Theme::copy_theme(const Ref<Theme> &p_other) {
 	_unfreeze_and_propagate_changes();
 }
 
+void Theme::merge_with(const Ref<Theme> &p_other) {
+	if (p_other.is_null()) {
+		return;
+	}
+
+	_freeze_change_propagation();
+
+	// Colors.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->color_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = p_other->color_map[*K].next(L))) {
+				set_color(*L, *K, p_other->color_map[*K][*L]);
+			}
+		}
+	}
+
+	// Constants.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->constant_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = p_other->constant_map[*K].next(L))) {
+				set_constant(*L, *K, p_other->constant_map[*K][*L]);
+			}
+		}
+	}
+
+	// Fonts.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->font_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = p_other->font_map[*K].next(L))) {
+				set_font(*L, *K, p_other->font_map[*K][*L]);
+			}
+		}
+	}
+
+	// Icons.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->icon_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = p_other->icon_map[*K].next(L))) {
+				set_icon(*L, *K, p_other->icon_map[*K][*L]);
+			}
+		}
+	}
+
+	// Shaders.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->shader_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = p_other->shader_map[*K].next(L))) {
+				set_shader(*L, *K, p_other->shader_map[*K][*L]);
+			}
+		}
+	}
+
+	// Styleboxes.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->style_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = p_other->style_map[*K].next(L))) {
+				set_stylebox(*L, *K, p_other->style_map[*K][*L]);
+			}
+		}
+	}
+
+	_unfreeze_and_propagate_changes();
+}
+
 void Theme::get_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
@@ -1281,6 +1357,7 @@ void Theme::_bind_methods() {
 
 	ClassDB::bind_method("copy_default_theme", &Theme::copy_default_theme);
 	ClassDB::bind_method(D_METHOD("copy_theme", "other"), &Theme::copy_theme);
+	ClassDB::bind_method(D_METHOD("merge_with", "other"), &Theme::merge_with);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "default_font", PROPERTY_HINT_RESOURCE_TYPE, "Font"), "set_default_font", "get_default_font");
 

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -187,6 +187,7 @@ public:
 
 	void copy_default_theme();
 	void copy_theme(const Ref<Theme> &p_other);
+	void merge_with(const Ref<Theme> &p_other);
 	void clear();
 
 	Theme();


### PR DESCRIPTION
This allows custom editor themes to be incomplete by merging them with the generated theme. This ensures that every theme item expected by the editor exists in some form, and allows custom themes to be more granular. For example:

![godot windows tools 64_2021-08-14_00-57-34](https://user-images.githubusercontent.com/11782833/129422880-e843a5af-9fc1-404a-9a2c-8fbc71410c66.png)

This result is achieved with a theme resource that looks something like this:
```
[gd_resource type="Theme" load_steps=2 format=2]

[sub_resource type="StyleBoxFlat" id=1]
content_margin_left = 8.0
content_margin_right = 8.0
content_margin_top = 5.0
content_margin_bottom = 18.0
bg_color = Color( 0.172549, 0.341176, 0.137255, 1 )
border_width_left = 2
border_width_top = 2
border_width_right = 2
border_width_bottom = 12
border_color = Color( 0.686275, 0.580392, 0.215686, 1 )

[resource]
Button/styles/normal = SubResource( 1 )
````

This should address problems like the one shown in https://github.com/godotengine/godot/issues/51414. This might also be useful for merging the default theme and the custom project theme for the projects made with Godot so there is less time spent on lookups, but that's a story for another time.

-----
This also removes unnecessary theme operations in the canvas item editor plugin. It was the only place in the engine that relied on copying the theme, which is completely unnecessary. From my superficial testing the operation took 630-640 microseconds and now takes 20. This only happens once, as the editor is created, but it may remove some hitching for some users, I think. Either way, the theming code is better now, plus the styling applied can now be customized with the editor theme.