### PR TITLE
Add support for partial custom editor themes

### DIFF
--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -81,19 +81,6 @@
 				Unmarks [code]theme_type[/code] as being a variation of any other type.
 			</description>
 		</method>
-		<method name="copy_default_theme">
-			<return type="void" />
-			<description>
-				Sets the theme's values to a copy of the default theme values.
-			</description>
-		</method>
-		<method name="copy_theme">
-			<return type="void" />
-			<argument index="0" name="other" type="Theme" />
-			<description>
-				Sets the theme's values to a copy of a given theme.
-			</description>
-		</method>
 		<method name="get_color" qualifiers="const">
 			<return type="Color" />
 			<argument index="0" name="name" type="StringName" />
@@ -338,6 +325,14 @@
 			<argument index="1" name="base_type" type="StringName" />
 			<description>
 				Returns [code]true[/code] if [code]theme_type[/code] is marked as a variation of [code]base_type[/code] in this theme.
+			</description>
+		</method>
+		<method name="merge_with">
+			<return type="void" />
+			<argument index="0" name="other" type="Theme" />
+			<description>
+				Adds missing and overrides existing definitions with values from the [code]other[/code] [Theme].
+				[b]Note:[/b] This modifies the current theme. If you want to merge two themes together without modifying either one, create a new empty theme and merge the other two into it one after another.
 			</description>
 		</method>
 		<method name="rename_color">

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -595,6 +595,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("panel", "PanelContainer", style_menu);
 	theme->set_stylebox("MenuPanel", "EditorStyles", style_menu);
 
+	// CanvasItem Editor
+	Ref<StyleBoxFlat> style_canvas_editor_info = make_flat_stylebox(Color(0.0, 0.0, 0.0, 0.2));
+	style_canvas_editor_info->set_expand_margin_size_all(4 * EDSCALE);
+	theme->set_stylebox("CanvasItemInfoOverlay", "EditorStyles", style_canvas_editor_info);
+
 	// Script Editor
 	theme->set_stylebox("ScriptEditorPanel", "EditorStyles", make_empty_stylebox(default_margin_size, 0, default_margin_size, default_margin_size));
 	theme->set_stylebox("ScriptEditor", "EditorStyles", make_empty_stylebox(0, 0, 0, 0));
@@ -1499,15 +1504,14 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 }
 
 Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
-	Ref<Theme> theme;
+	Ref<Theme> theme = create_editor_theme(p_theme);
 
-	const String custom_theme = EditorSettings::get_singleton()->get("interface/theme/custom_theme");
-	if (custom_theme != "") {
-		theme = ResourceLoader::load(custom_theme);
-	}
-
-	if (!theme.is_valid()) {
-		theme = create_editor_theme(p_theme);
+	const String custom_theme_path = EditorSettings::get_singleton()->get("interface/theme/custom_theme");
+	if (custom_theme_path != "") {
+		Ref<Theme> custom_theme = ResourceLoader::load(custom_theme_path);
+		if (custom_theme.is_valid()) {
+			theme->merge_with(custom_theme);
+		}
 	}
 
 	return theme;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3909,6 +3909,11 @@ void CanvasItemEditor::_notification(int p_what) {
 		anchors_popup->add_icon_item(get_theme_icon(SNAME("ControlAlignWide"), SNAME("EditorIcons")), TTR("Full Rect"), ANCHORS_PRESET_WIDE);
 
 		anchor_mode_button->set_icon(get_theme_icon(SNAME("Anchor"), SNAME("EditorIcons")));
+
+		info_overlay->get_theme()->set_stylebox("normal", "Label", get_theme_stylebox(SNAME("CanvasItemInfoOverlay"), SNAME("EditorStyles")));
+		warning_child_of_container->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+		warning_child_of_container->add_theme_font_override("font", get_theme_font(SNAME("main"), SNAME("EditorFonts")));
+		warning_child_of_container->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("main_size"), SNAME("EditorFonts")));
 	}
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
@@ -5280,21 +5285,13 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	info_overlay->add_theme_constant_override("separation", 10);
 	viewport_scrollable->add_child(info_overlay);
 
+	// Make sure all labels inside of the container are styled the same.
 	Theme *info_overlay_theme = memnew(Theme);
-	info_overlay_theme->copy_default_theme();
 	info_overlay->set_theme(info_overlay_theme);
-
-	StyleBoxFlat *info_overlay_label_stylebox = memnew(StyleBoxFlat);
-	info_overlay_label_stylebox->set_bg_color(Color(0.0, 0.0, 0.0, 0.2));
-	info_overlay_label_stylebox->set_expand_margin_size_all(4);
-	info_overlay_theme->set_stylebox("normal", "Label", info_overlay_label_stylebox);
 
 	warning_child_of_container = memnew(Label);
 	warning_child_of_container->hide();
 	warning_child_of_container->set_text(TTR("Warning: Children of a container get their position and size determined only by their parent."));
-	warning_child_of_container->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
-	warning_child_of_container->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("main"), SNAME("EditorFonts")));
-	warning_child_of_container->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("main_size"), SNAME("EditorFonts")));
 	add_control_to_info_overlay(warning_child_of_container);
 
 	h_scroll = memnew(HScrollBar);

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -1350,40 +1350,36 @@ void Theme::clear() {
 	_emit_theme_changed();
 }
 
-void Theme::copy_default_theme() {
-	Ref<Theme> default_theme2 = get_default();
-	copy_theme(default_theme2);
-}
-
-void Theme::copy_theme(const Ref<Theme> &p_other) {
+void Theme::merge_with(const Ref<Theme> &p_other) {
 	if (p_other.is_null()) {
-		clear();
 		return;
 	}
 
 	_freeze_change_propagation();
 
-	// These items need reconnecting, so add them normally.
+	// Colors.
 	{
 		const StringName *K = nullptr;
-		while ((K = p_other->icon_map.next(K))) {
+		while ((K = p_other->color_map.next(K))) {
 			const StringName *L = nullptr;
-			while ((L = p_other->icon_map[*K].next(L))) {
-				set_icon(*L, *K, p_other->icon_map[*K][*L]);
+			while ((L = p_other->color_map[*K].next(L))) {
+				set_color(*L, *K, p_other->color_map[*K][*L]);
 			}
 		}
 	}
 
+	// Constants.
 	{
 		const StringName *K = nullptr;
-		while ((K = p_other->style_map.next(K))) {
+		while ((K = p_other->constant_map.next(K))) {
 			const StringName *L = nullptr;
-			while ((L = p_other->style_map[*K].next(L))) {
-				set_stylebox(*L, *K, p_other->style_map[*K][*L]);
+			while ((L = p_other->constant_map[*K].next(L))) {
+				set_constant(*L, *K, p_other->constant_map[*K][*L]);
 			}
 		}
 	}
 
+	// Fonts.
 	{
 		const StringName *K = nullptr;
 		while ((K = p_other->font_map.next(K))) {
@@ -1394,13 +1390,46 @@ void Theme::copy_theme(const Ref<Theme> &p_other) {
 		}
 	}
 
-	// These items can be simply copied.
-	font_size_map = p_other->font_size_map;
-	color_map = p_other->color_map;
-	constant_map = p_other->constant_map;
+	// Font sizes.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->font_size_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = p_other->font_size_map[*K].next(L))) {
+				set_font_size(*L, *K, p_other->font_size_map[*K][*L]);
+			}
+		}
+	}
 
-	variation_map = p_other->variation_map;
-	variation_base_map = p_other->variation_base_map;
+	// Icons.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->icon_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = p_other->icon_map[*K].next(L))) {
+				set_icon(*L, *K, p_other->icon_map[*K][*L]);
+			}
+		}
+	}
+
+	// Styleboxes.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->style_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = p_other->style_map[*K].next(L))) {
+				set_stylebox(*L, *K, p_other->style_map[*K][*L]);
+			}
+		}
+	}
+
+	// Type variations.
+	{
+		const StringName *K = nullptr;
+		while ((K = p_other->variation_map.next(K))) {
+			set_type_variation(*K, p_other->variation_map[*K]);
+		}
+	}
 
 	_unfreeze_and_propagate_changes();
 }
@@ -1534,8 +1563,6 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_constant_list", "theme_type"), &Theme::_get_constant_list);
 	ClassDB::bind_method(D_METHOD("get_constant_type_list"), &Theme::_get_constant_type_list);
 
-	ClassDB::bind_method(D_METHOD("clear"), &Theme::clear);
-
 	ClassDB::bind_method(D_METHOD("set_default_font", "font"), &Theme::set_default_theme_font);
 	ClassDB::bind_method(D_METHOD("get_default_font"), &Theme::get_default_theme_font);
 
@@ -1558,8 +1585,8 @@ void Theme::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_type_list"), &Theme::_get_type_list);
 
-	ClassDB::bind_method("copy_default_theme", &Theme::copy_default_theme);
-	ClassDB::bind_method(D_METHOD("copy_theme", "other"), &Theme::copy_theme);
+	ClassDB::bind_method(D_METHOD("merge_with", "other"), &Theme::merge_with);
+	ClassDB::bind_method(D_METHOD("clear"), &Theme::clear);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "default_font", PROPERTY_HINT_RESOURCE_TYPE, "Font"), "set_default_font", "get_default_font");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "default_font_size"), "set_default_font_size", "get_default_font_size");

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -210,8 +210,7 @@ public:
 	void get_type_list(List<StringName> *p_list) const;
 	void get_type_dependencies(const StringName &p_base_type, const StringName &p_type_variant, List<StringName> *p_list);
 
-	void copy_default_theme();
-	void copy_theme(const Ref<Theme> &p_other);
+	void merge_with(const Ref<Theme> &p_other);
 	void clear();
 
 	Theme();


### PR DESCRIPTION
A `master` version of https://github.com/godotengine/godot/pull/51648.

Additionally this PR removes `copy_theme()` and `copy_default_theme()` from the `Theme` resource. Frankly, I don't see a point in them, and they weren't consistent. All resource items (icons, styleboxes, fonts) were added to the base theme, while all the other, primitive types were completely replaced. So I am not sure what the actual purpose of the methods has been, but if anyone relied on it — it was probably a bad decision. I've removed the only place in the editor where we relied on one of them (because it wasn't actually necessary).

The new `merge_with()` can be used to add all items from another theme, and standard `duplicate()` can be called if you want a copy of the resource. So I think the removal of those two methods is justified.