### PR TITLE
Fix type check for assignment to multi-type property in GDScript

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -34,6 +34,7 @@
 #include "core/object/method_bind.h"
 #include "core/object/object.h"
 #include "core/string/print_string.h"
+#include "core/templates/local_vector.h"
 
 /** To bind more then 6 parameters include this:
  *
@@ -228,6 +229,7 @@ public:
 	static void get_direct_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);
 	static StringName get_parent_class_nocheck(const StringName &p_class);
 	static StringName get_parent_class(const StringName &p_class);
+	static StringName get_common_ancestor_of_classes(const LocalVector<StringName> &p_classes);
 	static StringName get_compatibility_remapped_class(const StringName &p_class);
 	static bool class_exists(const StringName &p_class);
 	static bool is_parent_class(const StringName &p_class, const StringName &p_inherits);

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -107,6 +107,7 @@ class GDScriptAnalyzer {
 	GDScriptParser::DataType get_operation_type(Variant::Operator p_operation, const GDScriptParser::DataType &p_a, bool &r_valid, const GDScriptParser::Node *p_source);
 	void update_array_literal_element_type(const GDScriptParser::DataType &p_base_type, GDScriptParser::ArrayNode *p_array_literal);
 	bool is_type_compatible(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source, bool p_allow_implicit_conversion = false) const;
+	bool _is_type_compatible_impl(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source, bool p_allow_implicit_conversion) const;
 	void push_error(const String &p_message, const GDScriptParser::Node *p_origin);
 	void mark_node_unsafe(const GDScriptParser::Node *p_node);
 	bool class_exists(const StringName &p_class) const;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3540,8 +3540,11 @@ String GDScriptParser::DataType::to_string() const {
 		case NATIVE:
 			if (is_meta_type) {
 				return GDScriptNativeClass::get_class_static();
+			} else if (!specific_native_types_array.is_empty()) {
+				return specific_native_types.operator String();
+			} else {
+				return native_type.operator String();
 			}
-			return native_type.operator String();
 		case CLASS:
 			if (is_meta_type) {
 				return GDScript::get_class_static();

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -39,6 +39,7 @@
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/list.h"
+#include "core/templates/local_vector.h"
 #include "core/templates/map.h"
 #include "core/templates/vector.h"
 #include "core/variant/variant.h"
@@ -127,6 +128,8 @@ public:
 
 		Variant::Type builtin_type = Variant::NIL;
 		StringName native_type;
+		LocalVector<StringName> specific_native_types_array;
+		StringName specific_native_types;
 		StringName enum_type; // Enum name or the value name in an enum.
 		Ref<Script> script_type;
 		String script_path;
@@ -180,6 +183,10 @@ public:
 				case BUILTIN:
 					return builtin_type == p_other.builtin_type;
 				case NATIVE:
+					if (specific_native_types != p_other.specific_native_types) {
+						return false;
+					}
+					[[fallthrough]];
 				case ENUM:
 					return native_type == p_other.native_type;
 				case ENUM_VALUE:
@@ -207,6 +214,8 @@ public:
 			is_coroutine = p_other.is_coroutine;
 			builtin_type = p_other.builtin_type;
 			native_type = p_other.native_type;
+			specific_native_types_array = p_other.specific_native_types_array;
+			specific_native_types = p_other.specific_native_types;
 			enum_type = p_other.enum_type;
 			script_type = p_other.script_type;
 			script_path = p_other.script_path;


### PR DESCRIPTION
After this PR the type of a "multi-type" property, like the one in the bug fixed by this, is no longer the comma-joined string of types, but the common ancestor type. The individual types are bookkeeped separately to allow the type compatibility check to use them (or any other check that wishes to do it in the future). Using a single type (the common ancestor) as the effective type of the property for the purposes of GDScript may have unexpected side effects, but, if you ask me, I'd say they are necessarily good. That's because I believe that GDScript will work better if the assumption that a single type is there is not broken.

Fixes #42280.