### PR TITLE
Upgrade spirv-reflect

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -602,7 +602,7 @@ Godot. Please check the file to know what's new.
 ## spirv-reflect
 
 - Upstream: https://github.com/KhronosGroup/SPIRV-Reflect
-- Version: git (c0ce03a43ca77fedb5abfd1976ae2fd0eeb0e611, 2021)
+- Version: git (272e050728de8d4a4ce9e7101c1244e6ff56e5b0, 2021)
 - License: Apache 2.0
 
 Files extracted from upstream source:

--- a/thirdparty/spirv-reflect/patches/specialization-constants.patch
+++ b/thirdparty/spirv-reflect/patches/specialization-constants.patch
@@ -1,18 +1,18 @@
 diff --git a/thirdparty/spirv-reflect/spirv_reflect.c b/thirdparty/spirv-reflect/spirv_reflect.c
-index 0fc979a8a4..3e3643717a 100644
+index 1c94a2e00e..2786a7f3ad 100644
 --- a/thirdparty/spirv-reflect/spirv_reflect.c
 +++ b/thirdparty/spirv-reflect/spirv_reflect.c
-@@ -124,6 +124,9 @@ typedef struct Decorations {
-   NumberDecoration      location;
-   NumberDecoration      offset;
-   NumberDecoration      uav_counter_buffer;
+@@ -124,6 +124,9 @@ typedef struct SpvReflectPrvDecorations {
+   SpvReflectPrvNumberDecoration   location;
+   SpvReflectPrvNumberDecoration   offset;
+   SpvReflectPrvNumberDecoration   uav_counter_buffer;
 +// -- GODOT begin --
-+  NumberDecoration      specialization_constant;
++  SpvReflectPrvNumberDecoration   specialization_constant;
 +// -- GODOT end --
-   StringDecoration      semantic;
-   uint32_t              array_stride;
-   uint32_t              matrix_stride;
-@@ -610,6 +613,9 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
+   SpvReflectPrvStringDecoration   semantic;
+   uint32_t                        array_stride;
+   uint32_t                        matrix_stride;
+@@ -629,6 +632,9 @@ static SpvReflectResult ParseNodes(SpvReflectPrvParser* p_parser)
      p_parser->nodes[i].decorations.offset.value = (uint32_t)INVALID_VALUE;
      p_parser->nodes[i].decorations.uav_counter_buffer.value = (uint32_t)INVALID_VALUE;
      p_parser->nodes[i].decorations.built_in = (SpvBuiltIn)INVALID_VALUE;
@@ -22,7 +22,7 @@ index 0fc979a8a4..3e3643717a 100644
    }
    // Mark source file id node
    p_parser->source_file_id = (uint32_t)INVALID_VALUE;
-@@ -800,10 +806,16 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
+@@ -819,10 +825,16 @@ static SpvReflectResult ParseNodes(SpvReflectPrvParser* p_parser)
          CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->result_id);
        }
        break;
@@ -41,7 +41,16 @@ index 0fc979a8a4..3e3643717a 100644
        case SpvOpSpecConstantComposite:
        case SpvOpSpecConstantOp: {
          CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_type_id);
-@@ -1309,6 +1321,9 @@ static SpvReflectResult ParseDecorations(Parser* p_parser)
+@@ -854,7 +866,7 @@ static SpvReflectResult ParseNodes(SpvReflectPrvParser* p_parser)
+         CHECKED_READU32(p_parser, p_node->word_offset + 3, p_access_chain->base_id);
+         //
+         // SPIRV_ACCESS_CHAIN_INDEX_OFFSET (4) is the number of words up until the first index:
+-        //   [Node, Result Type Id, Result Id, Base Id, <Indexes>]
++        //   [SpvReflectPrvNode, Result Type Id, Result Id, Base Id, <Indexes>]
+         //
+         p_access_chain->index_count = (node_word_count - SPIRV_ACCESS_CHAIN_INDEX_OFFSET);
+         if (p_access_chain->index_count > 0) {
+@@ -1334,6 +1346,9 @@ static SpvReflectResult ParseDecorations(SpvReflectPrvParser* p_parser)
          skip = true;
        }
        break; 
@@ -51,7 +60,7 @@ index 0fc979a8a4..3e3643717a 100644
        case SpvDecorationBlock:
        case SpvDecorationBufferBlock:
        case SpvDecorationColMajor:
-@@ -1441,7 +1456,14 @@ static SpvReflectResult ParseDecorations(Parser* p_parser)
+@@ -1466,7 +1481,14 @@ static SpvReflectResult ParseDecorations(SpvReflectPrvParser* p_parser)
          p_target_decorations->input_attachment_index.word_offset = word_offset;
        }
        break;
@@ -67,7 +76,7 @@ index 0fc979a8a4..3e3643717a 100644
        case SpvReflectDecorationHlslCounterBufferGOOGLE: {
          uint32_t word_offset = p_node->word_offset + member_offset+ 3;
          CHECKED_READU32(p_parser, word_offset, p_target_decorations->uav_counter_buffer.value);
-@@ -1731,6 +1753,13 @@ static SpvReflectResult ParseType(
+@@ -1766,6 +1788,13 @@ static SpvReflectResult ParseType(
          p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_EXTERNAL_ACCELERATION_STRUCTURE;
        }
        break;
@@ -81,17 +90,17 @@ index 0fc979a8a4..3e3643717a 100644
      }
  
      if (result == SPV_REFLECT_RESULT_SUCCESS) {
-@@ -3187,6 +3216,69 @@ static SpvReflectResult ParseExecutionModes(Parser* p_parser, SpvReflectShaderMo
+@@ -3236,6 +3265,69 @@ static SpvReflectResult ParseExecutionModes(
    return SPV_REFLECT_RESULT_SUCCESS;
  }
  
 +// -- GODOT begin --
-+static SpvReflectResult ParseSpecializationConstants(Parser* p_parser, SpvReflectShaderModule* p_module)
++static SpvReflectResult ParseSpecializationConstants(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module)
 +{
 +  p_module->specialization_constant_count = 0;
 +  p_module->specialization_constants = NULL;
 +  for (size_t i = 0; i < p_parser->node_count; ++i) {
-+    Node* p_node = &(p_parser->nodes[i]);
++    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
 +    if (p_node->op == SpvOpSpecConstantTrue || p_node->op == SpvOpSpecConstantFalse || p_node->op == SpvOpSpecConstant) {
 +      p_module->specialization_constant_count++;
 +    }
@@ -106,7 +115,7 @@ index 0fc979a8a4..3e3643717a 100644
 +  uint32_t index = 0;
 +
 +  for (size_t i = 0; i < p_parser->node_count; ++i) {
-+    Node* p_node = &(p_parser->nodes[i]);
++    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
 +    switch(p_node->op) {
 +      default: continue;
 +      case SpvOpSpecConstantTrue: {
@@ -124,7 +133,7 @@ index 0fc979a8a4..3e3643717a 100644
 +        IF_READU32(result, p_parser, p_node->word_offset + 1, element_type_id);
 +        IF_READU32(result, p_parser, p_node->word_offset + 3, default_value);
 +
-+        Node* p_next_node = FindNode(p_parser, element_type_id);
++        SpvReflectPrvNode* p_next_node = FindNode(p_parser, element_type_id);
 +
 +        if (p_next_node->op == SpvOpTypeInt) {
 +          p_module->specialization_constants[index].constant_type = SPV_REFLECT_SPECIALIZATION_CONSTANT_INT;
@@ -148,10 +157,10 @@ index 0fc979a8a4..3e3643717a 100644
 +}
 +// -- GODOT end --
 +
- static SpvReflectResult ParsePushConstantBlocks(Parser* p_parser, SpvReflectShaderModule* p_module)
- {
-   for (size_t i = 0; i < p_parser->node_count; ++i) {
-@@ -3562,6 +3654,12 @@ SpvReflectResult spvReflectCreateShaderModule(
+ static SpvReflectResult ParsePushConstantBlocks(
+   SpvReflectPrvParser*    p_parser, 
+   SpvReflectShaderModule* p_module)
+@@ -3613,6 +3705,12 @@ SpvReflectResult spvReflectCreateShaderModule(
      result = ParsePushConstantBlocks(&parser, p_module);
      SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
    }
@@ -164,7 +173,7 @@ index 0fc979a8a4..3e3643717a 100644
    if (result == SPV_REFLECT_RESULT_SUCCESS) {
      result = ParseEntryPoints(&parser, p_module);
      SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
-@@ -3691,6 +3789,9 @@ void spvReflectDestroyShaderModule(SpvReflectShaderModule* p_module)
+@@ -3742,6 +3840,9 @@ void spvReflectDestroyShaderModule(SpvReflectShaderModule* p_module)
      SafeFree(p_entry->used_push_constants);
    }
    SafeFree(p_module->entry_points);
@@ -174,14 +183,14 @@ index 0fc979a8a4..3e3643717a 100644
  
    // Push constants
    for (size_t i = 0; i < p_module->push_constant_block_count; ++i) {
-@@ -3959,6 +4060,38 @@ SpvReflectResult spvReflectEnumerateEntryPointInterfaceVariables(
+@@ -4010,6 +4111,38 @@ SpvReflectResult spvReflectEnumerateEntryPointInterfaceVariables(
    return SPV_REFLECT_RESULT_SUCCESS;
  }
  
 +// -- GODOT begin --
 +SpvReflectResult spvReflectEnumerateSpecializationConstants(
-+  const SpvReflectShaderModule* p_module,
-+  uint32_t*                     p_count,
++  const SpvReflectShaderModule*      p_module,
++  uint32_t*                          p_count,
 +  SpvReflectSpecializationConstant** pp_constants
 +)
 +{
@@ -214,7 +223,7 @@ index 0fc979a8a4..3e3643717a 100644
    const SpvReflectShaderModule* p_module,
    uint32_t*                     p_count,
 diff --git a/thirdparty/spirv-reflect/spirv_reflect.h b/thirdparty/spirv-reflect/spirv_reflect.h
-index a5a956e9e8..21f8160770 100644
+index da05400973..50cc65222b 100644
 --- a/thirdparty/spirv-reflect/spirv_reflect.h
 +++ b/thirdparty/spirv-reflect/spirv_reflect.h
 @@ -292,6 +292,28 @@ typedef struct SpvReflectTypeDescription {
@@ -247,9 +256,9 @@ index a5a956e9e8..21f8160770 100644
  /*! @struct SpvReflectInterfaceVariable
  
 @@ -439,6 +461,10 @@ typedef struct SpvReflectShaderModule {
-   SpvReflectInterfaceVariable*      interface_variables;
-   uint32_t                          push_constant_block_count;
-   SpvReflectBlockVariable*          push_constant_blocks;
+   SpvReflectInterfaceVariable*      interface_variables;                              // Uses value(s) from first entry point
+   uint32_t                          push_constant_block_count;                        // Uses value(s) from first entry point
+   SpvReflectBlockVariable*          push_constant_blocks;                             // Uses value(s) from first entry point
 +  // -- GODOT begin --
 +  uint32_t                          specialization_constant_count;
 +  SpvReflectSpecializationConstant* specialization_constants;

--- a/thirdparty/spirv-reflect/spirv_reflect.c
+++ b/thirdparty/spirv-reflect/spirv_reflect.c
@@ -76,153 +76,157 @@ enum {
 // clang-format on
 
 // clang-format off
-typedef struct ArrayTraits {
-  uint32_t              element_type_id;
-  uint32_t              length_id;
-} ArrayTraits;
+typedef struct SpvReflectPrvArrayTraits {
+  uint32_t                        element_type_id;
+  uint32_t                        length_id;
+} SpvReflectPrvArrayTraits;
 // clang-format on
 
 // clang-format off
-typedef struct ImageTraits {
-  uint32_t              sampled_type_id;
-  SpvDim                dim;
-  uint32_t              depth;
-  uint32_t              arrayed;
-  uint32_t              ms;
-  uint32_t              sampled;
-  SpvImageFormat        image_format;
-} ImageTraits;
+typedef struct SpvReflectPrvImageTraits {
+  uint32_t                        sampled_type_id;
+  SpvDim                          dim;
+  uint32_t                        depth;
+  uint32_t                        arrayed;
+  uint32_t                        ms;
+  uint32_t                        sampled;
+  SpvImageFormat                  image_format;
+} SpvReflectPrvImageTraits;
 // clang-format on
 
 // clang-format off
-typedef struct NumberDecoration {
-  uint32_t              word_offset;
-  uint32_t              value;
-} NumberDecoration;
+typedef struct SpvReflectPrvNumberDecoration {
+  uint32_t                        word_offset;
+  uint32_t                        value;
+} SpvReflectPrvNumberDecoration;
 // clang-format on
 
 // clang-format off
-typedef struct StringDecoration {
-  uint32_t              word_offset;
-  const char*           value;
-} StringDecoration;
+typedef struct SpvReflectPrvStringDecoration {
+  uint32_t                        word_offset;
+  const char*                     value;
+} SpvReflectPrvStringDecoration;
 // clang-format on
 
 // clang-format off
-typedef struct Decorations {
-  bool                  is_block;
-  bool                  is_buffer_block;
-  bool                  is_row_major;
-  bool                  is_column_major;
-  bool                  is_built_in;
-  bool                  is_noperspective;
-  bool                  is_flat;
-  bool                  is_non_writable;
-  NumberDecoration      set;
-  NumberDecoration      binding;
-  NumberDecoration      input_attachment_index;
-  NumberDecoration      location;
-  NumberDecoration      offset;
-  NumberDecoration      uav_counter_buffer;
+typedef struct SpvReflectPrvDecorations {
+  bool                            is_block;
+  bool                            is_buffer_block;
+  bool                            is_row_major;
+  bool                            is_column_major;
+  bool                            is_built_in;
+  bool                            is_noperspective;
+  bool                            is_flat;
+  bool                            is_non_writable;
+  SpvReflectPrvNumberDecoration   set;
+  SpvReflectPrvNumberDecoration   binding;
+  SpvReflectPrvNumberDecoration   input_attachment_index;
+  SpvReflectPrvNumberDecoration   location;
+  SpvReflectPrvNumberDecoration   offset;
+  SpvReflectPrvNumberDecoration   uav_counter_buffer;
 // -- GODOT begin --
-  NumberDecoration      specialization_constant;
+  SpvReflectPrvNumberDecoration   specialization_constant;
 // -- GODOT end --
-  StringDecoration      semantic;
-  uint32_t              array_stride;
-  uint32_t              matrix_stride;
-  SpvBuiltIn            built_in;
-} Decorations;
+  SpvReflectPrvStringDecoration   semantic;
+  uint32_t                        array_stride;
+  uint32_t                        matrix_stride;
+  SpvBuiltIn                      built_in;
+} SpvReflectPrvDecorations;
 // clang-format on
 
 // clang-format off
-typedef struct Node {
-  uint32_t              result_id;
-  SpvOp                 op;
-  uint32_t              result_type_id;
-  uint32_t              type_id;
-  SpvStorageClass       storage_class;
-  uint32_t              word_offset;
-  uint32_t              word_count;
-  bool                  is_type;
+typedef struct SpvReflectPrvNode {
+  uint32_t                        result_id;
+  SpvOp                           op;
+  uint32_t                        result_type_id;
+  uint32_t                        type_id;
+  SpvStorageClass                 storage_class;
+  uint32_t                        word_offset;
+  uint32_t                        word_count;
+  bool                            is_type;
 
-  ArrayTraits           array_traits;
-  ImageTraits           image_traits;
-  uint32_t              image_type_id;
+  SpvReflectPrvArrayTraits        array_traits;
+  SpvReflectPrvImageTraits        image_traits;
+  uint32_t                        image_type_id;
 
-  const char*           name;
-  Decorations           decorations;
-  uint32_t              member_count;
-  const char**          member_names;
-  Decorations*          member_decorations;
-} Node;
+  const char*                     name;
+  SpvReflectPrvDecorations        decorations;
+  uint32_t                        member_count;
+  const char**                    member_names;
+  SpvReflectPrvDecorations*       member_decorations;
+} SpvReflectPrvNode;
 // clang-format on
 
 // clang-format off
-typedef struct String {
-  uint32_t              result_id;
-  const char*           string;
-} String;
+typedef struct SpvReflectPrvString {
+  uint32_t                        result_id;
+  const char*                     string;
+} SpvReflectPrvString;
 // clang-format on
 
 // clang-format off
-typedef struct Function {
-  uint32_t              id;
-  uint32_t              callee_count;
-  uint32_t*             callees;
-  struct Function**     callee_ptrs;
-  uint32_t              accessed_ptr_count;
-  uint32_t*             accessed_ptrs;
-} Function;
+typedef struct SpvReflectPrvFunction {
+  uint32_t                        id;
+  uint32_t                        callee_count;
+  uint32_t*                       callees;
+  struct SpvReflectPrvFunction**  callee_ptrs;
+  uint32_t                        accessed_ptr_count;
+  uint32_t*                       accessed_ptrs;
+} SpvReflectPrvFunction;
 // clang-format on
 
 // clang-format off
-typedef struct AccessChain {
-  uint32_t              result_id;
-  uint32_t              result_type_id;
+typedef struct SpvReflectPrvAccessChain {
+  uint32_t                        result_id;
+  uint32_t                        result_type_id;
   //
   // Pointing to the base of a composite object.
   // Generally the id of descriptor block variable
-  uint32_t              base_id;
+  uint32_t                        base_id;
   // 
   // From spec:
   //   The first index in Indexes will select the 
   //   top-level member/element/component/element 
   //   of the base composite
-  uint32_t              index_count;
-  uint32_t*             indexes;
-} AccessChain;
+  uint32_t                        index_count;
+  uint32_t*                       indexes;
+} SpvReflectPrvAccessChain;
 // clang-format on
 
 // clang-format off
-typedef struct Parser {
-  size_t                spirv_word_count;
-  uint32_t*             spirv_code;
-  uint32_t              string_count;
-  String*               strings;
-  SpvSourceLanguage     source_language;
-  uint32_t              source_language_version;
-  uint32_t              source_file_id;
-  const char*           source_embedded;
-  size_t                node_count;
-  Node*                 nodes;
-  uint32_t              entry_point_count;
-  uint32_t              function_count;
-  Function*             functions;
-  uint32_t              access_chain_count;
-  AccessChain*          access_chains;
+typedef struct SpvReflectPrvParser {
+  size_t                          spirv_word_count;
+  uint32_t*                       spirv_code;
+  uint32_t                        string_count;
+  SpvReflectPrvString*            strings;
+  SpvSourceLanguage               source_language;
+  uint32_t                        source_language_version;
+  uint32_t                        source_file_id;
+  const char*                     source_embedded;
+  size_t                          node_count;
+  SpvReflectPrvNode*              nodes;
+  uint32_t                        entry_point_count;
+  uint32_t                        function_count;
+  SpvReflectPrvFunction*          functions;
+  uint32_t                        access_chain_count;
+  SpvReflectPrvAccessChain*       access_chains;
 
-  uint32_t              type_count;
-  uint32_t              descriptor_count;
-  uint32_t              push_constant_count;
-} Parser;
+  uint32_t                        type_count;
+  uint32_t                        descriptor_count;
+  uint32_t                        push_constant_count;
+} SpvReflectPrvParser;
 // clang-format on
 
-static uint32_t Max(uint32_t a, uint32_t b)
+static uint32_t Max(
+   uint32_t a, 
+   uint32_t b)
 {
   return a > b ? a : b;
 }
 
-static uint32_t RoundUp(uint32_t value, uint32_t multiple)
+static uint32_t RoundUp(
+   uint32_t value,
+   uint32_t multiple)
 {
   assert(multiple && ((multiple & (multiple - 1)) == 0));
   return (value + multiple - 1) & ~(multiple - 1);
@@ -242,7 +246,9 @@ static uint32_t RoundUp(uint32_t value, uint32_t multiple)
      }                   \
   }
 
-static int SortCompareUint32(const void* a, const void* b)
+static int SortCompareUint32(
+  const void* a, 
+  const void* b)
 {
   const uint32_t* p_a = (const uint32_t*)a;
   const uint32_t* p_b = (const uint32_t*)b;
@@ -272,7 +278,10 @@ static size_t DedupSortedUint32(uint32_t* arr, size_t size)
   return dedup_idx+1;
 }
 
-static bool SearchSortedUint32(const uint32_t* arr, size_t size, uint32_t target)
+static bool SearchSortedUint32(
+  const uint32_t* arr, 
+  size_t          size, 
+  uint32_t        target)
 {
   size_t lo = 0;
   size_t hi = size;
@@ -341,7 +350,9 @@ static SpvReflectResult IntersectSortedUint32(
 }
 
 
-static bool InRange(const Parser* p_parser, uint32_t index)
+static bool InRange(
+  const SpvReflectPrvParser* p_parser, 
+  uint32_t                   index)
 {
   bool in_range = false;
   if (IsNotNull(p_parser)) {
@@ -350,7 +361,10 @@ static bool InRange(const Parser* p_parser, uint32_t index)
   return in_range;
 }
 
-static SpvReflectResult ReadU32(Parser* p_parser, uint32_t word_offset, uint32_t* p_value)
+static SpvReflectResult ReadU32(
+  SpvReflectPrvParser* p_parser,
+  uint32_t             word_offset,
+  uint32_t*            p_value)
 {
   assert(IsNotNull(p_parser));
   assert(IsNotNull(p_parser->spirv_code));
@@ -399,12 +413,12 @@ static SpvReflectResult ReadU32(Parser* p_parser, uint32_t word_offset, uint32_t
   }
 
 static SpvReflectResult ReadStr(
-  Parser*   p_parser, 
-  uint32_t  word_offset, 
-  uint32_t  word_index, 
-  uint32_t  word_count,
-  uint32_t* p_buf_size, 
-  char*     p_buf
+  SpvReflectPrvParser* p_parser, 
+  uint32_t             word_offset, 
+  uint32_t             word_index, 
+  uint32_t             word_count,
+  uint32_t*            p_buf_size, 
+  char*                p_buf
 )
 {
   uint32_t limit = (word_offset + word_count);
@@ -445,7 +459,7 @@ static SpvReflectResult ReadStr(
   return result;
 }
 
-static SpvReflectDecorationFlags ApplyDecorations(const Decorations* p_decoration_fields)
+static SpvReflectDecorationFlags ApplyDecorations(const SpvReflectPrvDecorations* p_decoration_fields)
 {
   SpvReflectDecorationFlags decorations = SPV_REFLECT_DECORATION_NONE;
   if (p_decoration_fields->is_block) {
@@ -485,11 +499,13 @@ static void ApplyArrayTraits(const SpvReflectTypeDescription* p_type, SpvReflect
   memcpy(p_array_traits, &p_type->traits.array, sizeof(p_type->traits.array));
 }
 
-static Node* FindNode(Parser* p_parser, uint32_t result_id)
+static SpvReflectPrvNode* FindNode(
+  SpvReflectPrvParser* p_parser,
+  uint32_t             result_id)
 {
-  Node* p_node = NULL;
+  SpvReflectPrvNode* p_node = NULL;
   for (size_t i = 0; i < p_parser->node_count; ++i) {
-    Node* p_elem = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_elem = &(p_parser->nodes[i]);
     if (p_elem->result_id == result_id) {
       p_node = p_elem;
       break;
@@ -511,7 +527,10 @@ static SpvReflectTypeDescription* FindType(SpvReflectShaderModule* p_module, uin
   return p_type;
 }
 
-static SpvReflectResult CreateParser(size_t size, void* p_code, Parser* p_parser)
+static SpvReflectResult CreateParser(
+  size_t               size, 
+  void*                p_code, 
+  SpvReflectPrvParser* p_parser)
 {
   if (p_code == NULL) {
     return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
@@ -534,12 +553,12 @@ static SpvReflectResult CreateParser(size_t size, void* p_code, Parser* p_parser
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static void DestroyParser(Parser* p_parser)
+static void DestroyParser(SpvReflectPrvParser* p_parser)
 {
   if (!IsNull(p_parser->nodes)) {
     // Free nodes
     for (size_t i = 0; i < p_parser->node_count; ++i) {
-      Node* p_node = &(p_parser->nodes[i]);
+      SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
       if (IsNotNull(p_node->member_names)) {
         SafeFree(p_node->member_names);
       }
@@ -569,7 +588,7 @@ static void DestroyParser(Parser* p_parser)
   }
 }
 
-static SpvReflectResult ParseNodes(Parser* p_parser)
+static SpvReflectResult ParseNodes(SpvReflectPrvParser* p_parser)
 {
   assert(IsNotNull(p_parser));
   assert(IsNotNull(p_parser->spirv_code));
@@ -599,7 +618,7 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
 
   // Allocate nodes
   p_parser->node_count = node_count;
-  p_parser->nodes = (Node*)calloc(p_parser->node_count, sizeof(*(p_parser->nodes)));
+  p_parser->nodes = (SpvReflectPrvNode*)calloc(p_parser->node_count, sizeof(*(p_parser->nodes)));
   if (IsNull(p_parser->nodes)) {
     return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
   }
@@ -626,7 +645,7 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
 
   // Allocate access chain
   if (p_parser->access_chain_count > 0) {
-    p_parser->access_chains = (AccessChain*)calloc(p_parser->access_chain_count, sizeof(*(p_parser->access_chains)));
+    p_parser->access_chains = (SpvReflectPrvAccessChain*)calloc(p_parser->access_chain_count, sizeof(*(p_parser->access_chains)));
     if (IsNull(p_parser->access_chains)) {
       return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
     }
@@ -641,7 +660,7 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
     SpvOp op = (SpvOp)(word & 0xFFFF);
     uint32_t node_word_count = (word >> 16) & 0xFFFF;
 
-    Node* p_node = &(p_parser->nodes[node_index]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[node_index]);
     p_node->op = op;
     p_node->word_offset = spirv_word_index;
     p_node->word_count = node_word_count;
@@ -841,13 +860,13 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
 
       case SpvOpAccessChain:
       {
-        AccessChain* p_access_chain = &(p_parser->access_chains[access_chain_index]);
+        SpvReflectPrvAccessChain* p_access_chain = &(p_parser->access_chains[access_chain_index]);
         CHECKED_READU32(p_parser, p_node->word_offset + 1, p_access_chain->result_type_id);
         CHECKED_READU32(p_parser, p_node->word_offset + 2, p_access_chain->result_id);
         CHECKED_READU32(p_parser, p_node->word_offset + 3, p_access_chain->base_id);
         //
         // SPIRV_ACCESS_CHAIN_INDEX_OFFSET (4) is the number of words up until the first index:
-        //   [Node, Result Type Id, Result Id, Base Id, <Indexes>]
+        //   [SpvReflectPrvNode, Result Type Id, Result Id, Base Id, <Indexes>]
         //
         p_access_chain->index_count = (node_word_count - SPIRV_ACCESS_CHAIN_INDEX_OFFSET);
         if (p_access_chain->index_count > 0) {
@@ -861,7 +880,7 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
             uint32_t index_id = 0;
             CHECKED_READU32(p_parser, p_node->word_offset + SPIRV_ACCESS_CHAIN_INDEX_OFFSET + index_index, index_id);
             // Find OpConstant node that contains index value
-            Node* p_index_value_node = FindNode(p_parser, index_id);
+            SpvReflectPrvNode* p_index_value_node = FindNode(p_parser, index_id);
             if ((p_index_value_node != NULL) && (p_index_value_node->op == SpvOpConstant)) {
               // Read index value
               uint32_t index_value = UINT32_MAX;
@@ -890,7 +909,7 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
       case SpvOpLabel:
       {
         if (function_node != (uint32_t)INVALID_VALUE) {
-          Node* p_func_node = &(p_parser->nodes[function_node]);
+          SpvReflectPrvNode* p_func_node = &(p_parser->nodes[function_node]);
           CHECKED_READU32(p_parser, p_func_node->word_offset + 2, p_func_node->result_id);
           ++(p_parser->function_count);
         }
@@ -914,7 +933,7 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static SpvReflectResult ParseStrings(Parser* p_parser)
+static SpvReflectResult ParseStrings(SpvReflectPrvParser* p_parser)
 {
   assert(IsNotNull(p_parser));
   assert(IsNotNull(p_parser->spirv_code));
@@ -927,11 +946,11 @@ static SpvReflectResult ParseStrings(Parser* p_parser)
 
   if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && IsNotNull(p_parser->nodes)) {
     // Allocate string storage
-    p_parser->strings = (String*)calloc(p_parser->string_count, sizeof(*(p_parser->strings)));  
+    p_parser->strings = (SpvReflectPrvString*)calloc(p_parser->string_count, sizeof(*(p_parser->strings)));  
 
     uint32_t string_index = 0;
     for (size_t i = 0; i < p_parser->node_count; ++i) {
-      Node* p_node = &(p_parser->nodes[i]);
+      SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
       if (p_node->op != SpvOpString) {
         continue;
       }
@@ -943,7 +962,7 @@ static SpvReflectResult ParseStrings(Parser* p_parser)
       }
 
       // Result id
-      String* p_string = &(p_parser->strings[string_index]);
+      SpvReflectPrvString* p_string = &(p_parser->strings[string_index]);
       CHECKED_READU32(p_parser, p_node->word_offset + 1, p_string->result_id);
 
       // String
@@ -958,7 +977,7 @@ static SpvReflectResult ParseStrings(Parser* p_parser)
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static SpvReflectResult ParseSource(Parser* p_parser, SpvReflectShaderModule* p_module)
+static SpvReflectResult ParseSource(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module)
 {
   assert(IsNotNull(p_parser));
   assert(IsNotNull(p_parser->spirv_code));
@@ -967,7 +986,7 @@ static SpvReflectResult ParseSource(Parser* p_parser, SpvReflectShaderModule* p_
     // Source file
     if (IsNotNull(p_parser->strings)) {
       for (uint32_t i = 0; i < p_parser->string_count; ++i) {
-        String* p_string = &(p_parser->strings[i]);
+        SpvReflectPrvString* p_string = &(p_parser->strings[i]);
         if (p_string->result_id == p_parser->source_file_id) {
           p_module->source_file = p_string->string;
           break;
@@ -998,7 +1017,11 @@ static SpvReflectResult ParseSource(Parser* p_parser, SpvReflectShaderModule* p_
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static SpvReflectResult ParseFunction(Parser* p_parser, Node* p_func_node, Function* p_func, size_t first_label_index)
+static SpvReflectResult ParseFunction(
+  SpvReflectPrvParser*   p_parser, 
+  SpvReflectPrvNode*     p_func_node, 
+  SpvReflectPrvFunction* p_func, 
+  size_t                 first_label_index)
 {
   p_func->id = p_func_node->result_id;
 
@@ -1006,7 +1029,7 @@ static SpvReflectResult ParseFunction(Parser* p_parser, Node* p_func_node, Funct
   p_func->accessed_ptr_count = 0;
 
   for (size_t i = first_label_index; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if (p_node->op == SpvOpFunctionEnd) {
       break;
     }
@@ -1056,7 +1079,7 @@ static SpvReflectResult ParseFunction(Parser* p_parser, Node* p_func_node, Funct
   p_func->callee_count = 0;
   p_func->accessed_ptr_count = 0;
   for (size_t i = first_label_index; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if (p_node->op == SpvOpFunctionEnd) {
       break;
     }
@@ -1119,14 +1142,16 @@ static SpvReflectResult ParseFunction(Parser* p_parser, Node* p_func_node, Funct
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static int SortCompareFunctions(const void* a, const void* b)
+static int SortCompareFunctions(
+  const void* a, 
+  const void* b)
 {
-  const Function* af = (const Function*)a;
-  const Function* bf = (const Function*)b;
+  const SpvReflectPrvFunction* af = (const SpvReflectPrvFunction*)a;
+  const SpvReflectPrvFunction* bf = (const SpvReflectPrvFunction*)b;
   return (int)af->id - (int)bf->id;
 }
 
-static SpvReflectResult ParseFunctions(Parser* p_parser)
+static SpvReflectResult ParseFunctions(SpvReflectPrvParser* p_parser)
 {
   assert(IsNotNull(p_parser));
   assert(IsNotNull(p_parser->spirv_code));
@@ -1137,15 +1162,15 @@ static SpvReflectResult ParseFunctions(Parser* p_parser)
       return SPV_REFLECT_RESULT_SUCCESS;
     }
 
-    p_parser->functions = (Function*)calloc(p_parser->function_count,
-                                            sizeof(*(p_parser->functions)));
+    p_parser->functions = (SpvReflectPrvFunction*)calloc(p_parser->function_count,
+                                                         sizeof(*(p_parser->functions)));
     if (IsNull(p_parser->functions)) {
       return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
     }
 
     size_t function_index = 0;
     for (size_t i = 0; i < p_parser->node_count; ++i) {
-      Node* p_node = &(p_parser->nodes[i]);
+      SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
       if (p_node->op != SpvOpFunction) {
         continue;
       }
@@ -1167,7 +1192,7 @@ static SpvReflectResult ParseFunctions(Parser* p_parser)
         continue;
       }
 
-      Function* p_function = &(p_parser->functions[function_index]);
+      SpvReflectPrvFunction* p_function = &(p_parser->functions[function_index]);
 
       SpvReflectResult result = ParseFunction(p_parser, p_node, p_function, i);
       if (result != SPV_REFLECT_RESULT_SUCCESS) {
@@ -1183,12 +1208,12 @@ static SpvReflectResult ParseFunctions(Parser* p_parser)
     // Once they're sorted, link the functions with pointers to improve graph
     // traversal efficiency
     for (size_t i = 0; i < p_parser->function_count; ++i) {
-      Function* p_func = &(p_parser->functions[i]);
+      SpvReflectPrvFunction* p_func = &(p_parser->functions[i]);
       if (p_func->callee_count == 0) {
         continue;
       }
-      p_func->callee_ptrs = (Function**)calloc(p_func->callee_count,
-                                               sizeof(*(p_func->callee_ptrs)));
+      p_func->callee_ptrs = (SpvReflectPrvFunction**)calloc(p_func->callee_count,
+                                                            sizeof(*(p_func->callee_ptrs)));
       for (size_t j = 0, k = 0; j < p_func->callee_count; ++j) {
         while (p_parser->functions[k].id != p_func->callees[j]) {
           ++k;
@@ -1205,7 +1230,7 @@ static SpvReflectResult ParseFunctions(Parser* p_parser)
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static SpvReflectResult ParseMemberCounts(Parser* p_parser)
+static SpvReflectResult ParseMemberCounts(SpvReflectPrvParser* p_parser)
 {
   assert(IsNotNull(p_parser));
   assert(IsNotNull(p_parser->spirv_code));
@@ -1213,7 +1238,7 @@ static SpvReflectResult ParseMemberCounts(Parser* p_parser)
 
   if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && IsNotNull(p_parser->nodes)) {
     for (size_t i = 0; i < p_parser->node_count; ++i) {
-      Node* p_node = &(p_parser->nodes[i]);
+      SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
       if ((p_node->op != SpvOpMemberName) && (p_node->op != SpvOpMemberDecorate)) {
         continue;
       }
@@ -1222,7 +1247,7 @@ static SpvReflectResult ParseMemberCounts(Parser* p_parser)
       uint32_t member_index = (uint32_t)INVALID_VALUE;
       CHECKED_READU32(p_parser, p_node->word_offset + 1, target_id);
       CHECKED_READU32(p_parser, p_node->word_offset + 2, member_index);
-      Node* p_target_node = FindNode(p_parser, target_id);
+      SpvReflectPrvNode* p_target_node = FindNode(p_parser, target_id);
       // Not all nodes get parsed, so FindNode returning NULL is expected.
       if (IsNull(p_target_node)) {
         continue;
@@ -1236,7 +1261,7 @@ static SpvReflectResult ParseMemberCounts(Parser* p_parser)
     }
 
     for (uint32_t i = 0; i < p_parser->node_count; ++i) {
-      Node* p_node = &(p_parser->nodes[i]);
+      SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
       if (p_node->member_count == 0) {
         continue;
       }
@@ -1246,7 +1271,7 @@ static SpvReflectResult ParseMemberCounts(Parser* p_parser)
         return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
       }
 
-      p_node->member_decorations = (Decorations*)calloc(p_node->member_count, sizeof(*(p_node->member_decorations)));
+      p_node->member_decorations = (SpvReflectPrvDecorations*)calloc(p_node->member_count, sizeof(*(p_node->member_decorations)));
       if (IsNull(p_node->member_decorations)) {
         return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
       }
@@ -1255,7 +1280,7 @@ static SpvReflectResult ParseMemberCounts(Parser* p_parser)
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static SpvReflectResult ParseNames(Parser* p_parser)
+static SpvReflectResult ParseNames(SpvReflectPrvParser* p_parser)
 {
   assert(IsNotNull(p_parser));
   assert(IsNotNull(p_parser->spirv_code));
@@ -1263,14 +1288,14 @@ static SpvReflectResult ParseNames(Parser* p_parser)
 
   if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && IsNotNull(p_parser->nodes)) {
     for (size_t i = 0; i < p_parser->node_count; ++i) {
-      Node* p_node = &(p_parser->nodes[i]);
+      SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
       if ((p_node->op != SpvOpName) && (p_node->op != SpvOpMemberName)) {
         continue;
       }
 
       uint32_t target_id = 0;
       CHECKED_READU32(p_parser, p_node->word_offset + 1, target_id);
-      Node* p_target_node = FindNode(p_parser, target_id);
+      SpvReflectPrvNode* p_target_node = FindNode(p_parser, target_id);
       // Not all nodes get parsed, so FindNode returning NULL is expected.
       if (IsNull(p_target_node)) {
         continue;
@@ -1289,10 +1314,10 @@ static SpvReflectResult ParseNames(Parser* p_parser)
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static SpvReflectResult ParseDecorations(Parser* p_parser)
+static SpvReflectResult ParseDecorations(SpvReflectPrvParser* p_parser)
 {
   for (uint32_t i = 0; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
 
     if (((uint32_t)p_node->op != (uint32_t)SpvOpDecorate) &&
         ((uint32_t)p_node->op != (uint32_t)SpvOpMemberDecorate) &&
@@ -1352,12 +1377,12 @@ static SpvReflectResult ParseDecorations(Parser* p_parser)
     // Find target target node 
     uint32_t target_id = 0;
     CHECKED_READU32(p_parser, p_node->word_offset + 1, target_id);
-    Node* p_target_node = FindNode(p_parser, target_id);
+    SpvReflectPrvNode* p_target_node = FindNode(p_parser, target_id);
     if (IsNull(p_target_node)) {
       return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
     }
     // Get decorations
-    Decorations* p_target_decorations = &(p_target_node->decorations);
+    SpvReflectPrvDecorations* p_target_decorations = &(p_target_node->decorations);
     // Update pointer if this is a member member decoration
     if (p_node->op == SpvOpMemberDecorate) {
       uint32_t member_index = (uint32_t)INVALID_VALUE;
@@ -1507,11 +1532,11 @@ static SpvReflectResult EnumerateAllUniforms(
 }
 
 static SpvReflectResult ParseType(
-  Parser*                     p_parser, 
-  Node*                       p_node, 
-  Decorations*                p_struct_member_decorations, 
-  SpvReflectShaderModule*     p_module, 
-  SpvReflectTypeDescription*  p_type
+  SpvReflectPrvParser*       p_parser, 
+  SpvReflectPrvNode*         p_node, 
+  SpvReflectPrvDecorations*  p_struct_member_decorations, 
+  SpvReflectShaderModule*    p_module, 
+  SpvReflectTypeDescription* p_type
 )
 {
   SpvReflectResult result = SPV_REFLECT_RESULT_SUCCESS;
@@ -1574,7 +1599,7 @@ static SpvReflectResult ParseType(
         IF_READU32(result, p_parser, p_node->word_offset + 2, component_type_id);
         IF_READU32(result, p_parser, p_node->word_offset + 3, p_type->traits.numeric.vector.component_count);
         // Parse component type
-        Node* p_next_node = FindNode(p_parser, component_type_id);
+        SpvReflectPrvNode* p_next_node = FindNode(p_parser, component_type_id);
         if (IsNotNull(p_next_node)) {
           result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
         }
@@ -1590,7 +1615,7 @@ static SpvReflectResult ParseType(
         uint32_t column_type_id = (uint32_t)INVALID_VALUE;
         IF_READU32(result, p_parser, p_node->word_offset + 2, column_type_id);
         IF_READU32(result, p_parser, p_node->word_offset + 3, p_type->traits.numeric.matrix.column_count);
-        Node* p_next_node = FindNode(p_parser, column_type_id);
+        SpvReflectPrvNode* p_next_node = FindNode(p_parser, column_type_id);
         if (IsNotNull(p_next_node)) {
           result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
         }
@@ -1609,6 +1634,15 @@ static SpvReflectResult ParseType(
 
       case SpvOpTypeImage: {
         p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_EXTERNAL_IMAGE;
+        uint32_t sampled_type_id = (uint32_t)INVALID_VALUE;
+        IF_READU32(result, p_parser, p_node->word_offset + 2, sampled_type_id);
+        SpvReflectPrvNode* p_next_node = FindNode(p_parser, sampled_type_id);
+        if (IsNotNull(p_next_node)) {
+          result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
+        }
+        else {
+          result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
         IF_READU32_CAST(result, p_parser, p_node->word_offset + 3, SpvDim, p_type->traits.image.dim);
         IF_READU32(result, p_parser, p_node->word_offset + 4, p_type->traits.image.depth);
         IF_READU32(result, p_parser, p_node->word_offset + 5, p_type->traits.image.arrayed);
@@ -1627,7 +1661,7 @@ static SpvReflectResult ParseType(
         p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_EXTERNAL_SAMPLED_IMAGE;
         uint32_t image_type_id = (uint32_t)INVALID_VALUE;
         IF_READU32(result, p_parser, p_node->word_offset + 2, image_type_id);
-        Node* p_next_node = FindNode(p_parser, image_type_id);
+        SpvReflectPrvNode* p_next_node = FindNode(p_parser, image_type_id);
         if (IsNotNull(p_next_node)) {
           result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
         }
@@ -1649,7 +1683,7 @@ static SpvReflectResult ParseType(
           //       OpMemberDecorate, even if the array is apart of a struct.
           p_type->traits.array.stride = p_node->decorations.array_stride;
           // Get length for current dimension
-          Node* p_length_node = FindNode(p_parser, length_id);
+          SpvReflectPrvNode* p_length_node = FindNode(p_parser, length_id);
           if (IsNotNull(p_length_node)) {
             if (p_length_node->op == SpvOpSpecConstant ||
                 p_length_node->op == SpvOpSpecConstantOp) {
@@ -1668,7 +1702,7 @@ static SpvReflectResult ParseType(
               }
             }
             // Parse next dimension or element type
-            Node* p_next_node = FindNode(p_parser, element_type_id);
+            SpvReflectPrvNode* p_next_node = FindNode(p_parser, element_type_id);
             if (IsNotNull(p_next_node)) {
               result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
             }
@@ -1682,10 +1716,11 @@ static SpvReflectResult ParseType(
       break;
 
       case SpvOpTypeRuntimeArray: {
+        p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_ARRAY;
         uint32_t element_type_id = (uint32_t)INVALID_VALUE;
         IF_READU32(result, p_parser, p_node->word_offset + 2, element_type_id);
         // Parse next dimension or element type
-        Node* p_next_node = FindNode(p_parser, element_type_id);
+        SpvReflectPrvNode* p_next_node = FindNode(p_parser, element_type_id);
         if (IsNotNull(p_next_node)) {
           result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
         }
@@ -1705,7 +1740,7 @@ static SpvReflectResult ParseType(
           uint32_t member_id = (uint32_t)INVALID_VALUE;
           IF_READU32(result, p_parser, p_node->word_offset + word_index, member_id);
           // Find member node
-          Node* p_member_node = FindNode(p_parser, member_id);
+          SpvReflectPrvNode* p_member_node = FindNode(p_parser, member_id);
           if (IsNull(p_member_node)) {
             result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
             SPV_REFLECT_ASSERT(false);
@@ -1713,7 +1748,7 @@ static SpvReflectResult ParseType(
           }
 
           // Member decorations
-          Decorations* p_member_decorations = &p_node->member_decorations[member_index];
+          SpvReflectPrvDecorations* p_member_decorations = &p_node->member_decorations[member_index];
 
           assert(member_index < p_type->member_count);
           // Parse member type
@@ -1738,7 +1773,7 @@ static SpvReflectResult ParseType(
         uint32_t type_id = (uint32_t)INVALID_VALUE;
         IF_READU32(result, p_parser, p_node->word_offset + 3, type_id);
         // Parse type
-        Node* p_next_node = FindNode(p_parser, type_id);
+        SpvReflectPrvNode* p_next_node = FindNode(p_parser, type_id);
         if (IsNotNull(p_next_node)) {
           result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
         }
@@ -1774,7 +1809,9 @@ static SpvReflectResult ParseType(
   return result;
 }
 
-static SpvReflectResult ParseTypes(Parser* p_parser, SpvReflectShaderModule* p_module)
+static SpvReflectResult ParseTypes(
+  SpvReflectPrvParser*    p_parser,
+  SpvReflectShaderModule* p_module)
 {
   if (p_parser->type_count == 0) {
     return SPV_REFLECT_RESULT_SUCCESS;
@@ -1797,7 +1834,7 @@ static SpvReflectResult ParseTypes(Parser* p_parser, SpvReflectShaderModule* p_m
 
   size_t type_index = 0;
   for (size_t i = 0; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if (! p_node->is_type) {
       continue;
     }
@@ -1826,11 +1863,13 @@ static int SortCompareDescriptorBinding(const void* a, const void* b)
   return value;
 }
 
-static SpvReflectResult ParseDescriptorBindings(Parser* p_parser, SpvReflectShaderModule* p_module)
+static SpvReflectResult ParseDescriptorBindings(
+  SpvReflectPrvParser*    p_parser,
+  SpvReflectShaderModule* p_module)
 {
   p_module->descriptor_binding_count = 0;
   for (size_t i = 0; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if ((p_node->op != SpvOpVariable) ||
         ((p_node->storage_class != SpvStorageClassUniform) &&
          (p_node->storage_class != SpvStorageClassStorageBuffer) &&
@@ -1866,7 +1905,7 @@ static SpvReflectResult ParseDescriptorBindings(Parser* p_parser, SpvReflectShad
 
   size_t descriptor_index = 0;
   for (size_t i = 0; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if ((p_node->op != SpvOpVariable) ||
         ((p_node->storage_class != SpvStorageClassUniform) &&
          (p_node->storage_class != SpvStorageClassStorageBuffer) &&
@@ -1888,7 +1927,7 @@ static SpvReflectResult ParseDescriptorBindings(Parser* p_parser, SpvReflectShad
     if (p_type->op == SpvOpTypePointer) {
       pointer_storage_class = p_type->storage_class;
       // Find the type's node
-      Node* p_type_node = FindNode(p_parser, p_type->id);
+      SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
       if (IsNull(p_type_node)) {
         return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
       }
@@ -2116,7 +2155,7 @@ static SpvReflectResult ParseUAVCounterBindings(SpvReflectShaderModule* p_module
 }
 
 static SpvReflectResult ParseDescriptorBlockVariable(
-  Parser*                     p_parser, 
+  SpvReflectPrvParser*        p_parser, 
   SpvReflectShaderModule*     p_module, 
   SpvReflectTypeDescription*  p_type, 
   SpvReflectBlockVariable*    p_var
@@ -2131,7 +2170,7 @@ static SpvReflectResult ParseDescriptorBlockVariable(
       return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
     }
 
-    Node* p_type_node = FindNode(p_parser, p_type->id);
+    SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
     if (IsNull(p_type_node)) {
       return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
     }
@@ -2195,12 +2234,12 @@ static SpvReflectResult ParseDescriptorBlockVariable(
 }
 
 static SpvReflectResult ParseDescriptorBlockVariableSizes(
-  Parser*                   p_parser, 
-  SpvReflectShaderModule*   p_module, 
-  bool                      is_parent_root, 
-  bool                      is_parent_aos, 
-  bool                      is_parent_rta, 
-  SpvReflectBlockVariable*  p_var
+  SpvReflectPrvParser*     p_parser, 
+  SpvReflectShaderModule*  p_module, 
+  bool                     is_parent_root, 
+  bool                     is_parent_aos, 
+  bool                     is_parent_rta, 
+  SpvReflectBlockVariable* p_var
 )
 {
   if (p_var->member_count == 0) {
@@ -2351,12 +2390,12 @@ static void MarkSelfAndAllMemberVarsAsUsed(SpvReflectBlockVariable* p_var)
 }
 
 static SpvReflectResult ParseDescriptorBlockVariableUsage(
-  Parser*                  p_parser,
-  SpvReflectShaderModule*  p_module,
-  AccessChain*             p_access_chain,
-  uint32_t                 index_index,
-  SpvOp                    override_op_type,
-  SpvReflectBlockVariable* p_var
+  SpvReflectPrvParser*      p_parser,
+  SpvReflectShaderModule*   p_module,
+  SpvReflectPrvAccessChain* p_access_chain,
+  uint32_t                  index_index,
+  SpvOp                     override_op_type,
+  SpvReflectBlockVariable*  p_var
 )
 {
   (void)p_parser;
@@ -2381,7 +2420,7 @@ static SpvReflectResult ParseDescriptorBlockVariableUsage(
       SpvReflectTypeDescription* p_type = p_var->type_description;
       while ((p_type->op == SpvOpTypeArray) && (index_index < p_access_chain->index_count)) {
         // Find the array element type id
-        Node* p_node = FindNode(p_parser, p_type->id);
+        SpvReflectPrvNode* p_node = FindNode(p_parser, p_type->id);
         if (p_node == NULL) {
           return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
         }
@@ -2480,7 +2519,9 @@ static SpvReflectResult ParseDescriptorBlockVariableUsage(
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static SpvReflectResult ParseDescriptorBlocks(Parser* p_parser, SpvReflectShaderModule* p_module)
+static SpvReflectResult ParseDescriptorBlocks(
+  SpvReflectPrvParser*    p_parser, 
+  SpvReflectShaderModule* p_module)
 {
   if (p_module->descriptor_binding_count == 0) {
     return SPV_REFLECT_RESULT_SUCCESS;
@@ -2504,7 +2545,7 @@ static SpvReflectResult ParseDescriptorBlocks(Parser* p_parser, SpvReflectShader
     }
 
     for (uint32_t access_chain_index = 0; access_chain_index < p_parser->access_chain_count; ++access_chain_index) {
-      AccessChain* p_access_chain = &(p_parser->access_chains[access_chain_index]);
+      SpvReflectPrvAccessChain* p_access_chain = &(p_parser->access_chains[access_chain_index]);
       // Skip any access chains that aren't touching this descriptor block
       if (p_descriptor->spirv_id != p_access_chain->base_id) {
         continue;
@@ -2557,6 +2598,8 @@ static SpvReflectResult ParseFormat(
             case 4: *p_format = SPV_REFLECT_FORMAT_R32G32B32A32_SFLOAT; break;
           }
         }
+        break;
+        
         case 64: {
           switch (component_count) {
             case 2: *p_format = SPV_REFLECT_FORMAT_R64G64_SFLOAT; break;
@@ -2576,6 +2619,8 @@ static SpvReflectResult ParseFormat(
             case 4: *p_format = signedness ? SPV_REFLECT_FORMAT_R32G32B32A32_SINT : SPV_REFLECT_FORMAT_R32G32B32A32_UINT; break;
           }
         }
+        break;
+        
         case 64: {
           switch (component_count) {
             case 2: *p_format = signedness ? SPV_REFLECT_FORMAT_R64G64_SINT : SPV_REFLECT_FORMAT_R64G64_UINT; break;
@@ -2616,15 +2661,15 @@ static SpvReflectResult ParseFormat(
 }
 
 static SpvReflectResult ParseInterfaceVariable(
-  Parser*                      p_parser,
-  const Decorations*           p_type_node_decorations,
-  SpvReflectShaderModule*      p_module,
-  SpvReflectTypeDescription*   p_type,
-  SpvReflectInterfaceVariable* p_var,
-  bool*                        p_has_built_in
+  SpvReflectPrvParser*            p_parser,
+  const SpvReflectPrvDecorations* p_type_node_decorations,
+  SpvReflectShaderModule*         p_module,
+  SpvReflectTypeDescription*      p_type,
+  SpvReflectInterfaceVariable*    p_var,
+  bool*                           p_has_built_in
 )
 {
-  Node* p_type_node = FindNode(p_parser, p_type->id);
+  SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
   if (IsNull(p_type_node)) {
     return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
   }
@@ -2637,7 +2682,7 @@ static SpvReflectResult ParseInterfaceVariable(
     }
 
     for (uint32_t member_index = 0; member_index < p_type_node->member_count; ++member_index) {
-      Decorations* p_member_decorations = &p_type_node->member_decorations[member_index];
+      SpvReflectPrvDecorations* p_member_decorations = &p_type_node->member_decorations[member_index];
       SpvReflectTypeDescription* p_member_type = &p_type->members[member_index];
       SpvReflectInterfaceVariable* p_member_var = &p_var->members[member_index];
       SpvReflectResult result = ParseInterfaceVariable(p_parser, p_member_decorations, p_module, p_member_type, p_member_var, p_has_built_in);
@@ -2673,7 +2718,7 @@ static SpvReflectResult ParseInterfaceVariable(
 }
 
 static SpvReflectResult ParseInterfaceVariables(
-  Parser*                 p_parser,
+  SpvReflectPrvParser*    p_parser,
   SpvReflectShaderModule* p_module,
   SpvReflectEntryPoint*   p_entry,
   uint32_t                interface_variable_count,
@@ -2689,7 +2734,7 @@ static SpvReflectResult ParseInterfaceVariables(
  p_entry->output_variable_count = 0;  
  for (size_t i = 0; i < interface_variable_count; ++i) {
    uint32_t var_result_id = *(p_interface_variable_ids + i);
-   Node* p_node = FindNode(p_parser, var_result_id);
+   SpvReflectPrvNode* p_node = FindNode(p_parser, var_result_id);
    if (IsNull(p_node)) {
      return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
    }
@@ -2727,7 +2772,7 @@ static SpvReflectResult ParseInterfaceVariables(
   size_t output_index = 0;
   for (size_t i = 0; i < interface_variable_count; ++i) {
     uint32_t var_result_id = *(p_interface_variable_ids + i);
-    Node* p_node = FindNode(p_parser, var_result_id);
+    SpvReflectPrvNode* p_node = FindNode(p_parser, var_result_id);
     if (IsNull(p_node)) {
       return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
     }
@@ -2739,7 +2784,7 @@ static SpvReflectResult ParseInterfaceVariables(
     // If the type is a pointer, resolve it
     if (p_type->op == SpvOpTypePointer) {
       // Find the type's node
-      Node* p_type_node = FindNode(p_parser, p_type->id);
+      SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
       if (IsNull(p_type_node)) {
         return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
       }
@@ -2750,7 +2795,7 @@ static SpvReflectResult ParseInterfaceVariables(
       }
     }
 
-    Node* p_type_node = FindNode(p_parser, p_type->id);
+    SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
     if (IsNull(p_type_node)) {
       return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
     }
@@ -2831,11 +2876,11 @@ static SpvReflectResult EnumerateAllPushConstants(
 }
 
 static SpvReflectResult TraverseCallGraph(
-  Parser*   p_parser,
-  Function* p_func,
-  size_t*   p_func_count,
-  uint32_t* p_func_ids,
-  uint32_t  depth
+  SpvReflectPrvParser*   p_parser,
+  SpvReflectPrvFunction* p_func,
+  size_t*                p_func_count,
+  uint32_t*              p_func_ids,
+  uint32_t               depth
 )
 {
   if (depth > p_parser->function_count) {
@@ -2860,7 +2905,7 @@ static SpvReflectResult TraverseCallGraph(
 }
 
 static SpvReflectResult ParseStaticallyUsedResources(
-  Parser*                 p_parser,
+  SpvReflectPrvParser*    p_parser,
   SpvReflectShaderModule* p_module,
   SpvReflectEntryPoint*   p_entry,
   size_t                  uniform_count,
@@ -2870,7 +2915,7 @@ static SpvReflectResult ParseStaticallyUsedResources(
 )
 {
   // Find function with the right id
-  Function* p_func = NULL;
+  SpvReflectPrvFunction* p_func = NULL;
   for (size_t i = 0; i < p_parser->function_count; ++i) {
     if (p_parser->functions[i].id == p_entry->id) {
       p_func = &(p_parser->functions[i]);
@@ -3004,7 +3049,9 @@ static SpvReflectResult ParseStaticallyUsedResources(
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static SpvReflectResult ParseEntryPoints(Parser* p_parser, SpvReflectShaderModule* p_module)
+static SpvReflectResult ParseEntryPoints(
+  SpvReflectPrvParser*    p_parser, 
+  SpvReflectShaderModule* p_module)
 {
   if (p_parser->entry_point_count == 0) {
     return SPV_REFLECT_RESULT_SUCCESS;
@@ -3033,7 +3080,7 @@ static SpvReflectResult ParseEntryPoints(Parser* p_parser, SpvReflectShaderModul
 
   size_t entry_point_index = 0;
   for (size_t i = 0; entry_point_index < p_parser->entry_point_count && i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if (p_node->op != SpvOpEntryPoint) {
       continue;
     }
@@ -3118,7 +3165,9 @@ static SpvReflectResult ParseEntryPoints(Parser* p_parser, SpvReflectShaderModul
   return SPV_REFLECT_RESULT_SUCCESS;
 }
 
-static SpvReflectResult ParseExecutionModes(Parser* p_parser, SpvReflectShaderModule* p_module)
+static SpvReflectResult ParseExecutionModes(
+  SpvReflectPrvParser*    p_parser,
+  SpvReflectShaderModule* p_module)
 {
   assert(IsNotNull(p_parser));
   assert(IsNotNull(p_parser->nodes));
@@ -3126,7 +3175,7 @@ static SpvReflectResult ParseExecutionModes(Parser* p_parser, SpvReflectShaderMo
 
   if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && IsNotNull(p_parser->nodes)) {
     for (size_t node_idx = 0; node_idx < p_parser->node_count; ++node_idx) {
-      Node* p_node = &(p_parser->nodes[node_idx]);
+      SpvReflectPrvNode* p_node = &(p_parser->nodes[node_idx]);
       if (p_node->op != SpvOpExecutionMode) {
         continue;
       }
@@ -3217,12 +3266,12 @@ static SpvReflectResult ParseExecutionModes(Parser* p_parser, SpvReflectShaderMo
 }
 
 // -- GODOT begin --
-static SpvReflectResult ParseSpecializationConstants(Parser* p_parser, SpvReflectShaderModule* p_module)
+static SpvReflectResult ParseSpecializationConstants(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module)
 {
   p_module->specialization_constant_count = 0;
   p_module->specialization_constants = NULL;
   for (size_t i = 0; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if (p_node->op == SpvOpSpecConstantTrue || p_node->op == SpvOpSpecConstantFalse || p_node->op == SpvOpSpecConstant) {
       p_module->specialization_constant_count++;
     }
@@ -3237,7 +3286,7 @@ static SpvReflectResult ParseSpecializationConstants(Parser* p_parser, SpvReflec
   uint32_t index = 0;
 
   for (size_t i = 0; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     switch(p_node->op) {
       default: continue;
       case SpvOpSpecConstantTrue: {
@@ -3255,7 +3304,7 @@ static SpvReflectResult ParseSpecializationConstants(Parser* p_parser, SpvReflec
         IF_READU32(result, p_parser, p_node->word_offset + 1, element_type_id);
         IF_READU32(result, p_parser, p_node->word_offset + 3, default_value);
 
-        Node* p_next_node = FindNode(p_parser, element_type_id);
+        SpvReflectPrvNode* p_next_node = FindNode(p_parser, element_type_id);
 
         if (p_next_node->op == SpvOpTypeInt) {
           p_module->specialization_constants[index].constant_type = SPV_REFLECT_SPECIALIZATION_CONSTANT_INT;
@@ -3279,10 +3328,12 @@ static SpvReflectResult ParseSpecializationConstants(Parser* p_parser, SpvReflec
 }
 // -- GODOT end --
 
-static SpvReflectResult ParsePushConstantBlocks(Parser* p_parser, SpvReflectShaderModule* p_module)
+static SpvReflectResult ParsePushConstantBlocks(
+  SpvReflectPrvParser*    p_parser, 
+  SpvReflectShaderModule* p_module)
 {
   for (size_t i = 0; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if ((p_node->op != SpvOpVariable) || (p_node->storage_class != SpvStorageClassPushConstant)) {
       continue;
     }
@@ -3301,7 +3352,7 @@ static SpvReflectResult ParsePushConstantBlocks(Parser* p_parser, SpvReflectShad
 
   uint32_t push_constant_index = 0;
   for (size_t i = 0; i < p_parser->node_count; ++i) {
-    Node* p_node = &(p_parser->nodes[i]);
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if ((p_node->op != SpvOpVariable) || (p_node->storage_class != SpvStorageClassPushConstant)) {
       continue;
     }
@@ -3313,7 +3364,7 @@ static SpvReflectResult ParsePushConstantBlocks(Parser* p_parser, SpvReflectShad
     // If the type is a pointer, resolve it
     if (p_type->op == SpvOpTypePointer) {
       // Find the type's node
-      Node* p_type_node = FindNode(p_parser, p_type->id);
+      SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
       if (IsNull(p_type_node)) {
         return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
       }
@@ -3324,7 +3375,7 @@ static SpvReflectResult ParsePushConstantBlocks(Parser* p_parser, SpvReflectShad
       }
     }
 
-    Node* p_type_node = FindNode(p_parser, p_type->id);
+    SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
     if (IsNull(p_type_node)) {
       return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
     }
@@ -3577,7 +3628,7 @@ SpvReflectResult spvReflectCreateShaderModule(
   }
   memcpy(p_module->_internal->spirv_code, p_code, size);
 
-  Parser parser = { 0 };
+  SpvReflectPrvParser parser = { 0 };
   SpvReflectResult result = CreateParser(p_module->_internal->spirv_size,
                                          p_module->_internal->spirv_code,
                                          &parser);
@@ -4062,8 +4113,8 @@ SpvReflectResult spvReflectEnumerateEntryPointInterfaceVariables(
 
 // -- GODOT begin --
 SpvReflectResult spvReflectEnumerateSpecializationConstants(
-  const SpvReflectShaderModule* p_module,
-  uint32_t*                     p_count,
+  const SpvReflectShaderModule*      p_module,
+  uint32_t*                          p_count,
   SpvReflectSpecializationConstant** pp_constants
 )
 {

--- a/thirdparty/spirv-reflect/spirv_reflect.h
+++ b/thirdparty/spirv-reflect/spirv_reflect.h
@@ -152,7 +152,7 @@ typedef enum SpvReflectFormat {
   SPV_REFLECT_FORMAT_R64G64_SFLOAT       = 115, // = VK_FORMAT_R64G64_SFLOAT
   SPV_REFLECT_FORMAT_R64G64B64_UINT      = 116, // = VK_FORMAT_R64G64B64_UINT
   SPV_REFLECT_FORMAT_R64G64B64_SINT      = 117, // = VK_FORMAT_R64G64B64_SINT
-  SPV_REFLECT_FORMAT_R64G64B64_SFLOAT    = 118, // = VK_FORMAT_R64G64B64_FLOAT
+  SPV_REFLECT_FORMAT_R64G64B64_SFLOAT    = 118, // = VK_FORMAT_R64G64B64_SFLOAT
   SPV_REFLECT_FORMAT_R64G64B64A64_UINT   = 119, // = VK_FORMAT_R64G64B64A64_UINT
   SPV_REFLECT_FORMAT_R64G64B64A64_SINT   = 120, // = VK_FORMAT_R64G64B64A64_SINT
   SPV_REFLECT_FORMAT_R64G64B64A64_SFLOAT = 121, // = VK_FORMAT_R64G64B64A64_SFLOAT
@@ -447,20 +447,20 @@ typedef struct SpvReflectShaderModule {
   uint32_t                          source_language_version;
   const char*                       source_file;
   const char*                       source_source;
-  SpvExecutionModel                 spirv_execution_model;
-  SpvReflectShaderStageFlagBits     shader_stage;
-  uint32_t                          descriptor_binding_count;
-  SpvReflectDescriptorBinding*      descriptor_bindings;
-  uint32_t                          descriptor_set_count;
-  SpvReflectDescriptorSet           descriptor_sets[SPV_REFLECT_MAX_DESCRIPTOR_SETS];
-  uint32_t                          input_variable_count;  
-  SpvReflectInterfaceVariable**     input_variables;       
-  uint32_t                          output_variable_count; 
-  SpvReflectInterfaceVariable**     output_variables;      
-  uint32_t                          interface_variable_count;
-  SpvReflectInterfaceVariable*      interface_variables;
-  uint32_t                          push_constant_block_count;
-  SpvReflectBlockVariable*          push_constant_blocks;
+  SpvExecutionModel                 spirv_execution_model;                            // Uses value(s) from first entry point
+  SpvReflectShaderStageFlagBits     shader_stage;                                     // Uses value(s) from first entry point
+  uint32_t                          descriptor_binding_count;                         // Uses value(s) from first entry point
+  SpvReflectDescriptorBinding*      descriptor_bindings;                              // Uses value(s) from first entry point
+  uint32_t                          descriptor_set_count;                             // Uses value(s) from first entry point
+  SpvReflectDescriptorSet           descriptor_sets[SPV_REFLECT_MAX_DESCRIPTOR_SETS]; // Uses value(s) from first entry point
+  uint32_t                          input_variable_count;                             // Uses value(s) from first entry point
+  SpvReflectInterfaceVariable**     input_variables;                                  // Uses value(s) from first entry point
+  uint32_t                          output_variable_count;                            // Uses value(s) from first entry point
+  SpvReflectInterfaceVariable**     output_variables;                                 // Uses value(s) from first entry point
+  uint32_t                          interface_variable_count;                         // Uses value(s) from first entry point
+  SpvReflectInterfaceVariable*      interface_variables;                              // Uses value(s) from first entry point
+  uint32_t                          push_constant_block_count;                        // Uses value(s) from first entry point
+  SpvReflectBlockVariable*          push_constant_blocks;                             // Uses value(s) from first entry point
   // -- GODOT begin --
   uint32_t                          specialization_constant_count;
   SpvReflectSpecializationConstant* specialization_constants;
@@ -1426,6 +1426,9 @@ public:
   ShaderModule(const std::vector<uint32_t>& code);
   ~ShaderModule();
 
+  ShaderModule(ShaderModule&& other);
+  ShaderModule& operator=(ShaderModule&& other);
+
   SpvReflectResult GetResult() const;
 
   const SpvReflectShaderModule& GetShaderModule() const;
@@ -1437,8 +1440,9 @@ public:
 
   const char*           GetSourceFile() const;
 
-  uint32_t              GetEntryPointCount() const;
-  const char*           GetEntryPointName(uint32_t index) const;
+  uint32_t                      GetEntryPointCount() const;
+  const char*                   GetEntryPointName(uint32_t index) const;
+  SpvReflectShaderStageFlagBits GetEntryPointShaderStage(uint32_t index) const;
 
   SpvReflectShaderStageFlagBits GetShaderStage() const;
   SPV_REFLECT_DEPRECATED("Renamed to GetShaderStage")
@@ -1568,6 +1572,20 @@ inline ShaderModule::~ShaderModule() {
 }
 
 
+inline ShaderModule::ShaderModule(ShaderModule&& other)
+{
+    *this = std::move(other);
+}
+
+inline ShaderModule& ShaderModule::operator=(ShaderModule&& other)
+{
+    m_result = std::move(other.m_result);
+    m_module = std::move(other.m_module);
+
+    other.m_module = {};
+    return *this;
+}
+
 /*! @fn GetResult
 
   @return
@@ -1644,9 +1662,18 @@ inline const char* ShaderModule::GetEntryPointName(uint32_t index) const {
   return m_module.entry_points[index].name;
 }
 
+/*! @fn GetEntryPointShaderStage
+
+  @param index
+  @return Returns the shader stage for the entry point at \b index
+*/
+inline SpvReflectShaderStageFlagBits ShaderModule::GetEntryPointShaderStage(uint32_t index) const {
+  return m_module.entry_points[index].shader_stage;
+}
+
 /*! @fn GetShaderStage
 
-  @return Returns Vulkan shader stage
+  @return Returns shader stage for the first entry point
 
 */
 inline SpvReflectShaderStageFlagBits ShaderModule::GetShaderStage() const {


### PR DESCRIPTION
~~This renames spirv-reflect's `String`.~~

The goal of this is avoiding a very annoying side effect of having two `String` types: on the MSVC debugger (others may be affected), Godot `Strings` may be interpreted as spirv-reflect `String`s, which will show wrong members with wrong values, hindering the ability to inspect their values and making debugging very hard.

At first I tried to hide the visibility of the struct with `static`, but MSVC was still finding and using it.