### PR TITLE
Improve GDScript Editor performance

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1579,17 +1579,10 @@ void CodeTextEditor::_update_text_editor_theme() {
 }
 
 void CodeTextEditor::_on_settings_change() {
-	if (settings_changed) {
-		return;
-	}
-
-	settings_changed = true;
-	MessageQueue::get_singleton()->push_callable(callable_mp(this, &CodeTextEditor::_apply_settings_change));
+	_apply_settings_change();
 }
 
 void CodeTextEditor::_apply_settings_change() {
-	settings_changed = false;
-
 	_update_text_editor_theme();
 
 	font_size = EditorSettings::get_singleton()->get("interface/editor/code_font_size");

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -162,8 +162,6 @@ class CodeTextEditor : public VBoxContainer {
 	int error_line;
 	int error_column;
 
-	bool settings_changed = false;
-
 	void _on_settings_change();
 	void _apply_settings_change();
 

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -467,7 +467,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	List<StringName> global_classes;
 	ScriptServer::get_global_class_list(&global_classes);
 	for (const StringName &E : global_classes) {
-		keywords[String(E)] = usertype_color;
+		keywords[E] = usertype_color;
 	}
 
 	/* Autoloads. */
@@ -486,7 +486,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	List<String> core_types;
 	gdscript->get_core_type_words(&core_types);
 	for (const String &E : core_types) {
-		keywords[E] = basetype_color;
+		keywords[StringName(E)] = basetype_color;
 	}
 
 	/* Reserved words. */
@@ -496,9 +496,9 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	gdscript->get_reserved_words(&keyword_list);
 	for (const String &E : keyword_list) {
 		if (gdscript->is_control_flow_keyword(E)) {
-			keywords[E] = control_flow_keyword_color;
+			keywords[StringName(E)] = control_flow_keyword_color;
 		} else {
-			keywords[E] = keyword_color;
+			keywords[StringName(E)] = keyword_color;
 		}
 	}
 

--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -47,8 +47,8 @@ private:
 	Vector<ColorRegion> color_regions;
 	Map<int, int> color_region_cache;
 
-	Dictionary keywords;
-	Dictionary member_keywords;
+	HashMap<StringName, Color> keywords;
+	HashMap<StringName, Color> member_keywords;
 
 	enum Type {
 		NONE,


### PR DESCRIPTION
Improvements:
- Fixes resizing the code
- GDScript Highlighter is faster by 25% as keys are smaller (hashes instead of strings)
- MessageQueue::push_callable took too long to notify for the settings change (the actual fix for the code editor)

Overall code editor latency is down and code resizing works correctly now.

TODO: profiling results