### PR TITLE
The `PagedAllocator` can now allocate objects with non empty constructors.

### DIFF
--- a/core/templates/paged_allocator.h
+++ b/core/templates/paged_allocator.h
@@ -50,7 +50,8 @@ class PagedAllocator {
 	SpinLock spin_lock;
 
 public:
-	T *alloc() {
+	template <class... Args>
+	T *alloc(const Args &&...p_args) {
 		if (thread_safe) {
 			spin_lock.lock();
 		}
@@ -75,7 +76,7 @@ public:
 		if (thread_safe) {
 			spin_lock.unlock();
 		}
-		memnew_placement(alloc, T);
+		memnew_placement(alloc, T(p_args...));
 		return alloc;
 	}
 


### PR DESCRIPTION
Add the possibility to initialize the classes allocated with the `PagedAllocator`

It uses the (`const T &&... p_args`) forward reference, to avoid copying the memory in case the passed argument is an rvalue, or pass a reference in case it's an lvalue.

This is an example:
```c++
PagedAllocator<btShapeBox> box_allocator;
btShapeBox* box = box_allocator.alloc( /* Half extension */btVector3(1.0, 1.0, 1.0) );
```

You can still use the `PagedAllocator` as usual, initializing the class using the empty constructor:
```c++
PagedAllocator<Transform> transform_allocator;
Transform* tansform = transform_allocator.alloc();
```