### PR TITLE
Use get_global_* functions instead of using transforms.

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -261,7 +261,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 		Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_global_transform();
 
 		Vector2 gpoint = mb->get_position();
-		Vector2 cpoint = _get_node()->get_global_transform().affine_inverse().xform(canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(mb->get_position())));
+		Vector2 cpoint = _get_node()->to_local(canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(mb->get_position())));
 
 		if (mode == MODE_EDIT || (_is_line() && mode == MODE_CREATE)) {
 			if (mb->get_button_index() == MOUSE_BUTTON_LEFT) {
@@ -396,7 +396,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 		Vector2 gpoint = mm->get_position();
 
 		if (edited_point.valid() && (wip_active || (mm->get_button_mask() & MOUSE_BUTTON_MASK_LEFT))) {
-			Vector2 cpoint = _get_node()->get_global_transform().affine_inverse().xform(canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(gpoint)));
+			Vector2 cpoint = _get_node()->to_local(canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(gpoint)));
 
 			//Move the point in a single axis. Should only work when editing a polygon and while holding shift.
 			if (mode == MODE_EDIT && mm->is_shift_pressed()) {

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -77,7 +77,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 		Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
 
 		Vector2 gpoint = mb->get_position();
-		Vector2 cpoint = node->get_global_transform().affine_inverse().xform(canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(mb->get_position())));
+		Vector2 cpoint = node->to_local(canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(mb->get_position())));
 
 		if (mb->is_pressed() && action == ACTION_NONE) {
 			Ref<Curve2D> curve = node->get_curve();

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -96,7 +96,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 	Size2 screen_size = _get_camera_screen_size();
 
-	Point2 new_camera_pos = get_global_transform().get_origin();
+	Point2 new_camera_pos = get_global_position();
 	Point2 ret_camera_pos;
 
 	if (!first) {
@@ -169,7 +169,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 	Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5 * zoom) : Point2());
 
-	real_t angle = get_global_transform().get_rotation();
+	real_t angle = get_global_rotation();
 	if (rotating) {
 		screen_offset = screen_offset.rotated(angle);
 	}
@@ -305,8 +305,8 @@ void Camera2D::_notification(int p_what) {
 					limit_drawing_width = 3;
 				}
 
-				Vector2 camera_origin = get_global_transform().get_origin();
-				Vector2 camera_scale = get_global_transform().get_scale().abs();
+				Vector2 camera_origin = get_global_position();
+				Vector2 camera_scale = get_global_scale().abs();
 				Vector2 limit_points[4] = {
 					(Vector2(limit[SIDE_LEFT], limit[SIDE_TOP]) - camera_origin) / camera_scale,
 					(Vector2(limit[SIDE_RIGHT], limit[SIDE_TOP]) - camera_origin) / camera_scale,
@@ -489,7 +489,7 @@ void Camera2D::align() {
 
 	Size2 screen_size = _get_camera_screen_size();
 
-	Point2 current_camera_pos = get_global_transform().get_origin();
+	Point2 current_camera_pos = get_global_position();
 	if (anchor_mode == ANCHOR_MODE_DRAG_CENTER) {
 		if (drag_horizontal_offset < 0) {
 			camera_pos.x = current_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_RIGHT] * drag_horizontal_offset;

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -252,7 +252,7 @@ void PinJoint2D::_notification(int p_what) {
 }
 
 void PinJoint2D::_configure_joint(RID p_joint, PhysicsBody2D *body_a, PhysicsBody2D *body_b) {
-	PhysicsServer2D::get_singleton()->joint_make_pin(p_joint, get_global_transform().get_origin(), body_a->get_rid(), body_b ? body_b->get_rid() : RID());
+	PhysicsServer2D::get_singleton()->joint_make_pin(p_joint, get_global_position(), body_a->get_rid(), body_b ? body_b->get_rid() : RID());
 	PhysicsServer2D::get_singleton()->pin_joint_set_param(p_joint, PhysicsServer2D::PIN_JOINT_SOFTNESS, softness);
 }
 

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -102,7 +102,7 @@ void NavigationAgent2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (agent_parent) {
-				NavigationServer2D::get_singleton()->agent_set_position(agent, agent_parent->get_global_transform().get_origin());
+				NavigationServer2D::get_singleton()->agent_set_position(agent, agent_parent->get_global_position());
 				_check_distance_to_target();
 			}
 		} break;
@@ -185,7 +185,7 @@ Vector2 NavigationAgent2D::get_next_location() {
 	update_navigation();
 	if (navigation_path.size() == 0) {
 		ERR_FAIL_COND_V(agent_parent == nullptr, Vector2());
-		return agent_parent->get_global_transform().get_origin();
+		return agent_parent->get_global_position();
 	} else {
 		return navigation_path[nav_path_index];
 	}
@@ -193,7 +193,7 @@ Vector2 NavigationAgent2D::get_next_location() {
 
 real_t NavigationAgent2D::distance_to_target() const {
 	ERR_FAIL_COND_V(agent_parent == nullptr, 0.0);
-	return agent_parent->get_global_transform().get_origin().distance_to(target_location);
+	return agent_parent->get_global_position().distance_to(target_location);
 }
 
 bool NavigationAgent2D::is_target_reached() const {
@@ -260,7 +260,7 @@ void NavigationAgent2D::update_navigation() {
 
 	update_frame_id = Engine::get_singleton()->get_physics_frames();
 
-	Vector2 o = agent_parent->get_global_transform().get_origin();
+	Vector2 o = agent_parent->get_global_position();
 
 	bool reload_path = false;
 

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -53,7 +53,7 @@ void NavigationObstacle2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (parent_node2d) {
-				NavigationServer2D::get_singleton()->agent_set_position(agent, parent_node2d->get_global_transform().get_origin());
+				NavigationServer2D::get_singleton()->agent_set_position(agent, parent_node2d->get_global_position());
 			}
 		} break;
 	}
@@ -92,13 +92,13 @@ void NavigationObstacle2D::update_agent_shape() {
 					// and add the enclosing shape radius
 					r += cs->get_shape()->get_enclosing_radius();
 				}
-				Size2 s = cs->get_global_transform().get_scale();
+				Size2 s = cs->get_global_scale();
 				r *= MAX(s.x, s.y);
 				// Takes the biggest radius
 				radius = MAX(radius, r);
 			}
 		}
-		Vector2 s = parent_node2d->get_global_transform().get_scale();
+		Vector2 s = parent_node2d->get_global_scale();
 		radius *= MAX(s.x, s.y);
 
 		if (radius == 0.0) {

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -325,7 +325,7 @@ bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p
 
 	Vector2 rel;
 	if (p_other_bone) {
-		rel = (p_other_bone->get_global_transform().get_origin() - get_global_transform().get_origin());
+		rel = (p_other_bone->get_global_position() - get_global_position());
 		rel = rel.rotated(-get_global_rotation()); // Undo Bone2D node's rotation so its drawn correctly regardless of the node's rotation
 	} else {
 		real_t angle_to_use = get_rotation() + bone_angle;
@@ -454,7 +454,7 @@ void Bone2D::calculate_length_and_rotation() {
 		for (int i = 0; i < child_count; i++) {
 			Bone2D *child = Object::cast_to<Bone2D>(get_child(i));
 			if (child) {
-				Vector2 child_local_pos = to_local(child->get_global_transform().get_origin());
+				Vector2 child_local_pos = to_local(child->get_global_position());
 				length = child_local_pos.length();
 				bone_angle = Math::atan2(child_local_pos.normalized().y, child_local_pos.normalized().x);
 				calculated = true;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -428,7 +428,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 
 				if (area && area->is_using_reverb_bus() && area->get_reverb_uniformity() > 0) {
 					area_sound_pos = space_state->get_closest_point_to_object_volume(area->get_rid(), listener_node->get_global_transform().origin);
-					listener_area_pos = listener_node->get_global_transform().affine_inverse().xform(area_sound_pos);
+					listener_area_pos = listener_node->to_local(area_sound_pos);
 				}
 
 				if (max_distance > 0) {

--- a/scene/3d/physics_joint_3d.cpp
+++ b/scene/3d/physics_joint_3d.cpp
@@ -259,11 +259,11 @@ real_t PinJoint3D::get_param(Param p_param) const {
 
 void PinJoint3D::_configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) {
 	Vector3 pinpos = get_global_transform().origin;
-	Vector3 local_a = body_a->get_global_transform().affine_inverse().xform(pinpos);
+	Vector3 local_a = body_a->to_local(pinpos);
 	Vector3 local_b;
 
 	if (body_b) {
-		local_b = body_b->get_global_transform().affine_inverse().xform(pinpos);
+		local_b = body_b->to_local(pinpos);
 	} else {
 		local_b = pinpos;
 	}

--- a/scene/resources/skeleton_modification_2d.cpp
+++ b/scene/resources/skeleton_modification_2d.cpp
@@ -166,13 +166,13 @@ void SkeletonModification2D::editor_draw_angle_constraints(Bone2D *p_operation_b
 
 			if (operation_bone_parent_bone) {
 				stack->skeleton->draw_set_transform(
-						stack->skeleton->get_global_transform().affine_inverse().xform(p_operation_bone->get_global_position()),
+						stack->skeleton->to_local(p_operation_bone->get_global_position()),
 						operation_bone_parent_bone->get_global_rotation() - stack->skeleton->get_global_rotation());
 			} else {
-				stack->skeleton->draw_set_transform(stack->skeleton->get_global_transform().affine_inverse().xform(p_operation_bone->get_global_position()));
+				stack->skeleton->draw_set_transform(stack->skeleton->to_local(p_operation_bone->get_global_position()));
 			}
 		} else {
-			stack->skeleton->draw_set_transform(stack->skeleton->get_global_transform().affine_inverse().xform(p_operation_bone->get_global_position()));
+			stack->skeleton->draw_set_transform(stack->skeleton->to_local(p_operation_bone->get_global_position()));
 		}
 
 		if (p_constraint_inverted) {
@@ -186,7 +186,7 @@ void SkeletonModification2D::editor_draw_angle_constraints(Bone2D *p_operation_b
 		stack->skeleton->draw_line(Vector2(0, 0), Vector2(Math::cos(arc_angle_max), Math::sin(arc_angle_max)) * p_operation_bone->get_length(), bone_ik_color, 1.0);
 
 	} else {
-		stack->skeleton->draw_set_transform(stack->skeleton->get_global_transform().affine_inverse().xform(p_operation_bone->get_global_position()));
+		stack->skeleton->draw_set_transform(stack->skeleton->to_local(p_operation_bone->get_global_position()));
 		stack->skeleton->draw_arc(Vector2(0, 0), p_operation_bone->get_length(), 0, Math_PI * 2, 32, bone_ik_color, 1.0);
 		stack->skeleton->draw_line(Vector2(0, 0), Vector2(1, 0) * p_operation_bone->get_length(), bone_ik_color, 1.0);
 	}

--- a/scene/resources/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/skeleton_modification_2d_ccdik.cpp
@@ -201,18 +201,18 @@ void SkeletonModification2DCCDIK::_execute_ccdik_joint(int p_joint_idx, Node2D *
 	if (ccdik_data.rotate_from_joint) {
 		// To rotate from the joint, simply look at the target!
 		operation_transform.set_rotation(
-				operation_transform.looking_at(p_target->get_global_transform().get_origin()).get_rotation() - operation_bone->get_bone_angle());
+				operation_transform.looking_at(p_target->get_global_position()).get_rotation() - operation_bone->get_bone_angle());
 	} else {
 		// How to rotate from the tip: get the difference of rotation needed from the tip to the target, from the perspective of the joint.
 		// Because we are only using the offset, we do not need to account for the bone angle of the Bone2D node.
-		float joint_to_tip = operation_transform.get_origin().angle_to_point(p_tip->get_global_transform().get_origin());
-		float joint_to_target = operation_transform.get_origin().angle_to_point(p_target->get_global_transform().get_origin());
+		float joint_to_tip = operation_transform.get_origin().angle_to_point(p_tip->get_global_position());
+		float joint_to_target = operation_transform.get_origin().angle_to_point(p_target->get_global_position());
 		operation_transform.set_rotation(
 				operation_transform.get_rotation() + (joint_to_target - joint_to_tip));
 	}
 
 	// Reset scale
-	operation_transform.set_scale(operation_bone->get_global_transform().get_scale());
+	operation_transform.set_scale(operation_bone->get_global_scale());
 
 	// Apply constraints in globalspace:
 	if (ccdik_data.enable_constraint && !ccdik_data.constraint_in_localspace) {

--- a/scene/resources/skeleton_modification_2d_fabrik.cpp
+++ b/scene/resources/skeleton_modification_2d_fabrik.cpp
@@ -161,25 +161,25 @@ void SkeletonModification2DFABRIK::_execute(float p_delta) {
 	}
 
 	Bone2D *final_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[fabrik_data_chain.size() - 1].bone2d_node_cache));
-	float final_bone2d_angle = final_bone2d_node->get_global_transform().get_rotation();
+	float final_bone2d_angle = final_bone2d_node->get_global_rotation();
 	if (fabrik_data_chain[fabrik_data_chain.size() - 1].use_target_rotation) {
 		final_bone2d_angle = target_global_pose.get_rotation();
 	}
 	Vector2 final_bone2d_direction = Vector2(Math::cos(final_bone2d_angle), Math::sin(final_bone2d_angle));
 	float final_bone2d_length = final_bone2d_node->get_length() * MIN(final_bone2d_node->get_global_scale().x, final_bone2d_node->get_global_scale().y);
-	float target_distance = (final_bone2d_node->get_global_transform().get_origin() + (final_bone2d_direction * final_bone2d_length)).distance_to(target->get_global_transform().get_origin());
+	float target_distance = (final_bone2d_node->get_global_position() + (final_bone2d_direction * final_bone2d_length)).distance_to(target->get_global_position());
 	chain_iterations = 0;
 
 	while (target_distance > chain_tolarance) {
 		chain_backwards();
 		chain_forwards();
 
-		final_bone2d_angle = final_bone2d_node->get_global_transform().get_rotation();
+		final_bone2d_angle = final_bone2d_node->get_global_rotation();
 		if (fabrik_data_chain[fabrik_data_chain.size() - 1].use_target_rotation) {
 			final_bone2d_angle = target_global_pose.get_rotation();
 		}
 		final_bone2d_direction = Vector2(Math::cos(final_bone2d_angle), Math::sin(final_bone2d_angle));
-		target_distance = (final_bone2d_node->get_global_transform().get_origin() + (final_bone2d_direction * final_bone2d_length)).distance_to(target->get_global_transform().get_origin());
+		target_distance = (final_bone2d_node->get_global_position() + (final_bone2d_direction * final_bone2d_length)).distance_to(target->get_global_position());
 
 		chain_iterations += 1;
 		if (chain_iterations >= chain_max_iterations) {
@@ -210,7 +210,7 @@ void SkeletonModification2DFABRIK::_execute(float p_delta) {
 		chain_trans.set_rotation(chain_trans.get_rotation() - joint_bone2d_node->get_bone_angle());
 
 		// Reset scale
-		chain_trans.set_scale(joint_bone2d_node->get_global_transform().get_scale());
+		chain_trans.set_scale(joint_bone2d_node->get_global_scale());
 
 		// Apply to the bone, and to the override
 		joint_bone2d_node->set_global_transform(chain_trans);

--- a/scene/resources/skeleton_modification_2d_jiggle.cpp
+++ b/scene/resources/skeleton_modification_2d_jiggle.cpp
@@ -171,7 +171,7 @@ void SkeletonModification2DJiggle::_execute_jiggle_joint(int p_joint_idx, Node2D
 	}
 
 	Transform2D operation_bone_trans = operation_bone->get_global_transform();
-	Vector2 target_position = p_target->get_global_transform().get_origin();
+	Vector2 target_position = p_target->get_global_position();
 
 	jiggle_data_chain.write[p_joint_idx].force = (target_position - jiggle_data_chain[p_joint_idx].dynamic_position) * jiggle_data_chain[p_joint_idx].stiffness * p_delta;
 
@@ -215,7 +215,7 @@ void SkeletonModification2DJiggle::_execute_jiggle_joint(int p_joint_idx, Node2D
 	operation_bone_trans.set_rotation(operation_bone_trans.get_rotation() - operation_bone->get_bone_angle());
 
 	// Reset scale
-	operation_bone_trans.set_scale(operation_bone->get_global_transform().get_scale());
+	operation_bone_trans.set_scale(operation_bone->get_global_scale());
 
 	operation_bone->set_global_transform(operation_bone_trans);
 	stack->skeleton->set_bone_local_pose_override(jiggle_data_chain[p_joint_idx].bone_idx, operation_bone->get_transform(), stack->strength, true);
@@ -244,7 +244,7 @@ void SkeletonModification2DJiggle::_setup_modification(SkeletonModificationStack
 				int bone_idx = jiggle_data_chain[i].bone_idx;
 				if (bone_idx > 0 && bone_idx < stack->skeleton->get_bone_count()) {
 					Bone2D *bone2d_node = stack->skeleton->get_bone(bone_idx);
-					jiggle_data_chain.write[i].dynamic_position = bone2d_node->get_global_transform().get_origin();
+					jiggle_data_chain.write[i].dynamic_position = bone2d_node->get_global_position();
 				}
 			}
 		}

--- a/scene/resources/skeleton_modification_2d_lookat.cpp
+++ b/scene/resources/skeleton_modification_2d_lookat.cpp
@@ -147,7 +147,7 @@ void SkeletonModification2DLookAt::_execute(float p_delta) {
 	// Look at the target!
 	operation_transform = operation_transform.looking_at(target_trans.get_origin());
 	// Apply whatever scale it had prior to looking_at
-	operation_transform.set_scale(operation_bone->get_global_transform().get_scale());
+	operation_transform.set_scale(operation_bone->get_global_scale());
 
 	// Account for the direction the bone faces in:
 	operation_transform.set_rotation(operation_transform.get_rotation() - operation_bone->get_bone_angle());

--- a/scene/resources/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/skeleton_modification_2d_twoboneik.cpp
@@ -142,7 +142,7 @@ void SkeletonModification2DTwoBoneIK::_execute(float p_delta) {
 	// http://theorangeduck.com/page/simple-two-joint
 	// https://www.alanzucconi.com/2018/05/02/ik-2d-2/
 	// With modifications by TwistedTwigleg
-	Vector2 target_difference = target->get_global_transform().get_origin() - joint_one_bone->get_global_transform().get_origin();
+	Vector2 target_difference = target->get_global_position() - joint_one_bone->get_global_position();
 	float joint_one_to_target = target_difference.length();
 	float angle_atan = Math::atan2(target_difference.y, target_difference.x);
 
@@ -206,7 +206,7 @@ void SkeletonModification2DTwoBoneIK::_draw_editor_gizmo() {
 		return;
 	}
 	stack->skeleton->draw_set_transform(
-			stack->skeleton->get_global_transform().affine_inverse().xform(operation_bone_one->get_global_position()),
+			stack->skeleton->to_local(operation_bone_one->get_global_position()),
 			operation_bone_one->get_global_rotation() - stack->skeleton->get_global_rotation());
 
 	Color bone_ik_color = Color(1.0, 0.65, 0.0, 0.4);


### PR DESCRIPTION
Use get_global_* functions instead of using transforms in classes that inherits Node2D/3D.

`get_global_transform().get_position()` -> `get_global_position()`
` get_global_transform().get_rotation()` ->` get_global_rotation() `
`get_global_transform().get_scale()` -> `get_global_scale()`
`get_global_transform().affine_inverse().xform` -> `to_local()`


There are still some remaining for `CanvasItem` inherited classes.
That could probably be done after the merge of https://github.com/godotengine/godot/pull/51595 

Additionally, get_global_transform().origin -> get_global_position(), once we have that method.