### PR TITLE
Add an argument to differentiate between left and right click in `ItemList.item_selected`

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -421,6 +421,14 @@
 				[member allow_rmb_select] must be enabled.
 			</description>
 		</signal>
+		<signal name="item_lmb_selected">
+			<argument index="0" name="index" type="int" />
+			<argument index="1" name="at_position" type="Vector2" />
+			<description>
+				Triggered when specified list item has been selected via left mouse clicking.
+				The click position is also provided to allow appropriate popup of context menus at the correct location.
+			</description>
+		</signal>
 		<signal name="item_selected">
 			<argument index="0" name="index" type="int" />
 			<description>

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -610,25 +610,23 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					return;
 				}
 
-				if (items[i].selected && mb->get_button_index() == MouseButton::RIGHT) {
-					emit_signal(SNAME("item_rmb_selected"), i, get_local_mouse_position());
-				} else {
-					bool selected = items[i].selected;
-
+				if (!items[i].selected || (mb->get_button_index() == MouseButton::LEFT && allow_reselect)) {
 					select(i, select_mode == SELECT_SINGLE || !mb->is_command_pressed());
 
-					if (!selected || allow_reselect) {
-						if (select_mode == SELECT_SINGLE) {
-							emit_signal(SNAME("item_selected"), i);
-						} else {
-							emit_signal(SNAME("multi_selected"), i, true);
-						}
+					if (select_mode == SELECT_SINGLE) {
+						emit_signal(SNAME("item_selected"), i);
+					} else {
+						emit_signal(SNAME("multi_selected"), i, true);
 					}
-
+				} else {
 					if (mb->get_button_index() == MouseButton::RIGHT) {
 						emit_signal(SNAME("item_rmb_selected"), i, get_local_mouse_position());
-					} else if (/*select_mode==SELECT_SINGLE &&*/ mb->is_double_click()) {
-						emit_signal(SNAME("item_activated"), i);
+					} else {
+						emit_signal(SNAME("item_lmb_selected"), i, get_local_mouse_position());
+
+						if (/*select_mode==SELECT_SINGLE &&*/ mb->is_double_click()) {
+							emit_signal(SNAME("item_activated"), i);
+						}
 					}
 				}
 			}
@@ -1681,6 +1679,7 @@ void ItemList::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "index")));
 	ADD_SIGNAL(MethodInfo("item_rmb_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::VECTOR2, "at_position")));
+	ADD_SIGNAL(MethodInfo("item_lmb_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::VECTOR2, "at_position")));
 	ADD_SIGNAL(MethodInfo("multi_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::BOOL, "selected")));
 	ADD_SIGNAL(MethodInfo("item_activated", PropertyInfo(Variant::INT, "index")));
 	ADD_SIGNAL(MethodInfo("rmb_clicked", PropertyInfo(Variant::VECTOR2, "at_position")));


### PR DESCRIPTION
Fix #23465 
Added second argument named as 'left' to ItemList.item_selected signal which would tell if the mb is left or not(right)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
