### PR TITLE
Add volume L/R controls to AudioStreamPlayer (master)

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -5,8 +5,7 @@
 	</brief_description>
 	<description>
 		Plays an audio stream non-positionally.
-		To play audio positionally, use [AudioStreamPlayer2D] or [AudioStreamPlayer3D] instead of [AudioStreamPlayer].
-		However, if you want manual control of stereo (left/right) volumes, this will work.
+		To play audio positionally, use [AudioStreamPlayer2D] or [AudioStreamPlayer3D] instead of [AudioStreamPlayer]. [AudioStreamPlayer] only provides manual stereo panning using the [member volume_scale_l] and [member volume_scale_r] properties.
 	</description>
 	<tutorials>
 		<link title="Audio streams">https://docs.godotengine.org/en/latest/tutorials/audio/audio_streams.html</link>
@@ -76,12 +75,10 @@
 			Volume of sound, in dB. (To convert to dB, try [code]linear2db[/code].)
 		</member>
 		<member name="volume_scale_l" type="float" setter="set_volume_scale_l" getter="get_volume_scale_l" default="1.0">
-			Volume scale for left channel in linear (0.0 is silent, 1.0 is full volume) form.
-			Can be used to forcefully globally pan sounds without relying on the camera.
+			Volume scale for left channel in linear (0.0 is silent, 1.0 is full volume) form. Can be used to forcefully globally pan sounds without relying on the camera.
 		</member>
 		<member name="volume_scale_r" type="float" setter="set_volume_scale_r" getter="get_volume_scale_r" default="1.0">
-			Volume scale for right channel in linear (0.0 is silent, 1.0 is full volume) form.
-			Can be used to forcefully globally pan sounds without relying on the camera.
+			Volume scale for right channel in linear (0.0 is silent, 1.0 is full volume) form. Can be used to forcefully globally pan sounds without relying on the camera.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -44,7 +44,7 @@
 		</method>
 		<method name="set_volume_balance">
 			<return type="void" />
-			<argument index="0" name="balance" type="float" default="0.0" />
+			<argument index="0" name="balance" type="float" />
 			<description>
 				Sets the [code]volume_scale_l[/code] and [code]volume_scale_r[/code] values to achieve a given balanced (loudness-preserving) pan. Balance is measured from -1.0 (left) to 1.0 (right).
 			</description>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -6,6 +6,7 @@
 	<description>
 		Plays an audio stream non-positionally.
 		To play audio positionally, use [AudioStreamPlayer2D] or [AudioStreamPlayer3D] instead of [AudioStreamPlayer].
+		However, if you want manual control of stereo (left/right) volumes, this will work.
 	</description>
 	<tutorials>
 		<link title="Audio streams">https://docs.godotengine.org/en/latest/tutorials/audio/audio_streams.html</link>
@@ -72,7 +73,15 @@
 			If [code]true[/code], the playback is paused. You can resume it by setting [code]stream_paused[/code] to [code]false[/code].
 		</member>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
-			Volume of sound, in dB.
+			Volume of sound, in dB. (To convert to dB, try [code]linear2db[/code].)
+		</member>
+		<member name="volume_scale_l" type="float" setter="set_volume_scale_l" getter="get_volume_scale_l" default="1.0">
+			Volume scale for left channel in linear (0.0 is silent, 1.0 is full volume) form.
+			Can be used to forcefully globally pan sounds without relying on the camera.
+		</member>
+		<member name="volume_scale_r" type="float" setter="set_volume_scale_r" getter="get_volume_scale_r" default="1.0">
+			Volume scale for right channel in linear (0.0 is silent, 1.0 is full volume) form.
+			Can be used to forcefully globally pan sounds without relying on the camera.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -42,6 +42,13 @@
 				Sets the position from which audio will be played, in seconds.
 			</description>
 		</method>
+		<method name="set_volume_balance">
+			<return type="void" />
+			<argument index="0" name="balance" type="float" default="0.0" />
+			<description>
+				Sets the [code]volume_scale_l[/code] and [code]volume_scale_r[/code] values to achieve a given balanced (loudness-preserving) pan. Balance is measured from -1.0 (left) to 1.0 (right).
+			</description>
+		</method>
 		<method name="stop">
 			<return type="void" />
 			<description>
@@ -72,7 +79,7 @@
 			If [code]true[/code], the playback is paused. You can resume it by setting [code]stream_paused[/code] to [code]false[/code].
 		</member>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
-			Volume of sound, in dB. (To convert to dB, try [code]linear2db[/code].)
+			Volume of sound, in dB. If you have a linear scale value and wish to convert it to dB, use [method @GlobalScope.linear2db].
 		</member>
 		<member name="volume_scale_l" type="float" setter="set_volume_scale_l" getter="get_volume_scale_l" default="1.0">
 			Volume scale for left channel in linear (0.0 is silent, 1.0 is full volume) form. Can be used to forcefully globally pan sounds without relying on the camera.

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -83,7 +83,7 @@ void AudioStreamPlayer::_mix_internal(bool p_fadeout) {
 	float vol_inc = (Math::db2linear(target_volume) - vol) / float(buffer_size);
 
 	for (int i = 0; i < buffer_size; i++) {
-		buffer[i] *= vol;
+		buffer[i] *= AudioFrame(vol * volume_scale_l, vol * volume_scale_r);
 		vol += vol_inc;
 	}
 
@@ -225,6 +225,20 @@ float AudioStreamPlayer::get_volume_db() const {
 	return volume_db;
 }
 
+void AudioStreamPlayer::set_volume_scale_l(float p_volume) {
+	volume_scale_l = p_volume;
+}
+float AudioStreamPlayer::get_volume_scale_l() const {
+	return volume_scale_l;
+}
+
+void AudioStreamPlayer::set_volume_scale_r(float p_volume) {
+	volume_scale_r = p_volume;
+}
+float AudioStreamPlayer::get_volume_scale_r() const {
+	return volume_scale_r;
+}
+
 void AudioStreamPlayer::set_pitch_scale(float p_pitch_scale) {
 	ERR_FAIL_COND(p_pitch_scale <= 0.0);
 	pitch_scale = p_pitch_scale;
@@ -362,6 +376,12 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_db", "volume_db"), &AudioStreamPlayer::set_volume_db);
 	ClassDB::bind_method(D_METHOD("get_volume_db"), &AudioStreamPlayer::get_volume_db);
 
+	ClassDB::bind_method(D_METHOD("set_volume_scale_l", "volume_scale_l"), &AudioStreamPlayer::set_volume_scale_l);
+	ClassDB::bind_method(D_METHOD("get_volume_scale_l"), &AudioStreamPlayer::get_volume_scale_l);
+
+	ClassDB::bind_method(D_METHOD("set_volume_scale_r", "volume_scale_r"), &AudioStreamPlayer::set_volume_scale_r);
+	ClassDB::bind_method(D_METHOD("get_volume_scale_r"), &AudioStreamPlayer::get_volume_scale_r);
+
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer::get_pitch_scale);
 
@@ -392,6 +412,8 @@ void AudioStreamPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_scale_l", PROPERTY_HINT_RANGE, "0.0,11,0.0,or_greater"), "set_volume_scale_l", "get_volume_scale_l");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_scale_r", PROPERTY_HINT_RANGE, "0.0,11,0.0,or_greater"), "set_volume_scale_r", "get_volume_scale_r");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stream_paused", PROPERTY_HINT_NONE, ""), "set_stream_paused", "get_stream_paused");

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -239,6 +239,14 @@ float AudioStreamPlayer::get_volume_scale_r() const {
 	return volume_scale.r;
 }
 
+void AudioStreamPlayer::set_volume_balance(float p_balance) {
+	// the 2.0 on left/right is critical to preserving loudness.
+	// a balance of 0.0 ought to be a no-op, which means a scale of 1.0,1.0
+	// therefore, left/right need to be scaled to 2.0 to compensate.
+	volume_scale.l = MIN(2.0, MAX(0.0, 1.0 - p_balance));
+	volume_scale.r = MIN(2.0, MAX(0.0, 1.0 + p_balance));
+}
+
 void AudioStreamPlayer::set_pitch_scale(float p_pitch_scale) {
 	ERR_FAIL_COND(p_pitch_scale <= 0.0);
 	pitch_scale = p_pitch_scale;
@@ -381,6 +389,8 @@ void AudioStreamPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_volume_scale_r", "volume_scale_r"), &AudioStreamPlayer::set_volume_scale_r);
 	ClassDB::bind_method(D_METHOD("get_volume_scale_r"), &AudioStreamPlayer::get_volume_scale_r);
+
+	ClassDB::bind_method(D_METHOD("set_volume_balance", "balance"), &AudioStreamPlayer::set_volume_balance);
 
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer::get_pitch_scale);

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -83,7 +83,7 @@ void AudioStreamPlayer::_mix_internal(bool p_fadeout) {
 	float vol_inc = (Math::db2linear(target_volume) - vol) / float(buffer_size);
 
 	for (int i = 0; i < buffer_size; i++) {
-		buffer[i] *= AudioFrame(vol * volume_scale_l, vol * volume_scale_r);
+		buffer[i] *= vol * volume_scale;
 		vol += vol_inc;
 	}
 
@@ -184,7 +184,7 @@ void AudioStreamPlayer::set_stream(Ref<AudioStream> p_stream) {
 		float vol_inc = (Math::db2linear(target_volume) - vol) / float(buffer_size);
 
 		for (int i = 0; i < buffer_size; i++) {
-			buffer[i] *= vol;
+			buffer[i] *= vol * volume_scale;
 			vol += vol_inc;
 		}
 
@@ -226,17 +226,17 @@ float AudioStreamPlayer::get_volume_db() const {
 }
 
 void AudioStreamPlayer::set_volume_scale_l(float p_volume) {
-	volume_scale_l = p_volume;
+	volume_scale.l = p_volume;
 }
 float AudioStreamPlayer::get_volume_scale_l() const {
-	return volume_scale_l;
+	return volume_scale.l;
 }
 
 void AudioStreamPlayer::set_volume_scale_r(float p_volume) {
-	volume_scale_r = p_volume;
+	volume_scale.r = p_volume;
 }
 float AudioStreamPlayer::get_volume_scale_r() const {
-	return volume_scale_r;
+	return volume_scale.r;
 }
 
 void AudioStreamPlayer::set_pitch_scale(float p_pitch_scale) {

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -412,8 +412,8 @@ void AudioStreamPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_scale_l", PROPERTY_HINT_RANGE, "0.0,11,0.0,or_greater"), "set_volume_scale_l", "get_volume_scale_l");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_scale_r", PROPERTY_HINT_RANGE, "0.0,11,0.0,or_greater"), "set_volume_scale_r", "get_volume_scale_r");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_scale_l", PROPERTY_HINT_RANGE, "0.0,1.0"), "set_volume_scale_l", "get_volume_scale_l");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_scale_r", PROPERTY_HINT_RANGE, "0.0,1.0"), "set_volume_scale_r", "get_volume_scale_r");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stream_paused", PROPERTY_HINT_NONE, ""), "set_stream_paused", "get_stream_paused");

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -96,6 +96,8 @@ public:
 	void set_volume_scale_r(float p_volume);
 	float get_volume_scale_r() const;
 
+	void set_volume_balance(float p_balance);
+
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
 

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -60,6 +60,8 @@ private:
 	float mix_volume_db = 0.0;
 	float pitch_scale = 1.0;
 	float volume_db = 0.0;
+	float volume_scale_l = 1.0;
+	float volume_scale_r = 1.0;
 	bool autoplay = false;
 	bool stream_paused = false;
 	bool stream_paused_fade = false;
@@ -88,6 +90,12 @@ public:
 
 	void set_volume_db(float p_volume);
 	float get_volume_db() const;
+
+	void set_volume_scale_l(float p_volume);
+	float get_volume_scale_l() const;
+
+	void set_volume_scale_r(float p_volume);
+	float get_volume_scale_r() const;
 
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -60,8 +60,7 @@ private:
 	float mix_volume_db = 0.0;
 	float pitch_scale = 1.0;
 	float volume_db = 0.0;
-	float volume_scale_l = 1.0;
-	float volume_scale_r = 1.0;
+	AudioFrame volume_scale = AudioFrame(1.0, 1.0);
 	bool autoplay = false;
 	bool stream_paused = false;
 	bool stream_paused_fade = false;


### PR DESCRIPTION
This is useful for manual panning.
Manual panning otherwise requires processing the sounds to have separate L and R variants.
Processing this in GDScript is insanely inefficient, so I decided this was the neater solution.

NOTE: Due to inherent interference between Godot 4.x hardware support and my own personal policies, a version of this PR will be made targetting 3.x directly, as the PR is effectively useless to me on 4.x-only.
Testing for this PR has only been performed with the 3.x version.

The 3.x PR will be submitted first so that it can be cross-linked-to, the master PR will be submitted a few seconds later with the link added.

3.x PR: https://github.com/godotengine/godot/pull/51666
