### PR TITLE
Immediately update Node2D values.

### DIFF
--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -38,19 +38,17 @@ class Node2D : public CanvasItem {
 
 	Point2 pos;
 	real_t angle = 0.0;
-	Size2 _scale = Vector2(1, 1);
+	Size2 scale = Vector2(1, 1);
 	real_t skew = 0.0;
+
 	int z_index = 0;
 	bool z_relative = true;
 	bool y_sort_enabled = false;
 
-	Transform2D _mat;
+	Transform2D transform;
 
-	bool _xform_dirty = false;
-
+	void re_create_full_transform();
 	void _update_transform();
-
-	void _update_xform_values();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
### This is open to discussions,and I am not sure if my solution is any good.

Trying to Fix Some problems as found in: https://github.com/godotengine/godot-proposals/issues/2742

From the proposal,

> There are also performance issues. For example, whenever "Node2D::translate" is called, instead of a simple vector addition, at least the following steps are performed:

    One vector addition.
    Two sines and two cosines are calculated.
    Four multiplications and two sums.

This was previously the case. With this PR, translate is just one vector addition, and two assignments.

Now:

Whenever we set a value, we immediately assign the value to corresponding Transform2d too. So that, whenever we want to access a value, we shouldn't 
`	if (_xform_dirty) {
		((Node2D *)this)->_update_xform_values();
	}` a branch, a cast, 

and _update_xform_values() ->
```
transform.set_rotation_scale_and_skew(angle, scale, skew);
transform.elements[2] = pos;
```





