### PR TITLE
OS::is_process_running function.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -269,6 +269,10 @@ Error OS::kill(int p_pid) {
 	return ::OS::get_singleton()->kill(p_pid);
 }
 
+bool OS::is_process_running(int p_pid) const {
+	return ::OS::get_singleton()->is_process_running(p_pid);
+}
+
 int OS::get_process_id() const {
 	return ::OS::get_singleton()->get_process_id();
 }
@@ -571,6 +575,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_instance", "arguments"), &OS::create_instance);
 	ClassDB::bind_method(D_METHOD("kill", "pid"), &OS::kill);
 	ClassDB::bind_method(D_METHOD("shell_open", "uri"), &OS::shell_open);
+	ClassDB::bind_method(D_METHOD("is_process_running", "pid"), &OS::is_process_running);
 	ClassDB::bind_method(D_METHOD("get_process_id"), &OS::get_process_id);
 
 	ClassDB::bind_method(D_METHOD("get_environment", "variable"), &OS::get_environment);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -173,6 +173,7 @@ public:
 	Error kill(int p_pid);
 	Error shell_open(String p_uri);
 
+	bool is_process_running(int p_pid) const;
 	int get_process_id() const;
 
 	bool has_environment(const String &p_var) const;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -152,6 +152,7 @@ public:
 	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) { return create_process(get_executable_path(), p_arguments, r_child_id); };
 	virtual Error kill(const ProcessID &p_pid) = 0;
 	virtual int get_process_id() const;
+	virtual bool is_process_running(const ProcessID &p_pid) const = 0;
 	virtual void vibrate_handheld(int p_duration_ms = 500);
 
 	virtual Error shell_open(String p_uri);

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -434,6 +434,15 @@
 				Returns [code]true[/code] if the input keycode corresponds to a Unicode character.
 			</description>
 		</method>
+		<method name="is_process_running" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="pid" type="int" />
+			<description>
+				Returns [code]true[/code] if the child process ID ([code]pid[/code]) is still running or [code]false[/code] if it has terminated.
+				Must be a valid ID generated from [method create_process].
+				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
+			</description>
+		</method>
 		<method name="is_stdout_verbose" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -412,6 +412,15 @@ int OS_Unix::get_process_id() const {
 	return getpid();
 }
 
+bool OS_Unix::is_process_running(const ProcessID &p_pid) const {
+	int status = 0;
+	if (waitpid(p_pid, &status, WNOHANG) != 0) {
+		return false;
+	}
+
+	return true;
+}
+
 bool OS_Unix::has_environment(const String &p_var) const {
 	return getenv(p_var.utf8().get_data()) != nullptr;
 }

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -76,6 +76,7 @@ public:
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	virtual Error kill(const ProcessID &p_pid) override;
 	virtual int get_process_id() const override;
+	virtual bool is_process_running(const ProcessID &p_pid) const override;
 
 	virtual bool has_environment(const String &p_var) const override;
 	virtual String get_environment(const String &p_var) const override;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -131,6 +131,10 @@ int OS_JavaScript::get_process_id() const {
 	ERR_FAIL_V_MSG(0, "OS::get_process_id() is not available on the HTML5 platform.");
 }
 
+bool OS_JavaScript::is_process_running(const ProcessID &p_pid) const {
+	return false;
+}
+
 int OS_JavaScript::get_processor_count() const {
 	return godot_js_os_hw_concurrency_get();
 }

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -79,6 +79,7 @@ public:
 	Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	Error kill(const ProcessID &p_pid) override;
 	int get_process_id() const override;
+	bool is_process_running(const ProcessID &p_pid) const override;
 	int get_processor_count() const override;
 	int get_default_thread_pool_size() const override { return 1; }
 

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -647,6 +647,10 @@ Error OS_UWP::kill(const ProcessID &p_pid) {
 	return FAILED;
 }
 
+bool OS_UWP::is_process_running(const ProcessID &p_pid) const {
+	return false;
+}
+
 Error OS_UWP::set_cwd(const String &p_cwd) {
 	return FAILED;
 }

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -198,6 +198,7 @@ public:
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false);
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false);
 	virtual Error kill(const ProcessID &p_pid);
+	virtual bool is_process_running(const ProcessID &p_pid) const;
 
 	virtual bool has_environment(const String &p_var) const;
 	virtual String get_environment(const String &p_var) const;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -517,6 +517,25 @@ int OS_Windows::get_process_id() const {
 	return _getpid();
 }
 
+bool OS_Windows::is_process_running(const ProcessID &p_pid) const {
+	if (!process_map->has(p_pid)) {
+		return false;
+	}
+
+	const PROCESS_INFORMATION &pi = (*process_map)[p_pid].pi;
+
+	DWORD dw_exit_code = 0;
+	if (!GetExitCodeProcess(pi.hProcess, &dw_exit_code)) {
+		return false;
+	}
+
+	if (dw_exit_code != STILL_ACTIVE) {
+		return false;
+	}
+
+	return true;
+}
+
 Error OS_Windows::set_cwd(const String &p_cwd) {
 	if (_wchdir((LPCWSTR)(p_cwd.utf16().get_data())) != 0) {
 		return ERR_CANT_OPEN;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -132,6 +132,7 @@ public:
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	virtual Error kill(const ProcessID &p_pid) override;
 	virtual int get_process_id() const override;
+	virtual bool is_process_running(const ProcessID &p_pid) const override;
 
 	virtual bool has_environment(const String &p_var) const override;
 	virtual String get_environment(const String &p_var) const override;


### PR DESCRIPTION
This PR adds the OS::is_process_running function that is exposed to script. The function has been implemented for Windows and Unix platforms and provides stubs for other platforms that are unsupported.

This is relevant to the godot-proposal [#1679](https://github.com/godotengine/godot-proposals/issues/1679).

A test project is provided that creates a process to run the 'ping' command and asserts that the is_process_running function properly returns the correct value.

[os-is-process-running-project.zip](https://github.com/godotengine/godot/files/6987421/os-is-process-running-project.zip)

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/1679.*