### PR TITLE
Don't translate function prototype in built-in doc

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1125,10 +1125,10 @@ void EditorHelp::_update_doc() {
 					if (method_map[cd.properties[i].setter].arguments.size() > 1) {
 						// Setters with additional arguments are exposed in the method list, so we link them here for quick access.
 						class_desc->push_meta("@method " + cd.properties[i].setter);
-						class_desc->add_text(cd.properties[i].setter + TTR("(value)"));
+						class_desc->add_text(cd.properties[i].setter + "(value)");
 						class_desc->pop();
 					} else {
-						class_desc->add_text(cd.properties[i].setter + TTR("(value)"));
+						class_desc->add_text(cd.properties[i].setter + "(value)");
 					}
 					class_desc->pop(); // color
 					class_desc->push_color(comment_color);


### PR DESCRIPTION
The string `(value)` is part of the function prototype for property setters in the built-in doc:

```gdscript
set_position(value)
```

It's currently being translated, but GDScript doesn't support unicode identifiers yet. So it should not be translated to

```gdscript
set_position(值)
```
