### PR TITLE
Portals - Fix cull roaming through multiple portals

### DIFF
--- a/servers/visual/portals/portal_tracer.cpp
+++ b/servers/visual/portals/portal_tracer.cpp
@@ -167,10 +167,10 @@ void PortalTracer::cull_roamers(const VSRoom &p_room, const LocalVector<Plane> &
 			continue;
 		}
 
-		// mark as done
-		moving.last_tick_hit = _tick;
-
 		if (test_cull_inside(moving.exact_aabb, p_planes)) {
+			// mark as done (and on visible list)
+			moving.last_tick_hit = _tick;
+
 			_result->visible_roamer_pool_ids.push_back(pool_id);
 		}
 	}


### PR DESCRIPTION
Small bug in the logic, the roaming objects only should be set to done when they have been marked as visible, rather than the first time they are examined. This is because they can be seen in a room through multiple portals, and each needs to be tested until there is either a visible result or all the portals in are visited.

Fixes #51688

## Notes
* The bug occurs because there are two portals into the room where the roaming object is. Through the first portal the roaming is not visible, but it is marked as done, so when it looks through the second portal, it never tested it a second time because it thought it was done already, so never sees it is visible.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
