### PR TITLE
Add tool quick-select to tile editor

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.h
+++ b/editor/plugins/tiles/tile_map_editor.h
@@ -104,12 +104,14 @@ private:
 	Vector2 drag_start_mouse_pos;
 	Vector2 drag_last_mouse_pos;
 	Map<Vector2i, TileMapCell> drag_modified;
+	bool rmb_erasing = false;
 
 	TileMapCell _pick_random_tile(const TileMapPattern *p_pattern);
 	Map<Vector2i, TileMapCell> _draw_line(Vector2 p_start_drag_mouse_pos, Vector2 p_from_mouse_pos, Vector2 p_to_mouse_pos);
 	Map<Vector2i, TileMapCell> _draw_rect(Vector2i p_start_cell, Vector2i p_end_cell);
 	Map<Vector2i, TileMapCell> _draw_bucket_fill(Vector2i p_coords, bool p_contiguous);
 	void _stop_dragging();
+	bool _is_erasing() const;
 
 	///// Selection system. /////
 	Set<Vector2i> tile_map_selection;


### PR DESCRIPTION
This is a feature I'm really missing from the old editor.

When Paint tool is selected:
- Hold Shift to draw lines
- Hold Shift + Ctrl to draw rectangles

When any drawing tool is selected (Paint, Line, Rect, Bucket):
- Hold Ctrl to pick tile

Also RMB will erase tiles. There was some controversy last time I suggested it (something with panning), so it's added in a second commit. RMB erasing has no preview (most notable with bucket tool).

![r9SBvo2rOW](https://user-images.githubusercontent.com/2223172/129483971-705c1208-3861-4e85-ac49-0dfce911348a.gif)

EDIT:
btw the change in BaseButton was required to make `_get_current_tool()` const.