### PR TITLE
Add method to print backtrace

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -205,6 +205,10 @@ void _OS::alert(const String &p_alert, const String &p_title) {
 	OS::get_singleton()->alert(p_alert, p_title);
 }
 
+void _OS::print_backtrace() const {
+	OS::get_singleton()->print_backtrace();
+}
+
 String _OS::get_executable_path() const {
 	return OS::get_singleton()->get_executable_path();
 }

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -212,6 +212,8 @@ public:
 
 	bool can_use_threads() const;
 
+	void print_backtrace() const;
+
 	bool is_userfs_persistent() const;
 
 	bool is_stdout_verbose() const;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -47,6 +47,9 @@ OS *OS::get_singleton() {
 	return singleton;
 }
 
+void OS::print_backtrace() {
+}
+
 uint64_t OS::get_ticks_msec() const {
 	return get_ticks_usec() / 1000ULL;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -148,6 +148,8 @@ public:
 	virtual List<String> get_cmdline_args() const { return _cmdline; }
 	virtual String get_model_name() const;
 
+	virtual void print_backtrace();
+
 	bool is_layered_allowed() const { return _allow_layered; }
 	bool is_hidpi_allowed() const { return _allow_hidpi; }
 

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8330,6 +8330,7 @@ void RenderingDeviceVulkan::_free_internal(RID p_id) {
 		frames[frame].compute_pipelines_to_dispose_of.push_back(*pipeline);
 		compute_pipeline_owner.free(p_id);
 	} else {
+		OS::get_singleton()->print_backtrace();
 		ERR_PRINT("Attempted to free invalid ID: " + itos(p_id.get_id()));
 	}
 }

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -94,6 +94,8 @@ public:
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
 
+	virtual void print_backtrace() override;
+
 	void run();
 
 	virtual void disable_crash_handler() override;


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/3062 but only for Linux now.

I'm not sure if OS is best class for it, but this works fine for now.

Not sure if I will finish this, so feel free to fork it.

This is quite slow(full backtrace prints ~5-10s on my OS).