### PR TITLE
Reimplement ColorPicker presets

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -116,7 +116,7 @@
 		</theme_item>
 		<theme_item name="picker_cursor" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="preset_bg" data_type="icon" type="Texture2D">
+		<theme_item name="sample_bg" data_type="icon" type="Texture2D">
 		</theme_item>
 		<theme_item name="screen_picker" data_type="icon" type="Texture2D">
 			The icon for the screen color picker button.

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1354,13 +1354,20 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
 	theme->set_icon("screen_picker", "ColorPicker", theme->get_icon("ColorPick", "EditorIcons"));
 	theme->set_icon("add_preset", "ColorPicker", theme->get_icon("Add", "EditorIcons"));
-	theme->set_icon("preset_bg", "ColorPicker", theme->get_icon("GuiMiniCheckerboard", "EditorIcons"));
+	theme->set_icon("sample_bg", "ColorPicker", theme->get_icon("GuiMiniCheckerboard", "EditorIcons"));
 	theme->set_icon("overbright_indicator", "ColorPicker", theme->get_icon("OverbrightIndicator", "EditorIcons"));
 	theme->set_icon("bar_arrow", "ColorPicker", theme->get_icon("ColorPickerBarArrow", "EditorIcons"));
 	theme->set_icon("picker_cursor", "ColorPicker", theme->get_icon("PickerCursor", "EditorIcons"));
 
 	// ColorPickerButton
 	theme->set_icon("bg", "ColorPickerButton", theme->get_icon("GuiMiniCheckerboard", "EditorIcons"));
+
+	// ColorPresetButton
+	Ref<StyleBoxFlat> preset_sb = make_flat_stylebox(Color(1, 1, 1), 2, 2, 2, 2, 2);
+	preset_sb->set_anti_aliased(false);
+	theme->set_stylebox("preset_fg", "ColorPresetButton", preset_sb);
+	theme->set_icon("preset_bg", "ColorPresetButton", theme->get_icon("GuiMiniCheckerboard", "EditorIcons"));
+	theme->set_icon("overbright_indicator", "ColorPresetButton", theme->get_icon("OverbrightIndicator", "EditorIcons"));
 
 	// Information on 3D viewport
 	Ref<StyleBoxFlat> style_info_3d_viewport = style_default->duplicate();

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -35,6 +35,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_button.h"
+#include "scene/gui/grid_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/popup.h"
@@ -42,6 +43,22 @@
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/texture_rect.h"
+
+class ColorPresetButton : public BaseButton {
+	GDCLASS(ColorPresetButton, BaseButton);
+
+	Color preset_color;
+
+protected:
+	void _notification(int);
+
+public:
+	void set_preset_color(const Color &p_color);
+	Color get_preset_color() const;
+
+	ColorPresetButton(Color p_color);
+	~ColorPresetButton();
+};
 
 class ColorPicker : public BoxContainer {
 	GDCLASS(ColorPicker, BoxContainer);
@@ -69,12 +86,9 @@ private:
 	Control *wheel = memnew(Control);
 	Control *wheel_uv = memnew(Control);
 	TextureRect *sample = memnew(TextureRect);
-	TextureRect *preset = memnew(TextureRect);
-	HBoxContainer *preset_container = memnew(HBoxContainer);
-	HBoxContainer *preset_container2 = memnew(HBoxContainer);
+	GridContainer *preset_container = memnew(GridContainer);
 	HSeparator *preset_separator = memnew(HSeparator);
-	Button *bt_add_preset = memnew(Button);
-	List<Color> presets;
+	Button *btn_add_preset = memnew(Button);
 	Button *btn_pick = memnew(Button);
 	CheckButton *btn_hsv = memnew(CheckButton);
 	CheckButton *btn_raw = memnew(CheckButton);
@@ -83,14 +97,19 @@ private:
 	Label *labels[4];
 	Button *text_type = memnew(Button);
 	LineEdit *c_text = memnew(LineEdit);
+
 	bool edit_alpha = true;
 	Size2i ms;
 	bool text_is_constructor = false;
-	int presets_per_row = 0;
 	PickerShapeType picker_type = SHAPE_HSV_WHEEL;
+
+	const int preset_column_count = 9;
+	int prev_preset_size = 0;
+	List<Color> presets;
 
 	Color color;
 	Color old_color;
+
 	bool display_old_color = false;
 	bool raw_mode_enabled = false;
 	bool hsv_mode_enabled = false;
@@ -100,6 +119,7 @@ private:
 	bool spinning = false;
 	bool presets_enabled = true;
 	bool presets_visible = true;
+
 	float h = 0.0;
 	float s = 0.0;
 	float v = 0.0;
@@ -109,7 +129,6 @@ private:
 	void _value_changed(double);
 	void _update_controls();
 	void _update_color(bool p_update_sliders = true);
-	void _update_presets();
 	void _update_text_value();
 	void _text_type_toggled();
 	void _sample_input(const Ref<InputEvent> &p_event);
@@ -119,13 +138,16 @@ private:
 
 	void _uv_input(const Ref<InputEvent> &p_event, Control *c);
 	void _w_input(const Ref<InputEvent> &p_event);
-	void _preset_input(const Ref<InputEvent> &p_event);
+	void _preset_input(const Ref<InputEvent> &p_event, const Color &p_color);
 	void _screen_input(const Ref<InputEvent> &p_event);
 	void _add_preset_pressed();
 	void _screen_pick_pressed();
 	void _focus_enter();
 	void _focus_exit();
 	void _html_focus_exit();
+
+	inline int _get_preset_size();
+	void _add_preset_button(int p_size, const Color &p_color);
 
 protected:
 	void _notification(int);
@@ -152,6 +174,7 @@ public:
 	void add_preset(const Color &p_color);
 	void erase_preset(const Color &p_color);
 	PackedColorArray get_presets() const;
+	void _update_presets();
 
 	void set_hsv_mode(bool p_enabled);
 	bool is_hsv_mode() const;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -212,26 +212,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("outline_size", "LinkButton", 0);
 	theme->set_constant("underline_spacing", "LinkButton", 2 * scale);
 
-	// ColorPickerButton
-
-	theme->set_stylebox("normal", "ColorPickerButton", sb_button_normal);
-	theme->set_stylebox("pressed", "ColorPickerButton", sb_button_pressed);
-	theme->set_stylebox("hover", "ColorPickerButton", sb_button_hover);
-	theme->set_stylebox("disabled", "ColorPickerButton", sb_button_disabled);
-	theme->set_stylebox("focus", "ColorPickerButton", sb_button_focus);
-
-	theme->set_font("font", "ColorPickerButton", Ref<Font>());
-	theme->set_font_size("font_size", "ColorPickerButton", -1);
-
-	theme->set_color("font_color", "ColorPickerButton", Color(1, 1, 1, 1));
-	theme->set_color("font_pressed_color", "ColorPickerButton", Color(0.8, 0.8, 0.8, 1));
-	theme->set_color("font_hover_color", "ColorPickerButton", Color(1, 1, 1, 1));
-	theme->set_color("font_disabled_color", "ColorPickerButton", Color(0.9, 0.9, 0.9, 0.3));
-	theme->set_color("font_outline_color", "ColorPickerButton", Color(1, 1, 1));
-
-	theme->set_constant("hseparation", "ColorPickerButton", 2 * scale);
-	theme->set_constant("outline_size", "ColorPickerButton", 0);
-
 	// OptionButton
 
 	Ref<StyleBox> sb_optbutton_focus = sb_expand(make_stylebox(button_focus_png, 4, 4, 4, 4, 6, 2, 6, 2), 2, 2, 2, 2);
@@ -858,7 +838,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("add_preset", "ColorPicker", make_icon(icon_add_png));
 	theme->set_icon("color_hue", "ColorPicker", make_icon(color_picker_hue_png));
 	theme->set_icon("color_sample", "ColorPicker", make_icon(color_picker_sample_png));
-	theme->set_icon("preset_bg", "ColorPicker", make_icon(mini_checkerboard_png));
+	theme->set_icon("sample_bg", "ColorPicker", make_icon(mini_checkerboard_png));
 	theme->set_icon("overbright_indicator", "ColorPicker", make_icon(overbright_indicator_png));
 	theme->set_icon("bar_arrow", "ColorPicker", make_icon(bar_arrow_png));
 	theme->set_icon("picker_cursor", "ColorPicker", make_icon(picker_cursor_png));
@@ -866,6 +846,34 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// ColorPickerButton
 
 	theme->set_icon("bg", "ColorPickerButton", make_icon(mini_checkerboard_png));
+	theme->set_stylebox("normal", "ColorPickerButton", sb_button_normal);
+	theme->set_stylebox("pressed", "ColorPickerButton", sb_button_pressed);
+	theme->set_stylebox("hover", "ColorPickerButton", sb_button_hover);
+	theme->set_stylebox("disabled", "ColorPickerButton", sb_button_disabled);
+	theme->set_stylebox("focus", "ColorPickerButton", sb_button_focus);
+
+	theme->set_font("font", "ColorPickerButton", Ref<Font>());
+	theme->set_font_size("font_size", "ColorPickerButton", -1);
+
+	theme->set_color("font_color", "ColorPickerButton", Color(1, 1, 1, 1));
+	theme->set_color("font_pressed_color", "ColorPickerButton", Color(0.8, 0.8, 0.8, 1));
+	theme->set_color("font_hover_color", "ColorPickerButton", Color(1, 1, 1, 1));
+	theme->set_color("font_disabled_color", "ColorPickerButton", Color(0.9, 0.9, 0.9, 0.3));
+	theme->set_color("font_outline_color", "ColorPickerButton", Color(1, 1, 1));
+
+	theme->set_constant("hseparation", "ColorPickerButton", 2 * scale);
+	theme->set_constant("outline_size", "ColorPickerButton", 0);
+
+	// ColorPresetButton
+
+	Ref<StyleBoxFlat> preset_sb = make_flat_stylebox(Color(1, 1, 1), 2, 2, 2, 2);
+	preset_sb->set_corner_radius_all(2);
+	preset_sb->set_corner_detail(2);
+	preset_sb->set_anti_aliased(false);
+
+	theme->set_stylebox("preset_fg", "ColorPresetButton", preset_sb);
+	theme->set_icon("preset_bg", "ColorPresetButton", make_icon(mini_checkerboard_png));
+	theme->set_icon("overbright_indicator", "ColorPresetButton", make_icon(overbright_indicator_png));
 
 	// TooltipPanel
 


### PR DESCRIPTION
Reimplements the color preset functionality of the ColorPicker:

![grafik](https://user-images.githubusercontent.com/50084500/129491085-e121ac1e-76d0-46f4-ad83-82bcb3408520.png)

Changes:
-	Reimplement color picker presets with custom Button (ColorPresetButton)
Presets were disabled due to the way they were implemented as stated by reduz's comment: `//presets should be shown using buttons or something else, this method is not a good idea` (the former method was using a TextureRect for the whole palette)
-	Add the overbright indicator which is already used in other places of the ColorPicker and an alpha checker board background for transparent colors
-	Some small structural improvements to the code for better readability

