### PR TITLE
Minor tweaks/fixes for the Command Palette

### DIFF
--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -250,6 +250,8 @@ void EditorSettingsDialog::_update_shortcuts() {
 
 	sections["Common"] = common_section;
 	common_section->set_text(0, TTR("Common"));
+	common_section->set_selectable(0, false);
+	common_section->set_selectable(1, false);
 	if (collapsed.has("Common")) {
 		common_section->set_collapsed(collapsed["Common"]);
 	}
@@ -343,14 +345,16 @@ void EditorSettingsDialog::_update_shortcuts() {
 
 			String item_name = section_name.capitalize();
 			section->set_text(0, item_name);
+			section->set_selectable(0, false);
+			section->set_selectable(1, false);
+			section->set_custom_bg_color(0, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
+			section->set_custom_bg_color(1, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 
 			if (collapsed.has(item_name)) {
 				section->set_collapsed(collapsed[item_name]);
 			}
 
 			sections[section_name] = section;
-			section->set_custom_bg_color(0, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
-			section->set_custom_bg_color(1, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 		}
 
 		// Don't match unassigned shortcuts when searching for assigned keys in search results.

--- a/scene/gui/shortcut.cpp
+++ b/scene/gui/shortcut.cpp
@@ -32,7 +32,7 @@
 #include "core/os/keyboard.h"
 
 void Shortcut::set_event(const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND(Object::cast_to<InputEventShortcut>(*p_event));
+	ERR_FAIL_COND_MSG(Object::cast_to<InputEventShortcut>(*p_event), "Cannot set a shortcut event to an instance of InputEventShortcut.");
 	event = p_event;
 	emit_changed();
 }


### PR DESCRIPTION
Had the wish for these changes to be made, but didn't want to keep bothering the student. So I just waited so I could do them myself.

- Fix first section being hidden by being scrolled up on popup.
- Made sections non-selectable. This prevents the dialog from trying to open a command with it, resulting in an error message.
- Took the time to also disable selecting the sections in the shortcut tab in the Editor Settings as well.
- Removed the "No matches found" when no commands are found given the search string. It implementation felt hacky, and I honestly don't feel it was really needed.
- General code tidy up.