### PR TITLE
Add a property to control the bounce indirect energy in LightmapGI

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="LightmapGI" inherits="VisualInstance3D" version="4.0">
 	<brief_description>
+		Prerendered light map for a scene.
 	</brief_description>
 	<description>
+		Baked lightmaps are an alternative workflow for adding indirect (or baked) lighting to a scene. Unlike the [VoxelGI] approach or [Environment]'s SDFGI, baked lightmaps work fine on low-end PCs and mobile devices as they consume almost no resources in run-time. Depending on the lights' configuration, the lightmap can store indirect lighting only, or store both direct and indirect lighting.
+		[b]Note:[/b] Due to how lightmaps work, most properties only have a visible effect once lightmaps are baked again.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,8 +13,14 @@
 	</methods>
 	<members>
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="0.0005">
+			Raycasting bias used during baking to avoid floating point precision issues.
+		</member>
+		<member name="bounce_indirect_energy" type="float" setter="set_bounce_indirect_energy" getter="get_bounce_indirect_energy" default="1.0">
+			The energy multiplier for each bounce. Higher values will make indirect lighting brighter. A value of [code]1.0[/code] represents physically accurate behavior, but higher values can be used to make indirect lighting propagate more visibly when using a low number of bounces. This can be used to speed up bake times by lowering the number of [member bounces] then increasing [member bounce_indirect_energy].
+			[b]Note:[/b] [member bounce_indirect_energy] only has an effect if [member bounces] is set to a value greater than or equal to [code]1[/code].
 		</member>
 		<member name="bounces" type="int" setter="set_bounces" getter="get_bounces" default="1">
+			Number of light bounces that are taken into account during baking. A higher amount of bounces will make the bake appear brighter and more natural overall, at the cost of making bake times longer. Due to the non-linear nature of light, there are diminishing returns to increasing the number of bounces.
 		</member>
 		<member name="directional" type="bool" setter="set_directional" getter="is_directional" default="false">
 		</member>

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -618,7 +618,7 @@ void LightmapperRD::_raster_geometry(RenderingDevice *rd, Size2i atlas_size, int
 	}
 }
 
-LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_denoiser, int p_bounces, float p_bias, int p_max_texture_size, bool p_bake_sh, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function, void *p_bake_userdata) {
+LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_denoiser, int p_bounces, float p_bounce_indirect_energy, float p_bias, int p_max_texture_size, bool p_bake_sh, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function, void *p_bake_userdata) {
 	if (p_step_function) {
 		p_step_function(0.0, TTR("Begin Bake"), p_bake_userdata, true);
 	}
@@ -990,6 +990,10 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		push_constant.to_cell_offset[1] = bounds.position.y;
 		push_constant.to_cell_offset[2] = bounds.position.z;
 		push_constant.bias = p_bias;
+		push_constant.bounce_indirect_energy = p_bounce_indirect_energy;
+		push_constant.pad[0] = 0;
+		push_constant.pad[1] = 0;
+		push_constant.pad[2] = 0;
 		push_constant.to_cell_size[0] = (1.0 / bounds.size.x) * float(grid_size);
 		push_constant.to_cell_size[1] = (1.0 / bounds.size.y) * float(grid_size);
 		push_constant.to_cell_size[2] = (1.0 / bounds.size.z) * float(grid_size);

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -214,6 +214,9 @@ class LightmapperRD : public Lightmapper {
 		float world_size[3] = {};
 		float bias = 0.0;
 
+		float bounce_indirect_energy = 1.0;
+		uint32_t pad[3] = {};
+
 		float to_cell_offset[3] = {};
 		uint32_t ray_from = 0;
 
@@ -240,7 +243,7 @@ public:
 	virtual void add_omni_light(bool p_static, const Vector3 &p_position, const Color &p_color, float p_energy, float p_range, float p_attenuation, float p_size) override;
 	virtual void add_spot_light(bool p_static, const Vector3 &p_position, const Vector3 p_direction, const Color &p_color, float p_energy, float p_range, float p_attenuation, float p_spot_angle, float p_spot_attenuation, float p_size) override;
 	virtual void add_probe(const Vector3 &p_position) override;
-	virtual BakeError bake(BakeQuality p_quality, bool p_use_denoiser, int p_bounces, float p_bias, int p_max_texture_size, bool p_bake_sh, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function = nullptr, void *p_bake_userdata = nullptr) override;
+	virtual BakeError bake(BakeQuality p_quality, bool p_use_denoiser, int p_bounces, float p_bounce_indirect_energy, float p_bias, int p_max_texture_size, bool p_bake_sh, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function = nullptr, void *p_bake_userdata = nullptr) override;
 
 	int get_bake_texture_count() const override;
 	Ref<Image> get_bake_texture(int p_index) const override;

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -78,6 +78,9 @@ layout(push_constant, binding = 0, std430) uniform Params {
 	vec3 world_size;
 	float bias;
 
+	float bounce_indirect_energy;
+	uint pad[3];
+
 	vec3 to_cell_offset;
 	uint ray_from;
 
@@ -371,7 +374,7 @@ void main() {
 	//keep for lightprobes
 	imageStore(primary_dynamic, ivec3(atlas_pos, params.atlas_slice), vec4(dynamic_light, 1.0));
 
-	dynamic_light += static_light * albedo; //send for bounces
+	dynamic_light += static_light * albedo * params.bounce_indirect_energy; //send for bounces
 	imageStore(dest_light, ivec3(atlas_pos, params.atlas_slice), vec4(dynamic_light, 1.0));
 
 #ifdef USE_SH_LIGHTMAPS

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -951,7 +951,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		}
 	}
 
-	Lightmapper::BakeError bake_err = lightmapper->bake(Lightmapper::BakeQuality(bake_quality), use_denoiser, bounces, bias, max_texture_size, directional, Lightmapper::GenerateProbes(gen_probes), environment_image, environment_transform, _lightmap_bake_step_function, &bsud);
+	Lightmapper::BakeError bake_err = lightmapper->bake(Lightmapper::BakeQuality(bake_quality), use_denoiser, bounces, bounce_indirect_energy, bias, max_texture_size, directional, Lightmapper::GenerateProbes(gen_probes), environment_image, environment_transform, _lightmap_bake_step_function, &bsud);
 
 	if (bake_err == Lightmapper::BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES) {
 		return BAKE_ERROR_MESHES_INVALID;
@@ -1334,6 +1334,15 @@ int LightmapGI::get_bounces() const {
 	return bounces;
 }
 
+void LightmapGI::set_bounce_indirect_energy(float p_indirect_energy) {
+	ERR_FAIL_COND(p_indirect_energy < 0.0);
+	bounce_indirect_energy = p_indirect_energy;
+}
+
+float LightmapGI::get_bounce_indirect_energy() const {
+	return bounce_indirect_energy;
+}
+
 void LightmapGI::set_bias(float p_bias) {
 	ERR_FAIL_COND(p_bias < 0.00001);
 	bias = p_bias;
@@ -1382,6 +1391,9 @@ void LightmapGI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bounces", "bounces"), &LightmapGI::set_bounces);
 	ClassDB::bind_method(D_METHOD("get_bounces"), &LightmapGI::get_bounces);
 
+	ClassDB::bind_method(D_METHOD("set_bounce_indirect_energy", "bounce_indirect_energy"), &LightmapGI::set_bounce_indirect_energy);
+	ClassDB::bind_method(D_METHOD("get_bounce_indirect_energy"), &LightmapGI::get_bounce_indirect_energy);
+
 	ClassDB::bind_method(D_METHOD("set_generate_probes", "subdivision"), &LightmapGI::set_generate_probes);
 	ClassDB::bind_method(D_METHOD("get_generate_probes"), &LightmapGI::get_generate_probes);
 
@@ -1417,6 +1429,7 @@ void LightmapGI::_bind_methods() {
 	ADD_GROUP("Tweaks", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "quality", PROPERTY_HINT_ENUM, "Low,Medium,High,Ultra"), "set_bake_quality", "get_bake_quality");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bounces", PROPERTY_HINT_RANGE, "0,16,1"), "set_bounces", "get_bounces");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bounce_indirect_energy", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_bounce_indirect_energy", "get_bounce_indirect_energy");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "directional"), "set_directional", "is_directional");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interior"), "set_interior", "is_interior");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_denoiser"), "set_use_denoiser", "is_using_denoiser");

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -136,6 +136,7 @@ private:
 	BakeQuality bake_quality = BAKE_QUALITY_MEDIUM;
 	bool use_denoiser = true;
 	int bounces = 1;
+	float bounce_indirect_energy = 1.0;
 	float bias = 0.0005;
 	int max_texture_size = 16384;
 	bool interior = false;
@@ -256,6 +257,9 @@ public:
 
 	void set_bounces(int p_bounces);
 	int get_bounces() const;
+
+	void set_bounce_indirect_energy(float p_indirect_energy);
+	float get_bounce_indirect_energy() const;
 
 	void set_bias(float p_bias);
 	float get_bias() const;

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -178,7 +178,7 @@ public:
 	virtual void add_omni_light(bool p_static, const Vector3 &p_position, const Color &p_color, float p_energy, float p_range, float p_attenuation, float p_size) = 0;
 	virtual void add_spot_light(bool p_static, const Vector3 &p_position, const Vector3 p_direction, const Color &p_color, float p_energy, float p_range, float p_attenuation, float p_spot_angle, float p_spot_attenuation, float p_size) = 0;
 	virtual void add_probe(const Vector3 &p_position) = 0;
-	virtual BakeError bake(BakeQuality p_quality, bool p_use_denoiser, int p_bounces, float p_bias, int p_max_texture_size, bool p_bake_sh, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function = nullptr, void *p_step_userdata = nullptr) = 0;
+	virtual BakeError bake(BakeQuality p_quality, bool p_use_denoiser, int p_bounces, float p_bounce_indirect_energy, float p_bias, int p_max_texture_size, bool p_bake_sh, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function = nullptr, void *p_step_userdata = nullptr) = 0;
 
 	virtual int get_bake_texture_count() const = 0;
 	virtual Ref<Image> get_bake_texture(int p_index) const = 0;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/50827.

Higher values will make indirect lighting brighter. A value of 1.0 represents physically accurate behavior, but higher values can be used to make indirect lighting propagate more visibly when using a low number of bounces.

This can be used to speed up bake times by lowering the number of bounces then increasing the bounce indirect energy.

This closes https://github.com/godotengine/godot/issues/50938.

**Testing project:** [test_lightmap_normalmap2.zip](https://github.com/godotengine/godot/files/6989140/test_lightmap_normalmap2.zip)

## TODO

- [ ] Implement when the lights' bake mode is **Dynamic**. Right now, it only works when lights' bake mode is **Static**. I haven't figured out how to multiply *only* bounce lighting when only indirect lighting is baked.

## Preview

### Bounce Indirect Energy 1.0 (default)

![2021-08-16_01 53 30](https://user-images.githubusercontent.com/180032/129497496-8b8c0f79-5ab6-4cf8-94d6-e95f34a6aed8.png)

### Bounce Indirect Energy 0.0

*Only direct, environment and emissive lighting are baked.*

![2021-08-16_02 15 47](https://user-images.githubusercontent.com/180032/129497497-4490d7fa-9a8e-4a39-b374-ff66dbfb4b68.png)

### Bounce Indirect Energy 4.0

*Can be used for artistic effects with less strong lights.*

![2021-08-16_02 16 04](https://user-images.githubusercontent.com/180032/129497498-81c3b6ee-74b0-4183-9ff2-a767fcfb9703.png)