### PR TITLE
Fix input methods returning zero strength when pressed status not requested

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -229,11 +229,12 @@ bool InputMap::event_get_action_status(const Ref<InputEvent> &p_event, const Str
 
 	Ref<InputEventAction> input_event_action = p_event;
 	if (input_event_action.is_valid()) {
+		bool pressed = input_event_action->is_pressed();
 		if (p_pressed != nullptr) {
-			*p_pressed = input_event_action->is_pressed();
+			*p_pressed = pressed;
 		}
 		if (p_strength != nullptr) {
-			*p_strength = (p_pressed != nullptr && *p_pressed) ? input_event_action->get_strength() : 0.0f;
+			*p_strength = pressed ? input_event_action->get_strength() : 0.0f;
 		}
 		return input_event_action->get_action() == p_action;
 	}

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -315,10 +315,11 @@ bool InputEventKey::action_match(const Ref<InputEvent> &p_event, bool *p_pressed
 	}
 
 	if (match) {
+		bool pressed = key->is_pressed();
 		if (p_pressed != nullptr) {
-			*p_pressed = key->is_pressed();
+			*p_pressed = pressed;
 		}
-		float strength = (p_pressed != nullptr && *p_pressed) ? 1.0f : 0.0f;
+		float strength = pressed ? 1.0f : 0.0f;
 		if (p_strength != nullptr) {
 			*p_strength = strength;
 		}
@@ -477,10 +478,11 @@ bool InputEventMouseButton::action_match(const Ref<InputEvent> &p_event, bool *p
 
 	bool match = mb->button_index == button_index;
 	if (match) {
+		bool pressed = mb->is_pressed();
 		if (p_pressed != nullptr) {
-			*p_pressed = mb->is_pressed();
+			*p_pressed = pressed;
 		}
-		float strength = (p_pressed != nullptr && *p_pressed) ? 1.0f : 0.0f;
+		float strength = pressed ? 1.0f : 0.0f;
 		if (p_strength != nullptr) {
 			*p_strength = strength;
 		}
@@ -809,10 +811,11 @@ bool InputEventJoypadButton::action_match(const Ref<InputEvent> &p_event, bool *
 
 	bool match = button_index == jb->button_index;
 	if (match) {
+		bool pressed = jb->is_pressed();
 		if (p_pressed != nullptr) {
-			*p_pressed = jb->is_pressed();
+			*p_pressed = pressed;
 		}
-		float strength = (p_pressed != nullptr && *p_pressed) ? 1.0f : 0.0f;
+		float strength = pressed ? 1.0f : 0.0f;
 		if (p_strength != nullptr) {
 			*p_strength = strength;
 		}
@@ -1048,10 +1051,11 @@ bool InputEventAction::action_match(const Ref<InputEvent> &p_event, bool *p_pres
 
 	bool match = action == act->action;
 	if (match) {
+		bool pressed = act->pressed;
 		if (p_pressed != nullptr) {
-			*p_pressed = act->pressed;
+			*p_pressed = pressed;
 		}
-		float strength = (p_pressed != nullptr && *p_pressed) ? 1.0f : 0.0f;
+		float strength = pressed ? 1.0f : 0.0f;
 		if (p_strength != nullptr) {
 			*p_strength = strength;
 		}


### PR DESCRIPTION
Fixes behavior of these methods:

`InputMap::event_get_action_status`
`InputEvent*::action_match`

Previously when `p_pressed` was `nullptr`, `p_strength` would be set to
`0.0f` regardless of event strength. This affected `InputEventAction` events
processed by `Input.parse_input_event` for example.

Regression found in afa89c9eea5c99

Affects 3.4 beta