### PR TITLE
[3.3] Fix deselect everything on clicking 'selecting only'

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -152,7 +152,6 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 			text_edit->cursor_set_line(line, false);
 			text_edit->cursor_set_column(col + text.length(), false);
 			text_edit->center_viewport_to_cursor();
-			text_edit->select(line, col, line, col + text.length());
 		}
 
 		text_edit->set_search_text(text);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #49329

![deselect-test](https://user-images.githubusercontent.com/12533045/129498029-402eacd5-e997-4a3d-a191-4713fc724f8d.gif)
