### PR TITLE
Moved disabling bokeh shader variants to before the version_create call

### DIFF
--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -2098,10 +2098,9 @@ EffectsRD::EffectsRD(bool p_prefer_raster_effects) {
 		}
 	} else {
 		bokeh.compute_shader.initialize(bokeh_modes);
-
-		bokeh.shader_version = bokeh.compute_shader.version_create();
 		bokeh.compute_shader.set_variant_enabled(BOKEH_GEN_BOKEH_BOX_NOWEIGHT, false);
 		bokeh.compute_shader.set_variant_enabled(BOKEH_GEN_BOKEH_HEXAGONAL_NOWEIGHT, false);
+		bokeh.shader_version = bokeh.compute_shader.version_create();
 
 		for (int i = 0; i < BOKEH_MAX; i++) {
 			if (bokeh.compute_shader.is_variant_enabled(i)) {


### PR DESCRIPTION
There are two shader variants for the bokeh shader that only apply for the raster version and are disabled in the compute version.

Disabling them has to happen _before_ the `version_create` call, not after.

Fixes #51696