### PR TITLE
Add `disable_alpha` render mode to shaders

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -65,6 +65,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	bool wireframe = false;
 
 	unshaded = false;
+	disable_alpha = false;
 	uses_vertex = false;
 	uses_sss = false;
 	uses_transmittance = false;
@@ -104,6 +105,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	actions.render_mode_flags["unshaded"] = &unshaded;
 	actions.render_mode_flags["wireframe"] = &wireframe;
 	actions.render_mode_flags["particle_trails"] = &uses_particle_trails;
+	actions.render_mode_flags["disable_alpha"] = &disable_alpha;
 
 	actions.usage_flag_pointers["ALPHA"] = &uses_alpha;
 	actions.render_mode_flags["depth_prepass_alpha"] = &uses_depth_pre_pass;
@@ -279,7 +281,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 				RD::PipelineDepthStencilState depth_stencil = depth_stencil_state;
 				RD::PipelineMultisampleState multisample_state;
 
-				if (uses_alpha || uses_blend_alpha) {
+				if (!disable_alpha && (uses_alpha || uses_blend_alpha)) {
 					// only allow these flags to go through if we have some form of msaa
 					if (alpha_antialiasing_mode == ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE) {
 						multisample_state.enable_alpha_to_coverage = true;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -136,6 +136,7 @@ public:
 		bool uses_particle_trails;
 
 		bool unshaded;
+		bool disable_alpha;
 		bool uses_vertex;
 		bool uses_sss;
 		bool uses_transmittance;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -68,6 +68,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	bool wireframe = false;
 
 	unshaded = false;
+	disable_alpha = false;
 	uses_vertex = false;
 	uses_sss = false;
 	uses_transmittance = false;
@@ -107,6 +108,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	actions.render_mode_flags["unshaded"] = &unshaded;
 	actions.render_mode_flags["wireframe"] = &wireframe;
 	actions.render_mode_flags["particle_trails"] = &uses_particle_trails;
+	actions.render_mode_flags["disable_alpha"] = &disable_alpha;
 
 	actions.usage_flag_pointers["ALPHA"] = &uses_alpha;
 	actions.render_mode_flags["depth_prepass_alpha"] = &uses_depth_pre_pass;
@@ -283,7 +285,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 				RD::PipelineDepthStencilState depth_stencil = depth_stencil_state;
 				RD::PipelineMultisampleState multisample_state;
 
-				if (uses_alpha || uses_blend_alpha) {
+				if (!disable_alpha && (uses_alpha || uses_blend_alpha)) {
 					// only allow these flags to go through if we have some form of msaa
 					if (alpha_antialiasing_mode == ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE) {
 						multisample_state.enable_alpha_to_coverage = true;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -127,6 +127,7 @@ public:
 		bool uses_particle_trails;
 
 		bool unshaded;
+		bool disable_alpha;
 		bool uses_vertex;
 		bool uses_sss;
 		bool uses_transmittance;

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -212,6 +212,7 @@ ShaderTypes::ShaderTypes() {
 
 	shader_modes[RS::SHADER_SPATIAL].modes.push_back("unshaded");
 	shader_modes[RS::SHADER_SPATIAL].modes.push_back("wireframe");
+	shader_modes[RS::SHADER_SPATIAL].modes.push_back("disable_alpha");
 
 	shader_modes[RS::SHADER_SPATIAL].modes.push_back("diffuse_lambert");
 	shader_modes[RS::SHADER_SPATIAL].modes.push_back("diffuse_lambert_wrap");


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51844. Follow-up to https://github.com/godotengine/godot/pull/51709.

This can be used by multipass shaders to write to a texture's alpha channel without causing the material to become transparent.

**Testing project:** [test_shader_disable_alpha_master.zip](https://github.com/godotengine/godot/files/6989503/test_shader_disable_alpha_master.zip)

## Preview

### Default render mode

![Default render mode](https://user-images.githubusercontent.com/180032/129505554-40995461-ffb2-4c85-99c0-344173fc6237.png)

### `disable_alpha` render mode

![`disable_alpha` render mode](https://user-images.githubusercontent.com/180032/129505553-557abce3-5dd6-4579-90de-4b1269391dbf.png)