### PR TITLE
Improve the appearance of Deep Parallax in SpatialMaterial

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -757,7 +757,9 @@ void SpatialMaterial::_update_shader() {
 			code += "\t\tfloat layer_depth = 1.0 / num_layers;\n";
 			code += "\t\tfloat current_layer_depth = 0.0;\n";
 			code += "\t\tvec2 P = view_dir.xy * depth_scale;\n";
-			code += "\t\tvec2 delta = P / num_layers;\n";
+			// Improve the depth impression when viewed at oblique angles by dividing with `dot(VIEW, NORMAL)`.
+			// This may require more samples than usual to avoid artifacts, but generally looks better in most real world use cases.
+			code += "\t\tvec2 delta = P / num_layers / dot(VIEW, NORMAL);\n";
 			code += "\t\tvec2 ofs = base_uv;\n";
 			code += "\t\tfloat depth = textureLod(texture_depth, ofs, 0.0).r;\n";
 			code += "\t\tfloat current_depth = 0.0;\n";


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50377. See also https://github.com/godotengine/godot/pull/51433.

This better preserves depth when viewed at oblique angles. Artifacts due to the amount of layers being low may be more noticeable as a result, but it's generally better to decrease the heightmap scale instead.

This is done by dividing the delta by the dot product of the view vector and normal vector.