### PR TITLE
Define normal_attrib when not using octahedral compression in GLES3

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -27,6 +27,8 @@ layout(location = 0) in highp vec4 vertex_attrib;
 /* clang-format on */
 #ifdef ENABLE_OCTAHEDRAL_COMPRESSION
 layout(location = 1) in vec4 normal_tangent_attrib;
+#else
+layout(location = 1) in vec3 normal_attrib;
 #endif
 #if defined(ENABLE_TANGENT_INTERP) || defined(ENABLE_NORMALMAP) || defined(LIGHT_USE_ANISOTROPY)
 #ifdef ENABLE_OCTAHEDRAL_COMPRESSION


### PR DESCRIPTION
Fixes a bug that hasn't been reported yet. 

If blend shapes are used in any GLES3 scene, a shader compiler error is thrown.

Looks like it was mistakenly removed in https://github.com/godotengine/godot/pull/51376

CC @the-o-king