### PR TITLE
Fix macOS fullscreen incorrect mouse position

### DIFF
--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -190,7 +190,7 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 
 	[wd.window_object setContentMinSize:NSMakeSize(0, 0)];
 	[wd.window_object setContentMaxSize:NSMakeSize(FLT_MAX, FLT_MAX)];
-	//Force window resize event
+	// Force window resize event.
 	[self windowDidResize:notification];
 }
 
@@ -219,7 +219,7 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 	if (wd.on_top) {
 		[wd.window_object setLevel:NSFloatingWindowLevel];
 	}
-	//Force window resize event
+	// Force window resize event.
 	[self windowDidResize:notification];
 }
 

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -190,6 +190,8 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 
 	[wd.window_object setContentMinSize:NSMakeSize(0, 0)];
 	[wd.window_object setContentMaxSize:NSMakeSize(FLT_MAX, FLT_MAX)];
+	//Force window resize event
+	[self windowDidResize:notification];
 }
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification {
@@ -217,6 +219,8 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 	if (wd.on_top) {
 		[wd.window_object setLevel:NSFloatingWindowLevel];
 	}
+	//Force window resize event
+	[self windowDidResize:notification];
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification {


### PR DESCRIPTION
In relation to #40061. 

This PR is fixing the incorrect mouse position in fullscreen mode which result UI click registered below expect point.
From my testing, it seems like the issue is that when the window getting into or out fullscreen mode, it wouldn't call the resize event to get correct sizing and scale.
I also notice that when i fullscreen and changing resolution of the display, it will call resize event, and the UI will work as it should. but when getting out from fullscreen mode, it will get back to the same issue, now in window mode.

So my PR is adding a call to resize event when changing to/from fullscreen mode.