### PR TITLE
Auto-reload scripts with external editor

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -942,7 +942,10 @@ void ScriptEditor::_res_saved_callback(const Ref<Resource> &p_res) {
 	}
 
 	_update_script_names();
+	_trigger_live_script_reload();
+}
 
+void ScriptEditor::_trigger_live_script_reload() {
 	if (!pending_auto_reload && auto_reload_running_scripts) {
 		call_deferred(SNAME("_live_auto_reload_running_scripts"));
 		pending_auto_reload = true;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -344,6 +344,7 @@ class ScriptEditor : public PanelContainer {
 
 	bool pending_auto_reload;
 	bool auto_reload_running_scripts;
+	void _trigger_live_script_reload();
 	void _live_auto_reload_running_scripts();
 
 	void _update_selected_editor_menu();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -666,6 +666,8 @@ void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_fo
 			script->set_source_code(rel_script->get_source_code());
 			script->set_last_modified_time(rel_script->get_last_modified_time());
 			script->update_exports();
+
+			_trigger_live_script_reload();
 		}
 	}
 }


### PR DESCRIPTION
The PR allows auto-reload with external editors.
 - It calls `_live_auto_reload_running_scripts` when appropriates.
 - It uses `NOTIFICATION_APPLICATION_FOCUS_IN` events to trigger reload as `NOTIFICATION_WM_WINDOW_FOCUS_IN` is never called on `master` branch. I'm not sure why, probably a bug?

Here's another patch for `3.x` branch. It also fixes error messages when script changed on external editor. (`Another resource is loaded from path` thing). I could create another PR if you prefer: https://gist.github.com/yjh0502/e2cb62f9216c953c8e54541199d7be09

related: #10946

<i>Bugsquad edit</i>: Fix #10946