### PR TITLE
Fix incorrect inheritance of `VisualShaderNodeParticleAccelerator`

### DIFF
--- a/doc/classes/VisualShaderNodeParticleAccelerator.xml
+++ b/doc/classes/VisualShaderNodeParticleAccelerator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeParticleAccelerator" inherits="VisualShaderNodeOutput" version="4.0">
+<class name="VisualShaderNodeParticleAccelerator" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/scene/resources/visual_shader_particle_nodes.h
+++ b/scene/resources/visual_shader_particle_nodes.h
@@ -181,8 +181,8 @@ VARIANT_ENUM_CAST(VisualShaderNodeParticleRandomness::OpType)
 
 // Process nodes
 
-class VisualShaderNodeParticleAccelerator : public VisualShaderNodeOutput {
-	GDCLASS(VisualShaderNodeParticleAccelerator, VisualShaderNodeOutput);
+class VisualShaderNodeParticleAccelerator : public VisualShaderNode {
+	GDCLASS(VisualShaderNodeParticleAccelerator, VisualShaderNode);
 
 public:
 	enum Mode {


### PR DESCRIPTION
I think I made a typo when creating this class - it's not related to the Output node in any way.
