### PR TITLE
Fix `MenuButton` not emitting `about_to_popup` signal

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -86,6 +86,7 @@ void MenuButton::_popup_visibility_changed(bool p_visible) {
 }
 
 void MenuButton::pressed() {
+	emit_signal(SNAME("about_to_popup"));
 	Size2 size = get_size();
 
 	Point2 gp = get_screen_position();


### PR DESCRIPTION
The emission of `MenuButton`'s `about_to_popup` signal has been gone for more than a year on `master` 😂 

This affects the update of these menus:

* The resource history menu of Inspector is always empty
* Scene menu's Reopen Closed Scene item is not disabled when nothing to reopen
* Add Node button in Blend Tree editor is not updated for node pasting