### PR TITLE
Move cursor to edge of selection when moving caret left/right

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2812,7 +2812,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		_reset_caret_blink_timer();
 
-		// Save here for insert mode, just in case it is cleared in the following section.
+		// Save here for insert mode as well as arrow navigation, just in case it is cleared in the following section.
 		bool had_selection = selection.active;
 
 		// Stuff to do when selection is active.
@@ -3168,6 +3168,11 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			case KEY_LEFT: {
 				if (k->get_shift()) {
 					_pre_shift_selection();
+				} else if (had_selection && !k->get_command() && !k->get_alt()) {
+					cursor_set_line(selection.from_line);
+					cursor_set_column(selection.from_column);
+					deselect();
+					break;
 #ifdef APPLE_STYLE_KEYS
 				} else {
 #else
@@ -3245,6 +3250,11 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			case KEY_RIGHT: {
 				if (k->get_shift()) {
 					_pre_shift_selection();
+				} else if (had_selection && !k->get_command() && !k->get_alt()) {
+					cursor_set_line(selection.to_line);
+					cursor_set_column(selection.to_column);
+					deselect();
+					break;
 #ifdef APPLE_STYLE_KEYS
 				} else {
 #else


### PR DESCRIPTION
(This was backported to 3.x from pull request #51502.)

This is to mimic the behavior of many third party text editors. The reasons it's not doing it when moving by word is due to that behavior being mostly the same on other editors.

I'm using `had_selection` here (because `selection.active` can get cleared), but I am also using `selection.from_line`, etc. It seem to work fine, but I am unsure about whether it's safe to use these integers, considering they might potentially also be outdated just like `selection.active`. Should I make temporary variables for these integers, or is this implementation okay?