### PR TITLE
Disable "Edit Resource from Clipboard" when nothing in clipboard

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -209,6 +209,12 @@ void InspectorDock::_paste_resource() {
 	}
 }
 
+void InspectorDock::_prepare_resource_extra_popup() {
+	RES r = EditorSettings::get_singleton()->get_resource_clipboard();
+	PopupMenu *popup = resource_extra_button->get_popup();
+	popup->set_item_disabled(popup->get_item_index(RESOURCE_EDIT_CLIPBOARD), r.is_null());
+}
+
 void InspectorDock::_prepare_history() {
 	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
 
@@ -525,6 +531,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	resource_extra_button->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 	resource_extra_button->set_tooltip(TTR("Extra resource options."));
 	general_options_hb->add_child(resource_extra_button);
+	resource_extra_button->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_resource_extra_popup));
 	resource_extra_button->get_popup()->add_icon_shortcut(get_theme_icon(SNAME("ActionPaste"), SNAME("EditorIcons")), ED_SHORTCUT("property_editor/paste_resource", TTR("Edit Resource from Clipboard")), RESOURCE_EDIT_CLIPBOARD);
 	resource_extra_button->get_popup()->add_icon_shortcut(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")), ED_SHORTCUT("property_editor/copy_resource", TTR("Copy Resource")), RESOURCE_COPY);
 	resource_extra_button->get_popup()->set_item_disabled(1, true);

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -102,6 +102,7 @@ class InspectorDock : public VBoxContainer {
 	void _unref_resource();
 	void _copy_resource();
 	void _paste_resource();
+	void _prepare_resource_extra_popup();
 
 	void _warning_pressed();
 	void _resource_created();


### PR DESCRIPTION
"Edit Resource from Clipboard" is a menu item in the resource menu of Inspector. It does nothing when there is no Resource in the clipboard, so disable it to be consistent with other buttons and menu items nearby.