### PR TITLE
Perform linear color conversion option on `ColorConstant` node in visual shader's

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -260,8 +260,12 @@ bool VisualShaderNodeColorConstant::is_output_port_expandable(int p_port) const 
 
 String VisualShaderNodeColorConstant::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String code;
-	code += "	" + p_output_vars[0] + " = " + vformat("vec3(%.6f, %.6f, %.6f)", constant.r, constant.g, constant.b) + ";\n";
-	code += "	" + p_output_vars[1] + " = " + vformat("%.6f", constant.a) + ";\n";
+	Color color = constant;
+	if (p_mode != Shader::MODE_CANVAS_ITEM) {
+		color = color.to_linear();
+	}
+	code += "	" + p_output_vars[0] + " = " + vformat("vec3(%.6f, %.6f, %.6f)", color.r, color.g, color.b) + ";\n";
+	code += "	" + p_output_vars[1] + " = " + vformat("%.6f", color.a) + ";\n";
 
 	return code;
 }


### PR DESCRIPTION
Some users may want to use more "natural" colors for 3d nodes (which is identical to Color they set using `VisualShaderNodeColor` node) so I've added a boolean which performs such conversion (before setting the color to shader):

![image](https://user-images.githubusercontent.com/3036176/129589839-ddbc65f7-dc39-4b10-95b6-20c1de56fe9d.png)

![vs_color](https://user-images.githubusercontent.com/3036176/129586084-ca82b168-0a46-4d96-9548-2186abc32425.gif)

