### PR TITLE
[3.x] Avoid useless call to move and collide during snapping

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1212,7 +1212,7 @@ Vector2 KinematicBody2D::move_and_slide_with_snap(const Vector2 &p_linear_veloci
 	bool was_on_floor = on_floor;
 
 	Vector2 ret = move_and_slide(p_linear_velocity, up_direction, p_stop_on_slope, p_max_slides, p_floor_max_angle, p_infinite_inertia);
-	if (!was_on_floor || p_snap == Vector2()) {
+	if (!was_on_floor || p_snap == Vector2() || on_floor) {
 		return ret;
 	}
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1172,7 +1172,7 @@ Vector3 KinematicBody::move_and_slide_with_snap(const Vector3 &p_linear_velocity
 	bool was_on_floor = on_floor;
 
 	Vector3 ret = move_and_slide(p_linear_velocity, up_direction, p_stop_on_slope, p_max_slides, p_floor_max_angle, p_infinite_inertia);
-	if (!was_on_floor || p_snap == Vector3()) {
+	if (!was_on_floor || p_snap == Vector3() || on_floor) {
 		return ret;
 	}
 


### PR DESCRIPTION
When snapping in on, this will prevent one extra call to `move and collide` each frame when you are on the floor.

Note:This is already fixed in 2D in 4.0, and it will be in 3D.