### PR TITLE
[3.3] [android] Fixed wrong button mask for right click

### DIFF
--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -663,7 +663,7 @@ int OS_Android::_android_button_mask_to_godot_button_mask(int android_button_mas
 	if (android_button_mask & AMOTION_EVENT_BUTTON_BACK) {
 		godot_button_mask |= BUTTON_MASK_XBUTTON1;
 	}
-	if (android_button_mask & AMOTION_EVENT_BUTTON_SECONDARY) {
+	if (android_button_mask & AMOTION_EVENT_BUTTON_FORWARD) {
 		godot_button_mask |= BUTTON_MASK_XBUTTON2;
 	}
 


### PR DESCRIPTION
Fixes #51737 for 3.3