### PR TITLE
Add a comment at the top of generated shaders (3.x)

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -32,6 +32,7 @@
 #include "core/message_queue.h"
 #include "core/method_bind_ext.gen.inc"
 #include "core/os/input.h"
+#include "core/version.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/font.h"
@@ -89,7 +90,10 @@ void CanvasItemMaterial::_update_shader() {
 
 	//must create a shader!
 
-	String code = "shader_type canvas_item;\nrender_mode ";
+	// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
+	String code = "// NOTE: Shader automatically converted from " VERSION_NAME " " VERSION_FULL_CONFIG "'s CanvasItemMaterial.\n\n";
+
+	code += "shader_type canvas_item;\nrender_mode ";
 	switch (blend_mode) {
 		case BLEND_MODE_MIX:
 			code += "blend_mix";

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -32,6 +32,7 @@
 
 #include "core/engine.h"
 #include "core/project_settings.h"
+#include "core/version.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_settings.h"
@@ -386,7 +387,10 @@ void SpatialMaterial::_update_shader() {
 
 	//must create a shader!
 
-	String code = "shader_type spatial;\nrender_mode ";
+	// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
+	String code = "// NOTE: Shader automatically converted from " VERSION_NAME " " VERSION_FULL_CONFIG "'s SpatialMaterial.\n\n";
+
+	code += "shader_type spatial;\nrender_mode ";
 	switch (blend_mode) {
 		case BLEND_MODE_MIX:
 			code += "blend_mix";

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -30,6 +30,8 @@
 
 #include "particles_material.h"
 
+#include "core/version.h"
+
 Mutex ParticlesMaterial::material_mutex;
 SelfList<ParticlesMaterial>::List *ParticlesMaterial::dirty_materials = nullptr;
 Map<ParticlesMaterial::MaterialKey, ParticlesMaterial::ShaderData> ParticlesMaterial::shader_map;
@@ -138,7 +140,10 @@ void ParticlesMaterial::_update_shader() {
 
 	//must create a shader!
 
-	String code = "shader_type particles;\n";
+	// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
+	String code = "// NOTE: Shader automatically converted from " VERSION_NAME " " VERSION_FULL_CONFIG "'s ParticlesMaterial.\n\n";
+
+	code += "shader_type particles;\n";
 
 	code += "uniform vec3 direction;\n";
 	code += "uniform float spread;\n";


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50159.

This comment is useful to determine the origin of ShaderMaterials converted from built-in material types (such as CanvasItemMaterial or SpatialMaterial).

The Godot version is also included in case the shader needs to be regenerated with a newer engine version.

## Preview

![image](https://user-images.githubusercontent.com/180032/129599872-ff8749d6-1533-44d1-afae-d3e7a0e282b4.png)