### PR TITLE
[3.x] Epsilon check for angular velocity in BodySW

### DIFF
--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -614,7 +614,7 @@ void BodySW::integrate_velocities(real_t p_step) {
 	real_t ang_vel = total_angular_velocity.length();
 	Transform transform = get_transform();
 
-	if (ang_vel != 0.0) {
+	if (!Math::is_zero_approx(ang_vel)) {
 		Vector3 ang_vel_axis = total_angular_velocity / ang_vel;
 		Basis rot(ang_vel_axis, ang_vel * p_step);
 		Basis identity3(1, 0, 0, 0, 1, 0, 0, 0, 1);


### PR DESCRIPTION
Replace exact zero check with approximate check for angular velocity in BodySW

Fixes #51640

Same as #51748 (since it can't be cherry-picked)