### PR TITLE
Fix caret not following while debugging (Fix #51754)

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1429,13 +1429,13 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 void CodeTextEditor::goto_line(int p_line) {
 	text_editor->deselect();
 	text_editor->unfold_line(p_line);
-	text_editor->call_deferred(SNAME("cursor_set_line"), p_line);
+	text_editor->call_deferred(SNAME("set_caret_line"), p_line);
 }
 
 void CodeTextEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
 	text_editor->unfold_line(p_line);
-	text_editor->call_deferred(SNAME("cursor_set_line"), p_line);
-	text_editor->call_deferred(SNAME("cursor_set_column"), p_begin);
+	text_editor->call_deferred(SNAME("set_caret_line"), p_line);
+	text_editor->call_deferred(SNAME("set_caret_column"), p_begin);
 	text_editor->select(p_line, p_begin, p_line, p_end);
 }
 


### PR DESCRIPTION
Fix #51754

### Issue :
While debugging, the carret didn't follow executed line anymore.

It's a regression since commit d5dcaee

### Identified cause

Some functions have been renamed in commit d5dcaee but old names were still used in code_editor.cpp causing the bug.

### Fix proposal :

Replace the old function names by the newer ones in code_editor.cpp

### Before : 

![bug_carret_debug](https://user-images.githubusercontent.com/3649998/129630810-e75dc7a9-86ca-422f-899b-fde7966f7f9f.gif)

### After

![bug_carret_debug_fixed](https://user-images.githubusercontent.com/3649998/129630832-6ee2645d-69fb-442c-83e4-03bf5f8788a8.gif)
