### PR TITLE
Fixed node not renaming when clicking elsewhere on the scene tree

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1206,11 +1206,10 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	}
 
 	tree->connect("cell_selected", callable_mp(this, &SceneTreeEditor::_selected_changed));
-	tree->connect("item_edited", callable_mp(this, &SceneTreeEditor::_renamed), varray(), CONNECT_DEFERRED);
+	tree->connect("item_edited", callable_mp(this, &SceneTreeEditor::_renamed));
 	tree->connect("multi_selected", callable_mp(this, &SceneTreeEditor::_cell_multi_selected));
 	tree->connect("button_pressed", callable_mp(this, &SceneTreeEditor::_cell_button_pressed));
 	tree->connect("nothing_selected", callable_mp(this, &SceneTreeEditor::_deselect_items));
-	//tree->connect("item_edited", this,"_renamed",Vector<Variant>(),true);
 
 	error = memnew(AcceptDialog);
 	add_child(error);


### PR DESCRIPTION
Fixes #51725

To be more exact, this issue only occurs when clicking the scene tree, clicking anywhere else renames the node just fine.

The issue seems to be caused by a kind of "race condition" where the scene tree updates, removing the textbox containing the new name,  before `_renamed` can be called.

I fixed it by making `_renamed` non-deferred. There might be a deeper issue at play here, but diagnosing it is beyond my current understanding of the engine and my fix seems to be working just fine.

