### PR TITLE
Deletion occurs when all text is selected

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4906,15 +4906,15 @@ void TextEdit::_backspace() {
 		return;
 	}
 
+	if (has_selection()) {
+		delete_selection();
+		return;
+	}
+
 	int cc = get_caret_column();
 	int cl = get_caret_line();
 
 	if (cc == 0 && cl == 0) {
-		return;
-	}
-
-	if (has_selection()) {
-		delete_selection();
 		return;
 	}
 


### PR DESCRIPTION
While all text of TextEdit was selected, deletion with backspace did not occur. It can now be deleted.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes: #51759