### PR TITLE
Fix crash when failing to load script from cache

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -200,7 +200,9 @@ Ref<GDScript> GDScriptCache::get_full_script(const String &p_path, Error &r_erro
 	if (singleton->full_gdscript_cache.has(p_path)) {
 		return singleton->full_gdscript_cache[p_path];
 	}
+
 	Ref<GDScript> script = get_shallow_script(p_path);
+	ERR_FAIL_COND_V(script.is_null(), Ref<GDScript>());
 
 	r_error = script->load_source_code(p_path);
 


### PR DESCRIPTION
I had a consistent crash when loading a project and this makes it an error when it happens instead.

I think it might have happened when I tried to open a project again after getting a new version from git in which some .gd files didn't exist anymore, and where not referenced in the project anymore but where still referenced in the cache. I haven't been able to reproduce the crash afterwards though (even with this fix reverted and trying to get to a similar state).