### PR TITLE
Convert output of GLES2 to linear color space

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -228,7 +228,7 @@
 			[b]Note:[/b] Requires [member usage] to be set to [constant USAGE_3D] or [constant USAGE_3D_NO_EFFECTS], since HDR is not supported for 2D.
 		</member>
 		<member name="keep_3d_linear" type="bool" setter="set_keep_3d_linear" getter="get_keep_3d_linear" default="false">
-			If [code]true[/code], the result after 3D rendering will not have a linear to sRGB color conversion applied. This is important when the viewport is used as a render target where the result is used as a texture on a 3D object rendered in another viewport. It is also important if the viewport is used to create data that is not color based (noise, heightmaps, pickmaps, etc.). Do not enable this when the viewport is used as a texture on a 2D object or if the viewport is your final output.
+			If [code]true[/code], the result after 3D rendering will not have a linear to sRGB color conversion applied. This is important when the viewport is used as a render target where the result is used as a texture on a 3D object rendered in another viewport. It is also important if the viewport is used to create data that is not color based (noise, heightmaps, pickmaps, etc.). Do not enable this when the viewport is used as a texture on a 2D object or if the viewport is your final output. For the GLES2 driver this will convert the sRGB output to linear, this should only be used for VR plugins that require input in linear color space!
 		</member>
 		<member name="msaa" type="int" setter="set_msaa" getter="get_msaa" enum="Viewport.MSAA" default="0">
 			The multisample anti-aliasing mode. A higher number results in smoother edges at the cost of significantly worse performance. A value of 4 is best unless targeting very high-end systems.

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -403,6 +403,7 @@ void RasterizerGLES2::blit_render_target_to_screen(RID p_render_target, const Re
 	canvas->_set_texture_rect_mode(true);
 
 	canvas->state.canvas_shader.set_custom_shader(0);
+	canvas->state.canvas_shader.set_conditional(CanvasShaderGLES2::LINEAR_TO_SRGB, rt->flags[RasterizerStorage::RENDER_TARGET_KEEP_3D_LINEAR]);
 	canvas->state.canvas_shader.bind();
 
 	canvas->canvas_begin();
@@ -421,6 +422,8 @@ void RasterizerGLES2::blit_render_target_to_screen(RID p_render_target, const Re
 
 	glBindTexture(GL_TEXTURE_2D, 0);
 	canvas->canvas_end();
+
+	canvas->state.canvas_shader.set_conditional(CanvasShaderGLES2::LINEAR_TO_SRGB, false);
 }
 
 void RasterizerGLES2::output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) {

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -701,5 +701,11 @@ FRAGMENT_SHADER_CODE
 //use lighting
 #endif
 
+#ifdef LINEAR_TO_SRGB
+	// regular Linear -> SRGB conversion
+	vec3 a = vec3(0.055);
+	color.rgb = mix((vec3(1.0) + a) * pow(color.rgb, vec3(1.0 / 2.4)) - a, 12.92 * color.rgb, vec3(lessThan(color.rgb, vec3(0.0031308))));
+#endif
+
 	gl_FragColor = color;
 }

--- a/drivers/gles2/shaders/copy.glsl
+++ b/drivers/gles2/shaders/copy.glsl
@@ -187,5 +187,10 @@ void main() {
 	color.rgb *= multiplier;
 #endif
 
+#ifdef OUTPUT_LINEAR
+	// sRGB -> linear
+	color.rgb = mix(pow((color.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), color.rgb * (1.0 / 12.92), vec3(lessThan(color.rgb, vec3(0.04045))));
+#endif
+
 	gl_FragColor = color;
 }

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -2307,6 +2307,11 @@ FRAGMENT_SHADER_CODE
 
 #endif //unshaded
 
+#ifdef OUTPUT_LINEAR
+	// sRGB -> linear
+	gl_FragColor.rgb = mix(pow((gl_FragColor.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), gl_FragColor.rgb * (1.0 / 12.92), vec3(lessThan(gl_FragColor.rgb, vec3(0.04045))));
+#endif
+
 #else // not RENDER_DEPTH
 //depth render
 #ifdef USE_RGBA_SHADOWS

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -855,6 +855,13 @@ FRAGMENT_SHADER_CODE
 
 //use lighting
 #endif
+
+#ifdef LINEAR_TO_SRGB
+	// regular Linear -> SRGB conversion
+	vec3 a = vec3(0.055);
+	color.rgb = mix((vec3(1.0) + a) * pow(color.rgb, vec3(1.0 / 2.4)) - a, 12.92 * color.rgb, lessThan(color.rgb, vec3(0.0031308)));
+#endif
+
 	//color.rgb *= color.a;
 	frag_color = color;
 }


### PR DESCRIPTION
In XR the render output is sent to a compositor that will do further processing of the images and output them to an HMD, one of the adjustments made here is converting to the color space that best suits the HMD.

The problem we've run into a few times is that as a result many of the compositors expect the render images to be in linear color space. 
Some like OpenVR and Oculus' VrAPI do have support for sRGB input (though it doesn't work in OpenVR when RGBA16F is used) but it looks like OpenXR only offers it through hardware sRGB buffers which don't seem to work as advertised when using GLES2. The bottom line is that OpenXR simply expects us to supply render buffers in linear color space.

For the GLES3 renderer we solved this issue a long time ago by introducing the `keep_3d_linear` switch as rendering happens in linear color space and we simply convert this to sRGB as part of our tonemapping post process. The introduced switch skips this conversion.

For the GLES2 renderer however we render everything in sRGB color space and this is all we have to offer, the `keep_3d_linear` switch has no effect. As it would be way to much work to convert the GLES2 renderer to work in linear color space and it requiring a post process to then convert to sRGB this isn't really an option.
This PR takes the opposite approach letting the renderer do its work in sRGB color space but converting the sRGB result to linear color space if `keep_3d_linear` is enabled. 

This PR also changes the arvr blit functions for creating the spectator view that if it is provided with a render buffer that has `keep_3d_linear` turned on, it converts the result to sRGB. This was a long outstanding wish I implemented while working on this anyway.

I need to do some more testing but this PR is basically ready.