### PR TITLE
Normalize the results of octahedral decompression

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -115,7 +115,7 @@ vec3 oct_to_vec3(vec2 e) {
 	vec3 v = vec3(e.xy, 1.0 - abs(e.x) - abs(e.y));
 	float t = max(-v.z, 0.0);
 	v.xy += t * -sign(v.xy);
-	return v;
+	return normalize(v);
 }
 #endif
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -264,7 +264,7 @@ vec3 oct_to_vec3(vec2 e) {
 	vec3 v = vec3(e.xy, 1.0 - abs(e.x) - abs(e.y));
 	float t = max(-v.z, 0.0);
 	v.xy += t * -sign(v.xy);
-	return v;
+	return normalize(v);
 }
 #endif
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -376,7 +376,7 @@ Vector3 VisualServer::oct_to_norm(const Vector2 v) {
 	float t = MAX(-res.z, 0.0f);
 	res.x += t * -SGN(res.x);
 	res.y += t * -SGN(res.y);
-	return res;
+	return res.normalized();
 }
 
 // Convert Octohedron-mapped normalized tangent vector back to Cartesian


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/51268 and https://github.com/godotengine/godot/pull/46800

Specifically this https://github.com/godotengine/godot/pull/51268#issuecomment-896185258

Octahedral compression is made specifically for unit vectors. The results of the decompression are non-normalized vectors pointing  in the same direction as the original value. It requires a normalization to return the original unit-length vector. 