### PR TITLE
Fix incorrect double types passing to particles shader pipeline

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -668,14 +668,14 @@ private:
 		};
 
 		uint32_t emitting;
-		double system_phase;
-		double prev_system_phase;
+		float system_phase;
+		float prev_system_phase;
 		uint32_t cycle;
 
 		real_t explosiveness;
 		real_t randomness;
-		double time;
-		double delta;
+		float time;
+		float delta;
 
 		uint32_t frame;
 		uint32_t pad0;
@@ -812,7 +812,7 @@ private:
 
 	struct ParticlesShader {
 		struct PushConstant {
-			double lifetime;
+			float lifetime;
 			uint32_t clear;
 			uint32_t total_particles;
 			uint32_t trail_size;


### PR DESCRIPTION
Shaders are not using double math currently, in any case.
Fix #51686