### PR TITLE
Fix renaming directories

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1560,15 +1560,17 @@ Error _Directory::copy(String p_from, String p_to) {
 
 Error _Directory::rename(String p_from, String p_to) {
 	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(p_from.is_empty() || p_from == "." || p_from == "..", ERR_INVALID_PARAMETER, "Invalid path to rename.");
+
 	if (!p_from.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_from);
-		ERR_FAIL_COND_V_MSG(!d->file_exists(p_from), ERR_DOES_NOT_EXIST, "File does not exist.");
+		ERR_FAIL_COND_V_MSG(!d->file_exists(p_from) && !d->dir_exists(p_from), ERR_DOES_NOT_EXIST, "File or directory does not exist.");
 		Error err = d->rename(p_from, p_to);
 		memdelete(d);
 		return err;
 	}
 
-	ERR_FAIL_COND_V_MSG(!d->file_exists(p_from), ERR_DOES_NOT_EXIST, "File does not exist.");
+	ERR_FAIL_COND_V_MSG(!d->file_exists(p_from) && !d->dir_exists(p_from), ERR_DOES_NOT_EXIST, "File or directory does not exist.");
 	return d->rename(p_from, p_to);
 }
 

--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -187,7 +187,7 @@
 			<argument index="0" name="from" type="String" />
 			<argument index="1" name="to" type="String" />
 			<description>
-				Renames (move) the [code]from[/code] file to the [code]to[/code] destination. Both arguments should be paths to files, either relative or absolute. If the destination file exists and is not access-protected, it will be overwritten.
+				Renames (move) the [code]from[/code] file or directory to the [code]to[/code] destination. Both arguments should be paths to files or directories, either relative or absolute. If the destination file or directory exists and is not access-protected, it will be overwritten.
 				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
 			</description>
 		</method>


### PR DESCRIPTION
Fixes #48254

Seems like `dir_exists()` is less strict with names, e.g. "" or ".." are valid directories even though it will result in the same bug as #41623, so I added some basic checks for invalid paths.