### PR TITLE
Fix init code so it works properly on Vulkan 1.1 devices

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -976,37 +976,35 @@ Error VulkanContext::_create_device() {
 		sdevice.queueCreateInfoCount = 2;
 	}
 
-#ifdef VK_VERSION_1_2
 	VkPhysicalDeviceVulkan11Features vulkan11features;
-
-	vulkan11features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
-	vulkan11features.pNext = nullptr;
-	// !BAS! Need to figure out which ones of these we want enabled...
-	vulkan11features.storageBuffer16BitAccess = 0;
-	vulkan11features.uniformAndStorageBuffer16BitAccess = 0;
-	vulkan11features.storagePushConstant16 = 0;
-	vulkan11features.storageInputOutput16 = 0;
-	vulkan11features.multiview = multiview_capabilities.is_supported;
-	vulkan11features.multiviewGeometryShader = multiview_capabilities.geometry_shader_is_supported;
-	vulkan11features.multiviewTessellationShader = multiview_capabilities.tessellation_shader_is_supported;
-	vulkan11features.variablePointersStorageBuffer = 0;
-	vulkan11features.variablePointers = 0;
-	vulkan11features.protectedMemory = 0;
-	vulkan11features.samplerYcbcrConversion = 0;
-	vulkan11features.shaderDrawParameters = 0;
-
-	sdevice.pNext = &vulkan11features;
-#elif VK_VERSION_1_1
 	VkPhysicalDeviceMultiviewFeatures multiview_features;
+	if (vulkan_major > 1 || vulkan_minor >= 2) {
+		vulkan11features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
+		vulkan11features.pNext = nullptr;
+		// !BAS! Need to figure out which ones of these we want enabled...
+		vulkan11features.storageBuffer16BitAccess = 0;
+		vulkan11features.uniformAndStorageBuffer16BitAccess = 0;
+		vulkan11features.storagePushConstant16 = 0;
+		vulkan11features.storageInputOutput16 = 0;
+		vulkan11features.multiview = multiview_capabilities.is_supported;
+		vulkan11features.multiviewGeometryShader = multiview_capabilities.geometry_shader_is_supported;
+		vulkan11features.multiviewTessellationShader = multiview_capabilities.tessellation_shader_is_supported;
+		vulkan11features.variablePointersStorageBuffer = 0;
+		vulkan11features.variablePointers = 0;
+		vulkan11features.protectedMemory = 0;
+		vulkan11features.samplerYcbcrConversion = 0;
+		vulkan11features.shaderDrawParameters = 0;
 
-	multiview_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES;
-	multiview_features.pNext = nullptr;
-	multiview_features.multiview = multiview_capabilities.is_supported;
-	multiview_features.multiviewGeometryShader = multiview_capabilities.geometry_shader_is_supported;
-	multiview_features.multiviewTessellationShader = multiview_capabilities.tessellation_shader_is_supported;
+		sdevice.pNext = &vulkan11features;
+	} else if (vulkan_major == 1 && vulkan_minor == 1) {
+		multiview_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES;
+		multiview_features.pNext = nullptr;
+		multiview_features.multiview = multiview_capabilities.is_supported;
+		multiview_features.multiviewGeometryShader = multiview_capabilities.geometry_shader_is_supported;
+		multiview_features.multiviewTessellationShader = multiview_capabilities.tessellation_shader_is_supported;
 
-	sdevice.pNext = &multiview_features;
-#endif
+		sdevice.pNext = &multiview_features;
+	}
 
 	err = vkCreateDevice(gpu, &sdevice, nullptr, &device);
 	ERR_FAIL_COND_V(err, ERR_CANT_CREATE);


### PR DESCRIPTION
We we're excluding Vulkan 1.2 code based on the Vulkan SDK we compiled against, not the capabilities of the device. As we were compiling against a Vulkan 1.1 SDK on android we didn't notice this was causing issues.

Now that we use Volk we are compiling against Vulkan 1.2 headers but we still need to prevent using Vulkan 1.2 structures if we're on a Vulkan 1.1 device.
