### PR TITLE
Fix Skeleton3D regression when bones are not sorted from root to leaves

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -173,12 +173,15 @@ void Skeleton3D::_update_process_order() {
 	parentless_bones.clear();
 
 	for (int i = 0; i < len; i++) {
+		bonesptr[i].child_bones.clear();
+	}
+
+	for (int i = 0; i < len; i++) {
 		if (bonesptr[i].parent >= len) {
 			//validate this just in case
 			ERR_PRINT("Bone " + itos(i) + " has invalid parent: " + itos(bonesptr[i].parent));
 			bonesptr[i].parent = -1;
 		}
-		bonesptr[i].child_bones.clear();
 
 		if (bonesptr[i].parent != -1) {
 			int parent_bone_idx = bonesptr[i].parent;


### PR DESCRIPTION
Tentative fix for missing bones when child bones are not sorted as expected.
Following up from https://github.com/godotengine/godot/pull/51368#discussion_r690482372 - CC @TwistedTwigleg

For example, if the root comes last, all child bones are removed and the skeleton ends up with just the root.
