### PR TITLE
Add note about batching to Line2D's anti-aliasing

### DIFF
--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -58,6 +58,7 @@
 	<members>
 		<member name="antialiased" type="bool" setter="set_antialiased" getter="get_antialiased" default="false">
 			If [code]true[/code], the line's border will be anti-aliased.
+			[b]Note:[/b] Line2D is not accelerated by batching when being anti-aliased.
 		</member>
 		<member name="begin_cap_mode" type="int" setter="set_begin_cap_mode" getter="get_begin_cap_mode" enum="Line2D.LineCapMode" default="0">
 			Controls the style of the line's first point. Use [enum LineCapMode] constants.


### PR DESCRIPTION
Added note to Line2D::antialiased about the fact that batching doesn't work for anti-aliased Line2D (as suggested by @lawnjelly in #51317)