### PR TITLE
Added increment_pressed and decrement_pressed icons to scrollbars

### DIFF
--- a/doc/classes/HScrollBar.xml
+++ b/doc/classes/HScrollBar.xml
@@ -19,6 +19,9 @@
 		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
 			Displayed when the mouse cursor hovers over the decrement button.
 		</theme_item>
+		<theme_item name="decrement_pressed" data_type="icon" type="Texture2D">
+			Displayed when the decrement button is being pressed.
+		</theme_item>
 		<theme_item name="grabber" data_type="style" type="StyleBox">
 			Used as texture for the grabber, the draggable element representing current scroll.
 		</theme_item>
@@ -33,6 +36,9 @@
 		</theme_item>
 		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Displayed when the mouse cursor hovers over the increment button.
+		</theme_item>
+		<theme_item name="increment_pressed" data_type="icon" type="Texture2D">
+			Displayed when the increment button is being pressed.
 		</theme_item>
 		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -23,6 +23,9 @@
 		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
 			Displayed when the mouse cursor hovers over the decrement button.
 		</theme_item>
+		<theme_item name="decrement_pressed" data_type="icon" type="Texture2D">
+			Displayed when the decrement button is being pressed.
+		</theme_item>
 		<theme_item name="grabber" data_type="style" type="StyleBox">
 			Used as texture for the grabber, the draggable element representing current scroll.
 		</theme_item>
@@ -37,6 +40,9 @@
 		</theme_item>
 		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Displayed when the mouse cursor hovers over the increment button.
+		</theme_item>
+		<theme_item name="increment_pressed" data_type="icon" type="Texture2D">
+			Displayed when the increment button is being pressed.
 		</theme_item>
 		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1136,8 +1136,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_icon("increment", "HScrollBar", empty_icon);
 	theme->set_icon("increment_highlight", "HScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "HScrollBar", empty_icon);
 	theme->set_icon("decrement", "HScrollBar", empty_icon);
 	theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
 
 	// VScrollBar
 	theme->set_stylebox("scroll", "VScrollBar", make_stylebox(theme->get_icon("GuiScrollBg", "EditorIcons"), 5, 5, 5, 5, 0, 0, 0, 0));
@@ -1148,8 +1150,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_icon("increment", "VScrollBar", empty_icon);
 	theme->set_icon("increment_highlight", "VScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "VScrollBar", empty_icon);
 	theme->set_icon("decrement", "VScrollBar", empty_icon);
 	theme->set_icon("decrement_highlight", "VScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "VScrollBar", empty_icon);
 
 	// HSlider
 	theme->set_icon("grabber_highlight", "HSlider", theme->get_icon("GuiSliderGrabberHl", "EditorIcons"));

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -80,12 +80,16 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 			double total = orientation == VERTICAL ? get_size().height : get_size().width;
 
 			if (ofs < decr_size) {
+				decr_active = true;
 				set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
+				update();
 				return;
 			}
 
 			if (ofs > total - incr_size) {
+				incr_active = true;
 				set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
+				update();
 				return;
 			}
 
@@ -130,6 +134,8 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 			}
 
 		} else {
+			incr_active = false;
+			decr_active = false;
 			drag.active = false;
 			update();
 		}
@@ -215,8 +221,24 @@ void ScrollBar::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
 		RID ci = get_canvas_item();
 
-		Ref<Texture2D> decr = highlight == HIGHLIGHT_DECR ? get_theme_icon(SNAME("decrement_highlight")) : get_theme_icon(SNAME("decrement"));
-		Ref<Texture2D> incr = highlight == HIGHLIGHT_INCR ? get_theme_icon(SNAME("increment_highlight")) : get_theme_icon(SNAME("increment"));
+		Ref<Texture2D> decr, incr;
+
+		if (decr_active) {
+			decr = get_theme_icon(SNAME("decrement_pressed"));
+		} else if (highlight == HIGHLIGHT_DECR) {
+			decr = get_theme_icon(SNAME("decrement_highlight"));
+		} else {
+			decr = get_theme_icon(SNAME("decrement"));
+		}
+
+		if (incr_active) {
+			incr = get_theme_icon(SNAME("increment_pressed"));
+		} else if (highlight == HIGHLIGHT_INCR) {
+			incr = get_theme_icon(SNAME("increment_highlight"));
+		} else {
+			incr = get_theme_icon(SNAME("increment"));
+		}
+
 		Ref<StyleBox> bg = has_focus() ? get_theme_stylebox(SNAME("scroll_focus")) : get_theme_stylebox(SNAME("scroll"));
 
 		Ref<StyleBox> grabber;

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -51,6 +51,9 @@ class ScrollBar : public Range {
 
 	HighlightStatus highlight = HIGHLIGHT_NONE;
 
+	bool incr_active = false;
+	bool decr_active = false;
+
 	struct Drag {
 		bool active = false;
 		float pos_at_click = 0.0;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -522,8 +522,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_icon("increment", "HScrollBar", empty_icon);
 	theme->set_icon("increment_highlight", "HScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "HScrollBar", empty_icon);
 	theme->set_icon("decrement", "HScrollBar", empty_icon);
 	theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
 
 	// VScrollBar
 
@@ -535,8 +537,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_icon("increment", "VScrollBar", empty_icon);
 	theme->set_icon("increment_highlight", "VScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "VScrollBar", empty_icon);
 	theme->set_icon("decrement", "VScrollBar", empty_icon);
 	theme->set_icon("decrement_highlight", "VScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "VScrollBar", empty_icon);
 
 	// HSlider
 


### PR DESCRIPTION
This PR adds textures for pressed increments and decrements within HScrollBar and VScrollBar. Since we have a texture for the pressed grabber it makes sense to be able to customize the pressed arrows as well.