### PR TITLE
Add word boundary search filter to Create Dialog

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -54,32 +54,36 @@
 
 static const int MAX_DECIMALS = 32;
 
-static _FORCE_INLINE_ bool is_digit(char32_t c) {
-	return (c >= '0' && c <= '9');
-}
-
-static _FORCE_INLINE_ bool is_hex_digit(char32_t c) {
-	return (is_digit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'));
-}
-
-static _FORCE_INLINE_ bool is_upper_case(char32_t c) {
-	return (c >= 'A' && c <= 'Z');
-}
-
-static _FORCE_INLINE_ bool is_lower_case(char32_t c) {
-	return (c >= 'a' && c <= 'z');
-}
-
-static _FORCE_INLINE_ char32_t lower_case(char32_t c) {
-	return (is_upper_case(c) ? (c + ('a' - 'A')) : c);
-}
-
 const char CharString::_null = 0;
 const char16_t Char16String::_null = 0;
 const char32_t String::_null = 0;
 
+bool is_digit(char32_t c) {
+	return (c >= '0' && c <= '9');
+}
+
+bool is_hex_digit(char32_t c) {
+	return (is_digit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'));
+}
+
+bool is_upper_case(char32_t c) {
+	return (c >= 'A' && c <= 'Z');
+}
+
+bool is_lower_case(char32_t c) {
+	return (c >= 'a' && c <= 'z');
+}
+
+bool is_alphabetic(char32_t c) {
+	return is_lower_case(c) || is_upper_case(c);
+}
+
 bool is_symbol(char32_t c) {
 	return c != '_' && ((c >= '!' && c <= '/') || (c >= ':' && c <= '@') || (c >= '[' && c <= '`') || (c >= '{' && c <= '~') || c == '\t' || c == ' ');
+}
+
+char32_t lower_case(char32_t c) {
+	return (is_upper_case(c) ? (c + ('a' - 'A')) : c);
 }
 
 bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end) {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -529,7 +529,15 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 String RTR(const String &p_text, const String &p_context = "");
 String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
 
+bool is_digit(char32_t c);
+bool is_hex_digit(char32_t c);
+bool is_upper_case(char32_t c);
+bool is_lower_case(char32_t c);
+bool is_alphabetic(char32_t c);
 bool is_symbol(char32_t c);
+
+char32_t lower_case(char32_t c);
+
 bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end);
 
 _FORCE_INLINE_ void sarray_add_str(Vector<String> &arr) {

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -37,10 +37,299 @@
 #include "editor_scale.h"
 #include "editor_settings.h"
 
-void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_select_type) {
-	_fill_type_list();
+bool FavoriteList::toggle_favorite(const String &p_type) {
+	favorites_changed = true;
 
-	icon_fallback = search_options->has_theme_icon(base_type, SNAME("EditorIcons")) ? base_type : "Object";
+	const bool already_favorited = favorites.has(p_type);
+	if (!already_favorited) {
+		favorites.push_back(p_type);
+	} else {
+		favorites.erase(p_type);
+	}
+
+	_update_tree();
+
+	return already_favorited;
+}
+
+void FavoriteList::load_favorites(const String &p_file_id, const String &p_icon_fallback) {
+	icon_fallback = p_icon_fallback;
+
+	String dir = EditorSettings::get_singleton()->get_project_settings_dir();
+
+	FileAccess *f = FileAccess::open(dir.plus_file("favorites." + p_file_id), FileAccess::READ);
+	if (f) {
+		while (!f->eof_reached()) {
+			String l = f->get_line().strip_edges();
+
+			if (l != String()) {
+				favorites.push_back(l);
+			}
+		}
+
+		memdelete(f);
+	}
+
+	_update_tree();
+}
+
+bool FavoriteList::save_favorites(const String &p_file_id) {
+	if (favorites_changed) {
+		FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("favorites." + p_file_id), FileAccess::WRITE);
+		if (f) {
+			for (int i = 0; i < favorites.size(); i++) {
+				String favorite = favorites[i];
+				String name = favorite.get_slicec(' ', 0);
+				if (!(ClassDB::class_exists(name) || ScriptServer::is_global_class(name))) {
+					continue;
+				}
+				f->store_line(favorite);
+
+				if (EditorFeatureProfileManager::get_singleton()->is_class_disabled(name)) {
+					continue;
+				}
+			}
+			memdelete(f);
+		}
+	}
+
+	favorites.clear();
+	clear();
+	return favorites_changed;
+}
+
+void FavoriteList::_update_tree() {
+	clear();
+	TreeItem *root = create_item();
+
+	for (int i = 0; i < favorites.size(); i++) {
+		String favorite = favorites[i];
+		String name = favorite.get_slicec(' ', 0);
+		if (!(ClassDB::class_exists(name) || ScriptServer::is_global_class(name))) {
+			continue;
+		}
+
+		if (EditorFeatureProfileManager::get_singleton()->is_class_disabled(name)) {
+			continue;
+		}
+
+		TreeItem *ti = create_item(root);
+		ti->set_text(0, favorite);
+		ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(name, icon_fallback));
+	}
+}
+
+Variant FavoriteList::_get_drag_data_fw(const Point2 &p_point, Control *p_from) {
+	TreeItem *ti = get_item_at_position(p_point);
+	if (ti) {
+		Dictionary d;
+		d["type"] = "create_favorite_drag";
+		d["class"] = ti->get_text(0);
+
+		Button *tb = memnew(Button);
+		tb->set_flat(true);
+		tb->set_icon(ti->get_icon(0));
+		tb->set_text(ti->get_text(0));
+		set_drag_preview(tb);
+
+		return d;
+	}
+
+	return Variant();
+}
+
+bool FavoriteList::_can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
+	Dictionary d = p_data;
+	if (d.has("type") && String(d["type"]) == "create_favorite_drag") {
+		set_drop_mode_flags(Tree::DROP_MODE_INBETWEEN);
+		return true;
+	}
+
+	return false;
+}
+
+void FavoriteList::_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
+	Dictionary d = p_data;
+
+	TreeItem *ti = get_item_at_position(p_point);
+	if (!ti) {
+		return;
+	}
+
+	String drop_at = ti->get_text(0);
+	int ds = get_drop_section_at_position(p_point);
+
+	int drop_idx = favorites.find(drop_at);
+	if (drop_idx < 0) {
+		return;
+	}
+
+	String type = d["class"];
+
+	int from_idx = favorites.find(type);
+	if (from_idx < 0) {
+		return;
+	}
+
+	if (drop_idx == from_idx) {
+		ds = -1; //cause it will be gone
+	} else if (drop_idx > from_idx) {
+		drop_idx--;
+	}
+
+	favorites.remove_at(from_idx);
+
+	if (ds < 0) {
+		favorites.insert(drop_idx, type);
+	} else {
+		if (drop_idx >= favorites.size() - 1) {
+			favorites.push_back(type);
+		} else {
+			favorites.insert(drop_idx + 1, type);
+		}
+	}
+
+	_update_tree();
+}
+
+void FavoriteList::_bind_methods() {
+	ClassDB::bind_method("_get_drag_data_fw", &FavoriteList::_get_drag_data_fw);
+	ClassDB::bind_method("_can_drop_data_fw", &FavoriteList::_can_drop_data_fw);
+	ClassDB::bind_method("_drop_data_fw", &FavoriteList::_drop_data_fw);
+}
+
+FavoriteList::FavoriteList() {
+	set_hide_root(true);
+	set_hide_folding(true);
+	set_allow_reselect(true);
+	add_theme_constant_override("draw_guides", 1);
+#ifndef _MSC_VER
+#warning cannot forward drag data to a non control, must be fixed
+#endif
+	//favorite_tree->set_drag_forwarding(this);
+}
+
+void HistoryList::save_to_history(const String &p_file_id, const String &p_item) {
+	FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("create_recent." + p_file_id), FileAccess::WRITE);
+	if (f) {
+		f->store_line(p_item);
+
+		for (int i = 0; i < MIN(32, get_item_count()); i++) {
+			if (get_item_text(i) != p_item) {
+				f->store_line(get_item_text(i));
+			}
+		}
+
+		memdelete(f);
+	}
+}
+
+void HistoryList::load_history(const String &p_file_id, const String &p_icon_fallback) {
+	String dir = EditorSettings::get_singleton()->get_project_settings_dir();
+	FileAccess *f = FileAccess::open(dir.plus_file("create_recent." + p_file_id), FileAccess::READ);
+	if (f) {
+		while (!f->eof_reached()) {
+			String l = f->get_line().strip_edges();
+			String name = l.get_slicec(' ', 0);
+
+			if ((ClassDB::class_exists(name) || ScriptServer::is_global_class(name)) && !EditorFeatureProfileManager::get_singleton()->is_class_disabled(name)) {
+				history.insert(l);
+				add_item(l, EditorNode::get_singleton()->get_class_icon(name, p_icon_fallback));
+			}
+		}
+
+		memdelete(f);
+	}
+}
+
+void HistoryList::clear_history() {
+	history.clear();
+	clear();
+}
+
+HistoryList::HistoryList() {
+	set_allow_reselect(true);
+	add_theme_constant_override("draw_guides", 1);
+}
+
+struct CandidateAlphComparator {
+	NoCaseComparator compare;
+
+	bool operator()(const CreateDialogCandidate &p_a, const CreateDialogCandidate &p_b) const {
+		return compare(p_a.get_type(), p_b.get_type());
+	}
+};
+
+float CreateDialogCandidate::_word_score(const String &p_word, const String &p_query) const {
+	const int start_pos = p_word.findn(p_query);
+	const float inverse_length = 1.f / float(p_word.length());
+
+	// Favor shorter items: they resemble the search term more.
+	float w = 0.1f;
+	float score = (1.0f - w) + w * (p_query.length() * inverse_length);
+
+	// Favor types where search term is a substring close to the start of the word.
+	w = 0.5f;
+	score *= (start_pos > -1) ? 1.0f - w * MIN(1.0, 3.0 * start_pos * inverse_length) : MAX(0.f, .9f - w);
+
+	return score;
+}
+
+float CreateDialogCandidate::compute_score(const String &p_query) const {
+	// Custom types include the file name in their path.
+	const String _type = type.get_slicec(' ', 0);
+	float score = _word_score(_type, p_query);
+	if (score == 1.0) {
+		return score;
+	}
+
+	score *= _word_score(wb_chars, p_query);
+
+	score *= is_preferred_type ? 1.0f : 0.6f;
+	score *= in_favorites ? 1.0f : 0.7f;
+	score *= in_recent ? 1.0f : 0.8f;
+
+	return score;
+}
+
+bool CreateDialogCandidate::is_valid(const String &p_query) const {
+	return type.findn(p_query) > -1 || p_query.is_subsequence_ofi(wb_chars);
+}
+
+String CreateDialogCandidate::_compute_word_boundary_characters() const {
+	Vector<char32_t> wb_chars;
+
+	const char32_t *src = type.get_data();
+	const int len = type.length();
+
+	for (int i = 0; i < len; i++) {
+		char32_t c = src[i];
+
+		if (is_upper_case(c) || is_digit(c)) {
+			wb_chars.push_back(c);
+		}
+	}
+
+	wb_chars.push_back(0); // Terminate string.
+
+	return String(wb_chars.ptr());
+}
+
+CreateDialogCandidate::CreateDialogCandidate(const String &p_type, const bool p_is_preferred_type, const bool p_in_favorites, const bool p_in_recent) {
+	type = p_type;
+	wb_chars = _compute_word_boundary_characters();
+	is_preferred_type = p_is_preferred_type;
+	in_favorites = p_in_favorites;
+	in_recent = p_in_recent;
+}
+
+void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_select_type) {
+	favorite_list->load_favorites(base_type, icon_fallback);
+	history_list->load_history(base_type, icon_fallback);
+
+	candidates = _compute_candidates();
+
+	icon_fallback = result_tree->has_theme_icon(base_type, SNAME("EditorIcons")) ? base_type : "Object";
 
 	if (p_dont_clear) {
 		search_box->select_all();
@@ -53,7 +342,7 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	}
 
 	search_box->grab_focus();
-	_update_search();
+	_update_result_tree();
 
 	if (p_replace_mode) {
 		set_title(vformat(TTR("Change %s Type"), base_type));
@@ -62,9 +351,6 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 		set_title(vformat(TTR("Create New %s"), base_type));
 		get_ok_button()->set_text(TTR("Create"));
 	}
-
-	_load_favorites_and_history();
-	_save_and_update_favorite_list();
 
 	// Restore valid window bounds or pop up at default size.
 	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "create_new_node", Rect2());
@@ -75,356 +361,13 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	}
 }
 
-void CreateDialog::_fill_type_list() {
-	List<StringName> complete_type_list;
-	ClassDB::get_class_list(&complete_type_list);
-	ScriptServer::get_global_class_list(&complete_type_list);
-
-	EditorData &ed = EditorNode::get_editor_data();
-
-	for (List<StringName>::Element *I = complete_type_list.front(); I; I = I->next()) {
-		String type = I->get();
-		if (!_should_hide_type(type)) {
-			type_list.push_back(type);
-
-			if (!ed.get_custom_types().has(type)) {
-				continue;
-			}
-
-			const Vector<EditorData::CustomType> &ct = ed.get_custom_types()[type];
-			for (int i = 0; i < ct.size(); i++) {
-				custom_type_parents[ct[i].name] = type;
-				custom_type_indices[ct[i].name] = i;
-				type_list.push_back(ct[i].name);
-			}
-		}
-	}
-	type_list.sort_custom<StringName::AlphCompare>();
-}
-
-bool CreateDialog::_is_type_preferred(const String &p_type) const {
-	if (ClassDB::class_exists(p_type)) {
-		return ClassDB::is_parent_class(p_type, preferred_search_result_type);
-	}
-
-	return EditorNode::get_editor_data().script_class_is_parent(p_type, preferred_search_result_type);
-}
-
-bool CreateDialog::_is_class_disabled_by_feature_profile(const StringName &p_class) const {
-	Ref<EditorFeatureProfile> profile = EditorFeatureProfileManager::get_singleton()->get_current_profile();
-
-	return !profile.is_null() && profile->is_class_disabled(p_class);
-}
-
-bool CreateDialog::_should_hide_type(const String &p_type) const {
-	if (_is_class_disabled_by_feature_profile(p_type)) {
-		return true;
-	}
-
-	if (base_type == "Node" && p_type.begins_with("Editor")) {
-		return true; // Do not show editor nodes.
-	}
-
-	if (p_type == base_type) {
-		return true; // Root is already added.
-	}
-
-	if (ClassDB::class_exists(p_type)) {
-		if (!ClassDB::can_instantiate(p_type)) {
-			return true; // Can't create abstract class.
-		}
-
-		if (!ClassDB::is_parent_class(p_type, base_type)) {
-			return true; // Wrong inheritance.
-		}
-
-		for (Set<StringName>::Element *E = type_blacklist.front(); E; E = E->next()) {
-			if (ClassDB::is_parent_class(p_type, E->get())) {
-				return true; // Parent type is blacklisted.
-			}
-		}
-	} else {
-		if (!EditorNode::get_editor_data().script_class_is_parent(p_type, base_type)) {
-			return true; // Wrong inheritance.
-		}
-		if (!ScriptServer::is_global_class(p_type)) {
-			return true;
-		}
-
-		String script_path = ScriptServer::get_global_class_path(p_type);
-		if (script_path.begins_with("res://addons/")) {
-			if (!EditorNode::get_singleton()->is_addon_plugin_enabled(script_path.get_slicec('/', 3))) {
-				return true; // Plugin is not enabled.
-			}
-		}
-	}
-
-	return false;
-}
-
-void CreateDialog::_update_search() {
-	search_options->clear();
-	search_options_types.clear();
-
-	TreeItem *root = search_options->create_item();
-	root->set_text(0, base_type);
-	root->set_icon(0, search_options->get_theme_icon(icon_fallback, SNAME("EditorIcons")));
-	search_options_types[base_type] = root;
-	_configure_search_option_item(root, base_type, ClassDB::class_exists(base_type));
-
-	const String search_text = search_box->get_text();
-	bool empty_search = search_text.is_empty();
-
-	// Filter all candidate results.
-	Vector<String> candidates;
-	for (List<StringName>::Element *I = type_list.front(); I; I = I->next()) {
-		if (empty_search || search_text.is_subsequence_ofi(I->get())) {
-			candidates.push_back(I->get());
-		}
-	}
-
-	// Build the type tree.
-	for (int i = 0; i < candidates.size(); i++) {
-		_add_type(candidates[i], ClassDB::class_exists(candidates[i]));
-	}
-
-	// Select the best result.
-	if (empty_search) {
-		select_type(base_type);
-	} else if (candidates.size() > 0) {
-		select_type(_top_result(candidates, search_text));
-	} else {
-		favorite->set_disabled(true);
-		help_bit->set_text(vformat(TTR("No results for \"%s\"."), search_text));
-		help_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 0.5));
-		get_ok_button()->set_disabled(true);
-		search_options->deselect_all();
-	}
-}
-
-void CreateDialog::_add_type(const String &p_type, bool p_cpp_type) {
-	if (search_options_types.has(p_type)) {
-		return;
-	}
-
-	String inherits;
-	if (p_cpp_type) {
-		inherits = ClassDB::get_parent_class(p_type);
-	} else if (ScriptServer::is_global_class(p_type)) {
-		inherits = EditorNode::get_editor_data().script_class_get_base(p_type);
-	} else {
-		inherits = custom_type_parents[p_type];
-	}
-
-	_add_type(inherits, p_cpp_type || ClassDB::class_exists(inherits));
-
-	TreeItem *item = search_options->create_item(search_options_types[inherits]);
-	search_options_types[p_type] = item;
-	_configure_search_option_item(item, p_type, p_cpp_type);
-}
-
-void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String &p_type, const bool p_cpp_type) {
-	bool script_type = ScriptServer::is_global_class(p_type);
-	if (p_cpp_type) {
-		r_item->set_text(0, p_type);
-	} else if (script_type) {
-		r_item->set_metadata(0, p_type);
-		r_item->set_text(0, p_type + " (" + ScriptServer::get_global_class_path(p_type).get_file() + ")");
-	} else {
-		r_item->set_metadata(0, custom_type_parents[p_type]);
-		r_item->set_text(0, p_type);
-	}
-
-	bool can_instantiate = (p_cpp_type && ClassDB::can_instantiate(p_type)) || !p_cpp_type;
-	if (!can_instantiate) {
-		r_item->set_custom_color(0, search_options->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
-		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, "NodeDisabled"));
-		r_item->set_selectable(0, false);
-	} else {
-		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
-	}
-
-	if (!search_box->get_text().is_empty()) {
-		r_item->set_collapsed(false);
-	} else {
-		// Don't collapse the root node or an abstract node on the first tree level.
-		bool should_collapse = p_type != base_type && (r_item->get_parent()->get_text(0) != base_type || can_instantiate);
-
-		if (should_collapse && bool(EditorSettings::get_singleton()->get("docks/scene_tree/start_create_dialog_fully_expanded"))) {
-			should_collapse = false; // Collapse all nodes anyway.
-		}
-		r_item->set_collapsed(should_collapse);
-	}
-
-	const String &description = DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description);
-	r_item->set_tooltip(0, description);
-
-	if (!p_cpp_type && !script_type) {
-		Ref<Texture2D> icon = EditorNode::get_editor_data().get_custom_types()[custom_type_parents[p_type]][custom_type_indices[p_type]].icon;
-		if (icon.is_valid()) {
-			r_item->set_icon(0, icon);
-		}
-	}
-}
-
-String CreateDialog::_top_result(const Vector<String> p_candidates, const String &p_search_text) const {
-	float highest_score = 0;
-	int highest_index = 0;
-	for (int i = 0; i < p_candidates.size(); i++) {
-		float score = _score_type(p_candidates[i].get_slicec(' ', 0), p_search_text);
-		if (score > highest_score) {
-			highest_score = score;
-			highest_index = i;
-		}
-	}
-
-	return p_candidates[highest_index];
-}
-
-float CreateDialog::_score_type(const String &p_type, const String &p_search) const {
-	float inverse_length = 1.f / float(p_type.length());
-
-	// Favor types where search term is a substring close to the start of the type.
-	float w = 0.5f;
-	int pos = p_type.findn(p_search);
-	float score = (pos > -1) ? 1.0f - w * MIN(1, 3 * pos * inverse_length) : MAX(0.f, .9f - w);
-
-	// Favor shorter items: they resemble the search term more.
-	w = 0.1f;
-	score *= (1 - w) + w * (p_search.length() * inverse_length);
-
-	score *= _is_type_preferred(p_type) ? 1.0f : 0.8f;
-
-	// Add score for being a favorite type.
-	score *= (favorite_list.find(p_type) > -1) ? 1.0f : 0.7f;
-
-	// Look through at most 5 recent items
-	bool in_recent = false;
-	for (int i = 0; i < MIN(5, recent->get_item_count()); i++) {
-		if (recent->get_item_text(i) == p_type) {
-			in_recent = true;
-			break;
-		}
-	}
-	score *= in_recent ? 1.0f : 0.8f;
-
-	return score;
-}
-
-void CreateDialog::_cleanup() {
-	type_list.clear();
-	favorite_list.clear();
-	favorites->clear();
-	recent->clear();
-	custom_type_parents.clear();
-	custom_type_indices.clear();
-}
-
-void CreateDialog::_confirmed() {
-	String selected_item = get_selected_type();
-	if (selected_item.is_empty()) {
-		return;
-	}
-
-	FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("create_recent." + base_type), FileAccess::WRITE);
-	if (f) {
-		f->store_line(selected_item);
-
-		for (int i = 0; i < MIN(32, recent->get_item_count()); i++) {
-			if (recent->get_item_text(i) != selected_item) {
-				f->store_line(recent->get_item_text(i));
-			}
-		}
-
-		memdelete(f);
-	}
-
-	// To prevent, emitting an error from the transient window (shader dialog for example) hide this dialog before emitting the "create" signal.
-	hide();
-
-	emit_signal(SNAME("create"));
-	_cleanup();
-}
-
-void CreateDialog::_text_changed(const String &p_newtext) {
-	_update_search();
-}
-
-void CreateDialog::_sbox_input(const Ref<InputEvent> &p_ie) {
-	Ref<InputEventKey> k = p_ie;
-	if (k.is_valid()) {
-		switch (k->get_keycode()) {
-			case Key::UP:
-			case Key::DOWN:
-			case Key::PAGEUP:
-			case Key::PAGEDOWN: {
-				search_options->gui_input(k);
-				search_box->accept_event();
-			} break;
-			default:
-				break;
-		}
-	}
-}
-
-void CreateDialog::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			connect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
-			search_box->set_right_icon(search_options->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
-			search_box->set_clear_button_enabled(true);
-			favorite->set_icon(search_options->get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")));
-		} break;
-		case NOTIFICATION_EXIT_TREE: {
-			disconnect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
-		} break;
-		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (is_visible()) {
-				search_box->call_deferred(SNAME("grab_focus")); // still not visible
-				search_box->select_all();
-			} else {
-				EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "create_new_node", Rect2(get_position(), get_size()));
-			}
-		} break;
-	}
-}
-
-void CreateDialog::select_type(const String &p_type) {
-	if (!search_options_types.has(p_type)) {
-		return;
-	}
-
-	TreeItem *to_select = search_options_types[p_type];
-	to_select->select(0);
-	search_options->scroll_to_item(to_select);
-
-	if (EditorHelp::get_doc_data()->class_list.has(p_type) && !DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description).is_empty()) {
-		// Display both class name and description, since the help bit may be displayed
-		// far away from the location (especially if the dialog was resized to be taller).
-		help_bit->set_text(vformat("[b]%s[/b]: %s", p_type, DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description)));
-		help_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 1));
-	} else {
-		// Use nested `vformat()` as translators shouldn't interfere with BBCode tags.
-		help_bit->set_text(vformat(TTR("No description available for %s."), vformat("[b]%s[/b]", p_type)));
-		help_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 0.5));
-	}
-
-	favorite->set_disabled(false);
-	favorite->set_pressed(favorite_list.find(p_type) != -1);
-	get_ok_button()->set_disabled(false);
-}
-
 String CreateDialog::get_selected_type() {
-	TreeItem *selected = search_options->get_selected();
-	if (!selected) {
-		return String();
-	}
-
-	return selected->get_text(0);
+	TreeItem *selected = result_tree->get_selected();
+	return selected ? selected->get_text(0) : String();
 }
 
 Variant CreateDialog::instance_selected() {
-	TreeItem *selected = search_options->get_selected();
+	TreeItem *selected = result_tree->get_selected();
 
 	if (!selected) {
 		return Variant();
@@ -461,9 +404,285 @@ Variant CreateDialog::instance_selected() {
 	return obj;
 }
 
+Vector<CreateDialogCandidate> CreateDialog::_compute_candidates() {
+	List<StringName> complete_type_list;
+	ClassDB::get_class_list(&complete_type_list);
+	ScriptServer::get_global_class_list(&complete_type_list);
+
+	EditorData &ed = EditorNode::get_editor_data();
+
+	Vector<CreateDialogCandidate> candidates;
+
+	for (List<StringName>::Element *I = complete_type_list.front(); I; I = I->next()) {
+		String type = I->get();
+		if (!_should_hide_type(type)) {
+			const bool is_preferred_type = ClassDB::class_exists(type) ? ClassDB::is_parent_class(type, preferred_search_result_type) : ed.script_class_is_parent(type, preferred_search_result_type);
+
+			candidates.push_back(CreateDialogCandidate(type, is_preferred_type, favorite_list->has_favorite(type), history_list->has_history(type)));
+
+			if (ed.get_custom_types().has(type)) {
+				const Vector<EditorData::CustomType> &custom_types = ed.get_custom_types()[type];
+				for (int i = 0; i < custom_types.size(); i++) {
+					const String custom_type = custom_types[i].name;
+					candidates.push_back(CreateDialogCandidate(custom_type, is_preferred_type, favorite_list->has_favorite(custom_type), history_list->has_history(custom_type)));
+
+					custom_type_parents[custom_type] = type;
+					custom_type_indices[custom_type] = i;
+				}
+			}
+		}
+	}
+	candidates.sort_custom<CandidateAlphComparator>();
+	return candidates;
+}
+
+bool CreateDialog::_should_hide_type(const String &p_type) const {
+	if (EditorFeatureProfileManager::get_singleton()->is_class_disabled(p_type)) {
+		return true;
+	}
+
+	if (base_type == "Node" && p_type.begins_with("Editor")) {
+		return true; // Do not show editor nodes.
+	}
+
+	if (ClassDB::class_exists(p_type)) {
+		if (!ClassDB::can_instantiate(p_type)) {
+			return true; // Can't create abstract class.
+		}
+
+		if (!ClassDB::is_parent_class(p_type, base_type)) {
+			return true; // Wrong inheritance.
+		}
+
+		for (Set<StringName>::Element *E = blacklisted_types.front(); E; E = E->next()) {
+			if (ClassDB::is_parent_class(p_type, E->get())) {
+				return true; // Parent type is blacklisted.
+			}
+		}
+	} else {
+		if (!EditorNode::get_editor_data().script_class_is_parent(p_type, base_type)) {
+			return true; // Wrong inheritance.
+		}
+		if (!ScriptServer::is_global_class(p_type)) {
+			return true;
+		}
+
+		String script_path = ScriptServer::get_global_class_path(p_type);
+		if (script_path.begins_with("res://addons/")) {
+			if (!EditorNode::get_singleton()->is_addon_plugin_enabled(script_path.get_slicec('/', 3))) {
+				return true; // Plugin is not enabled.
+			}
+		}
+	}
+
+	return false;
+}
+
+void CreateDialog::_update_result_tree() {
+	result_tree->clear();
+	result_tree_types.clear();
+
+	const String search_text = search_box->get_text();
+	bool empty_search = search_text.is_empty();
+
+	Vector<CreateDialogCandidate> valid_candidates;
+	for (int i = 0; i < candidates.size(); i++) {
+		CreateDialogCandidate c = candidates[i];
+		if (empty_search || c.is_valid(search_text)) {
+			valid_candidates.push_back(c);
+		}
+	}
+
+	if (valid_candidates.size() > 0) {
+		// Build the type tree and select the best result.
+		result_tree_types[base_type] = _create_type(base_type, nullptr, true);
+		for (int i = 0; i < valid_candidates.size(); i++) {
+			const String type = valid_candidates[i].get_type();
+			_add_type(type, ClassDB::class_exists(type));
+		}
+
+		_select_type(empty_search ? base_type : _top_result(valid_candidates, search_text));
+	} else {
+		result_tree->deselect_all();
+		favorite->set_disabled(true);
+		help_bit->set_text(vformat(TTR("No results for \"%s\"."), search_text));
+		help_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 0.5));
+
+		get_ok_button()->set_disabled(true);
+	}
+}
+
+void CreateDialog::_add_type(const String &p_type, bool p_cpp_type) {
+	if (result_tree_types.has(p_type)) {
+		return;
+	}
+
+	String parent_type;
+	if (p_cpp_type) {
+		parent_type = ClassDB::get_parent_class(p_type);
+	} else if (ScriptServer::is_global_class(p_type)) {
+		parent_type = EditorNode::get_editor_data().script_class_get_base(p_type);
+	} else {
+		parent_type = custom_type_parents[p_type];
+	}
+
+	// First create a branch to the root type.
+	_add_type(parent_type, p_cpp_type || ClassDB::class_exists(parent_type));
+
+	// Once a branch has been constructed, add the type as a child.
+	result_tree_types[p_type] = _create_type(p_type, result_tree_types[parent_type], p_cpp_type);
+}
+
+TreeItem *CreateDialog::_create_type(const String &p_type, TreeItem *p_parent_type, const bool p_cpp_type) {
+	TreeItem *item = result_tree->create_item(p_parent_type);
+
+	bool script_type = ScriptServer::is_global_class(p_type);
+	if (p_cpp_type) {
+		item->set_text(0, p_type);
+	} else if (script_type) {
+		item->set_metadata(0, p_type);
+		item->set_text(0, p_type + " (" + ScriptServer::get_global_class_path(p_type).get_file() + ")");
+	} else {
+		item->set_metadata(0, custom_type_parents[p_type]);
+		item->set_text(0, p_type);
+	}
+
+	bool can_instantiate = (p_cpp_type && ClassDB::can_instantiate(p_type)) || !p_cpp_type;
+	if (!can_instantiate) {
+		item->set_custom_color(0, result_tree->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
+		item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, "NodeDisabled"));
+		item->set_selectable(0, false);
+	} else {
+		item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
+	}
+
+	if (!search_box->get_text().is_empty()) {
+		item->set_collapsed(false);
+	} else {
+		// Don't collapse the root node or an abstract node on the first tree level.
+		bool should_collapse = p_type != base_type && (item->get_parent()->get_text(0) != base_type || can_instantiate);
+
+		if (should_collapse && bool(EditorSettings::get_singleton()->get("docks/scene_tree/start_create_dialog_fully_expanded"))) {
+			should_collapse = false;
+		}
+		item->set_collapsed(should_collapse);
+	}
+
+	const String &description = DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description);
+	item->set_tooltip(0, description);
+
+	if (!p_cpp_type && !script_type) {
+		Ref<Texture2D> icon = EditorNode::get_editor_data().get_custom_types()[custom_type_parents[p_type]][custom_type_indices[p_type]].icon;
+		if (icon.is_valid()) {
+			item->set_icon(0, icon);
+		}
+	}
+
+	return item;
+}
+
+String CreateDialog::_top_result(const Vector<CreateDialogCandidate> p_candidates, const String &p_query) const {
+	float highest_score = 0;
+	int highest_index = 0;
+	for (int i = 0; i < p_candidates.size(); i++) {
+		float score = p_candidates[i].compute_score(p_query);
+		if (score > highest_score) {
+			highest_score = score;
+			highest_index = i;
+			if (highest_score == 1.0f) {
+				break; // Cannot find a better match.
+			}
+		}
+	}
+
+	return p_candidates[highest_index].get_type();
+}
+
+void CreateDialog::_confirmed() {
+	String selected_item = get_selected_type();
+	if (selected_item.is_empty()) {
+		return;
+	}
+
+	history_list->save_to_history(base_type, selected_item);
+
+	// To prevent, emitting an error from the transient window (shader dialog for example) hide this dialog before emitting the "create" signal.
+	hide();
+
+	emit_signal(SNAME("create"));
+	_cleanup();
+}
+
+void CreateDialog::_text_changed(const String &p_newtext) {
+	_update_result_tree();
+}
+
+void CreateDialog::_search_box_input(const Ref<InputEvent> &p_ie) {
+	Ref<InputEventKey> k = p_ie;
+	if (k.is_valid()) {
+		switch (k->get_keycode()) {
+			case Key::UP:
+			case Key::DOWN:
+			case Key::PAGEUP:
+			case Key::PAGEDOWN: {
+				result_tree->gui_input(k);
+				search_box->accept_event();
+			} break;
+			default:
+				break;
+		}
+	}
+}
+
+void CreateDialog::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			connect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
+			search_box->set_right_icon(result_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+			search_box->set_clear_button_enabled(true);
+			favorite->set_icon(result_tree->get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")));
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			disconnect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
+		} break;
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible()) {
+				search_box->call_deferred(SNAME("grab_focus")); // still not visible
+				search_box->select_all();
+			} else {
+				EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "create_new_node", Rect2(get_position(), get_size()));
+			}
+		} break;
+	}
+}
+
+void CreateDialog::_select_type(const String &p_type) {
+	if (!result_tree_types.has(p_type)) {
+		return;
+	}
+
+	TreeItem *to_select = result_tree_types[p_type];
+	to_select->select(0);
+	result_tree->scroll_to_item(to_select);
+
+	if (EditorHelp::get_doc_data()->class_list.has(p_type) && !DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description).is_empty()) {
+		// Display both class name and description, since the help bit may be displayed
+		// far away from the location (especially if the dialog was resized to be taller).
+		help_bit->set_text(vformat("[b]%s[/b]: %s", p_type, DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description)));
+		help_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 1));
+	} else {
+		// Use nested `vformat()` as translators shouldn't interfere with BBCode tags.
+		help_bit->set_text(vformat(TTR("No description available for %s."), vformat("[b]%s[/b]", p_type)));
+		help_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 0.5));
+	}
+
+	favorite->set_disabled(false);
+	favorite->set_pressed(favorite_list->has_favorite(p_type));
+	get_ok_button()->set_disabled(false);
+}
+
 void CreateDialog::_item_selected() {
-	String name = get_selected_type();
-	select_type(name);
+	_select_type(get_selected_type());
 }
 
 void CreateDialog::_hide_requested() {
@@ -475,39 +694,29 @@ void CreateDialog::cancel_pressed() {
 }
 
 void CreateDialog::_favorite_toggled() {
-	TreeItem *item = search_options->get_selected();
+	TreeItem *item = result_tree->get_selected();
 	if (!item) {
 		return;
 	}
 
-	String name = item->get_text(0);
-
-	if (favorite_list.find(name) == -1) {
-		favorite_list.push_back(name);
-		favorite->set_pressed(true);
-	} else {
-		favorite_list.erase(name);
-		favorite->set_pressed(false);
-	}
-
-	_save_and_update_favorite_list();
+	favorite->set_pressed(favorite_list->toggle_favorite(item->get_text(0)));
 }
 
 void CreateDialog::_history_selected(int p_idx) {
-	search_box->set_text(recent->get_item_text(p_idx).get_slicec(' ', 0));
-	favorites->deselect_all();
-	_update_search();
+	search_box->set_text(history_list->get_item_text(p_idx).get_slicec(' ', 0));
+	favorite_list->deselect_all();
+	_update_result_tree();
 }
 
 void CreateDialog::_favorite_selected() {
-	TreeItem *item = favorites->get_selected();
+	TreeItem *item = favorite_list->get_selected();
 	if (!item) {
 		return;
 	}
 
 	search_box->set_text(item->get_text(0).get_slicec(' ', 0));
-	recent->deselect_all();
-	_update_search();
+	history_list->deselect_all();
+	_update_result_tree();
 }
 
 void CreateDialog::_history_activated(int p_idx) {
@@ -520,144 +729,20 @@ void CreateDialog::_favorite_activated() {
 	_confirmed();
 }
 
-Variant CreateDialog::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	TreeItem *ti = favorites->get_item_at_position(p_point);
-	if (ti) {
-		Dictionary d;
-		d["type"] = "create_favorite_drag";
-		d["class"] = ti->get_text(0);
+void CreateDialog::_cleanup() {
+	candidates.clear();
+	custom_type_parents.clear();
+	custom_type_indices.clear();
 
-		Button *tb = memnew(Button);
-		tb->set_flat(true);
-		tb->set_icon(ti->get_icon(0));
-		tb->set_text(ti->get_text(0));
-		favorites->set_drag_preview(tb);
-
-		return d;
+	bool favorites_changed = favorite_list->save_favorites(base_type);
+	if (favorites_changed) {
+		emit_signal(SNAME("favorites_updated"));
 	}
 
-	return Variant();
-}
-
-bool CreateDialog::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-	Dictionary d = p_data;
-	if (d.has("type") && String(d["type"]) == "create_favorite_drag") {
-		favorites->set_drop_mode_flags(Tree::DROP_MODE_INBETWEEN);
-		return true;
-	}
-
-	return false;
-}
-
-void CreateDialog::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	Dictionary d = p_data;
-
-	TreeItem *ti = favorites->get_item_at_position(p_point);
-	if (!ti) {
-		return;
-	}
-
-	String drop_at = ti->get_text(0);
-	int ds = favorites->get_drop_section_at_position(p_point);
-
-	int drop_idx = favorite_list.find(drop_at);
-	if (drop_idx < 0) {
-		return;
-	}
-
-	String type = d["class"];
-
-	int from_idx = favorite_list.find(type);
-	if (from_idx < 0) {
-		return;
-	}
-
-	if (drop_idx == from_idx) {
-		ds = -1; //cause it will be gone
-	} else if (drop_idx > from_idx) {
-		drop_idx--;
-	}
-
-	favorite_list.remove_at(from_idx);
-
-	if (ds < 0) {
-		favorite_list.insert(drop_idx, type);
-	} else {
-		if (drop_idx >= favorite_list.size() - 1) {
-			favorite_list.push_back(type);
-		} else {
-			favorite_list.insert(drop_idx + 1, type);
-		}
-	}
-
-	_save_and_update_favorite_list();
-}
-
-void CreateDialog::_save_and_update_favorite_list() {
-	favorites->clear();
-	TreeItem *root = favorites->create_item();
-
-	FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("favorites." + base_type), FileAccess::WRITE);
-	if (f) {
-		for (int i = 0; i < favorite_list.size(); i++) {
-			String l = favorite_list[i];
-			String name = l.get_slicec(' ', 0);
-			if (!(ClassDB::class_exists(name) || ScriptServer::is_global_class(name))) {
-				continue;
-			}
-			f->store_line(l);
-
-			if (_is_class_disabled_by_feature_profile(name)) {
-				continue;
-			}
-
-			TreeItem *ti = favorites->create_item(root);
-			ti->set_text(0, l);
-			ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(name, icon_fallback));
-		}
-		memdelete(f);
-	}
-
-	emit_signal(SNAME("favorites_updated"));
-}
-
-void CreateDialog::_load_favorites_and_history() {
-	String dir = EditorSettings::get_singleton()->get_project_settings_dir();
-	FileAccess *f = FileAccess::open(dir.plus_file("create_recent." + base_type), FileAccess::READ);
-	if (f) {
-		while (!f->eof_reached()) {
-			String l = f->get_line().strip_edges();
-			String name = l.get_slicec(' ', 0);
-
-			if ((ClassDB::class_exists(name) || ScriptServer::is_global_class(name)) && !_is_class_disabled_by_feature_profile(name)) {
-				recent->add_item(l, EditorNode::get_singleton()->get_class_icon(name, icon_fallback));
-			}
-		}
-
-		memdelete(f);
-	}
-
-	f = FileAccess::open(dir.plus_file("favorites." + base_type), FileAccess::READ);
-	if (f) {
-		while (!f->eof_reached()) {
-			String l = f->get_line().strip_edges();
-
-			if (!l.is_empty()) {
-				favorite_list.push_back(l);
-			}
-		}
-
-		memdelete(f);
-	}
+	history_list->clear_history();
 }
 
 void CreateDialog::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_save_and_update_favorite_list"), &CreateDialog::_save_and_update_favorite_list);
-
-	ClassDB::bind_method("_get_drag_data_fw", &CreateDialog::get_drag_data_fw);
-	ClassDB::bind_method("_can_drop_data_fw", &CreateDialog::can_drop_data_fw);
-	ClassDB::bind_method("_drop_data_fw", &CreateDialog::drop_data_fw);
-
 	ADD_SIGNAL(MethodInfo("create"));
 	ADD_SIGNAL(MethodInfo("favorites_updated"));
 }
@@ -666,8 +751,8 @@ CreateDialog::CreateDialog() {
 	base_type = "Object";
 	preferred_search_result_type = "";
 
-	type_blacklist.insert("PluginScript"); // PluginScript must be initialized before use, which is not possible here.
-	type_blacklist.insert("ScriptCreateDialog"); // This is an exposed editor Node that doesn't have an Editor prefix.
+	blacklisted_types.insert("PluginScript"); // PluginScript must be initialized before use, which is not possible here.
+	blacklisted_types.insert("ScriptCreateDialog"); // This is an exposed editor Node that doesn't have an Editor prefix.
 
 	HSplitContainer *hsc = memnew(HSplitContainer);
 	add_child(hsc);
@@ -675,35 +760,29 @@ CreateDialog::CreateDialog() {
 	VSplitContainer *vsc = memnew(VSplitContainer);
 	hsc->add_child(vsc);
 
-	VBoxContainer *fav_vb = memnew(VBoxContainer);
-	fav_vb->set_custom_minimum_size(Size2(150, 100) * EDSCALE);
-	fav_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	vsc->add_child(fav_vb);
+	{
+		VBoxContainer *fav_vb = memnew(VBoxContainer);
+		fav_vb->set_custom_minimum_size(Size2(150, 100) * EDSCALE);
+		fav_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		vsc->add_child(fav_vb);
 
-	favorites = memnew(Tree);
-	favorites->set_hide_root(true);
-	favorites->set_hide_folding(true);
-	favorites->set_allow_reselect(true);
-	favorites->connect("cell_selected", callable_mp(this, &CreateDialog::_favorite_selected));
-	favorites->connect("item_activated", callable_mp(this, &CreateDialog::_favorite_activated));
-	favorites->add_theme_constant_override("draw_guides", 1);
-#ifndef _MSC_VER
-#warning cannot forward drag data to a non control, must be fixed
-#endif
-	//favorites->set_drag_forwarding(this);
-	fav_vb->add_margin_child(TTR("Favorites:"), favorites, true);
+		favorite_list = memnew(FavoriteList);
+		favorite_list->connect("cell_selected", callable_mp(this, &CreateDialog::_favorite_selected));
+		favorite_list->connect("item_activated", callable_mp(this, &CreateDialog::_favorite_activated));
+		fav_vb->add_margin_child(TTR("Favorites:"), favorite_list, true);
+	}
 
-	VBoxContainer *rec_vb = memnew(VBoxContainer);
-	vsc->add_child(rec_vb);
-	rec_vb->set_custom_minimum_size(Size2(150, 100) * EDSCALE);
-	rec_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	{
+		VBoxContainer *rec_vb = memnew(VBoxContainer);
+		vsc->add_child(rec_vb);
+		rec_vb->set_custom_minimum_size(Size2(150, 100) * EDSCALE);
+		rec_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
-	recent = memnew(ItemList);
-	rec_vb->add_margin_child(TTR("Recent:"), recent, true);
-	recent->set_allow_reselect(true);
-	recent->connect("item_selected", callable_mp(this, &CreateDialog::_history_selected));
-	recent->connect("item_activated", callable_mp(this, &CreateDialog::_history_activated));
-	recent->add_theme_constant_override("draw_guides", 1);
+		history_list = memnew(HistoryList);
+		history_list->connect("item_selected", callable_mp(this, &CreateDialog::_history_selected));
+		history_list->connect("item_activated", callable_mp(this, &CreateDialog::_history_activated));
+		rec_vb->add_margin_child(TTR("Recent:"), history_list, true);
+	}
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	vbc->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
@@ -713,7 +792,7 @@ CreateDialog::CreateDialog() {
 	search_box = memnew(LineEdit);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search_box->connect("text_changed", callable_mp(this, &CreateDialog::_text_changed));
-	search_box->connect("gui_input", callable_mp(this, &CreateDialog::_sbox_input));
+	search_box->connect("gui_input", callable_mp(this, &CreateDialog::_search_box_input));
 
 	HBoxContainer *search_hb = memnew(HBoxContainer);
 	search_hb->add_child(search_box);
@@ -725,10 +804,10 @@ CreateDialog::CreateDialog() {
 	search_hb->add_child(favorite);
 	vbc->add_margin_child(TTR("Search:"), search_hb);
 
-	search_options = memnew(Tree);
-	search_options->connect("item_activated", callable_mp(this, &CreateDialog::_confirmed));
-	search_options->connect("cell_selected", callable_mp(this, &CreateDialog::_item_selected));
-	vbc->add_margin_child(TTR("Matches:"), search_options, true);
+	result_tree = memnew(Tree);
+	result_tree->connect("item_activated", callable_mp(this, &CreateDialog::_confirmed));
+	result_tree->connect("cell_selected", callable_mp(this, &CreateDialog::_item_selected));
+	vbc->add_margin_child(TTR("Matches:"), result_tree, true);
 
 	help_bit = memnew(EditorHelpBit);
 	help_bit->connect("request_hide", callable_mp(this, &CreateDialog::_hide_requested));

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -38,70 +38,121 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/tree.h"
 
+class CreateDialogCandidate {
+	String type;
+	String wb_chars;
+	bool is_preferred_type = false;
+	bool in_favorites = false;
+	bool in_recent = false;
+
+	String _compute_word_boundary_characters() const;
+
+	float _word_score(const String &p_word, const String &p_query) const;
+
+public:
+	bool is_valid(const String &p_query) const;
+	float compute_score(const String &p_query) const;
+
+	String get_type() const { return type; }
+
+	CreateDialogCandidate() {}
+	CreateDialogCandidate(const String &p_type, const bool p_is_preferred_type, const bool in_favorites, const bool in_recent);
+};
+
+class FavoriteList : public Tree {
+	GDCLASS(FavoriteList, Tree);
+
+	Vector<String> favorites;
+
+	String icon_fallback;
+	bool favorites_changed = false;
+
+	Variant _get_drag_data_fw(const Point2 &p_point, Control *p_from);
+	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
+	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
+
+	void _update_tree();
+
+protected:
+	void _notification(int p_what) {}
+	static void _bind_methods();
+
+public:
+	void load_favorites(const String &p_file_id, const String &p_icon_fallback);
+	bool toggle_favorite(const String &p_type);
+	bool has_favorite(const String &p_type) { return favorites.has(p_type); }
+	bool save_favorites(const String &p_file_id);
+
+	FavoriteList();
+};
+
+class HistoryList : public ItemList {
+	GDCLASS(HistoryList, ItemList);
+
+	Set<String> history;
+
+public:
+	void load_history(const String &p_file_id, const String &p_icon_fallback);
+	void save_to_history(const String &p_file_id, const String &p_item);
+	bool has_history(const String &p_type) const { return history.has(p_type); };
+	void clear_history();
+
+	HistoryList();
+};
+
 class CreateDialog : public ConfirmationDialog {
 	GDCLASS(CreateDialog, ConfirmationDialog);
 
 	LineEdit *search_box;
-	Tree *search_options;
+	Button *favorite;
+	Tree *result_tree;
+	EditorHelpBit *help_bit;
+
+	FavoriteList *favorite_list;
+	HistoryList *history_list;
 
 	String base_type;
 	String icon_fallback;
 	String preferred_search_result_type;
 
-	Button *favorite;
-	Vector<String> favorite_list;
-	Tree *favorites;
-	ItemList *recent;
-	EditorHelpBit *help_bit;
+	Vector<CreateDialogCandidate> candidates;
+	Set<StringName> blacklisted_types;
 
-	HashMap<String, TreeItem *> search_options_types;
+	HashMap<String, TreeItem *> result_tree_types;
 	HashMap<String, String> custom_type_parents;
 	HashMap<String, int> custom_type_indices;
-	List<StringName> type_list;
-	Set<StringName> type_blacklist;
 
-	void _update_search();
+	Vector<CreateDialogCandidate> _compute_candidates();
 	bool _should_hide_type(const String &p_type) const;
-	void _add_type(const String &p_current, bool p_cpp_type);
-	void _configure_search_option_item(TreeItem *r_item, const String &p_type, const bool p_cpp_type);
-	String _top_result(const Vector<String> p_candidates, const String &p_search_text) const;
-	float _score_type(const String &p_type, const String &p_search) const;
-	bool _is_type_preferred(const String &p_type) const;
 
-	void _fill_type_list();
-	void _cleanup();
+	void _update_result_tree();
+	void _add_type(const String &p_type, bool p_cpp_type);
+	TreeItem *_create_type(const String &p_type, TreeItem *p_parent_type, const bool p_cpp_type);
+	void _select_type(const String &p_type);
 
-	void _sbox_input(const Ref<InputEvent> &p_ie);
+	String _top_result(const Vector<CreateDialogCandidate> p_candidates, const String &p_query) const;
+
+	void _search_box_input(const Ref<InputEvent> &p_ie);
 	void _text_changed(const String &p_newtext);
-	void select_type(const String &p_type);
 	void _item_selected();
-	void _hide_requested();
-
-	void _confirmed();
-	virtual void cancel_pressed() override;
-
 	void _favorite_toggled();
-
+	void _hide_requested();
+	void _confirmed();
 	void _history_selected(int p_idx);
-	void _favorite_selected();
-
 	void _history_activated(int p_idx);
+	void _favorite_selected();
 	void _favorite_activated();
 
-	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
-	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
-	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
+	virtual void cancel_pressed() override;
 
-	bool _is_class_disabled_by_feature_profile(const StringName &p_class) const;
-	void _load_favorites_and_history();
+	void _cleanup();
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	void _save_and_update_favorite_list();
-
 public:
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_select_type = "Node");
 	Variant instance_selected();
 	String get_selected_type();
 
@@ -109,9 +160,6 @@ public:
 	String get_base_type() const { return base_type; }
 
 	void set_preferred_search_result_type(const String &p_preferred_type) { preferred_search_result_type = p_preferred_type; }
-	String get_preferred_search_result_type() { return preferred_search_result_type; }
-
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_select_type = "Node");
 
 	CreateDialog();
 };

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -844,6 +844,10 @@ Ref<EditorFeatureProfile> EditorFeatureProfileManager::get_current_profile() {
 	return current;
 }
 
+bool EditorFeatureProfileManager::is_class_disabled(const StringName &p_class) const {
+	return !current.is_null() && current->is_class_disabled(p_class);
+}
+
 EditorFeatureProfileManager *EditorFeatureProfileManager::singleton = nullptr;
 
 void EditorFeatureProfileManager::_bind_methods() {

--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -176,6 +176,7 @@ protected:
 public:
 	Ref<EditorFeatureProfile> get_current_profile();
 	void notify_changed();
+	bool is_class_disabled(const StringName &p_class) const;
 
 	static EditorFeatureProfileManager *get_singleton() { return singleton; }
 	EditorFeatureProfileManager();

--- a/tests/editor/test_create_dialog_candidate.h
+++ b/tests/editor/test_create_dialog_candidate.h
@@ -1,0 +1,172 @@
+/*************************************************************************/
+/*  test_create_dialog_candidate.h                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_CREATE_DIALOG_CANDIDATE_H
+#define TEST_CREATE_DIALOG_CANDIDATE_H
+
+#include "thirdparty/doctest/doctest.h"
+
+#include "editor/create_dialog.h"
+
+TEST_SUITE("[Candidate] isValid") {
+	TEST_CASE("Substring match") {
+		SUBCASE("Candidate with matching query.") {
+			CreateDialogCandidate candidate("Node", false, false, false);
+
+			CHECK(candidate.is_valid("node"));
+		}
+
+		SUBCASE("Should be valid with query should be case insensitive.") {
+			CreateDialogCandidate candidate("Node", false, false, false);
+
+			CHECK(candidate.is_valid("nODe"));
+		}
+
+		SUBCASE("Should be valid with query as a substring starting at the beginning.") {
+			CreateDialogCandidate candidate("Node", false, false, false);
+
+			CHECK(candidate.is_valid("nod"));
+		}
+
+		SUBCASE("Should be valid with query as a substring in the middle.") {
+			CreateDialogCandidate candidate("GraphNode", false, false, false);
+
+			CHECK(candidate.is_valid("nod"));
+		}
+
+		SUBCASE("Should be invalid with subequence query.") {
+			CreateDialogCandidate candidate("GraphNode", false, false, false);
+
+			CHECK(!candidate.is_valid("grph"));
+		}
+
+		SUBCASE("Should be invalid with excessive query.") {
+			CreateDialogCandidate candidate("GraphNode", false, false, false);
+
+			CHECK(!candidate.is_valid("grph"));
+		}
+	}
+
+	TEST_CASE("Word boundary") {
+		SUBCASE("Should be valid with subsequence match based on word boundary characters.") {
+			CreateDialogCandidate candidate("AnimationPlayer", false, false, false);
+
+			CHECK(candidate.is_valid("ap"));
+		}
+
+		SUBCASE("Should be valid with digit as word boundary character.") {
+			CreateDialogCandidate candidate("Node3D", false, false, false);
+
+			CHECK(candidate.is_valid("N3"));
+		}
+
+		SUBCASE("Should be invalid for query with non-word boundary matches.") {
+			CreateDialogCandidate candidate("AnimationPlayer", false, false, false);
+
+			CHECK(!candidate.is_valid("apl"));
+		}
+
+		SUBCASE("Should be valid with subsequence match on word boundary characters.") {
+			CreateDialogCandidate candidate("CharacterBody3D", false, false, false);
+
+			CHECK(candidate.is_valid("cbd"));
+		}
+
+		SUBCASE("Should be invalid without word boundary overlap.") {
+			CreateDialogCandidate candidate("AnimationPlayer", false, false, false);
+
+			CHECK(!candidate.is_valid("ai"));
+		}
+	}
+}
+
+TEST_SUITE("[Candidate] Score") {
+	TEST_CASE("Regular query") {
+		SUBCASE("Candidate with matching query should have maximum score.") {
+			CreateDialogCandidate candidate("Node", false, false, false);
+
+			CHECK(candidate.compute_score("node") == 1.0);
+		}
+
+		SUBCASE("Candidate which was a query match earlier in the string should score higher.") {
+			CreateDialogCandidate candidate("NodeGraph", false, false, false);
+			CreateDialogCandidate candidate2("GraphNode", false, false, false);
+
+			String query = "node";
+			CHECK(candidate.compute_score(query) > candidate2.compute_score(query));
+		}
+
+		SUBCASE("Candidate with shorter name should score higher.") {
+			CreateDialogCandidate candidate("Path2D", false, false, false);
+			CreateDialogCandidate candidate2("PathFollow2D", false, false, false);
+
+			String query = "path";
+			CHECK(candidate.compute_score(query) > candidate2.compute_score(query));
+		}
+	}
+
+	TEST_CASE("Word boundary query") {
+		SUBCASE("Substring match in the middle should score lower than word boundary match.") {
+			CreateDialogCandidate candidate("CheckBox", false, false, false);
+			CreateDialogCandidate candidate2("StaticBody", false, false, false);
+
+			String query = "cb";
+			CHECK(candidate.compute_score(query) > candidate2.compute_score(query));
+		}
+	}
+
+	TEST_CASE("Secondary features") {
+		SUBCASE("Candidate with preferred type, should score higher.") {
+			CreateDialogCandidate candidate("Node3D", true, false, false);
+			CreateDialogCandidate candidate2("Node2D", false, false, false);
+
+			String query = "node";
+			CHECK(candidate.compute_score(query) > candidate2.compute_score(query));
+		}
+
+		SUBCASE("Candidate which is a favorite should score higher.") {
+			CreateDialogCandidate candidate("Node3D", false, true, false);
+			CreateDialogCandidate candidate2("Node2D", false, false, false);
+
+			String query = "node";
+			CHECK(candidate.compute_score(query) > candidate2.compute_score(query));
+		}
+
+		SUBCASE("Candidate which was recently created should score higher.") {
+			CreateDialogCandidate candidate("Node3D", false, false, true);
+			CreateDialogCandidate candidate2("Node2D", false, false, false);
+
+			String query = "node";
+			CHECK(candidate.compute_score(query) > candidate2.compute_score(query));
+		}
+	}
+}
+
+#endif // TEST_CREATE_DIALOG_CANDIDATE_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -68,6 +68,7 @@
 #include "tests/core/variant/test_array.h"
 #include "tests/core/variant/test_dictionary.h"
 #include "tests/core/variant/test_variant.h"
+#include "tests/editor/test_create_dialog_candidate.h"
 #include "tests/scene/test_code_edit.h"
 #include "tests/scene/test_curve.h"
 #include "tests/scene/test_gradient.h"


### PR DESCRIPTION
Fixes #46427
Fixes #51632

Implements a substring + word boundary filter to replace the subsequence filter in the Create Dialog. This change lowers the number of spurious results when typing a query to select a particular node.

#### About the issue

A glaring example of the issues with just subsequence matching is the query "line", which currently matches Line2D, but also likely irrelevant types like MultiMeshInstance and CollisionShape3D. On the other hand, without this filter, we can not quickly select a 2D or 3D node without typing the entire name of the type. 

One user suggested looking into word boundary matching to solve the issue. The result of a word boundary filter is a subset of the results from a subsequence filter, as it only matches on word boundary characters (in this case: capital letters and digits). Together with a substring filter, this reduces the number of unwanted results, and improves the search ranking. Now, the filter is limited in the sense that you have to either use the word boundary characters, or use regular substring matching. I wasn't sure if being able to combine these in one query was necessary and as it can add back spurious results I decided not to implement it yet. See below for more examples and maybe try it out and see.

#### Notes

An issue preventing the user from instantiating the Node node from the history list was fixed. I have also taken the opportunity to  refactor the code a bit more, which also allowed me to write tests for the new scoring function. In order to extract word boundary characters, I needed access to some char functions that were not exposed. These functions are reimplemented all over the place and should now probably use the one in `ustring.h`. Also, if reordering the favorite section doesn't work, that's because it seems to be broken currently in master.

<details><summary>Examples comparing against 3.3.2 behaviour</summary>

![vergelijking](https://user-images.githubusercontent.com/25907608/129782929-2f7fdd86-3cb9-4710-ad9c-b829a7ce08a3.png)

</details>