### PR TITLE
Fixed crash when removing some shortcuts from Editor Settings

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1612,7 +1612,7 @@ void EditorSettings::set_builtin_action_override(const String &p_name, const Arr
 	}
 
 	// Update the shortcut (if it is used somewhere in the editor) to be the first event of the new list.
-	if (shortcuts.has(p_name)) {
+	if (shortcuts.has(p_name) && !event_list.is_empty()) {
 		shortcuts[p_name]->set_event(event_list.front()->get());
 	}
 }


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes: #51794