### PR TITLE
Add an option to preview the 3D scene as a background to the 2D editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4846,6 +4846,13 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(PREVIEW_CANVAS_SCALE), preview);
 
 		} break;
+		case PREVIEW_3D_SCENE_BACKGROUND: {
+			bool enable_3d = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(PREVIEW_3D_SCENE_BACKGROUND));
+			enable_3d = !enable_3d;
+			RenderingServer::get_singleton()->viewport_set_disable_3d(EditorNode::get_singleton()->get_scene_root()->get_viewport_rid(), !enable_3d);
+			view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(PREVIEW_3D_SCENE_BACKGROUND), enable_3d);
+
+		} break;
 		case SKELETON_MAKE_BONES: {
 			HashMap<Node *, Object *> &selection = editor_selection->get_selection();
 			Node *editor_root = get_tree()->get_edited_scene_root();
@@ -5662,6 +5669,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/clear_guides", TTRC("Clear Guides")), CLEAR_GUIDES);
 	p->add_separator();
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/preview_canvas_scale", TTRC("Preview Canvas Scale")), PREVIEW_CANVAS_SCALE);
+	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/preview_3d_scene_background", TTRC("Preview 3D Scene Background"), KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL | Key::H), PREVIEW_3D_SCENE_BACKGROUND);
 
 	theme_menu = memnew(PopupMenu);
 	theme_menu->connect(SceneStringName(id_pressed), callable_mp(this, &CanvasItemEditor::_switch_theme_preview));
@@ -6372,17 +6380,23 @@ void CanvasItemEditorViewport::_update_theme() {
 	label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 }
 
+void CanvasItemEditorViewport::_project_settings_changed() {
+	Viewport *viewport = EditorNode::get_singleton()->get_scene_root()->get_viewport();
+	viewport->apply_project_settings();
+}
+
 void CanvasItemEditorViewport::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
 		} break;
-
 		case NOTIFICATION_ENTER_TREE: {
 			_update_theme();
 			connect(SceneStringName(mouse_exited), callable_mp(this, &CanvasItemEditorViewport::_on_mouse_exit));
 		} break;
-
+		case NOTIFICATION_READY: {
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &CanvasItemEditorViewport::_project_settings_changed));
+		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect(SceneStringName(mouse_exited), callable_mp(this, &CanvasItemEditorViewport::_on_mouse_exit));
 		} break;

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -143,6 +143,7 @@ private:
 		VIEW_CENTER_TO_SELECTION,
 		VIEW_FRAME_TO_SELECTION,
 		PREVIEW_CANVAS_SCALE,
+		PREVIEW_3D_SCENE_BACKGROUND,
 		SKELETON_MAKE_BONES,
 		SKELETON_SHOW_BONES
 	};
@@ -650,6 +651,7 @@ class CanvasItemEditorViewport : public Control {
 	void _perform_drop_data();
 	void _show_texture_node_type_selector();
 	void _update_theme();
+	void _project_settings_changed();
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2851,61 +2851,7 @@ void Node3DEditorPlugin::edited_scene_changed() {
 }
 
 void Node3DEditorViewport::_project_settings_changed() {
-	// Update shadow atlas if changed.
-	int shadowmap_size = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_size");
-	bool shadowmap_16_bits = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_16_bits");
-	int atlas_q0 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_0_subdiv");
-	int atlas_q1 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_1_subdiv");
-	int atlas_q2 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_2_subdiv");
-	int atlas_q3 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_3_subdiv");
-
-	viewport->set_positional_shadow_atlas_size(shadowmap_size);
-	viewport->set_positional_shadow_atlas_16_bits(shadowmap_16_bits);
-	viewport->set_positional_shadow_atlas_quadrant_subdiv(0, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q0));
-	viewport->set_positional_shadow_atlas_quadrant_subdiv(1, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q1));
-	viewport->set_positional_shadow_atlas_quadrant_subdiv(2, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q2));
-	viewport->set_positional_shadow_atlas_quadrant_subdiv(3, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q3));
-
-	_update_shrink();
-
-	// Update MSAA, screen-space AA and debanding if changed
-
-	const int msaa_mode = GLOBAL_GET("rendering/anti_aliasing/quality/msaa_3d");
-	viewport->set_msaa_3d(Viewport::MSAA(msaa_mode));
-	const int ssaa_mode = GLOBAL_GET("rendering/anti_aliasing/quality/screen_space_aa");
-	viewport->set_screen_space_aa(Viewport::ScreenSpaceAA(ssaa_mode));
-	const bool use_taa = GLOBAL_GET("rendering/anti_aliasing/quality/use_taa");
-	viewport->set_use_taa(use_taa);
-
-	const bool transparent_background = GLOBAL_GET("rendering/viewport/transparent_background");
-	viewport->set_transparent_background(transparent_background);
-
-	const bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
-	viewport->set_use_hdr_2d(use_hdr_2d);
-
-	const bool use_debanding = GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding");
-	viewport->set_use_debanding(use_debanding);
-
-	const bool use_occlusion_culling = GLOBAL_GET("rendering/occlusion_culling/use_occlusion_culling");
-	viewport->set_use_occlusion_culling(use_occlusion_culling);
-
-	const float mesh_lod_threshold = GLOBAL_GET("rendering/mesh_lod/lod_change/threshold_pixels");
-	viewport->set_mesh_lod_threshold(mesh_lod_threshold);
-
-	const Viewport::Scaling3DMode scaling_3d_mode = Viewport::Scaling3DMode(int(GLOBAL_GET("rendering/scaling_3d/mode")));
-	viewport->set_scaling_3d_mode(scaling_3d_mode);
-
-	const float scaling_3d_scale = GLOBAL_GET("rendering/scaling_3d/scale");
-	viewport->set_scaling_3d_scale(scaling_3d_scale);
-
-	const float fsr_sharpness = GLOBAL_GET("rendering/scaling_3d/fsr_sharpness");
-	viewport->set_fsr_sharpness(fsr_sharpness);
-
-	const float texture_mipmap_bias = GLOBAL_GET("rendering/textures/default_filters/texture_mipmap_bias");
-	viewport->set_texture_mipmap_bias(texture_mipmap_bias);
-
-	const Viewport::AnisotropicFiltering anisotropic_filtering_level = Viewport::AnisotropicFiltering(int(GLOBAL_GET("rendering/textures/default_filters/anisotropic_filtering_level")));
-	viewport->set_anisotropic_filtering_level(anisotropic_filtering_level);
+	viewport->apply_project_settings();
 }
 
 void Node3DEditorViewport::_notification(int p_what) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -528,6 +528,62 @@ void Viewport::_update_viewport_path() {
 	}
 }
 
+void Viewport::apply_project_settings() {
+	// Update shadow atlas if changed.
+	int shadowmap_size = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_size");
+	bool shadowmap_16_bits = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_16_bits");
+	int atlas_q0 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_0_subdiv");
+	int atlas_q1 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_1_subdiv");
+	int atlas_q2 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_2_subdiv");
+	int atlas_q3 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_3_subdiv");
+
+	set_positional_shadow_atlas_size(shadowmap_size);
+	set_positional_shadow_atlas_16_bits(shadowmap_16_bits);
+	set_positional_shadow_atlas_quadrant_subdiv(0, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q0));
+	set_positional_shadow_atlas_quadrant_subdiv(1, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q1));
+	set_positional_shadow_atlas_quadrant_subdiv(2, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q2));
+	set_positional_shadow_atlas_quadrant_subdiv(3, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q3));
+
+	// Update MSAA, screen-space AA and debanding if changed.
+
+	const int msaa_mode = GLOBAL_GET("rendering/anti_aliasing/quality/msaa_3d");
+	set_msaa_3d(Viewport::MSAA(msaa_mode));
+	const int ssaa_mode = GLOBAL_GET("rendering/anti_aliasing/quality/screen_space_aa");
+	set_screen_space_aa(Viewport::ScreenSpaceAA(ssaa_mode));
+	const bool use_taa = GLOBAL_GET("rendering/anti_aliasing/quality/use_taa");
+	set_use_taa(use_taa);
+
+	const bool transparent_background = GLOBAL_GET("rendering/viewport/transparent_background");
+	set_transparent_background(transparent_background);
+
+	const bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
+	set_use_hdr_2d(use_hdr_2d);
+
+	const bool use_debanding = GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding");
+	set_use_debanding(use_debanding);
+
+	const bool use_occlusion_culling = GLOBAL_GET("rendering/occlusion_culling/use_occlusion_culling");
+	set_use_occlusion_culling(use_occlusion_culling);
+
+	const float mesh_lod_threshold = GLOBAL_GET("rendering/mesh_lod/lod_change/threshold_pixels");
+	set_mesh_lod_threshold(mesh_lod_threshold);
+
+	const Viewport::Scaling3DMode scaling_3d_mode = Viewport::Scaling3DMode(int(GLOBAL_GET("rendering/scaling_3d/mode")));
+	set_scaling_3d_mode(scaling_3d_mode);
+
+	const float scaling_3d_scale = GLOBAL_GET("rendering/scaling_3d/scale");
+	set_scaling_3d_scale(scaling_3d_scale);
+
+	const float fsr_sharpness = GLOBAL_GET("rendering/scaling_3d/fsr_sharpness");
+	set_fsr_sharpness(fsr_sharpness);
+
+	const float texture_mipmap_bias = GLOBAL_GET("rendering/textures/default_filters/texture_mipmap_bias");
+	set_texture_mipmap_bias(texture_mipmap_bias);
+
+	const Viewport::AnisotropicFiltering anisotropic_filtering_level = Viewport::AnisotropicFiltering(int(GLOBAL_GET("rendering/textures/default_filters/anisotropic_filtering_level")));
+	set_anisotropic_filtering_level(anisotropic_filtering_level);
+}
+
 void Viewport::_notification(int p_what) {
 	ERR_MAIN_THREAD_GUARD;
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -525,6 +525,8 @@ public:
 
 	void update_canvas_items();
 
+	void apply_project_settings();
+
 	Rect2 get_visible_rect() const;
 	RID get_viewport_rid() const;
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51840.

This can be used while designing a HUD to make sure it's readable on top of a 3D scene. This feature was "unintentionally" available until https://github.com/godotengine/godot/pull/50007, but exposing it as an option that's disabled by default makes more sense.

The main limitation right now is that you can't move the camera by switching to the 3D editor then going back to the 2D editor. Instead, its position will be set based on the initial camera position when the scene was opened.

This closes https://github.com/godotengine/godot-proposals/issues/2635.

## Preview

***Note:** MSAA/FXAA/debanding support for the 3D preview was added after this video was recorded. It will be synchronized with the project settings, like in the 3D editor.*

https://user-images.githubusercontent.com/180032/129816340-750b2444-f91d-4c11-a540-68f88c077ffc.mp4