### PR TITLE
Fixed magnet vector not working correctly in SkeletonModification2DFABRIK

### DIFF
--- a/scene/resources/skeleton_modification_2d_fabrik.cpp
+++ b/scene/resources/skeleton_modification_2d_fabrik.cpp
@@ -149,15 +149,6 @@ void SkeletonModification2DFABRIK::_execute(float p_delta) {
 			return;
 		}
 		fabrik_transform_chain.write[i] = joint_bone2d_node->get_global_transform();
-
-		// Apply magnet positions
-		if (i == 0) {
-			continue; // The origin cannot use a magnet position!
-		} else {
-			Transform2D joint_trans = fabrik_transform_chain[i];
-			joint_trans.set_origin(joint_trans.get_origin() + fabrik_data_chain[i].magnet_position);
-			fabrik_transform_chain.write[i] = joint_trans;
-		}
 	}
 
 	Bone2D *final_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[fabrik_data_chain.size() - 1].bone2d_node_cache));
@@ -223,6 +214,11 @@ void SkeletonModification2DFABRIK::chain_backwards() {
 	Bone2D *final_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[final_joint_index].bone2d_node_cache));
 	Transform2D final_bone2d_trans = fabrik_transform_chain[final_joint_index];
 
+	// Apply magnet position
+	if (final_joint_index != 0) {
+		final_bone2d_trans.set_origin(final_bone2d_trans.get_origin() + fabrik_data_chain[final_joint_index].magnet_position);
+	}
+
 	// Set the rotation of the tip bone
 	final_bone2d_trans = final_bone2d_trans.looking_at(target_global_pose.get_origin());
 
@@ -244,6 +240,11 @@ void SkeletonModification2DFABRIK::chain_backwards() {
 		i -= 1;
 		Bone2D *current_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[i].bone2d_node_cache));
 		Transform2D current_pose = fabrik_transform_chain[i];
+
+		// Apply magnet position
+		if (i != 0) {
+			current_pose.set_origin(current_pose.get_origin() + fabrik_data_chain[i].magnet_position);
+		}
 
 		float current_bone2d_node_length = current_bone2d_node->get_length() * MIN(current_bone2d_node->get_global_scale().x, current_bone2d_node->get_global_scale().y);
 		float length = current_bone2d_node_length / (previous_pose.get_origin() - current_pose.get_origin()).length();


### PR DESCRIPTION
Fixes an issue where the magnet vector was incorrectly changing the position of the FABRIK execution, rather than adjusting the bend. Here's what it looked like before when the middle joint magnet was set to `(0, 1)`:

![FABRIK_2D_MagnetFix_Before](https://user-images.githubusercontent.com/25082678/129819306-798af33e-a3d2-4c5a-86ba-5517618fc565.gif)

With this fix, it now no longer has that issue and will bend in the correct direction when extended and retracted:

![FABRIK_2D_MagnetFix_After](https://user-images.githubusercontent.com/25082678/129819340-8c3a321a-de6c-4528-b606-903c1bbe7e66.gif)

It also slightly optimizes applying the magnet vector when compared to the previous version, so it's a win-win for performance and fixing the bug :+1: 