### PR TITLE
Add comments at the top of each built-in shader to ease debugging

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1736,6 +1736,8 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	onion.capture.shader = Ref<Shader>(memnew(Shader));
 	onion.capture.shader->set_code(R"(
+// Animation editor onion skinning shader.
+
 shader_type canvas_item;
 
 uniform vec4 bkg_color;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5606,6 +5606,8 @@ void Node3DEditor::_init_indicators() {
 
 		Ref<Shader> grid_shader = memnew(Shader);
 		grid_shader->set_code(R"(
+// 3D editor grid shader.
+
 shader_type spatial;
 
 render_mode unshaded;
@@ -5847,6 +5849,8 @@ void fragment() {
 				Ref<Shader> rotate_shader = memnew(Shader);
 
 				rotate_shader->set_code(R"(
+// 3D editor rotation manipulator gizmo shader.
+
 shader_type spatial;
 
 render_mode unshaded, depth_test_disabled;
@@ -5895,6 +5899,8 @@ void fragment() {
 
 					Ref<Shader> border_shader = memnew(Shader);
 					border_shader->set_code(R"(
+// 3D editor rotation manipulator gizmo shader (white outline).
+
 shader_type spatial;
 
 render_mode unshaded, depth_test_disabled;
@@ -7515,6 +7521,8 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 
 		sun_direction_shader.instantiate();
 		sun_direction_shader->set_code(R"(
+// 3D editor Preview Sun direction shader.
+
 shader_type canvas_item;
 
 uniform vec3 sun_direction;

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -79,6 +79,8 @@ void Texture3DEditor::_update_material() {
 void Texture3DEditor::_make_shaders() {
 	shader.instantiate();
 	shader->set_code(R"(
+// Texture3DEditor preview shader.
+
 shader_type canvas_item;
 
 uniform sampler3D tex;

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -106,6 +106,8 @@ void TextureLayeredEditor::_update_material() {
 void TextureLayeredEditor::_make_shaders() {
 	shaders[0].instantiate();
 	shaders[0]->set_code(R"(
+// TextureLayeredEditor preview shader (2D array).
+
 shader_type canvas_item;
 
 uniform sampler2DArray tex;
@@ -118,6 +120,8 @@ void fragment() {
 
 	shaders[1].instantiate();
 	shaders[1]->set_code(R"(
+// TextureLayeredEditor preview shader (cubemap).
+
 shader_type canvas_item;
 
 uniform samplerCube tex;
@@ -132,6 +136,8 @@ void fragment() {
 
 	shaders[2].instantiate();
 	shaders[2]->set_code(R"(
+// TextureLayeredEditor preview shader (cubemap array).
+
 shader_type canvas_item;
 
 uniform samplerCubeArray tex;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -98,6 +98,8 @@ Ref<Shader> ColorPicker::circle_shader;
 void ColorPicker::init_shaders() {
 	wheel_shader.instantiate();
 	wheel_shader->set_code(R"(
+// ColorPicker wheel shader.
+
 shader_type canvas_item;
 
 void fragment() {
@@ -120,6 +122,8 @@ void fragment() {
 
 	circle_shader.instantiate();
 	circle_shader->set_code(R"(
+// ColorPicker circle shader.
+
 shader_type canvas_item;
 
 uniform float v = 1.0;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -683,6 +683,8 @@ void SceneShaderForwardClustered::init(RendererStorageRD *p_storage, const Strin
 		default_shader = storage->shader_allocate();
 		storage->shader_initialize(default_shader);
 		storage->shader_set_code(default_shader, R"(
+// Default 3D material shader (clustered).
+
 shader_type spatial;
 
 void vertex() {
@@ -712,6 +714,8 @@ void fragment() {
 		storage->shader_initialize(overdraw_material_shader);
 		// Use relatively low opacity so that more "layers" of overlapping objects can be distinguished.
 		storage->shader_set_code(overdraw_material_shader, R"(
+// 3D editor Overdraw debug draw mode shader (clustered).
+
 shader_type spatial;
 
 render_mode blend_add, unshaded;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -673,6 +673,8 @@ void SceneShaderForwardMobile::init(RendererStorageRD *p_storage, const String p
 		default_shader = storage->shader_allocate();
 		storage->shader_initialize(default_shader);
 		storage->shader_set_code(default_shader, R"(
+// Default 3D material shader (mobile).
+
 shader_type spatial;
 
 void vertex() {
@@ -701,6 +703,8 @@ void fragment() {
 		storage->shader_initialize(overdraw_material_shader);
 		// Use relatively low opacity so that more "layers" of overlapping objects can be distinguished.
 		storage->shader_set_code(overdraw_material_shader, R"(
+// 3D editor Overdraw debug draw mode shader (mobile).
+
 shader_type spatial;
 
 render_mode blend_add, unshaded;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2575,6 +2575,8 @@ RendererCanvasRenderRD::RendererCanvasRenderRD(RendererStorageRD *p_storage) {
 		storage->shader_initialize(default_canvas_group_shader);
 
 		storage->shader_set_code(default_canvas_group_shader, R"(
+// Default CanvasGroup shader.
+
 shader_type canvas_item;
 
 void fragment() {

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -855,6 +855,8 @@ void RendererSceneSkyRD::init(RendererStorageRD *p_storage) {
 		storage->shader_initialize(sky_shader.default_shader);
 
 		storage->shader_set_code(sky_shader.default_shader, R"(
+// Default sky shader.
+
 shader_type sky;
 
 void sky() {
@@ -942,6 +944,8 @@ void sky() {
 		storage->shader_initialize(sky_scene_state.fog_shader);
 
 		storage->shader_set_code(sky_scene_state.fog_shader, R"(
+// Default clear color sky shader.
+
 shader_type sky;
 
 uniform vec4 clear_color;

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -9398,6 +9398,8 @@ RendererStorageRD::RendererStorageRD() {
 		particles_shader.default_shader = shader_allocate();
 		shader_initialize(particles_shader.default_shader);
 		shader_set_code(particles_shader.default_shader, R"(
+// Default particles shader.
+
 shader_type particles;
 
 void process() {


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/50159, and possibly supersedes https://github.com/godotengine/godot/pull/51557. cc @Chaosus

When a shader error is printed about a built-in shader, the origin of the shader will now be recognizable immediately by looking at the top of the printed shader code.