### PR TITLE
[3.x] Fix `TextEditor` not checking Standard highlighter in non-English UI

### DIFF
--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -44,7 +44,7 @@ void TextEditor::set_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
 	if (p_highlighter != nullptr) {
 		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text(p_highlighter->get_name()), true);
 	} else {
-		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text("Standard"), true);
+		highlighter_menu->set_item_checked(highlighter_menu->get_item_idx_from_text(TTR("Standard")), true);
 	}
 
 	// little work around. GDScript highlighter goes through text_edit for colours,
@@ -657,7 +657,7 @@ TextEditor::TextEditor() {
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/capitalize", TTR("Capitalize")), EDIT_CAPITALIZE);
 	convert_case->connect("id_pressed", this, "_edit_option");
 
-	highlighters["Standard"] = NULL;
+	highlighters[TTR("Standard")] = NULL;
 	highlighter_menu = memnew(PopupMenu);
 	highlighter_menu->set_name("highlighter_menu");
 	edit_menu->get_popup()->add_child(highlighter_menu);


### PR DESCRIPTION
When using non-English UI, there were `Index p_idx = -1 is out of bounds (items.size() = 2)` errors on on startup if any text file is open in the script editor. And clicking the Standard highlighter option does not check that menu item.

This is caused by `TextEditor` searching for that menu item with unlocalized text. As already did in `ScriptTextEditor`, this PR stores and searches for menu item with `TTR`ed text.

This is `3.x` only because the way how "Standard" highlighter is handled changed in `master`.