### PR TITLE
CI: Upgrade Emscripten to 2.0.27

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -6,7 +6,7 @@ env:
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: platform=javascript verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2
   SCONS_CACHE_LIMIT: 4096
-  EM_VERSION: 2.0.25
+  EM_VERSION: 2.0.27
   EM_CACHE_FOLDER: 'emsdk-cache'
 
 jobs:


### PR DESCRIPTION
Did not test, but I guess that it's good to stay up to date and see if any compilations issues arise in this PR, before we can consider using it for 3.x.