### PR TITLE
Adjust the material key bit size for `ParticlesMaterial`

### DIFF
--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -61,6 +61,7 @@ public:
 		PARAM_MAX
 	};
 
+	// When extending, make sure not to overflow the size of the MaterialKey below.
 	enum ParticleFlags {
 		PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY,
 		PARTICLE_FLAG_ROTATE_Y,
@@ -68,6 +69,7 @@ public:
 		PARTICLE_FLAG_MAX
 	};
 
+	// When extending, make sure not to overflow the size of the MaterialKey below.
 	enum EmissionShape {
 		EMISSION_SHAPE_POINT,
 		EMISSION_SHAPE_SPHERE,
@@ -78,6 +80,7 @@ public:
 		EMISSION_SHAPE_MAX
 	};
 
+	// When extending, make sure not to overflow the size of the MaterialKey below.
 	enum SubEmitterMode {
 		SUB_EMITTER_DISABLED,
 		SUB_EMITTER_CONSTANT,
@@ -88,11 +91,13 @@ public:
 
 private:
 	union MaterialKey {
+		// The bit size of the struct must be kept below or equal to 32 bits.
+		// Consider this when extending ParticleFlags, EmissionShape, or SubEmitterMode.
 		struct {
 			uint32_t texture_mask : 16;
 			uint32_t texture_color : 1;
 			uint32_t particle_flags : 4;
-			uint32_t emission_shape : 2;
+			uint32_t emission_shape : 3;
 			uint32_t invalid_key : 1;
 			uint32_t has_emission_color : 1;
 			uint32_t sub_emitter : 2;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/51428.

I have very surface level understanding of this, but from what I can see — when we assign 

```cpp
mk.emission_shape = emission_shape;
```

a few lines below the change, we hit the size limit of the struct member size. The value for the ring emitter is 5, which is `101` in binary, but it gets truncated to only 2 bits, turning it into `01`.  `01` (or 1 in dec) is the same value as the sphere emitter, hence why changing between the two doesn't trigger the shader update that you see in the reported issue.

In fact, I think the issue existed before, as the directed points emitter also exceeds the size of the field. But, I guess, directed points are similar to the point emitter which they collide with (4 -> `100` -> `00`), so it went undetected. But it's worth checking if we have similar reported problems, this may also close them.

3 bits should be enough for a couple more emitter types for the time being.