### PR TITLE
[3.x] Add `disable_alpha` render mode to shaders

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -980,8 +980,10 @@ void RasterizerSceneGLES2::_add_geometry(RasterizerStorageGLES2::Geometry *p_geo
 	}
 }
 void RasterizerSceneGLES2::_add_geometry_with_material(RasterizerStorageGLES2::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES2::GeometryOwner *p_owner, RasterizerStorageGLES2::Material *p_material, bool p_depth_pass, bool p_shadow_pass) {
-	bool has_base_alpha = (p_material->shader->spatial.uses_alpha && !p_material->shader->spatial.uses_alpha_scissor) || p_material->shader->spatial.uses_screen_texture || p_material->shader->spatial.uses_depth_texture;
-	bool has_blend_alpha = p_material->shader->spatial.blend_mode != RasterizerStorageGLES2::Shader::Spatial::BLEND_MODE_MIX;
+	const bool has_base_alpha = !p_material->shader->spatial.disable_alpha &&
+								((p_material->shader->spatial.uses_alpha && !p_material->shader->spatial.uses_alpha_scissor) ||
+										p_material->shader->spatial.uses_screen_texture || p_material->shader->spatial.uses_depth_texture);
+	const bool has_blend_alpha = p_material->shader->spatial.blend_mode != RasterizerStorageGLES2::Shader::Spatial::BLEND_MODE_MIX;
 	bool has_alpha = has_base_alpha || has_blend_alpha;
 
 	bool mirror = p_instance->mirror;

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1434,6 +1434,7 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			p_shader->spatial.uses_alpha_scissor = false;
 			p_shader->spatial.uses_discard = false;
 			p_shader->spatial.unshaded = false;
+			p_shader->spatial.disable_alpha = false;
 			p_shader->spatial.no_depth_test = false;
 			p_shader->spatial.uses_sss = false;
 			p_shader->spatial.uses_time = false;
@@ -1461,6 +1462,7 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			shaders.actions_scene.render_mode_values["cull_disabled"] = Pair<int *, int>(&p_shader->spatial.cull_mode, Shader::Spatial::CULL_MODE_DISABLED);
 
 			shaders.actions_scene.render_mode_flags["unshaded"] = &p_shader->spatial.unshaded;
+			shaders.actions_scene.render_mode_flags["disable_alpha"] = &p_shader->spatial.disable_alpha;
 			shaders.actions_scene.render_mode_flags["depth_test_disable"] = &p_shader->spatial.no_depth_test;
 
 			shaders.actions_scene.render_mode_flags["vertex_lighting"] = &p_shader->spatial.uses_vertex_lighting;
@@ -1952,7 +1954,7 @@ void RasterizerStorageGLES2::_update_material(Material *p_material) {
 
 		if (p_material->shader && p_material->shader->mode == VS::SHADER_SPATIAL) {
 			if (p_material->shader->spatial.blend_mode == Shader::Spatial::BLEND_MODE_MIX &&
-					(!p_material->shader->spatial.uses_alpha || p_material->shader->spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS)) {
+					(p_material->shader->spatial.disable_alpha || !p_material->shader->spatial.uses_alpha || p_material->shader->spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS)) {
 				can_cast_shadow = true;
 			}
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -496,6 +496,7 @@ public:
 			bool uses_alpha;
 			bool uses_alpha_scissor;
 			bool unshaded;
+			bool disable_alpha;
 			bool no_depth_test;
 			bool uses_vertex;
 			bool uses_discard;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2219,8 +2219,10 @@ void RasterizerSceneGLES3::_add_geometry(RasterizerStorageGLES3::Geometry *p_geo
 }
 
 void RasterizerSceneGLES3::_add_geometry_with_material(RasterizerStorageGLES3::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES3::GeometryOwner *p_owner, RasterizerStorageGLES3::Material *p_material, bool p_depth_pass, bool p_shadow_pass) {
-	bool has_base_alpha = (p_material->shader->spatial.uses_alpha && !p_material->shader->spatial.uses_alpha_scissor) || p_material->shader->spatial.uses_screen_texture || p_material->shader->spatial.uses_depth_texture;
-	bool has_blend_alpha = p_material->shader->spatial.blend_mode != RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_MIX;
+	const bool has_base_alpha = !p_material->shader->spatial.disable_alpha &&
+								((p_material->shader->spatial.uses_alpha && !p_material->shader->spatial.uses_alpha_scissor) ||
+										p_material->shader->spatial.uses_screen_texture || p_material->shader->spatial.uses_depth_texture);
+	const bool has_blend_alpha = p_material->shader->spatial.blend_mode != RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_MIX;
 	bool has_alpha = has_base_alpha || has_blend_alpha;
 
 	bool mirror = p_instance->mirror;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2222,6 +2222,7 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			p_shader->spatial.uses_alpha_scissor = false;
 			p_shader->spatial.uses_discard = false;
 			p_shader->spatial.unshaded = false;
+			p_shader->spatial.disable_alpha = false;
 			p_shader->spatial.no_depth_test = false;
 			p_shader->spatial.uses_sss = false;
 			p_shader->spatial.uses_time = false;
@@ -2249,6 +2250,7 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			shaders.actions_scene.render_mode_values["cull_disabled"] = Pair<int *, int>(&p_shader->spatial.cull_mode, Shader::Spatial::CULL_MODE_DISABLED);
 
 			shaders.actions_scene.render_mode_flags["unshaded"] = &p_shader->spatial.unshaded;
+			shaders.actions_scene.render_mode_flags["disable_alpha"] = &p_shader->spatial.disable_alpha;
 			shaders.actions_scene.render_mode_flags["depth_test_disable"] = &p_shader->spatial.no_depth_test;
 
 			shaders.actions_scene.render_mode_flags["vertex_lighting"] = &p_shader->spatial.uses_vertex_lighting;
@@ -3164,7 +3166,7 @@ void RasterizerStorageGLES3::_update_material(Material *material) {
 
 		if (material->shader && material->shader->mode == VS::SHADER_SPATIAL) {
 			if (material->shader->spatial.blend_mode == Shader::Spatial::BLEND_MODE_MIX &&
-					(!material->shader->spatial.uses_alpha || material->shader->spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS)) {
+					(material->shader->spatial.disable_alpha || !material->shader->spatial.uses_alpha || material->shader->spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS)) {
 				can_cast_shadow = true;
 			}
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -497,6 +497,7 @@ public:
 			bool uses_alpha;
 			bool uses_alpha_scissor;
 			bool unshaded;
+			bool disable_alpha;
 			bool no_depth_test;
 			bool uses_vertex;
 			bool uses_discard;

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -175,6 +175,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("cull_disabled");
 
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("unshaded");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("disable_alpha");
 
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("diffuse_lambert");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("diffuse_lambert_wrap");


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/51711.

This can be used by multipass shaders to write to a texture's alpha channel without causing the material to become transparent.

## Preview

### Default render mode (GLES3)

![2021-08-16_05 08 20](https://user-images.githubusercontent.com/180032/129926445-13211e10-3744-4b2d-89ea-bc68277f9628.png)

### `disable_alpha` render mode (GLES3)

![2021-08-16_05 08 29](https://user-images.githubusercontent.com/180032/129926447-2c3c2f5f-8b3a-4b00-9fee-272b205f9a2d.png)

### Default render mode (GLES2)

![2021-08-16_05 09 06](https://user-images.githubusercontent.com/180032/129926450-b5872491-5c8d-40d8-8d25-3c38994dc0c9.png)

### `disable_alpha` render mode (GLES2)

![2021-08-16_05 09 15](https://user-images.githubusercontent.com/180032/129926451-590cba50-8adc-4b00-a8eb-d84c2edd3056.png)
