### PR TITLE
[3.x] Improve the docs for the float type

### DIFF
--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -4,9 +4,13 @@
 		Float built-in type.
 	</brief_description>
 	<description>
-		Float built-in type.
+		The [float] built-in type is a 64-bit double-precision floating-point number, equivalent to [code]double[/code] in C++. This type has 14 reliable decimal digits of precision. The [float] type can be stored in [Variant], which is the generic type used by the engine. The maximum value of [float] is approximately [code]1.79769e308[/code], and the minimum is approximately [code]-1.79769e308[/code].
+		Most methods and properties in the engine use 32-bit single-precision floating-point numbers instead, equivalent to [code]float[/code] in C++, which have 6 reliable decimal digits of precision. For data structures such as [Vector2] and [Vector3], Godot uses 32-bit floating-point numbers.
+		Math done using the [float] type is not guaranteed to be exact or deterministic, and will often result in small errors. You should usually use the [method @GDScript.is_equal_approx] and [method @GDScript.is_zero_approx] methods instead of [code]==[/code] to compare [float] values for equality.
 	</description>
 	<tutorials>
+		<link title="Wikipedia: Double-precision floating-point format">https://en.wikipedia.org/wiki/Double-precision_floating-point_format</link>
+		<link title="Wikipedia: Single-precision floating-point format">https://en.wikipedia.org/wiki/Single-precision_floating-point_format</link>
 	</tutorials>
 	<methods>
 		<method name="float">


### PR DESCRIPTION
3.x version of #51848

Compared with #51848, this PR doesn't feature operator documentation, and doesn't have the note about `float=64`.