### PR TITLE
Fix context menu does not disappear on single window mode

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2548,7 +2548,7 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 	//if the event is a mouse button, we need to check whether another window was clicked
 
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
+	if (mb.is_valid() && mb->is_pressed()) {
 		bool click_on_window = false;
 		for (int i = gui.sub_windows.size() - 1; i >= 0; i--) {
 			SubWindow &sw = gui.sub_windows.write[i];
@@ -2612,14 +2612,10 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 				click_on_window = true;
 			}
 
-			if (click_on_window) {
-				break;
+			if (!click_on_window && gui.subwindow_focused) {
+				//no window found and clicked, remove focus
+				_sub_window_grab_focus(nullptr);
 			}
-		}
-
-		if (!click_on_window && gui.subwindow_focused) {
-			//no window found and clicked, remove focus
-			_sub_window_grab_focus(nullptr);
 		}
 	}
 
@@ -2686,6 +2682,8 @@ void Viewport::input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 	}
 
 	if (is_embedding_subwindows() && _sub_windows_forward_input(p_event)) {
+		get_tree()->_call_input_pause(input_group, "_input", ev, this); //not a bug, must happen before GUI, order is _input -> gui input -> _unhandled input
+		_gui_input_event(ev);
 		set_input_as_handled();
 		return;
 	}


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixed #50309 

Clicking node and scene tab
![clicking_right_click_1](https://user-images.githubusercontent.com/12533045/129956787-7b0a490c-1998-492a-887e-9540da06dd10.gif)


Clicking nodes
![clicking_right_click_2](https://user-images.githubusercontent.com/12533045/129956870-5d0befd5-6169-4acc-a80b-6d31ee37f171.gif)


As you can see in the 2nd gif, the context menu does not open when clicking the nodes repeatedly. First it closes, then it needs to be opened. I solved most of the problem but I'm open to suggestions. This is what happens too when single window mode is disabled.