### PR TITLE
Add simple explanation messages to some errors

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -211,7 +211,7 @@ Object *Engine::get_singleton_object(const StringName &p_name) const {
 }
 
 bool Engine::is_singleton_user_created(const StringName &p_name) const {
-	ERR_FAIL_COND_V(!singleton_ptrs.has(p_name), false);
+	ERR_FAIL_COND_V_MSG(!singleton_ptrs.has(p_name), false, "Trying to check for non existent singleton - `" + p_name + "`.");
 
 	for (const Singleton &E : singletons) {
 		if (E.name == p_name && E.user_created) {
@@ -222,7 +222,7 @@ bool Engine::is_singleton_user_created(const StringName &p_name) const {
 	return false;
 }
 void Engine::remove_singleton(const StringName &p_name) {
-	ERR_FAIL_COND(!singleton_ptrs.has(p_name));
+	ERR_FAIL_COND_MSG(!singleton_ptrs.has(p_name), "Trying to remove non existent singleton - `" + p_name + "`.");
 
 	for (List<Singleton>::Element *E = singletons.front(); E; E = E->next()) {
 		if (E->get().name == p_name) {

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -946,7 +946,7 @@ void ProjectSettings::_add_property_info_bind(const Dictionary &p_info) {
 
 	PropertyInfo pinfo;
 	pinfo.name = p_info["name"];
-	ERR_FAIL_COND(!props.has(pinfo.name));
+	ERR_FAIL_COND_MSG(!props.has(pinfo.name), "Request for nonexistent project setting: " + pinfo.name + ".");
 	pinfo.type = Variant::Type(p_info["type"].operator int());
 	ERR_FAIL_INDEX(pinfo.type, Variant::VARIANT_MAX);
 
@@ -961,7 +961,7 @@ void ProjectSettings::_add_property_info_bind(const Dictionary &p_info) {
 }
 
 void ProjectSettings::set_custom_property_info(const String &p_prop, const PropertyInfo &p_info) {
-	ERR_FAIL_COND(!props.has(p_prop));
+	ERR_FAIL_COND_MSG(!props.has(p_prop), "Request for nonexistent project setting: " + p_prop + ".");
 	custom_prop_info[p_prop] = p_info;
 	custom_prop_info[p_prop].name = p_prop;
 }

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -195,7 +195,7 @@ Error ResourceFormatSaverCrypto::save(const String &p_path, const RES &p_resourc
 		String el = p_path.get_extension().to_lower();
 		err = key->save(p_path, el == "pub");
 	} else {
-		ERR_FAIL_V(ERR_INVALID_PARAMETER);
+		ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER, "Resource must be valid key or certificate.");
 	}
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save Crypto resource to file '" + p_path + "'.");
 	return OK;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -572,7 +572,7 @@ void ClassDB::_add_class2(const StringName &p_class, const StringName &p_inherit
 	ti.api = current_api;
 
 	if (ti.inherits) {
-		ERR_FAIL_COND(!classes.has(ti.inherits)); //it MUST be registered.
+		ERR_FAIL_COND_MSG(!classes.has(ti.inherits), "Class \"" + ti.inherits + "\" is not registered."); //it MUST be registered.
 		ti.inherits_ptr = &classes[ti.inherits];
 
 	} else {
@@ -727,12 +727,9 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 
 	ClassInfo *type = classes.getptr(p_class);
 
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_COND_MSG(!type, "Cannot find class \"" + p_class + "\".");
 
-	if (type->constant_map.has(p_name)) {
-		ERR_FAIL();
-	}
-
+	ERR_FAIL_COND_MSG(type->constant_map.has(p_name), "Class \"" + p_class + "\" already has integer constant \"" + p_name + "\".");
 	type->constant_map[p_name] = p_constant;
 
 	String enum_name = p_enum;
@@ -941,7 +938,7 @@ void ClassDB::add_signal(const StringName &p_class, const MethodInfo &p_signal) 
 	OBJTYPE_WLOCK;
 
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_COND_MSG(!type, "Cannot find class \"" + p_class + "\".");
 
 	StringName sname = p_signal.name;
 
@@ -960,7 +957,7 @@ void ClassDB::get_signal_list(const StringName &p_class, List<MethodInfo> *p_sig
 	OBJTYPE_RLOCK;
 
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_COND_MSG(!type, "Cannot find class \"" + p_class + "\".");
 
 	ClassInfo *check = type;
 
@@ -1015,7 +1012,7 @@ bool ClassDB::get_signal(const StringName &p_class, const StringName &p_signal, 
 void ClassDB::add_property_group(const StringName &p_class, const String &p_name, const String &p_prefix) {
 	OBJTYPE_WLOCK;
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_COND_MSG(!type, "Cannot find class \"" + p_class + "\".");
 
 	type->property_list.push_back(PropertyInfo(Variant::NIL, p_name, PROPERTY_HINT_NONE, p_prefix, PROPERTY_USAGE_GROUP));
 }
@@ -1023,7 +1020,7 @@ void ClassDB::add_property_group(const StringName &p_class, const String &p_name
 void ClassDB::add_property_subgroup(const StringName &p_class, const String &p_name, const String &p_prefix) {
 	OBJTYPE_WLOCK;
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_COND_MSG(!type, "Cannot find class \"" + p_class + "\".");
 
 	type->property_list.push_back(PropertyInfo(Variant::NIL, p_name, PROPERTY_HINT_NONE, p_prefix, PROPERTY_USAGE_SUBGROUP));
 }
@@ -1034,7 +1031,7 @@ void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinf
 	ClassInfo *type = classes.getptr(p_class);
 	lock.read_unlock();
 
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_COND_MSG(!type, "Cannot find class \"" + p_class + "\".");
 
 	MethodBind *mb_set = nullptr;
 	if (p_setter) {
@@ -1351,8 +1348,8 @@ void ClassDB::set_method_flags(const StringName &p_class, const StringName &p_me
 	OBJTYPE_WLOCK;
 	ClassInfo *type = classes.getptr(p_class);
 	ClassInfo *check = type;
-	ERR_FAIL_COND(!check);
-	ERR_FAIL_COND(!check->method_map.has(p_method));
+	ERR_FAIL_COND_MSG(!type, "Cannot find class \"" + p_class + "\".");
+	ERR_FAIL_COND_MSG(!check->method_map.has(p_method), "Cannot find method \"" + p_method + "\" in class \"" + p_class + "\".");
 	check->method_map[p_method]->set_hint_flags(p_flags);
 }
 
@@ -1527,7 +1524,7 @@ bool ClassDB::is_class_exposed(const StringName &p_class) {
 }
 
 StringName ClassDB::get_category(const StringName &p_node) {
-	ERR_FAIL_COND_V(!classes.has(p_node), StringName());
+	ERR_FAIL_COND_V_MSG(!classes.has(p_node), StringName(), "Cannot find `" + p_node + "` category.");
 #ifdef DEBUG_ENABLED
 	return classes[p_node].category;
 #else
@@ -1664,7 +1661,7 @@ void ClassDB::register_extension_class(ObjectNativeExtension *p_extension) {
 }
 
 void ClassDB::unregister_extension_class(const StringName &p_class) {
-	ERR_FAIL_COND(!classes.has(p_class));
+	ERR_FAIL_COND_MSG(!classes.has(p_class), "Cannot find class " + p_class + " to unregister it.");
 	classes.erase(p_class);
 }
 

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -186,7 +186,7 @@ public:
 		GLOBAL_LOCK_FUNCTION;
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
-		ERR_FAIL_COND(!t);
+		ERR_FAIL_COND_MSG(!t, "Class \"" + T::get_class_static() + "\" is not registered properly.");
 		t->creation_func = &creator<T>;
 		t->exposed = true;
 		t->class_ptr = T::get_class_ptr_static();
@@ -198,7 +198,7 @@ public:
 		GLOBAL_LOCK_FUNCTION;
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
-		ERR_FAIL_COND(!t);
+		ERR_FAIL_COND_MSG(!t, "Virtual class \"" + T::get_class_static() + "\" is not registered properly.");
 		t->exposed = true;
 		t->class_ptr = T::get_class_ptr_static();
 		//nothing
@@ -217,7 +217,7 @@ public:
 		GLOBAL_LOCK_FUNCTION;
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
-		ERR_FAIL_COND(!t);
+		ERR_FAIL_COND_MSG(!t, "Custom class \"" + T::get_class_static() + "\" is not registered properly.");
 		t->creation_func = &_create_ptr_func<T>;
 		t->exposed = true;
 		t->class_ptr = T::get_class_ptr_static();

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -273,7 +273,7 @@ void MessageQueue::flush() {
 
 	if (flushing) {
 		_THREAD_SAFE_UNLOCK_
-		ERR_FAIL_COND(flushing); //already flushing, you did something odd
+		ERR_FAIL_COND_MSG(flushing, "Godot is already flushing MessageQueue."); //already flushing, you did something odd
 	}
 	flushing = true;
 

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -74,7 +74,7 @@ void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 
 	void *mem = malloc(p_bytes + (prepad ? PAD_ALIGN : 0));
 
-	ERR_FAIL_COND_V(!mem, nullptr);
+	ERR_FAIL_COND_V_MSG(!mem, nullptr, "Failed to allocate memory.");
 
 	alloc_count.increment();
 
@@ -127,7 +127,7 @@ void *Memory::realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align) {
 			*s = p_bytes;
 
 			mem = (uint8_t *)realloc(mem, p_bytes + PAD_ALIGN);
-			ERR_FAIL_COND_V(!mem, nullptr);
+			ERR_FAIL_COND_V_MSG(!mem, nullptr, "Failed to reallocate memory.");
 
 			s = (uint64_t *)mem;
 
@@ -145,7 +145,7 @@ void *Memory::realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align) {
 }
 
 void Memory::free_static(void *p_ptr, bool p_pad_align) {
-	ERR_FAIL_COND(p_ptr == nullptr);
+	ERR_FAIL_COND_MSG(p_ptr == nullptr, "Trying to free null pointer.");
 
 	uint8_t *mem = (uint8_t *)p_ptr;
 

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -144,7 +144,7 @@ T *memnew_arr_template(size_t p_elements) {
 	size_t len = sizeof(T) * p_elements;
 	uint64_t *mem = (uint64_t *)Memory::alloc_static(len, true);
 	T *failptr = nullptr; //get rid of a warning
-	ERR_FAIL_COND_V(!mem, failptr);
+	ERR_FAIL_COND_V_MSG(!mem, failptr, "Failed to allocate array of objects.");
 	*(mem - 1) = p_elements;
 
 	if (!__has_trivial_constructor(T)) {

--- a/core/os/pool_allocator.cpp
+++ b/core/os/pool_allocator.cpp
@@ -548,7 +548,7 @@ void PoolAllocator::create_pool(void *p_mem, int p_size, int p_max_entries) {
 
 PoolAllocator::PoolAllocator(int p_size, bool p_needs_locking, int p_max_entries) {
 	mem_ptr = memalloc(p_size);
-	ERR_FAIL_COND(!mem_ptr);
+	ERR_FAIL_COND_MSG(!mem_ptr, "Failed to allocate memory in PoolAllocator.");
 	align = 1;
 	create_pool(mem_ptr, p_size, p_max_entries);
 	needs_locking = p_needs_locking;

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -98,7 +98,7 @@ private:
 	uint32_t elements = 0;
 
 	void make_hash_table() {
-		ERR_FAIL_COND(hash_table);
+		ERR_FAIL_COND_MSG(hash_table, "Hash table is already configured.");
 
 		hash_table = memnew_arr(Element *, (1 << MIN_HASH_TABLE_POWER));
 

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -386,13 +386,13 @@ Error Signal::connect(const Callable &p_callable, const Vector<Variant> &p_binds
 
 void Signal::disconnect(const Callable &p_callable) {
 	Object *object = get_object();
-	ERR_FAIL_COND(!object);
+	ERR_FAIL_COND_MSG(!object, "Object was removed before disconnection.");
 	object->disconnect(name, p_callable);
 }
 
 bool Signal::is_connected(const Callable &p_callable) const {
 	Object *object = get_object();
-	ERR_FAIL_COND_V(!object, false);
+	ERR_FAIL_COND_V_MSG(!object, false, "Object was removed before checking connection.");
 
 	return object->is_connected(name, p_callable);
 }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1070,28 +1070,28 @@ bool Variant::has_builtin_method(Variant::Type p_type, const StringName &p_metho
 Variant::ValidatedBuiltInMethod Variant::get_validated_builtin_method(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, nullptr);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, nullptr);
+	ERR_FAIL_COND_V_MSG(!method, nullptr, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	return method->validated_call;
 }
 
 Variant::PTRBuiltInMethod Variant::get_ptr_builtin_method(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, nullptr);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, nullptr);
+	ERR_FAIL_COND_V_MSG(!method, nullptr, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	return method->ptrcall;
 }
 
 int Variant::get_builtin_method_argument_count(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, 0);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, 0);
+	ERR_FAIL_COND_V_MSG(!method, 0, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	return method->argument_count;
 }
 
 Variant::Type Variant::get_builtin_method_argument_type(Variant::Type p_type, const StringName &p_method, int p_argument) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, Variant::NIL);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, Variant::NIL);
+	ERR_FAIL_COND_V_MSG(!method, Variant::NIL, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	ERR_FAIL_INDEX_V(p_argument, method->argument_count, Variant::NIL);
 	return method->get_argument_type(p_argument);
 }
@@ -1099,7 +1099,7 @@ Variant::Type Variant::get_builtin_method_argument_type(Variant::Type p_type, co
 String Variant::get_builtin_method_argument_name(Variant::Type p_type, const StringName &p_method, int p_argument) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, String());
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, String());
+	ERR_FAIL_COND_V_MSG(!method, String(), "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 #ifdef DEBUG_METHODS_ENABLED
 	ERR_FAIL_INDEX_V(p_argument, method->argument_count, String());
 	return method->argument_names[p_argument];
@@ -1111,14 +1111,14 @@ String Variant::get_builtin_method_argument_name(Variant::Type p_type, const Str
 Vector<Variant> Variant::get_builtin_method_default_arguments(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, Vector<Variant>());
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, Vector<Variant>());
+	ERR_FAIL_COND_V_MSG(!method, Vector<Variant>(), "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	return method->default_arguments;
 }
 
 bool Variant::has_builtin_method_return_value(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, false);
+	ERR_FAIL_COND_V_MSG(!method, false, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	return method->has_return_type;
 }
 
@@ -1137,35 +1137,35 @@ int Variant::get_builtin_method_count(Variant::Type p_type) {
 Variant::Type Variant::get_builtin_method_return_type(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, Variant::NIL);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, Variant::NIL);
+	ERR_FAIL_COND_V_MSG(!method, Variant::NIL, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	return method->return_type;
 }
 
 bool Variant::is_builtin_method_const(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, false);
+	ERR_FAIL_COND_V_MSG(!method, false, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	return method->is_const;
 }
 
 bool Variant::is_builtin_method_static(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, false);
+	ERR_FAIL_COND_V_MSG(!method, false, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	return method->is_static;
 }
 
 bool Variant::is_builtin_method_vararg(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, false);
+	ERR_FAIL_COND_V_MSG(!method, false, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	return method->is_vararg;
 }
 
 uint32_t Variant::get_builtin_method_hash(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, 0);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, 0);
+	ERR_FAIL_COND_V_MSG(!method, 0, "Cannot find \"" + p_method + "\" method in \"" + Variant::get_type_name(p_type) + "\" class.");
 	uint32_t hash = hash_djb2_one_32(method->is_const);
 	hash = hash_djb2_one_32(method->is_static, hash);
 	hash = hash_djb2_one_32(method->is_vararg, hash);
@@ -1190,7 +1190,7 @@ void Variant::get_method_list(List<MethodInfo> *p_list) const {
 	} else {
 		for (const StringName &E : builtin_method_names[type]) {
 			const VariantBuiltInMethodInfo *method = builtin_method_info[type].lookup_ptr(E);
-			ERR_CONTINUE(!method);
+			ERR_CONTINUE_MSG(!method, "Cannot find \"" + E + "\" method in \"" + Variant::get_type_name(type) + "\" class.");
 
 			MethodInfo mi;
 			mi.name = E;

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1130,7 +1130,7 @@ static void register_utility_function(const String &p_name, const Vector<String>
 		name = name.substr(1, name.length() - 1);
 	}
 	StringName sname = name;
-	ERR_FAIL_COND(utility_function_table.has(sname));
+	ERR_FAIL_COND_MSG(utility_function_table.has(sname), "Function \"" + name + "\" was already registered as utility function.");
 
 	VariantUtilityFunctionInfo bfi;
 	bfi.call_utility = T::call;

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -1718,7 +1718,7 @@ void VulkanContext::flush(bool p_flush_setup, bool p_flush_pending) {
 		submit_info.pSignalSemaphores = nullptr;
 		VkResult err = vkQueueSubmit(graphics_queue, 1, &submit_info, VK_NULL_HANDLE);
 		command_buffer_queue.write[0] = nullptr;
-		ERR_FAIL_COND(err);
+		ERR_FAIL_COND_MSG(err, "Failed to submit vulkan queue.");
 		vkDeviceWaitIdle(device);
 	}
 
@@ -1736,7 +1736,7 @@ void VulkanContext::flush(bool p_flush_setup, bool p_flush_pending) {
 		submit_info.signalSemaphoreCount = 0;
 		submit_info.pSignalSemaphores = nullptr;
 		VkResult err = vkQueueSubmit(graphics_queue, 1, &submit_info, VK_NULL_HANDLE);
-		ERR_FAIL_COND(err);
+		ERR_FAIL_COND_MSG(err, "Failed to submit vulkan queue.");
 		vkDeviceWaitIdle(device);
 
 		command_buffer_count = 1;
@@ -2099,16 +2099,11 @@ void VulkanContext::local_device_push_command_buffers(RID p_local_device, const 
 	submit_info.pSignalSemaphores = nullptr;
 
 	VkResult err = vkQueueSubmit(ld->queue, 1, &submit_info, VK_NULL_HANDLE);
-	if (err == VK_ERROR_OUT_OF_HOST_MEMORY) {
-		print_line("Vulkan: Out of host memory!");
-	}
-	if (err == VK_ERROR_OUT_OF_DEVICE_MEMORY) {
-		print_line("Vulkan: Out of device memory!");
-	}
-	if (err == VK_ERROR_DEVICE_LOST) {
-		print_line("Vulkan: Device lost!");
-	}
-	ERR_FAIL_COND(err);
+
+	ERR_FAIL_COND_MSG(err == VK_ERROR_OUT_OF_HOST_MEMORY, "Vulkan: Out of host memory!");
+	ERR_FAIL_COND_MSG(err == VK_ERROR_OUT_OF_DEVICE_MEMORY, "Vulkan: Out of device memory!");
+	ERR_FAIL_COND_MSG(err == VK_ERROR_DEVICE_LOST, "Vulkan: Device lost!");
+	ERR_FAIL_COND_MSG(err, "Failed to submit vulkan queue.");
 
 	ld->waiting = true;
 }

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -50,7 +50,7 @@
 #endif
 
 void FileAccessWindows::check_errors() const {
-	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	if (feof(f)) {
 		last_error = ERR_FILE_EOF;
@@ -195,7 +195,7 @@ bool FileAccessWindows::is_open() const {
 }
 
 void FileAccessWindows::seek(uint64_t p_position) {
-	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	last_error = OK;
 	if (_fseeki64(f, p_position, SEEK_SET)) {
@@ -205,7 +205,7 @@ void FileAccessWindows::seek(uint64_t p_position) {
 }
 
 void FileAccessWindows::seek_end(int64_t p_position) {
-	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	if (_fseeki64(f, p_position, SEEK_END)) {
 		check_errors();
@@ -275,7 +275,7 @@ Error FileAccessWindows::get_error() const {
 }
 
 void FileAccessWindows::flush() {
-	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	fflush(f);
 	if (prev_op == WRITE) {
@@ -284,7 +284,7 @@ void FileAccessWindows::flush() {
 }
 
 void FileAccessWindows::store_8(uint8_t p_dest) {
-	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == READ) {
@@ -298,7 +298,7 @@ void FileAccessWindows::store_8(uint8_t p_dest) {
 }
 
 void FileAccessWindows::store_buffer(const uint8_t *p_src, uint64_t p_length) {
-	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	ERR_FAIL_COND(!p_src && p_length > 0);
 
 	if (flags == READ_WRITE || flags == WRITE_READ) {

--- a/editor/debugger/editor_debugger_server.cpp
+++ b/editor/debugger/editor_debugger_server.cpp
@@ -99,7 +99,7 @@ EditorDebuggerServer *EditorDebuggerServer::create(const String &p_protocol) {
 }
 
 void EditorDebuggerServer::register_protocol_handler(const String &p_protocol, CreateServerFunc p_func) {
-	ERR_FAIL_COND(protocols.has(p_protocol));
+	ERR_FAIL_COND_MSG(protocols.has(p_protocol), "Protocol `" + p_protocol + "` is already registered.");
 	protocols[p_protocol] = p_func;
 }
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1154,7 +1154,7 @@ Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_re
 }
 
 Variant _EDITOR_GET(const String &p_setting) {
-	ERR_FAIL_COND_V(!EditorSettings::get_singleton()->has_setting(p_setting), Variant());
+	ERR_FAIL_COND_V_MSG(!EditorSettings::get_singleton()->has_setting(p_setting), Variant(), "Failed to find \"" + p_setting + "\" setting in editor settings.");
 	return EditorSettings::get_singleton()->get(p_setting);
 }
 

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -354,7 +354,7 @@ void ImportDock::_preset_selected(int p_idx) {
 			_update_preset_menu();
 		} break;
 		case ITEM_LOAD_DEFAULT: {
-			ERR_FAIL_COND(!ProjectSettings::get_singleton()->has_setting("importer_defaults/" + params->importer->get_importer_name()));
+			ERR_FAIL_COND_MSG(!ProjectSettings::get_singleton()->has_setting("importer_defaults/" + params->importer->get_importer_name()), "Missing \"importer_defaults/" + params->importer->get_importer_name() + "\" setting in project settings.");
 
 			Dictionary d = ProjectSettings::get_singleton()->get("importer_defaults/" + params->importer->get_importer_name());
 			List<Variant> v;

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -75,7 +75,7 @@ void BackgroundProgress::_update() {
 void BackgroundProgress::_task_step(const String &p_task, int p_step) {
 	_THREAD_SAFE_METHOD_
 
-	ERR_FAIL_COND(!tasks.has(p_task));
+	ERR_FAIL_COND_MSG(!tasks.has(p_task), "Task '" + p_task + "' not exists.");
 
 	Task &t = tasks[p_task];
 	if (p_step < 0) {
@@ -88,7 +88,7 @@ void BackgroundProgress::_task_step(const String &p_task, int p_step) {
 void BackgroundProgress::_end_task(const String &p_task) {
 	_THREAD_SAFE_METHOD_
 
-	ERR_FAIL_COND(!tasks.has(p_task));
+	ERR_FAIL_COND_MSG(!tasks.has(p_task), "Task '" + p_task + "' not exists.");
 	Task &t = tasks[p_task];
 
 	memdelete(t.hb);
@@ -185,7 +185,7 @@ void ProgressDialog::add_task(const String &p_task, const String &p_label, int p
 }
 
 bool ProgressDialog::task_step(const String &p_task, const String &p_state, int p_step, bool p_force_redraw) {
-	ERR_FAIL_COND_V(!tasks.has(p_task), cancelled);
+	ERR_FAIL_COND_V_MSG(!tasks.has(p_task), cancelled, "Task '" + p_task + "' not exists.");
 
 	if (!p_force_redraw) {
 		uint64_t tus = OS::get_singleton()->get_ticks_usec();
@@ -212,7 +212,7 @@ bool ProgressDialog::task_step(const String &p_task, const String &p_state, int 
 }
 
 void ProgressDialog::end_task(const String &p_task) {
-	ERR_FAIL_COND(!tasks.has(p_task));
+	ERR_FAIL_COND_MSG(!tasks.has(p_task), "Task '" + p_task + "' not exists.");
 	Task &t = tasks[p_task];
 
 	memdelete(t.vb);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1623,7 +1623,7 @@ void GDScriptLanguage::add_named_global_constant(const StringName &p_name, const
 }
 
 void GDScriptLanguage::remove_named_global_constant(const StringName &p_name) {
-	ERR_FAIL_COND(!named_globals.has(p_name));
+	ERR_FAIL_COND_MSG(!named_globals.has(p_name), "Cannot remove \"" + p_name + "\" from named global constants.");
 	named_globals.erase(p_name);
 }
 

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -496,7 +496,7 @@ COMMAND_1(free, RID, p_object) {
 		agent_owner.free(p_object);
 
 	} else {
-		ERR_FAIL_COND("Invalid ID.");
+		ERR_FAIL_MSG("Trying to free invalid ID: " + itos(p_object.get_id()) + ".");
 	}
 }
 

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -458,7 +458,7 @@ void Skeleton3D::add_bone(const String &p_name) {
 	ERR_FAIL_COND(p_name == "" || p_name.find(":") != -1 || p_name.find("/") != -1);
 
 	for (int i = 0; i < bones.size(); i++) {
-		ERR_FAIL_COND(bones[i].name == p_name);
+		ERR_FAIL_COND_MSG(bones[i].name == p_name, "Bone \"" + p_name + "\" already exists in Skeleton3D.");
 	}
 
 	Bone b;
@@ -491,7 +491,7 @@ void Skeleton3D::set_bone_name(int p_bone, const String &p_name) {
 
 	for (int i = 0; i < bone_size; i++) {
 		if (i != p_bone) {
-			ERR_FAIL_COND(bones[i].name == p_name);
+			ERR_FAIL_COND_MSG(bones[i].name == p_name, "Bone \"" + p_name + "\" already exists in Skeleton3D.");
 		}
 	}
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -890,7 +890,7 @@ void Node::_set_name_nocheck(const StringName &p_name) {
 void Node::set_name(const String &p_name) {
 	String name = p_name.validate_node_name();
 
-	ERR_FAIL_COND(name == "");
+	ERR_FAIL_COND_MSG(name.is_empty(), "New node name, cannot be empty.");
 	data.name = name;
 
 	if (data.parent) {
@@ -1649,11 +1649,11 @@ void Node::add_to_group(const StringName &p_identifier, bool p_persistent) {
 }
 
 void Node::remove_from_group(const StringName &p_identifier) {
-	ERR_FAIL_COND(!data.grouped.has(p_identifier));
+	ERR_FAIL_COND_MSG(!data.grouped.has(p_identifier), "Cannot find `" + p_identifier + "` group.");
 
 	Map<StringName, GroupData>::Element *E = data.grouped.find(p_identifier);
 
-	ERR_FAIL_COND(!E);
+	ERR_FAIL_COND_MSG(!E, "Node is not in " + p_identifier + " group.");
 
 	if (data.tree) {
 		data.tree->remove_from_group(E->key(), this);

--- a/scene/main/resource_preloader.cpp
+++ b/scene/main/resource_preloader.cpp
@@ -97,12 +97,12 @@ void ResourcePreloader::add_resource(const StringName &p_name, const RES &p_reso
 }
 
 void ResourcePreloader::remove_resource(const StringName &p_name) {
-	ERR_FAIL_COND(!resources.has(p_name));
+	ERR_FAIL_COND_MSG(!resources.has(p_name), "Resource `" + p_name + "` wasn't preloaded");
 	resources.erase(p_name);
 }
 
 void ResourcePreloader::rename_resource(const StringName &p_from_name, const StringName &p_to_name) {
-	ERR_FAIL_COND(!resources.has(p_from_name));
+	ERR_FAIL_COND_MSG(!resources.has(p_from_name), "Resource `" + p_from_name + "` wasn't preloaded");
 
 	RES res = resources[p_from_name];
 

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -417,7 +417,7 @@ bool CodeHighlighter::has_keyword_color(const String &p_keyword) const {
 }
 
 Color CodeHighlighter::get_keyword_color(const String &p_keyword) const {
-	ERR_FAIL_COND_V(!keywords.has(p_keyword), Color());
+	ERR_FAIL_COND_V_MSG(!keywords.has(p_keyword), Color(), "Missing \"" + p_keyword + "\" color in code highlighter keyword colors.");
 	return keywords[p_keyword];
 }
 
@@ -451,7 +451,7 @@ bool CodeHighlighter::has_member_keyword_color(const String &p_member_keyword) c
 }
 
 Color CodeHighlighter::get_member_keyword_color(const String &p_member_keyword) const {
-	ERR_FAIL_COND_V(!member_keywords.has(p_member_keyword), Color());
+	ERR_FAIL_COND_V_MSG(!member_keywords.has(p_member_keyword), Color(), "Missing \"" + p_member_keyword + "\" color in code highlighter member keyword colors.");
 	return member_keywords[p_member_keyword];
 }
 

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -93,7 +93,7 @@ NavigationServer3D *NavigationServer3D::get_singleton_mut() {
 }
 
 NavigationServer3D::NavigationServer3D() {
-	ERR_FAIL_COND(singleton != nullptr);
+	ERR_FAIL_COND_MSG(singleton != nullptr, "NavigationServer3D singleton already exists.");
 	singleton = this;
 }
 

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -443,7 +443,7 @@ void ShaderRD::_save_to_cache(Version *p_version) {
 	String path = shader_cache_dir.plus_file(name).plus_file(base_sha256).plus_file(sha1) + ".cache";
 
 	FileAccessRef f = FileAccess::open(path, FileAccess::WRITE);
-	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND_MSG(!f, "Failed to open file `" + path + "`.");
 	f->store_buffer((const uint8_t *)shader_file_header, 4);
 	f->store_32(cache_file_version); //file version
 	uint32_t variant_count = variant_defines.size();
@@ -650,7 +650,7 @@ void ShaderRD::initialize(const Vector<String> &p_variant_defines, const String 
 		base_sha256 = hash_build.as_string().sha256_text();
 
 		DirAccessRef d = DirAccess::open(shader_cache_dir);
-		ERR_FAIL_COND(!d);
+		ERR_FAIL_COND_MSG(!d, "Failed to open directory `" + shader_cache_dir + "`.");
 		if (d->change_dir(name) != OK) {
 			Error err = d->make_dir(name);
 			ERR_FAIL_COND(err != OK);


### PR DESCRIPTION
This helps to find what exactly is wrong with bad code.


example from https://github.com/godotengine/godot/issues/50471#issuecomment-880581824

Before
```
ERROR: Condition "!method" is true. Returning: false
   at: is_builtin_method_vararg (core/variant/variant_call.cpp:1125)
```

After
```
ERROR: Cannot find "call_me" method in "Nil" class.
   at: is_builtin_method_vararg (core/variant/variant_call.cpp:1161)
```

