### PR TITLE
SCons: Fix potential error when pruning cache on CI

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -934,9 +934,12 @@ def show_progress(env):
 
     def progress_finish(target, source, env):
         nonlocal node_count, progressor
-        with open(node_count_fname, "w") as f:
-            f.write("%d\n" % node_count)
-        progressor.delete(progressor.file_list())
+        try:
+            with open(node_count_fname, "w") as f:
+                f.write("%d\n" % node_count)
+            progressor.delete(progressor.file_list())
+        except Exception:
+            pass
 
     try:
         with open(node_count_fname) as f:


### PR DESCRIPTION
This could cause spurious errors on CI when trying to prune the cache,
as for some reason it tries to remove files/paths which do not exist.

That points at a bug in the `cache_progress` logic but at least this
workaround should prevent CI failures.

This should hopefully fix the frequent iOS false positive failures we get with this form:
```
scons: *** [progress_finish] /Users/runner/work/godot/godot/.scons_cache/FD/fdf7696e2c6192cf14e153ebfa2c0043.tmp7ec51a087eb6496485a4027ed7530e0d: No such file or directory
```