### PR TITLE
Fix String::num_real and test cases when compiling with doubles

### DIFF
--- a/tests/test_string.h
+++ b/tests/test_string.h
@@ -355,12 +355,22 @@ TEST_CASE("[String] Number to string") {
 	CHECK(String::num(-0.0) == "-0"); // Includes sign even for zero.
 	CHECK(String::num(3.141593) == "3.141593");
 	CHECK(String::num(3.141593, 3) == "3.142");
-	CHECK(String::num_real(3.141593) == "3.141593");
 	CHECK(String::num_scientific(30000000) == "3e+07");
 	CHECK(String::num_int64(3141593) == "3141593");
 	CHECK(String::num_int64(0xA141593, 16) == "a141593");
 	CHECK(String::num_int64(0xA141593, 16, true) == "A141593");
 	CHECK(String::num(42.100023, 4) == "42.1"); // No trailing zeros.
+
+	// String::num_real tests.
+	CHECK(String::num_real(3.141593) == "3.141593");
+	CHECK(String::num_real(3.141) == "3.141"); // No trailing zeros.
+#ifdef REAL_T_IS_DOUBLE
+	CHECK_MESSAGE(String::num_real(Math_PI) == "3.14159265358979", "Prints the appropriate amount of digits for real_t = double.");
+	CHECK_MESSAGE(String::num_real(3.1415f) == "3.14149999618530", "Prints more digits of 32-bit float when real_t = double (ones that would be reliable for double).");
+#else
+	CHECK_MESSAGE(String::num_real(Math_PI) == "3.141593", "Prints the appropriate amount of digits for real_t = float.");
+	CHECK_MESSAGE(String::num_real(3.1415f) == "3.1415", "Prints only reliable digits of 32-bit float when real_t = float.");
+#endif // REAL_T_IS_DOUBLE
 
 	// Checks doubles with many decimal places.
 	CHECK(String::num(0.0000012345432123454321, -1) == "0.00000123454321"); // -1 uses 14 as sane default.


### PR DESCRIPTION
This PR does three things:

* Fix a bug in String::num_real that causes trailing zeros to appear. I discovered this problem when testing float=64, but I was able to create a test case that reproduces the problem with float=32 on the current master:

```cpp
CHECK_MESSAGE(String::num_real(3.1415f) == "3.1415", "Prints only reliable digits of 32-bit float when real_t = float.");
```

```
tests/test_string.h:372: ERROR: CHECK( String::num_real(3.1415f) == "3.1415" ) is NOT correct!
  values: CHECK( "3.141500" == 3.1415 )
  logged: Prints only reliable digits of 32-bit float when real_t = float.
```

* Fix a bug in String::num_real when compiling with float=64 that causes integer overflows. The problem is that `int` only gives us 9 decimal digits, but we need at least 14 for doubles. I switched type to `int64_t` to fix the bug. Note that this will need to be changed to int128 if we ever decide to add float=128 as an option.

```
core/string/ustring.cpp:1673:22: runtime error: signed integer overflow: 999999999 * 10 cannot be represented in type 'int'
core/string/ustring.cpp:1672:34: runtime error: 1.41593e+10 is outside the range of representable values of type 'int'
core/string/ustring.cpp:1672:22: runtime error: signed integer overflow: 1415929999 * 10 cannot be represented in type 'int'
core/string/ustring.cpp:1676:29: runtime error: 1.41593e+10 is outside the range of representable values of type 'int'
core/string/ustring.cpp:1691:19: runtime error: 1.41593e+14 is outside the range of representable values of type 'int'
```

* Add several more test cases for String::num_real with messages.