### PR TITLE
Fix `line_separation` working incorrectly in `RichTextLabel`

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -555,7 +555,7 @@
 		<theme_item name="italics_font_size" data_type="font_size" type="int">
 			The font size used for italics text.
 		</theme_item>
-		<theme_item name="line_separation" data_type="constant" type="int" default="1">
+		<theme_item name="line_separation" data_type="constant" type="int" default="0">
 			The vertical space between lines.
 		</theme_item>
 		<theme_item name="mono_font" data_type="font" type="Font">

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1435,7 +1435,7 @@ void RichTextLabel::_notification(int p_what) {
 			while (ofs.y < size.height && from_line < main->lines.size()) {
 				visible_paragraph_count++;
 				visible_line_count += _draw_line(main, from_line, ofs, text_rect.size.x, base_color, outline_size, outline_color, font_shadow_color, use_outline, shadow_ofs);
-				ofs.y += main->lines[from_line].text_buf->get_size().y;
+				ofs.y += main->lines[from_line].text_buf->get_size().y + get_theme_constant(SNAME("line_separation"));
 				from_line++;
 			}
 		} break;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -916,7 +916,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * scale);
 	theme->set_constant("shadow_as_outline", "RichTextLabel", 0 * scale);
 
-	theme->set_constant("line_separation", "RichTextLabel", 1 * scale);
+	theme->set_constant("line_separation", "RichTextLabel", 0 * scale);
 	theme->set_constant("table_hseparation", "RichTextLabel", 3 * scale);
 	theme->set_constant("table_vseparation", "RichTextLabel", 3 * scale);
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixed #49455

Also, I set `line_separation` to 0 by default. Because every time we open and close the `line_separation` checkbox, there was a visual change. 

![line_separation_test](https://user-images.githubusercontent.com/12533045/129986353-4fbadc1c-8e44-42a8-ba8b-856c46228dc7.gif)
