### PR TITLE
Fix bad category name alignment in Inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2662,6 +2662,7 @@ void EditorInspector::update_tree() {
 		if (category_vbox == nullptr) {
 			category_vbox = memnew(VBoxContainer);
 			main_vbox->add_child(category_vbox);
+			main_vbox->notification(NOTIFICATION_SORT_CHILDREN);
 		}
 
 		// Find the correct section/vbox to add the property editor to.


### PR DESCRIPTION
Fix #51774 

### Issue : 

Name of the first inspector category is misaligned. 

### Fix proposal :

Parent main_vbox is notified with NOTIFICATION_SORT_CHILDREN to have correct alignment while adding category vbox as child.

### Before : 

![image](https://user-images.githubusercontent.com/3649998/129987398-ff2103e8-1f65-4425-9639-c4437b3a07c5.png)
![image](https://user-images.githubusercontent.com/3649998/129987406-115232c5-6936-4aad-8e6a-c9fa4b181435.png)

### After : 

![after1](https://user-images.githubusercontent.com/3649998/129987432-0cfd9fdd-6651-4023-85e9-aa4b2c81e146.jpg)
![after2](https://user-images.githubusercontent.com/3649998/129987436-a0d58db2-8d07-4e82-96e1-0e728254cf6c.jpg)
