### PR TITLE
Optionally render 3D content at scaled resolution

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1473,6 +1473,9 @@
 		</member>
 		<member name="rendering/2d/snap/snap_2d_vertices_to_pixel" type="bool" setter="" getter="" default="false">
 		</member>
+		<member name="rendering/3d/viewport/scale" type="int" setter="" getter="" default="0">
+			Scale the 3D render buffer based on the viewport size. The smaller the faster 3D rendering is performed but at the cost of quality.
+		</member>
 		<member name="rendering/anti_aliasing/quality/msaa" type="int" setter="" getter="" default="0">
 			Sets the number of MSAA samples to use (as a power of two). MSAA is used to reduce aliasing around the edges of polygons. A higher MSAA value results in smoother edges but can be significantly slower on some hardware.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3082,6 +3082,14 @@
 				If [code]true[/code], render the contents of the viewport directly to screen. This allows a low-level optimization where you can skip drawing a viewport to the root viewport. While this optimization can result in a significant increase in speed (especially on older devices), it comes at a cost of usability. When this is enabled, you cannot read from the viewport or from the [code]SCREEN_TEXTURE[/code]. You also lose the benefit of certain window settings, such as the various stretch modes. Another consequence to be aware of is that in 2D the rendering happens in window coordinates, so if you have a viewport that is double the size of the window, and you set this, then only the portion that fits within the window will be drawn, no automatic scaling is possible, even if your game scene is significantly larger than the window size.
 			</description>
 		</method>
+		<method name="viewport_set_scale_3d">
+			<return type="void" />
+			<argument index="0" name="viewport" type="RID" />
+			<argument index="1" name="scale" type="int" enum="RenderingServer.ViewportScale3D" />
+			<description>
+				Sets the scale at which we render 3D contents.
+			</description>
+		</method>
 		<method name="viewport_set_scenario">
 			<return type="void" />
 			<argument index="0" name="viewport" type="RID" />
@@ -3895,6 +3903,16 @@
 		<constant name="VIEWPORT_DEBUG_DRAW_CLUSTER_REFLECTION_PROBES" value="22" enum="ViewportDebugDraw">
 		</constant>
 		<constant name="VIEWPORT_DEBUG_DRAW_OCCLUDERS" value="23" enum="ViewportDebugDraw">
+		</constant>
+		<constant name="VIEWPORT_SCALE_3D_DISABLED" value="0" enum="ViewportScale3D">
+		</constant>
+		<constant name="VIEWPORT_SCALE_3D_75_PERCENT" value="1" enum="ViewportScale3D">
+		</constant>
+		<constant name="VIEWPORT_SCALE_3D_50_PERCENT" value="2" enum="ViewportScale3D">
+		</constant>
+		<constant name="VIEWPORT_SCALE_3D_33_PERCENT" value="3" enum="ViewportScale3D">
+		</constant>
+		<constant name="VIEWPORT_SCALE_3D_25_PERCENT" value="4" enum="ViewportScale3D">
 		</constant>
 		<constant name="SKY_MODE_AUTOMATIC" value="0" enum="SkyMode">
 		</constant>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -211,6 +211,9 @@
 		<member name="physics_object_picking" type="bool" setter="set_physics_object_picking" getter="get_physics_object_picking" default="false">
 			If [code]true[/code], the objects rendered by viewport become subjects of mouse picking process.
 		</member>
+		<member name="scale_3d" type="int" setter="set_scale_3d" getter="get_scale_3d" enum="Viewport.Scale3D" default="0">
+			The scale at which 3D content is rendered.
+		</member>
 		<member name="screen_space_aa" type="int" setter="set_screen_space_aa" getter="get_screen_space_aa" enum="Viewport.ScreenSpaceAA" default="0">
 			Sets the screen-space antialiasing method used. Screen-space antialiasing works by selectively blurring edges in a post-process shader. It differs from MSAA which takes multiple coverage samples while rendering objects. Screen-space AA methods are typically faster than MSAA and will smooth out specular aliasing, but tend to make scenes appear blurry.
 		</member>
@@ -271,6 +274,16 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="SCALE_3D_DISABLED" value="0" enum="Scale3D">
+		</constant>
+		<constant name="SCALE_3D_75_PERCENT" value="1" enum="Scale3D">
+		</constant>
+		<constant name="SCALE_3D_50_PERCENT" value="2" enum="Scale3D">
+		</constant>
+		<constant name="SCALE_3D_33_PERCENT" value="3" enum="Scale3D">
+		</constant>
+		<constant name="SCALE_3D_25_PERCENT" value="4" enum="Scale3D">
+		</constant>
 		<constant name="SHADOW_ATLAS_QUADRANT_SUBDIV_DISABLED" value="0" enum="ShadowAtlasQuadrantSubdiv">
 			This quadrant will not be used.
 		</constant>

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -2740,6 +2740,14 @@ bool RenderingDeviceVulkan::texture_is_valid(RID p_texture) {
 	return texture_owner.owns(p_texture);
 }
 
+Size2i RenderingDeviceVulkan::texture_size(RID p_texture) {
+	_THREAD_SAFE_METHOD_
+
+	Texture *tex = texture_owner.getornull(p_texture);
+	ERR_FAIL_COND_V(!tex, Size2i());
+	return Size2i(tex->width, tex->height);
+}
+
 Error RenderingDeviceVulkan::texture_copy(RID p_from_texture, RID p_to_texture, const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_size, uint32_t p_src_mipmap, uint32_t p_dst_mipmap, uint32_t p_src_layer, uint32_t p_dst_layer, uint32_t p_post_barrier) {
 	_THREAD_SAFE_METHOD_
 

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1044,6 +1044,7 @@ public:
 	virtual bool texture_is_format_supported_for_usage(DataFormat p_format, uint32_t p_usage) const;
 	virtual bool texture_is_shared(RID p_texture);
 	virtual bool texture_is_valid(RID p_texture);
+	virtual Size2i texture_size(RID p_texture);
 
 	virtual Error texture_copy(RID p_from_texture, RID p_to_texture, const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_size, uint32_t p_src_mipmap, uint32_t p_dst_mipmap, uint32_t p_src_layer, uint32_t p_dst_layer, uint32_t p_post_barrier = BARRIER_MASK_ALL);
 	virtual Error texture_clear(RID p_texture, const Color &p_color, uint32_t p_base_mipmap, uint32_t p_mipmaps, uint32_t p_base_layer, uint32_t p_layers, uint32_t p_post_barrier = BARRIER_MASK_ALL);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3451,6 +3451,17 @@ void Viewport::set_use_xr(bool p_use_xr) {
 bool Viewport::is_using_xr() {
 	return use_xr;
 }
+
+void Viewport::set_scale_3d(const Scale3D p_scale_3d) {
+	scale_3d = p_scale_3d;
+
+	RS::get_singleton()->viewport_set_scale_3d(viewport, RS::ViewportScale3D(scale_3d));
+}
+
+Viewport::Scale3D Viewport::get_scale_3d() const {
+	return scale_3d;
+}
+
 #endif // _3D_DISABLED
 
 void Viewport::_bind_methods() {
@@ -3575,8 +3586,12 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_xr", "use"), &Viewport::set_use_xr);
 	ClassDB::bind_method(D_METHOD("is_using_xr"), &Viewport::is_using_xr);
 
+	ClassDB::bind_method(D_METHOD("set_scale_3d", "scale"), &Viewport::set_scale_3d);
+	ClassDB::bind_method(D_METHOD("get_scale_3d"), &Viewport::get_scale_3d);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_3d"), "set_disable_3d", "is_3d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_xr"), "set_use_xr", "is_using_xr");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "scale_3d", PROPERTY_HINT_ENUM, String::utf8("Disabled,75%,50%,33%,25%")), "set_scale_3d", "get_scale_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_listener_enable_3d"), "set_as_audio_listener_3d", "is_audio_listener_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "own_world_3d"), "set_use_own_world_3d", "is_using_own_world_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_3d", PROPERTY_HINT_RESOURCE_TYPE, "World3D"), "set_world_3d", "get_world_3d");
@@ -3619,6 +3634,12 @@ void Viewport::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("size_changed"));
 	ADD_SIGNAL(MethodInfo("gui_focus_changed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
+
+	BIND_ENUM_CONSTANT(SCALE_3D_DISABLED);
+	BIND_ENUM_CONSTANT(SCALE_3D_75_PERCENT);
+	BIND_ENUM_CONSTANT(SCALE_3D_50_PERCENT);
+	BIND_ENUM_CONSTANT(SCALE_3D_33_PERCENT);
+	BIND_ENUM_CONSTANT(SCALE_3D_25_PERCENT);
 
 	BIND_ENUM_CONSTANT(SHADOW_ATLAS_QUADRANT_SUBDIV_DISABLED);
 	BIND_ENUM_CONSTANT(SHADOW_ATLAS_QUADRANT_SUBDIV_1);
@@ -3733,6 +3754,11 @@ Viewport::Viewport() {
 	// Window tooltip.
 	gui.tooltip_delay = GLOBAL_DEF("gui/timers/tooltip_delay_sec", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/timers/tooltip_delay_sec", PropertyInfo(Variant::FLOAT, "gui/timers/tooltip_delay_sec", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater")); // No negative numbers
+
+#ifndef _3D_DISABLED
+	int scale = GLOBAL_GET("rendering/3d/viewport/scale");
+	set_scale_3d((Scale3D)scale);
+#endif // _3D_DISABLED
 
 	set_sdf_oversize(sdf_oversize); //set to server
 }

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -88,6 +88,14 @@ class Viewport : public Node {
 	GDCLASS(Viewport, Node);
 
 public:
+	enum Scale3D {
+		SCALE_3D_DISABLED,
+		SCALE_3D_75_PERCENT,
+		SCALE_3D_50_PERCENT,
+		SCALE_3D_33_PERCENT,
+		SCALE_3D_25_PERCENT
+	};
+
 	enum ShadowAtlasQuadrantSubdiv {
 		SHADOW_ATLAS_QUADRANT_SUBDIV_DISABLED,
 		SHADOW_ATLAS_QUADRANT_SUBDIV_1,
@@ -577,6 +585,7 @@ public:
 
 #ifndef _3D_DISABLED
 	bool use_xr = false;
+	Scale3D scale_3d = SCALE_3D_DISABLED;
 	friend class Listener3D;
 	Listener3D *listener_3d = nullptr;
 	Set<Listener3D *> listener_3d_set;
@@ -647,6 +656,9 @@ public:
 
 	void set_use_xr(bool p_use_xr);
 	bool is_using_xr();
+
+	void set_scale_3d(const Scale3D p_scale_3d);
+	Scale3D get_scale_3d() const;
 #endif // _3D_DISABLED
 
 	Viewport();
@@ -705,6 +717,7 @@ VARIANT_ENUM_CAST(SubViewport::UpdateMode);
 VARIANT_ENUM_CAST(Viewport::ShadowAtlasQuadrantSubdiv);
 VARIANT_ENUM_CAST(Viewport::MSAA);
 VARIANT_ENUM_CAST(Viewport::ScreenSpaceAA);
+VARIANT_ENUM_CAST(Viewport::Scale3D);
 VARIANT_ENUM_CAST(Viewport::DebugDraw);
 VARIANT_ENUM_CAST(Viewport::SDFScale);
 VARIANT_ENUM_CAST(Viewport::SDFOversize);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -2591,6 +2591,8 @@ void RendererSceneRenderRD::render_buffers_configure(RID p_render_buffers, RID p
 	ERR_FAIL_COND_MSG(p_view_count == 0, "Must have at least 1 view");
 
 	RenderBuffers *rb = render_buffers_owner.getornull(p_render_buffers);
+
+	// Should we add an overrule per viewport?
 	rb->width = p_width;
 	rb->height = p_height;
 	rb->render_target = p_render_target;
@@ -2637,8 +2639,8 @@ void RendererSceneRenderRD::render_buffers_configure(RID p_render_buffers, RID p
 			tf.format = RD::DATA_FORMAT_R32_SFLOAT;
 		}
 
-		tf.width = p_width;
-		tf.height = p_height;
+		tf.width = rb->width;
+		tf.height = rb->height;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT;
 		tf.array_layers = rb->view_count; // create a layer for every view
 
@@ -2660,10 +2662,10 @@ void RendererSceneRenderRD::render_buffers_configure(RID p_render_buffers, RID p
 	}
 
 	RID target_texture = storage->render_target_get_rd_texture(rb->render_target);
-	rb->data->configure(rb->texture, rb->depth_texture, target_texture, p_width, p_height, p_msaa, p_view_count);
+	rb->data->configure(rb->texture, rb->depth_texture, target_texture, rb->width, rb->height, p_msaa, p_view_count);
 
 	if (is_clustered_enabled()) {
-		rb->cluster_builder->setup(Size2i(p_width, p_height), max_cluster_elements, rb->depth_texture, storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED), rb->texture);
+		rb->cluster_builder->setup(Size2i(rb->width, rb->height), max_cluster_elements, rb->depth_texture, storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED), rb->texture);
 	}
 }
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -71,6 +71,44 @@ static Transform2D _canvas_get_transform(RendererViewport::Viewport *p_viewport,
 	return xf;
 }
 
+void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
+	if (p_viewport->render_buffers.is_valid()) {
+		if (p_viewport->size.width == 0 || p_viewport->size.height == 0) {
+			RSG::scene->free(p_viewport->render_buffers);
+			p_viewport->render_buffers = RID();
+		} else {
+			RS::ViewportScale3D scale_3d = p_viewport->scale_3d;
+			if (Engine::get_singleton()->is_editor_hint()) { // ignore this inside of the editor
+				scale_3d = RS::VIEWPORT_SCALE_3D_DISABLED;
+			}
+
+			int width = p_viewport->size.width;
+			int height = p_viewport->size.height;
+			switch (scale_3d) {
+				case RS::VIEWPORT_SCALE_3D_75_PERCENT: {
+					width = (width * 3) / 4;
+					height = (height * 3) / 4;
+				}; break;
+				case RS::VIEWPORT_SCALE_3D_50_PERCENT: {
+					width = width >> 1;
+					height = height >> 1;
+				}; break;
+				case RS::VIEWPORT_SCALE_3D_33_PERCENT: {
+					width = width / 3;
+					height = height / 3;
+				}; break;
+				case RS::VIEWPORT_SCALE_3D_25_PERCENT: {
+					width = width >> 2;
+					height = height >> 2;
+				}; break;
+				default:
+					break;
+			}
+			RSG::scene->render_buffers_configure(p_viewport->render_buffers, p_viewport->render_target, width, height, p_viewport->msaa, p_viewport->screen_space_aa, p_viewport->use_debanding, p_viewport->get_view_count());
+		}
+	}
+}
+
 void RendererViewport::_draw_3d(Viewport *p_viewport) {
 	RENDER_TIMESTAMP(">Begin Rendering 3D Scene");
 
@@ -100,7 +138,7 @@ void RendererViewport::_draw_3d(Viewport *p_viewport) {
 	RENDER_TIMESTAMP("<End Rendering 3D Scene");
 }
 
-void RendererViewport::_draw_viewport(Viewport *p_viewport, uint32_t p_view_count) {
+void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 	if (p_viewport->measure_render_time) {
 		String rt_id = "vp_begin_" + itos(p_viewport->self.get_id());
 		RSG::storage->capture_timestamp(rt_id);
@@ -142,7 +180,8 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport, uint32_t p_view_coun
 	if ((scenario_draw_canvas_bg || can_draw_3d) && !p_viewport->render_buffers.is_valid()) {
 		//wants to draw 3D but there is no render buffer, create
 		p_viewport->render_buffers = RSG::scene->render_buffers_create();
-		RSG::scene->render_buffers_configure(p_viewport->render_buffers, p_viewport->render_target, p_viewport->size.width, p_viewport->size.height, p_viewport->msaa, p_viewport->screen_space_aa, p_viewport->use_debanding, p_view_count);
+
+		_configure_3d_render_buffers(p_viewport);
 	}
 
 	RSG::storage->render_target_request_clear(p_viewport->render_target, bgcolor);
@@ -556,7 +595,7 @@ void RendererViewport::draw_viewports() {
 			RSG::scene->set_debug_draw_mode(vp->debug_draw);
 
 			// and draw viewport
-			_draw_viewport(vp, view_count);
+			_draw_viewport(vp);
 
 			// measure
 
@@ -580,7 +619,7 @@ void RendererViewport::draw_viewports() {
 			RSG::scene->set_debug_draw_mode(vp->debug_draw);
 
 			// render standard mono camera
-			_draw_viewport(vp, 1);
+			_draw_viewport(vp);
 
 			if (vp->viewport_to_screen != DisplayServer::INVALID_WINDOW_ID && (!vp->viewport_render_direct_to_screen || !RSG::rasterizer->is_low_end())) {
 				//copy to screen if set as such
@@ -648,9 +687,19 @@ void RendererViewport::viewport_set_use_xr(RID p_viewport, bool p_use_xr) {
 	}
 
 	viewport->use_xr = p_use_xr;
-	if (viewport->render_buffers.is_valid()) {
-		RSG::scene->render_buffers_configure(viewport->render_buffers, viewport->render_target, viewport->size.width, viewport->size.height, viewport->msaa, viewport->screen_space_aa, viewport->use_debanding, viewport->get_view_count());
+	_configure_3d_render_buffers(viewport);
+}
+
+void RendererViewport::viewport_set_scale_3d(RID p_viewport, RenderingServer::ViewportScale3D p_scale_3d) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+
+	if (viewport->scale_3d == p_scale_3d) {
+		return;
 	}
+
+	viewport->scale_3d = p_scale_3d;
+	_configure_3d_render_buffers(viewport);
 }
 
 uint32_t RendererViewport::Viewport::get_view_count() {
@@ -677,14 +726,7 @@ void RendererViewport::viewport_set_size(RID p_viewport, int p_width, int p_heig
 	viewport->size = Size2(p_width, p_height);
 	uint32_t view_count = viewport->get_view_count();
 	RSG::storage->render_target_set_size(viewport->render_target, p_width, p_height, view_count);
-	if (viewport->render_buffers.is_valid()) {
-		if (p_width == 0 || p_height == 0) {
-			RSG::scene->free(viewport->render_buffers);
-			viewport->render_buffers = RID();
-		} else {
-			RSG::scene->render_buffers_configure(viewport->render_buffers, viewport->render_target, viewport->size.width, viewport->size.height, viewport->msaa, viewport->screen_space_aa, viewport->use_debanding, view_count);
-		}
-	}
+	_configure_3d_render_buffers(viewport);
 
 	viewport->occlusion_buffer_dirty = true;
 }
@@ -915,9 +957,7 @@ void RendererViewport::viewport_set_msaa(RID p_viewport, RS::ViewportMSAA p_msaa
 		return;
 	}
 	viewport->msaa = p_msaa;
-	if (viewport->render_buffers.is_valid()) {
-		RSG::scene->render_buffers_configure(viewport->render_buffers, viewport->render_target, viewport->size.width, viewport->size.height, p_msaa, viewport->screen_space_aa, viewport->use_debanding, viewport->get_view_count());
-	}
+	_configure_3d_render_buffers(viewport);
 }
 
 void RendererViewport::viewport_set_screen_space_aa(RID p_viewport, RS::ViewportScreenSpaceAA p_mode) {
@@ -928,9 +968,7 @@ void RendererViewport::viewport_set_screen_space_aa(RID p_viewport, RS::Viewport
 		return;
 	}
 	viewport->screen_space_aa = p_mode;
-	if (viewport->render_buffers.is_valid()) {
-		RSG::scene->render_buffers_configure(viewport->render_buffers, viewport->render_target, viewport->size.width, viewport->size.height, viewport->msaa, p_mode, viewport->use_debanding, viewport->get_view_count());
-	}
+	_configure_3d_render_buffers(viewport);
 }
 
 void RendererViewport::viewport_set_use_debanding(RID p_viewport, bool p_use_debanding) {
@@ -941,9 +979,7 @@ void RendererViewport::viewport_set_use_debanding(RID p_viewport, bool p_use_deb
 		return;
 	}
 	viewport->use_debanding = p_use_debanding;
-	if (viewport->render_buffers.is_valid()) {
-		RSG::scene->render_buffers_configure(viewport->render_buffers, viewport->render_target, viewport->size.width, viewport->size.height, viewport->msaa, viewport->screen_space_aa, p_use_debanding, viewport->get_view_count());
-	}
+	_configure_3d_render_buffers(viewport);
 }
 
 void RendererViewport::viewport_set_use_occlusion_culling(RID p_viewport, bool p_use_occlusion_culling) {

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -49,6 +49,8 @@ public:
 
 		bool use_xr; /* use xr interface to override camera positioning and projection matrices and control output */
 
+		RS::ViewportScale3D scale_3d = RenderingServer::VIEWPORT_SCALE_3D_DISABLED;
+
 		Size2i size;
 		RID camera;
 		RID scenario;
@@ -192,8 +194,9 @@ public:
 	int total_draw_calls_used = 0;
 
 private:
+	void _configure_3d_render_buffers(Viewport *p_viewport);
 	void _draw_3d(Viewport *p_viewport);
-	void _draw_viewport(Viewport *p_viewport, uint32_t p_view_count = 1);
+	void _draw_viewport(Viewport *p_viewport);
 
 	int occlusion_rays_per_thread = 512;
 
@@ -204,6 +207,7 @@ public:
 	void viewport_initialize(RID p_rid);
 
 	void viewport_set_use_xr(RID p_viewport, bool p_use_xr);
+	void viewport_set_scale_3d(RID p_viewport, RenderingServer::ViewportScale3D p_scale_3d);
 
 	void viewport_set_size(RID p_viewport, int p_width, int p_height);
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -495,6 +495,7 @@ public:
 	virtual bool texture_is_format_supported_for_usage(DataFormat p_format, uint32_t p_usage) const = 0;
 	virtual bool texture_is_shared(RID p_texture) = 0;
 	virtual bool texture_is_valid(RID p_texture) = 0;
+	virtual Size2i texture_size(RID p_texture) = 0;
 
 	virtual Error texture_copy(RID p_from_texture, RID p_to_texture, const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_size, uint32_t p_src_mipmap, uint32_t p_dst_mipmap, uint32_t p_src_layer, uint32_t p_dst_layer, uint32_t p_post_barrier = BARRIER_MASK_ALL) = 0;
 	virtual Error texture_clear(RID p_texture, const Color &p_color, uint32_t p_base_mipmap, uint32_t p_mipmaps, uint32_t p_base_layer, uint32_t p_layers, uint32_t p_post_barrier = BARRIER_MASK_ALL) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -526,6 +526,7 @@ public:
 	FUNCRIDSPLIT(viewport)
 
 	FUNC2(viewport_set_use_xr, RID, bool)
+	FUNC2(viewport_set_scale_3d, RID, ViewportScale3D)
 	FUNC3(viewport_set_size, RID, int, int)
 
 	FUNC2(viewport_set_active, RID, bool)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2138,6 +2138,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("viewport_create"), &RenderingServer::viewport_create);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_xr", "viewport", "use_xr"), &RenderingServer::viewport_set_use_xr);
+	ClassDB::bind_method(D_METHOD("viewport_set_scale_3d", "viewport", "scale"), &RenderingServer::viewport_set_scale_3d);
 	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::viewport_set_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_active", "viewport", "active"), &RenderingServer::viewport_set_active);
 	ClassDB::bind_method(D_METHOD("viewport_set_parent_viewport", "viewport", "parent_viewport"), &RenderingServer::viewport_set_parent_viewport);
@@ -2254,6 +2255,12 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(VIEWPORT_DEBUG_DRAW_CLUSTER_DECALS);
 	BIND_ENUM_CONSTANT(VIEWPORT_DEBUG_DRAW_CLUSTER_REFLECTION_PROBES);
 	BIND_ENUM_CONSTANT(VIEWPORT_DEBUG_DRAW_OCCLUDERS);
+
+	BIND_ENUM_CONSTANT(VIEWPORT_SCALE_3D_DISABLED);
+	BIND_ENUM_CONSTANT(VIEWPORT_SCALE_3D_75_PERCENT);
+	BIND_ENUM_CONSTANT(VIEWPORT_SCALE_3D_50_PERCENT);
+	BIND_ENUM_CONSTANT(VIEWPORT_SCALE_3D_33_PERCENT);
+	BIND_ENUM_CONSTANT(VIEWPORT_SCALE_3D_25_PERCENT);
 
 	/* SKY API */
 
@@ -2794,6 +2801,12 @@ RenderingServer::RenderingServer() {
 			PropertyInfo(Variant::INT,
 					"rendering/vulkan/rendering/back_end",
 					PROPERTY_HINT_ENUM, "Forward Clustered (Supports Desktop Only),Forward Mobile (Supports Desktop and Mobile)"));
+
+	GLOBAL_DEF("rendering/3d/viewport/scale", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/3d/viewport/scale",
+			PropertyInfo(Variant::INT,
+					"rendering/3d/viewport/scale",
+					PROPERTY_HINT_ENUM, "Disabled,75%,50%,33%,25%"));
 
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/enabled", true);
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/compress", true);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -752,9 +752,19 @@ public:
 		CANVAS_ITEM_TEXTURE_REPEAT_MAX,
 	};
 
+	enum ViewportScale3D {
+		VIEWPORT_SCALE_3D_DISABLED,
+		VIEWPORT_SCALE_3D_75_PERCENT,
+		VIEWPORT_SCALE_3D_50_PERCENT,
+		VIEWPORT_SCALE_3D_33_PERCENT,
+		VIEWPORT_SCALE_3D_25_PERCENT,
+		VIEWPORT_SCALE_3D_MAX,
+	};
+
 	virtual RID viewport_create() = 0;
 
 	virtual void viewport_set_use_xr(RID p_viewport, bool p_use_xr) = 0;
+	virtual void viewport_set_scale_3d(RID p_viewport, ViewportScale3D p_scale_3d) = 0;
 	virtual void viewport_set_size(RID p_viewport, int p_width, int p_height) = 0;
 	virtual void viewport_set_active(RID p_viewport, bool p_active) = 0;
 	virtual void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport) = 0;
@@ -1542,6 +1552,7 @@ VARIANT_ENUM_CAST(RenderingServer::ViewportDebugDraw);
 VARIANT_ENUM_CAST(RenderingServer::ViewportOcclusionCullingBuildQuality);
 VARIANT_ENUM_CAST(RenderingServer::ViewportSDFOversize);
 VARIANT_ENUM_CAST(RenderingServer::ViewportSDFScale);
+VARIANT_ENUM_CAST(RenderingServer::ViewportScale3D);
 VARIANT_ENUM_CAST(RenderingServer::SkyMode);
 VARIANT_ENUM_CAST(RenderingServer::EnvironmentBG);
 VARIANT_ENUM_CAST(RenderingServer::EnvironmentAmbientSource);


### PR DESCRIPTION
This PR adds a tickbox to viewports that instructs Godot to render 3D content of a viewport in a scaled resolution:
![image](https://user-images.githubusercontent.com/1945449/130324304-f7b43423-31e4-4a5b-b9b9-8e4a0f8639c6.png)

There is also a project setting that defines the default behavior (and thus lets you set the main viewport):
![image](https://user-images.githubusercontent.com/1945449/130324294-a83e07d7-1d36-45e5-ab3f-ce0be412de1e.png)

Or alternatively you can obviously do this in code:
```
get_viewport().scale_3d = Viewport.SCALE_3D_75_PERCENT
```
Note that the settings are ignored in the editor, the editor always renders at normal resolution.

![image](https://user-images.githubusercontent.com/1945449/129997590-be62aa8d-a32e-4fc3-940c-4cfc81e2617c.png)
