### PR TITLE
Fixed Camera2D's "current" property getting reset when switching scenes

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -261,6 +261,7 @@ void Camera2D::_notification(int p_what) {
 				if (viewport && !(custom_viewport && !ObjectDB::get_instance(custom_viewport_id))) {
 					viewport->set_canvas_transform(Transform2D());
 					clear_current();
+					current = true;
 				}
 			}
 			remove_from_group(group_name);


### PR DESCRIPTION
Fixes #51872

I based the changes off of Camera3D.
