### PR TITLE
Copy property name from inspector on double click

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -768,21 +768,24 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 
 				call_deferred(SNAME("_update_property"));
 			}
-		}
-		if (delete_rect.has_point(mpos)) {
+		} else if (delete_rect.has_point(mpos)) {
 			emit_signal(SNAME("property_deleted"), property);
 		}
 
-		if (revert_rect.has_point(mpos)) {
+		else if (revert_rect.has_point(mpos)) {
 			Variant revert_value = EditorPropertyRevert::get_property_revert_value(object, property);
 			emit_changed(property, revert_value);
 			update_property();
 		}
 
-		if (check_rect.has_point(mpos)) {
+		else if (check_rect.has_point(mpos)) {
 			checked = !checked;
 			update();
 			emit_signal(SNAME("property_checked"), property, checked);
+		}
+
+		else if (mb.is_valid() && mb->is_double_click() && (EDITOR_GET("interface/inspector/copy_property_name_on_doubleclick"))) {
+			DisplayServer::get_singleton()->clipboard_set(property);
 		}
 	}
 }
@@ -974,6 +977,7 @@ EditorProperty::EditorProperty() {
 	label_reference = nullptr;
 	bottom_editor = nullptr;
 	delete_hover = false;
+	set_mouse_filter(Control::MouseFilter::MOUSE_FILTER_STOP);
 }
 
 ////////////////////////////////////////////////

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5918,6 +5918,7 @@ EditorNode::EditorNode() {
 	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", false);
 	EDITOR_DEF_RST("interface/scene_tabs/show_thumbnail_on_hover", true);
 	EDITOR_DEF_RST("interface/inspector/capitalize_properties", true);
+	EDITOR_DEF_RST("interface/inspector/copy_property_name_on_doubleclick", true);
 	EDITOR_DEF_RST("interface/inspector/default_float_step", 0.001);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::FLOAT, "interface/inspector/default_float_step", PROPERTY_HINT_RANGE, "0,1,0"));
 	EDITOR_DEF_RST("interface/inspector/disable_folding", false);


### PR DESCRIPTION
I propose an optional feature that will save time and help beginners with real property names:
 
### **Ability to copy property name in clipboard from inspector on double click**

### What is the problem solved by this PR and use cases?

It can be hard to exactly remember a node property name while writing a script, especially when the real property name is hidden by capitalized properties in the inspector (default behaviour)

![image](https://user-images.githubusercontent.com/3649998/130041678-479fa0de-f751-44b2-a404-79664c019ccc.png)
The real name of the property is rect_position. It can be confusing for beginners.
It can be retrieved in the tooltip but it takes some times and then we have to write it by hand in script.

### How does this Pull Request fix these problems?

I propose to copy the real property name to clipboard by double clicking on the property name in inspector. It will help beginners to have to real property name and could be a time saver for others.

![doubleclick_copy](https://user-images.githubusercontent.com/3649998/130042314-7c7da8d0-fa28-456b-b688-c62b5705dfe0.gif)

I've also added an editor option to switch off this feature if someone doesn't want it.
![image](https://user-images.githubusercontent.com/3649998/130042513-6807343d-a48d-4bef-bc80-ad1276f6eab7.png)



