### PR TITLE
Fix ItemList layout (+EditorFileDialog)

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -403,6 +403,9 @@
 		<member name="select_mode" type="int" setter="set_select_mode" getter="get_select_mode" enum="ItemList.SelectMode" default="0">
 			Allows single or multiple item selection. See the [enum SelectMode] constants.
 		</member>
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextParagraph.OverrunBehavior" default="0">
+			Sets the clipping behavior when the text exceeds an item's bounding rectangle. See [enum TextParagraph.OverrunBehavior] for a description of all modes.
+		</member>
 	</members>
 	<signals>
 		<signal name="item_activated">

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -728,6 +728,7 @@ void EditorFileDialog::update_file_list() {
 		item_list->set_icon_mode(ItemList::ICON_MODE_TOP);
 		item_list->set_fixed_column_width(thumbnail_size * 3 / 2);
 		item_list->set_max_text_lines(2);
+		item_list->set_text_overrun_behavior(TextParagraph::OVERRUN_TRIM_ELLIPSIS);
 		item_list->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
 
 		if (thumbnail_size < 64) {
@@ -1645,6 +1646,7 @@ EditorFileDialog::EditorFileDialog() {
 	item_list->connect("item_rmb_selected", callable_mp(this, &EditorFileDialog::_item_list_item_rmb_selected));
 	item_list->connect("rmb_clicked", callable_mp(this, &EditorFileDialog::_item_list_rmb_clicked));
 	item_list->set_allow_rmb_select(true);
+
 	list_vb->add_child(item_list);
 
 	item_menu = memnew(PopupMenu);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -95,6 +95,7 @@ private:
 	SelectMode select_mode = SELECT_SINGLE;
 	IconMode icon_mode = ICON_MODE_LEFT;
 	VScrollBar *scroll_bar;
+	TextParagraph::OverrunBehavior text_overrun_behavior = TextParagraph::OVERRUN_NO_TRIMMING;
 
 	uint64_t search_time_msec = 0;
 	String search_string;
@@ -181,6 +182,9 @@ public:
 
 	void set_item_custom_fg_color(int p_idx, const Color &p_custom_fg_color);
 	Color get_item_custom_fg_color(int p_idx) const;
+
+	void set_text_overrun_behavior(TextParagraph::OverrunBehavior p_behavior);
+	TextParagraph::OverrunBehavior get_text_overrun_behavior() const;
 
 	void select(int p_idx, bool p_single = true);
 	void deselect(int p_idx);

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -437,7 +437,8 @@ Size2 TextParagraph::get_non_wraped_size() const {
 Size2 TextParagraph::get_size() const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	Size2 size;
-	for (int i = 0; i < lines_rid.size(); i++) {
+	int visible_lines = (max_lines_visible >= 0) ? MIN(max_lines_visible, lines_rid.size()) : lines_rid.size();
+	for (int i = 0; i < visible_lines; i++) {
 		Size2 lsize = TS->shaped_text_get_size(lines_rid[i]);
 		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			size.x = MAX(size.x, lsize.x);
@@ -587,15 +588,15 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 				l_width -= h_offset;
 			}
 		}
-		float length = TS->shaped_text_get_width(lines_rid[i]);
+		float line_width = TS->shaped_text_get_width(lines_rid[i]);
 		if (width > 0) {
 			switch (align) {
 				case HALIGN_FILL:
 					if (TS->shaped_text_get_direction(lines_rid[i]) == TextServer::DIRECTION_RTL) {
 						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += l_width - length;
+							ofs.x += l_width - line_width;
 						} else {
-							ofs.y += l_width - length;
+							ofs.y += l_width - line_width;
 						}
 					}
 					break;
@@ -603,16 +604,16 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 					break;
 				case HALIGN_CENTER: {
 					if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-						ofs.x += Math::floor((l_width - length) / 2.0);
+						ofs.x += Math::floor((l_width - line_width) / 2.0);
 					} else {
-						ofs.y += Math::floor((l_width - length) / 2.0);
+						ofs.y += Math::floor((l_width - line_width) / 2.0);
 					}
 				} break;
 				case HALIGN_RIGHT: {
 					if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-						ofs.x += l_width - length;
+						ofs.x += l_width - line_width;
 					} else {
-						ofs.y += l_width - length;
+						ofs.y += l_width - line_width;
 					}
 				} break;
 			}

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -665,9 +665,7 @@ Vector<Vector2i> TextServer::shaped_text_get_line_breaks(RID p_shaped, float p_w
 			continue;
 		}
 		if (l_gl[i].count > 0) {
-			//Ignore trailing spaces.
-			bool is_space = (l_gl[i].flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE;
-			if ((p_width > 0) && (width + (is_space ? 0 : l_gl[i].advance) > p_width) && (last_safe_break >= 0)) {
+			if ((p_width > 0) && (width + l_gl[i].advance * l_gl[i].repeat > p_width) && (last_safe_break >= 0)) {
 				lines.push_back(Vector2i(line_start, l_gl[last_safe_break].end));
 				line_start = l_gl[last_safe_break].end;
 				i = last_safe_break;
@@ -698,7 +696,7 @@ Vector<Vector2i> TextServer::shaped_text_get_line_breaks(RID p_shaped, float p_w
 				last_safe_break = i;
 			}
 		}
-		width += l_gl[i].advance;
+		width += l_gl[i].advance * l_gl[i].repeat;
 	}
 
 	if (l_size > 0) {


### PR DESCRIPTION
This PR aims to fix and improve the layout of the ItemList control when used with several columns, most noticeable in the EditorFileDialog:

CURRENT MASTER:
![grafik](https://user-images.githubusercontent.com/50084500/130072252-6b2705e6-bdf9-40ed-9bf6-6ed854404d40.png)
![grafik](https://user-images.githubusercontent.com/50084500/130072575-bfb90998-d93f-4ec9-94ed-c81fcd93452e.png)

THIS PR:
![grafik](https://user-images.githubusercontent.com/50084500/130072677-01e4ae24-2406-4713-ac51-09e9f8296f36.png)
![grafik](https://user-images.githubusercontent.com/50084500/130072634-92cae8bd-a940-44bf-85ac-0f4fa82fed16.png)

- Fixed ItemList's layout
  - Fixed TextParagraph get_size() calculation
  - Fixed ignored ItemList max_lines_visible property
- Added text overrrun property to ItemList
- Enabled ellipsis text overrun trimming in EditorFileDialog (in 3.x filenames are cut off, so you didn't notice immediately that a the filename doesn't fit in two lines)
- Fixed clipping in TextParagraph where at some widths the first character was cut off
    - Removed ignore trailing spaces for now in shaped_text_get_line_breaks() since it needs to be handled in many textserver other methods to work properly (possibly done in a future PR)
- Renamed a variable in TextParagraph for consistency/to be more descriptive
