### PR TITLE
Fix 51889 that cause a crash when you click on an AnimationTree that contains an invalid node

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -126,6 +126,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 		graph->add_child(node);
 
 		Ref<AnimationNode> agnode = blend_tree->get_node(E);
+		ERR_CONTINUE(!agnode.is_valid());
 
 		node->set_position_offset(blend_tree->get_node_position(E) * EDSCALE);
 


### PR DESCRIPTION
fix #51889

The project contains an invalid node (I don't check why, so maybe there is a root issue):

<img width="324" alt="Screenshot 2021-08-19 at 15 54 09" src="https://user-images.githubusercontent.com/6397893/130083162-4e198be4-54ad-470f-8601-23f2c290bbb7.png">

But the following code doesn't check if the reference is valid, that lead to a crash:

<img width="768" alt="Screenshot 2021-08-19 at 15 10 02" src="https://user-images.githubusercontent.com/6397893/130083198-61315e5d-c772-4992-8be1-609f27e06b77.png">

Is it an exaggeration to say every time we retrieve a reference in (`Ref<>`), we must check if the reference is valid? (If yes, it worth it to take time to verify that in the code base)