### PR TITLE
Add a custom physics for Top Down games in CharacterBody2D node to support slopes.

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -111,6 +111,7 @@
 				This method should be used in [method Node._physics_process] (or in a method called by [method Node._physics_process]), as it uses the physics step's [code]delta[/code] value automatically in calculations. Otherwise, the simulation will run at an incorrect speed.
 				Modifies [member linear_velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for detailed information about collisions that occurred, use [method get_slide_collision].
 				When the body touches a moving platform, the platform's velocity is automatically added to the body motion. If a collision occurs due to the platform's motion, it will always be first in the slide collisions.
+				The general behaviour and available properties change according to the [member motion_mode].
 				Returns [code]true[/code] if the body collided, otherwise, returns [code]false[/code].
 			</description>
 		</method>
@@ -139,11 +140,17 @@
 		<member name="floor_stop_on_slope" type="bool" setter="set_floor_stop_on_slope_enabled" getter="is_floor_stop_on_slope_enabled" default="false">
 			If [code]true[/code], the body will not slide on floor's slopes when you include gravity in [code]linear_velocity[/code] when calling [method move_and_slide] and the body is standing still.
 		</member>
+		<member name="free_mode_min_slide_angle" type="float" setter="set_free_mode_min_slide_angle" getter="get_free_mode_min_slide_angle" default="0.261799">
+			Minimum angle (in radians) where the body is allowed to slide when it encounters a slope. The default value equals 15 degrees.
+		</member>
 		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2(0, 0)">
 			Current velocity vector in pixels per second, used and modified during calls to [method move_and_slide].
 		</member>
 		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="4">
 			Maximum number of times the body can change direction before it stops when calling [method move_and_slide].
+		</member>
+		<member name="motion_mode" type="int" setter="set_motion_mode" getter="get_motion_mode" enum="CharacterBody2D.MotionMode" default="0">
+			Sets the motion mode which defines the behaviour of [method move_and_slide]. See [enum MotionMode] constants for available modes.
 		</member>
 		<member name="moving_platform_ignore_layers" type="int" setter="set_moving_platform_ignore_layers" getter="get_moving_platform_ignore_layers" default="0">
 			Collision layers that will be excluded for detecting bodies that will act as moving platforms to be followed by the [CharacterBody2D]. By default, all touching bodies are detected and propagate their velocity. You can add excluded layers to ignore bodies that are contained in these layers.
@@ -156,5 +163,11 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="MOTION_MODE_GROUNDED" value="0" enum="MotionMode">
+			Apply when notions of walls, ceiling and floor are relevant. In this mode the body motion will react to slopes (acceleration/slowdown). This mode is suitable for sided games like platformers.
+		</constant>
+		<constant name="MOTION_MODE_FREE" value="1" enum="MotionMode">
+			Apply when there is no notion of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will be always constant. This mode is suitable for top-down games.
+		</constant>
 	</constants>
 </class>

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -268,8 +268,35 @@ VARIANT_ENUM_CAST(RigidBody2D::CCDMode);
 class CharacterBody2D : public PhysicsBody2D {
 	GDCLASS(CharacterBody2D, PhysicsBody2D);
 
+public:
+	enum MotionMode {
+		MOTION_MODE_GROUNDED,
+		MOTION_MODE_FREE,
+	};
+	bool move_and_slide();
+
+	const Vector2 &get_linear_velocity() const;
+	void set_linear_velocity(const Vector2 &p_velocity);
+
+	bool is_on_floor() const;
+	bool is_on_floor_only() const;
+	bool is_on_wall() const;
+	bool is_on_wall_only() const;
+	bool is_on_ceiling() const;
+	bool is_on_ceiling_only() const;
+	Vector2 get_floor_normal() const;
+	real_t get_floor_angle(const Vector2 &p_up_direction = Vector2(0.0, -1.0)) const;
+	Vector2 get_platform_velocity() const;
+
+	int get_slide_collision_count() const;
+	PhysicsServer2D::MotionResult get_slide_collision(int p_bounce) const;
+
+	CharacterBody2D();
+	~CharacterBody2D();
+
 private:
 	real_t margin = 0.08;
+	MotionMode motion_mode = MOTION_MODE_GROUNDED;
 
 	bool floor_stop_on_slope = false;
 	bool floor_constant_speed = false;
@@ -279,6 +306,7 @@ private:
 	int platform_layer;
 	real_t floor_max_angle = Math::deg2rad((real_t)45.0);
 	float floor_snap_length = 0;
+	real_t free_mode_min_slide_angle = Math::deg2rad((real_t)15.0);
 	Vector2 up_direction = Vector2(0.0, -1.0);
 	uint32_t moving_platform_ignore_layers = 0;
 	Vector2 linear_velocity;
@@ -317,8 +345,17 @@ private:
 	real_t get_floor_snap_length();
 	void set_floor_snap_length(real_t p_floor_snap_length);
 
+	real_t get_free_mode_min_slide_angle() const;
+	void set_free_mode_min_slide_angle(real_t p_radians);
+
 	uint32_t get_moving_platform_ignore_layers() const;
 	void set_moving_platform_ignore_layers(const uint32_t p_exclude_layer);
+
+	void set_motion_mode(MotionMode p_mode);
+	MotionMode get_motion_mode() const;
+
+	void _move_and_slide_free(real_t p_delta);
+	void _move_and_slide_grounded(real_t p_delta, bool p_was_on_floor, const Vector2 &p_prev_platform_velocity);
 
 	Ref<KinematicCollision2D> _get_slide_collision(int p_bounce);
 	Ref<KinematicCollision2D> _get_last_slide_collision();
@@ -332,29 +369,10 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-
-public:
-	bool move_and_slide();
-
-	const Vector2 &get_linear_velocity() const;
-	void set_linear_velocity(const Vector2 &p_velocity);
-
-	bool is_on_floor() const;
-	bool is_on_floor_only() const;
-	bool is_on_wall() const;
-	bool is_on_wall_only() const;
-	bool is_on_ceiling() const;
-	bool is_on_ceiling_only() const;
-	Vector2 get_floor_normal() const;
-	real_t get_floor_angle(const Vector2 &p_up_direction = Vector2(0.0, -1.0)) const;
-	Vector2 get_platform_velocity() const;
-
-	int get_slide_collision_count() const;
-	PhysicsServer2D::MotionResult get_slide_collision(int p_bounce) const;
-
-	CharacterBody2D();
-	~CharacterBody2D();
+	virtual void _validate_property(PropertyInfo &property) const override;
 };
+
+VARIANT_ENUM_CAST(CharacterBody2D::MotionMode);
 
 class KinematicCollision2D : public RefCounted {
 	GDCLASS(KinematicCollision2D, RefCounted);


### PR DESCRIPTION
This will add a motion mode that applies a simplified physics for top down games.

- Add a new property `Motion_mode` to select what kind of game you want, this property will automatically show relevant properties for the selected mode.
- Add a simplified physics `(free mode)` for top down games where you don't want acceleration/slowdown in slopes.
- Add a setting for the `free_mode` to select the minimum angle before a slide

![Aug-20-2021 00-36-57](https://user-images.githubusercontent.com/6397893/130153210-53a2c026-9352-43f8-85b8-9ee3d0479d38.gif)

![PR movement](https://user-images.githubusercontent.com/6397893/130152517-ad1d6ce7-4735-4352-a5fe-0a35dd08840d.gif)



