### PR TITLE
Improvements for SyntaxHighlighters

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -58,6 +58,7 @@ private:
 		SYMBOL,
 		NUMBER,
 		FUNCTION,
+		SIGNAL,
 		KEYWORD,
 		MEMBER,
 		IDENTIFIER,


### PR DESCRIPTION
If a function was the first item in a lamba e.g `func(): print("Hello, World!")` the `p` in `print` was highlighted as a function definition, this has been fixed.

Previously if your signal definition had arguments, it was highlighted as a function. Now all signals are highlighted as members.

Quoted and non-quoted node-paths now have the same colour.

Escape chars are now highlighted in strings, this uses the symbol colour.

closes #33886
closes #33316
closes godotengine/godot-proposals/issues/3104