### PR TITLE
Rename C# string extensions to follow GDScript

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -64,7 +64,7 @@ namespace Godot
         /// <summary>
         /// If the string is a path to a file, return the path to the file without the extension.
         /// </summary>
-        public static string BaseName(this string instance)
+        public static string GetBaseName(this string instance)
         {
             int index = instance.LastIndexOf('.');
 
@@ -339,7 +339,7 @@ namespace Godot
         /// <summary>
         /// If the string is a path to a file, return the extension.
         /// </summary>
-        public static string Extension(this string instance)
+        public static string GetExtension(this string instance)
         {
             int pos = instance.FindLast(".");
 


### PR DESCRIPTION
**breaks-compat**

Follow up to d9d77291bca8dd1e87aa4d9e40de96d99e5ef1f6.

Renames `String.Extension` -> `String.GetExtension()` and `String.BaseName()` -> `String.GetBaseName()`.
This makes those methods more consistent with GDScript and with the `GetBaseDir` method.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
