### PR TITLE
Add missing SNAME macro optimization for StringName in some functions

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -495,10 +495,10 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			}
 			draw_rect(
 					Rect2(bs_from, bs_to - bs_from),
-					get_theme_color("box_selection_fill_color", "Editor"));
+					get_theme_color(SNAME("box_selection_fill_color"), SNAME("Editor")));
 			draw_rect(
 					Rect2(bs_from, bs_to - bs_from),
-					get_theme_color("box_selection_stroke_color", "Editor"),
+					get_theme_color(SNAME("box_selection_stroke_color"), SNAME("Editor")),
 					false,
 					Math::round(EDSCALE));
 		}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -396,15 +396,15 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				s->select(0);
 			}
 		}
-		emit_signal("stack_dump", stack_dump_info);
+		emit_signal(SNAME("stack_dump"), stack_dump_info);
 	} else if (p_msg == "stack_frame_vars") {
 		inspector->clear_stack_variables();
 		ERR_FAIL_COND(p_data.size() != 1);
-		emit_signal("stack_frame_vars", p_data[0]);
+		emit_signal(SNAME("stack_frame_vars"), p_data[0]);
 
 	} else if (p_msg == "stack_frame_var") {
 		inspector->add_stack_variable(p_data);
-		emit_signal("stack_frame_var", p_data);
+		emit_signal(SNAME("stack_frame_var"), p_data);
 
 	} else if (p_msg == "output") {
 		ERR_FAIL_COND(p_data.size() != 2);
@@ -433,7 +433,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				} break;
 			}
 			EditorNode::get_log()->add_message(output_strings[i], msg_type);
-			emit_signal("output", output_strings[i]);
+			emit_signal(SNAME("output"), output_strings[i]);
 		}
 	} else if (p_msg == "performance:profile_frame") {
 		Vector<float> frame_data;

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -114,8 +114,8 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 			section->set_text(0, item_name);
 			section->set_selectable(0, false);
 			section->set_selectable(1, false);
-			section->set_custom_bg_color(0, search_options->get_theme_color("prop_subsection", "Editor"));
-			section->set_custom_bg_color(1, search_options->get_theme_color("prop_subsection", "Editor"));
+			section->set_custom_bg_color(0, search_options->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
+			section->set_custom_bg_color(1, search_options->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 
 			sections[section_name] = section;
 		}
@@ -249,7 +249,7 @@ Ref<Shortcut> EditorCommandPalette::add_shortcut_command(const String &p_command
 }
 
 void EditorCommandPalette::_theme_changed() {
-	command_search_box->set_right_icon(search_options->get_theme_icon("Search", "EditorIcons"));
+	command_search_box->set_right_icon(search_options->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 }
 
 EditorCommandPalette *EditorCommandPalette::get_singleton() {

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -86,7 +86,7 @@ void EditorFileDialog::_notification(int p_what) {
 				if (preview_wheel_index >= 8) {
 					preview_wheel_index = 0;
 				}
-				Ref<Texture2D> frame = item_list->get_theme_icon("Progress" + itos(preview_wheel_index + 1), "EditorIcons");
+				Ref<Texture2D> frame = item_list->get_theme_icon("Progress" + itos(preview_wheel_index + 1), SNAME("EditorIcons"));
 				preview->set_texture(frame);
 				preview_wheel_timeout = 0.1;
 			}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -550,7 +550,7 @@ void EditorNode::_notification(int p_what) {
 
 				// update the icon itself only when the spinner is visible
 				if (EditorSettings::get_singleton()->get("interface/editor/show_update_spinner")) {
-					update_spinner->set_icon(gui_base->get_theme_icon("Progress" + itos(update_spinner_step + 1), "EditorIcons"));
+					update_spinner->set_icon(gui_base->get_theme_icon("Progress" + itos(update_spinner_step + 1), SNAME("EditorIcons")));
 				}
 			}
 
@@ -758,7 +758,7 @@ void EditorNode::_update_update_spinner() {
 		// On a light theme, icons are dark, so we need to modulate them with an even brighter color.
 		const bool dark_theme = EditorSettings::get_singleton()->is_dark_theme();
 		update_spinner->set_self_modulate(
-				gui_base->get_theme_color("error_color", "Editor") * (dark_theme ? Color(1.1, 1.1, 1.1) : Color(4.25, 4.25, 4.25)));
+				gui_base->get_theme_color(SNAME("error_color"), SNAME("Editor")) * (dark_theme ? Color(1.1, 1.1, 1.1) : Color(4.25, 4.25, 4.25)));
 	} else {
 		update_spinner->set_tooltip(TTR("Spins when the editor window redraws."));
 		update_spinner->set_self_modulate(Color(1, 1, 1));

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2810,8 +2810,8 @@ void EditorPropertyResource::_update_property_bg() {
 		count_subinspectors = MIN(15, count_subinspectors);
 
 		add_theme_color_override("property_color", get_theme_color(SNAME("sub_inspector_property_color"), SNAME("Editor")));
-		add_theme_style_override("bg_selected", get_theme_stylebox("sub_inspector_property_bg_selected" + itos(count_subinspectors), "Editor"));
-		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_property_bg" + itos(count_subinspectors), "Editor"));
+		add_theme_style_override("bg_selected", get_theme_stylebox("sub_inspector_property_bg_selected" + itos(count_subinspectors), SNAME("Editor")));
+		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_property_bg" + itos(count_subinspectors), SNAME("Editor")));
 
 		add_theme_constant_override("font_offset", get_theme_constant(SNAME("sub_inspector_font_offset"), SNAME("Editor")));
 		add_theme_constant_override("vseparation", 0);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -906,7 +906,7 @@ void EditorShaderPicker::set_create_options(Object *p_menu_node) {
 		return;
 	}
 
-	menu_node->add_icon_item(get_theme_icon("Shader", "EditorIcons"), TTR("New Shader"), OBJ_MENU_NEW_SHADER);
+	menu_node->add_icon_item(get_theme_icon(SNAME("Shader"), SNAME("EditorIcons")), TTR("New Shader"), OBJ_MENU_NEW_SHADER);
 	menu_node->add_separator();
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3968,7 +3968,7 @@ void CanvasItemEditor::edit(CanvasItem *p_canvas_item) {
 void CanvasItemEditor::_update_context_menu_stylebox() {
 	// This must be called when the theme changes to follow the new accent color.
 	Ref<StyleBoxFlat> context_menu_stylebox = memnew(StyleBoxFlat);
-	const Color accent_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color("accent_color", "Editor");
+	const Color accent_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 	context_menu_stylebox->set_bg_color(accent_color * Color(1, 1, 1, 0.1));
 	// Add an underline to the StyleBox, but prevent its minimum vertical size from changing.
 	context_menu_stylebox->set_border_color(accent_color);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6030,7 +6030,7 @@ void fragment() {
 void Node3DEditor::_update_context_menu_stylebox() {
 	// This must be called when the theme changes to follow the new accent color.
 	Ref<StyleBoxFlat> context_menu_stylebox = memnew(StyleBoxFlat);
-	const Color accent_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color("accent_color", "Editor");
+	const Color accent_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 	context_menu_stylebox->set_bg_color(accent_color * Color(1, 1, 1, 0.1));
 	// Add an underline to the StyleBox, but prevent its minimum vertical size from changing.
 	context_menu_stylebox->set_border_color(accent_color);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -520,7 +520,7 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 
 	if (p_node == selected) {
 		selected = nullptr;
-		emit_signal("node_selected");
+		emit_signal(SNAME("node_selected"));
 	}
 }
 
@@ -628,7 +628,7 @@ void SceneTreeEditor::_selected_changed() {
 	selected = get_node(np);
 
 	blocked++;
-	emit_signal("node_selected");
+	emit_signal(SNAME("node_selected"));
 	blocked--;
 }
 
@@ -755,7 +755,7 @@ void SceneTreeEditor::set_selected(Node *p_node, bool p_emit_selected) {
 	}
 
 	if (p_emit_selected) {
-		emit_signal("node_selected");
+		emit_signal(SNAME("node_selected"));
 	}
 }
 

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -190,7 +190,7 @@ void ShaderCreateDialog::_create_new() {
 		}
 	}
 
-	emit_signal("shader_created", shader);
+	emit_signal(SNAME("shader_created"), shader);
 	hide();
 }
 
@@ -203,7 +203,7 @@ void ShaderCreateDialog::_load_exist() {
 		return;
 	}
 
-	emit_signal("shader_created", p_shader);
+	emit_signal(SNAME("shader_created"), p_shader);
 	hide();
 }
 
@@ -404,18 +404,18 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 void ShaderCreateDialog::_msg_script_valid(bool valid, const String &p_msg) {
 	error_label->set_text("- " + p_msg);
 	if (valid) {
-		error_label->add_theme_color_override("font_color", gc->get_theme_color("success_color", "Editor"));
+		error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {
-		error_label->add_theme_color_override("font_color", gc->get_theme_color("error_color", "Editor"));
+		error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	}
 }
 
 void ShaderCreateDialog::_msg_path_valid(bool valid, const String &p_msg) {
 	path_error_label->set_text("- " + p_msg);
 	if (valid) {
-		path_error_label->add_theme_color_override("font_color", gc->get_theme_color("success_color", "Editor"));
+		path_error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {
-		path_error_label->add_theme_color_override("font_color", gc->get_theme_color("error_color", "Editor"));
+		path_error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	}
 }
 

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -161,7 +161,7 @@ void BoneAttachment3D::_check_bind() {
 			bone_idx = sk->find_bone(bone_name);
 		}
 		if (bone_idx != -1) {
-			sk->call_deferred("connect", "bone_pose_changed", callable_mp(this, &BoneAttachment3D::on_bone_pose_update));
+			sk->call_deferred(SNAME("connect"), "bone_pose_changed", callable_mp(this, &BoneAttachment3D::on_bone_pose_update));
 			bound = true;
 			call_deferred(SNAME("on_bone_pose_update"), bone_idx);
 		}

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2145,7 +2145,7 @@ void GraphEdit::arrange_nodes() {
 		largest_node_size = 0.0f;
 	}
 
-	emit_signal("begin_node_move");
+	emit_signal(SNAME("begin_node_move"));
 	for (const Set<StringName>::Element *E = selected_nodes.front(); E; E = E->next()) {
 		GraphNode *gn = Object::cast_to<GraphNode>(node_names[E->get()]);
 		gn->set_drag(true);
@@ -2158,7 +2158,7 @@ void GraphEdit::arrange_nodes() {
 		gn->set_position_offset(pos);
 		gn->set_drag(false);
 	}
-	emit_signal("end_node_move");
+	emit_signal(SNAME("end_node_move"));
 	arranging_graph = false;
 }
 

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -194,7 +194,7 @@ Popup::~Popup() {
 }
 
 Size2 PopupPanel::_get_contents_minimum_size() const {
-	Ref<StyleBox> p = get_theme_stylebox("panel", get_class_name());
+	Ref<StyleBox> p = get_theme_stylebox(SNAME("panel"), get_class_name());
 
 	Size2 ms;
 
@@ -217,7 +217,7 @@ Size2 PopupPanel::_get_contents_minimum_size() const {
 }
 
 void PopupPanel::_update_child_rects() {
-	Ref<StyleBox> p = get_theme_stylebox("panel", get_class_name());
+	Ref<StyleBox> p = get_theme_stylebox(SNAME("panel"), get_class_name());
 
 	Vector2 cpos(p->get_offset());
 	Vector2 csize(get_size() - p->get_minimum_size());
@@ -244,9 +244,9 @@ void PopupPanel::_update_child_rects() {
 
 void PopupPanel::_notification(int p_what) {
 	if (p_what == NOTIFICATION_THEME_CHANGED) {
-		panel->add_theme_style_override("panel", get_theme_stylebox("panel", get_class_name()));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), get_class_name()));
 	} else if (p_what == NOTIFICATION_READY || p_what == NOTIFICATION_ENTER_TREE) {
-		panel->add_theme_style_override("panel", get_theme_stylebox("panel", get_class_name()));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), get_class_name()));
 		_update_child_rects();
 	} else if (p_what == NOTIFICATION_WM_SIZE_CHANGED) {
 		_update_child_rects();


### PR DESCRIPTION
In commit 6631f66c2a9d54dc80d57df60376c84ce1252d08 , reduz changed all theme , signal emission and call_deferred usages to use the new SNAME optimization for StringName.

I find that some occurrences were missing for these usages.
I've added the SNAME macro to these occurrences.


There's a lot of other functions that use StringName parameters ( especially Object.connect() and disconnect() which are widely used). Should macro usage be added to all StringName everywhere ?