### PR TITLE
Revert sequence port VisualScriptPropertySet basic type

### DIFF
--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -901,11 +901,13 @@ static Ref<VisualScriptNode> create_function_call_node(const String &p_name) {
 //////////////////////////////////////////
 
 int VisualScriptPropertySet::get_output_sequence_port_count() const {
-	return 1;
+	return call_mode != CALL_MODE_BASIC_TYPE ? 1 : 0;
+	//return 1; //Adding a sequence port to set_basic_type breaks backwards compatibility
 }
 
 bool VisualScriptPropertySet::has_input_sequence_port() const {
-	return 1;
+	return call_mode != CALL_MODE_BASIC_TYPE;
+	//return 1; //Adding a sequence port to set_basic_type breaks backwards compatibility
 }
 
 Node *VisualScriptPropertySet::_get_base_node() const {


### PR DESCRIPTION
Revert a part of #50709.
Adding a sequence port to basic type set breaks backwards compatibility
![image](https://user-images.githubusercontent.com/20573784/130242757-8b5352af-3ea1-4fd0-b76d-906a6af796cf.png)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
