### PR TITLE
Implement Extension Loader

### DIFF
--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -35,6 +35,8 @@
 #include "core/object/method_bind.h"
 #include "core/os/os.h"
 
+const char *NativeExtension::EXTENSION_LIST_CONFIG_FILE = "res://.godot/extension_list.cfg";
+
 class NativeExtensionMethodBind : public MethodBind {
 	GDNativeExtensionClassMethodCall call_func;
 	GDNativeExtensionClassMethodPtrCall ptrcall_func;

--- a/core/extension/native_extension.h
+++ b/core/extension/native_extension.h
@@ -60,6 +60,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static const char *EXTENSION_LIST_CONFIG_FILE;
+
 	Error open_library(const String &p_path, const String &p_entry_symbol);
 	void close_library();
 

--- a/core/extension/native_extension_manager.h
+++ b/core/extension/native_extension_manager.h
@@ -55,6 +55,7 @@ public:
 	LoadStatus load_extension(const String &p_path);
 	LoadStatus reload_extension(const String &p_path);
 	LoadStatus unload_extension(const String &p_path);
+	bool is_extension_loaded(const String &p_path) const;
 	Vector<String> get_loaded_extensions() const;
 	Ref<NativeExtension> get_extension(const String &p_path);
 
@@ -62,6 +63,8 @@ public:
 	void deinitialize_extensions(NativeExtension::InitializationLevel p_level);
 
 	static NativeExtensionManager *get_singleton();
+
+	void load_extensions();
 
 	NativeExtensionManager();
 };

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -305,13 +305,7 @@ void register_core_singletons() {
 void register_core_extensions() {
 	// Hardcoded for now.
 	NativeExtension::initialize_native_extensions();
-	if (ProjectSettings::get_singleton()->has_setting("native_extensions/paths")) {
-		Vector<String> paths = ProjectSettings::get_singleton()->get("native_extensions/paths");
-		for (int i = 0; i < paths.size(); i++) {
-			NativeExtensionManager::LoadStatus status = native_extension_manager->load_extension(paths[i]);
-			ERR_CONTINUE_MSG(status != NativeExtensionManager::LOAD_STATUS_OK, "Error loading extension: " + paths[i]);
-		}
-	}
+	native_extension_manager->load_extensions();
 	native_extension_manager->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_CORE);
 }
 

--- a/doc/classes/NativeExtensionManager.xml
+++ b/doc/classes/NativeExtensionManager.xml
@@ -18,6 +18,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="is_extension_loaded" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="path" type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="load_extension">
 			<return type="int" enum="NativeExtensionManager.LoadStatus" />
 			<argument index="0" name="path" type="String" />

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
+#include "core/extension/native_extension.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
@@ -1051,6 +1052,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	if (FileAccess::exists(ResourceUID::CACHE_FILE)) {
 		Vector<uint8_t> array = FileAccess::get_file_as_array(ResourceUID::CACHE_FILE);
 		err = p_func(p_udata, ResourceUID::CACHE_FILE, array, idx, total, enc_in_filters, enc_ex_filters, key);
+		if (err != OK) {
+			return err;
+		}
+	}
+
+	if (FileAccess::exists(NativeExtension::EXTENSION_LIST_CONFIG_FILE)) {
+		Vector<uint8_t> array = FileAccess::get_file_as_array(NativeExtension::EXTENSION_LIST_CONFIG_FILE);
+		err = p_func(p_udata, NativeExtension::EXTENSION_LIST_CONFIG_FILE, array, idx, total, enc_in_filters, enc_ex_filters, key);
 		if (err != OK) {
 			return err;
 		}

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -255,6 +255,8 @@ class EditorFileSystem : public Node {
 
 	static ResourceUID::ID _resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate);
 
+	bool _scan_extensions();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -92,6 +92,7 @@ class VSplitContainer;
 class Window;
 class SubViewport;
 class SceneImportSettings;
+class EditorExtensionManager;
 
 class EditorNode : public Node {
 	GDCLASS(EditorNode, Node);
@@ -675,6 +676,9 @@ private:
 
 	void _pick_main_scene_custom_action(const String &p_custom_action_name);
 
+	bool immediate_dialog_confirmed = false;
+	void _immediate_dialog_confirmed();
+
 protected:
 	void _notification(int p_what);
 
@@ -898,6 +902,8 @@ public:
 	void run_stop();
 	bool is_run_playing() const;
 	String get_run_playing_scene() const;
+
+	static bool immediate_confirmation_dialog(const String &p_text, const String &p_ok_text = TTR("Ok"), const String &p_cancel_text = TTR("Cancel"));
 };
 
 struct EditorProgress {


### PR DESCRIPTION
* Extensions are now scanned and loaded on demand.
* Extensions found are cached into a file that is used to load them (which is also exported).
* Editor will ask to restart when an extension requires core functionality.
* Editor will attempt to load extensions always before importing or loading scenes. This ensures extensions can register the relevant types.