### PR TITLE
[3.x] Window transparency support on Android

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -970,10 +970,10 @@
 			If [code]true[/code], the window is minimized.
 		</member>
 		<member name="window_per_pixel_transparency_enabled" type="bool" setter="set_window_per_pixel_transparency_enabled" getter="get_window_per_pixel_transparency_enabled" default="false">
-			If [code]true[/code], the window background is transparent and window frame is removed.
+			If [code]true[/code], the window background is transparent and the window frame is removed.
 			Use [code]get_tree().get_root().set_transparent_background(true)[/code] to disable main viewport background rendering.
-			[b]Note:[/b] This property has no effect if [b]Project &gt; Project Settings &gt; Display &gt; Window &gt; Per-pixel transparency &gt; Allowed[/b] setting is disabled.
-			[b]Note:[/b] This property is implemented on HTML5, Linux, macOS and Windows.
+			[b]Note:[/b] This property has no effect if [member ProjectSettings.display/window/per_pixel_transparency/allowed] setting is disabled.
+			[b]Note:[/b] This property is implemented on HTML5, Linux, macOS, Windows, and Android. It can't be changed at runtime for Android. Use [member ProjectSettings.display/window/per_pixel_transparency/enabled] to set it at startup instead.
 		</member>
 		<member name="window_position" type="Vector2" setter="set_window_position" getter="get_window_position" default="Vector2( 0, 0 )">
 			The window position relative to the screen, the origin is the top left corner, +Y axis goes to the bottom and +X axis goes to the right.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -447,10 +447,14 @@
 			If [code]true[/code], the home indicator is hidden automatically. This only affects iOS devices without a physical home button.
 		</member>
 		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], allows per-pixel transparency in a desktop window. This affects performance, so leave it on [code]false[/code] unless you need it.
+			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, so leave it on [code]false[/code] unless you need it.
+			See [member OS.window_per_pixel_transparency_enabled] for more details.
+			[b]Note:[/b] This feature is implemented on HTML5, Linux, macOS, Windows, and Android.
 		</member>
 		<member name="display/window/per_pixel_transparency/enabled" type="bool" setter="" getter="" default="false">
 			Sets the window background to transparent when it starts.
+			See [member OS.window_per_pixel_transparency_enabled] for more details.
+			[b]Note:[/b] This feature is implemented on HTML5, Linux, macOS, Windows, and Android.
 		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="" default="false">
 			Forces the main window to be always on top.

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2552,6 +2552,11 @@ void EditorExportPlatformAndroid::get_command_line_flags(const Ref<EditorExportP
 		command_line_strings.push_back("--debug_opengl");
 	}
 
+	bool translucent = ProjectSettings::get_singleton()->get("display/window/per_pixel_transparency/enabled");
+	if (translucent) {
+		command_line_strings.push_back("--translucent");
+	}
+
 	if (command_line_strings.size()) {
 		r_command_line_flags.resize(4);
 		encode_uint32(command_line_strings.size(), &r_command_line_flags.write[0]);

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -130,6 +130,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	private boolean use_32_bits = false;
 	private boolean use_immersive = false;
 	private boolean use_debug_opengl = false;
+	private boolean translucent = false;
 	private boolean mStatePaused;
 	private boolean activityResumed;
 	private int mState;
@@ -357,7 +358,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		// ...add to FrameLayout
 		containerLayout.addView(edittext);
 
-		mView = new GodotView(activity, this, xrMode, use_gl3, use_32_bits, use_debug_opengl);
+		mView = new GodotView(activity, this, xrMode, use_gl3, use_32_bits, use_debug_opengl, translucent);
 		containerLayout.addView(mView, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 		edittext.setView(mView);
 		io.setEdit(edittext);
@@ -608,6 +609,8 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 				use_32_bits = true;
 			} else if (command_line[i].equals("--debug_opengl")) {
 				use_debug_opengl = true;
+			} else if (command_line[i].equals("--translucent")) {
+				translucent = true;
 			} else if (command_line[i].equals("--use_immersive")) {
 				use_immersive = true;
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) { // check if the application runs on an android 4.4+

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
@@ -76,7 +76,7 @@ public class GodotView extends GLSurfaceView {
 	private final GodotRenderer godotRenderer;
 
 	public GodotView(Context context, Godot godot, XRMode xrMode, boolean p_use_gl3,
-			boolean p_use_32_bits, boolean p_use_debug_opengl) {
+			boolean p_use_32_bits, boolean p_use_debug_opengl, boolean p_translucent) {
 		super(context);
 		GLUtils.use_gl3 = p_use_gl3;
 		GLUtils.use_32 = p_use_32_bits;
@@ -86,7 +86,8 @@ public class GodotView extends GLSurfaceView {
 		this.inputHandler = new GodotInputHandler(this);
 		this.detector = new GestureDetector(context, new GodotGestureHandler(this));
 		this.godotRenderer = new GodotRenderer();
-		init(xrMode, false, 16, 0);
+
+		init(xrMode, p_translucent, 16, 0);
 	}
 
 	public void initInputDevices() {
@@ -139,6 +140,7 @@ public class GodotView extends GLSurfaceView {
 				 * is interpreted as any 32-bit surface with alpha by SurfaceFlinger.
 				 */
 				if (translucent) {
+					this.setZOrderOnTop(true);
 					this.getHolder().setFormat(PixelFormat.TRANSLUCENT);
 				}
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -161,6 +161,8 @@ Error OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int
 		}
 	}
 
+	transparency_enabled = p_desired.layered;
+
 	if (gl_initialization_error) {
 		OS::get_singleton()->alert("Your device does not support any of the supported OpenGL versions.\n"
 								   "Please try updating your Android version.",

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -66,6 +66,8 @@ class OS_Android : public OS_Unix {
 
 	int video_driver_index;
 
+	bool transparency_enabled = false;
+
 public:
 	// functions used by main to initialize/deinitialize the OS
 	virtual int get_video_driver_count() const;
@@ -149,6 +151,9 @@ public:
 	virtual String get_clipboard() const;
 	virtual String get_model_name() const;
 	virtual int get_screen_dpi(int p_screen = 0) const;
+
+	virtual bool get_window_per_pixel_transparency_enabled() const { return transparency_enabled; }
+	virtual void set_window_per_pixel_transparency_enabled(bool p_enabled) { ERR_FAIL_MSG("Setting per-pixel transparency is not supported at runtime, please set it in project settings instead."); }
 
 	virtual String get_unique_id() const;
 


### PR DESCRIPTION
Implements per-pixel transparency feature on Android.
Allows plugins to do specific rendering and render godot UI on top (useful for camera support with drawing on top).

In order to do that, the plugin itself needs to move its own frame behind the main godot frame with something like that in java:
```
ViewGroup parentView = (ViewGroup)pluginFrame.getParent();
parentView.removeView(pluginFrame);
parentView.addView(pluginFrame, 0);
```

3.x only for now, because I haven't looked into how to do it with Vulkan yet.