### PR TITLE
Properly clear cubemap filter state when texture array environment disabled

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2066,6 +2066,7 @@ void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 		}
 		shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::USE_DUAL_PARABOLOID, false);
 		shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::USE_SOURCE_PANORAMA, false);
+		shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::USE_SOURCE_DUAL_PARABOLOID, false);
 
 		//restore ranges
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/51924

A state change in the cubemap filtering shader was accidentally left by the sky filtering code which infected the reflection probe filtering code. This PR properly resets the state of the cubemap filtering shader once the sky code finishes with it. 