### PR TITLE
assetlib: Fix race condition between CONFIG/SEARCH

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -886,6 +886,8 @@ void EditorAssetLibrary::_request_image(ObjectID p_for, String p_image_url, Imag
 }
 
 void EditorAssetLibrary::_repository_changed(int p_repository_id) {
+	filter->set_editable(false);
+
 	host = repository->get_item_metadata(p_repository_id);
 	if (templates_only) {
 		_api_request("configure", REQUESTING_CONFIG, "?type=project");
@@ -1128,6 +1130,8 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 					category_map[cat["id"]] = name;
 				}
 			}
+
+			filter->set_editable(true);
 
 			_search();
 		} break;


### PR DESCRIPTION
assetlib fails to work when user tries to search before CONFIG finishes.
The patch fixes the problem by blocking user input while fetching
CONFIG.

related: #30642

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
