### PR TITLE
Use Bake with NavigationMeshGenerator in Runtime

### DIFF
--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -298,11 +298,13 @@ void EditorNavigationMeshGenerator::_convert_detail_mesh_to_native_navigation_me
 	}
 }
 
-void EditorNavigationMeshGenerator::_build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh, EditorProgress *ep,
+void EditorNavigationMeshGenerator::_build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh, 
 		rcHeightfield *hf, rcCompactHeightfield *chf, rcContourSet *cset, rcPolyMesh *poly_mesh, rcPolyMeshDetail *detail_mesh,
-		Vector<float> &vertices, Vector<int> &indices) {
+		Vector<float> &vertices, Vector<int> &indices, EditorProgress *ep = NULL) {
 	rcContext ctx;
-	ep->step(TTR("Setting up Configuration..."), 1);
+
+	if (ep)
+		ep->step(TTR("Setting up Configuration..."), 1);
 
 	const float *verts = vertices.ptr();
 	const int nverts = vertices.size() / 3;
@@ -336,16 +338,20 @@ void EditorNavigationMeshGenerator::_build_recast_navigation_mesh(Ref<Navigation
 	cfg.bmax[1] = bmax[1];
 	cfg.bmax[2] = bmax[2];
 
-	ep->step(TTR("Calculating grid size..."), 2);
+	if (ep)
+		ep->step(TTR("Calculating grid size..."), 2);
+
 	rcCalcGridSize(cfg.bmin, cfg.bmax, cfg.cs, &cfg.width, &cfg.height);
 
-	ep->step(TTR("Creating heightfield..."), 3);
+	if (ep)
+		ep->step(TTR("Creating heightfield..."), 3);
 	hf = rcAllocHeightfield();
 
 	ERR_FAIL_COND(!hf);
 	ERR_FAIL_COND(!rcCreateHeightfield(&ctx, *hf, cfg.width, cfg.height, cfg.bmin, cfg.bmax, cfg.cs, cfg.ch));
 
-	ep->step(TTR("Marking walkable triangles..."), 4);
+	if (ep)
+		ep->step(TTR("Marking walkable triangles..."), 4);
 	{
 		Vector<unsigned char> tri_areas;
 		tri_areas.resize(ntris);
@@ -365,7 +371,8 @@ void EditorNavigationMeshGenerator::_build_recast_navigation_mesh(Ref<Navigation
 	if (p_nav_mesh->get_filter_walkable_low_height_spans())
 		rcFilterWalkableLowHeightSpans(&ctx, cfg.walkableHeight, *hf);
 
-	ep->step(TTR("Constructing compact heightfield..."), 5);
+	if (ep)
+		ep->step(TTR("Constructing compact heightfield..."), 5);
 
 	chf = rcAllocCompactHeightfield();
 
@@ -375,10 +382,13 @@ void EditorNavigationMeshGenerator::_build_recast_navigation_mesh(Ref<Navigation
 	rcFreeHeightField(hf);
 	hf = 0;
 
-	ep->step(TTR("Eroding walkable area..."), 6);
+	if (ep)
+		ep->step(TTR("Eroding walkable area..."), 6);
+
 	ERR_FAIL_COND(!rcErodeWalkableArea(&ctx, cfg.walkableRadius, *chf));
 
-	ep->step(TTR("Partitioning..."), 7);
+	if (ep)
+		ep->step(TTR("Partitioning..."), 7);
 	if (p_nav_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_WATERSHED) {
 		ERR_FAIL_COND(!rcBuildDistanceField(&ctx, *chf));
 		ERR_FAIL_COND(!rcBuildRegions(&ctx, *chf, 0, cfg.minRegionArea, cfg.mergeRegionArea));
@@ -388,14 +398,16 @@ void EditorNavigationMeshGenerator::_build_recast_navigation_mesh(Ref<Navigation
 		ERR_FAIL_COND(!rcBuildLayerRegions(&ctx, *chf, 0, cfg.minRegionArea));
 	}
 
-	ep->step(TTR("Creating contours..."), 8);
+	if (ep)
+		ep->step(TTR("Creating contours..."), 8);
 
 	cset = rcAllocContourSet();
 
 	ERR_FAIL_COND(!cset);
 	ERR_FAIL_COND(!rcBuildContours(&ctx, *chf, cfg.maxSimplificationError, cfg.maxEdgeLen, *cset));
 
-	ep->step(TTR("Creating polymesh..."), 9);
+	if (ep)
+		ep->step(TTR("Creating polymesh..."), 9);
 
 	poly_mesh = rcAllocPolyMesh();
 	ERR_FAIL_COND(!poly_mesh);
@@ -410,7 +422,8 @@ void EditorNavigationMeshGenerator::_build_recast_navigation_mesh(Ref<Navigation
 	rcFreeContourSet(cset);
 	cset = 0;
 
-	ep->step(TTR("Converting to native navigation mesh..."), 10);
+	if (ep)
+		ep->step(TTR("Converting to native navigation mesh..."), 10);
 
 	_convert_detail_mesh_to_native_navigation_mesh(detail_mesh, p_nav_mesh);
 
@@ -433,16 +446,15 @@ EditorNavigationMeshGenerator::~EditorNavigationMeshGenerator() {
 
 void EditorNavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node) {
 
-	if (!Engine::get_singleton()->is_editor_hint()) {
-		ERR_PRINTS("Invoking EditorNavigationMeshGenerator::bake(...) in-game is not supported in Godot 3.2 or below. Aborting bake...");
-		return;
+	 EditorProgress *ep = NULL;
+
+	 if (Engine::get_singleton()->is_editor_hint()) {
+		ep = memnew(EditorProgress("bake", TTR("Navigation Mesh Generator Setup:"), 11));
+		ep->step(TTR("Parsing Geometry..."), 0);
 	}
 
 	ERR_FAIL_COND(!p_nav_mesh.is_valid());
-
-	EditorProgress ep("bake", TTR("Navigation Mesh Generator Setup:"), 11);
-	ep.step(TTR("Parsing Geometry..."), 0);
-
+		
 	Vector<float> vertices;
 	Vector<int> indices;
 
@@ -470,8 +482,8 @@ void EditorNavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p
 		rcPolyMesh *poly_mesh = NULL;
 		rcPolyMeshDetail *detail_mesh = NULL;
 
-		_build_recast_navigation_mesh(p_nav_mesh, &ep, hf, chf, cset, poly_mesh, detail_mesh, vertices, indices);
-
+		_build_recast_navigation_mesh(p_nav_mesh, hf, chf, cset, poly_mesh, detail_mesh, vertices, indices, ep);
+		
 		rcFreeHeightField(hf);
 		hf = 0;
 
@@ -487,7 +499,10 @@ void EditorNavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p
 		rcFreePolyMeshDetail(detail_mesh);
 		detail_mesh = 0;
 	}
-	ep.step(TTR("Done!"), 11);
+	if (ep){
+		ep->step(TTR("Done!"), 11);
+		memdelete(ep);
+	}
 }
 
 void EditorNavigationMeshGenerator::clear(Ref<NavigationMesh> p_nav_mesh) {

--- a/modules/recast/navigation_mesh_generator.h
+++ b/modules/recast/navigation_mesh_generator.h
@@ -50,9 +50,9 @@ protected:
 	static void _parse_geometry(Transform p_accumulated_transform, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices, int p_generate_from, uint32_t p_collision_mask, bool p_recurse_children);
 
 	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_nav_mesh);
-	static void _build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh, EditorProgress *ep,
+	static void _build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh,
 			rcHeightfield *hf, rcCompactHeightfield *chf, rcContourSet *cset, rcPolyMesh *poly_mesh,
-			rcPolyMeshDetail *detail_mesh, Vector<float> &vertices, Vector<int> &indices);
+			rcPolyMeshDetail *detail_mesh, Vector<float> &vertices, Vector<int> &indices, EditorProgress *ep);
 
 public:
 	static EditorNavigationMeshGenerator *get_singleton();


### PR DESCRIPTION
Use bake with NavigationMeshGenerator in Runtime in Godot 3.3 and more

Hello

The use of the Bake in NavigationMeshGenerator method did not work in runtime (because of EditorProgress which wants to display a message in runtime) but only in the editor (hint_editor). This fix allows you to generate navigationmesh directly in the runtime. This is very useful, in particular, when creating procedural or random level.

This patch had already been used by
DragonOfWar committed on Jan 19, 2020 but in version 3.3 it looks like this has been destroyed.

The system checks if the code is executed in the editor then the EditorProgress is used otherwise it is ignored

EditorProgress crashes the game in Runtime

Thanks