### PR TITLE
Check if vibration duration is > 0 on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -317,7 +317,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	@SuppressLint("MissingPermission")
 	@Keep
 	private void vibrate(int durationMs) {
-		if (requestPermission("VIBRATE")) {
+		if (durationMs > 0 && requestPermission("VIBRATE")) {
 			Vibrator v = (Vibrator)getContext().getSystemService(Context.VIBRATOR_SERVICE);
 			if (v != null) {
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
If you would call `OS.vibrate_handheld(0)` (can e.g. happen when downcasted from `float`) the game would crash with an exception. I opted to fix it on the Java side, so we don't break behaviour on iOS (which ignores the duration and just vibrates for a fixed amount of time).
