### PR TITLE
Clamp EditorZoomWidget zoom

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4190,6 +4190,7 @@ void CanvasItemEditor::_zoom_on_position(real_t p_zoom, Point2 p_position) {
 	p_zoom = CLAMP(p_zoom, MIN_ZOOM, MAX_ZOOM);
 
 	if (p_zoom == zoom) {
+		zoom_widget->set_zoom(p_zoom);
 		return;
 	}
 


### PR DESCRIPTION
Clamp EditorZoomWidget::zoom.
Without that the zoom displayed does change past those values, but the actual zoom doesn't. 
I think that's what was mentioned in [this comment](https://github.com/godotengine/godot/pull/51551#issuecomment-897538686).

The defined constants are the same as for the actual zoom. They probably should be in one place, but I'll leave it to more involved members to decide what place should that be.