### PR TITLE
Allow clearcoat, anisotropy and refraction in SpatialMaterial in GLES2

### DIFF
--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -290,16 +290,16 @@
 			If [code]true[/code], the proximity fade effect is enabled. The proximity fade effect fades out each pixel based on its distance to another object.
 		</member>
 		<member name="refraction_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
-			If [code]true[/code], the refraction effect is enabled. Distorts transparency based on light from behind the object.
+			If [code]true[/code], the refraction effect is enabled. Refraction distorts transparency based on light from behind the object. When using the GLES3 backend, the material's roughness value will affect the blurriness of the refraction. Higher roughness values will make the refraction look blurrier.
 		</member>
 		<member name="refraction_scale" type="float" setter="set_refraction" getter="get_refraction">
-			The strength of the refraction effect.
+			The strength of the refraction effect. Higher values result in a more distorted appearance for the refraction.
 		</member>
 		<member name="refraction_texture" type="Texture" setter="set_texture" getter="get_texture">
 			Texture that controls the strength of the refraction per-pixel. Multiplied by [member refraction_scale].
 		</member>
 		<member name="refraction_texture_channel" type="int" setter="set_refraction_texture_channel" getter="get_refraction_texture_channel" enum="SpatialMaterial.TextureChannel">
-			Specifies the channel of the [member ao_texture] in which the ambient occlusion information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
+			Specifies the channel of the [member refraction_texture] in which the refraction information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
 		<member name="rim" type="float" setter="set_rim" getter="get_rim">
 			Sets the strength of the rim lighting effect.

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1402,10 +1402,7 @@ void SpatialMaterial::_validate_property(PropertyInfo &property) const {
 	_validate_feature("refraction", FEATURE_REFRACTION, property);
 	_validate_feature("detail", FEATURE_DETAIL, property);
 
-	_validate_high_end("refraction", property);
 	_validate_high_end("subsurf_scatter", property);
-	_validate_high_end("anisotropy", property);
-	_validate_high_end("clearcoat", property);
 	_validate_high_end("depth", property);
 
 	if (property.name.begins_with("particles_anim_") && billboard_mode != BILLBOARD_PARTICLES) {


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/50331.

These SpatialMaterial features work just fine in GLES2, but they were not exposed in the inspector when GLES2 was used.

After merging, remember to update [Differences between GLES2 and GLES3](https://docs.godotengine.org/en/stable/tutorials/misc/gles2_gles3_differences.html) in the documentation.

**HTML5 export for testing:** https://0x0.st/-yhx.zip <sup>(link expires in December 2021)</sup>
Unzip the archive, host a local web server from the extracted folder using something like [devd](https://github.com/cortesi/devd) then open the web server's homepage in a browser. I can confirm the HTML5 export looks as expected for anisotropy and refraction here.

## Preview

### Clearcoat

The difference is very subtle, but it's there. This is likely due to https://github.com/godotengine/godot/issues/14403. No screenshot for this one, as the difference is barely visible even when looking directly at the specular lobe on the wood material.

### Anisotropy

![Anisotropy](https://user-images.githubusercontent.com/180032/130337498-5e0d870a-aedb-4293-87f1-a97b4e13a6bc.png)

### Refraction

*Refractions will always be sharp regardless of material roughness. This is a GLES2 limitation, but the effect may still be enough for many use cases such as heat wave effects using particles.*

![Refraction](https://user-images.githubusercontent.com/180032/130337499-5bc204ee-5f1a-4df3-87d7-b8e74d884660.png)

