### PR TITLE
Document `Image.generate_mipmaps()` always running on the main thread

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -180,6 +180,7 @@
 			<argument index="0" name="renormalize" type="bool" default="false" />
 			<description>
 				Generates mipmaps for the image. Mipmaps are precalculated lower-resolution copies of the image that are automatically used if the image needs to be scaled down when rendered. They help improve image quality and performance when rendering. This method returns an error if the image is compressed, in a custom format, or if the image's width/height is [code]0[/code].
+				[b]Note:[/b] Mipmap generation is done on the CPU, is single-threaded and is [i]always[/i] done on the main thread. This means generating mipmaps will result in noticeable stuttering during gameplay, even if [method generate_mipmaps] is called from a [Thread].
 			</description>
 		</method>
 		<method name="get_data" qualifiers="const">


### PR DESCRIPTION
This closes https://github.com/godotengine/godot/issues/51966.