### PR TITLE
Define a default minimum window size to workaround rendering issues (3.x)

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -939,7 +939,8 @@
 			The maximum size of the window (without counting window manager decorations). Does not affect fullscreen mode. Set to [code](0, 0)[/code] to reset to the system default value.
 		</member>
 		<member name="min_window_size" type="Vector2" setter="set_min_window_size" getter="get_min_window_size" default="Vector2( 0, 0 )">
-			The minimum size of the window (without counting window manager decorations). Does not affect fullscreen mode. Set to [code](0, 0)[/code] to reset to the system default value.
+			The minimum size of the window in pixels (without counting window manager decorations). Does not affect fullscreen mode. Set to [code](0, 0)[/code] to reset to the system's default value.
+			[b]Note:[/b] By default, the project window has a minimum size of [code]Vector2(64, 64)[/code]. This prevents issues that can arise when the window is resized to a near-zero size.
 		</member>
 		<member name="screen_orientation" type="int" setter="set_screen_orientation" getter="get_screen_orientation" enum="_OS.ScreenOrientation" default="0">
 			The current screen orientation.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1878,6 +1878,10 @@ bool Main::start() {
 			OS::get_singleton()->set_window_title(appname);
 #endif
 
+			// Define a very small minimum window size to prevent bugs such as GH-37242.
+			// It can still be overridden by the user in a script.
+			OS::get_singleton()->set_min_window_size(Size2(64, 64));
+
 			int shadow_atlas_size = GLOBAL_GET("rendering/quality/shadow_atlas/size");
 			int shadow_atlas_q0_subdiv = GLOBAL_GET("rendering/quality/shadow_atlas/quadrant_0_subdiv");
 			int shadow_atlas_q1_subdiv = GLOBAL_GET("rendering/quality/shadow_atlas/quadrant_1_subdiv");


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/37260.

The minimum window size can still be set to `Vector2(0, 0)` in a script if needed.