### PR TITLE
Make GraphEdit connections consistent on zoom

### DIFF
--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -170,7 +170,7 @@ private:
 	bool lines_antialiased = true;
 
 	PackedVector2Array get_connection_line(const Vector2 &p_from, const Vector2 &p_to);
-	void _draw_connection_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color, float p_width);
+	void _draw_connection_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color, float p_width, float p_zoom);
 
 	void _graph_node_raised(Node *p_gn);
 	void _graph_node_moved(Node *p_gn);


### PR DESCRIPTION
Previously the connections would change shape depending on how far was zoomed in, which was particullary obvious after #51952.

**Before:**

https://user-images.githubusercontent.com/28286961/130350389-747f1364-6125-4ad0-9770-d71939122e01.mp4

**After:**

https://user-images.githubusercontent.com/28286961/130350393-4397e8c1-477c-4ea5-b2fd-15e372b49506.mp4
