### PR TITLE
Revert "Add Node processing and physics processing cumulative (as opposed to delta) time"

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -322,40 +322,16 @@
 				Returns the relative [NodePath] from this node to the specified [code]node[/code]. Both nodes must be in the same scene or the function will fail.
 			</description>
 		</method>
-		<method name="get_physics_process_cumulative_time" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the cumulative physics-bound frame time elapsed (in seconds) since this node has been active and running (i.e. not paused) in the current scene tree.
-			</description>
-		</method>
 		<method name="get_physics_process_delta_time" qualifiers="const">
 			<return type="float" />
 			<description>
 				Returns the time elapsed (in seconds) since the last physics-bound frame (see [method _physics_process]). This is always a constant value in physics processing unless the frames per second is changed via [member Engine.physics_ticks_per_second].
 			</description>
 		</method>
-		<method name="get_physics_process_total_time" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the total time elapsed (in seconds) since this node has been part of the current scene tree regardless of the pause state.
-			</description>
-		</method>
-		<method name="get_process_cumulative_time" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the cumulative time elapsed (in seconds) since this node has been active and running (i.e. not paused) in the current tree.
-			</description>
-		</method>
 		<method name="get_process_delta_time" qualifiers="const">
 			<return type="float" />
 			<description>
 				Returns the time elapsed (in seconds) since the last process callback. This value may vary from frame to frame.
-			</description>
-		</method>
-		<method name="get_process_total_time" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the total time elapsed (in seconds) since this node has been part of the current scene tree regardless of the pause state.
 			</description>
 		</method>
 		<method name="get_scene_instance_load_placeholder" qualifiers="const">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -55,17 +55,13 @@ void Node::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_PROCESS: {
 			if (get_script_instance()) {
-				double d_time = get_process_delta_time();
-				data.process_cumulative_time += d_time;
-				Variant time = d_time;
+				Variant time = get_process_delta_time();
 				get_script_instance()->call(SceneStringNames::get_singleton()->_process, time);
 			}
 		} break;
 		case NOTIFICATION_PHYSICS_PROCESS: {
 			if (get_script_instance()) {
-				double d_time = get_physics_process_delta_time();
-				data.physics_process_cumulative_time += d_time;
-				Variant time = d_time;
+				Variant time = get_physics_process_delta_time();
 				get_script_instance()->call(SceneStringNames::get_singleton()->_physics_process, time);
 			}
 
@@ -724,22 +720,6 @@ double Node::get_physics_process_delta_time() const {
 	}
 }
 
-double Node::get_physics_process_cumulative_time() const {
-	if (data.tree) {
-		return data.physics_process_cumulative_time;
-	} else {
-		return 0;
-	}
-}
-
-double Node::get_physics_process_total_time() const {
-	if (data.tree) {
-		return data.tree->get_physics_total_time();
-	} else {
-		return 0;
-	}
-}
-
 double Node::get_process_delta_time() const {
 	if (data.tree) {
 		return data.tree->get_process_time();
@@ -764,22 +744,6 @@ void Node::set_process(bool p_process) {
 
 bool Node::is_processing() const {
 	return data.process;
-}
-
-double Node::get_process_cumulative_time() const {
-	if (data.tree) {
-		return data.process_cumulative_time;
-	} else {
-		return 0;
-	}
-}
-
-double Node::get_process_total_time() const {
-	if (data.tree) {
-		return data.tree->get_process_total_time();
-	} else {
-		return 0;
-	}
 }
 
 void Node::set_process_internal(bool p_process_internal) {
@@ -2627,12 +2591,8 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("propagate_call", "method", "args", "parent_first"), &Node::propagate_call, DEFVAL(Array()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_physics_process", "enable"), &Node::set_physics_process);
 	ClassDB::bind_method(D_METHOD("get_physics_process_delta_time"), &Node::get_physics_process_delta_time);
-	ClassDB::bind_method(D_METHOD("get_physics_process_cumulative_time"), &Node::get_physics_process_cumulative_time);
-	ClassDB::bind_method(D_METHOD("get_physics_process_total_time"), &Node::get_physics_process_total_time);
 	ClassDB::bind_method(D_METHOD("is_physics_processing"), &Node::is_physics_processing);
 	ClassDB::bind_method(D_METHOD("get_process_delta_time"), &Node::get_process_delta_time);
-	ClassDB::bind_method(D_METHOD("get_process_cumulative_time"), &Node::get_process_cumulative_time);
-	ClassDB::bind_method(D_METHOD("get_process_total_time"), &Node::get_process_total_time);
 	ClassDB::bind_method(D_METHOD("set_process", "enable"), &Node::set_process);
 	ClassDB::bind_method(D_METHOD("set_process_priority", "priority"), &Node::set_process_priority);
 	ClassDB::bind_method(D_METHOD("get_process_priority"), &Node::get_process_priority);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -122,9 +122,6 @@ private:
 		int network_master = 1; // Server by default.
 		Vector<MultiplayerAPI::RPCConfig> rpc_methods;
 
-		double process_cumulative_time = 0.0;
-		double physics_process_cumulative_time = 0.0;
-
 		// Variables used to properly sort the node when processing, ignored otherwise.
 		// TODO: Should move all the stuff below to bits.
 		bool physics_process = false;
@@ -344,14 +341,10 @@ public:
 	/* PROCESSING */
 	void set_physics_process(bool p_process);
 	double get_physics_process_delta_time() const;
-	double get_physics_process_cumulative_time() const;
-	double get_physics_process_total_time() const;
 	bool is_physics_processing() const;
 
 	void set_process(bool p_process);
 	double get_process_delta_time() const;
-	double get_process_cumulative_time() const;
-	double get_process_total_time() const;
 	bool is_processing() const;
 
 	void set_physics_process_internal(bool p_process_internal);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -412,7 +412,6 @@ bool SceneTree::physics_process(double p_time) {
 
 	MainLoop::physics_process(p_time);
 	physics_process_time = p_time;
-	physics_total_time += p_time;
 
 	emit_signal(SNAME("physics_frame"));
 
@@ -439,7 +438,6 @@ bool SceneTree::process(double p_time) {
 	MainLoop::process(p_time);
 
 	process_time = p_time;
-	process_total_time += p_time;
 
 	if (multiplayer_poll) {
 		multiplayer->poll();

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -92,10 +92,7 @@ private:
 
 	uint64_t tree_version = 1;
 	double physics_process_time = 1.0;
-	double physics_total_time = 0.0;
-	double process_total_time = 0.0;
 	double process_time = 1.0;
-
 	bool accept_quit = true;
 	bool quit_on_go_back = true;
 
@@ -251,9 +248,7 @@ public:
 	void quit(int p_exit_code = EXIT_SUCCESS);
 
 	_FORCE_INLINE_ double get_physics_process_time() const { return physics_process_time; }
-	_FORCE_INLINE_ double get_physics_total_time() const { return physics_total_time; }
 	_FORCE_INLINE_ double get_process_time() const { return process_time; }
-	_FORCE_INLINE_ double get_process_total_time() const { return process_total_time; }
 
 #ifdef TOOLS_ENABLED
 	bool is_node_being_edited(const Node *p_node) const;


### PR DESCRIPTION
Reverts godotengine/godot#41850 because it does not work with the new GDVIRTUAL system for virtuals. Also this was not properly approved.