### PR TITLE
Remove deprecation warning for `BaseButton.enabled_focus_mode`

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -55,7 +55,7 @@
 			If [code]true[/code], the button is in disabled state and can't be clicked or toggled.
 		</member>
 		<member name="enabled_focus_mode" type="int" setter="set_enabled_focus_mode" getter="get_enabled_focus_mode" enum="Control.FocusMode" default="2">
-			[i]Deprecated.[/i] This property has been deprecated due to redundancy and no longer has any effect when set. Please use [member Control.focus_mode] instead.
+			[i]Deprecated.[/i] This property has been deprecated due to redundancy and will be removed in Godot 4.0. This property no longer has any effect when set. Please use [member Control.focus_mode] instead.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="group" type="ButtonGroup" setter="set_button_group" getter="get_button_group">

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -323,7 +323,6 @@ void BaseButton::set_enabled_focus_mode(FocusMode p_mode) {
 	if (!status.disabled) {
 		set_focus_mode(p_mode);
 	}
-	WARN_DEPRECATED_MSG("BaseButton's Enabled Focus Mode property has been deprecated due to redundancy and will be removed in Godot 4.0. Please use Control.set_focus_mode instead.");
 }
 
 Control::FocusMode BaseButton::get_enabled_focus_mode() const {


### PR DESCRIPTION
There were too many instances of false positives that are difficult to fix. The note in the class reference has been clarified instead.

This closes https://github.com/godotengine/godot/issues/48160 and closes https://github.com/godotengine/godot/issues/48199.