### PR TITLE
Fix quick open script results

### DIFF
--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -130,12 +130,6 @@ float EditorQuickOpen::_score_path(const String &p_search, const String &p_path)
 		return score * (1.0f - 0.1f * (float(pos) / file.length()));
 	}
 
-	// Positive bias for matches close to the end of the path.
-	pos = p_path.rfindn(p_search);
-	if (pos != -1) {
-		return 1.1f + 0.09 / (p_path.length() - pos + 1);
-	}
-
 	// Similarity
 	return p_path.to_lower().similarity(p_search.to_lower());
 }


### PR DESCRIPTION
This pull request fixes an issue where the top search result of the quick open script wouldn't be the most relevant when the first letter is typed.

This fix also seems to retain the improvements I made with #50707

Here we go again... I don't know if this is the best fix for this, but it seems to work pretty well, better than before anyway. I removed the positive bias for matches close to the end of the path as it seemed to be at least partially responsible for throwing off the accuracy of the quick open script results. It would seem it was made more or less redundant/pointless with the changes I made in #50707.

https://user-images.githubusercontent.com/62965063/130373474-15eb0af6-d2a2-4481-8a9e-10dd9f671c29.mp4

https://user-images.githubusercontent.com/62965063/130373482-27e86046-df50-442a-b759-2814747dc647.mp4

Resolves: #51811