### PR TITLE
Implement methods in EditorSceneImporterMesh, and add documentation.

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -115,6 +115,7 @@
 			<argument index="0" name="index" type="int" />
 			<argument index="1" name="name" type="StringName" />
 			<description>
+				Sets the name of the blend shape at this index.
 			</description>
 		</method>
 		<method name="surface_find_by_name" qualifiers="const">

--- a/doc/classes/EditorSceneImporterMesh.xml
+++ b/doc/classes/EditorSceneImporterMesh.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EditorSceneImporterMesh" inherits="Resource" version="4.0">
 	<brief_description>
+		A [Resource] that contains vertex array-based geometry during the import process.
 	</brief_description>
 	<description>
+		EditorSceneImporterMesh is a type of [Resource] analogous to [ArrayMesh]. It contains vertex array-based geometry, divided in [i]surfaces[/i]. Each surface contains a completely separate array and a material used to draw it. Design wise, a mesh with multiple surfaces is preferred to a single surface, because objects created in 3D editing software commonly contain multiple materials.
+
+		Unlike its runtime counterpart, [EditorSceneImporterMesh] contains mesh data before various import steps, such as lod and shadow mesh generation, have taken place. Modify surface data by calling [method clear], followed by [method add_surface] for each surface.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,6 +15,7 @@
 			<return type="void" />
 			<argument index="0" name="name" type="String" />
 			<description>
+				Adds name for a blend shape that will be added with [method add_surface]. Must be called before surface is added.
 			</description>
 		</method>
 		<method name="add_surface">
@@ -23,44 +28,56 @@
 			<argument index="4" name="material" type="Material" default="null" />
 			<argument index="5" name="name" type="String" default="&quot;&quot;" />
 			<description>
+				Creates a new surface, analogous to [method ArrayMesh.add_surface_from_arrays].
+				Surfaces are created to be rendered using a [code]primitive[/code], which may be any of the types defined in [enum Mesh.PrimitiveType]. (As a note, when using indices, it is recommended to only use points, lines, or triangles.) [method Mesh.get_surface_count] will become the [code]surf_idx[/code] for this new surface.
+				The [code]arrays[/code] argument is an array of arrays. See [enum Mesh.ArrayType] for the values used in this array. For example, [code]arrays[0][/code] is the array of vertices. That first vertex sub-array is always required; the others are optional. Adding an index array puts this function into "index mode" where the vertex and other arrays become the sources of data and the index array defines the vertex order. All sub-arrays must have the same length as the vertex array or be empty, except for [constant Mesh.ARRAY_INDEX] if it is used.
 			</description>
 		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>
+				Removes all surfaces and blend shapes from this [EditorSceneImporterMesh].
 			</description>
 		</method>
 		<method name="get_blend_shape_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the number of blend shapes that the mesh holds.
 			</description>
 		</method>
 		<method name="get_blend_shape_mode" qualifiers="const">
 			<return type="int" enum="Mesh.BlendShapeMode" />
 			<description>
+				Returns the blend shape mode for this Mesh.
 			</description>
 		</method>
 		<method name="get_blend_shape_name" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="blend_shape_idx" type="int" />
 			<description>
+				Returns the name of the blend shape at this index.
 			</description>
 		</method>
 		<method name="get_lightmap_size_hint" qualifiers="const">
 			<return type="Vector2i" />
 			<description>
+				Returns the size hint of this mesh for lightmap-unwrapping in UV-space.
 			</description>
 		</method>
 		<method name="get_mesh">
 			<return type="ArrayMesh" />
-			<argument index="0" name="arg0" type="Mesh" />
+			<argument index="0" name="base_mesh" type="ArrayMesh" default="null" />
 			<description>
+				Returns the mesh data represented by this [EditorSceneImporterMesh] as a usable [ArrayMesh].
+				This method caches the returned mesh, and subsequent calls will return the cached data until [method clear] is called.
+				If not yet cached and [code]base_mesh[/code] is provided, [code]base_mesh[/code] will be used and mutated.
 			</description>
 		</method>
 		<method name="get_surface_arrays" qualifiers="const">
 			<return type="Array" />
 			<argument index="0" name="surface_idx" type="int" />
 			<description>
+				Returns the arrays for the vertices, normals, uvs, etc. that make up the requested surface. See [method add_surface].
 			</description>
 		</method>
 		<method name="get_surface_blend_shape_arrays" qualifiers="const">
@@ -68,17 +85,20 @@
 			<argument index="0" name="surface_idx" type="int" />
 			<argument index="1" name="blend_shape_idx" type="int" />
 			<description>
+				Returns a single set of blend shape arrays for the requested blend shape index for a surface.
 			</description>
 		</method>
 		<method name="get_surface_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the amount of surfaces that the mesh holds.
 			</description>
 		</method>
 		<method name="get_surface_lod_count" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="surface_idx" type="int" />
 			<description>
+				Returns the amount of lods that the mesh holds on a given surface.
 			</description>
 		</method>
 		<method name="get_surface_lod_indices" qualifiers="const">
@@ -86,6 +106,7 @@
 			<argument index="0" name="surface_idx" type="int" />
 			<argument index="1" name="lod_idx" type="int" />
 			<description>
+				Returns the index buffer of a lod for a surface.
 			</description>
 		</method>
 		<method name="get_surface_lod_size" qualifiers="const">
@@ -93,36 +114,58 @@
 			<argument index="0" name="surface_idx" type="int" />
 			<argument index="1" name="lod_idx" type="int" />
 			<description>
+				Returns the screen ratio which activates a lod for a surface.
 			</description>
 		</method>
 		<method name="get_surface_material" qualifiers="const">
 			<return type="Material" />
 			<argument index="0" name="surface_idx" type="int" />
 			<description>
+				Returns a [Material] in a given surface. Surface is rendered using this material.
 			</description>
 		</method>
 		<method name="get_surface_name" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="surface_idx" type="int" />
 			<description>
+				Gets the name assigned to this surface.
 			</description>
 		</method>
 		<method name="get_surface_primitive_type">
 			<return type="int" enum="Mesh.PrimitiveType" />
 			<argument index="0" name="surface_idx" type="int" />
 			<description>
+				Returns the primitive type of the requested surface (see [method add_surface]).
 			</description>
 		</method>
 		<method name="set_blend_shape_mode">
 			<return type="void" />
 			<argument index="0" name="mode" type="int" enum="Mesh.BlendShapeMode" />
 			<description>
+				Sets the blend shape mode to one of [enum Mesh.BlendShapeMode].
 			</description>
 		</method>
 		<method name="set_lightmap_size_hint">
 			<return type="void" />
 			<argument index="0" name="size" type="Vector2i" />
 			<description>
+				Sets the size hint of this mesh for lightmap-unwrapping in UV-space.
+			</description>
+		</method>
+		<method name="set_surface_material">
+			<return type="void" />
+			<argument index="0" name="surface_idx" type="int" />
+			<argument index="1" name="material" type="Material" />
+			<description>
+				Sets a [Material] for a given surface. Surface will be rendered using this material.
+			</description>
+		</method>
+		<method name="set_surface_name">
+			<return type="void" />
+			<argument index="0" name="surface_idx" type="int" />
+			<argument index="1" name="name" type="String" />
+			<description>
+				Sets a name for a given surface.
 			</description>
 		</method>
 	</methods>

--- a/editor/import/scene_importer_mesh.cpp
+++ b/editor/import/scene_importer_mesh.cpp
@@ -110,6 +110,12 @@ String EditorSceneImporterMesh::get_surface_name(int p_surface) const {
 	ERR_FAIL_INDEX_V(p_surface, surfaces.size(), String());
 	return surfaces[p_surface].name;
 }
+void EditorSceneImporterMesh::set_surface_name(int p_surface, const String &p_name) {
+	ERR_FAIL_INDEX(p_surface, surfaces.size());
+	surfaces.write[p_surface].name = p_name;
+	mesh.unref();
+}
+
 Array EditorSceneImporterMesh::get_surface_blend_shape_arrays(int p_surface, int p_blend_shape) const {
 	ERR_FAIL_INDEX_V(p_surface, surfaces.size(), Array());
 	ERR_FAIL_INDEX_V(p_blend_shape, surfaces[p_surface].blend_shape_data.size(), Array());
@@ -140,6 +146,7 @@ Ref<Material> EditorSceneImporterMesh::get_surface_material(int p_surface) const
 void EditorSceneImporterMesh::set_surface_material(int p_surface, const Ref<Material> &p_material) {
 	ERR_FAIL_INDEX(p_surface, surfaces.size());
 	surfaces.write[p_surface].material = p_material;
+	mesh.unref();
 }
 
 Basis EditorSceneImporterMesh::compute_rotation_matrix_from_ortho_6d(Vector3 p_x_raw, Vector3 p_y_raw) {
@@ -244,7 +251,7 @@ bool EditorSceneImporterMesh::has_mesh() const {
 	return mesh.is_valid();
 }
 
-Ref<ArrayMesh> EditorSceneImporterMesh::get_mesh(const Ref<Mesh> &p_base) {
+Ref<ArrayMesh> EditorSceneImporterMesh::get_mesh(const Ref<ArrayMesh> &p_base) {
 	ERR_FAIL_COND_V(surfaces.size() == 0, Ref<ArrayMesh>());
 
 	if (mesh.is_null()) {
@@ -838,7 +845,10 @@ void EditorSceneImporterMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_surface_lod_indices", "surface_idx", "lod_idx"), &EditorSceneImporterMesh::get_surface_lod_indices);
 	ClassDB::bind_method(D_METHOD("get_surface_material", "surface_idx"), &EditorSceneImporterMesh::get_surface_material);
 
-	ClassDB::bind_method(D_METHOD("get_mesh"), &EditorSceneImporterMesh::get_mesh);
+	ClassDB::bind_method(D_METHOD("set_surface_name", "surface_idx", "name"), &EditorSceneImporterMesh::set_surface_name);
+	ClassDB::bind_method(D_METHOD("set_surface_material", "surface_idx", "material"), &EditorSceneImporterMesh::set_surface_material);
+
+	ClassDB::bind_method(D_METHOD("get_mesh", "base_mesh"), &EditorSceneImporterMesh::get_mesh, DEFVAL(Ref<ArrayMesh>()));
 	ClassDB::bind_method(D_METHOD("clear"), &EditorSceneImporterMesh::clear);
 
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &EditorSceneImporterMesh::_set_data);

--- a/editor/import/scene_importer_mesh.h
+++ b/editor/import/scene_importer_mesh.h
@@ -88,6 +88,7 @@ public:
 
 	Mesh::PrimitiveType get_surface_primitive_type(int p_surface);
 	String get_surface_name(int p_surface) const;
+	void set_surface_name(int p_surface, const String &p_name);
 	Array get_surface_arrays(int p_surface) const;
 	Array get_surface_blend_shape_arrays(int p_surface, int p_blend_shape) const;
 	int get_surface_lod_count(int p_surface) const;
@@ -112,7 +113,7 @@ public:
 	Size2i get_lightmap_size_hint() const;
 
 	bool has_mesh() const;
-	Ref<ArrayMesh> get_mesh(const Ref<Mesh> &p_base = Ref<Mesh>());
+	Ref<ArrayMesh> get_mesh(const Ref<ArrayMesh> &p_base = Ref<ArrayMesh>());
 	void clear();
 };
 #endif // EDITOR_SCENE_IMPORTER_MESH_H


### PR DESCRIPTION
While it is possible to clear all surfaces and add them anew, having `set_surface_name` and `set_surface_material` lower the complexity of doing material remapping in a custom importer (for example, swapping a StandardMaterial3D to a custom ShaderMaterial).

I also filled out the documentation page for all methods in EditorSceneImporterMesh.

Additionally, I corrected a bug with the `get_mesh` API in which it accepted a non-ArrayMesh.