### PR TITLE
Make Node editable_instance methods available to GDScript

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -384,7 +384,14 @@
 		<method name="is_displayed_folded" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node is folded (collapsed) in the Scene dock.
+				Returns [code]true[/code] if the node is folded (collapsed) in the Scene dock. This method is only intended for use with editor tooling.
+			</description>
+		</method>
+		<method name="is_editable_instance" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="node" type="Node" />
+			<description>
+				Returns [code]true[/code] if [code]node[/code] has editable children enabled relative to this node. This method is only intended for use with editor tooling.
 			</description>
 		</method>
 		<method name="is_greater_than" qualifiers="const">
@@ -592,7 +599,15 @@
 			<return type="void" />
 			<argument index="0" name="fold" type="bool" />
 			<description>
-				Sets the folded state of the node in the Scene dock.
+				Sets the folded state of the node in the Scene dock. This method is only intended for use with editor tooling.
+			</description>
+		</method>
+		<method name="set_editable_instance">
+			<return type="void" />
+			<argument index="0" name="node" type="Node" />
+			<argument index="1" name="is_editable" type="bool" />
+			<description>
+				Sets the editable children state of [code]node[/code] relative to this node. This method is only intended for use with editor tooling.
 			</description>
 		</method>
 		<method name="set_editor_description">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2616,6 +2616,8 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_scene_instance_load_placeholder", "load_placeholder"), &Node::set_scene_instance_load_placeholder);
 	ClassDB::bind_method(D_METHOD("get_scene_instance_load_placeholder"), &Node::get_scene_instance_load_placeholder);
+	ClassDB::bind_method(D_METHOD("set_editable_instance", "node", "is_editable"), &Node::set_editable_instance);
+	ClassDB::bind_method(D_METHOD("is_editable_instance", "node"), &Node::is_editable_instance);
 
 	ClassDB::bind_method(D_METHOD("get_viewport"), &Node::get_viewport);
 


### PR DESCRIPTION
Provides access to the existing is_editable_instance and set_editable_instance Node methods to GDScript.

These methods are needed to permit editor tooling to make scene changes to children of instanced scenes on behalf of the user. They do not create any editor dependencies which are not already present.

Note that some discussion has come up on other similar PRs such as #20569 (closed) and #48014 that methods which are "only relevant for the editor" should not be exposed on the Node api. However, some existing Node api methods are editor specific, including `is_displayed_folded` and `set_editor_description`.

This function has tangible usecases, and it is at present impossible to replicate its functionality within reason in another way. The api I choose to expose has remained stable for years, and doing so adds no new code to the engine. Pinging @reduz because this changes a class in core.