### PR TITLE
Document that RigidBody angular velocity is in degrees per second

### DIFF
--- a/doc/classes/CPUParticles.xml
+++ b/doc/classes/CPUParticles.xml
@@ -100,7 +100,7 @@
 			Rotation randomness ratio.
 		</member>
 		<member name="angular_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
+			Initial angular velocity applied to each particle in [i]degrees[/i] per second. Sets the speed of rotation of the particle.
 		</member>
 		<member name="angular_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's angular velocity will vary along this [Curve].

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -101,7 +101,7 @@
 			Rotation randomness ratio.
 		</member>
 		<member name="angular_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
+			Initial angular velocity applied to each particle in [i]degrees[/i] per second. Sets the speed of rotation of the particle.
 		</member>
 		<member name="angular_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's angular velocity will vary along this [Curve].

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -75,7 +75,7 @@
 	<members>
 		<member name="angle" type="float" setter="set_param" getter="get_param" default="0.0">
 			Initial rotation applied to each particle, in degrees.
-			Only applied when [member flag_disable_z] or [member flag_rotate_y] are [code]true[/code] or the [SpatialMaterial] being used to draw the particle is using [constant SpatialMaterial.BILLBOARD_PARTICLES].
+			[b]Note:[/b] Only applied when [member flag_disable_z] or [member flag_rotate_y] are [code]true[/code] or the [SpatialMaterial] being used to draw the particle is using [constant SpatialMaterial.BILLBOARD_PARTICLES].
 		</member>
 		<member name="angle_curve" type="Texture" setter="set_param_texture" getter="get_param_texture">
 			Each particle's rotation will be animated along this [CurveTexture].
@@ -84,8 +84,8 @@
 			Rotation randomness ratio.
 		</member>
 		<member name="angular_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
-			Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
-			Only applied when [member flag_disable_z] or [member flag_rotate_y] are [code]true[/code] or the [SpatialMaterial] being used to draw the particle is using [constant SpatialMaterial.BILLBOARD_PARTICLES].
+			Initial angular velocity applied to each particle in [i]degrees[/i] per second. Sets the speed of rotation of the particle.
+			[b]Note:[/b] Only applied when [member flag_disable_z] or [member flag_rotate_y] are [code]true[/code] or the [SpatialMaterial] being used to draw the particle is using [constant SpatialMaterial.BILLBOARD_PARTICLES].
 		</member>
 		<member name="angular_velocity_curve" type="Texture" setter="set_param_texture" getter="get_param_texture">
 			Each particle's angular velocity will vary along this [CurveTexture].
@@ -206,7 +206,7 @@
 		</member>
 		<member name="orbit_velocity" type="float" setter="set_param" getter="get_param">
 			Orbital velocity applied to each particle. Makes the particles circle around origin. Specified in number of full rotations around origin per second.
-			Only available when [member flag_disable_z] is [code]true[/code].
+			[b]Note:[/b] Only available when [member flag_disable_z] is [code]true[/code].
 		</member>
 		<member name="orbit_velocity_curve" type="Texture" setter="set_param_texture" getter="get_param_texture">
 			Each particle's orbital velocity will vary along this [CurveTexture].

--- a/doc/classes/Physics2DDirectBodyState.xml
+++ b/doc/classes/Physics2DDirectBodyState.xml
@@ -154,7 +154,7 @@
 	</methods>
 	<members>
 		<member name="angular_velocity" type="float" setter="set_angular_velocity" getter="get_angular_velocity">
-			The body's rotational velocity.
+			The body's rotational velocity in [i]radians[/i] per second.
 		</member>
 		<member name="inverse_inertia" type="float" setter="" getter="get_inverse_inertia">
 			The inverse of the inertia of the body.
@@ -163,7 +163,7 @@
 			The inverse of the mass of the body.
 		</member>
 		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity">
-			The body's linear velocity.
+			The body's linear velocity in pixels per second.
 		</member>
 		<member name="sleeping" type="bool" setter="set_sleep_state" getter="is_sleeping">
 			If [code]true[/code], this body is currently sleeping (not active).

--- a/doc/classes/PhysicsDirectBodyState.xml
+++ b/doc/classes/PhysicsDirectBodyState.xml
@@ -156,7 +156,7 @@
 	</methods>
 	<members>
 		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity">
-			The body's rotational velocity.
+			The body's rotational velocity in axis-angle format. The magnitude of the vector is the rotation rate in [i]radians[/i] per second.
 		</member>
 		<member name="center_of_mass" type="Vector3" setter="" getter="get_center_of_mass">
 		</member>
@@ -167,7 +167,7 @@
 			The inverse of the mass of the body.
 		</member>
 		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity">
-			The body's linear velocity.
+			The body's linear velocity in units per second.
 		</member>
 		<member name="principal_inertia_axes" type="Basis" setter="" getter="get_principal_inertia_axes">
 		</member>

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -112,7 +112,7 @@
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
 		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3( 0, 0, 0 )">
-			RigidBody's rotational velocity.
+			The body's rotational velocity in axis-angle format. The magnitude of the vector is the rotation rate in [i]radians[/i] per second.
 		</member>
 		<member name="axis_lock_angular_x" type="bool" setter="set_axis_lock" getter="get_axis_lock" default="false">
 			Lock the body's rotation in the X axis.
@@ -166,7 +166,7 @@
 			See [member ProjectSettings.physics/3d/default_linear_damp] for more details about damping.
 		</member>
 		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3( 0, 0, 0 )">
-			The body's linear velocity. Can be used sporadically, but [b]don't set this every frame[/b], because physics may run in another thread and runs at a different granularity. Use [method _integrate_forces] as your process loop for precise control of the body state.
+			The body's linear velocity in units per second. Can be used sporadically, but [b]don't set this every frame[/b], because physics may run in another thread and runs at a different granularity. Use [method _integrate_forces] as your process loop for precise control of the body state.
 		</member>
 		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="1.0">
 			The body's mass.

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -98,7 +98,7 @@
 			See [member ProjectSettings.physics/2d/default_angular_damp] for more details about damping.
 		</member>
 		<member name="angular_velocity" type="float" setter="set_angular_velocity" getter="get_angular_velocity" default="0.0">
-			The body's rotational velocity.
+			The body's rotational velocity in [i]radians[/i] per second.
 		</member>
 		<member name="applied_force" type="Vector2" setter="set_applied_force" getter="get_applied_force" default="Vector2( 0, 0 )">
 			The body's total applied force.
@@ -143,7 +143,7 @@
 			See [member ProjectSettings.physics/2d/default_linear_damp] for more details about damping.
 		</member>
 		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2( 0, 0 )">
-			The body's linear velocity.
+			The body's linear velocity in pixels per second. Can be used sporadically, but [b]don't set this every frame[/b], because physics may run in another thread and runs at a different granularity. Use [method _integrate_forces] as your process loop for precise control of the body state.
 		</member>
 		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="1.0">
 			The body's mass.


### PR DESCRIPTION
This will be changed to radians per second in Godot 4.0, but it can't be changed in 3.x to preserve compatibility with existing projects.