### PR TITLE
Fix VisualScriptEditor after namespaces

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1072,8 +1072,8 @@
 		<member name="TranslationServer" type="TranslationServer" setter="" getter="">
 			The [TranslationServer] singleton.
 		</member>
-		<member name="VisualScriptEditor" type="VisualScriptEditor" setter="" getter="">
-			The [VisualScriptEditor] singleton.
+		<member name="VisualScriptEditor" type="VisualScriptCustomNodes" setter="" getter="">
+			The [VisualScriptCustomNodes] singleton.
 		</member>
 		<member name="XRServer" type="XRServer" setter="" getter="">
 			The [XRServer] singleton.

--- a/doc/classes/VisualScriptCustomNodes.xml
+++ b/doc/classes/VisualScriptCustomNodes.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualScriptEditor" inherits="Object" version="4.0">
+<class name="VisualScriptCustomNodes" inherits="Object" version="4.0">
 	<brief_description>
+		Manages custom nodes for the Visual Script editor.
 	</brief_description>
 	<description>
+		This singleton can be used to manage (i.e., add or remove) custom nodes for the Visual Script editor.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -43,7 +43,7 @@
 
 VisualScriptLanguage *visual_script_language = nullptr;
 #ifdef TOOLS_ENABLED
-static vs_bind::VisualScriptEditor *vs_editor_singleton = nullptr;
+static VisualScriptCustomNodes *vs_custom_nodes_singleton = nullptr;
 #endif
 
 void register_visual_script_types() {
@@ -114,10 +114,10 @@ void register_visual_script_types() {
 
 #ifdef TOOLS_ENABLED
 	ClassDB::set_current_api(ClassDB::API_EDITOR);
-	GDREGISTER_CLASS(vs_bind::VisualScriptEditor);
+	GDREGISTER_CLASS(VisualScriptCustomNodes);
 	ClassDB::set_current_api(ClassDB::API_CORE);
-	vs_editor_singleton = memnew(vs_bind::VisualScriptEditor);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("VisualScriptEditor", vs_bind::VisualScriptEditor::get_singleton()));
+	vs_custom_nodes_singleton = memnew(VisualScriptCustomNodes);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("VisualScriptEditor", VisualScriptCustomNodes::get_singleton()));
 
 	VisualScriptEditor::register_editor();
 #endif
@@ -130,8 +130,8 @@ void unregister_visual_script_types() {
 
 #ifdef TOOLS_ENABLED
 	VisualScriptEditor::free_clipboard();
-	if (vs_editor_singleton) {
-		memdelete(vs_editor_singleton);
+	if (vs_custom_nodes_singleton) {
+		memdelete(vs_custom_nodes_singleton);
 	}
 #endif
 	if (visual_script_language) {

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -4522,46 +4522,44 @@ void VisualScriptEditor::register_editor() {
 void VisualScriptEditor::validate() {
 }
 
-namespace vs_bind {
+// VisualScriptCustomNodes
 
-Ref<VisualScriptNode> VisualScriptEditor::create_node_custom(const String &p_name) {
+Ref<VisualScriptNode> VisualScriptCustomNodes::create_node_custom(const String &p_name) {
 	Ref<VisualScriptCustomNode> node;
 	node.instantiate();
 	node->set_script(singleton->custom_nodes[p_name]);
 	return node;
 }
 
-VisualScriptEditor *VisualScriptEditor::singleton = nullptr;
-Map<String, REF> VisualScriptEditor::custom_nodes;
+VisualScriptCustomNodes *VisualScriptCustomNodes::singleton = nullptr;
+Map<String, REF> VisualScriptCustomNodes::custom_nodes;
 
-VisualScriptEditor::VisualScriptEditor() {
+VisualScriptCustomNodes::VisualScriptCustomNodes() {
 	singleton = this;
 }
 
-VisualScriptEditor::~VisualScriptEditor() {
+VisualScriptCustomNodes::~VisualScriptCustomNodes() {
 	custom_nodes.clear();
 }
 
-void VisualScriptEditor::add_custom_node(const String &p_name, const String &p_category, const Ref<Script> &p_script) {
+void VisualScriptCustomNodes::add_custom_node(const String &p_name, const String &p_category, const Ref<Script> &p_script) {
 	String node_name = "custom/" + p_category + "/" + p_name;
 	custom_nodes.insert(node_name, p_script);
-	VisualScriptLanguage::singleton->add_register_func(node_name, &VisualScriptEditor::create_node_custom);
+	VisualScriptLanguage::singleton->add_register_func(node_name, &VisualScriptCustomNodes::create_node_custom);
 	emit_signal(SNAME("custom_nodes_updated"));
 }
 
-void VisualScriptEditor::remove_custom_node(const String &p_name, const String &p_category) {
+void VisualScriptCustomNodes::remove_custom_node(const String &p_name, const String &p_category) {
 	String node_name = "custom/" + p_category + "/" + p_name;
 	custom_nodes.erase(node_name);
 	VisualScriptLanguage::singleton->remove_register_func(node_name);
 	emit_signal(SNAME("custom_nodes_updated"));
 }
 
-void VisualScriptEditor::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_custom_node", "name", "category", "script"), &VisualScriptEditor::add_custom_node);
-	ClassDB::bind_method(D_METHOD("remove_custom_node", "name", "category"), &VisualScriptEditor::remove_custom_node);
+void VisualScriptCustomNodes::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_custom_node", "name", "category", "script"), &VisualScriptCustomNodes::add_custom_node);
+	ClassDB::bind_method(D_METHOD("remove_custom_node", "name", "category"), &VisualScriptCustomNodes::remove_custom_node);
 	ADD_SIGNAL(MethodInfo("custom_nodes_updated"));
 }
-
-} // namespace vs_bind
 
 #endif

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -46,6 +46,8 @@ class VisualScriptEditorVariableEdit;
 // TODO: Maybe this class should be refactored.
 // See https://github.com/godotengine/godot/issues/51913
 class VisualScriptEditor : public ScriptEditorBase {
+	GDCLASS(VisualScriptEditor, ScriptEditorBase);
+
 	enum {
 		TYPE_SEQUENCE = 1000,
 		INDEX_BASE_SEQUENCE = 1024
@@ -330,32 +332,28 @@ public:
 	~VisualScriptEditor();
 };
 
-namespace vs_bind {
-
 // Singleton
-class VisualScriptEditor : public Object {
-	GDCLASS(VisualScriptEditor, Object);
+class VisualScriptCustomNodes : public Object {
+	GDCLASS(VisualScriptCustomNodes, Object);
 
 	friend class VisualScriptLanguage;
 
 protected:
 	static void _bind_methods();
-	static VisualScriptEditor *singleton;
+	static VisualScriptCustomNodes *singleton;
 
 	static Map<String, REF> custom_nodes;
 	static Ref<VisualScriptNode> create_node_custom(const String &p_name);
 
 public:
-	static VisualScriptEditor *get_singleton() { return singleton; }
+	static VisualScriptCustomNodes *get_singleton() { return singleton; }
 
 	void add_custom_node(const String &p_name, const String &p_category, const Ref<Script> &p_script);
 	void remove_custom_node(const String &p_name, const String &p_category);
 
-	VisualScriptEditor();
-	~VisualScriptEditor();
+	VisualScriptCustomNodes();
+	~VisualScriptCustomNodes();
 };
-
-} // namespace vs_bind
 
 #endif
 


### PR DESCRIPTION
New iteration on a fix for the VisualScript editor after the move to namespaces.
As both `VisualScriptEditor` classes need to be exposed to GDScript, this renames the small one to `VisualScriptCustomNodes`, but it still is bound as the `VisualScriptEditor` singleton like it previously was. This seems to fix the issues.

The `vs_bind` namespace is removed, as its then no longer needed.

As added in the code comment previously, we may want to refactor these two classes, but still is a fix until then.

Properly fixes https://github.com/godotengine/godot/issues/51894, after https://github.com/godotengine/godot/pull/51627 broke it
Also reverts https://github.com/godotengine/godot/pull/51916, as both classes need to be exposed