### PR TITLE
String.is_absolute_path now checks for two dots

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3720,7 +3720,7 @@ String String::humanize_size(uint64_t p_size) {
 
 bool String::is_absolute_path() const {
 	if (length() > 1) {
-		return (operator[](0) == '/' || operator[](0) == '\\' || find(":/") != -1 || find(":\\") != -1);
+		return (operator[](0) == '/' || operator[](0) == '\\' || find(":/") != -1 || find(":\\") != -1) && !(find("..") != -1);
 	} else if ((length()) == 1) {
 		return (operator[](0) == '/' || operator[](0) == '\\');
 	} else {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

The following:

```gdscript
print("res://../".is_absolute_path())
```
returns `True` without this patch.