### PR TITLE
Fix get_base_dir windows top level directory logic

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4329,23 +4329,39 @@ bool String::is_rel_path() const {
 }
 
 String String::get_base_dir() const {
-	int basepos = find(":/");
-	if (basepos == -1) {
-		basepos = find(":\\");
+	int end = 0;
+
+	// url scheme style base
+	int basepos = find("://");
+	if (basepos != -1) {
+		end = basepos + 3;
 	}
+
+	// windows top level directory base
+	if (end == 0) {
+		basepos = find(":/");
+		if (basepos == -1) {
+			basepos = find(":\\");
+		}
+		if (basepos != -1) {
+			end = basepos + 2;
+		}
+	}
+
+	// unix root directory base
+	if (end == 0) {
+		if (begins_with("/")) {
+			end = 1;
+		}
+	}
+
 	String rs;
 	String base;
-	if (basepos != -1) {
-		int end = basepos + 3;
+	if (end != 0) {
 		rs = substr(end, length());
 		base = substr(0, end);
 	} else {
-		if (begins_with("/")) {
-			rs = substr(1, length());
-			base = "/";
-		} else {
-			rs = *this;
-		}
+		rs = *this;
 	}
 
 	int sep = MAX(rs.rfind("/"), rs.rfind("\\"));

--- a/tests/test_string.h
+++ b/tests/test_string.h
@@ -1142,14 +1142,14 @@ TEST_CASE("[String] dedent") {
 }
 
 TEST_CASE("[String] Path functions") {
-	static const char *path[4] = { "C:\\Godot\\project\\test.tscn", "/Godot/project/test.xscn", "../Godot/project/test.scn", "Godot\\test.doc" };
-	static const char *base_dir[4] = { "C:\\Godot\\project", "/Godot/project", "../Godot/project", "Godot" };
-	static const char *base_name[4] = { "C:\\Godot\\project\\test", "/Godot/project/test", "../Godot/project/test", "Godot\\test" };
-	static const char *ext[4] = { "tscn", "xscn", "scn", "doc" };
-	static const char *file[4] = { "test.tscn", "test.xscn", "test.scn", "test.doc" };
-	static const bool abs[4] = { true, true, false, false };
+	static const char *path[7] = { "C:\\Godot\\project\\test.tscn", "/Godot/project/test.xscn", "../Godot/project/test.scn", "Godot\\test.doc", "C:\\test.", "res://test", "/.test" };
+	static const char *base_dir[7] = { "C:\\Godot\\project", "/Godot/project", "../Godot/project", "Godot", "C:\\", "res://", "/" };
+	static const char *base_name[7] = { "C:\\Godot\\project\\test", "/Godot/project/test", "../Godot/project/test", "Godot\\test", "C:\\test", "res://test", "/" };
+	static const char *ext[7] = { "tscn", "xscn", "scn", "doc", "", "", "test" };
+	static const char *file[7] = { "test.tscn", "test.xscn", "test.scn", "test.doc", "test.", "test", ".test" };
+	static const bool abs[7] = { true, true, false, false, true, true, true };
 
-	for (int i = 0; i < 4; i++) {
+	for (int i = 0; i < 7; i++) {
 		CHECK(String(path[i]).get_base_dir() == base_dir[i]);
 		CHECK(String(path[i]).get_basename() == base_name[i]);
 		CHECK(String(path[i]).get_extension() == ext[i]);


### PR DESCRIPTION
This is a fix for https://github.com/godotengine/godot/issues/52048

If we look at the diff for https://github.com/godotengine/godot/commit/cddff0404dbeadbe04d575c0211adba7fa4b3355 we observe that before it was looking for a `3` character string (`"://"`), and now it is looking for a `2` character string (either `":/"` or `":\\"`).

Edit: Updating the use of `substr` accordingly fixes windows top level directories (e.g. `"C:\\puff"`) but breaks Godot paths (e.g. `"res://puff"`). Also, it is worth noting that the code already has an special case for the unix root directory (`"/"`). Thus, we need to handle:

- Finding `"://"` (`3` characters).
- Finding `":\` (`2` characters).
- Finding `":/"` (`2` characters).
- `"/"` at the start (`1` character).

And we need to be careful with order in which we check because `"://"` contains `":/"`.

---

This code demonstrate the change:

```
func test(s:String):
	print("\"", s, "\" -> \"", s.get_base_dir(), "\"")

func _ready() -> void:
	test("C:")
	test("C:\\")
	test("C:\\puff")
	test("C:\\puff\\")
```	

Before https://github.com/godotengine/godot/commit/cddff0404dbeadbe04d575c0211adba7fa4b3355 (tested in Godot 3.2.3) the output is:

```
"C:" -> ""
"C:\" -> "C:"
"C:\puff" -> "C:"
"C:\puff\" -> "C:\puff"
```

After https://github.com/godotengine/godot/commit/cddff0404dbeadbe04d575c0211adba7fa4b3355 (tested in Godot 3.3.3) the output is:

```
"C:" -> ""
"C:\" -> "C:\"
"C:\puff" -> "C:\p"
"C:\puff\" -> "C:\puff"
```

With this PR (tested in custom build of Godot 4.0) the output is:

```
"C:" -> ""
"C:\" -> "C:\"
"C:\puff" -> "C:\"
"C:\puff\" -> "C:\puff"
```

*Bugsquad edit:* Fixes #52048.