### PR TITLE
Bind TabContainer::get_tab_idx_at_point() to ClassDB

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -57,6 +57,13 @@
 				Returns the [Texture2D] for the tab at index [code]tab_idx[/code] or [code]null[/code] if the tab has no [Texture2D].
 			</description>
 		</method>
+		<method name="get_tab_idx_at_point" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="point" type="Vector2" />
+			<description>
+				Returns the index of the tab at local coordinates [code]point[/code]. Returns [code]-1[/code] if the point is outside the control boundaries or if there's no tab at the queried position.
+			</description>
+		</method>
 		<method name="get_tab_title" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="tab_idx" type="int" />

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1211,6 +1211,7 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_icon", "tab_idx"), &TabContainer::get_tab_icon);
 	ClassDB::bind_method(D_METHOD("set_tab_disabled", "tab_idx", "disabled"), &TabContainer::set_tab_disabled);
 	ClassDB::bind_method(D_METHOD("get_tab_disabled", "tab_idx"), &TabContainer::get_tab_disabled);
+	ClassDB::bind_method(D_METHOD("get_tab_idx_at_point", "point"), &TabContainer::get_tab_idx_at_point);
 	ClassDB::bind_method(D_METHOD("set_popup", "popup"), &TabContainer::set_popup);
 	ClassDB::bind_method(D_METHOD("get_popup"), &TabContainer::get_popup);
 	ClassDB::bind_method(D_METHOD("set_drag_to_rearrange_enabled", "enabled"), &TabContainer::set_drag_to_rearrange_enabled);


### PR DESCRIPTION
As it currently stands, there's no reliable way from the GDScript to determine which tab the mouse is over, which is pretty important for being able to generate a relevant tooltip. This binds the already-used internal method to determine this to ClassDB.  

This update is for the `master` branch.  The 3.x version is located [here](https://github.com/godotengine/godot/pull/52047).
