### PR TITLE
[3.x] Fix Raycast3D color update when not colliding anymore (Fix #52051)

### DIFF
--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -427,7 +427,7 @@ void RayCast::_update_debug_shape_material(bool p_check_collision) {
 		color = get_tree()->get_debug_collisions_color();
 	}
 
-	if (p_check_collision) {
+	if (p_check_collision && collided) {
 		if ((color.get_h() < 0.055 || color.get_h() > 0.945) && color.get_s() > 0.5 && color.get_v() > 0.5) {
 			// If base color is already quite reddish, hightlight collision with green color
 			color = Color(0.0, 1.0, 0.0, color.a);


### PR DESCRIPTION
This PR fixes #52051 issue.

Only concerning 3.x cause it's already OK in master branch.

``collided`` variable wasn't check correctly in the update method.
(I've made a confusion between p_collision_check (which ask to check for raycast state) and collided (which is the real state of the raycast))

This has been already fixed in master branch.