### PR TITLE
[3.x] Allow to get list of non object methods

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -3062,7 +3062,26 @@ bool _ClassDB::is_class_enabled(StringName p_class) const {
 	return ClassDB::is_class_enabled(p_class);
 }
 
+Array _ClassDB::get_variant_method_list(Variant::Type p_type) const {
+	List<MethodInfo> methods;
+	Variant::get_method_list_by_type(&methods, p_type);
+	Array ret;
+
+	for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
+#ifdef DEBUG_METHODS_ENABLED
+		ret.push_back(E->get().operator Dictionary());
+#else
+		Dictionary dict;
+		dict["name"] = E->get().name;
+		ret.push_back(dict);
+#endif
+	}
+
+	return ret;
+}
+
 void _ClassDB::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_variant_method_list", "type"), &_ClassDB::get_variant_method_list);
 	ClassDB::bind_method(D_METHOD("get_class_list"), &_ClassDB::get_class_list);
 	ClassDB::bind_method(D_METHOD("get_inheriters_from_class", "class"), &_ClassDB::get_inheriters_from_class);
 	ClassDB::bind_method(D_METHOD("get_parent_class", "class"), &_ClassDB::get_parent_class);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -784,6 +784,7 @@ public:
 	bool has_method(StringName p_class, StringName p_method, bool p_no_inheritance = false) const;
 
 	Array get_method_list(StringName p_class, bool p_no_inheritance = false) const;
+	Array get_variant_method_list(Variant::Type p_type) const;
 
 	PoolStringArray get_integer_constant_list(const StringName &p_class, bool p_no_inheritance = false) const;
 	bool has_integer_constant(const StringName &p_class, const StringName &p_name) const;

--- a/core/variant.h
+++ b/core/variant.h
@@ -385,6 +385,7 @@ public:
 
 	static Variant construct(const Variant::Type, const Variant **p_args, int p_argcount, CallError &r_error, bool p_strict = true);
 
+	static void get_method_list_by_type(List<MethodInfo> *p_list, Variant::Type p_type);
 	void get_method_list(List<MethodInfo> *p_list) const;
 	bool has_method(const StringName &p_method) const;
 	static Vector<Variant::Type> get_method_argument_types(Variant::Type p_type, const StringName &p_method);

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1513,8 +1513,9 @@ Vector<Variant> Variant::get_method_default_arguments(Variant::Type p_type, cons
 	return E->get().default_args;
 }
 
-void Variant::get_method_list(List<MethodInfo> *p_list) const {
-	const _VariantCall::TypeFunc &tf = _VariantCall::type_funcs[type];
+void Variant::get_method_list_by_type(List<MethodInfo> *p_list, Variant::Type p_type) {
+	ERR_FAIL_INDEX(p_type, Variant::VARIANT_MAX);
+	const _VariantCall::TypeFunc &tf = _VariantCall::type_funcs[p_type];
 
 	for (const Map<StringName, _VariantCall::FuncData>::Element *E = tf.functions.front(); E; E = E->next()) {
 		const _VariantCall::FuncData &fd = E->get();
@@ -1546,6 +1547,17 @@ void Variant::get_method_list(List<MethodInfo> *p_list) const {
 #endif
 
 		p_list->push_back(mi);
+	}
+}
+
+void Variant::get_method_list(List<MethodInfo> *p_list) const {
+	if (type == OBJECT) {
+		Object *obj = _OBJ_PTR(*this);
+		if (obj) {
+			obj->get_method_list(p_list);
+		}
+	} else {
+		Variant::get_method_list_by_type(p_list, type);
 	}
 }
 

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -176,6 +176,12 @@
 				Returns the parent class of [code]class[/code].
 			</description>
 		</method>
+		<method name="get_variant_method_list" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="type" type="int" enum="Variant.Type" />
+			<description>
+			</description>
+		</method>
 		<method name="instance" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="class" type="String" />


### PR DESCRIPTION
3.x version of https://github.com/godotengine/godot/pull/49053.

This will allow to test builit-in types in CI
Also  it will allow to easily get list of all functions from GDScript which will help me to improve Godot 3 -> Godot 4 converter(https://github.com/godotengine/godot/pull/51950)