### PR TITLE
Update the matches  label in replace bar, after replacing something.

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -210,6 +210,7 @@ void FindReplaceBar::_replace() {
 	}
 	text_editor->end_complex_operation();
 	results_count = -1;
+	_update_matches_label();
 
 	if (selection_enabled && is_selection_only()) {
 		// Reselect in order to keep 'Replace' restricted to selection


### PR DESCRIPTION
Update the _matches_ label, after replacing one of them.
It was working in one of the builds I had locally, built like a month ago, but not on the latest master.

With this PR:

https://user-images.githubusercontent.com/17506575/130663314-134309ad-7ee0-48cf-aa54-7eeeb6df8a18.mp4
