### PR TITLE
Implement error return documentation

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -67,6 +67,7 @@ public:
 		String qualifiers;
 		String description;
 		Vector<ArgumentDoc> arguments;
+		Vector<int> errors_returned;
 		bool operator<(const MethodDoc &p_method) const {
 			if (name == p_method.name) {
 				// Must be a constructor since there is no overloading.

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -315,6 +315,8 @@ void ConfigFile::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("parse", "data"), &ConfigFile::parse);
 	ClassDB::bind_method(D_METHOD("save", "path"), &ConfigFile::save);
 
+	BIND_METHOD_ERR_RETURN_DOC("load", ERR_FILE_CANT_OPEN);
+
 	ClassDB::bind_method(D_METHOD("load_encrypted", "path", "key"), &ConfigFile::load_encrypted);
 	ClassDB::bind_method(D_METHOD("load_encrypted_pass", "path", "password"), &ConfigFile::load_encrypted_pass);
 

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -892,6 +892,32 @@ void ClassDB::get_enum_constants(const StringName &p_class, const StringName &p_
 	}
 }
 
+void ClassDB::set_method_error_return_values(const StringName &p_class, const StringName &p_method, const Vector<Error> &p_values) {
+	OBJTYPE_RLOCK;
+#ifdef DEBUG_METHODS_ENABLED
+	ClassInfo *type = classes.getptr(p_class);
+
+	ERR_FAIL_COND(!type);
+
+	type->method_error_values[p_method] = p_values;
+#endif
+}
+
+Vector<Error> ClassDB::get_method_error_return_values(const StringName &p_class, const StringName &p_method) {
+#ifdef DEBUG_METHODS_ENABLED
+	ClassInfo *type = classes.getptr(p_class);
+
+	ERR_FAIL_COND_V(!type, Vector<Error>());
+
+	if (!type->method_error_values.has(p_method)) {
+		return Vector<Error>();
+	}
+	return type->method_error_values[p_method];
+#else
+	return Vector<Error>();
+#endif
+}
+
 bool ClassDB::has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) {
 	OBJTYPE_RLOCK;
 

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -149,6 +149,8 @@
 		</method>
 		<method name="load">
 			<return type="int" enum="Error" />
+			<returns_error number="0"/>
+			<returns_error number="12"/>
 			<argument index="0" name="path" type="String" />
 			<description>
 				Loads the config file specified as a parameter. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_help.h"
 
+#include "core/core_constants.h"
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "doc_data_compressed.gen.h"
@@ -695,7 +696,7 @@ void EditorHelp::_update_doc() {
 					class_desc->pop(); //cell
 				}
 
-				if (m[i].description != "") {
+				if (m[i].description != "" || m[i].errors_returned.size() > 0) {
 					method_descr = true;
 				}
 
@@ -1227,6 +1228,31 @@ void EditorHelp::_update_doc() {
 				class_desc->push_color(text_color);
 				class_desc->push_font(doc_font);
 				class_desc->push_indent(1);
+				if (methods_filtered[i].errors_returned.size()) {
+					class_desc->append_bbcode(TTR("Error codes returned:"));
+					class_desc->add_newline();
+					class_desc->push_list(0, RichTextLabel::LIST_DOTS, false);
+					for (int j = 0; j < methods_filtered[i].errors_returned.size(); j++) {
+						if (j > 0) {
+							class_desc->add_newline();
+						}
+						int val = methods_filtered[i].errors_returned[j];
+						String text = itos(val);
+						for (int k = 0; k < CoreConstants::get_global_constant_count(); k++) {
+							if (CoreConstants::get_global_constant_value(k) == val && CoreConstants::get_global_constant_enum(k) == SNAME("Error")) {
+								text = CoreConstants::get_global_constant_name(k);
+								break;
+							}
+						}
+
+						class_desc->push_bold();
+						class_desc->append_bbcode(text);
+						class_desc->pop();
+					}
+					class_desc->pop();
+					class_desc->add_newline();
+					class_desc->add_newline();
+				}
 				if (!methods_filtered[i].description.strip_edges().is_empty()) {
 					_add_text(DTR(methods_filtered[i].description));
 				} else {


### PR DESCRIPTION
Adds ability to add error return documetation to the binder and class reference.
Usage example:

```C++
void MyClass::_bind_method() {
	[..]
	BIND_METHOD_ERR_RETURN_DOC("load", ERR_FILE_CANT_OPEN, ERR_FILE_UNRECOGNIZED);
}
```

One function of ConfigFile was changed as example.
