### PR TITLE
CI: Cancel previous builds if new commit is pushed

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -7,6 +7,10 @@ env:
   SCONSFLAGS: platform=android verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
 
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-android
+  cancel-in-progress: true
+
 jobs:
   android-template:
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -7,6 +7,10 @@ env:
   SCONSFLAGS: platform=iphone verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
 
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-ios
+  cancel-in-progress: true
+
 jobs:
   ios-template:
     runs-on: "macos-latest"

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -9,6 +9,10 @@ env:
   EM_VERSION: 2.0.27
   EM_CACHE_FOLDER: 'emsdk-cache'
 
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-javascript
+  cancel-in-progress: true
+
 jobs:
   javascript-template:
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -7,6 +7,10 @@ env:
   SCONSFLAGS: platform=linuxbsd verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
 
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-linux
+  cancel-in-progress: true
+
 jobs:
   linux-editor:
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -7,6 +7,10 @@ env:
   SCONSFLAGS: platform=osx verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
 
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-macos
+  cancel-in-progress: true
+
 jobs:
   macos-editor:
     runs-on: "macos-latest"

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,6 +1,10 @@
 name: 📊 Static Checks
 on: [push, pull_request]
 
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-static
+  cancel-in-progress: true
+
 jobs:
   static-checks:
     name: Static Checks (clang-format, black format, file format, documentation checks)

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -9,6 +9,10 @@ env:
   SCONS_CACHE_MSVC_CONFIG: true
   SCONS_CACHE_LIMIT: 3072
 
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-windows
+  cancel-in-progress: true
+
 jobs:
   windows-editor:
     # Windows 10 with latest image


### PR DESCRIPTION
This aims to cancel already ongoing builds if a new commit is pushed to the same branch/PR.

This is done using the new GitHub [concurrency groups](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/).

This should hopefully speed up CI by freeing up wasted resources.

Currently, the **repository** (i.e., `godot`), **head_ref**, the **actor** (user triggering the workflow) and the **ref** (source branch, or PR number in case of a PR) as well as the **platform** (`android`) are used for the concurrency key.
For non-PR commits directly against a branch like `master`, the job/workflow run number is used, so those still always run CI.

*Note: If this is cherrypicked, https://github.com/godotengine/godot/pull/52098 needs to be as well.*