### PR TITLE
RichTextLabel returns member (Array) for custom effects  for Editor

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3946,24 +3946,15 @@ float RichTextLabel::get_percent_visible() const {
 	return percent_visible;
 }
 
-void RichTextLabel::set_effects(const Vector<Variant> &effects) {
-	custom_effects.clear();
-	for (int i = 0; i < effects.size(); i++) {
-		Ref<RichTextEffect> effect = Ref<RichTextEffect>(effects[i]);
-		custom_effects.push_back(effect);
-	}
-
+void RichTextLabel::set_effects(Array p_effects) {
+	custom_effects = p_effects;
 	if ((bbcode != "") && use_bbcode) {
 		parse_bbcode(bbcode);
 	}
 }
 
-Vector<Variant> RichTextLabel::get_effects() {
-	Vector<Variant> r;
-	for (int i = 0; i < custom_effects.size(); i++) {
-		r.push_back(custom_effects[i]);
-	}
-	return r;
+Array RichTextLabel::get_effects() {
+	return custom_effects;
 }
 
 void RichTextLabel::install_effect(const Variant effect) {
@@ -4279,12 +4270,13 @@ void RichTextLabel::_draw_fbg_boxes(RID p_ci, RID p_rid, Vector2 line_off, Item 
 
 Ref<RichTextEffect> RichTextLabel::_get_custom_effect_by_code(String p_bbcode_identifier) {
 	for (int i = 0; i < custom_effects.size(); i++) {
-		if (!custom_effects[i].is_valid()) {
+		Ref<RichTextEffect> effect = custom_effects[i];
+		if (!effect.is_valid()) {
 			continue;
 		}
 
-		if (custom_effects[i]->get_bbcode() == p_bbcode_identifier) {
-			return custom_effects[i];
+		if (effect->get_bbcode() == p_bbcode_identifier) {
+			return effect;
 		}
 	}
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -363,7 +363,7 @@ private:
 	ItemMeta *meta_hovering = nullptr;
 	Variant current_meta;
 
-	Vector<Ref<RichTextEffect>> custom_effects;
+	Array custom_effects;
 
 	void _invalidate_current_line(ItemFrame *p_frame);
 	void _validate_line_caches(ItemFrame *p_frame);
@@ -577,8 +577,8 @@ public:
 	void set_percent_visible(float p_percent);
 	float get_percent_visible() const;
 
-	void set_effects(const Vector<Variant> &effects);
-	Vector<Variant> get_effects();
+	void set_effects(Array p_effects);
+	Array get_effects();
 
 	void install_effect(const Variant effect);
 


### PR DESCRIPTION
As RichTextLabel returned a copy of the member (Vector) the editor was notified
that the value had changed which caused the dropdown menu to be immediately
closed after opening.

The fix is to return the member (Array) in stead of a copy which is the same
instance and thereby does not notify the editor that the value has changed.

This PR should fix #51735 and fix #49817.