### PR TITLE
3.x: GDScript: Documentative signal typing annotations

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4170,10 +4170,30 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 							tokenizer->advance();
 						}
 
+						bool did_parse_type = false;
+						if (tokenizer->get_token() == GDScriptTokenizer::TK_COLON) {
+							// signal argument may have a type parameter.
+							// can't do anything with this right now, but it makes good inline documentation.
+							DataType argtype;
+							if (!_parse_type(argtype)) {
+								_set_error("Expected a type for an argument.");
+								return;
+							}
+							did_parse_type = true;
+						}
+
+						while (tokenizer->get_token() == GDScriptTokenizer::TK_NEWLINE) {
+							tokenizer->advance();
+						}
+
 						if (tokenizer->get_token() == GDScriptTokenizer::TK_COMMA) {
 							tokenizer->advance();
 						} else if (tokenizer->get_token() != GDScriptTokenizer::TK_PARENTHESIS_CLOSE) {
-							_set_error("Expected \",\" or \")\" after a \"signal\" parameter identifier.");
+							if (did_parse_type) {
+								_set_error("Expected \",\" or \")\" after a \"signal\" parameter type.");
+							} else {
+								_set_error("Expected \":\", \",\" or \")\" after a \"signal\" parameter identifier.");
+							}
 							return;
 						}
 					}


### PR DESCRIPTION
This is a backport of a little syntax addition from master without actually backporting the 1:1 code from master (since that's not possible).

Be aware that these annotations are *not* enforced. This is also in sync with what master does right now with signal annotations.

I'm adding this because it's confusing to see errors when trying to document a signal's types (although maybe I just use type annotations way too much).

It may actually be a good idea not to enforce signal types here, because of the recursive type reference problem.

Example GDScript code:
```gdscript
extends Node

signal test(a: int)

func _ready():
    pass
```

*Bugsquad edit: Related to https://github.com/godotengine/godot-proposals/issues/2557.*