### PR TITLE
Rename `String.IsAbsPath()` to `String.IsAbsolutePath()`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -575,7 +575,7 @@ namespace Godot
         /// <summary>
         /// If the string is a path to a file or directory, return <see langword="true"/> if the path is absolute.
         /// </summary>
-        public static bool IsAbsPath(this string instance)
+        public static bool IsAbsolutePath(this string instance)
         {
             if (string.IsNullOrEmpty(instance))
                 return false;
@@ -590,7 +590,7 @@ namespace Godot
         /// </summary>
         public static bool IsRelPath(this string instance)
         {
-            return !IsAbsPath(instance);
+            return !IsAbsolutePath(instance);
         }
 
         /// <summary>


### PR DESCRIPTION
**breaks compat**

Follow up to #49279 in C#