### PR TITLE
[3.x] Tree Fix line rendering when drag and dropping TreeItem

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1206,21 +1206,27 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				}
 			}
 
-			if (drop_mode_flags && drop_mode_over == p_item) {
+			if (drop_mode_flags && drop_mode_over) {
 				Rect2 r = cell_rect;
-				bool has_parent = p_item->get_children() != nullptr;
-
-				if (drop_mode_section == -1 || has_parent || drop_mode_section == 0) {
-					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), cache.drop_position_color);
-				}
-
-				if (drop_mode_section == 0) {
-					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, 1, r.size.y), cache.drop_position_color);
-					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x + r.size.x - 1, r.position.y, 1, r.size.y), cache.drop_position_color);
-				}
-
-				if ((drop_mode_section == 1 && !has_parent) || drop_mode_section == 0) {
-					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y + r.size.y, r.size.x, 1), cache.drop_position_color);
+				if (drop_mode_over == p_item) {
+					if (drop_mode_section == 0 || drop_mode_section == -1) {
+						// Line above.
+						VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), cache.drop_position_color);
+					}
+					if (drop_mode_section == 0) {
+						// Side lines.
+						VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, 1, r.size.y), cache.drop_position_color);
+						VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x + r.size.x - 1, r.position.y, 1, r.size.y), cache.drop_position_color);
+					}
+					if (drop_mode_section == 0 || (drop_mode_section == 1 && (!p_item->get_children() || p_item->is_collapsed()))) {
+						// Line below.
+						VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y + r.size.y, r.size.x, 1), cache.drop_position_color);
+					}
+				} else if (drop_mode_over == p_item->get_parent()) {
+					if (drop_mode_section == 1 && !p_item->get_prev() /* && !drop_mode_over->is_collapsed() */) { // The drop_mode_over shouldn't ever be collapsed in here, otherwise we would be drawing a child of a collapsed item.
+						// Line above.
+						VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), cache.drop_position_color);
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes line rendering when drag-dropping a `TreeItem` over "Below" section of a not collapsed `TreeItem` with children. The drop preview matches the behavior in the editor's Scene dock:
|Before|After|
|-|-|
|![Godot_v3 3 3-stable_win64_1awQQDwImh](https://user-images.githubusercontent.com/9283098/130772407-40114250-22e3-4f26-a0de-15fd80b9296f.png)|![godot windows tools 64_k60kgppMOH](https://user-images.githubusercontent.com/9283098/130772439-143234b7-de1b-4509-8ffb-36acafc00859.png)|
|![pXzugSiYqY](https://user-images.githubusercontent.com/9283098/130773802-3fd582cf-9ffb-473c-94a5-00dc8c31bc0b.png)|![godot windows tools 64_jZLnRYqiiy](https://user-images.githubusercontent.com/9283098/130773046-24f001f8-0ee1-4c2d-84e8-f8bb6b62ba3f.png)|
|![Godot_v3 3 3-stable_win64_Hg5m1ZTcS6](https://user-images.githubusercontent.com/9283098/130773968-65d3b9ca-58ed-43e7-8479-4e133652f3ef.png)|![LdeZ27TH6G](https://user-images.githubusercontent.com/9283098/130773995-e04bde75-cc2f-4372-bba5-9607ce8b0a0d.png)|


Fixes #46339.
Fixes #52053.

Doesn't fix an issue I've mentioned in [this comment](https://github.com/godotengine/godot/issues/52053#issuecomment-904845801): the preview for drop is drawed according to a hardcoded logic and user needs to perform the same logic in his drag and drop code to make the behavior match the preview. Anyway, solving that is out of scope of this PR (I'll open a proposal with a possible solution for it).