### PR TITLE
Fix CI after concurrency

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -8,7 +8,7 @@ env:
   SCONS_CACHE_LIMIT: 4096
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-android
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-android
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -8,7 +8,7 @@ env:
   SCONS_CACHE_LIMIT: 4096
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-ios
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-ios
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -10,7 +10,7 @@ env:
   EM_CACHE_FOLDER: 'emsdk-cache'
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-javascript
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-javascript
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -8,7 +8,7 @@ env:
   SCONS_CACHE_LIMIT: 4096
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-linux
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -8,7 +8,7 @@ env:
   SCONS_CACHE_LIMIT: 4096
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-macos
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -2,7 +2,7 @@ name: 📊 Static Checks
 on: [push, pull_request]
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-static
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -10,7 +10,7 @@ env:
   SCONS_CACHE_LIMIT: 3072
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || concat(github.ref, github.run_number)}}-${{github.ref}}-windows
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-windows
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Fix CI after https://github.com/godotengine/godot/pull/52079

This removes use of `concat` which isn't available. It's unnecessary anyway, as we already include `github.ref` elsewhere in the same string.