### PR TITLE
Add a README to link to the GDScript integration tests documentation

### DIFF
--- a/modules/gdscript/tests/README.md
+++ b/modules/gdscript/tests/README.md
@@ -1,0 +1,8 @@
+# GDScript integration tests
+
+The `scripts/` folder contains integration tests in the form of GDScript files
+and output files.
+
+See the
+[Integration tests for GDScript documentation](https://docs.godotengine.org/en/latest/development/cpp/unit_testing.html#integration-tests-for-gdscript)
+for information about creating and running GDScript integration tests.


### PR DESCRIPTION
This makes the documentation about creating and running GDScript integration tests more discoverable.

This is similar to the [README found in `editor/icons/`](https://github.com/godotengine/godot/tree/master/editor/icons#readme).