### PR TITLE
Print colored diffs when there are formatting failures in CI

### DIFF
--- a/misc/scripts/black_format.sh
+++ b/misc/scripts/black_format.sh
@@ -15,7 +15,7 @@ PY_FILES=$(find \( -path "./.git" \
                 \) -print)
 black -l 120 $PY_FILES
 
-git diff > patch.patch
+git diff --color > patch.patch
 
 # If no patch has been generated all is OK, clean up, and exit.
 if [ ! -s patch.patch ] ; then

--- a/misc/scripts/clang_format.sh
+++ b/misc/scripts/clang_format.sh
@@ -40,7 +40,7 @@ while IFS= read -rd '' f; do
     done
 done
 
-git diff > patch.patch
+git diff --color > patch.patch
 
 # If no patch has been generated all is OK, clean up, and exit.
 if [ ! -s patch.patch ] ; then

--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -42,7 +42,7 @@ while IFS= read -rd '' f; do
     perl -i -ple 's/\s*$//g' "$f"
 done
 
-git diff > patch.patch
+git diff --color > patch.patch
 
 # If no patch has been generated all is OK, clean up, and exit.
 if [ ! -s patch.patch ] ; then


### PR DESCRIPTION
This makes diffs more readable in CI logs.

## Preview

![image](https://user-images.githubusercontent.com/180032/130817869-4abb683f-f117-414c-86bd-b5c1cb960906.png)