### PR TITLE
Fix misspelled "overriden"

### DIFF
--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -23,7 +23,7 @@ _FORCE_INLINE_ bool _gdvirtual_##m_name##_call($CALLARGS) $CONST { \\
 \\
     return false;\\
 }\\
-_FORCE_INLINE_ bool _gdvirtual_##m_name##_overriden() const { \\
+_FORCE_INLINE_ bool _gdvirtual_##m_name##_overridden() const { \\
 	ScriptInstance *script_instance = ((Object*)(this))->get_script_instance();\\
 	if (script_instance) {\\
 	    return script_instance->has_method(_gdvirtual_##m_name##_sn);\\

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -289,8 +289,8 @@ struct ObjectNativeExtension {
 #else
 #define GDVIRTUAL_BIND(m_name, ...)
 #endif
-#define GDVIRTUAL_IS_OVERRIDEN(m_name) _gdvirtual_##m_name##_overriden()
-#define GDVIRTUAL_IS_OVERRIDEN_PTR(m_obj, m_name) m_obj->_gdvirtual_##m_name##_overriden()
+#define GDVIRTUAL_IS_OVERRIDDEN(m_name) _gdvirtual_##m_name##_overridden()
+#define GDVIRTUAL_IS_OVERRIDDEN_PTR(m_obj, m_name) m_obj->_gdvirtual_##m_name##_overridden()
 
 /*
    the following is an incomprehensible blob of hacks and workarounds to compensate for many of the fallencies in C++. As a plus, this macro pretty much alone defines the object model.

--- a/doc/classes/SkeletonModification3DJiggle.xml
+++ b/doc/classes/SkeletonModification3DJiggle.xml
@@ -175,19 +175,19 @@
 	</methods>
 	<members>
 		<member name="damping" type="float" setter="set_damping" getter="get_damping" default="0.75">
-			The default amount of dampening applied to the Jiggle joints, if they are not overriden. Higher values lead to more of the calculated velocity being applied.
+			The default amount of dampening applied to the Jiggle joints, if they are not overridden. Higher values lead to more of the calculated velocity being applied.
 		</member>
 		<member name="gravity" type="Vector3" setter="set_gravity" getter="get_gravity" default="Vector3(0, -6, 0)">
-			The default amount of gravity applied to the Jiggle joints, if they are not overriden.
+			The default amount of gravity applied to the Jiggle joints, if they are not overridden.
 		</member>
 		<member name="jiggle_data_chain_length" type="int" setter="set_jiggle_data_chain_length" getter="get_jiggle_data_chain_length" default="0">
 			The amount of Jiggle joints in the Jiggle modification.
 		</member>
 		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="0.75">
-			The default amount of mass assigned to the Jiggle joints, if they are not overriden. Higher values lead to faster movements and more overshooting.
+			The default amount of mass assigned to the Jiggle joints, if they are not overridden. Higher values lead to faster movements and more overshooting.
 		</member>
 		<member name="stiffness" type="float" setter="set_stiffness" getter="get_stiffness" default="3.0">
-			The default amount of stiffness assigned to the Jiggle joints, if they are not overriden. Higher values act more like springs, quickly moving into the correct position.
+			The default amount of stiffness assigned to the Jiggle joints, if they are not overridden. Higher values act more like springs, quickly moving into the correct position.
 		</member>
 		<member name="target_nodepath" type="NodePath" setter="set_target_node" getter="get_target_node" default="NodePath(&quot;&quot;)">
 			The NodePath to the node that is the target for the Jiggle modification. This node is what the Jiggle chain will attempt to rotate the bone chain to.

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2976,7 +2976,7 @@ public:
 
 	virtual int get_working_memory_size() const { return work_mem_size; }
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) {
-		if (GDVIRTUAL_IS_OVERRIDEN_PTR(node, _step)) {
+		if (GDVIRTUAL_IS_OVERRIDDEN_PTR(node, _step)) {
 			Array in_values;
 			Array out_values;
 			Array work_mem;

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2651,7 +2651,7 @@ TypedArray<String> CodeEdit::_get_delimiters(DelimiterType p_type) const {
 void CodeEdit::_filter_code_completion_candidates_impl() {
 	int line_height = get_line_height();
 
-	if (GDVIRTUAL_IS_OVERRIDEN(_filter_code_completion_candidates)) {
+	if (GDVIRTUAL_IS_OVERRIDDEN(_filter_code_completion_candidates)) {
 		code_completion_options.clear();
 		code_completion_base = "";
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -123,22 +123,22 @@ void Node::_notification(int p_notification) {
 		} break;
 		case NOTIFICATION_READY: {
 			if (get_script_instance()) {
-				if (GDVIRTUAL_IS_OVERRIDEN(_input)) {
+				if (GDVIRTUAL_IS_OVERRIDDEN(_input)) {
 					set_process_input(true);
 				}
 
-				if (GDVIRTUAL_IS_OVERRIDEN(_unhandled_input)) {
+				if (GDVIRTUAL_IS_OVERRIDDEN(_unhandled_input)) {
 					set_process_unhandled_input(true);
 				}
 
-				if (GDVIRTUAL_IS_OVERRIDEN(_unhandled_key_input)) {
+				if (GDVIRTUAL_IS_OVERRIDDEN(_unhandled_key_input)) {
 					set_process_unhandled_key_input(true);
 				}
 
-				if (GDVIRTUAL_IS_OVERRIDEN(_process)) {
+				if (GDVIRTUAL_IS_OVERRIDDEN(_process)) {
 					set_process(true);
 				}
-				if (GDVIRTUAL_IS_OVERRIDEN(_physics_process)) {
+				if (GDVIRTUAL_IS_OVERRIDDEN(_physics_process)) {
 					set_physics_process(true);
 				}
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -335,7 +335,7 @@ String VisualShaderNodeCustom::get_output_port_name(int p_port) const {
 }
 
 String VisualShaderNodeCustom::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	ERR_FAIL_COND_V(!GDVIRTUAL_IS_OVERRIDEN(_get_code), "");
+	ERR_FAIL_COND_V(!GDVIRTUAL_IS_OVERRIDDEN(_get_code), "");
 	Vector<String> input_vars;
 	for (int i = 0; i < get_input_port_count(); i++) {
 		input_vars.push_back(p_input_vars[i]);


### PR DESCRIPTION
Overriden → Overridden

This is a typo in the recent GDVIRTUAL PR (#51970).

This typo also appear in the doc for `SkeletonModification3DJiggle`, so it's fixed too.