### PR TITLE
Fix LocalVector crash on insert.

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -170,7 +170,7 @@ public:
 			push_back(p_val);
 		} else {
 			resize(count + 1);
-			for (U i = count; i > p_pos; i--) {
+			for (U i = count - 1; i > p_pos; i--) {
 				data[i] = data[i - 1];
 			}
 			data[p_pos] = p_val;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

While working on implementing array support in the inspector, I needed to use LocalVector::insert(...) but it was crashing.
I figured out that it was iterating outside of the boundaries of the array while moving the elements one by one.

It should very likely be cherry-picked for 3.x.