### PR TITLE
Silence false-positive warning for malformed placement new on GCC 11.1

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -49,6 +49,12 @@ class VMap;
 SAFE_NUMERIC_TYPE_PUN_GUARANTEES(uint32_t)
 #endif
 
+// Silence a false positive warning (see GH-52119).
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wplacement-new"
+#endif
+
 template <class T>
 class CowData {
 	template <class TV>
@@ -379,5 +385,9 @@ template <class T>
 CowData<T>::~CowData() {
 	_unref(_ptr);
 }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif // COWDATA_H


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This closes #52119. Right now I am moving the offset to its own variable in order to calm down GCC's warning. Better ideas always welcome.