### PR TITLE
Add immutable/one-time assignable variables to GDScript (`let`)

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -389,7 +389,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 				if (str[k] == '(') {
 					in_function_name = true;
-				} else if (prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::VAR)) {
+				} else if (prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::VAR) || prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::LET)) {
 					in_variable_declaration = true;
 				}
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2382,6 +2382,7 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		"enum",
 		"static",
 		"var",
+		"let",
 		// control flow
 		"break",
 		"continue",

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1235,7 +1235,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	static const char *_keywords_with_space[] = {
 		"and", "not", "or", "in", "as", "class", "class_name", "extends", "is", "func", "signal", "await",
-		"const", "enum", "static", "var", "if", "elif", "else", "for", "match", "while",
+		"const", "enum", "static", "var", "let", "if", "elif", "else", "for", "match", "while",
 		nullptr
 	};
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1187,6 +1187,12 @@ public:
 			PROP_SETGET,
 		};
 
+		// If `true`, the variable cannot be reassigned after it was assigned
+		// once (used with the `let` keyword). This does not provide data
+		// immutability for the variable's contents, but it can still be used to
+		// avoid mistakes.
+		bool immutable = false;
+
 		PropertyStyle property = PROP_NONE;
 		union {
 			FunctionNode *setter = nullptr;
@@ -1434,7 +1440,8 @@ private:
 	// Statements.
 	Node *parse_statement();
 	VariableNode *parse_variable();
-	VariableNode *parse_variable(bool p_allow_property);
+	VariableNode *parse_immutable_variable();
+	VariableNode *parse_variable(bool p_allow_property, bool p_immutable);
 	VariableNode *parse_property(VariableNode *p_variable, bool p_need_indent);
 	void parse_property_getter(VariableNode *p_variable);
 	void parse_property_setter(VariableNode *p_variable);

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -111,6 +111,7 @@ static const char *token_names[] = {
 	"func", // FUNC,
 	"in", // IN,
 	"is", // IS,
+	"let", // LET,
 	"namespace", // NAMESPACE
 	"preload", // PRELOAD,
 	"self", // SELF,
@@ -487,6 +488,8 @@ GDScriptTokenizer::Token GDScriptTokenizer::annotation() {
 	KEYWORD("if", Token::IF)                 \
 	KEYWORD("in", Token::IN)                 \
 	KEYWORD("is", Token::IS)                 \
+	KEYWORD_GROUP('l')                       \
+	KEYWORD("let", Token::LET)               \
 	KEYWORD_GROUP('m')                       \
 	KEYWORD("match", Token::MATCH)           \
 	KEYWORD_GROUP('n')                       \

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -118,6 +118,7 @@ public:
 			FUNC,
 			IN,
 			IS,
+			LET,
 			NAMESPACE,
 			PRELOAD,
 			SELF,


### PR DESCRIPTION
Both local variables and member variables can be made immutable by using the `let` keyword instead of `var` during the declaration.

This can be used to write safer code in situations where `const` is not suited (as `const` is limited to constant expressions).

This `let` keyword behaves in a way similar to Nim's `let` keyword, Kotlin's `val` keyword and JavaScript's `const` keyword. The immutability is "flat" in the sense that the underlying data can still be modified (e.g. arrays and dictionaries can be modified, but not reassigned).

Immutable variables must also be initialized as soon as they're declared.

This feature is backwards-compatible with existing projects, which means it's possible to reimplement it for `3.x`. I have a WIP branch here: https://github.com/Calinou/godot/tree/gdscript-add-immutable-variables-3.x

This closes https://github.com/godotengine/godot-proposals/issues/820.

## TODO

- [ ] Fix immutable variable checking for member immutable variables. There is some commented out code where I attempted this, but it didn't work because that part of the code was never called.
- [ ] Decide what to do with setters. Should it be allowed to define a setter on a `let` property?

## Preview

*As you can see on the preview, it works for local variables but not member variables yet:*

![image](https://user-images.githubusercontent.com/180032/130946811-895aa730-8dc7-4a6f-8dca-b8c2d9086fec.png)

```gdscript
extends Node

func _ready():
	var variable = []
	variable.append("hi")
	variable = ["bye"]
	print(variable)
	
	let variable_immutable = []
	variable_immutable.append("hi")  # This is allowed because it does not re-assign the variable.
	variable_immutable = ["bye"]  # ERROR: Cannot reassign immutable variable.
	print(variable_immutable)
```
