### PR TITLE
Added damping_factor property to the ScrollContainer for better deceleration control on touchscreen devices

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -525,6 +525,9 @@
 		<member name="editor/script/templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
 			Search path for project-specific script templates. Godot will search for script templates both in the editor-specific path and in this project-specific path.
 		</member>
+		<member name="gui/common/default_damping_factor" type="float" setter="" getter="" default="0.25">
+			Default value for [member ScrollContainer.scroll_damping_factor], which will be used for all [ScrollContainer]s unless overridden.
+		</member>
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.
 		</member>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -36,6 +36,9 @@
 			If [code]true[/code], the ScrollContainer will automatically scroll to focused children (including indirect children) to make sure they are fully visible.
 		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
+		<member name="scroll_damping_factor" type="float" setter="set_damping_factor" getter="get_damping_factor" default="0.25">
+			Defines how fast the scroll container decelerates on touchscreen/mobile devices. A value of [code]0.0[/code] means no deceleration at all and a value of [code]1.0[/code] means instant deceleration.
+		</member>
 		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -372,23 +372,17 @@ void ScrollContainer::_notification(int p_what) {
 					v_scroll->set_value(pos.y);
 				}
 
-				float sgn_x = drag_speed.x < 0 ? -1 : 1;
-				float val_x = Math::abs(drag_speed.x);
-				val_x -= 1000 * get_physics_process_delta_time();
+				float lerp_value = 1.0f - Math::pow(1.0f - damping_factor, (float)get_physics_process_delta_time());
+				lerp_value = CLAMP(lerp_value * 10.0, 0.0, 1.0);
+				drag_speed = drag_speed.lerp(Vector2(), lerp_value);
 
-				if (val_x < 0) {
+				if (abs(drag_speed.x) < 1.0) {
 					turnoff_h = true;
 				}
 
-				float sgn_y = drag_speed.y < 0 ? -1 : 1;
-				float val_y = Math::abs(drag_speed.y);
-				val_y -= 1000 * get_physics_process_delta_time();
-
-				if (val_y < 0) {
+				if (abs(drag_speed.y) < 1.0) {
 					turnoff_v = true;
 				}
-
-				drag_speed = Vector2(sgn_x * val_x, sgn_y * val_y);
 
 				if (turnoff_h && turnoff_v) {
 					_cancel_drag();
@@ -524,6 +518,14 @@ void ScrollContainer::set_deadzone(int p_deadzone) {
 	deadzone = p_deadzone;
 }
 
+float ScrollContainer::get_damping_factor() const {
+	return damping_factor;
+}
+
+void ScrollContainer::set_damping_factor(float p_daming_factor) {
+	damping_factor = p_daming_factor;
+}
+
 bool ScrollContainer::is_following_focus() const {
 	return follow_focus;
 }
@@ -591,6 +593,9 @@ void ScrollContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_deadzone", "deadzone"), &ScrollContainer::set_deadzone);
 	ClassDB::bind_method(D_METHOD("get_deadzone"), &ScrollContainer::get_deadzone);
 
+	ClassDB::bind_method(D_METHOD("set_damping_factor", "damping_factor"), &ScrollContainer::set_damping_factor);
+	ClassDB::bind_method(D_METHOD("get_damping_factor"), &ScrollContainer::get_damping_factor);
+
 	ClassDB::bind_method(D_METHOD("set_follow_focus", "enabled"), &ScrollContainer::set_follow_focus);
 	ClassDB::bind_method(D_METHOD("is_following_focus"), &ScrollContainer::is_following_focus);
 
@@ -611,8 +616,10 @@ void ScrollContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_horizontal_visible"), "set_h_scroll_visible", "is_h_scroll_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_vertical_visible"), "set_v_scroll_visible", "is_v_scroll_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_deadzone"), "set_deadzone", "get_deadzone");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_damping_factor", PROPERTY_HINT_RANGE, "0.00,1.00,0.001"), "set_damping_factor", "get_damping_factor");
 
 	GLOBAL_DEF("gui/common/default_scroll_deadzone", 0);
+	GLOBAL_DEF("gui/common/default_damping_factor", 0.25);
 };
 
 ScrollContainer::ScrollContainer() {
@@ -627,6 +634,7 @@ ScrollContainer::ScrollContainer() {
 	v_scroll->connect("value_changed", callable_mp(this, &ScrollContainer::_scroll_moved));
 
 	deadzone = GLOBAL_GET("gui/common/default_scroll_deadzone");
+	damping_factor = GLOBAL_GET("gui/common/default_damping_factor");
 
 	set_clip_contents(true);
 };

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -61,6 +61,7 @@ class ScrollContainer : public Container {
 	bool v_scroll_visible = true;
 
 	int deadzone = 0;
+	float damping_factor = 0.0;
 	bool follow_focus = false;
 
 	void _cancel_drag();
@@ -100,6 +101,9 @@ public:
 
 	int get_deadzone() const;
 	void set_deadzone(int p_deadzone);
+
+	float get_damping_factor() const;
+	void set_damping_factor(float p_daming_factor);
 
 	bool is_following_focus() const;
 	void set_follow_focus(bool p_follow);


### PR DESCRIPTION
### Why
On touchscreen/mobile devices the `ScrollContainer` behaves differently then on Desktop. It keeps scrolling based on the input velocity (swipe up/down/left/right) of the user. But unlike one would expect it's barley slowing down when the user stops scrolling. This feels really weird when you are used to the bahaviour of native apps which decelerate much faster. This PR adds the ability to define how fast the list should slow down when decelerating.

I'm not sure if this change would warrant a formal proposal, because for me this feels more like a bugfix anyway. :smile:

### How
It works by lerping `drag_speed` towards `Vector(0.0)` based on the new property `damping_factor`. A value of `0.0` does not change the speed at all. A damping value of `1.0` stops the scrolling instantly when the user stops scrolling. A value of `0.25` felt like a native Android app in my opinion, so i set the default to that. `0.05` feels like the current behaviour. If this PR is considered an unacceptable breaking change for `3.x` i can default to that value instead.

### Demo
This is how the ScrollContainer behaves **without this PR**. Just a slight swipe scrolls through the entire list.

https://user-images.githubusercontent.com/8750135/130963430-9ac2d915-9c84-44e8-8644-7de577bcb52c.mp4

Here i used a **damping_factor of 0.25** on the same list (i tried to swipe with the same speed as in the video above):

https://user-images.githubusercontent.com/8750135/130963517-12f7f556-127e-4ffd-b22e-58699e348bc9.mp4