### PR TITLE
Document how to use IK in skeleton2D.

### DIFF
--- a/doc/classes/Skeleton2D.xml
+++ b/doc/classes/Skeleton2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Skeleton2D parents a hierarchy of [Bone2D] objects. It is a requirement of [Bone2D]. Skeleton2D holds a reference to the rest pose of its children and acts as a single point of access to its bones.
+		To setup different types of inverse kinematics for the given Skeleton2D, a [SkeletonModificationStack2D] should be created. They can be applied by creating the desired number of modifications, which can be done by increasing [member SkeletonModificationStack2D.modification_count].
 	</description>
 	<tutorials>
 		<link title="2D skeletons">https://docs.godotengine.org/en/latest/tutorials/animation/2d_skeletons.html</link>


### PR DESCRIPTION
Since,there is skeleton3d IK, anyone would assume there's a 2d counterpart too..But there itsn't.

Also, it's difficult to guess, that IK is inside SkeletonModificationStack. I didn't and I learnt it from TwistedTwigleg's GSOC 2020 Showcase video.

![ik](https://user-images.githubusercontent.com/17506575/131070842-ff0ae0a1-095e-4530-997d-2910f34593fd.png)

