### PR TITLE
Fix AnimationBlendTree reset on resource loading

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1124,6 +1124,7 @@ void AnimationNodeBlendTree::_get_property_list(List<PropertyInfo> *p_list) cons
 void AnimationNodeBlendTree::reset_state() {
 	graph_offset = Vector2();
 	nodes.clear();
+	_initialize_node_tree();
 	emit_changed();
 	emit_signal(SNAME("tree_changed"));
 }
@@ -1162,7 +1163,7 @@ void AnimationNodeBlendTree::_bind_methods() {
 	BIND_CONSTANT(CONNECTION_ERROR_CONNECTION_EXISTS);
 }
 
-AnimationNodeBlendTree::AnimationNodeBlendTree() {
+void AnimationNodeBlendTree::_initialize_node_tree() {
 	Ref<AnimationNodeOutput> output;
 	output.instantiate();
 	Node n;
@@ -1170,6 +1171,10 @@ AnimationNodeBlendTree::AnimationNodeBlendTree() {
 	n.position = Vector2(300, 150);
 	n.connections.resize(1);
 	nodes["output"] = n;
+}
+
+AnimationNodeBlendTree::AnimationNodeBlendTree() {
+	_initialize_node_tree();
 }
 
 AnimationNodeBlendTree::~AnimationNodeBlendTree() {

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -345,6 +345,8 @@ class AnimationNodeBlendTree : public AnimationRootNode {
 	void _tree_changed();
 	void _node_changed(const StringName &p_node);
 
+	void _initialize_node_tree();
+
 protected:
 	static void _bind_methods();
 	bool _set(const StringName &p_name, const Variant &p_value);


### PR DESCRIPTION
When reset_state was called on an existing `AnimationBlendTree`, the output node would disappear, causing some errors in the editor and preventing animations to play properly.

This change ensures the output node is always present in the node tree.

Project I was using for tests (CC @TokageItLab):
https://github.com/TokageItLab/3d-platform-test-for-godot4