### PR TITLE
Rename Variant::is_ref() to is_ref_counted()

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3256,7 +3256,7 @@ bool Variant::hash_compare(const Variant &p_variant, int recursion_count) const 
 	return false;
 }
 
-bool Variant::is_ref() const {
+bool Variant::is_ref_counted() const {
 	return type == OBJECT && _get_obj().id.is_ref_counted();
 }
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -287,7 +287,7 @@ public:
 	static bool can_convert(Type p_type_from, Type p_type_to);
 	static bool can_convert_strict(Type p_type_from, Type p_type_to);
 
-	bool is_ref() const;
+	bool is_ref_counted() const;
 	_FORCE_INLINE_ bool is_num() const {
 		return type == INT || type == FLOAT;
 	}

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -433,7 +433,7 @@ struct VariantUtilityFunctions {
 	static inline Variant weakref(const Variant &obj, Callable::CallError &r_error) {
 		if (obj.get_type() == Variant::OBJECT) {
 			r_error.error = Callable::CallError::CALL_OK;
-			if (obj.is_ref()) {
+			if (obj.is_ref_counted()) {
 				Ref<WeakRef> wref = memnew(WeakRef);
 				REF r = obj;
 				if (r.is_valid()) {

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1121,7 +1121,7 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 		NodePath path = editor->get_edited_scene()->get_path_to(node);
 		int pathid = _get_node_path_cache(path);
 
-		if (p_value.is_ref()) {
+		if (p_value.is_ref_counted()) {
 			Ref<Resource> res = p_value;
 			if (res.is_valid() && !res->get_path().is_empty()) {
 				Array msg;
@@ -1147,7 +1147,7 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 		String respath = res->get_path();
 		int pathid = _get_res_path_cache(respath);
 
-		if (p_value.is_ref()) {
+		if (p_value.is_ref_counted()) {
 			Ref<Resource> res2 = p_value;
 			if (res2.is_valid() && !res2->get_path().is_empty()) {
 				Array msg;

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -108,7 +108,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 						Variant v = current->get(E->get().name);
 						REF ref = v;
 						RES res = ref;
-						if (v.is_ref() && ref.is_valid() && res.is_valid()) {
+						if (v.is_ref_counted() && ref.is_valid() && res.is_valid()) {
 							// Valid resource which would be duplicated if action is confirmed.
 							resource_propnames.append(E->get().name);
 						}
@@ -145,7 +145,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 						}
 
 						Variant v = current->get(prop_info.name);
-						if (v.is_ref()) {
+						if (v.is_ref_counted()) {
 							REF ref = v;
 							if (ref.is_valid()) {
 								RES res = ref;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3220,7 +3220,7 @@ void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap)
 		}
 
 		Variant v = p_node->get(E.name);
-		if (v.is_ref()) {
+		if (v.is_ref_counted()) {
 			RES res = v;
 			if (res.is_valid()) {
 				if (!states_stack_ready) {
@@ -3258,7 +3258,7 @@ void SceneTreeDock::_create_remap_for_resource(RES p_resource, Map<RES, RES> &r_
 		}
 
 		Variant v = p_resource->get(E.name);
-		if (v.is_ref()) {
+		if (v.is_ref_counted()) {
 			RES res = v;
 			if (res.is_valid()) {
 				if (res->is_built_in() && !r_remap.has(res)) {

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -248,7 +248,7 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 
 	// If the return value is a GDScriptFunctionState reference,
 	// then the function did await again after resuming.
-	if (ret.is_ref()) {
+	if (ret.is_ref_counted()) {
 		GDScriptFunctionState *gdfs = Object::cast_to<GDScriptFunctionState>(ret);
 		if (gdfs && gdfs->function == function) {
 			completed = false;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1532,7 +1532,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						}
 					} else if (methodstr == "free") {
 						if (err.error == Callable::CallError::CALL_ERROR_INVALID_METHOD) {
-							if (base->is_ref()) {
+							if (base->is_ref_counted()) {
 								err_text = "Attempted to free a reference.";
 								OPCODE_BREAK;
 							} else if (base->get_type() == Variant::OBJECT) {
@@ -1620,7 +1620,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						}
 					} else if (methodstr == "free") {
 						if (err.error == Callable::CallError::CALL_ERROR_INVALID_METHOD) {
-							if (base->is_ref()) {
+							if (base->is_ref_counted()) {
 								err_text = "Attempted to free a reference.";
 								OPCODE_BREAK;
 							} else if (base->get_type() == Variant::OBJECT) {

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -964,7 +964,7 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 				return;
 			}
 
-			if (p_inputs[0]->is_ref()) {
+			if (p_inputs[0]->is_ref_counted()) {
 				REF r = *p_inputs[0];
 				if (!r.is_valid()) {
 					return;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2186,7 +2186,7 @@ void Node::remap_node_resources(Node *p_node, const Map<RES, RES> &p_resource_re
 		}
 
 		Variant v = p_node->get(E.name);
-		if (v.is_ref()) {
+		if (v.is_ref_counted()) {
 			RES res = v;
 			if (res.is_valid()) {
 				if (p_resource_remap.has(res)) {
@@ -2212,7 +2212,7 @@ void Node::remap_nested_resources(RES p_resource, const Map<RES, RES> &p_resourc
 		}
 
 		Variant v = p_resource->get(E.name);
-		if (v.is_ref()) {
+		if (v.is_ref_counted()) {
 			RES res = v;
 			if (res.is_valid()) {
 				if (p_resource_remap.has(res)) {


### PR DESCRIPTION
Just realized this rename was missing from #49312.

**UPDATE:** Thinking a bit more about this. I've realized that the validity of this depends on how you look at it:
- `Variant::is_ref()` is the right name if the question is, is this `Variant` _acting as a `Ref`_?
- `Variant::is_ref_counted()` is the right name if the question is, is this `Variant` _pointing to a `RefCounted`_? (as a side effect it acts as a `Ref` in the sense that it contributes to the reference count of the `RefCounted`, but from this point of view that would not be relevant).