### PR TITLE
[3.x] Add a 2D scale factor property

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -215,9 +215,9 @@
 			<argument index="0" name="mode" type="int" enum="SceneTree.StretchMode" />
 			<argument index="1" name="aspect" type="int" enum="SceneTree.StretchAspect" />
 			<argument index="2" name="minsize" type="Vector2" />
-			<argument index="3" name="shrink" type="float" default="1" />
+			<argument index="3" name="scale" type="float" default="1" />
 			<description>
-				Configures screen stretching to the given [enum StretchMode], [enum StretchAspect], minimum size and [code]shrink[/code] ratio.
+				Configures screen stretching to the given [enum StretchMode], [enum StretchAspect], minimum size and [code]scale[/code].
 			</description>
 		</method>
 	</methods>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1843,7 +1843,8 @@ bool Main::start() {
 			String stretch_mode = GLOBAL_DEF("display/window/stretch/mode", "disabled");
 			String stretch_aspect = GLOBAL_DEF("display/window/stretch/aspect", "ignore");
 			Size2i stretch_size = Size2(GLOBAL_DEF("display/window/size/width", 0), GLOBAL_DEF("display/window/size/height", 0));
-			real_t stretch_shrink = GLOBAL_DEF("display/window/stretch/shrink", 1.0);
+			// out of compatability reasons stretch_scale is called shrink when exposed to the user.
+			real_t stretch_scale = GLOBAL_DEF("display/window/stretch/shrink", 1.0);
 
 			SceneTree::StretchMode sml_sm = SceneTree::STRETCH_MODE_DISABLED;
 			if (stretch_mode == "2d") {
@@ -1863,7 +1864,7 @@ bool Main::start() {
 				sml_aspect = SceneTree::STRETCH_ASPECT_EXPAND;
 			}
 
-			sml->set_screen_stretch(sml_sm, sml_aspect, stretch_size, stretch_shrink);
+			sml->set_screen_stretch(sml_sm, sml_aspect, stretch_size, stretch_scale);
 
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
@@ -1908,7 +1909,7 @@ bool Main::start() {
 			GLOBAL_DEF("display/window/stretch/aspect", "ignore");
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/aspect", PropertyInfo(Variant::STRING, "display/window/stretch/aspect", PROPERTY_HINT_ENUM, "ignore,keep,keep_width,keep_height,expand"));
 			GLOBAL_DEF("display/window/stretch/shrink", 1.0);
-			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/shrink", PropertyInfo(Variant::REAL, "display/window/stretch/shrink", PROPERTY_HINT_RANGE, "1.0,8.0,0.1"));
+			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/shrink", PropertyInfo(Variant::REAL, "display/window/stretch/shrink", PROPERTY_HINT_RANGE, "0.1,8,0.01,or_greater"));
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
 			GLOBAL_DEF("gui/common/snap_controls_to_pixels", true);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1106,11 +1106,11 @@ int SceneTree::get_node_count() const {
 
 void SceneTree::_update_root_rect() {
 	if (stretch_mode == STRETCH_MODE_DISABLED) {
-		_update_font_oversampling(1.0);
-		root->set_size((last_screen_size / stretch_shrink).floor());
+		_update_font_oversampling(stretch_scale);
+		root->set_size(last_screen_size.floor());
 		root->set_attach_to_screen_rect(Rect2(Point2(), last_screen_size));
-		root->set_size_override_stretch(false);
-		root->set_size_override(false, Size2());
+		root->set_size_override_stretch(true);
+		root->set_size_override(true, (last_screen_size / stretch_scale).floor());
 		root->update_canvas_items();
 		return; //user will take care
 	}
@@ -1185,20 +1185,19 @@ void SceneTree::_update_root_rect() {
 	switch (stretch_mode) {
 		case STRETCH_MODE_DISABLED: {
 			// Already handled above
-			_update_font_oversampling(1.0);
 		} break;
 		case STRETCH_MODE_2D: {
-			_update_font_oversampling(screen_size.x / viewport_size.x); //screen / viewport radio drives oversampling
-			root->set_size((screen_size / stretch_shrink).floor());
+			_update_font_oversampling((screen_size.x / viewport_size.x) * stretch_scale); //screen / viewport ratio drives oversampling
+			root->set_size(screen_size.floor());
 			root->set_attach_to_screen_rect(Rect2(margin, screen_size));
 			root->set_size_override_stretch(true);
-			root->set_size_override(true, (viewport_size / stretch_shrink).floor());
+			root->set_size_override(true, (viewport_size / stretch_scale).floor());
 			root->update_canvas_items(); //force them to update just in case
 
 		} break;
 		case STRETCH_MODE_VIEWPORT: {
 			_update_font_oversampling(1.0);
-			root->set_size((viewport_size / stretch_shrink).floor());
+			root->set_size((viewport_size / stretch_scale).floor());
 			root->set_attach_to_screen_rect(Rect2(margin, screen_size));
 			root->set_size_override_stretch(false);
 			root->set_size_override(false, Size2());
@@ -1212,11 +1211,11 @@ void SceneTree::_update_root_rect() {
 	}
 }
 
-void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 &p_minsize, real_t p_shrink) {
+void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 &p_minsize, real_t p_scale) {
 	stretch_mode = p_mode;
 	stretch_aspect = p_aspect;
 	stretch_min = p_minsize;
-	stretch_shrink = p_shrink;
+	stretch_scale = p_scale;
 	_update_root_rect();
 }
 
@@ -1826,7 +1825,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_frame"), &SceneTree::get_frame);
 	ClassDB::bind_method(D_METHOD("quit", "exit_code"), &SceneTree::quit, DEFVAL(-1));
 
-	ClassDB::bind_method(D_METHOD("set_screen_stretch", "mode", "aspect", "minsize", "shrink"), &SceneTree::set_screen_stretch, DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("set_screen_stretch", "mode", "aspect", "minsize", "scale"), &SceneTree::set_screen_stretch, DEFVAL(1));
 
 	ClassDB::bind_method(D_METHOD("queue_delete", "obj"), &SceneTree::queue_delete);
 
@@ -2111,7 +2110,7 @@ SceneTree::SceneTree() {
 
 	stretch_mode = STRETCH_MODE_DISABLED;
 	stretch_aspect = STRETCH_ASPECT_IGNORE;
-	stretch_shrink = 1;
+	stretch_scale = 1.0;
 
 	last_screen_size = Size2(OS::get_singleton()->get_window_size().width, OS::get_singleton()->get_window_size().height);
 	_update_root_rect();

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -146,7 +146,7 @@ private:
 	StretchMode stretch_mode;
 	StretchAspect stretch_aspect;
 	Size2i stretch_min;
-	real_t stretch_shrink;
+	real_t stretch_scale;
 
 	void _update_font_oversampling(float p_ratio);
 	void _update_root_rect();
@@ -362,7 +362,7 @@ public:
 	void get_nodes_in_group(const StringName &p_group, List<Node *> *p_list);
 	bool has_group(const StringName &p_identifier) const;
 
-	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 &p_minsize, real_t p_shrink = 1);
+	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 &p_minsize, real_t p_scale = 1.0);
 
 	void set_use_font_oversampling(bool p_oversampling);
 	bool is_using_font_oversampling() const;


### PR DESCRIPTION
This can be used to make 2D elements larger or smaller, independently of the current stretch mode.
Only the disabled and 2d stretch modes support this new property.

This is necessary to properly render 2D UI elements on high res monitors. I have used this myself for a couple of UI-heavy projects, and so far it has worked very well on my 4k monitor. The only real problem I experienced was image scaling, but to fix that we will need godotengine/godot-proposals#2924.


~3.x only for now, since the last time we discussed this @Calinou said that he would look into porting this to master himself because apparently some of the underlying logic changed.~ See #52170.

[DemoProject](https://github.com/godotengine/godot/files/2321558/2d-scaling-demo.zip)


Rebase of #21446

---------------------

Btw, I am sorry that it took me so long to PR a simple rebase, was on vacation for the last few weeks, and attempts to get work done on my laptop failed spectacularly. 😕 



