### PR TITLE
LinkButton's text now is automatically translated in 3.x

### DIFF
--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -30,9 +30,16 @@
 
 #include "link_button.h"
 
+#include "core/translation.h"
+
 void LinkButton::set_text(const String &p_text) {
+	if (text == p_text) {
+		return;
+	}
 	text = p_text;
+	xl_text = tr(p_text);
 	update();
+	_change_notify("text");
 	minimum_size_changed();
 }
 
@@ -50,11 +57,16 @@ LinkButton::UnderlineMode LinkButton::get_underline_mode() const {
 }
 
 Size2 LinkButton::get_minimum_size() const {
-	return get_font("font")->get_string_size(text);
+	return get_font("font")->get_string_size(xl_text);
 }
 
 void LinkButton::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			xl_text = tr(text);
+			minimum_size_changed();
+			update();
+		} break;
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
 			Size2 size = get_size();
@@ -96,11 +108,11 @@ void LinkButton::_notification(int p_what) {
 
 			Ref<Font> font = get_font("font");
 
-			draw_string(font, Vector2(0, font->get_ascent()), text, color);
+			draw_string(font, Vector2(0, font->get_ascent()), xl_text, color);
 
 			if (do_underline) {
 				int underline_spacing = get_constant("underline_spacing");
-				int width = font->get_string_size(text).width;
+				int width = font->get_string_size(xl_text).width;
 				int y = font->get_ascent() + underline_spacing;
 
 				draw_line(Vector2(0, y), Vector2(width, y), color);

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -46,6 +46,7 @@ public:
 
 private:
 	String text;
+	String xl_text;
 	UnderlineMode underline_mode;
 
 protected:


### PR DESCRIPTION
Fix #52120
Contributors:  @Lucas3H 

*Bugsquad edit: `3.x` version of https://github.com/godotengine/godot/pull/52145.*