### PR TITLE
Expose `String::camelcase_to_underscore`

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1387,6 +1387,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, repeat, sarray("count"), varray());
 	bind_method(String, insert, sarray("position", "what"), varray());
 	bind_method(String, capitalize, sarray(), varray());
+	bind_method(String, camelcase_to_underscore, sarray("lowercase"), varray(true));
 	bind_method(String, split, sarray("delimiter", "allow_empty", "maxsplit"), varray(true, 0));
 	bind_method(String, rsplit, sarray("delimiter", "allow_empty", "maxsplit"), varray(true, 0));
 	bind_method(String, split_floats, sarray("delimiter", "allow_empty"), varray(true));

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -79,6 +79,13 @@
 				[b]Note:[/b] Unlike the GDScript parser, this method doesn't support the [code]\uXXXX[/code] escape sequence.
 			</description>
 		</method>
+		<method name="camelcase_to_underscore" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="lowercase" type="bool" default="true" />
+			<description>
+				Adds underscores before uppercase characters (except for acronyms and the first character of the string). If [code]lowercase[/code] is [code]true[/code], the string will be converted to lowercase. For [code]ToHtml5 ToHTMLElement toHtml to_html TO_HTML A_B-C.D[/code], it will return [code]to_html_5 _to_html_element to_html to_html _to__html _a__b-_c._d[/code].
+			</description>
+		</method>
 		<method name="capitalize" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -285,6 +285,20 @@ namespace Godot
         }
 
         /// <summary>
+        /// Adds underscores before uppercase characters (except for acronyms and the first character
+        /// of the string). If <c>lowercase</c> is <c>true</c>, the string will be converted to lowercase.
+        /// For <c>ToHtml5 ToHTMLElement toHtml to_html TO_HTML A_B-C.D</c>, it will return
+        /// <c>to_html_5 _to_html_element to_html to_html _to__html _a__b-_c._d</c>.
+        /// </summary>
+        public static string CamelcaseToUnderscore(this string instance, bool lowercase = true)
+        {
+            return godot_icall_String_camelcase_to_underscore(instance, lowercase);
+        }
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static string godot_icall_String_camelcase_to_underscore(string str, bool lowercase);
+
+        /// <summary>
         /// Performs a case-sensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
         /// </summary>
         /// <seealso cref="NocasecmpTo(string, string)"/>

--- a/modules/mono/glue/string_glue.cpp
+++ b/modules/mono/glue/string_glue.cpp
@@ -36,6 +36,11 @@
 
 #include "../mono_gd/gd_mono_marshal.h"
 
+MonoString *godot_icall_String_camelcase_to_underscore(MonoString *p_str, bool p_lowercase) {
+	String ret = GDMonoMarshal::mono_string_to_godot(p_str).camelcase_to_underscore(p_lowercase);
+	return GDMonoMarshal::mono_string_from_godot(ret);
+}
+
 MonoArray *godot_icall_String_md5_buffer(MonoString *p_str) {
 	Vector<uint8_t> ret = GDMonoMarshal::mono_string_to_godot(p_str).md5_buffer();
 	// TODO Check possible Array/Vector<uint8_t> problem?
@@ -73,6 +78,7 @@ MonoString *godot_icall_String_simplify_path(MonoString *p_str) {
 }
 
 void godot_register_string_icalls() {
+	GDMonoUtils::add_internal_call("Godot.StringExtensions::godot_icall_String_camelcase_to_underscore", godot_icall_String_camelcase_to_underscore);
 	GDMonoUtils::add_internal_call("Godot.StringExtensions::godot_icall_String_md5_buffer", godot_icall_String_md5_buffer);
 	GDMonoUtils::add_internal_call("Godot.StringExtensions::godot_icall_String_md5_text", godot_icall_String_md5_text);
 	GDMonoUtils::add_internal_call("Godot.StringExtensions::godot_icall_String_rfind", godot_icall_String_rfind);


### PR DESCRIPTION
This function can be useful in plugins for converting filenames or in code for converting identifiers between different languages.