### PR TITLE
Replace close icon with button in the Bezier editor

### DIFF
--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -51,11 +51,14 @@ class AnimationBezierTrackEdit : public Control {
 	HandleMode handle_mode;
 	OptionButton *handle_mode_option;
 
-	AnimationTimelineEdit *timeline;
-	UndoRedo *undo_redo;
-	Node *root;
+	VBoxContainer *right_column;
+	Button *close_button;
+
+	AnimationTimelineEdit *timeline = nullptr;
+	UndoRedo *undo_redo = nullptr;
+	Node *root = nullptr;
 	Control *play_position; //separate control used to draw so updates for only position changed are much faster
-	float play_position_pos;
+	float play_position_pos = 0;
 
 	Ref<Animation> animation;
 	int track;
@@ -70,37 +73,35 @@ class AnimationBezierTrackEdit : public Control {
 
 	Map<int, Rect2> subtracks;
 
-	float v_scroll;
-	float v_zoom;
+	float v_scroll = 0;
+	float v_zoom = 1;
 
-	PopupMenu *menu;
+	PopupMenu *menu = nullptr;
 
 	void _zoom_changed();
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _menu_selected(int p_index);
 
-	bool *block_animation_update_ptr; //used to block all tracks re-gen (speed up)
-
 	void _play_position_draw();
 
 	Vector2 insert_at_pos;
 
-	bool moving_selection_attempt;
-	int select_single_attempt;
-	bool moving_selection;
+	bool moving_selection_attempt = false;
+	int select_single_attempt = -1;
+	bool moving_selection = false;
 	int moving_selection_from_key;
 
 	Vector2 moving_selection_offset;
 
-	bool box_selecting_attempt;
-	bool box_selecting;
-	bool box_selecting_add;
+	bool box_selecting_attempt = false;
+	bool box_selecting = false;
+	bool box_selecting_add = false;
 	Vector2 box_selection_from;
 	Vector2 box_selection_to;
 
-	int moving_handle; //0 no move -1 or +1 out
-	int moving_handle_key;
+	int moving_handle = 0; //0 no move -1 or +1 out
+	int moving_handle_key = 0;
 	Vector2 moving_handle_left;
 	Vector2 moving_handle_right;
 
@@ -129,7 +130,7 @@ class AnimationBezierTrackEdit : public Control {
 
 	Set<int> selection;
 
-	bool panning_timeline;
+	bool panning_timeline = false;
 	float panning_timeline_from;
 	float panning_timeline_at;
 
@@ -154,8 +155,6 @@ public:
 	void set_timeline(AnimationTimelineEdit *p_timeline);
 	void set_editor(AnimationTrackEditor *p_editor);
 	void set_root(Node *p_root);
-
-	void set_block_animation_update_ptr(bool *p_block_ptr);
 
 	void set_play_position(float p_pos);
 	void update_play_position();


### PR DESCRIPTION
This is the first (baby) step towards implementing https://github.com/godotengine/godot-proposals/issues/3141.

As this is my first contribution to Godot, I wanted to start really small and make incremental improvements to the Bezier editor.

This PR replaces the X icon in the Bezier editor with a button with a label. It also puts the handle options and the button in a VBoxContainer.

![Screenshot from 2021-08-26 17-22-05](https://user-images.githubusercontent.com/12694995/131048304-7bd99b35-f924-420b-a877-ef31a6007d56.png)
