### PR TITLE
LinkButton's text now is automatically translated

### DIFF
--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -41,12 +41,16 @@ void LinkButton::_shape() {
 	} else {
 		text_buf->set_direction((TextServer::Direction)text_direction);
 	}
-	TS->shaped_text_set_bidi_override(text_buf->get_rid(), structured_text_parser(st_parser, st_args, text));
-	text_buf->add_string(text, font, font_size, opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+	TS->shaped_text_set_bidi_override(text_buf->get_rid(), structured_text_parser(st_parser, st_args, xl_text));
+	text_buf->add_string(xl_text, font, font_size, opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 void LinkButton::set_text(const String &p_text) {
+	if (text == p_text) {
+		return;
+	}
 	text = p_text;
+	xl_text = atr(text);
 	_shape();
 	minimum_size_changed();
 	update();
@@ -141,7 +145,13 @@ Size2 LinkButton::get_minimum_size() const {
 
 void LinkButton::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_TRANSLATION_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			xl_text = atr(text);
+			_shape();
+
+			minimum_size_changed();
+			update();
+		} break;
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			update();
 		} break;

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -47,6 +47,7 @@ public:
 
 private:
 	String text;
+	String xl_text;
 	Ref<TextLine> text_buf;
 	UnderlineMode underline_mode = UNDERLINE_MODE_ALWAYS;
 


### PR DESCRIPTION
Fix #52120
Contributors: @Lucas3H

*Bugsquad edit: `master` version of https://github.com/godotengine/godot/pull/52138.*