### PR TITLE
Pin setuptools_scm version in CI workflow

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install -qq dos2unix recode clang-format-11
           sudo update-alternatives --remove-all clang-format
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
-          sudo pip3 install black==20.8b1 pygments
+          sudo pip3 install black==20.8b1 setuptools_scm==6.1.0 pygments
 
       - name: File formatting checks (file_format.sh)
         run: |


### PR DESCRIPTION
Static check CI is failing for `ModuleNotFoundError: No module named 'tomli'`.

<details><summary>Error log</summary>

```
Collecting black==20.8b1
  Downloading black-20.8b1.tar.gz (1.1 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 /tmp/tmpn26tv6wf prepare_metadata_for_build_wheel /tmp/tmpfq86l3fj
         cwd: /tmp/pip-install-zdhf9ohe/black
    Complete output (30 lines):
    Traceback (most recent call last):
      File "/tmp/tmpn26tv6wf", line 280, in <module>
        main()
      File "/tmp/tmpn26tv6wf", line 263, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/tmp/tmpn26tv6wf", line 133, in prepare_metadata_for_build_wheel
        return hook(metadata_directory, config_settings)
      File "/tmp/pip-build-env-mg0o7glr/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 166, in prepare_metadata_for_build_wheel
        self.run_setup()
      File "/tmp/pip-build-env-mg0o7glr/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 150, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 48, in <module>
        setup(
      File "/tmp/pip-build-env-mg0o7glr/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 153, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python3.8/distutils/core.py", line 108, in setup
        _setup_distribution = dist = klass(attrs)
      File "/tmp/pip-build-env-mg0o7glr/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 455, in __init__
        _Distribution.__init__(self, {
      File "/usr/lib/python3.8/distutils/dist.py", line 292, in __init__
        self.finalize_options()
      File "/tmp/pip-build-env-mg0o7glr/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 807, in finalize_options
        ep(self)
      File "/tmp/pip-build-env-mg0o7glr/overlay/lib/python3.8/site-packages/setuptools_scm/integration.py", line 52, in infer_version
        config = Configuration.from_file(dist_name=dist_name)
      File "/tmp/pip-build-env-mg0o7glr/overlay/lib/python3.8/site-packages/setuptools_scm/config.py", line 187, in from_file
        defn = _load_toml(data)
      File "/tmp/pip-build-env-mg0o7glr/overlay/lib/python3.8/site-packages/setuptools_scm/config.py", line 59, in _lazy_tomli_load
        from tomli import loads
    ModuleNotFoundError: No module named 'tomli'
    ----------------------------------------
ERROR: Command errored out with exit status 1: /usr/bin/python3 /tmp/tmpn26tv6wf prepare_metadata_for_build_wheel /tmp/tmpfq86l3fj Check the logs for full command output.
Error: Process completed with exit code 1.
```

</details>

This is caused by the recent update of `setuptools-scm` as described in <https://github.com/psf/black/issues/2449> and <https://github.com/pypa/setuptools_scm/issues/608>.

As suggested in the issues above, pinning the version of `setuptools-scm` to 6.1.0 avoids the error.