### PR TITLE
Add unit tests for `Array.pop_at()`

### DIFF
--- a/tests/test_array.h
+++ b/tests/test_array.h
@@ -39,6 +39,7 @@
 #include "core/variant/container_type_validate.h"
 #include "core/variant/variant.h"
 #include "tests/test_macros.h"
+#include "tests/test_tools.h"
 
 namespace TestArray {
 
@@ -168,6 +169,56 @@ TEST_CASE("[Array] push_front(), pop_front(), pop_back()") {
 	arr.pop_back();
 	CHECK(int(arr[1]) == 2);
 	CHECK(arr.size() == 2);
+}
+
+TEST_CASE("[Array] pop_at()") {
+	ErrorDetector ed;
+
+	Array arr;
+	arr.push_back(2);
+	arr.push_back(4);
+	arr.push_back(6);
+	arr.push_back(8);
+	arr.push_back(10);
+
+	REQUIRE(int(arr.pop_at(2)) == 6);
+	REQUIRE(arr.size() == 4);
+	CHECK(int(arr[0]) == 2);
+	CHECK(int(arr[1]) == 4);
+	CHECK(int(arr[2]) == 8);
+	CHECK(int(arr[3]) == 10);
+
+	REQUIRE(int(arr.pop_at(2)) == 8);
+	REQUIRE(arr.size() == 3);
+	CHECK(int(arr[0]) == 2);
+	CHECK(int(arr[1]) == 4);
+	CHECK(int(arr[2]) == 10);
+
+	// Negative index.
+	REQUIRE(int(arr.pop_at(-1)) == 10);
+	REQUIRE(arr.size() == 2);
+	CHECK(int(arr[0]) == 2);
+	CHECK(int(arr[1]) == 4);
+
+	// Invalid pop.
+	ed.clear();
+	ERR_PRINT_OFF;
+	const Variant ret = arr.pop_at(-15);
+	ERR_PRINT_ON;
+	REQUIRE(ret.is_null());
+	CHECK(ed.has_error);
+
+	REQUIRE(int(arr.pop_at(0)) == 2);
+	REQUIRE(arr.size() == 1);
+	CHECK(int(arr[0]) == 4);
+
+	REQUIRE(int(arr.pop_at(0)) == 4);
+	REQUIRE(arr.is_empty());
+
+	// Pop from empty array.
+	ed.clear();
+	REQUIRE(arr.pop_at(24).is_null());
+	CHECK_FALSE(ed.has_error);
 }
 
 TEST_CASE("[Array] max() and min()") {

--- a/tests/test_tools.h
+++ b/tests/test_tools.h
@@ -1,0 +1,61 @@
+/*************************************************************************/
+/*  test_tools.h                                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_TOOLS_H
+#define TEST_TOOLS_H
+
+#include "core/error/error_macros.h"
+
+struct ErrorDetector {
+	ErrorDetector() {
+		eh.errfunc = _detect_error;
+		eh.userdata = this;
+
+		add_error_handler(&eh);
+	}
+
+	~ErrorDetector() {
+		remove_error_handler(&eh);
+	}
+
+	void clear() {
+		has_error = false;
+	}
+
+	static void _detect_error(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, ErrorHandlerType p_type) {
+		ErrorDetector *self = (ErrorDetector *)p_self;
+		self->has_error = true;
+	}
+
+	ErrorHandlerList eh;
+	bool has_error = false;
+};
+
+#endif // TEST_TOOLS_H

--- a/tests/test_validate_testing.h
+++ b/tests/test_validate_testing.h
@@ -34,6 +34,7 @@
 #include "core/os/os.h"
 
 #include "tests/test_macros.h"
+#include "tests/test_tools.h"
 
 TEST_SUITE("Validate tests") {
 	TEST_CASE("Always pass") {
@@ -181,6 +182,17 @@ TEST_SUITE("Validate tests") {
 
 		// doctest string concatenation.
 		CHECK_MESSAGE(true, var, " ", vec2, " ", rect2, " ", color);
+	}
+	TEST_CASE("Detect error messages") {
+		ErrorDetector ed;
+
+		REQUIRE_FALSE(ed.has_error);
+
+		ERR_PRINT_OFF;
+		ERR_PRINT("Still waiting for Godot!");
+		ERR_PRINT_ON;
+
+		REQUIRE(ed.has_error);
 	}
 }
 


### PR DESCRIPTION
Test case from description in #37209.

Since `pop_at` with invalid index should print error depending on whether it's empty, and I couldn't find any existing methods of asserting for error message, so I added an ad-hoc error detector.