### PR TITLE
Fix bad size after restoring a minimized window under Windows Fix #52150

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2611,6 +2611,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			else if (wParam == SIZE_MINIMIZED) {
 				windows[window_id].maximized = false;
 				windows[window_id].minimized = true;
+				windows[window_id].preserve_window_size = false;
 			}
 			// The window has been resized, but neither the SIZE_MINIMIZED nor SIZE_MAXIMIZED value applies.
 			else if (wParam == SIZE_RESTORED) {


### PR DESCRIPTION
Fix #52150

On Windows, size of the editor window wasn't restore correctly after been minimized and restored after loading a project.

``windows[window_id].preserve_window_size`` has to be set to ``false`` on minimized.

Without that, on restoring the window, test at line 2576 will fail and window size is wrong.

(I've check the 3.x source and preserve_window_size is set to false on minimized.)