### PR TITLE
Add a debug draw density property to BakedLightmap

### DIFF
--- a/doc/classes/BakedLightmap.xml
+++ b/doc/classes/BakedLightmap.xml
@@ -49,6 +49,10 @@
 		<member name="capture_quality" type="int" setter="set_capture_quality" getter="get_capture_quality" enum="BakedLightmap.BakeQuality" default="1">
 			Bake quality of the capture data.
 		</member>
+		<member name="debug_draw_density" type="bool" setter="set_debug_draw_density" getter="is_debug_draw_density_enabled" default="false">
+			If [code]true[/code], draws a checkerboard pattern with 4×4 tiles over the lightmap to help diagnose issues related to lightmap texel density and lightmap seams. To check whether lightmap texel density is consistent, compare the sizes of the checkerboard tiles on different objects. To get good visual results, checkerboard tile sizes should be as similar as possible across objects. Background scenery objects can generally afford to have lower lightmap texel density since they won't be viewed up close by the camera.
+			[b]Note:[/b] Changes to [member debug_draw_density] only have an effect after baking lightmaps.
+		</member>
 		<member name="default_texels_per_unit" type="float" setter="set_default_texels_per_unit" getter="get_default_texels_per_unit" default="16.0">
 			If a baked mesh doesn't have a UV2 size hint, this value will be used to roughly compute a suitable lightmap size.
 		</member>

--- a/scene/3d/baked_lightmap.cpp
+++ b/scene/3d/baked_lightmap.cpp
@@ -541,6 +541,17 @@ void BakedLightmap::_save_image(String &r_base_path, Ref<Image> r_img, bool p_us
 				c = c.to_srgb();
 			}
 
+			if (debug_draw_density) {
+				// Draw a 4×4 checkerboard pattern over the baked lightmap to help
+				// diagnose lightmap density and seam issues.
+				const bool even_square = (int(i * 0.25) + int(j * 0.25)) % 2 == 0;
+				if (even_square) {
+					c *= 1.25;
+				} else {
+					c *= 0.75;
+				}
+			}
+
 			r_img->set_pixel(j, i, c);
 		}
 	}
@@ -1430,6 +1441,14 @@ float BakedLightmap::get_bias() const {
 	return bias;
 }
 
+void BakedLightmap::set_debug_draw_density(bool p_enabled) {
+	debug_draw_density = p_enabled;
+}
+
+bool BakedLightmap::is_debug_draw_density_enabled() const {
+	return debug_draw_density;
+}
+
 AABB BakedLightmap::get_aabb() const {
 	return AABB(-extents, extents * 2);
 }
@@ -1474,6 +1493,9 @@ void BakedLightmap::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_bias", "bias"), &BakedLightmap::set_bias);
 	ClassDB::bind_method(D_METHOD("get_bias"), &BakedLightmap::get_bias);
+
+	ClassDB::bind_method(D_METHOD("set_debug_draw_density", "enabled"), &BakedLightmap::set_debug_draw_density);
+	ClassDB::bind_method(D_METHOD("is_debug_draw_density_enabled"), &BakedLightmap::is_debug_draw_density_enabled);
 
 	ClassDB::bind_method(D_METHOD("set_environment_mode", "mode"), &BakedLightmap::set_environment_mode);
 	ClassDB::bind_method(D_METHOD("get_environment_mode"), &BakedLightmap::get_environment_mode);
@@ -1561,6 +1583,9 @@ void BakedLightmap::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "capture_quality", PROPERTY_HINT_ENUM, "Low,Medium,High"), "set_capture_quality", "get_capture_quality");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "capture_propagation", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_capture_propagation", "get_capture_propagation");
 
+	ADD_GROUP("Debug", "debug_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_draw_density"), "set_debug_draw_density", "is_debug_draw_density_enabled");
+
 	ADD_GROUP("Data", "");
 #ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "image_path", PROPERTY_HINT_DIR, "", 0), "set_image_path", "get_image_path");
@@ -1610,6 +1635,7 @@ BakedLightmap::BakedLightmap() {
 	use_hdr = true;
 	use_color = true;
 	bias = 0.005;
+	debug_draw_density = false;
 
 	generate_atlas = true;
 	max_atlas_size = 4096;

--- a/scene/3d/baked_lightmap.h
+++ b/scene/3d/baked_lightmap.h
@@ -158,6 +158,7 @@ private:
 	Vector3 extents;
 	float default_texels_per_unit;
 	float bias;
+	bool debug_draw_density;
 	BakeQuality bake_quality;
 	bool generate_atlas;
 	int max_atlas_size;
@@ -272,6 +273,9 @@ public:
 
 	void set_bias(float p_bias);
 	float get_bias() const;
+
+	void set_debug_draw_density(bool p_enabled);
+	bool is_debug_draw_density_enabled() const;
 
 	AABB get_aabb() const;
 	PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;


### PR DESCRIPTION
When enabled, `debug_draw_density` will draw a checkerboard on the baked lightmap. This is done by modifying the lightmap data itself.

This can be used to diagnose issues related to lightmap texel density and lightmap seams.

Ideally, this would be done directly in the shader to avoid having to bake lightmaps again. I don't know how to implement that though.
**Edit:** This is likely done by passing the lightmap texture size uniform is debug density is enabled, even if bicubic sampling is disabled in the project settings. However, the issue is that density debugging is configured on a per-node basis rather than a global project setting (like bicubic sampling).

This partially addresses https://github.com/godotengine/godot-proposals/issues/3213.

## Preview

| `debug_draw_density` disabled | `debug_draw_density` enabled |
|-|-|
| ![Disabled](https://user-images.githubusercontent.com/180032/131184706-7145396a-777b-42af-ab7a-53e964339379.png) | ![Enabled](https://user-images.githubusercontent.com/180032/131184701-e5df8cb9-faec-4e91-bf13-0cfabc4da9fd.png) |