### PR TITLE
[4.0] Add 2D scale factor property

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -287,6 +287,8 @@
 		</member>
 		<member name="content_scale_aspect" type="int" setter="set_content_scale_aspect" getter="get_content_scale_aspect" enum="Window.ContentScaleAspect" default="0">
 		</member>
+		<member name="content_scale_factor" type="float" setter="set_content_scale_factor" getter="get_content_scale_factor" default="1.0">
+		</member>
 		<member name="content_scale_mode" type="int" setter="set_content_scale_mode" getter="get_content_scale_mode" enum="Window.ContentScaleMode" default="0">
 		</member>
 		<member name="content_scale_size" type="Vector2i" setter="set_content_scale_size" getter="get_content_scale_size" default="Vector2i(0, 0)">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2321,6 +2321,7 @@ bool Main::start() {
 			String stretch_aspect = GLOBAL_DEF_BASIC("display/window/stretch/aspect", "keep");
 			Size2i stretch_size = Size2i(GLOBAL_DEF_BASIC("display/window/size/width", 0),
 					GLOBAL_DEF_BASIC("display/window/size/height", 0));
+			real_t stretch_scale = GLOBAL_DEF_BASIC("display/window/stretch/scale", 1.0);
 
 			Window::ContentScaleMode cs_sm = Window::CONTENT_SCALE_MODE_DISABLED;
 			if (stretch_mode == "canvas_items") {
@@ -2343,6 +2344,7 @@ bool Main::start() {
 			sml->get_root()->set_content_scale_mode(cs_sm);
 			sml->get_root()->set_content_scale_aspect(cs_aspect);
 			sml->get_root()->set_content_scale_size(stretch_size);
+			sml->get_root()->set_content_scale_factor(stretch_scale);
 
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -560,9 +560,12 @@ void Window::_update_viewport_size() {
 	float font_oversampling = 1.0;
 
 	if (content_scale_mode == CONTENT_SCALE_MODE_DISABLED || content_scale_size.x == 0 || content_scale_size.y == 0) {
-		stretch_transform = Transform2D();
+		font_oversampling = content_scale_factor;
 		final_size = size;
+		final_size_override = Size2(size) / content_scale_factor;
 
+		stretch_transform = Transform2D();
+		stretch_transform.scale(Size2(content_scale_factor, content_scale_factor));
 	} else {
 		//actual screen video mode
 		Size2 video_mode = size;
@@ -634,9 +637,9 @@ void Window::_update_viewport_size() {
 			} break;
 			case CONTENT_SCALE_MODE_CANVAS_ITEMS: {
 				final_size = screen_size;
-				final_size_override = viewport_size;
+				final_size_override = viewport_size / content_scale_factor;
 				attach_to_screen_rect = Rect2(margin, screen_size);
-				font_oversampling = screen_size.x / viewport_size.x;
+				font_oversampling = (screen_size.x / viewport_size.x) * content_scale_factor;
 
 				Size2 scale = Vector2(screen_size) / Vector2(final_size_override);
 				stretch_transform.scale(scale);
@@ -823,6 +826,16 @@ void Window::set_content_scale_aspect(ContentScaleAspect p_aspect) {
 
 Window::ContentScaleAspect Window::get_content_scale_aspect() const {
 	return content_scale_aspect;
+}
+
+void Window::set_content_scale_factor(real_t p_factor) {
+	ERR_FAIL_COND(p_factor <= 0);
+	content_scale_factor = p_factor;
+	_update_viewport_size();
+}
+
+real_t Window::get_content_scale_factor() const {
+	return content_scale_factor;
 }
 
 void Window::set_use_font_oversampling(bool p_oversampling) {
@@ -1468,6 +1481,9 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_content_scale_aspect", "aspect"), &Window::set_content_scale_aspect);
 	ClassDB::bind_method(D_METHOD("get_content_scale_aspect"), &Window::get_content_scale_aspect);
 
+	ClassDB::bind_method(D_METHOD("set_content_scale_factor", "factor"), &Window::set_content_scale_factor);
+	ClassDB::bind_method(D_METHOD("get_content_scale_factor"), &Window::get_content_scale_factor);
+
 	ClassDB::bind_method(D_METHOD("set_use_font_oversampling", "enable"), &Window::set_use_font_oversampling);
 	ClassDB::bind_method(D_METHOD("is_using_font_oversampling"), &Window::is_using_font_oversampling);
 
@@ -1539,6 +1555,7 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "content_scale_size"), "set_content_scale_size", "get_content_scale_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "content_scale_mode", PROPERTY_HINT_ENUM, "Disabled,Canvas Items,Viewport"), "set_content_scale_mode", "get_content_scale_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "content_scale_aspect", PROPERTY_HINT_ENUM, "Ignore,Keep,Keep Width,Keep Height,Expand"), "set_content_scale_aspect", "get_content_scale_aspect");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "content_scale_factor"), "set_content_scale_factor", "get_content_scale_factor");
 
 	ADD_GROUP("Theme", "theme_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, "Theme"), "set_theme", "get_theme");

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -112,6 +112,7 @@ private:
 	Size2i content_scale_size;
 	ContentScaleMode content_scale_mode = CONTENT_SCALE_MODE_DISABLED;
 	ContentScaleAspect content_scale_aspect = CONTENT_SCALE_ASPECT_IGNORE;
+	real_t content_scale_factor = 1.0;
 
 	void _make_window();
 	void _clear_window();
@@ -229,6 +230,9 @@ public:
 
 	void set_content_scale_aspect(ContentScaleAspect p_aspect);
 	ContentScaleAspect get_content_scale_aspect() const;
+
+	void set_content_scale_factor(real_t p_factor);
+	real_t get_content_scale_factor() const;
 
 	void set_use_font_oversampling(bool p_oversampling);
 	bool is_using_font_oversampling() const;


### PR DESCRIPTION
4.0 version of #52137. *Bugsquad edit: Rebase of #21446*

This can be used to make 2D elements larger or smaller, independently of the current stretch mode.
Only the disabled and canvas stretch modes support this new property.

As with the 3.x version this doesn't solve the image scaling problem (again, we would need godotengine/godot-proposals#2924). ~~In addition, font rendering currently looks weird when the scale factor is set to anything other than. After far too much time spent debugging I can now confirm that this is **NOT** caused by these changes. It would appear that font oversampling is currently broken. For more information please see #47957.~~ Looks fine as of 17/12/2021 on linux. Guess someone already fixed font oversampling.

[2d-scaling-demo4.zip](https://github.com/godotengine/godot/files/7069569/2d-scaling-demo4.zip)


Pinging @Calinou, since he wanted to port this to 4.0 himself.