### PR TITLE
Fix Vector's const iterator constructor

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -229,7 +229,7 @@ public:
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }
 		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return elem_ptr != b.elem_ptr; }
 
-		ConstIterator(T *p_ptr) { elem_ptr = p_ptr; }
+		ConstIterator(const T *p_ptr) { elem_ptr = p_ptr; }
 		ConstIterator() {}
 		ConstIterator(const ConstIterator &p_it) { elem_ptr = p_it.elem_ptr; }
 


### PR DESCRIPTION
For my polyphony PR (which is coming along well so far!) I'd like to iterate through a `Vector<Ref<AudioStreamPlayback>>` using a range based for, inside of a const getter function. I noticed that this currently isn't possible. The compiler says that the construction of a ConstIterator on line 251 of vector.h discards the const qualifier, so I switched the ConstIterator constructor to take a pointer to a const T. The semantics of const pointers vs pointers to consts are endlessly confusing to me but I think this is right. It lets my range-based for loop compile, at least.