### PR TITLE
Quote and escape ConfigFile keys when necessary

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -188,7 +188,7 @@ Error ConfigFile::_internal_save(FileAccess *file) {
 		for (OrderedHashMap<String, Variant>::Element F = E.get().front(); F; F = F.next()) {
 			String vstr;
 			VariantWriter::write_to_string(F.get(), vstr);
-			file->store_string(F.key() + "=" + vstr + "\n");
+			file->store_string(F.key().property_name_encode() + "=" + vstr + "\n");
 		}
 	}
 

--- a/tests/test_config_file.h
+++ b/tests/test_config_file.h
@@ -122,6 +122,8 @@ TEST_CASE("[ConfigFile] Saving file") {
 	config_file.set_value("player", "position", Vector2(3, 4));
 	config_file.set_value("graphics", "antialiasing", true);
 	config_file.set_value("graphics", "antiAliasing", false);
+	config_file.set_value("quoted", String::utf8("静音"), 42);
+	config_file.set_value("quoted", "a=b", 7);
 
 #ifdef WINDOWS_ENABLED
 	const String config_path = OS::get_singleton()->get_environment("TEMP").plus_file("config.ini");
@@ -132,7 +134,7 @@ TEST_CASE("[ConfigFile] Saving file") {
 	config_file.save(config_path);
 
 	// Expected contents of the saved ConfigFile.
-	const String contents = R"([player]
+	const String contents = String::utf8(R"([player]
 
 name="Unnamed Player"
 tagline="Waiting
@@ -145,7 +147,12 @@ position=Vector2(3, 4)
 
 antialiasing=true
 antiAliasing=false
-)";
+
+[quoted]
+
+"静音"=42
+"a=b"=7
+)");
 
 	FileAccessRef file = FileAccess::open(config_path, FileAccess::READ);
 	CHECK_MESSAGE(file->get_as_utf8_string() == contents,


### PR DESCRIPTION
Unexpected things happen when keys of `ConfigFile` contain special characters. For example:

* When the key is `a=b`, saving works fine. But it complains about invalid identifier when loading.

    ```
    ERROR: ConfigFile parse error at user://test.cfg:2: Unexpected identifier: 'b'..
       at: _parse (core/io/config_file.cpp:280)
    ```

* When the key contains non-Ascii characters like Chinese, saving works fine. But it might be decoded incorrectly when loaded again. (`静音` will become `éé³`.)

This PR encodes the keys with `String::property_name_encode()`. This is also how `ResourceFormatSaverText` encodes property names.

<details><summary>Test Script</summary>

```gdscript
extends SceneTree

const CONFIG_PATH := "user://test.cfg"

func _init():
	var config := ConfigFile.new()

	config.set_value("音频", "静音", 42)
	config.set_value("Audio", "a=b", 7)

	var err := config.save(CONFIG_PATH)
	assert(err == OK)

	config.clear()
	err = config.load(CONFIG_PATH)
	assert(err == OK)

	for section in config.get_sections():
		print(section)
		for key in config.get_section_keys(section):
			printt("", key, config.get_value(section, key))

	quit()
```
</details>