### PR TITLE
Portals - Fix RoomManager PVS enum

### DIFF
--- a/doc/classes/RoomManager.xml
+++ b/doc/classes/RoomManager.xml
@@ -94,13 +94,13 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="RoomManager::PVS_MODE_DISABLED" value="0" enum="PVSMode">
+		<constant name="PVS_MODE_DISABLED" value="0" enum="PVSMode">
 			Use only [Portal]s at runtime to determine visibility. PVS will not be generated at [Room]s conversion, and gameplay notifications cannot be used.
 		</constant>
-		<constant name="RoomManager::PVS_MODE_PARTIAL" value="1" enum="PVSMode">
+		<constant name="PVS_MODE_PARTIAL" value="1" enum="PVSMode">
 			Use a combination of PVS and [Portal]s to determine visibility (this is usually fastest and most accurate).
 		</constant>
-		<constant name="RoomManager::PVS_MODE_FULL" value="2" enum="PVSMode">
+		<constant name="PVS_MODE_FULL" value="2" enum="PVSMode">
 			Use only the PVS (potentially visible set) of [Room]s to determine visibility.
 		</constant>
 	</constants>

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -256,9 +256,9 @@ void RoomManager::_notification(int p_what) {
 }
 
 void RoomManager::_bind_methods() {
-	BIND_ENUM_CONSTANT(RoomManager::PVS_MODE_DISABLED);
-	BIND_ENUM_CONSTANT(RoomManager::PVS_MODE_PARTIAL);
-	BIND_ENUM_CONSTANT(RoomManager::PVS_MODE_FULL);
+	BIND_ENUM_CONSTANT(PVS_MODE_DISABLED);
+	BIND_ENUM_CONSTANT(PVS_MODE_PARTIAL);
+	BIND_ENUM_CONSTANT(PVS_MODE_FULL);
 
 	// main functions
 	ClassDB::bind_method(D_METHOD("rooms_convert"), &RoomManager::rooms_convert);


### PR DESCRIPTION
The PVS mode enum had been declared using scope operator, which does not seem to work correctly from GDScript with the BIND_ENUM_CONSTANT macro.

This PR removes the scope operator in the declaration.

Fixes #51926

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
