### PR TITLE
Allow nested complex ops in TextEdit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2644,6 +2644,8 @@ void TextEdit::insert_line_at(int p_at, const String &p_text) {
 }
 
 void TextEdit::insert_text_at_caret(const String &p_text) {
+	begin_complex_operation();
+
 	delete_selection();
 
 	int new_column, new_line;
@@ -2653,6 +2655,8 @@ void TextEdit::insert_text_at_caret(const String &p_text) {
 	set_caret_line(new_line, false);
 	set_caret_column(new_column);
 	update();
+
+	end_complex_operation();
 }
 
 void TextEdit::remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column) {
@@ -2937,13 +2941,20 @@ void TextEdit::menu_option(int p_option) {
 /* Versioning */
 void TextEdit::begin_complex_operation() {
 	_push_current_op();
-	next_operation_is_complex = true;
+	if (complex_operation_count == 0) {
+		next_operation_is_complex = true;
+	}
+	complex_operation_count++;
 }
 
 void TextEdit::end_complex_operation() {
 	_push_current_op();
 	ERR_FAIL_COND(undo_stack.size() == 0);
 
+	complex_operation_count = MAX(complex_operation_count - 1, 0);
+	if (complex_operation_count > 0) {
+		return;
+	}
 	if (undo_stack.back()->get().chain_forward) {
 		undo_stack.back()->get().chain_forward = false;
 		return;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -289,6 +289,7 @@ private:
 	bool undo_enabled = true;
 	int undo_stack_max_size = 50;
 
+	int complex_operation_count = 0;
 	bool next_operation_is_complex = false;
 
 	TextOperation current_op;


### PR DESCRIPTION
Allow calling nested `begin_complex_operation` and `end_complex_operation`, this should allow us to fix some of the "weird" undo / redo issues. In addition to making it more user friendly now this is exposed to the API.

Fixed one such case here, where `insert_text_at_caret` with selected text would class deleting the selection, then inserting the text as two operations rather then a single action.