### PR TITLE
Update filesystem dock on script, scene, and resource creation

### DIFF
--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -230,7 +230,8 @@ private:
 	void _files_moved(String p_old_file, String p_new_file);
 	void _folder_moved(String p_old_folder, String p_new_folder);
 
-	void _resource_created();
+	void _resource_created(const Ref<Resource> &p_resource);
+	void _resource_confirm();
 	void _make_dir_confirm();
 	void _make_scene_confirm();
 	void _rename_operation_confirm();


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/22686.

Fixes https://github.com/godotengine/godot/issues/22475 among other related issues. With this change the filesystem dock correctly updates on script creation, as well as any resource saving (so that we support resources and scenes, as mentioned by @KoBeWi). Unfortunately, proposed additions to `_make_scene_confirm()` and `_resource_created()` wouldn't work, as scenes and resources are saved after these calls. So I've moved to signals. Scenes don't have any that I can see, so I've reused the one for resources (after all, `PackedScene` is a resource, so it should be ok).

Note that when a folder is created, the whole dock shows a progress bar, but this is not the case for these new rescans. Not sure what's the problem here, as that code is supposed to be triggered by `_rescan()`. Either way this only results in the file list displaying the old order for a second and then quickly updating to display the correct names and order.

Also note, that this is unlikely Windows-specific (the initial issue with casing is, but not the entire situation).

@KoBeWi feel free to merge if you approve, consider me implementing the suggested changes as my own approval as well 🙂 