### PR TITLE
Fix-CustomPropertyEditor-Multiline

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -532,19 +532,6 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				text_edit->show();
 				text_edit->set_text(v);
 				text_edit->deselect();
-
-				int button_margin = text_edit->get_theme_constant(SNAME("button_margin"), SNAME("Dialogs"));
-				int margin = text_edit->get_theme_constant(SNAME("margin"), SNAME("Dialogs"));
-
-				action_buttons[0]->set_anchor(SIDE_LEFT, Control::ANCHOR_END);
-				action_buttons[0]->set_anchor(SIDE_TOP, Control::ANCHOR_END);
-				action_buttons[0]->set_anchor(SIDE_RIGHT, Control::ANCHOR_END);
-				action_buttons[0]->set_anchor(SIDE_BOTTOM, Control::ANCHOR_END);
-				action_buttons[0]->set_begin(Point2(-70 * EDSCALE, -button_margin + 5 * EDSCALE));
-				action_buttons[0]->set_end(Point2(-margin, -margin));
-				action_buttons[0]->set_text(TTR("Close"));
-				action_buttons[0]->show();
-
 			} else if (hint == PROPERTY_HINT_TYPE_STRING) {
 				if (!create_dialog) {
 					create_dialog = memnew(CreateDialog);
@@ -832,7 +819,6 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			color_picker->set_focus_on_line_edit();
 
 		} break;
-
 		case Variant::NODE_PATH: {
 			List<String> names;
 			names.push_back(TTR("Assign"));


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

When using Multiline editor the close button overlaps the entire working area.
[before](https://user-images.githubusercontent.com/20573784/131225836-00a17444-577d-42f3-bf77-5a2c69508c13.mp4)

After trying multiple ways of creating a compact in the bottom right close button. I gave up and simply deleted it.
Less is more it is possible to close the editor using escape or clicking outside of it.
[after](https://user-images.githubusercontent.com/20573784/131225839-c0376caa-ed19-4362-a25b-fbb6e58e7935.mp4)

```
/* ATEMPTED TO USE THESE TO MAKE IT BETER
int button_margin = text_edit->get_theme_constant(SNAME("button_margin"), SNAME("Dialogs"));
int margin = text_edit->get_theme_constant(SNAME("margin"), SNAME("Dialogs"));

action_buttons[0]->set_text(TTR("Close"));
action_buttons[0]->set_rect(Rect2(Vector2(0, 0), Vector2(50, 50)));
action_buttons[0]->set_anchor(SIDE_LEFT, Control::ANCHOR_END);
action_buttons[0]->set_anchor(SIDE_TOP, Control::ANCHOR_END);
action_buttons[0]->set_anchor(SIDE_RIGHT, Control::ANCHOR_END);
action_buttons[0]->set_anchor(SIDE_BOTTOM, Control::ANCHOR_END);
action_buttons[0]->set_offset(SIDE_LEFT, 0);
action_buttons[0]->set_offset(SIDE_TOP, 0);
action_buttons[0]->set_offset(SIDE_RIGHT, 0);
action_buttons[0]->set_offset(SIDE_BOTTOM, 0);
action_buttons[0]->set_size(Size2(0, 0));
//action_buttons[0]->set_v_size_flags(Control::SIZE_SHRINK_END);
//action_buttons[0]->set_h_size_flags(Control::SIZE_SHRINK_END);
action_buttons[0]->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
action_buttons[0]->set_v_grow_direction(Control::GROW_DIRECTION_BEGIN);

//	action_buttons[0]->set_begin(Point2(-70 * EDSCALE, -button_margin + 5 * EDSCALE));
//	action_buttons[0]->set_begin(Point2(70,70));
//	action_buttons[0]->set_end(Point2(-margin, -margin));
//	action_buttons[0]->set_end(Point2(-40, -40));
//		action_buttons[0]->show();

//	value_editor[0]->set_text(v);*/
```

PS: No need to backport.
