### PR TITLE
Fix wrong behavior of Action Map Editor with non QWERTY layouts (Fix #52169)

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -248,10 +248,8 @@ void InputEventConfigurationDialog::_listen_window_input(const Ref<InputEvent> &
 		k->set_pressed(false); // to avoid serialisation of 'pressed' property - doesn't matter for actions anyway.
 		// Maintain physical keycode option state
 		if (physical_key_checkbox->is_pressed()) {
-			k->set_physical_keycode(k->get_keycode());
 			k->set_keycode(KEY_NONE);
 		} else {
-			k->set_keycode((Key)k->get_physical_keycode());
 			k->set_physical_keycode(KEY_NONE);
 		}
 	}


### PR DESCRIPTION
This PR fixes #52169 issue.

### Issue description:
With non QWERTY keyboard layouts, action keys assigned with non physical checkbox unchecked were wrong (if key position wasn't the same as QWERTY layout).
In game, the key that trigger the action wasn't the pressed key during configuration.

### Identified cause:
Confusion in code between physical_keycode and keycode assignement in action map editor.

### How this PR fixes the issue: **outdated**
Instead of setting physical_keycode or keycode to KEY_NONE to determine if it's a physical key input or not, I've added a boolean in InputEventKey ``is_physical``. keycode variables are no more set to KEY_NONE after beeing assigned. It's more clear and should prevent confusion.
I also change the tests ``InputEventKey.get_keycode()==0`` by ``InputEventKey.is_physical_key()``
I've added an extra info in the checkbock label to inform that key shown in map editor when physical is checked is based on QWERTY layout to clarify the way it works.

### Result:
- Key defined in Action map Editor works correctly in both mode (physical and normal mode) even on non QWERTY layouts.
- Physical checkbox is more informative

![input_map_editor](https://user-images.githubusercontent.com/3649998/131233024-c8d37e49-42ed-4348-9c50-5fdec95734ab.gif)
