### PR TITLE
Add source rectangle to blit

### DIFF
--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -107,15 +107,16 @@
 		<method name="add_blit">
 			<return type="void" />
 			<argument index="0" name="render_target" type="RID" />
-			<argument index="1" name="rect" type="Rect2i" />
-			<argument index="2" name="use_layer" type="bool" />
-			<argument index="3" name="layer" type="int" />
-			<argument index="4" name="apply_lens_distortion" type="bool" />
-			<argument index="5" name="eye_center" type="Vector2" />
-			<argument index="6" name="k1" type="float" />
-			<argument index="7" name="k2" type="float" />
-			<argument index="8" name="upscale" type="float" />
-			<argument index="9" name="aspect_ratio" type="float" />
+			<argument index="1" name="src_rect" type="Rect2" />
+			<argument index="2" name="dst_rect" type="Rect2i" />
+			<argument index="3" name="use_layer" type="bool" />
+			<argument index="4" name="layer" type="int" />
+			<argument index="5" name="apply_lens_distortion" type="bool" />
+			<argument index="6" name="eye_center" type="Vector2" />
+			<argument index="7" name="k1" type="float" />
+			<argument index="8" name="k2" type="float" />
+			<argument index="9" name="upscale" type="float" />
+			<argument index="10" name="aspect_ratio" type="float" />
 			<description>
 				Blits our render results to screen optionally applying lens distortion. This can only be called while processing [code]_commit_views[/code].
 			</description>

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -455,16 +455,16 @@ Vector<BlitToScreen> MobileVRInterface::commit_views(RID p_render_target, const 
 	blit.lens_distortion.aspect_ratio = aspect;
 
 	// left eye
-	blit.rect = p_screen_rect;
-	blit.rect.size.width *= 0.5;
+	blit.dst_rect = p_screen_rect;
+	blit.dst_rect.size.width *= 0.5;
 	blit.multi_view.layer = 0;
 	blit.lens_distortion.eye_center.x = ((-intraocular_dist / 2.0) + (display_width / 4.0)) / (display_width / 2.0);
 	blit_to_screen.push_back(blit);
 
 	// right eye
-	blit.rect = p_screen_rect;
-	blit.rect.size.width *= 0.5;
-	blit.rect.position.x = blit.rect.size.width;
+	blit.dst_rect = p_screen_rect;
+	blit.dst_rect.size.width *= 0.5;
+	blit.dst_rect.position.x = blit.dst_rect.size.width;
 	blit.multi_view.layer = 1;
 	blit.lens_distortion.eye_center.x = ((intraocular_dist / 2.0) - (display_width / 4.0)) / (display_width / 2.0);
 	blit_to_screen.push_back(blit);

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -41,7 +41,8 @@
 class RendererSceneRender;
 struct BlitToScreen {
 	RID render_target;
-	Rect2i rect;
+	Rect2 src_rect = Rect2(0.0, 0.0, 1.0, 1.0);
+	Rect2i dst_rect;
 
 	struct {
 		bool use_layer = false;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -46,6 +46,8 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 		RID rd_texture = storage->texture_get_rd_texture(texture);
 		ERR_CONTINUE(rd_texture.is_null());
 
+		// TODO if keep_3d_linear was set when rendering to this render target we need to add a linear->sRGB conversion in.
+
 		if (!render_target_descriptors.has(rd_texture) || !RD::get_singleton()->uniform_set_is_valid(render_target_descriptors[rd_texture])) {
 			Vector<RD::Uniform> uniforms;
 			RD::Uniform u;
@@ -65,10 +67,14 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 		RD::get_singleton()->draw_list_bind_index_array(draw_list, blit.array);
 		RD::get_singleton()->draw_list_bind_uniform_set(draw_list, render_target_descriptors[rd_texture], 0);
 
-		blit.push_constant.rect[0] = p_render_targets[i].rect.position.x / screen_size.width;
-		blit.push_constant.rect[1] = p_render_targets[i].rect.position.y / screen_size.height;
-		blit.push_constant.rect[2] = p_render_targets[i].rect.size.width / screen_size.width;
-		blit.push_constant.rect[3] = p_render_targets[i].rect.size.height / screen_size.height;
+		blit.push_constant.src_rect[0] = p_render_targets[i].src_rect.position.x;
+		blit.push_constant.src_rect[1] = p_render_targets[i].src_rect.position.y;
+		blit.push_constant.src_rect[2] = p_render_targets[i].src_rect.size.width;
+		blit.push_constant.src_rect[3] = p_render_targets[i].src_rect.size.height;
+		blit.push_constant.dst_rect[0] = p_render_targets[i].dst_rect.position.x / screen_size.width;
+		blit.push_constant.dst_rect[1] = p_render_targets[i].dst_rect.position.y / screen_size.height;
+		blit.push_constant.dst_rect[2] = p_render_targets[i].dst_rect.size.width / screen_size.width;
+		blit.push_constant.dst_rect[3] = p_render_targets[i].dst_rect.size.height / screen_size.height;
 		blit.push_constant.layer = p_render_targets[i].multi_view.layer;
 		blit.push_constant.eye_center[0] = p_render_targets[i].lens_distortion.eye_center.x;
 		blit.push_constant.eye_center[1] = p_render_targets[i].lens_distortion.eye_center.y;
@@ -203,10 +209,14 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 	RD::get_singleton()->draw_list_bind_index_array(draw_list, blit.array);
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uset, 0);
 
-	blit.push_constant.rect[0] = screenrect.position.x;
-	blit.push_constant.rect[1] = screenrect.position.y;
-	blit.push_constant.rect[2] = screenrect.size.width;
-	blit.push_constant.rect[3] = screenrect.size.height;
+	blit.push_constant.src_rect[0] = 0.0;
+	blit.push_constant.src_rect[1] = 0.0;
+	blit.push_constant.src_rect[2] = 1.0;
+	blit.push_constant.src_rect[3] = 1.0;
+	blit.push_constant.dst_rect[0] = screenrect.position.x;
+	blit.push_constant.dst_rect[1] = screenrect.position.y;
+	blit.push_constant.dst_rect[2] = screenrect.size.width;
+	blit.push_constant.dst_rect[3] = screenrect.size.height;
 	blit.push_constant.layer = 0;
 	blit.push_constant.eye_center[0] = 0;
 	blit.push_constant.eye_center[1] = 0;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -55,7 +55,8 @@ protected:
 	};
 
 	struct BlitPushConstant {
-		float rect[4];
+		float src_rect[4];
+		float dst_rect[4];
 
 		float eye_center[2];
 		float k1;

--- a/servers/rendering/renderer_rd/shaders/blit.glsl
+++ b/servers/rendering/renderer_rd/shaders/blit.glsl
@@ -5,6 +5,7 @@
 #VERSION_DEFINES
 
 layout(push_constant, binding = 0, std140) uniform Pos {
+	vec4 src_rect;
 	vec4 dst_rect;
 
 	vec2 eye_center;
@@ -22,8 +23,8 @@ layout(location = 0) out vec2 uv;
 
 void main() {
 	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
-	uv = base_arr[gl_VertexIndex];
-	vec2 vtx = data.dst_rect.xy + uv * data.dst_rect.zw;
+	uv = data.src_rect.xy + base_arr[gl_VertexIndex] * data.src_rect.zw;
+	vec2 vtx = data.dst_rect.xy + base_arr[gl_VertexIndex] * data.dst_rect.zw;
 	gl_Position = vec4(vtx * 2.0 - 1.0, 0.0, 1.0);
 }
 
@@ -34,6 +35,7 @@ void main() {
 #VERSION_DEFINES
 
 layout(push_constant, binding = 0, std140) uniform Pos {
+	vec4 src_rect;
 	vec4 dst_rect;
 
 	vec2 eye_center;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -626,10 +626,10 @@ void RendererViewport::draw_viewports() {
 				BlitToScreen blit;
 				blit.render_target = vp->render_target;
 				if (vp->viewport_to_screen_rect != Rect2()) {
-					blit.rect = vp->viewport_to_screen_rect;
+					blit.dst_rect = vp->viewport_to_screen_rect;
 				} else {
-					blit.rect.position = Vector2();
-					blit.rect.size = vp->size;
+					blit.dst_rect.position = Vector2();
+					blit.dst_rect.size = vp->size;
 				}
 
 				if (!blit_to_screen_list.has(vp->viewport_to_screen)) {

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -41,7 +41,7 @@ void XRInterfaceExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_tracking_status);
 
-	ClassDB::bind_method(D_METHOD("add_blit", "render_target", "rect", "use_layer", "layer", "apply_lens_distortion", "eye_center", "k1", "k2", "upscale", "aspect_ratio"), &XRInterfaceExtension::add_blit);
+	ClassDB::bind_method(D_METHOD("add_blit", "render_target", "src_rect", "dst_rect", "use_layer", "layer", "apply_lens_distortion", "eye_center", "k1", "k2", "upscale", "aspect_ratio"), &XRInterfaceExtension::add_blit);
 
 	GDVIRTUAL_BIND(_get_render_target_size);
 	GDVIRTUAL_BIND(_get_view_count);
@@ -198,13 +198,14 @@ CameraMatrix XRInterfaceExtension::get_projection_for_view(uint32_t p_view, real
 	return CameraMatrix();
 }
 
-void XRInterfaceExtension::add_blit(RID p_render_target, Rect2i p_rect, bool p_use_layer, uint32_t p_layer, bool p_apply_lens_distortion, Vector2 p_eye_center, float p_k1, float p_k2, float p_upscale, float p_aspect_ratio) {
+void XRInterfaceExtension::add_blit(RID p_render_target, Rect2 p_src_rect, Rect2i p_dst_rect, bool p_use_layer, uint32_t p_layer, bool p_apply_lens_distortion, Vector2 p_eye_center, float p_k1, float p_k2, float p_upscale, float p_aspect_ratio) {
 	BlitToScreen blit;
 
 	ERR_FAIL_COND_MSG(!can_add_blits, "add_blit can only be called from an XR plugin from within _commit_views!");
 
 	blit.render_target = p_render_target;
-	blit.rect = p_rect;
+	blit.src_rect = p_src_rect;
+	blit.dst_rect = p_dst_rect;
 
 	blit.multi_view.use_layer = p_use_layer;
 	blit.multi_view.layer = p_layer;

--- a/servers/xr/xr_interface_extension.h
+++ b/servers/xr/xr_interface_extension.h
@@ -91,7 +91,7 @@ public:
 	GDVIRTUAL2R(Transform3D, _get_transform_for_view, uint32_t, const Transform3D &);
 	GDVIRTUAL4R(PackedFloat64Array, _get_projection_for_view, uint32_t, real_t, real_t, real_t);
 
-	void add_blit(RID p_render_target, Rect2i p_rect, bool p_use_layer = false, uint32_t p_layer = 0, bool p_apply_lens_distortion = false, Vector2 p_eye_center = Vector2(), float p_k1 = 0.0, float p_k2 = 0.0, float p_upscale = 1.0, float p_aspect_ratio = 1.0);
+	void add_blit(RID p_render_target, Rect2 p_src_rect, Rect2i p_dst_rect, bool p_use_layer = false, uint32_t p_layer = 0, bool p_apply_lens_distortion = false, Vector2 p_eye_center = Vector2(), float p_k1 = 0.0, float p_k2 = 0.0, float p_upscale = 1.0, float p_aspect_ratio = 1.0);
 	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) override;
 	GDVIRTUAL2(_commit_views, RID, const Rect2 &);
 


### PR DESCRIPTION
When rendering for VR we often render at high resolution, high FOV and at a different aspect ratio than the monitor. When we want to output the render result to screen as well as a spectator view we often don't want to show the whole image.
For this we need to tell the blit function to only use a part of the source buffer, this PR adds that capability.
