### PR TITLE
Fix add_sibling crash

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1087,6 +1087,7 @@ void Node::add_child(Node *p_child, bool p_legible_unique_name) {
 
 void Node::add_sibling(Node *p_sibling, bool p_legible_unique_name) {
 	ERR_FAIL_NULL(p_sibling);
+	ERR_FAIL_NULL_MSG(get_parent(), "The target node has no parent, and therefore cannot have a sibling node added.");
 	ERR_FAIL_COND_MSG(p_sibling == this, vformat("Can't add sibling '%s' to itself.", p_sibling->get_name())); // adding to itself!
 	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy setting up children, add_sibling() failed. Consider using call_deferred(\"add_sibling\", sibling) instead.");
 


### PR DESCRIPTION
This prevents a crash when trying to add a sibling to a node without a parent.

Closes https://github.com/godotengine/godot/issues/52146

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
