### PR TITLE
Update usability of the CustomPropertyEditor

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -1671,7 +1671,7 @@ void CustomPropertyEditor::_focus_exit() {
 }
 
 void CustomPropertyEditor::config_action_buttons(const List<String> &p_strings) {
-	Ref<StyleBox> sb = action_buttons[0]->get_theme_stylebox(SNAME("panel"));
+	Ref<StyleBox> sb = action_buttons[0]->get_theme_stylebox(SNAME("button"));
 	int margin_top = sb->get_margin(SIDE_TOP);
 	int margin_left = sb->get_margin(SIDE_LEFT);
 	int margin_bottom = sb->get_margin(SIDE_BOTTOM);
@@ -1804,26 +1804,18 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	}
 
 	text_edit = memnew(TextEdit);
-	add_child(text_edit);
+	value_vbox->add_child(text_edit);
 	text_edit->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
+	text_edit->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	text_edit->set_offset(SIDE_BOTTOM, -30);
 
 	text_edit->hide();
 	text_edit->connect("text_changed", callable_mp(this, &CustomPropertyEditor::_text_edit_changed));
 
-	for (int i = 0; i < MAX_ACTION_BUTTONS; i++) {
-		action_buttons[i] = memnew(Button);
-		action_buttons[i]->hide();
-		add_child(action_buttons[i]);
-		Vector<Variant> binds;
-		binds.push_back(i);
-		action_buttons[i]->connect("pressed", callable_mp(this, &CustomPropertyEditor::_action_pressed), binds);
-	}
-
 	color_picker = nullptr;
 
 	file = memnew(EditorFileDialog);
-	add_child(file);
+	value_vbox->add_child(file);
 	file->hide();
 
 	file->connect("file_selected", callable_mp(this, &CustomPropertyEditor::_file_selected));
@@ -1831,45 +1823,57 @@ CustomPropertyEditor::CustomPropertyEditor() {
 
 	error = memnew(ConfirmationDialog);
 	error->set_title(TTR("Error!"));
-	add_child(error);
+	value_vbox->add_child(error);
 
 	scene_tree = memnew(SceneTreeDialog);
-	add_child(scene_tree);
+	value_vbox->add_child(scene_tree);
 	scene_tree->connect("selected", callable_mp(this, &CustomPropertyEditor::_node_path_selected));
 	scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
 
 	texture_preview = memnew(TextureRect);
-	add_child(texture_preview);
+	value_vbox->add_child(texture_preview);
 	texture_preview->hide();
 
 	easing_draw = memnew(Control);
-	add_child(easing_draw);
+	value_vbox->add_child(easing_draw);
 	easing_draw->hide();
 	easing_draw->connect("draw", callable_mp(this, &CustomPropertyEditor::_draw_easing));
 	easing_draw->connect("gui_input", callable_mp(this, &CustomPropertyEditor::_drag_easing));
 	easing_draw->set_default_cursor_shape(Control::CURSOR_MOVE);
 
 	type_button = memnew(MenuButton);
-	add_child(type_button);
+	value_vbox->add_child(type_button);
 	type_button->hide();
 	type_button->get_popup()->connect("id_pressed", callable_mp(this, &CustomPropertyEditor::_type_create_selected));
 
 	menu = memnew(PopupMenu);
 	//	menu->set_pass_on_modal_close_click(false);
-	add_child(menu);
+	value_vbox->add_child(menu);
 	menu->connect("id_pressed", callable_mp(this, &CustomPropertyEditor::_menu_option));
 
 	evaluator = nullptr;
 
 	spinbox = memnew(SpinBox);
-	add_child(spinbox);
+	value_vbox->add_child(spinbox);
 	spinbox->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
 	spinbox->connect("value_changed", callable_mp(this, &CustomPropertyEditor::_range_modified));
 
 	slider = memnew(HSlider);
-	add_child(slider);
+	value_vbox->add_child(slider);
 	slider->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
 	slider->connect("value_changed", callable_mp(this, &CustomPropertyEditor::_range_modified));
+
+	action_hboxes = memnew(HBoxContainer);
+	action_hboxes->set_alignment(BoxContainer::ALIGN_CENTER);
+	value_vbox->add_child(action_hboxes);
+	for (int i = 0; i < MAX_ACTION_BUTTONS; i++) {
+		action_buttons[i] = memnew(Button);
+		action_buttons[i]->hide();
+		action_hboxes->add_child(action_buttons[i]);
+		Vector<Variant> binds;
+		binds.push_back(i);
+		action_buttons[i]->connect("pressed", callable_mp(this, &CustomPropertyEditor::_action_pressed), binds);
+	}
 
 	create_dialog = nullptr;
 	property_select = nullptr;

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -110,6 +110,7 @@ class CustomPropertyEditor : public PopupPanel {
 	int focused_value_editor;
 	Label *value_label[MAX_VALUE_EDITORS];
 	HScrollBar *scroll[4];
+	HBoxContainer *action_hboxes;
 	Button *action_buttons[MAX_ACTION_BUTTONS];
 	MenuButton *type_button;
 	Vector<String> inheritors_array;


### PR DESCRIPTION
Structure button layout so there is no more overlap.

They were all added to self instead of containers making the CustomProperty editor unusable in the master branch.

https://user-images.githubusercontent.com/20573784/125508184-79167207-6b78-4f66-acf0-269120f27f2f.png
[mrp_property_input.zip](https://github.com/godotengine/godot/files/7072581/mrp_property_input.zip)

A separate PR will be made to fix the object selector.

PS: My thanks to @NoFr1ends  for showing the way
Fix: #49441