### PR TITLE
Fix VisualScriptPropertySet value hint

### DIFF
--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -1010,7 +1010,7 @@ PropertyInfo VisualScriptPropertySet::get_input_value_port_info(int p_idx) const
 			if (index != StringName()) {
 				detail_prop_name += "." + String(index);
 			}
-			PropertyInfo pinfo = PropertyInfo(E.type, detail_prop_name, PROPERTY_HINT_TYPE_STRING, E.hint_string);
+			PropertyInfo pinfo = PropertyInfo(E.type, detail_prop_name, E.hint, E.hint_string);
 			_adjust_input_index(pinfo);
 			return pinfo;
 		}


### PR DESCRIPTION
master of #52219
Fix #49231
Fix #48127

If the buttons are overlapping the editable fields #52218 is not jet merged.
[mrp_property_input.zip](https://github.com/godotengine/godot/files/7072623/mrp_property_input.zip)

