### PR TITLE
[Editor] Editor debugger binds according to editor settings, add "--debug-server <uri>" option.

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -182,16 +182,16 @@ ScriptEditorDebugger *EditorDebuggerNode::get_default_debugger() const {
 	return Object::cast_to<ScriptEditorDebugger>(tabs->get_tab_control(0));
 }
 
-Error EditorDebuggerNode::start(const String &p_protocol) {
+Error EditorDebuggerNode::start(const String &p_uri) {
 	stop();
+	ERR_FAIL_COND_V(p_uri.find("://") < 0, ERR_INVALID_PARAMETER);
 	if (EDITOR_GET("run/output/always_open_output_on_play")) {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
 	} else {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(this);
 	}
-
-	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create(p_protocol));
-	const Error err = server->start();
+	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create(p_uri.substr(0, p_uri.find("://") + 3)));
+	const Error err = server->start(p_uri);
 	if (err != OK) {
 		return err;
 	}

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -188,7 +188,7 @@ public:
 	void set_camera_override(CameraOverride p_override);
 	CameraOverride get_camera_override();
 
-	Error start(const String &p_protocol = "tcp://");
+	Error start(const String &p_uri = "tcp://");
 
 	void stop();
 

--- a/editor/debugger/editor_debugger_server.h
+++ b/editor/debugger/editor_debugger_server.h
@@ -48,7 +48,7 @@ public:
 	static void register_protocol_handler(const String &p_protocol, CreateServerFunc p_func);
 	static EditorDebuggerServer *create(const String &p_protocol);
 	virtual void poll() = 0;
-	virtual Error start() = 0;
+	virtual Error start(const String &p_uri = "") = 0;
 	virtual void stop() = 0;
 	virtual bool is_active() const = 0;
 	virtual bool is_connection_available() const = 0;

--- a/modules/websocket/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor_debugger_server_websocket.cpp
@@ -48,11 +48,19 @@ void EditorDebuggerServerWebSocket::poll() {
 	server->poll();
 }
 
-Error EditorDebuggerServerWebSocket::start() {
-	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
+Error EditorDebuggerServerWebSocket::start(const String &p_uri) {
+	int bind_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
+	String bind_host = EditorSettings::get_singleton()->get("network/debug/remote_host");
+	if (!p_uri.is_empty() && p_uri != "ws://") {
+		String scheme, path;
+		Error err = p_uri.parse_url(scheme, bind_host, bind_port, path);
+		ERR_FAIL_COND_V(err != OK, ERR_INVALID_PARAMETER);
+		ERR_FAIL_COND_V(!bind_host.is_valid_ip_address() && bind_host != "*", ERR_INVALID_PARAMETER);
+	}
+	server->set_bind_ip(bind_host);
 	Vector<String> compatible_protocols;
 	compatible_protocols.push_back("binary"); // compatibility with EMSCRIPTEN TCP-to-WebSocket layer.
-	return server->listen(remote_port, compatible_protocols);
+	return server->listen(bind_port, compatible_protocols);
 }
 
 void EditorDebuggerServerWebSocket::stop() {

--- a/modules/websocket/editor_debugger_server_websocket.h
+++ b/modules/websocket/editor_debugger_server_websocket.h
@@ -48,7 +48,7 @@ public:
 	void _peer_disconnected(int p_peer, bool p_was_clean);
 
 	void poll() override;
-	Error start() override;
+	Error start(const String &p_uri) override;
 	void stop() override;
 	bool is_active() const override;
 	bool is_connection_available() const override;


### PR DESCRIPTION
In this PR:

- Editor debugger now binds to `127.0.0.1` by default (`network/debug/remote_host` editor settings).
- Add an option to start the debug server automatically from CLI (`--debug-server <uri>`).

I'll make a separate PR for `3.x`.
Would also like to add a UI to start/stop the debug server from the editor in a separate PR.