### PR TITLE
Improve Basis::get_quaternion error message

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -763,7 +763,7 @@ Basis::operator String() const {
 
 Quaternion Basis::get_quaternion() const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V_MSG(!is_rotation(), Quaternion(), "Basis must be normalized in order to be casted to a Quaternion. Use get_rotation_quaternion() or call orthonormalized() instead.");
+	ERR_FAIL_COND_V_MSG(!is_rotation(), Quaternion(), "Basis must be normalized in order to be casted to a Quaternion. Use get_rotation_quaternion() or call orthonormalized() if the Basis contains linearly independent vectors.");
 #endif
 	/* Allow getting a quaternion from an unnormalized transform */
 	Basis m = *this;


### PR DESCRIPTION
The previous error message incorrectly suggested that any Basis could be fixed by calling get_rotation_quation() or orthonormalize(). This PR points out that only a valid rotation Basis can be fixed in this way.

Fixes #49892

## Notes
* Based on suggestion from @kleonc I've changed to mention linearly independent vectors. This seemed the most easy to understand explanation, and implicitly suggests that the vectors are non-zero, which seems to be the most common problem causing this error.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
