### PR TITLE
Allow pinning property values + Consistent property defaults

### DIFF
--- a/core/property_utils.cpp
+++ b/core/property_utils.cpp
@@ -1,0 +1,186 @@
+/*************************************************************************/
+/*  property_utils.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "property_utils.h"
+
+#include "core/config/engine.h"
+#include "core/templates/local_vector.h"
+#include "editor/editor_node.h"
+#include "scene/resources/packed_scene.h"
+
+bool PropertyUtils::is_property_value_different(const Variant &p_a, const Variant &p_b) {
+	if (p_a.get_type() == Variant::FLOAT && p_b.get_type() == Variant::FLOAT) {
+		//this must be done because, as some scenes save as text, there might be a tiny difference in floats due to numerical error
+		return !Math::is_equal_approx((float)p_a, (float)p_b);
+	} else {
+		return p_a != p_b;
+	}
+}
+
+Variant PropertyUtils::get_property_default_value(const Object *p_object, const StringName &p_property, const Node *p_owner, const Vector<SceneState::PackState> *p_states_stack_cache, bool *r_is_class_default) {
+	// This function obeys the way property values are set when an object is instantiated,
+	// which is the following (the latter wins):
+	// 1. Default value from builtin class
+	// 2. Default value from script exported variable (from the topmost script)
+	// 3. Value overrides from the instantiation/inheritance stack
+
+	if (r_is_class_default) {
+		*r_is_class_default = false;
+	}
+
+	Ref<Script> topmost_script;
+
+	if (const Node *node = Object::cast_to<Node>(p_object)) {
+		// Check inheritance/instantiation ancestors
+
+		const Node *owner = p_owner;
+#ifdef TOOLS_ENABLED
+		if (!p_owner && Engine::get_singleton()->is_editor_hint()) {
+			owner = EditorNode::get_singleton()->get_edited_scene();
+		}
+#endif
+		ERR_FAIL_COND_V(!owner, Variant());
+
+		const Vector<SceneState::PackState> &states_stack = p_states_stack_cache ? *p_states_stack_cache : PropertyUtils::get_node_states_stack(node, owner);
+		for (int i = 0; i < states_stack.size(); ++i) {
+			const SceneState::PackState &ia = states_stack[i];
+			bool found = false;
+			Variant value_in_ancestor = ia.state->get_property_value(ia.node, p_property, found);
+			if (found) {
+				return value_in_ancestor;
+			}
+			// Save script for later
+			bool has_script = false;
+			Variant script = ia.state->get_property_value(ia.node, "script", has_script);
+			if (has_script) {
+				Ref<Script> scr = script;
+				if (scr.is_valid()) {
+					topmost_script = scr;
+				}
+			}
+		}
+	}
+
+	// Let's see what default is set by the topmost script having a default, if any
+	if (topmost_script.is_null()) {
+		topmost_script = p_object->get_script();
+	}
+	if (topmost_script.is_valid()) {
+		Variant default_value;
+		if (topmost_script->get_property_default_value(p_property, default_value)) {
+			return default_value;
+		}
+	}
+
+	// Fall back to the default from the native class
+	if (r_is_class_default) {
+		*r_is_class_default = true;
+	}
+	return ClassDB::class_get_default_property_value(p_object->get_class_name(), p_property);
+}
+
+// Like SceneState::PackState, but using a raw pointer to avoid the cost of
+// updating the reference count during the internal work of the functions below
+namespace {
+struct _FastPackState {
+	SceneState *state = nullptr;
+	int node = -1;
+};
+} // namespace
+
+static bool _collect_inheritance_chain(const Ref<SceneState> &p_state, const NodePath &p_path, LocalVector<_FastPackState> &r_states_stack) {
+	bool found = false;
+
+	LocalVector<_FastPackState> inheritance_states;
+
+	Ref<SceneState> state = p_state;
+	while (state.is_valid()) {
+		int node = state->find_node_by_path(p_path);
+		if (node >= 0) {
+			// This one has state for this node
+			inheritance_states.push_back({ state.ptr(), node });
+			found = true;
+		}
+		state = state->get_base_scene_state();
+	}
+
+	for (int i = inheritance_states.size() - 1; i >= 0; --i) {
+		r_states_stack.push_back(inheritance_states[i]);
+	}
+
+	return found;
+}
+
+Vector<SceneState::PackState> PropertyUtils::get_node_states_stack(const Node *p_node, const Node *p_owner, bool *r_instantiated_by_owner) {
+	if (r_instantiated_by_owner) {
+		*r_instantiated_by_owner = true;
+	}
+
+	LocalVector<_FastPackState> states_stack;
+	{
+		const Node *owner = p_owner;
+#ifdef TOOLS_ENABLED
+		if (!p_owner && Engine::get_singleton()->is_editor_hint()) {
+			owner = EditorNode::get_singleton()->get_edited_scene();
+		}
+#endif
+
+		const Node *n = p_node;
+		while (n) {
+			if (n == owner) {
+				const Ref<SceneState> &state = n->get_scene_inherited_state();
+				if (_collect_inheritance_chain(state, n->get_path_to(p_node), states_stack)) {
+					if (r_instantiated_by_owner) {
+						*r_instantiated_by_owner = false;
+					}
+				}
+				break;
+			} else if (n->get_filename() != String()) {
+				const Ref<SceneState> &state = n->get_scene_instance_state();
+				_collect_inheritance_chain(state, n->get_path_to(p_node), states_stack);
+			}
+			n = n->get_owner();
+		}
+	}
+
+	// Convert to the proper type for returning, inverting the vector on the go
+	// (it was more convenient to fill the vector in reverse order)
+	Vector<SceneState::PackState> states_stack_ret;
+	{
+		states_stack_ret.resize(states_stack.size());
+		_FastPackState *ps = states_stack.ptr();
+		for (int i = states_stack.size() - 1; i >= 0; --i) {
+			states_stack_ret.write[i].state.reference_ptr(ps->state);
+			states_stack_ret.write[i].node = ps->node;
+			++ps;
+		}
+	}
+	return states_stack_ret;
+}

--- a/core/property_utils.h
+++ b/core/property_utils.h
@@ -1,0 +1,51 @@
+/*************************************************************************/
+/*  property_utils.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PROPERTY_UTILS_H
+#define PROPERTY_UTILS_H
+
+#include "scene/main/node.h"
+#include "scene/resources/packed_scene.h"
+
+class PropertyUtils {
+public:
+	static bool is_property_value_different(const Variant &p_a, const Variant &p_b);
+	// Gets the most pure default value, the one that would be set when the node has just been instantiated
+	static Variant get_property_default_value(const Object *p_object, const StringName &p_property, const Node *p_owner = nullptr, const Vector<SceneState::PackState> *p_states_stack_cache = nullptr, bool *r_is_class_default = nullptr);
+
+	// Gets the instance/inheritance states of this node, in order of precedence,
+	// that is, from the topmost (the most able to override values) to the lowermost
+	// (Note that in nested instancing the one with the greatest precedence is the furthest
+	// in the tree, since every owner found while traversing towards the root gets a chance
+	// to override property values.)
+	static Vector<SceneState::PackState> get_node_states_stack(const Node *p_node, const Node *p_owner, bool *r_instantiated_by_owner = nullptr);
+};
+
+#endif // PROPERTY_UTILS_H

--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -110,7 +110,7 @@
 		</signal>
 		<signal name="property_checked">
 			<argument index="0" name="property" type="StringName" />
-			<argument index="1" name="bool" type="String" />
+			<argument index="1" name="checked" type="bool" />
 			<description>
 				Emitted when a property was checked. Used internally.
 			</description>
@@ -132,6 +132,13 @@
 			<argument index="1" name="value" type="Variant" />
 			<description>
 				Emit it if you want to key a property with a single value.
+			</description>
+		</signal>
+		<signal name="property_pin_changed">
+			<argument index="0" name="property" type="StringName" />
+			<argument index="1" name="pinned" type="bool" />
+			<description>
+				Emit it if you want to change the pinned state of a property.
 			</description>
 		</signal>
 		<signal name="resource_selected">

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -104,7 +104,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" default="{&quot;conn_count&quot;: 0,&quot;conns&quot;: PackedInt32Array(),&quot;editable_instances&quot;: [],&quot;names&quot;: PackedStringArray(),&quot;node_count&quot;: 0,&quot;node_paths&quot;: [],&quot;nodes&quot;: PackedInt32Array(),&quot;variants&quot;: [],&quot;version&quot;: 2}">
+		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" default="{&quot;conn_count&quot;: 0,&quot;conns&quot;: PackedInt32Array(),&quot;editable_instances&quot;: [],&quot;names&quot;: PackedStringArray(),&quot;node_count&quot;: 0,&quot;node_paths&quot;: [],&quot;nodes&quot;: PackedInt32Array(),&quot;variants&quot;: [],&quot;version&quot;: 3}">
 			A dictionary representation of the scene contents.
 			Available keys include "rnames" and "variants" for resources, "node_count", "nodes", "node_paths" for nodes, "editable_instances" for base scene children overrides, "conn_count" and "conns" for signal connections, and "version" for the format style of the PackedScene.
 		</member>
@@ -119,6 +119,10 @@
 		</constant>
 		<constant name="GEN_EDIT_STATE_MAIN" value="2" enum="GenEditState">
 			If passed to [method instantiate], provides local scene resources to the local scene. Only the main scene should receive the main edit state.
+			[b]Note:[/b] Only available in editor builds.
+		</constant>
+		<constant name="GEN_EDIT_STATE_MAIN_INHERITED" value="3" enum="GenEditState">
+			It's similar to [code]GEN_EDIT_STATE_MAIN[/code], but for the case where the scene is being instantiated to be the base of another one.
 			[b]Note:[/b] Only available in editor builds.
 		</constant>
 	</constants>

--- a/doc/classes/SceneState.xml
+++ b/doc/classes/SceneState.xml
@@ -168,5 +168,9 @@
 			If passed to [method PackedScene.instantiate], provides local scene resources to the local scene. Only the main scene should receive the main edit state.
 			[b]Note:[/b] Only available in editor builds.
 		</constant>
+		<constant name="GEN_EDIT_STATE_MAIN_INHERITED" value="3" enum="GenEditState">
+			If passed to [method PackedScene.instantiate], it's similar to [code]GEN_EDIT_STATE_MAIN[/code], but for the case where the scene is being instantiated to be the base of another one.
+			[b]Note:[/b] Only available in editor builds.
+		</constant>
 	</constants>
 </class>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -32,6 +32,7 @@
 
 #include "array_property_edit.h"
 #include "core/os/keyboard.h"
+#include "core/property_utils.h"
 #include "dictionary_property_edit.h"
 #include "editor/doc_tools.h"
 #include "editor_feature_profile.h"
@@ -396,177 +397,12 @@ bool EditorProperty::is_read_only() const {
 	return read_only;
 }
 
-bool EditorPropertyRevert::may_node_be_in_instance(Node *p_node) {
-	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
-
-	bool might_be = false;
-	Node *node = p_node;
-
-	while (node) {
-		if (node == edited_scene) {
-			if (node->get_scene_inherited_state().is_valid()) {
-				might_be = true;
-				break;
-			}
-			might_be = false;
-			break;
-		}
-		if (node->get_scene_instance_state().is_valid()) {
-			might_be = true;
-			break;
-		}
-		node = node->get_owner();
-	}
-
-	return might_be; // or might not be
-}
-
-bool EditorPropertyRevert::get_instantiated_node_original_property(Node *p_node, const StringName &p_prop, Variant &value, bool p_check_class_default) {
-	Node *node = p_node;
-	Node *orig = node;
-
-	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
-
-	bool found = false;
-
-	while (node) {
-		Ref<SceneState> ss;
-
-		if (node == edited_scene) {
-			ss = node->get_scene_inherited_state();
-
-		} else {
-			ss = node->get_scene_instance_state();
-		}
-
-		if (ss.is_valid()) {
-			NodePath np = node->get_path_to(orig);
-			int node_idx = ss->find_node_by_path(np);
-			if (node_idx >= 0) {
-				bool lfound = false;
-				Variant lvar;
-				lvar = ss->get_property_value(node_idx, p_prop, lfound);
-				if (lfound) {
-					found = true;
-					value = lvar;
-				}
-			}
-		}
-		if (node == edited_scene) {
-			//just in case
-			break;
-		}
-		node = node->get_owner();
-	}
-
-	if (p_check_class_default && !found && p_node) {
-		//if not found, try default class value
-		Variant attempt = ClassDB::class_get_default_property_value(p_node->get_class_name(), p_prop);
-		if (attempt.get_type() != Variant::NIL) {
-			found = true;
-			value = attempt;
-		}
-	}
-
-	return found;
-}
-
-bool EditorPropertyRevert::is_node_property_different(Node *p_node, const Variant &p_current, const Variant &p_orig) {
-	// this is a pretty difficult function, because a property may not be saved but may have
-	// the flag to not save if one or if zero
-
-	//make sure there is an actual state
-	{
-		Node *node = p_node;
-		if (!node) {
-			return false;
-		}
-
-		Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
-		bool found_state = false;
-
-		while (node) {
-			Ref<SceneState> ss;
-
-			if (node == edited_scene) {
-				ss = node->get_scene_inherited_state();
-
-			} else {
-				ss = node->get_scene_instance_state();
-			}
-
-			if (ss.is_valid()) {
-				found_state = true;
-				break;
-			}
-			if (node == edited_scene) {
-				//just in case
-				break;
-			}
-			node = node->get_owner();
-		}
-
-		if (!found_state) {
-			return false; //pointless to check if we are not comparing against anything.
-		}
-	}
-
-	return is_property_value_different(p_current, p_orig);
-}
-
-bool EditorPropertyRevert::is_property_value_different(const Variant &p_a, const Variant &p_b) {
-	if (p_a.get_type() == Variant::FLOAT && p_b.get_type() == Variant::FLOAT) {
-		//this must be done because, as some scenes save as text, there might be a tiny difference in floats due to numerical error
-		return !Math::is_equal_approx((float)p_a, (float)p_b);
-	} else {
-		return p_a != p_b;
-	}
-}
-
 Variant EditorPropertyRevert::get_property_revert_value(Object *p_object, const StringName &p_property) {
-	// If the object implements property_can_revert, rely on that completely
-	// (i.e. don't then try to revert to default value - the property_get_revert implementation
-	// can do that if so desired)
 	if (p_object->has_method("property_can_revert") && p_object->call("property_can_revert", p_property)) {
 		return p_object->call("property_get_revert", p_property);
 	}
 
-	Ref<Script> scr = p_object->get_script();
-	Node *node = Object::cast_to<Node>(p_object);
-	if (node && EditorPropertyRevert::may_node_be_in_instance(node)) {
-		//if this node is an instance or inherits, but it has a script attached which is unrelated
-		//to the one set for the parent and also has a default value for the property, consider that
-		//has precedence over the value from the parent, because that is an explicit source of defaults
-		//closer in the tree to the current node
-		bool ignore_parent = false;
-		if (scr.is_valid()) {
-			Variant sorig;
-			if (EditorPropertyRevert::get_instantiated_node_original_property(node, "script", sorig) && !scr->inherits_script(sorig)) {
-				Variant dummy;
-				if (scr->get_property_default_value(p_property, dummy)) {
-					ignore_parent = true;
-				}
-			}
-		}
-
-		if (!ignore_parent) {
-			//check for difference including instantiation
-			Variant vorig;
-			if (EditorPropertyRevert::get_instantiated_node_original_property(node, p_property, vorig, false)) {
-				return vorig;
-			}
-		}
-	}
-
-	if (scr.is_valid()) {
-		Variant orig_value;
-		if (scr->get_property_default_value(p_property, orig_value)) {
-			return orig_value;
-		}
-	}
-
-	//report default class value instead
-	return ClassDB::class_get_default_property_value(p_object->get_class_name(), p_property);
+	return PropertyUtils::get_property_default_value(p_object, p_property);
 }
 
 bool EditorPropertyRevert::can_property_revert(Object *p_object, const StringName &p_property) {
@@ -575,7 +411,7 @@ bool EditorPropertyRevert::can_property_revert(Object *p_object, const StringNam
 		return false;
 	}
 	Variant current_value = p_object->get(p_property);
-	return EditorPropertyRevert::is_property_value_different(current_value, revert_value);
+	return PropertyUtils::is_property_value_different(current_value, revert_value);
 }
 
 void EditorProperty::update_reload_status() {
@@ -583,10 +419,10 @@ void EditorProperty::update_reload_status() {
 		return; //no property, so nothing to do
 	}
 
-	bool has_reload = EditorPropertyRevert::can_property_revert(object, property);
+	bool new_can_revert = EditorPropertyRevert::can_property_revert(object, property);
 
-	if (has_reload != can_revert) {
-		can_revert = has_reload;
+	if (new_can_revert != can_revert) {
+		can_revert = new_can_revert;
 		update();
 	}
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -43,6 +43,8 @@ class UndoRedo;
 
 class EditorPropertyRevert {
 public:
+	static bool reverting;
+
 	static bool may_node_be_in_instance(Node *p_node);
 	static bool get_instantiated_node_original_property(Node *p_node, const StringName &p_prop, Variant &value, bool p_check_class_default = true);
 	static bool is_node_property_different(Node *p_node, const Variant &p_current, const Variant &p_orig);
@@ -81,8 +83,11 @@ private:
 	Rect2 right_child_rect;
 	Rect2 bottom_child_rect;
 
+	bool hover;
 	Rect2 keying_rect;
 	bool keying_hover = false;
+	Rect2 pin_rect;
+	bool pin_hover = false;
 	Rect2 revert_rect;
 	bool revert_hover = false;
 	Rect2 check_rect;
@@ -91,6 +96,9 @@ private:
 	bool delete_hover = false;
 
 	bool can_revert;
+	bool can_pin;
+	bool pin_hidden;
+	bool pinned;
 
 	bool use_folding;
 	bool draw_top_bg;
@@ -114,6 +122,8 @@ private:
 	Map<StringName, Variant> cache;
 
 	GDVIRTUAL0(_update_property)
+	void _update_pinnability();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -138,7 +148,7 @@ public:
 	StringName get_edited_property();
 
 	virtual void update_property();
-	void update_reload_status();
+	void update_revert_and_pin_status();
 
 	virtual bool use_keying_next() const;
 
@@ -461,8 +471,8 @@ class EditorInspector : public ScrollContainer {
 	void _property_keyed(const String &p_path, bool p_advance);
 	void _property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance);
 	void _property_deleted(const String &p_path);
-
 	void _property_checked(const String &p_path, bool p_checked);
+	void _property_pin_changed(const String &p_path, bool p_pinned);
 
 	void _resource_selected(const String &p_path, RES p_resource);
 	void _property_selected(const String &p_path, int p_focusable);
@@ -498,6 +508,8 @@ public:
 	static void cleanup_plugins();
 
 	static EditorProperty *instantiate_property_editor(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false);
+
+	static int get_property_new_pinned_state(Node *p_node, const String &p_property, const Variant &p_new_value);
 
 	void set_undo_redo(UndoRedo *p_undo_redo);
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -96,8 +96,6 @@ private:
 	bool draw_top_bg;
 
 	void _ensure_popup();
-	bool _is_property_different(const Variant &p_current, const Variant &p_orig);
-	bool _get_instantiated_node_original_property(const StringName &p_prop, Variant &value);
 	void _focusable_focused(int p_index);
 
 	bool selectable;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3581,7 +3581,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		sdata->set_path(lpath, true); //take over path
 	}
 
-	Node *new_scene = sdata->instantiate(PackedScene::GEN_EDIT_STATE_MAIN);
+	Node *new_scene = sdata->instantiate(p_set_inherited ? PackedScene::GEN_EDIT_STATE_MAIN_INHERITED : PackedScene::GEN_EDIT_STATE_MAIN);
 
 	if (!new_scene) {
 		sdata.unref();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -463,6 +463,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Property editor
 	_initial_set("docks/property_editor/auto_refresh_interval", 0.2); //update 5 times per second by default
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "docks/property_editor/subresource_hue_tint", 0.75, "0,1,0.01")
+	_initial_set("docks/property_editor/auto_pin_on_value_override", true);
+	_initial_set("docks/property_editor/auto_unpin_on_value_revert", true);
+	_initial_set("docks/property_editor/show_pin_ui_only_if_override_possible", true);
 
 	/* Text editor */
 

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -31,6 +31,7 @@
 #include "multi_node_edit.h"
 
 #include "core/math/math_fieldwise.h"
+#include "editor/editor_inspector.h"
 #include "editor_node.h"
 
 bool MultiNodeEdit::_set(const StringName &p_name, const Variant &p_value) {
@@ -86,6 +87,13 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 		}
 
 		ur->add_undo_property(n, name, n->get(name));
+
+		int new_pinned_state = EditorInspector::get_property_new_pinned_state(n, p_name, p_value);
+		if (new_pinned_state >= 0) {
+			bool new_pinned = new_pinned_state;
+			ur->add_do_method(n, "_set_property_pinned", name, new_pinned);
+			ur->add_undo_method(n, "_set_property_pinned", name, !new_pinned);
+		}
 	}
 	ur->add_do_method(EditorNode::get_singleton()->get_inspector(), "refresh");
 	ur->add_undo_method(EditorNode::get_singleton()->get_inspector(), "refresh");

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -35,6 +35,7 @@
 #include "core/io/resource_saver.h"
 #include "core/object/message_queue.h"
 #include "core/os/keyboard.h"
+#include "core/property_utils.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_node.h"
@@ -3117,7 +3118,6 @@ void SceneTreeDock::_clear_clipboard() {
 void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap) {
 	List<PropertyInfo> props;
 	p_node->get_property_list(&props);
-	bool is_instantiated = EditorPropertyRevert::may_node_be_in_instance(p_node);
 
 	for (const PropertyInfo &E : props) {
 		if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
@@ -3128,13 +3128,9 @@ void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap)
 		if (v.is_ref()) {
 			RES res = v;
 			if (res.is_valid()) {
-				if (is_instantiated) {
-					Variant orig;
-					if (EditorPropertyRevert::get_instantiated_node_original_property(p_node, E.name, orig)) {
-						if (!EditorPropertyRevert::is_node_property_different(p_node, v, orig)) {
-							continue;
-						}
-					}
+				Variant orig = PropertyUtils::get_property_default_value(p_node, E.name);
+				if (!PropertyUtils::is_property_value_different(v, orig)) {
+					continue;
 				}
 
 				if ((res->get_path() == "" || res->get_path().find("::") > -1) && !r_remap.has(res)) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1901,6 +1901,34 @@ Node *Node::get_deepest_editable_node(Node *p_start_node) const {
 	return node;
 }
 
+void Node::set_property_pinned(const StringName &p_property, bool p_pinned) {
+	StringName ppp = get_property_pin_proxy(p_property);
+	if (p_pinned) {
+		data.pinned_properties.insert(ppp);
+	} else {
+		data.pinned_properties.erase(ppp);
+	}
+}
+
+bool Node::is_property_pinned(const StringName &p_property) const {
+	StringName ppp = get_property_pin_proxy(p_property);
+	return data.pinned_properties.has(ppp);
+}
+
+StringName Node::get_property_pin_proxy(const StringName &p_property) const {
+	return p_property;
+}
+
+void Node::get_pinnable_properties(Set<StringName> &r_pinnable_properties) const {
+	List<PropertyInfo> pi;
+	get_property_list(&pi);
+	for (List<PropertyInfo>::Element *E = pi.front(); E; E = E->next()) {
+		if ((E->get().usage & PROPERTY_USAGE_STORAGE)) {
+			r_pinnable_properties.insert(E->get().name);
+		}
+	}
+}
+
 String Node::to_string() {
 	if (get_script_instance()) {
 		bool valid;
@@ -2695,6 +2723,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("print_tree_pretty"), &Node::print_tree_pretty);
 	ClassDB::bind_method(D_METHOD("set_filename", "filename"), &Node::set_filename);
 	ClassDB::bind_method(D_METHOD("get_filename"), &Node::get_filename);
+	ClassDB::bind_method(D_METHOD("_set_property_pinned", "property", "pinned"), &Node::set_property_pinned);
 	ClassDB::bind_method(D_METHOD("propagate_notification", "what"), &Node::propagate_notification);
 	ClassDB::bind_method(D_METHOD("propagate_call", "method", "args", "parent_first"), &Node::propagate_call, DEFVAL(Array()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_physics_process", "enable"), &Node::set_physics_process);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -150,6 +150,8 @@ private:
 		bool display_folded = false;
 		bool editable_instance = false;
 
+		Set<StringName> pinned_properties;
+
 		mutable NodePath *path_cache = nullptr;
 
 	} data;
@@ -362,6 +364,11 @@ public:
 	void set_editable_instance(Node *p_node, bool p_editable);
 	bool is_editable_instance(const Node *p_node) const;
 	Node *get_deepest_editable_node(Node *p_start_node) const;
+
+	void set_property_pinned(const StringName &p_property, bool p_pinned);
+	bool is_property_pinned(const StringName &p_property) const;
+	virtual StringName get_property_pin_proxy(const StringName &p_property) const;
+	void get_pinnable_properties(Set<StringName> &r_pinnable_properties) const;
 
 	virtual String to_string() override;
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -34,6 +34,8 @@
 #include "core/config/project_settings.h"
 #include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
+#include "core/property_utils.h"
+#include "editor/editor_inspector.h"
 #include "scene/2d/node_2d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/gui/control.h"
@@ -414,61 +416,22 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 	// with the instance states, we can query for identical properties/groups
 	// and only save what has changed
 
-	List<PackState> pack_state_stack;
+	bool instantiated_by_owner = false;
+	Vector<SceneState::PackState> states_stack = PropertyUtils::get_node_states_stack(p_node, p_owner, &instantiated_by_owner);
 
-	bool instantiated_by_owner = true;
-
-	{
-		Node *n = p_node;
-
-		while (n) {
-			if (n == p_owner) {
-				Ref<SceneState> state = n->get_scene_inherited_state();
-				if (state.is_valid()) {
-					int node = state->find_node_by_path(n->get_path_to(p_node));
-					if (node >= 0) {
-						//this one has state for this node, save
-						PackState ps;
-						ps.node = node;
-						ps.state = state;
-						pack_state_stack.push_back(ps);
-						instantiated_by_owner = false;
-					}
-				}
-
-				if (p_node->get_filename() != String() && p_node->get_owner() == p_owner && instantiated_by_owner) {
-					if (p_node->get_scene_instance_load_placeholder()) {
-						//it's a placeholder, use the placeholder path
-						nd.instance = _vm_get_variant(p_node->get_filename(), variant_map);
-						nd.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
-					} else {
-						//must instance ourselves
-						Ref<PackedScene> instance = ResourceLoader::load(p_node->get_filename());
-						if (!instance.is_valid()) {
-							return ERR_CANT_OPEN;
-						}
-
-						nd.instance = _vm_get_variant(instance, variant_map);
-					}
-				}
-				n = nullptr;
-			} else {
-				if (n->get_filename() != String()) {
-					//is an instance
-					Ref<SceneState> state = n->get_scene_instance_state();
-					if (state.is_valid()) {
-						int node = state->find_node_by_path(n->get_path_to(p_node));
-						if (node >= 0) {
-							//this one has state for this node, save
-							PackState ps;
-							ps.node = node;
-							ps.state = state;
-							pack_state_stack.push_back(ps);
-						}
-					}
-				}
-				n = n->get_owner();
+	if (p_node->get_filename() != String() && p_node->get_owner() == p_owner && instantiated_by_owner) {
+		if (p_node->get_scene_instance_load_placeholder()) {
+			//it's a placeholder, use the placeholder path
+			nd.instance = _vm_get_variant(p_node->get_filename(), variant_map);
+			nd.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
+		} else {
+			//must instance ourselves
+			Ref<PackedScene> instance = ResourceLoader::load(p_node->get_filename());
+			if (!instance.is_valid()) {
+				return ERR_CANT_OPEN;
 			}
+
+			nd.instance = _vm_get_variant(instance, variant_map);
 		}
 	}
 
@@ -477,7 +440,6 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 
 	List<PropertyInfo> plist;
 	p_node->get_property_list(&plist);
-	StringName type = p_node->get_class();
 
 	Ref<Script> script = p_node->get_script();
 	if (Engine::get_singleton()->is_editor_hint() && script.is_valid()) {
@@ -491,76 +453,18 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 			continue;
 		}
 
+		// If instance or inheriting, not saving if property requested so, or it's meta
+		if ((states_stack.size() && (E.usage & PROPERTY_USAGE_NO_INSTANCE_STATE)) || E.name == "__meta__") {
+			continue;
+		}
+
 		String name = E.name;
-		Variant value = p_node->get(E.name);
+		Variant value = p_node->get(name);
 
-		bool isdefault = false;
-		Variant default_value = ClassDB::class_get_default_property_value(type, name);
-
-		if (default_value.get_type() != Variant::NIL) {
-			isdefault = bool(Variant::evaluate(Variant::OP_EQUAL, value, default_value));
-		}
-
-		if (!isdefault && script.is_valid() && script->get_property_default_value(name, default_value)) {
-			isdefault = bool(Variant::evaluate(Variant::OP_EQUAL, value, default_value));
-		}
-		// the version above makes more sense, because it does not rely on placeholder or usage flag
-		// in the script, just the default value function.
-		// if (E.usage & PROPERTY_USAGE_SCRIPT_DEFAULT_VALUE) {
-		// 	isdefault = true; //is script default value
-		// }
-
-		if (pack_state_stack.size()) {
-			// we are on part of an instantiated subscene
-			// or part of instantiated scene.
-			// only save what has been changed
-			// only save changed properties in instance
-
-			if ((E.usage & PROPERTY_USAGE_NO_INSTANCE_STATE) || E.name == "__meta__") {
-				//property has requested that no instance state is saved, sorry
-				//also, meta won't be overridden or saved
-				continue;
-			}
-
-			bool exists = false;
-			Variant original;
-
-			for (List<PackState>::Element *F = pack_state_stack.back(); F; F = F->prev()) {
-				//check all levels of pack to see if the property exists somewhere
-				const PackState &ps = F->get();
-
-				original = ps.state->get_property_value(ps.node, E.name, exists);
-				if (exists) {
-					break;
-				}
-			}
-
-			if (exists) {
-				//check if already exists and did not change
-				if (value.get_type() == Variant::FLOAT && original.get_type() == Variant::FLOAT) {
-					//this must be done because, as some scenes save as text, there might be a tiny difference in floats due to numerical error
-					float a = value;
-					float b = original;
-
-					if (Math::is_equal_approx(a, b)) {
-						continue;
-					}
-				} else if (bool(Variant::evaluate(Variant::OP_EQUAL, value, original))) {
-					continue;
-				}
-			}
-
-			if (!exists && isdefault) {
-				//does not exist in original node, but it's the default value
-				//so safe to skip too.
-				continue;
-			}
-
-		} else {
-			if (isdefault) {
-				//it's the default value, no point in saving it
-				continue;
-			}
+		// It needs saving if different from the the default
+		Variant default_value = PropertyUtils::get_property_default_value(p_node, name, p_owner, &states_stack);
+		if (!PropertyUtils::is_property_value_different(value, default_value)) {
+			continue;
 		}
 
 		NodeData::Property prop;
@@ -584,10 +488,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 		*/
 
 		bool skip = false;
-		for (const PackState &F : pack_state_stack) {
+		for (const SceneState::PackState &ia : states_stack) {
 			//check all levels of pack to see if the group was added somewhere
-			const PackState &ps = F;
-			if (ps.state->is_node_in_group(ps.node, gi.name)) {
+			if (ia.state->is_node_in_group(ia.node, gi.name)) {
 				skip = true;
 				break;
 			}
@@ -617,7 +520,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 
 	// Save the right type. If this node was created by an instance
 	// then flag that the node should not be created but reused
-	if (pack_state_stack.is_empty() && !is_editable_instance) {
+	if (states_stack.is_empty() && !is_editable_instance) {
 		//this node is not part of an instancing process, so save the type
 		nd.type = _nm_get_string(p_node->get_class(), name_map);
 	} else {
@@ -634,7 +537,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 
 	bool save_node = nd.properties.size() || nd.groups.size(); // some local properties or groups exist
 	save_node = save_node || p_node == p_owner; // owner is always saved
-	save_node = save_node || (p_node->get_owner() == p_owner && instantiated_by_owner); //part of scene and not instantiated
+	save_node = save_node || (p_node->get_owner() == p_owner && instantiated_by_owner); //part of scene and not instanced
 
 	int idx = nodes.size();
 	int parent_node = NO_PARENT_SAVED;
@@ -931,7 +834,7 @@ void SceneState::clear() {
 	base_scene_idx = -1;
 }
 
-Ref<SceneState> SceneState::_get_base_scene_state() const {
+Ref<SceneState> SceneState::get_base_scene_state() const {
 	if (base_scene_idx >= 0) {
 		Ref<PackedScene> ps = variants[base_scene_idx];
 		if (ps.is_valid()) {
@@ -946,8 +849,8 @@ int SceneState::find_node_by_path(const NodePath &p_node) const {
 	ERR_FAIL_COND_V_MSG(node_path_cache.size() == 0, -1, "This operation requires the node cache to have been built.");
 
 	if (!node_path_cache.has(p_node)) {
-		if (_get_base_scene_state().is_valid()) {
-			int idx = _get_base_scene_state()->find_node_by_path(p_node);
+		if (get_base_scene_state().is_valid()) {
+			int idx = get_base_scene_state()->find_node_by_path(p_node);
 			if (idx != -1) {
 				int rkey = _find_base_scene_node_remap_key(idx);
 				if (rkey == -1) {
@@ -962,11 +865,11 @@ int SceneState::find_node_by_path(const NodePath &p_node) const {
 
 	int nid = node_path_cache[p_node];
 
-	if (_get_base_scene_state().is_valid() && !base_scene_node_remap.has(nid)) {
+	if (get_base_scene_state().is_valid() && !base_scene_node_remap.has(nid)) {
 		//for nodes that _do_ exist in current scene, still try to look for
 		//the node in the instantiated scene, as a property may be missing
 		//from the local one
-		int idx = _get_base_scene_state()->find_node_by_path(p_node);
+		int idx = get_base_scene_state()->find_node_by_path(p_node);
 		if (idx != -1) {
 			base_scene_node_remap[nid] = idx;
 		}
@@ -1006,7 +909,7 @@ Variant SceneState::get_property_value(int p_node, const StringName &p_property,
 	//property not found, try on instance
 
 	if (base_scene_node_remap.has(p_node)) {
-		return _get_base_scene_state()->get_property_value(base_scene_node_remap[p_node], p_property, found);
+		return get_base_scene_state()->get_property_value(base_scene_node_remap[p_node], p_property, found);
 	}
 
 	return Variant();
@@ -1025,7 +928,7 @@ bool SceneState::is_node_in_group(int p_node, const StringName &p_group) const {
 	}
 
 	if (base_scene_node_remap.has(p_node)) {
-		return _get_base_scene_state()->is_node_in_group(base_scene_node_remap[p_node], p_group);
+		return get_base_scene_state()->is_node_in_group(base_scene_node_remap[p_node], p_group);
 	}
 
 	return false;
@@ -1064,7 +967,7 @@ bool SceneState::is_connection(int p_node, const StringName &p_signal, int p_to_
 	}
 
 	if (base_scene_node_remap.has(p_node) && base_scene_node_remap.has(p_to_node)) {
-		return _get_base_scene_state()->is_connection(base_scene_node_remap[p_node], p_signal, base_scene_node_remap[p_to_node], p_to_method);
+		return get_base_scene_state()->is_connection(base_scene_node_remap[p_node], p_signal, base_scene_node_remap[p_to_node], p_to_method);
 	}
 
 	return false;
@@ -1487,7 +1390,7 @@ bool SceneState::has_connection(const NodePath &p_node_from, const StringName &p
 			}
 		}
 
-		ss = ss->_get_base_scene_state();
+		ss = ss->get_base_scene_state();
 	} while (ss.is_valid());
 
 	return false;

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -69,11 +69,6 @@ class SceneState : public RefCounted {
 		Vector<int> groups;
 	};
 
-	struct PackState {
-		Ref<SceneState> state;
-		int node = -1;
-	};
-
 	Vector<NodeData> nodes;
 
 	struct ConnectionData {
@@ -93,8 +88,6 @@ class SceneState : public RefCounted {
 	String path;
 
 	uint64_t last_modified_time = 0;
-
-	_FORCE_INLINE_ Ref<SceneState> _get_base_scene_state() const;
 
 	static bool disable_placeholders;
 
@@ -119,6 +112,11 @@ public:
 		GEN_EDIT_STATE_MAIN,
 	};
 
+	struct PackState {
+		Ref<SceneState> state;
+		int node = -1;
+	};
+
 	static void set_disable_placeholders(bool p_disable);
 
 	int find_node_by_path(const NodePath &p_node) const;
@@ -138,6 +136,8 @@ public:
 
 	bool can_instantiate() const;
 	Node *instantiate(GenEditState p_edit_state) const;
+
+	Ref<SceneState> get_base_scene_state() const;
 
 	//unbuild API
 

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -61,8 +61,13 @@ class SceneState : public RefCounted {
 		int index = 0;
 
 		struct Property {
+			enum Flags {
+				FLAG_PINNED = 1,
+			};
+
 			int name = 0;
 			int value = 0;
+			int flags = 0;
 		};
 
 		Vector<Property> properties;
@@ -110,6 +115,7 @@ public:
 		GEN_EDIT_STATE_DISABLED,
 		GEN_EDIT_STATE_INSTANCE,
 		GEN_EDIT_STATE_MAIN,
+		GEN_EDIT_STATE_MAIN_INHERITED,
 	};
 
 	struct PackState {
@@ -121,6 +127,7 @@ public:
 
 	int find_node_by_path(const NodePath &p_node) const;
 	Variant get_property_value(int p_node, const StringName &p_property, bool &found) const;
+	bool is_property_pinned(int p_node, const StringName &p_property) const;
 	bool is_node_in_group(int p_node, const StringName &p_group) const;
 	bool is_connection(int p_node, const StringName &p_signal, int p_to_node, const StringName &p_to_method) const;
 
@@ -155,6 +162,7 @@ public:
 	int get_node_property_count(int p_idx) const;
 	StringName get_node_property_name(int p_idx, int p_prop) const;
 	Variant get_node_property_value(int p_idx, int p_prop) const;
+	bool is_node_property_pinned(int p_idx, int p_prop) const;
 
 	int get_connection_count() const;
 	NodePath get_connection_source(int p_idx) const;
@@ -174,7 +182,7 @@ public:
 	int add_value(const Variant &p_value);
 	int add_node_path(const NodePath &p_path);
 	int add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index);
-	void add_node_property(int p_node, int p_name, int p_value);
+	void add_node_property(int p_node, int p_name, int p_value, bool p_pinned);
 	void add_node_group(int p_node, int p_group);
 	void set_base_scene(int p_idx);
 	void add_connection(int p_from, int p_to, int p_signal, int p_method, int p_flags, const Vector<int> &p_binds);
@@ -207,6 +215,7 @@ public:
 		GEN_EDIT_STATE_DISABLED,
 		GEN_EDIT_STATE_INSTANCE,
 		GEN_EDIT_STATE_MAIN,
+		GEN_EDIT_STATE_MAIN_INHERITED,
 	};
 
 	Error pack(Node *p_scene);


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/2280.

# Consistent property defaults

The first commit in this PR unifies what is considered to be the default value of a property, following the same precedence that the engine uses when instantiating an object. See the comments in the code for details. That means that **Godot now has a single, universal idea of what is the default value of a property**.

This (which is a follow up of #46270 + #51173) is important for the pinning (and, specifically, auto-pinning) to work reliably.

This first commit also does a lot of cleanup and refactor on the go, to remove duplicate code and make for that single source of truth goal in various aspects.

# Allow pinning property values

![Peek 2021-09-14 14-46](https://user-images.githubusercontent.com/11797174/133260178-863e2db7-7d28-42d8-9d43-4243a374a39e.gif)

The second commit is where the actual pinning magic happens. It implements the main idea described in the proposal, but taking some inspiration on one of the approaches suggested there, so the best of both worlds is present.

A key concept here is **potential overriding**. A property value is potentially overriding if the node has ancestors in the instance/inheritance chain, or if it has a script exporting that property. The latter means that **this PR extends the pinnability mechanics to script export values so they also benefit from it**. (Conversely, this means that the aforementioned cases where, without the protection brought by pinning, could be unexpectedly changed if some ancestor or the script exporting the variable changes are properly handled.)

Some highlights:
- Only properties that are stored can be pinned. Two points derive from that:
  - To avoid confusion, a property that is not pinnable won't show pinning UI and its tooltip will explain why.
  - Any property that is editor-only, so it's not stored, but is proxies to an editor-hidden real property can still be pinned, thanks to the pin proxy API added to `Node` (and used in the cases of nodes that needed that). In this PR for _master_ no cases have been found, since those properties are exposed in a different way, but the system is still there because it may be needed. In the version of this PR for 3.x a number of cases have found and been taken care of.
- Binary scene file format changes so properties can have the new `flags` field, which so far is onlt used for storing whether the value is pinned. **Therefore, the binary scene format compatibility is broken.**
- Text scene file format changes so the pinned flag can be stored, like this: `position = Vector2( 20, 0 ) [pinned]`. **Godot versions prior to this PR will not be able to open scene text files that have pinned values.**
- Some editor settings are introduced:
  - `docks/property_editor/auto_pin_on_value_override` (defaults to `true`): If enabled, when you change a property value in the inspector **in a potential overriding context** the value is automatically pinned.
  - `docks/property_editor/auto_unpin_on_value_revert` (defaults to `true`): If enabled, reverting a value (by clicking on the circular reset arrow icon) also unpins it.
  - `docks/property_editor/show_pin_ui_only_if_override_possible` (defaults to `true`): If enabled, only properties in a potential overriding context display the pinning UI on hovering.
  
  WIth all those enabled by default, the pinning experience is something users won't almost ever have to worry about and the pinning UI only appears where relevant. **That also provides the best experience possible to beginners, which won't see anything related to pinning until they start dealing with exported variables or instancing/inheritance.** More advanced users are free to tweak the settings for finer control if that's what they want.

More images:
![image](https://user-images.githubusercontent.com/11797174/133258655-5bf35bc8-1d5f-4274-8c21-d44e6a99d957.png)
![image](https://user-images.githubusercontent.com/11797174/133259044-cb70c25d-5108-4aed-979d-46f1b9cd6d39.png)

---
Version for 3.x submitted as #52234.