### PR TITLE
[3.x] Allow pinning property values + Consistent property defaults

### DIFF
--- a/core/property_utils.cpp
+++ b/core/property_utils.cpp
@@ -1,0 +1,186 @@
+/*************************************************************************/
+/*  property_utils.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "property_utils.h"
+
+#include "core/engine.h"
+#include "core/local_vector.h"
+#include "editor/editor_node.h"
+#include "scene/resources/packed_scene.h"
+
+bool PropertyUtils::is_property_value_different(const Variant &p_a, const Variant &p_b) {
+	if (p_a.get_type() == Variant::REAL && p_b.get_type() == Variant::REAL) {
+		//this must be done because, as some scenes save as text, there might be a tiny difference in floats due to numerical error
+		return !Math::is_equal_approx((float)p_a, (float)p_b);
+	} else {
+		return p_a != p_b;
+	}
+}
+
+Variant PropertyUtils::get_property_default_value(const Object *p_object, const StringName &p_property, const Node *p_owner, const Vector<SceneState::PackState> *p_states_stack_cache, bool *r_is_class_default) {
+	// This function obeys the way property values are set when an object is instantiated,
+	// which is the following (the latter wins):
+	// 1. Default value from builtin class
+	// 2. Default value from script exported variable (from the topmost script)
+	// 3. Value overrides from the instantiation/inheritance stack
+
+	if (r_is_class_default) {
+		*r_is_class_default = false;
+	}
+
+	Ref<Script> topmost_script;
+
+	if (const Node *node = Object::cast_to<Node>(p_object)) {
+		// Check inheritance/instantiation ancestors
+
+		const Node *owner = p_owner;
+#ifdef TOOLS_ENABLED
+		if (!p_owner && Engine::get_singleton()->is_editor_hint()) {
+			owner = EditorNode::get_singleton()->get_edited_scene();
+		}
+#endif
+		ERR_FAIL_COND_V(!owner, Variant());
+
+		const Vector<SceneState::PackState> &states_stack = p_states_stack_cache ? *p_states_stack_cache : PropertyUtils::get_node_states_stack(node, owner);
+		for (int i = 0; i < states_stack.size(); ++i) {
+			const SceneState::PackState &ia = states_stack[i];
+			bool found = false;
+			Variant value_in_ancestor = ia.state->get_property_value(ia.node, p_property, found);
+			if (found) {
+				return value_in_ancestor;
+			}
+			// Save script for later
+			bool has_script = false;
+			Variant script = ia.state->get_property_value(ia.node, "script", has_script);
+			if (has_script) {
+				Ref<Script> scr = script;
+				if (scr.is_valid()) {
+					topmost_script = scr;
+				}
+			}
+		}
+	}
+
+	// Let's see what default is set by the topmost script having a default, if any
+	if (topmost_script.is_null()) {
+		topmost_script = p_object->get_script();
+	}
+	if (topmost_script.is_valid()) {
+		Variant default_value;
+		if (topmost_script->get_property_default_value(p_property, default_value)) {
+			return default_value;
+		}
+	}
+
+	// Fall back to the default from the native class
+	if (r_is_class_default) {
+		*r_is_class_default = true;
+	}
+	return ClassDB::class_get_default_property_value(p_object->get_class_name(), p_property);
+}
+
+// Like SceneState::PackState, but using a raw pointer to avoid the cost of
+// updating the reference count during the internal work of the functions below
+namespace {
+struct _FastPackState {
+	SceneState *state = nullptr;
+	int node = -1;
+};
+} // namespace
+
+static bool _collect_inheritance_chain(const Ref<SceneState> &p_state, const NodePath &p_path, LocalVector<_FastPackState> &r_states_stack) {
+	bool found = false;
+
+	LocalVector<_FastPackState> inheritance_states;
+
+	Ref<SceneState> state = p_state;
+	while (state.is_valid()) {
+		int node = state->find_node_by_path(p_path);
+		if (node >= 0) {
+			// This one has state for this node
+			inheritance_states.push_back({ state.ptr(), node });
+			found = true;
+		}
+		state = state->get_base_scene_state();
+	}
+
+	for (int i = inheritance_states.size() - 1; i >= 0; --i) {
+		r_states_stack.push_back(inheritance_states[i]);
+	}
+
+	return found;
+}
+
+Vector<SceneState::PackState> PropertyUtils::get_node_states_stack(const Node *p_node, const Node *p_owner, bool *r_instanced_by_owner) {
+	if (r_instanced_by_owner) {
+		*r_instanced_by_owner = true;
+	}
+
+	LocalVector<_FastPackState> states_stack;
+	{
+		const Node *owner = p_owner;
+#ifdef TOOLS_ENABLED
+		if (!p_owner && Engine::get_singleton()->is_editor_hint()) {
+			owner = EditorNode::get_singleton()->get_edited_scene();
+		}
+#endif
+
+		const Node *n = p_node;
+		while (n) {
+			if (n == owner) {
+				const Ref<SceneState> &state = n->get_scene_inherited_state();
+				if (_collect_inheritance_chain(state, n->get_path_to(p_node), states_stack)) {
+					if (r_instanced_by_owner) {
+						*r_instanced_by_owner = false;
+					}
+				}
+				break;
+			} else if (n->get_filename() != String()) {
+				const Ref<SceneState> &state = n->get_scene_instance_state();
+				_collect_inheritance_chain(state, n->get_path_to(p_node), states_stack);
+			}
+			n = n->get_owner();
+		}
+	}
+
+	// Convert to the proper type for returning, inverting the vector on the go
+	// (it was more convenient to fill the vector in reverse order)
+	Vector<SceneState::PackState> states_stack_ret;
+	{
+		states_stack_ret.resize(states_stack.size());
+		_FastPackState *ps = states_stack.ptr();
+		for (int i = states_stack.size() - 1; i >= 0; --i) {
+			states_stack_ret.write[i].state.reference_ptr(ps->state);
+			states_stack_ret.write[i].node = ps->node;
+			++ps;
+		}
+	}
+	return states_stack_ret;
+}

--- a/core/property_utils.h
+++ b/core/property_utils.h
@@ -1,0 +1,51 @@
+/*************************************************************************/
+/*  property_utils.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PROPERTY_UTILS_H
+#define PROPERTY_UTILS_H
+
+#include "scene/main/node.h"
+#include "scene/resources/packed_scene.h"
+
+class PropertyUtils {
+public:
+	static bool is_property_value_different(const Variant &p_a, const Variant &p_b);
+	// Gets the most pure default value, the one that would be set when the node has just been instantiated
+	static Variant get_property_default_value(const Object *p_object, const StringName &p_property, const Node *p_owner = nullptr, const Vector<SceneState::PackState> *p_states_stack_cache = nullptr, bool *r_is_class_default = nullptr);
+
+	// Gets the instance/inheritance states of this node, in order of precedence,
+	// that is, from the topmost (the most able to override values) to the lowermost
+	// (Note that in nested instancing the one with the greatest precedence is the furthest
+	// in the tree, since every owner found while traversing towards the root gets a chance
+	// to override property values.)
+	static Vector<SceneState::PackState> get_node_states_stack(const Node *p_node, const Node *p_owner, bool *r_instanced_by_owner = nullptr);
+};
+
+#endif // PROPERTY_UTILS_H

--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -102,7 +102,7 @@
 		</signal>
 		<signal name="property_checked">
 			<argument index="0" name="property" type="String" />
-			<argument index="1" name="bool" type="String" />
+			<argument index="1" name="checked" type="bool" />
 			<description>
 				Emitted when a property was checked. Used internally.
 			</description>
@@ -118,6 +118,13 @@
 			<argument index="1" name="value" type="Variant" />
 			<description>
 				Emit it if you want to key a property with a single value.
+			</description>
+		</signal>
+		<signal name="property_pin_changed">
+			<argument index="0" name="property" type="String" />
+			<argument index="1" name="pinned" type="bool" />
+			<description>
+				Emit it if you want to change the pinned state of a property.
 			</description>
 		</signal>
 		<signal name="resource_selected">

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -86,5 +86,9 @@
 			If passed to [method instance], provides local scene resources to the local scene. Only the main scene should receive the main edit state.
 			[b]Note:[/b] Only available in editor builds.
 		</constant>
+		<constant name="GEN_EDIT_STATE_MAIN_INHERITED" value="3" enum="GenEditState">
+			It's similar to [code]GEN_EDIT_STATE_MAIN[/code], but for the case where the scene is being instantiated to be the base of another one.
+			[b]Note:[/b] Only available in editor builds.
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/SceneState.xml
+++ b/doc/classes/SceneState.xml
@@ -168,5 +168,9 @@
 			If passed to [method PackedScene.instance], provides local scene resources to the local scene. Only the main scene should receive the main edit state.
 			[b]Note:[/b] Only available in editor builds.
 		</constant>
+		<constant name="GEN_EDIT_STATE_MAIN_INHERITED" value="3" enum="GenEditState">
+			If passed to [method PackedScene.instance], it's similar to [code]GEN_EDIT_STATE_MAIN[/code], but for the case where the scene is being instantiated to be the base of another one.
+			[b]Note:[/b] Only available in editor builds.
+		</constant>
 	</constants>
 </class>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -29,7 +29,9 @@
 /*************************************************************************/
 
 #include "editor_inspector.h"
+
 #include "array_property_edit.h"
+#include "core/property_utils.h"
 #include "dictionary_property_edit.h"
 #include "editor_feature_profile.h"
 #include "editor_node.h"
@@ -318,177 +320,12 @@ bool EditorProperty::is_read_only() const {
 	return read_only;
 }
 
-bool EditorPropertyRevert::may_node_be_in_instance(Node *p_node) {
-	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
-
-	bool might_be = false;
-	Node *node = p_node;
-
-	while (node) {
-		if (node == edited_scene) {
-			if (node->get_scene_inherited_state().is_valid()) {
-				might_be = true;
-				break;
-			}
-			might_be = false;
-			break;
-		}
-		if (node->get_scene_instance_state().is_valid()) {
-			might_be = true;
-			break;
-		}
-		node = node->get_owner();
-	}
-
-	return might_be; // or might not be
-}
-
-bool EditorPropertyRevert::get_instanced_node_original_property(Node *p_node, const StringName &p_prop, Variant &value, bool p_check_class_default) {
-	Node *node = p_node;
-	Node *orig = node;
-
-	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
-
-	bool found = false;
-
-	while (node) {
-		Ref<SceneState> ss;
-
-		if (node == edited_scene) {
-			ss = node->get_scene_inherited_state();
-
-		} else {
-			ss = node->get_scene_instance_state();
-		}
-
-		if (ss.is_valid()) {
-			NodePath np = node->get_path_to(orig);
-			int node_idx = ss->find_node_by_path(np);
-			if (node_idx >= 0) {
-				bool lfound = false;
-				Variant lvar;
-				lvar = ss->get_property_value(node_idx, p_prop, lfound);
-				if (lfound) {
-					found = true;
-					value = lvar;
-				}
-			}
-		}
-		if (node == edited_scene) {
-			//just in case
-			break;
-		}
-		node = node->get_owner();
-	}
-
-	if (p_check_class_default && !found && p_node) {
-		//if not found, try default class value
-		Variant attempt = ClassDB::class_get_default_property_value(p_node->get_class_name(), p_prop);
-		if (attempt.get_type() != Variant::NIL) {
-			found = true;
-			value = attempt;
-		}
-	}
-
-	return found;
-}
-
-bool EditorPropertyRevert::is_node_property_different(Node *p_node, const Variant &p_current, const Variant &p_orig) {
-	// this is a pretty difficult function, because a property may not be saved but may have
-	// the flag to not save if one or if zero
-
-	//make sure there is an actual state
-	{
-		Node *node = p_node;
-		if (!node) {
-			return false;
-		}
-
-		Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
-		bool found_state = false;
-
-		while (node) {
-			Ref<SceneState> ss;
-
-			if (node == edited_scene) {
-				ss = node->get_scene_inherited_state();
-
-			} else {
-				ss = node->get_scene_instance_state();
-			}
-
-			if (ss.is_valid()) {
-				found_state = true;
-				break;
-			}
-			if (node == edited_scene) {
-				//just in case
-				break;
-			}
-			node = node->get_owner();
-		}
-
-		if (!found_state) {
-			return false; //pointless to check if we are not comparing against anything.
-		}
-	}
-
-	return is_property_value_different(p_current, p_orig);
-}
-
-bool EditorPropertyRevert::is_property_value_different(const Variant &p_a, const Variant &p_b) {
-	if (p_a.get_type() == Variant::REAL && p_b.get_type() == Variant::REAL) {
-		//this must be done because, as some scenes save as text, there might be a tiny difference in floats due to numerical error
-		return !Math::is_equal_approx((float)p_a, (float)p_b);
-	} else {
-		return p_a != p_b;
-	}
-}
-
 Variant EditorPropertyRevert::get_property_revert_value(Object *p_object, const StringName &p_property) {
-	// If the object implements property_can_revert, rely on that completely
-	// (i.e. don't then try to revert to default value - the property_get_revert implementation
-	// can do that if so desired)
 	if (p_object->has_method("property_can_revert") && p_object->call("property_can_revert", p_property)) {
 		return p_object->call("property_get_revert", p_property);
 	}
 
-	Ref<Script> scr = p_object->get_script();
-	Node *node = Object::cast_to<Node>(p_object);
-	if (node && EditorPropertyRevert::may_node_be_in_instance(node)) {
-		//if this node is an instance or inherits, but it has a script attached which is unrelated
-		//to the one set for the parent and also has a default value for the property, consider that
-		//has precedence over the value from the parent, because that is an explicit source of defaults
-		//closer in the tree to the current node
-		bool ignore_parent = false;
-		if (scr.is_valid()) {
-			Variant sorig;
-			if (EditorPropertyRevert::get_instanced_node_original_property(node, "script", sorig) && !scr->inherits_script(sorig)) {
-				Variant dummy;
-				if (scr->get_property_default_value(p_property, dummy)) {
-					ignore_parent = true;
-				}
-			}
-		}
-
-		if (!ignore_parent) {
-			//check for difference including instantiation
-			Variant vorig;
-			if (EditorPropertyRevert::get_instanced_node_original_property(node, p_property, vorig, false)) {
-				return vorig;
-			}
-		}
-	}
-
-	if (scr.is_valid()) {
-		Variant orig_value;
-		if (scr->get_property_default_value(p_property, orig_value)) {
-			return orig_value;
-		}
-	}
-
-	//report default class value instead
-	return ClassDB::class_get_default_property_value(p_object->get_class_name(), p_property);
+	return PropertyUtils::get_property_default_value(p_object, p_property);
 }
 
 bool EditorPropertyRevert::can_property_revert(Object *p_object, const StringName &p_property) {
@@ -497,7 +334,7 @@ bool EditorPropertyRevert::can_property_revert(Object *p_object, const StringNam
 		return false;
 	}
 	Variant current_value = p_object->get(p_property);
-	return EditorPropertyRevert::is_property_value_different(current_value, revert_value);
+	return PropertyUtils::is_property_value_different(current_value, revert_value);
 }
 
 void EditorProperty::update_reload_status() {
@@ -505,10 +342,10 @@ void EditorProperty::update_reload_status() {
 		return; //no property, so nothing to do
 	}
 
-	bool has_reload = EditorPropertyRevert::can_property_revert(object, property);
+	bool new_can_revert = EditorPropertyRevert::can_property_revert(object, property);
 
-	if (has_reload != can_revert) {
-		can_revert = has_reload;
+	if (new_can_revert != can_revert) {
+		can_revert = new_can_revert;
 		update();
 	}
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -39,6 +39,8 @@ class UndoRedo;
 
 class EditorPropertyRevert {
 public:
+	static bool reverting;
+
 	static bool may_node_be_in_instance(Node *p_node);
 	static bool get_instanced_node_original_property(Node *p_node, const StringName &p_prop, Variant &value, bool p_check_class_default = true);
 	static bool is_node_property_different(Node *p_node, const Variant &p_current, const Variant &p_orig);
@@ -69,14 +71,20 @@ private:
 	Rect2 right_child_rect;
 	Rect2 bottom_child_rect;
 
+	bool hover;
 	Rect2 keying_rect;
 	bool keying_hover;
+	Rect2 pin_rect;
+	bool pin_hover;
 	Rect2 revert_rect;
 	bool revert_hover;
 	Rect2 check_rect;
 	bool check_hover;
 
 	bool can_revert;
+	bool can_pin;
+	bool pin_hidden;
+	bool is_pinned;
 
 	bool use_folding;
 	bool draw_top_bg;
@@ -94,6 +102,8 @@ private:
 	Control *bottom_editor;
 
 	mutable String tooltip_text;
+
+	void _update_pinnability();
 
 protected:
 	void _notification(int p_what);
@@ -116,7 +126,7 @@ public:
 	StringName get_edited_property();
 
 	virtual void update_property();
-	void update_reload_status();
+	void update_revert_and_pin_status();
 
 	virtual bool use_keying_next() const;
 
@@ -306,8 +316,8 @@ class EditorInspector : public ScrollContainer {
 	void _multiple_properties_changed(Vector<String> p_paths, Array p_values);
 	void _property_keyed(const String &p_path, bool p_advance);
 	void _property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance);
-
 	void _property_checked(const String &p_path, bool p_checked);
+	void _property_pin_changed(const String &p_path, bool p_pinned);
 
 	void _resource_selected(const String &p_path, RES p_resource);
 	void _property_selected(const String &p_path, int p_focusable);
@@ -339,6 +349,8 @@ public:
 	static void cleanup_plugins();
 
 	static EditorProperty *instantiate_property_editor(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage);
+
+	static int get_property_new_pinned_state(Node *p_node, const String &p_property, const Variant &p_new_value);
 
 	void set_undo_redo(UndoRedo *p_undo_redo);
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -81,8 +81,6 @@ private:
 	bool use_folding;
 	bool draw_top_bg;
 
-	bool _is_property_different(const Variant &p_current, const Variant &p_orig);
-	bool _get_instanced_node_original_property(const StringName &p_prop, Variant &value);
 	void _focusable_focused(int p_index);
 
 	bool selectable;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3588,7 +3588,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		sdata->set_path(lpath, true); //take over path
 	}
 
-	Node *new_scene = sdata->instance(PackedScene::GEN_EDIT_STATE_MAIN);
+	Node *new_scene = sdata->instance(p_set_inherited ? PackedScene::GEN_EDIT_STATE_MAIN_INHERITED : PackedScene::GEN_EDIT_STATE_MAIN);
 
 	if (!new_scene) {
 		sdata.unref();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -411,6 +411,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/property_editor/auto_refresh_interval", 0.3);
 	_initial_set("docks/property_editor/subresource_hue_tint", 0.75);
 	hints["docks/property_editor/subresource_hue_tint"] = PropertyInfo(Variant::REAL, "docks/property_editor/subresource_hue_tint", PROPERTY_HINT_RANGE, "0,1,0.01", PROPERTY_USAGE_DEFAULT);
+	_initial_set("docks/property_editor/auto_pin_on_value_override", true);
+	_initial_set("docks/property_editor/auto_unpin_on_value_revert", true);
+	_initial_set("docks/property_editor/show_pin_ui_only_if_override_possible", true);
 
 	/* Text editor */
 

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -31,6 +31,7 @@
 #include "multi_node_edit.h"
 
 #include "core/math/math_fieldwise.h"
+#include "editor/editor_inspector.h"
 #include "editor_node.h"
 
 bool MultiNodeEdit::_set(const StringName &p_name, const Variant &p_value) {
@@ -79,6 +80,13 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 		}
 
 		ur->add_undo_property(n, name, n->get(name));
+
+		int new_pinned_state = EditorInspector::get_property_new_pinned_state(n, p_name, p_value);
+		if (new_pinned_state >= 0) {
+			bool new_pinned = new_pinned_state;
+			ur->add_do_method(n, "_set_property_pinned", name, new_pinned);
+			ur->add_undo_method(n, "_set_property_pinned", name, !new_pinned);
+		}
 	}
 	ur->add_do_method(EditorNode::get_singleton()->get_inspector(), "refresh");
 	ur->add_undo_method(EditorNode::get_singleton()->get_inspector(), "refresh");

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -34,7 +34,7 @@
 #include "core/os/input.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
-
+#include "core/property_utils.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
@@ -3073,7 +3073,6 @@ void SceneTreeDock::_clear_clipboard() {
 void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap) {
 	List<PropertyInfo> props;
 	p_node->get_property_list(&props);
-	bool is_instanced = EditorPropertyRevert::may_node_be_in_instance(p_node);
 
 	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 		if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
@@ -3084,13 +3083,9 @@ void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap)
 		if (v.is_ref()) {
 			RES res = v;
 			if (res.is_valid()) {
-				if (is_instanced) {
-					Variant orig;
-					if (EditorPropertyRevert::get_instanced_node_original_property(p_node, E->get().name, orig)) {
-						if (!EditorPropertyRevert::is_node_property_different(p_node, v, orig)) {
-							continue;
-						}
-					}
+				Variant orig = PropertyUtils::get_property_default_value(p_node, E->get().name);
+				if (!PropertyUtils::is_property_value_different(v, orig)) {
+					continue;
 				}
 
 				if ((res->get_path() == "" || res->get_path().find("::") > -1) && !r_remap.has(res)) {

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -439,6 +439,14 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "z_as_relative"), "set_z_as_relative", "is_z_relative");
 }
 
+StringName Node2D::get_property_pin_proxy(const StringName &p_property) const {
+	if (p_property == "rotation_degrees") {
+		return "rotation";
+	} else {
+		return Node::get_property_pin_proxy(p_property);
+	}
+}
+
 Node2D::Node2D() {
 	angle = 0;
 	_scale = Vector2(1, 1);

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -116,6 +116,8 @@ public:
 
 	Transform2D get_transform() const;
 
+	virtual StringName get_property_pin_proxy(const StringName &p_property) const override;
+
 	Node2D();
 };
 

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -302,6 +302,14 @@ void CanvasLayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "follow_viewport_scale", PROPERTY_HINT_RANGE, "0.001,1000,0.001,or_greater,or_lesser"), "set_follow_viewport_scale", "get_follow_viewport_scale");
 }
 
+StringName CanvasLayer::get_property_pin_proxy(const StringName &p_property) const {
+	if (p_property == "rotation_degrees") {
+		return "rotation";
+	} else {
+		return Node::get_property_pin_proxy(p_property);
+	}
+}
+
 CanvasLayer::CanvasLayer() {
 	vp = nullptr;
 	scale = Vector2(1, 1);

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -102,6 +102,8 @@ public:
 
 	RID get_canvas() const;
 
+	StringName get_property_pin_proxy(const StringName &p_property) const override;
+
 	CanvasLayer();
 	~CanvasLayer();
 };

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1866,6 +1866,34 @@ Node *Node::get_deepest_editable_node(Node *p_start_node) const {
 	return node;
 }
 
+void Node::set_property_pinned(const StringName &p_property, bool p_pinned) {
+	StringName ppp = get_property_pin_proxy(p_property);
+	if (p_pinned) {
+		data.pinned_properties.insert(ppp);
+	} else {
+		data.pinned_properties.erase(ppp);
+	}
+}
+
+bool Node::is_property_pinned(const StringName &p_property) const {
+	StringName ppp = get_property_pin_proxy(p_property);
+	return data.pinned_properties.has(ppp);
+}
+
+StringName Node::get_property_pin_proxy(const StringName &p_property) const {
+	return p_property;
+}
+
+void Node::get_pinnable_properties(Set<StringName> &r_pinnable_properties) const {
+	List<PropertyInfo> pi;
+	get_property_list(&pi);
+	for (List<PropertyInfo>::Element *E = pi.front(); E; E = E->next()) {
+		if ((E->get().usage & PROPERTY_USAGE_STORAGE)) {
+			r_pinnable_properties.insert(E->get().name);
+		}
+	}
+}
+
 String Node::to_string() {
 	if (get_script_instance()) {
 		bool valid;
@@ -2747,6 +2775,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("print_tree_pretty"), &Node::print_tree_pretty);
 	ClassDB::bind_method(D_METHOD("set_filename", "filename"), &Node::set_filename);
 	ClassDB::bind_method(D_METHOD("get_filename"), &Node::get_filename);
+	ClassDB::bind_method(D_METHOD("_set_property_pinned", "property", "pinned"), &Node::set_property_pinned);
 	ClassDB::bind_method(D_METHOD("propagate_notification", "what"), &Node::propagate_notification);
 	ClassDB::bind_method(D_METHOD("propagate_call", "method", "args", "parent_first"), &Node::propagate_call, DEFVAL(Array()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_physics_process", "enable"), &Node::set_physics_process);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -140,6 +140,8 @@ private:
 		bool display_folded;
 		bool editable_instance;
 
+		Set<StringName> pinned_properties;
+
 		mutable NodePath *path_cache;
 
 	} data;
@@ -313,6 +315,11 @@ public:
 	void set_editable_instance(Node *p_node, bool p_editable);
 	bool is_editable_instance(const Node *p_node) const;
 	Node *get_deepest_editable_node(Node *start_node) const;
+
+	void set_property_pinned(const StringName &p_property, bool p_pinned);
+	bool is_property_pinned(const StringName &p_property) const;
+	virtual StringName get_property_pin_proxy(const StringName &p_property) const;
+	void get_pinnable_properties(Set<StringName> &r_pinnable_properties) const;
 
 	virtual String to_string();
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -34,6 +34,8 @@
 #include "core/engine.h"
 #include "core/io/resource_loader.h"
 #include "core/project_settings.h"
+#include "core/property_utils.h"
+#include "editor/editor_inspector.h"
 #include "scene/2d/node_2d.h"
 #include "scene/3d/spatial.h"
 #include "scene/gui/control.h"
@@ -412,61 +414,22 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 	// with the instance states, we can query for identical properties/groups
 	// and only save what has changed
 
-	List<PackState> pack_state_stack;
+	bool instanced_by_owner = false;
+	Vector<SceneState::PackState> states_stack = PropertyUtils::get_node_states_stack(p_node, p_owner, &instanced_by_owner);
 
-	bool instanced_by_owner = true;
-
-	{
-		Node *n = p_node;
-
-		while (n) {
-			if (n == p_owner) {
-				Ref<SceneState> state = n->get_scene_inherited_state();
-				if (state.is_valid()) {
-					int node = state->find_node_by_path(n->get_path_to(p_node));
-					if (node >= 0) {
-						//this one has state for this node, save
-						PackState ps;
-						ps.node = node;
-						ps.state = state;
-						pack_state_stack.push_back(ps);
-						instanced_by_owner = false;
-					}
-				}
-
-				if (p_node->get_filename() != String() && p_node->get_owner() == p_owner && instanced_by_owner) {
-					if (p_node->get_scene_instance_load_placeholder()) {
-						//it's a placeholder, use the placeholder path
-						nd.instance = _vm_get_variant(p_node->get_filename(), variant_map);
-						nd.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
-					} else {
-						//must instance ourselves
-						Ref<PackedScene> instance = ResourceLoader::load(p_node->get_filename());
-						if (!instance.is_valid()) {
-							return ERR_CANT_OPEN;
-						}
-
-						nd.instance = _vm_get_variant(instance, variant_map);
-					}
-				}
-				n = nullptr;
-			} else {
-				if (n->get_filename() != String()) {
-					//is an instance
-					Ref<SceneState> state = n->get_scene_instance_state();
-					if (state.is_valid()) {
-						int node = state->find_node_by_path(n->get_path_to(p_node));
-						if (node >= 0) {
-							//this one has state for this node, save
-							PackState ps;
-							ps.node = node;
-							ps.state = state;
-							pack_state_stack.push_back(ps);
-						}
-					}
-				}
-				n = n->get_owner();
+	if (p_node->get_filename() != String() && p_node->get_owner() == p_owner && instanced_by_owner) {
+		if (p_node->get_scene_instance_load_placeholder()) {
+			//it's a placeholder, use the placeholder path
+			nd.instance = _vm_get_variant(p_node->get_filename(), variant_map);
+			nd.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
+		} else {
+			//must instance ourselves
+			Ref<PackedScene> instance = ResourceLoader::load(p_node->get_filename());
+			if (!instance.is_valid()) {
+				return ERR_CANT_OPEN;
 			}
+
+			nd.instance = _vm_get_variant(instance, variant_map);
 		}
 	}
 
@@ -475,7 +438,6 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 
 	List<PropertyInfo> plist;
 	p_node->get_property_list(&plist);
-	StringName type = p_node->get_class();
 
 	Ref<Script> script = p_node->get_script();
 	if (Engine::get_singleton()->is_editor_hint() && script.is_valid()) {
@@ -489,76 +451,18 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 			continue;
 		}
 
+		// If instance or inheriting, not saving if property requested so, or it's meta
+		if ((states_stack.size() && (E->get().usage & PROPERTY_USAGE_NO_INSTANCE_STATE)) || E->get().name == "__meta__") {
+			continue;
+		}
+
 		String name = E->get().name;
-		Variant value = p_node->get(E->get().name);
+		Variant value = p_node->get(name);
 
-		bool isdefault = false;
-		Variant default_value = ClassDB::class_get_default_property_value(type, name);
-
-		if (default_value.get_type() != Variant::NIL) {
-			isdefault = bool(Variant::evaluate(Variant::OP_EQUAL, value, default_value));
-		}
-
-		if (!isdefault && script.is_valid() && script->get_property_default_value(name, default_value)) {
-			isdefault = bool(Variant::evaluate(Variant::OP_EQUAL, value, default_value));
-		}
-		// the version above makes more sense, because it does not rely on placeholder or usage flag
-		// in the script, just the default value function.
-		// if (E->get().usage & PROPERTY_USAGE_SCRIPT_DEFAULT_VALUE) {
-		// 	isdefault = true; //is script default value
-		// }
-
-		if (pack_state_stack.size()) {
-			// we are on part of an instanced subscene
-			// or part of instanced scene.
-			// only save what has been changed
-			// only save changed properties in instance
-
-			if ((E->get().usage & PROPERTY_USAGE_NO_INSTANCE_STATE) || E->get().name == "__meta__") {
-				//property has requested that no instance state is saved, sorry
-				//also, meta won't be overridden or saved
-				continue;
-			}
-
-			bool exists = false;
-			Variant original;
-
-			for (List<PackState>::Element *F = pack_state_stack.back(); F; F = F->prev()) {
-				//check all levels of pack to see if the property exists somewhere
-				const PackState &ps = F->get();
-
-				original = ps.state->get_property_value(ps.node, E->get().name, exists);
-				if (exists) {
-					break;
-				}
-			}
-
-			if (exists) {
-				//check if already exists and did not change
-				if (value.get_type() == Variant::REAL && original.get_type() == Variant::REAL) {
-					//this must be done because, as some scenes save as text, there might be a tiny difference in floats due to numerical error
-					float a = value;
-					float b = original;
-
-					if (Math::is_equal_approx(a, b)) {
-						continue;
-					}
-				} else if (bool(Variant::evaluate(Variant::OP_EQUAL, value, original))) {
-					continue;
-				}
-			}
-
-			if (!exists && isdefault) {
-				//does not exist in original node, but it's the default value
-				//so safe to skip too.
-				continue;
-			}
-
-		} else {
-			if (isdefault) {
-				//it's the default value, no point in saving it
-				continue;
-			}
+		// It needs saving if different from the the default
+		Variant default_value = PropertyUtils::get_property_default_value(p_node, name, p_owner, &states_stack);
+		if (!PropertyUtils::is_property_value_different(value, default_value)) {
+			continue;
 		}
 
 		NodeData::Property prop;
@@ -584,10 +488,10 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 		*/
 
 		bool skip = false;
-		for (List<PackState>::Element *F = pack_state_stack.front(); F; F = F->next()) {
+		for (int i = 0; i < states_stack.size(); ++i) {
+			const auto &ia = states_stack[i];
 			//check all levels of pack to see if the group was added somewhere
-			const PackState &ps = F->get();
-			if (ps.state->is_node_in_group(ps.node, gi.name)) {
+			if (ia.state->is_node_in_group(ia.node, gi.name)) {
 				skip = true;
 				break;
 			}
@@ -617,7 +521,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 
 	// Save the right type. If this node was created by an instance
 	// then flag that the node should not be created but reused
-	if (pack_state_stack.empty() && !is_editable_instance) {
+	if (states_stack.empty() && !is_editable_instance) {
 		//this node is not part of an instancing process, so save the type
 		nd.type = _nm_get_string(p_node->get_class(), name_map);
 	} else {
@@ -931,7 +835,7 @@ void SceneState::clear() {
 	base_scene_idx = -1;
 }
 
-Ref<SceneState> SceneState::_get_base_scene_state() const {
+Ref<SceneState> SceneState::get_base_scene_state() const {
 	if (base_scene_idx >= 0) {
 		Ref<PackedScene> ps = variants[base_scene_idx];
 		if (ps.is_valid()) {
@@ -946,8 +850,8 @@ int SceneState::find_node_by_path(const NodePath &p_node) const {
 	ERR_FAIL_COND_V_MSG(node_path_cache.size() == 0, -1, "This operation requires the node cache to have been built.");
 
 	if (!node_path_cache.has(p_node)) {
-		if (_get_base_scene_state().is_valid()) {
-			int idx = _get_base_scene_state()->find_node_by_path(p_node);
+		if (get_base_scene_state().is_valid()) {
+			int idx = get_base_scene_state()->find_node_by_path(p_node);
 			if (idx != -1) {
 				int rkey = _find_base_scene_node_remap_key(idx);
 				if (rkey == -1) {
@@ -962,11 +866,11 @@ int SceneState::find_node_by_path(const NodePath &p_node) const {
 
 	int nid = node_path_cache[p_node];
 
-	if (_get_base_scene_state().is_valid() && !base_scene_node_remap.has(nid)) {
+	if (get_base_scene_state().is_valid() && !base_scene_node_remap.has(nid)) {
 		//for nodes that _do_ exist in current scene, still try to look for
 		//the node in the instanced scene, as a property may be missing
 		//from the local one
-		int idx = _get_base_scene_state()->find_node_by_path(p_node);
+		int idx = get_base_scene_state()->find_node_by_path(p_node);
 		if (idx != -1) {
 			base_scene_node_remap[nid] = idx;
 		}
@@ -1006,7 +910,7 @@ Variant SceneState::get_property_value(int p_node, const StringName &p_property,
 	//property not found, try on instance
 
 	if (base_scene_node_remap.has(p_node)) {
-		return _get_base_scene_state()->get_property_value(base_scene_node_remap[p_node], p_property, found);
+		return get_base_scene_state()->get_property_value(base_scene_node_remap[p_node], p_property, found);
 	}
 
 	return Variant();
@@ -1025,7 +929,7 @@ bool SceneState::is_node_in_group(int p_node, const StringName &p_group) const {
 	}
 
 	if (base_scene_node_remap.has(p_node)) {
-		return _get_base_scene_state()->is_node_in_group(base_scene_node_remap[p_node], p_group);
+		return get_base_scene_state()->is_node_in_group(base_scene_node_remap[p_node], p_group);
 	}
 
 	return false;
@@ -1064,7 +968,7 @@ bool SceneState::is_connection(int p_node, const StringName &p_signal, int p_to_
 	}
 
 	if (base_scene_node_remap.has(p_node) && base_scene_node_remap.has(p_to_node)) {
-		return _get_base_scene_state()->is_connection(base_scene_node_remap[p_node], p_signal, base_scene_node_remap[p_to_node], p_to_method);
+		return get_base_scene_state()->is_connection(base_scene_node_remap[p_node], p_signal, base_scene_node_remap[p_to_node], p_to_method);
 	}
 
 	return false;
@@ -1482,7 +1386,7 @@ bool SceneState::has_connection(const NodePath &p_node_from, const StringName &p
 			}
 		}
 
-		ss = ss->_get_base_scene_state();
+		ss = ss->get_base_scene_state();
 	} while (ss.is_valid());
 
 	return false;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -185,6 +185,12 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 			// may not have found the node (part of instanced scene and removed)
 			// if found all is good, otherwise ignore
 
+			Set<StringName> pinnable_properties;
+			// we only want pinned flag to be set if instancing as pure main (no instance, no inheriting)
+			if (p_edit_state == GEN_EDIT_STATE_MAIN) {
+				node->get_pinnable_properties(pinnable_properties);
+			}
+
 			//properties
 			int nprop_count = n.properties.size();
 			if (nprop_count) {
@@ -226,7 +232,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 									} else {
 										Node *base = i == 0 ? node : ret_nodes[0];
 
-										if (p_edit_state == GEN_EDIT_STATE_MAIN) {
+										if (p_edit_state == GEN_EDIT_STATE_MAIN || p_edit_state == GEN_EDIT_STATE_MAIN_INHERITED) {
 											//for the main scene, use the resource as is
 											res->configure_for_local_scene(base, resources_local_to_scene);
 											resources_local_to_scene[res] = res;
@@ -247,6 +253,13 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 							value = value.duplicate(true); // Duplicate arrays and dictionaries for the editor
 						}
 						node->set(snames[nprops[j].name], value, &valid);
+					}
+
+					if (p_edit_state != GEN_EDIT_STATE_DISABLED) {
+						StringName property_name = snames[nprops[j].name];
+						if (nprops[j].pinned && pinnable_properties.has(node->get_property_pin_proxy(property_name))) {
+							node->set_property_pinned(property_name, true);
+						}
 					}
 				}
 			}
@@ -459,15 +472,23 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 		String name = E->get().name;
 		Variant value = p_node->get(name);
 
-		// It needs saving if different from the the default
-		Variant default_value = PropertyUtils::get_property_default_value(p_node, name, p_owner, &states_stack);
-		if (!PropertyUtils::is_property_value_different(value, default_value)) {
+		bool is_pinned = p_node->is_property_pinned(name);
+		bool needs_save = false;
+		if (is_pinned) {
+			needs_save = true;
+		} else {
+			// If not pinned, it needs saving if different from the the default
+			Variant default_value = PropertyUtils::get_property_default_value(p_node, name, p_owner, &states_stack);
+			needs_save = PropertyUtils::is_property_value_different(value, default_value);
+		}
+		if (!needs_save) {
 			continue;
 		}
 
 		NodeData::Property prop;
 		prop.name = _nm_get_string(name, name_map);
 		prop.value = _vm_get_variant(value, variant_map);
+		prop.pinned = is_pinned;
 		nd.properties.push_back(prop);
 	}
 
@@ -916,6 +937,22 @@ Variant SceneState::get_property_value(int p_node, const StringName &p_property,
 	return Variant();
 }
 
+bool SceneState::is_property_pinned(int p_node, const StringName &p_property) const {
+	ERR_FAIL_INDEX_V(p_node, nodes.size(), false);
+
+	int pc = nodes[p_node].properties.size();
+	const StringName *namep = names.ptr();
+
+	const NodeData::Property *p = nodes[p_node].properties.ptr();
+	for (int i = 0; i < pc; i++) {
+		if (p_property == namep[p[i].name]) {
+			return p[i].pinned;
+		}
+	}
+
+	return false;
+}
+
 bool SceneState::is_node_in_group(int p_node, const StringName &p_group) const {
 	ERR_FAIL_COND_V(p_node < 0, false);
 
@@ -1038,7 +1075,10 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 			nd.properties.resize(r[idx++]);
 			for (int j = 0; j < nd.properties.size(); j++) {
 				nd.properties.write[j].name = r[idx++];
-				nd.properties.write[j].value = r[idx++];
+				// For back compat, pinned flag is stored as the MSB of value
+				int value = r[idx++];
+				nd.properties.write[j].value = value & ~0x80000000;
+				nd.properties.write[j].pinned = value & 0x80000000;
 			}
 			nd.groups.resize(r[idx++]);
 			for (int j = 0; j < nd.groups.size(); j++) {
@@ -1125,7 +1165,9 @@ Dictionary SceneState::get_bundled_scene() const {
 		rnodes.push_back(nd.properties.size());
 		for (int j = 0; j < nd.properties.size(); j++) {
 			rnodes.push_back(nd.properties[j].name);
-			rnodes.push_back(nd.properties[j].value);
+			// For back compat, store pinned flag as the MSB of value
+			int value = nd.properties[j].value | (0x80000000 * nd.properties[j].pinned);
+			rnodes.push_back(value);
 		}
 		rnodes.push_back(nd.groups.size());
 		for (int j = 0; j < nd.groups.size(); j++) {
@@ -1295,8 +1337,12 @@ StringName SceneState::get_node_property_name(int p_idx, int p_prop) const {
 Variant SceneState::get_node_property_value(int p_idx, int p_prop) const {
 	ERR_FAIL_INDEX_V(p_idx, nodes.size(), Variant());
 	ERR_FAIL_INDEX_V(p_prop, nodes[p_idx].properties.size(), Variant());
-
 	return variants[nodes[p_idx].properties[p_prop].value];
+}
+bool SceneState::is_node_property_pinned(int p_idx, int p_prop) const {
+	ERR_FAIL_INDEX_V(p_idx, nodes.size(), false);
+	ERR_FAIL_INDEX_V(p_prop, nodes[p_idx].properties.size(), false);
+	return nodes[p_idx].properties[p_prop].pinned;
 }
 
 NodePath SceneState::get_node_owner_path(int p_idx) const {
@@ -1434,7 +1480,7 @@ int SceneState::add_node(int p_parent, int p_owner, int p_type, int p_name, int 
 
 	return nodes.size() - 1;
 }
-void SceneState::add_node_property(int p_node, int p_name, int p_value) {
+void SceneState::add_node_property(int p_node, int p_name, int p_value, bool p_pinned) {
 	ERR_FAIL_INDEX(p_node, nodes.size());
 	ERR_FAIL_INDEX(p_name, names.size());
 	ERR_FAIL_INDEX(p_value, variants.size());
@@ -1442,6 +1488,7 @@ void SceneState::add_node_property(int p_node, int p_name, int p_value) {
 	NodeData::Property prop;
 	prop.name = p_name;
 	prop.value = p_value;
+	prop.pinned = p_pinned;
 	nodes.write[p_node].properties.push_back(prop);
 }
 void SceneState::add_node_group(int p_node, int p_group) {
@@ -1511,6 +1558,7 @@ void SceneState::_bind_methods() {
 	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_DISABLED);
 	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_INSTANCE);
 	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_MAIN);
+	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_MAIN_INHERITED);
 }
 
 SceneState::SceneState() {
@@ -1601,6 +1649,7 @@ void PackedScene::_bind_methods() {
 	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_DISABLED);
 	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_INSTANCE);
 	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_MAIN);
+	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_MAIN_INHERITED);
 }
 
 PackedScene::PackedScene() {

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -69,12 +69,6 @@ class SceneState : public Reference {
 		Vector<int> groups;
 	};
 
-	struct PackState {
-		Ref<SceneState> state;
-		int node;
-		PackState() { node = -1; }
-	};
-
 	Vector<NodeData> nodes;
 
 	struct ConnectionData {
@@ -94,8 +88,6 @@ class SceneState : public Reference {
 	String path;
 
 	uint64_t last_modified_time;
-
-	_FORCE_INLINE_ Ref<SceneState> _get_base_scene_state() const;
 
 	static bool disable_placeholders;
 
@@ -120,6 +112,11 @@ public:
 		GEN_EDIT_STATE_MAIN,
 	};
 
+	struct PackState {
+		Ref<SceneState> state;
+		int node = -1;
+	};
+
 	static void set_disable_placeholders(bool p_disable);
 
 	int find_node_by_path(const NodePath &p_node) const;
@@ -139,6 +136,8 @@ public:
 
 	bool can_instance() const;
 	Node *instance(GenEditState p_edit_state) const;
+
+	Ref<SceneState> get_base_scene_state() const;
 
 	//unbuild API
 

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -63,6 +63,7 @@ class SceneState : public Reference {
 		struct Property {
 			int name;
 			int value;
+			bool pinned;
 		};
 
 		Vector<Property> properties;
@@ -110,6 +111,7 @@ public:
 		GEN_EDIT_STATE_DISABLED,
 		GEN_EDIT_STATE_INSTANCE,
 		GEN_EDIT_STATE_MAIN,
+		GEN_EDIT_STATE_MAIN_INHERITED,
 	};
 
 	struct PackState {
@@ -121,6 +123,7 @@ public:
 
 	int find_node_by_path(const NodePath &p_node) const;
 	Variant get_property_value(int p_node, const StringName &p_property, bool &found) const;
+	bool is_property_pinned(int p_node, const StringName &p_property) const;
 	bool is_node_in_group(int p_node, const StringName &p_group) const;
 	bool is_connection(int p_node, const StringName &p_signal, int p_to_node, const StringName &p_to_method) const;
 
@@ -155,6 +158,7 @@ public:
 	int get_node_property_count(int p_idx) const;
 	StringName get_node_property_name(int p_idx, int p_prop) const;
 	Variant get_node_property_value(int p_idx, int p_prop) const;
+	bool is_node_property_pinned(int p_idx, int p_prop) const;
 
 	int get_connection_count() const;
 	NodePath get_connection_source(int p_idx) const;
@@ -175,7 +179,7 @@ public:
 	int add_value(const Variant &p_value);
 	int add_node_path(const NodePath &p_path);
 	int add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index);
-	void add_node_property(int p_node, int p_name, int p_value);
+	void add_node_property(int p_node, int p_name, int p_value, bool p_pinned);
 	void add_node_group(int p_node, int p_group);
 	void set_base_scene(int p_idx);
 	void add_connection(int p_from, int p_to, int p_signal, int p_method, int p_flags, const Vector<int> &p_binds);
@@ -207,6 +211,7 @@ public:
 		GEN_EDIT_STATE_DISABLED,
 		GEN_EDIT_STATE_INSTANCE,
 		GEN_EDIT_STATE_MAIN,
+		GEN_EDIT_STATE_MAIN_INHERITED,
 	};
 
 	Error pack(Node *p_scene);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -244,6 +244,10 @@ Ref<PackedScene> ResourceInteractiveLoaderText::_parse_node_tag(VariantParser::R
 				}
 			}
 
+			struct {
+				int name_idx = -1;
+				int value_idx = -1;
+			} pending_assign;
 			while (true) {
 				String assign;
 				Variant value;
@@ -255,18 +259,40 @@ Ref<PackedScene> ResourceInteractiveLoaderText::_parse_node_tag(VariantParser::R
 						_printerr();
 						return Ref<PackedScene>();
 					} else {
-						return packed_scene;
+						break;
 					}
 				}
 
 				if (assign != String()) {
-					int nameidx = packed_scene->get_state()->add_name(assign);
-					int valueidx = packed_scene->get_state()->add_value(value);
-					packed_scene->get_state()->add_node_property(node_id, nameidx, valueidx);
-					//it's assignment
+					//it's assignment; flush pending first
+					if (pending_assign.name_idx != -1) {
+						packed_scene->get_state()->add_node_property(node_id, pending_assign.name_idx, pending_assign.value_idx, false);
+					}
+					pending_assign = {
+						packed_scene->get_state()->add_name(assign),
+						packed_scene->get_state()->add_value(value)
+					};
+				} else if (next_tag.name == "pinned") {
+					if (pending_assign.name_idx == -1) {
+						error = ERR_FILE_CORRUPT;
+						error_text = "Found 'pinned' tag with no assignment";
+						return Ref<PackedScene>();
+					} else {
+						//now we can flush knowing it's pinned
+						packed_scene->get_state()->add_node_property(node_id, pending_assign.name_idx, pending_assign.value_idx, true);
+						pending_assign = { -1, -1 };
+					}
 				} else if (next_tag.name != String()) {
 					break;
 				}
+			}
+			// flush the last one, which for sure it's not pinned
+			if (pending_assign.name_idx != -1) {
+				packed_scene->get_state()->add_node_property(node_id, pending_assign.name_idx, pending_assign.value_idx, false);
+			}
+			if (error == ERR_FILE_EOF) {
+				error = OK;
+				return packed_scene;
 			}
 		} else if (next_tag.name == "connection") {
 			if (!next_tag.fields.has("from")) {
@@ -1666,7 +1692,11 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 				String vars;
 				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, _write_resources, this);
 
-				f->store_string(String(state->get_node_property_name(i, j)).property_name_encode() + " = " + vars + "\n");
+				String assign = String(state->get_node_property_name(i, j)).property_name_encode() + " = " + vars;
+				if (state->is_node_property_pinned(i, j)) {
+					assign += " [pinned]";
+				}
+				f->store_string(assign + "\n");
 			}
 
 			if (i < state->get_node_count() - 1) {


### PR DESCRIPTION
Version of #52233 for 3.x. See details there.

However, there's an important difference: the binary scene file format is kept compatible, by storing the pinned flag in the MSB of other field. (The compatibility node about scene text format still holds.)