### PR TITLE
Display a matrix for Node2D

### DIFF
--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -116,7 +116,7 @@
 		</member>
 		<member name="skew" type="float" setter="set_skew" getter="get_skew" default="0.0">
 		</member>
-		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform">
+		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			Local [Transform2D].
 		</member>
 		<member name="y_sort_enabled" type="bool" setter="set_y_sort_enabled" getter="is_y_sort_enabled" default="false">

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -265,7 +265,7 @@
 	</methods>
 	<members>
 		<member name="basis" type="Basis" setter="set_basis" getter="get_basis">
-			Direct access to the 3x3 basis of the [Transform3D] property.
+			Local space [Basis] of the [Transform3D] of this node, with respect to the parent node. This is the same as [code]transform.basis[/code].
 		</member>
 		<member name="global_transform" type="Transform3D" setter="set_global_transform" getter="get_global_transform">
 			World3D space (global) [Transform3D] of this node.

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3453,7 +3453,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 
 		} break;
 		case Variant::TRANSFORM2D: {
-			EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D);
+			EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D(p_usage != PROPERTY_USAGE_EDITOR));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
 			return editor;

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -421,11 +421,13 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rotation", PROPERTY_HINT_RANGE, "-360,360,0.1,or_lesser,or_greater,radians"), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "scale"), "set_scale", "get_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "skew", PROPERTY_HINT_RANGE, "-89.9,89.9,0.1,radians"), "set_skew", "get_skew");
-	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_transform", "get_transform");
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_position", "get_global_position");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_rotation", "get_global_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_scale", "get_global_scale");
+
+	ADD_GROUP("Raw Matrix", "");
+	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_transform", "get_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "global_transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_transform", "get_global_transform");
 
 	ADD_GROUP("Ordering", "");

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -218,6 +218,7 @@ void Node3D::_notification(int p_what) {
 void Node3D::set_basis(const Basis &p_basis) {
 	set_transform(Transform3D(p_basis, data.local_transform.origin));
 }
+
 void Node3D::set_quaternion(const Quaternion &p_quaternion) {
 	set_transform(Transform3D(Basis(p_quaternion), data.local_transform.origin));
 }
@@ -234,6 +235,7 @@ void Node3D::set_transform(const Transform3D &p_transform) {
 Basis Node3D::get_basis() const {
 	return get_transform().basis;
 }
+
 Quaternion Node3D::get_quaternion() const {
 	return Quaternion(get_transform().basis);
 }


### PR DESCRIPTION
This was closed, but I still think this is worth having, so here's a branch: https://github.com/aaronfranke/godot/tree/node2d3d-transform

---

EDIT: The comments from @reduz are now out-of-date because they refer to when this PR used to change Node3D.

The matrix is now displayed for Node2D, while previously it just wasn't displayed at all. I also updated the docs for Node3D's basis property (not super related but it's a holdover from a previous version of this PR).

Before/after pic (left is before, right is after):

![node2d](https://user-images.githubusercontent.com/1646875/139522355-ce52f51f-29f0-4dd6-ba00-11b3ce4487bb.png)

