### PR TITLE
Rename `String::is_rel_path` to `String::is_relative_path`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1504,7 +1504,7 @@ String Directory::get_current_dir() {
 
 Error Directory::make_dir(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
-	if (!p_dir.is_rel_path()) {
+	if (!p_dir.is_relative_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir(p_dir);
 		memdelete(d);
@@ -1515,7 +1515,7 @@ Error Directory::make_dir(String p_dir) {
 
 Error Directory::make_dir_recursive(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
-	if (!p_dir.is_rel_path()) {
+	if (!p_dir.is_relative_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir_recursive(p_dir);
 		memdelete(d);
@@ -1526,7 +1526,7 @@ Error Directory::make_dir_recursive(String p_dir) {
 
 bool Directory::file_exists(String p_file) {
 	ERR_FAIL_COND_V_MSG(!d, false, "Directory is not configured properly.");
-	if (!p_file.is_rel_path()) {
+	if (!p_file.is_relative_path()) {
 		return FileAccess::exists(p_file);
 	}
 
@@ -1535,7 +1535,7 @@ bool Directory::file_exists(String p_file) {
 
 bool Directory::dir_exists(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, false, "Directory is not configured properly.");
-	if (!p_dir.is_rel_path()) {
+	if (!p_dir.is_relative_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		bool exists = d->dir_exists(p_dir);
 		memdelete(d);
@@ -1559,7 +1559,7 @@ Error Directory::rename(String p_from, String p_to) {
 	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	ERR_FAIL_COND_V_MSG(p_from.is_empty() || p_from == "." || p_from == "..", ERR_INVALID_PARAMETER, "Invalid path to rename.");
 
-	if (!p_from.is_rel_path()) {
+	if (!p_from.is_relative_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_from);
 		ERR_FAIL_COND_V_MSG(!d->file_exists(p_from) && !d->dir_exists(p_from), ERR_DOES_NOT_EXIST, "File or directory does not exist.");
 		Error err = d->rename(p_from, p_to);
@@ -1573,7 +1573,7 @@ Error Directory::rename(String p_from, String p_to) {
 
 Error Directory::remove(String p_name) {
 	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
-	if (!p_name.is_rel_path()) {
+	if (!p_name.is_relative_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_name);
 		Error err = d->remove(p_name);
 		memdelete(d);

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -135,7 +135,7 @@ Error DirAccess::make_dir_recursive(String p_dir) {
 
 	String full_dir;
 
-	if (p_dir.is_rel_path()) {
+	if (p_dir.is_relative_path()) {
 		//append current
 		full_dir = get_current_dir().plus_file(p_dir);
 
@@ -345,7 +345,7 @@ Error DirAccess::_copy_dir(DirAccess *p_target_da, String p_to, int p_chmod_flag
 				dirs.push_back(n);
 			} else {
 				const String &rel_path = n;
-				if (!n.is_rel_path()) {
+				if (!n.is_relative_path()) {
 					list_dir_end();
 					return ERR_BUG;
 				}

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -335,7 +335,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 					String exttype = get_unicode_string();
 					String path = get_unicode_string();
 
-					if (path.find("://") == -1 && path.is_rel_path()) {
+					if (path.find("://") == -1 && path.is_relative_path()) {
 						// path is relative to file being loaded, so convert to a resource path
 						path = ProjectSettings::get_singleton()->localize_path(res_path.get_base_dir().plus_file(path));
 					}
@@ -626,7 +626,7 @@ Error ResourceLoaderBinary::load() {
 			path = remaps[path];
 		}
 
-		if (path.find("://") == -1 && path.is_rel_path()) {
+		if (path.find("://") == -1 && path.is_relative_path()) {
 			// path is relative to file being loaded, so convert to a resource path
 			path = ProjectSettings::get_singleton()->localize_path(path.get_base_dir().plus_file(external_resources[i].path));
 		}

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -278,7 +278,7 @@ static String _validate_local_path(const String &p_path) {
 	ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(p_path);
 	if (uid != ResourceUID::INVALID_ID) {
 		return ResourceUID::get_singleton()->get_id_path(uid);
-	} else if (p_path.is_rel_path()) {
+	} else if (p_path.is_relative_path()) {
 		return "res://" + p_path;
 	} else {
 		return ProjectSettings::get_singleton()->localize_path(p_path);

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4324,7 +4324,7 @@ bool String::is_resource_file() const {
 	return begins_with("res://") && find("::") == -1;
 }
 
-bool String::is_rel_path() const {
+bool String::is_relative_path() const {
 	return !is_absolute_path();
 }
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -398,7 +398,7 @@ public:
 
 	// path functions
 	bool is_absolute_path() const;
-	bool is_rel_path() const;
+	bool is_relative_path() const;
 	bool is_resource_file() const;
 	String path_to(const String &p_path) const;
 	String path_to_file(const String &p_path) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1421,7 +1421,7 @@ static void _register_variant_builtin_methods() {
 	//bind_method(String, humanize_size, sarray("size"), varray());
 
 	bind_method(String, is_absolute_path, sarray(), varray());
-	bind_method(String, is_rel_path, sarray(), varray());
+	bind_method(String, is_relative_path, sarray(), varray());
 	bind_method(String, simplify_path, sarray(), varray());
 	bind_method(String, get_base_dir, sarray(), varray());
 	bind_method(String, get_file, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -248,7 +248,7 @@
 				Returns [code]true[/code] if the length of the string equals [code]0[/code].
 			</description>
 		</method>
-		<method name="is_rel_path" qualifiers="const">
+		<method name="is_relative_path" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the string is a path to a file or directory and its starting point is implicitly defined within the context it is being used. The starting point may refer to the current directory ([code]./[/code]), or the current [Node].

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -71,7 +71,7 @@ Error DirAccessUnix::list_dir_begin() {
 bool DirAccessUnix::file_exists(String p_file) {
 	GLOBAL_LOCK_FUNCTION
 
-	if (p_file.is_rel_path()) {
+	if (p_file.is_relative_path()) {
 		p_file = current_dir.plus_file(p_file);
 	}
 
@@ -90,7 +90,7 @@ bool DirAccessUnix::file_exists(String p_file) {
 bool DirAccessUnix::dir_exists(String p_dir) {
 	GLOBAL_LOCK_FUNCTION
 
-	if (p_dir.is_rel_path()) {
+	if (p_dir.is_relative_path()) {
 		p_dir = get_current_dir().plus_file(p_dir);
 	}
 
@@ -105,7 +105,7 @@ bool DirAccessUnix::dir_exists(String p_dir) {
 bool DirAccessUnix::is_readable(String p_dir) {
 	GLOBAL_LOCK_FUNCTION
 
-	if (p_dir.is_rel_path()) {
+	if (p_dir.is_relative_path()) {
 		p_dir = get_current_dir().plus_file(p_dir);
 	}
 
@@ -116,7 +116,7 @@ bool DirAccessUnix::is_readable(String p_dir) {
 bool DirAccessUnix::is_writable(String p_dir) {
 	GLOBAL_LOCK_FUNCTION
 
-	if (p_dir.is_rel_path()) {
+	if (p_dir.is_relative_path()) {
 		p_dir = get_current_dir().plus_file(p_dir);
 	}
 
@@ -125,7 +125,7 @@ bool DirAccessUnix::is_writable(String p_dir) {
 }
 
 uint64_t DirAccessUnix::get_modified_time(String p_file) {
-	if (p_file.is_rel_path()) {
+	if (p_file.is_relative_path()) {
 		p_file = current_dir.plus_file(p_file);
 	}
 
@@ -293,7 +293,7 @@ bool DirAccessUnix::drives_are_shortcuts() {
 Error DirAccessUnix::make_dir(String p_dir) {
 	GLOBAL_LOCK_FUNCTION
 
-	if (p_dir.is_rel_path()) {
+	if (p_dir.is_relative_path()) {
 		p_dir = get_current_dir().plus_file(p_dir);
 	}
 
@@ -328,7 +328,7 @@ Error DirAccessUnix::change_dir(String p_dir) {
 
 	// try_dir is the directory we are trying to change into
 	String try_dir = "";
-	if (p_dir.is_rel_path()) {
+	if (p_dir.is_relative_path()) {
 		String next_dir = current_dir.plus_file(p_dir);
 		next_dir = next_dir.simplify_path();
 		try_dir = next_dir;
@@ -372,13 +372,13 @@ String DirAccessUnix::get_current_dir(bool p_include_drive) {
 }
 
 Error DirAccessUnix::rename(String p_path, String p_new_path) {
-	if (p_path.is_rel_path()) {
+	if (p_path.is_relative_path()) {
 		p_path = get_current_dir().plus_file(p_path);
 	}
 
 	p_path = fix_path(p_path);
 
-	if (p_new_path.is_rel_path()) {
+	if (p_new_path.is_relative_path()) {
 		p_new_path = get_current_dir().plus_file(p_new_path);
 	}
 
@@ -388,7 +388,7 @@ Error DirAccessUnix::rename(String p_path, String p_new_path) {
 }
 
 Error DirAccessUnix::remove(String p_path) {
-	if (p_path.is_rel_path()) {
+	if (p_path.is_relative_path()) {
 		p_path = get_current_dir().plus_file(p_path);
 	}
 
@@ -407,7 +407,7 @@ Error DirAccessUnix::remove(String p_path) {
 }
 
 bool DirAccessUnix::is_link(String p_file) {
-	if (p_file.is_rel_path()) {
+	if (p_file.is_relative_path()) {
 		p_file = get_current_dir().plus_file(p_file);
 	}
 
@@ -422,7 +422,7 @@ bool DirAccessUnix::is_link(String p_file) {
 }
 
 String DirAccessUnix::read_link(String p_file) {
-	if (p_file.is_rel_path()) {
+	if (p_file.is_relative_path()) {
 		p_file = get_current_dir().plus_file(p_file);
 	}
 
@@ -439,7 +439,7 @@ String DirAccessUnix::read_link(String p_file) {
 }
 
 Error DirAccessUnix::create_link(String p_source, String p_target) {
-	if (p_target.is_rel_path()) {
+	if (p_target.is_relative_path()) {
 		p_target = get_current_dir().plus_file(p_target);
 	}
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -392,7 +392,7 @@ String OS_Unix::get_locale() const {
 Error OS_Unix::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path) {
 	String path = p_path;
 
-	if (FileAccess::exists(path) && path.is_rel_path()) {
+	if (FileAccess::exists(path) && path.is_relative_path()) {
 		// dlopen expects a slash, in this case a leading ./ for it to be interpreted as a relative path,
 		//  otherwise it will end up searching various system directories for the lib instead and finally failing.
 		path = "./" + path;

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -155,7 +155,7 @@ Error DirAccessWindows::make_dir(String p_dir) {
 	GLOBAL_LOCK_FUNCTION
 
 	p_dir = fix_path(p_dir);
-	if (p_dir.is_rel_path()) {
+	if (p_dir.is_relative_path()) {
 		p_dir = current_dir.plus_file(p_dir);
 	}
 
@@ -227,7 +227,7 @@ bool DirAccessWindows::file_exists(String p_file) {
 bool DirAccessWindows::dir_exists(String p_dir) {
 	GLOBAL_LOCK_FUNCTION
 
-	if (p_dir.is_rel_path()) {
+	if (p_dir.is_relative_path()) {
 		p_dir = get_current_dir().plus_file(p_dir);
 	}
 
@@ -242,13 +242,13 @@ bool DirAccessWindows::dir_exists(String p_dir) {
 }
 
 Error DirAccessWindows::rename(String p_path, String p_new_path) {
-	if (p_path.is_rel_path()) {
+	if (p_path.is_relative_path()) {
 		p_path = get_current_dir().plus_file(p_path);
 	}
 
 	p_path = fix_path(p_path);
 
-	if (p_new_path.is_rel_path()) {
+	if (p_new_path.is_relative_path()) {
 		p_new_path = get_current_dir().plus_file(p_new_path);
 	}
 
@@ -281,7 +281,7 @@ Error DirAccessWindows::rename(String p_path, String p_new_path) {
 }
 
 Error DirAccessWindows::remove(String p_path) {
-	if (p_path.is_rel_path()) {
+	if (p_path.is_relative_path()) {
 		p_path = get_current_dir().plus_file(p_path);
 	}
 

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -958,7 +958,7 @@ String EditorFileDialog::get_current_path() const {
 }
 
 void EditorFileDialog::set_current_dir(const String &p_dir) {
-	if (p_dir.is_rel_path()) {
+	if (p_dir.is_relative_path()) {
 		dir_access->change_dir(OS::get_singleton()->get_resource_dir());
 	}
 	dir_access->change_dir(p_dir);

--- a/editor/import/collada.cpp
+++ b/editor/import/collada.cpp
@@ -287,7 +287,7 @@ void Collada::_parse_image(XMLParser &parser) {
 	if (state.version < State::Version(1, 4, 0)) {
 		/* <1.4 */
 		String path = parser.get_attribute_value("source").strip_edges();
-		if (path.find("://") == -1 && path.is_rel_path()) {
+		if (path.find("://") == -1 && path.is_relative_path()) {
 			// path is relative to file being loaded, so convert to a resource path
 			image.path = ProjectSettings::get_singleton()->localize_path(state.local_path.get_base_dir().plus_file(path.uri_decode()));
 		}
@@ -300,7 +300,7 @@ void Collada::_parse_image(XMLParser &parser) {
 					parser.read();
 					String path = parser.get_node_data().strip_edges().uri_decode();
 
-					if (path.find("://") == -1 && path.is_rel_path()) {
+					if (path.find("://") == -1 && path.is_relative_path()) {
 						// path is relative to file being loaded, so convert to a resource path
 						path = ProjectSettings::get_singleton()->localize_path(state.local_path.get_base_dir().plus_file(path));
 

--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -78,7 +78,7 @@ static String _include_function(const String &p_path, void *userpointer) {
 	String *base_path = (String *)userpointer;
 
 	String include = p_path;
-	if (include.is_rel_path()) {
+	if (include.is_relative_path()) {
 		include = base_path->plus_file(include);
 	}
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -831,7 +831,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 		if (info.is_singleton) {
 			EditorNode::get_singleton()->load_scene(info.path);
 		}
-	} else if (p_symbol.is_rel_path()) {
+	} else if (p_symbol.is_relative_path()) {
 		// Every symbol other than absolute path is relative path so keep this condition at last.
 		String path = _get_absolute_path(p_symbol);
 		if (FileAccess::exists(path)) {
@@ -858,7 +858,7 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 	ScriptLanguage::LookupResult result;
 	if (ScriptServer::is_global_class(p_symbol) || p_symbol.is_resource_file() || script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_symbol_lookup(), p_symbol, script->get_path(), base, result) == OK || (ProjectSettings::get_singleton()->has_autoload(p_symbol) && ProjectSettings::get_singleton()->get_autoload(p_symbol).is_singleton)) {
 		text_edit->set_symbol_lookup_word_as_valid(true);
-	} else if (p_symbol.is_rel_path()) {
+	} else if (p_symbol.is_relative_path()) {
 		String path = _get_absolute_path(p_symbol);
 		if (FileAccess::exists(path)) {
 			text_edit->set_symbol_lookup_word_as_valid(true);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1967,7 +1967,7 @@ bool Main::start() {
 		for (int i = 0; i < _doc_data_class_path_count; i++) {
 			// Custom modules are always located by absolute path.
 			String path = _doc_data_class_paths[i].path;
-			if (path.is_rel_path()) {
+			if (path.is_relative_path()) {
 				path = doc_tool_path.plus_file(path);
 			}
 			String name = _doc_data_class_paths[i].name;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -625,9 +625,9 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 				String path = "";
 				if (String(c->extends_path) != "" && String(c->extends_path) != get_path()) {
 					path = c->extends_path;
-					if (path.is_rel_path()) {
+					if (path.is_relative_path()) {
 						String base = get_path();
-						if (base == "" || base.is_rel_path()) {
+						if (base == "" || base.is_relative_path()) {
 							ERR_PRINT(("Could not resolve relative path for parent class: " + path).utf8().get_data());
 						} else {
 							path = base.get_base_dir().plus_file(path);
@@ -2059,7 +2059,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 		if (r_icon_path) {
 			if (c->icon_path.is_empty() || c->icon_path.is_absolute_path()) {
 				*r_icon_path = c->icon_path;
-			} else if (c->icon_path.is_rel_path()) {
+			} else if (c->icon_path.is_relative_path()) {
 				*r_icon_path = p_path.get_base_dir().plus_file(c->icon_path).simplify_path();
 			}
 		}
@@ -2087,7 +2087,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 								break;
 							}
 							String subpath = subclass->extends_path;
-							if (subpath.is_rel_path()) {
+							if (subpath.is_relative_path()) {
 								subpath = path.get_base_dir().plus_file(subpath).simplify_path();
 							}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2727,7 +2727,7 @@ void GDScriptAnalyzer::reduce_preload(GDScriptParser::PreloadNode *p_preload) {
 	} else {
 		p_preload->resolved_path = p_preload->path->reduced_value;
 		// TODO: Save this as script dependency.
-		if (p_preload->resolved_path.is_rel_path()) {
+		if (p_preload->resolved_path.is_relative_path()) {
 			p_preload->resolved_path = parser->script_path.get_base_dir().plus_file(p_preload->resolved_path);
 		}
 		p_preload->resolved_path = p_preload->resolved_path.simplify_path();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -588,7 +588,7 @@ namespace Godot
         /// <summary>
         /// If the string is a path to a file or directory, return <see langword="true"/> if the path is relative.
         /// </summary>
-        public static bool IsRelPath(this string instance)
+        public static bool IsRelativePath(this string instance)
         {
             return !IsAbsolutePath(instance);
         }

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -161,7 +161,7 @@ bool DirAccessJAndroid::dir_exists(String p_dir) {
 	if (current_dir == "")
 		sd = p_dir;
 	else {
-		if (p_dir.is_rel_path())
+		if (p_dir.is_relative_path())
 			sd = current_dir.plus_file(p_dir);
 		else
 			sd = fix_path(p_dir);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2609,7 +2609,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 
 		String export_filename = p_path.get_file();
 		String export_path = p_path.get_base_dir();
-		if (export_path.is_rel_path()) {
+		if (export_path.is_relative_path()) {
 			export_path = OS::get_singleton()->get_resource_dir().plus_file(export_path);
 		}
 		export_path = ProjectSettings::get_singleton()->globalize_path(export_path).simplify_path();

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -424,7 +424,7 @@ Error ResourceLoaderText::load() {
 			}
 		}
 
-		if (path.find("://") == -1 && path.is_rel_path()) {
+		if (path.find("://") == -1 && path.is_relative_path()) {
 			// path is relative to file being loaded, so convert to a resource path
 			path = ProjectSettings::get_singleton()->localize_path(local_path.get_base_dir().plus_file(path));
 		}
@@ -768,7 +768,7 @@ void ResourceLoaderText::get_dependencies(FileAccess *p_f, List<String> *p_depen
 			}
 		}
 
-		if (!using_uid && path.find("://") == -1 && path.is_rel_path()) {
+		if (!using_uid && path.find("://") == -1 && path.is_relative_path()) {
 			// path is relative to file being loaded, so convert to a resource path
 			path = ProjectSettings::get_singleton()->localize_path(local_path.get_base_dir().plus_file(path));
 		}

--- a/tests/test_string.h
+++ b/tests/test_string.h
@@ -1155,7 +1155,7 @@ TEST_CASE("[String] Path functions") {
 		CHECK(String(path[i]).get_extension() == ext[i]);
 		CHECK(String(path[i]).get_file() == file[i]);
 		CHECK(String(path[i]).is_absolute_path() == abs[i]);
-		CHECK(String(path[i]).is_rel_path() != abs[i]);
+		CHECK(String(path[i]).is_relative_path() != abs[i]);
 		CHECK(String(path[i]).simplify_path().get_base_dir().plus_file(file[i]) == String(path[i]).simplify_path());
 	}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Follow up of #49279.
See https://github.com/godotengine/godot/issues/16863#issuecomment-845276240.
See https://github.com/godotengine/godot/pull/49279#issuecomment-905474924.

For what is worth, I also find the abbreviation confusing  now that `String::is_absolute_path` is not abbreviated anymore in `master`.