### PR TITLE
[3.x] Fix `String::simplify_path` return type

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1688,7 +1688,7 @@ void register_variant_methods() {
 	ADDFUNC0R(STRING, BOOL, String, empty, varray());
 	ADDFUNC1R(STRING, STRING, String, humanize_size, INT, "size", varray());
 	ADDFUNC0R(STRING, BOOL, String, is_abs_path, varray());
-	ADDFUNC0R(STRING, BOOL, String, simplify_path, varray());
+	ADDFUNC0R(STRING, STRING, String, simplify_path, varray());
 	ADDFUNC0R(STRING, BOOL, String, is_rel_path, varray());
 	ADDFUNC0R(STRING, STRING, String, get_base_dir, varray());
 	ADDFUNC0R(STRING, STRING, String, get_file, varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -667,7 +667,7 @@
 			</description>
 		</method>
 		<method name="simplify_path">
-			<return type="bool" />
+			<return type="String" />
 			<description>
 				Returns a simplified canonical path.
 			</description>


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
