### PR TITLE
Fix Light2D UBO initialization

### DIFF
--- a/drivers/gles3/rasterizer_canvas_base_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_base_gles3.cpp
@@ -91,7 +91,7 @@ RID RasterizerCanvasBaseGLES3::light_internal_create() {
 
 	glGenBuffers(1, &li->ubo);
 	glBindBuffer(GL_UNIFORM_BUFFER, li->ubo);
-	glBufferData(GL_UNIFORM_BUFFER, sizeof(LightInternal::UBOData), &state.canvas_item_ubo_data, GL_DYNAMIC_DRAW);
+	glBufferData(GL_UNIFORM_BUFFER, sizeof(LightInternal::UBOData), nullptr, GL_DYNAMIC_DRAW);
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
 	return light_internal_owner.make_rid(li);


### PR DESCRIPTION
Light2D UBO was initialized with `state.canvas_item_ubo_data` instead of `li->ubo_data` in `light_internal_create()` so looking at structures underneath (UBOData is larger than CanvasItemUBO) it was initialized with some random memory values.