### PR TITLE
fix(ios): Clipboard get/set missing implement

### DIFF
--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -109,8 +109,8 @@ public:
 	virtual String get_name() const;
 	virtual String get_model_name() const;
 
-  virtual void set_clipboard(const String &p_text) ;
-  virtual String get_clipboard() const;
+	virtual void set_clipboard(const String &p_text) ;
+	virtual String get_clipboard() const;
 
 	Error shell_open(String p_uri);
 

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -109,6 +109,9 @@ public:
 	virtual String get_name() const;
 	virtual String get_model_name() const;
 
+  virtual void set_clipboard(const String &p_text) ;
+  virtual String get_clipboard() const;
+
 	Error shell_open(String p_uri);
 
 	String get_user_data_dir() const;

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -109,7 +109,7 @@ public:
 	virtual String get_name() const;
 	virtual String get_model_name() const;
 
-	virtual void set_clipboard(const String &p_text) ;
+	virtual void set_clipboard(const String &p_text);
 	virtual String get_clipboard() const;
 
 	Error shell_open(String p_uri);

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -484,6 +484,16 @@ String OSIPhone::get_name() const {
 	return "iOS";
 }
 
+void OSIPhone::set_clipboard(const String &p_text) {
+	[UIPasteboard generalPasteboard].string = [NSString stringWithUTF8String:p_text.utf8()];
+}
+
+String OSIPhone::get_clipboard() const {
+	NSString *text = [UIPasteboard generalPasteboard].string;
+
+	return String::utf8([text UTF8String]);
+}
+
 String OSIPhone::get_model_name() const {
 	String model = ios->get_model();
 	if (model != "") {


### PR DESCRIPTION
This should fix the get/set clipboard not working on iphone mentioned in https://github.com/godotengine/godot/issues/52228
