### PR TITLE
Syntax highlight c# verbatim string literal

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -337,7 +337,7 @@ void CSharpLanguage::get_comment_delimiters(List<String> *p_delimiters) const {
 void CSharpLanguage::get_string_delimiters(List<String> *p_delimiters) const {
 	p_delimiters->push_back("' '"); // character literal
 	p_delimiters->push_back("\" \""); // regular string literal
-	// Verbatim string literals (`@" "`) don't render correctly, so don't highlight them.
+	p_delimiters->push_back("@\" \""); // verbatim string literal
 	// Generic string highlighting suffices as a workaround for now.
 }
 


### PR DESCRIPTION
Syntax highlighters have been re-written so this now works.

Superseeds #37540