### PR TITLE
Fix Ctrl+V wrong behavior in inspector textedit (Fix #52208)

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -795,7 +795,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void EditorProperty::unhandled_key_input(const Ref<InputEvent> &p_event) {
-	if (!selected) {
+	if (!selected || !p_event->is_pressed()) {
 		return;
 	}
 


### PR DESCRIPTION
This PR fixes #52208

### **Issue description**
Pasting text in inspector textedit didn't work correctly. We can see the text is pasted, then, it's set to "null" (or old inspector copied value).

### **Identified cause**

It's a regression from 0205fff (Copy/Paste property paths/values in inspector.)

When pressing CTRL+V in inspector textedit, the event is managed 2 times :

first time on keypressed by TextEdit in TextEdit::gui_input(const Ref<InputEvent> &p_gui_input)
It pastes the text in the textedit (that what's we want here)

then on key release, by EditorProperty::unhandled_key_input(const Ref<InputEvent> &p_event)
It pastes the editor property. Null if no editor property was copy before and it overwrite the correct text that was just paste.

Event consumed in textedit is the key pressed action.
Event handle in EditorProperty didn't check the keypressed property of the event. It was fired on key release causing the bug.

### **Fix proposal**
Add a check in EditorProperty to ensure the event is a keypressed one. So, it will be consumed by textedit and bug doesn't occur.