### PR TITLE
Fix undo/redo for properties set as PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -457,8 +457,7 @@ class EditorInspector : public ScrollContainer {
 
 	void _edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field);
 
-	void _property_changed(const String &p_path, const Variant &p_value, const String &p_name = "", bool p_changing = false);
-	void _property_changed_update_all(const String &p_path, const Variant &p_value, const String &p_name = "", bool p_changing = false);
+	void _property_changed(const String &p_path, const Variant &p_value, const String &p_name = "", bool p_changing = false, bool p_update_all = false);
 	void _multiple_properties_changed(Vector<String> p_paths, Array p_values, bool p_changing = false);
 	void _property_keyed(const String &p_path, bool p_advance);
 	void _property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance);


### PR DESCRIPTION
Full inspector update was triggered only on property changed, but not on undo/redo actions, which can cause inspector discrepancies when some properties are supposed to be shown or hidden.

Now update all flag is passed into `_edit_set()` method which already has logic to handle this case properly (it still triggers `update_tree()` down the line).