### PR TITLE
Rename plane shape to world margin shape in 3D physics server

### DIFF
--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -845,11 +845,6 @@
 				Sets a pin_joint parameter (see [enum PinJointParam] constants).
 			</description>
 		</method>
-		<method name="plane_shape_create">
-			<return type="RID" />
-			<description>
-			</description>
-		</method>
 		<method name="separation_ray_shape_create">
 			<return type="RID" />
 			<description>
@@ -961,6 +956,11 @@
 			</description>
 		</method>
 		<method name="sphere_shape_create">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="world_margin_shape_create">
 			<return type="RID" />
 			<description>
 			</description>
@@ -1174,7 +1174,7 @@
 		<constant name="G6DOF_JOINT_FLAG_ENABLE_LINEAR_MOTOR" value="5" enum="G6DOFJointAxisFlag">
 			If [code]set[/code] there is a linear motor on this axis that targets a specific velocity.
 		</constant>
-		<constant name="SHAPE_PLANE" value="0" enum="ShapeType">
+		<constant name="SHAPE_WORLD_MARGIN" value="0" enum="ShapeType">
 			The [Shape3D] is a [WorldMarginShape3D].
 		</constant>
 		<constant name="SHAPE_SEPARATION_RAY" value="1" enum="ShapeType">

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -87,8 +87,8 @@ RID BulletPhysicsServer3D::shape_create(ShapeType p_shape) {
 	ShapeBullet *shape = nullptr;
 
 	switch (p_shape) {
-		case SHAPE_PLANE: {
-			shape = bulletnew(PlaneShapeBullet);
+		case SHAPE_WORLD_MARGIN: {
+			shape = bulletnew(WorldMarginShapeBullet);
 		} break;
 		case SHAPE_SPHERE: {
 			shape = bulletnew(SphereShapeBullet);

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -110,7 +110,7 @@ btEmptyShape *ShapeBullet::create_shape_empty() {
 	return bulletnew(btEmptyShape);
 }
 
-btStaticPlaneShape *ShapeBullet::create_shape_plane(const btVector3 &planeNormal, btScalar planeConstant) {
+btStaticPlaneShape *ShapeBullet::create_shape_world_margin(const btVector3 &planeNormal, btScalar planeConstant) {
 	return bulletnew(btStaticPlaneShape(planeNormal, planeConstant));
 }
 
@@ -164,32 +164,32 @@ btRayShape *ShapeBullet::create_shape_ray(real_t p_length, bool p_slips_on_slope
 	return r;
 }
 
-/* PLANE */
+/* World margin */
 
-PlaneShapeBullet::PlaneShapeBullet() :
+WorldMarginShapeBullet::WorldMarginShapeBullet() :
 		ShapeBullet() {}
 
-void PlaneShapeBullet::set_data(const Variant &p_data) {
+void WorldMarginShapeBullet::set_data(const Variant &p_data) {
 	setup(p_data);
 }
 
-Variant PlaneShapeBullet::get_data() const {
+Variant WorldMarginShapeBullet::get_data() const {
 	return plane;
 }
 
-PhysicsServer3D::ShapeType PlaneShapeBullet::get_type() const {
-	return PhysicsServer3D::SHAPE_PLANE;
+PhysicsServer3D::ShapeType WorldMarginShapeBullet::get_type() const {
+	return PhysicsServer3D::SHAPE_WORLD_MARGIN;
 }
 
-void PlaneShapeBullet::setup(const Plane &p_plane) {
+void WorldMarginShapeBullet::setup(const Plane &p_plane) {
 	plane = p_plane;
 	notifyShapeChanged();
 }
 
-btCollisionShape *PlaneShapeBullet::create_bt_shape(const btVector3 &p_implicit_scale, real_t p_extra_edge) {
+btCollisionShape *WorldMarginShapeBullet::create_bt_shape(const btVector3 &p_implicit_scale, real_t p_extra_edge) {
 	btVector3 btPlaneNormal;
 	G_TO_B(plane.normal, btPlaneNormal);
-	return prepare(PlaneShapeBullet::create_shape_plane(btPlaneNormal, plane.d));
+	return prepare(WorldMarginShapeBullet::create_shape_world_margin(btPlaneNormal, plane.d));
 }
 
 /* Sphere */

--- a/modules/bullet/shape_bullet.h
+++ b/modules/bullet/shape_bullet.h
@@ -81,7 +81,7 @@ public:
 
 public:
 	static class btEmptyShape *create_shape_empty();
-	static class btStaticPlaneShape *create_shape_plane(const btVector3 &planeNormal, btScalar planeConstant);
+	static class btStaticPlaneShape *create_shape_world_margin(const btVector3 &planeNormal, btScalar planeConstant);
 	static class btSphereShape *create_shape_sphere(btScalar radius);
 	static class btBoxShape *create_shape_box(const btVector3 &boxHalfExtents);
 	static class btCapsuleShape *create_shape_capsule(btScalar radius, btScalar height);
@@ -93,11 +93,11 @@ public:
 	static class btRayShape *create_shape_ray(real_t p_length, bool p_slips_on_slope);
 };
 
-class PlaneShapeBullet : public ShapeBullet {
+class WorldMarginShapeBullet : public ShapeBullet {
 	Plane plane;
 
 public:
-	PlaneShapeBullet();
+	WorldMarginShapeBullet();
 
 	virtual void set_data(const Variant &p_data);
 	virtual Variant get_data() const;

--- a/scene/resources/world_margin_shape_3d.cpp
+++ b/scene/resources/world_margin_shape_3d.cpp
@@ -83,6 +83,6 @@ void WorldMarginShape3D::_bind_methods() {
 }
 
 WorldMarginShape3D::WorldMarginShape3D() :
-		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_PLANE)) {
+		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_WORLD_MARGIN)) {
 	set_plane(Plane(0, 1, 0, 0));
 }

--- a/servers/physics_3d/collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/collision_solver_3d_sat.cpp
@@ -2272,13 +2272,13 @@ static void _collision_convex_polygon_face(const Shape3DSW *p_a, const Transform
 bool sat_calculate_penetration(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, CollisionSolver3DSW::CallbackResult p_result_callback, void *p_userdata, bool p_swap, Vector3 *r_prev_axis, real_t p_margin_a, real_t p_margin_b) {
 	PhysicsServer3D::ShapeType type_A = p_shape_A->get_type();
 
-	ERR_FAIL_COND_V(type_A == PhysicsServer3D::SHAPE_PLANE, false);
+	ERR_FAIL_COND_V(type_A == PhysicsServer3D::SHAPE_WORLD_MARGIN, false);
 	ERR_FAIL_COND_V(type_A == PhysicsServer3D::SHAPE_SEPARATION_RAY, false);
 	ERR_FAIL_COND_V(p_shape_A->is_concave(), false);
 
 	PhysicsServer3D::ShapeType type_B = p_shape_B->get_type();
 
-	ERR_FAIL_COND_V(type_B == PhysicsServer3D::SHAPE_PLANE, false);
+	ERR_FAIL_COND_V(type_B == PhysicsServer3D::SHAPE_WORLD_MARGIN, false);
 	ERR_FAIL_COND_V(type_B == PhysicsServer3D::SHAPE_SEPARATION_RAY, false);
 	ERR_FAIL_COND_V(p_shape_B->is_concave(), false);
 

--- a/servers/physics_3d/collision_solver_3d_sw.cpp
+++ b/servers/physics_3d/collision_solver_3d_sw.cpp
@@ -37,12 +37,12 @@
 #define collision_solver sat_calculate_penetration
 //#define collision_solver gjk_epa_calculate_penetration
 
-bool CollisionSolver3DSW::solve_static_plane(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, bool p_swap_result) {
-	const PlaneShape3DSW *plane = static_cast<const PlaneShape3DSW *>(p_shape_A);
-	if (p_shape_B->get_type() == PhysicsServer3D::SHAPE_PLANE) {
+bool CollisionSolver3DSW::solve_static_world_margin(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, bool p_swap_result) {
+	const WorldMarginShape3DSW *world_margin = static_cast<const WorldMarginShape3DSW *>(p_shape_A);
+	if (p_shape_B->get_type() == PhysicsServer3D::SHAPE_WORLD_MARGIN) {
 		return false;
 	}
-	Plane p = p_transform_A.xform(plane->get_plane());
+	Plane p = p_transform_A.xform(world_margin->get_plane());
 
 	static const int max_supports = 16;
 	Vector3 supports[max_supports];
@@ -365,8 +365,8 @@ bool CollisionSolver3DSW::solve_static(const Shape3DSW *p_shape_A, const Transfo
 		swap = true;
 	}
 
-	if (type_A == PhysicsServer3D::SHAPE_PLANE) {
-		if (type_B == PhysicsServer3D::SHAPE_PLANE) {
+	if (type_A == PhysicsServer3D::SHAPE_WORLD_MARGIN) {
+		if (type_B == PhysicsServer3D::SHAPE_WORLD_MARGIN) {
 			return false;
 		}
 		if (type_B == PhysicsServer3D::SHAPE_SEPARATION_RAY) {
@@ -377,9 +377,9 @@ bool CollisionSolver3DSW::solve_static(const Shape3DSW *p_shape_A, const Transfo
 		}
 
 		if (swap) {
-			return solve_static_plane(p_shape_B, p_transform_B, p_shape_A, p_transform_A, p_result_callback, p_userdata, true);
+			return solve_static_world_margin(p_shape_B, p_transform_B, p_shape_A, p_transform_A, p_result_callback, p_userdata, true);
 		} else {
-			return solve_static_plane(p_shape_A, p_transform_A, p_shape_B, p_transform_B, p_result_callback, p_userdata, false);
+			return solve_static_world_margin(p_shape_A, p_transform_A, p_shape_B, p_transform_B, p_result_callback, p_userdata, false);
 		}
 
 	} else if (type_A == PhysicsServer3D::SHAPE_SEPARATION_RAY) {
@@ -443,12 +443,12 @@ bool CollisionSolver3DSW::concave_distance_callback(void *p_userdata, Shape3DSW 
 	return false;
 }
 
-bool CollisionSolver3DSW::solve_distance_plane(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, Vector3 &r_point_A, Vector3 &r_point_B) {
-	const PlaneShape3DSW *plane = static_cast<const PlaneShape3DSW *>(p_shape_A);
-	if (p_shape_B->get_type() == PhysicsServer3D::SHAPE_PLANE) {
+bool CollisionSolver3DSW::solve_distance_world_margin(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, Vector3 &r_point_A, Vector3 &r_point_B) {
+	const WorldMarginShape3DSW *world_margin = static_cast<const WorldMarginShape3DSW *>(p_shape_A);
+	if (p_shape_B->get_type() == PhysicsServer3D::SHAPE_WORLD_MARGIN) {
 		return false;
 	}
-	Plane p = p_transform_A.xform(plane->get_plane());
+	Plane p = p_transform_A.xform(world_margin->get_plane());
 
 	static const int max_supports = 16;
 	Vector3 supports[max_supports];
@@ -500,9 +500,9 @@ bool CollisionSolver3DSW::solve_distance(const Shape3DSW *p_shape_A, const Trans
 		return false;
 	}
 
-	if (p_shape_B->get_type() == PhysicsServer3D::SHAPE_PLANE) {
+	if (p_shape_B->get_type() == PhysicsServer3D::SHAPE_WORLD_MARGIN) {
 		Vector3 a, b;
-		bool col = solve_distance_plane(p_shape_B, p_transform_B, p_shape_A, p_transform_A, a, b);
+		bool col = solve_distance_world_margin(p_shape_B, p_transform_B, p_shape_A, p_transform_A, a, b);
 		r_point_A = b;
 		r_point_B = a;
 		return !col;

--- a/servers/physics_3d/collision_solver_3d_sw.h
+++ b/servers/physics_3d/collision_solver_3d_sw.h
@@ -42,12 +42,12 @@ private:
 	static void soft_body_contact_callback(const Vector3 &p_point_A, int p_index_A, const Vector3 &p_point_B, int p_index_B, void *p_userdata);
 	static bool soft_body_concave_callback(void *p_userdata, Shape3DSW *p_convex);
 	static bool concave_callback(void *p_userdata, Shape3DSW *p_convex);
-	static bool solve_static_plane(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, bool p_swap_result);
+	static bool solve_static_world_margin(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, bool p_swap_result);
 	static bool solve_separation_ray(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, bool p_swap_result, real_t p_margin = 0);
 	static bool solve_soft_body(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, bool p_swap_result);
 	static bool solve_concave(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, bool p_swap_result, real_t p_margin_A = 0, real_t p_margin_B = 0);
 	static bool concave_distance_callback(void *p_userdata, Shape3DSW *p_convex);
-	static bool solve_distance_plane(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, Vector3 &r_point_A, Vector3 &r_point_B);
+	static bool solve_distance_world_margin(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, Vector3 &r_point_A, Vector3 &r_point_B);
 
 public:
 	static bool solve_static(const Shape3DSW *p_shape_A, const Transform3D &p_transform_A, const Shape3DSW *p_shape_B, const Transform3D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, Vector3 *r_sep_axis = nullptr, real_t p_margin_A = 0, real_t p_margin_B = 0);

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -42,8 +42,8 @@
 #define FLUSH_QUERY_CHECK(m_object) \
 	ERR_FAIL_COND_MSG(m_object->get_space() && flushing_queries, "Can't change this state while flushing queries. Use call_deferred() or set_deferred() to change monitoring state instead.");
 
-RID PhysicsServer3DSW::plane_shape_create() {
-	Shape3DSW *shape = memnew(PlaneShape3DSW);
+RID PhysicsServer3DSW::world_margin_shape_create() {
+	Shape3DSW *shape = memnew(WorldMarginShape3DSW);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_self(rid);
 	return rid;

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -82,7 +82,7 @@ public:
 
 	static void _shape_col_cbk(const Vector3 &p_point_A, int p_index_A, const Vector3 &p_point_B, int p_index_B, void *p_userdata);
 
-	virtual RID plane_shape_create() override;
+	virtual RID world_margin_shape_create() override;
 	virtual RID separation_ray_shape_create() override;
 	virtual RID sphere_shape_create() override;
 	virtual RID box_shape_create() override;

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -78,7 +78,7 @@ public:
 #include "servers/server_wrap_mt_common.h"
 
 	//FUNC1RID(shape,ShapeType); todo fix
-	FUNCRID(plane_shape)
+	FUNCRID(world_margin_shape)
 	FUNCRID(separation_ray_shape)
 	FUNCRID(sphere_shape)
 	FUNCRID(box_shape)

--- a/servers/physics_3d/shape_3d_sw.cpp
+++ b/servers/physics_3d/shape_3d_sw.cpp
@@ -110,21 +110,21 @@ Shape3DSW::~Shape3DSW() {
 	ERR_FAIL_COND(owners.size());
 }
 
-Plane PlaneShape3DSW::get_plane() const {
+Plane WorldMarginShape3DSW::get_plane() const {
 	return plane;
 }
 
-void PlaneShape3DSW::project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const {
+void WorldMarginShape3DSW::project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const {
 	// gibberish, a plane is infinity
 	r_min = -1e7;
 	r_max = 1e7;
 }
 
-Vector3 PlaneShape3DSW::get_support(const Vector3 &p_normal) const {
+Vector3 WorldMarginShape3DSW::get_support(const Vector3 &p_normal) const {
 	return p_normal * 1e15;
 }
 
-bool PlaneShape3DSW::intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal) const {
+bool WorldMarginShape3DSW::intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal) const {
 	bool inters = plane.intersects_segment(p_begin, p_end, &r_result);
 	if (inters) {
 		r_normal = plane.normal;
@@ -132,11 +132,11 @@ bool PlaneShape3DSW::intersect_segment(const Vector3 &p_begin, const Vector3 &p_
 	return inters;
 }
 
-bool PlaneShape3DSW::intersect_point(const Vector3 &p_point) const {
+bool WorldMarginShape3DSW::intersect_point(const Vector3 &p_point) const {
 	return plane.distance_to(p_point) < 0;
 }
 
-Vector3 PlaneShape3DSW::get_closest_point_to(const Vector3 &p_point) const {
+Vector3 WorldMarginShape3DSW::get_closest_point_to(const Vector3 &p_point) const {
 	if (plane.is_point_over(p_point)) {
 		return plane.project(p_point);
 	} else {
@@ -144,24 +144,24 @@ Vector3 PlaneShape3DSW::get_closest_point_to(const Vector3 &p_point) const {
 	}
 }
 
-Vector3 PlaneShape3DSW::get_moment_of_inertia(real_t p_mass) const {
-	return Vector3(); //wtf
+Vector3 WorldMarginShape3DSW::get_moment_of_inertia(real_t p_mass) const {
+	return Vector3(); // not applicable.
 }
 
-void PlaneShape3DSW::_setup(const Plane &p_plane) {
+void WorldMarginShape3DSW::_setup(const Plane &p_plane) {
 	plane = p_plane;
 	configure(AABB(Vector3(-1e4, -1e4, -1e4), Vector3(1e4 * 2, 1e4 * 2, 1e4 * 2)));
 }
 
-void PlaneShape3DSW::set_data(const Variant &p_data) {
+void WorldMarginShape3DSW::set_data(const Variant &p_data) {
 	_setup(p_data);
 }
 
-Variant PlaneShape3DSW::get_data() const {
+Variant WorldMarginShape3DSW::get_data() const {
 	return plane;
 }
 
-PlaneShape3DSW::PlaneShape3DSW() {
+WorldMarginShape3DSW::WorldMarginShape3DSW() {
 }
 
 //

--- a/servers/physics_3d/shape_3d_sw.h
+++ b/servers/physics_3d/shape_3d_sw.h
@@ -111,7 +111,7 @@ public:
 	ConcaveShape3DSW() {}
 };
 
-class PlaneShape3DSW : public Shape3DSW {
+class WorldMarginShape3DSW : public Shape3DSW {
 	Plane plane;
 
 	void _setup(const Plane &p_plane);
@@ -120,7 +120,7 @@ public:
 	Plane get_plane() const;
 
 	virtual real_t get_area() const override { return INFINITY; }
-	virtual PhysicsServer3D::ShapeType get_type() const override { return PhysicsServer3D::SHAPE_PLANE; }
+	virtual PhysicsServer3D::ShapeType get_type() const override { return PhysicsServer3D::SHAPE_WORLD_MARGIN; }
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override { r_amount = 0; }
@@ -133,7 +133,7 @@ public:
 	virtual void set_data(const Variant &p_data) override;
 	virtual Variant get_data() const override;
 
-	PlaneShape3DSW();
+	WorldMarginShape3DSW();
 };
 
 class SeparationRayShape3DSW : public Shape3DSW {

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -461,8 +461,8 @@ bool PhysicsServer3D::_body_test_motion(RID p_body, const Transform3D &p_from, c
 
 RID PhysicsServer3D::shape_create(ShapeType p_shape) {
 	switch (p_shape) {
-		case SHAPE_PLANE:
-			return plane_shape_create();
+		case SHAPE_WORLD_MARGIN:
+			return world_margin_shape_create();
 		case SHAPE_SEPARATION_RAY:
 			return separation_ray_shape_create();
 		case SHAPE_SPHERE:
@@ -489,7 +489,7 @@ RID PhysicsServer3D::shape_create(ShapeType p_shape) {
 void PhysicsServer3D::_bind_methods() {
 #ifndef _3D_DISABLED
 
-	ClassDB::bind_method(D_METHOD("plane_shape_create"), &PhysicsServer3D::plane_shape_create);
+	ClassDB::bind_method(D_METHOD("world_margin_shape_create"), &PhysicsServer3D::world_margin_shape_create);
 	ClassDB::bind_method(D_METHOD("separation_ray_shape_create"), &PhysicsServer3D::separation_ray_shape_create);
 	ClassDB::bind_method(D_METHOD("sphere_shape_create"), &PhysicsServer3D::sphere_shape_create);
 	ClassDB::bind_method(D_METHOD("box_shape_create"), &PhysicsServer3D::box_shape_create);
@@ -750,7 +750,7 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_process_info", "process_info"), &PhysicsServer3D::get_process_info);
 
-	BIND_ENUM_CONSTANT(SHAPE_PLANE);
+	BIND_ENUM_CONSTANT(SHAPE_WORLD_MARGIN);
 	BIND_ENUM_CONSTANT(SHAPE_SEPARATION_RAY);
 	BIND_ENUM_CONSTANT(SHAPE_SPHERE);
 	BIND_ENUM_CONSTANT(SHAPE_BOX);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -221,7 +221,7 @@ public:
 	static PhysicsServer3D *get_singleton();
 
 	enum ShapeType {
-		SHAPE_PLANE, ///< plane:"plane"
+		SHAPE_WORLD_MARGIN, ///< plane:"plane"
 		SHAPE_SEPARATION_RAY, ///< float:"length"
 		SHAPE_SPHERE, ///< float:"radius"
 		SHAPE_BOX, ///< vec3:"extents"
@@ -236,7 +236,7 @@ public:
 
 	RID shape_create(ShapeType p_shape);
 
-	virtual RID plane_shape_create() = 0;
+	virtual RID world_margin_shape_create() = 0;
 	virtual RID separation_ray_shape_create() = 0;
 	virtual RID sphere_shape_create() = 0;
 	virtual RID box_shape_create() = 0;

--- a/tests/test_physics_3d.cpp
+++ b/tests/test_physics_3d.cpp
@@ -103,7 +103,7 @@ protected:
 	RID create_static_plane(const Plane &p_plane) {
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
 
-		RID world_margin_shape = ps->shape_create(PhysicsServer3D::SHAPE_PLANE);
+		RID world_margin_shape = ps->shape_create(PhysicsServer3D::SHAPE_WORLD_MARGIN);
 		ps->shape_set_data(world_margin_shape, p_plane);
 
 		RID b = ps->body_create();


### PR DESCRIPTION
Same as already done for 2D and for the 3D shape resource, for consistency.
Also made the changes in Bullet server even though it's disabled for now.

Following up from https://github.com/godotengine/godot/pull/51636#issue-712533967 (CC @Calinou)