### PR TITLE
Show help for built-in functions (@GlobalScope)

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1328,6 +1328,8 @@ void EditorHelp::_help_callback(const String &p_topic) {
 	} else if (what == "class_global") {
 		if (constant_line.has(name)) {
 			line = constant_line[name];
+		} else if (method_line.has(name)) {
+			line = method_line[name];
 		} else {
 			Map<String, Map<String, int>>::Element *iter = enum_values_line.front();
 			while (true) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3078,6 +3078,15 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						r_result.class_member = p_symbol;
 						return OK;
 					}
+				} else {
+					List<StringName> utility_functions;
+					Variant::get_utility_function_list(&utility_functions);
+					if (utility_functions.find(p_symbol) != nullptr) {
+						r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_TBD_GLOBALSCOPE;
+						r_result.class_name = "@GlobalScope";
+						r_result.class_member = p_symbol;
+						return OK;
+					}
 				}
 			}
 		} break;


### PR DESCRIPTION
This should fix #51687.

Although the help of the method is selected, it doesn't scroll in view. This seems a different issue which is also mentioned in https://github.com/godotengine/godot/issues/52124#issuecomment-907340160.
