### PR TITLE
Fix missing renames in the GLTF module

### DIFF
--- a/modules/gltf/doc_classes/GLTFCamera.xml
+++ b/modules/gltf/doc_classes/GLTFCamera.xml
@@ -9,13 +9,13 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="depth_far" type="float" setter="set_depth_far" getter="get_depth_far" default="4000.0">
+		</member>
+		<member name="depth_near" type="float" setter="set_depth_near" getter="get_depth_near" default="0.05">
+		</member>
 		<member name="fov_size" type="float" setter="set_fov_size" getter="get_fov_size" default="75.0">
 		</member>
 		<member name="perspective" type="bool" setter="set_perspective" getter="get_perspective" default="true">
-		</member>
-		<member name="zfar" type="float" setter="set_zfar" getter="get_zfar" default="4000.0">
-		</member>
-		<member name="znear" type="float" setter="set_znear" getter="get_znear" default="0.05">
 		</member>
 	</members>
 	<constants>

--- a/modules/gltf/doc_classes/GLTFLight.xml
+++ b/modules/gltf/doc_classes/GLTFLight.xml
@@ -15,11 +15,11 @@
 		</member>
 		<member name="intensity" type="float" setter="set_intensity" getter="get_intensity" default="0.0">
 		</member>
+		<member name="light_type" type="String" setter="set_light_type" getter="get_light_type" default="&quot;&quot;">
+		</member>
 		<member name="outer_cone_angle" type="float" setter="set_outer_cone_angle" getter="get_outer_cone_angle" default="0.0">
 		</member>
 		<member name="range" type="float" setter="set_range" getter="get_range" default="0.0">
-		</member>
-		<member name="type" type="String" setter="set_type" getter="get_type" default="&quot;&quot;">
 		</member>
 	</members>
 	<constants>

--- a/modules/gltf/doc_classes/GLTFNode.xml
+++ b/modules/gltf/doc_classes/GLTFNode.xml
@@ -23,6 +23,8 @@
 		</member>
 		<member name="parent" type="int" setter="set_parent" getter="get_parent" default="-1">
 		</member>
+		<member name="position" type="Vector3" setter="set_position" getter="get_position" default="Vector3(0, 0, 0)">
+		</member>
 		<member name="rotation" type="Quaternion" setter="set_rotation" getter="get_rotation" default="Quaternion(0, 0, 0, 1)">
 		</member>
 		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale" default="Vector3(1, 1, 1)">
@@ -30,8 +32,6 @@
 		<member name="skeleton" type="int" setter="set_skeleton" getter="get_skeleton" default="-1">
 		</member>
 		<member name="skin" type="int" setter="set_skin" getter="get_skin" default="-1">
-		</member>
-		<member name="translation" type="Vector3" setter="set_translation" getter="get_translation" default="Vector3(0, 0, 0)">
 		</member>
 		<member name="xform" type="Transform3D" setter="set_xform" getter="get_xform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 		</member>

--- a/modules/gltf/gltf_animation.h
+++ b/modules/gltf/gltf_animation.h
@@ -55,7 +55,7 @@ public:
 	};
 
 	struct Track {
-		Channel<Vector3> translation_track;
+		Channel<Vector3> position_track;
 		Channel<Quaternion> rotation_track;
 		Channel<Vector3> scale_track;
 		Vector<Channel<float>> weight_tracks;

--- a/modules/gltf/gltf_camera.cpp
+++ b/modules/gltf/gltf_camera.cpp
@@ -35,13 +35,13 @@ void GLTFCamera::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_perspective", "perspective"), &GLTFCamera::set_perspective);
 	ClassDB::bind_method(D_METHOD("get_fov_size"), &GLTFCamera::get_fov_size);
 	ClassDB::bind_method(D_METHOD("set_fov_size", "fov_size"), &GLTFCamera::set_fov_size);
-	ClassDB::bind_method(D_METHOD("get_zfar"), &GLTFCamera::get_zfar);
-	ClassDB::bind_method(D_METHOD("set_zfar", "zfar"), &GLTFCamera::set_zfar);
-	ClassDB::bind_method(D_METHOD("get_znear"), &GLTFCamera::get_znear);
-	ClassDB::bind_method(D_METHOD("set_znear", "znear"), &GLTFCamera::set_znear);
+	ClassDB::bind_method(D_METHOD("get_depth_far"), &GLTFCamera::get_depth_far);
+	ClassDB::bind_method(D_METHOD("set_depth_far", "zdepth_far"), &GLTFCamera::set_depth_far);
+	ClassDB::bind_method(D_METHOD("get_depth_near"), &GLTFCamera::get_depth_near);
+	ClassDB::bind_method(D_METHOD("set_depth_near", "zdepth_near"), &GLTFCamera::set_depth_near);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "perspective"), "set_perspective", "get_perspective"); // bool
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fov_size"), "set_fov_size", "get_fov_size"); // float
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "zfar"), "set_zfar", "get_zfar"); // float
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "znear"), "set_znear", "get_znear"); // float
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "depth_far"), "set_depth_far", "get_depth_far"); // float
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "depth_near"), "set_depth_near", "get_depth_near"); // float
 }

--- a/modules/gltf/gltf_camera.h
+++ b/modules/gltf/gltf_camera.h
@@ -39,8 +39,8 @@ class GLTFCamera : public Resource {
 private:
 	bool perspective = true;
 	float fov_size = 75.0;
-	float zfar = 4000.0;
-	float znear = 0.05;
+	float depth_far = 4000.0;
+	float depth_near = 0.05;
 
 protected:
 	static void _bind_methods();
@@ -50,9 +50,9 @@ public:
 	void set_perspective(bool p_val) { perspective = p_val; }
 	float get_fov_size() const { return fov_size; }
 	void set_fov_size(float p_val) { fov_size = p_val; }
-	float get_zfar() const { return zfar; }
-	void set_zfar(float p_val) { zfar = p_val; }
-	float get_znear() const { return znear; }
-	void set_znear(float p_val) { znear = p_val; }
+	float get_depth_far() const { return depth_far; }
+	void set_depth_far(float p_val) { depth_far = p_val; }
+	float get_depth_near() const { return depth_near; }
+	void set_depth_near(float p_val) { depth_near = p_val; }
 };
 #endif // GLTF_CAMERA_H

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -426,8 +426,8 @@ Error GLTFDocument::_serialize_nodes(Ref<GLTFState> state) {
 			node["scale"] = _vec3_to_arr(n->scale);
 		}
 
-		if (!n->translation.is_equal_approx(Vector3())) {
-			node["translation"] = _vec3_to_arr(n->translation);
+		if (!n->position.is_equal_approx(Vector3())) {
+			node["translation"] = _vec3_to_arr(n->position);
 		}
 		if (n->children.size()) {
 			Array children;
@@ -581,7 +581,7 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> state) {
 			node->xform = _arr_to_xform(n["matrix"]);
 		} else {
 			if (n.has("translation")) {
-				node->translation = _arr_to_vec3(n["translation"]);
+				node->position = _arr_to_vec3(n["translation"]);
 			}
 			if (n.has("rotation")) {
 				node->rotation = _arr_to_quaternion(n["rotation"]);
@@ -591,7 +591,7 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> state) {
 			}
 
 			node->xform.basis.set_quaternion_scale(node->rotation, node->scale);
-			node->xform.origin = node->translation;
+			node->xform.origin = node->position;
 		}
 
 		if (n.has("extensions")) {
@@ -4356,8 +4356,8 @@ Error GLTFDocument::_serialize_lights(Ref<GLTFState> state) {
 		color[1] = light->color.g;
 		color[2] = light->color.b;
 		d["color"] = color;
-		d["type"] = light->type;
-		if (light->type == "spot") {
+		d["type"] = light->light_type;
+		if (light->light_type == "spot") {
 			Dictionary s;
 			float inner_cone_angle = light->inner_cone_angle;
 			s["innerConeAngle"] = inner_cone_angle;
@@ -4403,16 +4403,16 @@ Error GLTFDocument::_serialize_cameras(Ref<GLTFState> state) {
 			Dictionary og;
 			og["ymag"] = Math::deg2rad(camera->get_fov_size());
 			og["xmag"] = Math::deg2rad(camera->get_fov_size());
-			og["zfar"] = camera->get_zfar();
-			og["znear"] = camera->get_znear();
+			og["zfar"] = camera->get_depth_far();
+			og["znear"] = camera->get_depth_near();
 			d["orthographic"] = og;
 			d["type"] = "orthographic";
 		} else if (camera->get_perspective()) {
 			Dictionary ppt;
 			// GLTF spec is in radians, Godot's camera is in degrees.
 			ppt["yfov"] = Math::deg2rad(camera->get_fov_size());
-			ppt["zfar"] = camera->get_zfar();
-			ppt["znear"] = camera->get_znear();
+			ppt["zfar"] = camera->get_depth_far();
+			ppt["znear"] = camera->get_depth_near();
 			d["perspective"] = ppt;
 			d["type"] = "perspective";
 		}
@@ -4452,7 +4452,7 @@ Error GLTFDocument::_parse_lights(Ref<GLTFState> state) {
 		light.instantiate();
 		ERR_FAIL_COND_V(!d.has("type"), ERR_PARSE_ERROR);
 		const String &type = d["type"];
-		light->type = type;
+		light->light_type = type;
 
 		if (d.has("color")) {
 			const Array &arr = d["color"];
@@ -4503,8 +4503,8 @@ Error GLTFDocument::_parse_cameras(Ref<GLTFState> state) {
 				const Dictionary &og = d["orthographic"];
 				// GLTF spec is in radians, Godot's camera is in degrees.
 				camera->set_fov_size(Math::rad2deg(real_t(og["ymag"])));
-				camera->set_zfar(og["zfar"]);
-				camera->set_znear(og["znear"]);
+				camera->set_depth_far(og["zfar"]);
+				camera->set_depth_near(og["znear"]);
 			} else {
 				camera->set_fov_size(10);
 			}
@@ -4514,8 +4514,8 @@ Error GLTFDocument::_parse_cameras(Ref<GLTFState> state) {
 				const Dictionary &ppt = d["perspective"];
 				// GLTF spec is in radians, Godot's camera is in degrees.
 				camera->set_fov_size(Math::rad2deg(real_t(ppt["yfov"])));
-				camera->set_zfar(ppt["zfar"]);
-				camera->set_znear(ppt["znear"]);
+				camera->set_depth_far(ppt["zfar"]);
+				camera->set_depth_near(ppt["znear"]);
 			} else {
 				camera->set_fov_size(10);
 			}
@@ -4576,15 +4576,15 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 
 		for (Map<int, GLTFAnimation::Track>::Element *track_i = gltf_animation->get_tracks().front(); track_i; track_i = track_i->next()) {
 			GLTFAnimation::Track track = track_i->get();
-			if (track.translation_track.times.size()) {
+			if (track.position_track.times.size()) {
 				Dictionary t;
 				t["sampler"] = samplers.size();
 				Dictionary s;
 
-				s["interpolation"] = interpolation_to_string(track.translation_track.interpolation);
-				Vector<real_t> times = Variant(track.translation_track.times);
+				s["interpolation"] = interpolation_to_string(track.position_track.interpolation);
+				Vector<real_t> times = Variant(track.position_track.times);
 				s["input"] = _encode_accessor_as_floats(state, times, false);
-				Vector<Vector3> values = Variant(track.translation_track.values);
+				Vector<Vector3> values = Variant(track.position_track.values);
 				s["output"] = _encode_accessor_as_vec3(state, values, false);
 
 				samplers.push_back(s);
@@ -4769,10 +4769,10 @@ Error GLTFDocument::_parse_animations(Ref<GLTFState> state) {
 
 			const Vector<float> times = _decode_accessor_as_floats(state, input, false);
 			if (path == "translation") {
-				const Vector<Vector3> translations = _decode_accessor_as_vec3(state, output, false);
-				track->translation_track.interpolation = interp;
-				track->translation_track.times = Variant(times); //convert via variant
-				track->translation_track.values = Variant(translations); //convert via variant
+				const Vector<Vector3> positions = _decode_accessor_as_vec3(state, output, false);
+				track->position_track.interpolation = interp;
+				track->position_track.times = Variant(times); //convert via variant
+				track->position_track.values = Variant(positions); //convert via variant
 			} else if (path == "rotation") {
 				const Vector<Quaternion> rotations = _decode_accessor_as_quaternion(state, output, false);
 				track->rotation_track.interpolation = interp;
@@ -4950,7 +4950,7 @@ Node3D *GLTFDocument::_generate_light(Ref<GLTFState> state, Node *scene_parent, 
 		intensity /= 100;
 	}
 
-	if (l->type == "directional") {
+	if (l->light_type == "directional") {
 		DirectionalLight3D *light = memnew(DirectionalLight3D);
 		light->set_param(Light3D::PARAM_ENERGY, intensity);
 		light->set_color(l->color);
@@ -4961,14 +4961,14 @@ Node3D *GLTFDocument::_generate_light(Ref<GLTFState> state, Node *scene_parent, 
 	// Doubling the range will double the effective brightness, so we need double attenuation (half brightness).
 	// We want to have double intensity give double brightness, so we need half the attenuation.
 	const float attenuation = range / intensity;
-	if (l->type == "point") {
+	if (l->light_type == "point") {
 		OmniLight3D *light = memnew(OmniLight3D);
 		light->set_param(OmniLight3D::PARAM_ATTENUATION, attenuation);
 		light->set_param(OmniLight3D::PARAM_RANGE, range);
 		light->set_color(l->color);
 		return light;
 	}
-	if (l->type == "spot") {
+	if (l->light_type == "spot") {
 		SpotLight3D *light = memnew(SpotLight3D);
 		light->set_param(SpotLight3D::PARAM_ATTENUATION, attenuation);
 		light->set_param(SpotLight3D::PARAM_RANGE, range);
@@ -4995,9 +4995,9 @@ Camera3D *GLTFDocument::_generate_camera(Ref<GLTFState> state, Node *scene_paren
 
 	Ref<GLTFCamera> c = state->cameras[gltf_node->camera];
 	if (c->get_perspective()) {
-		camera->set_perspective(c->get_fov_size(), c->get_znear(), c->get_zfar());
+		camera->set_perspective(c->get_fov_size(), c->get_depth_near(), c->get_depth_far());
 	} else {
-		camera->set_orthogonal(c->get_fov_size(), c->get_znear(), c->get_zfar());
+		camera->set_orthogonal(c->get_fov_size(), c->get_depth_near(), c->get_depth_far());
 	}
 
 	return camera;
@@ -5011,14 +5011,10 @@ GLTFCameraIndex GLTFDocument::_convert_camera(Ref<GLTFState> state, Camera3D *p_
 
 	if (p_camera->get_projection() == Camera3D::Projection::PROJECTION_PERSPECTIVE) {
 		c->set_perspective(true);
-		c->set_fov_size(p_camera->get_fov());
-		c->set_zfar(p_camera->get_far());
-		c->set_znear(p_camera->get_near());
-	} else {
-		c->set_fov_size(p_camera->get_fov());
-		c->set_zfar(p_camera->get_far());
-		c->set_znear(p_camera->get_near());
 	}
+	c->set_fov_size(p_camera->get_fov());
+	c->set_depth_far(p_camera->get_far());
+	c->set_depth_near(p_camera->get_near());
 	GLTFCameraIndex camera_index = state->cameras.size();
 	state->cameras.push_back(c);
 	return camera_index;
@@ -5031,18 +5027,18 @@ GLTFLightIndex GLTFDocument::_convert_light(Ref<GLTFState> state, Light3D *p_lig
 	l.instantiate();
 	l->color = p_light->get_color();
 	if (cast_to<DirectionalLight3D>(p_light)) {
-		l->type = "directional";
+		l->light_type = "directional";
 		DirectionalLight3D *light = cast_to<DirectionalLight3D>(p_light);
 		l->intensity = light->get_param(DirectionalLight3D::PARAM_ENERGY);
 		l->range = FLT_MAX; // Range for directional lights is infinite in Godot.
 	} else if (cast_to<OmniLight3D>(p_light)) {
-		l->type = "point";
+		l->light_type = "point";
 		OmniLight3D *light = cast_to<OmniLight3D>(p_light);
 		l->range = light->get_param(OmniLight3D::PARAM_RANGE);
 		float attenuation = p_light->get_param(OmniLight3D::PARAM_ATTENUATION);
 		l->intensity = l->range / attenuation;
 	} else if (cast_to<SpotLight3D>(p_light)) {
-		l->type = "spot";
+		l->light_type = "spot";
 		SpotLight3D *light = cast_to<SpotLight3D>(p_light);
 		l->range = light->get_param(SpotLight3D::PARAM_RANGE);
 		float attenuation = light->get_param(SpotLight3D::PARAM_ATTENUATION);
@@ -5075,7 +5071,7 @@ void GLTFDocument::_convert_spatial(Ref<GLTFState> state, Node3D *p_spatial, Ref
 	Transform3D xform = p_spatial->get_transform();
 	p_node->scale = xform.basis.get_scale();
 	p_node->rotation = xform.basis.get_rotation_quaternion();
-	p_node->translation = xform.origin;
+	p_node->position = xform.origin;
 }
 
 Node3D *GLTFDocument::_generate_spatial(Ref<GLTFState> state, Node *scene_parent, const GLTFNodeIndex node_index) {
@@ -5658,8 +5654,8 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 		for (int i = 0; i < track.rotation_track.times.size(); i++) {
 			length = MAX(length, track.rotation_track.times[i]);
 		}
-		for (int i = 0; i < track.translation_track.times.size(); i++) {
-			length = MAX(length, track.translation_track.times[i]);
+		for (int i = 0; i < track.position_track.times.size(); i++) {
+			length = MAX(length, track.position_track.times[i]);
 		}
 		for (int i = 0; i < track.scale_track.times.size(); i++) {
 			length = MAX(length, track.scale_track.times[i]);
@@ -5673,7 +5669,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 
 		// Animated TRS properties will not affect a skinned mesh.
 		const bool transform_affects_skinned_mesh_instance = gltf_node->skeleton < 0 && gltf_node->skin >= 0;
-		if ((track.rotation_track.values.size() || track.translation_track.values.size() || track.scale_track.values.size()) && !transform_affects_skinned_mesh_instance) {
+		if ((track.rotation_track.values.size() || track.position_track.values.size() || track.scale_track.values.size()) && !transform_affects_skinned_mesh_instance) {
 			//make transform track
 			int track_idx = animation->get_track_count();
 			animation->add_track(Animation::TYPE_TRANSFORM3D);
@@ -5691,8 +5687,8 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 				base_rot = state->nodes[track_i->key()]->rotation.normalized();
 			}
 
-			if (!track.translation_track.values.size()) {
-				base_pos = state->nodes[track_i->key()]->translation;
+			if (!track.position_track.values.size()) {
+				base_pos = state->nodes[track_i->key()]->position;
 			}
 
 			if (!track.scale_track.values.size()) {
@@ -5705,8 +5701,8 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 				Quaternion rot = base_rot;
 				Vector3 scale = base_scale;
 
-				if (track.translation_track.times.size()) {
-					pos = _interpolate_track<Vector3>(track.translation_track.times, track.translation_track.values, time, track.translation_track.interpolation);
+				if (track.position_track.times.size()) {
+					pos = _interpolate_track<Vector3>(track.position_track.times, track.position_track.values, time, track.position_track.interpolation);
 				}
 
 				if (track.rotation_track.times.size()) {
@@ -5814,7 +5810,7 @@ void GLTFDocument::_convert_mesh_instances(Ref<GLTFState> state) {
 		Transform3D mi_xform = mi->get_transform();
 		node->scale = mi_xform.basis.get_scale();
 		node->rotation = mi_xform.basis.get_rotation_quaternion();
-		node->translation = mi_xform.origin;
+		node->position = mi_xform.origin;
 
 		Dictionary json_skin;
 		Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(mi->get_node(mi->get_skeleton_path()));
@@ -5878,7 +5874,7 @@ void GLTFDocument::_convert_mesh_instances(Ref<GLTFState> state) {
 			Transform3D bone_rest_xform = skeleton->get_bone_rest(bone_index);
 			joint_node->scale = bone_rest_xform.basis.get_scale();
 			joint_node->rotation = bone_rest_xform.basis.get_rotation_quaternion();
-			joint_node->translation = bone_rest_xform.origin;
+			joint_node->position = bone_rest_xform.origin;
 			joint_node->joint = true;
 
 			int32_t joint_node_i = state->nodes.size();
@@ -6024,8 +6020,8 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 	}
 	const float BAKE_FPS = 30.0f;
 	if (track_type == Animation::TYPE_TRANSFORM3D) {
-		p_track.translation_track.times = times;
-		p_track.translation_track.interpolation = gltf_interpolation;
+		p_track.position_track.times = times;
+		p_track.position_track.interpolation = gltf_interpolation;
 		p_track.rotation_track.times = times;
 		p_track.rotation_track.interpolation = gltf_interpolation;
 		p_track.scale_track.times = times;
@@ -6033,27 +6029,27 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 
 		p_track.scale_track.values.resize(key_count);
 		p_track.scale_track.interpolation = gltf_interpolation;
-		p_track.translation_track.values.resize(key_count);
-		p_track.translation_track.interpolation = gltf_interpolation;
+		p_track.position_track.values.resize(key_count);
+		p_track.position_track.interpolation = gltf_interpolation;
 		p_track.rotation_track.values.resize(key_count);
 		p_track.rotation_track.interpolation = gltf_interpolation;
 		for (int32_t key_i = 0; key_i < key_count; key_i++) {
-			Vector3 translation;
+			Vector3 position;
 			Quaternion rotation;
 			Vector3 scale;
-			Error err = p_animation->transform_track_get_key(p_track_i, key_i, &translation, &rotation, &scale);
+			Error err = p_animation->transform_track_get_key(p_track_i, key_i, &position, &rotation, &scale);
 			ERR_CONTINUE(err != OK);
 			Transform3D xform;
 			xform.basis.set_quaternion_scale(rotation, scale);
-			xform.origin = translation;
+			xform.origin = position;
 			xform = p_bone_rest * xform;
-			p_track.translation_track.values.write[key_i] = xform.get_origin();
+			p_track.position_track.values.write[key_i] = xform.get_origin();
 			p_track.rotation_track.values.write[key_i] = xform.basis.get_rotation_quaternion();
 			p_track.scale_track.values.write[key_i] = xform.basis.get_scale();
 		}
 	} else if (path.find(":transform") != -1) {
-		p_track.translation_track.times = times;
-		p_track.translation_track.interpolation = gltf_interpolation;
+		p_track.position_track.times = times;
+		p_track.position_track.interpolation = gltf_interpolation;
 		p_track.rotation_track.times = times;
 		p_track.rotation_track.interpolation = gltf_interpolation;
 		p_track.scale_track.times = times;
@@ -6061,13 +6057,13 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 
 		p_track.scale_track.values.resize(key_count);
 		p_track.scale_track.interpolation = gltf_interpolation;
-		p_track.translation_track.values.resize(key_count);
-		p_track.translation_track.interpolation = gltf_interpolation;
+		p_track.position_track.values.resize(key_count);
+		p_track.position_track.interpolation = gltf_interpolation;
 		p_track.rotation_track.values.resize(key_count);
 		p_track.rotation_track.interpolation = gltf_interpolation;
 		for (int32_t key_i = 0; key_i < key_count; key_i++) {
 			Transform3D xform = p_animation->track_get_key_value(p_track_i, key_i);
-			p_track.translation_track.values.write[key_i] = xform.get_origin();
+			p_track.position_track.values.write[key_i] = xform.get_origin();
 			p_track.rotation_track.values.write[key_i] = xform.basis.get_rotation_quaternion();
 			p_track.scale_track.values.write[key_i] = xform.basis.get_scale();
 		}
@@ -6083,16 +6079,16 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 				Quaternion rotation_track = p_animation->track_get_key_value(p_track_i, key_i);
 				p_track.rotation_track.values.write[key_i] = rotation_track;
 			}
-		} else if (path.find(":translation") != -1) {
-			p_track.translation_track.times = times;
-			p_track.translation_track.interpolation = gltf_interpolation;
+		} else if (path.find(":position") != -1) {
+			p_track.position_track.times = times;
+			p_track.position_track.interpolation = gltf_interpolation;
 
-			p_track.translation_track.values.resize(key_count);
-			p_track.translation_track.interpolation = gltf_interpolation;
+			p_track.position_track.values.resize(key_count);
+			p_track.position_track.interpolation = gltf_interpolation;
 
 			for (int32_t key_i = 0; key_i < key_count; key_i++) {
-				Vector3 translation = p_animation->track_get_key_value(p_track_i, key_i);
-				p_track.translation_track.values.write[key_i] = translation;
+				Vector3 position = p_animation->track_get_key_value(p_track_i, key_i);
+				p_track.position_track.values.write[key_i] = position;
 			}
 		} else if (path.find(":rotation") != -1) {
 			p_track.rotation_track.times = times;
@@ -6151,34 +6147,34 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 				}
 				p_track.scale_track.values.write[key_i] = bezier_track;
 			}
-		} else if (path.find("/translation") != -1) {
+		} else if (path.find("/position") != -1) {
 			const int32_t keys = p_animation->track_get_key_time(p_track_i, key_count - 1) * BAKE_FPS;
-			if (!p_track.translation_track.times.size()) {
+			if (!p_track.position_track.times.size()) {
 				Vector<float> new_times;
 				new_times.resize(keys);
 				for (int32_t key_i = 0; key_i < keys; key_i++) {
 					new_times.write[key_i] = key_i / BAKE_FPS;
 				}
-				p_track.translation_track.times = new_times;
-				p_track.translation_track.interpolation = gltf_interpolation;
+				p_track.position_track.times = new_times;
+				p_track.position_track.interpolation = gltf_interpolation;
 
-				p_track.translation_track.values.resize(keys);
-				p_track.translation_track.interpolation = gltf_interpolation;
+				p_track.position_track.values.resize(keys);
+				p_track.position_track.interpolation = gltf_interpolation;
 			}
 
 			for (int32_t key_i = 0; key_i < keys; key_i++) {
-				Vector3 bezier_track = p_track.translation_track.values[key_i];
-				if (path.find("/translation:x") != -1) {
+				Vector3 bezier_track = p_track.position_track.values[key_i];
+				if (path.find("/position:x") != -1) {
 					bezier_track.x = p_animation->bezier_track_interpolate(p_track_i, key_i / BAKE_FPS);
 					bezier_track.x = p_bone_rest.affine_inverse().origin.x * bezier_track.x;
-				} else if (path.find("/translation:y") != -1) {
+				} else if (path.find("/position:y") != -1) {
 					bezier_track.y = p_animation->bezier_track_interpolate(p_track_i, key_i / BAKE_FPS);
 					bezier_track.y = p_bone_rest.affine_inverse().origin.y * bezier_track.y;
-				} else if (path.find("/translation:z") != -1) {
+				} else if (path.find("/position:z") != -1) {
 					bezier_track.z = p_animation->bezier_track_interpolate(p_track_i, key_i / BAKE_FPS);
 					bezier_track.z = p_bone_rest.affine_inverse().origin.z * bezier_track.z;
 				}
-				p_track.translation_track.values.write[key_i] = bezier_track;
+				p_track.position_track.values.write[key_i] = bezier_track;
 			}
 		}
 	}
@@ -6197,17 +6193,17 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			continue;
 		}
 		String orig_track_path = animation->track_get_path(track_i);
-		if (String(orig_track_path).find(":translation") != -1) {
-			const Vector<String> node_suffix = String(orig_track_path).split(":translation");
+		if (String(orig_track_path).find(":position") != -1) {
+			const Vector<String> node_suffix = String(orig_track_path).split(":position");
 			const NodePath path = node_suffix[0];
 			const Node *node = ap->get_parent()->get_node_or_null(path);
-			for (Map<GLTFNodeIndex, Node *>::Element *translation_scene_node_i = state->scene_nodes.front(); translation_scene_node_i; translation_scene_node_i = translation_scene_node_i->next()) {
-				if (translation_scene_node_i->get() == node) {
-					GLTFNodeIndex node_index = translation_scene_node_i->key();
-					Map<int, GLTFAnimation::Track>::Element *translation_track_i = gltf_animation->get_tracks().find(node_index);
+			for (Map<GLTFNodeIndex, Node *>::Element *position_scene_node_i = state->scene_nodes.front(); position_scene_node_i; position_scene_node_i = position_scene_node_i->next()) {
+				if (position_scene_node_i->get() == node) {
+					GLTFNodeIndex node_index = position_scene_node_i->key();
+					Map<int, GLTFAnimation::Track>::Element *position_track_i = gltf_animation->get_tracks().find(node_index);
 					GLTFAnimation::Track track;
-					if (translation_track_i) {
-						track = translation_track_i->get();
+					if (position_track_i) {
+						track = position_track_i->get();
 					}
 					track = _convert_animation_track(state, track, animation, Transform3D(), track_i, node_index);
 					gltf_animation->get_tracks().insert(node_index, track);

--- a/modules/gltf/gltf_light.cpp
+++ b/modules/gltf/gltf_light.cpp
@@ -35,8 +35,8 @@ void GLTFLight::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_color", "color"), &GLTFLight::set_color);
 	ClassDB::bind_method(D_METHOD("get_intensity"), &GLTFLight::get_intensity);
 	ClassDB::bind_method(D_METHOD("set_intensity", "intensity"), &GLTFLight::set_intensity);
-	ClassDB::bind_method(D_METHOD("get_type"), &GLTFLight::get_type);
-	ClassDB::bind_method(D_METHOD("set_type", "type"), &GLTFLight::set_type);
+	ClassDB::bind_method(D_METHOD("get_light_type"), &GLTFLight::get_light_type);
+	ClassDB::bind_method(D_METHOD("set_light_type", "light_type"), &GLTFLight::set_light_type);
 	ClassDB::bind_method(D_METHOD("get_range"), &GLTFLight::get_range);
 	ClassDB::bind_method(D_METHOD("set_range", "range"), &GLTFLight::set_range);
 	ClassDB::bind_method(D_METHOD("get_inner_cone_angle"), &GLTFLight::get_inner_cone_angle);
@@ -46,7 +46,7 @@ void GLTFLight::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color"); // Color
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "intensity"), "set_intensity", "get_intensity"); // float
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "type"), "set_type", "get_type"); // String
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "light_type"), "set_light_type", "get_light_type"); // String
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "range"), "set_range", "get_range"); // float
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "inner_cone_angle"), "set_inner_cone_angle", "get_inner_cone_angle"); // float
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "outer_cone_angle"), "set_outer_cone_angle", "get_outer_cone_angle"); // float
@@ -68,12 +68,12 @@ void GLTFLight::set_intensity(float p_intensity) {
 	intensity = p_intensity;
 }
 
-String GLTFLight::get_type() {
-	return type;
+String GLTFLight::get_light_type() {
+	return light_type;
 }
 
-void GLTFLight::set_type(String p_type) {
-	type = p_type;
+void GLTFLight::set_light_type(String p_light_type) {
+	light_type = p_light_type;
 }
 
 float GLTFLight::get_range() {

--- a/modules/gltf/gltf_light.h
+++ b/modules/gltf/gltf_light.h
@@ -44,7 +44,7 @@ protected:
 private:
 	Color color;
 	float intensity = 0.0f;
-	String type;
+	String light_type;
 	float range = 0.0f;
 	float inner_cone_angle = 0.0f;
 	float outer_cone_angle = 0.0f;
@@ -56,8 +56,8 @@ public:
 	float get_intensity();
 	void set_intensity(float p_intensity);
 
-	String get_type();
-	void set_type(String p_type);
+	String get_light_type();
+	void set_light_type(String p_light_type);
 
 	float get_range();
 	void set_range(float p_range);

--- a/modules/gltf/gltf_node.cpp
+++ b/modules/gltf/gltf_node.cpp
@@ -47,8 +47,8 @@ void GLTFNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skeleton", "skeleton"), &GLTFNode::set_skeleton);
 	ClassDB::bind_method(D_METHOD("get_joint"), &GLTFNode::get_joint);
 	ClassDB::bind_method(D_METHOD("set_joint", "joint"), &GLTFNode::set_joint);
-	ClassDB::bind_method(D_METHOD("get_translation"), &GLTFNode::get_translation);
-	ClassDB::bind_method(D_METHOD("set_translation", "translation"), &GLTFNode::set_translation);
+	ClassDB::bind_method(D_METHOD("get_position"), &GLTFNode::get_position);
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &GLTFNode::set_position);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &GLTFNode::get_rotation);
 	ClassDB::bind_method(D_METHOD("set_rotation", "rotation"), &GLTFNode::set_rotation);
 	ClassDB::bind_method(D_METHOD("get_scale"), &GLTFNode::get_scale);
@@ -66,7 +66,7 @@ void GLTFNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "skin"), "set_skin", "get_skin"); // GLTFSkinIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "skeleton"), "set_skeleton", "get_skeleton"); // GLTFSkeletonIndex
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "joint"), "set_joint", "get_joint"); // bool
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "translation"), "set_translation", "get_translation"); // Vector3
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::QUATERNION, "rotation"), "set_rotation", "get_rotation"); // Quaternion
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale"), "set_scale", "get_scale"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "children"), "set_children", "get_children"); // Vector<int>
@@ -137,12 +137,12 @@ void GLTFNode::set_joint(bool p_joint) {
 	joint = p_joint;
 }
 
-Vector3 GLTFNode::get_translation() {
-	return translation;
+Vector3 GLTFNode::get_position() {
+	return position;
 }
 
-void GLTFNode::set_translation(Vector3 p_translation) {
-	translation = p_translation;
+void GLTFNode::set_position(Vector3 p_position) {
+	position = p_position;
 }
 
 Quaternion GLTFNode::get_rotation() {

--- a/modules/gltf/gltf_node.h
+++ b/modules/gltf/gltf_node.h
@@ -49,7 +49,7 @@ private:
 	GLTFSkinIndex skin = -1;
 	GLTFSkeletonIndex skeleton = -1;
 	bool joint = false;
-	Vector3 translation;
+	Vector3 position;
 	Quaternion rotation;
 	Vector3 scale = Vector3(1, 1, 1);
 	Vector<int> children;
@@ -83,8 +83,8 @@ public:
 	bool get_joint();
 	void set_joint(bool p_joint);
 
-	Vector3 get_translation();
-	void set_translation(Vector3 p_translation);
+	Vector3 get_position();
+	void set_position(Vector3 p_position);
 
 	Quaternion get_rotation();
 	void set_rotation(Quaternion p_rotation);


### PR DESCRIPTION
These were discovered by @qarmin here: https://github.com/godotengine/godot/issues/16863#issuecomment-907586412

* `translation` -> `position`
* `zfar` -> `depth_far` (changed based on fire's suggestion, was `far`)
* `znear` -> `depth_near` (changed based on fire's suggestion, was `near`)
* `type` -> `light_type`


