### PR TITLE
Change delta type to double in Physics_body_2/3D

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -293,7 +293,7 @@ void StaticBody2D::_notification(int p_what) {
 			// Used by sync to physics, send the new transform to the physics...
 			Transform2D new_transform = get_global_transform();
 
-			real_t delta_time = get_physics_process_delta_time();
+			double delta_time = get_physics_process_delta_time();
 			new_transform.translate(constant_linear_velocity * delta_time);
 			new_transform.set_rotation(new_transform.get_rotation() + constant_angular_velocity * delta_time);
 
@@ -316,7 +316,7 @@ void StaticBody2D::_notification(int p_what) {
 
 			Transform2D new_transform = get_global_transform();
 
-			real_t delta_time = get_physics_process_delta_time();
+			double delta_time = get_physics_process_delta_time();
 			new_transform.translate(constant_linear_velocity * delta_time);
 			new_transform.set_rotation(new_transform.get_rotation() + constant_angular_velocity * delta_time);
 
@@ -1045,7 +1045,7 @@ void RigidBody2D::_reload_physics_characteristics() {
 
 bool CharacterBody2D::move_and_slide() {
 	// Hack in order to work with calling from _process as well as from _physics_process; calling from thread is risky.
-	float delta = Engine::get_singleton()->is_in_physics_frame() ? get_physics_process_delta_time() : get_process_delta_time();
+	double delta = Engine::get_singleton()->is_in_physics_frame() ? get_physics_process_delta_time() : get_process_delta_time();
 
 	Vector2 current_platform_velocity = platform_velocity;
 
@@ -1095,7 +1095,7 @@ bool CharacterBody2D::move_and_slide() {
 	return motion_results.size() > 0;
 }
 
-void CharacterBody2D::_move_and_slide_grounded(real_t p_delta, bool p_was_on_floor, const Vector2 &p_prev_platform_velocity) {
+void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_floor, const Vector2 &p_prev_platform_velocity) {
 	Vector2 motion = linear_velocity * p_delta;
 	Vector2 motion_slide_up = motion.slide(up_direction);
 
@@ -1239,7 +1239,7 @@ void CharacterBody2D::_move_and_slide_grounded(real_t p_delta, bool p_was_on_flo
 	}
 }
 
-void CharacterBody2D::_move_and_slide_free(real_t p_delta) {
+void CharacterBody2D::_move_and_slide_free(double p_delta) {
 	Vector2 motion = linear_velocity * p_delta;
 
 	platform_rid = RID();

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -356,8 +356,8 @@ private:
 	void set_motion_mode(MotionMode p_mode);
 	MotionMode get_motion_mode() const;
 
-	void _move_and_slide_free(real_t p_delta);
-	void _move_and_slide_grounded(real_t p_delta, bool p_was_on_floor, const Vector2 &p_prev_platform_velocity);
+	void _move_and_slide_free(double p_delta);
+	void _move_and_slide_grounded(double p_delta, bool p_was_on_floor, const Vector2 &p_prev_platform_velocity);
 
 	Ref<KinematicCollision2D> _get_slide_collision(int p_bounce);
 	Ref<KinematicCollision2D> _get_last_slide_collision();

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -347,7 +347,7 @@ void StaticBody3D::_notification(int p_what) {
 			// Used by sync to physics, send the new transform to the physics...
 			Transform3D new_transform = get_global_transform();
 
-			real_t delta_time = get_physics_process_delta_time();
+			double delta_time = get_physics_process_delta_time();
 			new_transform.origin += constant_linear_velocity * delta_time;
 
 			real_t ang_vel = constant_angular_velocity.length();
@@ -378,7 +378,7 @@ void StaticBody3D::_notification(int p_what) {
 
 			Transform3D new_transform = get_global_transform();
 
-			real_t delta_time = get_physics_process_delta_time();
+			double delta_time = get_physics_process_delta_time();
 			new_transform.origin += constant_linear_velocity * delta_time;
 
 			real_t ang_vel = constant_angular_velocity.length();
@@ -1083,7 +1083,7 @@ bool CharacterBody3D::move_and_slide() {
 	bool was_on_floor = on_floor;
 
 	// Hack in order to work with calling from _process as well as from _physics_process; calling from thread is risky
-	float delta = Engine::get_singleton()->is_in_physics_frame() ? get_physics_process_delta_time() : get_process_delta_time();
+	double delta = Engine::get_singleton()->is_in_physics_frame() ? get_physics_process_delta_time() : get_process_delta_time();
 
 	for (int i = 0; i < 3; i++) {
 		if (locked_axis & (1 << i)) {


### PR DESCRIPTION
I noticed the delta time type returned is now a double in `get_physics_process_delta_time` (since #51294) , this PR change the delta time type from float to double in physics body files.