### PR TITLE
Fix bad popups offset in editor with single window off

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -663,7 +663,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
 		menu_insert_key = mb->get_position();
 		if (menu_insert_key.x >= timeline->get_name_limit() && menu_insert_key.x <= get_size().width - timeline->get_buttons_width()) {
-			Vector2 popup_pos = get_global_transform().xform(mb->get_position());
+			Vector2 popup_pos = get_screen_position() + mb->get_position();
 
 			menu->clear();
 			menu->add_icon_item(bezier_icon, TTR("Insert Key Here"), MENU_KEY_INSERT);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2878,8 +2878,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 			menu->set_as_minsize();
 
-			Vector2 popup_pos = get_screen_transform().xform(get_local_mouse_position());
-			menu->set_position(popup_pos);
+			menu->set_position(get_screen_position() + get_local_mouse_position());
 			menu->popup();
 
 			insert_at_pos = offset + timeline->get_value();

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -838,13 +838,15 @@ void ConnectionsDock::_rmb_pressed(Vector2 position) {
 		return;
 	}
 
-	Vector2 global_position = tree->get_global_position() + position;
+	Vector2 screen_position = tree->get_screen_position() + position;
 
 	if (_is_item_signal(*item)) {
-		signal_menu->set_position(global_position);
+		signal_menu->set_position(screen_position);
+		signal_menu->reset_size();
 		signal_menu->popup();
 	} else {
-		slot_menu->set_position(global_position);
+		slot_menu->set_position(screen_position);
+		slot_menu->reset_size();
 		slot_menu->popup();
 	}
 }

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -107,7 +107,7 @@ void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position) {
 	item_menu->clear();
 	item_menu->add_icon_item(get_theme_icon(SNAME("CreateNewSceneFrom"), SNAME("EditorIcons")), TTR("Save Branch as Scene"), ITEM_MENU_SAVE_REMOTE_NODE);
 	item_menu->add_icon_item(get_theme_icon(SNAME("CopyNodePath"), SNAME("EditorIcons")), TTR("Copy Node Path"), ITEM_MENU_COPY_NODE_PATH);
-	item_menu->set_position(get_screen_transform().xform(get_local_mouse_position()));
+	item_menu->set_position(get_screen_position() + get_local_mouse_position());
 	item_menu->popup();
 }
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1428,7 +1428,7 @@ void ScriptEditorDebugger::_error_tree_item_rmb_selected(const Vector2 &p_pos) {
 	}
 
 	if (item_menu->get_item_count() > 0) {
-		item_menu->set_position(error_tree->get_global_position() + p_pos);
+		item_menu->set_position(error_tree->get_screen_position() + p_pos);
 		item_menu->popup();
 	}
 }

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -275,7 +275,8 @@ void DependencyEditorOwners::_list_rmb_select(int p_item, const Vector2 &p_pos) 
 		file_options->add_item(TTR("Open"), FILE_OPEN);
 	}
 
-	file_options->set_position(owners->get_global_position() + p_pos);
+	file_options->set_position(owners->get_screen_position() + p_pos);
+	file_options->reset_size();
 	file_options->popup();
 }
 

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -487,7 +487,8 @@ void EditorAudioBus::_effect_edited() {
 	if (effect->get_metadata(0) == Variant()) {
 		Rect2 area = effects->get_item_rect(effect);
 
-		effect_options->set_position(effects->get_global_position() + area.position + Vector2(0, area.size.y));
+		effect_options->set_position(effects->get_screen_position() + area.position + Vector2(0, area.size.y));
+		effect_options->reset_size();
 		effect_options->popup();
 		//add effect
 	} else {
@@ -535,8 +536,8 @@ void EditorAudioBus::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
-		Vector2 pos = mb->get_position();
-		bus_popup->set_position(get_global_position() + pos);
+		bus_popup->set_position(get_screen_position() + mb->get_position());
+		bus_popup->reset_size();
 		bus_popup->popup();
 	}
 }
@@ -737,7 +738,8 @@ void EditorAudioBus::_effect_rmb(const Vector2 &p_pos) {
 		return;
 	}
 
-	delete_effect_popup->set_position(get_global_mouse_position());
+	delete_effect_popup->set_position(get_screen_position() + get_local_mouse_position());
+	delete_effect_popup->reset_size();
 	delete_effect_popup->popup();
 }
 

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -608,7 +608,8 @@ void EditorFileDialog::_item_list_item_rmb_selected(int p_item, const Vector2 &p
 	}
 
 	if (item_menu->get_item_count() > 0) {
-		item_menu->set_position(item_list->get_global_position() + p_pos);
+		item_menu->set_position(item_list->get_screen_position() + p_pos);
+		item_menu->reset_size();
 		item_menu->popup();
 	}
 }
@@ -629,7 +630,8 @@ void EditorFileDialog::_item_list_rmb_clicked(const Vector2 &p_pos) {
 	item_menu->add_separator();
 	item_menu->add_icon_item(item_list->get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")), TTR("Open in File Manager"), ITEM_MENU_SHOW_IN_EXPLORER);
 
-	item_menu->set_position(item_list->get_global_position() + p_pos);
+	item_menu->set_position(item_list->get_screen_position() + p_pos);
+	item_menu->reset_size();
 	item_menu->popup();
 }
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1555,7 +1555,7 @@ void EditorInspectorArray::_panel_gui_input(Ref<InputEvent> p_event, int p_index
 			popup_array_index_pressed = begin_array_index + p_index;
 			rmb_popup->set_item_disabled(OPTION_MOVE_UP, popup_array_index_pressed == 0);
 			rmb_popup->set_item_disabled(OPTION_MOVE_DOWN, popup_array_index_pressed == count - 1);
-			rmb_popup->set_position(mb->get_global_position());
+			rmb_popup->set_position(get_screen_position() + mb->get_position());
 			rmb_popup->reset_size();
 			rmb_popup->popup();
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5051,7 +5051,8 @@ void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
 				scene_tabs_context_menu->add_item(TTR("Close Tabs to the Right"), FILE_CLOSE_RIGHT);
 				scene_tabs_context_menu->add_item(TTR("Close All Tabs"), FILE_CLOSE_ALL);
 			}
-			scene_tabs_context_menu->set_position(mb->get_global_position());
+			scene_tabs_context_menu->set_position(scene_tabs->get_screen_position() + mb->get_position());
+			scene_tabs_context_menu->reset_size();
 			scene_tabs_context_menu->popup();
 		}
 		if (mb->get_button_index() == MouseButton::WHEEL_UP && mb->is_pressed()) {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1283,7 +1283,8 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 		}
 
 		if (mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
-			preset->set_position(easing_draw->get_screen_transform().xform(mb->get_position()));
+			preset->set_position(easing_draw->get_screen_position() + mb->get_position());
+			preset->reset_size();
 			preset->popup();
 
 			// Ensure the easing doesn't appear as being dragged

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2521,6 +2521,7 @@ void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
 		tree_popup->reset_size();
 		_file_and_folders_fill_popup(tree_popup, paths);
 		tree_popup->set_position(tree->get_screen_position() + p_pos);
+		tree_popup->reset_size();
 		tree_popup->popup();
 	}
 }
@@ -2535,7 +2536,8 @@ void FileSystemDock::_tree_rmb_empty(const Vector2 &p_pos) {
 	tree_popup->add_icon_item(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), TTR("New Script..."), FILE_NEW_SCRIPT);
 	tree_popup->add_icon_item(get_theme_icon(SNAME("Object"), SNAME("EditorIcons")), TTR("New Resource..."), FILE_NEW_RESOURCE);
 	tree_popup->add_icon_item(get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons")), TTR("New TextFile..."), FILE_NEW_TEXTFILE);
-	tree_popup->set_position(tree->get_global_position() + p_pos);
+	tree_popup->set_position(tree->get_screen_position() + p_pos);
+	tree_popup->reset_size();
 	tree_popup->popup();
 }
 
@@ -2560,9 +2562,9 @@ void FileSystemDock::_file_list_rmb_select(int p_item, const Vector2 &p_pos) {
 	// Popup.
 	if (!paths.is_empty()) {
 		file_list_popup->clear();
-		file_list_popup->reset_size();
 		_file_and_folders_fill_popup(file_list_popup, paths, searched_string.length() == 0);
-		file_list_popup->set_position(files->get_global_position() + p_pos);
+		file_list_popup->set_position(files->get_screen_position() + p_pos);
+		file_list_popup->reset_size();
 		file_list_popup->popup();
 	}
 }
@@ -2583,7 +2585,8 @@ void FileSystemDock::_file_list_rmb_pressed(const Vector2 &p_pos) {
 	file_list_popup->add_icon_item(get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons")), TTR("New TextFile..."), FILE_NEW_TEXTFILE);
 	file_list_popup->add_separator();
 	file_list_popup->add_icon_item(get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")), TTR("Open in File Manager"), FILE_SHOW_IN_EXPLORER);
-	file_list_popup->set_position(files->get_global_position() + p_pos);
+	file_list_popup->set_position(files->get_screen_position() + p_pos);
+	file_list_popup->reset_size();
 	file_list_popup->popup();
 }
 

--- a/editor/import/dynamicfont_import_settings.cpp
+++ b/editor/import/dynamicfont_import_settings.cpp
@@ -1159,7 +1159,7 @@ void DynamicFontImportSettings::_range_update(int32_t p_start, int32_t p_end) {
 /*************************************************************************/
 
 void DynamicFontImportSettings::_lang_add() {
-	menu_langs->set_position(lang_list->get_screen_transform().xform(lang_list->get_local_mouse_position()));
+	menu_langs->set_position(lang_list->get_screen_position() + lang_list->get_local_mouse_position());
 	menu_langs->reset_size();
 	menu_langs->popup();
 }
@@ -1186,7 +1186,7 @@ void DynamicFontImportSettings::_lang_remove(Object *p_item, int p_column, int p
 }
 
 void DynamicFontImportSettings::_script_add() {
-	menu_scripts->set_position(script_list->get_screen_transform().xform(script_list->get_local_mouse_position()));
+	menu_scripts->set_position(script_list->get_screen_position() + script_list->get_local_mouse_position());
 	menu_scripts->reset_size();
 	menu_scripts->popup();
 }

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -98,7 +98,8 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 		menu->add_separator();
 		menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
-		menu->set_position(blend_space_draw->get_screen_transform().xform(mb->get_position()));
+		menu->set_position(blend_space_draw->get_screen_position() + mb->get_position());
+		menu->reset_size();
 		menu->popup();
 
 		add_point_pos = (mb->get_position() / blend_space_draw->get_size()).x;

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -121,7 +121,8 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 		menu->add_separator();
 		menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
-		menu->set_position(blend_space_draw->get_screen_transform().xform(mb->get_position()));
+		menu->set_position(blend_space_draw->get_screen_position() + mb->get_position());
+		menu->reset_size();
 		menu->popup();
 		add_point_pos = (mb->get_position() / blend_space_draw->get_size());
 		add_point_pos.y = 1.0 - add_point_pos.y;

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -83,7 +83,7 @@ void AnimationNodeBlendTreeEditor::_update_options_menu(bool p_has_input_ports) 
 	}
 	add_node->get_popup()->add_separator();
 	add_node->get_popup()->add_item(TTR("Load..."), MENU_LOAD_FILE);
-	use_popup_menu_position = false;
+	use_position_from_popup_menu = false;
 }
 
 Size2 AnimationNodeBlendTreeEditor::get_minimum_size() const {
@@ -319,8 +319,8 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 	}
 
 	Point2 instance_pos = graph->get_scroll_ofs();
-	if (use_popup_menu_position) {
-		instance_pos += popup_menu_position;
+	if (use_position_from_popup_menu) {
+		instance_pos += position_from_popup_menu;
 	} else {
 		instance_pos += graph->get_size() * 0.5;
 	}
@@ -355,14 +355,15 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 
 void AnimationNodeBlendTreeEditor::_popup(bool p_has_input_ports, const Vector2 &p_popup_position, const Vector2 &p_node_position) {
 	_update_options_menu(p_has_input_ports);
-	use_popup_menu_position = true;
-	popup_menu_position = p_popup_position;
-	add_node->get_popup()->set_position(p_node_position);
+	use_position_from_popup_menu = true;
+	position_from_popup_menu = p_node_position;
+	add_node->get_popup()->set_position(p_popup_position);
+	add_node->get_popup()->reset_size();
 	add_node->get_popup()->popup();
 }
 
 void AnimationNodeBlendTreeEditor::_popup_request(const Vector2 &p_position) {
-	_popup(false, graph->get_local_mouse_position(), p_position);
+	_popup(false, graph->get_screen_position() + graph->get_local_mouse_position(), p_position);
 }
 
 void AnimationNodeBlendTreeEditor::_connection_to_empty(const String &p_from, int p_from_slot, const Vector2 &p_release_position) {
@@ -918,7 +919,7 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	singleton = this;
 	updating = false;
-	use_popup_menu_position = false;
+	use_position_from_popup_menu = false;
 
 	graph = memnew(GraphEdit);
 	add_child(graph);

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -49,8 +49,8 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNodeBlendTree> blend_tree;
 	GraphEdit *graph;
 	MenuButton *add_node;
-	Vector2 popup_menu_position;
-	bool use_popup_menu_position;
+	Vector2 position_from_popup_menu;
+	bool use_position_from_popup_menu;
 
 	PanelContainer *error_panel;
 	Label *error_label;

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -118,7 +118,8 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		menu->add_separator();
 		menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
-		menu->set_position(state_machine_draw->get_screen_transform().xform(mb->get_position()));
+		menu->set_position(state_machine_draw->get_screen_position() + mb->get_position());
+		menu->reset_size();
 		menu->popup();
 		add_node_pos = mb->get_position() / EDSCALE + state_machine->get_graph_offset();
 	}
@@ -151,7 +152,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				edit_rect.position -= line_sb->get_offset();
 				edit_rect.size += line_sb->get_minimum_size();
 
-				name_edit_popup->set_position(state_machine_draw->get_screen_transform().xform(edit_rect.position));
+				name_edit_popup->set_position(state_machine_draw->get_screen_position() + edit_rect.position);
 				name_edit_popup->set_size(edit_rect.size);
 				name_edit->set_text(node_rects[i].node_name);
 				name_edit_popup->popup();

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2258,7 +2258,8 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 				}
 
 				selection_menu_additive_selection = b->is_shift_pressed();
-				selection_menu->set_position(get_screen_transform().xform(b->get_position()));
+				selection_menu->set_position(get_screen_position() + b->get_position());
+				selection_menu->reset_size();
 				selection_menu->popup();
 				return true;
 			}
@@ -2266,7 +2267,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 
 		if (b.is_valid() && b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
 			add_node_menu->reset_size();
-			add_node_menu->set_position(get_screen_position() + b->get_position());
+			add_node_menu->set_position(get_screen_transform().xform(get_local_mouse_position()));
 			add_node_menu->popup();
 			node_create_position = transform.affine_inverse().xform((get_local_mouse_position()));
 			return true;

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -117,7 +117,7 @@ void CurveEditor::gui_input(const Ref<InputEvent> &p_event) {
 			switch (mb.get_button_index()) {
 				case MouseButton::RIGHT:
 					_context_click_pos = mpos;
-					open_context_menu(get_global_transform().xform(mpos));
+					open_context_menu(get_screen_position() + mpos);
 					break;
 
 				case MouseButton::MIDDLE:

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1291,7 +1291,8 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 			selection_menu->set_item_tooltip(i, String(spat->get_name()) + "\nType: " + spat->get_class() + "\nPath: " + node_path);
 		}
 
-		selection_menu->set_position(get_screen_transform().xform(b->get_position()));
+		selection_menu->set_position(get_screen_position() + b->get_position());
+		selection_menu->reset_size();
 		selection_menu->popup();
 	}
 }
@@ -6646,6 +6647,7 @@ void Node3DEditor::unhandled_key_input(const Ref<InputEvent> &p_event) {
 void Node3DEditor::_sun_environ_settings_pressed() {
 	Vector2 pos = sun_environ_settings->get_screen_position() + sun_environ_settings->get_size();
 	sun_environ_popup->set_position(pos - Vector2(sun_environ_popup->get_contents_minimum_size().width / 2, 0));
+	sun_environ_popup->reset_size();
 	sun_environ_popup->popup();
 }
 

--- a/editor/plugins/ot_features_plugin.cpp
+++ b/editor/plugins/ot_features_plugin.cpp
@@ -136,6 +136,7 @@ void OpenTypeFeaturesAdd::update_property() {
 void OpenTypeFeaturesAdd::_features_menu() {
 	Size2 size = get_size();
 	menu->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
+	menu->reset_size();
 	menu->popup();
 }
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3055,7 +3055,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_sort"), WINDOW_SORT);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/toggle_scripts_panel"), TOGGLE_SCRIPTS_PANEL);
 
-	context_menu->set_position(get_global_transform().xform(get_local_mouse_position()));
+	context_menu->set_position(get_screen_position() + get_local_mouse_position());
 	context_menu->reset_size();
 	context_menu->popup();
 }

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1611,7 +1611,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					float alpha = color.size() > 3 ? color[3] : 1.0f;
 					color_picker->set_pick_color(Color(color[0], color[1], color[2], alpha));
 				}
-				color_panel->set_position(get_global_transform().xform(local_pos));
+				color_panel->set_position(get_screen_position() + local_pos);
 			} else {
 				has_color = false;
 			}
@@ -1688,7 +1688,7 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_UNDO), !tx->has_undo());
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_REDO), !tx->has_redo());
 
-	context_menu->set_position(get_global_transform().xform(p_pos));
+	context_menu->set_position(get_screen_position() + p_pos);
 	context_menu->reset_size();
 	context_menu->popup();
 }

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -645,7 +645,7 @@ void ShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) {
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
 
-	context_menu->set_position(get_global_transform().xform(p_position));
+	context_menu->set_position(get_screen_position() + p_position);
 	context_menu->reset_size();
 	context_menu->popup();
 }

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -507,7 +507,7 @@ void TextEditor::_make_context_menu(bool p_selection, bool p_can_fold, bool p_is
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_UNDO), !tx->has_undo());
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_REDO), !tx->has_redo());
 
-	context_menu->set_position(get_global_transform().xform(p_position));
+	context_menu->set_position(get_screen_position() + p_position);
 	context_menu->reset_size();
 	context_menu->popup();
 }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2078,6 +2078,7 @@ void VisualShaderEditor::_comment_desc_popup_show(const Point2 &p_position, int 
 	}
 	comment_desc_change_edit->set_text(node->get_description());
 	comment_desc_change_popup->set_meta("id", p_node_id);
+	comment_desc_change_popup->reset_size();
 	comment_desc_change_popup->popup();
 	comment_desc_change_popup->set_position(p_position);
 }
@@ -3165,7 +3166,7 @@ void VisualShaderEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			menu_point = graph->get_local_mouse_position();
-			Point2 gpos = Input::get_singleton()->get_mouse_position();
+			Point2 gpos = get_screen_position() + get_local_mouse_position();
 			popup_menu->set_position(gpos);
 			popup_menu->reset_size();
 			popup_menu->popup();
@@ -3184,28 +3185,21 @@ void VisualShaderEditor::_show_members_dialog(bool at_mouse_pos, VisualShaderNod
 		saved_node_pos_dirty = true;
 		saved_node_pos = graph->get_local_mouse_position();
 
-		Point2 gpos = Input::get_singleton()->get_mouse_position();
-		members_dialog->popup();
+		Point2 gpos = get_screen_position() + get_local_mouse_position();
 		members_dialog->set_position(gpos);
 	} else {
-		members_dialog->popup();
 		saved_node_pos_dirty = false;
-		members_dialog->set_position(graph->get_global_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
+		members_dialog->set_position(graph->get_screen_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
 	}
+	members_dialog->popup();
 
-	// keep dialog within window bounds
-	Size2 window_size = DisplayServer::get_singleton()->window_get_size();
+	// Keep dialog within window bounds.
+	Rect2 window_rect = Rect2(DisplayServer::get_singleton()->window_get_position(), DisplayServer::get_singleton()->window_get_size());
 	Rect2 dialog_rect = Rect2(members_dialog->get_position(), members_dialog->get_size());
-	if (dialog_rect.position.y + dialog_rect.size.y > window_size.y) {
-		int difference = dialog_rect.position.y + dialog_rect.size.y - window_size.y;
-		members_dialog->set_position(members_dialog->get_position() - Point2(0, difference));
-	}
-	if (dialog_rect.position.x + dialog_rect.size.x > window_size.x) {
-		int difference = dialog_rect.position.x + dialog_rect.size.x - window_size.x;
-		members_dialog->set_position(members_dialog->get_position() - Point2(difference, 0));
-	}
+	Vector2 difference = (dialog_rect.get_end() - window_rect.get_end()).max(Vector2());
+	members_dialog->set_position(members_dialog->get_position() - difference);
 
-	node_filter->call_deferred(SNAME("grab_focus")); // still not visible
+	node_filter->call_deferred(SNAME("grab_focus")); // Still not visible.
 	node_filter->select_all();
 }
 
@@ -3781,10 +3775,10 @@ void VisualShaderEditor::_node_menu_id_pressed(int p_idx) {
 			_convert_constants_to_uniforms(true);
 			break;
 		case NodeMenuOptions::SET_COMMENT_TITLE:
-			_comment_title_popup_show(get_global_mouse_position(), selected_comment);
+			_comment_title_popup_show(get_screen_position() + get_local_mouse_position(), selected_comment);
 			break;
 		case NodeMenuOptions::SET_COMMENT_DESCRIPTION:
-			_comment_desc_popup_show(get_global_mouse_position(), selected_comment);
+			_comment_desc_popup_show(get_screen_position() + get_local_mouse_position(), selected_comment);
 			break;
 		default:
 			break;

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1122,7 +1122,7 @@ void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 }
 
 void SceneTreeEditor::_rmb_select(const Vector2 &p_pos) {
-	emit_signal(SNAME("rmb_pressed"), tree->get_screen_transform().xform(p_pos));
+	emit_signal(SNAME("rmb_pressed"), tree->get_screen_position() + p_pos);
 }
 
 void SceneTreeEditor::update_warning() {

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -1506,7 +1506,7 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 		}
 	} else if (ti->get_parent() == root->get_first_child()) {
 		selected = ti->get_text(0);
-		function_name_edit->set_position(Input::get_singleton()->get_mouse_position() - Vector2(60, -10));
+		function_name_edit->set_position(get_screen_position() + get_local_mouse_position() - Vector2(60, -10));
 		function_name_edit->popup();
 		function_name_box->set_text(selected);
 		function_name_box->select_all();
@@ -1974,7 +1974,7 @@ void VisualScriptEditor::input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> key = p_event;
 
 	if (key.is_valid() && !key->is_pressed()) {
-		mouse_up_position = Input::get_singleton()->get_mouse_position();
+		mouse_up_position = get_screen_position() + get_local_mouse_position();
 	}
 }
 
@@ -1984,7 +1984,7 @@ void VisualScriptEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid() && key->is_pressed() && key->get_button_mask() == MouseButton::RIGHT) {
 		saved_position = graph->get_local_mouse_position();
 
-		Point2 gpos = Input::get_singleton()->get_mouse_position();
+		Point2 gpos = get_screen_position() + get_local_mouse_position();
 		_generic_search(script->get_instance_base_type(), gpos);
 	}
 }
@@ -3704,7 +3704,7 @@ void VisualScriptEditor::_default_value_edited(Node *p_button, int p_id, int p_i
 		Variant::construct(pinfo.type, existing, &existingp, 1, ce);
 	}
 
-	default_value_edit->set_position(Object::cast_to<Control>(p_button)->get_global_position() + Vector2(0, Object::cast_to<Control>(p_button)->get_size().y));
+	default_value_edit->set_position(Object::cast_to<Control>(p_button)->get_screen_position() + Vector2(0, Object::cast_to<Control>(p_button)->get_size().y));
 	default_value_edit->reset_size();
 
 	if (pinfo.type == Variant::NODE_PATH) {
@@ -4160,10 +4160,10 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 	ERR_FAIL_COND(!ti);
 
 	member_popup->clear();
-	member_popup->set_position(members->get_global_position() + p_pos);
+	member_popup->set_position(members->get_screen_position() + p_pos);
 	member_popup->reset_size();
 
-	function_name_edit->set_position(members->get_global_position() + p_pos);
+	function_name_edit->set_position(members->get_screen_position() + p_pos);
 	function_name_edit->reset_size();
 
 	TreeItem *root = members->get_root();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2590,7 +2590,7 @@ Control *Control::get_focus_owner() const {
 
 void Control::warp_mouse(const Point2 &p_to_pos) {
 	ERR_FAIL_COND(!is_inside_tree());
-	get_viewport()->warp_mouse(get_global_transform().xform(p_to_pos));
+	get_viewport()->warp_mouse(get_screen_transform().xform(p_to_pos));
 }
 
 bool Control::is_text_field() const {

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1166,7 +1166,7 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 					top_layer->update();
 					minimap->update();
 				} else {
-					emit_signal(SNAME("popup_request"), b->get_global_position());
+					emit_signal(SNAME("popup_request"), get_screen_position() + b->get_position());
 				}
 			}
 		}

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -227,7 +227,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		if (b->is_pressed() && b->get_button_index() == MouseButton::RIGHT && context_menu_enabled) {
 			_ensure_menu();
-			menu->set_position(get_screen_transform().xform(get_local_mouse_position()));
+			menu->set_position(get_screen_position() + get_local_mouse_position());
 			menu->reset_size();
 			menu->popup();
 			grab_focus();
@@ -392,7 +392,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (k->is_action("ui_menu", true)) {
 				_ensure_menu();
 				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + get_theme_font(SNAME("font"))->get_height(get_theme_font_size(SNAME("font_size")))) / 2);
-				menu->set_position(get_global_transform().xform(pos));
+				menu->set_position(get_screen_position() + pos);
 				menu->reset_size();
 				menu->popup();
 				menu->grab_focus();

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -216,7 +216,7 @@ void PopupMenu::_activate_submenu(int p_over) {
 		submenu_pos.x = this_pos.x + submenu_size.width;
 	}
 
-	if (submenu_pos.x + submenu_size.width > get_parent_rect().size.width) {
+	if (submenu_pos.x + submenu_size.width > get_parent_rect().position.x + get_parent_rect().size.width) {
 		submenu_pos.x = this_pos.x - submenu_size.width;
 	}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1624,7 +1624,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 
 				_generate_context_menu();
-				menu->set_position(get_screen_transform().xform(mpos));
+				menu->set_position(get_screen_position() + mpos);
 				menu->reset_size();
 				menu->popup();
 				grab_focus();
@@ -1871,7 +1871,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (context_menu_enabled) {
 				_generate_context_menu();
 				adjust_viewport_to_caret();
-				menu->set_position(get_screen_transform().xform(get_caret_draw_pos()));
+				menu->set_position(get_screen_position() + get_caret_draw_pos());
 				menu->reset_size();
 				menu->popup();
 				menu->grab_focus();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2532,7 +2532,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 					}
 
 					popup_menu->set_size(Size2(col_width, 0));
-					popup_menu->set_position(get_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h) - cache.offset);
+					popup_menu->set_position(get_screen_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h) - cache.offset);
 					popup_menu->popup();
 					popup_edited_item = p_item;
 					popup_edited_item_col = col;
@@ -3441,7 +3441,7 @@ bool Tree::edit_selected() {
 		}
 
 		popup_menu->set_size(Size2(rect.size.width, 0));
-		popup_menu->set_position(get_global_position() + rect.position + Point2i(0, rect.size.height));
+		popup_menu->set_position(get_screen_position() + rect.position + Point2i(0, rect.size.height));
 		popup_menu->popup();
 		popup_edited_item = s;
 		popup_edited_item_col = col;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1183,7 +1183,7 @@ void Viewport::_gui_show_tooltip() {
 	Control *tooltip_owner = nullptr;
 	String tooltip_text = _gui_get_tooltip(
 			gui.tooltip_control,
-			gui.tooltip_control->get_global_transform().xform_inv(gui.last_mouse_pos),
+			gui.tooltip_control->get_screen_transform().xform_inv(gui.last_mouse_pos),
 			&tooltip_owner);
 	tooltip_text = tooltip_text.strip_edges();
 	if (tooltip_text.is_empty()) {
@@ -1712,7 +1712,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 				if (gui.tooltip_popup) {
 					if (gui.tooltip_control) {
-						String tooltip = _gui_get_tooltip(over, gui.tooltip_control->get_global_transform().xform_inv(mpos));
+						String tooltip = _gui_get_tooltip(over, gui.tooltip_control->get_screen_transform().xform_inv(mpos));
 
 						if (tooltip.length() == 0) {
 							_gui_cancel_tooltip();


### PR DESCRIPTION
Fix #47217

### Issue description

When single window is disabled, popup menus in editor pops at a bad offset (see GIFs below)

### Fix proposal (Updated after Kobewi comment)

Using ``get_screen_transform()`` instead of ``get_global_transform()`` to set the popup position to deal with offset in multiwindow mode correctly.

### BEFORE
![bug_bezier](https://user-images.githubusercontent.com/3649998/131512600-caa65c0e-f603-4511-94c7-3b2abe16472f.gif)
Bezier Editor bug

![bug_script_editor](https://user-images.githubusercontent.com/3649998/131513032-636e3de0-07ad-4815-b145-018ced593789.gif)
Script Editor bug

![bug_shader](https://user-images.githubusercontent.com/3649998/131513057-8b4ca472-2017-48ed-a580-0934056dcc31.gif)
Shader Editor Bug

![bug_curve](https://user-images.githubusercontent.com/3649998/131512751-535a1f05-b693-49b4-b18e-afea0c4e8330.gif)
Curve editor bug

![bug_node2](https://user-images.githubusercontent.com/3649998/131513152-a7d47350-359b-4c00-a055-2e8890e1cde1.gif)
Canvas editor bug

### AFTER

![fix_bezier](https://user-images.githubusercontent.com/3649998/131513398-b0f5ccf7-0620-4026-8d3c-3fb5161d41a8.gif)
Bezier editor fixed

![fix_script_editor](https://user-images.githubusercontent.com/3649998/131513420-4d910b72-9865-436c-9315-a22ef276aa2e.gif)
Script editor fixed

![fix_script_shader](https://user-images.githubusercontent.com/3649998/131513481-d41c610c-73bc-4b43-8a94-e3ca874c54b4.gif)
Shader Editor Fixed

![fix_curve](https://user-images.githubusercontent.com/3649998/131513499-32d0e13d-7223-4218-a8a7-02d97c4e848b.gif)
Curve Editor Fixed

![fix_node2](https://user-images.githubusercontent.com/3649998/131513515-7d0c667c-d243-4e98-9b84-34c5b55f7a0f.gif)
Canvas Editor Fixed
