### PR TITLE
Improve messages when compiling for Linux/*BSD

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -18,40 +18,42 @@ def can_build():
     # Check the minimal dependencies
     x11_error = os.system("pkg-config --version > /dev/null")
     if x11_error:
+        print("Error: pkg-config not found. Aborting.")
         return False
 
-    x11_error = os.system("pkg-config x11 --modversion > /dev/null ")
+    x11_error = os.system("pkg-config x11 --modversion > /dev/null")
     if x11_error:
+        print("Error: X11 libraries not found. Aborting.")
         return False
 
-    x11_error = os.system("pkg-config xcursor --modversion > /dev/null ")
+    x11_error = os.system("pkg-config xcursor --modversion > /dev/null")
     if x11_error:
-        print("xcursor not found.. x11 disabled.")
+        print("Error: Xcursor library not found. Aborting.")
         return False
 
-    x11_error = os.system("pkg-config xinerama --modversion > /dev/null ")
+    x11_error = os.system("pkg-config xinerama --modversion > /dev/null")
     if x11_error:
-        print("xinerama not found.. x11 disabled.")
+        print("Error: Xinerama library not found. Aborting.")
         return False
 
-    x11_error = os.system("pkg-config xext --modversion > /dev/null ")
+    x11_error = os.system("pkg-config xext --modversion > /dev/null")
     if x11_error:
-        print("xext not found.. x11 disabled.")
+        print("Error: Xext library not found. Aborting.")
         return False
 
-    x11_error = os.system("pkg-config xrandr --modversion > /dev/null ")
+    x11_error = os.system("pkg-config xrandr --modversion > /dev/null")
     if x11_error:
-        print("xrandr not found.. x11 disabled.")
+        print("Error: XrandR library not found. Aborting.")
         return False
 
-    x11_error = os.system("pkg-config xrender --modversion > /dev/null ")
+    x11_error = os.system("pkg-config xrender --modversion > /dev/null")
     if x11_error:
-        print("xrender not found.. x11 disabled.")
+        print("Error: XRender library not found. Aborting.")
         return False
 
-    x11_error = os.system("pkg-config xi --modversion > /dev/null ")
+    x11_error = os.system("pkg-config xi --modversion > /dev/null")
     if x11_error:
-        print("xi not found.. Aborting.")
+        print("Error: Xi library not found. Aborting.")
         return False
 
     return True
@@ -138,7 +140,7 @@ def configure(env):
                 # A convenience so you don't need to write use_lto too when using SCons
                 env["use_lto"] = True
         else:
-            print("Using LLD with GCC is not supported yet, try compiling with 'use_llvm=yes'.")
+            print("Using LLD with GCC is not supported yet. Try compiling with 'use_llvm=yes'.")
             sys.exit(255)
 
     if env["use_coverage"]:
@@ -334,36 +336,32 @@ def configure(env):
     ## Flags
 
     if os.system("pkg-config --exists alsa") == 0:  # 0 means found
-        print("Enabling ALSA")
         env["alsa"] = True
         env.Append(CPPDEFINES=["ALSA_ENABLED", "ALSAMIDI_ENABLED"])
     else:
-        print("ALSA libraries not found, disabling driver")
+        print("Warning: ALSA libraries not found. Disabling the ALSA audio driver.")
 
     if env["pulseaudio"]:
         if os.system("pkg-config --exists libpulse") == 0:  # 0 means found
-            print("Enabling PulseAudio")
             env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED"])
             env.ParseConfig("pkg-config --cflags libpulse")
         else:
-            print("PulseAudio development libraries not found, disabling driver")
+            print("Warning: PulseAudio development libraries not found. Disabling the PulseAudio audio driver.")
 
     if env["dbus"]:
         if os.system("pkg-config --exists dbus-1") == 0:  # 0 means found
-            print("Enabling D-Bus")
             env.Append(CPPDEFINES=["DBUS_ENABLED"])
             env.ParseConfig("pkg-config --cflags --libs dbus-1")
         else:
-            print("D-Bus development libraries not found, disabling dependent features")
+            print("Warning: D-Bus development libraries not found. Disabling screensaver prevention.")
 
     if platform.system() == "Linux":
         env.Append(CPPDEFINES=["JOYDEV_ENABLED"])
         if env["udev"]:
             if os.system("pkg-config --exists libudev") == 0:  # 0 means found
-                print("Enabling udev support")
                 env.Append(CPPDEFINES=["UDEV_ENABLED"])
             else:
-                print("libudev development libraries not found, disabling udev support")
+                print("Warning: libudev development libraries not found. Disabling controller hotplugging support.")
     else:
         env["udev"] = False  # Linux specific
 
@@ -412,7 +410,7 @@ def configure(env):
         gnu_ld_version = re.search("^GNU ld [^$]*(\d+\.\d+)$", linker_version_str, re.MULTILINE)
         if not gnu_ld_version:
             print(
-                "Warning: Creating template binaries enabled for PCK embedding is currently only supported with GNU ld"
+                "Warning: Creating template binaries enabled for PCK embedding is currently only supported with GNU ld, not gold or LLD."
             )
         else:
             if float(gnu_ld_version.group(1)) >= 2.30:


### PR DESCRIPTION
- Don't display messages when enabling PulseAudio/ALSA/D-Bus/udev as these become noisy in incremental builds.
- Improve warning and error messages to be more descriptive and consistent.


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->