### PR TITLE
Write node groups on a single line when saving a `.tscn` file

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1849,10 +1849,16 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 			}
 
 			if (groups.size()) {
+				// Write all groups on the same line as they're part of a section header.
+				// This improves readability while not impacting VCS friendliness too much,
+				// since it's rare to have more than 5 groups assigned to a single node.
 				groups.sort_custom<StringName::AlphCompare>();
-				String sgroups = " groups=[\n";
+				String sgroups = " groups=[";
 				for (int j = 0; j < groups.size(); j++) {
-					sgroups += "\"" + String(groups[j]).c_escape() + "\",\n";
+					sgroups += "\"" + String(groups[j]).c_escape() + "\"";
+					if (j < groups.size() - 1) {
+						sgroups += ", ";
+					}
 				}
 				sgroups += "]";
 				header += sgroups;


### PR DESCRIPTION
Split from https://github.com/godotengine/godot/pull/32124.

This makes `.tscn` files more readable by ensuring sections are always written on a single line. This is compatible with existing scenes (both backwards and forwards-compatible).

As a bonus, it also results in better syntax highlighting on GitHub when using the `ini` syntax highlighter :slightly_smiling_face: 

## Preview

### Before

```ini
[gd_scene format=3 uid="uid://dctlrgcoo4tc8"]

[node name="Node2D" type="Node2D" groups=[
"2",
"bar",
"baz",
"foo",
"hello",
"world",
]]
script = null

[node name="Sprite2D" type="Sprite2D" parent="." groups=[
"hello",
]]
position = Vector2(15, 18)
script = null

[node name="Sprite2D2" type="Sprite2D" parent="."]
script = null
```

### After

```ini
[gd_scene format=3 uid="uid://dctlrgcoo4tc8"]

[node name="Node2D" type="Node2D" groups=["2", "bar", "baz", "foo", "hello", "world"]]
script = null

[node name="Sprite2D" type="Sprite2D" parent="." groups=["hello"]]
position = Vector2(15, 18)
script = null

[node name="Sprite2D2" type="Sprite2D" parent="."]
script = null
```