### PR TITLE
Remove `#ifdefs` for handling compilation with Visual Studio < 2015

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1653,13 +1653,13 @@ String String::num_scientific(double p_num) {
 
 #if defined(__GNUC__) || defined(_MSC_VER)
 
-#if (defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900)) && defined(_TWO_DIGIT_EXPONENT) && !defined(_UCRT)
-	// MinGW and old MSC require _set_output_format() to conform to C99 output for printf
+#if defined(__MINGW32__) && defined(_TWO_DIGIT_EXPONENT) && !defined(_UCRT)
+	// MinGW requires _set_output_format() to conform to C99 output for printf
 	unsigned int old_exponent_format = _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
 	snprintf(buf, 256, "%lg", p_num);
 
-#if (defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900)) && defined(_TWO_DIGIT_EXPONENT) && !defined(_UCRT)
+#if defined(__MINGW32__) && defined(_TWO_DIGIT_EXPONENT) && !defined(_UCRT)
 	_set_output_format(old_exponent_format);
 #endif
 

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -200,7 +200,7 @@ String str_format(const char *p_format, ...) {
 	return res;
 }
 
-#if defined(MINGW_ENABLED) || defined(_MSC_VER) && _MSC_VER < 1900
+#if defined(MINGW_ENABLED)
 #define gd_vsnprintf(m_buffer, m_count, m_format, m_args_copy) vsnprintf_s(m_buffer, m_count, _TRUNCATE, m_format, m_args_copy)
 #define gd_vscprintf(m_format, m_args_copy) _vscprintf(m_format, m_args_copy)
 #else


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/48903.

Godot 3.3 and later require Visual Studio 2017 to be compiled. Reference with MSVC macro versions: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros