### PR TITLE
[TextServer] Fix regression from #51908, HarfBuzz handle init and MinGW build.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1231,7 +1231,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 		int error = 0;
 		if (!library) {
 			error = FT_Init_FreeType(&library);
-			ERR_FAIL_COND_V_MSG(error != 0, false, TTR("FreeType: Error initializing library:") + " '" + String(FT_Error_String(error)) + "'.");
+			ERR_FAIL_COND_V_MSG(error != 0, false, RTR("FreeType: Error initializing library:") + " '" + String(FT_Error_String(error)) + "'.");
 		}
 
 		memset(&fd->stream, 0, sizeof(FT_StreamRec));
@@ -1249,13 +1249,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 		if (error) {
 			FT_Done_Face(fd->face);
 			fd->face = nullptr;
-			ERR_FAIL_V_MSG(false, TTR("FreeType: Error loading font:") + " '" + String(FT_Error_String(error)) + "'.");
-		}
-		fd->hb_handle = hb_ft_font_create(fd->face, nullptr);
-		if (fd->hb_handle == nullptr) {
-			FT_Done_Face(fd->face);
-			fd->face = nullptr;
-			ERR_FAIL_V_MSG(false, TTR("HarfBuzz: Error creating FreeType font object."));
+			ERR_FAIL_V_MSG(false, RTR("FreeType: Error loading font:") + " '" + String(FT_Error_String(error)) + "'.");
 		}
 
 		if (p_font_data->msdf) {
@@ -1283,6 +1277,8 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 		} else {
 			FT_Set_Pixel_Sizes(fd->face, 0, fd->size.x * fd->oversampling);
 		}
+
+		fd->hb_handle = hb_ft_font_create(fd->face, nullptr);
 
 		fd->ascent = (fd->face->size->metrics.ascender / 64.0) / fd->oversampling * fd->scale;
 		fd->descent = (-fd->face->size->metrics.descender / 64.0) / fd->oversampling * fd->scale;
@@ -1598,14 +1594,11 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 			FT_Done_MM_Var(library, amaster);
 		}
 #else
-		ERR_FAIL_V_MSG(false, TTR("FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
+		ERR_FAIL_V_MSG(false, RTR("FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
 #endif
 	} else {
 		// Init bitmap font.
 		fd->hb_handle = hb_bmp_font_create(fd, nullptr);
-		if (!fd->hb_handle) {
-			ERR_FAIL_V_MSG(false, TTR("HarfBuzz: Error creating bitmap font object."));
-		}
 	}
 	p_font_data->cache[p_size] = fd;
 	return true;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -686,7 +686,7 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontDataFallback 
 		int error = 0;
 		if (!library) {
 			error = FT_Init_FreeType(&library);
-			ERR_FAIL_COND_V_MSG(error != 0, false, TTR("FreeType: Error initializing library:") + " '" + String(FT_Error_String(error)) + "'.");
+			ERR_FAIL_COND_V_MSG(error != 0, false, RTR("FreeType: Error initializing library:") + " '" + String(FT_Error_String(error)) + "'.");
 		}
 
 		memset(&fd->stream, 0, sizeof(FT_StreamRec));
@@ -704,7 +704,7 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontDataFallback 
 		if (error) {
 			FT_Done_Face(fd->face);
 			fd->face = nullptr;
-			ERR_FAIL_V_MSG(false, TTR("FreeType: Error loading font:") + " '" + String(FT_Error_String(error)) + "'.");
+			ERR_FAIL_V_MSG(false, RTR("FreeType: Error loading font:") + " '" + String(FT_Error_String(error)) + "'.");
 		}
 
 		if (p_font_data->msdf) {
@@ -784,7 +784,7 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontDataFallback 
 			FT_Done_MM_Var(library, amaster);
 		}
 #else
-		ERR_FAIL_V_MSG(false, TTR("FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
+		ERR_FAIL_V_MSG(false, RTR("FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
 #endif
 	}
 	p_font_data->cache[p_size] = fd;


### PR DESCRIPTION
Move HarfBuzz handle creation, after setting font size.

Fixes regression from #51908 mentioned in the comment - https://github.com/godotengine/godot/pull/51908#issuecomment-909520725

Fixes #52318

<img width="400" alt="Screenshot 2021-08-31 at 22 31 19" src="https://user-images.githubusercontent.com/7645683/131564455-5e818666-6af9-47c4-a1de-915a29ab2105.png">
