### PR TITLE
fix animation blend tree update on inspector property input count change

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -868,7 +868,7 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 		hide();
 	} else {
 		blend_tree->connect("removed_from_graph", callable_mp(this, &AnimationNodeBlendTreeEditor::_removed_from_graph));
-
+		blend_tree->connect("tree_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_update_graph));
 		_update_graph();
 	}
 }

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -34,6 +34,7 @@
 
 void AnimationNodeAnimation::set_animation(const StringName &p_name) {
 	animation = p_name;
+	emit_signal(SNAME("tree_changed"));
 }
 
 StringName AnimationNodeAnimation::get_animation() const {
@@ -641,6 +642,8 @@ void AnimationNodeTransition::set_enabled_inputs(int p_inputs) {
 	ERR_FAIL_INDEX(p_inputs, MAX_INPUTS);
 	enabled_inputs = p_inputs;
 	_update_inputs();
+
+	emit_signal(SNAME("tree_changed"));
 }
 
 int AnimationNodeTransition::get_enabled_inputs() {
@@ -661,6 +664,8 @@ void AnimationNodeTransition::set_input_caption(int p_input, const String &p_nam
 	ERR_FAIL_INDEX(p_input, MAX_INPUTS);
 	inputs[p_input].name = p_name;
 	set_input_name(p_input, p_name);
+
+	emit_signal(SNAME("tree_changed"));
 }
 
 String AnimationNodeTransition::get_input_caption(int p_input) const {


### PR DESCRIPTION
Fixes #45437 and  #49375

Connects blend tree plugin to the `"tree_changed"` signal which is emited when input count is updated in the inspector. The signal then calls `_update_graph()` to refresh the blend tree graph.

Duplicate of #49404 
I did not realize that deleting the fork would cause me to be unable to edit the pull request after re-forking (I was not planning on contributing for a while). 

I was told I would have to make a new pull request. I apologize for any duplicated work on the maintainers.

