### PR TITLE
[3.x] TabContainer Fix drawing current tab when it's disabled

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -363,10 +363,10 @@ void TabContainer::_notification(int p_what) {
 				}
 
 				int tab_width = tab_widths[i];
-				if (get_tab_disabled(index)) {
-					_draw_tab(tab_disabled, font_color_disabled, index, tabs_ofs_cache + x);
-				} else if (index == current) {
+				if (index == current) {
 					x_current = x;
+				} else if (get_tab_disabled(index)) {
+					_draw_tab(tab_disabled, font_color_disabled, index, tabs_ofs_cache + x);
 				} else {
 					_draw_tab(tab_bg, font_color_bg, index, tabs_ofs_cache + x);
 				}
@@ -380,9 +380,10 @@ void TabContainer::_notification(int p_what) {
 				panel->draw(canvas, Rect2(0, header_height, size.width, size.height - header_height));
 			}
 
-			// Draw selected tab in front. only draw selected tab when it's in visible range.
+			// Draw selected tab in front. Only draw selected tab when it's in visible range.
 			if (tabs.size() > 0 && current - first_tab_cache < tab_widths.size() && current >= first_tab_cache) {
-				_draw_tab(tab_fg, font_color_fg, current, tabs_ofs_cache + x_current);
+				Ref<StyleBox> current_style_box = get_tab_disabled(current) ? tab_disabled : tab_fg;
+				_draw_tab(current_style_box, font_color_fg, current, tabs_ofs_cache + x_current);
 			}
 
 			// Draw the popup menu.
@@ -495,8 +496,8 @@ void TabContainer::_on_mouse_exited() {
 
 int TabContainer::_get_tab_width(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, get_tab_count(), 0);
-	Control *control = Object::cast_to<Control>(_get_tabs()[p_index]);
-	if (!control || control->is_set_as_toplevel() || get_tab_hidden(p_index)) {
+	Control *control = get_tab_control(p_index);
+	if (!control || get_tab_hidden(p_index)) {
 		return 0;
 	}
 


### PR DESCRIPTION
When current tab was disabled it was drawn twice: with disabled StyleBox at correct position (possibly not in front) and with foreground StyleBox at possibly incorrect position (its x offset wasn't stored for drawing in front because it was drawn as disabled). This PR makes it being drawn in front at correct position with disabled/foreground StyleBox. In action:
- Before (`3.x`):
![Cy9QqVRqmM](https://user-images.githubusercontent.com/9283098/131603255-a8a37656-401b-4687-b93b-35e83ac36377.gif)
- After (this PR):
![BOhUbuNgtI](https://user-images.githubusercontent.com/9283098/131603825-475395ea-3495-4138-9dd0-d20927ed90a2.gif)

Note that disabled/foreground StyleBoxes differ a little in size which is visible in GIFs above when disabling/enabling current tab. There's no such difference between disabled/background StyleBoxes.  Thus maybe a StyleBox for disabled foreground (which would look like foreground one but dimmed etc.) should be added to the Theme? No idea if it would breal compat anyhow though. Anyway, if such change is desired it can be made in another PR.

Cherry-pickable `3.3`.