### PR TITLE
Fix ParallaxLayer's transform resetting in editor

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -100,6 +100,10 @@ void ParallaxLayer::_notification(int p_what) {
 			_update_mirroring();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
+			if (Engine::get_singleton()->is_editor_hint()) {
+				break;
+			}
+
 			set_position(orig_offset);
 			set_scale(orig_scale);
 		} break;


### PR DESCRIPTION
Disable resetting of ParallaxLayer's position and scale in editor to allow setting the initial values.

Fixes #51914
