### PR TITLE
Display an alert when attempting to run a project with no main scene

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1090,7 +1090,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		editor = false;
 #else
 		const String error_msg = "Error: Couldn't load project data at path \"" + project_path + "\". Is the .pck file missing?\nIf you've renamed the executable, the associated .pck file should also be renamed to match the executable's name (without the extension).\n";
-		OS::get_singleton()->print("%s", error_msg.ascii().get_data());
+		OS::get_singleton()->print("%s", error_msg.utf8().get_data());
 		OS::get_singleton()->alert(error_msg);
 
 		goto error;
@@ -1184,7 +1184,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 		if (!editor && !project_manager) {
 #endif
-			OS::get_singleton()->print("Error: Can't run project: no main scene defined.\n");
+			const String error_msg = "Error: Can't run project: no main scene defined in the project.\n";
+			OS::get_singleton()->print("%s", error_msg.utf8().get_data());
+			OS::get_singleton()->alert(error_msg);
 			goto error;
 #ifdef TOOLS_ENABLED
 		}


### PR DESCRIPTION
This gives visual feedback when not starting Godot from a terminal. This could lead to confusion when placing a Godot binary within a project folder that has no main scene defined.

## Preview

![image](https://user-images.githubusercontent.com/180032/131688201-9a7375ca-2833-4f8c-85f7-c195f5a036ae.png)

This closes https://github.com/godotengine/godot/issues/19570.