### PR TITLE
Add support for adding plugin views behind the main view on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -295,7 +295,11 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
 			View pluginView = plugin.onMainCreate(activity);
 			if (pluginView != null) {
-				containerLayout.addView(pluginView);
+				if (plugin.shouldBeOnTop()) {
+					containerLayout.addView(pluginView);
+				} else {
+					containerLayout.addView(pluginView, 0);
+				}
 			}
 		}
 	}

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
@@ -191,6 +191,9 @@ public abstract class GodotPlugin {
 	 * The plugin can return a non-null {@link View} layout in order to add it to the Godot view
 	 * hierarchy.
 	 *
+	 * Use shouldBeOnTop() to set whether the plugin's {@link View} should be added on top or behind
+	 * the main Godot view.
+	 *
 	 * @see Activity#onCreate(Bundle)
 	 * @return the plugin's view to be included; null if no views should be included.
 	 */
@@ -308,6 +311,17 @@ public abstract class GodotPlugin {
 	@NonNull
 	protected Set<String> getPluginGDNativeLibrariesPaths() {
 		return Collections.emptySet();
+	}
+
+	/**
+	 * Returns whether the plugin's {@link View} returned in onMainCreate() should be placed on
+	 * top of the main Godot view.
+	 *
+	 * Returning false causes the plugin's {@link View} to be placed behind, which can be useful
+	 * when used with transparency in order to let the Godot view handle inputs.
+	 */
+	public boolean shouldBeOnTop() {
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot/pull/51935#discussion_r700370117

Doesn't change the default behavior, but allows plugins to add their view behind the main view, which gives more control over what happens with inputs and can be useful along with transparent rendering.