### PR TITLE
Add a second, deferred visibility check for lights

### DIFF
--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -195,6 +195,11 @@ void Light2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		RS::get_singleton()->canvas_light_attach_to_canvas(canvas_light, get_canvas());
 		_update_light_visibility();
+		// Effectively causes _update_visibility() to be called deferred.
+		// This is necessary, because duplicating or reparenting a light will first
+		// issue NOTIFICATION_ENTER_TREE, and only afterwards call set_owner(). But
+		// _update_visibility() relies on a properly set owner.
+		call_deferred("set_editor_only", editor_only);
 	}
 
 	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -187,6 +187,11 @@ void Light3D::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		_update_visibility();
+		// Effectively causes _update_visibility() to be called deferred.
+		// This is necessary, because duplicating or reparenting a light will first
+		// issue NOTIFICATION_ENTER_TREE, and only afterwards call set_owner(). But
+		// _update_visibility() relies on a properly set owner.
+		call_deferred("set_editor_only", editor_only);
 	}
 }
 


### PR DESCRIPTION
Based on https://github.com/Windfisch/godot/commit/d4b4e0472cb130093ab4301c7b954327219ffe9a (Did it get lost in space?)

I read the discussion under original issue and it seems that PR never arrived?

Fix #26399 in master.