### PR TITLE
[3.x]Add a second, deferred visibility check for lights.

### DIFF
--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -326,6 +326,11 @@ void Light2D::_notification(int p_what) {
 
 		VS::get_singleton()->canvas_light_attach_to_canvas(canvas_light, get_canvas());
 		_update_light_visibility();
+		// Effectively causes _update_light_visibility() to be called deferred.
+		// This is necessary, because duplicating or reparenting a light will first
+		// issue NOTIFICATION_ENTER_TREE, and only afterwards call set_owner(). But
+		// _update_light_visibility() relies on a properly set owner.
+		call_deferred("set_editor_only", editor_only);
 	}
 
 	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {

--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -193,6 +193,11 @@ void Light::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		_update_visibility();
+		// Effectively causes _update_visibility() to be called deferred.
+		// This is necessary, because duplicating or reparenting a light will first
+		// issue NOTIFICATION_ENTER_TREE, and only afterwards call set_owner(). But
+		// _update_visibility() relies on a properly set owner.
+		call_deferred("set_editor_only", editor_only);
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {


### PR DESCRIPTION
The deferred visibility check will see the correct value for
get_owner(), while the first might not.

Fixes #26399 for 3.x.
3.x version of https://github.com/godotengine/godot/pull/52327

I checked and original fix still works so I'm making a PR. Sorry!