### PR TITLE
GDScript: Fix for UNUSED_PRIVATE_CLASS_VARIABLE

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2411,6 +2411,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 				case GDScriptParser::ClassNode::Member::VARIABLE:
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_VARIABLE;
 					p_identifier->variable_source = member.variable;
+					member.variable->usages += 1;
 					break;
 				case GDScriptParser::ClassNode::Member::FUNCTION:
 					resolve_function_signature(member.function);


### PR DESCRIPTION
Fixes following issues in master:

Fixes #47888
Fixes #42318

Usage count of member variables was never increased. This lead to UNUSED_PRIVATE_CLASS_VARIABLE warnings for private variables like "_my_private_var" even if the variable was used.

Test script, which will only report "_private_unused" with this fix:

```gdscript
var _private_used: int = 1
var _private_unused: int = 1

var public_used: int = 1
var public_unused: int = 1

func test() -> void:
	public_used = _private_used
```

