### PR TITLE
LSP: Add support for custom host setting

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -36,6 +36,7 @@
 #include "editor/editor_node.h"
 
 GDScriptLanguageServer::GDScriptLanguageServer() {
+	_EDITOR_DEF("network/language_server/remote_host", host);
 	_EDITOR_DEF("network/language_server/remote_port", port);
 	_EDITOR_DEF("network/language_server/enable_smart_resolve", true);
 	_EDITOR_DEF("network/language_server/show_native_symbols_in_editor", false);
@@ -56,9 +57,10 @@ void GDScriptLanguageServer::_notification(int p_what) {
 			}
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			String host = String(_EDITOR_GET("network/language_server/remote_host"));
 			int port = (int)_EDITOR_GET("network/language_server/remote_port");
 			bool use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
-			if (port != this->port || use_thread != this->use_thread) {
+			if (host != this->host || port != this->port || use_thread != this->use_thread) {
 				this->stop();
 				this->start();
 			}
@@ -76,9 +78,10 @@ void GDScriptLanguageServer::thread_main(void *p_userdata) {
 }
 
 void GDScriptLanguageServer::start() {
+	host = String(_EDITOR_GET("network/language_server/remote_host"));
 	port = (int)_EDITOR_GET("network/language_server/remote_port");
 	use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
-	if (protocol.start(port, IPAddress("127.0.0.1")) == OK) {
+	if (protocol.start(port, IPAddress(host)) == OK) {
 		EditorNode::get_log()->add_message("--- GDScript language server started ---", EditorLog::MSG_TYPE_EDITOR);
 		if (use_thread) {
 			thread_running = true;

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -44,6 +44,7 @@ class GDScriptLanguageServer : public EditorPlugin {
 	bool thread_running = false;
 	bool started = false;
 	bool use_thread = false;
+	String host = "127.0.0.1";
 	int port = 6008;
 	static void thread_main(void *p_userdata);
 


### PR DESCRIPTION
You can now set host in the language_server settings in the editor settings. I am also making a pull request to make changes to the VSCode godot-tools to be able to set the language_server host as well. 

This allows you to connect to the godot language_server when using WSL2 and docker. 

This is a link to the pull request in the vscode plugin
https://github.com/godotengine/godot-vscode-plugin/pull/297

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
