### PR TITLE
Tweak tooltip style (slightly less dark/unified margins)

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1201,11 +1201,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// TooltipPanel
 	Ref<StyleBoxFlat> style_tooltip = style_popup->duplicate();
 	style_tooltip->set_shadow_size(0);
-	style_tooltip->set_default_margin(SIDE_LEFT, default_margin_size * EDSCALE);
+	style_tooltip->set_default_margin(SIDE_LEFT, default_margin_size * EDSCALE * 0.5);
 	style_tooltip->set_default_margin(SIDE_TOP, default_margin_size * EDSCALE * 0.5);
-	style_tooltip->set_default_margin(SIDE_RIGHT, default_margin_size * EDSCALE);
+	style_tooltip->set_default_margin(SIDE_RIGHT, default_margin_size * EDSCALE * 0.5);
 	style_tooltip->set_default_margin(SIDE_BOTTOM, default_margin_size * EDSCALE * 0.5);
-	style_tooltip->set_bg_color(mono_color.inverted() * Color(1, 1, 1, 0.9));
+	style_tooltip->set_bg_color(dark_color_3 * Color(0.8, 0.8, 0.8, 0.9));
 	style_tooltip->set_border_width_all(0);
 	theme->set_color("font_color", "TooltipLabel", font_hover_color);
 	theme->set_color("font_color_shadow", "TooltipLabel", Color(0, 0, 0, 0));


### PR DESCRIPTION
This PR slightly tweaks the appearence of tooltips, as I found them a little out of place compared to the rest of the UI. Any feedback is welcome :)

CURRENT MASTER:
![grafik](https://user-images.githubusercontent.com/50084500/131763786-2dfb0a3a-d3bb-4a40-85f2-feafb921a228.png)
![grafik](https://user-images.githubusercontent.com/50084500/131763807-be46e2a6-3e23-4b1d-b31d-60710431abe8.png)

THIS PR:
![grafik](https://user-images.githubusercontent.com/50084500/131765948-9e3ec179-e61e-4e9d-9686-a681b95374a6.png)
![grafik](https://user-images.githubusercontent.com/50084500/131765954-238cd7a6-ebe0-410d-b578-43e5d0aabe8e.png)
