### PR TITLE
Renamed `Vector3.FORWARD` to `FRONT`

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2053,7 +2053,7 @@ static void _register_variant_builtin_methods() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3(1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "DOWN", Vector3(0, -1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "FORWARD", Vector3(0, 0, -1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "FRONT", Vector3(0, 0, -1));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACK", Vector3(0, 0, 1));
 
 	_VariantCall::add_constant(Variant::VECTOR3I, "AXIS_X", Vector3i::AXIS_X);
@@ -2066,7 +2066,7 @@ static void _register_variant_builtin_methods() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "RIGHT", Vector3i(1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "UP", Vector3i(0, 1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "DOWN", Vector3i(0, -1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "FORWARD", Vector3i(0, 0, -1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "FRONT", Vector3i(0, 0, -1));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "BACK", Vector3i(0, 0, 1));
 
 	_VariantCall::add_constant(Variant::VECTOR2, "AXIS_X", Vector2::AXIS_X);

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -462,8 +462,8 @@
 		<constant name="DOWN" value="Vector3(0, -1, 0)">
 			Down unit vector.
 		</constant>
-		<constant name="FORWARD" value="Vector3(0, 0, -1)">
-			Forward unit vector. Represents the local direction of forward, and the global direction of north.
+		<constant name="FRONT" value="Vector3(0, 0, -1)">
+			Front unit vector. Represents the local direction of front, and the global direction of north.
 		</constant>
 		<constant name="BACK" value="Vector3(0, 0, 1)">
 			Back unit vector. Represents the local direction of back, and the global direction of south.

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -226,8 +226,8 @@
 		<constant name="DOWN" value="Vector3i(0, -1, 0)">
 			Down unit vector.
 		</constant>
-		<constant name="FORWARD" value="Vector3i(0, 0, -1)">
-			Forward unit vector. Represents the local direction of forward, and the global direction of north.
+		<constant name="FRONT" value="Vector3i(0, 0, -1)">
+			Front unit vector. Represents the local direction of front, and the global direction of north.
 		</constant>
 		<constant name="BACK" value="Vector3i(0, 0, 1)">
 			Back unit vector. Represents the local direction of back, and the global direction of south.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -592,7 +592,7 @@ namespace Godot
         private static readonly Vector3 _down = new Vector3(0, -1, 0);
         private static readonly Vector3 _right = new Vector3(1, 0, 0);
         private static readonly Vector3 _left = new Vector3(-1, 0, 0);
-        private static readonly Vector3 _forward = new Vector3(0, 0, -1);
+        private static readonly Vector3 _front = new Vector3(0, 0, -1);
         private static readonly Vector3 _back = new Vector3(0, 0, 1);
 
         /// <summary>
@@ -634,11 +634,11 @@ namespace Godot
         /// <value>Equivalent to `new Vector3(-1, 0, 0)`</value>
         public static Vector3 Left { get { return _left; } }
         /// <summary>
-        /// Forward unit vector. Represents the local direction of forward,
+        /// Front unit vector. Represents the local direction of front,
         /// and the global direction of north.
         /// </summary>
         /// <value>Equivalent to `new Vector3(0, 0, -1)`</value>
-        public static Vector3 Forward { get { return _forward; } }
+        public static Vector3 Front { get { return _front; } }
         /// <summary>
         /// Back unit vector. Represents the local direction of back,
         /// and the global direction of south.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -236,7 +236,7 @@ namespace Godot
         private static readonly Vector3i _down = new Vector3i(0, -1, 0);
         private static readonly Vector3i _right = new Vector3i(1, 0, 0);
         private static readonly Vector3i _left = new Vector3i(-1, 0, 0);
-        private static readonly Vector3i _forward = new Vector3i(0, 0, -1);
+        private static readonly Vector3i _front = new Vector3i(0, 0, -1);
         private static readonly Vector3i _back = new Vector3i(0, 0, 1);
 
         /// <summary>
@@ -273,11 +273,11 @@ namespace Godot
         /// <value>Equivalent to `new Vector3i(-1, 0, 0)`</value>
         public static Vector3i Left { get { return _left; } }
         /// <summary>
-        /// Forward unit vector. Represents the local direction of forward,
+        /// Front unit vector. Represents the local direction of front,
         /// and the global direction of north.
         /// </summary>
         /// <value>Equivalent to `new Vector3i(0, 0, -1)`</value>
-        public static Vector3i Forward { get { return _forward; } }
+        public static Vector3i Front { get { return _front; } }
         /// <summary>
         /// Back unit vector. Represents the local direction of back,
         /// and the global direction of south.


### PR DESCRIPTION
Renamed `FORWARD` instead of `BACKWARD` as @reduz suggested:  https://github.com/godotengine/godot/pull/50047#issuecomment-909462111
