### PR TITLE
Updated documentation for ENetMultiplayerPeer::close_connection to better match its actual behavior

### DIFF
--- a/modules/enet/doc_classes/ENetMultiplayerPeer.xml
+++ b/modules/enet/doc_classes/ENetMultiplayerPeer.xml
@@ -25,7 +25,7 @@
 			<return type="void" />
 			<argument index="0" name="wait_usec" type="int" default="100" />
 			<description>
-				Closes the connection. Throws an error if no connection is currently established. If this is a server it tries to notify all clients before forcibly disconnecting them. If this is a client it simply closes the connection to the server.
+				Closes the connection. Prints an error message if no connection is currently established. If this is a server it tries to notify all clients before forcibly disconnecting them. If this is a client it simply closes the connection to the server.
 			</description>
 		</method>
 		<method name="create_client">

--- a/modules/enet/doc_classes/ENetMultiplayerPeer.xml
+++ b/modules/enet/doc_classes/ENetMultiplayerPeer.xml
@@ -25,7 +25,7 @@
 			<return type="void" />
 			<argument index="0" name="wait_usec" type="int" default="100" />
 			<description>
-				Closes the connection. Ignored if no connection is currently established. If this is a server it tries to notify all clients before forcibly disconnecting them. If this is a client it simply closes the connection to the server.
+				Closes the connection. Throws an error if no connection is currently established. If this is a server it tries to notify all clients before forcibly disconnecting them. If this is a client it simply closes the connection to the server.
 			</description>
 		</method>
 		<method name="create_client">


### PR DESCRIPTION
Attempts to fix https://github.com/godotengine/godot/issues/51823
Updated description of method `close_connection` that better matches with actual behavior.

Relevant code
```c++
void NetworkedMultiplayerENet::close_connection(uint32_t wait_usec) {
	ERR_FAIL_COND_MSG(!active, "The multiplayer instance isn't currently active.");
```
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
