### PR TITLE
Portals - fix import of portal normal + small bug fixes

### DIFF
--- a/scene/3d/portal.h
+++ b/scene/3d/portal.h
@@ -110,7 +110,7 @@ private:
 	void _sanitize_points();
 	void _update_aabb();
 	static Vector3 _vec2to3(const Vector2 &p_pt) { return Vector3(p_pt.x, p_pt.y, 0.0); }
-	void _sort_verts_clockwise(bool portal_plane_convention, Vector<Vector3> &r_verts);
+	void _sort_verts_clockwise(const Vector3 &p_portal_normal, Vector<Vector3> &r_verts);
 	Plane _plane_from_points_newell(const Vector<Vector3> &p_pts);
 	void resolve_links(const LocalVector<Room *, int32_t> &p_rooms, const RID &p_from_room_rid);
 	void _changed();

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -873,7 +873,14 @@ void RoomManager::_second_pass_portals(Spatial *p_roomlist, LocalVector<Portal *
 			String string_link_room = string_link_room_shortname + "-room";
 
 			if (string_link_room_shortname != "") {
+				// try the room name plus the postfix first, this will be the most common case during import
 				Room *linked_room = Object::cast_to<Room>(p_roomlist->find_node(string_link_room, true, false));
+
+				// try the short name as a last ditch attempt
+				if (!linked_room) {
+					linked_room = Object::cast_to<Room>(p_roomlist->find_node(string_link_room_shortname, true, false));
+				}
+
 				if (linked_room) {
 					NodePath path = portal->get_path_to(linked_room);
 					portal->set_linked_room_internal(path);


### PR DESCRIPTION
When converting portal meshes during import, indices were not being taken into account, which could lead to incorrect estimation of the portal direction. This PR now copes with either indexed or non-indexed portal meshes.

Added a bug fix to cope with portals pointing almost directly straight up or down, which could cause problems with the lookat transform.

Added the ability for named portals to link to short room names (in addition to postfix room names).

Fixes portal normal bug mentioned in #52322

## Notes
* This was a small oversight in the portal importing, should now be much more robust.
* No one had noticed the straight up / down portal bug yet but `Transform::lookat` doesn't work correctly if the view direction is too close to the up direction. This uses a different up vector in such situations, the up vector is arbitrary so just uses the x axis.
* The ability to link to non-prefixed room names isn't necessary during normal import but I noticed it as confusing during debugging, and was easy to add.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
