### PR TITLE
Fix missing SConscript warning when building using SCons

### DIFF
--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -17,7 +17,6 @@ env_gdnative.Prepend(CPPPATH=["#modules/gdnative/include/"])
 Export("env_gdnative")
 
 SConscript("net/SCsub")
-SConscript("xr/SCsub")
 SConscript("pluginscript/SCsub")
 SConscript("videodecoder/SCsub")
 SConscript("text/SCsub")


### PR DESCRIPTION
This closes https://github.com/godotengine/godot/issues/52281.

Not cherry-pickable to `3.x` as this is only relevant after GDExtension changes.