### PR TITLE
[Net] Silence ENetMultiplayerPeer close_connection.

### DIFF
--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -393,7 +393,9 @@ bool ENetMultiplayerPeer::is_server() const {
 }
 
 void ENetMultiplayerPeer::close_connection(uint32_t wait_usec) {
-	ERR_FAIL_COND_MSG(!_is_active(), "The multiplayer instance isn't currently active.");
+	if (!_is_active()) {
+		return;
+	}
 
 	_pop_current_packet();
 


### PR DESCRIPTION
Used to print an error when it was not active, now it just returns
immediately as per the documentation.

Closes #52337.
Fixes #51823 .