### PR TITLE
[3.x] [Net] Silence ENetMultiplayerPeer close_connection.

### DIFF
--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -446,7 +446,9 @@ bool NetworkedMultiplayerENet::is_server() const {
 }
 
 void NetworkedMultiplayerENet::close_connection(uint32_t wait_usec) {
-	ERR_FAIL_COND_MSG(!active, "The multiplayer instance isn't currently active.");
+	if (!active) {
+		return;
+	}
 
 	_pop_current_packet();
 


### PR DESCRIPTION
Used to print an error when it was not active, now it just returns
immediately as per the documentation.

`3.x` version of #52342