### PR TITLE
Load assets before enabling editor plugins

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -595,19 +595,6 @@ void EditorNode::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			{
-				_initializing_addons = true;
-				Vector<String> addons;
-				if (ProjectSettings::get_singleton()->has_setting("editor_plugins/enabled")) {
-					addons = ProjectSettings::get_singleton()->get("editor_plugins/enabled");
-				}
-
-				for (int i = 0; i < addons.size(); i++) {
-					set_addon_plugin_enabled(addons[i], true);
-				}
-				_initializing_addons = false;
-			}
-
 			RenderingServer::get_singleton()->viewport_set_disable_2d(get_scene_root()->get_viewport_rid(), true);
 			RenderingServer::get_singleton()->viewport_set_disable_environment(get_viewport()->get_viewport_rid(), true);
 
@@ -970,6 +957,18 @@ void EditorNode::_sources_changed(bool p_exist) {
 			load_scene(defer_load_scene);
 			defer_load_scene = "";
 		}
+
+		// Only enable addons once resources have been imported
+		_initializing_addons = true;
+		Vector<String> addons;
+		if (ProjectSettings::get_singleton()->has_setting("editor_plugins/enabled")) {
+			addons = ProjectSettings::get_singleton()->get("editor_plugins/enabled");
+		}
+
+		for (int i = 0; i < addons.size(); i++) {
+			set_addon_plugin_enabled(addons[i], true);
+		}
+		_initializing_addons = false;
 	}
 }
 


### PR DESCRIPTION
Closes #36713 by moving the code for enabling plugins in `EditorNode` from `NOTIFICATION_READY` to after the first scan of the filesystem has been completed.