### PR TITLE
Symbol lookup jumps to the correct position in help editor

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -117,7 +117,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		} else {
 			if (table->has(link)) {
 				// Found in the current page
-				class_desc->scroll_to_line((*table)[link]);
+				class_desc->scroll_to_paragraph((*table)[link]);
 			} else {
 				if (topic == "class_enum") {
 					// Try to find the enum in @GlobalScope
@@ -1343,7 +1343,7 @@ void EditorHelp::_help_callback(const String &p_topic) {
 		}
 	}
 
-	class_desc->call_deferred(SNAME("scroll_to_line"), line);
+	class_desc->call_deferred(SNAME("scroll_to_paragraph"), line);
 }
 
 static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
@@ -1651,7 +1651,7 @@ Vector<Pair<String, int>> EditorHelp::get_sections() {
 
 void EditorHelp::scroll_to_section(int p_section_index) {
 	int line = section_line[p_section_index].second;
-	class_desc->scroll_to_line(line);
+	class_desc->scroll_to_paragraph(line);
 }
 
 void EditorHelp::popup_search() {


### PR DESCRIPTION
Commit `e4651a4` introduced `scroll_to_paragraph` and changed the implementation
of `scroll_to_line`, which also counts lines within paragraphs.

The help editor still used the `scroll_to_line` method
while it should use the newly implemented `scroll_to_paragraph` as that is
stored in its tables.

This should fix #52335.