### PR TITLE
[3.x] Temporarily disable fullscreen when changing current screen

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2004,8 +2004,10 @@ Point2 OS_Windows::get_window_position() const {
 }
 
 void OS_Windows::set_window_position(const Point2 &p_position) {
-	if (video_mode.fullscreen)
-		return;
+	//remember fullscreen setting and turn off fullscreen while window is moved to new position
+	bool wasFullscreen = video_mode.fullscreen;
+	set_window_fullscreen(false);
+
 	RECT r;
 	GetWindowRect(hWnd, &r);
 	MoveWindow(hWnd, p_position.x, p_position.y, r.right - r.left, r.bottom - r.top, TRUE);
@@ -2021,6 +2023,8 @@ void OS_Windows::set_window_position(const Point2 &p_position) {
 
 	last_pos = p_position;
 	update_real_mouse_position();
+	//enable fullscreen back based on saved setting
+	set_window_fullscreen(wasFullscreen);
 }
 
 Size2 OS_Windows::get_window_size() const {


### PR DESCRIPTION
3.x fix for #43876.

Basically I'm turning off fullscreen when moving window to new screen and then re-enabling it 👀 

It solved an issue, but is it a valid fix for it?
I would feel better if someone could verify it. I checked MRP from original issue and everything seems to work without any regressions.

I will check if issue exists in current master