### PR TITLE
Fixed property info by changing Window current_screen parameter from string to int

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1497,7 +1497,7 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "position"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Windowed,Minimized,Maximized,Fullscreen"), "set_mode", "get_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "current_screen"), "set_current_screen", "get_current_screen");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_screen"), "set_current_screen", "get_current_screen");
 
 	ADD_GROUP("Flags", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");


### PR DESCRIPTION
I was working on some issue and I noticed that

`Window.current_screen` wants to take String as parameter instead of integer
![bug1](https://user-images.githubusercontent.com/37214990/131919990-85e4a2a1-b6b6-4e2a-b8d0-e1c346b275d4.png)

Setter and getter for this method are fine.