### PR TITLE
Add visual feedback when hovering or dragging the code minimap grabber (3.x)

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -392,6 +392,7 @@ private:
 	bool smooth_scroll_enabled;
 	bool scrolling;
 	bool dragging_selection;
+	bool hovering_minimap;
 	bool dragging_minimap;
 	bool can_drag_minimap;
 	bool minimap_clicked;
@@ -476,6 +477,7 @@ private:
 	void _update_selection_mode_word();
 	void _update_selection_mode_line();
 
+	void _update_minimap_hover();
 	void _update_minimap_click();
 	void _update_minimap_drag();
 	void _scroll_up(real_t p_delta);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/35859.

This makes it more obvious that the minimap grabber can be dragged to scroll.

## Preview (`3.x`)

https://user-images.githubusercontent.com/180032/131926397-8044130b-20d9-4cbe-a57d-8be90d9f4548.mp4