### PR TITLE
[3.x] Fix ViewportTexture error when viewport is used from a child scene

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -53,16 +53,16 @@
 #include "servers/physics_2d_server.h"
 
 void ViewportTexture::setup_local_to_scene() {
+	Node *local_scene = get_local_scene();
+	if (!local_scene) {
+		return;
+	}
+
 	if (vp) {
 		vp->viewport_textures.erase(this);
 	}
 
 	vp = nullptr;
-
-	Node *local_scene = get_local_scene();
-	if (!local_scene) {
-		return;
-	}
 
 	Node *vpn = local_scene->get_node(path);
 	ERR_FAIL_COND_MSG(!vpn, "ViewportTexture: Path to node is invalid.");


### PR DESCRIPTION
This should hopefully fix some of the viewport errors mentioned in https://github.com/godotengine/godot/issues/27790