### PR TITLE
Inaccurate HTTPRequest documentation node

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -192,7 +192,7 @@
 			<description>
 				Creates request on the underlying [HTTPClient]. If there is no configuration errors, it tries to connect using [method HTTPClient.connect_to_host] and passes parameters onto [method HTTPClient.request].
 				Returns [constant OK] if request is successfully created. (Does not imply that the server has responded), [constant ERR_UNCONFIGURED] if not in the tree, [constant ERR_BUSY] if still processing previous request, [constant ERR_INVALID_PARAMETER] if given string is not a valid URL format, or [constant ERR_CANT_CONNECT] if not using thread and the [HTTPClient] cannot connect to host.
-				[b]Note:[/b] The [code]request_data[/code] parameter is ignored if [code]method[/code] is [constant HTTPClient.METHOD_GET]. This is because GET methods can't contain request data. As a workaround, you can pass request data as a query string in the URL. See [method String.uri_encode] for an example.
+				[b]Note:[/b] When [code]method[/code] is [constant HTTPClient.METHOD_GET], the payload sent via [code]request_data[/code] might be ignored by the server or even cause the server to reject the request (check [url=https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1]RFC 7231 section 4.3.1[/url] for more details). As a workaround, you can send data as a query string in the URL. See [method String.uri_encode] for an example.
 			</description>
 		</method>
 		<method name="request_raw">


### PR DESCRIPTION
Removing the note that says that request data is ignored when using the GET method.

I was able to send request data with the code:
```
extends HTTPRequest

func _ready() -> void:
	set_use_threads(true)
	var body = {"email": "gm", "password": "pw"}
	request(
		"http://localhost:5000/login",
		["Content-Type: application/json"],
		false,
		HTTPClient.METHOD_GET,
		to_json(body)
	)
```
Then, in my Python server (using Flask), I was able to recover the data with the code:
```
from flask import Flask, request

app = Flask(__name__)

@app.route("/login", methods=["GET"])
def login():
    request_data = request.get_json()
    email = request_data["email"]
    password = request_data["password"]
```