### PR TITLE
Expose soft body pin methods to GDScript

### DIFF
--- a/doc/classes/SoftBody.xml
+++ b/doc/classes/SoftBody.xml
@@ -37,6 +37,20 @@
 				Returns an individual bit on the collision mask.
 			</description>
 		</method>
+		<method name="get_point_transform">
+			<return type="Vector3" />
+			<argument index="0" name="point_index" type="int" />
+			<description>
+				Returns local translation of a vertex in the surface array.
+			</description>
+		</method>
+		<method name="is_point_pinned" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="point_index" type="int" />
+			<description>
+				Returns [code]true[/code] if vertex is set to pinned.
+			</description>
+		</method>
 		<method name="remove_collision_exception_with">
 			<return type="void" />
 			<argument index="0" name="body" type="Node" />
@@ -58,6 +72,15 @@
 			<argument index="1" name="value" type="bool" />
 			<description>
 				Sets individual bits on the collision mask. Use this if you only need to change one layer's value.
+			</description>
+		</method>
+		<method name="set_point_pinned">
+			<return type="void" />
+			<argument index="0" name="point_index" type="int" />
+			<argument index="1" name="pinned" type="bool" />
+			<argument index="2" name="attachment_path" type="NodePath" default="NodePath(&quot;&quot;)" />
+			<description>
+				Sets the pinned state of a surface vertex. When set to [code]true[/code], the optional [code]attachment_path[/code] can define a [Spatial] the pinned vertex will be attached to.
 			</description>
 		</method>
 	</methods>

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -365,6 +365,11 @@ void SoftBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_drag_coefficient", "drag_coefficient"), &SoftBody::set_drag_coefficient);
 	ClassDB::bind_method(D_METHOD("get_drag_coefficient"), &SoftBody::get_drag_coefficient);
 
+	ClassDB::bind_method(D_METHOD("get_point_transform", "point_index"), &SoftBody::get_point_transform);
+
+	ClassDB::bind_method(D_METHOD("set_point_pinned", "point_index", "pinned", "attachment_path"), &SoftBody::pin_point, DEFVAL(NodePath()));
+	ClassDB::bind_method(D_METHOD("is_point_pinned", "point_index"), &SoftBody::is_point_pinned);
+
 	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &SoftBody::set_ray_pickable);
 	ClassDB::bind_method(D_METHOD("is_ray_pickable"), &SoftBody::is_ray_pickable);
 


### PR DESCRIPTION
This change was merged into master #51364 but requires class name changes for 3.x in code and documentation.
Node3D changed to Spatial and SoftBody3D to SoftBody.