### PR TITLE
Add TextServer parentheses stack dynamic reallocation support.

### DIFF
--- a/modules/text_server_adv/script_iterator.h
+++ b/modules/text_server_adv/script_iterator.h
@@ -43,6 +43,8 @@
 #include <hb.h>
 
 class ScriptIterator {
+	static const int PAREN_STACK_DEPTH = 128;
+
 public:
 	struct ScriptRange {
 		int start = 0;


### PR DESCRIPTION
Fixes crash on long nested bracket sequences described it https://github.com/godotengine/godot/issues/52113#issuecomment-912183572
