### PR TITLE
Don't handle property_editor shortcuts on release.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -799,15 +799,19 @@ void EditorProperty::unhandled_key_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	if (ED_IS_SHORTCUT("property_editor/copy_property", p_event)) {
-		menu_option(MENU_COPY_PROPERTY);
-		accept_event();
-	} else if (ED_IS_SHORTCUT("property_editor/paste_property", p_event) && !is_read_only()) {
-		menu_option(MENU_PASTE_PROPERTY);
-		accept_event();
-	} else if (ED_IS_SHORTCUT("property_editor/copy_property_path", p_event)) {
-		menu_option(MENU_COPY_PROPERTY_PATH);
-		accept_event();
+	const Ref<InputEventKey> k = p_event;
+
+	if (k.is_valid() && k->is_pressed()) {
+		if (ED_IS_SHORTCUT("property_editor/copy_property", p_event)) {
+			menu_option(MENU_COPY_PROPERTY);
+			accept_event();
+		} else if (ED_IS_SHORTCUT("property_editor/paste_property", p_event) && !is_read_only()) {
+			menu_option(MENU_PASTE_PROPERTY);
+			accept_event();
+		} else if (ED_IS_SHORTCUT("property_editor/copy_property_path", p_event)) {
+			menu_option(MENU_COPY_PROPERTY_PATH);
+			accept_event();
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #52336.

EditorProperty::unhandled_key_input was handling both press and release.
This means that if you press `ctrl+v` on an EditorProperty line input,
it will paste as expected on pressing `ctrl+v`, and accept the event so
EditorProperty will not see it. However, on release, LineEdit ignores
the event and EditorProperty still catches and handles it, using its own
paste implementation.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
