### PR TITLE
Fix out of bounds error when folding last line of code

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1400,7 +1400,7 @@ void CodeEdit::fold_line(int p_line) {
 	}
 
 	/* Find the last line to be hidden. */
-	int end_line = get_line_count();
+	int end_line = get_line_count() - 1;
 
 	int in_comment = is_in_comment(p_line);
 	int in_string = (in_comment == -1) ? is_in_string(p_line) : -1;


### PR DESCRIPTION
Fixes #52385

### CLOSED : Replaced by more complete PR : #52339

### Issue ;

Folding a block of code at the end of a script file causes an out of bounds error in the console.

### Identified cause : 

Error in folding loop. ``i`` should never be equal to endline. Valid line index goes from ``0`` to ``get_line_count() -1``

https://github.com/godotengine/godot/blob/18c0f0b3ba46caf3f6dda401362bc5993eaf7f8d/scene/gui/code_edit.cpp#L1433-L1435

### Fix proposal

Simply replace ``<=`` compare operator by ``<`` .

### Result

No more error. Folding OK.