### PR TITLE
Fix Windows cursor with trails disappearing in fullscreen

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -217,6 +217,7 @@ void OS_Windows::initialize_core() {
 	crash_handler.initialize();
 
 	last_button_state = 0;
+	restore_mouse_trails = 0;
 
 	//RedirectIOToConsole();
 	maximized = false;
@@ -1472,6 +1473,12 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 			video_mode.fullscreen=false;
 		}*/
 		pre_fs_valid = false;
+
+		// If the user has mouse trails enabled in windows, then sometimes the cursor disappears in fullscreen mode.
+		// Save number of trails so we can restore when exiting, then turn off mouse trails
+		SystemParametersInfoA(SPI_GETMOUSETRAILS, 0, &restore_mouse_trails, 0);
+		if (restore_mouse_trails > 0)
+			SystemParametersInfoA(SPI_SETMOUSETRAILS, 0, 0, 0);
 	}
 
 	DWORD dwExStyle;
@@ -1831,6 +1838,9 @@ void OS_Windows::finalize() {
 	if (user_proc) {
 		SetWindowLongPtr(hWnd, GWLP_WNDPROC, (LONG_PTR)user_proc);
 	};
+
+	if (restore_mouse_trails > 0)
+		SystemParametersInfoA(SPI_SETMOUSETRAILS, restore_mouse_trails, 0, 0);
 }
 
 void OS_Windows::finalize_core() {
@@ -2216,6 +2226,9 @@ void OS_Windows::set_window_fullscreen(bool p_enabled) {
 
 		MoveWindow(hWnd, pos.x, pos.y, size.width, size.height, TRUE);
 
+		SystemParametersInfoA(SPI_GETMOUSETRAILS, 0, &restore_mouse_trails, 0);
+		if (restore_mouse_trails > 0)
+			SystemParametersInfoA(SPI_SETMOUSETRAILS, 0, 0, 0);
 	} else {
 
 		RECT rect;
@@ -2236,6 +2249,9 @@ void OS_Windows::set_window_fullscreen(bool p_enabled) {
 		MoveWindow(hWnd, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, TRUE);
 
 		pre_fs_valid = true;
+
+		if (restore_mouse_trails > 0)
+			SystemParametersInfoA(SPI_SETMOUSETRAILS, restore_mouse_trails, 0, 0);
 	}
 }
 bool OS_Windows::is_window_fullscreen() const {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1477,8 +1477,9 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 		// If the user has mouse trails enabled in windows, then sometimes the cursor disappears in fullscreen mode.
 		// Save number of trails so we can restore when exiting, then turn off mouse trails
 		SystemParametersInfoA(SPI_GETMOUSETRAILS, 0, &restore_mouse_trails, 0);
-		if (restore_mouse_trails > 0)
+		if (restore_mouse_trails > 1) {
 			SystemParametersInfoA(SPI_SETMOUSETRAILS, 0, 0, 0);
+		}
 	}
 
 	DWORD dwExStyle;
@@ -1839,8 +1840,9 @@ void OS_Windows::finalize() {
 		SetWindowLongPtr(hWnd, GWLP_WNDPROC, (LONG_PTR)user_proc);
 	};
 
-	if (restore_mouse_trails > 0)
+	if (restore_mouse_trails > 1) {
 		SystemParametersInfoA(SPI_SETMOUSETRAILS, restore_mouse_trails, 0, 0);
+	}
 }
 
 void OS_Windows::finalize_core() {
@@ -2227,8 +2229,9 @@ void OS_Windows::set_window_fullscreen(bool p_enabled) {
 		MoveWindow(hWnd, pos.x, pos.y, size.width, size.height, TRUE);
 
 		SystemParametersInfoA(SPI_GETMOUSETRAILS, 0, &restore_mouse_trails, 0);
-		if (restore_mouse_trails > 0)
+		if (restore_mouse_trails > 1) {
 			SystemParametersInfoA(SPI_SETMOUSETRAILS, 0, 0, 0);
+		}
 	} else {
 
 		RECT rect;
@@ -2250,8 +2253,9 @@ void OS_Windows::set_window_fullscreen(bool p_enabled) {
 
 		pre_fs_valid = true;
 
-		if (restore_mouse_trails > 0)
+		if (restore_mouse_trails > 1) {
 			SystemParametersInfoA(SPI_SETMOUSETRAILS, restore_mouse_trails, 0, 0);
+		}
 	}
 }
 bool OS_Windows::is_window_fullscreen() const {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -335,6 +335,7 @@ class OS_Windows : public OS {
 	Vector2 im_position;
 
 	MouseMode mouse_mode;
+	int restore_mouse_trails;
 	bool alt_mem;
 	bool gr_mem;
 	bool shift_mem;


### PR DESCRIPTION
Fixed by turning off mouse trails when going into fullscreen, then restoring trails when exiting fullscreen or game

This fix might be a bit iffy because it turns off the users mouse trail setting in windows using:
SystemParametersInfoA(SPI_SETMOUSETRAILS, 0, 0, 0);

Which will leave the trails off even if the user exits the game, so to fix I used SPI_GETMOUSETRAILS to get the users current setting and then restore that when exiting the game or fullscreen. 

If the game where to crash then the mouse trails aren't turned back on.

I made this pull request to 3.3 instead of master because master moved the relevant code from os_windows.cpp to display_server_windows.cpp.

If this pull request is accepted I can make one for master.

fixes #49321, fixes #40230 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
