### PR TITLE
Added Viewport canvas cull mask / CanvasItem rendering layers.

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -349,13 +349,6 @@
 				Returns the global transform matrix of this item in relation to the canvas.
 			</description>
 		</method>
-		<method name="get_layer_mask_value" qualifiers="const">
-			<return type="bool" />
-			<argument index="0" name="layer_number" type="int" />
-			<description>
-				Returns whether or not the specified layer of the [member layers] mask is enabled, given a [code]layer_number[/code] between 1 and 20.
-			</description>
-		</method>
 		<method name="get_local_mouse_position" qualifiers="const">
 			<return type="Vector2" />
 			<description>
@@ -378,6 +371,13 @@
 			<return type="Transform2D" />
 			<description>
 				Returns this item's transform in relation to the viewport.
+			</description>
+		</method>
+		<method name="get_visibility_layer_value" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member visibility_layer] is enabled, given a [code]layer_number[/code] between 1 and 20.
 			</description>
 		</method>
 		<method name="get_world_2d" qualifiers="const">
@@ -407,20 +407,20 @@
 		<method name="is_visible_in_tree" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member layers] property is not masked by the current [Viewport] and all of its antecedents are also visible to and not masked by the current [Viewport]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree.
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member visibility_layer] property is not masked by the current [Viewport] and all of its antecedents are also visible to and not masked by the current [Viewport]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree.
 			</description>
 		</method>
 		<method name="is_visible_in_tree_ignoring_cull_masks" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all of its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree. This method ignores the [member layers] property and any [Viewport] cull masks.
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all of its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree. This method ignores the [member visibility_layer] property and any [Viewport] cull masks.
 			</description>
 		</method>
 		<method name="is_visible_in_tree_with_cull_mask" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="mask" type="int" />
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member layers] property is not masked by the specified [code]mask[/code] and all of its antecedents are also not masked by the specified [code]mask[/code]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree if the specified [code]mask[/code] is used to cull nodes.
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member visibility_layer] property is not masked by the specified [code]mask[/code] and all of its antecedents are also not masked by the specified [code]mask[/code]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree if the specified [code]mask[/code] is used to cull nodes.
 			</description>
 		</method>
 		<method name="make_canvas_position_local" qualifiers="const">
@@ -437,14 +437,6 @@
 				Transformations issued by [code]event[/code]'s inputs are applied in local space instead of global space.
 			</description>
 		</method>
-		<method name="set_layer_mask_value">
-			<return type="void" />
-			<argument index="0" name="layer_number" type="int" />
-			<argument index="1" name="value" type="bool" />
-			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member layers] mask, given a [code]layer_number[/code] between 1 and 20.
-			</description>
-		</method>
 		<method name="set_notify_local_transform">
 			<return type="void" />
 			<argument index="0" name="enable" type="bool" />
@@ -457,6 +449,14 @@
 			<argument index="0" name="enable" type="bool" />
 			<description>
 				If [code]enable[/code] is [code]true[/code], children will be updated with global transform data.
+			</description>
+		</method>
+		<method name="set_visibility_layer_value">
+			<return type="void" />
+			<argument index="0" name="layer_number" type="int" />
+			<argument index="1" name="value" type="bool" />
+			<description>
+				Based on [code]value[/code], enables or disables the specified layer in the [member visibility_layer], given a [code]layer_number[/code] between 1 and 20.
 			</description>
 		</method>
 		<method name="show">
@@ -476,11 +476,7 @@
 		<member name="clip_children" type="bool" setter="set_clip_children" getter="is_clipping_children" default="false">
 		</member>
 		<member name="cull_children" type="bool" setter="set_cull_children" getter="is_cull_children_enabled" default="false">
-			If [code]true[/code], this [CanvasItem] will prevent rendering of its children if it itself is culled via the [member layers] mask when rendered.
-		</member>
-		<member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask" default="1">
-			The 2D rendering layers this [CanvasItem] is drawn on.
-			This object will only be visible for [Viewport]s whose cull_mask does not exclude the 2D render layer(s) that this [CanvasItem] is set to.
+			If [code]true[/code], this [CanvasItem] will prevent rendering of its children if it itself is culled via the [member visibility_layer] when rendered.
 		</member>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" default="1">
 			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes.
@@ -511,6 +507,10 @@
 		</member>
 		<member name="use_parent_material" type="bool" setter="set_use_parent_material" getter="get_use_parent_material" default="false">
 			If [code]true[/code], the parent [CanvasItem]'s [member material] property is used as this one's material.
+		</member>
+		<member name="visibility_layer" type="int" setter="set_visibility_layer" getter="get_visibility_layer" default="1">
+			The 2D rendering layers this [CanvasItem] is drawn on.
+			This object will only be visible for [Viewport]s whose cull_mask does not exclude the 2D render layer(s) that this [CanvasItem] is set to.
 		</member>
 		<member name="visible" type="bool" setter="set_visible" getter="is_visible" default="true">
 			If [code]true[/code], this [CanvasItem] is drawn. The node is only visible if all of its antecedents are visible as well (in other words, [method is_visible_in_tree] must return [code]true[/code]).

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -349,6 +349,13 @@
 				Returns the global transform matrix of this item in relation to the canvas.
 			</description>
 		</method>
+		<method name="get_layer_mask_value" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member layers] mask is enabled, given a [code]layer_number[/code] between 1 and 20.
+			</description>
+		</method>
 		<method name="get_local_mouse_position" qualifiers="const">
 			<return type="Vector2" />
 			<description>
@@ -400,7 +407,20 @@
 		<method name="is_visible_in_tree" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree.
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member layers] property is not masked by the current [Viewport] and all of its antecedents are also visible to and not masked by the current [Viewport]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree.
+			</description>
+		</method>
+		<method name="is_visible_in_tree_ignoring_cull_masks" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all of its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree. This method ignores the [member layers] property and any [Viewport] cull masks.
+			</description>
+		</method>
+		<method name="is_visible_in_tree_with_cull_mask" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="mask" type="int" />
+			<description>
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member layers] property is not masked by the specified [code]mask[/code] and all of its antecedents are also not masked by the specified [code]mask[/code]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree if the specified [code]mask[/code] is used to cull nodes.
 			</description>
 		</method>
 		<method name="make_canvas_position_local" qualifiers="const">
@@ -415,6 +435,14 @@
 			<argument index="0" name="event" type="InputEvent" />
 			<description>
 				Transformations issued by [code]event[/code]'s inputs are applied in local space instead of global space.
+			</description>
+		</method>
+		<method name="set_layer_mask_value">
+			<return type="void" />
+			<argument index="0" name="layer_number" type="int" />
+			<argument index="1" name="value" type="bool" />
+			<description>
+				Based on [code]value[/code], enables or disables the specified layer in the [member layers] mask, given a [code]layer_number[/code] between 1 and 20.
 			</description>
 		</method>
 		<method name="set_notify_local_transform">
@@ -446,6 +474,13 @@
 	</methods>
 	<members>
 		<member name="clip_children" type="bool" setter="set_clip_children" getter="is_clipping_children" default="false">
+		</member>
+		<member name="cull_children" type="bool" setter="set_cull_children" getter="is_cull_children_enabled" default="false">
+			If [code]true[/code], this [CanvasItem] will prevent rendering of its children if it itself is culled via the [member layers] mask when rendered.
+		</member>
+		<member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask" default="1">
+			The 2D rendering layers this [CanvasItem] is drawn on.
+			This object will only be visible for [Viewport]s whose cull_mask does not exclude the 2D render layer(s) that this [CanvasItem] is set to.
 		</member>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" default="1">
 			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes.

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -377,7 +377,7 @@
 			<return type="bool" />
 			<argument index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member visibility_layer] is enabled, given a [code]layer_number[/code] between 1 and 20.
+				Returns whether or not the specified layer of the [member visibility_layer] mask is enabled, given a [code]layer_number[/code] between 1 and 20.
 			</description>
 		</method>
 		<method name="get_world_2d" qualifiers="const">
@@ -407,13 +407,13 @@
 		<method name="is_visible_in_tree" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all of its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree. This method ignores the [member visibility_layer] property and any [Viewport] cull masks.
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all of its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree. This method ignores the [member visibility_layer] mask property and any [Viewport] cull masks.
 			</description>
 		</method>
 		<method name="is_visible_in_viewport" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member visibility_layer] property is not masked by the current [Viewport] and all of its antecedents are also visible to and not masked by the current [Viewport]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree.
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member visibility_layer] mask property is not masked by the current [Viewport] and all of its antecedents are also visible to and not masked by the current [Viewport]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree.
 			</description>
 		</method>
 		<method name="make_canvas_position_local" qualifiers="const">
@@ -449,7 +449,7 @@
 			<argument index="0" name="layer_number" type="int" />
 			<argument index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member visibility_layer], given a [code]layer_number[/code] between 1 and 20.
+				Based on [code]value[/code], enables or disables the specified layer in the [member visibility_layer] mask, given a [code]layer_number[/code] between 1 and 20.
 			</description>
 		</method>
 		<method name="show">
@@ -469,7 +469,7 @@
 		<member name="clip_children" type="bool" setter="set_clip_children" getter="is_clipping_children" default="false">
 		</member>
 		<member name="cull_children" type="bool" setter="set_cull_children" getter="is_cull_children_enabled" default="false">
-			If [code]true[/code], this [CanvasItem] will prevent rendering of its children if it itself is culled via the [member visibility_layer] when rendered.
+			If [code]true[/code], this [CanvasItem] will prevent rendering of its children if it itself is culled via the [member visibility_layer] mask property when rendered.
 		</member>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" default="1">
 			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes.
@@ -503,7 +503,7 @@
 		</member>
 		<member name="visibility_layer" type="int" setter="set_visibility_layer" getter="get_visibility_layer" default="1">
 			The 2D rendering layers this [CanvasItem] is drawn on.
-			This object will only be visible for [Viewport]s whose cull_mask does not exclude the 2D render layer(s) that this [CanvasItem] is set to.
+			This object will only be visible for [Viewport]s whose [code]cull_mask[/code] does not exclude the 2D render layer(s) that this [CanvasItem] is set to.
 		</member>
 		<member name="visible" type="bool" setter="set_visible" getter="is_visible" default="true">
 			If [code]true[/code], this [CanvasItem] is drawn. The node is only visible if all of its antecedents are visible as well (in other words, [method is_visible_in_tree] must return [code]true[/code]).

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -407,20 +407,13 @@
 		<method name="is_visible_in_tree" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member visibility_layer] property is not masked by the current [Viewport] and all of its antecedents are also visible to and not masked by the current [Viewport]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree.
-			</description>
-		</method>
-		<method name="is_visible_in_tree_ignoring_cull_masks" qualifiers="const">
-			<return type="bool" />
-			<description>
 				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all of its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree. This method ignores the [member visibility_layer] property and any [Viewport] cull masks.
 			</description>
 		</method>
-		<method name="is_visible_in_tree_with_cull_mask" qualifiers="const">
+		<method name="is_visible_in_viewport" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="mask" type="int" />
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member visibility_layer] property is not masked by the specified [code]mask[/code] and all of its antecedents are also not masked by the specified [code]mask[/code]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree if the specified [code]mask[/code] is used to cull nodes.
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member visibility_layer] property is not masked by the current [Viewport] and all of its antecedents are also visible to and not masked by the current [Viewport]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree.
 			</description>
 		</method>
 		<method name="make_canvas_position_local" qualifiers="const">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -402,14 +402,6 @@
 				Sets the index for the [CanvasItem].
 			</description>
 		</method>
-		<method name="canvas_item_set_layer_mask">
-			<return type="void" />
-			<argument index="0" name="item" type="RID" />
-			<argument index="1" name="mask" type="int" />
-			<description>
-				Sets the 2D render layers that this canvas item will be drawn to. Equivalent to [member CanvasItem.layers].
-			</description>
-		</method>
 		<method name="canvas_item_set_light_mask">
 			<return type="void" />
 			<argument index="0" name="item" type="RID" />
@@ -466,6 +458,14 @@
 			<argument index="1" name="enabled" type="bool" />
 			<description>
 				Sets if the [CanvasItem] uses its parent's material.
+			</description>
+		</method>
+		<method name="canvas_item_set_visibility_layer">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<argument index="1" name="layer" type="int" />
+			<description>
+				Sets the 2D render layers that this canvas item will be drawn to. Equivalent to [member CanvasItem.visibility_layer].
 			</description>
 		</method>
 		<method name="canvas_item_set_visibility_notifier">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -350,6 +350,14 @@
 				Sets the [CanvasItem] to copy a rect to the backbuffer.
 			</description>
 		</method>
+		<method name="canvas_item_set_cull_children">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<argument index="1" name="enable" type="bool" />
+			<description>
+				If [code]true[/code], this canvas item will prevent rendering of its children if it itself is culled via its layer mask when rendered.
+			</description>
+		</method>
 		<method name="canvas_item_set_custom_rect">
 			<return type="void" />
 			<argument index="0" name="item" type="RID" />
@@ -392,6 +400,14 @@
 			<argument index="1" name="index" type="int" />
 			<description>
 				Sets the index for the [CanvasItem].
+			</description>
+		</method>
+		<method name="canvas_item_set_layer_mask">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<argument index="1" name="mask" type="int" />
+			<description>
+				Sets the 2D render layers that this canvas item will be drawn to. Equivalent to [member CanvasItem.layers].
 			</description>
 		</method>
 		<method name="canvas_item_set_light_mask">
@@ -3025,6 +3041,14 @@
 			<argument index="1" name="active" type="bool" />
 			<description>
 				If [code]true[/code], sets the viewport active, else sets it inactive.
+			</description>
+		</method>
+		<method name="viewport_set_canvas_cull_mask">
+			<return type="void" />
+			<argument index="0" name="viewport" type="RID" />
+			<argument index="1" name="mask" type="int" />
+			<description>
+				Sets the cull mask that describes which 2D render layers are rendered by this viewport. If a bit is not set, then that layer will not be rendered. Equivalent to [member Viewport.canvas_cull_mask].
 			</description>
 		</method>
 		<method name="viewport_set_canvas_stacking">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -46,6 +46,13 @@
 				Returns the currently active 3D camera.
 			</description>
 		</method>
+		<method name="get_canvas_cull_mask_value" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member canvas_cull_mask] is enabled, given a [code]layer_number[/code] between 1 and 20. If a layer is enabled (set to [code]true[/code]) then that layer will be rendered, if it is [code]false[/code] then it will not be rendered.
+			</description>
+		</method>
 		<method name="get_final_transform" qualifiers="const">
 			<return type="Transform2D" />
 			<description>
@@ -150,6 +157,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_canvas_cull_mask_value">
+			<return type="void" />
+			<argument index="0" name="layer_number" type="int" />
+			<argument index="1" name="value" type="bool" />
+			<description>
+				Based on [code]value[/code], enables or disables the specified layer in the [member canvas_cull_mask], given a [code]layer_number[/code] between 1 and 20. If a layer is enabled (set to [code]true[/code]) then that layer will be rendered, if it is [code]false[/code] then it will not be rendered.
+			</description>
+		</method>
 		<method name="set_input_as_handled">
 			<return type="void" />
 			<description>
@@ -178,6 +193,9 @@
 		</member>
 		<member name="audio_listener_enable_3d" type="bool" setter="set_as_audio_listener_3d" getter="is_audio_listener_3d" default="false">
 			If [code]true[/code], the viewport will process 3D audio streams.
+		</member>
+		<member name="canvas_cull_mask" type="int" setter="set_canvas_cull_mask" getter="get_canvas_cull_mask" default="1048575">
+			The culling mask that describes which 2D render layers are rendered by this viewport. If a bit is not set, then that layer will not be rendered.
 		</member>
 		<member name="canvas_item_default_texture_filter" type="int" setter="set_default_canvas_item_texture_filter" getter="get_default_canvas_item_texture_filter" enum="Viewport.DefaultCanvasItemTextureFilter" default="1">
 			Sets the default filter mode used by [CanvasItem]s in this Viewport. See [enum DefaultCanvasItemTextureFilter] for options.

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1214,7 +1214,7 @@ void RasterizerCanvasGLES3::canvas_render_items_end() {
 	batch_canvas_render_items_end();
 }
 
-void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) {
+void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, uint32_t p_visible_layers) {
 	storage->frame.current_rt = nullptr;
 
 	// first set the current render target

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -61,7 +61,7 @@ public:
 	void canvas_begin() override;
 	void canvas_end() override;
 
-	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) override;
+	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, uint32_t p_visible_layers) override;
 
 	void initialize();
 	RasterizerCanvasGLES3();

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -103,7 +103,7 @@ bool CanvasItem::is_visible_in_tree_ignoring_cull_masks() const {
 	return true;
 }
 
-bool CanvasItem::is_visible_in_tree_with_cull_mask(int p_mask) const {
+bool CanvasItem::is_visible_in_tree_with_cull_mask(uint32_t p_mask) const {
 	if (!is_inside_tree()) {
 		return false;
 	}
@@ -505,12 +505,12 @@ int CanvasItem::get_light_mask() const {
 	return light_mask;
 }
 
-void CanvasItem::set_layer_mask(int p_layer_mask) {
+void CanvasItem::set_layer_mask(uint32_t p_layer_mask) {
 	layers = p_layer_mask;
 	RenderingServer::get_singleton()->canvas_item_set_layer_mask(canvas_item, layers);
 }
 
-int CanvasItem::get_layer_mask() const {
+uint32_t CanvasItem::get_layer_mask() const {
 	return layers;
 }
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -61,7 +61,7 @@ bool CanvasItem::is_visible_in_tree() const {
 	}
 
 	// check this item's mask separately, since it doesn't depend on cull_children
-	if (!visible || (layers & get_viewport()->get_canvas_cull_mask()) == 0) {
+	if (!visible || (visibility_layer & get_viewport()->get_canvas_cull_mask()) == 0) {
 		return false;
 	}
 
@@ -74,7 +74,7 @@ bool CanvasItem::is_visible_in_tree() const {
 		if (p->window && !p->window->is_visible()) {
 			return false;
 		}
-		if (p->cull_children && (p->layers & p->get_viewport()->get_canvas_cull_mask()) == 0) {
+		if (p->cull_children && (p->visibility_layer & p->get_viewport()->get_canvas_cull_mask()) == 0) {
 			return false;
 		}
 		p = p->get_parent_item();
@@ -109,7 +109,7 @@ bool CanvasItem::is_visible_in_tree_with_cull_mask(uint32_t p_mask) const {
 	}
 
 	// check this item's mask separately, since it doesn't depend on cull_children
-	if (!visible || (layers & p_mask) == 0) {
+	if (!visible || (visibility_layer & p_mask) == 0) {
 		return false;
 	}
 
@@ -122,7 +122,7 @@ bool CanvasItem::is_visible_in_tree_with_cull_mask(uint32_t p_mask) const {
 		if (p->window && !p->window->is_visible()) {
 			return false;
 		}
-		if (p->cull_children && (p->layers & p_mask) == 0) {
+		if (p->cull_children && (p->visibility_layer & p_mask) == 0) {
 			return false;
 		}
 		p = p->get_parent_item();
@@ -295,7 +295,7 @@ void CanvasItem::_enter_canvas() {
 		}
 
 		RenderingServer::get_singleton()->canvas_item_set_parent(canvas_item, canvas);
-		RenderingServer::get_singleton()->canvas_item_set_layer_mask(canvas_item, layers);
+		RenderingServer::get_singleton()->canvas_item_set_visibility_layer(canvas_item, visibility_layer);
 
 		group = "root_canvas" + itos(canvas.get_id());
 
@@ -313,7 +313,7 @@ void CanvasItem::_enter_canvas() {
 		canvas_layer = parent->canvas_layer;
 		RenderingServer::get_singleton()->canvas_item_set_parent(canvas_item, parent->get_canvas_item());
 		RenderingServer::get_singleton()->canvas_item_set_draw_index(canvas_item, get_index());
-		RenderingServer::get_singleton()->canvas_item_set_layer_mask(canvas_item, layers);
+		RenderingServer::get_singleton()->canvas_item_set_visibility_layer(canvas_item, visibility_layer);
 	}
 
 	pending_update = false;
@@ -505,31 +505,31 @@ int CanvasItem::get_light_mask() const {
 	return light_mask;
 }
 
-void CanvasItem::set_layer_mask(uint32_t p_layer_mask) {
-	layers = p_layer_mask;
-	RenderingServer::get_singleton()->canvas_item_set_layer_mask(canvas_item, layers);
+void CanvasItem::set_visibility_layer(uint32_t p_layer) {
+	visibility_layer = p_layer;
+	RenderingServer::get_singleton()->canvas_item_set_visibility_layer(canvas_item, visibility_layer);
 }
 
-uint32_t CanvasItem::get_layer_mask() const {
-	return layers;
+uint32_t CanvasItem::get_visibility_layer() const {
+	return visibility_layer;
 }
 
-void CanvasItem::set_layer_mask_value(int p_layer_number, bool p_value) {
+void CanvasItem::set_visibility_layer_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number < 1, "Render layer number must be between 1 and 20 inclusive.");
 	ERR_FAIL_COND_MSG(p_layer_number > 20, "Render layer number must be between 1 and 20 inclusive.");
-	int mask = get_layer_mask();
+	int mask = get_visibility_layer();
 	if (p_value) {
 		mask |= 1 << (p_layer_number - 1);
 	} else {
 		mask &= ~(1 << (p_layer_number - 1));
 	}
-	set_layer_mask(mask);
+	set_visibility_layer(mask);
 }
 
-bool CanvasItem::get_layer_mask_value(int p_layer_number) const {
+bool CanvasItem::get_visibility_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Render layer number must be between 1 and 20 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 20, false, "Render layer number must be between 1 and 20 inclusive.");
-	return (layers & (1 << (p_layer_number - 1)));
+	return (visibility_layer & (1 << (p_layer_number - 1)));
 }
 
 void CanvasItem::set_cull_children(bool p_enable) {
@@ -962,10 +962,10 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_light_mask", "light_mask"), &CanvasItem::set_light_mask);
 	ClassDB::bind_method(D_METHOD("get_light_mask"), &CanvasItem::get_light_mask);
 
-	ClassDB::bind_method(D_METHOD("set_layer_mask", "mask"), &CanvasItem::set_layer_mask);
-	ClassDB::bind_method(D_METHOD("get_layer_mask"), &CanvasItem::get_layer_mask);
-	ClassDB::bind_method(D_METHOD("set_layer_mask_value", "layer_number", "value"), &CanvasItem::set_layer_mask_value);
-	ClassDB::bind_method(D_METHOD("get_layer_mask_value", "layer_number"), &CanvasItem::get_layer_mask_value);
+	ClassDB::bind_method(D_METHOD("set_visibility_layer", "layer"), &CanvasItem::set_visibility_layer);
+	ClassDB::bind_method(D_METHOD("get_visibility_layer"), &CanvasItem::get_visibility_layer);
+	ClassDB::bind_method(D_METHOD("set_visibility_layer_value", "layer_number", "value"), &CanvasItem::set_visibility_layer_value);
+	ClassDB::bind_method(D_METHOD("get_visibility_layer_value", "layer_number"), &CanvasItem::get_visibility_layer_value);
 	ClassDB::bind_method(D_METHOD("set_cull_children", "enable"), &CanvasItem::set_cull_children);
 	ClassDB::bind_method(D_METHOD("is_cull_children_enabled"), &CanvasItem::is_cull_children_enabled);
 
@@ -1055,7 +1055,7 @@ void CanvasItem::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_on_top", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "_set_on_top", "_is_on_top"); //compatibility
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_children"), "set_clip_children", "is_clipping_children");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_light_mask", "get_light_mask");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "layers", PROPERTY_HINT_LAYERS_2D_RENDER), "set_layer_mask", "get_layer_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "visibility_layer", PROPERTY_HINT_LAYERS_2D_RENDER), "set_visibility_layer", "get_visibility_layer");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cull_children"), "set_cull_children", "is_cull_children_enabled");
 
 	ADD_GROUP("Texture", "texture_");

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -60,34 +60,6 @@ bool CanvasItem::is_visible_in_tree() const {
 		return false;
 	}
 
-	// check this item's mask separately, since it doesn't depend on cull_children
-	if (!visible || (visibility_layer & get_viewport()->get_canvas_cull_mask()) == 0) {
-		return false;
-	}
-
-	const CanvasItem *p = get_parent_item();
-
-	while (p) {
-		if (!p->visible) {
-			return false;
-		}
-		if (p->window && !p->window->is_visible()) {
-			return false;
-		}
-		if (p->cull_children && (p->visibility_layer & p->get_viewport()->get_canvas_cull_mask()) == 0) {
-			return false;
-		}
-		p = p->get_parent_item();
-	}
-
-	return true;
-}
-
-bool CanvasItem::is_visible_in_tree_ignoring_cull_masks() const {
-	if (!is_inside_tree()) {
-		return false;
-	}
-
 	const CanvasItem *p = this;
 
 	while (p) {
@@ -103,13 +75,13 @@ bool CanvasItem::is_visible_in_tree_ignoring_cull_masks() const {
 	return true;
 }
 
-bool CanvasItem::is_visible_in_tree_with_cull_mask(uint32_t p_mask) const {
+bool CanvasItem::is_visible_in_viewport() const {
 	if (!is_inside_tree()) {
 		return false;
 	}
 
 	// check this item's mask separately, since it doesn't depend on cull_children
-	if (!visible || (visibility_layer & p_mask) == 0) {
+	if (!visible || (visibility_layer & get_viewport()->get_canvas_cull_mask()) == 0) {
 		return false;
 	}
 
@@ -122,7 +94,7 @@ bool CanvasItem::is_visible_in_tree_with_cull_mask(uint32_t p_mask) const {
 		if (p->window && !p->window->is_visible()) {
 			return false;
 		}
-		if (p->cull_children && (p->visibility_layer & p_mask) == 0) {
+		if (p->cull_children && (p->visibility_layer & p->get_viewport()->get_canvas_cull_mask()) == 0) {
 			return false;
 		}
 		p = p->get_parent_item();
@@ -198,7 +170,7 @@ void CanvasItem::_update_callback() {
 
 	RenderingServer::get_singleton()->canvas_item_clear(get_canvas_item());
 	//todo updating = true - only allow drawing here
-	if (is_visible_in_tree_ignoring_cull_masks()) { //todo optimize this!!
+	if (is_visible_in_tree()) { //todo optimize this!!
 		if (first_draw) {
 			notification(NOTIFICATION_VISIBILITY_CHANGED);
 			first_draw = false;
@@ -949,8 +921,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_visible", "visible"), &CanvasItem::set_visible);
 	ClassDB::bind_method(D_METHOD("is_visible"), &CanvasItem::is_visible);
 	ClassDB::bind_method(D_METHOD("is_visible_in_tree"), &CanvasItem::is_visible_in_tree);
-	ClassDB::bind_method(D_METHOD("is_visible_in_tree_ignoring_cull_masks"), &CanvasItem::is_visible_in_tree_ignoring_cull_masks);
-	ClassDB::bind_method(D_METHOD("is_visible_in_tree_with_cull_mask", "mask"), &CanvasItem::is_visible_in_tree_with_cull_mask);
+	ClassDB::bind_method(D_METHOD("is_visible_in_viewport"), &CanvasItem::is_visible_in_viewport);
 	ClassDB::bind_method(D_METHOD("show"), &CanvasItem::show);
 	ClassDB::bind_method(D_METHOD("hide"), &CanvasItem::hide);
 

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -81,7 +81,7 @@ private:
 	List<CanvasItem *>::Element *C = nullptr;
 
 	int light_mask = 1;
-	uint32_t layers = 1;
+	uint32_t visibility_layer = 1;
 
 	Window *window = nullptr;
 	bool first_draw = false;
@@ -211,10 +211,10 @@ public:
 	virtual void set_light_mask(int p_light_mask);
 	int get_light_mask() const;
 
-	void set_layer_mask(uint32_t p_layer_mask);
-	uint32_t get_layer_mask() const;
-	void set_layer_mask_value(int p_layer_number, bool p_value);
-	bool get_layer_mask_value(int p_layer_number) const;
+	void set_visibility_layer(uint32_t p_layer);
+	uint32_t get_visibility_layer() const;
+	void set_visibility_layer_value(int p_layer_number, bool p_value);
+	bool get_visibility_layer_value(int p_layer_number) const;
 	void set_cull_children(bool p_enable);
 	bool is_cull_children_enabled() const;
 

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -198,8 +198,7 @@ public:
 	void set_visible(bool p_visible);
 	bool is_visible() const;
 	bool is_visible_in_tree() const;
-	bool is_visible_in_tree_ignoring_cull_masks() const;
-	bool is_visible_in_tree_with_cull_mask(uint32_t p_mask) const;
+	bool is_visible_in_viewport() const;
 	void show();
 	void hide();
 

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -81,6 +81,7 @@ private:
 	List<CanvasItem *>::Element *C = nullptr;
 
 	int light_mask = 1;
+	int layers = 1;
 
 	Window *window = nullptr;
 	bool first_draw = false;
@@ -94,6 +95,7 @@ private:
 	bool use_parent_material = false;
 	bool notify_local_transform = false;
 	bool notify_transform = false;
+	bool cull_children = false;
 
 	RS::CanvasItemTextureFilter texture_filter_cache = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
 	RS::CanvasItemTextureRepeat texture_repeat_cache = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
@@ -196,6 +198,8 @@ public:
 	void set_visible(bool p_visible);
 	bool is_visible() const;
 	bool is_visible_in_tree() const;
+	bool is_visible_in_tree_ignoring_cull_masks() const;
+	bool is_visible_in_tree_with_cull_mask(int p_mask) const;
 	void show();
 	void hide();
 
@@ -206,6 +210,13 @@ public:
 
 	virtual void set_light_mask(int p_light_mask);
 	int get_light_mask() const;
+
+	void set_layer_mask(int p_layer_mask);
+	int get_layer_mask() const;
+	void set_layer_mask_value(int p_layer_number, bool p_value);
+	bool get_layer_mask_value(int p_layer_number) const;
+	void set_cull_children(bool p_enable);
+	bool is_cull_children_enabled() const;
 
 	void set_modulate(const Color &p_modulate);
 	Color get_modulate() const;

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -81,7 +81,7 @@ private:
 	List<CanvasItem *>::Element *C = nullptr;
 
 	int light_mask = 1;
-	int layers = 1;
+	uint32_t layers = 1;
 
 	Window *window = nullptr;
 	bool first_draw = false;
@@ -199,7 +199,7 @@ public:
 	bool is_visible() const;
 	bool is_visible_in_tree() const;
 	bool is_visible_in_tree_ignoring_cull_masks() const;
-	bool is_visible_in_tree_with_cull_mask(int p_mask) const;
+	bool is_visible_in_tree_with_cull_mask(uint32_t p_mask) const;
 	void show();
 	void hide();
 
@@ -211,8 +211,8 @@ public:
 	virtual void set_light_mask(int p_light_mask);
 	int get_light_mask() const;
 
-	void set_layer_mask(int p_layer_mask);
-	int get_layer_mask() const;
+	void set_layer_mask(uint32_t p_layer_mask);
+	uint32_t get_layer_mask() const;
 	void set_layer_mask_value(int p_layer_number, bool p_value);
 	bool get_layer_mask_value(int p_layer_number) const;
 	void set_cull_children(bool p_enable);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2949,8 +2949,8 @@ bool Viewport::is_handling_input_locally() const {
 	return handle_input_locally;
 }
 
-void Viewport::set_canvas_cull_mask(uint32_t p_layers) {
-	canvas_cull_mask = p_layers;
+void Viewport::set_canvas_cull_mask(uint32_t p_mask) {
+	canvas_cull_mask = p_mask;
 	RenderingServer::get_singleton()->viewport_set_canvas_cull_mask(viewport, canvas_cull_mask);
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2949,7 +2949,7 @@ bool Viewport::is_handling_input_locally() const {
 	return handle_input_locally;
 }
 
-void Viewport::set_canvas_cull_mask(int p_layers) {
+void Viewport::set_canvas_cull_mask(uint32_t p_layers) {
 	canvas_cull_mask = p_layers;
 	RenderingServer::get_singleton()->viewport_set_canvas_cull_mask(viewport, canvas_cull_mask);
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2954,7 +2954,7 @@ void Viewport::set_canvas_cull_mask(uint32_t p_mask) {
 	RenderingServer::get_singleton()->viewport_set_canvas_cull_mask(viewport, canvas_cull_mask);
 }
 
-int Viewport::get_canvas_cull_mask() const {
+uint32_t Viewport::get_canvas_cull_mask() const {
 	return canvas_cull_mask;
 }
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -299,6 +299,8 @@ private:
 	float lod_threshold = 1.0;
 	bool use_occlusion_culling = false;
 
+	int canvas_cull_mask = 0xfffff;
+
 	Ref<ViewportTexture> default_texture;
 	Set<ViewportTexture *> viewport_textures;
 
@@ -581,6 +583,11 @@ public:
 
 	bool gui_is_dragging() const;
 	bool gui_is_drag_successful() const;
+
+	void set_canvas_cull_mask(int p_layers);
+	int get_canvas_cull_mask() const;
+	void set_canvas_cull_mask_value(int p_layer_number, bool p_value);
+	bool get_canvas_cull_mask_value(int p_layer_number) const;
 
 	Control *gui_find_control(const Point2 &p_global);
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -299,7 +299,7 @@ private:
 	float lod_threshold = 1.0;
 	bool use_occlusion_culling = false;
 
-	int canvas_cull_mask = 0xfffff;
+	uint32_t canvas_cull_mask = 0xfffff;
 
 	Ref<ViewportTexture> default_texture;
 	Set<ViewportTexture *> viewport_textures;
@@ -584,7 +584,7 @@ public:
 	bool gui_is_dragging() const;
 	bool gui_is_drag_successful() const;
 
-	void set_canvas_cull_mask(int p_layers);
+	void set_canvas_cull_mask(uint32_t p_layers);
 	int get_canvas_cull_mask() const;
 	void set_canvas_cull_mask_value(int p_layer_number, bool p_value);
 	bool get_canvas_cull_mask_value(int p_layer_number) const;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -585,7 +585,7 @@ public:
 	bool gui_is_drag_successful() const;
 
 	void set_canvas_cull_mask(uint32_t p_mask);
-	int get_canvas_cull_mask() const;
+	uint32_t get_canvas_cull_mask() const;
 	void set_canvas_cull_mask_value(int p_layer_number, bool p_value);
 	bool get_canvas_cull_mask_value(int p_layer_number) const;
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -584,7 +584,7 @@ public:
 	bool gui_is_dragging() const;
 	bool gui_is_drag_successful() const;
 
-	void set_canvas_cull_mask(uint32_t p_layers);
+	void set_canvas_cull_mask(uint32_t p_mask);
 	int get_canvas_cull_mask() const;
 	void set_canvas_cull_mask_value(int p_layer_number, bool p_value);
 	bool get_canvas_cull_mask_value(int p_layer_number) const;

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -720,7 +720,7 @@ public:
 	PolygonID request_polygon(const Vector<int> &p_indices, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs = Vector<Point2>(), const Vector<int> &p_bones = Vector<int>(), const Vector<float> &p_weights = Vector<float>()) override { return 0; }
 	void free_polygon(PolygonID p_polygon) override {}
 
-	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, int p_visible_layers) override {}
+	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, uint32_t p_visible_layers) override {}
 	void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) override {}
 
 	RID light_create() override { return RID(); }

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -720,7 +720,7 @@ public:
 	PolygonID request_polygon(const Vector<int> &p_indices, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs = Vector<Point2>(), const Vector<int> &p_bones = Vector<int>(), const Vector<float> &p_weights = Vector<float>()) override { return 0; }
 	void free_polygon(PolygonID p_polygon) override {}
 
-	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) override {}
+	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, int p_visible_layers) override {}
 	void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) override {}
 
 	RID light_create() override { return RID(); }

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -37,7 +37,7 @@
 
 static const int z_range = RS::CANVAS_ITEM_Z_MAX - RS::CANVAS_ITEM_Z_MIN + 1;
 
-void RendererCanvasCull::_render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RenderingServer::CanvasItemTextureFilter p_default_filter, RenderingServer::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, int p_visible_layers) {
+void RendererCanvasCull::_render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RenderingServer::CanvasItemTextureFilter p_default_filter, RenderingServer::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, uint32_t p_visible_layers) {
 	RENDER_TIMESTAMP("Cull CanvasItem Tree");
 
 	memset(z_list, 0, z_range * sizeof(RendererCanvasRender::Item *));
@@ -213,7 +213,7 @@ void RendererCanvasCull::_attach_canvas_item_for_draw(RendererCanvasCull::Item *
 	}
 }
 
-void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **z_list, RendererCanvasRender::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool allow_y_sort, int p_visible_layers) {
+void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **z_list, RendererCanvasRender::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool allow_y_sort, uint32_t p_visible_layers) {
 	Item *ci = p_canvas_item;
 
 	if (!ci->visible) {
@@ -343,7 +343,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 	}
 }
 
-void RendererCanvasCull::render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, const Rect2 &p_clip_rect, RenderingServer::CanvasItemTextureFilter p_default_filter, RenderingServer::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_vertices_to_pixel, int p_visible_layers) {
+void RendererCanvasCull::render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, const Rect2 &p_clip_rect, RenderingServer::CanvasItemTextureFilter p_default_filter, RenderingServer::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_vertices_to_pixel, uint32_t p_visible_layers) {
 	RENDER_TIMESTAMP(">Render Canvas");
 
 	sdf_used = false;
@@ -500,7 +500,7 @@ void RendererCanvasCull::canvas_item_set_light_mask(RID p_item, int p_mask) {
 	canvas_item->light_mask = p_mask;
 }
 
-void RendererCanvasCull::canvas_item_set_layer_mask(RID p_item, int p_mask) {
+void RendererCanvasCull::canvas_item_set_layer_mask(RID p_item, uint32_t p_mask) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -220,7 +220,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		return;
 	}
 
-	if (ci->cull_children && (ci->layer_mask & p_visible_layers) == 0) {
+	if (ci->cull_children && (ci->visibility_layer & p_visible_layers) == 0) {
 		return;
 	}
 
@@ -304,7 +304,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 				_cull_canvas_item(child_items[i], xform * child_items[i]->ysort_xform, p_clip_rect, modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner, false, p_visible_layers);
 			}
 		} else {
-			if (ci->layer_mask & p_visible_layers) {
+			if (ci->visibility_layer & p_visible_layers) {
 				RendererCanvasRender::Item *canvas_group_from = nullptr;
 				bool use_canvas_group = ci->canvas_group != nullptr && (ci->canvas_group->fit_empty || ci->commands != nullptr);
 				if (use_canvas_group) {
@@ -330,7 +330,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			_cull_canvas_item(child_items[i], xform, p_clip_rect, modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, p_material_owner, true, p_visible_layers);
 		}
 
-		if (ci->layer_mask & p_visible_layers) {
+		if (ci->visibility_layer & p_visible_layers) {
 			_attach_canvas_item_for_draw(ci, p_canvas_clip, z_list, z_last_list, xform, p_clip_rect, global_rect, modulate, p_z, p_material_owner, use_canvas_group, canvas_group_from, xform);
 		}
 
@@ -500,11 +500,11 @@ void RendererCanvasCull::canvas_item_set_light_mask(RID p_item, int p_mask) {
 	canvas_item->light_mask = p_mask;
 }
 
-void RendererCanvasCull::canvas_item_set_layer_mask(RID p_item, uint32_t p_mask) {
+void RendererCanvasCull::canvas_item_set_visibility_layer(RID p_item, uint32_t p_layer) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
-	canvas_item->layer_mask = p_mask;
+	canvas_item->visibility_layer = p_layer;
 }
 
 void RendererCanvasCull::canvas_item_set_cull_children(RID p_item, bool p_enable) {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -501,14 +501,14 @@ void RendererCanvasCull::canvas_item_set_light_mask(RID p_item, int p_mask) {
 }
 
 void RendererCanvasCull::canvas_item_set_visibility_layer(RID p_item, uint32_t p_layer) {
-	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->visibility_layer = p_layer;
 }
 
 void RendererCanvasCull::canvas_item_set_cull_children(RID p_item, bool p_enable) {
-	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->cull_children = p_enable;

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -53,7 +53,7 @@ public:
 		Transform2D ysort_xform;
 		Vector2 ysort_pos;
 		int ysort_index;
-		int layer_mask;
+		uint32_t layer_mask;
 		bool cull_children;
 
 		Vector<Item *> child_items;
@@ -181,14 +181,14 @@ public:
 	_FORCE_INLINE_ void _attach_canvas_item_for_draw(Item *ci, Item *p_canvas_clip, RendererCanvasRender::Item **z_list, RendererCanvasRender::Item **z_last_list, const Transform2D &xform, const Rect2 &p_clip_rect, Rect2 global_rect, const Color &modulate, int p_z, RendererCanvasCull::Item *p_material_owner, bool use_canvas_group, RendererCanvasRender::Item *canvas_group_from, const Transform2D &p_xform);
 
 private:
-	void _render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, int p_visible_layers);
-	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **z_list, RendererCanvasRender::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool allow_y_sort, int p_visible_layers);
+	void _render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, uint32_t p_visible_layers);
+	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **z_list, RendererCanvasRender::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool allow_y_sort, uint32_t p_visible_layers);
 
 	RendererCanvasRender::Item **z_list;
 	RendererCanvasRender::Item **z_last_list;
 
 public:
-	void render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, const Rect2 &p_clip_rect, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_vertices_to_pixel, int p_visible_layers);
+	void render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, const Rect2 &p_clip_rect, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_vertices_to_pixel, uint32_t p_visible_layers);
 
 	bool was_sdf_used();
 
@@ -208,7 +208,7 @@ public:
 	void canvas_item_set_visible(RID p_item, bool p_visible);
 	void canvas_item_set_light_mask(RID p_item, int p_mask);
 
-	void canvas_item_set_layer_mask(RID p_item, int p_mask);
+	void canvas_item_set_layer_mask(RID p_item, uint32_t p_mask);
 	void canvas_item_set_cull_children(RID p_item, bool p_enable);
 
 	void canvas_item_set_transform(RID p_item, const Transform2D &p_transform);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -53,6 +53,8 @@ public:
 		Transform2D ysort_xform;
 		Vector2 ysort_pos;
 		int ysort_index;
+		int layer_mask;
+		bool cull_children;
 
 		Vector<Item *> child_items;
 
@@ -84,6 +86,8 @@ public:
 			ysort_xform = Transform2D();
 			ysort_pos = Vector2();
 			ysort_index = 0;
+			layer_mask = 0xfffff;
+			cull_children = false;
 		}
 	};
 
@@ -177,14 +181,14 @@ public:
 	_FORCE_INLINE_ void _attach_canvas_item_for_draw(Item *ci, Item *p_canvas_clip, RendererCanvasRender::Item **z_list, RendererCanvasRender::Item **z_last_list, const Transform2D &xform, const Rect2 &p_clip_rect, Rect2 global_rect, const Color &modulate, int p_z, RendererCanvasCull::Item *p_material_owner, bool use_canvas_group, RendererCanvasRender::Item *canvas_group_from, const Transform2D &p_xform);
 
 private:
-	void _render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel);
-	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **z_list, RendererCanvasRender::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool allow_y_sort);
+	void _render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, int p_visible_layers);
+	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **z_list, RendererCanvasRender::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool allow_y_sort, int p_visible_layers);
 
 	RendererCanvasRender::Item **z_list;
 	RendererCanvasRender::Item **z_last_list;
 
 public:
-	void render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, const Rect2 &p_clip_rect, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_vertices_to_pixel);
+	void render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, const Rect2 &p_clip_rect, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_vertices_to_pixel, int p_visible_layers);
 
 	bool was_sdf_used();
 
@@ -203,6 +207,9 @@ public:
 
 	void canvas_item_set_visible(RID p_item, bool p_visible);
 	void canvas_item_set_light_mask(RID p_item, int p_mask);
+
+	void canvas_item_set_layer_mask(RID p_item, int p_mask);
+	void canvas_item_set_cull_children(RID p_item, bool p_enable);
 
 	void canvas_item_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_set_clip(RID p_item, bool p_clip);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -53,7 +53,7 @@ public:
 		Transform2D ysort_xform;
 		Vector2 ysort_pos;
 		int ysort_index;
-		uint32_t layer_mask;
+		uint32_t visibility_layer;
 		bool cull_children;
 
 		Vector<Item *> child_items;
@@ -86,7 +86,7 @@ public:
 			ysort_xform = Transform2D();
 			ysort_pos = Vector2();
 			ysort_index = 0;
-			layer_mask = 0xfffff;
+			visibility_layer = 0xfffff;
 			cull_children = false;
 		}
 	};
@@ -208,7 +208,7 @@ public:
 	void canvas_item_set_visible(RID p_item, bool p_visible);
 	void canvas_item_set_light_mask(RID p_item, int p_mask);
 
-	void canvas_item_set_layer_mask(RID p_item, uint32_t p_mask);
+	void canvas_item_set_visibility_layer(RID p_item, uint32_t p_layer);
 	void canvas_item_set_cull_children(RID p_item, bool p_enable);
 
 	void canvas_item_set_transform(RID p_item, const Transform2D &p_transform);

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -574,7 +574,7 @@ public:
 		}
 	};
 
-	virtual void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) = 0;
+	virtual void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, int p_visible_layers) = 0;
 	virtual void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) = 0;
 
 	struct LightOccluderInstance {

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -574,7 +574,7 @@ public:
 		}
 	};
 
-	virtual void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, int p_visible_layers) = 0;
+	virtual void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, uint32_t p_visible_layers) = 0;
 	virtual void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) = 0;
 
 	struct LightOccluderInstance {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1126,7 +1126,7 @@ void RendererCanvasRenderRD::_render_items(RID p_to_render_target, int p_item_co
 	RD::get_singleton()->draw_list_end();
 }
 
-void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_light_list, const Transform2D &p_canvas_transform, RenderingServer::CanvasItemTextureFilter p_default_filter, RenderingServer::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) {
+void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_light_list, const Transform2D &p_canvas_transform, RenderingServer::CanvasItemTextureFilter p_default_filter, RenderingServer::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, int p_visible_layers) {
 	r_sdf_used = false;
 	int item_count = 0;
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1126,7 +1126,7 @@ void RendererCanvasRenderRD::_render_items(RID p_to_render_target, int p_item_co
 	RD::get_singleton()->draw_list_end();
 }
 
-void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_light_list, const Transform2D &p_canvas_transform, RenderingServer::CanvasItemTextureFilter p_default_filter, RenderingServer::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, int p_visible_layers) {
+void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_light_list, const Transform2D &p_canvas_transform, RenderingServer::CanvasItemTextureFilter p_default_filter, RenderingServer::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, uint32_t p_visible_layers) {
 	r_sdf_used = false;
 	int item_count = 0;
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -454,7 +454,7 @@ public:
 	void occluder_polygon_set_shape(RID p_occluder, const Vector<Vector2> &p_points, bool p_closed);
 	void occluder_polygon_set_cull_mode(RID p_occluder, RS::CanvasOccluderPolygonCullMode p_mode);
 
-	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_light_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used);
+	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_light_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, int p_visible_layers);
 
 	void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) {}
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -454,7 +454,7 @@ public:
 	void occluder_polygon_set_shape(RID p_occluder, const Vector<Vector2> &p_points, bool p_closed);
 	void occluder_polygon_set_cull_mode(RID p_occluder, RS::CanvasOccluderPolygonCullMode p_mode);
 
-	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_light_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, int p_visible_layers);
+	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_light_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, uint32_t p_visible_layers);
 
 	void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) {}
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1092,7 +1092,7 @@ void RendererViewport::viewport_set_lod_threshold(RID p_viewport, float p_pixels
 }
 
 void RendererViewport::viewport_set_canvas_cull_mask(RID p_viewport, uint32_t p_mask) {
-	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
 	ERR_FAIL_COND(!viewport);
 	viewport->canvas_visible_layers = p_mask;
 }

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -505,7 +505,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 				ptr = ptr->filter_next_ptr;
 			}
 
-			RSG::canvas->render_canvas(p_viewport->render_target, canvas, xform, canvas_lights, canvas_directional_lights, clip_rect, p_viewport->texture_filter, p_viewport->texture_repeat, p_viewport->snap_2d_transforms_to_pixel, p_viewport->snap_2d_vertices_to_pixel);
+			RSG::canvas->render_canvas(p_viewport->render_target, canvas, xform, canvas_lights, canvas_directional_lights, clip_rect, p_viewport->texture_filter, p_viewport->texture_repeat, p_viewport->snap_2d_transforms_to_pixel, p_viewport->snap_2d_vertices_to_pixel, p_viewport->canvas_visible_layers);
 			if (RSG::canvas->was_sdf_used()) {
 				p_viewport->sdf_active = true;
 			}
@@ -1089,6 +1089,12 @@ void RendererViewport::viewport_set_lod_threshold(RID p_viewport, float p_pixels
 	ERR_FAIL_COND(!viewport);
 
 	viewport->lod_threshold = p_pixels;
+}
+
+void RendererViewport::viewport_set_canvas_cull_mask(RID p_viewport, int p_mask) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+	viewport->canvas_visible_layers = p_mask;
 }
 
 int RendererViewport::viewport_get_render_info(RID p_viewport, RS::ViewportRenderInfoType p_type, RS::ViewportRenderInfo p_info) {

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1091,7 +1091,7 @@ void RendererViewport::viewport_set_lod_threshold(RID p_viewport, float p_pixels
 	viewport->lod_threshold = p_pixels;
 }
 
-void RendererViewport::viewport_set_canvas_cull_mask(RID p_viewport, int p_mask) {
+void RendererViewport::viewport_set_canvas_cull_mask(RID p_viewport, uint32_t p_mask) {
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);
 	viewport->canvas_visible_layers = p_mask;

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -108,7 +108,7 @@ public:
 
 		bool transparent_bg;
 
-		int canvas_visible_layers;
+		uint32_t canvas_visible_layers;
 
 		struct CanvasKey {
 			int64_t stacking;
@@ -261,7 +261,7 @@ public:
 	void viewport_set_occlusion_rays_per_thread(int p_rays_per_thread);
 	void viewport_set_occlusion_culling_build_quality(RS::ViewportOcclusionCullingBuildQuality p_quality);
 	void viewport_set_lod_threshold(RID p_viewport, float p_pixels);
-	void viewport_set_canvas_cull_mask(RID p_viewport, int p_mask);
+	void viewport_set_canvas_cull_mask(RID p_viewport, uint32_t p_mask);
 
 	virtual int viewport_get_render_info(RID p_viewport, RS::ViewportRenderInfoType p_type, RS::ViewportRenderInfo p_info);
 	virtual void viewport_set_debug_draw(RID p_viewport, RS::ViewportDebugDraw p_draw);

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -108,6 +108,8 @@ public:
 
 		bool transparent_bg;
 
+		int canvas_visible_layers;
+
 		struct CanvasKey {
 			int64_t stacking;
 			RID canvas;
@@ -168,6 +170,8 @@ public:
 
 			time_gpu_begin = 0;
 			time_gpu_end = 0;
+
+			canvas_visible_layers = 0;
 		}
 
 		uint32_t get_view_count();
@@ -257,6 +261,7 @@ public:
 	void viewport_set_occlusion_rays_per_thread(int p_rays_per_thread);
 	void viewport_set_occlusion_culling_build_quality(RS::ViewportOcclusionCullingBuildQuality p_quality);
 	void viewport_set_lod_threshold(RID p_viewport, float p_pixels);
+	void viewport_set_canvas_cull_mask(RID p_viewport, int p_mask);
 
 	virtual int viewport_get_render_info(RID p_viewport, RS::ViewportRenderInfoType p_type, RS::ViewportRenderInfo p_info);
 	virtual void viewport_set_debug_draw(RID p_viewport, RS::ViewportDebugDraw p_draw);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -754,7 +754,7 @@ public:
 	FUNC2(canvas_item_set_visible, RID, bool)
 	FUNC2(canvas_item_set_light_mask, RID, int)
 
-	FUNC2(canvas_item_set_layer_mask, RID, uint32_t)
+	FUNC2(canvas_item_set_visibility_layer, RID, uint32_t)
 	FUNC2(canvas_item_set_cull_children, RID, bool)
 
 	FUNC2(canvas_item_set_update_when_visible, RID, bool)

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -576,6 +576,7 @@ public:
 	FUNC1(viewport_set_occlusion_rays_per_thread, int)
 	FUNC1(viewport_set_occlusion_culling_build_quality, ViewportOcclusionCullingBuildQuality)
 	FUNC2(viewport_set_lod_threshold, RID, float)
+	FUNC2(viewport_set_canvas_cull_mask, RID, int)
 
 	FUNC3R(int, viewport_get_render_info, RID, ViewportRenderInfoType, ViewportRenderInfo)
 	FUNC2(viewport_set_debug_draw, RID, ViewportDebugDraw)
@@ -752,6 +753,9 @@ public:
 
 	FUNC2(canvas_item_set_visible, RID, bool)
 	FUNC2(canvas_item_set_light_mask, RID, int)
+
+	FUNC2(canvas_item_set_layer_mask, RID, int)
+	FUNC2(canvas_item_set_cull_children, RID, bool)
 
 	FUNC2(canvas_item_set_update_when_visible, RID, bool)
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -576,7 +576,7 @@ public:
 	FUNC1(viewport_set_occlusion_rays_per_thread, int)
 	FUNC1(viewport_set_occlusion_culling_build_quality, ViewportOcclusionCullingBuildQuality)
 	FUNC2(viewport_set_lod_threshold, RID, float)
-	FUNC2(viewport_set_canvas_cull_mask, RID, int)
+	FUNC2(viewport_set_canvas_cull_mask, RID, uint32_t)
 
 	FUNC3R(int, viewport_get_render_info, RID, ViewportRenderInfoType, ViewportRenderInfo)
 	FUNC2(viewport_set_debug_draw, RID, ViewportDebugDraw)
@@ -754,7 +754,7 @@ public:
 	FUNC2(canvas_item_set_visible, RID, bool)
 	FUNC2(canvas_item_set_light_mask, RID, int)
 
-	FUNC2(canvas_item_set_layer_mask, RID, int)
+	FUNC2(canvas_item_set_layer_mask, RID, uint32_t)
 	FUNC2(canvas_item_set_cull_children, RID, bool)
 
 	FUNC2(canvas_item_set_update_when_visible, RID, bool)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2204,6 +2204,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_use_occlusion_culling", "viewport", "enable"), &RenderingServer::viewport_set_use_occlusion_culling);
 	ClassDB::bind_method(D_METHOD("viewport_set_occlusion_rays_per_thread", "rays_per_thread"), &RenderingServer::viewport_set_occlusion_rays_per_thread);
 	ClassDB::bind_method(D_METHOD("viewport_set_occlusion_culling_build_quality", "quality"), &RenderingServer::viewport_set_occlusion_culling_build_quality);
+	ClassDB::bind_method(D_METHOD("viewport_set_canvas_cull_mask", "viewport", "mask"), &RenderingServer::viewport_set_canvas_cull_mask);
 
 	ClassDB::bind_method(D_METHOD("viewport_get_render_info", "viewport", "type", "info"), &RenderingServer::viewport_get_render_info);
 	ClassDB::bind_method(D_METHOD("viewport_set_debug_draw", "viewport", "draw"), &RenderingServer::viewport_set_debug_draw);
@@ -2543,6 +2544,8 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_default_texture_repeat", "item", "repeat"), &RenderingServer::canvas_item_set_default_texture_repeat);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_visible", "item", "visible"), &RenderingServer::canvas_item_set_visible);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_light_mask", "item", "mask"), &RenderingServer::canvas_item_set_light_mask);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_layer_mask", "item", "mask"), &RenderingServer::canvas_item_set_layer_mask);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_cull_children", "item", "enable"), &RenderingServer::canvas_item_set_cull_children);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_transform", "item", "transform"), &RenderingServer::canvas_item_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_clip", "item", "clip"), &RenderingServer::canvas_item_set_clip);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_distance_field_mode", "item", "enabled"), &RenderingServer::canvas_item_set_distance_field_mode);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2544,7 +2544,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_default_texture_repeat", "item", "repeat"), &RenderingServer::canvas_item_set_default_texture_repeat);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_visible", "item", "visible"), &RenderingServer::canvas_item_set_visible);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_light_mask", "item", "mask"), &RenderingServer::canvas_item_set_light_mask);
-	ClassDB::bind_method(D_METHOD("canvas_item_set_layer_mask", "item", "mask"), &RenderingServer::canvas_item_set_layer_mask);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_visibility_layer", "item", "layer"), &RenderingServer::canvas_item_set_visibility_layer);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_cull_children", "item", "enable"), &RenderingServer::canvas_item_set_cull_children);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_transform", "item", "transform"), &RenderingServer::canvas_item_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_clip", "item", "clip"), &RenderingServer::canvas_item_set_clip);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -884,7 +884,7 @@ public:
 
 	virtual void viewport_set_occlusion_culling_build_quality(ViewportOcclusionCullingBuildQuality p_quality) = 0;
 
-	virtual void viewport_set_canvas_cull_mask(RID p_viewport, int p_mask) = 0;
+	virtual void viewport_set_canvas_cull_mask(RID p_viewport, uint32_t p_mask) = 0;
 
 	enum ViewportRenderInfo {
 		VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME,
@@ -1264,7 +1264,7 @@ public:
 
 	virtual void canvas_item_set_visible(RID p_item, bool p_visible) = 0;
 	virtual void canvas_item_set_light_mask(RID p_item, int p_mask) = 0;
-	virtual void canvas_item_set_layer_mask(RID p_item, int p_mask) = 0;
+	virtual void canvas_item_set_layer_mask(RID p_item, uint32_t p_mask) = 0;
 	virtual void canvas_item_set_cull_children(RID p_item, bool p_enable) = 0;
 
 	virtual void canvas_item_set_update_when_visible(RID p_item, bool p_update) = 0;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -884,6 +884,8 @@ public:
 
 	virtual void viewport_set_occlusion_culling_build_quality(ViewportOcclusionCullingBuildQuality p_quality) = 0;
 
+	virtual void viewport_set_canvas_cull_mask(RID p_viewport, int p_mask) = 0;
+
 	enum ViewportRenderInfo {
 		VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME,
 		VIEWPORT_RENDER_INFO_PRIMITIVES_IN_FRAME,
@@ -1262,6 +1264,8 @@ public:
 
 	virtual void canvas_item_set_visible(RID p_item, bool p_visible) = 0;
 	virtual void canvas_item_set_light_mask(RID p_item, int p_mask) = 0;
+	virtual void canvas_item_set_layer_mask(RID p_item, int p_mask) = 0;
+	virtual void canvas_item_set_cull_children(RID p_item, bool p_enable) = 0;
 
 	virtual void canvas_item_set_update_when_visible(RID p_item, bool p_update) = 0;
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1264,7 +1264,7 @@ public:
 
 	virtual void canvas_item_set_visible(RID p_item, bool p_visible) = 0;
 	virtual void canvas_item_set_light_mask(RID p_item, int p_mask) = 0;
-	virtual void canvas_item_set_layer_mask(RID p_item, uint32_t p_mask) = 0;
+	virtual void canvas_item_set_visibility_layer(RID p_item, uint32_t p_layer) = 0;
 	virtual void canvas_item_set_cull_children(RID p_item, bool p_enable) = 0;
 
 	virtual void canvas_item_set_update_when_visible(RID p_item, bool p_update) = 0;


### PR DESCRIPTION
A godot4-ified rewrite and extension of the great work in #31877.

This PR adds:
- a `layers` property to all `CanvasItem`s so that they can be culled via
- a new `canvas_cull_mask` property in `Viewport`s to control which layers to render in said viewport
- feature parity with the behaviour of culling `VisualInstance3D`, i.e. don't cull child nodes if they are on different layers, only cull `CanvasItem`s that do not match the `Viewport.canvas_cull_mask` (this is different to #31877)
- if the above behaviour isn't desirable (and it's not in all cases) a new `cull_children` property of `CanvasItem`s that prevents rendering of any child nodes if the parent node is itself culled. (this is useful when creating reuseable scenes of which you don't know what layers you'd like to bake the nodes into; this can now easily be done by a designer with no code on a parent node outside of the instanced scene)
- the ability to cull and propagate input of `Control` nodes on separate `Viewport`s, i.e. `Control` nodes do not receive input if they are masked
- support for doing all of the above via the servers rather than instantiating nodes
- some new functions for querying visibility in the scene tree:
- `CanvasItem.is_visible_in_tree_ignoring_cull_masks()` check if the canvas item is visible with no regards to culling and
- `CanvasItem.is_visible_in_tree_with_mask(mask)` check if the canvas item is going to be culled with the specified mask

I would have liked to have sat on the changes a little and made sure I've gotten everything that I'd need implemented but I feel a little pressured to push as-is with other conflicting PRs targetting this feature. I feel that matching the behaviour of `VisualInstance3D` is important and that interacting with `Control` nodes on viewports is a valuable win.

Possible future work for another PR: Be able to set the main viewport mask purely in the editor without code such as `get_viewport().canvas_cull_mask = ???`.

Here's a small motivating example of the kinds of effects that are now incredibly simple to do, with little code:

![puddles2](https://user-images.githubusercontent.com/86566939/132078426-93b36a5f-6c33-4660-893d-eeaa0bd9dedc.gif)

This is just a viewport set to render the same scene as the main viewport. The main scene culls reflections and the sub viewport is used to render those culled reflections to an offscreen texture which is then in turn used as a mask on the reflective surfaces. Currently this requires a lot of code and juggling of the scene tree to do in Godot otherwise (and is often 1 frame delayed).

![example](https://user-images.githubusercontent.com/86566939/132078922-1f03eb9a-ff59-42cf-acc7-13f1f12a2809.png)