### PR TITLE
[3.x] Added Viewport canvas cull mask / CanvasItem rendering layers.

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -299,6 +299,13 @@
 				Returns the global transform matrix of this item in relation to the canvas.
 			</description>
 		</method>
+		<method name="get_layer_mask_bit" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="layer" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member layers] mask is enabled, given a [code]layer_number[/code] between 1 and 20.
+			</description>
+		</method>
 		<method name="get_local_mouse_position" qualifiers="const">
 			<return type="Vector2" />
 			<description>
@@ -356,7 +363,20 @@
 		<method name="is_visible_in_tree" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree.
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member layers] property is not masked by the current [Viewport] and all of its antecedents are also visible to and not masked by the current [Viewport]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree.
+			</description>
+		</method>
+		<method name="is_visible_in_tree_ignoring_cull_masks" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all of its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree. This method ignores the [member layers] property and any [Viewport] cull masks.
+			</description>
+		</method>
+		<method name="is_visible_in_tree_with_cull_mask" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="mask" type="int" />
+			<description>
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code], its [member layers] property is not masked by the specified [code]mask[/code] and all of its antecedents are also not masked by the specified [code]mask[/code]. If any antecedent is hidden or masked-and-marked with [member cull_children], then this node will not be visible in the scene tree if the specified [code]mask[/code] is used to cull nodes.
 			</description>
 		</method>
 		<method name="make_canvas_position_local" qualifiers="const">
@@ -378,6 +398,14 @@
 			<argument index="0" name="enable" type="bool" />
 			<description>
 				If [code]enable[/code] is [code]true[/code], this [CanvasItem] will [i]not[/i] inherit its transform from parent [CanvasItem]s. Its draw order will also be changed to make it draw on top of other [CanvasItem]s that are not set as top-level. The [CanvasItem] will effectively act as if it was placed as a child of a bare [Node]. See also [method is_set_as_toplevel].
+			</description>
+		</method>
+		<method name="set_layer_mask_bit">
+			<return type="void" />
+			<argument index="0" name="layer" type="int" />
+			<argument index="1" name="enable" type="bool" />
+			<description>
+				Based on [code]value[/code], enables or disables the specified layer in the [member layers] mask.
 			</description>
 		</method>
 		<method name="set_notify_local_transform">
@@ -408,6 +436,13 @@
 		</method>
 	</methods>
 	<members>
+		<member name="cull_children" type="bool" setter="set_cull_children" getter="is_cull_children_enabled" default="false">
+			If [code]true[/code], this [CanvasItem] will prevent rendering of its children if it itself is culled via the [member layers] mask when rendered.
+		</member>
+		<member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask" default="1">
+			The 2D rendering layers this [CanvasItem] is drawn on.
+			This object will only be visible for [Viewport]s whose cull mask does not exclude the 2D render layer(s) that this [CanvasItem] is set to.
+		</member>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" default="1">
 			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes.
 		</member>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -41,6 +41,13 @@
 				Returns the active 3D camera.
 			</description>
 		</method>
+		<method name="get_canvas_cull_mask_bit" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="layer" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member canvas_cull_mask] is enabled. If a layer is enabled (set to [code]true[/code]) then that layer will be rendered, if it is [code]false[/code] then it will not be rendered.
+			</description>
+		</method>
 		<method name="get_final_transform" qualifiers="const">
 			<return type="Transform2D" />
 			<description>
@@ -150,6 +157,14 @@
 				Attaches this [Viewport] to the root [Viewport] with the specified rectangle. This bypasses the need for another node to display this [Viewport] but makes you responsible for updating the position of this [Viewport] manually.
 			</description>
 		</method>
+		<method name="set_canvas_cull_mask_bit">
+			<return type="void" />
+			<argument index="0" name="layer" type="int" />
+			<argument index="1" name="enable" type="bool" />
+			<description>
+				Based on [code]value[/code], enables or disables the specified layer in the [member canvas_cull_mask]. If a layer is enabled (set to [code]true[/code]) then that layer will be rendered, if it is [code]false[/code] then it will not be rendered.
+			</description>
+		</method>
 		<method name="set_input_as_handled">
 			<return type="void" />
 			<description>
@@ -202,6 +217,9 @@
 		</member>
 		<member name="audio_listener_enable_3d" type="bool" setter="set_as_audio_listener" getter="is_audio_listener" default="false">
 			If [code]true[/code], the viewport will process 3D audio streams.
+		</member>
+		<member name="canvas_cull_mask" type="int" setter="set_canvas_cull_mask" getter="get_canvas_cull_mask" default="1048575">
+			The culling mask that describes which 2D render layers are rendered by this viewport. If a bit is not set, then that layer will not be rendered.
 		</member>
 		<member name="canvas_transform" type="Transform2D" setter="set_canvas_transform" getter="get_canvas_transform">
 			The canvas transform of the viewport, useful for changing the on-screen positions of all child [CanvasItem]s. This is relative to the global canvas transform of the viewport.

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -326,6 +326,14 @@
 				Sets the [CanvasItem] to copy a rect to the backbuffer.
 			</description>
 		</method>
+		<method name="canvas_item_set_cull_children">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<argument index="1" name="enable" type="bool" />
+			<description>
+				If [code]true[/code], this canvas item will prevent rendering of its children if it itself is culled via its layer mask when rendered.
+			</description>
+		</method>
 		<method name="canvas_item_set_custom_rect">
 			<return type="void" />
 			<argument index="0" name="item" type="RID" />
@@ -357,6 +365,14 @@
 			<argument index="1" name="index" type="int" />
 			<description>
 				Sets the index for the [CanvasItem].
+			</description>
+		</method>
+		<method name="canvas_item_set_layer_mask">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<argument index="1" name="mask" type="int" />
+			<description>
+				Sets the 2D render layers that this canvas item will be drawn to. Equivalent to [member CanvasItem.layers].
 			</description>
 		</method>
 		<method name="canvas_item_set_light_mask">
@@ -2938,6 +2954,14 @@
 			<argument index="1" name="active" type="bool" />
 			<description>
 				If [code]true[/code], sets the viewport active, else sets it inactive.
+			</description>
+		</method>
+		<method name="viewport_set_canvas_cull_mask">
+			<return type="void" />
+			<argument index="0" name="viewport" type="RID" />
+			<argument index="1" name="mask" type="int" />
+			<description>
+				Sets the cull mask that describes which 2D render layers are rendered by this viewport. If a bit is not set, then that layer will not be rendered. Equivalent to [member Viewport.canvas_cull_mask].
 			</description>
 		</method>
 		<method name="viewport_set_canvas_stacking">

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -190,6 +190,7 @@ private:
 	List<CanvasItem *>::Element *C;
 
 	int light_mask;
+	int layers;
 
 	bool first_draw;
 	bool visible;
@@ -201,6 +202,7 @@ private:
 	bool use_parent_material;
 	bool notify_local_transform;
 	bool notify_transform;
+	bool cull_children;
 
 	Ref<Material> material;
 
@@ -293,6 +295,8 @@ public:
 	void set_visible(bool p_visible);
 	bool is_visible() const;
 	bool is_visible_in_tree() const;
+	bool is_visible_in_tree_ignoring_cull_masks() const;
+	bool is_visible_in_tree_with_cull_mask(int p_mask) const;
 	void show();
 	void hide();
 
@@ -300,6 +304,13 @@ public:
 
 	virtual void set_light_mask(int p_light_mask);
 	int get_light_mask() const;
+
+	void set_layer_mask(int p_layer_mask);
+	int get_layer_mask() const;
+	void set_layer_mask_bit(int p_layer, bool p_enable);
+	bool get_layer_mask_bit(int p_layer) const;
+	void set_cull_children(bool p_enable);
+	bool is_cull_children_enabled() const;
 
 	void set_modulate(const Color &p_modulate);
 	Color get_modulate() const;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -288,6 +288,8 @@ private:
 	bool hdr;
 	bool use_32_bpc_depth;
 
+	int canvas_cull_mask;
+
 	Ref<ViewportTexture> default_texture;
 	Set<ViewportTexture *> viewport_textures;
 
@@ -585,6 +587,11 @@ public:
 
 	bool gui_is_dragging() const;
 	bool gui_is_drag_successful() const;
+
+	void set_canvas_cull_mask(int p_layers);
+	int get_canvas_cull_mask() const;
+	void set_canvas_cull_mask_bit(int p_layers, bool p_enable);
+	bool get_canvas_cull_mask_bit(int p_layers) const;
 
 	Viewport();
 	~Viewport();

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -52,6 +52,8 @@ public:
 		Transform2D ysort_xform;
 		Vector2 ysort_pos;
 		int ysort_index;
+		int layer_mask;
+		bool cull_children;
 
 		Vector<Item *> child_items;
 
@@ -69,6 +71,8 @@ public:
 			ysort_xform = Transform2D();
 			ysort_pos = Vector2();
 			ysort_index = 0;
+			layer_mask = 0xfffff;
+			cull_children = false;
 		}
 	};
 
@@ -154,15 +158,15 @@ public:
 	bool disable_scale;
 
 private:
-	void _render_canvas_item_tree(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RasterizerCanvas::Light *p_lights);
-	void _render_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner);
+	void _render_canvas_item_tree(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RasterizerCanvas::Light *p_lights, int p_visible_layers);
+	void _render_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, int p_visible_layers);
 	void _light_mask_canvas_items(int p_z, RasterizerCanvas::Item *p_canvas_item, RasterizerCanvas::Light *p_masked_lights, int p_canvas_layer_id);
 
 	RasterizerCanvas::Item **z_list;
 	RasterizerCanvas::Item **z_last_list;
 
 public:
-	void render_canvas(Canvas *p_canvas, const Transform2D &p_transform, RasterizerCanvas::Light *p_lights, RasterizerCanvas::Light *p_masked_lights, const Rect2 &p_clip_rect, int p_canvas_layer_id);
+	void render_canvas(Canvas *p_canvas, const Transform2D &p_transform, RasterizerCanvas::Light *p_lights, RasterizerCanvas::Light *p_masked_lights, const Rect2 &p_clip_rect, int p_canvas_layer_id, int p_visible_layers);
 
 	RID canvas_create();
 	void canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring);
@@ -175,6 +179,9 @@ public:
 
 	void canvas_item_set_visible(RID p_item, bool p_visible);
 	void canvas_item_set_light_mask(RID p_item, int p_mask);
+
+	void canvas_item_set_layer_mask(RID p_item, int p_mask);
+	void canvas_item_set_cull_children(RID p_item, bool p_enable);
 
 	void canvas_item_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_set_clip(RID p_item, bool p_clip);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -520,6 +520,7 @@ public:
 	BIND2(viewport_set_hdr, RID, bool)
 	BIND2(viewport_set_use_32_bpc_depth, RID, bool)
 	BIND2(viewport_set_usage, RID, ViewportUsage)
+	BIND2(viewport_set_canvas_cull_mask, RID, int)
 
 	BIND2R(int, viewport_get_render_info, RID, ViewportRenderInfo)
 	BIND2(viewport_set_debug_draw, RID, ViewportDebugDraw)
@@ -684,6 +685,9 @@ public:
 
 	BIND2(canvas_item_set_visible, RID, bool)
 	BIND2(canvas_item_set_light_mask, RID, int)
+
+	BIND2(canvas_item_set_layer_mask, RID, int)
+	BIND2(canvas_item_set_cull_children, RID, bool)
 
 	BIND2(canvas_item_set_update_when_visible, RID, bool)
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -234,7 +234,7 @@ void VisualServerViewport::_draw_viewport(Viewport *p_viewport, ARVRInterface::E
 				ptr = ptr->filter_next_ptr;
 			}
 
-			VSG::canvas->render_canvas(canvas, xform, canvas_lights, lights_with_mask, clip_rect, canvas_layer_id);
+			VSG::canvas->render_canvas(canvas, xform, canvas_lights, lights_with_mask, clip_rect, canvas_layer_id, p_viewport->canvas_visible_layers);
 			i++;
 
 			if (scenario_draw_canvas_bg && E->key().get_layer() >= scenario_canvas_max_layer) {
@@ -706,6 +706,12 @@ void VisualServerViewport::viewport_set_usage(RID p_viewport, VS::ViewportUsage 
 			viewport->disable_3d_by_usage = false;
 		} break;
 	}
+}
+
+void VisualServerViewport::viewport_set_canvas_cull_mask(RID p_viewport, int p_mask) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+	viewport->canvas_visible_layers = p_mask;
 }
 
 int VisualServerViewport::viewport_get_render_info(RID p_viewport, VS::ViewportRenderInfo p_info) {

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -76,6 +76,8 @@ public:
 
 		bool transparent_bg;
 
+		int canvas_visible_layers;
+
 		struct CanvasKey {
 			int64_t stacking;
 			RID canvas;
@@ -122,6 +124,8 @@ public:
 				render_info[i] = 0;
 			}
 			use_arvr = false;
+
+			canvas_visible_layers = 0;
 		}
 	};
 
@@ -192,6 +196,7 @@ public:
 	void viewport_set_hdr(RID p_viewport, bool p_enabled);
 	void viewport_set_use_32_bpc_depth(RID p_viewport, bool p_enabled);
 	void viewport_set_usage(RID p_viewport, VS::ViewportUsage p_usage);
+	void viewport_set_canvas_cull_mask(RID p_viewport, int p_mask);
 
 	virtual int viewport_get_render_info(RID p_viewport, VS::ViewportRenderInfo p_info);
 	virtual void viewport_set_debug_draw(RID p_viewport, VS::ViewportDebugDraw p_draw);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -429,6 +429,7 @@ public:
 	FUNC2(viewport_set_hdr, RID, bool)
 	FUNC2(viewport_set_use_32_bpc_depth, RID, bool)
 	FUNC2(viewport_set_usage, RID, ViewportUsage)
+	FUNC2(viewport_set_canvas_cull_mask, RID, int)
 
 	//this passes directly to avoid stalling, but it's pretty dangerous, so don't call after freeing a viewport
 	virtual int viewport_get_render_info(RID p_viewport, ViewportRenderInfo p_info) {
@@ -586,6 +587,8 @@ public:
 
 	FUNC2(canvas_item_set_visible, RID, bool)
 	FUNC2(canvas_item_set_light_mask, RID, int)
+	FUNC2(canvas_item_set_layer_mask, RID, int)
+	FUNC2(canvas_item_set_cull_children, RID, bool)
 
 	FUNC2(canvas_item_set_update_when_visible, RID, bool)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2095,6 +2095,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_sharpen_intensity", "viewport", "intensity"), &VisualServer::viewport_set_sharpen_intensity);
 	ClassDB::bind_method(D_METHOD("viewport_set_hdr", "viewport", "enabled"), &VisualServer::viewport_set_hdr);
 	ClassDB::bind_method(D_METHOD("viewport_set_usage", "viewport", "usage"), &VisualServer::viewport_set_usage);
+	ClassDB::bind_method(D_METHOD("viewport_set_canvas_cull_mask", "viewport", "mask"), &VisualServer::viewport_set_canvas_cull_mask);
 	ClassDB::bind_method(D_METHOD("viewport_get_render_info", "viewport", "info"), &VisualServer::viewport_get_render_info);
 	ClassDB::bind_method(D_METHOD("viewport_set_debug_draw", "viewport", "draw"), &VisualServer::viewport_set_debug_draw);
 
@@ -2162,6 +2163,9 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_parent", "item", "parent"), &VisualServer::canvas_item_set_parent);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_visible", "item", "visible"), &VisualServer::canvas_item_set_visible);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_light_mask", "item", "mask"), &VisualServer::canvas_item_set_light_mask);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_layer_mask", "item", "mask"), &VisualServer::canvas_item_set_layer_mask);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_cull_children", "item", "enable"), &VisualServer::canvas_item_set_cull_children);
+
 	ClassDB::bind_method(D_METHOD("canvas_item_set_transform", "item", "transform"), &VisualServer::canvas_item_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_clip", "item", "clip"), &VisualServer::canvas_item_set_clip);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_distance_field_mode", "item", "enabled"), &VisualServer::canvas_item_set_distance_field_mode);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -716,6 +716,7 @@ public:
 	virtual void viewport_set_hdr(RID p_viewport, bool p_enabled) = 0;
 	virtual void viewport_set_use_32_bpc_depth(RID p_viewport, bool p_enabled) = 0;
 	virtual void viewport_set_usage(RID p_viewport, ViewportUsage p_usage) = 0;
+	virtual void viewport_set_canvas_cull_mask(RID p_viewport, int p_mask) = 0;
 
 	enum ViewportRenderInfo {
 
@@ -1006,6 +1007,8 @@ public:
 
 	virtual void canvas_item_set_visible(RID p_item, bool p_visible) = 0;
 	virtual void canvas_item_set_light_mask(RID p_item, int p_mask) = 0;
+	virtual void canvas_item_set_layer_mask(RID p_item, int p_mask) = 0;
+	virtual void canvas_item_set_cull_children(RID p_item, bool p_enable) = 0;
 
 	virtual void canvas_item_set_update_when_visible(RID p_item, bool p_update) = 0;
 


### PR DESCRIPTION
A godot3x-ified rewrite and extension of the great work in #31877 targeting 3.x as it's a hard cherry to pick. Please see: #52389 for all the details on what's new and changed. This PR is simply the 3.x flavour/style.

Here's an example of what this PR is intending to make easy:
![puddles2](https://user-images.githubusercontent.com/86566939/132079349-d5869aa2-7d22-49ff-8f92-957b540b6b36.gif)
