### PR TITLE
Implement range iterators in OrderedHashMap, Use KeyValue in HashMap

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1065,19 +1065,19 @@ void ProjectSettings::_add_builtin_input_map() {
 	if (InputMap::get_singleton()) {
 		OrderedHashMap<String, List<Ref<InputEvent>>> builtins = InputMap::get_singleton()->get_builtins();
 
-		for (OrderedHashMap<String, List<Ref<InputEvent>>>::Element E = builtins.front(); E; E = E.next()) {
+		for (const KeyValue<String, List<Ref<InputEvent>>> &E : builtins) {
 			Array events;
 
 			// Convert list of input events into array
-			for (List<Ref<InputEvent>>::Element *I = E.get().front(); I; I = I->next()) {
-				events.push_back(I->get());
+			for (const Ref<InputEvent> &I : E.value) {
+				events.push_back(I);
 			}
 
 			Dictionary action;
 			action["deadzone"] = Variant(0.5f);
 			action["events"] = events;
 
-			String action_name = "input/" + E.key();
+			String action_name = "input/" + E.key;
 			GLOBAL_DEF(action_name, action);
 			input_presets.push_back(action_name);
 		}

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -132,7 +132,8 @@ public:
 			data->erase(this);
 		}
 
-		_FORCE_INLINE_ Element() {}
+		_FORCE_INLINE_ Element(T p_value) :
+				value(p_value) {}
 	};
 
 	typedef T ValueType;
@@ -279,7 +280,7 @@ public:
 	/**
 	 * store a new element at the end of the list
 	 */
-	Element *push_back(const T &value) {
+	Element *push_back(const T &p_value) {
 		if (!_data) {
 			_data = memnew_allocator(_Data, A);
 			_data->first = nullptr;
@@ -287,9 +288,7 @@ public:
 			_data->size_cache = 0;
 		}
 
-		Element *n = memnew_allocator(Element, A);
-		n->value = (T &)value;
-
+		Element *n = memnew_allocator(Element((T &)p_value), A);
 		n->prev_ptr = _data->last;
 		n->next_ptr = nullptr;
 		n->data = _data;
@@ -318,7 +317,7 @@ public:
 	/**
 	 * store a new element at the beginning of the list
 	 */
-	Element *push_front(const T &value) {
+	Element *push_front(const T &p_value) {
 		if (!_data) {
 			_data = memnew_allocator(_Data, A);
 			_data->first = nullptr;
@@ -326,8 +325,7 @@ public:
 			_data->size_cache = 0;
 		}
 
-		Element *n = memnew_allocator(Element, A);
-		n->value = (T &)value;
+		Element *n = memnew_allocator(Element((T &)p_value), A);
 		n->prev_ptr = nullptr;
 		n->next_ptr = _data->first;
 		n->data = _data;
@@ -360,8 +358,7 @@ public:
 			return push_back(p_value);
 		}
 
-		Element *n = memnew_allocator(Element, A);
-		n->value = (T &)p_value;
+		Element *n = memnew_allocator(Element((T &)p_value), A);
 		n->prev_ptr = p_element;
 		n->next_ptr = p_element->next_ptr;
 		n->data = _data;
@@ -386,8 +383,7 @@ public:
 			return push_back(p_value);
 		}
 
-		Element *n = memnew_allocator(Element, A);
-		n->value = (T &)p_value;
+		Element *n = memnew_allocator(Element((T &)p_value), A);
 		n->prev_ptr = p_element->prev_ptr;
 		n->next_ptr = p_element;
 		n->data = _data;


### PR DESCRIPTION
- Implements Range Iterators in `OrderedHashMap` following #50284.
- Makes `HashMap` use `KeyValue` (like `Map`) and remove its internal `Pair` struct which seemed unnecessary.
- Modifies `List` to work with `KeyValue`