### PR TITLE
Expose get_skew and add new constructor for transform2d 

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -63,7 +63,7 @@ Transform2D Transform2D::affine_inverse() const {
 	return inv;
 }
 
-void Transform2D::rotate(real_t p_phi) {
+void Transform2D::rotate(const real_t p_phi) {
 	*this = Transform2D(p_phi, Vector2()) * (*this);
 }
 
@@ -72,7 +72,7 @@ real_t Transform2D::get_skew() const {
 	return Math::acos(elements[0].normalized().dot(SGN(det) * elements[1].normalized())) - Math_PI * 0.5;
 }
 
-void Transform2D::set_skew(float p_angle) {
+void Transform2D::set_skew(const real_t p_angle) {
 	real_t det = basis_determinant();
 	elements[1] = SGN(det) * elements[0].rotated((Math_PI * 0.5 + p_angle)).normalized() * elements[1].length();
 }
@@ -81,7 +81,7 @@ real_t Transform2D::get_rotation() const {
 	return Math::atan2(elements[0].y, elements[0].x);
 }
 
-void Transform2D::set_rotation(real_t p_rot) {
+void Transform2D::set_rotation(const real_t p_rot) {
 	Size2 scale = get_scale();
 	real_t cr = Math::cos(p_rot);
 	real_t sr = Math::sin(p_rot);
@@ -92,13 +92,21 @@ void Transform2D::set_rotation(real_t p_rot) {
 	set_scale(scale);
 }
 
-Transform2D::Transform2D(real_t p_rot, const Vector2 &p_pos) {
+Transform2D::Transform2D(const real_t p_rot, const Vector2 &p_pos) {
 	real_t cr = Math::cos(p_rot);
 	real_t sr = Math::sin(p_rot);
 	elements[0][0] = cr;
 	elements[0][1] = sr;
 	elements[1][0] = -sr;
 	elements[1][1] = cr;
+	elements[2] = p_pos;
+}
+
+Transform2D::Transform2D(const real_t p_rot, const Size2 &p_scale, const real_t p_skew, const Vector2 &p_pos) {
+	elements[0][0] = Math::cos(p_rot) * p_scale.x;
+	elements[1][1] = Math::cos(p_rot + p_skew) * p_scale.y;
+	elements[1][0] = -Math::sin(p_rot + p_skew) * p_scale.y;
+	elements[0][1] = Math::sin(p_rot) * p_scale.x;
 	elements[2] = p_pos;
 }
 
@@ -126,7 +134,7 @@ void Transform2D::scale_basis(const Size2 &p_scale) {
 	elements[1][1] *= p_scale.y;
 }
 
-void Transform2D::translate(real_t p_tx, real_t p_ty) {
+void Transform2D::translate(const real_t p_tx, const real_t p_ty) {
 	translate(Vector2(p_tx, p_ty));
 }
 
@@ -231,7 +239,7 @@ Transform2D Transform2D::translated(const Vector2 &p_offset) const {
 	return copy;
 }
 
-Transform2D Transform2D::rotated(real_t p_phi) const {
+Transform2D Transform2D::rotated(const real_t p_phi) const {
 	Transform2D copy = *this;
 	copy.rotate(p_phi);
 	return copy;
@@ -241,7 +249,7 @@ real_t Transform2D::basis_determinant() const {
 	return elements[0].x * elements[1].y - elements[0].y * elements[1].x;
 }
 
-Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, real_t p_c) const {
+Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, const real_t p_c) const {
 	//extract parameters
 	Vector2 p1 = get_origin();
 	Vector2 p2 = p_transform.get_origin();

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -68,17 +68,17 @@ struct Transform2D {
 	void affine_invert();
 	Transform2D affine_inverse() const;
 
-	void set_rotation(real_t p_rot);
+	void set_rotation(const real_t p_rot);
 	real_t get_rotation() const;
 	real_t get_skew() const;
-	void set_skew(float p_angle);
-	_FORCE_INLINE_ void set_rotation_and_scale(real_t p_rot, const Size2 &p_scale);
-	_FORCE_INLINE_ void set_rotation_scale_and_skew(real_t p_rot, const Size2 &p_scale, float p_skew);
-	void rotate(real_t p_phi);
+	void set_skew(const real_t p_angle);
+	_FORCE_INLINE_ void set_rotation_and_scale(const real_t p_rot, const Size2 &p_scale);
+	_FORCE_INLINE_ void set_rotation_scale_and_skew(const real_t p_rot, const Size2 &p_scale, const real_t p_skew);
+	void rotate(const real_t p_phi);
 
 	void scale(const Size2 &p_scale);
 	void scale_basis(const Size2 &p_scale);
-	void translate(real_t p_tx, real_t p_ty);
+	void translate(const real_t p_tx, const real_t p_ty);
 	void translate(const Vector2 &p_translation);
 
 	real_t basis_determinant() const;
@@ -92,7 +92,7 @@ struct Transform2D {
 	Transform2D scaled(const Size2 &p_scale) const;
 	Transform2D basis_scaled(const Size2 &p_scale) const;
 	Transform2D translated(const Vector2 &p_offset) const;
-	Transform2D rotated(real_t p_phi) const;
+	Transform2D rotated(const real_t p_phi) const;
 
 	Transform2D untranslated() const;
 
@@ -110,7 +110,7 @@ struct Transform2D {
 	void operator*=(const real_t p_val);
 	Transform2D operator*(const real_t p_val) const;
 
-	Transform2D interpolate_with(const Transform2D &p_transform, real_t p_c) const;
+	Transform2D interpolate_with(const Transform2D &p_transform, const real_t p_c) const;
 
 	_FORCE_INLINE_ Vector2 basis_xform(const Vector2 &p_vec) const;
 	_FORCE_INLINE_ Vector2 basis_xform_inv(const Vector2 &p_vec) const;
@@ -123,7 +123,7 @@ struct Transform2D {
 
 	operator String() const;
 
-	Transform2D(real_t xx, real_t xy, real_t yx, real_t yy, real_t ox, real_t oy) {
+	Transform2D(const real_t xx, const real_t xy, const real_t yx, const real_t yy, const real_t ox, const real_t oy) {
 		elements[0][0] = xx;
 		elements[0][1] = xy;
 		elements[1][0] = yx;
@@ -138,7 +138,10 @@ struct Transform2D {
 		elements[2] = p_origin;
 	}
 
-	Transform2D(real_t p_rot, const Vector2 &p_pos);
+	Transform2D(const real_t p_rot, const Vector2 &p_pos);
+
+	Transform2D(const real_t p_rot, const Size2 &p_scale, const real_t p_skew, const Vector2 &p_pos);
+
 	Transform2D() {
 		elements[0][0] = 1.0;
 		elements[1][1] = 1.0;
@@ -185,14 +188,14 @@ Rect2 Transform2D::xform(const Rect2 &p_rect) const {
 	return new_rect;
 }
 
-void Transform2D::set_rotation_and_scale(real_t p_rot, const Size2 &p_scale) {
+void Transform2D::set_rotation_and_scale(const real_t p_rot, const Size2 &p_scale) {
 	elements[0][0] = Math::cos(p_rot) * p_scale.x;
 	elements[1][1] = Math::cos(p_rot) * p_scale.y;
 	elements[1][0] = -Math::sin(p_rot) * p_scale.y;
 	elements[0][1] = Math::sin(p_rot) * p_scale.x;
 }
 
-void Transform2D::set_rotation_scale_and_skew(real_t p_rot, const Size2 &p_scale, float p_skew) {
+void Transform2D::set_rotation_scale_and_skew(const real_t p_rot, const Size2 &p_scale, const real_t p_skew) {
 	elements[0][0] = Math::cos(p_rot) * p_scale.x;
 	elements[1][1] = Math::cos(p_rot + p_skew) * p_scale.y;
 	elements[1][0] = -Math::sin(p_rot + p_skew) * p_scale.y;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1703,6 +1703,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform2D, get_rotation, sarray(), varray());
 	bind_method(Transform2D, get_origin, sarray(), varray());
 	bind_method(Transform2D, get_scale, sarray(), varray());
+	bind_method(Transform2D, get_skew, sarray(), varray());
 	bind_method(Transform2D, orthonormalized, sarray(), varray());
 	bind_method(Transform2D, rotated, sarray("phi"), varray());
 	bind_method(Transform2D, scaled, sarray("scale"), varray());
@@ -1712,6 +1713,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform2D, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform2D, is_equal_approx, sarray("xform"), varray());
 	bind_method(Transform2D, set_rotation, sarray("rotation"), varray());
+	bind_method(Transform2D, set_scale, sarray("scale"), varray());
+	bind_method(Transform2D, set_skew, sarray("skew"), varray());
 	bind_method(Transform2D, looking_at, sarray("target"), varray(Vector2()));
 
 	/* Basis */

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -114,6 +114,7 @@ void Variant::_register_variant_constructors() {
 	add_constructor<VariantConstructNoArgs<Transform2D>>(sarray());
 	add_constructor<VariantConstructor<Transform2D, Transform2D>>(sarray("from"));
 	add_constructor<VariantConstructor<Transform2D, float, Vector2>>(sarray("rotation", "position"));
+	add_constructor<VariantConstructor<Transform2D, float, Size2, float, Vector2>>(sarray("rotation", "scale", "skew", "position"));
 	add_constructor<VariantConstructor<Transform2D, Vector2, Vector2, Vector2>>(sarray("x_axis", "y_axis", "origin"));
 
 	add_constructor<VariantConstructNoArgs<Plane>>(sarray());

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -37,6 +37,16 @@
 		</method>
 		<method name="Transform2D" qualifiers="constructor">
 			<return type="Transform2D" />
+			<argument index="0" name="rotation" type="float" />
+			<argument index="1" name="scale" type="Vector2" />
+			<argument index="2" name="skew" type="float" />
+			<argument index="3" name="position" type="Vector2" />
+			<description>
+				Constructs the transform from a given angle (in radians), scale, skew (in radians) and position.
+			</description>
+		</method>
+		<method name="Transform2D" qualifiers="constructor">
+			<return type="Transform2D" />
 			<argument index="0" name="x_axis" type="Vector2" />
 			<argument index="1" name="y_axis" type="Vector2" />
 			<argument index="2" name="origin" type="Vector2" />
@@ -84,6 +94,12 @@
 				Returns the scale.
 			</description>
 		</method>
+		<method name="get_skew" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the transform's skew (in radians).
+			</description>
+		</method>
 		<method name="interpolate_with" qualifiers="const">
 			<return type="Transform2D" />
 			<argument index="0" name="xform" type="Transform2D" />
@@ -120,14 +136,8 @@
 			</description>
 		</method>
 		<method name="operator *" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Rect2" />
-			<argument index="0" name="right" type="Rect2" />
+			<return type="PackedVector2Array" />
+			<argument index="0" name="right" type="PackedVector2Array" />
 			<description>
 			</description>
 		</method>
@@ -138,8 +148,14 @@
 			</description>
 		</method>
 		<method name="operator *" qualifiers="operator">
-			<return type="PackedVector2Array" />
-			<argument index="0" name="right" type="PackedVector2Array" />
+			<return type="Rect2" />
+			<argument index="0" name="right" type="Rect2" />
+			<description>
+			</description>
+		</method>
+		<method name="operator *" qualifiers="operator">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="Vector2" />
 			<description>
 			</description>
 		</method>
@@ -194,6 +210,20 @@
 			<argument index="0" name="rotation" type="float" />
 			<description>
 				Sets the transform's rotation (in radians).
+			</description>
+		</method>
+		<method name="set_scale">
+			<return type="void" />
+			<argument index="0" name="scale" type="Vector2" />
+			<description>
+				Sets the transform's scale.
+			</description>
+		</method>
+		<method name="set_skew">
+			<return type="void" />
+			<argument index="0" name="skew" type="float" />
+			<description>
+				Sets the transform's skew (in radians).
 			</description>
 		</method>
 		<method name="translated" qualifiers="const">


### PR DESCRIPTION
For Transform2D, `get_skew()` method missed in gdscript.

Exposed `set_scale()` and `set_skew()` methods (as `set_rotation() and origin` are exposed).

Also added constructor with all transform2D properties (rotation, scale, skew and position) equivalent and easier to use than transform matrix constructor.
