### PR TITLE
Add missing parameter names to _commit_views GDVIRTUAL_BIND

### DIFF
--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -11,8 +11,8 @@
 	<methods>
 		<method name="_commit_views" qualifiers="virtual">
 			<return type="void" />
-			<argument index="0" name="" type="RID" />
-			<argument index="1" name="" type="Rect2" />
+			<argument index="0" name="render_target" type="RID" />
+			<argument index="1" name="screen_rect" type="Rect2" />
 			<description>
 			</description>
 		</method>

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -49,7 +49,7 @@ void XRInterfaceExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_transform_for_view, "view", "cam_transform");
 	GDVIRTUAL_BIND(_get_projection_for_view, "view", "aspect", "z_near", "z_far");
 
-	GDVIRTUAL_BIND(_commit_views);
+	GDVIRTUAL_BIND(_commit_views, "render_target", "screen_rect");
 
 	GDVIRTUAL_BIND(_process);
 	GDVIRTUAL_BIND(_notification, "what");


### PR DESCRIPTION
Forgot to name parameters when registering `_commit_views`, this resolves that.