### PR TITLE
Fix invalid string cast

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -523,10 +523,10 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 #define TTRGET(m_value) TTR(m_value)
 
 #else
-#define TTR(m_value) (String())
-#define TTRN(m_value) (String())
-#define DTR(m_value) (String())
-#define DTRN(m_value) (String())
+#define TTR(m_value) String()
+#define TTRN(m_value) String()
+#define DTR(m_value) String()
+#define DTRN(m_value) String()
 #define TTRC(m_value) (m_value)
 #define TTRGET(m_value) (m_value)
 #endif


### PR DESCRIPTION
In PR #51908 these lines were added:
https://github.com/godotengine/godot/blob/f3ab0941335d373ce44317961af7fbc864ea5759/modules/text_server_adv/text_server_adv.cpp#L1234 https://github.com/godotengine/godot/blob/f3ab0941335d373ce44317961af7fbc864ea5759/modules/text_server_adv/text_server_adv.cpp#L1252

While this compiles when tools=yes, when tools=no it produces a compile error.
```
./core/string/ustring.h:526:22: error: invalid cast to function type 'String()'
  526 | #define TTR(m_value) (String())
./core/error/error_macros.h:94:26: note: in definition of macro 'DEBUG_STR'
   94 | #define DEBUG_STR(m_msg) m_msg
      |                          ^~~~~
modules/text_server_adv/text_server_adv.cpp:1234:25: note: in expansion of macro 'ERR_FAIL_COND_V_MSG'
 1234 |                         ERR_FAIL_COND_V_MSG(error != 0, false, TTR("FreeType: Error initializing library:") + " '" + String(FT_Error_String(error)) + "'.");
      |                         ^~~~~~~~~~~~~~~~~~~
modules/text_server_adv/text_server_adv.cpp:1234:64: note: in expansion of macro 'TTR'
 1234 |                         ERR_FAIL_COND_V_MSG(error != 0, false, TTR("FreeType: Error initializing library:") + " '" + String(FT_Error_String(error)) + "'.");
      |                                                                ^~~
./core/string/ustring.h:526:22: error: invalid cast to function type 'String()'
  526 | #define TTR(m_value) (String())
./core/error/error_macros.h:94:26: note: in definition of macro 'DEBUG_STR'
   94 | #define DEBUG_STR(m_msg) m_msg
      |                          ^~~~~
modules/text_server_adv/text_server_adv.cpp:1252:25: note: in expansion of macro 'ERR_FAIL_V_MSG'
 1252 |                         ERR_FAIL_V_MSG(false, TTR("FreeType: Error loading font:") + " '" + String(FT_Error_String(error)) + "'.");
      |                         ^~~~~~~~~~~~~~
modules/text_server_adv/text_server_adv.cpp:1252:47: note: in expansion of macro 'TTR'
 1252 |                         ERR_FAIL_V_MSG(false, TTR("FreeType: Error loading font:") + " '" + String(FT_Error_String(error)) + "'.");
      |                                               ^~~
```
A similar problem is also present in text_server_fb, but is disabled by default.

This PR alters the tools=no stubs of TTR and other Tool Translate functions to allow compiling again.