### PR TITLE
Fix global properties setters and add global skew for node2d

### DIFF
--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -102,6 +102,9 @@
 		<member name="global_scale" type="Vector2" setter="set_global_scale" getter="get_global_scale">
 			Global scale.
 		</member>
+		<member name="global_skew" type="float" setter="set_global_skew" getter="get_global_skew">
+			Global skew in radians.
+		</member>
 		<member name="global_transform" type="Transform2D" setter="set_global_transform" getter="get_global_transform">
 			Global [Transform2D].
 		</member>

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -244,9 +244,9 @@ Point2 Node2D::get_global_position() const {
 }
 
 void Node2D::set_global_position(const Point2 &p_pos) {
-	CanvasItem *pi = get_parent_item();
-	if (pi) {
-		Transform2D inv = pi->get_global_transform().affine_inverse();
+	CanvasItem *parent = get_parent_item();
+	if (parent) {
+		Transform2D inv = parent->get_global_transform().affine_inverse();
 		set_position(inv.xform(p_pos));
 	} else {
 		set_position(p_pos);
@@ -257,13 +257,33 @@ real_t Node2D::get_global_rotation() const {
 	return get_global_transform().get_rotation();
 }
 
-void Node2D::set_global_rotation(real_t p_radians) {
-	CanvasItem *pi = get_parent_item();
-	if (pi) {
-		const real_t parent_global_rot = pi->get_global_transform().get_rotation();
-		set_rotation(p_radians - parent_global_rot);
+real_t Node2D::get_global_skew() const {
+	return get_global_transform().get_skew();
+}
+
+void Node2D::set_global_rotation(const real_t p_radians) {
+	CanvasItem *parent = get_parent_item();
+	if (parent) {
+		Transform2D parent_global_transform = parent->get_global_transform();
+		Transform2D new_transform = parent_global_transform * get_transform();
+		new_transform.set_rotation(p_radians);
+		new_transform = parent_global_transform.affine_inverse() * new_transform;
+		set_rotation(new_transform.get_rotation());
 	} else {
 		set_rotation(p_radians);
+	}
+}
+
+void Node2D::set_global_skew(const real_t p_radians) {
+	CanvasItem *parent = get_parent_item();
+	if (parent) {
+		Transform2D parent_global_transform = parent->get_global_transform();
+		Transform2D new_transform = parent_global_transform * get_transform();
+		new_transform.set_skew(p_radians);
+		new_transform = parent_global_transform.affine_inverse() * new_transform;
+		set_skew(new_transform.get_skew());
+	} else {
+		set_skew(p_radians);
 	}
 }
 
@@ -272,10 +292,13 @@ Size2 Node2D::get_global_scale() const {
 }
 
 void Node2D::set_global_scale(const Size2 &p_scale) {
-	CanvasItem *pi = get_parent_item();
-	if (pi) {
-		const Size2 parent_global_scale = pi->get_global_transform().get_scale();
-		set_scale(p_scale / parent_global_scale);
+	CanvasItem *parent = get_parent_item();
+	if (parent) {
+		Transform2D parent_global_transform = parent->get_global_transform();
+		Transform2D new_transform = parent_global_transform * get_transform();
+		new_transform.set_scale(p_scale);
+		new_transform = parent_global_transform.affine_inverse() * new_transform;
+		set_scale(new_transform.get_scale());
 	} else {
 		set_scale(p_scale);
 	}
@@ -295,9 +318,9 @@ void Node2D::set_transform(const Transform2D &p_transform) {
 }
 
 void Node2D::set_global_transform(const Transform2D &p_transform) {
-	CanvasItem *pi = get_parent_item();
-	if (pi) {
-		set_transform(pi->get_global_transform().affine_inverse() * p_transform);
+	CanvasItem *parent = get_parent_item();
+	if (parent) {
+		set_transform(parent->get_global_transform().affine_inverse() * p_transform);
 	} else {
 		set_transform(p_transform);
 	}
@@ -388,6 +411,8 @@ void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_global_position"), &Node2D::get_global_position);
 	ClassDB::bind_method(D_METHOD("set_global_rotation", "radians"), &Node2D::set_global_rotation);
 	ClassDB::bind_method(D_METHOD("get_global_rotation"), &Node2D::get_global_rotation);
+	ClassDB::bind_method(D_METHOD("set_global_skew", "radians"), &Node2D::set_global_skew);
+	ClassDB::bind_method(D_METHOD("get_global_skew"), &Node2D::get_global_skew);
 	ClassDB::bind_method(D_METHOD("set_global_scale", "scale"), &Node2D::set_global_scale);
 	ClassDB::bind_method(D_METHOD("get_global_scale"), &Node2D::get_global_scale);
 
@@ -421,6 +446,7 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_global_position", "get_global_position");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_rotation", PROPERTY_HINT_NONE, "radians", PROPERTY_USAGE_NONE), "set_global_rotation", "get_global_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_scale", "get_global_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_skew", PROPERTY_HINT_NONE, "radians", PROPERTY_USAGE_NONE), "set_global_skew", "get_global_skew");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "global_transform", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_global_transform", "get_global_transform");
 
 	ADD_GROUP("Ordering", "");

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -92,12 +92,14 @@ public:
 
 	Point2 get_global_position() const;
 	real_t get_global_rotation() const;
+	real_t get_global_skew() const;
 	Size2 get_global_scale() const;
 
 	void set_transform(const Transform2D &p_transform);
 	void set_global_transform(const Transform2D &p_transform);
 	void set_global_position(const Point2 &p_pos);
-	void set_global_rotation(real_t p_radians);
+	void set_global_rotation(const real_t p_radians);
+	void set_global_skew(const real_t p_radians);
 	void set_global_scale(const Size2 &p_scale);
 
 	void set_z_index(int p_z);


### PR DESCRIPTION
The introduction of the skew makes the setter of global properties false in some cases.

> For example, a parent has `local skew of 45° and scale of (1,1)`, and a child with `local skew of -45° and scale of (1,1)`.
> The child will have a global scale of `(1,a)`. If we want to put `global scale of (1,1)`, the current global method will set the local scale with `new_global_scale/parent_global_scale` so `(1,1)/(1,1) = (1,1)`. So the global scale will stay `(1,a)`.
>
> with `a = ]0,1[`

Same wrong behavior can be reproduced with the rotation. So fixed the setters of global rotation and scale.

Also added global skew property and added const when possible.