### PR TITLE
Initialize n_warnings_dropped to 0 in ScriptDebuggerRemote

### DIFF
--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -1197,6 +1197,7 @@ ScriptDebuggerRemote::ScriptDebuggerRemote() :
 		max_errors_per_second(GLOBAL_GET("network/limits/debugger_stdout/max_errors_per_second")),
 		max_warnings_per_second(GLOBAL_GET("network/limits/debugger_stdout/max_warnings_per_second")),
 		n_errors_dropped(0),
+		n_warnings_dropped(0),
 		max_cps(GLOBAL_GET("network/limits/debugger_stdout/max_chars_per_second")),
 		char_count(0),
 		err_count(0),


### PR DESCRIPTION
Unlike the other member variables, `n_warnings_dropped` was not correctly initialized in the contructor list. Sometimes this value would get set to random values triggering the issue in #43710.

Fixes #43710.