### PR TITLE
Fix crash during completion lookback

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2744,7 +2744,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 		/* If we have a space, previous word might be a keyword. eg "func |". */
 	} else if (cofs > 0 && line[cofs - 1] == ' ') {
 		int ofs = cofs - 1;
-		while (ofs >= 0 && line[ofs] == ' ') {
+		while (ofs > 0 && line[ofs] == ' ') {
 			ofs--;
 		}
 		prev_is_word = _is_char(line[ofs]);


### PR DESCRIPTION
Fixes a crash that can occur during completion lookback.

With default Editor settings this is not likely to be encountered, however if `indent` is set to `spaces` it can occur frequently as the lookback function searches backwards for " " chars, which will lead to a -1 index when calling `_is_char`. This will result in an index out of bounds error:
```
ERROR: FATAL: Index p_index = -1 is out of bounds (size() = 5).
   at: get (./core/templates/cowdata.h:157)
```

