### PR TITLE
Fix the "AudioEffectRecord" descriptions.

### DIFF
--- a/doc/classes/AudioEffectRecord.xml
+++ b/doc/classes/AudioEffectRecord.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectRecord" inherits="AudioEffect" version="4.0">
 	<brief_description>
-		Audio effect used for recording sound from a microphone.
+		Audio effect used for recording the sound from an audio bus.
 	</brief_description>
 	<description>
-		Allows the user to record sound from a microphone. It sets and gets the format in which the audio file will be recorded (8-bit, 16-bit, or compressed). It checks whether or not the recording is active, and if it is, records the sound. It then returns the recorded sample.
+		Allows the user to record the sound from an audio bus. This can include all audio output by Godot when used on the "Master" audio bus.
+		Can be used (with an [AudioStreamMicrophone]) to record from a microphone.
+		It sets and gets the format in which the audio file will be recorded (8-bit, 16-bit, or compressed). It checks whether or not the recording is active, and if it is, records the sound. It then returns the recorded sample.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/audio/recording_with_microphone.html</link>


### PR DESCRIPTION
The `AudioEffectRecord` effect has no microphone capture-specific functionality--it can be used with any audio bus.

This patch attempts to clarify this fact (so people like me who want to capture audio output know they're in the right place) while still providing a pointer to use of the effect with `AudioStreamMicrophone` for microphone capture.

### Additional context

 * Feel free to reword as desired--my goal was to provide *a* fix at least--I'm not attached to the specific wording.
 * Intentionally preserved as much of previous PR as possible: https://github.com/godotengine/godot/pull/39453.
 * `AudioStreamMicrophone` needs to be documented.
 * The microphone tutorial would benefit from clarifying the use of `AudioStreamMicrophone`.
 * Read more on social media: https://twitter.com/RancidBacon/status/1434877933823299588 :D

_Edited to add:_
Forgot to mention that I discovered the [Audio Buses tutorial](https://docs.godotengine.org/en/3.3/tutorials/audio/audio_buses.html#record) _does_ have a mostly (i.e. probably doesn't *have* to be a file) correct description for this effect:

> The Record effect allows audio passing through the bus to be written to a file.