### PR TITLE
Fix brace placement with space auto indent

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -654,7 +654,7 @@ void CodeEdit::_backspace_internal() {
 	// For space indentation we need to do a simple unindent if there are no chars to the left, acting in the
 	// same way as tabs.
 	if (indent_using_spaces && cc != 0) {
-		if (get_first_non_whitespace_column(cl) > cc) {
+		if (get_first_non_whitespace_column(cl) >= cc) {
 			prev_column = cc - _calculate_spaces_till_next_left_indent(cc);
 			prev_line = cl;
 		}
@@ -987,10 +987,10 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 				/* No need to move the brace below if we are not taking the text with us. */
 				if (p_split_current_line) {
 					brace_indent = true;
-					ins += "\n" + ins.substr(1, ins.length() - 2);
+					ins += "\n" + ins.substr(indent_text.size(), ins.length() - 2);
 				} else {
 					brace_indent = false;
-					ins = "\n" + ins.substr(1, ins.length() - 2);
+					ins = "\n" + ins.substr(indent_text.size(), ins.length() - 2);
 				}
 			}
 		}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2517,10 +2517,10 @@ void TextEdit::set_text(const String &p_text) {
 		set_caret_column(0);
 
 		begin_complex_operation();
+		deselect();
 		_remove_text(0, 0, MAX(0, get_line_count() - 1), MAX(get_line(MAX(get_line_count() - 1, 0)).size() - 1, 0));
 		insert_text_at_caret(p_text);
 		end_complex_operation();
-		selection.active = false;
 	}
 
 	set_caret_line(0);


### PR DESCRIPTION
Was writing some unit tests as part of #50375 and found these.

When auto indent is enabled with spaces, the closing brace was incorrectly indented.

Also a minor bug fix where calling `set_text` with a active selection would print errors to the console.