### PR TITLE
[3.x] Fix NodePath default argument in mono bindings

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2577,7 +2577,13 @@ bool BindingsGenerator::_arg_default_value_from_variant(const Variant &p_val, Ar
 			break;
 		case Variant::STRING:
 		case Variant::NODE_PATH:
-			r_iarg.default_argument = "\"" + r_iarg.default_argument + "\"";
+			if (r_iarg.type.cname == name_cache.type_NodePath) {
+				r_iarg.default_argument = "(%s)\"" + r_iarg.default_argument + "\"";
+				r_iarg.def_param_mode = ArgumentInterface::NULLABLE_REF;
+			} else {
+				CRASH_COND(r_iarg.type.cname != name_cache.type_String);
+				r_iarg.default_argument = "\"" + r_iarg.default_argument + "\"";
+			}
 			break;
 		case Variant::PLANE: {
 			Plane plane = p_val.operator Plane();

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -522,6 +522,7 @@ class BindingsGenerator {
 		StringName type_Reference;
 		StringName type_RID;
 		StringName type_String;
+		StringName type_NodePath;
 		StringName type_at_GlobalScope;
 		StringName enum_Error;
 
@@ -546,6 +547,7 @@ class BindingsGenerator {
 			type_Reference = StaticCString::create("Reference");
 			type_RID = StaticCString::create("RID");
 			type_String = StaticCString::create("String");
+			type_NodePath = StaticCString::create("NodePath");
 			type_at_GlobalScope = StaticCString::create("@GlobalScope");
 			enum_Error = StaticCString::create("Error");
 


### PR DESCRIPTION
Backport from master, mono was generating `""` as default argument instead of `(NodePath)""`.

Follow-up from https://github.com/godotengine/godot/pull/52369#issuecomment-912902669
(fixes mono error in CI in that PR)