### PR TITLE
Replace Vector3.to_diagonal_matrix with Basis.from_scale

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -207,6 +207,10 @@ Basis Basis::transposed() const {
 	return tr;
 }
 
+Basis Basis::from_scale(const Vector3 &p_scale) {
+	return Basis(p_scale.x, 0, 0, 0, p_scale.y, 0, 0, 0, p_scale.z);
+}
+
 // Multiplies the matrix from left by the scaling matrix: M -> S.M
 // See the comment for Basis::rotated for further explanation.
 void Basis::scale(const Vector3 &p_scale) {
@@ -246,10 +250,7 @@ void Basis::make_scale_uniform() {
 }
 
 Basis Basis::scaled_local(const Vector3 &p_scale) const {
-	Basis b;
-	b.set_diagonal(p_scale);
-
-	return (*this) * b;
+	return (*this) * Basis::from_scale(p_scale);
 }
 
 Vector3 Basis::get_scale_abs() const {
@@ -991,21 +992,23 @@ void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_phi) {
 }
 
 void Basis::set_axis_angle_scale(const Vector3 &p_axis, real_t p_phi, const Vector3 &p_scale) {
-	set_diagonal(p_scale);
+	_set_diagonal(p_scale);
 	rotate(p_axis, p_phi);
 }
 
 void Basis::set_euler_scale(const Vector3 &p_euler, const Vector3 &p_scale) {
-	set_diagonal(p_scale);
+	_set_diagonal(p_scale);
 	rotate(p_euler);
 }
 
 void Basis::set_quaternion_scale(const Quaternion &p_quaternion, const Vector3 &p_scale) {
-	set_diagonal(p_scale);
+	_set_diagonal(p_scale);
 	rotate(p_quaternion);
 }
 
-void Basis::set_diagonal(const Vector3 &p_diag) {
+// This also sets the non-diagonal elements to 0, which is misleading from the
+// name, so we want this method to be private. Use `from_scale` externally.
+void Basis::_set_diagonal(const Vector3 &p_diag) {
 	elements[0][0] = p_diag.x;
 	elements[0][1] = 0;
 	elements[0][2] = 0;

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -35,6 +35,9 @@
 #include "core/math/vector3.h"
 
 class Basis {
+private:
+	void _set_diagonal(const Vector3 &p_diag);
+
 public:
 	Vector3 elements[3] = {
 		Vector3(1, 0, 0),
@@ -166,8 +169,6 @@ public:
 	int get_orthogonal_index() const;
 	void set_orthogonal_index(int p_index);
 
-	void set_diagonal(const Vector3 &p_diag);
-
 	bool is_orthogonal() const;
 	bool is_diagonal() const;
 	bool is_rotation() const;
@@ -254,6 +255,7 @@ public:
 
 	Basis(const Vector3 &p_axis, real_t p_phi) { set_axis_angle(p_axis, p_phi); }
 	Basis(const Vector3 &p_axis, real_t p_phi, const Vector3 &p_scale) { set_axis_angle_scale(p_axis, p_phi, p_scale); }
+	static Basis from_scale(const Vector3 &p_scale);
 
 	_FORCE_INLINE_ Basis(const Vector3 &row0, const Vector3 &row1, const Vector3 &row2) {
 		elements[0] = row0;

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -115,12 +115,6 @@ Basis Vector3::outer(const Vector3 &p_b) const {
 	return Basis(row0, row1, row2);
 }
 
-Basis Vector3::to_diagonal_matrix() const {
-	return Basis(x, 0, 0,
-			0, y, 0,
-			0, 0, z);
-}
-
 bool Vector3::is_equal_approx(const Vector3 &p_v) const {
 	return Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y) && Math::is_equal_approx(z, p_v.z);
 }

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -106,7 +106,6 @@ struct Vector3 {
 	_FORCE_INLINE_ Vector3 cross(const Vector3 &p_b) const;
 	_FORCE_INLINE_ real_t dot(const Vector3 &p_b) const;
 	Basis outer(const Vector3 &p_b) const;
-	Basis to_diagonal_matrix() const;
 
 	_FORCE_INLINE_ Vector3 abs() const;
 	_FORCE_INLINE_ Vector3 floor() const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1568,7 +1568,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3, dot, sarray("with"), varray());
 	bind_method(Vector3, cross, sarray("with"), varray());
 	bind_method(Vector3, outer, sarray("with"), varray());
-	bind_method(Vector3, to_diagonal_matrix, sarray(), varray());
 	bind_method(Vector3, abs, sarray(), varray());
 	bind_method(Vector3, floor, sarray(), varray());
 	bind_method(Vector3, ceil, sarray(), varray());
@@ -1732,6 +1731,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Basis, is_equal_approx, sarray("b"), varray());
 	bind_method(Basis, get_rotation_quaternion, sarray(), varray());
 	bind_static_method(Basis, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
+	bind_static_method(Basis, from_scale, sarray("scale"), varray());
 
 	/* AABB */
 

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -71,6 +71,13 @@
 				A negative determinant means the basis has a negative scale. A zero determinant means the basis isn't invertible, and is usually considered invalid.
 			</description>
 		</method>
+		<method name="from_scale" qualifiers="static">
+			<return type="Basis" />
+			<argument index="0" name="scale" type="Vector3" />
+			<description>
+				Constructs a pure scale basis matrix with no rotation or shearing. The scale values are set as the diagonal of the matrix, and the other parts of the matrix are zero.
+			</description>
+		</method>
 		<method name="get_euler" qualifiers="const">
 			<return type="Vector3" />
 			<description>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -412,13 +412,6 @@
 				Returns this vector with each component snapped to the nearest multiple of [code]step[/code]. This can also be used to round to an arbitrary number of decimals.
 			</description>
 		</method>
-		<method name="to_diagonal_matrix" qualifiers="const">
-			<return type="Basis" />
-			<description>
-				Returns a diagonal matrix with the vector as main diagonal.
-				This is equivalent to a Basis with no rotation or shearing and this vector's components set as the scale.
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="x" type="float" setter="" getter="" default="0.0">

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -110,7 +110,7 @@ void Body3DSW::update_mass_properties() {
 
 					real_t mass = area * this->mass / total_area;
 
-					Basis shape_inertia_tensor = shape->get_moment_of_inertia(mass).to_diagonal_matrix();
+					Basis shape_inertia_tensor = Basis::from_scale(shape->get_moment_of_inertia(mass));
 					Transform3D shape_transform = get_shape_transform(i);
 					Basis shape_basis = shape_transform.basis.orthonormalized();
 
@@ -123,7 +123,7 @@ void Body3DSW::update_mass_properties() {
 
 				// Set the inertia to a valid value when there are no valid shapes.
 				if (!inertia_set) {
-					inertia_tensor.set_diagonal(Vector3(1.0, 1.0, 1.0));
+					inertia_tensor = Basis();
 				}
 
 				// Handle partial custom inertia.
@@ -215,7 +215,7 @@ void Body3DSW::set_param(PhysicsServer3D::BodyParameter p_param, const Variant &
 			} else {
 				calculate_inertia = false;
 				if (mode == PhysicsServer3D::BODY_MODE_DYNAMIC) {
-					principal_inertia_axes_local.set_diagonal(Vector3(1.0, 1.0, 1.0));
+					principal_inertia_axes_local = Basis();
 					_inv_inertia = inertia.inverse();
 					_update_transform_dependant();
 				}
@@ -301,7 +301,7 @@ void Body3DSW::set_mode(PhysicsServer3D::BodyMode p_mode) {
 		case PhysicsServer3D::BODY_MODE_DYNAMIC: {
 			_inv_mass = mass > 0 ? (1.0 / mass) : 0;
 			if (!calculate_inertia) {
-				principal_inertia_axes_local.set_diagonal(Vector3(1.0, 1.0, 1.0));
+				principal_inertia_axes_local = Basis();
 				_inv_inertia = inertia.inverse();
 				_update_transform_dependant();
 			}


### PR DESCRIPTION
EDIT: An alternative option is to just remove this method without a replacement since we can just create a Basis and then set its scale. This would be less efficient than directly constructing with the diagonal as the scale, but maybe that's better if this API is not needed often.

Since we have static methods in Godot 4.0, we can replace `Vector3.to_diagonal_matrix` with `Basis.from_scale`. Test code:

```gdscript
print(Basis.from_scale(Vector3(2, 3, 4)))
```

Two notes:

* This is one of the three places where Vector3 depends on Basis. It would be nice if Vector3 did not depend on Basis to avoid a circular dependency, but that can wait for a future PR.

* There is a similar API in Basis only used internally, `set_diagonal`. It's a bit of a confusing API since it doesn't just set the diagonal, it also sets the other parts of the matrix to zero. It could be replaced later. I didn't touch it in this PR, but I did replace some potentially confusing usages of it in Body3DSW.