### PR TITLE
Add support for CTRL + ALT + special character

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -490,9 +490,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 		// Allow unicode handling if:
 		// * No Modifiers are pressed (except shift)
-		bool allow_unicode_handling = !(k->is_command_pressed() || k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed());
-
-		if (allow_unicode_handling && editable && k->get_unicode() >= 32) {
+		if (editable && k->get_unicode() >= 32) {
 			// Handle Unicode (if no modifiers active)
 			selection_delete();
 			char32_t ucodestr[2] = { (char32_t)k->get_unicode(), 0 };
@@ -501,7 +499,6 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (text.length() != prev_len) {
 				_text_changed();
 			}
-			accept_event();
 		}
 	}
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1583,10 +1583,6 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		_reset_caret_blink_timer();
 
-		// Allow unicode handling if:
-		// * No Modifiers are pressed (except shift)
-		bool allow_unicode_handling = !(k->is_command_pressed() || k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed());
-
 		selection.selecting_text = false;
 
 		// Check and handle all built in shortcuts.
@@ -1794,9 +1790,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		// Handle Unicode (if no modifiers active). Tab	has a value of 0x09.
-		if (allow_unicode_handling && editable && (k->get_unicode() >= 32 || k->get_keycode() == KEY_TAB)) {
+		if (editable && (k->get_unicode() >= 32 || k->get_keycode() == KEY_TAB)) {
 			handle_unicode_input(k->get_unicode());
-			accept_event();
 			return;
 		}
 	}


### PR DESCRIPTION
This PR is an attempt to implement/fix #6851 again (hopefully without any regressions):
By removing the accept_event call all shortcuts which are using the exact same keys do still work. I could not notice any regressions on Windows 10, but further testing is required. Note that if a shortcut consists of Ctrl + Alt + [some key used for a special character], the character input is handled AND the command associated to the shortcut is executed.

Testing/feedback is welcome :)