### PR TITLE
SpriteFramesEditor Fix preview grid in "Select Frames" dialog

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -135,6 +135,7 @@ class SpriteFramesEditor : public HSplitContainer {
 
 	void _open_sprite_sheet();
 	void _prepare_sprite_sheet(const String &p_file);
+	int _sheet_preview_position_to_frame_index(const Vector2 &p_position);
 	void _sheet_preview_draw();
 	void _sheet_spin_changed(double);
 	void _sheet_preview_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
Fixes #52099 (I'll probably enhance this dialog in another PR, this one is bugfix only).
Fixes #52745.
Cherry-pickable `3.x`, `3.3`.


Makes grid being drawn according to the frames this dialog outputs (it allows integer-only frame sizes), scaling/zooming wasn't properly taken into account. Input handling is changed accordingly too. Output frames are unchanged, the preview was broken.

Example:

![Godot_v3 4-beta4_win64_mGsOKTC3rh](https://user-images.githubusercontent.com/9283098/132354378-40ef59a4-0b2f-4e48-9ccd-f8103e00b42a.png)
so the frame size is (64, 64) / (13, 11) = (4, 5)

| `3.4.beta4`: | this PR (against `3.x`):  |
|-|-|
| ![O93WQ2gDRn](https://user-images.githubusercontent.com/9283098/132355051-f03ea28d-140f-4330-ba75-9738b81acf9d.png) | ![QcskcHrE9x](https://user-images.githubusercontent.com/9283098/132354886-a2396fbf-baaf-45a0-bf72-ad6575fedac1.png)  |
| ![cjo3qlcwIb](https://user-images.githubusercontent.com/9283098/132355054-14546bae-7124-4e30-a1e4-407d0c703182.png) | ![hvMlLyt1G7](https://user-images.githubusercontent.com/9283098/132354889-d82dcdba-a32d-4320-b4b8-0a5e3366413d.png)  |
| ![XKQvrIGTt6](https://user-images.githubusercontent.com/9283098/132355057-52bd3a70-c044-4dcd-86c3-4dd02042f938.png) | ![jVQhotk0ZF](https://user-images.githubusercontent.com/9283098/132354890-92e75338-ebc1-49dc-bb0d-cb7bdaf10527.png)  |
| ![cVtkUpkptT](https://user-images.githubusercontent.com/9283098/132355059-db36f526-e7ed-436a-8b3d-5b614f120e99.png) | ![YuPPnn9f93](https://user-images.githubusercontent.com/9283098/132354891-35e8bc2e-6495-4e21-ba06-428eaed037c2.png)  |
| ![pswXOyGA2b](https://user-images.githubusercontent.com/9283098/132355060-5cbf27a0-378f-4032-ba93-ad549a12fb44.png) | ![WkOCVFARhL](https://user-images.githubusercontent.com/9283098/132354892-8def8265-807d-4ac6-ad8f-e054901af3b9.png)  |
| ![sP3dr1zjyf](https://user-images.githubusercontent.com/9283098/132355062-ba7fab09-8652-4d5d-966d-ca0870f526c8.png) | ![0ILJF8EZ9W](https://user-images.githubusercontent.com/9283098/132354896-ca40e90b-ba1b-4a42-9f1a-1efc0cc0954b.png)  |