### PR TITLE
Fixed regression of skinning with skeleton

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -2097,7 +2097,6 @@ void Skeleton3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Color bonecolor = Color(1.0, 0.4, 0.4, 0.3);
 	Color rootcolor = Color(0.4, 1.0, 0.4, 0.1);
 
-	//LocalVector<int> bones_to_process = skel->get_parentless_bones();
 	LocalVector<int> bones_to_process;
 	bones_to_process = skel->get_parentless_bones();
 
@@ -2109,19 +2108,18 @@ void Skeleton3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		child_bones_vector = skel->get_bone_children(current_bone_idx);
 		int child_bones_size = child_bones_vector.size();
 
-		// You have children but no parent, then you must be a root/parentless bone.
-		if (child_bones_size >= 0 && skel->get_bone_parent(current_bone_idx) <= 0) {
-			grests[current_bone_idx] = skel->global_pose_to_local_pose(current_bone_idx, skel->get_bone_global_pose(current_bone_idx));
+		if (skel->get_bone_parent(current_bone_idx) < 0) {
+			grests[current_bone_idx] = skel->get_bone_rest(current_bone_idx);
 		}
 
 		for (int i = 0; i < child_bones_size; i++) {
 			int child_bone_idx = child_bones_vector[i];
 
-			grests[child_bone_idx] = skel->global_pose_to_local_pose(child_bone_idx, skel->get_bone_global_pose(child_bone_idx));
+			grests[child_bone_idx] = grests[current_bone_idx] * skel->get_bone_rest(child_bone_idx);
 			Vector3 v0 = grests[current_bone_idx].origin;
 			Vector3 v1 = grests[child_bone_idx].origin;
-			Vector3 d = skel->get_bone_rest(child_bone_idx).origin.normalized();
-			real_t dist = skel->get_bone_rest(child_bone_idx).origin.length();
+			Vector3 d = (v1 - v0).normalized();
+			real_t dist = v0.distance_to(v1);
 
 			// Find closest axis.
 			int closest = -1;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/51368#issuecomment-900738166. The calculation of global rest in skinning is wrong. This also broke the gizmo, so I fixed that as well.