### PR TITLE
Fix buffer_info may be used uninitialized

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8394,6 +8394,7 @@ void RenderingDeviceVulkan::_free_internal(RID p_id) {
 		b.allocation = index_buffer->allocation;
 		b.buffer = index_buffer->buffer;
 		b.size = index_buffer->size;
+		b.buffer_info = {};
 		frames[frame].buffers_to_dispose_of.push_back(b);
 		index_buffer_owner.free(p_id);
 	} else if (index_array_owner.owns(p_id)) {


### PR DESCRIPTION
Context: https://github.com/godotengine/godot/pull/52395#discussion_r703501104

Not sure what `buffer_info` should be assigned to but since it was previously uninitialized I assumed the default constructor would be fine.