### PR TITLE
Automatically mark and later remove stale issues/PRs to save time

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+on:
+  schedule:
+    - cron: "0 * * * *"
+name: Stale Bot workflow
+jobs:
+  build:
+    name: stale
+    runs-on: ubuntu-latest
+    steps:
+      # 9 months + 3 months = 1 year
+      - name: Stale Issues policy
+        id: stale-issue
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-pr-labels: "no stale"
+          days-before-stale: 1
+          days-before-close: 1
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-label: "stale"
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it hasn't had any activity in past 9 months. It will be closed in 3 months if no further activity occurs.
+            To keep this issue alive, please leave comment.
+
+      # 1 year + 1 year = 2 year
+      - name: Stale PR policy
+        id: stale-pr
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-pr-labels: "no stale"
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-pr-stale: 365
+          days-before-pr-close: 365
+          stale-issue-label: "stale"
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it hasn't had any activity in past 12 months. It will be closed in 12 months if no further activity occurs.
+            To keep this PR alive, please leave comment.


### PR DESCRIPTION
This PR automatically mark as stale(not updated) PRs and issues.

It mark issue and adds stale label after 270 days and later close it after 90 days
PRs marks after 365 days and close after another 365 days.

This numbers are only a proposal and can be freely changed.

Adding comment to issue/PR or just removing stale label, is enough to stop process of closing it

### Why?

Currently Godot repository contains almost 5300 issues, even after disallowing to post here feature proposals(https://github.com/godotengine/godot-proposals have ~2k proposals).

Such big number means, that with current amount of users and contributors, some issues are non checked by others, non confirmed or even fixed already in past.

Automatic closing of issues without any activity probably could reduce number of issues to 4-4.5k(currently ~1,7k issues were updated more than year ago) and allow contributors which now closing them manually to spend more time on e.g. creating new features.

As I wrote before, process of closing issues can be easily stopped by just commenting or removing `stale` label and can be done by everyone.

More options are available here - https://github.com/actions/stale#list-of-input-options