### PR TITLE
Close built-in script from any scene

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -566,6 +566,10 @@ void EditorData::remove_scene(int p_idx) {
 		current_edited_scene--;
 	}
 
+	if (edited_scene[p_idx].path != String()) {
+		ScriptEditor::get_singleton()->close_builtin_scripts_from_scene(edited_scene[p_idx].path);
+	}
+
 	edited_scene.remove(p_idx);
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3263,10 +3263,6 @@ void EditorNode::_remove_edited_scene(bool p_change_tab) {
 		new_index = 1;
 	}
 
-	if (editor_data.get_scene_path(old_index) != String()) {
-		ScriptEditor::get_singleton()->close_builtin_scripts_from_scene(editor_data.get_scene_path(old_index));
-	}
-
 	if (p_change_tab) {
 		_scene_tab_changed(new_index);
 	}


### PR DESCRIPTION
Fixes #10423

Editor was closing built-in scripts only when the current scene was closed. Now it happens for any scene.