### PR TITLE
Multiplayer networking renames/simplification

### DIFF
--- a/core/multiplayer/multiplayer.h
+++ b/core/multiplayer/multiplayer.h
@@ -45,8 +45,8 @@ enum TransferMode {
 
 enum RPCMode {
 	RPC_MODE_DISABLED, // No rpc for this method, calls to this will be blocked (default)
-	RPC_MODE_ANY, // Any peer can call this rpc()
-	RPC_MODE_AUTHORITY, // / Only the node's network authority (server by default) can call this rpc()
+	RPC_MODE_ANY, // Any peer can call this RPC
+	RPC_MODE_AUTHORITY, // / Only the node's multiplayer authority (server by default) can call this RPC
 };
 
 struct RPCConfig {

--- a/core/multiplayer/multiplayer_api.h
+++ b/core/multiplayer/multiplayer_api.h
@@ -82,7 +82,7 @@ private:
 		Map<int, NodeInfo> nodes;
 	};
 
-	Ref<MultiplayerPeer> network_peer;
+	Ref<MultiplayerPeer> multiplayer_peer;
 	Set<int> connected_peers;
 	int remote_sender_id = 0;
 	int remote_sender_override = 0;
@@ -112,8 +112,8 @@ public:
 	void clear();
 	void set_root_node(Node *p_node);
 	Node *get_root_node();
-	void set_network_peer(const Ref<MultiplayerPeer> &p_peer);
-	Ref<MultiplayerPeer> get_network_peer() const;
+	void set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer);
+	Ref<MultiplayerPeer> get_multiplayer_peer() const;
 
 	Error send_bytes(Vector<uint8_t> p_data, int p_to = MultiplayerPeer::TARGET_PEER_BROADCAST, Multiplayer::TransferMode p_mode = Multiplayer::TRANSFER_MODE_RELIABLE, int p_channel = 0);
 
@@ -135,15 +135,15 @@ public:
 	void _connection_failed();
 	void _server_disconnected();
 
-	bool has_network_peer() const { return network_peer.is_valid(); }
-	Vector<int> get_network_connected_peers() const;
+	bool has_multiplayer_peer() const { return multiplayer_peer.is_valid(); }
+	Vector<int> get_peer_ids() const;
 	const Set<int> get_connected_peers() const { return connected_peers; }
 	int get_remote_sender_id() const { return remote_sender_override ? remote_sender_override : remote_sender_id; }
 	void set_remote_sender_override(int p_id) { remote_sender_override = p_id; }
-	int get_network_unique_id() const;
-	bool is_network_server() const;
-	void set_refuse_new_network_connections(bool p_refuse);
-	bool is_refusing_new_network_connections() const;
+	int get_unique_id() const;
+	bool is_server() const;
+	void set_refuse_new_connections(bool p_refuse);
+	bool is_refusing_new_connections() const;
 
 	void set_allow_object_decoding(bool p_enable);
 	bool is_object_decoding_allowed() const;

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2472,7 +2472,7 @@
 			Used with [method Node.rpc_config] to set a method to be callable remotely by any peer. Analogous to the [code]@rpc(any)[/code] annotation. Calls are accepted from all remote peers, no matter if they are node's authority or not.
 		</constant>
 		<constant name="RPC_MODE_AUTH" value="2" enum="RPCMode">
-			Used with [method Node.rpc_config] to set a method to be callable remotely only by the current network authority (which is the server by default). Analogous to the [code]@rpc(auth)[/code] annotation. See [method Node.set_network_authority].
+			Used with [method Node.rpc_config] to set a method to be callable remotely only by the current multiplayer authority (which is the server by default). Analogous to the [code]@rpc(auth)[/code] annotation. See [method Node.set_multiplayer_authority].
 		</constant>
 		<constant name="TRANSFER_MODE_UNRELIABLE" value="0" enum="TransferMode">
 			Packets are not acknowledged, no resend attempts are made for lost packets. Packets may arrive in any order. Potentially faster than [constant TRANSFER_MODE_ORDERED]. Use for non-critical data, and always consider whether the order matters.

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -4,7 +4,7 @@
 		High-level multiplayer API.
 	</brief_description>
 	<description>
-		This class implements most of the logic behind the high-level multiplayer API. See also [MultiplayerPeer].
+		This class implements the high-level multiplayer API. See also [MultiplayerPeer].
 		By default, [SceneTree] has a reference to this class that is used to provide multiplayer capabilities (i.e. RPC/RSET) across the whole scene.
 		It is possible to override the MultiplayerAPI instance used by specific Nodes by setting the [member Node.custom_multiplayer] property, effectively allowing to run both client and server in the same scene.
 		[b]Note:[/b] The high-level multiplayer API protocol is an implementation detail and isn't meant to be used by non-Godot servers. It may change without notice.
@@ -18,16 +18,10 @@
 				Clears the current MultiplayerAPI network state (you shouldn't call this unless you know what you are doing).
 			</description>
 		</method>
-		<method name="get_network_connected_peers" qualifiers="const">
+		<method name="get_peers" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<description>
-				Returns the peer IDs of all connected peers of this MultiplayerAPI's [member network_peer].
-			</description>
-		</method>
-		<method name="get_network_unique_id" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the unique peer ID of this MultiplayerAPI's [member network_peer].
+				Returns the peer IDs of all connected peers of this MultiplayerAPI's [member multiplayer_peer].
 			</description>
 		</method>
 		<method name="get_remote_sender_id" qualifiers="const">
@@ -37,16 +31,22 @@
 				[b]Note:[/b] If not inside an RPC this method will return 0.
 			</description>
 		</method>
-		<method name="has_network_peer" qualifiers="const">
-			<return type="bool" />
+		<method name="get_unique_id" qualifiers="const">
+			<return type="int" />
 			<description>
-				Returns [code]true[/code] if there is a [member network_peer] set.
+				Returns the unique peer ID of this MultiplayerAPI's [member multiplayer_peer].
 			</description>
 		</method>
-		<method name="is_network_server" qualifiers="const">
+		<method name="has_multiplayer_peer" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this MultiplayerAPI's [member network_peer] is in server mode (listening for connections).
+				Returns [code]true[/code] if there is a [member multiplayer_peer] set.
+			</description>
+		</method>
+		<method name="is_server" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this MultiplayerAPI's [member multiplayer_peer] is valid and in server mode (listening for connections).
 			</description>
 		</method>
 		<method name="poll">
@@ -72,11 +72,11 @@
 			If [code]true[/code], the MultiplayerAPI will allow encoding and decoding of object during RPCs/RSETs.
 			[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 		</member>
-		<member name="network_peer" type="MultiplayerPeer" setter="set_network_peer" getter="get_network_peer">
-			The peer object to handle the RPC system (effectively enabling networking when set). Depending on the peer itself, the MultiplayerAPI will become a network server (check with [method is_network_server]) and will set root node's network mode to authority, or it will become a regular client peer. All child nodes are set to inherit the network mode by default. Handling of networking-related events (connection, disconnection, new clients) is done by connecting to MultiplayerAPI's signals.
+		<member name="multiplayer_peer" type="MultiplayerPeer" setter="set_multiplayer_peer" getter="get_multiplayer_peer">
+			The peer object to handle the RPC system (effectively enabling networking when set). Depending on the peer itself, the MultiplayerAPI will become a network server (check with [method is_server]) and will set root node's network mode to authority, or it will become a regular client peer. All child nodes are set to inherit the network mode by default. Handling of networking-related events (connection, disconnection, new clients) is done by connecting to MultiplayerAPI's signals.
 		</member>
-		<member name="refuse_new_network_connections" type="bool" setter="set_refuse_new_network_connections" getter="is_refusing_new_network_connections" default="false">
-			If [code]true[/code], the MultiplayerAPI's [member network_peer] refuses new incoming connections.
+		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" default="false">
+			If [code]true[/code], the MultiplayerAPI's [member multiplayer_peer] refuses new incoming connections.
 		</member>
 		<member name="replicator" type="MultiplayerReplicator" setter="" getter="get_replicator">
 		</member>
@@ -88,36 +88,36 @@
 	<signals>
 		<signal name="connected_to_server">
 			<description>
-				Emitted when this MultiplayerAPI's [member network_peer] successfully connected to a server. Only emitted on clients.
+				Emitted when this MultiplayerAPI's [member multiplayer_peer] successfully connected to a server. Only emitted on clients.
 			</description>
 		</signal>
 		<signal name="connection_failed">
 			<description>
-				Emitted when this MultiplayerAPI's [member network_peer] fails to establish a connection to a server. Only emitted on clients.
+				Emitted when this MultiplayerAPI's [member multiplayer_peer] fails to establish a connection to a server. Only emitted on clients.
 			</description>
 		</signal>
-		<signal name="network_peer_connected">
+		<signal name="peer_connected">
 			<argument index="0" name="id" type="int" />
 			<description>
-				Emitted when this MultiplayerAPI's [member network_peer] connects with a new peer. ID is the peer ID of the new peer. Clients get notified when other clients connect to the same server. Upon connecting to a server, a client also receives this signal for the server (with ID being 1).
+				Emitted when this MultiplayerAPI's [member multiplayer_peer] connects with a new peer. ID is the peer ID of the new peer. Clients get notified when other clients connect to the same server. Upon connecting to a server, a client also receives this signal for the server (with ID being 1).
 			</description>
 		</signal>
-		<signal name="network_peer_disconnected">
+		<signal name="peer_disconnected">
 			<argument index="0" name="id" type="int" />
 			<description>
-				Emitted when this MultiplayerAPI's [member network_peer] disconnects from a peer. Clients get notified when other clients disconnect from the same server.
+				Emitted when this MultiplayerAPI's [member multiplayer_peer] disconnects from a peer. Clients get notified when other clients disconnect from the same server.
 			</description>
 		</signal>
-		<signal name="network_peer_packet">
+		<signal name="peer_packet">
 			<argument index="0" name="id" type="int" />
 			<argument index="1" name="packet" type="PackedByteArray" />
 			<description>
-				Emitted when this MultiplayerAPI's [member network_peer] receive a [code]packet[/code] with custom data (see [method send_bytes]). ID is the peer ID of the peer that sent the packet.
+				Emitted when this MultiplayerAPI's [member multiplayer_peer] receives a [code]packet[/code] with custom data (see [method send_bytes]). ID is the peer ID of the peer that sent the packet.
 			</description>
 		</signal>
 		<signal name="server_disconnected">
 			<description>
-				Emitted when this MultiplayerAPI's [member network_peer] disconnects from server. Only emitted on clients.
+				Emitted when this MultiplayerAPI's [member multiplayer_peer] disconnects from server. Only emitted on clients.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -4,7 +4,7 @@
 		A high-level network interface to simplify multiplayer interactions.
 	</brief_description>
 	<description>
-		Manages the connection to network peers. Assigns unique IDs to each client connected to the server. See also [MultiplayerAPI].
+		Manages the connection to multiplayer peers. Assigns unique IDs to each client connected to the server. See also [MultiplayerAPI].
 		[b]Note:[/b] The high-level multiplayer API protocol is an implementation detail and isn't meant to be used by non-Godot servers. It may change without notice.
 	</description>
 	<tutorials>

--- a/doc/classes/MultiplayerReplicator.xml
+++ b/doc/classes/MultiplayerReplicator.xml
@@ -44,7 +44,7 @@
 			<argument index="2" name="data" type="Variant" default="null" />
 			<argument index="3" name="path" type="NodePath" default="NodePath(&quot;&quot;)" />
 			<description>
-				Sends a despawn request for the scene identified by [code]scene_id[/code] to the given [code]peer_id[/code] (see [method MultiplayerPeer.set_target_peer]). If the scene is configured as [constant REPLICATION_MODE_SERVER] (see [method spawn_config]) and the request is sent by the server (see [method MultiplayerAPI.is_network_server]), the receiving peer(s) will automatically queue for deletion the node at [code]path[/code] and emit the signal [signal despawned]. In all other cases no deletion happens, and the signal [signal despawn_requested] is emitted instead.
+				Sends a despawn request for the scene identified by [code]scene_id[/code] to the given [code]peer_id[/code] (see [method MultiplayerPeer.set_target_peer]). If the scene is configured as [constant REPLICATION_MODE_SERVER] (see [method spawn_config]) and the request is sent by the server (see [method MultiplayerAPI.is_server]), the receiving peer(s) will automatically queue for deletion the node at [code]path[/code] and emit the signal [signal despawned]. In all other cases no deletion happens, and the signal [signal despawn_requested] is emitted instead.
 			</description>
 		</method>
 		<method name="send_spawn">
@@ -54,7 +54,7 @@
 			<argument index="2" name="data" type="Variant" default="null" />
 			<argument index="3" name="path" type="NodePath" default="NodePath(&quot;&quot;)" />
 			<description>
-				Sends a spawn request for the scene identified by [code]scene_id[/code] to the given [code]peer_id[/code] (see [method MultiplayerPeer.set_target_peer]). If the scene is configured as [constant REPLICATION_MODE_SERVER] (see [method spawn_config]) and the request is sent by the server (see [method MultiplayerAPI.is_network_server]), the receiving peer(s) will automatically instantiate that scene, add it to the [SceneTree] at the given [code]path[/code] and emit the signal [signal spawned]. In all other cases no instantiation happens, and the signal [signal spawn_requested] is emitted instead.
+				Sends a spawn request for the scene identified by [code]scene_id[/code] to the given [code]peer_id[/code] (see [method MultiplayerPeer.set_target_peer]). If the scene is configured as [constant REPLICATION_MODE_SERVER] (see [method spawn_config]) and the request is sent by the server (see [method MultiplayerAPI.is_server]), the receiving peer(s) will automatically instantiate that scene, add it to the [SceneTree] at the given [code]path[/code] and emit the signal [signal spawned]. In all other cases no instantiation happens, and the signal [signal spawn_requested] is emitted instead.
 			</description>
 		</method>
 		<method name="send_sync">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -246,10 +246,10 @@
 				If [code]include_internal[/code] is [code]false[/code], the index won't take internal children into account, i.e. first non-internal child will have index of 0 (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>
-		<method name="get_network_authority" qualifiers="const">
+		<method name="get_multiplayer_authority" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the peer ID of the network authority for this node. See [method set_network_authority].
+				Returns the peer ID of the multiplayer authority for this node. See [method set_multiplayer_authority].
 			</description>
 		</method>
 		<method name="get_node" qualifiers="const">
@@ -417,10 +417,10 @@
 				Returns [code]true[/code] if this node is currently inside a [SceneTree].
 			</description>
 		</method>
-		<method name="is_network_authority" qualifiers="const">
+		<method name="is_multiplayer_authority" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the local system is the authority of this node.
+				Returns [code]true[/code] if the local system is the multiplayer authority of this node.
 			</description>
 		</method>
 		<method name="is_physics_processing" qualifiers="const">
@@ -578,7 +578,7 @@
 			<argument index="0" name="method" type="StringName" />
 			<description>
 				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. Returns an empty [Variant].
-				[b]Note:[/b] You can only safely use RPCs on clients after you received the [code]connected_to_server[/code] signal from the [MultiplayerAPI]. You also need to keep track of the connection state, either by the [MultiplayerAPI] signals like [code]server_disconnected[/code] or by checking [code]get_multiplayer().network_peer.get_connection_status() == CONNECTION_CONNECTED[/code].
+				[b]Note:[/b] You can only safely use RPCs on clients after you received the [code]connected_to_server[/code] signal from the [MultiplayerAPI]. You also need to keep track of the connection state, either by the [MultiplayerAPI] signals like [code]server_disconnected[/code] or by checking [code]get_multiplayer().peer.get_connection_status() == CONNECTION_CONNECTED[/code].
 			</description>
 		</method>
 		<method name="rpc_config">
@@ -620,12 +620,12 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_network_authority">
+		<method name="set_multiplayer_authority">
 			<return type="void" />
 			<argument index="0" name="id" type="int" />
 			<argument index="1" name="recursive" type="bool" default="true" />
 			<description>
-				Sets the node's network authority to the peer with the given peer ID. The network authority is the peer that has authority over the node on the network. Useful in conjunction with [method rpc_config] and the [MultiplayerAPI]. Inherited from the parent node by default, which ultimately defaults to peer ID 1 (the server). If [code]recursive[/code], the given peer is recursively set as the authority for all children of this node.
+				Sets the node's multiplayer authority to the peer with the given peer ID. The multiplayer authority is the peer that has authority over the node on the network. Useful in conjunction with [method rpc_config] and the [MultiplayerAPI]. Inherited from the parent node by default, which ultimately defaults to peer ID 1 (the server). If [code]recursive[/code], the given peer is recursively set as the authority for all children of this node.
 			</description>
 		</method>
 		<method name="set_physics_process">

--- a/modules/enet/doc_classes/ENetMultiplayerPeer.xml
+++ b/modules/enet/doc_classes/ENetMultiplayerPeer.xml
@@ -4,7 +4,7 @@
 		A MultiplayerPeer implementation using the [url=http://enet.bespin.org/index.html]ENet[/url] library.
 	</brief_description>
 	<description>
-		A MultiplayerPeer implementation that should be passed to [member MultiplayerAPI.network_peer] after being initialized as either a client, server, or mesh. Events can then be handled by connecting to [MultiplayerAPI] signals. See [ENetConnection] for more information on the ENet library wrapper.
+		A MultiplayerPeer implementation that should be passed to [member MultiplayerAPI.multiplayer_peer] after being initialized as either a client, server, or mesh. Events can then be handled by connecting to [MultiplayerAPI] signals. See [ENetConnection] for more information on the ENet library wrapper.
 		[b]Note:[/b] ENet only uses UDP, not TCP. When forwarding the server port to make your server accessible on the public Internet, you only need to forward the server port in UDP. You can use the [UPNP] class to try to forward the server port automatically when starting the server.
 	</description>
 	<tutorials>
@@ -44,7 +44,7 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="unique_id" type="int" />
 			<description>
-				Initialize this [MultiplayerPeer] in mesh mode. The provided [code]unique_id[/code] will be used as the local peer network unique ID once assigned as the [member MultiplayerAPI.network_peer]. In the mesh configuration you will need to set up each new peer manually using [ENetConnection] before calling [method add_mesh_peer]. While this technique is more advanced, it allows for better control over the connection process (e.g. when dealing with NAT punch-through) and for better distribution of the network load (which would otherwise be more taxing on the server).
+				Initialize this [MultiplayerPeer] in mesh mode. The provided [code]unique_id[/code] will be used as the local peer network unique ID once assigned as the [member MultiplayerAPI.multiplayer_peer]. In the mesh configuration you will need to set up each new peer manually using [ENetConnection] before calling [method add_mesh_peer]. While this technique is more advanced, it allows for better control over the connection process (e.g. when dealing with NAT punch-through) and for better distribution of the network load (which would otherwise be more taxing on the server).
 			</description>
 		</method>
 		<method name="create_server">

--- a/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
+++ b/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
@@ -4,7 +4,7 @@
 		A simple interface to create a peer-to-peer mesh network composed of [WebRTCPeerConnection] that is compatible with the [MultiplayerAPI].
 	</brief_description>
 	<description>
-		This class constructs a full mesh of [WebRTCPeerConnection] (one connection for each peer) that can be used as a [member MultiplayerAPI.network_peer].
+		This class constructs a full mesh of [WebRTCPeerConnection] (one connection for each peer) that can be used as a [member MultiplayerAPI.multiplayer_peer].
 		You can add each [WebRTCPeerConnection] via [method add_peer] or remove them via [method remove_peer]. Peers must be added in [constant WebRTCPeerConnection.STATE_NEW] state to allow it to create the appropriate channels. This class will not create offers nor set descriptions, it will only poll them, and notify connections and disconnections.
 		[signal MultiplayerPeer.connection_succeeded] and [signal MultiplayerPeer.server_disconnected] will not be emitted unless [code]server_compatibility[/code] is [code]true[/code] in [method initialize]. Beside that data transfer works like in a [MultiplayerPeer].
 	</description>

--- a/modules/websocket/doc_classes/WebSocketClient.xml
+++ b/modules/websocket/doc_classes/WebSocketClient.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		This class implements a WebSocket client compatible with any RFC 6455-compliant WebSocket server.
-		This client can be optionally used as a network peer for the [MultiplayerAPI].
+		This client can be optionally used as a multiplayer peer for the [MultiplayerAPI].
 		After starting the client ([method connect_to_url]), you will need to [method MultiplayerPeer.poll] it at regular intervals (e.g. inside [method Node._process]).
 		You will receive appropriate signals when connecting, disconnecting, or when new data is available.
 	</description>
@@ -20,7 +20,7 @@
 			<argument index="3" name="custom_headers" type="PackedStringArray" default="PackedStringArray()" />
 			<description>
 				Connects to the given URL requesting one of the given [code]protocols[/code] as sub-protocol. If the list empty (default), no sub-protocol will be requested.
-				If [code]true[/code] is passed as [code]gd_mp_api[/code], the client will behave like a network peer for the [MultiplayerAPI], connections to non-Godot servers will not work, and [signal data_received] will not be emitted.
+				If [code]true[/code] is passed as [code]gd_mp_api[/code], the client will behave like a multiplayer peer for the [MultiplayerAPI], connections to non-Godot servers will not work, and [signal data_received] will not be emitted.
 				If [code]false[/code] is passed instead (default), you must call [PacketPeer] functions ([code]put_packet[/code], [code]get_packet[/code], etc.) on the [WebSocketPeer] returned via [code]get_peer(1)[/code] and not on this object directly (e.g. [code]get_peer(1).put_packet(data)[/code]).
 				You can optionally pass a list of [code]custom_headers[/code] to be added to the handshake HTTP request.
 				[b]Note:[/b] To avoid mixed content warnings or errors in HTML5, you may have to use a [code]url[/code] that starts with [code]wss://[/code] (secure) instead of [code]ws://[/code]. When doing so, make sure to use the fully qualified domain name that matches the one defined in the server's SSL certificate. Do not connect directly via the IP address for [code]wss://[/code] connections, as it won't match with the SSL certificate.

--- a/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
+++ b/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
@@ -4,7 +4,7 @@
 		Base class for WebSocket server and client.
 	</brief_description>
 	<description>
-		Base class for WebSocket server and client, allowing them to be used as network peer for the [MultiplayerAPI].
+		Base class for WebSocket server and client, allowing them to be used as multiplayer peer for the [MultiplayerAPI].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/websocket/doc_classes/WebSocketServer.xml
+++ b/modules/websocket/doc_classes/WebSocketServer.xml
@@ -55,7 +55,7 @@
 			<description>
 				Starts listening on the given port.
 				You can specify the desired subprotocols via the "protocols" array. If the list empty (default), no sub-protocol will be requested.
-				If [code]true[/code] is passed as [code]gd_mp_api[/code], the server will behave like a network peer for the [MultiplayerAPI], connections from non-Godot clients will not work, and [signal data_received] will not be emitted.
+				If [code]true[/code] is passed as [code]gd_mp_api[/code], the server will behave like a multiplayer peer for the [MultiplayerAPI], connections from non-Godot clients will not work, and [signal data_received] will not be emitted.
 				If [code]false[/code] is passed instead (default), you must call [PacketPeer] functions ([code]put_packet[/code], [code]get_packet[/code], etc.), on the [WebSocketPeer] returned via [code]get_peer(id)[/code] to communicate with the peer with given [code]id[/code] (e.g. [code]get_peer(id).get_available_packet_count[/code]).
 			</description>
 		</method>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -516,24 +516,24 @@ void Node::_propagate_process_owner(Node *p_owner, int p_pause_notification, int
 	}
 }
 
-void Node::set_network_authority(int p_peer_id, bool p_recursive) {
-	data.network_authority = p_peer_id;
+void Node::set_multiplayer_authority(int p_peer_id, bool p_recursive) {
+	data.multiplayer_authority = p_peer_id;
 
 	if (p_recursive) {
 		for (int i = 0; i < data.children.size(); i++) {
-			data.children[i]->set_network_authority(p_peer_id, true);
+			data.children[i]->set_multiplayer_authority(p_peer_id, true);
 		}
 	}
 }
 
-int Node::get_network_authority() const {
-	return data.network_authority;
+int Node::get_multiplayer_authority() const {
+	return data.multiplayer_authority;
 }
 
-bool Node::is_network_authority() const {
+bool Node::is_multiplayer_authority() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), false);
 
-	return get_multiplayer()->get_network_unique_id() == data.network_authority;
+	return get_multiplayer()->get_unique_id() == data.multiplayer_authority;
 }
 
 /***** RPC CONFIG ********/
@@ -2737,10 +2737,10 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("request_ready"), &Node::request_ready);
 
-	ClassDB::bind_method(D_METHOD("set_network_authority", "id", "recursive"), &Node::set_network_authority, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("get_network_authority"), &Node::get_network_authority);
+	ClassDB::bind_method(D_METHOD("set_multiplayer_authority", "id", "recursive"), &Node::set_multiplayer_authority, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_multiplayer_authority"), &Node::get_multiplayer_authority);
 
-	ClassDB::bind_method(D_METHOD("is_network_authority"), &Node::is_network_authority);
+	ClassDB::bind_method(D_METHOD("is_multiplayer_authority"), &Node::is_multiplayer_authority);
 
 	ClassDB::bind_method(D_METHOD("get_multiplayer"), &Node::get_multiplayer);
 	ClassDB::bind_method(D_METHOD("get_custom_multiplayer"), &Node::get_custom_multiplayer);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -127,7 +127,7 @@ private:
 		ProcessMode process_mode = PROCESS_MODE_INHERIT;
 		Node *process_owner = nullptr;
 
-		int network_authority = 1; // Server by default.
+		int multiplayer_authority = 1; // Server by default.
 		Vector<Multiplayer::RPCConfig> rpc_methods;
 
 		// Variables used to properly sort the node when processing, ignored otherwise.
@@ -462,9 +462,9 @@ public:
 	bool is_displayed_folded() const;
 	/* NETWORK */
 
-	void set_network_authority(int p_peer_id, bool p_recursive = true);
-	int get_network_authority() const;
-	bool is_network_authority() const;
+	void set_multiplayer_authority(int p_peer_id, bool p_recursive = true);
+	int get_multiplayer_authority() const;
+	bool is_multiplayer_authority() const;
 
 	uint16_t rpc_config(const StringName &p_method, Multiplayer::RPCMode p_rpc_mode, Multiplayer::TransferMode p_transfer_mode, int p_channel = 0); // config a local method for RPC
 	Vector<Multiplayer::RPCConfig> get_node_rpc_methods() const;


### PR DESCRIPTION
Removes the **networking** prefix from some methods and members, now that multiplayer has been largely moved out of Node and SceneTree and is seperated into its own set of classes. Previously, it was useful to mark these so people knew they were multiplayer related when looking at them on **Node** or **SceneTree**, but now they have moved to **Multiplayer** its self-evident and just makes them longer and less readable.

Part of https://github.com/godotengine/godot/issues/16863.

----

**RENAMES**

**MultiplayerAPI**
**Functions and Properties**
`multiplayer.is_network_server()` -> `multiplayer.is_server()`

`multiplayer.network_peer` -> `multiplayer.multiplayer_peer`
`multiplayer.has_network_peer()` ->`multiplayer.has_multiplayer_peer()`
`multiplayer.get_network_peer()` -> `multiplayer.get_multiplayer_peer()`
`multiplayer.set_network_peer()` -> `multiplayer.set_multiplayer_peer()`

`multiplayer.get_network_connected_peers()` -> `multiplayer.get_peers()`

`multiplayer.get_network_unique_id` -> `multiplayer.get_unique_id()`

`multiplayer.refuse_new_network_connections` -> `multiplayer.refuse_new_connections`
`multiplayer.set_refuse_new_network_connections()` -> `multiplayer.set_refuse_new_connections()`
`multiplayer.is_refusing_new_network_connections()` -> `multiplayer.is_refusing_new_connections`

**Signals**
`network_peer_connected` -> `peer_connected`
`network_peer_disconnected` -> `peer_disconnected`
`network_peer_packet` -> `peer_packet`

**Node**
**Functions and Properties**

`Node.network_authority` -> `Node.multiplayer_authority`
`Node.is_network_authority()` -> `Node.is_multiplayer_authority()`
`Node.set_network_authority()` -> `Node.set_multiplayer_authority()`
`Node.get_network_authority()` -> `Node.get_multiplayer_authority()`

----

Note this contains very minor changes to some log messages that are now cleaned up in `RPCManager::_send_rpc()`. I had to edit a few of them anyway for consistency with these changes.