### PR TITLE
Use current androidx Fragment library instead of legacy libraries

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -34,9 +34,8 @@ allprojects {
 }
 
 dependencies {
-    implementation libraries.supportCoreUtils
     implementation libraries.kotlinStdLib
-    implementation libraries.v4Support
+    implementation libraries.androidxFragment
 
     if (rootProject.findProject(":lib")) {
         implementation project(":lib")

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -4,9 +4,8 @@ ext.versions = [
     minSdk             : 19,
     targetSdk          : 30,
     buildTools         : '30.0.3',
-    supportCoreUtils   : '1.0.0',
     kotlinVersion      : '1.5.10',
-    v4Support          : '1.0.0',
+    fragmentVersion    : '1.3.6',
     javaVersion        : 1.8,
     ndkVersion         : '21.4.7075529' // Also update 'platform/android/detect.py#get_project_ndk_version()' when this is updated.
 
@@ -14,10 +13,9 @@ ext.versions = [
 
 ext.libraries = [
     androidGradlePlugin: "com.android.tools.build:gradle:$versions.androidGradlePlugin",
-    supportCoreUtils   : "androidx.legacy:legacy-support-core-utils:$versions.supportCoreUtils",
     kotlinGradlePlugin : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinVersion",
     kotlinStdLib       : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlinVersion",
-    v4Support          : "androidx.legacy:legacy-support-v4:$versions.v4Support"
+    androidxFragment   : "androidx.fragment:fragment:$versions.fragmentVersion",
 ]
 
 ext.getExportPackageName = { ->

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -2,9 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 dependencies {
-    implementation libraries.supportCoreUtils
     implementation libraries.kotlinStdLib
-    implementation libraries.v4Support
+    implementation libraries.androidxFragment
 }
 
 def pathToRootDir = "../../../../"


### PR DESCRIPTION
**Note:** The current androidx.core and androidx.annotation libraries are included with the androidx.fragment library so that don't need to be specified and included separately.

Can be cherry-picked for 3.x too.
