### PR TITLE
Mediump implementation to optimize mobile

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4452,8 +4452,9 @@ bool RenderingDeviceVulkan::_uniform_add_binding(Vector<Vector<VkDescriptorSetLa
 
 //version 1: initial
 //version 2: Added shader name
+//version 3: fixed bug regarding to storing booleans
 
-#define SHADER_BINARY_VERSION 2
+#define SHADER_BINARY_VERSION 3
 
 String RenderingDeviceVulkan::shader_get_binary_cache_key() const {
 	return "Vulkan-SV" + itos(SHADER_BINARY_VERSION);
@@ -4687,6 +4688,7 @@ Vector<uint8_t> RenderingDeviceVulkan::shader_compile_binary_from_spirv(const Ve
 						int32_t existing = -1;
 						RenderingDeviceVulkanShaderBinarySpecializationConstant sconst;
 						sconst.constant_id = spec_constants[j]->constant_id;
+						sconst.int_value = 0; // clear memory since bool may be smaller
 						switch (spec_constants[j]->constant_type) {
 							case SPV_REFLECT_SPECIALIZATION_CONSTANT_BOOL: {
 								sconst.type = PIPELINE_SPECIALIZATION_CONSTANT_TYPE_BOOL;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -604,31 +604,31 @@ void BaseMaterial3D::_update_shader() {
 
 	code += ";\n";
 
-	code += "uniform vec4 albedo : hint_color;\n";
-	code += "uniform sampler2D texture_albedo : hint_albedo," + texfilter_str + ";\n";
+	code += "uniform mediump vec4 albedo : hint_color;\n";
+	code += "uniform mediump sampler2D texture_albedo : hint_albedo," + texfilter_str + ";\n";
 	if (grow_enabled) {
 		code += "uniform float grow;\n";
 	}
 
 	if (proximity_fade_enabled) {
-		code += "uniform float proximity_fade_distance;\n";
+		code += "uniform highp float proximity_fade_distance;\n";
 	}
 	if (distance_fade != DISTANCE_FADE_DISABLED) {
-		code += "uniform float distance_fade_min;\n";
-		code += "uniform float distance_fade_max;\n";
+		code += "uniform highp float distance_fade_min;\n";
+		code += "uniform highp float distance_fade_max;\n";
 	}
 
 	// alpha scissor is only valid if there is not antialiasing edge
 	// alpha hash is valid whenever, but not with alpha scissor
 	if (transparency == TRANSPARENCY_ALPHA_SCISSOR) {
-		code += "uniform float alpha_scissor_threshold;\n";
+		code += "uniform mediump float alpha_scissor_threshold;\n";
 	} else if (transparency == TRANSPARENCY_ALPHA_HASH) {
-		code += "uniform float alpha_hash_scale;\n";
+		code += "uniform mediump float alpha_hash_scale;\n";
 	}
 	// if alpha antialiasing isn't off, add in the edge variable
 	if (alpha_antialiasing_mode != ALPHA_ANTIALIASING_OFF &&
 			(transparency == TRANSPARENCY_ALPHA_SCISSOR || transparency == TRANSPARENCY_ALPHA_HASH)) {
-		code += "uniform float alpha_antialiasing_edge;\n";
+		code += "uniform mediump float alpha_antialiasing_edge;\n";
 		code += "uniform ivec2 albedo_texture_size;\n";
 	}
 
@@ -636,33 +636,33 @@ void BaseMaterial3D::_update_shader() {
 
 	//TODO ALL HINTS
 	if (!orm) {
-		code += "uniform float roughness : hint_range(0,1);\n";
-		code += "uniform sampler2D texture_metallic : hint_white," + texfilter_str + ";\n";
-		code += "uniform vec4 metallic_texture_channel;\n";
+		code += "uniform mediump float roughness : hint_range(0,1);\n";
+		code += "uniform mediump sampler2D texture_metallic : hint_white," + texfilter_str + ";\n";
+		code += "uniform lowp vec4 metallic_texture_channel;\n";
 		switch (roughness_texture_channel) {
 			case TEXTURE_CHANNEL_RED: {
-				code += "uniform sampler2D texture_roughness : hint_roughness_r," + texfilter_str + ";\n";
+				code += "uniform mediump sampler2D texture_roughness : hint_roughness_r," + texfilter_str + ";\n";
 			} break;
 			case TEXTURE_CHANNEL_GREEN: {
-				code += "uniform sampler2D texture_roughness : hint_roughness_g," + texfilter_str + ";\n";
+				code += "uniform mediump sampler2D texture_roughness : hint_roughness_g," + texfilter_str + ";\n";
 			} break;
 			case TEXTURE_CHANNEL_BLUE: {
-				code += "uniform sampler2D texture_roughness : hint_roughness_b," + texfilter_str + ";\n";
+				code += "uniform mediump sampler2D texture_roughness : hint_roughness_b," + texfilter_str + ";\n";
 			} break;
 			case TEXTURE_CHANNEL_ALPHA: {
-				code += "uniform sampler2D texture_roughness : hint_roughness_a," + texfilter_str + ";\n";
+				code += "uniform mediump sampler2D texture_roughness : hint_roughness_a," + texfilter_str + ";\n";
 			} break;
 			case TEXTURE_CHANNEL_GRAYSCALE: {
-				code += "uniform sampler2D texture_roughness : hint_roughness_gray," + texfilter_str + ";\n";
+				code += "uniform mediump sampler2D texture_roughness : hint_roughness_gray," + texfilter_str + ";\n";
 			} break;
 			case TEXTURE_CHANNEL_MAX:
 				break; // Internal value, skip.
 		}
 
-		code += "uniform float specular;\n";
-		code += "uniform float metallic;\n";
+		code += "uniform mediump float specular;\n";
+		code += "uniform mediump float metallic;\n";
 	} else {
-		code += "uniform sampler2D texture_orm : hint_roughness_g," + texfilter_str + ";\n";
+		code += "uniform mediump sampler2D texture_orm : hint_roughness_g," + texfilter_str + ";\n";
 	}
 
 	if (billboard_mode == BILLBOARD_PARTICLES) {
@@ -672,91 +672,91 @@ void BaseMaterial3D::_update_shader() {
 	}
 
 	if (features[FEATURE_EMISSION]) {
-		code += "uniform sampler2D texture_emission : hint_black_albedo," + texfilter_str + ";\n";
-		code += "uniform vec4 emission : hint_color;\n";
-		code += "uniform float emission_energy;\n";
+		code += "uniform mediump sampler2D texture_emission : hint_black_albedo," + texfilter_str + ";\n";
+		code += "uniform mediump vec4 emission : hint_color;\n";
+		code += "uniform mediump float emission_energy;\n";
 	}
 
 	if (features[FEATURE_REFRACTION]) {
-		code += "uniform sampler2D texture_refraction : " + texfilter_str + ";\n";
-		code += "uniform float refraction : hint_range(-16,16);\n";
-		code += "uniform vec4 refraction_texture_channel;\n";
+		code += "uniform mediump sampler2D texture_refraction : " + texfilter_str + ";\n";
+		code += "uniform mediump float refraction : hint_range(-16,16);\n";
+		code += "uniform lowp vec4 refraction_texture_channel;\n";
 	}
 
 	if (features[FEATURE_NORMAL_MAPPING]) {
-		code += "uniform sampler2D texture_normal : hint_roughness_normal," + texfilter_str + ";\n";
-		code += "uniform float normal_scale : hint_range(-16,16);\n";
+		code += "uniform mediump sampler2D texture_normal : hint_roughness_normal," + texfilter_str + ";\n";
+		code += "uniform mediump float normal_scale : hint_range(-16,16);\n";
 	}
 	if (features[FEATURE_RIM]) {
-		code += "uniform float rim : hint_range(0,1);\n";
-		code += "uniform float rim_tint : hint_range(0,1);\n";
-		code += "uniform sampler2D texture_rim : hint_white," + texfilter_str + ";\n";
+		code += "uniform mediump float rim : hint_range(0,1);\n";
+		code += "uniform mediump float rim_tint : hint_range(0,1);\n";
+		code += "uniform mediump sampler2D texture_rim : hint_white," + texfilter_str + ";\n";
 	}
 	if (features[FEATURE_CLEARCOAT]) {
-		code += "uniform float clearcoat : hint_range(0,1);\n";
-		code += "uniform float clearcoat_gloss : hint_range(0,1);\n";
-		code += "uniform sampler2D texture_clearcoat : hint_white," + texfilter_str + ";\n";
+		code += "uniform mediump float clearcoat : hint_range(0,1);\n";
+		code += "uniform mediump float clearcoat_gloss : hint_range(0,1);\n";
+		code += "uniform mediump sampler2D texture_clearcoat : hint_white," + texfilter_str + ";\n";
 	}
 	if (features[FEATURE_ANISOTROPY]) {
-		code += "uniform float anisotropy_ratio : hint_range(0,256);\n";
-		code += "uniform sampler2D texture_flowmap : hint_aniso," + texfilter_str + ";\n";
+		code += "uniform mediump float anisotropy_ratio : hint_range(0,256);\n";
+		code += "uniform mediump sampler2D texture_flowmap : hint_aniso," + texfilter_str + ";\n";
 	}
 	if (features[FEATURE_AMBIENT_OCCLUSION]) {
-		code += "uniform sampler2D texture_ambient_occlusion : hint_white, " + texfilter_str + ";\n";
-		code += "uniform vec4 ao_texture_channel;\n";
-		code += "uniform float ao_light_affect;\n";
+		code += "uniform mediump sampler2D texture_ambient_occlusion : hint_white, " + texfilter_str + ";\n";
+		code += "uniform mediump vec4 ao_texture_channel;\n";
+		code += "uniform mediump float ao_light_affect;\n";
 	}
 
 	if (features[FEATURE_DETAIL]) {
-		code += "uniform sampler2D texture_detail_albedo : hint_albedo," + texfilter_str + ";\n";
-		code += "uniform sampler2D texture_detail_normal : hint_normal," + texfilter_str + ";\n";
-		code += "uniform sampler2D texture_detail_mask : hint_white," + texfilter_str + ";\n";
+		code += "uniform mediump sampler2D texture_detail_albedo : hint_albedo," + texfilter_str + ";\n";
+		code += "uniform mediump sampler2D texture_detail_normal : hint_normal," + texfilter_str + ";\n";
+		code += "uniform mediump sampler2D texture_detail_mask : hint_white," + texfilter_str + ";\n";
 	}
 
 	if (features[FEATURE_SUBSURFACE_SCATTERING]) {
-		code += "uniform float subsurface_scattering_strength : hint_range(0,1);\n";
-		code += "uniform sampler2D texture_subsurface_scattering : hint_white," + texfilter_str + ";\n";
+		code += "uniform mediump float subsurface_scattering_strength : hint_range(0,1);\n";
+		code += "uniform mediump sampler2D texture_subsurface_scattering : hint_white," + texfilter_str + ";\n";
 	}
 
 	if (features[FEATURE_SUBSURFACE_TRANSMITTANCE]) {
-		code += "uniform vec4 transmittance_color : hint_color;\n";
-		code += "uniform float transmittance_depth;\n";
-		code += "uniform sampler2D texture_subsurface_transmittance : hint_white," + texfilter_str + ";\n";
-		code += "uniform float transmittance_boost;\n";
+		code += "uniform mediump vec4 transmittance_color : hint_color;\n";
+		code += "uniform mediump float transmittance_depth;\n";
+		code += "uniform mediump sampler2D texture_subsurface_transmittance : hint_white," + texfilter_str + ";\n";
+		code += "uniform mediump float transmittance_boost;\n";
 	}
 
 	if (features[FEATURE_BACKLIGHT]) {
-		code += "uniform vec4 backlight : hint_color;\n";
-		code += "uniform sampler2D texture_backlight : hint_black," + texfilter_str + ";\n";
+		code += "uniform mediump vec4 backlight : hint_color;\n";
+		code += "uniform mediump sampler2D texture_backlight : hint_black," + texfilter_str + ";\n";
 	}
 
 	if (features[FEATURE_HEIGHT_MAPPING]) {
-		code += "uniform sampler2D texture_heightmap : hint_black," + texfilter_str + ";\n";
-		code += "uniform float heightmap_scale;\n";
+		code += "uniform mediump sampler2D texture_heightmap : hint_black," + texfilter_str + ";\n";
+		code += "uniform mediump float heightmap_scale;\n";
 		code += "uniform int heightmap_min_layers;\n";
 		code += "uniform int heightmap_max_layers;\n";
-		code += "uniform vec2 heightmap_flip;\n";
+		code += "uniform mediump vec2 heightmap_flip;\n";
 	}
 	if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-		code += "varying vec3 uv1_triplanar_pos;\n";
+		code += "varying highp vec3 uv1_triplanar_pos;\n";
 	}
 	if (flags[FLAG_UV2_USE_TRIPLANAR]) {
-		code += "varying vec3 uv2_triplanar_pos;\n";
+		code += "varying highp vec3 uv2_triplanar_pos;\n";
 	}
 	if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-		code += "uniform float uv1_blend_sharpness;\n";
-		code += "varying vec3 uv1_power_normal;\n";
+		code += "uniform mediump float uv1_blend_sharpness;\n";
+		code += "varying mediump vec3 uv1_power_normal;\n";
 	}
 
 	if (flags[FLAG_UV2_USE_TRIPLANAR]) {
-		code += "uniform float uv2_blend_sharpness;\n";
-		code += "varying vec3 uv2_power_normal;\n";
+		code += "uniform mediump float uv2_blend_sharpness;\n";
+		code += "varying mediump vec3 uv2_power_normal;\n";
 	}
 
-	code += "uniform vec3 uv1_scale;\n";
-	code += "uniform vec3 uv1_offset;\n";
-	code += "uniform vec3 uv2_scale;\n";
-	code += "uniform vec3 uv2_offset;\n";
+	code += "uniform mediump vec3 uv1_scale;\n";
+	code += "uniform mediump vec3 uv1_offset;\n";
+	code += "uniform mediump vec3 uv2_scale;\n";
+	code += "uniform mediump vec3 uv2_offset;\n";
 
 	code += "\n\n";
 
@@ -888,8 +888,8 @@ void BaseMaterial3D::_update_shader() {
 	code += "}\n";
 	code += "\n\n";
 	if (flags[FLAG_UV1_USE_TRIPLANAR] || flags[FLAG_UV2_USE_TRIPLANAR]) {
-		code += "vec4 triplanar_texture(sampler2D p_sampler,vec3 p_weights,vec3 p_triplanar_pos) {\n";
-		code += "	vec4 samp=vec4(0.0);\n";
+		code += "mediump vec4 triplanar_texture(sampler2D p_sampler,mediump vec3 p_weights,highp vec3 p_triplanar_pos) {\n";
+		code += "	mediump vec4 samp=vec4(0.0);\n";
 		code += "	samp+= texture(p_sampler,p_triplanar_pos.xy) * p_weights.z;\n";
 		code += "	samp+= texture(p_sampler,p_triplanar_pos.xz) * p_weights.y;\n";
 		code += "	samp+= texture(p_sampler,p_triplanar_pos.zy * vec2(-1.0,1.0)) * p_weights.x;\n";
@@ -900,11 +900,11 @@ void BaseMaterial3D::_update_shader() {
 	code += "void fragment() {\n";
 
 	if (!flags[FLAG_UV1_USE_TRIPLANAR]) {
-		code += "	vec2 base_uv = UV;\n";
+		code += "	highp vec2 base_uv = UV;\n";
 	}
 
 	if ((features[FEATURE_DETAIL] && detail_uv == DETAIL_UV_2) || (features[FEATURE_AMBIENT_OCCLUSION] && flags[FLAG_AO_ON_UV2]) || (features[FEATURE_EMISSION] && flags[FLAG_EMISSION_ON_UV2])) {
-		code += "	vec2 base_uv2 = UV2;\n";
+		code += "	highp vec2 base_uv2 = UV2;\n";
 	}
 
 	if (features[FEATURE_HEIGHT_MAPPING] && flags[FLAG_UV1_USE_TRIPLANAR]) {
@@ -923,7 +923,7 @@ void BaseMaterial3D::_update_shader() {
 
 	if (!RenderingServer::get_singleton()->is_low_end() && features[FEATURE_HEIGHT_MAPPING] && !flags[FLAG_UV1_USE_TRIPLANAR]) { //heightmap not supported with triplanar
 		code += "	{\n";
-		code += "		vec3 view_dir = normalize(normalize(-VERTEX)*mat3(TANGENT*heightmap_flip.x,-BINORMAL*heightmap_flip.y,NORMAL));\n"; // binormal is negative due to mikktspace, flip 'unflips' it ;-)
+		code += "		mediump vec3 view_dir = normalize(normalize(-VERTEX)*mat3(TANGENT*heightmap_flip.x,-BINORMAL*heightmap_flip.y,NORMAL));\n"; // binormal is negative due to mikktspace, flip 'unflips' it ;-)
 
 		if (deep_parallax) {
 			code += "		float num_layers = mix(float(heightmap_max_layers),float(heightmap_min_layers), abs(dot(vec3(0.0, 0.0, 1.0), view_dir)));\n";
@@ -977,12 +977,12 @@ void BaseMaterial3D::_update_shader() {
 	}
 
 	if (flags[FLAG_USE_POINT_SIZE]) {
-		code += "	vec4 albedo_tex = texture(texture_albedo,POINT_COORD);\n";
+		code += "	mediump vec4 albedo_tex = texture(texture_albedo,POINT_COORD);\n";
 	} else {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	vec4 albedo_tex = triplanar_texture(texture_albedo,uv1_power_normal,uv1_triplanar_pos);\n";
+			code += "	mediump vec4 albedo_tex = triplanar_texture(texture_albedo,uv1_power_normal,uv1_triplanar_pos);\n";
 		} else {
-			code += "	vec4 albedo_tex = texture(texture_albedo,base_uv);\n";
+			code += "	mediump vec4 albedo_tex = texture(texture_albedo,base_uv);\n";
 		}
 	}
 
@@ -997,44 +997,44 @@ void BaseMaterial3D::_update_shader() {
 
 	if (!orm) {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	float metallic_tex = dot(triplanar_texture(texture_metallic,uv1_power_normal,uv1_triplanar_pos),metallic_texture_channel);\n";
+			code += "	mediump float metallic_tex = dot(triplanar_texture(texture_metallic,uv1_power_normal,uv1_triplanar_pos),metallic_texture_channel);\n";
 		} else {
-			code += "	float metallic_tex = dot(texture(texture_metallic,base_uv),metallic_texture_channel);\n";
+			code += "	mediump float metallic_tex = dot(texture(texture_metallic,base_uv),metallic_texture_channel);\n";
 		}
 		code += "	METALLIC = metallic_tex * metallic;\n";
 
 		switch (roughness_texture_channel) {
 			case TEXTURE_CHANNEL_RED: {
-				code += "	vec4 roughness_texture_channel = vec4(1.0,0.0,0.0,0.0);\n";
+				code += "	lowp vec4 roughness_texture_channel = vec4(1.0,0.0,0.0,0.0);\n";
 			} break;
 			case TEXTURE_CHANNEL_GREEN: {
-				code += "	vec4 roughness_texture_channel = vec4(0.0,1.0,0.0,0.0);\n";
+				code += "	lowp vec4 roughness_texture_channel = vec4(0.0,1.0,0.0,0.0);\n";
 			} break;
 			case TEXTURE_CHANNEL_BLUE: {
-				code += "	vec4 roughness_texture_channel = vec4(0.0,0.0,1.0,0.0);\n";
+				code += "	lowp vec4 roughness_texture_channel = vec4(0.0,0.0,1.0,0.0);\n";
 			} break;
 			case TEXTURE_CHANNEL_ALPHA: {
-				code += "	vec4 roughness_texture_channel = vec4(0.0,0.0,0.0,1.0);\n";
+				code += "	lowp vec4 roughness_texture_channel = vec4(0.0,0.0,0.0,1.0);\n";
 			} break;
 			case TEXTURE_CHANNEL_GRAYSCALE: {
-				code += "	vec4 roughness_texture_channel = vec4(0.333333,0.333333,0.333333,0.0);\n";
+				code += "	lowp vec4 roughness_texture_channel = vec4(0.333333,0.333333,0.333333,0.0);\n";
 			} break;
 			case TEXTURE_CHANNEL_MAX:
 				break; // Internal value, skip.
 		}
 
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	float roughness_tex = dot(triplanar_texture(texture_roughness,uv1_power_normal,uv1_triplanar_pos),roughness_texture_channel);\n";
+			code += "	mediump float roughness_tex = dot(triplanar_texture(texture_roughness,uv1_power_normal,uv1_triplanar_pos),roughness_texture_channel);\n";
 		} else {
-			code += "	float roughness_tex = dot(texture(texture_roughness,base_uv),roughness_texture_channel);\n";
+			code += "	mediump float roughness_tex = dot(texture(texture_roughness,base_uv),roughness_texture_channel);\n";
 		}
 		code += "	ROUGHNESS = roughness_tex * roughness;\n";
 		code += "	SPECULAR = specular;\n";
 	} else {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	vec4 orm_tex = triplanar_texture(texture_orm,uv1_power_normal,uv1_triplanar_pos);\n";
+			code += "	mediump vec4 orm_tex = triplanar_texture(texture_orm,uv1_power_normal,uv1_triplanar_pos);\n";
 		} else {
-			code += "	vec4 orm_tex = texture(texture_orm,base_uv);\n";
+			code += "	mediump vec4 orm_tex = texture(texture_orm,base_uv);\n";
 		}
 
 		code += "	ROUGHNESS = orm_tex.g;\n";
@@ -1053,15 +1053,15 @@ void BaseMaterial3D::_update_shader() {
 	if (features[FEATURE_EMISSION]) {
 		if (flags[FLAG_EMISSION_ON_UV2]) {
 			if (flags[FLAG_UV2_USE_TRIPLANAR]) {
-				code += "	vec3 emission_tex = triplanar_texture(texture_emission,uv2_power_normal,uv2_triplanar_pos).rgb;\n";
+				code += "	mediump vec3 emission_tex = triplanar_texture(texture_emission,uv2_power_normal,uv2_triplanar_pos).rgb;\n";
 			} else {
-				code += "	vec3 emission_tex = texture(texture_emission,base_uv2).rgb;\n";
+				code += "	mediump vec3 emission_tex = texture(texture_emission,base_uv2).rgb;\n";
 			}
 		} else {
 			if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-				code += "	vec3 emission_tex = triplanar_texture(texture_emission,uv1_power_normal,uv1_triplanar_pos).rgb;\n";
+				code += "	mediump vec3 emission_tex = triplanar_texture(texture_emission,uv1_power_normal,uv1_triplanar_pos).rgb;\n";
 			} else {
-				code += "	vec3 emission_tex = texture(texture_emission,base_uv).rgb;\n";
+				code += "	mediump vec3 emission_tex = texture(texture_emission,base_uv).rgb;\n";
 			}
 		}
 
@@ -1074,17 +1074,17 @@ void BaseMaterial3D::_update_shader() {
 
 	if (features[FEATURE_REFRACTION]) {
 		if (features[FEATURE_NORMAL_MAPPING]) {
-			code += "	vec3 unpacked_normal = NORMAL_MAP;\n";
+			code += "	mediump vec3 unpacked_normal = NORMAL_MAP;\n";
 			code += "	unpacked_normal.xy = unpacked_normal.xy * 2.0 - 1.0;\n";
 			code += "	unpacked_normal.z = sqrt(max(0.0, 1.0 - dot(unpacked_normal.xy, unpacked_normal.xy)));\n";
-			code += "	vec3 ref_normal = normalize( mix(NORMAL,TANGENT * unpacked_normal.x + BINORMAL * unpacked_normal.y + NORMAL * unpacked_normal.z,NORMAL_MAP_DEPTH) );\n";
+			code += "	mediump vec3 ref_normal = normalize( mix(NORMAL,TANGENT * unpacked_normal.x + BINORMAL * unpacked_normal.y + NORMAL * unpacked_normal.z,NORMAL_MAP_DEPTH) );\n";
 		} else {
-			code += "	vec3 ref_normal = NORMAL;\n";
+			code += "	mediump vec3 ref_normal = NORMAL;\n";
 		}
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	vec2 ref_ofs = SCREEN_UV - ref_normal.xy * dot(triplanar_texture(texture_refraction,uv1_power_normal,uv1_triplanar_pos),refraction_texture_channel) * refraction;\n";
+			code += "	highp vec2 ref_ofs = SCREEN_UV - ref_normal.xy * dot(triplanar_texture(texture_refraction,uv1_power_normal,uv1_triplanar_pos),refraction_texture_channel) * refraction;\n";
 		} else {
-			code += "	vec2 ref_ofs = SCREEN_UV - ref_normal.xy * dot(texture(texture_refraction,base_uv),refraction_texture_channel) * refraction;\n";
+			code += "	highp vec2 ref_ofs = SCREEN_UV - ref_normal.xy * dot(texture(texture_refraction,base_uv),refraction_texture_channel) * refraction;\n";
 		}
 		code += "	float ref_amount = 1.0 - albedo.a * albedo_tex.a;\n";
 		code += "	EMISSION += textureLod(SCREEN_TEXTURE,ref_ofs,ROUGHNESS * 8.0).rgb * ref_amount;\n";
@@ -1105,8 +1105,8 @@ void BaseMaterial3D::_update_shader() {
 	}
 
 	if (proximity_fade_enabled) {
-		code += "	float depth_tex = textureLod(DEPTH_TEXTURE,SCREEN_UV,0.0).r;\n";
-		code += "	vec4 world_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV*2.0-1.0,depth_tex*2.0-1.0,1.0);\n";
+		code += "	highp float depth_tex = textureLod(DEPTH_TEXTURE,SCREEN_UV,0.0).r;\n";
+		code += "	highp vec4 world_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV*2.0-1.0,depth_tex*2.0-1.0,1.0);\n";
 		code += "	world_pos.xyz/=world_pos.w;\n";
 		code += "	ALPHA*=clamp(1.0-smoothstep(world_pos.z+proximity_fade_distance,world_pos.z,VERTEX.z),0.0,1.0);\n";
 	}
@@ -1116,17 +1116,17 @@ void BaseMaterial3D::_update_shader() {
 			if (!RenderingServer::get_singleton()->is_low_end()) {
 				code += "	{\n";
 				if (distance_fade == DISTANCE_FADE_OBJECT_DITHER) {
-					code += "		float fade_distance = abs((INV_CAMERA_MATRIX * WORLD_MATRIX[3]).z);\n";
+					code += "		highp float fade_distance = abs((INV_CAMERA_MATRIX * WORLD_MATRIX[3]).z);\n";
 
 				} else {
-					code += "		float fade_distance=-VERTEX.z;\n";
+					code += "		highp float fade_distance=-VERTEX.z;\n";
 				}
 
-				code += "		float fade=clamp(smoothstep(distance_fade_min,distance_fade_max,fade_distance),0.0,1.0);\n";
+				code += "		mediump float fade=clamp(smoothstep(distance_fade_min,distance_fade_max,fade_distance),0.0,1.0);\n";
 				code += "		int x = int(FRAGCOORD.x) % 4;\n";
 				code += "		int y = int(FRAGCOORD.y) % 4;\n";
 				code += "		int index = x + y * 4;\n";
-				code += "		float limit = 0.0;\n\n";
+				code += "		mediump float limit = 0.0;\n\n";
 				code += "		if (x < 8) {\n";
 				code += "			if (index == 0) limit = 0.0625;\n";
 				code += "			if (index == 1) limit = 0.5625;\n";
@@ -1157,9 +1157,9 @@ void BaseMaterial3D::_update_shader() {
 
 	if (features[FEATURE_RIM]) {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	vec2 rim_tex = triplanar_texture(texture_rim,uv1_power_normal,uv1_triplanar_pos).xy;\n";
+			code += "	mediump vec2 rim_tex = triplanar_texture(texture_rim,uv1_power_normal,uv1_triplanar_pos).xy;\n";
 		} else {
-			code += "	vec2 rim_tex = texture(texture_rim,base_uv).xy;\n";
+			code += "	mediump vec2 rim_tex = texture(texture_rim,base_uv).xy;\n";
 		}
 		code += "	RIM = rim*rim_tex.x;";
 		code += "	RIM_TINT = rim_tint*rim_tex.y;\n";
@@ -1167,9 +1167,9 @@ void BaseMaterial3D::_update_shader() {
 
 	if (features[FEATURE_CLEARCOAT]) {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	vec2 clearcoat_tex = triplanar_texture(texture_clearcoat,uv1_power_normal,uv1_triplanar_pos).xy;\n";
+			code += "	mediump vec2 clearcoat_tex = triplanar_texture(texture_clearcoat,uv1_power_normal,uv1_triplanar_pos).xy;\n";
 		} else {
-			code += "	vec2 clearcoat_tex = texture(texture_clearcoat,base_uv).xy;\n";
+			code += "	mediump vec2 clearcoat_tex = texture(texture_clearcoat,base_uv).xy;\n";
 		}
 		code += "	CLEARCOAT = clearcoat*clearcoat_tex.x;";
 		code += "	CLEARCOAT_GLOSS = clearcoat_gloss*clearcoat_tex.y;\n";
@@ -1177,9 +1177,9 @@ void BaseMaterial3D::_update_shader() {
 
 	if (features[FEATURE_ANISOTROPY]) {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	vec3 anisotropy_tex = triplanar_texture(texture_flowmap,uv1_power_normal,uv1_triplanar_pos).rga;\n";
+			code += "	mediump vec3 anisotropy_tex = triplanar_texture(texture_flowmap,uv1_power_normal,uv1_triplanar_pos).rga;\n";
 		} else {
-			code += "	vec3 anisotropy_tex = texture(texture_flowmap,base_uv).rga;\n";
+			code += "	mediump vec3 anisotropy_tex = texture(texture_flowmap,base_uv).rga;\n";
 		}
 		code += "	ANISOTROPY = anisotropy_ratio*anisotropy_tex.b;\n";
 		code += "	ANISOTROPY_FLOW = anisotropy_tex.rg*2.0-1.0;\n";
@@ -1209,18 +1209,18 @@ void BaseMaterial3D::_update_shader() {
 
 	if (features[FEATURE_SUBSURFACE_SCATTERING]) {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	float sss_tex = triplanar_texture(texture_subsurface_scattering,uv1_power_normal,uv1_triplanar_pos).r;\n";
+			code += "	mediump float sss_tex = triplanar_texture(texture_subsurface_scattering,uv1_power_normal,uv1_triplanar_pos).r;\n";
 		} else {
-			code += "	float sss_tex = texture(texture_subsurface_scattering,base_uv).r;\n";
+			code += "	mediump float sss_tex = texture(texture_subsurface_scattering,base_uv).r;\n";
 		}
 		code += "	SSS_STRENGTH=subsurface_scattering_strength*sss_tex;\n";
 	}
 
 	if (features[FEATURE_SUBSURFACE_TRANSMITTANCE]) {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	vec4 trans_color_tex = triplanar_texture(texture_subsurface_transmittance,uv1_power_normal,uv1_triplanar_pos);\n";
+			code += "	mediump vec4 trans_color_tex = triplanar_texture(texture_subsurface_transmittance,uv1_power_normal,uv1_triplanar_pos);\n";
 		} else {
-			code += "	vec4 trans_color_tex = texture(texture_subsurface_transmittance,base_uv);\n";
+			code += "	mediump vec4 trans_color_tex = texture(texture_subsurface_transmittance,base_uv);\n";
 		}
 		code += "	SSS_TRANSMITTANCE_COLOR=transmittance_color*trans_color_tex;\n";
 
@@ -1230,9 +1230,9 @@ void BaseMaterial3D::_update_shader() {
 
 	if (features[FEATURE_BACKLIGHT]) {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	vec3 backlight_tex = triplanar_texture(texture_backlight,uv1_power_normal,uv1_triplanar_pos).rgb;\n";
+			code += "	mediump vec3 backlight_tex = triplanar_texture(texture_backlight,uv1_power_normal,uv1_triplanar_pos).rgb;\n";
 		} else {
-			code += "	vec3 backlight_tex = texture(texture_backlight,base_uv).rgb;\n";
+			code += "	mediump vec3 backlight_tex = texture(texture_backlight,base_uv).rgb;\n";
 		}
 		code += "	BACKLIGHT = (backlight.rgb+backlight_tex);\n";
 	}
@@ -1242,39 +1242,39 @@ void BaseMaterial3D::_update_shader() {
 
 		if (triplanar) {
 			String tp_uv = detail_uv == DETAIL_UV_1 ? "uv1" : "uv2";
-			code += "	vec4 detail_tex = triplanar_texture(texture_detail_albedo," + tp_uv + "_power_normal," + tp_uv + "_triplanar_pos);\n";
-			code += "	vec4 detail_norm_tex = triplanar_texture(texture_detail_normal," + tp_uv + "_power_normal," + tp_uv + "_triplanar_pos);\n";
+			code += "	mediump vec4 detail_tex = triplanar_texture(texture_detail_albedo," + tp_uv + "_power_normal," + tp_uv + "_triplanar_pos);\n";
+			code += "	mediump vec4 detail_norm_tex = triplanar_texture(texture_detail_normal," + tp_uv + "_power_normal," + tp_uv + "_triplanar_pos);\n";
 
 		} else {
 			String det_uv = detail_uv == DETAIL_UV_1 ? "base_uv" : "base_uv2";
-			code += "	vec4 detail_tex = texture(texture_detail_albedo," + det_uv + ");\n";
-			code += "	vec4 detail_norm_tex = texture(texture_detail_normal," + det_uv + ");\n";
+			code += "	mediump vec4 detail_tex = texture(texture_detail_albedo," + det_uv + ");\n";
+			code += "	mediump vec4 detail_norm_tex = texture(texture_detail_normal," + det_uv + ");\n";
 		}
 
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-			code += "	vec4 detail_mask_tex = triplanar_texture(texture_detail_mask,uv1_power_normal,uv1_triplanar_pos);\n";
+			code += "	mediump vec4 detail_mask_tex = triplanar_texture(texture_detail_mask,uv1_power_normal,uv1_triplanar_pos);\n";
 		} else {
-			code += "	vec4 detail_mask_tex = texture(texture_detail_mask,base_uv);\n";
+			code += "	mediump vec4 detail_mask_tex = texture(texture_detail_mask,base_uv);\n";
 		}
 
 		switch (detail_blend_mode) {
 			case BLEND_MODE_MIX: {
-				code += "	vec3 detail = mix(ALBEDO.rgb,detail_tex.rgb,detail_tex.a);\n";
+				code += "	mediump vec3 detail = mix(ALBEDO.rgb,detail_tex.rgb,detail_tex.a);\n";
 			} break;
 			case BLEND_MODE_ADD: {
-				code += "	vec3 detail = mix(ALBEDO.rgb,ALBEDO.rgb+detail_tex.rgb,detail_tex.a);\n";
+				code += "	mediump vec3 detail = mix(ALBEDO.rgb,ALBEDO.rgb+detail_tex.rgb,detail_tex.a);\n";
 			} break;
 			case BLEND_MODE_SUB: {
-				code += "	vec3 detail = mix(ALBEDO.rgb,ALBEDO.rgb-detail_tex.rgb,detail_tex.a);\n";
+				code += "	mediump vec3 detail = mix(ALBEDO.rgb,ALBEDO.rgb-detail_tex.rgb,detail_tex.a);\n";
 			} break;
 			case BLEND_MODE_MUL: {
-				code += "	vec3 detail = mix(ALBEDO.rgb,ALBEDO.rgb*detail_tex.rgb,detail_tex.a);\n";
+				code += "	mediump vec3 detail = mix(ALBEDO.rgb,ALBEDO.rgb*detail_tex.rgb,detail_tex.a);\n";
 			} break;
 			case BLEND_MODE_MAX:
 				break; // Internal value, skip.
 		}
 
-		code += "	vec3 detail_norm = mix(NORMAL_MAP,detail_norm_tex.rgb,detail_tex.a);\n";
+		code += "	mediump vec3 detail_norm = mix(NORMAL_MAP,detail_norm_tex.rgb,detail_tex.a);\n";
 		code += "	NORMAL_MAP = mix(NORMAL_MAP,detail_norm,detail_mask_tex.r);\n";
 		code += "	ALBEDO.rgb = mix(ALBEDO.rgb,detail,detail_mask_tex.r);\n";
 	}

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -433,6 +433,8 @@ float sample_directional_soft_shadow(texture2D shadow, vec3 pssm_coord, vec2 tex
 
 #endif //USE_NO_SHADOWS
 
+precision mediump float;
+
 float get_omni_attenuation(float distance, float inv_range, float decay) {
 	float nd = distance * inv_range;
 	nd *= nd;

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile_inc.glsl
@@ -1,5 +1,6 @@
 #define M_PI 3.14159265359
 #define MAX_VIEWS 2
+#define MEDIUMP_FLT_MAX 65504.0
 
 #if defined(USE_MULTIVIEW) && defined(has_VK_KHR_multiview)
 #extension GL_EXT_multiview : enable
@@ -210,7 +211,7 @@ layout(set = 1, binding = 4) uniform highp texture2D shadow_atlas;
 layout(set = 1, binding = 5) uniform highp texture2D directional_shadow_atlas;
 
 // this needs to change to providing just the lightmap we're using..
-layout(set = 1, binding = 6) uniform texture2DArray lightmap_textures[MAX_LIGHTMAP_TEXTURES];
+layout(set = 1, binding = 6) uniform mediump texture2DArray lightmap_textures[MAX_LIGHTMAP_TEXTURES];
 
 layout(set = 1, binding = 9) uniform highp texture2D depth_buffer;
 layout(set = 1, binding = 10) uniform mediump texture2D color_buffer;

--- a/servers/rendering/renderer_rd/shaders/scene_mobile_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_mobile_lights_inc.glsl
@@ -1,0 +1,616 @@
+
+
+vec3 F0(float metallic, float specular, vec3 albedo) {
+	float dielectric = 0.16 * specular * specular;
+	// use albedo * metallic as colored specular reflectance at 0 angle for metallic materials;
+	// see https://google.github.io/filament/Filament.md.html
+	return mix(vec3(dielectric), albedo, vec3(metallic));
+}
+
+// Optimized version based on Lagrange's identity
+// see: https://github.com/google/filament/blob/main/shaders/src/brdf.fs
+float D_GGX(float roughness, float NoH, const vec3 h) {
+	float oneMinusNoHSquared = 1.0 - NoH * NoH;
+	float a = NoH * roughness;
+	float k = roughness / (oneMinusNoHSquared + a * a);
+	float d = k * k * (1.0 / M_PI);
+	return min(d, MEDIUMP_FLT_MAX);
+}
+
+float D_GGX_Anisotropic(float at, float ab, float ToH, float BoH, float NoH) {
+	// Burley 2012, "Physically-Based Shading at Disney"
+
+	// The values at and ab are perceptualRoughness^2, a2 is therefore perceptualRoughness^4
+	// The dot product below computes perceptualRoughness^8. We cannot fit in fp16 without clamping
+	// the roughness to too high values so we perform the dot product and the division in fp32
+	float a2 = at * ab;
+	highp vec3 d = vec3(ab * ToH, at * BoH, a2 * NoH);
+	highp float d2 = dot(d, d);
+	float b2 = a2 / d2;
+	return a2 * b2 * b2 * (1.0 / M_PI);
+}
+
+float V_SmithGGXCorrelated_Fast(float roughness, float NoV, float NoL) {
+	// Hammon 2017, "PBR Diffuse Lighting for GGX+Smith Microsurfaces"
+	float v = 0.5 / mix(2.0 * NoL * NoV, NoL + NoV, roughness);
+	return min(v, MEDIUMP_FLT_MAX);
+}
+
+vec3 F_Schlick(const vec3 f0, float VoH) {
+	float f = pow(1.0 - VoH, 5.0);
+	return f + f0 * (1.0 - f);
+}
+
+float sample_directional_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec4 coord) {
+	vec2 pos = coord.xy;
+	float depth = coord.z;
+
+	return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
+}
+
+float sample_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec4 coord) {
+	vec2 pos = coord.xy;
+	float depth = coord.z;
+
+	return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
+}
+
+void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, float attenuation, vec3 f0, float metallic, float roughness, float specular_amount,
+#ifdef LIGHT_BACKLIGHT_USED
+		vec3 backlight,
+#endif
+#ifdef LIGHT_TRANSMITTANCE_USED
+		vec4 transmittance_color,
+		float transmittance_depth,
+		float transmittance_boost,
+		float transmittance_z,
+#endif
+#ifdef LIGHT_RIM_USED
+		float rim, float rim_tint, vec3 rim_color,
+#endif
+#ifdef LIGHT_CLEARCOAT_USED
+		float clearcoat, float clearcoat_gloss,
+#endif
+#ifdef LIGHT_ANISOTROPY_USED
+		vec3 B, vec3 T, float anisotropy,
+#endif
+#ifdef USE_SHADOW_TO_OPACITY
+		inout float alpha,
+#endif
+		inout vec3 diffuse_light, inout vec3 specular_light) {
+
+#if defined(LIGHT_CODE_USED)
+	// light is written by the light shader
+
+	vec3 normal = N;
+	vec3 light = L;
+	vec3 view = V;
+
+#CODE : LIGHT
+
+#else
+
+	float NdotL = min(dot(N, L), 1.0);
+	float cNdotL = max(NdotL, 0.0); // clamped NdotL
+	float NdotV = dot(N, V);
+	float cNdotV = max(NdotV, 0.0);
+
+#if defined(SPECULAR_SCHLICK_GGX) || defined(LIGHT_CLEARCOAT_USED)
+	vec3 H = normalize(V + L);
+#endif
+
+#if defined(SPECULAR_SCHLICK_GGX) || defined(LIGHT_CLEARCOAT_USED)
+	float cNdotH = clamp(dot(N, H), 0.0, 1.0);
+#endif
+
+#if defined(SPECULAR_SCHLICK_GGX) || defined(LIGHT_CLEARCOAT_USED)
+	float cLdotH = clamp(dot(L, H), 0.0, 1.0);
+#endif
+
+	if (metallic < 1.0) {
+		float diffuse_brdf_NL; // BRDF times N.L for calculating diffuse radiance
+
+#if defined(DIFFUSE_LAMBERT_WRAP)
+		// energy conserving lambert wrap shader
+		diffuse_brdf_NL = max(0.0, (NdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness)));
+#elif defined(DIFFUSE_TOON)
+
+		diffuse_brdf_NL = smoothstep(-roughness, max(roughness, 0.01), NdotL);
+#else
+		// lambert
+		diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
+#endif
+
+		diffuse_light += light_color * diffuse_brdf_NL * attenuation;
+
+#if defined(LIGHT_BACKLIGHT_USED)
+		diffuse_light += light_color * (vec3(1.0 / M_PI) - diffuse_brdf_NL) * backlight * attenuation;
+#endif
+
+#if defined(LIGHT_RIM_USED)
+		float rim_light = pow(max(0.0, 1.0 - cNdotV), max(0.0, (1.0 - roughness) * 16.0));
+		diffuse_light += rim_light * rim * mix(vec3(1.0), rim_color, rim_tint) * light_color;
+#endif
+	}
+
+	if (roughness > 0.0) { // FIXME: roughness == 0 should not disable specular light entirely
+
+#if defined(SPECULAR_TOON)
+
+		vec3 R = normalize(-reflect(L, N));
+		float RdotV = dot(R, V);
+		float mid = 1.0 - roughness;
+		mid *= mid;
+		float intensity = smoothstep(mid - roughness * 0.5, mid + roughness * 0.5, RdotV) * mid;
+		diffuse_light += light_color * intensity * attenuation * specular_amount; // write to diffuse_light, as in toon shading you generally want no reflection
+
+#elif defined(SPECULAR_DISABLED)
+		// none..
+
+#elif defined(SPECULAR_SCHLICK_GGX)
+		// shlick+ggx as default
+
+		float alpha_ggx = roughness * roughness;
+
+		float D = D_GGX(alpha_ggx, cNdotH, H);
+		float V = V_SmithGGXCorrelated_Fast(alpha_ggx, cNdotV, cNdotL);
+		vec3 F = F_Schlick(f0, cLdotH);
+
+		vec3 specular_brdf_NL = cNdotL * D * V * F;
+
+		specular_light += specular_brdf_NL * light_color * attenuation * specular_amount;
+#endif
+	}
+
+#ifdef USE_SHADOW_TO_OPACITY
+	alpha = min(alpha, clamp(1.0 - attenuation), 0.0, 1.0));
+#endif
+
+#endif //defined(LIGHT_CODE_USED)
+}
+
+float get_omni_attenuation(float distance, float inv_range, float decay) {
+	float nd = distance * inv_range;
+	nd *= nd;
+	nd *= nd; // nd^4
+	nd = max(1.0 - nd, 0.0);
+	nd *= nd; // nd^2
+	return nd * pow(max(distance, 0.0001), -decay);
+}
+
+float light_process_omni_shadow(uint idx, highp vec3 vertex, vec3 normal) {
+#ifndef USE_NO_SHADOWS
+	if (omni_lights.data[idx].shadow_enabled) {
+		// there is a shadowmap
+
+		highp vec3 light_rel_vec = omni_lights.data[idx].position - vertex;
+		highp float light_length = length(light_rel_vec);
+
+		highp vec4 v = vec4(vertex, 1.0);
+
+		highp vec4 splane = (omni_lights.data[idx].shadow_matrix * v);
+
+		highp float shadow_len = length(splane.xyz); //need to remember shadow len from here
+
+		float shadow;
+
+		splane.xyz = normalize(splane.xyz);
+		highp vec4 clamp_rect = omni_lights.data[idx].atlas_rect;
+
+		if (splane.z >= 0.0) {
+			splane.z += 1.0;
+
+			clamp_rect.y += clamp_rect.w;
+
+		} else {
+			splane.z = 1.0 - splane.z;
+		}
+
+		splane.xy /= splane.z;
+
+		splane.xy = splane.xy * 0.5 + 0.5;
+		splane.z = shadow_len * omni_lights.data[idx].inv_radius;
+		splane.z -= omni_lights.data[idx].shadow_bias;
+		splane.xy = clamp_rect.xy + splane.xy * clamp_rect.zw;
+		splane.w = 1.0; //needed? i think it should be 1 already
+		shadow = sample_pcf_shadow(shadow_atlas, omni_lights.data[idx].soft_shadow_scale * scene_data.shadow_atlas_pixel_size, splane);
+
+		return shadow;
+	}
+#endif
+
+	return 1.0;
+}
+
+void light_process_omni(uint idx, highp vec3 vertex, vec3 eye_vec, vec3 normal, highp vec3 vertex_ddx, highp vec3 vertex_ddy, vec3 f0, float metallic, float roughness, float shadow,
+#ifdef LIGHT_BACKLIGHT_USED
+		vec3 backlight,
+#endif
+#ifdef LIGHT_TRANSMITTANCE_USED
+		vec4 transmittance_color,
+		float transmittance_depth,
+		float transmittance_boost,
+#endif
+#ifdef LIGHT_RIM_USED
+		float rim, float rim_tint, vec3 rim_color,
+#endif
+#ifdef LIGHT_CLEARCOAT_USED
+		float clearcoat, float clearcoat_gloss,
+#endif
+#ifdef LIGHT_ANISOTROPY_USED
+		vec3 binormal, vec3 tangent, float anisotropy,
+#endif
+#ifdef USE_SHADOW_TO_OPACITY
+		inout float alpha,
+#endif
+		inout vec3 diffuse_light, inout vec3 specular_light) {
+	vec3 light_rel_vec = omni_lights.data[idx].position - vertex;
+	float light_length = length(light_rel_vec);
+	float omni_attenuation = get_omni_attenuation(light_length, omni_lights.data[idx].inv_radius, omni_lights.data[idx].attenuation);
+	float light_attenuation = omni_attenuation;
+	vec3 color = omni_lights.data[idx].color;
+
+#ifdef LIGHT_TRANSMITTANCE_USED
+	float transmittance_z = transmittance_depth; //no transmittance by default
+	transmittance_color.a *= light_attenuation;
+	{
+		highp vec4 clamp_rect = omni_lights.data[idx].atlas_rect;
+
+		//redo shadowmapping, but shrink the model a bit to avoid arctifacts
+		highp vec4 splane = (omni_lights.data[idx].shadow_matrix * vec4(vertex - normalize(normal_interp) * omni_lights.data[idx].transmittance_bias, 1.0));
+
+		highp float shadow_len = length(splane.xyz);
+		splane.xyz = normalize(splane.xyz);
+
+		if (splane.z >= 0.0) {
+			splane.z += 1.0;
+			clamp_rect.y += clamp_rect.w;
+		} else {
+			splane.z = 1.0 - splane.z;
+		}
+
+		splane.xy /= splane.z;
+
+		splane.xy = splane.xy * 0.5 + 0.5;
+		splane.z = shadow_len * omni_lights.data[idx].inv_radius;
+		splane.xy = clamp_rect.xy + splane.xy * clamp_rect.zw;
+		//		splane.xy = clamp(splane.xy,clamp_rect.xy + scene_data.shadow_atlas_pixel_size,clamp_rect.xy + clamp_rect.zw - scene_data.shadow_atlas_pixel_size );
+		splane.w = 1.0; //needed? i think it should be 1 already
+
+		float shadow_z = textureLod(sampler2D(shadow_atlas, material_samplers[SAMPLER_LINEAR_CLAMP]), splane.xy, 0.0).r;
+		transmittance_z = (splane.z - shadow_z) / omni_lights.data[idx].inv_radius;
+	}
+#endif
+
+	if (sc_use_light_projector && omni_lights.data[idx].projector_rect != vec4(0.0)) {
+		highp vec3 local_v = (omni_lights.data[idx].shadow_matrix * vec4(vertex, 1.0)).xyz;
+		local_v = normalize(local_v);
+
+		highp vec4 atlas_rect = omni_lights.data[idx].projector_rect;
+
+		if (local_v.z >= 0.0) {
+			local_v.z += 1.0;
+			atlas_rect.y += atlas_rect.w;
+
+		} else {
+			local_v.z = 1.0 - local_v.z;
+		}
+
+		local_v.xy /= local_v.z;
+		local_v.xy = local_v.xy * 0.5 + 0.5;
+		highp vec2 proj_uv = local_v.xy * atlas_rect.zw;
+
+		if (sc_projector_use_mipmaps) {
+			highp vec2 proj_uv_ddx;
+			highp vec2 proj_uv_ddy;
+			{
+				highp vec3 local_v_ddx = (omni_lights.data[idx].shadow_matrix * vec4(vertex + vertex_ddx, 1.0)).xyz;
+				local_v_ddx = normalize(local_v_ddx);
+
+				if (local_v_ddx.z >= 0.0) {
+					local_v_ddx.z += 1.0;
+				} else {
+					local_v_ddx.z = 1.0 - local_v_ddx.z;
+				}
+
+				local_v_ddx.xy /= local_v_ddx.z;
+				local_v_ddx.xy = local_v_ddx.xy * 0.5 + 0.5;
+
+				proj_uv_ddx = local_v_ddx.xy * atlas_rect.zw - proj_uv;
+
+				highp vec3 local_v_ddy = (omni_lights.data[idx].shadow_matrix * vec4(vertex + vertex_ddy, 1.0)).xyz;
+				local_v_ddy = normalize(local_v_ddy);
+
+				if (local_v_ddy.z >= 0.0) {
+					local_v_ddy.z += 1.0;
+				} else {
+					local_v_ddy.z = 1.0 - local_v_ddy.z;
+				}
+
+				local_v_ddy.xy /= local_v_ddy.z;
+				local_v_ddy.xy = local_v_ddy.xy * 0.5 + 0.5;
+
+				proj_uv_ddy = local_v_ddy.xy * atlas_rect.zw - proj_uv;
+			}
+
+			highp vec4 proj = textureGrad(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + atlas_rect.xy, proj_uv_ddx, proj_uv_ddy);
+			color *= proj.rgb * proj.a;
+		} else {
+			highp vec4 proj = textureLod(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + atlas_rect.xy, 0.0);
+			color *= proj.rgb * proj.a;
+		}
+	}
+
+	light_attenuation *= shadow;
+
+	light_compute(normal, normalize(light_rel_vec), eye_vec, 0, color, light_attenuation, f0, metallic, roughness, omni_lights.data[idx].specular_amount,
+#ifdef LIGHT_BACKLIGHT_USED
+			backlight,
+#endif
+#ifdef LIGHT_TRANSMITTANCE_USED
+			transmittance_color,
+			transmittance_depth,
+			transmittance_boost,
+			transmittance_z,
+#endif
+#ifdef LIGHT_RIM_USED
+			rim * omni_attenuation, rim_tint, rim_color,
+#endif
+#ifdef LIGHT_CLEARCOAT_USED
+			clearcoat, clearcoat_gloss,
+#endif
+#ifdef LIGHT_ANISOTROPY_USED
+			binormal, tangent, anisotropy,
+#endif
+#ifdef USE_SHADOW_TO_OPACITY
+			alpha,
+#endif
+			diffuse_light,
+			specular_light);
+}
+
+float light_process_spot_shadow(uint idx, highp vec3 vertex, vec3 normal) {
+#ifndef USE_NO_SHADOWS
+	if (spot_lights.data[idx].shadow_enabled) {
+		highp vec3 light_rel_vec = spot_lights.data[idx].position - vertex;
+		highp float light_length = length(light_rel_vec);
+		highp vec3 spot_dir = spot_lights.data[idx].direction;
+		//there is a shadowmap
+		highp vec4 v = vec4(vertex, 1.0);
+
+		float shadow;
+
+		highp vec4 splane = (spot_lights.data[idx].shadow_matrix * v);
+		splane /= splane.w;
+		splane.z -= spot_lights.data[idx].shadow_bias;
+
+		//hard shadow
+		highp vec4 shadow_uv = vec4(splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy, splane.z, 1.0);
+
+		shadow = sample_pcf_shadow(shadow_atlas, spot_lights.data[idx].soft_shadow_scale * scene_data.shadow_atlas_pixel_size, shadow_uv);
+
+		return shadow;
+	}
+
+#endif //USE_NO_SHADOWS
+
+	return 1.0;
+}
+
+vec2 normal_to_panorama(highp vec3 n) {
+	n = normalize(n);
+	highp vec2 panorama_coords = vec2(atan(n.x, n.z), acos(-n.y));
+
+	if (panorama_coords.x < 0.0) {
+		panorama_coords.x += M_PI * 2.0;
+	}
+
+	panorama_coords /= vec2(M_PI * 2.0, M_PI);
+	return panorama_coords;
+}
+
+void light_process_spot(uint idx, highp vec3 vertex, vec3 eye_vec, vec3 normal, highp vec3 vertex_ddx, highp vec3 vertex_ddy, vec3 f0, float metallic, float roughness, float shadow,
+#ifdef LIGHT_BACKLIGHT_USED
+		vec3 backlight,
+#endif
+#ifdef LIGHT_TRANSMITTANCE_USED
+		vec4 transmittance_color,
+		float transmittance_depth,
+		float transmittance_boost,
+#endif
+#ifdef LIGHT_RIM_USED
+		float rim, float rim_tint, vec3 rim_color,
+#endif
+#ifdef LIGHT_CLEARCOAT_USED
+		float clearcoat, float clearcoat_gloss,
+#endif
+#ifdef LIGHT_ANISOTROPY_USED
+		vec3 binormal, vec3 tangent, float anisotropy,
+#endif
+#ifdef USE_SHADOW_TO_OPACITY
+		inout float alpha,
+#endif
+		inout vec3 diffuse_light,
+		inout vec3 specular_light) {
+	highp vec3 light_rel_vec = spot_lights.data[idx].position - vertex;
+	float light_length = length(light_rel_vec);
+	float spot_attenuation = get_omni_attenuation(light_length, spot_lights.data[idx].inv_radius, spot_lights.data[idx].attenuation);
+	vec3 spot_dir = spot_lights.data[idx].direction;
+	float scos = max(dot(-normalize(light_rel_vec), spot_dir), spot_lights.data[idx].cone_angle);
+	float spot_rim = max(0.0001, (1.0 - scos) / (1.0 - spot_lights.data[idx].cone_angle));
+	spot_attenuation *= 1.0 - pow(spot_rim, spot_lights.data[idx].cone_attenuation);
+	float light_attenuation = spot_attenuation;
+	vec3 color = spot_lights.data[idx].color;
+	float specular_amount = spot_lights.data[idx].specular_amount;
+
+#ifdef LIGHT_TRANSMITTANCE_USED
+	float transmittance_z = transmittance_depth;
+	transmittance_color.a *= light_attenuation;
+	{
+		highp vec4 splane = (spot_lights.data[idx].shadow_matrix * vec4(vertex - normalize(normal_interp) * spot_lights.data[idx].transmittance_bias, 1.0));
+		splane /= splane.w;
+		splane.xy = splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy;
+
+		highp float shadow_z = textureLod(sampler2D(shadow_atlas, material_samplers[SAMPLER_LINEAR_CLAMP]), splane.xy, 0.0).r;
+
+		shadow_z = shadow_z * 2.0 - 1.0;
+		highp float z_far = 1.0 / spot_lights.data[idx].inv_radius;
+		highp float z_near = 0.01;
+		shadow_z = 2.0 * z_near * z_far / (z_far + z_near - shadow_z * (z_far - z_near));
+
+		//distance to light plane
+		highp float z = dot(spot_dir, -light_rel_vec);
+		transmittance_z = z - shadow_z;
+	}
+#endif //LIGHT_TRANSMITTANCE_USED
+
+	if (sc_use_light_projector && spot_lights.data[idx].projector_rect != vec4(0.0)) {
+		highp vec4 splane = (spot_lights.data[idx].shadow_matrix * vec4(vertex, 1.0));
+		splane /= splane.w;
+
+		vec2 proj_uv = normal_to_panorama(splane.xyz) * spot_lights.data[idx].projector_rect.zw;
+
+		if (sc_projector_use_mipmaps) {
+			//ensure we have proper mipmaps
+			highp vec4 splane_ddx = (spot_lights.data[idx].shadow_matrix * vec4(vertex + vertex_ddx, 1.0));
+			splane_ddx /= splane_ddx.w;
+			highp vec2 proj_uv_ddx = normal_to_panorama(splane_ddx.xyz) * spot_lights.data[idx].projector_rect.zw - proj_uv;
+
+			highp vec4 splane_ddy = (spot_lights.data[idx].shadow_matrix * vec4(vertex + vertex_ddy, 1.0));
+			splane_ddy /= splane_ddy.w;
+			highp vec2 proj_uv_ddy = normal_to_panorama(splane_ddy.xyz) * spot_lights.data[idx].projector_rect.zw - proj_uv;
+
+			vec4 proj = textureGrad(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + spot_lights.data[idx].projector_rect.xy, proj_uv_ddx, proj_uv_ddy);
+			color *= proj.rgb * proj.a;
+		} else {
+			vec4 proj = textureLod(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + spot_lights.data[idx].projector_rect.xy, 0.0);
+			color *= proj.rgb * proj.a;
+		}
+	}
+	light_attenuation *= shadow;
+
+	light_compute(normal, normalize(light_rel_vec), eye_vec, 0, color, light_attenuation, f0, metallic, roughness, spot_lights.data[idx].specular_amount,
+#ifdef LIGHT_BACKLIGHT_USED
+			backlight,
+#endif
+#ifdef LIGHT_TRANSMITTANCE_USED
+			transmittance_color,
+			transmittance_depth,
+			transmittance_boost,
+			transmittance_z,
+#endif
+#ifdef LIGHT_RIM_USED
+			rim * spot_attenuation, rim_tint, rim_color,
+#endif
+#ifdef LIGHT_CLEARCOAT_USED
+			clearcoat, clearcoat_gloss,
+#endif
+#ifdef LIGHT_ANISOTROPY_USED
+			binormal, tangent, anisotropy,
+#endif
+#ifdef USE_SHADOW_TO_OPACITY
+			alpha,
+#endif
+			diffuse_light, specular_light);
+}
+
+void reflection_process(uint ref_index, highp vec3 vertex, vec3 normal, float roughness, vec3 ambient_light, vec3 specular_light, inout vec4 ambient_accum, inout vec4 reflection_accum) {
+	vec3 box_extents = reflections.data[ref_index].box_extents;
+	vec3 local_pos = (reflections.data[ref_index].local_matrix * vec4(vertex, 1.0)).xyz;
+
+	if (any(greaterThan(abs(local_pos), box_extents))) { //out of the reflection box
+		return;
+	}
+
+	vec3 ref_vec = normalize(reflect(vertex, normal));
+
+	vec3 inner_pos = abs(local_pos / box_extents);
+	float blend = max(inner_pos.x, max(inner_pos.y, inner_pos.z));
+	//make blend more rounded
+	blend = mix(length(inner_pos), blend, blend);
+	blend *= blend;
+	blend = max(0.0, 1.0 - blend);
+
+	if (reflections.data[ref_index].intensity > 0.0) { // compute reflection
+
+		vec3 local_ref_vec = (reflections.data[ref_index].local_matrix * vec4(ref_vec, 0.0)).xyz;
+
+		if (reflections.data[ref_index].box_project) { //box project
+
+			vec3 nrdir = normalize(local_ref_vec);
+			vec3 rbmax = (box_extents - local_pos) / nrdir;
+			vec3 rbmin = (-box_extents - local_pos) / nrdir;
+
+			vec3 rbminmax = mix(rbmin, rbmax, greaterThan(nrdir, vec3(0.0, 0.0, 0.0)));
+
+			float fa = min(min(rbminmax.x, rbminmax.y), rbminmax.z);
+			vec3 posonbox = local_pos + nrdir * fa;
+			local_ref_vec = posonbox - reflections.data[ref_index].box_offset;
+		}
+
+		vec4 reflection;
+
+		reflection.rgb = textureLod(samplerCubeArray(reflection_atlas, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), vec4(local_ref_vec, reflections.data[ref_index].index), roughness * MAX_ROUGHNESS_LOD).rgb;
+
+		if (reflections.data[ref_index].exterior) {
+			reflection.rgb = mix(specular_light, reflection.rgb, blend);
+		}
+
+		reflection.rgb *= reflections.data[ref_index].intensity; //intensity
+		reflection.a = blend;
+		reflection.rgb *= reflection.a;
+
+		reflection_accum += reflection;
+	}
+
+	switch (reflections.data[ref_index].ambient_mode) {
+		case REFLECTION_AMBIENT_DISABLED: {
+			//do nothing
+		} break;
+		case REFLECTION_AMBIENT_ENVIRONMENT: {
+			//do nothing
+			vec3 local_amb_vec = (reflections.data[ref_index].local_matrix * vec4(normal, 0.0)).xyz;
+
+			vec4 ambient_out;
+
+			ambient_out.rgb = textureLod(samplerCubeArray(reflection_atlas, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), vec4(local_amb_vec, reflections.data[ref_index].index), MAX_ROUGHNESS_LOD).rgb;
+			ambient_out.a = blend;
+			if (reflections.data[ref_index].exterior) {
+				ambient_out.rgb = mix(ambient_light, ambient_out.rgb, blend);
+			}
+
+			ambient_out.rgb *= ambient_out.a;
+			ambient_accum += ambient_out;
+		} break;
+		case REFLECTION_AMBIENT_COLOR: {
+			vec4 ambient_out;
+			ambient_out.a = blend;
+			ambient_out.rgb = reflections.data[ref_index].ambient;
+			if (reflections.data[ref_index].exterior) {
+				ambient_out.rgb = mix(ambient_light, ambient_out.rgb, blend);
+			}
+			ambient_out.rgb *= ambient_out.a;
+			ambient_accum += ambient_out;
+		} break;
+	}
+}
+
+float blur_shadow(float shadow) {
+	return shadow;
+#if 0
+	//disabling for now, will investigate later
+	float interp_shadow = shadow;
+	if (gl_HelperInvocation) {
+		interp_shadow = -4.0; // technically anything below -4 will do but just to make sure
+	}
+
+	uvec2 fc2 = uvec2(gl_FragCoord.xy);
+	interp_shadow -= dFdx(interp_shadow) * (float(fc2.x & 1) - 0.5);
+	interp_shadow -= dFdy(interp_shadow) * (float(fc2.y & 1) - 0.5);
+
+	if (interp_shadow >= 0.0) {
+		shadow = interp_shadow;
+	}
+	return shadow;
+#endif
+}


### PR DESCRIPTION
* Implement mediump in the mobile renderer.
* Separate lighting implementation to enable mobile optimizations.
* Add precision qualifiers to default material.

WARNING: Does not seem to work on Adreno, still trying to figure out what is going on.

The bug on Adreno is an impossibility of creating the graphics pipelines, and a consequent gray screen:

```
09-08 14:43:32.330 22678 22719 E godot   : ERROR: vkCreateGraphicsPipelines failed with error 5 for shader 'SceneForwardMobileShaderRD:0'.
09-08 14:43:32.330 22678 22719 E godot   :    at: render_pipeline_create (drivers/vulkan/rendering_device_vulkan.cpp:6511) - Condition "err" is true. Returning: RID()
```