### PR TITLE
[3.x] CSGPolygon fixes and features: Angle simplification, UV tiling distance, interval type.

### DIFF
--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -346,6 +346,11 @@ public:
 		MODE_PATH
 	};
 
+	enum PathIntervalType {
+		PATH_INTERVAL_DISTANCE,
+		PATH_INTERVAL_SUBDIVIDE
+	};
+
 	enum PathRotation {
 		PATH_ROTATION_POLYGON,
 		PATH_ROTATION_PATH,
@@ -366,7 +371,9 @@ private:
 	int spin_sides;
 
 	NodePath path_node;
+	PathIntervalType path_interval_type;
 	float path_interval;
+	float path_simplify_angle;
 	PathRotation path_rotation;
 	bool path_local;
 
@@ -374,6 +381,7 @@ private:
 
 	bool smooth_faces;
 	bool path_continuous_u;
+	real_t path_u_distance;
 	bool path_joined;
 
 	bool _is_editable_3d_polygon() const;
@@ -406,8 +414,14 @@ public:
 	void set_path_node(const NodePath &p_path);
 	NodePath get_path_node() const;
 
+	void set_path_interval_type(PathIntervalType p_interval_type);
+	PathIntervalType get_path_interval_type() const;
+
 	void set_path_interval(float p_interval);
 	float get_path_interval() const;
+
+	void set_path_simplify_angle(float p_angle);
+	float get_path_simplify_angle() const;
 
 	void set_path_rotation(PathRotation p_rotation);
 	PathRotation get_path_rotation() const;
@@ -417,6 +431,9 @@ public:
 
 	void set_path_continuous_u(bool p_enable);
 	bool is_path_continuous_u() const;
+
+	void set_path_u_distance(real_t p_path_u_distance);
+	real_t get_path_u_distance() const;
 
 	void set_path_joined(bool p_enable);
 	bool is_path_joined() const;
@@ -432,5 +449,6 @@ public:
 
 VARIANT_ENUM_CAST(CSGPolygon::Mode)
 VARIANT_ENUM_CAST(CSGPolygon::PathRotation)
+VARIANT_ENUM_CAST(CSGPolygon::PathIntervalType)
 
 #endif // CSG_SHAPE_H

--- a/modules/csg/doc_classes/CSGPolygon.xml
+++ b/modules/csg/doc_classes/CSGPolygon.xml
@@ -26,6 +26,9 @@
 		<member name="path_interval" type="float" setter="set_path_interval" getter="get_path_interval">
 			When [member mode] is [constant MODE_PATH], the path interval or ratio of path points to extrusions.
 		</member>
+		<member name="path_interval_type" type="int" setter="set_path_interval_type" getter="get_path_interval_type" enum="CSGPolygon.PathIntervalType">
+			When [member mode] is [constant MODE_PATH], this will determine if the interval should be by distance ([constant PATH_INTERVAL_DISTANCE]) or subdivision fractions ([constant PATH_INTERVAL_SUBDIVIDE]).
+		</member>
 		<member name="path_joined" type="bool" setter="set_path_joined" getter="is_path_joined">
 			When [member mode] is [constant MODE_PATH], if [code]true[/code] the ends of the path are joined, by adding an extrusion between the last and first points of the path.
 		</member>
@@ -37,6 +40,12 @@
 		</member>
 		<member name="path_rotation" type="int" setter="set_path_rotation" getter="get_path_rotation" enum="CSGPolygon.PathRotation">
 			When [member mode] is [constant MODE_PATH], the [enum PathRotation] method used to rotate the [member polygon] as it is extruded.
+		</member>
+		<member name="path_simplify_angle" type="float" setter="set_path_simplify_angle" getter="get_path_simplify_angle">
+			When [member mode] is [constant MODE_PATH], extrusions that are less than this angle, will be merged together to reduce polygon count.
+		</member>
+		<member name="path_u_distance" type="float" setter="set_path_u_distance" getter="get_path_u_distance">
+			When [member mode] is [constant MODE_PATH], this is the distance along the path, in meters, the texture coordinates will tile. When set to 0, texture coordinates will match geometry exactly with no tiling.
 		</member>
 		<member name="polygon" type="PoolVector2Array" setter="set_polygon" getter="get_polygon" default="PoolVector2Array( 0, 0, 0, 1, 1, 1, 1, 0 )">
 			The point array that defines the 2D polygon that is extruded.
@@ -71,6 +80,12 @@
 		</constant>
 		<constant name="PATH_ROTATION_PATH_FOLLOW" value="2" enum="PathRotation">
 			The [member polygon] shape follows the path and its rotations around the path axis.
+		</constant>
+		<constant name="PATH_INTERVAL_DISTANCE" value="0" enum="PathIntervalType">
+			When [member mode] is set to [constant MODE_PATH], [member path_interval] will determine the distance, in meters, each interval of the path will extrude.
+		</constant>
+		<constant name="PATH_INTERVAL_SUBDIVIDE" value="1" enum="PathIntervalType">
+			When [member mode] is set to [constant MODE_PATH], [member path_interval] will subdivide the polygons along the path.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
This is to address new issues introduced in 3.4: https://github.com/godotengine/godot/issues/52179
Namely the removal of distance-based intervals and the way UV tiles.  I needed these for creating cables in my game.

I also added an option for simplifying geometry (In my game, it reduced the polycount of a cable from around 2900 triangles to 600).

I'm submitting this directly to 3.x because of changes to the class names, removal of pool vector, etc. mean this can't be merged cleanly from master, and it might be nice to get these fixed before 3.4 rolls out.  I'll do a separate pull request for master.