### PR TITLE
Fix CSGBox3D's UV map

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1134,7 +1134,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 		{
 			for (int i = 0; i < 6; i++) {
 				Vector3 face_points[4];
-				float uv_points[8] = { 0, 0, 0, 1, 1, 1, 1, 0 };
+				float uv_points[8] = { 1, 0, 1, 1, 0, 1, 0, 0 };
 
 				for (int j = 0; j < 4; j++) {
 					float v[3];


### PR DESCRIPTION
CSGBox3D appears to be mirrored on the X axis at least on my machine (Arch Linux/Nvidia) and another (Windows 10/Nvidia).
This PR fixes that by simply inverting the X axis of each point pair in `CSGBox3D`'s `uv_point` float array, changing it from:
https://github.com/godotengine/godot/blob/3174e2782c5bf7c56dbb7318d69289220c4ad753/modules/csg/csg_shape.cpp#L1137
to:
https://github.com/godotengine/godot/blob/5d915593ce2c23d5caad3876735cb8abb37c41a1/modules/csg/csg_shape.cpp#L1137

I'm aware that this isn't the most ideal fix (and maybe a comment could explain this) but this is the simplest solution I found and I haven't looked enough into `CSGBrush` construction process to know why this happens in the first place. As usual, feel free to reject this PR if you find this not a right solution.

I can replicate this bug as back as 8d199a9b2c.

Before this PR (3174e2782c):
![3174e2782c](https://user-images.githubusercontent.com/31065808/132736830-add27184-1276-4828-8a72-7dc5e443aabb.png)

After this PR (5d915593ce):
![5d915593ce](https://user-images.githubusercontent.com/31065808/132736936-30feca26-06c6-4d86-a3e0-649ebac12fd9.png)

Test Project:
[CSGBox3D UV Test.tar.gz](https://github.com/godotengine/godot/files/7138740/CSGBox3D.UV.Test.tar.gz)