### PR TITLE
[3.x] Fix parsing 'preload': increase/decrease parenthesis count

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -435,7 +435,9 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 			bool valid = false;
 			ConstantNode *cn;
 
+			parenthesis++;
 			Node *subexpr = _parse_and_reduce_expression(p_parent, p_static);
+			parenthesis--;
 			if (subexpr) {
 				if (subexpr->type == Node::TYPE_CONSTANT) {
 					cn = static_cast<ConstantNode *>(subexpr);


### PR DESCRIPTION
This PR fixes #52499. The fix is very simple and safe - we just skip newline tokens if we encounter them after the '(' and before the ')'.
This fix is intended only for 3.4 version. The version 4.0 doesn't have this problem since all the parsing code is rewritten.