### PR TITLE
[3.x] Add support for Android Play Asset Delivery

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -221,6 +221,9 @@ static const LauncherIcon launcher_adaptive_icon_backgrounds[icon_densities_coun
 static const int EXPORT_FORMAT_APK = 0;
 static const int EXPORT_FORMAT_AAB = 1;
 
+static const char *APK_ASSETS_DIRECTORY = "res://android/build/assets";
+static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPacks/installTime/src/main/assets";
+
 void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 	EditorExportPlatformAndroid *ea = (EditorExportPlatformAndroid *)ud;
 
@@ -428,6 +431,11 @@ String EditorExportPlatformAndroid::get_package_name(const String &p_package) co
 	pname = pname.replace("$genname", name);
 
 	return pname;
+}
+
+String EditorExportPlatformAndroid::get_assets_directory(const Ref<EditorExportPreset> &p_preset) const {
+	int export_format = int(p_preset->get("custom_template/export_format"));
+	return export_format == EXPORT_FORMAT_AAB ? AAB_ASSETS_DIRECTORY : APK_ASSETS_DIRECTORY;
 }
 
 bool EditorExportPlatformAndroid::is_package_name_valid(const String &p_package, String *r_error) const {
@@ -2659,11 +2667,21 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 
 void EditorExportPlatformAndroid::_clear_assets_directory() {
 	DirAccessRef da_res = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	if (da_res->dir_exists("res://android/build/assets")) {
-		print_verbose("Clearing assets directory..");
-		DirAccessRef da_assets = DirAccess::open("res://android/build/assets");
+
+	// Clear the APK assets directory
+	if (da_res->dir_exists(APK_ASSETS_DIRECTORY)) {
+		print_verbose("Clearing APK assets directory..");
+		DirAccessRef da_assets = DirAccess::open(APK_ASSETS_DIRECTORY);
 		da_assets->erase_contents_recursive();
-		da_res->remove("res://android/build/assets");
+		da_res->remove(APK_ASSETS_DIRECTORY);
+	}
+
+	// Clear the AAB assets directory
+	if (da_res->dir_exists(AAB_ASSETS_DIRECTORY)) {
+		print_verbose("Clearing AAB assets directory..");
+		DirAccessRef da_assets = DirAccess::open(AAB_ASSETS_DIRECTORY);
+		da_assets->erase_contents_recursive();
+		da_res->remove(AAB_ASSETS_DIRECTORY);
 	}
 }
 
@@ -2785,6 +2803,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 				return ERR_UNCONFIGURED;
 			}
 		}
+		const String assets_directory = get_assets_directory(p_preset);
 		String sdk_path = EDITOR_GET("export/android/android_sdk_path");
 		ERR_FAIL_COND_V_MSG(sdk_path.empty(), ERR_UNCONFIGURED, "Android SDK path must be configured in Editor Settings at 'export/android/android_sdk_path'.");
 		print_verbose("Android sdk path: " + sdk_path);
@@ -2806,6 +2825,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		if (!apk_expansion) {
 			print_verbose("Exporting project files..");
 			CustomExportData user_data;
+			user_data.assets_directory = assets_directory;
 			user_data.debug = p_debug;
 			err = export_project_files(p_preset, rename_and_store_file_in_gradle_project, &user_data, copy_gradle_so);
 			if (err != OK) {
@@ -2826,7 +2846,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			}
 		}
 		print_verbose("Storing command line flags..");
-		store_file_at_path("res://android/build/assets/_cl_", command_line_flags);
+		store_file_at_path(assets_directory + "/_cl_", command_line_flags);
 
 		print_verbose("Updating ANDROID_HOME environment to " + sdk_path);
 		OS::get_singleton()->set_environment("ANDROID_HOME", sdk_path); //set and overwrite if required

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -87,11 +87,6 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		EditorProgress *ep;
 	};
 
-	struct CustomExportData {
-		bool debug;
-		Vector<String> libs;
-	};
-
 	Vector<PluginConfigAndroid> plugins;
 	String last_plugin_names;
 	uint64_t last_custom_build_time = 0;
@@ -108,6 +103,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 	String get_project_name(const String &p_name) const;
 
 	String get_package_name(const String &p_package) const;
+
+	String get_assets_directory(const Ref<EditorExportPreset> &p_preset) const;
 
 	bool is_package_name_valid(const String &p_package, String *r_error = nullptr) const;
 

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -121,7 +121,8 @@ Error store_string_at_path(const String &p_path, const String &p_data) {
 // It's functionality mirrors that of the method save_apk_file.
 // This method will be called ONLY when custom build is enabled.
 Error rename_and_store_file_in_gradle_project(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total) {
-	String dst_path = p_path.replace_first("res://", "res://android/build/assets/");
+	CustomExportData *export_data = (CustomExportData *)p_userdata;
+	String dst_path = p_path.replace_first("res://", export_data->assets_directory + "/");
 	print_verbose("Saving project files from " + p_path + " into " + dst_path);
 	Error err = store_file_at_path(dst_path, p_data);
 	return err;

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -44,6 +44,12 @@ const String godot_project_name_xml_string = R"(<?xml version="1.0" encoding="ut
 </resources>
 )";
 
+struct CustomExportData {
+	String assets_directory;
+	bool debug;
+	Vector<String> libs;
+};
+
 int _get_android_orientation_value(OS::ScreenOrientation screen_orientation);
 
 String _get_android_orientation_label(OS::ScreenOrientation screen_orientation);

--- a/platform/android/java/app/assetPacks/installTime/build.gradle
+++ b/platform/android/java/app/assetPacks/installTime/build.gradle
@@ -1,0 +1,8 @@
+apply plugin: 'com.android.asset-pack'
+
+assetPack {
+    packName = "installTime" // Directory name for the asset pack
+    dynamicDelivery {
+        deliveryType = "install-time" // Delivery mode
+    }
+}

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -85,6 +85,8 @@ android {
         targetCompatibility versions.javaVersion
     }
 
+    assetPacks = [":assetPacks:installTime"]
+
     defaultConfig {
         // The default ignore pattern for the 'assets' directory includes hidden files and directories which are used by Godot projects.
         aaptOptions {

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -1,2 +1,2 @@
-// Empty settings.gradle file to denote this directory as being the root project
-// of the Godot custom build.
+// This is the root directory of the Godot custom build.
+include ':assetPacks:installTime'

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -4,3 +4,6 @@ rootProject.name = "Godot"
 include ':app'
 include ':lib'
 include ':nativeSrcsConfigs'
+
+include ':assetPacks:installTime'
+project(':assetPacks:installTime').projectDir = file("app/assetPacks/installTime")


### PR DESCRIPTION
Add support for [Android Play Asset Delivery](https://developer.android.com/guide/playcore/asset-delivery) which replaces APK's expansion files (OBBs) for Android App Bundle (AAB) binaries.

Addresses part of #48636.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
