### PR TITLE
Add support for Android Play Asset Delivery

### DIFF
--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -87,11 +87,6 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		EditorProgress *ep = nullptr;
 	};
 
-	struct CustomExportData {
-		bool debug;
-		Vector<String> libs;
-	};
-
 	Vector<PluginConfigAndroid> plugins;
 	String last_plugin_names;
 	uint64_t last_custom_build_time = 0;
@@ -108,6 +103,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 	String get_project_name(const String &p_name) const;
 
 	String get_package_name(const String &p_package) const;
+
+	String get_assets_directory(const Ref<EditorExportPreset> &p_preset) const;
 
 	bool is_package_name_valid(const String &p_package, String *r_error = nullptr) const;
 

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -121,7 +121,8 @@ Error store_string_at_path(const String &p_path, const String &p_data) {
 // It's functionality mirrors that of the method save_apk_file.
 // This method will be called ONLY when custom build is enabled.
 Error rename_and_store_file_in_gradle_project(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key) {
-	String dst_path = p_path.replace_first("res://", "res://android/build/assets/");
+	CustomExportData *export_data = (CustomExportData *)p_userdata;
+	String dst_path = p_path.replace_first("res://", export_data->assets_directory + "/");
 	print_verbose("Saving project files from " + p_path + " into " + dst_path);
 	Error err = store_file_at_path(dst_path, p_data);
 	return err;

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -44,6 +44,12 @@ const String godot_project_name_xml_string = R"(<?xml version="1.0" encoding="ut
 </resources>
 )";
 
+struct CustomExportData {
+	String assets_directory;
+	bool debug;
+	Vector<String> libs;
+};
+
 int _get_android_orientation_value(DisplayServer::ScreenOrientation screen_orientation);
 
 String _get_android_orientation_label(DisplayServer::ScreenOrientation screen_orientation);

--- a/platform/android/java/app/assetPacks/installTime/build.gradle
+++ b/platform/android/java/app/assetPacks/installTime/build.gradle
@@ -1,0 +1,8 @@
+apply plugin: 'com.android.asset-pack'
+
+assetPack {
+    packName = "installTime" // Directory name for the asset pack
+    dynamicDelivery {
+        deliveryType = "install-time" // Delivery mode
+    }
+}

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -72,6 +72,8 @@ android {
         targetCompatibility versions.javaVersion
     }
 
+    assetPacks = [":assetPacks:installTime"]
+
     defaultConfig {
         // The default ignore pattern for the 'assets' directory includes hidden files and directories which are used by Godot projects.
         aaptOptions {

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -1,2 +1,2 @@
-// Empty settings.gradle file to denote this directory as being the root project
-// of the Godot custom build.
+// This is the root directory of the Godot custom build.
+include ':assetPacks:installTime'

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -4,3 +4,6 @@ rootProject.name = "Godot"
 include ':app'
 include ':lib'
 include ':nativeSrcsConfigs'
+
+include ':assetPacks:installTime'
+project(':assetPacks:installTime').projectDir = file("app/assetPacks/installTime")


### PR DESCRIPTION
Add support for [Android Play Asset Delivery](https://developer.android.com/guide/playcore/asset-delivery) which replaces APK's expansion files (OBBs) for Android App Bundle (AAB) binaries.

Addresses part of #48636.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
