### PR TITLE
Trigger material update on texture update

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -234,6 +234,9 @@ private:
 	RID_Owner<CanvasTexture, true> canvas_texture_owner;
 
 	/* TEXTURE API */
+
+	struct Material;
+
 	struct Texture {
 		enum Type {
 			TYPE_2D,
@@ -292,6 +295,8 @@ private:
 		void *detect_roughness_callback_ud = nullptr;
 
 		CanvasTexture *canvas_texture = nullptr;
+
+		Set<Material *> materials;
 	};
 
 	struct TextureToRDFormat {
@@ -365,8 +370,6 @@ private:
 	void _update_decal_atlas();
 
 	/* SHADER */
-
-	struct Material;
 
 	struct Shader {
 		ShaderData *data;


### PR DESCRIPTION
This PR makes textures store which materials they were used in, and when the texture changes, triggers material updates for all stored materials. This fixes some issues where a material would continue using an out of date texture.

Fixes #52505