### PR TITLE
Fix linear to srgb, now texelfetch returns correct color

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -180,17 +180,18 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 
 		} break;
 		case Image::FORMAT_RGB8: {
-			r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? GL_SRGB8 : GL_RGB8;
+			const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+			r_gl_internal_format = is_srgb ? GL_SRGB8 : GL_RGB8;
 			r_gl_format = GL_RGB;
 			r_gl_type = GL_UNSIGNED_BYTE;
-			r_srgb = true;
-
+			r_srgb = is_srgb;
 		} break;
 		case Image::FORMAT_RGBA8: {
+			const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
 			r_gl_format = GL_RGBA;
-			r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? GL_SRGB8_ALPHA8 : GL_RGBA8;
+			r_gl_internal_format = is_srgb ? GL_SRGB8_ALPHA8 : GL_RGBA8;
 			r_gl_type = GL_UNSIGNED_BYTE;
-			r_srgb = true;
+			r_srgb = is_srgb;
 
 		} break;
 		case Image::FORMAT_RGBA4444: {
@@ -260,11 +261,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_DXT1: {
 			if (config.s3tc_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_NV : _EXT_COMPRESSED_RGBA_S3TC_DXT1_EXT;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_NV : _EXT_COMPRESSED_RGBA_S3TC_DXT1_EXT;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
+				r_srgb = is_srgb;
 
 			} else {
 				need_decompress = true;
@@ -273,12 +275,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_DXT3: {
 			if (config.s3tc_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_NV : _EXT_COMPRESSED_RGBA_S3TC_DXT3_EXT;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_NV : _EXT_COMPRESSED_RGBA_S3TC_DXT3_EXT;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
-
+				r_srgb = is_srgb;
 			} else {
 				need_decompress = true;
 			}
@@ -286,12 +288,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_DXT5: {
 			if (config.s3tc_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_NV : _EXT_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_NV : _EXT_COMPRESSED_RGBA_S3TC_DXT5_EXT;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
-
+				r_srgb = is_srgb;
 			} else {
 				need_decompress = true;
 			}
@@ -322,11 +324,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_BPTC_RGBA: {
 			if (config.bptc_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB_ALPHA_BPTC_UNORM : _EXT_COMPRESSED_RGBA_BPTC_UNORM;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB_ALPHA_BPTC_UNORM : _EXT_COMPRESSED_RGBA_BPTC_UNORM;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
+				r_srgb = is_srgb;
 
 			} else {
 				need_decompress = true;
@@ -354,11 +357,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_PVRTC2: {
 			if (config.pvrtc_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB_PVRTC_2BPPV1_EXT : _EXT_COMPRESSED_RGB_PVRTC_2BPPV1_IMG;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB_PVRTC_2BPPV1_EXT : _EXT_COMPRESSED_RGB_PVRTC_2BPPV1_IMG;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
+				r_srgb = is_srgb;
 
 			} else {
 				need_decompress = true;
@@ -366,11 +370,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_PVRTC2A: {
 			if (config.pvrtc_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV1_EXT : _EXT_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV1_EXT : _EXT_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
+				r_srgb = is_srgb;
 
 			} else {
 				need_decompress = true;
@@ -379,12 +384,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_PVRTC4: {
 			if (config.pvrtc_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB_PVRTC_4BPPV1_EXT : _EXT_COMPRESSED_RGB_PVRTC_4BPPV1_IMG;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB_PVRTC_4BPPV1_EXT : _EXT_COMPRESSED_RGB_PVRTC_4BPPV1_IMG;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
-
+				r_srgb = is_srgb;
 			} else {
 				need_decompress = true;
 			}
@@ -392,11 +397,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_PVRTC4A: {
 			if (config.pvrtc_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV1_EXT : _EXT_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV1_EXT : _EXT_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
+				r_srgb = is_srgb;
 
 			} else {
 				need_decompress = true;
@@ -461,11 +467,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_ETC2_RGB8: {
 			if (config.etc2_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB8_ETC2 : _EXT_COMPRESSED_RGB8_ETC2;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB8_ETC2 : _EXT_COMPRESSED_RGB8_ETC2;
 				r_gl_format = GL_RGB;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
+				r_srgb = is_srgb;
 
 			} else {
 				need_decompress = true;
@@ -473,11 +480,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_ETC2_RGBA8: {
 			if (config.etc2_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC : _EXT_COMPRESSED_RGBA8_ETC2_EAC;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC : _EXT_COMPRESSED_RGBA8_ETC2_EAC;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
+				r_srgb = is_srgb;
 
 			} else {
 				need_decompress = true;
@@ -485,11 +493,12 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 		} break;
 		case Image::FORMAT_ETC2_RGB8A1: {
 			if (config.etc2_supported) {
-				r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? _EXT_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 : _EXT_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+				const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
+				r_gl_internal_format = is_srgb ? _EXT_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 : _EXT_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
-				r_srgb = true;
+				r_srgb = is_srgb;
 
 			} else {
 				need_decompress = true;
@@ -508,12 +517,13 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 			image->convert(Image::FORMAT_RGBA8);
 		}
 
+		const auto is_srgb = config.srgb_decode_supported && (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR);
 		r_gl_format = GL_RGBA;
-		r_gl_internal_format = (config.srgb_decode_supported || (p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR)) ? GL_SRGB8_ALPHA8 : GL_RGBA8;
+		r_gl_internal_format = is_srgb ? GL_SRGB8_ALPHA8 : GL_RGBA8;
 		r_gl_type = GL_UNSIGNED_BYTE;
 		r_compressed = false;
 		r_real_format = Image::FORMAT_RGBA8;
-		r_srgb = true;
+		r_srgb = is_srgb;
 
 		return image;
 	}


### PR DESCRIPTION
This needs testing. But we use this and so far and it's good.
Probably fixes #31732
There were workarounds to this like:

```
float srgb_to_linear(float srgb) {
	if(srgb <= 0.0031308) {
		return srgb * 12.92;
	} else {
		return pow(srgb, 1.0 / 2.4) * 1.055 - 0.055;
	}
}

vec3 vsrgb_to_linear(vec3 srgb) {
	return vec3(srgb_to_linear(srgb.r), srgb_to_linear(srgb.g), srgb_to_linear(srgb.b));
}
```
_Originally posted by @nathanfranke in https://github.com/godotengine/godot/issues/31732#issuecomment-562411279_

But it was hardware dependent. For example on our nvidia top tier cards we needed to make linearToRGB(texelFetch(....)) to get the correct color. On the order hand our tester on Radeon card already had this converted. This was making in total something like linearToRGB(linearToRGB(texelFetch(....))) which resulted in incorrect color. After this fix there is no need for conversion and texelfetch(...) and texture(...) returns correct color on all hardware so far.  Simply there should be && instead of || in changed lines.