### PR TITLE
Implement animated tiles

### DIFF
--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -15,16 +15,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="can_move_tile_in_atlas" qualifiers="const">
-			<return type="bool" />
-			<argument index="0" name="atlas_coords" type="Vector2i" />
-			<argument index="1" name="new_atlas_coords" type="Vector2i" default="Vector2i(-1, -1)" />
-			<argument index="2" name="new_size" type="Vector2i" default="Vector2i(-1, -1)" />
-			<description>
-				Returns true if the tile at the [code]atlas_coords[/code] coordinates can be moved to the [code]new_atlas_coords[/code] coordinates with the [code]new_size[/code] size. This functions returns false if a tile is already present in the given area, or if this area is outside the atlas boundaries.
-				If [code]new_atlas_coords[/code] is [code]Vector2i(-1, -1)[/code], keeps the tile's coordinates. If [code]new_size[/code] is [code]Vector2i(-1, -1)[/code], keeps the tile's size.
-			</description>
-		</method>
 		<method name="clear_tiles_outside_texture">
 			<return type="void" />
 			<description>
@@ -61,6 +51,49 @@
 				Returns the alternative ID a following call to [method create_alternative_tile] would return.
 			</description>
 		</method>
+		<method name="get_tile_animation_columns" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<description>
+				Returns how many columns the tile at [code]atlas_coords[/code] has in its animation layout.
+			</description>
+		</method>
+		<method name="get_tile_animation_frame_duration" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<argument index="1" name="frame_index" type="int" />
+			<description>
+				Returns the animation frame duration of frame [code]frame_index[/code] for the tile at coordinates [code]atlas_coords[/code].
+			</description>
+		</method>
+		<method name="get_tile_animation_frames_count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<description>
+				Returns how many animation frames has the tile at coordinates [code]atlas_coords[/code].
+			</description>
+		</method>
+		<method name="get_tile_animation_separation" qualifiers="const">
+			<return type="Vector2i" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<description>
+				Returns the separation (as in the atlas grid) between each frame of an animated tile at coordinates [code]atlas_coords[/code].
+			</description>
+		</method>
+		<method name="get_tile_animation_speed" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<description>
+				Returns the animation speed of the tile at coordinates [code]atlas_coords[/code].
+			</description>
+		</method>
+		<method name="get_tile_animation_total_duration" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<description>
+				Returns the sum of the sum of the frame durations of the tile at coordinates [code]atlas_coords[/code]. This value needs to be divided by the animation speed to get the actual animation loop duration.
+			</description>
+		</method>
 		<method name="get_tile_at_coords" qualifiers="const">
 			<return type="Vector2i" />
 			<argument index="0" name="atlas_coords" type="Vector2i" />
@@ -86,8 +119,21 @@
 		<method name="get_tile_texture_region" qualifiers="const">
 			<return type="Rect2i" />
 			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<argument index="1" name="frame" type="int" default="0" />
 			<description>
-				Returns a tile's texture region in the atlas texture.
+				Returns a tile's texture region in the atlas texture. For animated tiles, a [code]frame[/code] argument might be provided for the different frames of the animation.
+			</description>
+		</method>
+		<method name="has_room_for_tile" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<argument index="1" name="size" type="Vector2i" />
+			<argument index="2" name="animation_columns" type="int" />
+			<argument index="3" name="animation_separation" type="Vector2i" />
+			<argument index="4" name="frames_count" type="int" />
+			<argument index="5" name="ignored_tile" type="Vector2i" default="Vector2i(-1, -1)" />
+			<description>
+				Returns whether there is enough room in an atlas to create/modify a tile with the given properties. If [code]ignored_tile[/code] is provided, act as is the given tile was not present in the atlas. This may be used when you want to modify a tile's properties.
 			</description>
 		</method>
 		<method name="has_tiles_outside_texture">
@@ -104,7 +150,7 @@
 			<description>
 				Move the tile and its alternatives at the [code]atlas_coords[/code] coordinates to the [code]new_atlas_coords[/code] coordinates with the [code]new_size[/code] size. This functions will fail if a tile is already present in the given area.
 				If [code]new_atlas_coords[/code] is [code]Vector2i(-1, -1)[/code], keeps the tile's coordinates. If [code]new_size[/code] is [code]Vector2i(-1, -1)[/code], keeps the tile's size.
-				To avoid an error, first check if a move is possible using [method can_move_tile_in_atlas].
+				To avoid an error, first check if a move is possible using [method has_room_for_tile].
 			</description>
 		</method>
 		<method name="remove_alternative_tile">
@@ -131,6 +177,47 @@
 			<description>
 				Change a tile's alternative ID from [code]alternative_tile[/code] to [code]new_id[/code].
 				Calling this function with [code]alternative_id[/code] equals to 0 will fail, as the base tile alternative cannot be moved.
+			</description>
+		</method>
+		<method name="set_tile_animation_columns">
+			<return type="void" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<argument index="1" name="frame_columns" type="int" />
+			<description>
+				Sets the number of columns in the animation layout of the tile at coordinates [code]atlas_coords[/code]. If set to 0, then the different frames of the animation are laid out as a single horizontal line in the atlas.
+			</description>
+		</method>
+		<method name="set_tile_animation_frame_duration">
+			<return type="void" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<argument index="1" name="frame_index" type="int" />
+			<argument index="2" name="duration" type="float" />
+			<description>
+				Sets the animation frame duration of frame [code]frame_index[/code] for the tile at coordinates [code]atlas_coords[/code].
+			</description>
+		</method>
+		<method name="set_tile_animation_frames_count">
+			<return type="void" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<argument index="1" name="frames_count" type="int" />
+			<description>
+				Sets how many animation frames the tile at coordinates [code]atlas_coords[/code] has.
+			</description>
+		</method>
+		<method name="set_tile_animation_separation">
+			<return type="void" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<argument index="1" name="separation" type="Vector2i" />
+			<description>
+				Sets the margin (in grid tiles) between each tile in the animation layout of the tile at coordinates [code]atlas_coords[/code] has.
+			</description>
+		</method>
+		<method name="set_tile_animation_speed">
+			<return type="void" />
+			<argument index="0" name="atlas_coords" type="Vector2i" />
+			<argument index="1" name="speed" type="float" />
+			<description>
+				Sets the animation speed of the tile at coordinates [code]atlas_coords[/code] has.
 			</description>
 		</method>
 	</methods>

--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -94,12 +94,14 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 				}
 
 				// Copy the texture.
-				Rect2i src_rect = atlas_source->get_tile_texture_region(tile_id);
-				Rect2 dst_rect_wide = Rect2i(new_tile_rect_in_altas.position * new_texture_region_size, new_tile_rect_in_altas.size * new_texture_region_size);
-				if (dst_rect_wide.get_end().x > output_image->get_width() || dst_rect_wide.get_end().y > output_image->get_height()) {
-					output_image->crop(MAX(dst_rect_wide.get_end().x, output_image->get_width()), MAX(dst_rect_wide.get_end().y, output_image->get_height()));
+				for (int frame = 0; frame < atlas_source->get_tile_animation_frames_count(tile_id); frame++) {
+					Rect2i src_rect = atlas_source->get_tile_texture_region(tile_id, frame);
+					Rect2 dst_rect_wide = Rect2i(new_tile_rect_in_altas.position * new_texture_region_size, new_tile_rect_in_altas.size * new_texture_region_size);
+					if (dst_rect_wide.get_end().x > output_image->get_width() || dst_rect_wide.get_end().y > output_image->get_height()) {
+						output_image->crop(MAX(dst_rect_wide.get_end().x, output_image->get_width()), MAX(dst_rect_wide.get_end().y, output_image->get_height()));
+					}
+					output_image->blit_rect(atlas_source->get_texture()->get_image(), src_rect, dst_rect_wide.get_center() - src_rect.size / 2);
 				}
-				output_image->blit_rect(atlas_source->get_texture()->get_image(), src_rect, dst_rect_wide.get_center() - src_rect.size / 2);
 			}
 
 			// Compute the atlas offset.

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -1456,13 +1456,25 @@ void TileMapEditorTilesPlugin::_tile_atlas_control_draw() {
 	Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
 	for (Set<TileMapCell>::Element *E = tile_set_selection.front(); E; E = E->next()) {
 		if (E->get().source_id == source_id && E->get().alternative_tile == 0) {
-			tile_atlas_control->draw_rect(atlas->get_tile_texture_region(E->get().get_atlas_coords()), selection_color, false);
+			for (int frame = 0; frame < atlas->get_tile_animation_frames_count(E->get().get_atlas_coords()); frame++) {
+				Color color = selection_color;
+				if (frame > 0) {
+					color.a *= 0.3;
+				}
+				tile_atlas_control->draw_rect(atlas->get_tile_texture_region(E->get().get_atlas_coords(), frame), color, false);
+			}
 		}
 	}
 
 	// Draw the hovered tile.
 	if (hovered_tile.get_atlas_coords() != TileSetSource::INVALID_ATLAS_COORDS && hovered_tile.alternative_tile == 0 && !tile_set_dragging_selection) {
-		tile_atlas_control->draw_rect(atlas->get_tile_texture_region(hovered_tile.get_atlas_coords()), Color(1.0, 1.0, 1.0), false);
+		for (int frame = 0; frame < atlas->get_tile_animation_frames_count(hovered_tile.get_atlas_coords()); frame++) {
+			Color color = Color(1.0, 1.0, 1.0);
+			if (frame > 0) {
+				color.a *= 0.3;
+			}
+			tile_atlas_control->draw_rect(atlas->get_tile_texture_region(hovered_tile.get_atlas_coords(), frame), color, false);
+		}
 	}
 
 	// Draw the selection rect.

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -305,7 +305,7 @@ public:
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
 
-	static void draw_tile(RID p_canvas_item, Vector2i p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, Vector2i p_atlas_coords, int p_alternative_tile, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0));
+	static void draw_tile(RID p_canvas_item, Vector2i p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, Vector2i p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0));
 
 	// Layers management.
 	int get_layers_count() const;

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -447,16 +447,23 @@ public:
 class TileSetAtlasSource : public TileSetSource {
 	GDCLASS(TileSetAtlasSource, TileSetSource);
 
-public:
+private:
 	struct TileAlternativesData {
 		Vector2i size_in_atlas = Vector2i(1, 1);
 		Vector2i texture_offset;
+
+		// Animation
+		int animation_columns = 0;
+		Vector2i animation_separation;
+		real_t animation_speed = 1.0;
+		LocalVector<real_t> animation_frames_durations;
+
+		// Alternatives
 		Map<int, TileData *> alternatives;
 		Vector<int> alternatives_ids;
 		int next_alternative_id = 1;
 	};
 
-private:
 	Ref<Texture2D> texture;
 	Vector2i margins;
 	Vector2i separation;
@@ -470,6 +477,9 @@ private:
 	const TileData *_get_atlas_tile_data(Vector2i p_atlas_coords, int p_alternative_tile) const;
 
 	void _compute_next_alternative_id(const Vector2i p_atlas_coords);
+
+	void _create_coords_mapping_cache(Vector2i p_atlas_coords);
+	void _clear_coords_mapping_cache(Vector2i p_atlas_coords);
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -513,17 +523,31 @@ public:
 	Vector2i get_texture_region_size() const;
 
 	// Base tiles.
-	void create_tile(const Vector2i p_atlas_coords, const Vector2i p_size = Vector2i(1, 1)); // Create a tile if it does not exists, or add alternative tile if it does.
-	void remove_tile(Vector2i p_atlas_coords); // Remove a tile. If p_tile_key.alternative_tile if different from 0, remove the alternative
+	void create_tile(const Vector2i p_atlas_coords, const Vector2i p_size = Vector2i(1, 1));
+	void remove_tile(Vector2i p_atlas_coords);
 	virtual bool has_tile(Vector2i p_atlas_coords) const override;
-	bool can_move_tile_in_atlas(Vector2i p_atlas_coords, Vector2i p_new_atlas_coords = INVALID_ATLAS_COORDS, Vector2i p_new_size = Vector2i(-1, -1)) const;
 	void move_tile_in_atlas(Vector2i p_atlas_coords, Vector2i p_new_atlas_coords = INVALID_ATLAS_COORDS, Vector2i p_new_size = Vector2i(-1, -1));
 	Vector2i get_tile_size_in_atlas(Vector2i p_atlas_coords) const;
 
 	virtual int get_tiles_count() const override;
 	virtual Vector2i get_tile_id(int p_index) const override;
 
+	bool has_room_for_tile(Vector2i p_atlas_coords, Vector2i p_size, int p_animation_columns, Vector2i p_animation_separation, int p_frames_count, Vector2i p_ignored_tile = INVALID_ATLAS_COORDS) const;
+
 	Vector2i get_tile_at_coords(Vector2i p_atlas_coords) const;
+
+	// Animation.
+	void set_tile_animation_columns(const Vector2i p_atlas_coords, int p_frame_columns);
+	int get_tile_animation_columns(const Vector2i p_atlas_coords) const;
+	void set_tile_animation_separation(const Vector2i p_atlas_coords, const Vector2i p_separation);
+	Vector2i get_tile_animation_separation(const Vector2i p_atlas_coords) const;
+	void set_tile_animation_speed(const Vector2i p_atlas_coords, real_t p_speed);
+	real_t get_tile_animation_speed(const Vector2i p_atlas_coords) const;
+	void set_tile_animation_frames_count(const Vector2i p_atlas_coords, int p_frames_count);
+	int get_tile_animation_frames_count(const Vector2i p_atlas_coords) const;
+	void set_tile_animation_frame_duration(const Vector2i p_atlas_coords, int p_frame_index, real_t p_duration);
+	real_t get_tile_animation_frame_duration(const Vector2i p_atlas_coords, int p_frame_index) const;
+	real_t get_tile_animation_total_duration(const Vector2i p_atlas_coords) const;
 
 	// Alternative tiles.
 	int create_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_id_override = -1);
@@ -542,7 +566,7 @@ public:
 	Vector2i get_atlas_grid_size() const;
 	bool has_tiles_outside_texture();
 	void clear_tiles_outside_texture();
-	Rect2i get_tile_texture_region(Vector2i p_atlas_coords) const;
+	Rect2i get_tile_texture_region(Vector2i p_atlas_coords, int p_frame = 0) const;
 	Vector2i get_tile_effective_texture_offset(Vector2i p_atlas_coords, int p_alternative_tile) const;
 
 	~TileSetAtlasSource();


### PR DESCRIPTION
This PR implements animated tiles. To do so it makes in so base tiles in atlases (not alternative tiles) can use several tiles instead of one, which will then be used as part of the animation.

By default, increasing the frames count will make the tile consider the X tiles to its right as part of its animation frames. If you specify a number of columns different from 0, the layout will instead go to the next line once the given column number is reached (This means a column value of 1 leads to a vertical layout).

You may also specify a separation between each tile, this may be useful in some situations, like animated autotiles from RPG make for example. See this example found on *the Internet*: https://forums.rpgmakerweb.com/data/attachments/101/101694-9e750e94efbbeaa7bb89cb010912e002.jpg

The animation speed can be modified via a property, but each frame duration can also be modified individually (by default it's  1.0).

I also replace can_move_tile_in_atlas by has_room_for_tile, as now several properties may impact the room a tiles take in the atlas.

See it in action (I made this gif before implementing animation speed, and things are a little bit choppy due to my gif recorder):
![Peek 09-09-2021 18-07](https://user-images.githubusercontent.com/6093119/132875493-bdbd71e4-a708-4479-9085-fa91253a9f5f.gif)
