### PR TITLE
Fixed `AnimationNodeTransition`'s behavior when xfade time is zero

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -718,7 +718,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek) {
 
 	} else { // cross-fading from prev to current
 
-		float blend = xfade ? (prev_xfading / xfade) : 1;
+		float blend = xfade == 0 ? 0 : (prev_xfading / xfade);
 
 		if (!p_seek && switched) { //just switched, seek to start of current
 


### PR DESCRIPTION
Fixed partly #52518.

When xfade time is 0, the animation should be changed immediately when the transition fires, but because the blend calculation in that case is wrong, it has been playing the animation which is before the transition. So I fixed it.