### PR TITLE
GDScript: Removed spurious UNASSIGNED_VARIABLE warning for locals

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2369,8 +2369,12 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_assignment(ExpressionNode 
 	}
 
 #ifdef DEBUG_ENABLED
-	if (has_operator && source_variable != nullptr && source_variable->assignments == 0) {
-		push_warning(assignment, GDScriptWarning::UNASSIGNED_VARIABLE_OP_ASSIGN, source_variable->identifier->name);
+	if (source_variable != nullptr) {
+		if (has_operator && source_variable->assignments == 0) {
+			push_warning(assignment, GDScriptWarning::UNASSIGNED_VARIABLE_OP_ASSIGN, source_variable->identifier->name);
+		}
+
+		source_variable->assignments += 1;
 	}
 #endif
 

--- a/modules/gdscript/tests/scripts/parser/features/variable_declaration.gd
+++ b/modules/gdscript/tests/scripts/parser/features/variable_declaration.gd
@@ -1,12 +1,19 @@
-var a # No init.
-var b = 42 # Init.
+var m1 # No init.
+var m2 = 22 # Init.
+var m3: String # No init, typed.
+var m4: String = "44" # Init, typed.
 
 func test():
-	var c # No init, local.
-	var d = 23 # Init, local.
+	var loc5 # No init, local.
+	var loc6 = 66 # Init, local.
+	var loc7: String # No init, typed.
+	var loc8: String = "88" # Init, typed.
 
-	a = 1
-	c = 2
+	m1 = 11
+	m3 = "33"
 
-	prints(a, b, c, d)
+	loc5 = 55
+	loc7 = "77"
+
+	prints(m1, m2, m3, m4, loc5, loc6, loc7, loc8)
 	print("OK")

--- a/modules/gdscript/tests/scripts/parser/features/variable_declaration.out
+++ b/modules/gdscript/tests/scripts/parser/features/variable_declaration.out
@@ -1,7 +1,3 @@
 GDTEST_OK
->> WARNING
->> Line: 5
->> UNASSIGNED_VARIABLE
->> The variable 'c' was used but never assigned a value.
-1 42 2 23
+11 22 33 44 55 66 77 88
 OK


### PR DESCRIPTION
Fixes #52551

* variable->assignment needs to be incremented when assigned a value.
* Still show a warning when has_operator is true and the variable was not yet initialized. Example: not_initialized += 1
* Also fixed and improved unit test 'variable_declaration.gd'.
