### PR TITLE
Enable Pixel Snap by default in the 2D editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5204,7 +5204,9 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	snap_rotation = false;
 	snap_scale = false;
 	snap_relative = false;
-	snap_pixel = false;
+	// Enable pixel snapping even if pixel snap rendering is disabled in the Project Settings.
+	// This results in crisper visuals by preventing 2D nodes from being placed at subpixel coordinates.
+	snap_pixel = true;
 	snap_target[0] = SNAP_TARGET_NONE;
 	snap_target[1] = SNAP_TARGET_NONE;
 


### PR DESCRIPTION
Since this avoids accidentally placing 2D nodes at subpixel positions, this results in more crisp visuals by default, even when pixel snapping is disabled in the project settings.

I would recommend cherry-picking this to `3.x`, since the subpixel position placement is likely not a behavior that people rely on a voluntary basis.

This closes https://github.com/godotengine/godot-proposals/issues/3209.