### PR TITLE
Fixed seeking behavior of property track with discrete interpolation

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -958,7 +958,7 @@ void AnimationTree::_process_graph(real_t p_delta) {
 
 							Variant::interpolate(t->value, value, blend, t->value);
 
-						} else if (delta != 0) {
+						} else {
 							List<int> indices;
 							a->value_track_get_key_indices(i, time, delta, &indices);
 


### PR DESCRIPTION
Fixed #52518 in conjunction with #52543.

`AnimationNodeTransition` seeks the animation of transition destination, but the seeking of property track with discrete interpolation was broken. With track of discrete interpolation, it may be wrong to do nothing in the frame of seeking.