### PR TITLE
Add a notice about `master` not being production-ready in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
   </a>
 </p>
 
+:warning: *You are browsing the `master` branch, which is the main focus of development.
+**The `master` branch is not production-ready.**
+See [Godot release policy](https://docs.godotengine.org/en/stable/about/release_policy.html)
+in the documentation for more information.*
+
 ## 2D and 3D cross-platform game engine
 
 **[Godot Engine](https://godotengine.org) is a feature-packed, cross-platform


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/52560.

It's not always obvious for new users that they need to switch to `3.x` or `3.3` to compile their own build, if they want something suited for production.

## Preview

https://github.com/Calinou/godot/blob/readme-add-branch-notice/README.md#readme