### PR TITLE
Add a notice about `3.x`'s stability status in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
   </a>
 </p>
 
+:information_source: *You are browsing the `3.x` branch, which is a development
+branch leading to Godot 3.4. **The `3.x` branch is usually safe to use in production,
+although `3.3` is ultimately more stable.**
+Switch to the [`master` branch](https://github.com/godotengine/godot/tree/master)
+to explore Godot 4.0's current state, or switch to the
+[`3.3` branch](https://github.com/godotengine/godot/tree/3.3) to compile a
+production-ready build.
+See [Godot release policy](https://docs.godotengine.org/en/stable/about/release_policy.html)
+in the documentation for more information.*
+
 ## 2D and 3D cross-platform game engine
 
 **[Godot Engine](https://godotengine.org) is a feature-packed, cross-platform


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/52559.

It's not always obvious for new users that they need to switch to `3.x` or `3.3` to compile their own build, if they want something suited for production.

## Preview

https://github.com/Calinou/godot/blob/readme-add-branch-notice-3.x/README.md#readme