### PR TITLE
Add a notice about `3.3`'s stability status in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
   </a>
 </p>
 
+:heavy_check_mark:  *You are browsing the `3.3` branch, which is a stable branch
+for 3.3.x bugfix releases. **The `3.3` branch is considered production-ready.**
+Switch to the [`master` branch](https://github.com/godotengine/godot/tree/master)
+to explore Godot 4.0's current state, or switch to the
+[`3.x` branch](https://github.com/godotengine/godot/tree/3.x) to explore the
+upcoming backwards-compatible update, Godot 3.4.
+See [Godot release policy](https://docs.godotengine.org/en/stable/about/release_policy.html)
+in the documentation for more information.*
+
 ## 2D and 3D cross-platform game engine
 
 **[Godot Engine](https://godotengine.org) is a feature-packed, cross-platform


### PR DESCRIPTION
`3.3` version of https://github.com/godotengine/godot/pull/52560.

It's not always obvious for new users that they need to switch to `3.x` or `3.3` to compile their own build, if they want something suited for production.

## Preview

https://github.com/Calinou/godot/blob/readme-add-branch-notice-3.3/README.md#readme