### PR TITLE
Add support for building shared libraries on linuxbsd 

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -59,6 +59,15 @@ jobs:
             sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes deprecated=no minizip=no
             artifact: true
 
+          - name: Editor Shared Build (target=release_debug, tools=yes, tests=yes, sharedlibs=yes)
+            cache-name: linux-editor-shared
+            target: release_debug
+            tools: true
+            tests: true
+            sconsflags: sharedlibs=yes
+            bin: "./bin/godot.linuxbsd.opt.tools.64"
+            artifact: false
+
     steps:
       - uses: actions/checkout@v2
 

--- a/SConstruct
+++ b/SConstruct
@@ -53,6 +53,8 @@ _helper_module("editor.template_builders", "editor/template_builders.py")
 _helper_module("main.main_builders", "main/main_builders.py")
 _helper_module("modules.modules_builders", "modules/modules_builders.py")
 
+import SCons
+
 # Local
 import methods
 import glsl_builders
@@ -704,6 +706,7 @@ if selected_platform in platform_list:
 
     env["PROGSUFFIX"] = suffix + env.module_version_string + env["PROGSUFFIX"]
     env["OBJSUFFIX"] = suffix + env["OBJSUFFIX"]
+    env["SHOBJSUFFIX"] = suffix + env["SHOBJSUFFIX"]
     # (SH)LIBSUFFIX will be used for our own built libraries
     # LIBSUFFIXES contains LIBSUFFIX and SHLIBSUFFIX by default,
     # so we need to append the default suffixes to keep the ability

--- a/core/SCsub
+++ b/core/SCsub
@@ -196,9 +196,10 @@ SConscript("string/SCsub")
 SConscript("config/SCsub")
 SConscript("error/SCsub")
 
+core_env = env.Clone()
 
 # Build it all as a library
-lib = env.add_library("core", env.core_sources)
+lib = core_env.add_library("core", env.core_sources)
 env.Prepend(LIBS=[lib])
 
 # Needed to force rebuilding the core files when the thirdparty code is updated.

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -35,5 +35,6 @@ SConscript("spirv-reflect/SCsub")
 
 env.add_source_files(env.drivers_sources, "*.cpp")
 
-lib = env.add_library("drivers", env.drivers_sources)
+drivers_env = env.Clone()
+lib = drivers_env.add_library("drivers", env.drivers_sources)
 env.Prepend(LIBS=[lib])

--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -19,6 +19,8 @@ elif env["platform"] == "iphone":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_IOS_MVK"])
 elif env["platform"] == "linuxbsd":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_XLIB_KHR"])
+    if env.get("sharedlibs"):
+        env.AppendUnique(CPPDEFINES=["VOLK_DEFAULT_VISIBILITY"])
 elif env["platform"] == "osx":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_MACOS_MVK"])
 elif env["platform"] == "windows":

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -116,5 +116,7 @@ if env["tools"]:
     SConscript("import/SCsub")
     SConscript("plugins/SCsub")
 
-    lib = env.add_library("editor", env.editor_sources)
+    editor_env = env.Clone()
+
+    lib = editor_env.add_library("editor", env.editor_sources)
     env.Prepend(LIBS=[lib])

--- a/methods.py
+++ b/methods.py
@@ -16,7 +16,7 @@ from SCons.Variables.BoolVariable import _text2bool
 from platform_methods import run_in_subprocess
 
 
-def add_source_files(self, sources, files):
+def add_source_files(self, sources, files, **kwargs):
     # Convert string to list of absolute paths (including expanding wildcard)
     if isinstance(files, (str, bytes)):
         # Keep SCons project-absolute path as they are (no wildcard support)
@@ -36,7 +36,10 @@ def add_source_files(self, sources, files):
 
     # Add each path as compiled Object following environment (self) configuration
     for path in files:
-        obj = self.Object(path)
+        if self.get("sharedlibs"):
+            obj = self.SharedObject(path, **kwargs)
+        else:
+            obj = self.Object(path, **kwargs)
         if obj in sources:
             print('WARNING: Object "{}" already included in environment sources.'.format(obj))
             continue
@@ -817,7 +820,10 @@ def add_shared_library(env, name, sources, **args):
 
 
 def add_library(env, name, sources, **args):
-    library = env.Library(name, sources, **args)
+    if not env.get("sharedlibs"):
+        library = env.Library(name, sources, **args)
+    else:
+        library = env.SharedLibrary(name, sources, **args)
     env.NoCache(library)
     return library
 

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -28,12 +28,13 @@ test_headers = []
 # libmodule_<name>.a for each active module.
 for name, path in env.module_list.items():
     env.modules_sources = []
+    env_module = env_modules.Clone()
 
     # Name for built-in modules, (absolute) path for custom ones.
     base_path = path if os.path.isabs(path) else name
-    SConscript(base_path + "/SCsub")
+    SConscript(base_path + "/SCsub", exports={"env_module": env_module})
 
-    lib = env_modules.add_library("module_%s" % name, env.modules_sources)
+    lib = env_module.add_library("module_%s" % name, env.modules_sources)
     env.Prepend(LIBS=[lib])
     if env["vsproj"]:
         vs_sources += env.modules_sources

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -55,13 +55,19 @@ if env["builtin_pcre2"]:
     def pcre2_builtin(width):
         env_pcre2 = env_regex.Clone()
         env_pcre2.disable_warnings()
-        env_pcre2["OBJSUFFIX"] = "_" + width + env_pcre2["OBJSUFFIX"]
-        env_pcre2.Append(CPPDEFINES=[("PCRE2_CODE_UNIT_WIDTH", width)])
-        env_pcre2.add_source_files(thirdparty_obj, thirdparty_sources)
-        env.modules_sources += thirdparty_obj
+
+        env_pcre2.add_source_files(
+            thirdparty_obj,
+            thirdparty_sources,
+            OBJSUFFIX="_" + width + env_pcre2["OBJSUFFIX"],
+            SHOBJSUFFIX="_" + width + env_pcre2["SHOBJSUFFIX"],
+            CPPDEFINES=env_pcre2["CPPDEFINES"] + [("PCRE2_CODE_UNIT_WIDTH", width)],
+        )
 
     pcre2_builtin("16")
     pcre2_builtin("32")
+
+    env.modules_sources += thirdparty_obj
 
 
 # Godot source files

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -39,8 +39,71 @@ thirdparty_obj = []
 freetype_enabled = env.module_check_dependencies("text_server_adv", ["freetype"], True)
 msdngen_enabled = env.module_check_dependencies("text_server_adv", ["msdfgen"], True)
 
+if env["builtin_graphite"] and freetype_enabled:
+    env_graphite = env_text_server_adv.Clone()
+    env_graphite.disable_warnings()
+
+    thirdparty_dir = "#thirdparty/graphite/"
+    thirdparty_sources = [
+        "src/gr_char_info.cpp",
+        "src/gr_face.cpp",
+        "src/gr_features.cpp",
+        "src/gr_font.cpp",
+        "src/gr_logging.cpp",
+        "src/gr_segment.cpp",
+        "src/gr_slot.cpp",
+        "src/CmapCache.cpp",
+        "src/Code.cpp",
+        "src/Collider.cpp",
+        "src/Decompressor.cpp",
+        "src/Face.cpp",
+        #'src/FileFace.cpp',
+        "src/FeatureMap.cpp",
+        "src/Font.cpp",
+        "src/GlyphCache.cpp",
+        "src/GlyphFace.cpp",
+        "src/Intervals.cpp",
+        "src/Justifier.cpp",
+        "src/NameTable.cpp",
+        "src/Pass.cpp",
+        "src/Position.cpp",
+        "src/Segment.cpp",
+        "src/Silf.cpp",
+        "src/Slot.cpp",
+        "src/Sparse.cpp",
+        "src/TtfUtil.cpp",
+        "src/UtfCodec.cpp",
+        "src/FileFace.cpp",
+        "src/json.cpp",
+    ]
+    if not env_graphite.msvc:
+        thirdparty_sources += ["src/direct_machine.cpp"]
+    else:
+        thirdparty_sources += ["src/call_machine.cpp"]
+
+    thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
+
+    env_graphite.Append(CPPPATH=["#thirdparty/graphite/src", "#thirdparty/graphite/include"])
+    env_graphite.Append(
+        CCFLAGS=[
+            "-DGRAPHITE2_NTRACING",
+            "-DGRAPHITE2_NFILEFACE",
+        ],
+    )
+    if not env.get("sharedlibs"):
+        env_graphite.Append(
+            CCFLAGS=[
+                "-DGRAPHITE2_STATIC",
+            ]
+        )
+
+    gr_sources = []
+    env_graphite.add_source_files(gr_sources, thirdparty_sources)
+    graphite_lib = env_graphite.add_library("graphite_builtin", gr_sources)
+    thirdparty_obj += graphite_lib
+
 if env["builtin_harfbuzz"]:
-    env_harfbuzz = env_modules.Clone()
+    env_harfbuzz = env_text_server_adv.Clone()
     env_harfbuzz.disable_warnings()
 
     thirdparty_dir = "#thirdparty/harfbuzz/"
@@ -151,99 +214,39 @@ if env["builtin_harfbuzz"]:
             CCFLAGS=[
                 "-DHAVE_FREETYPE",
                 "-DHAVE_GRAPHITE2",
-                "-DGRAPHITE2_STATIC",
             ]
         )
+        if not env.get("sharedlibs"):
+            env_harfbuzz.Append(
+                CCFLAGS=[
+                    "-DGRAPHITE2_STATIC",
+                ]
+            )
 
-    lib = env_harfbuzz.add_library("harfbuzz_builtin", thirdparty_sources)
-    thirdparty_obj += lib
-
-    # Needs to be appended to arrive after libscene in the linker call,
-    # but we don't want it to arrive *after* system libs, so manual hack
-    # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
-    # and then plain strings for system library. We insert between the two.
-    inserted = False
-    for idx, linklib in enumerate(env["LIBS"]):
-        if isinstance(linklib, (str, bytes)):  # first system lib such as "X11", otherwise SCons lib object
-            env["LIBS"].insert(idx, lib)
-            inserted = True
-            break
-    if not inserted:
-        env.Append(LIBS=[lib])
-
-
-if env["builtin_graphite"] and freetype_enabled:
-    env_graphite = env_modules.Clone()
-    env_graphite.disable_warnings()
-
-    thirdparty_dir = "#thirdparty/graphite/"
-    thirdparty_sources = [
-        "src/gr_char_info.cpp",
-        "src/gr_face.cpp",
-        "src/gr_features.cpp",
-        "src/gr_font.cpp",
-        "src/gr_logging.cpp",
-        "src/gr_segment.cpp",
-        "src/gr_slot.cpp",
-        "src/CmapCache.cpp",
-        "src/Code.cpp",
-        "src/Collider.cpp",
-        "src/Decompressor.cpp",
-        "src/Face.cpp",
-        #'src/FileFace.cpp',
-        "src/FeatureMap.cpp",
-        "src/Font.cpp",
-        "src/GlyphCache.cpp",
-        "src/GlyphFace.cpp",
-        "src/Intervals.cpp",
-        "src/Justifier.cpp",
-        "src/NameTable.cpp",
-        "src/Pass.cpp",
-        "src/Position.cpp",
-        "src/Segment.cpp",
-        "src/Silf.cpp",
-        "src/Slot.cpp",
-        "src/Sparse.cpp",
-        "src/TtfUtil.cpp",
-        "src/UtfCodec.cpp",
-        "src/FileFace.cpp",
-        "src/json.cpp",
-    ]
-    if not env_graphite.msvc:
-        thirdparty_sources += ["src/direct_machine.cpp"]
-    else:
-        thirdparty_sources += ["src/call_machine.cpp"]
-
-    thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-
-    env_graphite.Append(CPPPATH=["#thirdparty/graphite/src", "#thirdparty/graphite/include"])
-    env_graphite.Append(
-        CCFLAGS=[
-            "-DGRAPHITE2_STATIC",
-            "-DGRAPHITE2_NTRACING",
-            "-DGRAPHITE2_NFILEFACE",
-        ]
-    )
-
-    lib = env_graphite.add_library("graphite_builtin", thirdparty_sources)
-    thirdparty_obj += lib
+    hb_sources = []
+    env_harfbuzz.add_source_files(hb_sources, thirdparty_sources)
+    if env.get("sharedlibs") and env["builtin_graphite"] and freetype_enabled:
+        env_harfbuzz.Append(LIBS=graphite_lib)
+    harfbuzz_lib = env_harfbuzz.add_library("harfbuzz_builtin", hb_sources)
+    thirdparty_obj += harfbuzz_lib
 
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
     # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
     # and then plain strings for system library. We insert between the two.
-    inserted = False
-    for idx, linklib in enumerate(env["LIBS"]):
-        if isinstance(linklib, (str, bytes)):  # first system lib such as "X11", otherwise SCons lib object
-            env["LIBS"].insert(idx, lib)
-            inserted = True
-            break
-    if not inserted:
-        env.Append(LIBS=[lib])
+    for lib in [harfbuzz_lib, graphite_lib]:
+        inserted = False
+        for idx, linklib in enumerate(env["LIBS"]):
+            if isinstance(linklib, (str, bytes)):  # first system lib such as "X11", otherwise SCons lib object
+                env["LIBS"].insert(idx, lib)
+                inserted = True
+                break
+        if not inserted:
+            env.Append(LIBS=[lib])
 
 
 if env["builtin_icu"]:
-    env_icu = env_modules.Clone()
+    env_icu = env_text_server_adv.Clone()
     env_icu.disable_warnings()
 
     thirdparty_dir = "#thirdparty/icu4c/"
@@ -447,6 +450,9 @@ if env["builtin_icu"]:
         "common/uvectr64.cpp",
         "common/wintz.cpp",
     ]
+    if env.get("sharedlibs"):
+        thirdparty_sources += ["common/ushape.cpp"]
+
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     icu_data_name = "icudt70l.dat"
@@ -460,7 +466,6 @@ if env["builtin_icu"]:
     env_icu.Append(CPPPATH=["#thirdparty/icu4c/common/"])
     env_icu.Append(
         CXXFLAGS=[
-            "-DU_STATIC_IMPLEMENTATION",
             "-DU_COMMON_IMPLEMENTATION",
             "-DUCONFIG_NO_COLLATION",
             "-DUCONFIG_NO_CONVERSION",
@@ -473,13 +478,22 @@ if env["builtin_icu"]:
             "-DICU_DATA_NAME=" + icu_data_name,
         ]
     )
+    if not env.get("sharedlibs"):
+        env_icu.Append(
+            CXXFLAGS=[
+                "-DU_STATIC_IMPLEMENTATION",
+            ]
+        )
+
     env_text_server_adv.Append(
         CXXFLAGS=[
             "-DICU_DATA_NAME=" + icu_data_name,
         ]
     )
 
-    lib = env_icu.add_library("icu_builtin", thirdparty_sources)
+    icu_sources = []
+    env_icu.add_source_files(icu_sources, thirdparty_sources)
+    lib = env_icu.add_library("icu_builtin", icu_sources)
     thirdparty_obj += lib
 
     # Needs to be appended to arrive after libscene in the linker call,

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -26,5 +26,7 @@ with open("register_platform_apis.gen.cpp", "w", encoding="utf-8") as f:
 
 env.add_source_files(env.platform_sources, "register_platform_apis.gen.cpp")
 
-lib = env.add_library("platform", env.platform_sources)
+platform_env = env.Clone()
+
+lib = platform_env.add_library("platform", env.platform_sources)
 env.Prepend(LIBS=[lib])

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -26,7 +26,12 @@ if "vulkan" in env and env["vulkan"]:
 if "udev" in env and env["udev"]:
     common_linuxbsd.append("libudev-so_wrap.c")
 
-prog = env.add_program("#bin/godot", ["godot_linuxbsd.cpp"] + common_linuxbsd)
+if env.get("sharedlibs"):
+    obj_suffix = env["SHOBJSUFFIX"]
+else:
+    obj_suffix = env["OBJSUFFIX"]
+
+prog = env.add_program("#bin/godot", ["godot_linuxbsd.cpp"] + common_linuxbsd, OBJSUFFIX=obj_suffix)
 
 if env["debug_symbols"] and env["separate_debug_symbols"]:
     env.AddPostAction(prog, run_in_subprocess(platform_linuxbsd_builders.make_debug_linuxbsd))

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -81,6 +81,7 @@ def get_opts():
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("touch", "Enable touch events", True),
         BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
+        BoolVariable("sharedlibs", "Build shared libraries (only available on linuxbsd platform)", False),
     ]
 
 
@@ -115,7 +116,7 @@ def configure(env):
 
     ## Architecture
 
-    is64 = sys.maxsize > 2 ** 32
+    is64 = sys.maxsize > 2**32
     if env["bits"] == "default":
         env["bits"] = "64" if is64 else "32"
 

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -116,7 +116,7 @@ def configure(env):
 
     ## Architecture
 
-    is64 = sys.maxsize > 2**32
+    is64 = sys.maxsize > 2 ** 32
     if env["bits"] == "default":
         env["bits"] = "64" if is64 else "32"
 

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -19,6 +19,8 @@ SConscript("audio/SCsub")
 SConscript("resources/SCsub")
 SConscript("debugger/SCsub")
 
+scene_env = env.Clone()
+
 # Build it all as a library
-lib = env.add_library("scene", env.scene_sources)
+lib = scene_env.add_library("scene", env.scene_sources)
 env.Prepend(LIBS=[lib])

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -13,6 +13,7 @@ SConscript("rendering/SCsub")
 SConscript("audio/SCsub")
 SConscript("text/SCsub")
 
-lib = env.add_library("servers", env.servers_sources)
+servers_env = env.Clone()
 
+lib = servers_env.add_library("servers", env.servers_sources)
 env.Prepend(LIBS=[lib])

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4669,7 +4669,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 				expr = _parse_array_constructor(p_block, p_function_info);
 			} else {
 				DataType datatype;
-				DataPrecision precision;
+				DataPrecision precision = DataPrecision::PRECISION_DEFAULT;
 				bool precision_defined = false;
 
 				if (is_token_precision(tk.type)) {


### PR DESCRIPTION
This adds shared build support for the scons build.

The build can now be built shared by passing `shared=True` in the scons command. This does drastically speed up the link time for the godot bin (anecdotally for my machine from 5 seconds to less than a second).

This PR mainly is to aid in faster development as outlined in https://github.com/godotengine/godot-proposals/issues/1796
