### PR TITLE
GPULightmapper's triangles and their bounding box will be in-sync

### DIFF
--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -7,6 +7,9 @@ env_lightmapper_rd = env_modules.Clone()
 env_lightmapper_rd.GLSL_HEADER("lm_raster.glsl")
 env_lightmapper_rd.GLSL_HEADER("lm_compute.glsl")
 env_lightmapper_rd.GLSL_HEADER("lm_blendseams.glsl")
+env_lightmapper_rd.Depends("lm_raster.glsl.gen.h", "lm_common_inc.glsl")
+env_lightmapper_rd.Depends("lm_compute.glsl.gen.h", "lm_common_inc.glsl")
+env_lightmapper_rd.Depends("lm_blendseams.glsl.gen.h", "lm_common_inc.glsl")
 
 # Godot source files
 env_lightmapper_rd.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -157,16 +157,13 @@ class LightmapperRD : public Lightmapper {
 		}
 	};
 
-	struct Box {
+	struct Triangle {
+		uint32_t indices[3] = {};
+		uint32_t slice = 0;
 		float min_bounds[3] = {};
 		float pad0 = 0.0;
 		float max_bounds[3] = {};
 		float pad1 = 0.0;
-	};
-
-	struct Triangle {
-		uint32_t indices[3] = {};
-		uint32_t slice = 0;
 		bool operator<(const Triangle &p_triangle) const {
 			return slice < p_triangle.slice;
 		}
@@ -231,7 +228,7 @@ class LightmapperRD : public Lightmapper {
 	Vector<Color> probe_values;
 
 	BakeError _blit_meshes_into_atlas(int p_max_texture_size, Vector<Ref<Image>> &albedo_images, Vector<Ref<Image>> &emission_images, AABB &bounds, Size2i &atlas_size, int &atlas_slices, BakeStepFunc p_step_function, void *p_bake_userdata);
-	void _create_acceleration_structures(RenderingDevice *rd, Size2i atlas_size, int atlas_slices, AABB &bounds, int grid_size, Vector<Probe> &probe_positions, GenerateProbes p_generate_probes, Vector<int> &slice_triangle_count, Vector<int> &slice_seam_count, RID &vertex_buffer, RID &triangle_buffer, RID &box_buffer, RID &lights_buffer, RID &triangle_cell_indices_buffer, RID &probe_positions_buffer, RID &grid_texture, RID &seams_buffer, BakeStepFunc p_step_function, void *p_bake_userdata);
+	void _create_acceleration_structures(RenderingDevice *rd, Size2i atlas_size, int atlas_slices, AABB &bounds, int grid_size, Vector<Probe> &probe_positions, GenerateProbes p_generate_probes, Vector<int> &slice_triangle_count, Vector<int> &slice_seam_count, RID &vertex_buffer, RID &triangle_buffer, RID &lights_buffer, RID &triangle_cell_indices_buffer, RID &probe_positions_buffer, RID &grid_texture, RID &seams_buffer, BakeStepFunc p_step_function, void *p_bake_userdata);
 	void _raster_geometry(RenderingDevice *rd, Size2i atlas_size, int atlas_slices, int grid_size, AABB bounds, float p_bias, Vector<int> slice_triangle_count, RID position_tex, RID unocclude_tex, RID normal_tex, RID raster_depth_buffer, RID rasterize_shader, RID raster_base_uniform);
 
 public:

--- a/modules/lightmapper_rd/lm_common_inc.glsl
+++ b/modules/lightmapper_rd/lm_common_inc.glsl
@@ -16,6 +16,10 @@ vertices;
 struct Triangle {
 	uvec3 indices;
 	uint slice;
+	vec3 min_bounds;
+	uint pad0;
+	vec3 max_bounds;
+	uint pad1;
 };
 
 layout(set = 0, binding = 2, std430) restrict readonly buffer Triangles {
@@ -23,19 +27,7 @@ layout(set = 0, binding = 2, std430) restrict readonly buffer Triangles {
 }
 triangles;
 
-struct Box {
-	vec3 min_bounds;
-	uint pad0;
-	vec3 max_bounds;
-	uint pad1;
-};
-
-layout(set = 0, binding = 3, std430) restrict readonly buffer Boxes {
-	Box data[];
-}
-boxes;
-
-layout(set = 0, binding = 4, std430) restrict readonly buffer GridIndices {
+layout(set = 0, binding = 3, std430) restrict readonly buffer GridIndices {
 	uint data[];
 }
 grid_indices;
@@ -63,7 +55,7 @@ struct Light {
 	uint pad[3];
 };
 
-layout(set = 0, binding = 5, std430) restrict readonly buffer Lights {
+layout(set = 0, binding = 4, std430) restrict readonly buffer Lights {
 	Light data[];
 }
 lights;
@@ -73,19 +65,19 @@ struct Seam {
 	uvec2 b;
 };
 
-layout(set = 0, binding = 6, std430) restrict readonly buffer Seams {
+layout(set = 0, binding = 5, std430) restrict readonly buffer Seams {
 	Seam data[];
 }
 seams;
 
-layout(set = 0, binding = 7, std430) restrict readonly buffer Probes {
+layout(set = 0, binding = 6, std430) restrict readonly buffer Probes {
 	vec4 data[];
 }
 probe_positions;
 
-layout(set = 0, binding = 8) uniform utexture3D grid;
+layout(set = 0, binding = 7) uniform utexture3D grid;
 
-layout(set = 0, binding = 9) uniform texture2DArray albedo_tex;
-layout(set = 0, binding = 10) uniform texture2DArray emission_tex;
+layout(set = 0, binding = 8) uniform texture2DArray albedo_tex;
+layout(set = 0, binding = 9) uniform texture2DArray emission_tex;
 
-layout(set = 0, binding = 11) uniform sampler linear_sampler;
+layout(set = 0, binding = 10) uniform sampler linear_sampler;

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -160,18 +160,19 @@ bool trace_ray(vec3 p_from, vec3 p_to
 				uint tidx = grid_indices.data[cell_data.y + i];
 
 				//Ray-Box test
-				vec3 t0 = (boxes.data[tidx].min_bounds - p_from) * inv_dir;
-				vec3 t1 = (boxes.data[tidx].max_bounds - p_from) * inv_dir;
+				Triangle triangle = triangles.data[tidx];
+				vec3 t0 = (triangle.min_bounds - p_from) * inv_dir;
+				vec3 t1 = (triangle.max_bounds - p_from) * inv_dir;
 				vec3 tmin = min(t0, t1), tmax = max(t0, t1);
 
-				if (max(tmin.x, max(tmin.y, tmin.z)) <= min(tmax.x, min(tmax.y, tmax.z))) {
+				if (max(tmin.x, max(tmin.y, tmin.z)) > min(tmax.x, min(tmax.y, tmax.z))) {
 					continue; //ray box failed
 				}
 
 				//prepare triangle vertices
-				vec3 vtx0 = vertices.data[triangles.data[tidx].indices.x].position;
-				vec3 vtx1 = vertices.data[triangles.data[tidx].indices.y].position;
-				vec3 vtx2 = vertices.data[triangles.data[tidx].indices.z].position;
+				vec3 vtx0 = vertices.data[triangle.indices.x].position;
+				vec3 vtx1 = vertices.data[triangle.indices.y].position;
+				vec3 vtx2 = vertices.data[triangle.indices.z].position;
 #if defined(MODE_UNOCCLUDE)
 				vec3 normal = -normalize(cross((vtx0 - vtx1), (vtx0 - vtx2)));
 


### PR DESCRIPTION
Previously the bounding boxes and triangles were maintained in two separate
arrays (Vectors). As the triangle vector was sorted and the bounding-box array
was not , the order of both arrays differed. This meant that the index in one
was different than the other, which caused lookup issues.

To prevent this, the bounding-box is now part of the triangle structure so that
there is a single structure that cannot become out-of-sync anymore.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
