### PR TITLE
Expose enum related methods in ClassDB

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2042,6 +2042,42 @@ StringName ClassDB::get_category(const StringName &p_node) const {
 	return ::ClassDB::get_category(p_node);
 }
 
+bool ClassDB::has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) const {
+	return ::ClassDB::has_enum(p_class, p_name, p_no_inheritance);
+}
+
+PackedStringArray ClassDB::get_enum_list(const StringName &p_class, bool p_no_inheritance) const {
+	List<StringName> enums;
+	::ClassDB::get_enum_list(p_class, &enums, p_no_inheritance);
+
+	PackedStringArray ret;
+	ret.resize(enums.size());
+	int idx = 0;
+	for (const StringName &E : enums) {
+		ret.set(idx++, E);
+	}
+
+	return ret;
+}
+
+PackedStringArray ClassDB::get_enum_constants(const StringName &p_class, const StringName &p_enum, bool p_no_inheritance) const {
+	List<StringName> constants;
+	::ClassDB::get_enum_constants(p_class, p_enum, &constants, p_no_inheritance);
+
+	PackedStringArray ret;
+	ret.resize(constants.size());
+	int idx = 0;
+	for (const StringName &E : constants) {
+		ret.set(idx++, E);
+	}
+
+	return ret;
+}
+
+StringName ClassDB::get_integer_constant_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) const {
+	return ::ClassDB::get_integer_constant_enum(p_class, p_name, p_no_inheritance);
+}
+
 bool ClassDB::is_class_enabled(StringName p_class) const {
 	return ::ClassDB::is_class_enabled(p_class);
 }
@@ -2071,6 +2107,11 @@ void ClassDB::_bind_methods() {
 
 	::ClassDB::bind_method(D_METHOD("class_has_integer_constant", "class", "name"), &ClassDB::has_integer_constant);
 	::ClassDB::bind_method(D_METHOD("class_get_integer_constant", "class", "name"), &ClassDB::get_integer_constant);
+
+	::ClassDB::bind_method(D_METHOD("class_has_enum", "class", "name", "no_inheritance"), &ClassDB::has_enum, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_get_enum_list", "class", "no_inheritance"), &ClassDB::get_enum_list, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_get_enum_constants", "class", "enum", "no_inheritance"), &ClassDB::get_enum_constants, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_get_integer_constant_enum", "class", "name", "no_inheritance"), &ClassDB::get_integer_constant_enum, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("class_get_category", "class"), &ClassDB::get_category);
 	::ClassDB::bind_method(D_METHOD("is_class_enabled", "class"), &ClassDB::is_class_enabled);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -592,6 +592,11 @@ public:
 	int get_integer_constant(const StringName &p_class, const StringName &p_name) const;
 	StringName get_category(const StringName &p_node) const;
 
+	bool has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false) const;
+	PackedStringArray get_enum_list(const StringName &p_class, bool p_no_inheritance = false) const;
+	PackedStringArray get_enum_constants(const StringName &p_class, const StringName &p_enum, bool p_no_inheritance = false) const;
+	StringName get_integer_constant_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false) const;
+
 	bool is_class_enabled(StringName p_class) const;
 
 	ClassDB() {}

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -30,12 +30,38 @@
 				Returns a category associated with the class for use in documentation and the Asset Library. Debug mode required.
 			</description>
 		</method>
+		<method name="class_get_enum_constants" qualifiers="const">
+			<return type="PackedStringArray" />
+			<argument index="0" name="class" type="StringName" />
+			<argument index="1" name="enum" type="StringName" />
+			<argument index="2" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns an array with all the keys in [code]enum[/code] of [code]class[/code] or its ancestry.
+			</description>
+		</method>
+		<method name="class_get_enum_list" qualifiers="const">
+			<return type="PackedStringArray" />
+			<argument index="0" name="class" type="StringName" />
+			<argument index="1" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns an array with all the enums of [code]class[/code] or its ancestry.
+			</description>
+		</method>
 		<method name="class_get_integer_constant" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="class" type="StringName" />
 			<argument index="1" name="name" type="StringName" />
 			<description>
 				Returns the value of the integer constant [code]name[/code] of [code]class[/code] or its ancestry. Always returns 0 when the constant could not be found.
+			</description>
+		</method>
+		<method name="class_get_integer_constant_enum" qualifiers="const">
+			<return type="StringName" />
+			<argument index="0" name="class" type="StringName" />
+			<argument index="1" name="name" type="StringName" />
+			<argument index="2" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns which enum the integer constant [code]name[/code] of [code]class[/code] or its ancestry belongs to.
 			</description>
 		</method>
 		<method name="class_get_integer_constant_list" qualifiers="const">
@@ -85,6 +111,15 @@
 			<argument index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
 				Returns an array with all the signals of [code]class[/code] or its ancestry if [code]no_inheritance[/code] is [code]false[/code]. Every element of the array is a [Dictionary] as described in [method class_get_signal].
+			</description>
+		</method>
+		<method name="class_has_enum" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="class" type="StringName" />
+			<argument index="1" name="name" type="StringName" />
+			<argument index="2" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns whether [code]class[/code] or its ancestry has an enum called [code]name[/code] or not.
 			</description>
 		</method>
 		<method name="class_has_integer_constant" qualifiers="const">


### PR DESCRIPTION
This PR exposes 4 enum related methods in `ClassDB`:

* `class_has_enum(class, name)` to tell whether `name` is an enum in `class`
* `class_get_enum_list(class)` to retrieve a list of enums in `class`
* `class_get_enum_constants(class, enum)` to retrieve a list of all valid keys `class.enum` has.
* `class_get_integer_constant_enum(class, name)` to get which enum the constant `name` belongs to.

Useful when writing plugins.

```gdscript
extends SceneTree

func _init():
        # HTTPClient has enum Method? True
	print("HTTPClient has enum Method? ", ClassDB.class_has_enum("HTTPClient", "Method"))

        # Enums in HTTPClient: [Status, Method, ResponseCode, ConnectFlags]
	print("Enums in HTTPClient: ", ClassDB.class_get_enum_list("HTTPClient"))

        # Values in HTTPClient.Method: [METHOD_GET, METHOD_HEAD, METHOD_POST, METHOD_PUT, METHOD_DELETE, METHOD_OPTIONS, METHOD_TRACE, METHOD_CONNECT, METHOD_PATCH, METHOD_MAX]
	print("Values in HTTPClient.Method: ", ClassDB.class_get_enum_constants("HTTPClient", "Method"))

        # METHOD_GET belongs to enum: Method
	print("METHOD_GET belongs to enum: ", ClassDB.class_get_integer_constant_enum("HTTPClient", "METHOD_GET"))

	quit()
```