### PR TITLE
[3.x] Expose enum related methods in ClassDB

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2886,6 +2886,42 @@ StringName _ClassDB::get_category(const StringName &p_node) const {
 	return ClassDB::get_category(p_node);
 }
 
+bool _ClassDB::has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) const {
+	return ClassDB::has_enum(p_class, p_name, p_no_inheritance);
+}
+
+PoolStringArray _ClassDB::get_enum_list(const StringName &p_class, bool p_no_inheritance) const {
+	List<StringName> enums;
+	ClassDB::get_enum_list(p_class, &enums, p_no_inheritance);
+
+	PoolStringArray ret;
+	ret.resize(enums.size());
+	int idx = 0;
+	for (List<StringName>::Element *E = enums.front(); E; E = E->next()) {
+		ret.set(idx++, E->get());
+	}
+
+	return ret;
+}
+
+PoolStringArray _ClassDB::get_enum_constants(const StringName &p_class, const StringName &p_enum, bool p_no_inheritance) const {
+	List<StringName> constants;
+	ClassDB::get_enum_constants(p_class, p_enum, &constants, p_no_inheritance);
+
+	PoolStringArray ret;
+	ret.resize(constants.size());
+	int idx = 0;
+	for (List<StringName>::Element *E = constants.front(); E; E = E->next()) {
+		ret.set(idx++, E->get());
+	}
+
+	return ret;
+}
+
+StringName _ClassDB::get_integer_constant_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) const {
+	return ClassDB::get_integer_constant_enum(p_class, p_name, p_no_inheritance);
+}
+
 bool _ClassDB::is_class_enabled(StringName p_class) const {
 	return ClassDB::is_class_enabled(p_class);
 }
@@ -2915,6 +2951,11 @@ void _ClassDB::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("class_has_integer_constant", "class", "name"), &_ClassDB::has_integer_constant);
 	ClassDB::bind_method(D_METHOD("class_get_integer_constant", "class", "name"), &_ClassDB::get_integer_constant);
+
+	ClassDB::bind_method(D_METHOD("class_has_enum", "class", "name", "no_inheritance"), &_ClassDB::has_enum, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("class_get_enum_list", "class", "no_inheritance"), &_ClassDB::get_enum_list, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("class_get_enum_constants", "class", "enum", "no_inheritance"), &_ClassDB::get_enum_constants, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("class_get_integer_constant_enum", "class", "name", "no_inheritance"), &_ClassDB::get_integer_constant_enum, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("class_get_category", "class"), &_ClassDB::get_category);
 	ClassDB::bind_method(D_METHOD("is_class_enabled", "class"), &_ClassDB::is_class_enabled);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -741,6 +741,11 @@ public:
 	int get_integer_constant(const StringName &p_class, const StringName &p_name) const;
 	StringName get_category(const StringName &p_node) const;
 
+	bool has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false) const;
+	PoolStringArray get_enum_list(const StringName &p_class, bool p_no_inheritance = false) const;
+	PoolStringArray get_enum_constants(const StringName &p_class, const StringName &p_enum, bool p_no_inheritance = false) const;
+	StringName get_integer_constant_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false) const;
+
 	bool is_class_enabled(StringName p_class) const;
 
 	_ClassDB();

--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -790,6 +790,24 @@ void ClassDB::get_enum_constants(const StringName &p_class, const StringName &p_
 	}
 }
 
+bool ClassDB::has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) {
+	OBJTYPE_RLOCK;
+
+	ClassInfo *type = classes.getptr(p_class);
+
+	while (type) {
+		if (type->enum_map.has(p_name)) {
+			return true;
+		}
+		if (p_no_inheritance) {
+			return false;
+		}
+		type = type->inherits_ptr;
+	}
+
+	return false;
+}
+
 void ClassDB::add_signal(StringName p_class, const MethodInfo &p_signal) {
 	OBJTYPE_WLOCK;
 

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -360,6 +360,7 @@ public:
 	static StringName get_integer_constant_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
 	static void get_enum_list(const StringName &p_class, List<StringName> *p_enums, bool p_no_inheritance = false);
 	static void get_enum_constants(const StringName &p_class, const StringName &p_enum, List<StringName> *p_constants, bool p_no_inheritance = false);
+	static bool has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
 
 	static Variant class_get_default_property_value(const StringName &p_class, const StringName &p_property, bool *r_valid = nullptr);
 

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -30,12 +30,38 @@
 				Returns a category associated with the class for use in documentation and the Asset Library. Debug mode required.
 			</description>
 		</method>
+		<method name="class_get_enum_constants" qualifiers="const">
+			<return type="PoolStringArray" />
+			<argument index="0" name="class" type="String" />
+			<argument index="1" name="enum" type="String" />
+			<argument index="2" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns an array with all the keys in [code]enum[/code] of [code]class[/code] or its ancestry.
+			</description>
+		</method>
+		<method name="class_get_enum_list" qualifiers="const">
+			<return type="PoolStringArray" />
+			<argument index="0" name="class" type="String" />
+			<argument index="1" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns an array with all the enums of [code]class[/code] or its ancestry.
+			</description>
+		</method>
 		<method name="class_get_integer_constant" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="class" type="String" />
 			<argument index="1" name="name" type="String" />
 			<description>
 				Returns the value of the integer constant [code]name[/code] of [code]class[/code] or its ancestry. Always returns 0 when the constant could not be found.
+			</description>
+		</method>
+		<method name="class_get_integer_constant_enum" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="class" type="String" />
+			<argument index="1" name="name" type="String" />
+			<argument index="2" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns which enum the integer constant [code]name[/code] of [code]class[/code] or its ancestry belongs to.
 			</description>
 		</method>
 		<method name="class_get_integer_constant_list" qualifiers="const">
@@ -85,6 +111,15 @@
 			<argument index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
 				Returns an array with all the signals of [code]class[/code] or its ancestry if [code]no_inheritance[/code] is [code]false[/code]. Every element of the array is a [Dictionary] as described in [method class_get_signal].
+			</description>
+		</method>
+		<method name="class_has_enum" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="class" type="String" />
+			<argument index="1" name="name" type="String" />
+			<argument index="2" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns whether [code]class[/code] or its ancestry has an enum called [code]name[/code] or not.
 			</description>
 		</method>
 		<method name="class_has_integer_constant" qualifiers="const">


### PR DESCRIPTION
`3.x` version of #52571.

Added `ClassDB::has_enum()` in C++ based on the `master` version.