### PR TITLE
Corrected "Save Scene" and "Save All Scenes" function when dir renamed

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1742,13 +1742,15 @@ void EditorNode::restart_editor() {
 void EditorNode::_save_all_scenes() {
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		Node *scene = editor_data.get_edited_scene_root(i);
-		if (scene && scene->get_filename() != "") {
+		if (scene && scene->get_filename() != "" && DirAccess::exists(scene->get_filename().get_base_dir())) {
 			if (i != editor_data.get_edited_scene()) {
 				_save_scene(scene->get_filename(), i);
 			} else {
 				_save_scene_with_preview(scene->get_filename());
 			}
-		} // else: ignore new scenes
+		} else {
+			show_warning(TTR("Could not save one or more scenes!"), TTR("Save All Scenes"));
+		}
 	}
 
 	_save_default_environment();
@@ -2469,20 +2471,22 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case SCENE_TAB_CLOSE:
 		case FILE_SAVE_SCENE: {
 			int scene_idx = (p_option == FILE_SAVE_SCENE) ? -1 : tab_closing;
-
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
 			if (scene && scene->get_filename() != "") {
-				if (scene_idx != editor_data.get_edited_scene()) {
-					_save_scene_with_preview(scene->get_filename(), scene_idx);
+				if (DirAccess::exists(scene->get_filename().get_base_dir())) {
+					if (scene_idx != editor_data.get_edited_scene()) {
+						_save_scene_with_preview(scene->get_filename(), scene_idx);
+					} else {
+						_save_scene_with_preview(scene->get_filename());
+					}
+
+					if (scene_idx != -1) {
+						_discard_changes();
+					}
+					save_layout();
 				} else {
-					_save_scene_with_preview(scene->get_filename());
+					show_save_accept(vformat(TTR("%s no longer exists! Please specify a new save location."), scene->get_filename().get_base_dir()), TTR("OK"));
 				}
-
-				if (scene_idx != -1) {
-					_discard_changes();
-				}
-				save_layout();
-
 				break;
 			}
 			[[fallthrough]];
@@ -4137,6 +4141,13 @@ void EditorNode::show_accept(const String &p_text, const String &p_title) {
 	accept->get_ok_button()->set_text(p_title);
 	accept->set_text(p_text);
 	accept->popup_centered();
+}
+
+void EditorNode::show_save_accept(const String &p_text, const String &p_title) {
+	current_option = -1;
+	save_accept->get_ok_button()->set_text(p_title);
+	save_accept->set_text(p_text);
+	save_accept->popup_centered();
 }
 
 void EditorNode::show_warning(const String &p_text, const String &p_title) {
@@ -6253,6 +6264,10 @@ EditorNode::EditorNode() {
 	accept = memnew(AcceptDialog);
 	gui_base->add_child(accept);
 	accept->connect("confirmed", callable_mp(this, &EditorNode::_menu_confirm_current));
+
+	save_accept = memnew(AcceptDialog);
+	gui_base->add_child(save_accept);
+	save_accept->connect("confirmed", callable_mp(this, &EditorNode::_menu_option), make_binds((int)MenuOptions::FILE_SAVE_AS_SCENE));
 
 	project_export = memnew(ProjectExportDialog);
 	gui_base->add_child(project_export);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -309,6 +309,7 @@ private:
 	ConfirmationDialog *pick_main_scene;
 	Button *select_current_scene_button;
 	AcceptDialog *accept;
+	AcceptDialog *save_accept;
 	EditorAbout *about;
 	AcceptDialog *warning;
 
@@ -812,6 +813,7 @@ public:
 	Ref<Texture2D> get_class_icon(const String &p_class, const String &p_fallback = "Object") const;
 
 	void show_accept(const String &p_text, const String &p_title);
+	void show_save_accept(const String &p_text, const String &p_title);
 	void show_warning(const String &p_text, const String &p_title = TTR("Warning!"));
 
 	void _copy_warning(const String &p_str);


### PR DESCRIPTION
fix #52078

This problem seems to occur as the code checks whether the filename is defined but doesn't check if that filename/location actually exists. The problem can also be seen if you rename the directory outside of the editor for all scenes saved in that folder, regardless of if they have already been saved or not.

For "Save Scene", I added a DirAccess::exists check to see if the directory exists before attempting to save, and if it doesn't, prompting the user with an alert box. If the user clicks the ok on the alert, it triggers off a "Save Scene As" prompt.

![image](https://user-images.githubusercontent.com/9070198/132950186-4e23b28b-ef96-4de3-8a5c-9057e20b9788.png)


For "Save All Scenes" this was not a viable solution to add, so I did the same DirAccess::exists check, and if any of the scenes failed it, prompted the user with a warning popup to say at least one scene was not able to be saved.

![image](https://user-images.githubusercontent.com/9070198/132950192-471334f8-5c71-41ac-b110-0f3b1aafc532.png)