### PR TITLE
Document that ConfigFiles can use any file extension

### DIFF
--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -86,6 +86,7 @@
 		[/codeblocks]
 		Keep in mind that section and property names can't contain spaces. Anything after a space will be ignored on save and on load.
 		ConfigFiles can also contain manually written comment lines starting with a semicolon ([code];[/code]). Those lines will be ignored when parsing the file. Note that comments will be lost when saving the ConfigFile. This can still be useful for dedicated server configuration files, which are typically never overwritten without explicit user action.
+		[b]Note:[/b] The file extension given to a ConfigFile does not have any impact on its formatting or behavior. By convention, the [code].cfg[/code] extension is used here, but any other extension such as [code].ini[/code] is also valid. Since neither [code].cfg[/code] nor [code].ini[/code] are standardized, Godot's ConfigFile formatting may differ from files written by other programs.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
The file extension given to a ConfigFile has no impact on its formatting or behavior.

See https://github.com/godotengine/godot/pull/39212 for background. I'd still lean towards recommending `.ini`, but I kept `.cfg` here to make the change less intrusive.