### PR TITLE
Fix for issue where Godot crashes on reparenting bones in the skeleton gizmo editor

### DIFF
--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -553,6 +553,8 @@ void Skeleton3DEditor::update_joint_tree() {
 
 	Ref<Texture> bone_icon = get_theme_icon(SNAME("BoneAttachment3D"), SNAME("EditorIcons"));
 
+	skeleton->_update_process_order();
+
 	Vector<int> bones_to_process = skeleton->get_parentless_bones();
 	while (bones_to_process.size() > 0) {
 		int current_bone_idx = bones_to_process[0];

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -139,8 +139,6 @@ private:
 
 	uint64_t version = 1;
 
-	void _update_process_order();
-
 protected:
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
@@ -167,6 +165,7 @@ public:
 	};
 
 	// skeleton creation api
+	void _update_process_order();
 	void add_bone(const String &p_name);
 	int find_bone(const String &p_name) const;
 	String get_bone_name(int p_bone) const;


### PR DESCRIPTION
Fixes #52533 

The issue was that it was trying to access bones before updating the process order, causing the issue. Calling `_update_process_order` right before the gizmo tries to build will cause it to update if it needs it and fixes the crash.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
