### PR TITLE
Prevent inferring type of parameter from null value without explicit type

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1478,6 +1478,10 @@ void GDScriptAnalyzer::resolve_parameter(GDScriptParser::ParameterNode *p_parame
 		}
 	}
 
+	if (result.builtin_type == Variant::Type::NIL && result.type_source == GDScriptParser::DataType::ANNOTATED_INFERRED && p_parameter->datatype_specifier == nullptr) {
+		push_error(vformat(R"(Could not infer the type of the variable "%s" because the initial value is "null".)", p_parameter->identifier->name), p_parameter->default_value);
+	}
+
 	p_parameter->set_datatype(result);
 }
 


### PR DESCRIPTION
Fix #52569

### Issue description

Inferring function parameters type from null without explicit type are allowed in function parameters.
It should throw same kind of error as when we initialize a variable in that way : 
``var a:=null`` raises an error : Could not infer the type of the variable "a" because the initial value is "null".

### Fix proposal

Raise an error when parameter type is inferred from a null value without an explicit type.

### Result

![image](https://user-images.githubusercontent.com/3649998/132959299-7bee16c2-636f-42f7-992f-a4ca0bd6ff58.png)

