### PR TITLE
Removed updates that caused unnecessary window updates

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2027,7 +2027,9 @@ String CodeEdit::get_text_for_symbol_lookup() {
 void CodeEdit::set_symbol_lookup_word_as_valid(bool p_valid) {
 	symbol_lookup_word = p_valid ? symbol_lookup_new_word : "";
 	symbol_lookup_new_word = "";
-	_set_symbol_lookup_word(symbol_lookup_word);
+	if (lookup_symbol_word != symbol_lookup_word) {
+		_set_symbol_lookup_word(symbol_lookup_word);
+	}
 }
 
 void CodeEdit::_bind_methods() {


### PR DESCRIPTION
Fix #52360

The unnecessary updates were happening in both the tab and the text edit part of the script window.

In regards to the text edit part, it seemed to happen while updating a string. I changed it to only update if the string was changed.

The tab update seemed to not affect anything I could see, and removing it doesn't seem to have made a difference.

I am unsure about these changes, specifically the tab change, so I'd appreciate extra scrutiny to be sure that I haven't caused a problem elsewhere.