### PR TITLE
Change example used for StringName call methods

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -92,12 +92,12 @@
 				Calls the [code]method[/code] on the object and returns the result. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
 				[codeblocks]
 				[gdscript]
-				var node = Node2D.new()
-				node.call("set", "position", Vector2(42, 0))
+				var node = Node3D.new()
+				node.call("rotate", Vector3(1.0, 0.0, 0.0), 1.571)
 				[/gdscript]
 				[csharp]
-				var node = new Node2D();
-				node.Call("set", "position", new Vector2(42, 0));
+				var node = new Node3D();
+				node.Call("rotate", new Vector3(1f, 0f, 0f), 1.571f);
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] In C#, the method name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined methods where you should use the same convention as in the C# source (typically PascalCase).
@@ -110,12 +110,12 @@
 				Calls the [code]method[/code] on the object during idle time. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
 				[codeblocks]
 				[gdscript]
-				var node = Node2D.new()
-				node.call_deferred("set", "position", Vector2(42, 0))
+				var node = Node3D.new()
+				node.call_deferred("rotate", Vector3(1.0, 0.0, 0.0), 1.571)
 				[/gdscript]
 				[csharp]
-				var node = new Node2D();
-				node.CallDeferred("set", "position", new Vector2(42, 0));
+				var node = new Node3D();
+				node.CallDeferred("rotate", new Vector3(1f, 0f, 0f), 1.571f);
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] In C#, the method name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined methods where you should use the same convention as in the C# source (typically PascalCase).
@@ -129,12 +129,12 @@
 				Calls the [code]method[/code] on the object and returns the result. Contrarily to [method call], this method does not support a variable number of arguments but expects all parameters to be via a single [Array].
 				[codeblocks]
 				[gdscript]
-				var node = Node2D.new()
-				node.callv("set", ["position", Vector2(42, 0)])
+				var node = Node3D.new()
+				node.callv("rotate", [Vector3(1.0, 0.0, 0.0), 1.571])
 				[/gdscript]
 				[csharp]
-				var node = new Node2D();
-				node.Callv("set", new Godot.Collections.Array { "position", new Vector2(42, 0) });
+				var node = new Node3D();
+				node.Callv("rotate", new Godot.Collections.Array { new Vector3(1f, 0f, 0f), 1.571f });
 				[/csharp]
 				[/codeblocks]
 			</description>


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Changes the example function call used for `call`, `callv`, and `call_deferred` in `Object` docs.

The reason for this is a noticed ambiguity in the original example (which used `set("position"`)

Someone on the help discord misinterpreted that example as attempting to call `set_position(`, and attempted to defer an `add_child()` call as `call_deferred("add", "child", some_node)`

The example was changed to calling Node3D `rotate()` to keep use of a simpler function with multiple parameters to showcase difference between `call()` and `callv()`

The example was changed in all 3 for consistency.