### PR TITLE
[3.x] Remove do{ } while(0) wrapper around error macros

### DIFF
--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -126,91 +126,84 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * error message and returns from the function. This macro should be preferred to
  * `ERR_FAIL_COND` for bounds checking.
  */
-#define ERR_FAIL_INDEX(m_index, m_size)                                                                             \
-	do {                                                                                                            \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return;                                                                                                 \
-		}                                                                                                           \
-	} while (0); // (*)
+#define ERR_FAIL_INDEX(m_index, m_size)                                                                         \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		return;                                                                                                 \
+	} else                                                                                                      \
+		((void)0)
 
 /**
  * If `m_index` is less than 0 or greater than or equal to `m_size`, prints a custom
  * error message and returns from the function. This macro should be preferred to
  * `ERR_FAIL_COND_MSG` for bounds checking.
  */
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                    \
-	do {                                                                                                                              \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-			return;                                                                                                                   \
-		}                                                                                                                             \
-	} while (0); // (*)
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return;                                                                                                                   \
+	} else                                                                                                                        \
+		((void)0)
 
 /**
  * If `m_index` is less than 0 or greater than or equal to `m_size`,
  * prints a generic error message and returns the value specified in `m_retval`.
  * This macro should be preferred to `ERR_FAIL_COND_V` for bounds checking.
  */
-#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                 \
-	do {                                                                                                            \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return m_retval;                                                                                        \
-		}                                                                                                           \
-	} while (0); // (*)
+#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                             \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		return m_retval;                                                                                        \
+	} else                                                                                                      \
+		((void)0)
 
 /**
  * If `m_index` is less than 0 or greater than or equal to `m_size`,
  * prints a custom error message and returns the value specified in `m_retval`.
  * This macro should be preferred to `ERR_FAIL_COND_V_MSG` for bounds checking.
  */
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                        \
-	do {                                                                                                                              \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-			return m_retval;                                                                                                          \
-		}                                                                                                                             \
-	} while (0); // (*)
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                    \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                          \
+	} else                                                                                                                        \
+		((void)0)
 
 /**
  * If `m_index` is greater than or equal to `m_size`,
  * prints a generic error message and returns the value specified in `m_retval`.
  * This macro should be preferred to `ERR_FAIL_COND_V` for unsigned bounds checking.
  */
-#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                    \
-	do {                                                                                                            \
-		if (unlikely((m_index) >= (m_size))) {                                                                      \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return;                                                                                                 \
-		}                                                                                                           \
-	} while (0); // (*)
+#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                \
+	if (unlikely((m_index) >= (m_size))) {                                                                      \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		return;                                                                                                 \
+	} else                                                                                                      \
+		((void)0)
 
 /**
  * If `m_index` is greater than or equal to `m_size`,
  * prints a generic error message and returns the value specified in `m_retval`.
  * This macro should be preferred to `ERR_FAIL_COND_V` for unsigned bounds checking.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                        \
-	do {                                                                                                            \
-		if (unlikely((m_index) >= (m_size))) {                                                                      \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-			return m_retval;                                                                                        \
-		}                                                                                                           \
-	} while (0); // (*)
+#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                    \
+	if (unlikely((m_index) >= (m_size))) {                                                                      \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		return m_retval;                                                                                        \
+	} else                                                                                                      \
+		((void)0)
 
 /**
  * If `m_index` is greater than or equal to `m_size`,
  * prints a custom error message and returns the value specified in `m_retval`.
  * This macro should be preferred to `ERR_FAIL_COND_V_MSG` for unsigned bounds checking.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                               \
-	do {                                                                                                                              \
-		if (unlikely((m_index) >= (m_size))) {                                                                                        \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-			return m_retval;                                                                                                          \
-		}                                                                                                                             \
-	} while (0); // (*)
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                           \
+	if (unlikely((m_index) >= (m_size))) {                                                                                        \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                          \
+	} else                                                                                                                        \
+		((void)0)
 
 /**
  * If `m_index` is less than 0 or greater than or equal to `m_size`,
@@ -218,13 +211,12 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
  * This macro should be preferred to `CRASH_COND` for bounds checking.
  */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                      \
-	do {                                                                                                                      \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                               \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
-			GENERATE_TRAP                                                                                                     \
-		}                                                                                                                     \
-	} while (0); // (*)
+#define CRASH_BAD_INDEX(m_index, m_size)                                                                                  \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                               \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
+		GENERATE_TRAP                                                                                                     \
+	} else                                                                                                                \
+		((void)0)
 
 /**
  * If `m_index` is less than 0 or greater than or equal to `m_size`,
@@ -232,13 +224,12 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
  * This macro should be preferred to `CRASH_COND` for bounds checking.
  */
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                              \
-	do {                                                                                                                         \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-			GENERATE_TRAP                                                                                                        \
-		}                                                                                                                        \
-	} while (0); // (*)
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                          \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+		GENERATE_TRAP                                                                                                        \
+	} else                                                                                                                   \
+		((void)0)
 
 /**
  * If `m_index` is greater than or equal to `m_size`,
@@ -246,79 +237,72 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
  * This macro should be preferred to `CRASH_COND` for bounds checking.
  */
-#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                             \
-	do {                                                                                                                      \
-		if (unlikely((m_index) >= (m_size))) {                                                                                \
-			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
-			GENERATE_TRAP                                                                                                     \
-		}                                                                                                                     \
-	} while (0); // (*)
+#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                         \
+	if (unlikely((m_index) >= (m_size))) {                                                                                \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
+		GENERATE_TRAP                                                                                                     \
+	} else                                                                                                                \
+		((void)0)
 
 /**
  * If `m_param` is `null`, prints a generic error message and returns from the function.
  */
-#define ERR_FAIL_NULL(m_param)                                                                              \
-	{                                                                                                       \
-		if (unlikely(!m_param)) {                                                                           \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-			return;                                                                                         \
-		}                                                                                                   \
-	}
+#define ERR_FAIL_NULL(m_param)                                                                          \
+	if (unlikely(!m_param)) {                                                                           \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
+		return;                                                                                         \
+	} else                                                                                              \
+		((void)0)
 
 /**
  * If `m_param` is `null`, prints a custom error message and returns from the function.
  */
-#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                                     \
-	{                                                                                                                         \
-		if (unlikely(!m_param)) {                                                                                             \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
-			return;                                                                                                           \
-		}                                                                                                                     \
-	}
+#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                                 \
+	if (unlikely(!m_param)) {                                                                                             \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
+		return;                                                                                                           \
+	} else                                                                                                                \
+		((void)0)
 
 /**
  * If `m_param` is `null`, prints a generic error message and returns the value specified in `m_retval`.
  */
-#define ERR_FAIL_NULL_V(m_param, m_retval)                                                                  \
-	{                                                                                                       \
-		if (unlikely(!m_param)) {                                                                           \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-			return m_retval;                                                                                \
-		}                                                                                                   \
-	}
+#define ERR_FAIL_NULL_V(m_param, m_retval)                                                              \
+	if (unlikely(!m_param)) {                                                                           \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
+		return m_retval;                                                                                \
+	} else                                                                                              \
+		((void)0)
 
 /**
  * If `m_param` is `null`, prints a custom error message and returns the value specified in `m_retval`.
  */
-#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                                         \
-	{                                                                                                                         \
-		if (unlikely(!m_param)) {                                                                                             \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
-			return m_retval;                                                                                                  \
-		}                                                                                                                     \
-	}
+#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                                     \
+	if (unlikely(!m_param)) {                                                                                             \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                  \
+	} else                                                                                                                \
+		((void)0)
 
 /**
  * If `m_cond` evaluates to `true`, prints a generic error message and returns from the function.
  */
-#define ERR_FAIL_COND(m_cond)                                                                              \
-	{                                                                                                      \
-		if (unlikely(m_cond)) {                                                                            \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
-			return;                                                                                        \
-		}                                                                                                  \
-	}
+#define ERR_FAIL_COND(m_cond)                                                                          \
+	if (unlikely(m_cond)) {                                                                            \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
+		return;                                                                                        \
+	} else                                                                                             \
+		((void)0)
 
 /**
  * If `m_cond` evaluates to `true`, prints a custom error message and returns from the function.
  */
-#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                                     \
-	{                                                                                                                        \
-		if (unlikely(m_cond)) {                                                                                              \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
-			return;                                                                                                          \
-		}                                                                                                                    \
-	}
+#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                                 \
+	if (unlikely(m_cond)) {                                                                                              \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
+		return;                                                                                                          \
+	} else                                                                                                               \
+		((void)0)
 
 /**
  * Should assert only if making a build with dev asserts.
@@ -327,13 +311,12 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  */
 // #define DEV_ASSERTS_ENABLED
 #ifdef DEV_ASSERTS_ENABLED
-#define DEV_ASSERT(m_cond)                                                                                                  \
-	{                                                                                                                       \
-		if (unlikely(!(m_cond))) {                                                                                          \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
-			GENERATE_TRAP                                                                                                   \
-		}                                                                                                                   \
-	}
+#define DEV_ASSERT(m_cond)                                                                                              \
+	if (unlikely(!(m_cond))) {                                                                                          \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
+		GENERATE_TRAP                                                                                                   \
+	} else                                                                                                              \
+		((void)0)
 #else
 #define DEV_ASSERT(m_cond)
 #endif
@@ -342,215 +325,213 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * If `m_cond` evaluates to `true`, crashes the engine immediately with a generic error message.
  * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
  */
-#define CRASH_COND(m_cond)                                                                                        \
-	{                                                                                                             \
-		if (unlikely(m_cond)) {                                                                                   \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
-			GENERATE_TRAP                                                                                         \
-		}                                                                                                         \
-	}
+#define CRASH_COND(m_cond)                                                                                    \
+	if (unlikely(m_cond)) {                                                                                   \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
+		GENERATE_TRAP                                                                                         \
+	} else                                                                                                    \
+		((void)0)
 
 /**
  * If `m_cond` evaluates to `true`, crashes the engine immediately with a custom error message.
  * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
  */
-#define CRASH_COND_MSG(m_cond, m_msg)                                                                                               \
-	{                                                                                                                               \
-		if (unlikely(m_cond)) {                                                                                                     \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
-			GENERATE_TRAP                                                                                                           \
-		}                                                                                                                           \
-	}
+#define CRASH_COND_MSG(m_cond, m_msg)                                                                                           \
+	if (unlikely(m_cond)) {                                                                                                     \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
+		GENERATE_TRAP                                                                                                           \
+	} else                                                                                                                      \
+		((void)0)
 
 /**
  * If `m_cond` evaluates to `true`, prints a generic error message and returns the value specified in `m_retval`.
  */
-#define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                            \
-	{                                                                                                                                \
-		if (unlikely(m_cond)) {                                                                                                      \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returned: " _STR(m_retval)); \
-			return m_retval;                                                                                                         \
-		}                                                                                                                            \
-	}
+#define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                        \
+	if (unlikely(m_cond)) {                                                                                                      \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returned: " _STR(m_retval)); \
+		return m_retval;                                                                                                         \
+	} else                                                                                                                       \
+		((void)0)
 
 /**
  * If `m_cond` evaluates to `true`, prints a custom error message and returns the value specified in `m_retval`.
  */
-#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                                   \
-	{                                                                                                                                                  \
-		if (unlikely(m_cond)) {                                                                                                                        \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returned: " _STR(m_retval), DEBUG_STR(m_msg)); \
-			return m_retval;                                                                                                                           \
-		}                                                                                                                                              \
-	}
+#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                               \
+	if (unlikely(m_cond)) {                                                                                                                        \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returned: " _STR(m_retval), DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                                           \
+	} else                                                                                                                                         \
+		((void)0)
 
 /**
  * If `m_cond` evaluates to `true`, prints a custom error message and continues the loop the macro is located in.
  */
-#define ERR_CONTINUE(m_cond)                                                                                           \
-	{                                                                                                                  \
-		if (unlikely(m_cond)) {                                                                                        \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
-			continue;                                                                                                  \
-		}                                                                                                              \
-	}
+#define ERR_CONTINUE(m_cond)                                                                                       \
+	if (unlikely(m_cond)) {                                                                                        \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
+		continue;                                                                                                  \
+	} else                                                                                                         \
+		((void)0)
 
 /**
  * If `m_cond` evaluates to `true`, prints a custom error message and continues the loop the macro is located in.
  */
-#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                                  \
-	{                                                                                                                                    \
-		if (unlikely(m_cond)) {                                                                                                          \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", DEBUG_STR(m_msg)); \
-			continue;                                                                                                                    \
-		}                                                                                                                                \
-	}
+#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                              \
+	if (unlikely(m_cond)) {                                                                                                          \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", DEBUG_STR(m_msg)); \
+		continue;                                                                                                                    \
+	} else                                                                                                                           \
+		((void)0)
 
 /**
  * If `m_cond` evaluates to `true`, prints a generic error message and breaks from the loop the macro is located in.
  */
-#define ERR_BREAK(m_cond)                                                                                            \
-	{                                                                                                                \
-		if (unlikely(m_cond)) {                                                                                      \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
-			break;                                                                                                   \
-		}                                                                                                            \
-	}
+#define ERR_BREAK(m_cond)                                                                                        \
+	if (unlikely(m_cond)) {                                                                                      \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
+		break;                                                                                                   \
+	} else                                                                                                       \
+		((void)0)
 
 /**
  * If `m_cond` evaluates to `true`, prints a custom error message and breaks from the loop the macro is located in.
  */
-#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                                   \
-	{                                                                                                                                  \
-		if (unlikely(m_cond)) {                                                                                                        \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", DEBUG_STR(m_msg)); \
-			break;                                                                                                                     \
-		}                                                                                                                              \
-	}
+#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                               \
+	if (unlikely(m_cond)) {                                                                                                        \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", DEBUG_STR(m_msg)); \
+		break;                                                                                                                     \
+	} else                                                                                                                         \
+		((void)0)
 
 /**
  * Prints a generic error message and returns from the function.
  */
 #define ERR_FAIL()                                                            \
-	{                                                                         \
+	if (true) {                                                               \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method failed."); \
 		return;                                                               \
-	}
+	} else                                                                    \
+		((void)0)
 
 /**
  * Prints a custom error message and returns from the function.
  */
 #define ERR_FAIL_MSG(m_msg)                                                                     \
-	{                                                                                           \
+	if (true) {                                                                                 \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method failed.", DEBUG_STR(m_msg)); \
 		return;                                                                                 \
-	}
+	} else                                                                                      \
+		((void)0)
 
 /**
  * Prints a generic error message and returns the value specified in `m_retval`.
  */
 #define ERR_FAIL_V(m_retval)                                                                              \
-	{                                                                                                     \
+	if (true) {                                                                                           \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method failed. Returning: " __STR(m_retval)); \
 		return m_retval;                                                                                  \
-	}
+	} else                                                                                                \
+		((void)0)
 
 /**
  * Prints a custom error message and returns the value specified in `m_retval`.
  */
 #define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                     \
-	{                                                                                                                       \
+	if (true) {                                                                                                             \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method failed. Returning: " __STR(m_retval), DEBUG_STR(m_msg)); \
 		return m_retval;                                                                                                    \
-	}
+	} else                                                                                                                  \
+		((void)0)
 
 /**
  * Crashes the engine immediately with a generic error message.
  * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
  */
 #define CRASH_NOW()                                                                  \
-	{                                                                                \
+	if (true) {                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method failed."); \
 		GENERATE_TRAP                                                                \
-	}
+	} else                                                                           \
+		((void)0)
 
 /**
  * Crashes the engine immediately with a custom error message.
  * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
  */
 #define CRASH_NOW_MSG(m_msg)                                                                           \
-	{                                                                                                  \
+	if (true) {                                                                                        \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method failed.", DEBUG_STR(m_msg)); \
 		GENERATE_TRAP                                                                                  \
-	}
+	} else                                                                                             \
+		((void)0)
 
 /**
  * Prints an error message without returning.
  */
-#define ERR_PRINT(m_string)                                           \
-	{                                                                 \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string); \
-	}
+#define ERR_PRINT(m_string) \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string)
 
 /**
  * Prints an error message without returning, but only do so once in the application lifecycle.
  * This can be used to avoid spamming the console with error messages.
  */
 #define ERR_PRINT_ONCE(m_string)                                          \
-	{                                                                     \
+	if (true) {                                                           \
 		static bool first_print = true;                                   \
 		if (first_print) {                                                \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string); \
 			first_print = false;                                          \
 		}                                                                 \
-	}
+	} else                                                                \
+		((void)0)
 
 /**
  * Prints a warning message without returning. To warn about deprecated usage,
  * use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
  */
-#define WARN_PRINT(m_string)                                                               \
-	{                                                                                      \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string, ERR_HANDLER_WARNING); \
-	}
+#define WARN_PRINT(m_string) \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string, ERR_HANDLER_WARNING)
 
 /**
  * Prints a warning message without returning, but only do so once in the application lifecycle.
  * This can be used to avoid spamming the console with warning messages.
  */
 #define WARN_PRINT_ONCE(m_string)                                                              \
-	{                                                                                          \
+	if (true) {                                                                                \
 		static bool first_print = true;                                                        \
 		if (first_print) {                                                                     \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_string, ERR_HANDLER_WARNING); \
 			first_print = false;                                                               \
 		}                                                                                      \
-	}
+	} else                                                                                     \
+		((void)0)
 
 /**
  * Prints a generic deprecation warning message without returning.
  * This should be preferred to `WARN_PRINT` for deprecation warnings.
  */
 #define WARN_DEPRECATED                                                                                                                                    \
-	{                                                                                                                                                      \
+	if (true) {                                                                                                                                            \
 		static SafeFlag warning_shown;                                                                                                                     \
 		if (!warning_shown.is_set()) {                                                                                                                     \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", ERR_HANDLER_WARNING); \
 			warning_shown.set();                                                                                                                           \
 		}                                                                                                                                                  \
-	}
+	} else                                                                                                                                                 \
+		((void)0)
 
 /**
  * Prints a custom deprecation warning message without returning.
  * This should be preferred to `WARN_PRINT` for deprecation warnings.
  */
 #define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                \
-	{                                                                                                                                                             \
+	if (true) {                                                                                                                                                   \
 		static SafeFlag warning_shown;                                                                                                                            \
 		if (!warning_shown.is_set()) {                                                                                                                            \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, ERR_HANDLER_WARNING); \
 			warning_shown.set();                                                                                                                                  \
 		}                                                                                                                                                         \
-	}
+	} else                                                                                                                                                        \
+		((void)0)
 
 #endif

--- a/core/math/bsp_tree.cpp
+++ b/core/math/bsp_tree.cpp
@@ -324,7 +324,7 @@ static int _bsp_create_node(const Face3 *p_faces, const Vector<int> &p_indices, 
 	ERR_FAIL_COND_V(p_nodes.size() == BSP_Tree::MAX_NODES, -1);
 
 	// should not reach here
-	ERR_FAIL_COND_V(p_indices.size() == 0, -1)
+	ERR_FAIL_COND_V(p_indices.size() == 0, -1);
 
 	int ic = p_indices.size();
 	const int *indices = p_indices.ptr();

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -75,16 +75,15 @@ subject to the following restrictions:
 // -- GODOT end --
 
 #ifdef DEBUG_ENABLED
-#define CHULL_ASSERT(m_cond)                                    \
-	do {                                                        \
-		if (unlikely(!(m_cond))) {                              \
-			ERR_PRINT("Assertion \"" _STR(m_cond) "\" failed.") \
-		}                                                       \
-	} while (0)
+#define CHULL_ASSERT(m_cond)                                 \
+	if (unlikely(!(m_cond))) {                               \
+		ERR_PRINT("Assertion \"" _STR(m_cond) "\" failed."); \
+	} else                                                   \
+		((void)0)
 #else
 #define CHULL_ASSERT(m_cond) \
 	do {                     \
-	} while (0)
+	} while (false)
 #endif
 
 #if defined(DEBUG_CONVEX_HULL) || defined(SHOW_ITERATIONS)

--- a/drivers/gles2/shader_gles2.h
+++ b/drivers/gles2/shader_gles2.h
@@ -261,7 +261,7 @@ int ShaderGLES2::_get_uniform(int p_which) const {
 
 void ShaderGLES2::_set_conditional(int p_which, bool p_value) {
 	ERR_FAIL_INDEX(p_which, conditional_count);
-	ERR_FAIL_INDEX(static_cast<unsigned int>(p_which), sizeof(new_conditional_version.version) * 8)
+	ERR_FAIL_INDEX(static_cast<unsigned int>(p_which), sizeof(new_conditional_version.version) * 8);
 
 	if (p_value) {
 		new_conditional_version.version |= (uint64_t(1) << p_which);

--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -2825,7 +2825,7 @@ case RasterizerCanvas::Item::Command::TYPE_POLYGON:
 
 PREAMBLE(bool)::sort_items_from(int p_start) {
 #if defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED)
-	ERR_FAIL_COND_V((p_start + 1) >= bdata.sort_items.size(), false)
+	ERR_FAIL_COND_V((p_start + 1) >= bdata.sort_items.size(), false);
 #endif
 
 	const BSortItem &start = bdata.sort_items[p_start];

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -61,7 +61,7 @@ void EditorVCSInterface::_bind_methods() {
 }
 
 bool EditorVCSInterface::_initialize(String p_project_root_path) {
-	WARN_PRINT("Selected VCS addon does not implement an initialization function. This warning will be suppressed.")
+	WARN_PRINT("Selected VCS addon does not implement an initialization function. This warning will be suppressed.");
 	return true;
 }
 

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -178,7 +178,7 @@ void VersionControlEditorPlugin::_refresh_stage_area() {
 			commit_status->set_text("New changes detected");
 		}
 	} else {
-		WARN_PRINT("No VCS addon is initialized. Select a Version Control Addon from Project menu.")
+		WARN_PRINT("No VCS addon is initialized. Select a Version Control Addon from Project menu.");
 	}
 }
 

--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -171,7 +171,7 @@ bool AreaBullet::is_monitoring() const {
 }
 
 void AreaBullet::main_shape_changed() {
-	CRASH_COND(!get_main_shape())
+	CRASH_COND(!get_main_shape());
 	btGhost->setCollisionShape(get_main_shape());
 }
 

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -330,7 +330,7 @@ void RigidBodyBullet::destroy_kinematic_utilities() {
 }
 
 void RigidBodyBullet::main_shape_changed() {
-	CRASH_COND(!get_main_shape())
+	CRASH_COND(!get_main_shape());
 	btBody->setCollisionShape(get_main_shape());
 	set_continuous_collision_detection(is_continuous_collision_detection_enabled()); // Reset
 }

--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -1087,7 +1087,7 @@ HashMap<int, R> FBXMeshData::extract_per_vertex_data(
 				// https://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_layer_element_html
 				ERR_FAIL_COND_V_MSG((int)p_mapping_data.index.size() != p_vertex_count, (HashMap<int, R>()), "FBX file corrupted: #ERR02");
 				for (size_t vertex_index = 0; vertex_index < p_mapping_data.index.size(); vertex_index += 1) {
-					ERR_FAIL_INDEX_V_MSG(p_mapping_data.index[vertex_index], (int)p_mapping_data.data.size(), (HashMap<int, R>()), "FBX file seems corrupted: #ERR03.")
+					ERR_FAIL_INDEX_V_MSG(p_mapping_data.index[vertex_index], (int)p_mapping_data.data.size(), (HashMap<int, R>()), "FBX file seems corrupted: #ERR03.");
 					aggregate_vertex_data[vertex_index].push_back({ -1, p_mapping_data.data[p_mapping_data.index[vertex_index]] });
 				}
 			}
@@ -1136,9 +1136,9 @@ HashMap<int, R> FBXMeshData::extract_per_vertex_data(
 					}
 					const int vertex_index = get_vertex_from_polygon_vertex(p_mesh_indices, polygon_vertex_index);
 					ERR_FAIL_COND_V_MSG(vertex_index < 0, (HashMap<int, R>()), "FBX file corrupted: #ERR8");
-					ERR_FAIL_COND_V_MSG(vertex_index >= p_vertex_count, (HashMap<int, R>()), "FBX file seems corrupted: #ERR9.")
-					ERR_FAIL_COND_V_MSG(p_mapping_data.index[polygon_vertex_index] < 0, (HashMap<int, R>()), "FBX file seems corrupted: #ERR10.")
-					ERR_FAIL_COND_V_MSG(p_mapping_data.index[polygon_vertex_index] >= (int)p_mapping_data.data.size(), (HashMap<int, R>()), "FBX file seems corrupted: #ERR11.")
+					ERR_FAIL_COND_V_MSG(vertex_index >= p_vertex_count, (HashMap<int, R>()), "FBX file seems corrupted: #ERR9.");
+					ERR_FAIL_COND_V_MSG(p_mapping_data.index[polygon_vertex_index] < 0, (HashMap<int, R>()), "FBX file seems corrupted: #ERR10.");
+					ERR_FAIL_COND_V_MSG(p_mapping_data.index[polygon_vertex_index] >= (int)p_mapping_data.data.size(), (HashMap<int, R>()), "FBX file seems corrupted: #ERR11.");
 					aggregate_vertex_data[vertex_index].push_back({ polygon_id, p_mapping_data.data[p_mapping_data.index[polygon_vertex_index]] });
 				}
 			}
@@ -1164,7 +1164,7 @@ HashMap<int, R> FBXMeshData::extract_per_vertex_data(
 
 					aggregate_vertex_data[vertex_index].push_back({ polygon_index, p_mapping_data.data[polygon_index] });
 				}
-				ERR_FAIL_COND_V_MSG((polygon_index + 1) != polygon_count, (HashMap<int, R>()), "FBX file seems corrupted: #ERR16. Not all Polygons are present in the file.")
+				ERR_FAIL_COND_V_MSG((polygon_index + 1) != polygon_count, (HashMap<int, R>()), "FBX file seems corrupted: #ERR16. Not all Polygons are present in the file.");
 			} else {
 				// The data is mapped per polygon using a reference.
 				// The indices array, contains a *reference_id for each polygon.
@@ -1190,7 +1190,7 @@ HashMap<int, R> FBXMeshData::extract_per_vertex_data(
 
 					aggregate_vertex_data[vertex_index].push_back({ polygon_index, p_mapping_data.data[p_mapping_data.index[polygon_index]] });
 				}
-				ERR_FAIL_COND_V_MSG((polygon_index + 1) != polygon_count, (HashMap<int, R>()), "FBX file seems corrupted: #ERR22. Not all Polygons are present in the file.")
+				ERR_FAIL_COND_V_MSG((polygon_index + 1) != polygon_count, (HashMap<int, R>()), "FBX file seems corrupted: #ERR22. Not all Polygons are present in the file.");
 			}
 		} break;
 		case FBXDocParser::MeshGeometry::MapType::edge: {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1650,8 +1650,7 @@ bool CSharpInstance::has_method(const StringName &p_method) const {
 }
 
 Variant CSharpInstance::call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
-	if (!script.is_valid())
-		ERR_FAIL_V(Variant());
+	ERR_FAIL_COND_V(!script.is_valid(), Variant());
 
 	GD_MONO_SCOPE_THREAD_ATTACH;
 

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -846,7 +846,7 @@ Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, 
 	EMSCRIPTEN_RESULT result;
 #define EM_CHECK(ev)                         \
 	if (result != EMSCRIPTEN_RESULT_SUCCESS) \
-	ERR_PRINT("Error while setting " #ev " callback: Code " + itos(result))
+		ERR_PRINT("Error while setting " #ev " callback: Code " + itos(result));
 #define SET_EM_CALLBACK(target, ev, cb)                               \
 	result = emscripten_set_##ev##_callback(target, NULL, true, &cb); \
 	EM_CHECK(ev)

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -416,7 +416,7 @@ void MeshInstance::_update_skinning() {
 		uint32_t array_offsets_write[Mesh::ARRAY_MAX];
 		uint32_t array_strides_write[Mesh::ARRAY_MAX];
 		visual_server->mesh_surface_make_offsets_from_format(format_write, vertex_count_write, index_count_write, array_offsets_write, array_strides_write);
-		ERR_FAIL_COND(array_strides_write[Mesh::ARRAY_VERTEX] != array_strides_write[Mesh::ARRAY_NORMAL])
+		ERR_FAIL_COND(array_strides_write[Mesh::ARRAY_VERTEX] != array_strides_write[Mesh::ARRAY_NORMAL]);
 		const uint32_t stride_write = array_strides_write[Mesh::ARRAY_VERTEX];
 		const uint32_t offset_vertices_write = array_offsets_write[Mesh::ARRAY_VERTEX];
 		const uint32_t offset_normals_write = array_offsets_write[Mesh::ARRAY_NORMAL];
@@ -438,7 +438,7 @@ void MeshInstance::_update_skinning() {
 		uint32_t array_offsets[Mesh::ARRAY_MAX];
 		uint32_t array_strides[Mesh::ARRAY_MAX];
 		visual_server->mesh_surface_make_offsets_from_format(format_read, vertex_count, index_count, array_offsets, array_strides);
-		ERR_FAIL_COND(array_strides[Mesh::ARRAY_VERTEX] != array_strides[Mesh::ARRAY_NORMAL])
+		ERR_FAIL_COND(array_strides[Mesh::ARRAY_VERTEX] != array_strides[Mesh::ARRAY_NORMAL]);
 		const uint32_t stride = array_strides[Mesh::ARRAY_VERTEX];
 		const uint32_t offset_vertices = array_offsets[Mesh::ARRAY_VERTEX];
 		const uint32_t offset_normals = array_offsets[Mesh::ARRAY_NORMAL];

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1821,7 +1821,7 @@ bool Viewport::_gui_drop(Control *p_at_control, Point2 p_at_pos, bool p_just_che
 }
 
 void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
-	ERR_FAIL_COND(p_event.is_null())
+	ERR_FAIL_COND(p_event.is_null());
 
 	//?
 	/*

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -338,7 +338,7 @@ Vector2 VisualServer::norm_to_oct(const Vector3 v) {
 	// NOTE: this will mean it decompresses to 0,0,1
 	// Discussed heavily here: https://github.com/godotengine/godot/pull/51268 as to why we did this
 	if (Math::is_zero_approx(L1Norm)) {
-		WARN_PRINT_ONCE("Octahedral compression cannot be used to compress a zero-length vector, please use normalized normal values or disable octahedral compression")
+		WARN_PRINT_ONCE("Octahedral compression cannot be used to compress a zero-length vector, please use normalized normal values or disable octahedral compression");
 		return Vector2(0, 0);
 	}
 


### PR DESCRIPTION
This PR is basically the `3.x` version of #36011, changing `do {} while (0)` to `if (cond) {} else ((void)0)`.

The main motivation to backport the PR is to suppress static analyzer warnings about using integers instead of boolean literals (`while (0)` instead of `while (false)`).

Main changes are in `core/error_macro.h`. These changes expose missing semicolon errors when using `ERR_*` macros, so other files are touched to fix them.
