### PR TITLE
[3.x] Add editor keyboard shortcut for Mono Build solution button

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -39,9 +39,11 @@
 #include "core/project_settings.h"
 
 #ifdef TOOLS_ENABLED
+#include "core/os/keyboard.h"
 #include "editor/bindings_generator.h"
 #include "editor/csharp_project.h"
 #include "editor/editor_node.h"
+#include "editor/editor_settings.h"
 #include "editor/node_dock.h"
 #endif
 
@@ -1178,6 +1180,7 @@ void CSharpLanguage::_editor_init_callback() {
 
 	// Enable it as a plugin
 	EditorNode::add_editor_plugin(godotsharp_editor);
+	ED_SHORTCUT("mono/build_solution", TTR("Build Solution"), KEY_MASK_ALT | KEY_B);
 	godotsharp_editor->enable_plugin();
 
 	get_singleton()->godotsharp_editor = godotsharp_editor;

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -440,11 +440,15 @@ namespace GodotTools
 
             AddToolSubmenuItem("C#", menuPopup);
 
+            var buildSolutionShortcut = (ShortCut)EditorShortcut("mono/build_solution");
+
             toolBarButton = new ToolButton
             {
                 Text = "Build",
-                HintTooltip = "Build solution",
-                FocusMode = Control.FocusModeEnum.None
+                HintTooltip = "Build Solution".TTR(),
+                FocusMode = Control.FocusModeEnum.None,
+                Shortcut = buildSolutionShortcut,
+                ShortcutInTooltip = true
             };
             toolBarButton.Connect("pressed", this, nameof(BuildSolutionPressed));
             AddControlToContainer(CustomControlContainer.Toolbar, toolBarButton);

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Globals.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Globals.cs
@@ -13,6 +13,9 @@ namespace GodotTools.Internals
         public static object EditorDef(string setting, object defaultValue, bool restartIfChanged = false) =>
             internal_EditorDef(setting, defaultValue, restartIfChanged);
 
+        public static object EditorShortcut(string setting) =>
+            internal_EditorShortcut(setting);
+
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         public static string TTR(this string text) => internal_TTR(text);
 
@@ -26,6 +29,9 @@ namespace GodotTools.Internals
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern object internal_EditorDef(string setting, object defaultValue, bool restartIfChanged);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern object internal_EditorShortcut(string setting);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_TTR(string text);

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -349,6 +349,12 @@ MonoObject *godot_icall_Globals_EditorDef(MonoString *p_setting, MonoObject *p_d
 	return GDMonoMarshal::variant_to_mono_object(result);
 }
 
+MonoObject *godot_icall_Globals_EditorShortcut(MonoString *p_setting) {
+	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
+	Ref<ShortCut> result = ED_GET_SHORTCUT(setting);
+	return GDMonoMarshal::variant_to_mono_object(result);
+}
+
 MonoString *godot_icall_Globals_TTR(MonoString *p_text) {
 	String text = GDMonoMarshal::mono_string_to_godot(p_text);
 	return GDMonoMarshal::mono_string_from_godot(TTR(text));
@@ -427,6 +433,7 @@ void register_editor_internal_calls() {
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_EditorScale", godot_icall_Globals_EditorScale);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_GlobalDef", godot_icall_Globals_GlobalDef);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_EditorDef", godot_icall_Globals_EditorDef);
+	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_EditorShortcut", godot_icall_Globals_EditorShortcut);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_TTR", godot_icall_Globals_TTR);
 
 	// Utils.OS


### PR DESCRIPTION
Related issue: #39633 

This adds a keyboard shortcut for the Build button in Godot Mono 3.x. Default is `Alt+B` (since other suggestions from the issue were taken by the script editor bookmark shortcuts).

![image](https://user-images.githubusercontent.com/233380/133003904-2a728cc8-0377-4034-ba2a-7ec0910f0c4e.png)

![image](https://user-images.githubusercontent.com/233380/133003910-21d7d138-453b-4aa1-a540-f2cb83ab9a00.png)

This exposes the `ED_GET_SHORTCUT` function from `modules\mono\editor\editor_internal_calls.cpp` to the GodotTools C# solution, via a new `GodotTools.Internals.Globals` function: `GodotTools.Internals.Globals::internal_EditorShortcut` - allowing the `GodotSharpEditor.cs` EditorPlugin to retrieve editor shortcuts, which it does to attach a new ~~`script_editor/build_mono_solution`~~ `mono/build_solution` shortcut definition to the mono Build button.

I couldn't get these changes to compile against `master`; firstly I got an error because `ShortCut` is now `Shortcut`, but then I got errors related to the `mono/editor/code_completion.cpp` file (unchanged):

```
modules\mono\editor\code_completion.cpp(126): error C3536: '<begin>$L1': cannot be used before it is initialized
modules\mono\editor\code_completion.cpp(126): error C3536: '<end>$L1': cannot be used before it is initialized
[Initial build] modules\mono\editor\code_completion.cpp(126): error C2100: illegal indirection
[Initial build] modules\mono\editor\code_completion.cpp(126): error C2440: 'initializing': cannot convert from 'int' to 'const KeyValue<StringName,ProjectSettings::AutoloadInfo> &'
[Initial build] modules\mono\editor\code_completion.cpp(126): note: Reason: cannot convert from 'int' to 'const KeyValue<StringName,ProjectSettings::AutoloadInfo>'
modules\mono\editor\code_completion.cpp(126): note: No constructor could take the source type, or constructor overload resolution was ambiguous
```

I'm unsure what the status of Mono is in Godot 4? So, I made these changes against `3.x` since that's what I'm using, let me know if this needs to be moved to `master`, and if I need to change anything to do so.

~~Additionally, I've added the keyboard shortcut under the `script_editor` shortcut setting group, since that seemed most relevant, however this shortcut will be available even in non-Mono builds; is there a way to conditionally add the shortcut only in a Mono build?~~ Shortcut is now under `mono/build_solution` settings key.

Cheers.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/3197.*