### PR TITLE
Add project setting to change scene file casing

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -217,6 +217,12 @@ private:
 		TOOL_MENU_BASE = 1000
 	};
 
+	enum ScriptNameCasing {
+		SCENE_NAME_CASING_AUTO,
+		SCENE_NAME_CASING_PASCAL_CASE,
+		SCENE_NAME_CASING_SNAKE_CASE
+	};
+
 	SubViewport *scene_root; // root of the scene being edited
 
 	PanelContainer *scene_root_parent;


### PR DESCRIPTION
*Bugsquad edit: `master` version of https://github.com/godotengine/godot/pull/56909.*

The documentation recommends file names to be in snake case, which is hard to implement because scene files take the name of the root node by default. This adds a project settings to change the default scene name to be either automatically generated, pascal case or snake case.

Should snake case be the default, like #47275 implemented?

Supersedes #47275