### PR TITLE
Fix autoloads iteration in `code_completion.cpp`

### DIFF
--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -123,8 +123,8 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				// AutoLoads
 				OrderedHashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
 
-				for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
-					const ProjectSettings::AutoloadInfo &info = E.value;
+				for (OrderedHashMap<StringName, ProjectSettings::AutoloadInfo>::Element E = autoloads.front(); E; E = E.next()) {
+					const ProjectSettings::AutoloadInfo &info = E.value();
 					suggestions.push_back(quoted("/root/" + String(info.name)));
 				}
 			}


### PR DESCRIPTION
Removes the range iterator usage in the autoloads map since `OrderedHashMap` does not implement range iterators yet (implemented in #52395 but it might take a while to merge that and in the meantime the C# module does not compile).

Closes #52268
