### PR TITLE
Fix load resource not found in cache

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -666,6 +666,7 @@ Error ResourceLoaderBinary::load() {
 		//maybe it is loaded already
 		String path;
 		String id;
+		RES res;
 
 		if (!main) {
 			path = internal_resources[i].path;
@@ -683,7 +684,8 @@ Error ResourceLoaderBinary::load() {
 					//already loaded, don't do anything
 					stage++;
 					error = OK;
-					continue;
+					Resource *r = ResourceCache::get(path);
+					res = Ref<Resource>(r);
 				}
 			}
 		} else {
@@ -697,8 +699,6 @@ Error ResourceLoaderBinary::load() {
 		f->seek(offset);
 
 		String t = get_unicode_string();
-
-		RES res;
 
 		if (cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && ResourceCache::has(path)) {
 			//use the existing one


### PR DESCRIPTION
Fix #48290

When loading a binary resource in the `ResourceLoaderBinary::load()` method, if the resource was already found in the `ResourceCache`, the resource was not pushed inside the `internal_index_cache`.

This PR simply removes the `continue` which prevented the next code to load the resource into the  `internal_index_cache`.

Thanks @MarvinFF for finding the root cause and @darrylryan for testing.