### PR TITLE
Make restore_scenes_on_load true by default

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5956,7 +5956,7 @@ EditorNode::EditorNode() {
 	EDITOR_DEF_RST("interface/editor/save_each_scene_on_quit", true);
 	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_continuously", false);
-	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", false);
+	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", true);
 	EDITOR_DEF_RST("interface/scene_tabs/show_thumbnail_on_hover", true);
 	EDITOR_DEF_RST("interface/inspector/capitalize_properties", true);
 	EDITOR_DEF_RST("interface/inspector/default_float_step", 0.001);


### PR DESCRIPTION
It's a very useful option that many people don't know about. This changes only the default, if you have a "big project" and this affects your startup time (which is unlikely; I have such project myself and scenes add ~5 seconds to the regular >1 minute startup) you will also know how to disable it.

Closes #16317