### PR TITLE
Improve C# method listing

### DIFF
--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -293,7 +293,7 @@ public:
 	void get_property_list(List<PropertyInfo> *p_properties) const override;
 	Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid) const override;
 
-	/* TODO */ void get_method_list(List<MethodInfo> *p_list) const override {}
+	void get_method_list(List<MethodInfo> *p_list) const override;
 	bool has_method(const StringName &p_method) const override;
 	Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 


### PR DESCRIPTION
This is mainly a PR for 3.x.  
Fixes several issues with animation's method tracks and C# scripts:
  - methods from base classes not being listed
    - #46408
  - error messages when selecting a method from the list
    - #39156
    - #37803

Cheers.

*Bugsquad edit:* Fixes #46408, #39156, #37803.