### PR TITLE
Fixed buggy interactions between button presses and focus changes

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -108,6 +108,11 @@ void BaseButton::_notification(int p_what) {
 		} else if (status.hovering) {
 			update();
 		}
+
+		if (status.pressed_down) {
+			status.pressed_down = false;
+			emit_signal(SNAME("button_up"));
+		}
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE || (p_what == NOTIFICATION_VISIBILITY_CHANGED && !is_visible_in_tree())) {
@@ -133,9 +138,10 @@ void BaseButton::_toggled(bool p_pressed) {
 }
 
 void BaseButton::on_action_event(Ref<InputEvent> p_event) {
-	if (p_event->is_pressed()) {
+	if (p_event->is_pressed() && !status.pressed_down) {
 		status.press_attempt = true;
 		status.pressing_inside = true;
+		status.pressed_down = true;
 		emit_signal(SNAME("button_down"));
 	}
 
@@ -160,20 +166,21 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 			}
 		} else {
 			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
+				status.press_attempt = false;
+				status.pressing_inside = false;
 				_pressed();
 			}
 		}
 	}
 
-	if (!p_event->is_pressed()) {
+	if (!p_event->is_pressed() && status.pressed_down) {
 		Ref<InputEventMouseButton> mouse_button = p_event;
 		if (mouse_button.is_valid()) {
 			if (!has_point(mouse_button->get_position())) {
 				status.hovering = false;
 			}
 		}
-		status.press_attempt = false;
-		status.pressing_inside = false;
+		status.pressed_down = false;
 		emit_signal(SNAME("button_up"));
 	}
 

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -58,7 +58,7 @@ private:
 		bool hovering = false;
 		bool press_attempt = false;
 		bool pressing_inside = false;
-
+		bool pressed_down = false;
 		bool disabled = false;
 
 	} status;


### PR DESCRIPTION
Fix #52578

This bug was caused by the button_up event being sent to the newly focused control rather than the original. With this bug, I also discovered that using LMB, enter, and space, you could trigger multiple button_down/pressed events with no button_up in between them.

The multiple button downs bug has been fixed by adding a status.button_down flag which tracks whether the button is pressed down or not, and not permitting the button to be pressed down further when already pressed or releasing further when it's unpressed.

The original issue proposed having the original button receive the button_up event even when the focus has changed, however this feels like it would take a large restructuring of the code to achieve.

I have set it up so when a button is currently down, and the focus is changed, the button is unpressed with no pressed event if the button is in Button Release mode. I see this as the best solution to this problem, as to still pass key-presses to an unfocused button seems unintuitive to me. It also serves as a way to cancel an accidental button press. I would also argue the same should be implemented for the mouse presses too (When the mouse no longer hovers over the button, the button down should be undone).

Another possible addition to this could be to button up the now unfocused button, and button down the newly focused button, however this could cause awkwardness with a mix of Button Release and Button Press buttons.

I am open to changing this based on criticism.