### PR TITLE
Sync AudioServer & AudioDriver buffer sizes and fix latency inaccuracies

### DIFF
--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -262,6 +262,10 @@ int AudioDriverALSA::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverALSA::get_mix_buffer_size() const {
+	return (int)period_size;
+}
+
 AudioDriver::SpeakerMode AudioDriverALSA::get_speaker_mode() const {
 	return speaker_mode;
 }
@@ -331,6 +335,13 @@ void AudioDriverALSA::finish() {
 	thread.wait_to_finish();
 
 	finish_device();
+}
+
+float AudioDriverALSA::get_latency() {
+	if (mix_rate == 0) {
+		return 0;
+	}
+	return (float)period_size / mix_rate;
 }
 
 #endif // ALSA_ENABLED

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -76,6 +76,7 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual Array get_device_list();
 	virtual String get_device();
@@ -83,6 +84,8 @@ public:
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	AudioDriverALSA() {}
 	~AudioDriverALSA() {}

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -268,6 +268,10 @@ int AudioDriverCoreAudio::get_mix_rate() const {
 	return mix_rate;
 };
 
+int AudioDriverCoreAudio::get_mix_buffer_size() const {
+	return (int)buffer_frames;
+}
+
 AudioDriver::SpeakerMode AudioDriverCoreAudio::get_speaker_mode() const {
 	return get_speaker_mode_by_total_channels(channels);
 };
@@ -333,6 +337,13 @@ void AudioDriverCoreAudio::finish() {
 		audio_unit = nullptr;
 		unlock();
 	}
+}
+
+float AudioDriverCoreAudio::get_latency() {
+	if (mix_rate == 0) {
+		return 0;
+	}
+	return (float)buffer_frames / mix_rate;
 }
 
 Error AudioDriverCoreAudio::capture_init() {

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -94,11 +94,14 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	virtual Error capture_start();
 	virtual Error capture_stop();

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -572,6 +572,10 @@ int AudioDriverPulseAudio::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverPulseAudio::get_mix_buffer_size() const {
+	return buffer_frames;
+}
+
 AudioDriver::SpeakerMode AudioDriverPulseAudio::get_speaker_mode() const {
 	return get_speaker_mode_by_total_channels(channels);
 }

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -101,6 +101,7 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 
 	virtual Array get_device_list();

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -518,6 +518,10 @@ int AudioDriverWASAPI::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverWASAPI::get_mix_buffer_size() const {
+	return buffer_frames;
+}
+
 AudioDriver::SpeakerMode AudioDriverWASAPI::get_speaker_mode() const {
 	return get_speaker_mode_by_total_channels(channels);
 }
@@ -884,6 +888,13 @@ void AudioDriverWASAPI::finish() {
 
 	finish_capture_device();
 	finish_render_device();
+}
+
+float AudioDriverWASAPI::get_latency() {
+	if (mix_rate == 0) {
+		return 0;
+	}
+	return (float)buffer_frames / mix_rate;
 }
 
 Error AudioDriverWASAPI::capture_start() {

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -98,6 +98,7 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual Array get_device_list();
 	virtual String get_device();
@@ -105,6 +106,8 @@ public:
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	virtual Error capture_start();
 	virtual Error capture_stop();

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -131,6 +131,10 @@ int AudioDriverXAudio2::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverXAudio2::get_mix_buffer_size() const {
+	return buffer_size;
+}
+
 AudioDriver::SpeakerMode AudioDriverXAudio2::get_speaker_mode() const {
 	return speaker_mode;
 }

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -95,6 +95,7 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual float get_latency();
 	virtual void lock();

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -307,6 +307,10 @@ int AudioDriverOpenSL::get_mix_rate() const {
 	return 44100; // hardcoded for Android, as selected by SL_SAMPLINGRATE_44_1
 }
 
+int AudioDriverOpenSL::get_mix_buffer_size() const {
+	return buffer_size;
+}
+
 AudioDriver::SpeakerMode AudioDriverOpenSL::get_speaker_mode() const {
 	return SPEAKER_MODE_STEREO;
 }
@@ -323,6 +327,10 @@ void AudioDriverOpenSL::unlock() {
 
 void AudioDriverOpenSL::finish() {
 	(*sl)->Destroy(sl);
+}
+
+float AudioDriverOpenSL::get_latency() {
+	return buffer_size / get_mix_rate();
 }
 
 void AudioDriverOpenSL::set_pause(bool p_pause) {

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -96,10 +96,13 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	virtual void set_pause(bool p_pause);
 

--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -153,6 +153,10 @@ int AudioDriverJavaScript::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverJavaScript::get_mix_buffer_size() const {
+	return buffer_length;
+}
+
 AudioDriver::SpeakerMode AudioDriverJavaScript::get_speaker_mode() const {
 	return get_speaker_mode_by_total_channels(channel_count);
 }

--- a/platform/javascript/audio_driver_javascript.h
+++ b/platform/javascript/audio_driver_javascript.h
@@ -113,6 +113,7 @@ public:
 	void resume();
 	virtual float get_latency();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual void lock();
 	virtual void unlock();

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -81,6 +81,10 @@ int AudioDriverDummy::get_mix_rate() const {
 	return mix_rate;
 };
 
+int AudioDriverDummy::get_mix_buffer_size() const {
+	return AudioServer::DEFAULT_MIX_BUFFER_SIZE;
+}
+
 AudioDriver::SpeakerMode AudioDriverDummy::get_speaker_mode() const {
 	return speaker_mode;
 };
@@ -101,3 +105,10 @@ void AudioDriverDummy::finish() {
 		memdelete_arr(samples_in);
 	};
 };
+
+float AudioDriverDummy::get_latency() {
+	if (mix_rate != 0) {
+		return (float)get_mix_buffer_size() / mix_rate;
+	}
+	return 0;
+}

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -62,10 +62,13 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	AudioDriverDummy() {}
 	~AudioDriverDummy() {}

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1345,7 +1345,14 @@ void AudioServer::init() {
 	channel_disable_threshold_db = GLOBAL_DEF_RST("audio/buses/channel_disable_threshold_db", -60.0);
 	channel_disable_frames = float(GLOBAL_DEF_RST("audio/buses/channel_disable_time", 2.0)) * get_mix_rate();
 	ProjectSettings::get_singleton()->set_custom_property_info("audio/buses/channel_disable_time", PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
-	buffer_size = 512; //hardcoded for now
+	if (AudioDriver::get_singleton()) {
+		buffer_size = AudioDriver::get_singleton()->get_mix_buffer_size();
+	}
+
+	if (buffer_size < 1) {
+		WARN_PRINT("AudioServer: Invalid mix buffer size given by driver; falling back to " + itos(DEFAULT_MIX_BUFFER_SIZE));
+		buffer_size = DEFAULT_MIX_BUFFER_SIZE;
+	}
 
 	init_channels_and_buffers();
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -107,7 +107,8 @@ public:
 	virtual String capture_get_device() { return "Default"; }
 	virtual Array capture_get_device_list(); // TODO: convert this and get_device_list to PackedStringArray
 
-	virtual float get_latency() { return 0; }
+	virtual float get_latency() = 0;
+	virtual int get_mix_buffer_size() const = 0;
 
 	SpeakerMode get_speaker_mode_by_total_channels(int p_channels) const;
 	int get_total_channels_by_speaker_mode(SpeakerMode) const;
@@ -164,6 +165,7 @@ public:
 		MAX_CHANNELS_PER_BUS = 4,
 		MAX_BUSES_PER_PLAYBACK = 6,
 		LOOKAHEAD_BUFFER_SIZE = 64,
+		DEFAULT_MIX_BUFFER_SIZE = 512,
 	};
 
 	typedef void (*AudioCallback)(void *p_userdata);


### PR DESCRIPTION
This is a rebase of  #38280 with some style fixes and slight changes all around. More accurately I reapplied all changes by hand, so if you've previously reviewed that PR please still look carefully at this one.

Please review paying special attention to any assumptions that may have been made about the buffer size in the AudioServer being 1024, and more recently 512. According to Ben and another developer in the comments of # #38280 it sounds like this change or some variation of it has been used in at least one shipped title, but I worry that (as an example) perhaps there's an FFT in one of the AudioEffects that will break when passed a non-power-of-two by an AudioDriver that chooses to only allocate 500 samples instead of 512, or something.

Overall this change will be an incredible help for developers that need low-latency audio, since before the AudioServer limited latency to at least the length of its hardcoded buffer.