### PR TITLE
Disallow class names to be the same as global names

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -78,6 +78,14 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 		return false;
 	}
 
+	if (ScriptServer::is_global_class(p_name)) {
+		if (r_error) {
+			*r_error = TTR("Invalid name.") + "\n" + TTR("Must not collide with an existing global script class name.");
+		}
+
+		return false;
+	}
+
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 		if (Variant::get_type_name(Variant::Type(i)) == p_name) {
 			if (r_error) {


### PR DESCRIPTION
Also forbid autoloads to have the same name as global script class.

Fix #50321
