### PR TITLE
Add editor keyboard shortcut for Mono Build solution button

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -43,8 +43,10 @@
 #include "core/os/thread.h"
 
 #ifdef TOOLS_ENABLED
+#include "core/os/keyboard.h"
 #include "editor/bindings_generator.h"
 #include "editor/editor_node.h"
+#include "editor/editor_settings.h"
 #include "editor/node_dock.h"
 #endif
 
@@ -1353,6 +1355,7 @@ void CSharpLanguage::_editor_init_callback() {
 
 	// Enable it as a plugin
 	EditorNode::add_editor_plugin(godotsharp_editor);
+	ED_SHORTCUT("mono/build_solution", TTR("Build Solution"), KEY_MASK_ALT | KEY_B);
 	godotsharp_editor->enable_plugin();
 
 	get_singleton()->godotsharp_editor = godotsharp_editor;

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -418,11 +418,15 @@ namespace GodotTools
 
             AddToolSubmenuItem("C#", _menuPopup);
 
+            var buildSolutionShortcut = (Shortcut)EditorShortcut("mono/build_solution");
+
             _toolBarBuildButton = new Button
             {
                 Text = "Build",
-                HintTooltip = "Build solution",
-                FocusMode = Control.FocusModeEnum.None
+                HintTooltip = "Build Solution".TTR(),
+                FocusMode = Control.FocusModeEnum.None,
+                Shortcut = buildSolutionShortcut,
+                ShortcutInTooltip = true
             };
             _toolBarBuildButton.PressedSignal += BuildSolutionPressed;
             AddControlToContainer(CustomControlContainer.Toolbar, _toolBarBuildButton);

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Globals.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Globals.cs
@@ -13,6 +13,9 @@ namespace GodotTools.Internals
         public static object EditorDef(string setting, object defaultValue, bool restartIfChanged = false) =>
             internal_EditorDef(setting, defaultValue, restartIfChanged);
 
+        public static object EditorShortcut(string setting) =>
+            internal_EditorShortcut(setting);
+
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         public static string TTR(this string text) => internal_TTR(text);
 
@@ -26,6 +29,9 @@ namespace GodotTools.Internals
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern object internal_EditorDef(string setting, object defaultValue, bool restartIfChanged);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern object internal_EditorShortcut(string setting);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_TTR(string text);

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -306,6 +306,12 @@ MonoObject *godot_icall_Globals_EditorDef(MonoString *p_setting, MonoObject *p_d
 	return GDMonoMarshal::variant_to_mono_object(result);
 }
 
+MonoObject *godot_icall_Globals_EditorShortcut(MonoString *p_setting) {
+	String setting = GDMonoMarshal::mono_string_to_godot(p_setting);
+	Ref<Shortcut> result = ED_GET_SHORTCUT(setting);
+	return GDMonoMarshal::variant_to_mono_object(result);
+}
+
 MonoString *godot_icall_Globals_TTR(MonoString *p_text) {
 	String text = GDMonoMarshal::mono_string_to_godot(p_text);
 	return GDMonoMarshal::mono_string_from_godot(TTR(text));
@@ -380,6 +386,7 @@ void register_editor_internal_calls() {
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_EditorScale", godot_icall_Globals_EditorScale);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_GlobalDef", godot_icall_Globals_GlobalDef);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_EditorDef", godot_icall_Globals_EditorDef);
+	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_EditorShortcut", godot_icall_Globals_EditorShortcut);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Globals::internal_TTR", godot_icall_Globals_TTR);
 
 	// Utils.OS


### PR DESCRIPTION
This is the 4.0 version of the following PR, now that Mono can compile again on master: https://github.com/godotengine/godot/pull/52595

This adds an editor shortcut named `mono/build_solution` and applies it to the editor's `Build` button if Mono is enabled. Default shortcut is `Alt+B`. It exposes the `ED_GET_SHORTCUT` macro to the GodotTools mono module via `GodotTools.Internals.Globals.EditorShortcut` to more generally allow editor shortcuts to be accessed by the mono C# project.

The minor difference between the `3.x` and `master` changes is that the `ShortCut` Resource type on `3.x` has been renamed to `Shortcut` on `master`.