### PR TITLE
Highlight hovered inspector categories

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1266,9 +1266,13 @@ void EditorInspectorSection::_notification(int p_what) {
 			}
 			header_height += get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
 
+			Rect2 header_rect = Rect2(Vector2(), Vector2(get_size().width, header_height));
 			Color c = bg_color;
 			c.a *= 0.4;
-			draw_rect(Rect2(Vector2(), Vector2(get_size().width, header_height)), c);
+			if (foldable && header_rect.has_point(get_local_mouse_position())) {
+				c = c.lightened(Input::get_singleton()->is_mouse_button_pressed(MOUSE_BUTTON_LEFT) ? -0.05 : 0.2);
+			}
+			draw_rect(header_rect, c);
 
 			const int arrow_margin = 2;
 			const int arrow_width = arrow.is_valid() ? arrow->get_width() : 0;
@@ -1315,12 +1319,14 @@ void EditorInspectorSection::_notification(int p_what) {
 			if (dropping) {
 				dropping_unfold_timer->start();
 			}
+			update();
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT: {
 			if (dropping) {
 				dropping_unfold_timer->stop();
 			}
+			update();
 		} break;
 	}
 }
@@ -1395,6 +1401,8 @@ void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 		} else {
 			fold();
 		}
+	} else if (mb.is_valid() && !mb->is_pressed()) {
+		update();
 	}
 }
 


### PR DESCRIPTION
As this is a visual change it is very subjective, but it just felt natural to give visual feedback about which category is being hovered over:

![hover_showcase](https://user-images.githubusercontent.com/28286961/133126236-ebd14d21-e650-419e-b3a2-87619eeb75b1.gif)

I found out that updating a control while handling a notification doesn't work, and used call_deferred to avoid the issue. Seeing that it isn't done this way very often is there a better solution? Funnily enough it works when adding a print statement before the call to update.