### PR TITLE
Display an error message in autoload settings when autoload name is invalid

### DIFF
--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -70,6 +70,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 	LineEdit *autoload_add_name;
 	Button *add_autoload;
 	LineEdit *autoload_add_path;
+	Label *error_message;
 	Button *browse_button;
 	EditorFileDialog *file_dialog;
 


### PR DESCRIPTION
Fixes #52631

### Issue

In autoload settings window, when autoload name was invalid, "Add" button was disabled without any further information about the reason.

### Fix Proposal

Add a label under the linedit.
The label is shown only if name is invalid (and not empty).
The label contains the reason of invalidity.

### What it looks like

![error_messages](https://user-images.githubusercontent.com/3649998/133157783-d349c3d0-8d88-4a77-b768-c84d910b580f.gif)
