### PR TITLE
Don't update CSG Shape when not inside tree

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -280,7 +280,7 @@ void CSGShape3D::mikktSetTSpaceDefault(const SMikkTSpaceContext *pContext, const
 }
 
 void CSGShape3D::_update_shape() {
-	if (parent) {
+	if (parent || !is_inside_tree()) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #52642.

`CSGPolygon3D::_make_dirty()` will be called when exiting the tree. Although it returns when not inside tree, the actual call to `_update_shape()` is deferred. So the cause is that the shape & path are still inside tree when `_make_dirty()` is called, but no longer inside tree when `_update_shape()` is called.

https://github.com/godotengine/godot/blob/7cdd8629ad4c2994c7882fe2c1dccd29ce5dec2c/modules/csg/csg_shape.cpp#L139-L148

This PR adds a `is_inside_tree()` check at the beginning of `_update_shape()`.

Note for 3.x: `CSGShape3D` →  `CSGShape`