### PR TITLE
[3.x] added optional cropping for texture atlas importer

### DIFF
--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -71,6 +71,7 @@ String ResourceImporterTextureAtlas::get_preset_name(int p_idx) const {
 void ResourceImporterTextureAtlas::get_import_options(List<ImportOption> *r_options, int p_preset) const {
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "atlas_file", PROPERTY_HINT_SAVE_FILE, "*.png"), ""));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "import_mode", PROPERTY_HINT_ENUM, "Region,Mesh2D"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "crop_to_region"), false));
 }
 
 String ResourceImporterTextureAtlas::get_option_group_file() const {
@@ -203,6 +204,7 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 		ERR_CONTINUE(err != OK);
 
 		pack_data.image = image;
+		pack_data.is_cropped = options["crop_to_region"];
 
 		int mode = options["import_mode"];
 
@@ -325,7 +327,10 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 			atlas_texture.instance();
 			atlas_texture->set_atlas(cache);
 			atlas_texture->set_region(Rect2(offset, pack_data.region.size));
-			atlas_texture->set_margin(Rect2(pack_data.region.position, Size2(pack_data.image->get_width(), pack_data.image->get_height()) - pack_data.region.size));
+
+			if (!pack_data.is_cropped) {
+				atlas_texture->set_margin(Rect2(pack_data.region.position, pack_data.image->get_size() - pack_data.region.size));
+			}
 
 			texture = atlas_texture;
 		} else {

--- a/editor/import/resource_importer_texture_atlas.h
+++ b/editor/import/resource_importer_texture_atlas.h
@@ -38,6 +38,7 @@ class ResourceImporterTextureAtlas : public ResourceImporter {
 
 	struct PackData {
 		Rect2 region;
+		bool is_cropped;
 		bool is_mesh;
 		Vector<int> chart_pieces; //one for region, many for mesh
 		Vector<Vector<Vector2>> chart_vertices; //for mesh


### PR DESCRIPTION
added optional region cropping to Texture Atlas importer. See godotengine/godot-proposals#1661

this is my second try of #52564, sorry, first ever PR. Let me know if did anything wrong.