### PR TITLE
Added status bar and toggle scripts panel button to EditorHelp/VScripts

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1657,11 +1657,8 @@ void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
 }
 
 void CodeTextEditor::_toggle_scripts_pressed() {
-	if (is_layout_rtl()) {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")) : get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
-	} else {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon(SNAME("Back"), SNAME("EditorIcons")) : get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
-	}
+	ScriptEditor::get_singleton()->toggle_scripts_panel();
+	update_toggle_scripts_button();
 }
 
 void CodeTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
@@ -1791,11 +1788,11 @@ void CodeTextEditor::show_toggle_scripts_button() {
 
 void CodeTextEditor::update_toggle_scripts_button() {
 	if (is_layout_rtl()) {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")) : get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
+		toggle_scripts_button->set_icon(get_theme_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? SNAME("Forward") : SNAME("Back"), SNAME("EditorIcons")));
 	} else {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon(SNAME("Back"), SNAME("EditorIcons")) : get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
+		toggle_scripts_button->set_icon(get_theme_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? SNAME("Back") : SNAME("Forward"), SNAME("EditorIcons")));
 	}
-	toggle_scripts_button->set_tooltip(TTR("Toggle Scripts Panel") + " (" + ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text() + ")");
+	toggle_scripts_button->set_tooltip(vformat("%s (%s)", TTR("Toggle Scripts Panel"), ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text()));
 }
 
 CodeTextEditor::CodeTextEditor() {

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1612,6 +1612,11 @@ void EditorHelp::generate_doc() {
 	doc->merge_from(compdoc); //ensure all is up to date
 }
 
+void EditorHelp::_toggle_scripts_pressed() {
+	ScriptEditor::get_singleton()->toggle_scripts_panel();
+	update_toggle_scripts_button();
+}
+
 void EditorHelp::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY:
@@ -1622,7 +1627,11 @@ void EditorHelp::_notification(int p_what) {
 			if (is_inside_tree()) {
 				_class_desc_resized();
 			}
+			update_toggle_scripts_button();
 		} break;
+		case NOTIFICATION_VISIBILITY_CHANGED:
+			update_toggle_scripts_button();
+			break;
 		default:
 			break;
 	}
@@ -1676,6 +1685,15 @@ void EditorHelp::set_scroll(int p_scroll) {
 	class_desc->get_v_scroll()->set_value(p_scroll);
 }
 
+void EditorHelp::update_toggle_scripts_button() {
+	if (is_layout_rtl()) {
+		toggle_scripts_button->set_icon(get_theme_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? SNAME("Forward") : SNAME("Back"), SNAME("EditorIcons")));
+	} else {
+		toggle_scripts_button->set_icon(get_theme_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? SNAME("Back") : SNAME("Forward"), SNAME("EditorIcons")));
+	}
+	toggle_scripts_button->set_tooltip(vformat("%s (%s)", TTR("Toggle Scripts Panel"), ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text()));
+}
+
 void EditorHelp::_bind_methods() {
 	ClassDB::bind_method("_class_list_select", &EditorHelp::_class_list_select);
 	ClassDB::bind_method("_request_help", &EditorHelp::_request_help);
@@ -1705,6 +1723,16 @@ EditorHelp::EditorHelp() {
 	add_child(find_bar);
 	find_bar->hide();
 	find_bar->set_rich_text_label(class_desc);
+
+	status_bar = memnew(HBoxContainer);
+	add_child(status_bar);
+	status_bar->set_h_size_flags(SIZE_EXPAND_FILL);
+	status_bar->set_custom_minimum_size(Size2(0, 24 * EDSCALE));
+
+	toggle_scripts_button = memnew(Button);
+	toggle_scripts_button->set_flat(true);
+	toggle_scripts_button->connect("pressed", callable_mp(this, &EditorHelp::_toggle_scripts_pressed));
+	status_bar->add_child(toggle_scripts_button);
 
 	class_desc->set_selection_enabled(true);
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -123,6 +123,8 @@ class EditorHelp : public VBoxContainer {
 	ConfirmationDialog *search_dialog;
 	LineEdit *search;
 	FindBar *find_bar;
+	HBoxContainer *status_bar;
+	Button *toggle_scripts_button;
 
 	String base_path;
 
@@ -159,6 +161,7 @@ class EditorHelp : public VBoxContainer {
 	void _search(bool p_search_previous = false);
 
 	String _fix_constant(const String &p_constant) const;
+	void _toggle_scripts_pressed();
 
 protected:
 	void _notification(int p_what);
@@ -184,6 +187,8 @@ public:
 
 	int get_scroll() const;
 	void set_scroll(int p_scroll);
+
+	void update_toggle_scripts_button();
 
 	EditorHelp();
 	~EditorHelp();

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -46,6 +46,7 @@
 #include "editor/find_in_files.h"
 #include "editor/node_dock.h"
 #include "editor/plugins/shader_editor_plugin.h"
+#include "modules/visual_script/visual_script_editor.h"
 #include "scene/main/window.h"
 #include "scene/scene_string_names.h"
 #include "script_text_editor.h"
@@ -1236,14 +1237,15 @@ void ScriptEditor::_menu_option(int p_option) {
 			_update_script_names();
 		} break;
 		case TOGGLE_SCRIPTS_PANEL: {
+			toggle_scripts_panel();
 			if (current) {
-				ScriptTextEditor *editor = Object::cast_to<ScriptTextEditor>(current);
-				toggle_scripts_panel();
-				if (editor) {
-					editor->update_toggle_scripts_button();
-				}
+				current->update_toggle_scripts_button();
 			} else {
-				toggle_scripts_panel();
+				Control *tab = tab_container->get_current_tab_control();
+				EditorHelp *editor_help = Object::cast_to<EditorHelp>(tab);
+				if (editor_help) {
+					editor_help->update_toggle_scripts_button();
+				}
 			}
 		}
 	}

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -161,6 +161,7 @@ public:
 	virtual void update_settings() = 0;
 	virtual void set_debugger_active(bool p_active) = 0;
 	virtual bool can_lose_focus_on_node_selection() { return true; }
+	virtual void update_toggle_scripts_button() {}
 
 	virtual bool show_members_overview() = 0;
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -876,9 +876,7 @@ String ScriptTextEditor::_get_absolute_path(const String &rel_path) {
 }
 
 void ScriptTextEditor::update_toggle_scripts_button() {
-	if (code_editor != nullptr) {
-		code_editor->update_toggle_scripts_button();
-	}
+	code_editor->update_toggle_scripts_button();
 }
 
 void ScriptTextEditor::_update_connected_methods() {

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -197,7 +197,7 @@ public:
 
 	virtual void add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) override;
 	virtual void set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) override;
-	void update_toggle_scripts_button();
+	void update_toggle_scripts_button() override;
 
 	virtual void apply_code() override;
 	virtual RES get_edited_resource() const override;

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -513,6 +513,10 @@ void TextEditor::_make_context_menu(bool p_selection, bool p_can_fold, bool p_is
 	context_menu->popup();
 }
 
+void TextEditor::update_toggle_scripts_button() {
+	code_editor->update_toggle_scripts_button();
+}
+
 TextEditor::TextEditor() {
 	code_editor = memnew(CodeTextEditor);
 	add_child(code_editor);
@@ -521,6 +525,7 @@ TextEditor::TextEditor() {
 	code_editor->connect("validate_script", callable_mp(this, &TextEditor::_validate_script));
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	code_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	code_editor->show_toggle_scripts_button();
 
 	update_settings();
 

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -139,6 +139,7 @@ public:
 	virtual void set_debugger_active(bool p_active) override;
 	virtual void set_tooltip_request_func(String p_method, Object *p_obj) override;
 	virtual void add_callback(const String &p_function, PackedStringArray p_args) override;
+	void update_toggle_scripts_button() override;
 
 	virtual Control *get_edit_menu() override;
 	virtual void clear_edit_menu() override;

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3592,6 +3592,11 @@ void VisualScriptEditor::_hide_timer() {
 	hint_text->hide();
 }
 
+void VisualScriptEditor::_toggle_scripts_pressed() {
+	ScriptEditor::get_singleton()->toggle_scripts_panel();
+	update_toggle_scripts_button();
+}
+
 void VisualScriptEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
@@ -3605,6 +3610,8 @@ void VisualScriptEditor::_notification(int p_what) {
 			if (p_what != NOTIFICATION_READY && !is_visible_in_tree()) {
 				return;
 			}
+
+			update_toggle_scripts_button();
 
 			edit_variable_edit->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 			edit_signal_edit->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
@@ -3650,6 +3657,7 @@ void VisualScriptEditor::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
+			update_toggle_scripts_button();
 			members_section->set_visible(is_visible_in_tree());
 		} break;
 	}
@@ -4232,6 +4240,15 @@ void VisualScriptEditor::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_h
 void VisualScriptEditor::set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 }
 
+void VisualScriptEditor::update_toggle_scripts_button() {
+	if (is_layout_rtl()) {
+		toggle_scripts_button->set_icon(Control::get_theme_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? SNAME("Forward") : SNAME("Back"), SNAME("EditorIcons")));
+	} else {
+		toggle_scripts_button->set_icon(Control::get_theme_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? SNAME("Back") : SNAME("Forward"), SNAME("EditorIcons")));
+	}
+	toggle_scripts_button->set_tooltip(vformat("%s (%s)", TTR("Toggle Scripts Panel"), ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text()));
+}
+
 void VisualScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_move_node", &VisualScriptEditor::_move_node);
 	ClassDB::bind_method("_update_graph", &VisualScriptEditor::_update_graph, DEFVAL(-1));
@@ -4332,6 +4349,16 @@ VisualScriptEditor::VisualScriptEditor() {
 	graph->set_minimap_opacity(graph_minimap_opacity);
 	graph->hide();
 	graph->connect("scroll_offset_changed", callable_mp(this, &VisualScriptEditor::_graph_ofs_changed));
+
+	status_bar = memnew(HBoxContainer);
+	add_child(status_bar);
+	status_bar->set_h_size_flags(SIZE_EXPAND_FILL);
+	status_bar->set_custom_minimum_size(Size2(0, 24 * EDSCALE));
+
+	toggle_scripts_button = memnew(Button);
+	toggle_scripts_button->set_flat(true);
+	toggle_scripts_button->connect("pressed", callable_mp(this, &VisualScriptEditor::_toggle_scripts_pressed));
+	status_bar->add_child(toggle_scripts_button);
 
 	/// Add Buttons to Top Bar/Zoom bar.
 	HBoxContainer *graph_hbc = graph->get_zoom_hbox();

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -93,6 +93,8 @@ class VisualScriptEditor : public ScriptEditorBase {
 	ConfirmationDialog *function_create_dialog;
 
 	GraphEdit *graph;
+	HBoxContainer *status_bar;
+	Button *toggle_scripts_button;
 
 	VisualScriptEditorSignalEdit *signal_editor;
 
@@ -281,6 +283,8 @@ class VisualScriptEditor : public ScriptEditorBase {
 	void _member_rmb_selected(const Vector2 &p_pos);
 	void _member_option(int p_option);
 
+	void _toggle_scripts_pressed();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -329,6 +333,8 @@ public:
 	static void register_editor();
 
 	static void free_clipboard();
+
+	void update_toggle_scripts_button() override;
 
 	VisualScriptEditor();
 	~VisualScriptEditor();


### PR DESCRIPTION
This PR adds this functionality to in-editor docs and VisualScripts:

![image](https://user-images.githubusercontent.com/3036176/133231300-740729c9-6af0-4650-9db8-11eabaef06c7.png)
![image](https://user-images.githubusercontent.com/3036176/133231421-79776bda-da2a-442e-9f92-e93be99a7b2a.png)

Fix #52529