### PR TITLE
Rename VisualScriptEditor singleton to VisualScriptCustomNodes

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1069,7 +1069,7 @@
 		<member name="TranslationServer" type="TranslationServer" setter="" getter="">
 			The [TranslationServer] singleton.
 		</member>
-		<member name="VisualScriptEditor" type="VisualScriptCustomNodes" setter="" getter="">
+		<member name="VisualScriptCustomNodes" type="VisualScriptCustomNodes" setter="" getter="">
 			The [VisualScriptCustomNodes] singleton.
 		</member>
 		<member name="XRServer" type="XRServer" setter="" getter="">

--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -117,7 +117,7 @@ void register_visual_script_types() {
 	GDREGISTER_CLASS(VisualScriptCustomNodes);
 	ClassDB::set_current_api(ClassDB::API_CORE);
 	vs_custom_nodes_singleton = memnew(VisualScriptCustomNodes);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("VisualScriptEditor", VisualScriptCustomNodes::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("VisualScriptCustomNodes", VisualScriptCustomNodes::get_singleton()));
 
 	VisualScriptEditor::register_editor();
 #endif


### PR DESCRIPTION
Follow-up to #51916, fixes inconsistency between singleton name and class
as documented in https://github.com/godotengine/godot/issues/52162#issuecomment-918979753.