### PR TITLE
Make sure IK target is inside tree before using its transform

### DIFF
--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -542,7 +542,7 @@ Transform3D SkeletonIK3D::_get_target_transform() {
 		target_node_override = Object::cast_to<Node3D>(get_node(target_node_path_override));
 	}
 
-	if (target_node_override) {
+	if (target_node_override && target_node_override->is_inside_tree()) {
 		return target_node_override->get_global_transform();
 	} else {
 		return target;


### PR DESCRIPTION
Fixes #52589.

When `SkeletonIK3D` node is entering / exiting the tree,  the target node may or may not be inside the tree depending on its relative position to the IK node, so trying to access its global transform property will emit an error.

This PR checks `is_inside_tree` before accessing the target node's global transform. If the target node is not inside tree, `target` transform property is used as if the target node is not available.

Note for 3.x: `SkeletonIK3D` → `SkeletonIK`.