### PR TITLE
Fix transform of TileMap nodes and tilemap selection

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -327,10 +327,12 @@ void TileAtlasView::_draw_base_tiles_shape_grid() {
 		Vector2i tile_id = tile_set_atlas_source->get_tile_id(i);
 		Vector2 in_tile_base_offset = tile_set_atlas_source->get_tile_effective_texture_offset(tile_id, 0);
 		Rect2i texture_region = tile_set_atlas_source->get_tile_texture_region(tile_id);
-		Vector2 origin = texture_region.position + (texture_region.size - tile_shape_size) / 2 + in_tile_base_offset;
 
 		// Draw only if the tile shape fits in the texture region
-		tile_set->draw_tile_shape(base_tiles_shape_grid, Rect2(origin, tile_shape_size), grid_color);
+		Transform2D tile_xform;
+		tile_xform.set_origin(texture_region.position + texture_region.size / 2 + in_tile_base_offset);
+		tile_xform.set_scale(tile_shape_size);
+		tile_set->draw_tile_shape(base_tiles_shape_grid, tile_xform, grid_color);
 	}
 }
 

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -124,7 +124,9 @@ void GenericTilePolygonEditor::_base_control_draw() {
 	base_control->draw_set_transform_matrix(xform);
 
 	// Draw the tile shape filled.
-	tile_set->draw_tile_shape(base_control, Rect2(-tile_size / 2, tile_size), Color(1.0, 1.0, 1.0, 0.3), true);
+	Transform2D tile_xform;
+	tile_xform.set_scale(tile_size);
+	tile_set->draw_tile_shape(base_control, tile_xform, Color(1.0, 1.0, 1.0, 0.3), true);
 
 	// Draw the background.
 	if (background_texture.is_valid()) {
@@ -213,7 +215,7 @@ void GenericTilePolygonEditor::_base_control_draw() {
 
 	// Draw the tile shape line.
 	base_control->draw_set_transform_matrix(xform);
-	tile_set->draw_tile_shape(base_control, Rect2(-tile_size / 2, tile_size), grid_color, false);
+	tile_set->draw_tile_shape(base_control, tile_xform, grid_color, false);
 	base_control->draw_set_transform_matrix(Transform2D());
 }
 
@@ -1072,14 +1074,15 @@ void TileDataTextureOffsetEditor::draw_over_tile(CanvasItem *p_canvas_item, Tran
 	ERR_FAIL_COND(!tile_data);
 
 	Vector2i tile_set_tile_size = tile_set->get_tile_size();
-	Rect2i rect = Rect2i(-tile_set_tile_size / 2, tile_set_tile_size);
 	Color color = Color(1.0, 0.0, 0.0);
 	if (p_selected) {
 		Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
 		Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
 		color = selection_color;
 	}
-	tile_set->draw_tile_shape(p_canvas_item, p_transform.xform(rect), color);
+	Transform2D tile_xform;
+	tile_xform.set_scale(tile_set_tile_size);
+	tile_set->draw_tile_shape(p_canvas_item, p_transform * tile_xform, color);
 }
 
 void TileDataPositionEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected) {
@@ -1514,9 +1517,10 @@ void TileDataTerrainsEditor::forward_draw_over_atlas(TileAtlasView *p_tile_atlas
 				}
 			} else {
 				// Draw hovered tile.
-				Vector2i tile_size = tile_set->get_tile_size();
-				Rect2i rect = p_transform.xform(Rect2i(position - tile_size / 2, tile_size));
-				tile_set->draw_tile_shape(p_canvas_item, rect, Color(1.0, 1.0, 1.0, 0.5), true);
+				Transform2D tile_xform;
+				tile_xform.set_origin(position);
+				tile_xform.set_scale(tile_set->get_tile_size());
+				tile_set->draw_tile_shape(p_canvas_item, p_transform * tile_xform, Color(1.0, 1.0, 1.0, 0.5), true);
 			}
 		}
 	}
@@ -1686,9 +1690,10 @@ void TileDataTerrainsEditor::forward_draw_over_alternatives(TileAtlasView *p_til
 				}
 			} else {
 				// Draw hovered tile.
-				Vector2i tile_size = tile_set->get_tile_size();
-				Rect2i rect = p_transform.xform(Rect2i(position - tile_size / 2, tile_size));
-				tile_set->draw_tile_shape(p_canvas_item, rect, Color(1.0, 1.0, 1.0, 0.5), true);
+				Transform2D tile_xform;
+				tile_xform.set_origin(position);
+				tile_xform.set_scale(tile_set->get_tile_size());
+				tile_set->draw_tile_shape(p_canvas_item, p_transform * tile_xform, Color(1.0, 1.0, 1.0, 0.5), true);
 			}
 		}
 	}

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -636,8 +636,10 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 				for (int y = rect.position.y; y < rect.get_end().y; y++) {
 					Vector2i coords = Vector2i(x, y);
 					if (tile_map->get_cell_source_id(tile_map_layer, coords) != TileSet::INVALID_SOURCE) {
-						Rect2 cell_region = xform.xform(Rect2(tile_map->map_to_world(coords) - tile_shape_size / 2, tile_shape_size));
-						tile_set->draw_tile_shape(p_overlay, cell_region, Color(1.0, 1.0, 1.0), false);
+						Transform2D tile_xform;
+						tile_xform.set_origin(tile_map->map_to_world(coords));
+						tile_xform.set_scale(tile_shape_size);
+						tile_set->draw_tile_shape(p_overlay, xform * tile_xform, Color(1.0, 1.0, 1.0), false);
 					}
 				}
 			}
@@ -734,10 +736,12 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 							float bottom_opacity = CLAMP(Math::inverse_lerp((float)drawn_grid_rect.size.y, (float)(drawn_grid_rect.size.y - fading), (float)pos_in_rect.y), 0.0f, 1.0f);
 							float opacity = CLAMP(MIN(left_opacity, MIN(right_opacity, MIN(top_opacity, bottom_opacity))) + 0.1, 0.0f, 1.0f);
 
-							Rect2 cell_region = xform.xform(Rect2(tile_map->map_to_world(Vector2(x, y)) - tile_shape_size / 2, tile_shape_size));
+							Transform2D tile_xform;
+							tile_xform.set_origin(tile_map->map_to_world(Vector2(x, y)));
+							tile_xform.set_scale(tile_shape_size);
 							Color color = grid_color;
 							color.a = color.a * opacity;
-							tile_set->draw_tile_shape(p_overlay, cell_region, color, false);
+							tile_set->draw_tile_shape(p_overlay, xform * tile_xform, color, false);
 						}
 					}
 				}
@@ -745,11 +749,11 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 
 			// Draw the preview.
 			for (Map<Vector2i, TileMapCell>::Element *E = preview.front(); E; E = E->next()) {
-				Vector2i size = tile_set->get_tile_size();
-				Vector2 position = tile_map->map_to_world(E->key()) - size / 2;
-				Rect2 cell_region = xform.xform(Rect2(position, size));
+				Transform2D tile_xform;
+				tile_xform.set_origin(tile_map->map_to_world(E->key()));
+				tile_xform.set_scale(tile_set->get_tile_size());
 				if (!erase_button->is_pressed() && random_tile_checkbox->is_pressed()) {
-					tile_set->draw_tile_shape(p_overlay, cell_region, Color(1.0, 1.0, 1.0, 0.5), true);
+					tile_set->draw_tile_shape(p_overlay, xform * tile_xform, Color(1.0, 1.0, 1.0, 0.5), true);
 				} else {
 					if (tile_set->has_source(E->get().source_id)) {
 						TileSetSource *source = *tile_set->get_source(E->get().source_id);
@@ -791,10 +795,10 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 							// Draw the tile.
 							p_overlay->draw_texture_rect_region(atlas_source->get_texture(), dest_rect, source_rect, modulate * Color(1.0, 1.0, 1.0, 0.5), transpose, tile_set->is_uv_clipping());
 						} else {
-							tile_set->draw_tile_shape(p_overlay, cell_region, Color(1.0, 1.0, 1.0, 0.5), true);
+							tile_set->draw_tile_shape(p_overlay, xform * tile_xform, Color(1.0, 1.0, 1.0, 0.5), true);
 						}
 					} else {
-						tile_set->draw_tile_shape(p_overlay, cell_region, Color(0.0, 0.0, 0.0, 0.5), true);
+						tile_set->draw_tile_shape(p_overlay, xform * tile_xform, Color(0.0, 0.0, 0.0, 0.5), true);
 					}
 				}
 			}
@@ -3689,8 +3693,10 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 								0.8);
 
 						// Draw the scaled tile.
-						Rect2 cell_region = xform.xform(Rect2(tile_map->map_to_world(coords) - Vector2(tile_shape_size) / 2, Vector2(tile_shape_size)));
-						tile_set->draw_tile_shape(p_overlay, cell_region, color, true, warning_pattern_texture);
+						Transform2D tile_xform;
+						tile_xform.set_origin(tile_map->map_to_world(coords));
+						tile_xform.set_scale(tile_shape_size);
+						tile_set->draw_tile_shape(p_overlay, xform * tile_xform, color, true, warning_pattern_texture);
 					}
 
 					// Draw the warning icon.
@@ -3746,10 +3752,12 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 				float bottom_opacity = CLAMP(Math::inverse_lerp((float)displayed_rect.size.y, (float)(displayed_rect.size.y - fading), (float)pos_in_rect.y), 0.0f, 1.0f);
 				float opacity = CLAMP(MIN(left_opacity, MIN(right_opacity, MIN(top_opacity, bottom_opacity))) + 0.1, 0.0f, 1.0f);
 
-				Rect2 cell_region = xform.xform(Rect2(tile_map->map_to_world(Vector2(x, y)) - tile_shape_size / 2, tile_shape_size));
+				Transform2D tile_xform;
+				tile_xform.set_origin(tile_map->map_to_world(Vector2(x, y)));
+				tile_xform.set_scale(tile_shape_size);
 				Color color = grid_color;
 				color.a = color.a * opacity;
-				tile_set->draw_tile_shape(p_overlay, cell_region, color, false);
+				tile_set->draw_tile_shape(p_overlay, xform * tile_xform, color, false);
 			}
 		}
 	}

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -982,10 +982,10 @@ void TileSet::clear_tile_proxies() {
 Vector<Vector2> TileSet::get_tile_shape_polygon() {
 	Vector<Vector2> points;
 	if (tile_shape == TileSet::TILE_SHAPE_SQUARE) {
-		points.append(Vector2(0.0, 0.0));
-		points.append(Vector2(1.0, 0.0));
-		points.append(Vector2(1.0, 1.0));
-		points.append(Vector2(0.0, 1.0));
+		points.append(Vector2(-0.5, -0.5));
+		points.append(Vector2(0.5, -0.5));
+		points.append(Vector2(0.5, 0.5));
+		points.append(Vector2(-0.5, 0.5));
 	} else {
 		float overlap = 0.0;
 		switch (tile_shape) {
@@ -1002,31 +1002,24 @@ Vector<Vector2> TileSet::get_tile_shape_polygon() {
 				break;
 		}
 
-		points.append(Vector2(0.5, 0.0));
-		points.append(Vector2(0.0, overlap));
-		points.append(Vector2(0.0, 1.0 - overlap));
-		points.append(Vector2(0.5, 1.0));
-		points.append(Vector2(1.0, 1.0 - overlap));
-		points.append(Vector2(1.0, overlap));
-		points.append(Vector2(0.5, 0.0));
+		points.append(Vector2(0.0, -0.5));
+		points.append(Vector2(-0.5, overlap - 0.5));
+		points.append(Vector2(-0.5, 0.5 - overlap));
+		points.append(Vector2(0.0, 0.5));
+		points.append(Vector2(0.5, 0.5 - overlap));
+		points.append(Vector2(0.5, overlap - 0.5));
 		if (get_tile_offset_axis() == TileSet::TILE_OFFSET_AXIS_VERTICAL) {
 			for (int i = 0; i < points.size(); i++) {
 				points.write[i] = Vector2(points[i].y, points[i].x);
 			}
 		}
 	}
-	for (int i = 0; i < points.size(); i++) {
-		points.write[i] = points[i] * tile_size - tile_size / 2;
-	}
 	return points;
 }
 
-void TileSet::draw_tile_shape(CanvasItem *p_canvas_item, Rect2 p_region, Color p_color, bool p_filled, Ref<Texture2D> p_texture) {
+void TileSet::draw_tile_shape(CanvasItem *p_canvas_item, Transform2D p_transform, Color p_color, bool p_filled, Ref<Texture2D> p_texture) {
 	if (tile_meshes_dirty) {
 		Vector<Vector2> uvs = get_tile_shape_polygon();
-		for (int i = 0; i < uvs.size(); i++) {
-			uvs.write[i] = (uvs[i] + tile_size / 2) / tile_size;
-		}
 
 		Vector<Color> colors;
 		colors.resize(uvs.size());
@@ -1056,13 +1049,10 @@ void TileSet::draw_tile_shape(CanvasItem *p_canvas_item, Rect2 p_region, Color p
 		tile_meshes_dirty = false;
 	}
 
-	Transform2D xform;
-	xform.scale(p_region.size);
-	xform.set_origin(p_region.get_position());
 	if (p_filled) {
-		p_canvas_item->draw_mesh(tile_filled_mesh, p_texture, xform, p_color);
+		p_canvas_item->draw_mesh(tile_filled_mesh, p_texture, p_transform, p_color);
 	} else {
-		p_canvas_item->draw_mesh(tile_lines_mesh, Ref<Texture2D>(), xform, p_color);
+		p_canvas_item->draw_mesh(tile_lines_mesh, Ref<Texture2D>(), p_transform, p_color);
 	}
 }
 

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -385,7 +385,7 @@ public:
 
 	// Helpers
 	Vector<Vector2> get_tile_shape_polygon();
-	void draw_tile_shape(CanvasItem *p_canvas_item, Rect2 p_region, Color p_color, bool p_filled = false, Ref<Texture2D> p_texture = Ref<Texture2D>());
+	void draw_tile_shape(CanvasItem *p_canvas_item, Transform2D p_transform, Color p_color, bool p_filled = false, Ref<Texture2D> p_texture = Ref<Texture2D>());
 
 	Vector<Point2> get_terrain_bit_polygon(int p_terrain_set, TileSet::CellNeighbor p_bit);
 	void draw_terrains(CanvasItem *p_canvas_item, Transform2D p_transform, const TileData *p_tile_data);


### PR DESCRIPTION
This PR makes the TileMap node usable with transformations, especially when skewed. The tiles are now drawn correctly.

![Peek 14-09-2021 12-17](https://user-images.githubusercontent.com/6093119/133240236-df2f37fc-fc48-4939-bbd0-57813a54288b.gif)

Also, this fixes the TileMap selection with isometric, hexagonal and half squared shapes.
