### PR TITLE
Sphere occluders - self occlusion and improvements

### DIFF
--- a/servers/visual/portals/portal_occlusion_culler.h
+++ b/servers/visual/portals/portal_occlusion_culler.h
@@ -42,10 +42,25 @@ class PortalOcclusionCuller {
 public:
 	PortalOcclusionCuller();
 	void prepare(PortalRenderer &p_portal_renderer, const VSRoom &p_room, const Vector3 &pt_camera, const LocalVector<Plane> &p_planes, const Plane *p_near_plane) {
-		prepare_generic(p_portal_renderer, p_room._occluder_pool_ids, pt_camera, p_planes, p_near_plane);
+		if (p_near_plane) {
+			static LocalVector<Plane> local_planes;
+			int size_wanted = p_planes.size() + 1;
+
+			if ((int)local_planes.size() != size_wanted) {
+				local_planes.resize(size_wanted);
+			}
+			for (int n = 0; n < (int)p_planes.size(); n++) {
+				local_planes[n] = p_planes[n];
+			}
+			local_planes[size_wanted - 1] = *p_near_plane;
+
+			prepare_generic(p_portal_renderer, p_room._occluder_pool_ids, pt_camera, local_planes);
+		} else {
+			prepare_generic(p_portal_renderer, p_room._occluder_pool_ids, pt_camera, p_planes);
+		}
 	}
 
-	void prepare_generic(PortalRenderer &p_portal_renderer, const LocalVector<uint32_t, uint32_t> &p_occluder_pool_ids, const Vector3 &pt_camera, const LocalVector<Plane> &p_planes, const Plane *p_near_plane);
+	void prepare_generic(PortalRenderer &p_portal_renderer, const LocalVector<uint32_t, uint32_t> &p_occluder_pool_ids, const Vector3 &pt_camera, const LocalVector<Plane> &p_planes);
 	bool cull_aabb(const AABB &p_aabb) const {
 		if (!_num_spheres) {
 			return false;
@@ -53,21 +68,34 @@ public:
 
 		return cull_sphere(p_aabb.get_center(), p_aabb.size.length() * 0.5);
 	}
-	bool cull_sphere(const Vector3 &p_occludee_center, real_t p_occludee_radius) const;
+	bool cull_sphere(const Vector3 &p_occludee_center, real_t p_occludee_radius, int p_ignore_sphere = -1) const;
 
 private:
 	// if a sphere is entirely in front of any of the culling planes, it can't be seen so returns false
-	bool is_sphere_culled(const Vector3 &p_pos, real_t p_radius, const LocalVector<Plane> &p_planes, const Plane *p_near_plane) const {
-		if (p_near_plane) {
-			real_t dist = p_near_plane->distance_to(p_pos);
+	bool is_sphere_culled(const Vector3 &p_pos, real_t p_radius, const LocalVector<Plane> &p_planes) const {
+		for (unsigned int p = 0; p < p_planes.size(); p++) {
+			real_t dist = p_planes[p].distance_to(p_pos);
 			if (dist > p_radius) {
 				return true;
 			}
 		}
 
-		for (unsigned int p = 0; p < p_planes.size(); p++) {
-			real_t dist = p_planes[p].distance_to(p_pos);
-			if (dist > p_radius) {
+		return false;
+	}
+
+	bool is_aabb_culled(const AABB &p_aabb, const LocalVector<Plane> &p_planes) const {
+		const Vector3 &size = p_aabb.size;
+		Vector3 half_extents = size * 0.5;
+		Vector3 ofs = p_aabb.position + half_extents;
+
+		for (unsigned int i = 0; i < p_planes.size(); i++) {
+			const Plane &p = p_planes[i];
+			Vector3 point(
+					(p.normal.x > 0) ? -half_extents.x : half_extents.x,
+					(p.normal.y > 0) ? -half_extents.y : half_extents.y,
+					(p.normal.z > 0) ? -half_extents.z : half_extents.z);
+			point += ofs;
+			if (p.is_point_over(point)) {
 				return true;
 			}
 		}

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -335,6 +335,10 @@ inline void PortalRenderer::occluder_ensure_up_to_date_sphere(VSOccluder &r_occl
 	Vector3 scale3 = tr.basis.get_scale_abs();
 	real_t scale = (scale3.x + scale3.y + scale3.z) / 3.0;
 
+	// update the AABB
+	Vector3 bb_min = Vector3(FLT_MAX, FLT_MAX, FLT_MAX);
+	Vector3 bb_max = Vector3(-FLT_MAX, -FLT_MAX, -FLT_MAX);
+
 	// transform spheres
 	for (int n = 0; n < r_occluder.list_ids.size(); n++) {
 		uint32_t pool_id = r_occluder.list_ids[n];
@@ -343,7 +347,21 @@ inline void PortalRenderer::occluder_ensure_up_to_date_sphere(VSOccluder &r_occl
 		// transform position and radius
 		osphere.world.pos = tr.xform(osphere.local.pos);
 		osphere.world.radius = osphere.local.radius * scale;
+
+		Vector3 bradius = Vector3(osphere.world.radius, osphere.world.radius, osphere.world.radius);
+		Vector3 bmin = osphere.world.pos - bradius;
+		Vector3 bmax = osphere.world.pos + bradius;
+
+		bb_min.x = MIN(bb_min.x, bmin.x);
+		bb_min.y = MIN(bb_min.y, bmin.y);
+		bb_min.z = MIN(bb_min.z, bmin.z);
+		bb_max.x = MAX(bb_max.x, bmax.x);
+		bb_max.y = MAX(bb_max.y, bmax.y);
+		bb_max.z = MAX(bb_max.z, bmax.z);
 	}
+
+	r_occluder.aabb.position = bb_min;
+	r_occluder.aabb.size = bb_max - bb_min;
 }
 
 #endif

--- a/servers/visual/portals/portal_tracer.cpp
+++ b/servers/visual/portals/portal_tracer.cpp
@@ -544,7 +544,7 @@ int PortalTracer::occlusion_cull(PortalRenderer &p_portal_renderer, const Vector
 		local_planes[n] = p_convex[n];
 	}
 
-	_occlusion_culler.prepare_generic(p_portal_renderer, p_portal_renderer.get_occluders_active_list(), p_point, local_planes, nullptr);
+	_occlusion_culler.prepare_generic(p_portal_renderer, p_portal_renderer.get_occluders_active_list(), p_point, local_planes);
 
 	// cull each instance
 	int count = p_num_results;

--- a/servers/visual/portals/portal_types.h
+++ b/servers/visual/portals/portal_types.h
@@ -400,6 +400,9 @@ struct VSOccluder {
 	// location for finding the room
 	Vector3 pt_center;
 
+	// world space aabb, only updated when dirty
+	AABB aabb;
+
 	// global xform
 	Transform xform;
 


### PR DESCRIPTION
Sphere occluders are now tested for self occlusion. Spheres that are behind another sphere in the current view are superfluous so can be removed, cutting down on the runtime calculations.

AABBs are now maintained for Occluders as well as individual spheres, meaning a bunch of occluder spheres can be frustum rejected as a block.

Small bug fix for closest sphere.

## Notes
* Typically you might be cull checking e.g. 1000 objects against 8 occluder spheres. If you can detect ahead of time that one of these spheres is behind another, the former sphere contributes nothing to the culling, and the number of checks can be decreased by 7/8ths.
* There is a small amount of extra processing to maintain the AABBs when occluders move. This is a bit of a trade off, of whether this cost will be outweighed by the broad phase frustum culling, in a game where you had e.g. 1000 spaceships each using occluders. I think it's highly likely to be a win in all cases. It should pretty much always be a good thing to do with static spheres.
* Maintaining an AABB per occluder (each of which can hold as many spheres as you like) allows more efficient quick rejection should you wish to have e.g. 1000 spheres. (If you built them in several Occluders with e.g. 20 in each, this means it only needs to do 50 broadphase checks).
* I've also toyed with the idea of maintaining a BVH for the spheres, but I'm not convinced it is necessary at this stage. On the other hand something like a BVH may be more likely to be useful with OccluderMeshes (where the number of polys can easily get quite high).

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
