### PR TITLE
Fix editor crash on pressing `Go to Previous Bookmark` menu button

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1735,7 +1735,7 @@ void CodeTextEditor::goto_prev_bookmark() {
 		text_editor->set_caret_line(bmarks[bmarks.size() - 1]);
 		text_editor->center_viewport_to_caret();
 	} else {
-		for (int i = bmarks.size(); i >= 0; i--) {
+		for (int i = bmarks.size() - 1; i >= 0; i--) {
 			int bmark_line = bmarks[i];
 			if (bmark_line < line) {
 				text_editor->unfold_line(bmark_line);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1242,7 +1242,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				tx->set_caret_line(bpoints[bpoints.size() - 1]);
 				tx->center_viewport_to_caret();
 			} else {
-				for (int i = bpoints.size(); i >= 0; i--) {
+				for (int i = bpoints.size() - 1; i >= 0; i--) {
 					int bline = bpoints[i];
 					if (bline < line) {
 						tx->unfold_line(bline);


### PR DESCRIPTION
Fix #52660
