### PR TITLE
[3.x] Fix scale sensitivity for 3D objects.

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -1612,6 +1612,8 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							motion = Vector3(scale, scale, scale);
 						}
 
+						motion /= click.distance_to(_edit.center);
+
 						List<Node *> &selection = editor_selection->get_selected_node_list();
 
 						// Disable local transformation for TRANSFORM_VIEW


### PR DESCRIPTION
Scaling 3D objects has been broken for a long time, it works well **only** when scale values stay around their original ones. Meaning that if you try scaling an objects that already at scale 30, the scaling function becomes unusable. Simple as that.

**Current godot implementation vs. this PR:**

https://user-images.githubusercontent.com/38346332/133256881-79c4eb1c-9e4d-4ee0-8f3c-f5645b0d1046.mp4

This PR also divides the scale factor by the distance of the mouse click from the object. This is neat as it gives users the ability to choose scaling sensitivity in a very simple way: "The further from the object's center you mouse is, the slower it scales and vice versa"

**A video showing the variable scaling sensitivity:**

https://user-images.githubusercontent.com/38346332/133257142-bbb31dcf-c1e2-4f94-9b8b-ec501f0bef58.mp4

I'm new to contributing and a novice at C++, I welcome all feedback. I heard the codebase for specifically this has changed loads for 4.0, chances are it's already fixed if not I could try my hand at porting it?