### PR TITLE
Fix error which generates if `Delete Line` used on the last line in `CodeEditor`

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1302,7 +1302,9 @@ void CodeTextEditor::_delete_line(int p_line) {
 		text_editor->set_caret_column(0);
 	}
 	text_editor->backspace();
-	text_editor->unfold_line(p_line);
+	if (p_line < text_editor->get_line_count()) {
+		text_editor->unfold_line(p_line);
+	}
 	text_editor->set_caret_line(p_line);
 }
 


### PR DESCRIPTION
Fix the following error:

![delete_line_bug](https://user-images.githubusercontent.com/3036176/133274828-0978569b-3801-4692-b0e7-818bc6281a7c.gif)

