### PR TITLE
Fix error when moving graph node

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -356,16 +356,6 @@ void GraphEdit::_graph_node_raised(Node *p_gn) {
 	} else {
 		gn->raise();
 	}
-	int first_not_comment = 0;
-	for (int i = 0; i < get_child_count(); i++) {
-		GraphNode *gn2 = Object::cast_to<GraphNode>(get_child(i));
-		if (gn2 && !gn2->is_comment()) {
-			first_not_comment = i;
-			break;
-		}
-	}
-
-	move_child(connections_layer, first_not_comment);
 	emit_signal(SNAME("node_selected"), p_gn);
 }
 


### PR DESCRIPTION
Fixes #52669

`connections_layer` is now an internal child, so we don't need to move it anymore.

I noticed an issue however. Comment nodes are supposed to be under connections. However after #30391, the connections are now always on bottom. Either we accept it or make the connections layer non-internal (which means that a user might accidentally free it etc., basically what #30391 fixed). Another option is making another internal child that would draw comment nodes, but it doesn't sound like something easy to do.

CC @Chaosus 