### PR TITLE
Print the Vulkan API version and device used on the same line

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -275,22 +275,21 @@ Error VulkanContext::_obtain_vulkan_version() {
 		if (res == VK_SUCCESS) {
 			vulkan_major = VK_VERSION_MAJOR(api_version);
 			vulkan_minor = VK_VERSION_MINOR(api_version);
-			uint32_t vulkan_patch = VK_VERSION_PATCH(api_version);
-
-			print_line("Vulkan API " + itos(vulkan_major) + "." + itos(vulkan_minor) + "." + itos(vulkan_patch));
+			vulkan_patch = VK_VERSION_PATCH(api_version);
 		} else {
 			// according to the documentation this shouldn't fail with anything except a memory allocation error
 			// in which case we're in deep trouble anyway
 			ERR_FAIL_V(ERR_CANT_CREATE);
 		}
 	} else {
-		print_line("vkEnumerateInstanceVersion not available, assuming Vulkan 1.0");
+		print_line("vkEnumerateInstanceVersion not available, assuming Vulkan 1.0.");
 	}
 
 	// we don't go above 1.2
 	if ((vulkan_major > 1) || (vulkan_major == 1 && vulkan_minor > 2)) {
 		vulkan_major = 1;
 		vulkan_minor = 2;
+		vulkan_patch = 0;
 	}
 
 	return OK;
@@ -759,7 +758,9 @@ Error VulkanContext::_create_physical_device() {
 		}
 	}
 
-	print_line("Using Vulkan Device #" + itos(device_index) + ": " + device_vendor + " - " + device_name);
+	print_line(
+			"Vulkan API " + itos(vulkan_major) + "." + itos(vulkan_minor) + "." + itos(vulkan_patch) +
+			" - " + "Using Vulkan Device #" + itos(device_index) + ": " + device_vendor + " - " + device_name);
 
 	device_api_version = gpu_props.apiVersion;
 

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -85,6 +85,7 @@ private:
 	// Vulkan 1.0 doesn't return version info so we assume this by default until we know otherwise
 	uint32_t vulkan_major = 1;
 	uint32_t vulkan_minor = 0;
+	uint32_t vulkan_patch = 0;
 	SubgroupCapabilities subgroup_capabilities;
 	MultiviewCapabilities multiview_capabilities;
 


### PR DESCRIPTION
This matches Godot 3.x's OpenGL renderer behavior and is more compact.

## Preview

### Before

```
❯ godot                                               
Godot Engine v4.0.dev.custom_build.43e96e0c6 - https://godotengine.org
Vulkan API 1.2.162
Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080
```

### After

```
❯ godot
Godot Engine v4.0.dev.custom_build.254c5cbeb - https://godotengine.org
Vulkan API 1.2.162 - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080
```