### PR TITLE
Tweak the script editor's line/column indicator for readability

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -834,11 +834,9 @@ void CodeTextEditor::_line_col_changed() {
 	}
 
 	StringBuilder sb;
-	sb.append("(");
-	sb.append(itos(text_editor->get_caret_line() + 1).lpad(3));
-	sb.append(",");
+	sb.append(itos(text_editor->get_caret_line() + 1).lpad(4));
+	sb.append(" : ");
 	sb.append(itos(positional_column + 1).lpad(3));
-	sb.append(")");
 
 	line_and_col_txt->set_text(sb.as_string());
 }


### PR DESCRIPTION
Salvaged version of https://github.com/godotengine/godot/pull/41862.

- Use a colon instead of parentheses and a comma to reduce visual clutter.
- Pad the line number with 4 spaces to account for scripts longer than 999 lines.
  - This isn't needed for the column number as it's very unlikely to go past 999.

## Preview

![image](https://user-images.githubusercontent.com/180032/133328694-a42570ba-766e-4b43-bf46-c3d8288e197b.png)
