### PR TITLE
Fix scale sensitivity for 3D objects

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1831,6 +1831,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							motion = Vector3(scale, scale, scale);
 						}
 
+						motion /= click.distance_to(_edit.center);
+
 						// Disable local transformation for TRANSFORM_VIEW
 						bool local_coords = (spatial_editor->are_local_coords_enabled() && _edit.plane != TRANSFORM_VIEW);
 


### PR DESCRIPTION
The master version of #52665

Scaling 3D objects has been broken for a long time, it works well only when scale values stay around their original ones. Meaning that if you try scaling an objects that already at scale 30, the scaling function becomes unusable. Simple as that.

With this PR the motion vector is divided by the distance of the mouse click from the object. This is neat as it gives users the ability to choose scaling sensitivity in a very simple way: "The further from the object's center you mouse is, the slower it scales and vice versa"