### PR TITLE
TextServer: Fix build with freetype disabled

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -30,6 +30,7 @@
 
 #include "text_server_adv.h"
 
+#include "core/error/error_macros.h"
 #include "core/string/print_string.h"
 #include "core/string/translation.h"
 
@@ -1225,7 +1226,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 		int error = 0;
 		if (!library) {
 			error = FT_Init_FreeType(&library);
-			ERR_FAIL_COND_V_MSG(error != 0, false, RTR("FreeType: Error initializing library:") + " '" + String(FT_Error_String(error)) + "'.");
+			ERR_FAIL_COND_V_MSG(error != 0, false, "FreeType: Error initializing library: '" + String(FT_Error_String(error)) + "'.");
 		}
 
 		memset(&fd->stream, 0, sizeof(FT_StreamRec));
@@ -1243,7 +1244,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 		if (error) {
 			FT_Done_Face(fd->face);
 			fd->face = nullptr;
-			ERR_FAIL_V_MSG(false, RTR("FreeType: Error loading font:") + " '" + String(FT_Error_String(error)) + "'.");
+			ERR_FAIL_V_MSG(false, "FreeType: Error loading font: '" + String(FT_Error_String(error)) + "'.");
 		}
 
 		if (p_font_data->msdf) {
@@ -1588,7 +1589,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 			FT_Done_MM_Var(library, amaster);
 		}
 #else
-		ERR_FAIL_V_MSG(false, RTR("FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
+		ERR_FAIL_V_MSG(false, "FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
 #endif
 	} else {
 		// Init bitmap font.

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -30,6 +30,7 @@
 
 #include "text_server_fb.h"
 
+#include "core/error/error_macros.h"
 #include "core/string/print_string.h"
 
 #ifdef MODULE_MSDFGEN_ENABLED
@@ -686,7 +687,7 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontDataFallback 
 		int error = 0;
 		if (!library) {
 			error = FT_Init_FreeType(&library);
-			ERR_FAIL_COND_V_MSG(error != 0, false, RTR("FreeType: Error initializing library:") + " '" + String(FT_Error_String(error)) + "'.");
+			ERR_FAIL_COND_V_MSG(error != 0, false, "FreeType: Error initializing library: '" + String(FT_Error_String(error)) + "'.");
 		}
 
 		memset(&fd->stream, 0, sizeof(FT_StreamRec));
@@ -704,7 +705,7 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontDataFallback 
 		if (error) {
 			FT_Done_Face(fd->face);
 			fd->face = nullptr;
-			ERR_FAIL_V_MSG(false, RTR("FreeType: Error loading font:") + " '" + String(FT_Error_String(error)) + "'.");
+			ERR_FAIL_V_MSG(false, "FreeType: Error loading font: '" + String(FT_Error_String(error)) + "'.");
 		}
 
 		if (p_font_data->msdf) {
@@ -784,7 +785,7 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontDataFallback 
 			FT_Done_MM_Var(library, amaster);
 		}
 #else
-		ERR_FAIL_V_MSG(false, RTR("FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
+		ERR_FAIL_V_MSG(false, "FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
 #endif
 	}
 	p_font_data->cache[p_size] = fd;


### PR DESCRIPTION
Also remove RTR calls as we don't translate internal error messages.

As reported by @aaronfranke on the Godot Chat:

> I noticed that a `scons tools=no modules_enabled_by_default=no` build of Godot doesn't work due to not being able to find a TextServer. Which modules are required for TextServer to work?
>
> Enabling only text_server_adv and/or text_server_fb gives this error (it's very similar for text_server_adv):
> ```
> modules/text_server_fb/text_server_fb.cpp: In member function 'bool TextServerFallback::_ensure_cache_for_size(TextServerFallback::FontDataFallback*, const Vector2i&) const':
> modules/text_server_fb/text_server_fb.cpp:787:3: error: 'ERR_FAIL_V_MSG' was not declared in this scope
>   787 |   ERR_FAIL_V_MSG(false, RTR("FreeType: Can't load dynamic font, engine is compiled without FreeType support!");
>       |   ^~~~~~~~~~~~~~
> modules/text_server_fb/text_server_fb.cpp:787:3: error: expected '}' at end of input
> modules/text_server_fb/text_server_fb.cpp:683:29: note: to match this '{'
> ```