### PR TITLE
[HTML5] Use browser mix rate by default on the Web.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -279,6 +279,9 @@
 		<member name="audio/driver/mix_rate" type="int" setter="" getter="" default="44100">
 			The mixing rate used for audio (in Hz). In general, it's better to not touch this and leave it to the host operating system.
 		</member>
+		<member name="audio/driver/mix_rate.web" type="int" setter="" getter="" default="0">
+			Safer override for [member audio/driver/mix_rate] in the Web platform. Here [code]0[/code] means "let the browser choose" (since some browsers do not like forcing the mix rate).
+		</member>
 		<member name="audio/driver/output_latency" type="int" setter="" getter="" default="15">
 			Output latency in milliseconds for audio. Lower values will result in lower audio latency at the cost of increased CPU usage. Low values may result in audible cracking on slower hardware.
 		</member>

--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -108,7 +108,7 @@ Error AudioDriverJavaScript::init() {
 	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
 	int latency = GLOBAL_GET("audio/driver/output_latency");
 
-	channel_count = godot_audio_init(mix_rate, latency, &_state_change_callback, &_latency_update_callback);
+	channel_count = godot_audio_init(&mix_rate, latency, &_state_change_callback, &_latency_update_callback);
 	buffer_length = closest_power_of_2((latency * mix_rate / 1000));
 #ifndef NO_THREADS
 	node = memnew(WorkletNode);

--- a/platform/javascript/godot_audio.h
+++ b/platform/javascript/godot_audio.h
@@ -38,7 +38,7 @@ extern "C" {
 #include "stddef.h"
 
 extern int godot_audio_is_available();
-extern int godot_audio_init(int p_mix_rate, int p_latency, void (*_state_cb)(int), void (*_latency_cb)(float));
+extern int godot_audio_init(int *p_mix_rate, int p_latency, void (*_state_cb)(int), void (*_latency_cb)(float));
 extern void godot_audio_resume();
 
 extern int godot_audio_capture_start();

--- a/platform/javascript/js/libs/library_godot_audio.js
+++ b/platform/javascript/js/libs/library_godot_audio.js
@@ -37,10 +37,14 @@ const GodotAudio = {
 		interval: 0,
 
 		init: function (mix_rate, latency, onstatechange, onlatencyupdate) {
-			const ctx = new (window.AudioContext || window.webkitAudioContext)({
-				sampleRate: mix_rate,
-				// latencyHint: latency / 1000 // Do not specify, leave 'interactive' for good performance.
-			});
+			const opts = {};
+			// If mix_rate is 0, let the browser choose.
+			if (mix_rate) {
+				opts['sampleRate'] = mix_rate;
+			}
+			// Do not specify, leave 'interactive' for good performance.
+			// opts['latencyHint'] = latency / 1000;
+			const ctx = new (window.AudioContext || window.webkitAudioContext)(opts);
 			GodotAudio.ctx = ctx;
 			ctx.onstatechange = function () {
 				let state = 0;
@@ -159,7 +163,10 @@ const GodotAudio = {
 	godot_audio_init: function (p_mix_rate, p_latency, p_state_change, p_latency_update) {
 		const statechange = GodotRuntime.get_func(p_state_change);
 		const latencyupdate = GodotRuntime.get_func(p_latency_update);
-		return GodotAudio.init(p_mix_rate, p_latency, statechange, latencyupdate);
+		const mix_rate = GodotRuntime.getHeapValue(p_mix_rate, 'i32');
+		const channels = GodotAudio.init(mix_rate, p_latency, statechange, latencyupdate);
+		GodotRuntime.setHeapValue(p_mix_rate, GodotAudio.ctx.sampleRate, 'i32');
+		return channels;
 	},
 
 	godot_audio_resume__sig: 'v',

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -196,6 +196,7 @@ int AudioDriverManager::get_driver_count() {
 void AudioDriverManager::initialize(int p_driver) {
 	GLOBAL_DEF_RST("audio/driver/enable_input", false);
 	GLOBAL_DEF_RST("audio/driver/mix_rate", DEFAULT_MIX_RATE);
+	GLOBAL_DEF_RST("audio/driver/mix_rate.web", 0); // Safer default output_latency for web (use browser default).
 	GLOBAL_DEF_RST("audio/driver/output_latency", DEFAULT_OUTPUT_LATENCY);
 	GLOBAL_DEF_RST("audio/driver/output_latency.web", 50); // Safer default output_latency for web.
 


### PR DESCRIPTION
Browsers doesn't really like forcing the mix rate, e.g. Firefox does not allow input (microphone) if the mix rate is not the default one, Chrom* will exhibit worse performances, etc.