### PR TITLE
Fix small timers only triggering once per frame

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -49,11 +49,13 @@ void Timer::_notification(int p_what) {
 			}
 			time_left -= get_process_delta_time();
 
-			if (time_left < 0) {
+			while (time_left < 0) {
 				if (!one_shot) {
 					time_left += wait_time;
 				} else {
 					stop();
+					emit_signal(SNAME("timeout"));
+					break;
 				}
 
 				emit_signal(SNAME("timeout"));
@@ -66,11 +68,13 @@ void Timer::_notification(int p_what) {
 			}
 			time_left -= get_physics_process_delta_time();
 
-			if (time_left < 0) {
+			while (time_left < 0) {
 				if (!one_shot) {
 					time_left += wait_time;
 				} else {
 					stop();
+					emit_signal(SNAME("timeout"));
+					break;
 				}
 				emit_signal(SNAME("timeout"));
 			}


### PR DESCRIPTION
Fixes #52687

Timers with very small values have less accuracy if FPS are not high enough *(for example, a 0.01s timer needs at least 100FPS for full accuracy)*. This helps to combat that issue by triggering multiple times on the same frame if needed.

~~Also related to this issue, the `delta` time was lower than expected when target FPS is much lower than physics FPS *(eg: at 1 target FPS and 60 physics FPS, delta was being set to `0.13` when it should have been close to `1.00`)*. That came from this line which I removed:~~
```
process_step -= (advance.physics_steps - max_physics_steps) * physics_step;
```
~~I couldn't understand the logic behind this since it's modifying process time when dealing with physics time, and after some simple tests I didn't find any issue with it's removal.~~

~~I wasn't able to test this properly on a full test/demo for `4.0` though, so in the meantime I'll apply this on `3.x` to find out.~~

EDIT: Reverted this last change, see comments below