### PR TITLE
GDScript: Allow string keys on Lua-style dictionaries

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -440,7 +440,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						break;
 					case GDScriptParser::DictionaryNode::LUA_TABLE:
 						// Lua-style: key is an identifier interpreted as StringName.
-						StringName key = static_cast<const GDScriptParser::IdentifierNode *>(dn->elements[i].key)->name;
+						StringName key = dn->elements[i].key->reduced_value.operator StringName();
 						element = codegen.add_constant(key);
 						break;
 				}

--- a/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_lua.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_lua.gd
@@ -1,0 +1,6 @@
+func test():
+	var lua_dict = {
+		a = 1,
+		b = 2,
+		a = 3, # Duplicate isn't allowed.
+	}

--- a/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_lua.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_lua.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Key "a" was already used in this dictionary (at line 3).

--- a/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_lua_with_string.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_lua_with_string.gd
@@ -1,0 +1,6 @@
+func test():
+	var lua_dict_with_string = {
+		a = 1,
+		b = 2,
+		"a" = 3, # Duplicate isn't allowed.
+	}

--- a/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_lua_with_string.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_lua_with_string.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Key "a" was already used in this dictionary (at line 3).

--- a/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_python.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_python.gd
@@ -1,0 +1,6 @@
+func test():
+	var python_dict = {
+		"a": 1,
+		"b": 2,
+		"a": 3, # Duplicate isn't allowed.
+	}

--- a/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_python.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/dictionary_duplicate_key_python.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Key "a" was already used in this dictionary (at line 3).

--- a/modules/gdscript/tests/scripts/parser/features/dictionary_lua_style.gd
+++ b/modules/gdscript/tests/scripts/parser/features/dictionary_lua_style.gd
@@ -1,0 +1,9 @@
+func test():
+	var lua_dict = {
+		a = 1,
+		"b" = 2, # Using strings are allowed too.
+		"with spaces" = 3, # Especially useful when key has spaces...
+		"2" = 4, # ... or invalid identifiers.
+	}
+
+	print(lua_dict)

--- a/modules/gdscript/tests/scripts/parser/features/dictionary_lua_style.out
+++ b/modules/gdscript/tests/scripts/parser/features/dictionary_lua_style.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+{2:4, a:1, b:2, with spaces:3}


### PR DESCRIPTION
Which is useful when the key isn't a valid identifier, such as keys with spaces or numeric keys.

Fix #44977

