### PR TITLE
GDScript: Show error on unary operators without argument

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2123,22 +2123,34 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_unary_operator(ExpressionN
 			operation->operation = UnaryOpNode::OP_NEGATIVE;
 			operation->variant_op = Variant::OP_NEGATE;
 			operation->operand = parse_precedence(PREC_SIGN, false);
+			if (operation->operand == nullptr) {
+				push_error(R"(Expected expression after "-" operator.)");
+			}
 			break;
 		case GDScriptTokenizer::Token::PLUS:
 			operation->operation = UnaryOpNode::OP_POSITIVE;
 			operation->variant_op = Variant::OP_POSITIVE;
 			operation->operand = parse_precedence(PREC_SIGN, false);
+			if (operation->operand == nullptr) {
+				push_error(R"(Expected expression after "+" operator.)");
+			}
 			break;
 		case GDScriptTokenizer::Token::TILDE:
 			operation->operation = UnaryOpNode::OP_COMPLEMENT;
 			operation->variant_op = Variant::OP_BIT_NEGATE;
 			operation->operand = parse_precedence(PREC_BIT_NOT, false);
+			if (operation->operand == nullptr) {
+				push_error(R"(Expected expression after "~" operator.)");
+			}
 			break;
 		case GDScriptTokenizer::Token::NOT:
 		case GDScriptTokenizer::Token::BANG:
 			operation->operation = UnaryOpNode::OP_LOGIC_NOT;
 			operation->variant_op = Variant::OP_NOT;
 			operation->operand = parse_precedence(PREC_LOGIC_NOT, false);
+			if (operation->operand == nullptr) {
+				push_error(vformat(R"(Expected expression after "%s" operator.)", op_type == GDScriptTokenizer::Token::NOT ? "not" : "!"));
+			}
 			break;
 		default:
 			return nullptr; // Unreachable.

--- a/modules/gdscript/tests/scripts/parser/errors/binary_complement_without_argument.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/binary_complement_without_argument.gd
@@ -1,0 +1,2 @@
+func test():
+	print(~)

--- a/modules/gdscript/tests/scripts/parser/errors/binary_complement_without_argument.out
+++ b/modules/gdscript/tests/scripts/parser/errors/binary_complement_without_argument.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected expression after "~" operator.

--- a/modules/gdscript/tests/scripts/parser/errors/boolean_negation_without_argument.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/boolean_negation_without_argument.gd
@@ -1,0 +1,2 @@
+func test():
+	print(not)

--- a/modules/gdscript/tests/scripts/parser/errors/boolean_negation_without_argument.out
+++ b/modules/gdscript/tests/scripts/parser/errors/boolean_negation_without_argument.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected expression after "not" operator.

--- a/modules/gdscript/tests/scripts/parser/errors/boolean_negation_without_argument_using_bang.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/boolean_negation_without_argument_using_bang.gd
@@ -1,0 +1,2 @@
+func test():
+	print(!)

--- a/modules/gdscript/tests/scripts/parser/errors/boolean_negation_without_argument_using_bang.out
+++ b/modules/gdscript/tests/scripts/parser/errors/boolean_negation_without_argument_using_bang.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected expression after "!" operator.

--- a/modules/gdscript/tests/scripts/parser/errors/mistaken_decrement_operator.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/mistaken_decrement_operator.gd
@@ -1,0 +1,3 @@
+func test():
+	var a = 0
+	print(a--)

--- a/modules/gdscript/tests/scripts/parser/errors/mistaken_decrement_operator.out
+++ b/modules/gdscript/tests/scripts/parser/errors/mistaken_decrement_operator.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected expression after "-" operator.

--- a/modules/gdscript/tests/scripts/parser/errors/mistaken_increment_operator.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/mistaken_increment_operator.gd
@@ -1,0 +1,3 @@
+func test():
+	var a = 0
+	print(a++)

--- a/modules/gdscript/tests/scripts/parser/errors/mistaken_increment_operator.out
+++ b/modules/gdscript/tests/scripts/parser/errors/mistaken_increment_operator.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected expression after "+" operator.


### PR DESCRIPTION
Fix #49124
