### PR TITLE
GDScript: Show error when missing expression after ternary else

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2275,6 +2275,10 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_ternary_operator(Expressio
 
 	operation->false_expr = parse_precedence(PREC_TERNARY, false);
 
+	if (operation->false_expr == nullptr) {
+		push_error(R"(Expected expression after "else".)");
+	}
+
 	return operation;
 }
 

--- a/modules/gdscript/tests/scripts/parser/errors/missing_expression_after_ternary_else.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/missing_expression_after_ternary_else.gd
@@ -1,0 +1,4 @@
+func test():
+	var x = 1 if false else
+	print("oops")
+	print(x)

--- a/modules/gdscript/tests/scripts/parser/errors/missing_expression_after_ternary_else.out
+++ b/modules/gdscript/tests/scripts/parser/errors/missing_expression_after_ternary_else.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected expression after "else".


### PR DESCRIPTION
Fix #50714