### PR TITLE
Show correct debug tooltips for existing variables

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -265,5 +265,11 @@ void EditorDebuggerInspector::clear_stack_variables() {
 }
 
 String EditorDebuggerInspector::get_stack_variable(const String &p_var) {
-	return variables->get_variant(p_var);
+	for (Map<StringName, Variant>::Element *E = variables->prop_values.front(); E; E = E->next()) {
+		String v = E->key().operator String();
+		if (v.get_slice("/", 1) == p_var) {
+			return variables->get_variant(v);
+		}
+	}
+	return String();
 }


### PR DESCRIPTION
Fixes #49939

I'm not entirely sure how this regression happened, I just applied a fix that restores the old behavior.
~~I didn't find any occurrence of `prop_values` being indexed using the type and name of a variable, so I think it's fine.~~ nvm, it's used in the Debugger dock.
