### PR TITLE
In nodes RichTextLabel and Label, get_total_character_count() now has a parameter to include or not spaces

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -41,8 +41,10 @@
 		</method>
 		<method name="get_total_character_count" qualifiers="const">
 			<return type="int" />
+			<argument index="0" name="p_include_spaces" type="bool" default="true" />
 			<description>
-				Returns the total number of printable characters in the text (excluding spaces and newlines).
+				Returns the total number of printable characters in the text (excluding newlines).
+				If [code]include_spaces[/code] is set to [code]false[/code], it doesn't count spaces.
 			</description>
 		</method>
 		<method name="get_visible_line_count" qualifiers="const">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -93,8 +93,10 @@
 		</method>
 		<method name="get_total_character_count" qualifiers="const">
 			<return type="int" />
+			<argument index="0" name="p_include_spaces" type="bool" default="true" />
 			<description>
 				Returns the total number of characters from text tags. Does not include BBCodes.
+				If [code]include_spaces[/code] is set to [code]false[/code], it doesn't count spaces.
 			</description>
 		</method>
 		<method name="get_v_scroll">

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -748,12 +748,22 @@ int Label::get_max_lines_visible() const {
 	return max_lines_visible;
 }
 
-int Label::get_total_character_count() const {
+int Label::get_total_character_count(bool p_include_spaces) const {
 	if (dirty || lines_dirty) {
 		const_cast<Label *>(this)->_shape();
 	}
 
-	return xl_text.length();
+	if (p_include_spaces) {
+		return xl_text.length();
+	} else {
+		int space_count = 0;
+		for (int i = 0; i < xl_text.length(); i++) {
+			if (xl_text[i] == ' ') {
+				space_count++;
+			}
+		}
+		return xl_text.length() - space_count;
+	}
 }
 
 bool Label::_set(const StringName &p_name, const Variant &p_value) {
@@ -831,7 +841,7 @@ void Label::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_line_height", "line"), &Label::get_line_height, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("get_line_count"), &Label::get_line_count);
 	ClassDB::bind_method(D_METHOD("get_visible_line_count"), &Label::get_visible_line_count);
-	ClassDB::bind_method(D_METHOD("get_total_character_count"), &Label::get_total_character_count);
+	ClassDB::bind_method(D_METHOD("get_total_character_count", "p_include_spaces"), &Label::get_total_character_count, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("set_visible_characters", "amount"), &Label::set_visible_characters);
 	ClassDB::bind_method(D_METHOD("get_visible_characters"), &Label::get_visible_characters);
 	ClassDB::bind_method(D_METHOD("set_percent_visible", "percent_visible"), &Label::set_percent_visible);

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -142,7 +142,7 @@ public:
 
 	void set_visible_characters(int p_amount);
 	int get_visible_characters() const;
-	int get_total_character_count() const;
+	int get_total_character_count(bool p_include_spaces = true) const;
 
 	void set_clip_text(bool p_clip);
 	bool is_clipping_text() const;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4134,7 +4134,7 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_percent_visible", "percent_visible"), &RichTextLabel::set_percent_visible);
 	ClassDB::bind_method(D_METHOD("get_percent_visible"), &RichTextLabel::get_percent_visible);
 
-	ClassDB::bind_method(D_METHOD("get_total_character_count"), &RichTextLabel::get_total_character_count);
+	ClassDB::bind_method(D_METHOD("get_total_character_count", "p_include_spaces"), &RichTextLabel::get_total_character_count, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("set_use_bbcode", "enable"), &RichTextLabel::set_use_bbcode);
 	ClassDB::bind_method(D_METHOD("is_using_bbcode"), &RichTextLabel::is_using_bbcode);
@@ -4241,14 +4241,23 @@ int RichTextLabel::get_visible_characters() const {
 	return visible_characters;
 }
 
-int RichTextLabel::get_total_character_count() const {
+int RichTextLabel::get_total_character_count(bool p_include_spaces) const {
 	// Note: Do not use line buffer "char_count", it includes only visible characters.
+
 	int tc = 0;
 	Item *it = main;
 	while (it) {
 		if (it->type == ITEM_TEXT) {
 			ItemText *t = static_cast<ItemText *>(it);
 			tc += t->text.length();
+
+			if (!p_include_spaces) {
+				for (int i = 0; i < t->text.length(); i++) {
+					if (t->text[i] == ' ') {
+						tc--;
+					}
+				}
+			}
 		} else if (it->type == ITEM_NEWLINE) {
 			tc++;
 		} else if (it->type == ITEM_IMAGE) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -575,7 +575,7 @@ public:
 
 	void set_visible_characters(int p_visible);
 	int get_visible_characters() const;
-	int get_total_character_count() const;
+	int get_total_character_count(bool p_include_spaces = true) const;
 
 	void set_percent_visible(float p_percent);
 	float get_percent_visible() const;


### PR DESCRIPTION
The default value of this new parameter is true.

This was made mainly because the behavior of the function was inconsistent with the description in the documentation.

Fixes #27896.
