### PR TITLE
Mention that rebooting is required after updating graphics driver on X11

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -351,6 +351,7 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	if (gl_initialization_error) {
 		OS::get_singleton()->alert("Your video card driver does not support any of the supported OpenGL versions.\n"
 								   "Please update your drivers or if you have a very old or integrated GPU, upgrade it.\n"
+								   "If you have updated your graphics drivers recently, try rebooting.\n"
 								   "Alternatively, you can force software rendering by running Godot with the `LIBGL_ALWAYS_SOFTWARE=1`\n"
 								   "environment variable set, but this will be very slow.",
 				"Unable to initialize Video driver");


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/52715.

This is a common source of confusion for Linux users. The message is growing quite long by now, but hopefully, this should prevent further duplicate issues from being created :slightly_smiling_face: 

See https://github.com/godotengine/godot/issues/52704.