### PR TITLE
Improve TileMap physics for moving platforms and conveyor belts like movements

### DIFF
--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -37,6 +37,20 @@
 				Returns how many polygons the tile has for TileSet physics layer with index [code]layer_id[/code].
 			</description>
 		</method>
+		<method name="get_constant_angular_velocity" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="layer_id" type="int" />
+			<description>
+				Returns the constant angular velocity applied to objects colliding with this tile.
+			</description>
+		</method>
+		<method name="get_constant_linear_velocity" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="layer_id" type="int" />
+			<description>
+				Returns the constant linear velocity applied to objects colliding with this tile.
+			</description>
+		</method>
 		<method name="get_custom_data" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="layer_name" type="String" />
@@ -121,6 +135,22 @@
 			<argument index="1" name="polygons_count" type="int" />
 			<description>
 				Sets the polygons count for TileSet physics layer with index [code]layer_id[/code].
+			</description>
+		</method>
+		<method name="set_constant_angular_velocity">
+			<return type="void" />
+			<argument index="0" name="layer_id" type="int" />
+			<argument index="1" name="velocity" type="float" />
+			<description>
+				Sets the constant angular velocity. This does not rotate the tile. This angular velocity is applied to objects colliding with this tile.
+			</description>
+		</method>
+		<method name="set_constant_linear_velocity">
+			<return type="void" />
+			<argument index="0" name="layer_id" type="int" />
+			<argument index="1" name="velocity" type="Vector2" />
+			<description>
+				Sets the constant linear velocity. This does not move the tile. This linear velocity is applied to objects colliding with this tile. This is useful to create conveyor belts.
 			</description>
 		</method>
 		<method name="set_custom_data">

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -29,6 +29,13 @@
 				Clears all cells.
 			</description>
 		</method>
+		<method name="clear_layer">
+			<return type="void" />
+			<argument index="0" name="layer" type="int" />
+			<description>
+				Clears all cells on the given layer.
+			</description>
+		</method>
 		<method name="fix_invalid_tiles">
 			<return type="void" />
 			<description>
@@ -60,6 +67,13 @@
 			<argument index="2" name="use_proxies" type="bool" />
 			<description>
 				Returns the tile source ID of the cell on layer [code]layer[/code] at coordinates [code]coords[/code]. If [code]use_proxies[/code] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
+			</description>
+		</method>
+		<method name="get_coords_for_body_rid">
+			<return type="Vector2i" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+				Returns the coodinates of the tile for given physics body RID. Such RID can be retrieved from [member KinematicCollision2D.collider_rid], when colliding with a tile.
 			</description>
 		</method>
 		<method name="get_layer_name" qualifiers="const">
@@ -219,6 +233,10 @@
 	<members>
 		<member name="cell_quadrant_size" type="int" setter="set_quadrant_size" getter="get_quadrant_size" default="16">
 			The TileMap's quadrant size. Optimizes drawing by batching, using chunks of this size.
+		</member>
+		<member name="collision_animatable" type="bool" setter="set_collision_animatable" getter="is_collision_animatable" default="false">
+			If enabled, the TileMap will see its collisions synced to the physics tick and change its collision type from static to kinematic. This is required to create TileMap-based moving platform.
+			[b]Note:[/b] Enabling [code]collision_animatable[/code] may have a small performance impact, only do it if the TileMap is moving and has colliding tiles.
 		</member>
 		<member name="collision_visibility_mode" type="int" setter="set_collision_visibility_mode" getter="get_collision_visibility_mode" enum="TileMap.VisibilityMode" default="0">
 			Show or hide the TileMap's collision shapes. If set to [code]VISIBILITY_MODE_DEFAULT[/code], this depends on the show collision debug settings.

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -202,6 +202,7 @@ private:
 	// Properties.
 	Ref<TileSet> tile_set;
 	int quadrant_size = 16;
+	bool collision_animatable = false;
 	VisibilityMode collision_visibility_mode = VISIBILITY_MODE_DEFAULT;
 	VisibilityMode navigation_visibility_mode = VISIBILITY_MODE_DEFAULT;
 
@@ -228,6 +229,9 @@ private:
 	};
 	LocalVector<TileMapLayer> layers;
 	int selected_layer = -1;
+
+	// Mapping for RID to coords.
+	Map<RID, Vector2i> bodies_coords;
 
 	// Quadrants and internals management.
 	Vector2i _coords_to_quadrant_coords(int p_layer, const Vector2i &p_coords) const;
@@ -259,9 +263,10 @@ private:
 	void _rendering_cleanup_quadrant(TileMapQuadrant *p_quadrant);
 	void _rendering_draw_quadrant_debug(TileMapQuadrant *p_quadrant);
 
+	Transform2D last_valid_transform;
+	Transform2D new_transform;
 	void _physics_notification(int p_what);
 	void _physics_update_dirty_quadrants(SelfList<TileMapQuadrant>::List &r_dirty_quadrant_list);
-	void _physics_create_quadrant(TileMapQuadrant *p_quadrant);
 	void _physics_cleanup_quadrant(TileMapQuadrant *p_quadrant);
 	void _physics_draw_quadrant_debug(TileMapQuadrant *p_quadrant);
 
@@ -325,6 +330,9 @@ public:
 	void set_selected_layer(int p_layer_id); // For editor use.
 	int get_selected_layer() const;
 
+	void set_collision_animatable(bool p_enabled);
+	bool is_collision_animatable() const;
+
 	void set_collision_visibility_mode(VisibilityMode p_show_collision);
 	VisibilityMode get_collision_visibility_mode();
 
@@ -363,6 +371,9 @@ public:
 	virtual void set_use_parent_material(bool p_use_parent_material) override;
 	virtual void set_texture_filter(CanvasItem::TextureFilter p_texture_filter) override;
 	virtual void set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) override;
+
+	// For finding tiles from collision.
+	Vector2i get_coords_for_body_rid(RID p_physics_body);
 
 	// Fixing a nclearing methods.
 	void fix_invalid_tiles();

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -645,6 +645,8 @@ private:
 			float one_way_margin = 1.0;
 		};
 
+		Vector2 linear_velocity;
+		float angular_velocity;
 		Vector<PolygonShapeTileData> polygons;
 	};
 	Vector<PhysicsLayerTileData> physics;
@@ -718,8 +720,12 @@ public:
 	Ref<OccluderPolygon2D> get_occluder(int p_layer_id) const;
 
 	// Physics
-	int get_collision_polygons_count(int p_layer_id) const;
+	void set_constant_linear_velocity(int p_layer_id, const Vector2 &p_velocity);
+	Vector2 get_constant_linear_velocity(int p_layer_id) const;
+	void set_constant_angular_velocity(int p_layer_id, real_t p_velocity);
+	real_t get_constant_angular_velocity(int p_layer_id) const;
 	void set_collision_polygons_count(int p_layer_id, int p_shapes_count);
+	int get_collision_polygons_count(int p_layer_id) const;
 	void add_collision_polygon(int p_layer_id);
 	void remove_collision_polygon(int p_layer_id, int p_polygon_index);
 	void set_collision_polygon_points(int p_layer_id, int p_polygon_index, Vector<Vector2> p_polygon);


### PR DESCRIPTION
This allows both the TileMap node to act as a moving platform, or to define some tiles as a having a constant velocity (for conveyor belts). Also:
- Fixes a small bug when restoring the tile shape/snapping in the physics shape TileSet editor,
- ~~Fixes a bug with "texture_region_size" of atlas not being editable.~~ (fixed by https://github.com/godotengine/godot/pull/53095)