### PR TITLE
[3.x] Add a node configuration warning using NinePatchRect's Tile or Tile Fit modes in GLES2

### DIFF
--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -156,6 +156,7 @@ bool NinePatchRect::is_draw_center_enabled() const {
 
 void NinePatchRect::set_h_axis_stretch_mode(AxisStretchMode p_mode) {
 	axis_h = p_mode;
+	update_configuration_warning();
 	update();
 }
 
@@ -165,11 +166,27 @@ NinePatchRect::AxisStretchMode NinePatchRect::get_h_axis_stretch_mode() const {
 
 void NinePatchRect::set_v_axis_stretch_mode(AxisStretchMode p_mode) {
 	axis_v = p_mode;
+	update_configuration_warning();
 	update();
 }
 
 NinePatchRect::AxisStretchMode NinePatchRect::get_v_axis_stretch_mode() const {
 	return axis_v;
+}
+
+String NinePatchRect::get_configuration_warning() const {
+	String warning = Control::get_configuration_warning();
+
+	if (String(GLOBAL_GET("rendering/quality/driver/driver_name")) == "GLES2") {
+		if (axis_v > AXIS_STRETCH_MODE_STRETCH || axis_h > AXIS_STRETCH_MODE_STRETCH) {
+			if (!warning.empty()) {
+				warning += "\n\n";
+			}
+			warning += TTR("The Tile and Tile Fit options for Axis Stretch properties are only effective when using the GLES3 rendering backend.\nThe GLES2 backend is currently in use, so these modes will act like Stretch instead.");
+		}
+	}
+
+	return warning;
 }
 
 NinePatchRect::NinePatchRect() {

--- a/scene/gui/nine_patch_rect.h
+++ b/scene/gui/nine_patch_rect.h
@@ -74,6 +74,8 @@ public:
 	void set_v_axis_stretch_mode(AxisStretchMode p_mode);
 	AxisStretchMode get_v_axis_stretch_mode() const;
 
+	String get_configuration_warning() const;
+
 	NinePatchRect();
 	~NinePatchRect();
 };


### PR DESCRIPTION
Fix #52708

### Issue fixed :

The options "Tile" and "Tile Fit" of NinePatchRect are without effect with GLES2 driver but there isn't any node configuration warning.

### Fix proposal

Add a node configuration warning when using one of these modes with GLES2 driver.

![image](https://user-images.githubusercontent.com/3649998/133660730-87bb6deb-e087-4535-b49a-ec207328979c.png)


### Notes
As it's the first time I use NodeConfigurationWarning, I'm not sure about some points : 

- I only check ``ProjectSettings::get_singleton()->get("rendering/quality/driver/driver_name")`` but not the fallback_to_gles2 to avoid false positive warning.

(fixed) - When modifying the Tile mode, warning icon update only if we click outside the inspector. Don't know if it's the attented behavior or if I need to call an update function.

- As it's the only warning for that node, not sure that this test is needed (seems to be used in other nodes warning) 
```
	if (!warning.empty()) {
				warning += "\n\n";
			}```

