### PR TITLE
[3.4] Fix InputMap.action_erase_event() failing to erase events correctly.

### DIFF
--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -214,7 +214,7 @@ public:
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const;
-	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
+	virtual bool shortcut_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const;
 	virtual bool is_action_type() const;
 
 	virtual bool accumulate(const Ref<InputEvent> &p_event) { return false; }
@@ -263,6 +263,8 @@ public:
 
 	void set_modifiers_from_event(const InputEventWithModifiers *event);
 
+	uint32_t get_modifiers_mask() const;
+
 	InputEventWithModifiers();
 };
 
@@ -300,7 +302,7 @@ public:
 	uint32_t get_physical_scancode_with_modifiers() const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const;
-	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
+	virtual bool shortcut_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const;
 
 	virtual bool is_action_type() const { return true; }
 
@@ -359,6 +361,7 @@ public:
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const;
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const;
+	virtual bool shortcut_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const;
 
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;
@@ -416,6 +419,7 @@ public:
 	virtual bool is_pressed() const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const;
+	virtual bool shortcut_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const;
 
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;
@@ -443,7 +447,7 @@ public:
 	float get_pressure() const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const;
-	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
+	virtual bool shortcut_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const;
 
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;
@@ -531,7 +535,7 @@ public:
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const;
 
-	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
+	virtual bool shortcut_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const;
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;
 

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -85,8 +85,10 @@
 		<method name="shortcut_match" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="event" type="InputEvent" />
+			<argument index="1" name="exact_match" type="bool" default="true" />
 			<description>
-				Returns [code]true[/code] if the given input event is checking for the same key ([InputEventKey]), button ([InputEventJoypadButton]) or action ([InputEventAction]).
+				Returns [code]true[/code] if the specified [code]event[/code] matches this event. Only valid for action events i.e key ([InputEventKey]), button ([InputEventMouseButton] or [InputEventJoypadButton]), axis [InputEventJoypadMotion] or action ([InputEventAction]) events.
+				If [code]exact_match[/code] is [code]false[/code], it ignores the input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 			</description>
 		</method>
 		<method name="xformed_by" qualifiers="const">


### PR DESCRIPTION
(3.x backport of 7104229a85acbc30bf5dcc9c8a0ada8571910456)

Fixes #52733