### PR TITLE
Retrieve platform layer from PhysicsServer2D

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1306,11 +1306,7 @@ void CharacterBody2D::_set_collision_direction(const PhysicsServer2D::MotionResu
 void CharacterBody2D::_set_platform_data(const PhysicsServer2D::MotionResult &p_result) {
 	platform_rid = p_result.collider;
 	platform_velocity = p_result.collider_velocity;
-	platform_layer = 0;
-	CollisionObject2D *collision_object = Object::cast_to<CollisionObject2D>(ObjectDB::get_instance(p_result.collider_id));
-	if (collision_object) {
-		platform_layer = collision_object->get_collision_layer();
-	}
+	platform_layer = PhysicsServer2D::get_singleton()->body_get_collision_layer(platform_rid);
 }
 
 const Vector2 &CharacterBody2D::get_linear_velocity() const {


### PR DESCRIPTION
This change fix an issue when the moving platform is not a CollisionObject2D (like a Tilemap #52724), the `platform_layer` was not retrieved.