### PR TITLE
Use EditorFileDialog instead of FileDialog in the project manager

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -72,6 +72,7 @@ private:
 	Map<StringName, Object *> singleton_ptrs;
 
 	bool editor_hint = false;
+	bool project_manager_hint = false;
 
 	static Engine *singleton;
 
@@ -119,9 +120,15 @@ public:
 #ifdef TOOLS_ENABLED
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) { editor_hint = p_enabled; }
 	_FORCE_INLINE_ bool is_editor_hint() const { return editor_hint; }
+
+	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) { project_manager_hint = p_enabled; }
+	_FORCE_INLINE_ bool is_project_manager_hint() const { return project_manager_hint; }
 #else
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) {}
 	_FORCE_INLINE_ bool is_editor_hint() const { return false; }
+
+	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) {}
+	_FORCE_INLINE_ bool is_project_manager_hint() const { return false; }
 #endif
 
 	Dictionary get_version_info() const;

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -685,7 +685,7 @@ Ref<Translation> TranslationServer::get_tool_translation() const {
 
 String TranslationServer::get_tool_locale() {
 #ifdef TOOLS_ENABLED
-	if (TranslationServer::get_singleton()->get_tool_translation().is_valid() && (Engine::get_singleton()->is_editor_hint() || Main::is_project_manager())) {
+	if (TranslationServer::get_singleton()->get_tool_translation().is_valid() && (Engine::get_singleton()->is_editor_hint() || Engine::get_singleton()->is_project_manager_hint())) {
 		return tool_translation->get_locale();
 	} else {
 #else

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -32,6 +32,7 @@
 #define EDITORFILEDIALOG_H
 
 #include "core/io/dir_access.h"
+#include "editor/plugins/editor_preview_plugins.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
@@ -88,7 +89,7 @@ private:
 
 	Button *makedir;
 	Access access;
-	//Button *action;
+
 	VBoxContainer *vbox;
 	FileMode mode;
 	bool can_create_dir;
@@ -109,10 +110,11 @@ private:
 	HBoxContainer *file_box;
 	LineEdit *file;
 	OptionButton *filter;
-	AcceptDialog *mkdirerr;
+	AcceptDialog *error_dialog;
 	DirAccess *dir_access;
 	ConfirmationDialog *confirm_save;
-	DependencyRemoveDialog *remove_dialog;
+	DependencyRemoveDialog *dep_remove_dialog;
+	ConfirmationDialog *global_remove_dialog;
 
 	Button *mode_thumbnails;
 	Button *mode_list;
@@ -133,9 +135,11 @@ private:
 
 	Vector<String> filters;
 
+	bool previews_enabled;
 	bool preview_waiting;
 	int preview_wheel_index;
 	float preview_wheel_timeout;
+
 	static bool default_show_hidden_files;
 	static DisplayMode default_display_mode;
 	bool show_hidden_files;
@@ -179,8 +183,10 @@ private:
 	void _make_dir_confirm();
 
 	void _delete_items();
+	void _delete_files_global();
 
 	void _update_drives(bool p_select = true);
+	void _update_icons();
 
 	void _go_up();
 	void _go_back();
@@ -189,7 +195,7 @@ private:
 	virtual void _post_popup() override;
 
 	void _save_to_recent();
-	//callback function is callback(String p_path,Ref<Texture2D> preview,Variant udata) preview null if could not load
+	// Callback function is callback(String p_path,Ref<Texture2D> preview,Variant udata) preview null if could not load.
 
 	void _thumbnail_result(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
 	void _thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
@@ -202,7 +208,7 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	//bind helpers
+
 public:
 	void popup_file_dialog();
 	void clear_filters();
@@ -230,16 +236,18 @@ public:
 	void set_access(Access p_access);
 	Access get_access() const;
 
-	void set_show_hidden_files(bool p_show);
-	bool is_showing_hidden_files() const;
-
 	static void set_default_show_hidden_files(bool p_show);
 	static void set_default_display_mode(DisplayMode p_mode);
+	void set_show_hidden_files(bool p_show);
+	bool is_showing_hidden_files() const;
 
 	void invalidate();
 
 	void set_disable_overwrite_warning(bool p_disable);
 	bool is_overwrite_warning_disabled() const;
+
+	void set_previews_enabled(bool p_enabled);
+	bool are_previews_enabled();
 
 	EditorFileDialog();
 	~EditorFileDialog();

--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -193,7 +193,7 @@ EditorPaths::EditorPaths() {
 	// Validate or create project-specific editor data dir,
 	// including shader cache subdir.
 
-	if (Main::is_project_manager() || Main::is_cmdline_tool()) {
+	if (Engine::get_singleton()->is_project_manager_hint() || Main::is_cmdline_tool()) {
 		// Nothing to create, use shared editor data dir for shader cache.
 		Engine::get_singleton()->set_shader_cache_path(data_dir);
 	} else {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -845,7 +845,7 @@ void EditorSettings::create() {
 
 		singleton->setup_language();
 		singleton->setup_network();
-		singleton->load_favorites();
+		singleton->load_favorites_and_recent_dirs();
 		singleton->list_text_editor_themes();
 
 		return;
@@ -1103,7 +1103,13 @@ Variant EditorSettings::get_project_metadata(const String &p_section, const Stri
 
 void EditorSettings::set_favorites(const Vector<String> &p_favorites) {
 	favorites = p_favorites;
-	FileAccess *f = FileAccess::open(get_project_settings_dir().plus_file("favorites"), FileAccess::WRITE);
+	String favorites_file;
+	if (Engine::get_singleton()->is_project_manager_hint()) {
+		favorites_file = EditorPaths::get_singleton()->get_config_dir().plus_file("favorite_dirs");
+	} else {
+		favorites_file = get_project_settings_dir().plus_file("favorites");
+	}
+	FileAccess *f = FileAccess::open(favorites_file, FileAccess::WRITE);
 	if (f) {
 		for (int i = 0; i < favorites.size(); i++) {
 			f->store_line(favorites[i]);
@@ -1118,7 +1124,13 @@ Vector<String> EditorSettings::get_favorites() const {
 
 void EditorSettings::set_recent_dirs(const Vector<String> &p_recent_dirs) {
 	recent_dirs = p_recent_dirs;
-	FileAccess *f = FileAccess::open(get_project_settings_dir().plus_file("recent_dirs"), FileAccess::WRITE);
+	String recent_dirs_file;
+	if (Engine::get_singleton()->is_project_manager_hint()) {
+		recent_dirs_file = EditorPaths::get_singleton()->get_config_dir().plus_file("recent_dirs");
+	} else {
+		recent_dirs_file = get_project_settings_dir().plus_file("recent_dirs");
+	}
+	FileAccess *f = FileAccess::open(recent_dirs_file, FileAccess::WRITE);
 	if (f) {
 		for (int i = 0; i < recent_dirs.size(); i++) {
 			f->store_line(recent_dirs[i]);
@@ -1131,8 +1143,17 @@ Vector<String> EditorSettings::get_recent_dirs() const {
 	return recent_dirs;
 }
 
-void EditorSettings::load_favorites() {
-	FileAccess *f = FileAccess::open(get_project_settings_dir().plus_file("favorites"), FileAccess::READ);
+void EditorSettings::load_favorites_and_recent_dirs() {
+	String favorites_file;
+	String recent_dirs_file;
+	if (Engine::get_singleton()->is_project_manager_hint()) {
+		favorites_file = EditorPaths::get_singleton()->get_config_dir().plus_file("favorite_dirs");
+		recent_dirs_file = EditorPaths::get_singleton()->get_config_dir().plus_file("recent_dirs");
+	} else {
+		favorites_file = get_project_settings_dir().plus_file("favorites");
+		recent_dirs_file = get_project_settings_dir().plus_file("recent_dirs");
+	}
+	FileAccess *f = FileAccess::open(favorites_file, FileAccess::READ);
 	if (f) {
 		String line = f->get_line().strip_edges();
 		while (!line.is_empty()) {
@@ -1142,7 +1163,7 @@ void EditorSettings::load_favorites() {
 		memdelete(f);
 	}
 
-	f = FileAccess::open(get_project_settings_dir().plus_file("recent_dirs"), FileAccess::READ);
+	f = FileAccess::open(recent_dirs_file, FileAccess::READ);
 	if (f) {
 		String line = f->get_line().strip_edges();
 		while (!line.is_empty()) {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -161,7 +161,7 @@ public:
 	Vector<String> get_favorites() const;
 	void set_recent_dirs(const Vector<String> &p_recent_dirs);
 	Vector<String> get_recent_dirs() const;
-	void load_favorites();
+	void load_favorites_and_recent_dirs();
 
 	bool is_dark_theme();
 

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -50,6 +50,9 @@ enum FilterOption {
 class ProjectManager : public Control {
 	GDCLASS(ProjectManager, Control);
 
+	static Map<String, Ref<Texture2D>> icon_type_cache;
+	static void _build_icon_type_cache(Ref<Theme> p_theme);
+
 	TabContainer *tabs;
 
 	ProjectList *_project_list;
@@ -67,7 +70,7 @@ class ProjectManager : public Control {
 
 	EditorAssetLibrary *asset_library;
 
-	FileDialog *scan_dir;
+	EditorFileDialog *scan_dir;
 	ConfirmationDialog *language_restart_ask;
 
 	ConfirmationDialog *erase_ask;
@@ -128,6 +131,8 @@ class ProjectManager : public Control {
 	void _on_order_option_changed(int p_idx);
 	void _on_tab_changed(int p_tab);
 	void _on_search_term_changed(const String &p_term);
+
+	static Ref<Texture2D> _file_dialog_get_icon(const String &p_path);
 
 protected:
 	void _notification(int p_what);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -182,13 +182,6 @@ bool profile_gpu = false;
 
 /* Helper methods */
 
-// Used by Mono module, should likely be registered in Engine singleton instead
-// FIXME: This is also not 100% accurate, `project_manager` is only true when it was requested,
-// but not if e.g. we fail to load and project and fallback to the manager.
-bool Main::is_project_manager() {
-	return project_manager;
-}
-
 bool Main::is_cmdline_tool() {
 	return cmdline_tool;
 }
@@ -934,7 +927,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			editor = true;
 		} else if (I->get() == "-p" || I->get() == "--project-manager") { // starts project manager
-
 			project_manager = true;
 		} else if (I->get() == "--debug-server") {
 			if (I->next()) {
@@ -2548,6 +2540,7 @@ bool Main::start() {
 #ifdef TOOLS_ENABLED
 		if (project_manager) {
 			Engine::get_singleton()->set_editor_hint(true);
+			Engine::get_singleton()->set_project_manager_hint(true);
 			ProjectManager *pmanager = memnew(ProjectManager);
 			ProgressDialog *progress_dialog = memnew(ProgressDialog);
 			pmanager->add_child(progress_dialog);

--- a/main/main.h
+++ b/main/main.h
@@ -45,7 +45,6 @@ class Main {
 	static bool agile_input_event_flushing;
 
 public:
-	static bool is_project_manager();
 	static bool is_cmdline_tool();
 	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
 	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -52,10 +52,6 @@
 #include "gd_mono_marshal.h"
 #include "gd_mono_utils.h"
 
-#ifdef TOOLS_ENABLED
-#include "main/main.h"
-#endif
-
 #ifdef ANDROID_ENABLED
 #include "android_mono_config.h"
 #include "support/android_support.h"
@@ -143,7 +139,7 @@ void gd_mono_debug_init() {
 
 	if (Engine::get_singleton()->is_editor_hint() ||
 			ProjectSettings::get_singleton()->get_resource_path().is_empty() ||
-			Main::is_project_manager()) {
+			Engine::get_singleton()->is_project_manager_hint()) {
 		if (da_args.size() == 0) {
 			return;
 		}
@@ -423,7 +419,7 @@ void GDMono::initialize_load_assemblies() {
 	bool tool_assemblies_loaded = _load_tools_assemblies();
 	CRASH_COND_MSG(!tool_assemblies_loaded, "Mono: Failed to load '" TOOLS_ASM_NAME "' assemblies.");
 
-	if (Main::is_project_manager()) {
+	if (Engine::get_singleton()->is_project_manager_hint()) {
 		return;
 	}
 #endif
@@ -815,7 +811,7 @@ bool GDMono::_load_core_api_assembly(LoadedApiAssembly &r_loaded_api_assembly, c
 	// For the editor and the editor player we want to load it from a specific path to make sure we can keep it up to date
 
 	// If running the project manager, load it from the prebuilt API directory
-	String assembly_dir = !Main::is_project_manager()
+	String assembly_dir = !Engine::get_singleton()->is_project_manager_hint()
 			? GodotSharpDirs::get_res_assemblies_base_dir().plus_file(p_config)
 			: GodotSharpDirs::get_data_editor_prebuilt_api_dir().plus_file(p_config);
 
@@ -848,7 +844,7 @@ bool GDMono::_load_editor_api_assembly(LoadedApiAssembly &r_loaded_api_assembly,
 	// For the editor and the editor player we want to load it from a specific path to make sure we can keep it up to date
 
 	// If running the project manager, load it from the prebuilt API directory
-	String assembly_dir = !Main::is_project_manager()
+	String assembly_dir = !Engine::get_singleton()->is_project_manager_hint()
 			? GodotSharpDirs::get_res_assemblies_base_dir().plus_file(p_config)
 			: GodotSharpDirs::get_data_editor_prebuilt_api_dir().plus_file(p_config);
 
@@ -932,7 +928,7 @@ void GDMono::_load_api_assemblies() {
 		// this time update them from the prebuilt assemblies directory before trying to load them again.
 
 		// Shouldn't happen. The project manager loads the prebuilt API assemblies
-		CRASH_COND_MSG(Main::is_project_manager(), "Failed to load one of the prebuilt API assemblies.");
+		CRASH_COND_MSG(Engine::get_singleton()->is_project_manager_hint(), "Failed to load one of the prebuilt API assemblies.");
 
 		// 1. Unload the scripts domain
 		Error domain_unload_err = _unload_scripts_domain();


### PR DESCRIPTION
Use EditorFileDialog instead of FileDialog in the project manager (primarily because of the favorites/recent_dir functionality), aiming to accelerate the workflow when frequently creating new projects/dealing with many projects in general. This allows for easier navigation to common folders in which you create many small projects (e.g. for testing/prototyping).

Changes:
- Use EditorFileDialog instead of FileDialog in the project manager
    - Only single files and empty directories can be deleted (for safety/implementation simplicity)
- Add option to disable previews in EditorFileDialog
- Add a proper project_manager_hint to the Engine singleton (removed Main::is_project_manager)
- some refactoring of EditorFileDialog to reduce code duplication and improve code style

![main](https://user-images.githubusercontent.com/50084500/133602798-f719eacd-b823-41d5-8894-8dea84c160c6.gif)
