### PR TITLE
[3.x] Fix get_base_dir windows top level directory logic

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3967,26 +3967,42 @@ bool String::is_rel_path() const {
 }
 
 String String::get_base_dir() const {
-	int basepos = find(":/");
-	if (basepos == -1) {
-		basepos = find(":\\");
-	}
-	String rs;
-	String base;
+	int end = 0;
+
+	// url scheme style base
+	int basepos = find("://");
 	if (basepos != -1) {
-		int end = basepos + 3;
-		rs = substr(end, length());
-		base = substr(0, end);
-	} else {
-		if (begins_with("/")) {
-			rs = substr(1, length());
-			base = "/";
-		} else {
-			rs = *this;
+		end = basepos + 3;
+	}
+
+	// windows top level directory base
+	if (end == 0) {
+		basepos = find(":/");
+		if (basepos == -1) {
+			basepos = find(":\\");
+		}
+		if (basepos != -1) {
+			end = basepos + 2;
 		}
 	}
 
-	int sep = MAX(rs.find_last("/"), rs.find_last("\\"));
+	// unix root directory base
+	if (end == 0) {
+		if (begins_with("/")) {
+			end = 1;
+		}
+	}
+
+	String rs;
+	String base;
+	if (end != 0) {
+		rs = substr(end, length());
+		base = substr(0, end);
+	} else {
+		rs = *this;
+	}
+
+	int sep = MAX(rs.rfind("/"), rs.rfind("\\"));
 	if (sep == -1) {
 		return base;
 	}


### PR DESCRIPTION
This is a fix for https://github.com/godotengine/godot/issues/52048, counterpart of https://github.com/godotengine/godot/pull/52049 for 3.x.