### PR TITLE
Fix Windows cursor with trails disappearing in fullscreen

### DIFF
--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -334,6 +334,7 @@ class OS_Windows : public OS {
 	Vector2 im_position;
 
 	MouseMode mouse_mode;
+	int restore_mouse_trails;
 	bool alt_mem;
 	bool gr_mem;
 	bool shift_mem;


### PR DESCRIPTION
This Pull request replaces https://github.com/godotengine/godot/pull/52388

Fixed by turning off mouse trails when going into fullscreen, then restoring trails when exiting fullscreen or game

This fix might be a bit iffy because it turns off the users mouse trail setting in windows using:
SystemParametersInfoA(SPI_SETMOUSETRAILS, 0, 0, 0);

Which will leave the trails off even if the user exits the game, so to fix I used SPI_GETMOUSETRAILS to get the users current setting and then restore that when exiting the game or fullscreen.

If the game where to crash then the mouse trails aren't turned back on.

I made this pull request to 3.x instead of master because master moved the relevant code from os_windows.cpp to display_server_windows.cpp.

If this pull request is accepted I can make one for master.

fixes #49321, fixes #40230