### PR TITLE
Display a editor gizmo icon for Listener

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -6245,6 +6245,7 @@ void SpatialEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<CameraSpatialGizmoPlugin>(memnew(CameraSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<LightSpatialGizmoPlugin>(memnew(LightSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<AudioStreamPlayer3DSpatialGizmoPlugin>(memnew(AudioStreamPlayer3DSpatialGizmoPlugin)));
+	add_gizmo_plugin(Ref<ListenerSpatialGizmoPlugin>(memnew(ListenerSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<MeshInstanceSpatialGizmoPlugin>(memnew(MeshInstanceSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<SoftBodySpatialGizmoPlugin>(memnew(SoftBodySpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<Sprite3DSpatialGizmoPlugin>(memnew(Sprite3DSpatialGizmoPlugin)));

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -1226,6 +1226,29 @@ void AudioStreamPlayer3DSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) 
 
 //////
 
+ListenerSpatialGizmoPlugin::ListenerSpatialGizmoPlugin() {
+	create_icon_material("listener_icon", SpatialEditor::get_singleton()->get_icon("GizmoListener", "EditorIcons"));
+}
+
+bool ListenerSpatialGizmoPlugin::has_gizmo(Spatial *p_spatial) {
+	return Object::cast_to<Listener>(p_spatial) != nullptr;
+}
+
+String ListenerSpatialGizmoPlugin::get_name() const {
+	return "Listener";
+}
+
+int ListenerSpatialGizmoPlugin::get_priority() const {
+	return -1;
+}
+
+void ListenerSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
+	const Ref<Material> icon = get_material("listener_icon", p_gizmo);
+	p_gizmo->add_unscaled_billboard(icon, 0.05);
+}
+
+//////
+
 CameraSpatialGizmoPlugin::CameraSpatialGizmoPlugin() {
 	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/camera", Color(0.8, 0.4, 0.8));
 

--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -70,6 +70,19 @@ public:
 	AudioStreamPlayer3DSpatialGizmoPlugin();
 };
 
+class ListenerSpatialGizmoPlugin : public EditorSpatialGizmoPlugin {
+	GDCLASS(ListenerSpatialGizmoPlugin, EditorSpatialGizmoPlugin);
+
+public:
+	bool has_gizmo(Spatial *p_spatial);
+	String get_name() const;
+	int get_priority() const;
+
+	void redraw(EditorSpatialGizmo *p_gizmo);
+
+	ListenerSpatialGizmoPlugin();
+};
+
 class CameraSpatialGizmoPlugin : public EditorSpatialGizmoPlugin {
 	GDCLASS(CameraSpatialGizmoPlugin, EditorSpatialGizmoPlugin);
 

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -258,10 +258,6 @@ bool Camera::is_current() const {
 	}
 }
 
-bool Camera::_can_gizmo_scale() const {
-	return false;
-}
-
 Vector3 Camera::project_ray_normal(const Point2 &p_pos) const {
 	Vector3 ray = project_local_ray_normal(p_pos);
 	return get_camera_transform().basis.xform(ray).normalized();

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -82,8 +82,6 @@ private:
 
 	Ref<Environment> environment;
 
-	virtual bool _can_gizmo_scale() const;
-
 	//void _camera_make_current(Node *p_camera);
 	friend class Viewport;
 	void _update_audio_listener_state();

--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -34,10 +34,6 @@
 #include "core/project_settings.h"
 #include "scene/resources/surface_tool.h"
 
-bool Light::_can_gizmo_scale() const {
-	return false;
-}
-
 void Light::set_param(Param p_param, float p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 	param[p_param] = p_value;

--- a/scene/3d/light.h
+++ b/scene/3d/light.h
@@ -84,8 +84,6 @@ private:
 protected:
 	RID light;
 
-	virtual bool _can_gizmo_scale() const;
-
 	static void _bind_methods();
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &property) const;

--- a/scene/3d/listener.cpp
+++ b/scene/3d/listener.cpp
@@ -140,16 +140,6 @@ bool Listener::is_current() const {
 	return false;
 }
 
-bool Listener::_can_gizmo_scale() const {
-	return false;
-}
-
-RES Listener::_get_gizmo_geometry() const {
-	Ref<ArrayMesh> mesh = memnew(ArrayMesh);
-
-	return mesh;
-}
-
 void Listener::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("make_current"), &Listener::make_current);
 	ClassDB::bind_method(D_METHOD("clear_current"), &Listener::clear_current);
@@ -161,7 +151,6 @@ Listener::Listener() {
 	current = false;
 	force_change = false;
 	set_notify_transform(true);
-	//active=false;
 }
 
 Listener::~Listener() {

--- a/scene/3d/listener.h
+++ b/scene/3d/listener.h
@@ -43,9 +43,6 @@ private:
 
 	RID scenario_id;
 
-	virtual bool _can_gizmo_scale() const;
-	virtual RES _get_gizmo_geometry() const;
-
 	friend class Viewport;
 	void _update_audio_listener_state();
 

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -86,9 +86,6 @@ SceneStringNames::SceneStringNames() {
 	update = StaticCString::create("update");
 	updated = StaticCString::create("updated");
 
-	_get_gizmo_geometry = StaticCString::create("_get_gizmo_geometry");
-	_can_gizmo_scale = StaticCString::create("_can_gizmo_scale");
-
 	_physics_process = StaticCString::create("_physics_process");
 	_process = StaticCString::create("_process");
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -105,9 +105,6 @@ public:
 	StringName _body_inout;
 	StringName _area_inout;
 
-	StringName _get_gizmo_geometry;
-	StringName _can_gizmo_scale;
-
 	StringName _physics_process;
 	StringName _process;
 	StringName _enter_world;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/49284.

The icon was present in `editor/icons/`, but it was never implemented in the editor gizmos code. This gizmo's visibility can be toggled in the 3D viewport's **View** menu as usual.

This also removes some unused gizmo drawing code (overridden methods that are no longer called anywhere).

## Preview

![image](https://user-images.githubusercontent.com/180032/133688912-bdcbaefc-a61f-4672-9d9d-288fd7154822.png)
