### PR TITLE
Print a warning if a 3D editor gizmo has no name defined

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -1003,7 +1003,9 @@ String EditorNode3DGizmoPlugin::get_gizmo_name() const {
 	if (get_script_instance() && get_script_instance()->has_method("_get_gizmo_name")) {
 		return get_script_instance()->call("_get_gizmo_name");
 	}
-	return TTR("Nameless gizmo");
+
+	WARN_PRINT_ONCE("A 3D editor gizmo has no name defined (it will appear as \"Unnamed Gizmo\" in the \"View > Gizmos\" menu). To resolve this, override the `_get_gizmo_name()` function to return a String in the script that extends EditorNode3DGizmoPlugin.");
+	return TTR("Unnamed Gizmo");
 }
 
 int EditorNode3DGizmoPlugin::get_priority() const {


### PR DESCRIPTION
Unnamed gizmos should be avoided, so this should help editor plugin authors resolve issues with gizmo naming if they forgot to override the function.

"Nameless gizmo" was also renamed to "Unnamed Gizmo" for consistency.