### PR TITLE
Propogate previously unused NOTIFICATION_WORLD_2D_CHANGED, make CanvasItem/Camera2D/CollisionObject2D use it

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -272,6 +272,18 @@ void Camera2D::_notification(int p_what) {
 			viewport = nullptr;
 
 		} break;
+		case NOTIFICATION_WORLD_2D_CHANGED: {
+			if (is_current()) {
+				if (viewport && !(custom_viewport && !ObjectDB::get_instance(custom_viewport_id))) {
+					viewport->set_canvas_transform(Transform2D());
+				}
+			}
+			remove_from_group(group_name);
+			remove_from_group(canvas_group_name);
+
+			_setup_viewport();
+			_update_scroll();
+		} break;
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_DRAW: {
 			if (!is_inside_tree() || !Engine::get_singleton()->is_editor_hint()) {

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -596,6 +596,13 @@ void CanvasItem::_notification(int p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			emit_signal(SceneStringNames::get_singleton()->visibility_changed);
 		} break;
+		case NOTIFICATION_WORLD_2D_CHANGED: {
+			_exit_canvas();
+			_enter_canvas();
+			if (get_script_instance()) {
+				get_script_instance()->call_multilevel(SceneStringNames::get_singleton()->_world_2d_changed, nullptr, 0);
+			}
+		} break;
 	}
 }
 
@@ -1199,6 +1206,7 @@ void CanvasItem::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_VISIBILITY_CHANGED);
 	BIND_CONSTANT(NOTIFICATION_ENTER_CANVAS);
 	BIND_CONSTANT(NOTIFICATION_EXIT_CANVAS);
+	BIND_CONSTANT(NOTIFICATION_WORLD_2D_CHANGED);
 }
 
 Transform2D CanvasItem::get_canvas_transform() const {

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -97,6 +97,27 @@ void CollisionObject2D::_notification(int p_what) {
 				Physics2DServer::get_singleton()->body_attach_canvas_instance_id(rid, 0);
 			}
 		} break;
+
+		case NOTIFICATION_WORLD_2D_CHANGED: {
+			Transform2D global_transform = get_global_transform();
+
+			if (area) {
+				Physics2DServer::get_singleton()->area_set_transform(rid, global_transform);
+			} else {
+				Physics2DServer::get_singleton()->body_set_state(rid, Physics2DServer::BODY_STATE_TRANSFORM, global_transform);
+			}
+
+			RID space = get_world_2d()->get_space();
+			if (area) {
+				Physics2DServer::get_singleton()->area_set_space(rid, space);
+			} else {
+				Physics2DServer::get_singleton()->body_set_space(rid, space);
+			}
+
+			_update_pickable();
+
+			//get space
+		} break;
 	}
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1018,6 +1018,10 @@ void Viewport::set_world_2d(const Ref<World2D> &p_world_2d) {
 	_update_listener_2d();
 
 	if (is_inside_tree()) {
+		_propagate_world_2d_changed(this);
+	}
+
+	if (is_inside_tree()) {
 		current_canvas = find_world_2d()->get_canvas();
 		VisualServer::get_singleton()->viewport_attach_canvas(viewport, current_canvas);
 		find_world_2d()->_register_viewport(this, Rect2());
@@ -1054,6 +1058,29 @@ void Viewport::_propagate_enter_world(Node *p_node) {
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		_propagate_enter_world(p_node->get_child(i));
+	}
+}
+
+void Viewport::_propagate_world_2d_changed(Node *p_node) {
+	if (p_node != this) {
+		if (!p_node->is_inside_tree()) { //may not have entered scene yet
+			return;
+		}
+
+		if (Object::cast_to<CanvasItem>(p_node)) {
+			p_node->notification(CanvasItem::NOTIFICATION_WORLD_2D_CHANGED);
+		} else {
+			Viewport *v = Object::cast_to<Viewport>(p_node);
+			if (v) {
+				if (v->world_2d.is_valid()) {
+					return;
+				}
+			}
+		}
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_propagate_world_2d_changed(p_node->get_child(i));
 	}
 }
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -260,6 +260,7 @@ private:
 
 	void _propagate_enter_world(Node *p_node);
 	void _propagate_exit_world(Node *p_node);
+	void _propagate_world_2d_changed(Node *p_node);
 	void _propagate_viewport_notification(Node *p_node, int p_what);
 
 	void _update_stretch_transform();

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -96,6 +96,7 @@ SceneStringNames::SceneStringNames() {
 	_exit_tree = StaticCString::create("_exit_tree");
 	_enter_world = StaticCString::create("_enter_world");
 	_exit_world = StaticCString::create("_exit_world");
+	_world_2d_changed = StaticCString::create("_world_2d_changed");
 	_ready = StaticCString::create("_ready");
 
 	_update_scroll = StaticCString::create("_update_scroll");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -112,6 +112,7 @@ public:
 	StringName _process;
 	StringName _enter_world;
 	StringName _exit_world;
+	StringName _world_2d_changed;
 	StringName _enter_tree;
 	StringName _exit_tree;
 	StringName _draw;


### PR DESCRIPTION
(Fixes godotengine/godot#52423)

I'm not sure how do this in the master branch. I see in the comment in the PR template saying to do things for master first - if I could get some guidance on that, I would appreciate it.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
