### PR TITLE
[WIP] Fixed Timestep Interpolation (3D) (3.x)

### DIFF
--- a/core/engine.h
+++ b/core/engine.h
@@ -60,6 +60,7 @@ private:
 	bool _gpu_pixel_snap;
 	uint64_t _physics_frames;
 	float _physics_interpolation_fraction;
+	bool _physics_interpolation_enabled;
 	bool _portals_active;
 	bool _occlusion_culling_active;
 
@@ -95,6 +96,9 @@ public:
 	uint64_t get_idle_frame_ticks() const { return _frame_ticks; }
 	float get_idle_frame_step() const { return _frame_step; }
 	float get_physics_interpolation_fraction() const { return _physics_interpolation_fraction; }
+
+	bool is_physics_interpolation_enabled() const { return _physics_interpolation_enabled; }
+	void set_physics_interpolation_enabled(bool p_enabled) { _physics_interpolation_enabled = p_enabled; }
 
 	void set_time_scale(float p_scale);
 	float get_time_scale() const;

--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -101,6 +101,22 @@ public:
 		}
 	}
 
+	U erase_multiple_unordered(const T &p_val) {
+		U from = 0;
+		U count = 0;
+		while (true) {
+			int64_t idx = find(p_val, from);
+
+			if (idx == -1) {
+				break;
+			}
+			remove_unordered(idx);
+			from = idx;
+			count++;
+		}
+		return count;
+	}
+
 	void invert() {
 		for (U i = 0; i < count / 2; i++) {
 			SWAP(data[i], data[count - i - 1]);

--- a/core/math/interpolator.h
+++ b/core/math/interpolator.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  interpolated_camera.h                                                */
+/*  interpolator.h                                                       */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,43 +28,29 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef INTERPOLATED_CAMERA_H
-#define INTERPOLATED_CAMERA_H
+#ifndef INTERPOLATOR_H
+#define INTERPOLATOR_H
 
-#include "scene/3d/camera.h"
+#include "core/math/math_defs.h"
+#include "core/math/vector3.h"
 
-class InterpolatedCamera : public Camera {
-	GDCLASS(InterpolatedCamera, Camera);
+// Keep all the functions for fixed timestep interpolation together
 
-	bool enabled;
-	real_t speed;
-	NodePath target;
+class Transform;
 
-	Transform target_transform_curr;
-	Transform target_transform_prev;
-
-	void update_process_modes();
-	void lerp_camera_to(Spatial *p_node, const Transform &p_target_xform, real_t p_delta);
-
-protected:
-	void _notification(int p_what);
-	static void _bind_methods();
-	void _set_target(const Object *p_target);
-
-	virtual void _physics_interpolated_changed();
+class Interpolator {
+	static real_t vec3_sum(const Vector3 &p_pt) { return p_pt.x + p_pt.y + p_pt.z; }
 
 public:
-	void set_target(const Spatial *p_target);
-	void set_target_path(const NodePath &p_path);
-	NodePath get_target_path() const;
+	enum Method {
+		INTERP_LERP,
+		INTERP_SLERP,
+	};
 
-	void set_speed(real_t p_speed);
-	real_t get_speed() const;
-
-	void set_interpolation_enabled(bool p_enable);
-	bool is_interpolation_enabled() const;
-
-	InterpolatedCamera();
+	static void interpolate_transform_linear(const Transform &p_prev, const Transform &p_curr, Transform &r_result, real_t p_fraction);
+	static void interpolate_transform(const Transform &p_prev, const Transform &p_curr, Transform &r_result, real_t p_fraction, Method p_method);
+	static real_t checksum_transform(const Transform &p_transform);
+	static bool should_slerp(const Basis &p_a, const Basis &p_b);
 };
 
-#endif // INTERPOLATED_CAMERA_H
+#endif // INTERPOLATOR_H

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1100,6 +1100,8 @@
 			The number of fixed iterations per second. This controls how often physics simulation and [method Node._physics_process] methods are run.
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.iterations_per_second] instead.
 		</member>
+		<member name="physics/common/physics_interpolation" type="bool" setter="" getter="" default="true">
+		</member>
 		<member name="physics/common/physics_jitter_fix" type="float" setter="" getter="" default="0.5">
 			Controls how much physics ticks are synchronized with real time. For 0 or less, the ticks are synchronized. Such values are recommended for network games, where clock synchronization matters. Higher values cause higher deviation of in-game clock and real clock, but allows smoothing out framerate jitters. The default value of 0.5 should be fine for most; values above 2 could cause the game to react to dropped frames with a noticeable delay and are not recommended.
 			[b]Note:[/b] For best results, when using a custom physics interpolation solution, the physics jitter fix should be disabled by setting [member physics/common/physics_jitter_fix] to [code]0[/code].

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -172,6 +172,12 @@
 				Sets whether the node uses a scale of [code](1, 1, 1)[/code] or its local transformation scale. Changes to the local transformation scale are preserved.
 			</description>
 		</method>
+		<method name="set_global_transform_interpolated">
+			<return type="void" />
+			<argument index="0" name="global" type="Transform" />
+			<description>
+			</description>
+		</method>
 		<method name="set_identity">
 			<return type="void" />
 			<description>
@@ -197,6 +203,12 @@
 			<argument index="0" name="enable" type="bool" />
 			<description>
 				Sets whether the node notifies about its global and local transformation changes. [Spatial] will not propagate this by default, unless it is in the editor context and it has a valid gizmo.
+			</description>
+		</method>
+		<method name="set_transform_interpolated">
+			<return type="void" />
+			<argument index="0" name="local" type="Transform" />
+			<description>
 			</description>
 		</method>
 		<method name="show">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1184,6 +1184,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	Engine::get_singleton()->set_iterations_per_second(GLOBAL_DEF("physics/common/physics_fps", 60));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/common/physics_fps", PropertyInfo(Variant::INT, "physics/common/physics_fps", PROPERTY_HINT_RANGE, "1,1000,1"));
+	Engine::get_singleton()->set_physics_interpolation_enabled(GLOBAL_DEF("physics/common/physics_interpolation", true));
 	Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_DEF("physics/common/physics_jitter_fix", 0.5));
 	Engine::get_singleton()->set_target_fps(GLOBAL_DEF("debug/settings/fps/force_fps", 0));
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/settings/fps/force_fps", PropertyInfo(Variant::INT, "debug/settings/fps/force_fps", PROPERTY_HINT_RANGE, "0,1000,1"));
@@ -2123,6 +2124,8 @@ bool Main::iteration() {
 	bool exit = false;
 
 	for (int iters = 0; iters < advance.physics_steps; ++iters) {
+		VisualServer::get_singleton()->tick();
+
 		if (InputDefault::get_singleton()->is_using_input_buffering() && agile_input_event_flushing) {
 			InputDefault::get_singleton()->flush_buffered_events();
 		}
@@ -2182,6 +2185,8 @@ bool Main::iteration() {
 			Engine::get_singleton()->frames_drawn++;
 			force_redraw_requested = false;
 		}
+	} else {
+		VisualServer::get_singleton()->no_draw();
 	}
 
 #ifndef TOOLS_ENABLED

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -291,6 +291,17 @@ int64_t MainTimerSync::DeltaSmoother::smooth_delta(int64_t p_delta) {
 // before advance_core considers changing the physics_steps return from
 // the typical values as defined by typical_physics_steps
 float MainTimerSync::get_physics_jitter_fix() {
+	// Turn off jitter fix when using fixed timestep interpolation
+	// Note this shouldn't be on UNTIL 2d interpolation is implemented,
+	// otherwise we will get people making 2d games with the physics_interpolation
+	// set to on getting jitter fix disabled unexpectedly.
+#if 0
+	if (Engine::get_singleton()->is_physics_interpolation_enabled()) {
+		// would be better to write a simple bypass for jitter fix but this will do to get started
+		return 0.0;
+	}
+#endif
+
 	return Engine::get_singleton()->get_physics_jitter_fix();
 }
 

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -79,7 +79,7 @@ void Camera::_update_camera() {
 		return;
 	}
 
-	VisualServer::get_singleton()->camera_set_transform(camera, get_camera_transform());
+	VisualServer::get_singleton()->camera_set_transform_interpolated(camera, get_camera_transform(), is_physics_interpolated());
 
 	// here goes listener stuff
 	/*

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -357,7 +357,7 @@ void RigidBody::_direct_state_changed(Object *p_state) {
 	ERR_FAIL_COND_MSG(!state, "Method '_direct_state_changed' must receive a valid PhysicsDirectBodyState object as argument");
 
 	set_ignore_transform_notification(true);
-	set_global_transform(state->get_transform());
+	set_global_transform_interpolated(state->get_transform());
 	linear_velocity = state->get_linear_velocity();
 	angular_velocity = state->get_angular_velocity();
 	inverse_inertia_tensor = state->get_inverse_inertia_tensor();
@@ -1041,7 +1041,7 @@ bool KinematicBody::move_and_collide(const Vector3 &p_motion, bool p_infinite_in
 
 	if (!p_test_only) {
 		gt.origin += result.motion;
-		set_global_transform(gt);
+		set_global_transform_interpolated(gt);
 	}
 
 	return colliding;
@@ -1133,7 +1133,7 @@ Vector3 KinematicBody::_move_and_slide_internal(const Vector3 &p_linear_velocity
 						} else {
 							gt.origin -= collision.travel;
 						}
-						set_global_transform(gt);
+						set_global_transform_interpolated(gt);
 						return Vector3();
 					}
 				}
@@ -1188,7 +1188,7 @@ Vector3 KinematicBody::_move_and_slide_internal(const Vector3 &p_linear_velocity
 			}
 			if (apply) {
 				gt.origin += col.travel;
-				set_global_transform(gt);
+				set_global_transform_interpolated(gt);
 			}
 		}
 	}
@@ -1274,7 +1274,7 @@ bool KinematicBody::separate_raycast_shapes(bool p_infinite_inertia, Collision &
 	}
 
 	gt.origin += recover;
-	set_global_transform(gt);
+	set_global_transform_interpolated(gt);
 
 	if (deepest != -1) {
 		r_collision.collider = sep_res[deepest].collider_id;
@@ -1380,7 +1380,7 @@ void KinematicBody::_direct_state_changed(Object *p_state) {
 
 	last_valid_transform = state->get_transform();
 	set_notify_local_transform(false);
-	set_global_transform(last_valid_transform);
+	set_global_transform_interpolated(last_valid_transform);
 	set_notify_local_transform(true);
 	_on_transform_changed();
 }
@@ -1404,7 +1404,7 @@ void KinematicBody::_notification(int p_what) {
 		PhysicsServer::get_singleton()->body_set_state(get_rid(), PhysicsServer::BODY_STATE_TRANSFORM, new_transform);
 		//but then revert changes
 		set_notify_local_transform(false);
-		set_global_transform(last_valid_transform);
+		set_global_transform_interpolated(last_valid_transform);
 		set_notify_local_transform(true);
 		_on_transform_changed();
 	}

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -113,10 +113,18 @@ private:
 
 	void _propagate_visibility_changed();
 
+	void _set_transform(const Transform &p_transform);
+
 protected:
 	_FORCE_INLINE_ void set_ignore_transform_notification(bool p_ignore) { data.ignore_notification = p_ignore; }
 
 	_FORCE_INLINE_ void _update_local_transform() const;
+	void _set_transform_interpolated(const Transform &p_transform, bool p_interpolated = true);
+	void _set_transform_auto(const Transform &p_transform) { _set_transform_interpolated(p_transform, is_physics_interpolated()); }
+	void _set_global_transform_interpolated(const Transform &p_transform, bool p_interpolated = true);
+	void _set_global_transform_auto(const Transform &p_transform) {
+		_set_global_transform_interpolated(p_transform, is_physics_interpolated());
+	}
 
 	uint32_t _get_spatial_flags() const { return data.spatial_flags; }
 	void _replace_spatial_flags(uint32_t p_flags) { data.spatial_flags = p_flags; }
@@ -158,8 +166,13 @@ public:
 	Vector3 get_rotation_degrees() const;
 	Vector3 get_scale() const;
 
-	void set_transform(const Transform &p_transform);
+	void set_transform(const Transform &p_transform) {
+		_set_branch_interpolated(false);
+		_set_transform(p_transform);
+	}
+	void set_transform_interpolated(const Transform &p_transform) { _set_transform_interpolated(p_transform, true); }
 	void set_global_transform(const Transform &p_transform);
+	void set_global_transform_interpolated(const Transform &p_transform) { _set_global_transform_interpolated(p_transform, true); }
 
 	Transform get_transform() const;
 	Transform get_global_transform() const;

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -833,7 +833,7 @@ void VehicleBody::_direct_state_changed(Object *p_state) {
 
 	for (int i = 0; i < wheels.size(); i++) {
 		_ray_cast(i, state);
-		wheels[i]->set_transform(state->get_transform().inverse() * wheels[i]->m_worldTransform);
+		wheels[i]->set_transform_interpolated(state->get_transform().inverse() * wheels[i]->m_worldTransform);
 	}
 
 	_update_suspension(state);

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -82,7 +82,7 @@ void VisualInstance::_notification(int p_what) {
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (_get_spatial_flags() & SPATIAL_FLAG_VI_VISIBLE) {
 				Transform gt = get_global_transform();
-				VisualServer::get_singleton()->instance_set_transform(instance, gt);
+				VisualServer::get_singleton()->instance_set_transform_interpolated(instance, gt, is_physics_interpolated());
 			}
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -189,6 +189,19 @@ void Node::_propagate_ready() {
 	}
 }
 
+void Node::_propagate_interpolated(bool p_interpolated) {
+	data.physics_interpolated = p_interpolated;
+
+	// allow a call to the VisualServer etc in derived classes
+	_physics_interpolated_changed();
+
+	data.blocked++;
+	for (int i = 0; i < data.children.size(); i++) {
+		data.children[i]->_propagate_interpolated(p_interpolated);
+	}
+	data.blocked--;
+}
+
 void Node::_propagate_enter_tree() {
 	// this needs to happen to all children before any enter_tree
 
@@ -1757,6 +1770,14 @@ void Node::propagate_call(const StringName &p_method, const Array &p_args, const
 	data.blocked--;
 }
 
+void Node::_set_branch_interpolated(bool p_interpolated) {
+	// most common case, noop
+	if (is_physics_interpolated() == p_interpolated) {
+		return;
+	}
+	_propagate_interpolated(p_interpolated);
+}
+
 void Node::_propagate_replace_owner(Node *p_owner, Node *p_by_owner) {
 	if (get_owner() == p_owner) {
 		set_owner(p_by_owner);
@@ -2936,6 +2957,7 @@ Node::Node() {
 	data.idle_process_internal = false;
 	data.inside_tree = false;
 	data.ready_notified = false;
+	data.physics_interpolated = false;
 
 	data.owner = nullptr;
 	data.OW = nullptr;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -100,9 +100,6 @@ private:
 		int blocked; // safeguard that throws an error when attempting to modify the tree in a harmful way while being traversed.
 		StringName name;
 		SceneTree *tree;
-		bool inside_tree;
-		bool ready_notified; //this is a small hack, so if a node is added during _ready() to the tree, it correctly gets the _ready() notification
-		bool ready_first;
 #ifdef TOOLS_ENABLED
 		NodePath import_path; //path used when imported, used by scene editors to keep tracking
 #endif
@@ -120,25 +117,31 @@ private:
 		Map<StringName, MultiplayerAPI::RPCMode> rpc_methods;
 		Map<StringName, MultiplayerAPI::RPCMode> rpc_properties;
 
-		// variables used to properly sort the node when processing, ignored otherwise
-		//should move all the stuff below to bits
-		bool physics_process;
-		bool idle_process;
 		int process_priority;
 
-		bool physics_process_internal;
-		bool idle_process_internal;
+		// variables used to properly sort the node when processing, ignored otherwise
+		//should move all the stuff below to bits
+		bool physics_process : 1;
+		bool idle_process : 1;
 
-		bool input;
-		bool unhandled_input;
-		bool unhandled_key_input;
+		bool physics_process_internal : 1;
+		bool idle_process_internal : 1;
 
-		bool parent_owned;
-		bool in_constructor;
-		bool use_placeholder;
+		bool input : 1;
+		bool unhandled_input : 1;
+		bool unhandled_key_input : 1;
+		bool physics_interpolated : 1;
 
-		bool display_folded;
-		bool editable_instance;
+		bool parent_owned : 1;
+		bool in_constructor : 1;
+		bool use_placeholder : 1;
+
+		bool display_folded : 1;
+		bool editable_instance : 1;
+
+		bool inside_tree : 1;
+		bool ready_notified : 1; //this is a small hack, so if a node is added during _ready() to the tree, it correctly gets the _ready() notification
+		bool ready_first : 1;
 
 		mutable NodePath *path_cache;
 
@@ -163,6 +166,7 @@ private:
 	void _propagate_exit_tree();
 	void _propagate_after_exit_tree();
 	void _propagate_validate_owner();
+	void _propagate_interpolated(bool p_interpolated);
 	void _print_stray_nodes();
 	void _propagate_pause_owner(Node *p_owner);
 	Array _get_node_and_resource(const NodePath &p_path);
@@ -193,7 +197,10 @@ protected:
 	virtual void remove_child_notify(Node *p_child);
 	virtual void move_child_notify(Node *p_child);
 
+	virtual void _physics_interpolated_changed() {}
+
 	void _propagate_replace_owner(Node *p_owner, Node *p_by_owner);
+	void _set_branch_interpolated(bool p_interpolated);
 
 	static void _bind_methods();
 	static String _get_name_num_separator();
@@ -271,6 +278,7 @@ public:
 	}
 
 	_FORCE_INLINE_ bool is_inside_tree() const { return data.inside_tree; }
+	_FORCE_INLINE_ bool is_physics_interpolated() const { return data.physics_interpolated; }
 
 	bool is_a_parent_of(const Node *p_node) const;
 	bool is_greater_than(const Node *p_node) const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -32,6 +32,7 @@
 #define RASTERIZER_H
 
 #include "core/math/camera_matrix.h"
+#include "core/math/interpolator.h"
 #include "servers/visual_server.h"
 
 #include "core/self_list.h"
@@ -89,7 +90,15 @@ public:
 		RID skeleton;
 		RID material_override;
 
+		// This is the main transform to be drawn with ..
+		// This will either be the interpolated transform (when using fixed timestep interpolation)
+		// or the ONLY transform (when not using FTI).
 		Transform transform;
+
+		// for interpolation we store the current transform (this physics tick)
+		// and the transform in the previous tick
+		Transform transform_curr;
+		Transform transform_prev;
 
 		int depth_layer;
 		uint32_t layer_mask;
@@ -106,11 +115,16 @@ public:
 		VS::ShadowCastingSetting cast_shadows;
 
 		//fit in 32 bits
-		bool mirror : 8;
-		bool receive_shadows : 8;
-		bool visible : 8;
-		bool baked_light : 4; //this flag is only to know if it actually did use baked light
-		bool redraw_if_visible : 4;
+		bool mirror : 1;
+		bool receive_shadows : 1;
+		bool visible : 1;
+		bool baked_light : 1; //this flag is only to know if it actually did use baked light
+		bool redraw_if_visible : 1;
+
+		bool on_interpolate_list : 1;
+		bool on_interpolate_transform_list : 1;
+		bool interpolated : 1;
+		Interpolator::Method interpolation_method : 3;
 
 		float depth; //used for sorting
 
@@ -137,6 +151,10 @@ public:
 			lightmap_capture = nullptr;
 			lightmap_slice = -1;
 			lightmap_uv_rect = Rect2(0, 0, 1, 1);
+			on_interpolate_list = false;
+			on_interpolate_transform_list = false;
+			interpolated = true;
+			interpolation_method = Interpolator::INTERP_LERP;
 		}
 	};
 

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -94,7 +94,19 @@ void VisualServerRaster::request_frame_drawn_callback(Object *p_where, const Str
 	frame_drawn_callbacks.push_back(fdc);
 }
 
+void VisualServerRaster::tick() {
+	VSG::scene->update_interpolation_transform_list(true);
+}
+
+void VisualServerRaster::no_draw() {
+	// dummy version called if there is no draw() called.
+	// This is necessary to clear out intermediate per frame lists.
+	VSG::scene->update_interpolate_list(false);
+}
+
 void VisualServerRaster::draw(bool p_swap_buffers, double frame_step) {
+	VSG::scene->update_interpolate_list();
+
 	//needs to be done before changes is reset to 0, to not force the editor to redraw
 	VS::get_singleton()->emit_signal("frame_pre_draw");
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -438,6 +438,7 @@ public:
 	BIND4(camera_set_orthogonal, RID, float, float, float)
 	BIND5(camera_set_frustum, RID, float, Vector2, float, float)
 	BIND2(camera_set_transform, RID, const Transform &)
+	BIND3(camera_set_transform_interpolated, RID, const Transform &, bool)
 	BIND2(camera_set_cull_mask, RID, uint32_t)
 	BIND2(camera_set_environment, RID, RID)
 	BIND2(camera_set_use_vertical_aspect, RID, bool)
@@ -546,6 +547,7 @@ public:
 	BIND2(instance_set_scenario, RID, RID)
 	BIND2(instance_set_layer_mask, RID, uint32_t)
 	BIND2(instance_set_transform, RID, const Transform &)
+	BIND3(instance_set_transform_interpolated, RID, const Transform &, bool)
 	BIND2(instance_attach_object_instance_id, RID, ObjectID)
 	BIND3(instance_set_blend_shape_weight, RID, int, float)
 	BIND3(instance_set_surface_material, RID, int, RID)
@@ -729,6 +731,8 @@ public:
 	virtual void request_frame_drawn_callback(Object *p_where, const StringName &p_method, const Variant &p_userdata);
 
 	virtual void draw(bool p_swap_buffers, double frame_step);
+	virtual void no_draw();
+	virtual void tick();
 	virtual void sync();
 	virtual bool has_changed() const;
 	virtual void init();

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -30,6 +30,7 @@
 
 #include "visual_server_scene.h"
 
+#include "core/math/interpolator.h"
 #include "core/os/os.h"
 #include "visual_server_globals.h"
 #include "visual_server_raster.h"
@@ -37,6 +38,16 @@
 #include <new>
 
 /* CAMERA API */
+
+Transform VisualServerScene::Camera::get_transform() const {
+	if (!interpolated) {
+		return transform;
+	}
+
+	Transform final;
+	Interpolator::interpolate_transform_linear(transform_prev, transform, final, Engine::get_singleton()->get_physics_interpolation_fraction());
+	return final;
+}
 
 RID VisualServerScene::camera_create() {
 	Camera *camera = memnew(Camera);
@@ -71,10 +82,36 @@ void VisualServerScene::camera_set_frustum(RID p_camera, float p_size, Vector2 p
 	camera->zfar = p_z_far;
 }
 
+void VisualServerScene::camera_set_transform_interpolated(RID p_camera, const Transform &p_transform, bool p_interpolated) {
+	Camera *camera = camera_owner.get(p_camera);
+	ERR_FAIL_COND(!camera);
+	camera->transform = p_transform.orthonormalized();
+
+	if (Engine::get_singleton()->is_physics_interpolation_enabled() && p_interpolated) {
+		camera->interpolated = true;
+		if (!camera->on_interpolate_transform_list) {
+			_interpolation_data.camera_transform_update_list_curr->push_back(p_camera);
+			camera->on_interpolate_transform_list = true;
+		}
+
+	} else {
+		camera->interpolated = false;
+
+		if (Engine::get_singleton()->is_physics_interpolation_enabled()) {
+			camera->transform_prev = camera->transform;
+		}
+	}
+}
+
 void VisualServerScene::camera_set_transform(RID p_camera, const Transform &p_transform) {
 	Camera *camera = camera_owner.get(p_camera);
 	ERR_FAIL_COND(!camera);
 	camera->transform = p_transform.orthonormalized();
+
+	if (Engine::get_singleton()->is_physics_interpolation_enabled()) {
+		camera->transform_prev = camera->transform;
+		camera->interpolated = false;
+	}
 }
 
 void VisualServerScene::camera_set_cull_mask(RID p_camera, uint32_t p_layers) {
@@ -675,11 +712,194 @@ void VisualServerScene::instance_set_layer_mask(RID p_instance, uint32_t p_mask)
 
 	instance->layer_mask = p_mask;
 }
+
+void VisualServerScene::instance_set_transform_interpolated(RID p_instance, const Transform &p_transform, bool p_interpolated) {
+	if (!Engine::get_singleton()->is_physics_interpolation_enabled() || !p_interpolated) {
+		instance_set_transform(p_instance, p_transform);
+		return;
+	}
+
+	Instance *instance = instance_owner.get(p_instance);
+	ERR_FAIL_COND(!instance);
+
+	// we can't entirely reject no changes because we need the interpolation
+	// system to keep on stewing
+	bool no_change = (instance->transform_curr == p_transform) && (instance->transform_prev == p_transform);
+
+	if (!no_change) {
+#ifdef DEBUG_ENABLED
+
+		for (int i = 0; i < 4; i++) {
+			const Vector3 &v = i < 3 ? p_transform.basis.elements[i] : p_transform.origin;
+			ERR_FAIL_COND(Math::is_inf(v.x));
+			ERR_FAIL_COND(Math::is_nan(v.x));
+			ERR_FAIL_COND(Math::is_inf(v.y));
+			ERR_FAIL_COND(Math::is_nan(v.y));
+			ERR_FAIL_COND(Math::is_inf(v.z));
+			ERR_FAIL_COND(Math::is_nan(v.z));
+		}
+
+#endif
+		instance->transform_curr = p_transform;
+
+		// decide on the interpolation method .. slerp if possible
+		bool can_slerp = Interpolator::should_slerp(instance->transform_prev.basis, instance->transform_curr.basis);
+		instance->interpolation_method = can_slerp ? Interpolator::INTERP_SLERP : Interpolator::INTERP_LERP;
+
+		if (!instance->on_interpolate_transform_list) {
+			_interpolation_data.instance_transform_update_list_curr->push_back(p_instance);
+			instance->on_interpolate_transform_list = true;
+		} else {
+			DEV_ASSERT(_interpolation_data.instance_transform_update_list_curr->size());
+		}
+
+		if (!instance->on_interpolate_list) {
+			_interpolation_data.instance_interpolate_update_list.push_back(p_instance);
+			instance->on_interpolate_list = true;
+		} else {
+			DEV_ASSERT(_interpolation_data.instance_interpolate_update_list.size());
+		}
+
+		_instance_queue_update(instance, true);
+	}
+}
+
+void VisualServerScene::InterpolationData::notify_free_camera(RID p_rid) {
+	if (!Engine::get_singleton()->is_physics_interpolation_enabled()) {
+		return;
+	}
+
+	// if the camera was on any of the lists, remove
+	camera_transform_update_list_curr->erase_multiple_unordered(p_rid);
+	camera_transform_update_list_prev->erase_multiple_unordered(p_rid);
+}
+
+void VisualServerScene::InterpolationData::notify_free_instance(RID p_rid) {
+	if (!Engine::get_singleton()->is_physics_interpolation_enabled()) {
+		return;
+	}
+
+	// if the instance was on any of the lists, remove
+	instance_interpolate_update_list.erase_multiple_unordered(p_rid);
+	instance_transform_update_list_curr->erase_multiple_unordered(p_rid);
+	instance_transform_update_list_prev->erase_multiple_unordered(p_rid);
+}
+
+void VisualServerScene::update_interpolation_transform_list(bool p_process) {
+	// detect any that were on the previous transform list that are no longer active,
+	// we should remove them from the interpolate list
+	for (unsigned int n = 0; n < _interpolation_data.instance_transform_update_list_prev->size(); n++) {
+		const RID &rid = (*_interpolation_data.instance_transform_update_list_prev)[n];
+		Instance *instance = instance_owner.getornull(rid);
+
+		bool active = true;
+
+		// no longer active? (either the instance deleted or no longer being transformed)
+		if (instance && !instance->on_interpolate_transform_list) {
+			active = false;
+			instance->on_interpolate_list = false;
+
+			// make sure the most recent transform is set
+			instance->transform = instance->transform_curr;
+
+			// and that both prev and current are the same, just in case of any interpolations
+			instance->transform_prev = instance->transform_curr;
+		}
+
+		if (!instance) {
+			active = false;
+		}
+
+		if (!active) {
+			_interpolation_data.instance_interpolate_update_list.erase(rid);
+		}
+	}
+
+	// and now for any in the transform list (being actively interpolated), keep the previous transform
+	// value up to date ready for the next tick
+	if (p_process) {
+		for (unsigned int n = 0; n < _interpolation_data.instance_transform_update_list_curr->size(); n++) {
+			const RID &rid = (*_interpolation_data.instance_transform_update_list_curr)[n];
+			Instance *instance = instance_owner.getornull(rid);
+			if (instance) {
+				instance->transform_prev = instance->transform_curr;
+				instance->on_interpolate_transform_list = false;
+			}
+		}
+	}
+
+	// we maintain a mirror list for the transform updates, so we can detect when an instance
+	// is no longer being transformed, and remove it from the interpolate list
+	SWAP(_interpolation_data.instance_transform_update_list_curr, _interpolation_data.instance_transform_update_list_prev);
+
+	// prepare for the next iteration
+	_interpolation_data.instance_transform_update_list_curr->clear();
+
+	// CAMERAS
+	// detect any that were on the previous transform list that are no longer active,
+	for (unsigned int n = 0; n < _interpolation_data.camera_transform_update_list_prev->size(); n++) {
+		const RID &rid = (*_interpolation_data.camera_transform_update_list_prev)[n];
+		Camera *camera = camera_owner.getornull(rid);
+
+		//bool active = true;
+
+		// no longer active? (either the instance deleted or no longer being transformed)
+		if (camera && !camera->on_interpolate_transform_list) {
+			//active = false;
+			camera->transform = camera->transform_prev;
+		}
+
+		//		if (!camera) {
+		//			active = false;
+		//		}
+
+		//		if (!active) {
+		//			_interpolation_data.instance_interpolate_update_list.erase(rid);
+		//		}
+	}
+
+	// cameras , swap any current with previous
+	for (unsigned int n = 0; n < _interpolation_data.camera_transform_update_list_curr->size(); n++) {
+		const RID &rid = (*_interpolation_data.camera_transform_update_list_curr)[n];
+		Camera *camera = camera_owner.getornull(rid);
+		if (camera) {
+			camera->transform_prev = camera->transform;
+			camera->on_interpolate_transform_list = false;
+		}
+	}
+
+	// we maintain a mirror list for the transform updates, so we can detect when an instance
+	// is no longer being transformed, and remove it from the interpolate list
+	SWAP(_interpolation_data.camera_transform_update_list_curr, _interpolation_data.camera_transform_update_list_prev);
+
+	// prepare for the next iteration
+	_interpolation_data.camera_transform_update_list_curr->clear();
+}
+
+void VisualServerScene::update_interpolate_list(bool p_process) {
+	if (p_process) {
+		real_t f = Engine::get_singleton()->get_physics_interpolation_fraction();
+
+		for (unsigned int i = 0; i < _interpolation_data.instance_interpolate_update_list.size(); i++) {
+			const RID &rid = _interpolation_data.instance_interpolate_update_list[i];
+			Instance *instance = instance_owner.getornull(rid);
+			if (instance) {
+				Interpolator::interpolate_transform(instance->transform_prev, instance->transform_curr, instance->transform, f, instance->interpolation_method);
+			}
+		} // for n
+	}
+}
+
 void VisualServerScene::instance_set_transform(RID p_instance, const Transform &p_transform) {
 	Instance *instance = instance_owner.get(p_instance);
 	ERR_FAIL_COND(!instance);
 
 	if (instance->transform == p_transform) {
+		if (Engine::get_singleton()->is_physics_interpolation_enabled()) {
+			instance->transform_curr = p_transform;
+			instance->transform_prev = p_transform;
+			instance->interpolated = false;
+		}
 		return; //must be checked to avoid worst evil
 	}
 
@@ -697,6 +917,13 @@ void VisualServerScene::instance_set_transform(RID p_instance, const Transform &
 
 #endif
 	instance->transform = p_transform;
+
+	if (Engine::get_singleton()->is_physics_interpolation_enabled()) {
+		instance->transform_curr = p_transform;
+		instance->transform_prev = p_transform;
+		instance->interpolated = false;
+	}
+
 	_instance_queue_update(instance, true);
 }
 void VisualServerScene::instance_attach_object_instance_id(RID p_instance, ObjectID p_id) {
@@ -1529,22 +1756,30 @@ void VisualServerScene::instance_geometry_set_as_instance_lod(RID p_instance, RI
 void VisualServerScene::_update_instance(Instance *p_instance) {
 	p_instance->version++;
 
+	// when not using interpolation the transform is used straight
+	const Transform *instance_xform = &p_instance->transform;
+
+	// but when using interpolation the current transform is the most up to date on the tick
+	if (Engine::get_singleton()->is_physics_interpolation_enabled() && p_instance->interpolated) {
+		instance_xform = &p_instance->transform_curr;
+	}
+
 	if (p_instance->base_type == VS::INSTANCE_LIGHT) {
 		InstanceLightData *light = static_cast<InstanceLightData *>(p_instance->base_data);
 
-		VSG::scene_render->light_instance_set_transform(light->instance, p_instance->transform);
+		VSG::scene_render->light_instance_set_transform(light->instance, *instance_xform);
 		light->shadow_dirty = true;
 	}
 
 	if (p_instance->base_type == VS::INSTANCE_REFLECTION_PROBE) {
 		InstanceReflectionProbeData *reflection_probe = static_cast<InstanceReflectionProbeData *>(p_instance->base_data);
 
-		VSG::scene_render->reflection_probe_instance_set_transform(reflection_probe->instance, p_instance->transform);
+		VSG::scene_render->reflection_probe_instance_set_transform(reflection_probe->instance, *instance_xform);
 		reflection_probe->reflection_dirty = true;
 	}
 
 	if (p_instance->base_type == VS::INSTANCE_PARTICLES) {
-		VSG::storage->particles_set_emission_transform(p_instance->base, p_instance->transform);
+		VSG::storage->particles_set_emission_transform(p_instance->base, *instance_xform);
 	}
 
 	if (p_instance->base_type == VS::INSTANCE_LIGHTMAP_CAPTURE) {
@@ -1579,11 +1814,11 @@ void VisualServerScene::_update_instance(Instance *p_instance) {
 		}
 	}
 
-	p_instance->mirror = p_instance->transform.basis.determinant() < 0.0;
+	p_instance->mirror = instance_xform->basis.determinant() < 0.0;
 
 	AABB new_aabb;
 
-	new_aabb = p_instance->transform.xform(p_instance->aabb);
+	new_aabb = instance_xform->xform(p_instance->aabb);
 
 	p_instance->transformed_aabb = new_aabb;
 
@@ -2378,8 +2613,11 @@ void VisualServerScene::render_camera(RID p_camera, RID p_scenario, Size2 p_view
 		} break;
 	}
 
-	_prepare_scene(camera->transform, camera_matrix, ortho, camera->env, camera->visible_layers, p_scenario, p_shadow_atlas, RID(), camera->previous_room_id_hint);
-	_render_scene(camera->transform, camera_matrix, 0, ortho, camera->env, p_scenario, p_shadow_atlas, RID(), -1);
+	// This getter allows optional fixed timestep interpolation for the camera.
+	Transform camera_transform = camera->get_transform();
+
+	_prepare_scene(camera_transform, camera_matrix, ortho, camera->env, camera->visible_layers, p_scenario, p_shadow_atlas, RID(), camera->previous_room_id_hint);
+	_render_scene(camera_transform, camera_matrix, 0, ortho, camera->env, p_scenario, p_shadow_atlas, RID(), -1);
 #endif
 }
 
@@ -4030,7 +4268,7 @@ bool VisualServerScene::free(RID p_rid) {
 
 		camera_owner.free(p_rid);
 		memdelete(camera);
-
+		_interpolation_data.notify_free_camera(p_rid);
 	} else if (scenario_owner.owns(p_rid)) {
 		Scenario *scenario = scenario_owner.get(p_rid);
 
@@ -4059,6 +4297,7 @@ bool VisualServerScene::free(RID p_rid) {
 
 		instance_owner.free(p_rid);
 		memdelete(instance);
+		_interpolation_data.notify_free_instance(p_rid);
 	} else if (room_owner.owns(p_rid)) {
 		Room *room = room_owner.get(p_rid);
 		room_owner.free(p_rid);

--- a/servers/visual/visual_server_wrap_mt.cpp
+++ b/servers/visual/visual_server_wrap_mt.cpp
@@ -36,6 +36,18 @@ void VisualServerWrapMT::thread_exit() {
 	exit.set();
 }
 
+void VisualServerWrapMT::thread_tick() {
+	if (!draw_pending.decrement()) {
+		visual_server->tick();
+	}
+}
+
+void VisualServerWrapMT::thread_no_draw() {
+	if (!draw_pending.decrement()) {
+		visual_server->no_draw();
+	}
+}
+
 void VisualServerWrapMT::thread_draw(bool p_swap_buffers, double frame_step) {
 	if (!draw_pending.decrement()) {
 		visual_server->draw(p_swap_buffers, frame_step);
@@ -79,6 +91,24 @@ void VisualServerWrapMT::sync() {
 		command_queue.push_and_sync(this, &VisualServerWrapMT::thread_flush);
 	} else {
 		command_queue.flush_all(); //flush all pending from other threads
+	}
+}
+
+void VisualServerWrapMT::tick() {
+	if (create_thread) {
+		draw_pending.increment();
+		command_queue.push(this, &VisualServerWrapMT::thread_tick);
+	} else {
+		visual_server->tick();
+	}
+}
+
+void VisualServerWrapMT::no_draw() {
+	if (create_thread) {
+		draw_pending.increment();
+		command_queue.push(this, &VisualServerWrapMT::thread_no_draw);
+	} else {
+		visual_server->no_draw();
 	}
 }
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -53,6 +53,8 @@ class VisualServerWrapMT : public VisualServer {
 
 	SafeNumeric<uint64_t> draw_pending;
 	void thread_draw(bool p_swap_buffers, double frame_step);
+	void thread_no_draw();
+	void thread_tick();
 	void thread_flush();
 
 	void thread_exit();
@@ -369,6 +371,7 @@ public:
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
 	FUNC2(camera_set_transform, RID, const Transform &)
+	FUNC3(camera_set_transform_interpolated, RID, const Transform &, bool)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
 	FUNC2(camera_set_environment, RID, RID)
 	FUNC2(camera_set_use_vertical_aspect, RID, bool)
@@ -469,6 +472,7 @@ public:
 	FUNC2(instance_set_scenario, RID, RID)
 	FUNC2(instance_set_layer_mask, RID, uint32_t)
 	FUNC2(instance_set_transform, RID, const Transform &)
+	FUNC3(instance_set_transform_interpolated, RID, const Transform &, bool)
 	FUNC2(instance_attach_object_instance_id, RID, ObjectID)
 	FUNC3(instance_set_blend_shape_weight, RID, int, float)
 	FUNC3(instance_set_surface_material, RID, int, RID)
@@ -650,6 +654,8 @@ public:
 	virtual void init();
 	virtual void finish();
 	virtual void draw(bool p_swap_buffers, double frame_step);
+	virtual void no_draw();
+	virtual void tick();
 	virtual void sync();
 	FUNC0RC(bool, has_changed)
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -612,6 +612,7 @@ public:
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform) = 0;
+	virtual void camera_set_transform_interpolated(RID p_camera, const Transform &p_transform, bool p_interpolated) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable) = 0;
@@ -849,6 +850,7 @@ public:
 	virtual void instance_set_scenario(RID p_instance, RID p_scenario) = 0;
 	virtual void instance_set_layer_mask(RID p_instance, uint32_t p_mask) = 0;
 	virtual void instance_set_transform(RID p_instance, const Transform &p_transform) = 0;
+	virtual void instance_set_transform_interpolated(RID p_instance, const Transform &p_transform, bool p_interpolated) = 0;
 	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id) = 0;
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight) = 0;
 	virtual void instance_set_surface_material(RID p_instance, int p_surface, RID p_material) = 0;
@@ -1094,6 +1096,8 @@ public:
 	/* EVENT QUEUING */
 
 	virtual void draw(bool p_swap_buffers = true, double frame_step = 0.0) = 0;
+	virtual void no_draw() = 0; // dummy version, call this if not drawing a frame to prevent memory leaks
+	virtual void tick() = 0; // physics tick
 	virtual void sync() = 0;
 	virtual bool has_changed() const = 0;
 	virtual void init() = 0;


### PR DESCRIPTION
Adds fixed timestep interpolation to the visual server.
Switchable on and off with project setting.

Loosely based around https://github.com/godotengine/godot-proposals/issues/2753

## Notes
* The `no_draw` function is historical and may not be needed, it will probably get taken out.
* Still have to put in some warning for users if they call the interpolated functions outside of the physics tick
* Interpolation method will automatically switch from basis lerp to slerp where possible / necessary
* InterpolatedCamera TODO

## More Info
Physics objects automatically call `set_global_transform_interpolated`, which calls the interpolated functions in the visual server (these fallback to normal funcs if interpolation is switched off in settings). For user code, users should call `set_transform_interpolated`, `set_global_transform_interpolated` during the physics tick. This sets a propagated 'interpolated' flag in the node and children.

## Implicit `set_transform` problem
A complication with the proposal has turned out to be that `Spatial`contains a large number of functions that internally call `set_transform`. This will break interpolation if it currently active, as it will cause a teleport. We've been evaluating various methods to get around this problem.

The huge potential for future bugs due to this problem (both in the engine and in user games) leads me to believe we should take the simpler alternative approach provided in #52846, where instead of providing a new API, we simply add an `physics_interpolated` property to each node. Then we add a `teleport` function for the rare case when we want to break interpolation for a single tick. This is how fixed timestep interpolation is normally implemented - on by default, with a special case for `teleport`s. This has the advantage of being a tried and tested approach, and it means in most cases games can be converted to and from fixed timestep interpolation simply by switching the feature off and on.

In this PR I've been trying various approaches suggested by reduz to try and solve this inherent problem in the proposal, but all of them have been problematic in some way in practice, leading to time spent debugging gdscript calls, which I fear may make this too difficult to use for users, or put them off using it.

The obvious extension to the explicit approach in the proposal is to change the entire set of functions available on `Spatial` which implicitly call `set_transform`, and add an `interpolated` argument to each:

```
	void set_translation(const Vector3 &p_translation);
	void set_rotation(const Vector3 &p_euler_rad);
	void set_rotation_degrees(const Vector3 &p_euler_deg);
	void set_scale(const Vector3 &p_scale);

	void rotate(const Vector3 &p_axis, float p_angle, bool p_interpolated);
	void rotate_x(float p_angle, bool p_interpolated);
	void rotate_y(float p_angle, bool p_interpolated);
	void rotate_z(float p_angle, bool p_interpolated);
	void translate(const Vector3 &p_offset, bool p_interpolated);
	void scale(const Vector3 &p_ratio, bool p_interpolated);

	void rotate_object_local(const Vector3 &p_axis, float p_angle, bool p_interpolated);
	void scale_object_local(const Vector3 &p_scale, bool p_interpolated);
	void translate_object_local(const Vector3 &p_offset, bool p_interpolated);

	void global_rotate(const Vector3 &p_axis, float p_angle, bool p_interpolated);
	void global_scale(const Vector3 &p_scale, bool p_interpolated);
	void global_translate(const Vector3 &p_offset, bool p_interpolated);

	void look_at(const Vector3 &p_target, const Vector3 &p_up, bool p_interpolated);
	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up, bool p_interpolated);

	Vector3 to_local(Vector3 p_global, bool p_interpolated) const;
	Vector3 to_global(Vector3 p_local, bool p_interpolated) const;

	void orthonormalize(bool p_interpolated);
	void set_identity(bool p_interpolated);
```
In addition this does not look possible for `set_translation` -> `set_scale` because these are accessors for the Transform properties and this is incompatible with the property panel.

Imo this is needlessly pushing the complexity onto the user, there is no good reason for a user to have to take care in each of these functions when at the end of the day the only thing being set is a single bool per node.

Adding this bool parameter to each function also means in practice searching through game code to find each instance of these functions and rewriting them, for no apparent reason.

## Compromise
As a compromise here I've added an internal function `_set_transform_auto`, which is used internally in these above functions, and calls `set_translate` or `set_translate_interpolated` based on the current flag of the node, thereby shielding the user from this complexity.

This means that effectively:
* calling `set_transform()` is a combination of `set_interpolated(false);` and `set_transform()`
* calling `set_transform_interpolated()` is a combination of `set_interpolated(true)` and `set_transform()`

This does mean that if the user isn't intending to call either of these functions (e.g. in a Camera where they use a `look_at` function) they should remember to call either `set_transform` or `set_transform_interpolated` at startup to set the `interpolated` flag of the node. But again this seems more difficult to explain to a user who is scratching their head than to just say 'just set the interpolated property'.

Essentially the pros/cons of the two approaches are as follows:
### Explicit calls
* Changing a lot of game gdscript
* Dealing with game / engine bugs where interpolation is broken, tracking down the offending calls
* User confusion
* This effectively means all engine programmers will need to be conscious of these differences, and call `set_transform_interpolated` when adding new game functionality - we will constantly get changes causing game breaking regressions.

### Per node setting
* Little to no changes to game code.
* Adding a `teleport` to parts of the game where objects are moved long distances. (Note that this can be done automatically for objects entering the scene tree, so it is quite a rare occurrence in practice.)
* Probably sensible to turn off interpolation globally when `is_editor_hint` is set, as most editor operations don't want / require interpolation.
* There may be occasions in Engine code where we might want to add a `teleport` call. This should be rare, and if we miss one, the worst regression will be an object being interpolated for a frame when it shouldn't, which isn't that visually jarring, rather than game breaking bugs.

## Other game changes necessary to get fixed timestep working
Typically for most games some small adjustment for the Camera is all that is required. The easiest is to process the camera in `_physics_process` and call the `set_transform_interpolated` or `set_global_transform_interpolated` funcs, or just inherit the position from an interpolated parent.

If processing a camera in `_process` you will currently need to do the target interpolation yourself, by recording the target previous and current positions etc. I had a little look into automating this, but on discussion with reduz we decided this might be best to leave to the user to start with.

e.g. This is 3d platformer demo running at 20 ticks per second with interpolation:
https://user-images.githubusercontent.com/21999379/133752437-4a749906-b574-429c-ac6f-b6f2ea4c21cd.mp4
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
