### PR TITLE
Remove unused `out_of_range_mode` property from AudioStreamPlayer3D

### DIFF
--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -81,13 +81,10 @@
 			Sets the absolute maximum of the soundlevel, in decibels.
 		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="0.0">
-			Sets the distance from which the [member out_of_range_mode] takes effect. Has no effect if set to 0.
+			The distance past which the sound can no longer be heard at all. Only has an effect if set to a value greater than [code]0.0[/code]. [member max_distance] works in tandem with [member unit_size]. However, unlike [member unit_size] whose behavior depends on the [member attenuation_model], [member max_distance] always works in a linear fashion. This can be used to prevent the [AudioStreamPlayer3D] from requiring audio mixing when the listener is far away, which saves CPU resources.
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
-		</member>
-		<member name="out_of_range_mode" type="int" setter="set_out_of_range_mode" getter="get_out_of_range_mode" enum="AudioStreamPlayer3D.OutOfRangeMode" default="0">
-			Decides if audio should pause when source is outside of [member max_distance] range.
 		</member>
 		<member name="pitch_scale" type="float" setter="set_pitch_scale" getter="get_pitch_scale" default="1.0">
 			The pitch and the tempo of the audio, as a multiplier of the audio sample's sample rate.
@@ -127,12 +124,6 @@
 		</constant>
 		<constant name="ATTENUATION_DISABLED" value="3" enum="AttenuationModel">
 			No dampening of loudness according to distance. The sound will still be heard positionally, unlike an [AudioStreamPlayer].
-		</constant>
-		<constant name="OUT_OF_RANGE_MIX" value="0" enum="OutOfRangeMode">
-			Mix this audio in, even when it's out of range. This increases CPU usage, but keeps the sound playing at the correct position if the camera leaves and enters the [AudioStreamPlayer3D]'s [member max_distance] radius.
-		</constant>
-		<constant name="OUT_OF_RANGE_PAUSE" value="1" enum="OutOfRangeMode">
-			Pause this audio when it gets out of range. This decreases CPU usage, but will cause the sound to restart if the camera leaves and enters the [AudioStreamPlayer3D]'s [member max_distance] radius.
 		</constant>
 		<constant name="DOPPLER_TRACKING_DISABLED" value="0" enum="DopplerTracking">
 			Disables doppler tracking.

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -713,15 +713,6 @@ AudioStreamPlayer3D::AttenuationModel AudioStreamPlayer3D::get_attenuation_model
 	return attenuation_model;
 }
 
-void AudioStreamPlayer3D::set_out_of_range_mode(OutOfRangeMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 2);
-	out_of_range_mode = p_mode;
-}
-
-AudioStreamPlayer3D::OutOfRangeMode AudioStreamPlayer3D::get_out_of_range_mode() const {
-	return out_of_range_mode;
-}
-
 void AudioStreamPlayer3D::set_doppler_tracking(DopplerTracking p_tracking) {
 	if (doppler_tracking == p_tracking) {
 		return;
@@ -832,9 +823,6 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_attenuation_model", "model"), &AudioStreamPlayer3D::set_attenuation_model);
 	ClassDB::bind_method(D_METHOD("get_attenuation_model"), &AudioStreamPlayer3D::get_attenuation_model);
 
-	ClassDB::bind_method(D_METHOD("set_out_of_range_mode", "mode"), &AudioStreamPlayer3D::set_out_of_range_mode);
-	ClassDB::bind_method(D_METHOD("get_out_of_range_mode"), &AudioStreamPlayer3D::get_out_of_range_mode);
-
 	ClassDB::bind_method(D_METHOD("set_doppler_tracking", "mode"), &AudioStreamPlayer3D::set_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_doppler_tracking"), &AudioStreamPlayer3D::get_doppler_tracking);
 
@@ -856,7 +844,6 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stream_paused", PROPERTY_HINT_NONE, ""), "set_stream_paused", "get_stream_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_distance", PROPERTY_HINT_RANGE, "0,4096,1,or_greater,exp"), "set_max_distance", "get_max_distance");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "out_of_range_mode", PROPERTY_HINT_ENUM, "Mix,Pause"), "set_out_of_range_mode", "get_out_of_range_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_polyphony", PROPERTY_HINT_NONE, ""), "set_max_polyphony", "get_max_polyphony");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bus", PROPERTY_HINT_ENUM, ""), "set_bus", "get_bus");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "area_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_area_mask", "get_area_mask");
@@ -874,9 +861,6 @@ void AudioStreamPlayer3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(ATTENUATION_INVERSE_SQUARE_DISTANCE);
 	BIND_ENUM_CONSTANT(ATTENUATION_LOGARITHMIC);
 	BIND_ENUM_CONSTANT(ATTENUATION_DISABLED);
-
-	BIND_ENUM_CONSTANT(OUT_OF_RANGE_MIX);
-	BIND_ENUM_CONSTANT(OUT_OF_RANGE_PAUSE);
 
 	BIND_ENUM_CONSTANT(DOPPLER_TRACKING_DISABLED);
 	BIND_ENUM_CONSTANT(DOPPLER_TRACKING_IDLE_STEP);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -51,11 +51,6 @@ public:
 		ATTENUATION_DISABLED,
 	};
 
-	enum OutOfRangeMode {
-		OUT_OF_RANGE_MIX,
-		OUT_OF_RANGE_PAUSE,
-	};
-
 	enum DopplerTracking {
 		DOPPLER_TRACKING_DISABLED,
 		DOPPLER_TRACKING_IDLE_STEP,
@@ -117,8 +112,6 @@ private:
 	Ref<VelocityTracker3D> velocity_tracker;
 
 	DopplerTracking doppler_tracking = DOPPLER_TRACKING_DISABLED;
-
-	OutOfRangeMode out_of_range_mode = OUT_OF_RANGE_MIX;
 
 	float _get_attenuation_db(float p_distance) const;
 
@@ -182,9 +175,6 @@ public:
 	void set_attenuation_model(AttenuationModel p_model);
 	AttenuationModel get_attenuation_model() const;
 
-	void set_out_of_range_mode(OutOfRangeMode p_mode);
-	OutOfRangeMode get_out_of_range_mode() const;
-
 	void set_doppler_tracking(DopplerTracking p_tracking);
 	DopplerTracking get_doppler_tracking() const;
 
@@ -198,6 +188,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(AudioStreamPlayer3D::AttenuationModel)
-VARIANT_ENUM_CAST(AudioStreamPlayer3D::OutOfRangeMode)
 VARIANT_ENUM_CAST(AudioStreamPlayer3D::DopplerTracking)
 #endif // AUDIO_STREAM_PLAYER_3D_H


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/52770 and https://github.com/godotengine/godot/pull/52773.

The `out_of_range_mode` property is no longer used since [audio mixing was moved out of the various AudioStreamPlayer nodes in `master`](https://github.com/godotengine/godot/pull/51296).