### PR TITLE
Fail at instantiating a packed scene if the root node is instantiated

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -99,8 +99,9 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 #endif
 			parent = nparent;
 		} else {
-			// i == 0 is root node. Confirm that it doesn't have a parent defined.
+			// i == 0 is root node.
 			ERR_FAIL_COND_V_MSG(n.parent != -1, nullptr, vformat("Invalid scene: root node %s cannot specify a parent node.", snames[n.name]));
+			ERR_FAIL_COND_V_MSG(n.type == TYPE_INSTANCED && base_scene_idx < 0, nullptr, vformat("Invalid scene: root node %s in an instance, but there's no base scene.", snames[n.name]));
 		}
 
 		Node *node = nullptr;


### PR DESCRIPTION
Godot corrupted one of my scenes and revealed a bug that crashes godot when it tries to load it. To reproduce it you can use a scene file like:

```
[gd_scene]
[node name="a"]
[node name="b" parent="c"]
```

While this patch fixes the crash, I am not familiar enough with godot to know if this type of file is supposed to be invalid. I also didn't use ERR_FAIL_COND_V_MSG because it don't really understand what the problem is.