### PR TITLE
Infer shader type based on edited node

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -35,6 +35,9 @@
 #include "editor_node.h"
 #include "editor_properties_array_dict.h"
 #include "editor_scale.h"
+#include "scene/2d/gpu_particles_2d.h"
+#include "scene/3d/fog_volume.h"
+#include "scene/3d/gpu_particles_3d.h"
 #include "scene/main/window.h"
 #include "scene/resources/font.h"
 
@@ -2969,6 +2972,35 @@ void EditorPropertyResource::_update_property_bg() {
 	update();
 }
 
+void EditorPropertyResource::_update_preferred_shader() {
+	Node *parent = get_parent();
+	EditorProperty *parent_property = nullptr;
+
+	while (parent && !parent_property) {
+		parent_property = Object::cast_to<EditorProperty>(parent);
+		parent = parent->get_parent();
+	}
+
+	if (parent_property) {
+		EditorShaderPicker *shader_picker = Object::cast_to<EditorShaderPicker>(resource_picker);
+		Object *object = parent_property->get_edited_object();
+		const StringName &property = parent_property->get_edited_property();
+
+		// Set preferred shader based on edited parent type.
+		if ((Object::cast_to<GPUParticles2D>(object) || Object::cast_to<GPUParticles3D>(object)) && property == SNAME("process_material")) {
+			shader_picker->set_preferred_mode(Shader::MODE_PARTICLES);
+		} else if (Object::cast_to<FogVolume>(object)) {
+			shader_picker->set_preferred_mode(Shader::MODE_FOG);
+		} else if (Object::cast_to<CanvasItem>(object)) {
+			shader_picker->set_preferred_mode(Shader::MODE_CANVAS_ITEM);
+		} else if (Object::cast_to<Node3D>(object)) {
+			shader_picker->set_preferred_mode(Shader::MODE_SPATIAL);
+		} else if (Object::cast_to<Sky>(object)) {
+			shader_picker->set_preferred_mode(Shader::MODE_SKY);
+		}
+	}
+}
+
 void EditorPropertyResource::_viewport_selected(const NodePath &p_path) {
 	Node *to_node = get_node(p_path);
 	if (!Object::cast_to<Viewport>(to_node)) {
@@ -3000,6 +3032,7 @@ void EditorPropertyResource::setup(Object *p_object, const String &p_path, const
 		EditorShaderPicker *shader_picker = memnew(EditorShaderPicker);
 		shader_picker->set_edited_material(Object::cast_to<ShaderMaterial>(p_object));
 		resource_picker = shader_picker;
+		connect(SNAME("ready"), callable_mp(this, &EditorPropertyResource::_update_preferred_shader));
 	} else {
 		resource_picker = memnew(EditorResourcePicker);
 	}

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -669,6 +669,7 @@ class EditorPropertyResource : public EditorProperty {
 	void _open_editor_pressed();
 	void _fold_other_editors(Object *p_self);
 	void _update_property_bg();
+	void _update_preferred_shader();
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -934,7 +934,7 @@ bool EditorShaderPicker::handle_menu_selected(int p_which) {
 	switch (p_which) {
 		case OBJ_MENU_NEW_SHADER: {
 			if (material.is_valid()) {
-				EditorNode::get_singleton()->get_scene_tree_dock()->open_shader_dialog(material);
+				EditorNode::get_singleton()->get_scene_tree_dock()->open_shader_dialog(material, preferred_mode);
 				return true;
 			}
 		} break;
@@ -950,6 +950,10 @@ void EditorShaderPicker::set_edited_material(ShaderMaterial *p_material) {
 
 ShaderMaterial *EditorShaderPicker::get_edited_material() const {
 	return edited_material;
+}
+
+void EditorShaderPicker::set_preferred_mode(int p_mode) {
+	preferred_mode = p_mode;
 }
 
 EditorShaderPicker::EditorShaderPicker() {

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -156,6 +156,7 @@ class EditorShaderPicker : public EditorResourcePicker {
 	};
 
 	ShaderMaterial *edited_material = nullptr;
+	int preferred_mode = -1;
 
 public:
 	virtual void set_create_options(Object *p_menu_node) override;
@@ -163,6 +164,7 @@ public:
 
 	void set_edited_material(ShaderMaterial *p_material);
 	ShaderMaterial *get_edited_material() const;
+	void set_preferred_mode(int p_preferred_mode);
 
 	EditorShaderPicker();
 };

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2943,7 +2943,7 @@ void SceneTreeDock::open_script_dialog(Node *p_for_node, bool p_extend) {
 	}
 }
 
-void SceneTreeDock::attach_shader_to_selected() {
+void SceneTreeDock::attach_shader_to_selected(int p_preferred_mode) {
 	if (selected_shader_material.is_null()) {
 		return;
 	}
@@ -2970,13 +2970,13 @@ void SceneTreeDock::attach_shader_to_selected() {
 	shader_create_dialog->connect("shader_created", callable_mp(this, &SceneTreeDock::_shader_created));
 	shader_create_dialog->connect("confirmed", callable_mp(this, &SceneTreeDock::_shader_creation_closed));
 	shader_create_dialog->connect("cancelled", callable_mp(this, &SceneTreeDock::_shader_creation_closed));
-	shader_create_dialog->config(path);
+	shader_create_dialog->config(path, true, true, p_preferred_mode);
 	shader_create_dialog->popup_centered();
 }
 
-void SceneTreeDock::open_shader_dialog(Ref<ShaderMaterial> &p_for_material) {
+void SceneTreeDock::open_shader_dialog(Ref<ShaderMaterial> &p_for_material, int p_preferred_mode) {
 	selected_shader_material = p_for_material;
-	attach_shader_to_selected();
+	attach_shader_to_selected(p_preferred_mode);
 }
 
 void SceneTreeDock::open_add_child_dialog() {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -300,8 +300,8 @@ public:
 	void attach_script_to_selected(bool p_extend);
 	void open_script_dialog(Node *p_for_node, bool p_extend);
 
-	void attach_shader_to_selected();
-	void open_shader_dialog(Ref<ShaderMaterial> &p_for_material);
+	void attach_shader_to_selected(int p_preferred_mode = -1);
+	void open_shader_dialog(Ref<ShaderMaterial> &p_for_material, int p_preferred_mode = -1);
 
 	void open_add_child_dialog();
 	void open_instance_child_dialog();

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -324,7 +324,7 @@ void ShaderCreateDialog::_path_submitted(const String &p_path) {
 	ok_pressed();
 }
 
-void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabled, bool p_load_enabled) {
+void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabled, bool p_load_enabled, int p_preferred_mode) {
 	if (p_base_path != "") {
 		initial_base_path = p_base_path.get_basename();
 		file_path->set_text(initial_base_path + "." + language_data[language_menu->get_selected()].default_extension);
@@ -337,6 +337,11 @@ void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabl
 
 	built_in_enabled = p_built_in_enabled;
 	load_enabled = p_load_enabled;
+
+	if (p_preferred_mode > -1) {
+		mode_menu->select(p_preferred_mode);
+		_mode_changed(p_preferred_mode);
+	}
 
 	_language_changed(current_language);
 	_path_changed(file_path->get_text());

--- a/editor/shader_create_dialog.h
+++ b/editor/shader_create_dialog.h
@@ -108,7 +108,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void config(const String &p_base_path, bool p_built_in_enabled = true, bool p_load_enabled = true);
+	void config(const String &p_base_path, bool p_built_in_enabled = true, bool p_load_enabled = true, int p_preferred_mode = -1);
 	ShaderCreateDialog();
 };
 


### PR DESCRIPTION
Follow-up to #51356

Previously, when creating a shader  the dialog would select whatever you had selected before. This is not always useful. With this PR, the dialog will automatically pick a shader type based on where you add this shader to:
- GPUParticles `process_material` = Particles shader
- CanvasItem = CanvasItem shader
- Node3D = Spatial shader
- Sky = Sky shader
- FogVolume = Fog shader