### PR TITLE
GDScript: Avoid inferred types from giving hard errors

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/features/auto_inferred_type_dont_error.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/auto_inferred_type_dont_error.gd
@@ -1,0 +1,9 @@
+func inferred_parameter(param = null):
+	if param == null:
+		param = Node.new()
+	param.name = "Ok"
+	print(param.name)
+	param.free()
+
+func test():
+	inferred_parameter()

--- a/modules/gdscript/tests/scripts/analyzer/features/auto_inferred_type_dont_error.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/auto_inferred_type_dont_error.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+Ok


### PR DESCRIPTION
Fix #49183
