### PR TITLE
ViewportContainer Optimization: UPDATE_ALWAYS to UPDATE_WHEN_VISIBLE for Viewport

### DIFF
--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -114,7 +114,7 @@ void ViewportContainer::_notification(int p_what) {
 			}
 
 			if (is_visible_in_tree()) {
-				c->set_update_mode(Viewport::UPDATE_ALWAYS);
+				c->set_update_mode(Viewport::UPDATE_WHEN_VISIBLE);
 			} else {
 				c->set_update_mode(Viewport::UPDATE_DISABLED);
 			}


### PR DESCRIPTION
Optimization: UPDATE_WHEN_VISIBLE instead of UPDATE_ALWAYS for Viewport on ViewportContainer visibility or enter tree event when visible in tree

fixe #52786

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
