### PR TITLE
GDScript: Properly catch error when missing index in subscript

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2592,6 +2592,10 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_subscript(ExpressionNode *
 	subscript->base = p_previous_operand;
 	subscript->index = parse_expression(false);
 
+	if (subscript->index == nullptr) {
+		push_error(R"(Expected expression after "[".)");
+	}
+
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::BRACKET_CLOSE, R"(Expected "]" after subscription index.)");
 

--- a/modules/gdscript/tests/scripts/parser/errors/subscript_without_index.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/subscript_without_index.gd
@@ -1,0 +1,3 @@
+func test():
+	var array = [1, 2, 3]
+	array[] = 4

--- a/modules/gdscript/tests/scripts/parser/errors/subscript_without_index.out
+++ b/modules/gdscript/tests/scripts/parser/errors/subscript_without_index.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected expression after "[".


### PR DESCRIPTION
Fix #52617