### PR TITLE
Initialize(again) variables in `core`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -244,9 +244,9 @@ bool ProjectSettings::_get(const StringName &p_name, Variant &r_ret) const {
 
 struct _VCSort {
 	String name;
-	Variant::Type type;
-	int order;
-	uint32_t flags;
+	Variant::Type type = Variant::Type::VARIANT_MAX;
+	int order = 0;
+	uint32_t flags = 0;
 
 	bool operator<(const _VCSort &p_vcs) const { return order == p_vcs.order ? name < p_vcs.name : order < p_vcs.order; }
 };

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -78,8 +78,8 @@ public:
 	};
 
 	struct JoyAxisValue {
-		int min;
-		float value;
+		int min = 0;
+		float value = 0.0;
 	};
 
 	typedef void (*EventDispatchFunc)(const Ref<InputEvent> &p_event);
@@ -99,12 +99,12 @@ private:
 	int64_t mouse_window = 0;
 
 	struct Action {
-		uint64_t physics_frame;
-		uint64_t process_frame;
-		bool pressed;
-		bool exact;
-		float strength;
-		float raw_strength;
+		uint64_t physics_frame = 0;
+		uint64_t process_frame = 0;
+		bool pressed = false;
+		bool exact = false;
+		float strength = 0.0;
+		float raw_strength = 0.0;
 	};
 
 	Map<StringName, Action> action_state;
@@ -117,12 +117,12 @@ private:
 	int mouse_from_touch_index = -1;
 
 	struct SpeedTrack {
-		uint64_t last_tick;
+		uint64_t last_tick = 0;
 		Vector2 speed;
 		Vector2 accum;
-		float accum_t;
-		float min_ref_frame;
-		float max_ref_frame;
+		float accum_t = 0.0;
+		float min_ref_frame = 0.0;
+		float max_ref_frame = 0.0;
 
 		void update(const Vector2 &p_delta_p);
 		void reset();
@@ -161,13 +161,13 @@ private:
 	};
 
 	struct JoyEvent {
-		int type;
-		int index;
-		float value;
+		int type = 0;
+		int index = 0;
+		float value = 0.0;
 	};
 
 	struct JoyBinding {
-		JoyType inputType;
+		JoyType inputType = JoyType::TYPE_AXIS;
 		union {
 			JoyButton button;
 
@@ -184,7 +184,7 @@ private:
 
 		} input;
 
-		JoyType outputType;
+		JoyType outputType = JoyType::TYPE_AXIS;
 		union {
 			JoyButton button;
 
@@ -229,10 +229,10 @@ private:
 
 protected:
 	struct VibrationInfo {
-		float weak_magnitude;
-		float strong_magnitude;
-		float duration; // Duration in seconds
-		uint64_t timestamp;
+		float weak_magnitude = 0.0;
+		float strong_magnitude = 0.0;
+		float duration = 0.0; // Duration in seconds
+		uint64_t timestamp = 0;
 	};
 
 	Map<int, VibrationInfo> joy_vibration;

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -46,8 +46,8 @@ public:
 	static int ALL_DEVICES;
 
 	struct Action {
-		int id;
-		float deadzone;
+		int id = 0;
+		float deadzone = 0.0;
 		List<Ref<InputEvent>> inputs;
 	};
 

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -46,8 +46,8 @@ class FileAccessCompressed : public FileAccess {
 	mutable bool at_end = false;
 
 	struct ReadBlock {
-		uint32_t csize;
-		uint64_t offset;
+		uint32_t csize = 0;
+		uint64_t offset = 0;
 	};
 
 	mutable Vector<uint8_t> comp_buffer;

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -40,9 +40,9 @@ class FileAccessNetwork;
 
 class FileAccessNetworkClient {
 	struct BlockRequest {
-		int32_t id;
-		uint64_t offset;
-		int32_t size;
+		int32_t id = 0;
+		uint64_t offset = 0;
+		int32_t size = 0;
 	};
 
 	List<BlockRequest> block_requests;
@@ -86,15 +86,15 @@ class FileAccessNetwork : public FileAccess {
 	Semaphore page_sem;
 	Mutex buffer_mutex;
 	bool opened = false;
-	uint64_t total_size;
+	uint64_t total_size = 0;
 	mutable uint64_t pos = 0;
-	int32_t id;
+	int32_t id = 0;
 	mutable bool eof_flag = false;
 	mutable int32_t last_page = -1;
 	mutable uint8_t *last_page_buff = nullptr;
 
-	int32_t page_size;
-	int32_t read_ahead;
+	int32_t page_size = 0;
+	int32_t read_ahead = 0;
 
 	mutable int waiting_on_page = -1;
 
@@ -106,9 +106,9 @@ class FileAccessNetwork : public FileAccess {
 
 	mutable Vector<Page> pages;
 
-	mutable Error response;
+	mutable Error response = OK;
 
-	uint64_t exists_modtime;
+	uint64_t exists_modtime = 0;
 	friend class FileAccessNetworkClient;
 	void _queue_page(int32_t p_page) const;
 	void _respond(uint64_t p_len, Error p_status);

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -61,11 +61,11 @@ class PackedData {
 public:
 	struct PackedFile {
 		String pack;
-		uint64_t offset; //if offset is ZERO, the file was ERASED
-		uint64_t size;
+		uint64_t offset = 0; //if offset is ZERO, the file was ERASED
+		uint64_t size = 0;
 		uint8_t md5[16];
-		PackSource *src;
-		bool encrypted;
+		PackSource *src = nullptr;
+		bool encrypted = false;
 	};
 
 private:
@@ -146,11 +146,11 @@ public:
 class FileAccessPack : public FileAccess {
 	PackedData::PackedFile pf;
 
-	mutable uint64_t pos;
-	mutable bool eof;
-	uint64_t off;
+	mutable uint64_t pos = 0;
+	mutable bool eof = false;
+	uint64_t off = 0;
 
-	FileAccess *f;
+	FileAccess *f = nullptr;
 	virtual Error _open(const String &p_path, int p_mode_flags);
 	virtual uint64_t _get_modified_time(const String &p_file) { return 0; }
 	virtual uint32_t _get_unix_permissions(const String &p_file) { return 0; }

--- a/core/io/ip_address.h
+++ b/core/io/ip_address.h
@@ -41,8 +41,8 @@ private:
 		uint32_t field32[4];
 	};
 
-	bool valid;
-	bool wildcard;
+	bool valid = false;
+	bool wildcard = false;
 
 protected:
 	void _parse_ipv6(const String &p_string);

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -79,7 +79,7 @@ public:
  */
 class RotatedFileLogger : public Logger {
 	String base_path;
-	int max_files;
+	int max_files = 0;
 
 	FileAccess *file = nullptr;
 

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -71,7 +71,7 @@ class ResourceLoaderBinary {
 
 	struct IntResource {
 		String path;
-		uint64_t offset;
+		uint64_t offset = 0;
 	};
 
 	Vector<IntResource> internal_resources;
@@ -122,12 +122,12 @@ class ResourceFormatSaverBinaryInstance {
 	String local_path;
 	String path;
 
-	bool relative_paths;
-	bool bundle_resources;
-	bool skip_editor;
-	bool big_endian;
-	bool takeover_paths;
-	FileAccess *f;
+	bool relative_paths = false;
+	bool bundle_resources = false;
+	bool skip_editor = false;
+	bool big_endian = false;
+	bool takeover_paths = false;
+	FileAccess *f = nullptr;
 	String magic;
 	Set<RES> resource_set;
 
@@ -145,7 +145,7 @@ class ResourceFormatSaverBinaryInstance {
 	List<RES> saved_resources;
 
 	struct Property {
-		int name_idx;
+		int name_idx = 0;
 		Variant value;
 		PropertyInfo pi;
 	};

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -668,26 +668,20 @@ private:
 		tree._extra[p_handle.id()].last_updated_tick = 0;
 	}
 
-	PairCallback pair_callback;
-	UnpairCallback unpair_callback;
-	void *pair_callback_userdata;
-	void *unpair_callback_userdata;
+	PairCallback pair_callback = nullptr;
+	UnpairCallback unpair_callback = nullptr;
+	void *pair_callback_userdata = nullptr;
+	void *unpair_callback_userdata = nullptr;
 
 	BVHTREE_CLASS tree;
 
 	// for collision pairing,
 	// maintain a list of all items moved etc on each frame / tick
 	LocalVector<BVHHandle, uint32_t, true> changed_items;
-	uint32_t _tick;
+	uint32_t _tick = 1; // start from 1 so items with 0 indicate never updated
 
 public:
-	BVH_Manager() {
-		_tick = 1; // start from 1 so items with 0 indicate never updated
-		pair_callback = nullptr;
-		unpair_callback = nullptr;
-		pair_callback_userdata = nullptr;
-		unpair_callback_userdata = nullptr;
-	}
+	BVH_Manager() {}
 };
 
 #undef BVHTREE_CLASS

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -37,9 +37,9 @@ struct BVH_ABB {
 	struct ConvexHull {
 		// convex hulls (optional)
 		const Plane *planes;
-		int num_planes;
+		int num_planes = 0;
 		const Vector3 *points;
-		int num_points;
+		int num_points = 0;
 	};
 
 	struct Segment {

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -90,7 +90,7 @@ struct BVHHandle {
 	operator uint32_t() const { return _data; }
 	void set(uint32_t p_value) { _data = p_value; }
 
-	uint32_t _data;
+	uint32_t _data = 0;
 
 	void set_invalid() { _data = BVHCommon::INVALID; }
 	bool is_invalid() const { return _data == BVHCommon::INVALID; }

--- a/core/math/delaunay_2d.h
+++ b/core/math/delaunay_2d.h
@@ -36,7 +36,7 @@
 class Delaunay2D {
 public:
 	struct Triangle {
-		int points[3];
+		int points[3] = {};
 		bool bad = false;
 		Triangle() {}
 		Triangle(int p_a, int p_b, int p_c) {
@@ -47,7 +47,7 @@ public:
 	};
 
 	struct Edge {
-		int edge[2];
+		int edge[2] = {};
 		bool bad = false;
 		Edge() {}
 		Edge(int p_a, int p_b) {

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -55,7 +55,7 @@ class Delaunay3D {
 	};
 
 	struct Simplex {
-		uint32_t points[4];
+		uint32_t points[4] = {};
 		R128 circum_center_x;
 		R128 circum_center_y;
 		R128 circum_center_z;

--- a/core/math/octree.h
+++ b/core/math/octree.h
@@ -73,7 +73,7 @@ private:
 				OctreeElementID A;
 				OctreeElementID B;
 			};
-			uint64_t key;
+			uint64_t key = 0;
 		};
 
 		_FORCE_INLINE_ bool operator<(const PairKey &p_pair) const {
@@ -144,10 +144,10 @@ private:
 	};
 
 	struct PairData {
-		int refcount;
-		bool intersect;
-		Element *A, *B;
-		void *ud;
+		int refcount = 0;
+		bool intersect = false;
+		Element *A = nullptr, *B = nullptr;
+		void *ud = nullptr;
 		typename List<PairData *, AL>::Element *eA, *eB;
 	};
 
@@ -156,18 +156,18 @@ private:
 	ElementMap element_map;
 	PairMap pair_map;
 
-	PairCallback pair_callback;
-	UnpairCallback unpair_callback;
-	void *pair_callback_userdata;
-	void *unpair_callback_userdata;
+	PairCallback pair_callback = nullptr;
+	UnpairCallback unpair_callback = nullptr;
+	void *pair_callback_userdata = nullptr;
+	void *unpair_callback_userdata = nullptr;
 
-	OctreeElementID last_element_id;
-	uint64_t pass;
+	OctreeElementID last_element_id = 1;
+	uint64_t pass = 1;
 
 	real_t unit_size;
-	Octant *root;
-	int octant_count;
-	int pair_count;
+	Octant *root = nullptr;
+	int octant_count = 0;
+	int pair_count = 0;
 
 	_FORCE_INLINE_ void _pair_check(PairData *p_pair) {
 		bool intersect = p_pair->A->aabb.intersects_inclusive(p_pair->B->aabb);
@@ -1275,18 +1275,7 @@ void Octree<T, use_pairs, AL>::set_unpair_callback(UnpairCallback p_callback, vo
 
 template <class T, bool use_pairs, class AL>
 Octree<T, use_pairs, AL>::Octree(real_t p_unit_size) {
-	last_element_id = 1;
-	pass = 1;
 	unit_size = p_unit_size;
-	root = nullptr;
-
-	octant_count = 0;
-	pair_count = 0;
-
-	pair_callback = nullptr;
-	unpair_callback = nullptr;
-	pair_callback_userdata = nullptr;
-	unpair_callback_userdata = nullptr;
 }
 
 #endif // OCTREE_H

--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -61,8 +61,8 @@ static int __bsr_clz32(uint32_t x) {
 
 class RandomPCG {
 	pcg32_random_t pcg;
-	uint64_t current_seed; // The seed the current generator state started from.
-	uint64_t current_inc;
+	uint64_t current_seed = 0; // The seed the current generator state started from.
+	uint64_t current_inc = 0;
 
 public:
 	static const uint64_t DEFAULT_SEED = 12047754176567800795U;

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -699,7 +699,4 @@ Vector<Face3> TriangleMesh::get_faces() const {
 	return faces;
 }
 
-TriangleMesh::TriangleMesh() {
-	valid = false;
-	max_depth = 0;
-}
+TriangleMesh::TriangleMesh() {}

--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -40,7 +40,7 @@ class TriangleMesh : public RefCounted {
 public:
 	struct Triangle {
 		Vector3 normal;
-		int indices[3];
+		int indices[3] = {};
 	};
 
 private:
@@ -50,10 +50,10 @@ private:
 	struct BVH {
 		AABB aabb;
 		Vector3 center; //used for sorting
-		int left;
-		int right;
+		int left = 0;
+		int right = 0;
 
-		int face_index;
+		int face_index = 0;
 	};
 
 	struct BVHCmpX {
@@ -76,8 +76,8 @@ private:
 	int _create_bvh(BVH *p_bvh, BVH **p_bb, int p_from, int p_size, int p_depth, int &max_depth, int &max_alloc);
 
 	Vector<BVH> bvh;
-	int max_depth;
-	bool valid;
+	int max_depth = 0;
+	bool valid = false;
 
 public:
 	bool is_valid() const;

--- a/core/multiplayer/multiplayer_api.h
+++ b/core/multiplayer/multiplayer_api.h
@@ -69,7 +69,7 @@ private:
 	//path sent caches
 	struct PathSentCache {
 		Map<int, bool> confirmed_peers;
-		int id;
+		int id = 0;
 	};
 
 	//path get caches
@@ -89,7 +89,7 @@ private:
 
 	HashMap<NodePath, PathSentCache> path_send_cache;
 	Map<int, PathGetCache> path_get_cache;
-	int last_send_cache_id;
+	int last_send_cache_id = 0;
 	Vector<uint8_t> packet_cache;
 
 	Node *root_node = nullptr;

--- a/core/object/callable_method_pointer.h
+++ b/core/object/callable_method_pointer.h
@@ -38,9 +38,9 @@
 #include "core/variant/callable.h"
 
 class CallableCustomMethodPointerBase : public CallableCustom {
-	uint32_t *comp_ptr;
-	uint32_t comp_size;
-	uint32_t h;
+	uint32_t *comp_ptr = nullptr;
+	uint32_t comp_size = 0;
+	uint32_t h = 0;
 #ifdef DEBUG_METHODS_ENABLED
 	const char *text = "";
 #endif

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -104,12 +104,12 @@ public:
 
 public:
 	struct PropertySetGet {
-		int index;
+		int index = 0;
 		StringName setter;
 		StringName getter;
-		MethodBind *_setptr;
-		MethodBind *_getptr;
-		Variant::Type type;
+		MethodBind *_setptr = nullptr;
+		MethodBind *_getptr = nullptr;
+		Variant::Type type = Variant::Type::VARIANT_MAX;
 	};
 
 	struct ClassInfo {

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -52,17 +52,17 @@ class MessageQueue {
 
 	struct Message {
 		Callable callable;
-		int16_t type;
+		int16_t type = 0;
 		union {
-			int16_t notification;
+			int16_t notification = 0;
 			int16_t args;
 		};
 	};
 
-	uint8_t *buffer;
+	uint8_t *buffer = nullptr;
 	uint32_t buffer_end = 0;
 	uint32_t buffer_max_used = 0;
-	uint32_t buffer_size;
+	uint32_t buffer_size = 0;
 
 	void _call_function(const Callable &p_callable, const Variant *p_args, int p_argcount, bool p_show_error);
 

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -52,7 +52,7 @@ VARIANT_ENUM_CAST(MethodFlags)
 // some helpers
 
 class MethodBind {
-	int method_id;
+	int method_id = 0;
 	uint32_t hint_flags = METHOD_FLAGS_DEFAULT;
 	StringName name;
 	StringName instance_class;

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -263,7 +263,7 @@ public:
 	struct Warning {
 		int start_line = -1, end_line = -1;
 		int leftmost_column = -1, rightmost_column = -1;
-		int code;
+		int code = 0;
 		String string_code;
 		String message;
 	};
@@ -306,12 +306,12 @@ public:
 			RESULT_CLASS_ENUM,
 			RESULT_CLASS_TBD_GLOBALSCOPE
 		};
-		Type type;
+		Type type = RESULT_CLASS;
 		Ref<Script> script;
 		String class_name;
 		String class_member;
 		String class_path;
-		int location;
+		int location = 0;
 	};
 
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) { return ERR_UNAVAILABLE; }
@@ -331,7 +331,7 @@ public:
 	struct StackInfo {
 		String file;
 		String func;
-		int line;
+		int line = 0;
 	};
 
 	virtual String debug_get_error() const = 0;
@@ -357,9 +357,9 @@ public:
 
 	struct ProfilingInfo {
 		StringName signature;
-		uint64_t call_count;
-		uint64_t total_time;
-		uint64_t self_time;
+		uint64_t call_count = 0;
+		uint64_t total_time = 0;
+		uint64_t self_time = 0;
 	};
 
 	virtual void profiling_start() = 0;

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -71,7 +71,7 @@ private:
 		String name;
 		List<Operation> do_ops;
 		List<Operation> undo_ops;
-		uint64_t last_tick;
+		uint64_t last_tick = 0;
 	};
 
 	Vector<Action> actions;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -55,13 +55,13 @@ class OS {
 	bool _single_window = false;
 	String _local_clipboard;
 	int _exit_code = EXIT_FAILURE; // unexpected exit is marked as failure
-	int _orientation;
+	int _orientation = 0;
 	bool _allow_hidpi = false;
 	bool _allow_layered = false;
 	bool _stdout_enabled = true;
 	bool _stderr_enabled = true;
 
-	char *last_error;
+	char *last_error = nullptr;
 
 	CompositeLogger *_logger = nullptr;
 
@@ -186,21 +186,21 @@ public:
 	};
 
 	struct Date {
-		int64_t year;
-		Month month;
-		uint8_t day;
-		Weekday weekday;
-		bool dst;
+		int64_t year = 0;
+		Month month = Month::MONTH_JANUARY;
+		uint8_t day = 0;
+		Weekday weekday = Weekday::WEEKDAY_MONDAY;
+		bool dst = false;
 	};
 
 	struct Time {
-		uint8_t hour;
-		uint8_t minute;
-		uint8_t second;
+		uint8_t hour = 0;
+		uint8_t minute = 0;
+		uint8_t second = 0;
 	};
 
 	struct TimeZoneInfo {
-		int bias;
+		int bias = 0;
 		String name;
 	};
 

--- a/core/os/pool_allocator.h
+++ b/core/os/pool_allocator.h
@@ -76,22 +76,22 @@ private:
 	typedef int EntryArrayPos;
 	typedef int EntryIndicesPos;
 
-	Entry *entry_array;
-	int *entry_indices;
-	int entry_max;
-	int entry_count;
+	Entry *entry_array = nullptr;
+	int *entry_indices = nullptr;
+	int entry_max = 0;
+	int entry_count = 0;
 
-	uint8_t *pool;
-	void *mem_ptr;
-	int pool_size;
+	uint8_t *pool = nullptr;
+	void *mem_ptr = nullptr;
+	int pool_size = 0;
 
-	int free_mem;
-	int free_mem_peak;
+	int free_mem = 0;
+	int free_mem_peak = 0;
 
-	unsigned int check_count;
-	int align;
+	unsigned int check_count = 0;
+	int align = 0;
 
-	bool needs_locking;
+	bool needs_locking = false;
 
 	inline int entry_end(const Entry &p_entry) const {
 		return p_entry.pos + aligned(p_entry.len);

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -40,8 +40,8 @@ class NodePath {
 		Vector<StringName> path;
 		Vector<StringName> subpath;
 		StringName concatenated_subpath;
-		bool absolute;
-		bool has_slashes;
+		bool absolute = false;
+		bool has_slashes = false;
 		mutable bool hash_cache_valid;
 		mutable uint32_t hash_cache;
 	};

--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -47,14 +47,14 @@ class OptimizedTranslation : public Translation {
 	Vector<uint8_t> strings;
 
 	struct Bucket {
-		int size;
-		uint32_t func;
+		int size = 0;
+		uint32_t func = 0;
 
 		struct Elem {
-			uint32_t key;
-			uint32_t str_offset;
-			uint32_t comp_size;
-			uint32_t uncomp_size;
+			uint32_t key = 0;
+			uint32_t str_offset = 0;
+			uint32_t comp_size = 0;
+			uint32_t uncomp_size = 0;
 		};
 
 		Elem elem[1];

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -71,7 +71,7 @@ class StringName {
 
 	union _HashUnion {
 		_Data *ptr;
-		uint32_t hash;
+		uint32_t hash = 0;
 	};
 
 	void unref();

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -303,7 +303,7 @@ public:
 	}
 
 	struct Iterator {
-		bool valid;
+		bool valid = false;
 
 		const TKey *key;
 		TValue *value;

--- a/core/templates/pooled_list.h
+++ b/core/templates/pooled_list.h
@@ -51,12 +51,10 @@ class PooledList {
 	LocalVector<uint32_t, uint32_t, true> freelist;
 
 	// not all list members are necessarily used
-	int _used_size;
+	int _used_size = 0;
 
 public:
-	PooledList() {
-		_used_size = 0;
-	}
+	PooledList() {}
 
 	int estimate_memory_use() const {
 		return (list.size() * sizeof(T)) + (freelist.size() * sizeof(uint32_t));

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -73,7 +73,7 @@ class RID_Alloc : public RID_AllocBase {
 	uint32_t **free_list_chunks = nullptr;
 	uint32_t **validator_chunks = nullptr;
 
-	uint32_t elements_in_chunk;
+	uint32_t elements_in_chunk = 0;
 	uint32_t max_alloc = 0;
 	uint32_t alloc_count = 0;
 

--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -38,7 +38,7 @@ class RingBuffer {
 	Vector<T> data;
 	int read_pos = 0;
 	int write_pos = 0;
-	int size_mask;
+	int size_mask = 0;
 
 	inline int inc(int &p_var, int p_size) const {
 		int ret = p_var;

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -264,7 +264,7 @@ public:
 
 class SafeFlag {
 protected:
-	bool flag;
+	bool flag = false;
 
 public:
 	_ALWAYS_INLINE_ bool is_set() const {

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -57,7 +57,7 @@ public:
 
 class CallableCustomUnbind : public CallableCustom {
 	Callable callable;
-	int argcount;
+	int argcount = 0;
 
 	static bool _equal_func(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool _less_func(const CallableCustom *p_a, const CallableCustom *p_b);

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -38,12 +38,13 @@ void AndroidInputHandler::process_joy_event(AndroidInputHandler::JoypadEvent p_e
 		case JOY_EVENT_BUTTON:
 			Input::get_singleton()->joy_button(p_event.device, (JoyButton)p_event.index, p_event.pressed);
 			break;
-		case JOY_EVENT_AXIS:
+		case JOY_EVENT_AXIS: {
 			Input::JoyAxisValue value;
 			value.min = -1;
 			value.value = p_event.value;
 			Input::get_singleton()->joy_axis(p_event.device, (JoyAxis)p_event.index, value);
 			break;
+		}
 		case JOY_EVENT_HAT:
 			Input::get_singleton()->joy_hat(p_event.device, (HatMask)p_event.hat);
 			break;


### PR DESCRIPTION
Another part of #43636

Now I'm using this regex to find unitialized variables
```
^[\t ]+(int|bool|char|float|double|real_t|uint32_t|uint64_t|uint8_t|uint16_t)[^=^,^(^)^<^>]+;
```
Also some variables are initialized in class body, even later value is set in constructor - I checked on https://godbolt.org/ that even with `-Og` flag, compiler optimize such code.

Valgrind reports now a lot of less problems, but still some uninitialised variables are used like:
```
==90267== Conditional jump or move depends on uninitialised value(s)
==90267==    at 0x6467BEA: exchange_if_greater (safe_refcount.h:111)
==90267==    by 0x6467BEA: Memory::alloc_static(unsigned long, bool) (memory.cpp:89)
==90267==    by 0x29F4C24: CowData<TextServer::Glyph>::_copy_on_write() (cowdata.h:239)
==90267==    by 0x29EE9DB: CowData<TextServer::Glyph>::ptrw() (cowdata.h:130)
==90267==    by 0x29E8B27: Vector<TextServer::Glyph>::ptrw() (vector.h:79)
==90267==    by 0x29E9111: void Vector<TextServer::Glyph>::sort_custom<TextServer::GlyphCompare>() (vector.h:106)
==90267==    by 0x29D9C81: TextServerAdvanced::shaped_text_sort_logical(RID) (text_server_adv.cpp:4519)
==90267==    by 0x5DD4D77: TextServer::shaped_text_get_line_breaks(RID, float, int, unsigned char) const (text_server.cpp:706)
==90267==    by 0x598D7B9: TextParagraph::_shape_lines() (text_paragraph.cpp:179)
==90267==    by 0x598EF3F: TextParagraph::get_line_count() const (text_paragraph.cpp:455)
==90267==    by 0x51267A0: TextEdit::Text::get_line_wrap_amount(int) const (text_edit.cpp:137)
==90267==    by 0x51270B0: TextEdit::Text::invalidate_cache(int, int, String const&, Vector<Vector2i> const&) (text_edit.cpp:221)
==90267==    by 0x5127823: TextEdit::Text::set(int, String const&, Vector<Vector2i> const&) (text_edit.cpp:293
```

Also Cppcheck shows now  smaller amount of them