### PR TITLE
Initialize(again) variables in `editor` 1

### DIFF
--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -192,9 +192,7 @@ PackedStringArray MIDIDriverALSAMidi::get_connected_inputs() {
 	return list;
 }
 
-MIDIDriverALSAMidi::MIDIDriverALSAMidi() {
-	exit_thread = false;
-}
+MIDIDriverALSAMidi::MIDIDriverALSAMidi() {}
 
 MIDIDriverALSAMidi::~MIDIDriverALSAMidi() {
 	close();

--- a/drivers/alsamidi/midi_driver_alsamidi.h
+++ b/drivers/alsamidi/midi_driver_alsamidi.h
@@ -47,7 +47,7 @@ class MIDIDriverALSAMidi : public MIDIDriver {
 
 	Vector<snd_rawmidi_t *> connected_inputs;
 
-	bool exit_thread;
+	bool exit_thread = false;
 
 	static void thread_func(void *p_udata);
 

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -476,9 +476,6 @@ bool DirAccessUnix::is_hidden(const String &p_name) {
 }
 
 DirAccessUnix::DirAccessUnix() {
-	dir_stream = nullptr;
-	_cisdir = false;
-
 	/* determine drive count */
 
 	// set current directory to an absolute path of the current directory

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -41,13 +41,13 @@
 #include <unistd.h>
 
 class DirAccessUnix : public DirAccess {
-	DIR *dir_stream;
+	DIR *dir_stream = nullptr;
 
 	static DirAccess *create_fs();
 
 	String current_dir;
-	bool _cisdir;
-	bool _cishidden;
+	bool _cisdir = false;
+	bool _cishidden = false;
 
 protected:
 	virtual String fix_unicode_name(const char *p_name) const { return String::utf8(p_name); }

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -362,11 +362,11 @@ class RenderingDeviceVulkan : public RenderingDevice {
 	struct Framebuffer {
 		FramebufferFormatID format_id = 0;
 		struct VersionKey {
-			InitialAction initial_color_action;
-			FinalAction final_color_action;
-			InitialAction initial_depth_action;
-			FinalAction final_depth_action;
-			uint32_t view_count;
+			InitialAction initial_color_action = INITIAL_ACTION_MAX;
+			FinalAction final_color_action = FINAL_ACTION_MAX;
+			InitialAction initial_depth_action = INITIAL_ACTION_MAX;
+			FinalAction final_depth_action = FINAL_ACTION_MAX;
+			uint32_t view_count = 0;
 
 			bool operator<(const VersionKey &p_key) const {
 				if (initial_color_action == p_key.initial_color_action) {
@@ -400,7 +400,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 		Map<VersionKey, Version> framebuffers;
 		Size2 size;
-		uint32_t view_count;
+		uint32_t view_count = 0;
 	};
 
 	RID_Owner<Framebuffer, true> framebuffer_owner;
@@ -699,7 +699,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 	struct DescriptorPool {
 		VkDescriptorPool pool;
-		uint32_t usage;
+		uint32_t usage = 0;
 	};
 
 	Map<DescriptorPoolKey, Set<DescriptorPool *>> descriptor_pools;
@@ -736,7 +736,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 		VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
 		//VkPipelineLayout pipeline_layout; //not owned, inherited from shader
 		struct AttachableTexture {
-			uint32_t bind;
+			uint32_t bind = 0;
 			RID texture;
 		};
 
@@ -878,7 +878,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 		struct Validation {
 			uint32_t vertex_array_size = 0;
 			uint32_t index_array_size = 0;
-			uint32_t index_array_offset;
+			uint32_t index_array_offset = 0;
 		} validation;
 #endif
 	};
@@ -931,7 +931,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 			uint32_t local_group_size[3] = { 0, 0, 0 };
 			VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
 			uint32_t pipeline_push_constant_stages = 0;
-			bool allow_draw_overlap;
+			bool allow_draw_overlap = false;
 		} state;
 
 #ifdef DEBUG_ENABLED

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -47,7 +47,7 @@
 class VulkanContext {
 public:
 	struct SubgroupCapabilities {
-		uint32_t size;
+		uint32_t size = 0;
 		VkShaderStageFlags supportedStages;
 		VkSubgroupFeatureFlags supportedOperations;
 		VkBool32 quadOperationsInAllStages;
@@ -59,11 +59,11 @@ public:
 	};
 
 	struct MultiviewCapabilities {
-		bool is_supported;
-		bool geometry_shader_is_supported;
-		bool tessellation_shader_is_supported;
-		uint32_t max_view_count;
-		uint32_t max_instance_count;
+		bool is_supported = false;
+		bool geometry_shader_is_supported = false;
+		bool tessellation_shader_is_supported = false;
+		uint32_t max_view_count = 0;
+		uint32_t max_instance_count = 0;
 	};
 
 private:

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -62,7 +62,7 @@ private:
 	Label *event_as_text;
 
 	// List of All Key/Mouse/Joypad input options.
-	int allowed_input_types;
+	int allowed_input_types = 0;
 	Tree *input_list_tree;
 	LineEdit *input_list_search;
 
@@ -156,7 +156,7 @@ private:
 
 	// Filtering and Adding actions
 
-	bool show_builtin_actions;
+	bool show_builtin_actions = false;
 	CheckButton *show_builtin_actions_checkbutton;
 	LineEdit *action_list_search;
 

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -61,7 +61,7 @@ class AnimationBezierTrackEdit : public Control {
 	float play_position_pos = 0;
 
 	Ref<Animation> animation;
-	int track;
+	int track = 0;
 
 	Vector<Rect2> view_rects;
 
@@ -90,7 +90,7 @@ class AnimationBezierTrackEdit : public Control {
 	bool moving_selection_attempt = false;
 	int select_single_attempt = -1;
 	bool moving_selection = false;
-	int moving_selection_from_key;
+	int moving_selection_from_key = 0;
 
 	Vector2 moving_selection_offset;
 
@@ -131,8 +131,8 @@ class AnimationBezierTrackEdit : public Control {
 	Set<int> selection;
 
 	bool panning_timeline = false;
-	float panning_timeline_from;
-	float panning_timeline_at;
+	float panning_timeline_from = 0.0;
+	float panning_timeline_at = 0.0;
 
 	void _draw_line_clipped(const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, int p_clip_left, int p_clip_right);
 	void _draw_track(int p_track, const Color &p_color);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1762,11 +1762,7 @@ void AnimationTimelineEdit::_bind_methods() {
 }
 
 AnimationTimelineEdit::AnimationTimelineEdit() {
-	use_fps = false;
-	editing = false;
 	name_limit = 150 * EDSCALE;
-	zoom = nullptr;
-	track_edit = nullptr;
 
 	play_position_pos = 0;
 	play_position = memnew(Control);
@@ -1810,10 +1806,6 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	add_track->hide();
 	add_track->get_popup()->connect("index_pressed", callable_mp(this, &AnimationTimelineEdit::_track_added));
 	len_hb->hide();
-
-	panning_timeline = false;
-	dragging_timeline = false;
-	dragging_hsize = false;
 
 	set_layout_direction(Control::LAYOUT_DIRECTION_LTR);
 }
@@ -2982,22 +2974,6 @@ void AnimationTrackEdit::_bind_methods() {
 }
 
 AnimationTrackEdit::AnimationTrackEdit() {
-	undo_redo = nullptr;
-	timeline = nullptr;
-	root = nullptr;
-	path = nullptr;
-	path_popup = nullptr;
-	menu = nullptr;
-	clicking_on_name = false;
-	dropping_at = 0;
-
-	in_group = false;
-
-	moving_selection_attempt = false;
-	moving_selection = false;
-	select_single_attempt = -1;
-
-	play_position_pos = 0;
 	play_position = memnew(Control);
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);
@@ -5767,8 +5743,6 @@ void AnimationTrackEditor::_pick_track_filter_input(const Ref<InputEvent> &p_ie)
 }
 
 AnimationTrackEditor::AnimationTrackEditor() {
-	root = nullptr;
-
 	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	main_panel = memnew(PanelContainer);
@@ -5950,11 +5924,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	add_child(method_selector);
 	method_selector->connect("selected", callable_mp(this, &AnimationTrackEditor::_add_method_key));
 
-	inserting = false;
-	insert_query = false;
-	insert_frame = 0;
-	insert_queue = false;
-
 	insert_confirm = memnew(ConfirmationDialog);
 	add_child(insert_confirm);
 	insert_confirm->connect("confirmed", callable_mp(this, &AnimationTrackEditor::_confirm_insert_list));
@@ -5972,10 +5941,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	insert_confirm_reset->set_text(TTR("Create RESET Track(s)", ""));
 	insert_confirm_reset->set_pressed(EDITOR_GET("editors/animation/default_create_reset_tracks"));
 	ichb->add_child(insert_confirm_reset);
-	keying = false;
-	moving_selection = false;
-	key_edit = nullptr;
-	multi_key_edit = nullptr;
 
 	box_selection = memnew(Control);
 	add_child(box_selection);
@@ -5983,7 +5948,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	box_selection->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	box_selection->hide();
 	box_selection->connect("draw", callable_mp(this, &AnimationTrackEditor::_box_selection_draw));
-	box_selecting = false;
 
 	//default plugins
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -55,18 +55,18 @@ class AnimationTimelineEdit : public Range {
 	GDCLASS(AnimationTimelineEdit, Range);
 
 	Ref<Animation> animation;
-	AnimationTrackEdit *track_edit;
-	int name_limit;
-	Range *zoom;
+	AnimationTrackEdit *track_edit = nullptr;
+	int name_limit = 0;
+	Range *zoom = nullptr;
 	Range *h_scroll;
-	float play_position_pos;
+	float play_position_pos = 0.0;
 
 	HBoxContainer *len_hb;
 	EditorSpinSlider *length;
 	Button *loop;
 	TextureRect *time_icon;
 
-	MenuButton *add_track;
+	MenuButton *add_track = nullptr;
 	Control *play_position; //separate control used to draw so updates for only position changed are much faster
 	HScrollBar *hscroll;
 
@@ -78,16 +78,16 @@ class AnimationTimelineEdit : public Range {
 	UndoRedo *undo_redo;
 	Rect2 hsize_rect;
 
-	bool editing;
-	bool use_fps;
+	bool editing = false;
+	bool use_fps = false;
 
-	bool panning_timeline;
-	float panning_timeline_from;
-	float panning_timeline_at;
-	bool dragging_timeline;
-	bool dragging_hsize;
-	float dragging_hsize_from;
-	float dragging_hsize_at;
+	bool panning_timeline = false;
+	float panning_timeline_from = 0.0;
+	float panning_timeline_at = 0.0;
+	bool dragging_timeline = false;
+	bool dragging_hsize = false;
+	float dragging_hsize_from = 0.0;
+	float dragging_hsize_at = 0.0;
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _track_added(int p_track);
@@ -142,17 +142,17 @@ class AnimationTrackEdit : public Control {
 		MENU_KEY_DUPLICATE,
 		MENU_KEY_DELETE
 	};
-	AnimationTimelineEdit *timeline;
-	UndoRedo *undo_redo;
-	Popup *path_popup;
-	LineEdit *path;
-	Node *root;
-	Control *play_position; //separate control used to draw so updates for only position changed are much faster
-	float play_position_pos;
+	AnimationTimelineEdit *timeline = nullptr;
+	UndoRedo *undo_redo = nullptr;
+	Popup *path_popup = nullptr;
+	LineEdit *path = nullptr;
+	Node *root = nullptr;
+	Control *play_position = nullptr; //separate control used to draw so updates for only position changed are much faster
+	float play_position_pos = 0.0;
 	NodePath node_path;
 
 	Ref<Animation> animation;
-	int track;
+	int track = 0;
 
 	Rect2 check_rect;
 	Rect2 path_rect;
@@ -166,9 +166,9 @@ class AnimationTrackEdit : public Control {
 	Ref<Texture2D> type_icon;
 	Ref<Texture2D> selected_icon;
 
-	PopupMenu *menu;
+	PopupMenu *menu = nullptr;
 
-	bool clicking_on_name;
+	bool clicking_on_name = false;
 
 	void _zoom_changed();
 
@@ -181,15 +181,15 @@ class AnimationTrackEdit : public Control {
 	void _play_position_draw();
 	bool _is_value_key_valid(const Variant &p_key_value, Variant::Type &r_valid_type) const;
 
-	mutable int dropping_at;
-	float insert_at_pos;
-	bool moving_selection_attempt;
-	int select_single_attempt;
-	bool moving_selection;
-	float moving_selection_from_ofs;
+	mutable int dropping_at = 0;
+	float insert_at_pos = 0.0;
+	bool moving_selection_attempt = false;
+	int select_single_attempt = -1;
+	bool moving_selection = false;
+	float moving_selection_from_ofs = 0.0;
 
-	bool in_group;
-	AnimationTrackEditor *editor;
+	bool in_group = false;
+	AnimationTrackEditor *editor = nullptr;
 
 protected:
 	static void _bind_methods();
@@ -280,33 +280,33 @@ class AnimationTrackEditor : public VBoxContainer {
 	GDCLASS(AnimationTrackEditor, VBoxContainer);
 
 	Ref<Animation> animation;
-	Node *root;
+	Node *root = nullptr;
 
-	MenuButton *edit;
+	MenuButton *edit = nullptr;
 
-	PanelContainer *main_panel;
-	HScrollBar *hscroll;
-	ScrollContainer *scroll;
-	VBoxContainer *track_vbox;
-	AnimationBezierTrackEdit *bezier_edit;
+	PanelContainer *main_panel = nullptr;
+	HScrollBar *hscroll = nullptr;
+	ScrollContainer *scroll = nullptr;
+	VBoxContainer *track_vbox = nullptr;
+	AnimationBezierTrackEdit *bezier_edit = nullptr;
 
-	Label *info_message;
+	Label *info_message = nullptr;
 
-	AnimationTimelineEdit *timeline;
-	HSlider *zoom;
-	EditorSpinSlider *step;
-	TextureRect *zoom_icon;
-	Button *snap;
-	OptionButton *snap_mode;
+	AnimationTimelineEdit *timeline = nullptr;
+	HSlider *zoom = nullptr;
+	EditorSpinSlider *step = nullptr;
+	TextureRect *zoom_icon = nullptr;
+	Button *snap = nullptr;
+	OptionButton *snap_mode = nullptr;
 
-	Button *imported_anim_warning;
+	Button *imported_anim_warning = nullptr;
 	void _show_imported_anim_warning();
 
 	void _snap_mode_changed(int p_mode);
 	Vector<AnimationTrackEdit *> track_edits;
 	Vector<AnimationTrackEditGroup *> groups;
 
-	bool animation_changing_awaiting_update;
+	bool animation_changing_awaiting_update = 0;
 	void _animation_update();
 	int _get_track_selected();
 	void _animation_changed();
@@ -333,10 +333,10 @@ class AnimationTrackEditor : public VBoxContainer {
 	PropertySelector *prop_selector;
 	PropertySelector *method_selector;
 	SceneTreeDialog *pick_track;
-	int adding_track_type;
+	int adding_track_type = 0;
 	NodePath adding_track_path;
 
-	bool keying;
+	bool keying = false;
 
 	struct InsertData {
 		Animation::TrackType type;
@@ -351,18 +351,18 @@ class AnimationTrackEditor : public VBoxContainer {
 	CheckBox *insert_confirm_bezier;
 	CheckBox *insert_confirm_reset;
 	ConfirmationDialog *insert_confirm;
-	bool insert_queue;
-	bool inserting;
-	bool insert_query;
+	bool insert_queue = false;
+	bool inserting = false;
+	bool insert_query = false;
 	List<InsertData> insert_data;
-	uint64_t insert_frame;
+	uint64_t insert_frame = 0;
 
 	void _query_insert(const InsertData &p_id);
 	Ref<Animation> _create_and_get_reset_animation();
 	void _confirm_insert_list();
 	struct TrackIndices {
-		int normal;
-		int reset;
+		int normal = 0;
+		int reset = 0;
 
 		TrackIndices(const Animation *p_anim = nullptr, const Animation *p_reset_anim = nullptr) {
 			normal = p_anim ? p_anim->get_track_count() : 0;
@@ -378,8 +378,8 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _timeline_value_changed(double);
 
-	float insert_key_from_track_call_ofs;
-	int insert_key_from_track_call_track;
+	float insert_key_from_track_call_ofs = 0.0;
+	int insert_key_from_track_call_track = 0;
 	void _insert_key_from_track(float p_ofs, int p_track);
 	void _add_method_key(const String &p_method);
 
@@ -404,22 +404,22 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _key_selected(int p_key, bool p_single, int p_track);
 	void _key_deselected(int p_key, int p_track);
 
-	bool moving_selection;
-	float moving_selection_offset;
+	bool moving_selection = false;
+	float moving_selection_offset = 0.0;
 	void _move_selection_begin();
 	void _move_selection(float p_offset);
 	void _move_selection_commit();
 	void _move_selection_cancel();
 
-	AnimationTrackKeyEdit *key_edit;
-	AnimationMultiTrackKeyEdit *multi_key_edit;
+	AnimationTrackKeyEdit *key_edit = nullptr;
+	AnimationMultiTrackKeyEdit *multi_key_edit = nullptr;
 	void _update_key_edit();
 
 	void _clear_key_edit();
 
 	Control *box_selection;
 	void _box_selection_draw();
-	bool box_selecting;
+	bool box_selecting = false;
 	Vector2 box_selecting_from;
 	Rect2 box_select_rect;
 	void _scroll_input(const Ref<InputEvent> &p_event);
@@ -431,24 +431,24 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	////////////// edit menu stuff
 
-	ConfirmationDialog *optimize_dialog;
-	SpinBox *optimize_linear_error;
-	SpinBox *optimize_angular_error;
-	SpinBox *optimize_max_angle;
+	ConfirmationDialog *optimize_dialog = nullptr;
+	SpinBox *optimize_linear_error = nullptr;
+	SpinBox *optimize_angular_error = nullptr;
+	SpinBox *optimize_max_angle = nullptr;
 
-	ConfirmationDialog *cleanup_dialog;
-	CheckBox *cleanup_keys;
-	CheckBox *cleanup_tracks;
-	CheckBox *cleanup_all;
+	ConfirmationDialog *cleanup_dialog = nullptr;
+	CheckBox *cleanup_keys = nullptr;
+	CheckBox *cleanup_tracks = nullptr;
+	CheckBox *cleanup_all = nullptr;
 
-	ConfirmationDialog *scale_dialog;
-	SpinBox *scale;
+	ConfirmationDialog *scale_dialog = nullptr;
+	SpinBox *scale = nullptr;
 
 	void _select_all_tracks_for_copy();
 
 	void _edit_menu_about_to_popup();
 	void _edit_menu_pressed(int p_option);
-	int last_menu_track_opt;
+	int last_menu_track_opt = 0;
 
 	void _cleanup_animation(Ref<Animation> p_animation);
 

--- a/editor/array_property_edit.cpp
+++ b/editor/array_property_edit.cpp
@@ -286,7 +286,6 @@ void ArrayPropertyEdit::_bind_methods() {
 }
 
 ArrayPropertyEdit::ArrayPropertyEdit() {
-	page = 0;
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 		if (i > 0) {
 			vtypes += ",";

--- a/editor/array_property_edit.h
+++ b/editor/array_property_edit.h
@@ -36,7 +36,7 @@
 class ArrayPropertyEdit : public RefCounted {
 	GDCLASS(ArrayPropertyEdit, RefCounted);
 
-	int page;
+	int page = 0;
 	ObjectID obj;
 	StringName property;
 	String vtypes;

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -90,9 +90,7 @@ float AudioStreamPreview::get_min(float p_time, float p_time_next) const {
 	return (vmin / 255.0) * 2.0 - 1.0;
 }
 
-AudioStreamPreview::AudioStreamPreview() {
-	length = 0;
-}
+AudioStreamPreview::AudioStreamPreview() {}
 
 ////
 

--- a/editor/audio_stream_preview.h
+++ b/editor/audio_stream_preview.h
@@ -40,7 +40,7 @@ class AudioStreamPreview : public RefCounted {
 	GDCLASS(AudioStreamPreview, RefCounted);
 	friend class AudioStream;
 	Vector<uint8_t> preview;
-	float length;
+	float length = 0.0;
 
 	friend class AudioStreamPreviewGenerator;
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -618,10 +618,6 @@ void FindReplaceBar::_bind_methods() {
 }
 
 FindReplaceBar::FindReplaceBar() {
-	results_count = -1;
-	replace_all_mode = false;
-	preserve_cursor = false;
-
 	vbc_lineedit = memnew(VBoxContainer);
 	add_child(vbc_lineedit);
 	vbc_lineedit->set_alignment(ALIGN_CENTER);
@@ -1794,7 +1790,6 @@ void CodeTextEditor::update_toggle_scripts_button() {
 }
 
 CodeTextEditor::CodeTextEditor() {
-	code_complete_func = nullptr;
 	ED_SHORTCUT("script_editor/zoom_in", TTR("Zoom In"), KEY_MASK_CMD | KEY_EQUAL);
 	ED_SHORTCUT("script_editor/zoom_out", TTR("Zoom Out"), KEY_MASK_CMD | KEY_MINUS);
 	ED_SHORTCUT("script_editor/reset_zoom", TTR("Reset Zoom"), KEY_MASK_CMD | KEY_0);
@@ -1847,9 +1842,6 @@ CodeTextEditor::CodeTextEditor() {
 	code_complete_timer->set_one_shot(true);
 	code_complete_timer->set_wait_time(EDITOR_GET("text_editor/completion/code_complete_delay"));
 
-	error_line = 0;
-	error_column = 0;
-
 	toggle_scripts_button = memnew(Button);
 	toggle_scripts_button->set_flat(true);
 	toggle_scripts_button->connect("pressed", callable_mp(this, &CodeTextEditor::_toggle_scripts_pressed));
@@ -1882,7 +1874,6 @@ CodeTextEditor::CodeTextEditor() {
 	error_button->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
 	error_button->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 
-	is_errors_panel_opened = false;
 	set_error_count(0);
 
 	// Warnings
@@ -1898,7 +1889,6 @@ CodeTextEditor::CodeTextEditor() {
 	warning_button->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
 	warning_button->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 
-	is_warnings_panel_opened = false;
 	set_warning_count(0);
 
 	// Line and column

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -82,12 +82,12 @@ class FindReplaceBar : public HBoxContainer {
 	CodeTextEditor *base_text_editor = nullptr;
 	CodeEdit *text_editor;
 
-	int result_line;
-	int result_col;
-	int results_count;
+	int result_line = 0;
+	int result_col = 0;
+	int results_count = -1;
 
-	bool replace_all_mode;
-	bool preserve_cursor;
+	bool replace_all_mode = false;
+	bool preserve_cursor = false;
 
 	void _get_search_from(int &r_line, int &r_col);
 	void _update_results_count();
@@ -155,12 +155,12 @@ class CodeTextEditor : public VBoxContainer {
 	Timer *code_complete_timer;
 
 	Timer *font_resize_timer;
-	int font_resize_val;
-	real_t font_size;
+	int font_resize_val = 0;
+	real_t font_size = 0.0;
 
 	Label *error;
-	int error_line;
-	int error_column;
+	int error_line = 0;
+	int error_column = 0;
 
 	bool settings_changed = false;
 
@@ -183,7 +183,7 @@ class CodeTextEditor : public VBoxContainer {
 	Color completion_font_color;
 	Color completion_string_color;
 	Color completion_comment_color;
-	CodeTextEditorCodeCompleteFunc code_complete_func;
+	CodeTextEditorCodeCompleteFunc code_complete_func = nullptr;
 	void *code_complete_ud;
 
 	void _error_button_pressed();
@@ -207,8 +207,8 @@ protected:
 	void _notification(int);
 	static void _bind_methods();
 
-	bool is_warnings_panel_opened;
-	bool is_errors_panel_opened;
+	bool is_warnings_panel_opened = false;
+	bool is_errors_panel_opened = false;
 
 public:
 	void trim_trailing_whitespace();

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -88,7 +88,7 @@ private:
 	StringName signal;
 	LineEdit *dst_method;
 	ConnectDialogBinds *cdbinds;
-	bool bEditMode;
+	bool bEditMode = false;
 	NodePath dst_path;
 	VBoxContainer *vbc_right;
 

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -111,9 +111,9 @@ private:
 	String _current_request;
 	Ref<DAPeer> _current_peer;
 
-	int breakpoint_id;
-	int stackframe_id;
-	int variable_id;
+	int breakpoint_id = 0;
+	int stackframe_id = 0;
+	int variable_id = 0;
 	List<DAP::Breakpoint> breakpoint_list;
 	Map<DAP::StackFrame, List<int>> stackframe_list;
 	Map<int, Array> variable_list;

--- a/editor/debugger/debug_adapter/debug_adapter_types.h
+++ b/editor/debugger/debug_adapter/debug_adapter_types.h
@@ -100,10 +100,10 @@ public:
 };
 
 struct Breakpoint {
-	int id;
-	bool verified;
+	int id = 0;
+	bool verified = false;
 	Source source;
-	int line;
+	int line = 0;
 
 	bool operator==(const Breakpoint &p_other) const {
 		return source.path == p_other.source.path && line == p_other.line;
@@ -121,7 +121,7 @@ struct Breakpoint {
 };
 
 struct BreakpointLocation {
-	int line;
+	int line = 0;
 	int endLine = -1;
 
 	_FORCE_INLINE_ Dictionary to_json() const {
@@ -169,10 +169,10 @@ struct Capabilities {
 };
 
 struct Message {
-	int id;
+	int id = 0;
 	String format;
 	bool sendTelemetry = false; // Just in case :)
-	bool showUser;
+	bool showUser = false;
 	Dictionary variables;
 
 	_FORCE_INLINE_ Dictionary to_json() const {
@@ -190,8 +190,8 @@ struct Message {
 struct Scope {
 	String name;
 	String presentationHint;
-	int variablesReference;
-	bool expensive;
+	int variablesReference = 0;
+	bool expensive = false;
 
 	_FORCE_INLINE_ Dictionary to_json() const {
 		Dictionary dict;
@@ -205,7 +205,7 @@ struct Scope {
 };
 
 struct SourceBreakpoint {
-	int line;
+	int line = 0;
 
 	_FORCE_INLINE_ void from_json(const Dictionary &p_params) {
 		line = p_params["line"];
@@ -213,11 +213,11 @@ struct SourceBreakpoint {
 };
 
 struct StackFrame {
-	int id;
+	int id = 0;
 	String name;
 	Source source;
-	int line;
-	int column;
+	int line = 0;
+	int column = 0;
 
 	bool operator<(const StackFrame &p_other) const {
 		return id < p_other.id;
@@ -244,7 +244,7 @@ struct StackFrame {
 };
 
 struct Thread {
-	int id;
+	int id = 0;
 	String name;
 
 	_FORCE_INLINE_ Dictionary to_json() const {

--- a/editor/debugger/editor_performance_profiler.h
+++ b/editor/debugger/editor_performance_profiler.h
@@ -66,7 +66,7 @@ private:
 	Control *monitor_draw;
 	Label *info_message;
 	StringName marker_key;
-	int marker_frame;
+	int marker_frame = 0;
 	const int MARGIN = 4;
 	const int POINT_SEPARATION = 5;
 	const int MARKER_MARGIN = 2;

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -656,9 +656,6 @@ EditorProfiler::EditorProfiler() {
 
 	int metric_size = CLAMP(int(EDITOR_DEF("debugger/profiler_frame_history_size", 600)), 60, 1024);
 	frame_metrics.resize(metric_size);
-	total_metrics = 0;
-	last_metric = -1;
-	hover_metric = -1;
 
 	EDITOR_DEF("debugger/profiler_frame_max_functions", 64);
 
@@ -676,7 +673,4 @@ EditorProfiler::EditorProfiler() {
 
 	plot_sigs.insert("physics_frame_time");
 	plot_sigs.insert("category_frame_time");
-
-	seeking = false;
-	graph_height = 1;
 }

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -106,18 +106,18 @@ private:
 	SpinBox *cursor_metric_edit;
 
 	Vector<Metric> frame_metrics;
-	int total_metrics;
-	int last_metric;
+	int total_metrics = 0;
+	int last_metric = -1;
 
-	int max_functions;
+	int max_functions = 0;
 
-	bool updating_frame;
+	bool updating_frame = false;
 
-	int hover_metric;
+	int hover_metric = -1;
 
-	float graph_height;
+	float graph_height = 1.0;
 
-	bool seeking;
+	bool seeking = false;
 
 	Timer *frame_delay;
 	Timer *plot_delay;

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -798,9 +798,6 @@ EditorVisualProfiler::EditorVisualProfiler() {
 
 	int metric_size = CLAMP(int(EDITOR_DEF("debugger/profiler_frame_history_size", 600)), 60, 1024);
 	frame_metrics.resize(metric_size);
-	last_metric = -1;
-	//cursor_metric=-1;
-	hover_metric = -1;
 
 	//display_mode=DISPLAY_FRAME_TIME;
 
@@ -815,12 +812,6 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	plot_delay->set_one_shot(true);
 	add_child(plot_delay);
 	plot_delay->connect("timeout", callable_mp(this, &EditorVisualProfiler::_update_plot));
-
-	seeking = false;
-	graph_height_cpu = 1;
-	graph_height_gpu = 1;
-
-	graph_limit = 1000 / 60.0;
 
 	//activate->set_disabled(true);
 }

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -83,21 +83,21 @@ private:
 	SpinBox *cursor_metric_edit;
 
 	Vector<Metric> frame_metrics;
-	int last_metric;
+	int last_metric = -1;
 
 	StringName selected_area;
 
 	bool updating_frame;
 
-	//int cursor_metric;
-	int hover_metric;
+	//int cursor_metric = -1;
+	int hover_metric = -1;
 
-	float graph_height_cpu;
-	float graph_height_gpu;
+	float graph_height_cpu = 1;
+	float graph_height_gpu = 1;
 
-	float graph_limit;
+	float graph_limit = 1000 / 60.0;
 
-	bool seeking;
+	bool seeking = false;
 
 	Timer *frame_delay;
 	Timer *plot_delay;

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1836,11 +1836,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	msgdialog = memnew(AcceptDialog);
 	add_child(msgdialog);
 
-	live_debug = true;
-	camera_override = CameraOverride::OVERRIDE_NONE;
-	last_path_id = false;
-	error_count = 0;
-	warning_count = 0;
 	_update_buttons_state();
 }
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -104,8 +104,8 @@ private:
 	};
 	FileDialogPurpose file_dialog_purpose;
 
-	int error_count;
-	int warning_count;
+	int error_count = 0;
+	int warning_count = 0;
 
 	bool skip_breakpoints_value = false;
 	Ref<Script> stack_script;
@@ -138,7 +138,7 @@ private:
 	Ref<RemoteDebuggerPeer> peer;
 
 	HashMap<NodePath, int> node_path_cache;
-	int last_path_id;
+	int last_path_id = false;
 	Map<String, int> res_path_cache;
 
 	EditorProfiler *profiler;
@@ -153,9 +153,9 @@ private:
 	bool can_debug = false;
 	bool move_to_foreground = true;
 
-	bool live_debug;
+	bool live_debug = true;
 
-	EditorDebuggerNode::CameraOverride camera_override;
+	EditorDebuggerNode::CameraOverride camera_override = EditorDebuggerNode::CameraOverride::OVERRIDE_NONE;
 
 	Map<Ref<Script>, EditorDebuggerPlugin *> debugger_plugins;
 

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -400,7 +400,5 @@ EditorAssetInstaller::EditorAssetInstaller() {
 	get_ok_button()->set_text(TTR("Install"));
 	set_title(TTR("Asset Installer"));
 
-	updating = false;
-
 	set_hide_on_ok(true);
 }

--- a/editor/editor_asset_installer.h
+++ b/editor/editor_asset_installer.h
@@ -42,7 +42,7 @@ class EditorAssetInstaller : public ConfirmationDialog {
 	String asset_name;
 	AcceptDialog *error;
 	Map<String, TreeItem *> status_map;
-	bool updating;
+	bool updating = false;
 	void _update_subitems(TreeItem *p_item, bool p_check, bool p_first = false);
 	void _uncheck_parent(TreeItem *p_item);
 	void _item_edited();

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -758,9 +758,7 @@ void EditorAudioBus::_bind_methods() {
 
 EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	buses = p_buses;
-	updating_bus = false;
 	is_master = p_is_master;
-	hovering_drop = false;
 
 	set_tooltip(TTR("Drag & drop to rearrange."));
 

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -57,7 +57,7 @@ class EditorAudioBus : public PanelContainer {
 	MenuButton *bus_options;
 	VSlider *slider;
 
-	int cc;
+	int cc = 0;
 	static const int CHANNELS_MAX = 4;
 
 	struct {
@@ -86,9 +86,9 @@ class EditorAudioBus : public PanelContainer {
 
 	Tree *effects;
 
-	bool updating_bus;
-	bool is_master;
-	mutable bool hovering_drop;
+	bool updating_bus = false;
+	bool is_master = false;
+	mutable bool hovering_drop = false;
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _effects_gui_input(Ref<InputEvent> p_event);

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -830,7 +830,6 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	autoload_changed = "autoload_changed";
 
-	updating_autoload = false;
 	selected_autoload = "";
 
 	HBoxContainer *hbc = memnew(HBoxContainer);

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -62,8 +62,8 @@ class EditorAutoloadSettings : public VBoxContainer {
 
 	List<AutoLoadInfo> autoload_cache;
 
-	bool updating_autoload;
-	int number_of_autoloads;
+	bool updating_autoload = false;
+	int number_of_autoloads = 0;
 	String selected_autoload;
 
 	Tree *tree;

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -257,9 +257,7 @@ void EditorHistory::clear() {
 	current = -1;
 }
 
-EditorHistory::EditorHistory() {
-	current = -1;
-}
+EditorHistory::EditorHistory() {}
 
 EditorPlugin *EditorData::get_editor(Object *p_object) {
 	// We need to iterate backwards so that we can check user-created plugins first.
@@ -1022,8 +1020,6 @@ void EditorData::script_class_load_icon_paths() {
 }
 
 EditorData::EditorData() {
-	current_edited_scene = -1;
-
 	//load_imported_scenes_from_globals();
 	script_class_load_icon_paths();
 }
@@ -1195,11 +1191,7 @@ void EditorSelection::clear() {
 	nl_changed = true;
 }
 
-EditorSelection::EditorSelection() {
-	emitted = false;
-	changed = false;
-	nl_changed = false;
-}
+EditorSelection::EditorSelection() {}
 
 EditorSelection::~EditorSelection() {
 	clear();

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -57,7 +57,7 @@ class EditorHistory {
 	friend class EditorData;
 
 	Vector<History> history;
-	int current;
+	int current = -1;
 
 	//Vector<EditorPlugin*> editor_plugins;
 
@@ -138,7 +138,7 @@ private:
 	void _cleanup_history();
 
 	Vector<EditedScene> edited_scene;
-	int current_edited_scene;
+	int current_edited_scene = -1;
 
 	bool _find_updated_instances(Node *p_root, Node *p_node, Set<String> &checked_paths);
 
@@ -241,9 +241,9 @@ class EditorSelection : public Object {
 private:
 	Map<Node *, Object *> selection;
 
-	bool emitted;
-	bool changed;
-	bool nl_changed;
+	bool emitted = false;
+	bool changed = false;
+	bool nl_changed = false;
 
 	void _node_removed(Node *p_node);
 

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -172,8 +172,6 @@ void EditorDirDialog::_bind_methods() {
 }
 
 EditorDirDialog::EditorDirDialog() {
-	updating = false;
-
 	set_title(TTR("Choose a Directory"));
 	set_hide_on_ok(false);
 
@@ -203,6 +201,4 @@ EditorDirDialog::EditorDirDialog() {
 	add_child(mkdirerr);
 
 	get_ok_button()->set_text(TTR("Choose"));
-
-	must_reload = false;
 }

--- a/editor/editor_dir_dialog.h
+++ b/editor/editor_dir_dialog.h
@@ -47,7 +47,7 @@ class EditorDirDialog : public ConfirmationDialog {
 	Set<String> opened_paths;
 
 	Tree *tree;
-	bool updating;
+	bool updating = false;
 
 	void _item_collapsed(Object *p_item);
 	void _item_activated();
@@ -58,7 +58,7 @@ class EditorDirDialog : public ConfirmationDialog {
 
 	void ok_pressed() override;
 
-	bool must_reload;
+	bool must_reload = false;
 
 protected:
 	void _notification(int p_what);

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -663,9 +663,7 @@ void EditorExportPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_export_end);
 }
 
-EditorExportPlugin::EditorExportPlugin() {
-	skipped = false;
-}
+EditorExportPlugin::EditorExportPlugin() {}
 
 EditorExportPlatform::FeatureContainers EditorExportPlatform::get_feature_containers(const Ref<EditorExportPreset> &p_preset) {
 	Ref<EditorExportPlatform> platform = p_preset->get_platform();
@@ -1723,7 +1721,6 @@ EditorExport::EditorExport() {
 	save_timer->set_wait_time(0.8);
 	save_timer->set_one_shot(true);
 	save_timer->connect("timeout", callable_mp(this, &EditorExport::_save));
-	block_save = false;
 
 	_export_presets_updated = "export_presets_updated";
 
@@ -1975,10 +1972,7 @@ void EditorExportPlatformPC::set_fixup_embedded_pck_func(FixUpEmbeddedPckFunc p_
 	fixup_embedded_pck_func = p_fixup_embedded_pck_func;
 }
 
-EditorExportPlatformPC::EditorExportPlatformPC() {
-	chmod_flags = -1;
-	fixup_embedded_pck_func = nullptr;
-}
+EditorExportPlatformPC::EditorExportPlatformPC() {}
 
 ///////////////////////
 

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -298,7 +298,7 @@ class EditorExportPlugin : public RefCounted {
 		bool remap = false;
 	};
 	Vector<ExtraFile> extra_files;
-	bool skipped;
+	bool skipped = false;
 
 	Vector<String> ios_frameworks;
 	Vector<String> ios_embedded_frameworks;
@@ -375,7 +375,7 @@ class EditorExport : public Node {
 	StringName _export_presets_updated;
 
 	Timer *save_timer;
-	bool block_save;
+	bool block_save = false;
 
 	static EditorExport *singleton;
 
@@ -429,9 +429,9 @@ private:
 	String debug_file_32;
 	String debug_file_64;
 
-	int chmod_flags;
+	int chmod_flags = -1;
 
-	FixUpEmbeddedPckFunc fixup_embedded_pck_func;
+	FixUpEmbeddedPckFunc fixup_embedded_pck_func = nullptr;
 
 public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) override;

--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -63,7 +63,7 @@ private:
 
 	Set<StringName> collapsed_classes;
 
-	bool features_disabled[FEATURE_MAX];
+	bool features_disabled[FEATURE_MAX] = {};
 	static const char *feature_names[FEATURE_MAX];
 	static const char *feature_descriptions[FEATURE_MAX];
 	static const char *feature_identifiers[FEATURE_MAX];
@@ -156,7 +156,7 @@ class EditorFeatureProfileManager : public AcceptDialog {
 	void _import_profiles(const Vector<String> &p_paths);
 	void _export_profile(const String &p_path);
 
-	bool updating_features;
+	bool updating_features = false;
 
 	void _class_list_item_selected();
 	void _class_list_item_edited();


### PR DESCRIPTION
Another part of #43636

One step closer to proper memory sanitizer reports and clearer Cppcheck/Coverity scan reports about unitialised variables.