### PR TITLE
Use Rect2's get_end().

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -901,7 +901,7 @@ public:
 					if (layer_index >= layer_count) {
 						if (!flag_rects.is_empty() && (expansion_rows == 0)) {
 							const Rect2 &last_rect = flag_rects[flag_rects.size() - 1];
-							arrow_pos = last_rect.position + last_rect.size;
+							arrow_pos = last_rect.get_end();
 						}
 						break;
 					}
@@ -913,7 +913,7 @@ public:
 						// Keep last valid cell position for the expansion icon.
 						if (!flag_rects.is_empty() && (expansion_rows == 0)) {
 							const Rect2 &last_rect = flag_rects[flag_rects.size() - 1];
-							arrow_pos = last_rect.position + last_rect.size;
+							arrow_pos = last_rect.get_end();
 						}
 						++expansion_rows;
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -176,7 +176,7 @@ void EditorPropertyArray::_change_type(Object *p_button, int p_index) {
 	changing_type_index = p_index;
 	Rect2 rect = button->get_screen_rect();
 	change_type->set_as_minsize();
-	change_type->set_position(rect.position + rect.size - Vector2(change_type->get_contents_minimum_size().x, 0));
+	change_type->set_position(rect.get_end() - Vector2(change_type->get_contents_minimum_size().x, 0));
 	change_type->popup();
 }
 
@@ -726,7 +726,7 @@ void EditorPropertyDictionary::_change_type(Object *p_button, int p_index) {
 
 	Rect2 rect = button->get_screen_rect();
 	change_type->set_as_minsize();
-	change_type->set_position(rect.position + rect.size - Vector2(change_type->get_contents_minimum_size().x, 0));
+	change_type->set_position(rect.get_end() - Vector2(change_type->get_contents_minimum_size().x, 0));
 	change_type->popup();
 	changing_type_index = p_index;
 }

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -145,7 +145,7 @@ void EditorResourcePicker::_update_menu() {
 	Rect2 gt = edit_button->get_screen_rect();
 	edit_menu->set_as_minsize();
 	int ms = edit_menu->get_contents_minimum_size().width;
-	Vector2 popup_pos = gt.position + gt.size - Vector2(ms, 0);
+	Vector2 popup_pos = gt.get_end() - Vector2(ms, 0);
 	edit_menu->set_position(popup_pos);
 	edit_menu->popup();
 }

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -344,7 +344,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 									r = obj_styleBox->get_region_rect();
 								}
 								rect.expand_to(r.position);
-								rect.expand_to(r.position + r.size);
+								rect.expand_to(r.get_end());
 							}
 							undo_redo->create_action(TTR("Set Region Rect"));
 							if (atlas_tex.is_valid()) {
@@ -544,7 +544,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 
 				switch (drag_index) {
 					case 0: {
-						Vector2 p = rect_prev.position + rect_prev.size;
+						Vector2 p = rect_prev.get_end();
 						rect = Rect2(p, Size2());
 						rect.expand_to(new_pos);
 						apply_rect(rect);


### PR DESCRIPTION
1.Use Rect2' get_end() function, where it doesn't hurt readability.
https://github.com/godotengine/godot/blob/87de2e7c4a38b1258d9a554c7f50cdbd8ac825fa/core/math/rect2.h#L319-L321

~~2.Simplified Cases like this:
`(rect.get_position() + rect.get_end()) / 2` to `rect.get_position() + rect.get_size() / 2`~~
 (Merged in https://github.com/godotengine/godot/pull/52878)