### PR TITLE
Release pressed events when the window is blurred on HTML5 platform

### DIFF
--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -595,6 +595,12 @@ void DisplayServerJavaScript::virtual_keyboard_hide() {
 	godot_js_display_vk_hide();
 }
 
+// Window blur callback
+EM_BOOL DisplayServerJavaScript::blur_callback(int p_event_type, const EmscriptenFocusEvent *p_event, void *p_user_data) {
+	Input::get_singleton()->release_pressed_events();
+	return false;
+}
+
 // Gamepad
 void DisplayServerJavaScript::gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid) {
 	Input *input = Input::get_singleton();
@@ -797,6 +803,7 @@ DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_drive
 	SET_EM_CALLBACK(canvas_id, mousedown, mouse_button_callback)
 	SET_EM_WINDOW_CALLBACK(mousemove, mousemove_callback)
 	SET_EM_WINDOW_CALLBACK(mouseup, mouse_button_callback)
+	SET_EM_WINDOW_CALLBACK(blur, blur_callback)
 	SET_EM_CALLBACK(canvas_id, wheel, wheel_callback)
 	SET_EM_CALLBACK(canvas_id, touchstart, touch_press_callback)
 	SET_EM_CALLBACK(canvas_id, touchmove, touchmove_callback)

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -85,6 +85,8 @@ private:
 	static EM_BOOL touch_press_callback(int p_event_type, const EmscriptenTouchEvent *p_event, void *p_user_data);
 	static EM_BOOL touchmove_callback(int p_event_type, const EmscriptenTouchEvent *p_event, void *p_user_data);
 
+	static EM_BOOL blur_callback(int p_event_type, const EmscriptenFocusEvent *p_event, void *p_user_data);
+
 	static void gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid);
 	void process_joypads();
 


### PR DESCRIPTION
Fixes #49021

On the JS/HTML5 platform, when the user switches to another tab/window, any keys that were held down at the time would stay held down, so when the user switched back to the game window they would have to press the same keys again to release them.

This was due to the fact that we weren't calling the `release_pressed_events()` of the `Input` singleton like we do on other platforms. Browsers fire a `blur` event on the `window` object when it loses focus, and it's possible to add a callback handler to the same event in Emscripten.

So in this patch we simply add a callback handler to this event and invoke `release_pressed_events()`. In contrast to the `focusout` event which occurs *before* the focus is lost (and doesn't fire from the `window` object anyway), the `blur` event can bubble, so we just return `false` from the callback.

Also, we already propagate the `focus` and `blur` events and turn them into window notifications via the `godot_js_display_notification_cb()` JavaScript function, so we don't have to do it in the new callback.

I don't think we can apply the same patch to the 3.x branch with a cherry-pick because both the location of the patch and the way of accessing the input singleton are a little bit different. Once we're good to go on this I can open another PR for that branch.

See:
- [Window: blur event](https://developer.mozilla.org/en-US/docs/Web/API/Window/blur_event)
- [emscripten_set_blur_callback()](https://emscripten.org/docs/api_reference/html5.h.html?highlight=emscripten_set#c.emscripten_set_blur_callback)