### PR TITLE
Fix some minor issues in C# XML doc comments

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -78,7 +78,8 @@ namespace Godot
         /// </example>
         /// <seealso cref="GetNode{T}(NodePath)"/>
         /// <param name="path">The path to the node to fetch.</param>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>/// ///////// <returns>
+        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <returns>
         /// The <see cref="Node"/> at the given <paramref name="path"/>, or <see langword="null"/> if not found.
         /// </returns>
         public T GetNodeOrNull<T>(NodePath path) where T : class
@@ -97,7 +98,8 @@ namespace Godot
         /// <exception cref="InvalidCastException">
         /// Thrown when the given the fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>/// ///////// <returns>
+        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <returns>
         /// The child <see cref="Node"/> at the given index <paramref name="idx"/>.
         /// </returns>
         public T GetChild<T>(int idx) where T : class

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -478,7 +478,7 @@ namespace Godot
         /// <summary>
         /// Returns a Vector2 transformed (multiplied) by the inverse transformation matrix.
         /// </summary>
-        /// <param name="vector">A vector to inversely transform.</param>
+        /// <param name="vector">A Vector2 to inversely transform.</param>
         /// <param name="transform">The transformation to apply.</param>
         /// <returns>The inversely transformed Vector2.</returns>
         public static Vector2 operator *(Vector2 vector, Transform2D transform)
@@ -522,7 +522,7 @@ namespace Godot
         /// Returns a copy of the given Vector2[] transformed (multiplied) by transformation matrix.
         /// </summary>
         /// <param name="transform">The transformation to apply.</param>
-        /// <param name="array">a Vector2[] to transform.</param>
+        /// <param name="array">A Vector2[] to transform.</param>
         /// <returns>The transformed copy of the Vector2[].</returns>
         public static Vector2[] operator *(Transform2D transform, Vector2[] array)
         {


### PR DESCRIPTION
Labeling as "bug" since these are typos but they're just documentation bugs.