### PR TITLE
Reference RefCounted when creating variant from object pointer

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2517,6 +2517,7 @@ Variant::Variant(const Object *p_object) {
 		if (p_object->is_ref_counted()) {
 			RefCounted *ref_counted = const_cast<RefCounted *>(static_cast<const RefCounted *>(p_object));
 			if (!ref_counted->init_ref()) {
+				ref_counted->reference();
 				_get_obj().obj = nullptr;
 				_get_obj().id = ObjectID();
 				return;


### PR DESCRIPTION
Fixes #52558

Previously, this seemed to cause issues with `GDScriptFunction::call` since `p_instance->owner` (`Object *`) was cast to `Variant` and then destroyed when it exited the stack.

Hopefully, someone experienced with this part of the engine can review this.