### PR TITLE
Improve the Attach Script Dialog

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1943,6 +1943,9 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 
 	editor->push_item(p_script.operator->());
 	_update_script_button();
+
+	// Remember the directory we're in so we can use it again next time.
+	a_path = p_script->get_path().get_base_dir().plus_file(p_script->get_name());
 }
 
 void SceneTreeDock::_shader_created(Ref<Shader> p_shader) {
@@ -2884,6 +2887,9 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 	Ref<Script> existing = selected->get_script();
 
 	String path = selected->get_filename();
+	if (a_path != "") { // If we have an associated directory, use it.
+		path = a_path.get_base_dir().plus_file(selected->get_name());
+	}
 	if (path == "") {
 		String root_path = editor_data->get_edited_scene_root()->get_filename();
 		if (root_path == "") {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -148,6 +148,7 @@ class SceneTreeDock : public VBoxContainer {
 	ConfirmationDialog *delete_dialog;
 	ConfirmationDialog *editable_instance_remove_dialog;
 	ConfirmationDialog *placeholder_editable_instance_remove_dialog;
+	String a_path;
 
 	ReparentDialog *reparent_dialog;
 	EditorQuickOpen *quick_open;


### PR DESCRIPTION
In Godot, when you go to attach a script to a node the engine will automatically start the path from the same directory as the scene you're in. This is fine if you're planning on having a messy and unorganized project. However, if you're like me and most other people, you will keep your scripts in their own folder away from your scenes. 

Attaching scripts to your nodes is a very frequently repeated operation that becomes exponentially more tedious because you spend most of that time surfing through the file system trying to get back to the folder that the engine should really just remember.

I've implemented a way for Godot to remember the last directory you were in when you last attached a script. That way, the next time you attach a script to a node it will be smart enough to _**start**_ from that directory first. I'm calling it "associative directory pathing" because the engine will now "associate" a particular directory as the starting path when attaching scripts to nodes. Of course, saying "it remembers the last directory you were in when you attached a script to a node so it can use it again later." doesn't really roll off the tongue that well, so "associative directory pathing" it is.

A lot of people have noticed this and complained about it for a long time. It's just never been a priority issue to fix, so it's just been sitting on the back-burner for a while. This should be a nice quality of life improvement for the everyday user. Anyway, here's a video demonstrating the difference:

https://user-images.githubusercontent.com/62965063/133924166-afad2834-0c8e-4eda-afbe-5fb8a9ee9efb.mp4