### PR TITLE
Remove binds from Signal.connect

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -377,11 +377,11 @@ Error Signal::emit(const Variant **p_arguments, int p_argcount) const {
 	return obj->emit_signal(name, p_arguments, p_argcount);
 }
 
-Error Signal::connect(const Callable &p_callable, const Vector<Variant> &p_binds, uint32_t p_flags) {
+Error Signal::connect(const Callable &p_callable, uint32_t p_flags) {
 	Object *object = get_object();
 	ERR_FAIL_COND_V(!object, ERR_UNCONFIGURED);
 
-	return object->connect(name, p_callable, p_binds, p_flags);
+	return object->connect(name, p_callable, varray(), p_flags);
 }
 
 void Signal::disconnect(const Callable &p_callable) {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -159,7 +159,7 @@ public:
 	operator String() const;
 
 	Error emit(const Variant **p_arguments, int p_argcount) const;
-	Error connect(const Callable &p_callable, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);
+	Error connect(const Callable &p_callable, uint32_t p_flags = 0);
 	void disconnect(const Callable &p_callable);
 	bool is_connected(const Callable &p_callable) const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1688,7 +1688,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Signal, get_object_id, sarray(), varray());
 	bind_method(Signal, get_name, sarray(), varray());
 
-	bind_method(Signal, connect, sarray("callable", "binds", "flags"), varray(Array(), 0));
+	bind_method(Signal, connect, sarray("callable", "flags"), varray(0));
 	bind_method(Signal, disconnect, sarray("callable"), varray());
 	bind_method(Signal, is_connected, sarray("callable"), varray());
 	bind_method(Signal, get_connections, sarray(), varray());

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -32,10 +32,16 @@
 		<method name="connect">
 			<return type="int" />
 			<argument index="0" name="callable" type="Callable" />
-			<argument index="1" name="binds" type="Array" default="[]" />
-			<argument index="2" name="flags" type="int" default="0" />
+			<argument index="1" name="flags" type="int" default="0" />
 			<description>
-				Connects this signal to the specified [Callable], optionally providing binds and connection flags.
+				Connects this signal to the specified [Callable], optionally providing connection flags. You can provide additional arguments to the connected method call by using [method Callable.bind].
+				[codeblock]
+				for button in $Buttons.get_children():
+				    button.pressed.connect(on_pressed.bind(button))
+
+				func on_pressed(button):
+				    print(button.name, " was pressed")
+				[/codeblock]
 			</description>
 		</method>
 		<method name="disconnect">

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -2138,7 +2138,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					retvalue = gdfs;
 
-					Error err = sig.connect(Callable(gdfs.ptr(), "_signal_callback"), varray(gdfs), Object::CONNECT_ONESHOT);
+					Error err = sig.connect(callable_bind(Callable(gdfs.ptr(), "_signal_callback"), retvalue), Object::CONNECT_ONESHOT);
 					if (err != OK) {
 						err_text = "Error connecting to signal: " + sig.get_name() + " during await.";
 						OPCODE_BREAK;


### PR DESCRIPTION
This PR removes the redundant `binds` parameter from `Signal.connect`. You can just use `Callable.bind` instead, it's more typesafe etc. (although we probably don't do Callable argument validation yet, idk)

The `Object.connect` method is untouched, so there is no compatibility break. That method is already documented as legacy.

Closes #52837