### PR TITLE
Prevent local constant default value from incorrect overriding by a global constant in GDScript autocompletion

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -781,6 +781,9 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 						if (p_only_functions) {
 							continue;
 						}
+						if (r_result.has(member.constant->identifier->name)) {
+							continue;
+						}
 						option = ScriptCodeCompletionOption(member.constant->identifier->name, ScriptCodeCompletionOption::KIND_CONSTANT);
 						if (member.constant->initializer) {
 							option.default_value = member.constant->initializer->reduced_value;


### PR DESCRIPTION
This will fix showing incorrect color rects:

![image](https://user-images.githubusercontent.com/3036176/133941079-cf76f9fd-947f-411a-9e24-2d6166c6c7d5.png)

On the screenshot above WHITE color constant should override BLACK if defined. This fix would work fine with multiple functions:

![gds_fix_constant](https://user-images.githubusercontent.com/3036176/133941164-d713833e-a279-47cf-b471-a302b120a570.gif)
 