### PR TITLE
Corrected GLTFDocument::save_scene from processing a nullptr

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6744,6 +6744,8 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> state, const String p_path) {
 Error GLTFDocument::save_scene(Node *p_node, const String &p_path,
 		const String &p_src_path, uint32_t p_flags,
 		float p_bake_fps, Ref<GLTFState> r_state) {
+	ERR_FAIL_NULL_V(p_node, ERR_INVALID_PARAMETER);
+
 	Ref<GLTFDocument> gltf_document;
 	gltf_document.instantiate();
 	if (r_state == Ref<GLTFState>()) {


### PR DESCRIPTION
Fixes #52816

Error was caused by dereferencing of p_node when it's a nullptr.

I have added a check to save_scene to return ERR_INVALID_PARAMETER if p_node is a nullptr.

I am questioning whether or not Node::get_name() should be setup to throw the same error.