### PR TITLE
Fix Windows cursor with trails disappearing in fullscreen

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -955,6 +955,11 @@ void DisplayServerWindows::window_set_mode(WindowMode p_mode, WindowID p_window)
 		_update_window_style(p_window, false);
 
 		MoveWindow(wd.hWnd, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, TRUE);
+
+		if (restore_mouse_trails > 1) {
+			SystemParametersInfoA(SPI_SETMOUSETRAILS, restore_mouse_trails, 0, 0);
+			restore_mouse_trails = 0;
+		}
 	} else if (p_mode == WINDOW_MODE_WINDOWED) {
 		ShowWindow(wd.hWnd, SW_RESTORE);
 		wd.maximized = false;
@@ -994,6 +999,13 @@ void DisplayServerWindows::window_set_mode(WindowMode p_mode, WindowID p_window)
 		_update_window_style(false);
 
 		MoveWindow(wd.hWnd, pos.x, pos.y, size.width, size.height, TRUE);
+
+		// If the user has mouse trails enabled in windows, then sometimes the cursor disappears in fullscreen mode.
+		// Save number of trails so we can restore when exiting, then turn off mouse trails
+		SystemParametersInfoA(SPI_GETMOUSETRAILS, 0, &restore_mouse_trails, 0);
+		if (restore_mouse_trails > 1) {
+			SystemParametersInfoA(SPI_SETMOUSETRAILS, 0, 0, 0);
+		}
 	}
 }
 
@@ -3395,4 +3407,8 @@ DisplayServerWindows::~DisplayServerWindows() {
 			memdelete(context_vulkan);
 	}
 #endif
+
+	if (restore_mouse_trails > 1) {
+		SystemParametersInfoA(SPI_SETMOUSETRAILS, restore_mouse_trails, 0, 0);
+	}
 }

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -403,6 +403,7 @@ class DisplayServerWindows : public DisplayServer {
 	void _get_window_style(bool p_main_window, bool p_fullscreen, bool p_borderless, bool p_resizable, bool p_maximized, bool p_no_activate_focus, DWORD &r_style, DWORD &r_style_ex);
 
 	MouseMode mouse_mode;
+	int restore_mouse_trails = 0;
 	bool alt_mem = false;
 	bool gr_mem = false;
 	bool shift_mem = false;


### PR DESCRIPTION
Fixed by turning off mouse trails when going into fullscreen, then restoring trails when exiting fullscreen or game

This Pull request fixes master with the same fix as #52753 that was for 3.x

Fixes #49321, fixes #40230