### PR TITLE
Fix access to render target texture for XR interfaces

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -2415,6 +2415,13 @@ RID RendererSceneRenderRD::render_buffers_get_back_depth_texture(RID p_render_bu
 	return rb->depth_back_texture;
 }
 
+RID RendererSceneRenderRD::render_buffers_get_depth_texture(RID p_render_buffers) {
+	RenderBuffers *rb = render_buffers_owner.getornull(p_render_buffers);
+	ERR_FAIL_COND_V(!rb, RID());
+
+	return rb->depth_texture;
+}
+
 RID RendererSceneRenderRD::render_buffers_get_ao_texture(RID p_render_buffers) {
 	RenderBuffers *rb = render_buffers_owner.getornull(p_render_buffers);
 	ERR_FAIL_COND_V(!rb, RID());

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -1197,6 +1197,7 @@ public:
 	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding, uint32_t p_view_count) override;
 	virtual void gi_set_use_half_resolution(bool p_enable) override;
 
+	RID render_buffers_get_depth_texture(RID p_render_buffers);
 	RID render_buffers_get_ao_texture(RID p_render_buffers);
 	RID render_buffers_get_back_buffer_texture(RID p_render_buffers);
 	RID render_buffers_get_back_depth_texture(RID p_render_buffers);

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "xr_interface_extension.h"
+#include "servers/rendering/renderer_rd/renderer_storage_rd.h"
 #include "servers/rendering/renderer_storage.h"
 #include "servers/rendering/rendering_server_globals.h"
 
@@ -246,17 +247,21 @@ void XRInterfaceExtension::notification(int p_what) {
 }
 
 RID XRInterfaceExtension::get_render_target_texture(RID p_render_target) {
-	RendererStorage *storage = RSG::storage;
-	ERR_FAIL_NULL_V_MSG(storage, RID(), "Renderer storage not setup");
+	// In due time this will need to be enhance to return the correct INTERNAL RID for the chosen rendering engine.
+	// So once a GLES driver is implemented we'll return that and the implemented plugin needs to handle this correctly too.
+	RendererStorageRD *rd_storage = RendererStorageRD::base_singleton;
+	ERR_FAIL_NULL_V_MSG(rd_storage, RID(), "Renderer storage not setup");
 
-	return storage->render_target_get_texture(p_render_target);
+	return rd_storage->render_target_get_rd_texture(p_render_target);
 }
 
 /*
 RID XRInterfaceExtension::get_render_target_depth(RID p_render_target) {
-	RendererStorage *storage = RSG::storage;
-	ERR_FAIL_NULL_V_MSG(storage, RID(), "Renderer storage not setup");
+	// TODO implement this, the problem is that our depth texture isn't part of our render target as it is used for 3D rendering only
+	// but we don't have access to our render buffers from here....
+	RendererSceneRenderRD * rd_scene = ?????;
+	ERR_FAIL_NULL_V_MSG(rd_scene, RID(), "Renderer scene render not setup");
 
-	return storage->render_target_get_depth(p_render_target);
+	return rd_scene->render_buffers_get_depth_texture(????????????);
 }
 */


### PR DESCRIPTION
This PR fixes access to the correct texture RID so we can present render results inside of XR interfaces.

Still working on access to the depth buffer but as it is not part of the render target we don't seem to be able to have a link to the associated 3D render buffers. @reduz what are your thoughts on this?

This type of access is needed for VR plugins like OpenVR to work. Depth buffer is optional but allows features such as reprojection and solutions such as LIV
