### PR TITLE
Import: Disable thread import for OBJ meshes

### DIFF
--- a/editor/import/resource_importer_obj.h
+++ b/editor/import/resource_importer_obj.h
@@ -64,6 +64,9 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	// Threaded import can currently cause deadlocks, see GH-48265.
+	virtual bool can_import_threaded() const override { return false; }
+
 	ResourceImporterOBJ();
 };
 


### PR DESCRIPTION
This can currently lead to deadlocks, possibly due to some race condition
in the Vulkan renderer.

Works around #48265.

As pointed out in https://github.com/godotengine/godot/issues/48265#issuecomment-922763642, instead of a deadlock, we now get errors:
```
ERROR: Creating buffers with data is forbidden during creation of a draw list
   at: vertex_buffer_create (drivers/vulkan/rendering_device_vulkan.cpp:4013)
ERROR: Creating buffers with data is forbidden during creation of a draw list
   at: vertex_buffer_create (drivers/vulkan/rendering_device_vulkan.cpp:4013)
ERROR: Creating buffers with data is forbidden during creation of a draw list
   at: index_buffer_create (drivers/vulkan/rendering_device_vulkan.cpp:4144)
ERROR: Condition "!index_buffer_owner.owns(p_index_buffer)" is true. Returning: RID()
   at: index_array_create (drivers/vulkan/rendering_device_vulkan.cpp:4198)
ERROR: Condition "!vertex_buffer_owner.owns(p_src_buffers[i])" is true. Returning: RID()
   at: vertex_array_create (drivers/vulkan/rendering_device_vulkan.cpp:4095)
ERROR: No vertex array was bound, and render pipeline expects vertices.
   at: draw_list_draw (drivers/vulkan/rendering_device_vulkan.cpp:7399)
ERROR: Condition "!vertex_buffer_owner.owns(p_src_buffers[i])" is true. Returning: RID()
   at: vertex_array_create (drivers/vulkan/rendering_device_vulkan.cpp:4095)
ERROR: No vertex array was bound, and render pipeline expects vertices.
   at: draw_list_draw (drivers/vulkan/rendering_device_vulkan.cpp:7399)
ERROR: Attempted to free invalid ID: 0
   at: _free_internal (drivers/vulkan/rendering_device_vulkan.cpp:8436)
Using present mode: VK_PRESENT_MODE_FIFO_KHR
OBJ: Current material library  has 0
OBJ: Current material  has 0
OBJ: Added surface: 
Using present mode: VK_PRESENT_MODE_FIFO_KHR
OBJ: Current material library  has 0
OBJ: Current material  has 0
OBJ: Added surface: 
```