### PR TITLE
Allow mouse button event detection in Action Map Editor

### DIFF
--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -32,6 +32,7 @@
 #define ACTION_MAP_EDITOR_H
 
 #include "editor/editor_data.h"
+#include <scene/gui/color_rect.h>
 
 // Confirmation Dialog used when configuring an input event.
 // Separate from ActionMapEditor for code cleanliness and separation of responsibilities.
@@ -60,6 +61,7 @@ private:
 
 	// Listening for input
 	Label *event_as_text;
+	ColorRect *mouse_detection_rect;
 
 	// List of All Key/Mouse/Joypad input options.
 	int allowed_input_types;


### PR DESCRIPTION
Implements proposal : https://github.com/godotengine/godot-proposals/issues/3318

### Issue

In godot 4.0, mouse buttons cannot be detected automaticaly in the "Listen for Input" tab when adding a new trigger for an action.
Mouse buttons need to be selected in the list in the "Manual Selection Tab"
Mouse button events were disabled here because clicking on the OK button was always setting the input event to a Left Mouse Button click.

### Fix proposal

We could re-enable mouse detection by adding a detection zone. I've used a ColorRect.
Mouse Button Event are only detected if mouse is over this rect.
So, click on UI elements in the window doesn't cause interference with event detection anymore.

Detecting events for other inputs (keys, joypad) are not modified. The rect is used only for mouse button detection.

### Implementation

I'm using a regular ColorRect as detection area.
~~I've connected it to a callback function on mouse_entered and mouse_exited signal to keep a boolean value synchronized with mouse over status.~~
When listening for input, on mouse button event,  ~~check the boolean~~ check if mouse is in the ColorRect.
If not, ignore the mouse button event.

~~For the color of the ColorRect, i've used an hardcoded color.
We should use a color from default theme but I didn't know which one to choose.~~
Edit : Now color comes from editor theme.

### Result

As you can see, Mouse button event are detected over the rect and there is no problem with UI elements anymore.

![mb_detection2](https://user-images.githubusercontent.com/3649998/133996246-a101912a-9a73-4ccd-a14e-7b20ddfd1242.gif)

