### PR TITLE
Improve the documentation for `ease()` and `smoothstep()`

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -201,7 +201,18 @@
 			<argument index="0" name="x" type="float" />
 			<argument index="1" name="curve" type="float" />
 			<description>
-				Easing function, based on exponent. The curve values are: 0 is constant, 1 is linear, 0 to 1 is ease-in, 1+ is ease out. Negative values are in-out/out in.
+				Returns an "eased" value of [code]x[/code] based on an easing function defined with [code]curve[/code]. This easing function is based on an exponent. The [code]curve[/code] can be any floating-point number, with specific values leading to the following behaviors:
+				[codeblock]
+				- Lower than -1.0 (exclusive): Ease in-out
+				- 1.0: Linear
+				- Between -1.0 and 0.0 (exclusive): Ease out-in
+				- 0.0: Constant
+				- Between 0.0 to 1.0 (exclusive): Ease in
+				- 1.0: Linear
+				- Greater than 1.0 (exclusive): Ease out
+				[/codeblock]
+				[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/ease_cheatsheet.png]ease() curve values cheatsheet[/url]
+				See also [method smoothstep]. If you need to perform more advanced transitions, use [Tween] or [AnimationPlayer].
 			</description>
 		</method>
 		<method name="error_string">
@@ -795,6 +806,8 @@
 				smoothstep(0, 2, 1.0) # Returns 0.5
 				smoothstep(0, 2, 2.0) # Returns 1.0
 				[/codeblock]
+				Compared to [method ease] with a curve value of [code]-1.6521[/code], [method smoothstep] returns the smoothest possible curve with no sudden changes in the derivative. If you need to perform more advanced transitions, use [Tween] or [AnimationPlayer].
+				[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/smoothstep_ease_comparison.png]Comparison between smoothstep() and ease(x, -1.6521) return values[/url]
 			</description>
 		</method>
 		<method name="snapped">


### PR DESCRIPTION
*Marked as draft since https://github.com/godotengine/godot-docs/pull/5271 needs to be merged first.*

This adds a cheatsheet for `ease()` and a comparison graph for `smoothstep()`, among other things.

This closes https://github.com/godotengine/godot/issues/10572.