### PR TITLE
Exposed scene_tree's "_update_font_oversampling" method in GDScript

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -225,6 +225,36 @@
 				Configures screen stretching to the given [enum StretchMode], [enum StretchAspect], minimum size and [code]scale[/code].
 			</description>
 		</method>
+		<method name="update_font_oversampling">
+			<return type="void" />
+			<argument index="0" name="ratio" type="float" />
+			<description>
+				If [member use_font_oversampling] is [code]true[/code], configures [DynamicFont] oversampling to use the given [code]ratio[/code].
+				This can be used to customize the screen stretching algorithm, e.g. to enforce pixel perfect scaling ratios.
+				[b]Example:[/b]
+				[codeblock]
+				var base_size = Vector2(480, 270) # Base game size.
+
+				func ready():
+				    # Disable automatic render stretching algorithm.
+				    get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED, SceneTree.STRETCH_ASPECT_IGNORE, base_size, 1.0)
+				    on_screen_resized()
+				    get_tree().connect("screen_resized", self, "on_screen_resized")
+
+				# Custom render stretching algorithm.
+				func on_screen_resized():
+				    var scale = 3.0 # Custom desired game scale (here 3 times base size).
+				    var viewport_size = base_size * scale # Scaled viewport size.
+				    var margin = Vector2() # No margin.
+				    get_tree().update_font_oversampling(scale) # Match font oversampling to the custom scale.
+				    var root = get_tree().root
+				    root.set_size(viewport_size)
+				    root.set_attach_to_screen_rect(Rect2(margin, viewport_size)) # Offset the viewport inside screen.
+				    root.set_size_override_stretch(true)
+				    root.set_size_override(true, base_size)
+				[/codeblock]
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="current_scene" type="Node" setter="set_current_scene" getter="get_current_scene">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -502,7 +502,7 @@ bool SceneTree::iteration(float p_time) {
 	return _quit;
 }
 
-void SceneTree::_update_font_oversampling(float p_ratio) {
+void SceneTree::update_font_oversampling(float p_ratio) {
 #ifdef MODULE_FREETYPE_ENABLED
 	if (use_font_oversampling) {
 		DynamicFontAtSize::font_oversampling = p_ratio;
@@ -1123,7 +1123,7 @@ int SceneTree::get_node_count() const {
 
 void SceneTree::_update_root_rect() {
 	if (stretch_mode == STRETCH_MODE_DISABLED) {
-		_update_font_oversampling(stretch_scale);
+		update_font_oversampling(stretch_scale);
 		root->set_size(last_screen_size.floor());
 		root->set_attach_to_screen_rect(Rect2(Point2(), last_screen_size));
 		root->set_size_override_stretch(true);
@@ -1204,7 +1204,7 @@ void SceneTree::_update_root_rect() {
 			// Already handled above
 		} break;
 		case STRETCH_MODE_2D: {
-			_update_font_oversampling((screen_size.x / viewport_size.x) * stretch_scale); //screen / viewport ratio drives oversampling
+			update_font_oversampling((screen_size.x / viewport_size.x) * stretch_scale); //screen / viewport ratio drives oversampling
 			root->set_size(screen_size.floor());
 			root->set_attach_to_screen_rect(Rect2(margin, screen_size));
 			root->set_size_override_stretch(true);
@@ -1213,7 +1213,7 @@ void SceneTree::_update_root_rect() {
 
 		} break;
 		case STRETCH_MODE_VIEWPORT: {
-			_update_font_oversampling(1.0);
+			update_font_oversampling(1.0);
 			root->set_size((viewport_size / stretch_scale).floor());
 			root->set_attach_to_screen_rect(Rect2(margin, screen_size));
 			root->set_size_override_stretch(false);
@@ -1898,6 +1898,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_connection_failed"), &SceneTree::_connection_failed);
 	ClassDB::bind_method(D_METHOD("_server_disconnected"), &SceneTree::_server_disconnected);
 
+	ClassDB::bind_method(D_METHOD("update_font_oversampling", "ratio"), &SceneTree::update_font_oversampling);
 	ClassDB::bind_method(D_METHOD("set_use_font_oversampling", "enable"), &SceneTree::set_use_font_oversampling);
 	ClassDB::bind_method(D_METHOD("is_using_font_oversampling"), &SceneTree::is_using_font_oversampling);
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -152,7 +152,7 @@ private:
 	Size2i stretch_min;
 	real_t stretch_scale;
 
-	void _update_font_oversampling(float p_ratio);
+	void update_font_oversampling(float p_ratio);
 	void _update_root_rect();
 
 	List<ObjectID> delete_queue;


### PR DESCRIPTION
This commit expose scene_tree's "_update_font_oversampling" method in GDScript, fixing issues with custom scaling implementations and font oversampling.

I required a pixel perfect solution for my game, where I can only scale the game in perfect multiples of the base size (1x,2x,3x,4x, etc) and celeste style HD font rendering (font oversampling).
Reading the [documentation](https://docs.godotengine.org/en/stable/tutorials/viewports/multiple_resolutions.html), there is a recommendation for the [integer resolution handler plugin](https://github.com/Yukitty/godot-addon-integer_resolution_handler):

> Godot currently doesn't have a way to enforce integer scaling when using the 2d or viewport stretch mode, which means pixel art may look bad if the final window size is not a multiple of the base window size. To fix this, use an add-on such as the Integer Resolution Handler.

That plugin replicates the godot internal scaling found in gdscript scene_tree with the exception of the "_update_font_oversampling" line because the method isn't available in GDScript. This plugin uses "STRETCH_MODE_DISABLED" + "STRETCH_ASPECT_IGNORE" flags scaling the base resolution in floored screen values (1x,2x,3x, etc). 
Because of this limitation, that plugin misses the font oversampling support, only available for "STRETCH_MODE_2D" using an internal scaling formula not compatible with all custom implementations.

With this commit the user can call in that plugin:
get_tree().update_font_oversampling(scale)
And have full font oversampling support in any stretch mode.

*Bugsquad edit:* Implements / closes https://github.com/godotengine/godot-proposals/issues/3325