### PR TITLE
Update connection comparison operator to compare connection sources based on instance ID instead of by pointer

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -357,7 +357,7 @@ bool Object::Connection::operator<(const Connection &p_conn) const {
 			return signal < p_conn.signal;
 		}
 	} else {
-		return source < p_conn.source;
+		return source->get_instance_id() < p_conn.source->get_instance_id();
 	}
 }
 Object::Connection::Connection(const Variant &p_variant) {


### PR DESCRIPTION
Similar change to the recently merged PR [52493](https://github.com/godotengine/godot/pull/52493), which I came across while investigating the unpredictable signal ordering detailed in [Issue 35084](https://github.com/godotengine/godot/issues/35084). PR 52493 fixed comparisons of `target` between 2 connections, but there is a similar issue comparing `source` between connections. The current setup compares pointers which results in inconsistent comparison outputs for connections with different sources. 

As far as I can tell, there's not currently much impact from how connection sources get compared -- I believe the only current caller of `Object::Connection::operator<` is `SceneState::_parse_connections`  via `conns.sort` on line 693 of `packed_scene.cpp` which gets called while saving scenes, and that method already builds up a list connections one node at a time, so `source` is always identical between any connections that get compared. So after some testing it doesn't seem like this is actually a cause of the unpredictable signal order described in [Issue 35084](https://github.com/godotengine/godot/issues/35084). But it does seem like the comparison logic here is inaccurate and could potentially cause other problems in the future.

Tested some basic operations on my local build of Godot after this change and all seemed good. I think this connection comparison method would be a good candidate for some unit tests, but I'm not too familiar with how testing works in Godot so I haven't included them for now.