### PR TITLE
Fix RTL layout Label text, VBox child, 3D node editor controls, and popup menu alignment.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4196,7 +4196,8 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 
 	VBoxContainer *vbox = memnew(VBoxContainer);
 	surface->add_child(vbox);
-	vbox->set_position(Point2(10, 10) * EDSCALE);
+	vbox->set_offset(SIDE_LEFT, 10 * EDSCALE);
+	vbox->set_offset(SIDE_TOP, 10 * EDSCALE);
 
 	view_menu = memnew(MenuButton);
 	view_menu->set_flat(false);

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -96,17 +96,18 @@ void Container::fit_child_in_rect(Control *p_child, const Rect2 &p_rect) {
 	ERR_FAIL_COND(!p_child);
 	ERR_FAIL_COND(p_child->get_parent() != this);
 
+	bool rtl = is_layout_rtl();
 	Size2 minsize = p_child->get_combined_minimum_size();
 	Rect2 r = p_rect;
 
 	if (!(p_child->get_h_size_flags() & SIZE_FILL)) {
 		r.size.x = minsize.width;
 		if (p_child->get_h_size_flags() & SIZE_SHRINK_END) {
-			r.position.x += p_rect.size.width - minsize.width;
+			r.position.x += rtl ? 0 : (p_rect.size.width - minsize.width);
 		} else if (p_child->get_h_size_flags() & SIZE_SHRINK_CENTER) {
 			r.position.x += Math::floor((p_rect.size.x - minsize.width) / 2);
 		} else {
-			r.position.x += 0;
+			r.position.x += rtl ? (p_rect.size.width - minsize.width) : 0;
 		}
 	}
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -270,6 +270,10 @@ void Label::_notification(int p_what) {
 		update();
 	}
 
+	if (p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED) {
+		update();
+	}
+
 	if (p_what == NOTIFICATION_DRAW) {
 		if (clip) {
 			RenderingServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), true);
@@ -293,6 +297,7 @@ void Label::_notification(int p_what) {
 		int outline_size = get_theme_constant(SNAME("outline_size"));
 		int shadow_outline_size = get_theme_constant(SNAME("shadow_outline_size"));
 		bool rtl = TS->shaped_text_get_direction(text_rid);
+		bool rtl_layout = is_layout_rtl();
 
 		style->draw(ci, Rect2(Point2(0, 0), get_size()));
 
@@ -364,13 +369,21 @@ void Label::_notification(int p_what) {
 					}
 					break;
 				case ALIGN_LEFT: {
-					ofs.x = style->get_offset().x;
+					if (rtl_layout) {
+						ofs.x = int(size.width - style->get_margin(SIDE_RIGHT) - line_size.width);
+					} else {
+						ofs.x = style->get_offset().x;
+					}
 				} break;
 				case ALIGN_CENTER: {
 					ofs.x = int(size.width - line_size.width) / 2;
 				} break;
 				case ALIGN_RIGHT: {
-					ofs.x = int(size.width - style->get_margin(SIDE_RIGHT) - line_size.width);
+					if (rtl_layout) {
+						ofs.x = style->get_offset().x;
+					} else {
+						ofs.x = int(size.width - style->get_margin(SIDE_RIGHT) - line_size.width);
+					}
 				} break;
 			}
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -89,13 +89,15 @@ void MenuButton::pressed() {
 	emit_signal(SNAME("about_to_popup"));
 	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
 
+	popup->set_size(Size2(size.width, 0));
 	Point2 gp = get_screen_position();
 	gp.y += size.y;
-
+	if (is_layout_rtl()) {
+		gp.x += size.width - popup->get_size().width;
+	}
 	popup->set_position(gp);
-
-	popup->set_size(Size2(size.width, 0));
 	popup->set_parent_rect(Rect2(Point2(gp - popup->get_position()), size));
+
 	popup->take_mouse_focus();
 	popup->popup();
 }


### PR DESCRIPTION
### Fixes a bunch of RTL layout alignment bugs.

Fixes label text alignment mirroring:

<img width="892" alt="Screenshot 2021-09-21 at 10 02 01" src="https://user-images.githubusercontent.com/7645683/134131065-e9555569-1714-4ed5-a2d8-58532812df88.png">

Fixes #52784 (fixes 3D Note Editor hard-coded positions and `VBox` container child alignment).

<img width="1091" alt="Screenshot 2021-09-21 at 10 13 07" src="https://user-images.githubusercontent.com/7645683/134131075-621bbd70-9f44-4130-9910-da9894a946b5.png">

Fixes #52782 (fixes `MenuButton` popup).

https://user-images.githubusercontent.com/7645683/134131806-f300fcd1-ddb2-422a-a2c0-f4e7c9575257.mov

Note: Vertical menu alignment seems off, but it's not RTL specific and probably macOS specific issue related to window decorations.