### PR TITLE
Port 2D improvements to move and slide 3D (with extras)

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -170,7 +170,7 @@
 			Apply when notions of walls, ceiling and floor are relevant. In this mode the body motion will react to slopes (acceleration/slowdown). This mode is suitable for sided games like platformers.
 		</constant>
 		<constant name="MOTION_MODE_FREE" value="1" enum="MotionMode">
-			Apply when there is no notion of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will be always constant. This mode is suitable for top-down games.
+			Apply when there is no notion of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will always be constant. This mode is suitable for top-down games.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -29,6 +29,12 @@
 				Returns the surface normal of the floor at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
+		<method name="get_last_motion" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the last motion applied to the [CharacterBody3D] during the last call to [method move_and_slide]. The movement can be split if needed into multiple motion, this method return the last one, it's useful to retrieve the current direction of the movement.
+			</description>
+		</method>
 		<method name="get_last_slide_collision">
 			<return type="KinematicCollision3D" />
 			<description>
@@ -39,6 +45,18 @@
 			<return type="Vector3" />
 			<description>
 				Returns the linear velocity of the floor at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
+			</description>
+		</method>
+		<method name="get_position_delta" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the travel (position delta) that occurred during the last call to [method move_and_slide].
+			</description>
+		</method>
+		<method name="get_real_velocity" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the current real velocity since the last call to [method move_and_slide]. For example, when you climb a slope, you will move diagonally even though the velocity is horizontal. This method returns the diagonal movement, as opposed to [member linear_velocity] which returns the requested velocity.
 			</description>
 		</method>
 		<method name="get_slide_collision">
@@ -52,6 +70,12 @@
 			<return type="int" />
 			<description>
 				Returns the number of times the body collided and changed direction during the last call to [method move_and_slide].
+			</description>
+		</method>
+		<method name="get_wall_normal" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the surface normal of the wall at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_wall] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="is_on_ceiling" qualifiers="const">
@@ -108,8 +132,19 @@
 			A higher value means it's more flexible for detecting collision, which helps with consistently detecting walls and floors.
 			A lower value forces the collision algorithm to use more exact detection, so it can be used in cases that specifically require precision, e.g at very low scale to avoid visible jittering, or for stability with a stack of character bodies.
 		</member>
+		<member name="floor_block_on_wall" type="bool" setter="set_floor_block_on_wall_enabled" getter="is_floor_block_on_wall_enabled" default="true">
+			If [code]true[/code], the body will be able to move on the floor only. This option avoids to be able to walk on walls, it will however allow to slide down along them.
+		</member>
+		<member name="floor_constant_speed" type="bool" setter="set_floor_constant_speed_enabled" getter="is_floor_constant_speed_enabled" default="false">
+			If [code]false[/code] (by default), the body will move faster on downward slopes and slower on upward slopes.
+			If [code]true[/code], the body will always move at the same speed on the ground no matter the slope. Note that you need to use [member floor_snap_length] to stick along a downward slope at constant speed.
+		</member>
 		<member name="floor_max_angle" type="float" setter="set_floor_max_angle" getter="get_floor_max_angle" default="0.785398">
 			Maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. The default value equals 45 degrees.
+		</member>
+		<member name="floor_snap_length" type="float" setter="set_floor_snap_length" getter="get_floor_snap_length" default="0.1">
+			Sets a snapping distance. When set to a value different from [code]0.0[/code], the body is kept attached to slopes when calling [method move_and_slide]. The snapping vector is determined by the given distance along the opposite direction of the [member up_direction].
+			As long as the snapping vector is in contact with the ground and the body moves against `up_direction`, the body will remain attached to the surface. Snapping is not applied if the body moves along `up_direction`, so it will be able to detach from the ground when jumping.
 		</member>
 		<member name="floor_stop_on_slope" type="bool" setter="set_floor_stop_on_slope_enabled" getter="is_floor_stop_on_slope_enabled" default="false">
 			If [code]true[/code], the body will not slide on slopes when you include gravity in [code]linear_velocity[/code] when calling [method move_and_slide] and the body is standing still.
@@ -117,15 +152,46 @@
 		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3(0, 0, 0)">
 			Current velocity vector (typically meters per second), used and modified during calls to [method move_and_slide].
 		</member>
-		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="4">
+		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="6">
 			Maximum number of times the body can change direction before it stops when calling [method move_and_slide].
 		</member>
-		<member name="snap" type="Vector3" setter="set_snap" getter="get_snap" default="Vector3(0, 0, 0)">
-			When set to a value different from [code]Vector3(0, 0, 0)[/code], the body is kept attached to slopes when calling [method move_and_slide].
-			As long as the [code]snap[/code] vector is in contact with the ground, the body will remain attached to the surface. This means you must disable snap in order to jump, for example. You can do this by setting [code]snap[/code] to [code]Vector3(0, 0, 0)[/code].
+		<member name="motion_mode" type="int" setter="set_motion_mode" getter="get_motion_mode" enum="CharacterBody3D.MotionMode" default="0">
+			Sets the motion mode which defines the behaviour of [method move_and_slide]. See [enum MotionMode] constants for available modes.
+		</member>
+		<member name="moving_platform_apply_velocity_on_leave" type="int" setter="set_moving_platform_apply_velocity_on_leave" getter="get_moving_platform_apply_velocity_on_leave" enum="CharacterBody3D.MovingPlatformApplyVelocityOnLeave" default="0">
+			Sets the behaviour to apply when you leave a moving platform. By default, to be physically accurate, when you leave the last platform velocity is applied. See [enum MovingPlatformApplyVelocityOnLeave] constants for available behaviour.
+		</member>
+		<member name="moving_platform_floor_layers" type="int" setter="set_moving_platform_floor_layers" getter="get_moving_platform_floor_layers" default="4294967295">
+			Collision layers that will be included for detecting floor bodies that will act as moving platforms to be followed by the [CharacterBody2D]. By default, all floor bodies are detected and propagate their velocity.
+		</member>
+		<member name="moving_platform_wall_layers" type="int" setter="set_moving_platform_wall_layers" getter="get_moving_platform_wall_layers" default="0">
+			Collision layers that will be included for detecting wall bodies that will act as moving platforms to be followed by the [CharacterBody2D]. By default, all wall bodies are ignored.
+		</member>
+		<member name="slide_on_ceiling" type="bool" setter="set_slide_on_ceiling_enabled" getter="is_slide_on_ceiling_enabled" default="true">
+			If [code]true[/code], during a jump against the ceiling, the body will slide, if [code]false[/code] it will be stopped and will fall vertically.
 		</member>
 		<member name="up_direction" type="Vector3" setter="set_up_direction" getter="get_up_direction" default="Vector3(0, 1, 0)">
 			Direction vector used to determine what is a wall and what is a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. Defaults to [code]Vector3.UP[/code]. If set to [code]Vector3(0, 0, 0)[/code], everything is considered a wall. This is useful for topdown games.
 		</member>
+		<member name="wall_min_slide_angle" type="float" setter="set_wall_min_slide_angle" getter="get_wall_min_slide_angle" default="0.261799">
+			Minimum angle (in radians) where the body is allowed to slide when it encounters a slope. The default value equals 15 degrees. In [code]MOTION_MODE_GROUNDED[/code], it works only when [member floor_block_on_wall] is [code]true[/code].
+		</member>
 	</members>
+	<constants>
+		<constant name="MOTION_MODE_GROUNDED" value="0" enum="MotionMode">
+			Apply when notions of walls, ceiling and floor are relevant. In this mode the body motion will react to slopes (acceleration/slowdown). This mode is suitable for grounded games like platformers.
+		</constant>
+		<constant name="MOTION_MODE_FREE" value="1" enum="MotionMode">
+			Apply when there is no notion of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will always be constant. This mode is suitable for games without ground like space games.
+		</constant>
+		<constant name="PLATFORM_VEL_ON_LEAVE_ALWAYS" value="0" enum="MovingPlatformApplyVelocityOnLeave">
+			Add the last platform velocity to the [member linear_velocity] when you leave a moving platform.
+		</constant>
+		<constant name="PLATFORM_VEL_ON_LEAVE_UPWARD_ONLY" value="1" enum="MovingPlatformApplyVelocityOnLeave">
+			Add the last platform velocity to the [member linear_velocity] when you leave a moving platform, but any downward motion is ignored. It's useful to keep full jump height even when the platform is moving down.
+		</constant>
+		<constant name="PLATFORM_VEL_ON_LEAVE_NEVER" value="2" enum="MovingPlatformApplyVelocityOnLeave">
+			Do nothing when leaving a platform.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/KinematicCollision3D.xml
+++ b/doc/classes/KinematicCollision3D.xml
@@ -12,41 +12,114 @@
 	<methods>
 		<method name="get_angle" qualifiers="const">
 			<return type="float" />
-			<argument index="0" name="up_direction" type="Vector3" default="Vector3(0, 1, 0)" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<argument index="1" name="up_direction" type="Vector3" default="Vector3(0, 1, 0)" />
 			<description>
 				The collision angle according to [code]up_direction[/code], which is [code]Vector3.UP[/code] by default. This value is always positive.
 			</description>
 		</method>
+		<method name="get_collider" qualifiers="const">
+			<return type="Object" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider by index (the latest by default).
+			</description>
+		</method>
+		<method name="get_collider_id" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider ID by index (the latest by default).
+			</description>
+		</method>
+		<method name="get_collider_metadata" qualifiers="const">
+			<return type="Variant" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider metadata by index (the latest by default).
+			</description>
+		</method>
+		<method name="get_collider_rid" qualifiers="const">
+			<return type="RID" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider RID by index (the latest by default).
+			</description>
+		</method>
+		<method name="get_collider_shape" qualifiers="const">
+			<return type="Object" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider shape by index (the latest by default).
+			</description>
+		</method>
+		<method name="get_collider_shape_index" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider shape index by index (the latest by default).
+			</description>
+		</method>
+		<method name="get_collider_velocity" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider velocity by index (the latest by default).
+			</description>
+		</method>
+		<method name="get_local_shape" qualifiers="const">
+			<return type="Object" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider velocity by index (the latest by default).
+			</description>
+		</method>
+		<method name="get_normal" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider normal by index (the latest by default).
+			</description>
+		</method>
+		<method name="get_position" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+				Returns the collider collision point by index (the latest by default).
+			</description>
+		</method>
 	</methods>
 	<members>
-		<member name="collider" type="Object" setter="" getter="get_collider">
+		<member name="collider" type="Object" setter="" getter="get_best_collider">
 			The colliding body.
 		</member>
-		<member name="collider_id" type="int" setter="" getter="get_collider_id" default="0">
+		<member name="collider_id" type="int" setter="" getter="get_best_collider_id" default="0">
 			The colliding body's unique instance ID. See [method Object.get_instance_id].
 		</member>
-		<member name="collider_metadata" type="Variant" setter="" getter="get_collider_metadata">
+		<member name="collider_metadata" type="Variant" setter="" getter="get_best_collider_metadata">
 			The colliding body's metadata. See [Object].
 		</member>
-		<member name="collider_rid" type="RID" setter="" getter="get_collider_rid">
+		<member name="collider_rid" type="RID" setter="" getter="get_best_collider_rid">
 			The colliding body's [RID] used by the [PhysicsServer3D].
 		</member>
-		<member name="collider_shape" type="Object" setter="" getter="get_collider_shape">
+		<member name="collider_shape" type="Object" setter="" getter="get_best_collider_shape">
 			The colliding body's shape.
 		</member>
-		<member name="collider_shape_index" type="int" setter="" getter="get_collider_shape_index" default="0">
+		<member name="collider_shape_index" type="int" setter="" getter="get_best_collider_shape_index" default="0">
 			The colliding shape's index. See [CollisionObject3D].
 		</member>
-		<member name="collider_velocity" type="Vector3" setter="" getter="get_collider_velocity" default="Vector3(0, 0, 0)">
+		<member name="collider_velocity" type="Vector3" setter="" getter="get_best_collider_velocity" default="Vector3(0, 0, 0)">
 			The colliding object's velocity.
 		</member>
-		<member name="local_shape" type="Object" setter="" getter="get_local_shape">
+		<member name="collision_count" type="int" setter="" getter="get_collision_count" default="0">
+		</member>
+		<member name="local_shape" type="Object" setter="" getter="get_best_local_shape">
 			The moving object's colliding shape.
 		</member>
-		<member name="normal" type="Vector3" setter="" getter="get_normal" default="Vector3(0, 0, 0)">
+		<member name="normal" type="Vector3" setter="" getter="get_best_normal" default="Vector3(0, 0, 0)">
 			The colliding body's shape's normal at the point of collision.
 		</member>
-		<member name="position" type="Vector3" setter="" getter="get_position" default="Vector3(0, 0, 0)">
+		<member name="position" type="Vector3" setter="" getter="get_best_position" default="Vector3(0, 0, 0)">
 			The point of collision, in global coordinates.
 		</member>
 		<member name="remainder" type="Vector3" setter="" getter="get_remainder" default="Vector3(0, 0, 0)">

--- a/doc/classes/PhysicsBody3D.xml
+++ b/doc/classes/PhysicsBody3D.xml
@@ -35,10 +35,12 @@
 			<argument index="0" name="rel_vec" type="Vector3" />
 			<argument index="1" name="test_only" type="bool" default="false" />
 			<argument index="2" name="safe_margin" type="float" default="0.001" />
+			<argument index="3" name="max_collisions" type="int" default="1" />
 			<description>
 				Moves the body along the vector [code]rel_vec[/code]. The body will stop if it collides. Returns a [KinematicCollision3D], which contains information about the collision.
 				If [code]test_only[/code] is [code]true[/code], the body does not move but the would-be collision information is given.
 				[code]safe_margin[/code] is the extra margin used for collision recovery (see [member CharacterBody3D.collision/safe_margin] for more details).
+				[code]max_collisions[/code] allows to retrieve more than one collision result.
 			</description>
 		</method>
 		<method name="remove_collision_exception_with">
@@ -62,10 +64,12 @@
 			<argument index="1" name="rel_vec" type="Vector3" />
 			<argument index="2" name="collision" type="KinematicCollision3D" default="null" />
 			<argument index="3" name="safe_margin" type="float" default="0.001" />
+			<argument index="4" name="max_collisions" type="int" default="1" />
 			<description>
 				Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given [Transform3D], then tries to move the body along the vector [code]rel_vec[/code]. Returns [code]true[/code] if a collision would occur.
 				[code]collision[/code] is an optional object of type [KinematicCollision3D], which contains additional information about the collision (should there be one).
 				[code]safe_margin[/code] is the extra margin used for collision recovery (see [member CharacterBody3D.collision/safe_margin] for more details).
+				[code]max_collisions[/code] allows to retrieve more than one collision result.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -583,6 +583,7 @@
 			<argument index="4" name="result" type="PhysicsTestMotionResult3D" default="null" />
 			<argument index="5" name="collide_separation_ray" type="bool" default="false" />
 			<argument index="6" name="exclude" type="Array" default="[]" />
+			<argument index="7" name="max_collisions" type="int" default="1" />
 			<description>
 				Returns [code]true[/code] if a collision would result from moving in the given direction from a given point in space. Margin increases the size of the shapes involved in the collision detection. [PhysicsTestMotionResult3D] can be passed to return additional information in.
 			</description>

--- a/doc/classes/PhysicsTestMotionResult3D.xml
+++ b/doc/classes/PhysicsTestMotionResult3D.xml
@@ -6,30 +6,82 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_collider" qualifiers="const">
+			<return type="Object" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+			</description>
+		</method>
+		<method name="get_collider_id" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+			</description>
+		</method>
+		<method name="get_collider_rid" qualifiers="const">
+			<return type="RID" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+			</description>
+		</method>
+		<method name="get_collider_shape" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+			</description>
+		</method>
+		<method name="get_collider_velocity" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+			</description>
+		</method>
+		<method name="get_collision_depth" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+			</description>
+		</method>
+		<method name="get_collision_normal" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+			</description>
+		</method>
+		<method name="get_collision_point" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="collision_index" type="int" default="0" />
+			<description>
+			</description>
+		</method>
+	</methods>
 	<members>
-		<member name="collider" type="Object" setter="" getter="get_collider">
+		<member name="collider" type="Object" setter="" getter="get_best_collider">
 		</member>
-		<member name="collider_id" type="int" setter="" getter="get_collider_id" default="0">
+		<member name="collider_id" type="int" setter="" getter="get_best_collider_id" default="0">
 		</member>
-		<member name="collider_rid" type="RID" setter="" getter="get_collider_rid">
+		<member name="collider_rid" type="RID" setter="" getter="get_best_collider_rid">
 		</member>
-		<member name="collider_shape" type="int" setter="" getter="get_collider_shape" default="0">
+		<member name="collider_shape" type="int" setter="" getter="get_best_collider_shape" default="0">
 		</member>
-		<member name="collider_velocity" type="Vector3" setter="" getter="get_collider_velocity" default="Vector3(0, 0, 0)">
+		<member name="collider_velocity" type="Vector3" setter="" getter="get_best_collider_velocity" default="Vector3(0, 0, 0)">
 		</member>
-		<member name="collision_depth" type="float" setter="" getter="get_collision_depth" default="0.0">
+		<member name="collision_count" type="int" setter="" getter="get_collision_count" default="0">
 		</member>
-		<member name="collision_normal" type="Vector3" setter="" getter="get_collision_normal" default="Vector3(0, 0, 0)">
+		<member name="collision_depth" type="float" setter="" getter="get_best_collision_depth" default="0.0">
 		</member>
-		<member name="collision_point" type="Vector3" setter="" getter="get_collision_point" default="Vector3(0, 0, 0)">
+		<member name="collision_normal" type="Vector3" setter="" getter="get_best_collision_normal" default="Vector3(0, 0, 0)">
 		</member>
-		<member name="collision_safe_fraction" type="float" setter="" getter="get_collision_safe_fraction" default="0.0">
-		</member>
-		<member name="collision_unsafe_fraction" type="float" setter="" getter="get_collision_unsafe_fraction" default="0.0">
+		<member name="collision_point" type="Vector3" setter="" getter="get_best_collision_point" default="Vector3(0, 0, 0)">
 		</member>
 		<member name="remainder" type="Vector3" setter="" getter="get_remainder" default="Vector3(0, 0, 0)">
 		</member>
+		<member name="safe_fraction" type="float" setter="" getter="get_safe_fraction" default="0.0">
+		</member>
 		<member name="travel" type="Vector3" setter="" getter="get_travel" default="Vector3(0, 0, 0)">
+		</member>
+		<member name="unsafe_fraction" type="float" setter="" getter="get_unsafe_fraction" default="0.0">
 		</member>
 	</members>
 </class>

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -334,7 +334,7 @@ private:
 	int max_slides = 4;
 	int platform_layer;
 	real_t floor_max_angle = Math::deg2rad((real_t)45.0);
-	float floor_snap_length = 0;
+	real_t floor_snap_length = 0;
 	real_t free_mode_min_slide_angle = Math::deg2rad((real_t)15.0);
 	Vector2 up_direction = Vector2(0.0, -1.0);
 	uint32_t moving_platform_floor_layers = UINT32_MAX;

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -868,7 +868,7 @@ void PhysicsServer3DSW::body_set_ray_pickable(RID p_body, bool p_enable) {
 	body->set_ray_pickable(p_enable);
 }
 
-bool PhysicsServer3DSW::body_test_motion(RID p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin, MotionResult *r_result, bool p_collide_separation_ray, const Set<RID> &p_exclude) {
+bool PhysicsServer3DSW::body_test_motion(RID p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin, MotionResult *r_result, int p_max_collisions, bool p_collide_separation_ray, const Set<RID> &p_exclude) {
 	Body3DSW *body = body_owner.getornull(p_body);
 	ERR_FAIL_COND_V(!body, false);
 	ERR_FAIL_COND_V(!body->get_space(), false);
@@ -876,7 +876,7 @@ bool PhysicsServer3DSW::body_test_motion(RID p_body, const Transform3D &p_from, 
 
 	_update_shapes();
 
-	return body->get_space()->test_body_motion(body, p_from, p_motion, p_margin, r_result, p_collide_separation_ray, p_exclude);
+	return body->get_space()->test_body_motion(body, p_from, p_motion, p_margin, r_result, p_max_collisions, p_collide_separation_ray, p_exclude);
 }
 
 PhysicsDirectBodyState3D *PhysicsServer3DSW::body_get_direct_state(RID p_body) {

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -242,7 +242,7 @@ public:
 
 	virtual void body_set_ray_pickable(RID p_body, bool p_enable) override;
 
-	virtual bool body_test_motion(RID p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin = 0.001, MotionResult *r_result = nullptr, bool p_collide_separation_ray = false, const Set<RID> &p_exclude = Set<RID>()) override;
+	virtual bool body_test_motion(RID p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin = 0.001, MotionResult *r_result = nullptr, int p_max_collisions = 1, bool p_collide_separation_ray = false, const Set<RID> &p_exclude = Set<RID>()) override;
 
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override;

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -253,9 +253,9 @@ public:
 
 	FUNC2(body_set_ray_pickable, RID, bool);
 
-	bool body_test_motion(RID p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin = 0.001, MotionResult *r_result = nullptr, bool p_collide_separation_ray = false, const Set<RID> &p_exclude = Set<RID>()) override {
+	bool body_test_motion(RID p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin = 0.001, MotionResult *r_result = nullptr, int p_max_collisions = 1, bool p_collide_separation_ray = false, const Set<RID> &p_exclude = Set<RID>()) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
-		return physics_3d_server->body_test_motion(p_body, p_from, p_motion, p_margin, r_result, p_collide_separation_ray, p_exclude);
+		return physics_3d_server->body_test_motion(p_body, p_from, p_motion, p_margin, r_result, p_max_collisions, p_collide_separation_ray, p_exclude);
 	}
 
 	// this function only works on physics process, errors and returns null otherwise

--- a/servers/physics_3d/space_3d_sw.h
+++ b/servers/physics_3d/space_3d_sw.h
@@ -208,7 +208,7 @@ public:
 	void set_elapsed_time(ElapsedTime p_time, uint64_t p_msec) { elapsed_time[p_time] = p_msec; }
 	uint64_t get_elapsed_time(ElapsedTime p_time) const { return elapsed_time[p_time]; }
 
-	bool test_body_motion(Body3DSW *p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin, PhysicsServer3D::MotionResult *r_result, bool p_collide_separation_ray = false, const Set<RID> &p_exclude = Set<RID>());
+	bool test_body_motion(Body3DSW *p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin, PhysicsServer3D::MotionResult *r_result, int p_max_collisions = 1, bool p_collide_separation_ray = false, const Set<RID> &p_exclude = Set<RID>());
 
 	Space3DSW();
 	~Space3DSW();

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -370,77 +370,132 @@ Vector3 PhysicsTestMotionResult3D::get_remainder() const {
 	return result.remainder;
 }
 
-Vector3 PhysicsTestMotionResult3D::get_collision_point() const {
-	return result.collision_point;
+real_t PhysicsTestMotionResult3D::get_safe_fraction() const {
+	return result.safe_fraction;
 }
 
-Vector3 PhysicsTestMotionResult3D::get_collision_normal() const {
-	return result.collision_normal;
+real_t PhysicsTestMotionResult3D::get_unsafe_fraction() const {
+	return result.unsafe_fraction;
 }
 
-Vector3 PhysicsTestMotionResult3D::get_collider_velocity() const {
-	return result.collider_velocity;
+int PhysicsTestMotionResult3D::get_collision_count() const {
+	return result.collision_count;
 }
 
-ObjectID PhysicsTestMotionResult3D::get_collider_id() const {
-	return result.collider_id;
+Vector3 PhysicsTestMotionResult3D::get_collision_point(int p_collision_index) const {
+	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, Vector3());
+	return result.collisions[p_collision_index].position;
 }
 
-RID PhysicsTestMotionResult3D::get_collider_rid() const {
-	return result.collider;
+Vector3 PhysicsTestMotionResult3D::get_collision_normal(int p_collision_index) const {
+	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, Vector3());
+	return result.collisions[p_collision_index].normal;
 }
 
-Object *PhysicsTestMotionResult3D::get_collider() const {
-	return ObjectDB::get_instance(result.collider_id);
+Vector3 PhysicsTestMotionResult3D::get_collider_velocity(int p_collision_index) const {
+	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, Vector3());
+	return result.collisions[p_collision_index].collider_velocity;
 }
 
-int PhysicsTestMotionResult3D::get_collider_shape() const {
-	return result.collider_shape;
+ObjectID PhysicsTestMotionResult3D::get_collider_id(int p_collision_index) const {
+	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, ObjectID());
+	return result.collisions[p_collision_index].collider_id;
 }
 
-real_t PhysicsTestMotionResult3D::get_collision_depth() const {
-	return result.collision_depth;
+RID PhysicsTestMotionResult3D::get_collider_rid(int p_collision_index) const {
+	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, RID());
+	return result.collisions[p_collision_index].collider;
 }
 
-real_t PhysicsTestMotionResult3D::get_collision_safe_fraction() const {
-	return result.collision_safe_fraction;
+Object *PhysicsTestMotionResult3D::get_collider(int p_collision_index) const {
+	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, nullptr);
+	return ObjectDB::get_instance(result.collisions[p_collision_index].collider_id);
 }
 
-real_t PhysicsTestMotionResult3D::get_collision_unsafe_fraction() const {
-	return result.collision_unsafe_fraction;
+int PhysicsTestMotionResult3D::get_collider_shape(int p_collision_index) const {
+	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, 0);
+	return result.collisions[p_collision_index].collider_shape;
+}
+
+real_t PhysicsTestMotionResult3D::get_collision_depth(int p_collision_index) const {
+	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, 0.0);
+	return result.collisions[p_collision_index].depth;
+}
+
+Vector3 PhysicsTestMotionResult3D::get_best_collision_point() const {
+	return result.collision_count ? get_collision_point() : Vector3();
+}
+
+Vector3 PhysicsTestMotionResult3D::get_best_collision_normal() const {
+	return result.collision_count ? get_collision_normal() : Vector3();
+}
+
+Vector3 PhysicsTestMotionResult3D::get_best_collider_velocity() const {
+	return result.collision_count ? get_collider_velocity() : Vector3();
+}
+
+ObjectID PhysicsTestMotionResult3D::get_best_collider_id() const {
+	return result.collision_count ? get_collider_id() : ObjectID();
+}
+
+RID PhysicsTestMotionResult3D::get_best_collider_rid() const {
+	return result.collision_count ? get_collider_rid() : RID();
+}
+
+Object *PhysicsTestMotionResult3D::get_best_collider() const {
+	return result.collision_count ? get_collider() : nullptr;
+}
+
+int PhysicsTestMotionResult3D::get_best_collider_shape() const {
+	return result.collision_count ? get_collider_shape() : 0;
+}
+
+real_t PhysicsTestMotionResult3D::get_best_collision_depth() const {
+	return result.collision_count ? get_collision_depth() : 0.0;
 }
 
 void PhysicsTestMotionResult3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_travel"), &PhysicsTestMotionResult3D::get_travel);
 	ClassDB::bind_method(D_METHOD("get_remainder"), &PhysicsTestMotionResult3D::get_remainder);
-	ClassDB::bind_method(D_METHOD("get_collision_point"), &PhysicsTestMotionResult3D::get_collision_point);
-	ClassDB::bind_method(D_METHOD("get_collision_normal"), &PhysicsTestMotionResult3D::get_collision_normal);
-	ClassDB::bind_method(D_METHOD("get_collider_velocity"), &PhysicsTestMotionResult3D::get_collider_velocity);
-	ClassDB::bind_method(D_METHOD("get_collider_id"), &PhysicsTestMotionResult3D::get_collider_id);
-	ClassDB::bind_method(D_METHOD("get_collider_rid"), &PhysicsTestMotionResult3D::get_collider_rid);
-	ClassDB::bind_method(D_METHOD("get_collider"), &PhysicsTestMotionResult3D::get_collider);
-	ClassDB::bind_method(D_METHOD("get_collider_shape"), &PhysicsTestMotionResult3D::get_collider_shape);
-	ClassDB::bind_method(D_METHOD("get_collision_depth"), &PhysicsTestMotionResult3D::get_collision_depth);
-	ClassDB::bind_method(D_METHOD("get_collision_safe_fraction"), &PhysicsTestMotionResult3D::get_collision_safe_fraction);
-	ClassDB::bind_method(D_METHOD("get_collision_unsafe_fraction"), &PhysicsTestMotionResult3D::get_collision_unsafe_fraction);
+	ClassDB::bind_method(D_METHOD("get_safe_fraction"), &PhysicsTestMotionResult3D::get_safe_fraction);
+	ClassDB::bind_method(D_METHOD("get_unsafe_fraction"), &PhysicsTestMotionResult3D::get_unsafe_fraction);
+	ClassDB::bind_method(D_METHOD("get_collision_count"), &PhysicsTestMotionResult3D::get_collision_count);
+	ClassDB::bind_method(D_METHOD("get_collision_point", "collision_index"), &PhysicsTestMotionResult3D::get_collision_point, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_collision_normal", "collision_index"), &PhysicsTestMotionResult3D::get_collision_normal, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_collider_velocity", "collision_index"), &PhysicsTestMotionResult3D::get_collider_velocity, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_collider_id", "collision_index"), &PhysicsTestMotionResult3D::get_collider_id, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_collider_rid", "collision_index"), &PhysicsTestMotionResult3D::get_collider_rid, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_collider", "collision_index"), &PhysicsTestMotionResult3D::get_collider, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_collider_shape", "collision_index"), &PhysicsTestMotionResult3D::get_collider_shape, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_collision_depth", "collision_index"), &PhysicsTestMotionResult3D::get_collision_depth, DEFVAL(0));
+
+	ClassDB::bind_method(D_METHOD("get_best_collision_point"), &PhysicsTestMotionResult3D::get_best_collision_point);
+	ClassDB::bind_method(D_METHOD("get_best_collision_normal"), &PhysicsTestMotionResult3D::get_best_collision_normal);
+	ClassDB::bind_method(D_METHOD("get_best_collider_velocity"), &PhysicsTestMotionResult3D::get_best_collider_velocity);
+	ClassDB::bind_method(D_METHOD("get_best_collider_id"), &PhysicsTestMotionResult3D::get_best_collider_id);
+	ClassDB::bind_method(D_METHOD("get_best_collider_rid"), &PhysicsTestMotionResult3D::get_best_collider_rid);
+	ClassDB::bind_method(D_METHOD("get_best_collider"), &PhysicsTestMotionResult3D::get_best_collider);
+	ClassDB::bind_method(D_METHOD("get_best_collider_shape"), &PhysicsTestMotionResult3D::get_best_collider_shape);
+	ClassDB::bind_method(D_METHOD("get_best_collision_depth"), &PhysicsTestMotionResult3D::get_best_collision_depth);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "travel"), "", "get_travel");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "remainder"), "", "get_remainder");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collision_point"), "", "get_collision_point");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collision_normal"), "", "get_collision_normal");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collider_velocity"), "", "get_collider_velocity");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_id", PROPERTY_HINT_OBJECT_ID), "", "get_collider_id");
-	ADD_PROPERTY(PropertyInfo(Variant::RID, "collider_rid"), "", "get_collider_rid");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "collider"), "", "get_collider");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_shape"), "", "get_collider_shape");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_depth"), "", "get_collision_depth");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_safe_fraction"), "", "get_collision_safe_fraction");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_unsafe_fraction"), "", "get_collision_unsafe_fraction");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "safe_fraction"), "", "get_safe_fraction");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unsafe_fraction"), "", "get_unsafe_fraction");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_count"), "", "get_collision_count");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collision_point"), "", "get_best_collision_point");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collision_normal"), "", "get_best_collision_normal");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collider_velocity"), "", "get_best_collider_velocity");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_id", PROPERTY_HINT_OBJECT_ID), "", "get_best_collider_id");
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "collider_rid"), "", "get_best_collider_rid");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "collider"), "", "get_best_collider");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_shape"), "", "get_best_collider_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_depth"), "", "get_best_collision_depth");
 }
 
 ///////////////////////////////////////
 
-bool PhysicsServer3D::_body_test_motion(RID p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin, const Ref<PhysicsTestMotionResult3D> &p_result, bool p_collide_separation_ray, const Vector<RID> &p_exclude) {
+bool PhysicsServer3D::_body_test_motion(RID p_body, const Transform3D &p_from, const Vector3 &p_motion, real_t p_margin, const Ref<PhysicsTestMotionResult3D> &p_result, bool p_collide_separation_ray, const Vector<RID> &p_exclude, int p_max_collisions) {
 	MotionResult *r = nullptr;
 	if (p_result.is_valid()) {
 		r = p_result->get_result_ptr();
@@ -449,7 +504,7 @@ bool PhysicsServer3D::_body_test_motion(RID p_body, const Transform3D &p_from, c
 	for (int i = 0; i < p_exclude.size(); i++) {
 		exclude.insert(p_exclude[i]);
 	}
-	return body_test_motion(p_body, p_from, p_motion, p_margin, r, p_collide_separation_ray, exclude);
+	return body_test_motion(p_body, p_from, p_motion, p_margin, r, p_max_collisions, p_collide_separation_ray, exclude);
 }
 
 RID PhysicsServer3D::shape_create(ShapeType p_shape) {
@@ -607,7 +662,7 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("body_set_ray_pickable", "body", "enable"), &PhysicsServer3D::body_set_ray_pickable);
 
-	ClassDB::bind_method(D_METHOD("body_test_motion", "body", "from", "motion", "margin", "result", "collide_separation_ray", "exclude"), &PhysicsServer3D::_body_test_motion, DEFVAL(0.001), DEFVAL(Variant()), DEFVAL(false), DEFVAL(Array()));
+	ClassDB::bind_method(D_METHOD("body_test_motion", "body", "from", "motion", "margin", "result", "collide_separation_ray", "exclude", "max_collisions"), &PhysicsServer3D::_body_test_motion, DEFVAL(0.001), DEFVAL(Variant()), DEFVAL(false), DEFVAL(Array()), DEFVAL(1));
 
 	ClassDB::bind_method(D_METHOD("body_get_direct_state", "body"), &PhysicsServer3D::body_get_direct_state);
 


### PR DESCRIPTION
Thanks to @pouleyKetchoupp for his help/work on this, as this was harder than I thought. The latest "jitters" are definitively the worst :)

fix #30310
fix #50756
fix #51874
fix #52887

Test project: https://github.com/fabriceci/3d-platform-test-for-godot4 (based on the @TokageItLab one, thanks to him)

This PR should provide a good physics by default for CharacterBody3D, without any effort.

- all the improvement added in 2D to move and slide + new improvement (ability to choice the behaviour when the body left a platform)

![Screenshot 2021-09-21 at 10 18 57](https://user-images.githubusercontent.com/6397893/134136735-1d010dd3-e3d1-4d9e-8f99-ac14c6b9158a.png)

- the ability to detect multiple collisions on `move_and_collide` which allows us to handle advanced cases like the one below in the screenshot when the body is stuck between two walls

![Screenshot 2021-09-21 at 00 13 40](https://user-images.githubusercontent.com/6397893/134082955-f314d691-255a-4968-8cc8-33ed35b7c0de.png)

- new methods to retrieve important information (latest motion, true velocity, etc.)
- tweak value/code to behave nicely by default: minimal floor snap, default floor snap, etc.
