### PR TITLE
Prevent being able to set skeleton bone's parent as itself

### DIFF
--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -456,6 +456,7 @@ int Skeleton::get_bone_count() const {
 void Skeleton::set_bone_parent(int p_bone, int p_parent) {
 	ERR_FAIL_INDEX(p_bone, bones.size());
 	ERR_FAIL_COND(p_parent != -1 && (p_parent < 0));
+	ERR_FAIL_COND(p_bone == p_parent);
 
 	bones.write[p_bone].parent = p_parent;
 	process_order_dirty = true;


### PR DESCRIPTION
This PR prevents being able to set a skeleton's bone's parent as itself. Previously, this caused an infinite loop when trying to run `Skeleton::unparent_bone_and_rest`.

Resolves #52875 
