### PR TITLE
GDScript: Remove conversion assign mistakenly done when unneeded

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1754,7 +1754,6 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 				} else {
 					// TODO: Warning in this case.
 					mark_node_unsafe(p_assignment);
-					p_assignment->use_conversion_assign = true;
 				}
 			}
 		} else {


### PR DESCRIPTION
Fix #52029