### PR TITLE
[3.x] Editor connection signal selects Case according to the script extension. 

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -722,6 +722,38 @@ String String::camelcase_to_underscore(bool lowercase) const {
 	return lowercase ? new_string.to_lower() : new_string;
 }
 
+String String::snake_to_pascal_case(bool p_input_is_upper) const {
+	String ret;
+	Vector<String> parts = this->split("_", true);
+
+	for (int i = 0; i < parts.size(); i++) {
+		String part = parts[i];
+
+		if (part.length()) {
+			part[0] = _find_upper(part[0]);
+			if (p_input_is_upper) {
+				for (int j = 1; j < part.length(); j++)
+					part[j] = _find_lower(part[j]);
+			}
+			ret += part;
+		} else {
+			if (i == 0 || i == (parts.size() - 1)) {
+				// Preserve underscores at the beginning and end
+				ret += "_";
+			} else {
+				// Preserve contiguous underscores
+				if (parts[i - 1].length()) {
+					ret += "__";
+				} else {
+					ret += "_";
+				}
+			}
+		}
+	}
+
+	return ret;
+}
+
 int String::get_slice_count(String p_splitter) const {
 	if (empty()) {
 		return 0;

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -257,6 +257,7 @@ public:
 	static int64_t to_int(const CharType *p_str, int p_len = -1);
 	String capitalize() const;
 	String camelcase_to_underscore(bool lowercase = true) const;
+	String snake_to_pascal_case(bool p_input_is_upper = false) const;
 
 	int get_slice_count(String p_splitter) const;
 	String get_slice(String p_splitter, int p_slice) const;

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -31,6 +31,7 @@
 #include "connections_dialog.h"
 
 #include "core/print_string.h"
+#include "core/ustring.h"
 #include "editor_node.h"
 #include "editor_scale.h"
 #include "editor_settings.h"
@@ -719,18 +720,24 @@ void ConnectionsDock::_open_connection_dialog(TreeItem &item) {
 		midname[i] = c;
 	}
 
+	Connection c;
 	Node *dst_node = selectedNode->get_owner() ? selectedNode->get_owner() : selectedNode;
 	if (!dst_node || dst_node->get_script().is_null()) {
 		dst_node = _find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root());
+	} else {
+		Ref<Script> script = dst_node->get_script();
+		String extensionname = script->get_path().get_extension();
+		StringName dst_method;
+		if (extensionname == "cs") {
+			dst_method = "On" + midname.snake_to_pascal_case() + signal.snake_to_pascal_case();
+		} else {
+			dst_method = "_on_" + midname + "_" + signal;
+		}
+		c.method = dst_method;
 	}
-
-	StringName dst_method = "_on_" + midname + "_" + signal;
-
-	Connection c;
 	c.source = selectedNode;
 	c.signal = StringName(signalname);
 	c.target = dst_node;
-	c.method = dst_method;
 	connect_dialog->popup_dialog(signalname);
 	connect_dialog->init(c);
 	connect_dialog->set_title(TTR("Connect a Signal to a Method"));

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -39,6 +39,7 @@
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 #include "core/ucaps.h"
+#include "core/ustring.h"
 #include "main/main.h"
 
 #include "../glue/cs_glue_version.gen.h"
@@ -107,38 +108,6 @@ static String fix_doc_description(const String &p_bbcode) {
 			.replace("\t", "")
 			.replace("\r", "")
 			.strip_edges();
-}
-
-static String snake_to_pascal_case(const String &p_identifier, bool p_input_is_upper = false) {
-	String ret;
-	Vector<String> parts = p_identifier.split("_", true);
-
-	for (int i = 0; i < parts.size(); i++) {
-		String part = parts[i];
-
-		if (part.length()) {
-			part[0] = _find_upper(part[0]);
-			if (p_input_is_upper) {
-				for (int j = 1; j < part.length(); j++)
-					part[j] = _find_lower(part[j]);
-			}
-			ret += part;
-		} else {
-			if (i == 0 || i == (parts.size() - 1)) {
-				// Preserve underscores at the beginning and end
-				ret += "_";
-			} else {
-				// Preserve contiguous underscores
-				if (parts[i - 1].length()) {
-					ret += "__";
-				} else {
-					ret += "_";
-				}
-			}
-		}
-	}
-
-	return ret;
 }
 
 static String snake_to_camel_case(const String &p_identifier, bool p_input_is_upper = false) {
@@ -688,7 +657,7 @@ void BindingsGenerator::_apply_prefix_to_enum_constants(BindingsGenerator::EnumI
 				constant_name += parts[i];
 			}
 
-			curr_const.proxy_name = snake_to_pascal_case(constant_name, true);
+			curr_const.proxy_name = constant_name.snake_to_pascal_case(true);
 		}
 	}
 }
@@ -2269,7 +2238,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			iprop.index = ClassDB::get_property_index(type_cname, iprop.cname, &valid);
 			ERR_FAIL_COND_V(!valid, false);
 
-			iprop.proxy_name = escape_csharp_keyword(snake_to_pascal_case(iprop.cname));
+			iprop.proxy_name = escape_csharp_keyword(String(iprop.cname).snake_to_pascal_case());
 
 			// Prevent the property and its enclosing type from sharing the same name
 			if (iprop.proxy_name == itype.proxy_name) {
@@ -2425,7 +2394,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				imethod.add_argument(ivararg);
 			}
 
-			imethod.proxy_name = escape_csharp_keyword(snake_to_pascal_case(imethod.name));
+			imethod.proxy_name = escape_csharp_keyword(imethod.name.snake_to_pascal_case());
 
 			// Prevent the method and its enclosing type from sharing the same name
 			if (imethod.proxy_name == itype.proxy_name) {
@@ -2495,7 +2464,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				ERR_FAIL_NULL_V(value, false);
 				constants.erase(constant_name);
 
-				ConstantInterface iconstant(constant_name, snake_to_pascal_case(constant_name, true), *value);
+				ConstantInterface iconstant(constant_name, constant_name.snake_to_pascal_case(true), *value);
 
 				iconstant.const_doc = NULL;
 				for (int i = 0; i < itype.class_doc->constants.size(); i++) {
@@ -2530,7 +2499,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			int *value = class_info->constant_map.getptr(StringName(E->get()));
 			ERR_FAIL_NULL_V(value, false);
 
-			ConstantInterface iconstant(constant_name, snake_to_pascal_case(constant_name, true), *value);
+			ConstantInterface iconstant(constant_name, constant_name.snake_to_pascal_case(true), *value);
 
 			iconstant.const_doc = NULL;
 			for (int i = 0; i < itype.class_doc->constants.size(); i++) {
@@ -2998,7 +2967,7 @@ void BindingsGenerator::_populate_global_constants() {
 			int constant_value = GlobalConstants::get_global_constant_value(i);
 			StringName enum_name = GlobalConstants::get_global_constant_enum(i);
 
-			ConstantInterface iconstant(constant_name, snake_to_pascal_case(constant_name, true), constant_value);
+			ConstantInterface iconstant(constant_name, constant_name.snake_to_pascal_case(true), constant_value);
 			iconstant.const_doc = const_doc;
 
 			if (enum_name != StringName()) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Submit in two.
Move the snake_to_pascal_case above bindings_generator.cpp to ustring.cpp.
Editor connection signal selects Case according to the script extension.
When there is no problem in the test and everyone thinks the scheme is feasible, I will PR to 4.0.

![image](https://user-images.githubusercontent.com/14800320/134287224-e3b28ac3-787b-4fd0-8733-78587f744eaa.png)

分两个提交.
将原本bindings_generator.cpp上面的snake_to_pascal_case移动到了ustring.cpp.
编辑器连接信号根据脚本后缀名选择CASE.
等测试没有问题, 并且大家觉得方案可行, 我就PR到4.0.