### PR TITLE
[3.3] SpriteFramesEditor Fix preview grid in "Select Frames" dialog and preserve source texture margins when creating frames from AtlasTexture

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -115,6 +115,7 @@ class SpriteFramesEditor : public HSplitContainer {
 
 	void _open_sprite_sheet();
 	void _prepare_sprite_sheet(const String &p_file);
+	int _sheet_preview_position_to_frame_index(const Vector2 &p_position);
 	void _sheet_preview_draw();
 	void _sheet_spin_changed(double);
 	void _sheet_preview_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
@akien-mga According to https://github.com/godotengine/godot/pull/52461#issuecomment-924117952 bugfix-only `3.3` backport of: #51030 (it's a pure bugfix) and #52461 (but there's no zooming in here so it's a little changed / simplified).

Didn't backport #47802 or #48977 since these are enhancements.