### PR TITLE
Remove `default_env.tres` from generating in new projects

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1576,7 +1576,7 @@
 			Default background clear color. Overridable per [Viewport] using its [Environment]. See [member Environment.background_mode] and [member Environment.background_color] in particular. To change this default color programmatically, use [method RenderingServer.set_default_clear_color].
 		</member>
 		<member name="rendering/environment/defaults/default_environment" type="String" setter="" getter="" default="&quot;&quot;">
-			[Environment] that will be used as a fallback environment in case a scene does not specify its own environment. The default environment is loaded in at scene load time regardless of whether you have set an environment or not. If you do not rely on the fallback environment, it is best to delete [code]default_env.tres[/code], or to specify a different default environment here.
+			[Environment] that will be used as a fallback environment in case a scene does not specify its own environment. The default environment is loaded in at scene load time regardless of whether you have set an environment or not. If you do not rely on the fallback environment, you do not need to set this property.
 		</member>
 		<member name="rendering/environment/glow/upscale_mode" type="int" setter="" getter="" default="1">
 			Sets how the glow effect is upscaled before being copied onto the screen. Linear is faster, but looks blocky. Bicubic is slower but looks smooth.

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -102,7 +102,6 @@ private:
 	FileDialog *fdialog;
 	FileDialog *fdialog_install;
 	OptionButton *vcs_metadata_selection;
-	CheckBox *create_default_environment;
 	String zip_path;
 	String zip_title;
 	AcceptDialog *dialog_error;
@@ -495,31 +494,10 @@ private:
 					initial_settings["application/config/name"] = project_name->get_text().strip_edges();
 					initial_settings["application/config/icon"] = "res://icon.png";
 
-					if (create_default_environment->is_pressed()) {
-						initial_settings["rendering/environment/defaults/default_environment"] = "res://default_env.tres";
-					}
-
 					if (ProjectSettings::get_singleton()->save_custom(dir.plus_file("project.godot"), initial_settings, Vector<String>(), false) != OK) {
 						set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 					} else {
 						ResourceSaver::save(dir.plus_file("icon.png"), create_unscaled_default_project_icon());
-						FileAccess *f;
-						if (create_default_environment->is_pressed()) {
-							f = FileAccess::open(dir.plus_file("default_env.tres"), FileAccess::WRITE);
-							if (!f) {
-								set_message(TTR("Couldn't create default_env.tres in project path."), MESSAGE_ERROR);
-							} else {
-								f->store_line("[gd_resource type=\"Environment\" load_steps=2 format=2]");
-								f->store_line("");
-								f->store_line("[sub_resource type=\"Sky\" id=\"1\"]");
-								f->store_line("");
-								f->store_line("[resource]");
-								f->store_line("background_mode = 2");
-								f->store_line("sky = SubResource( \"1\" )");
-								memdelete(f);
-							}
-						}
-
 						EditorVCSInterface::create_vcs_metadata_files(EditorVCSInterface::VCSMetadata(vcs_metadata_selection->get_selected()), dir);
 					}
 				} else if (mode == MODE_INSTALL) {
@@ -945,10 +923,6 @@ public:
 		Control *spacer = memnew(Control);
 		spacer->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		default_files_container->add_child(spacer);
-		create_default_environment = memnew(CheckBox);
-		create_default_environment->set_text("Create Default Environment");
-		create_default_environment->set_pressed(true);
-		default_files_container->add_child(create_default_environment);
 
 		fdialog = memnew(FileDialog);
 		fdialog->set_access(FileDialog::ACCESS_FILESYSTEM);


### PR DESCRIPTION
This PR removes the code that generates `default_env.tres` in new projects. Existing projects aren't affected.

This is not needed anymore in 4.0 because the editor now has a preview environment. With this PR, there is a behavior change, since now empty projects with only a Camera3D will have a gray sky. I have double-checked with both @reduz and @Calinou that this behavior is intentional, and users are expected to create their own environment (likely by creating nodes from the preview environment menu).

In the future one idea that @Calinou had is to detect when a project has a Camera3D but no environment, and then show a warning. I'm not sure if that should be its own separate PR or if we should add it to this one, but they changes aren't directly dependent on each other, so we can do it separately.