### PR TITLE
Backport new 3D point light attenuation as an option (3.x)

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1377,6 +1377,10 @@
 		<member name="rendering/quality/shading/force_vertex_shading.mobile" type="bool" setter="" getter="" default="true">
 			Lower-end override for [member rendering/quality/shading/force_vertex_shading] on mobile devices, due to performance concerns or driver support.
 		</member>
+		<member name="rendering/quality/shading/use_physical_light_attenuation" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], enables new physical light attenuation for [OmniLight]s and [SpotLight]s. This results in more realistic lighting appearance with a very small performance cost. When physical light attenuation is enabled, lights will appear to be darker as a result of the new attenuation formula. This can be compensated by adjusting the lights' energy or attenuation values.
+			Changes to this setting will only be applied upon restarting the application.
+		</member>
 		<member name="rendering/quality/shadow_atlas/cubemap_size" type="int" setter="" getter="" default="512">
 			Size for cubemap into which the shadow is rendered before being copied into the shadow atlas. A higher number can result in higher resolution shadows when used with a higher [member rendering/quality/shadow_atlas/size]. Setting higher than a quarter of the [member rendering/quality/shadow_atlas/size] will not result in a perceptible increase in visual quality.
 		</member>

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2426,6 +2426,8 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 			storage->info.render.surface_switch_count++;
 		}
 
+		state.scene_shader.set_conditional(SceneShaderGLES2::USE_PHYSICAL_LIGHT_ATTENUATION, storage->config.use_physical_light_attenuation);
+
 		bool octahedral_compression = ((RasterizerStorageGLES2::Surface *)e->geometry)->format & VisualServer::ArrayFormat::ARRAY_FLAG_USE_OCTAHEDRAL_COMPRESSION;
 		if (octahedral_compression != prev_octahedral_compression) {
 			state.scene_shader.set_conditional(SceneShaderGLES2::ENABLE_OCTAHEDRAL_COMPRESSION, octahedral_compression);

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -6508,6 +6508,8 @@ void RasterizerStorageGLES2::initialize() {
 	GLOBAL_DEF_RST("rendering/quality/lightmapping/use_bicubic_sampling.mobile", false);
 	config.use_lightmap_filter_bicubic = GLOBAL_GET("rendering/quality/lightmapping/use_bicubic_sampling");
 
+	config.use_physical_light_attenuation = GLOBAL_GET("rendering/quality/shading/use_physical_light_attenuation");
+
 	int orphan_mode = GLOBAL_GET("rendering/2d/opengl/legacy_orphan_buffers");
 	switch (orphan_mode) {
 		default: {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -58,6 +58,7 @@ public:
 		bool use_anisotropic_filter;
 		bool use_skeleton_software;
 		bool use_lightmap_filter_bicubic;
+		bool use_physical_light_attenuation;
 
 		int max_vertex_texture_image_units;
 		int max_texture_image_units;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2111,6 +2111,8 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 			}
 		}
 
+		state.scene_shader.set_conditional(SceneShaderGLES3::USE_PHYSICAL_LIGHT_ATTENUATION, storage->config.use_physical_light_attenuation);
+
 		bool octahedral_compression = ((RasterizerStorageGLES3::Surface *)e->geometry)->format & VisualServer::ArrayFormat::ARRAY_FLAG_USE_OCTAHEDRAL_COMPRESSION;
 		if (octahedral_compression != prev_octahedral_compression) {
 			state.scene_shader.set_conditional(SceneShaderGLES3::ENABLE_OCTAHEDRAL_COMPRESSION, octahedral_compression);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8252,6 +8252,8 @@ void RasterizerStorageGLES3::initialize() {
 	GLOBAL_DEF("rendering/quality/lightmapping/use_bicubic_sampling.mobile", false);
 	config.use_lightmap_filter_bicubic = GLOBAL_GET("rendering/quality/lightmapping/use_bicubic_sampling");
 
+	config.use_physical_light_attenuation = GLOBAL_GET("rendering/quality/shading/use_physical_light_attenuation");
+
 	config.use_depth_prepass = bool(GLOBAL_GET("rendering/quality/depth_prepass/enable"));
 	if (config.use_depth_prepass) {
 		String vendors = GLOBAL_GET("rendering/quality/depth_prepass/disable_for_vendors");

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -74,6 +74,7 @@ public:
 		bool use_fast_texture_filter;
 		bool use_anisotropic_filter;
 		bool use_lightmap_filter_bicubic;
+		bool use_physical_light_attenuation;
 
 		bool s3tc_supported;
 		bool latc_supported;

--- a/modules/lightmapper_cpu/lightmapper_cpu.h
+++ b/modules/lightmapper_cpu/lightmapper_cpu.h
@@ -85,6 +85,7 @@ class LightmapperCPU : public Lightmapper {
 		float bounce_indirect_energy;
 		int samples;
 		bool use_denoiser = true;
+		bool use_physical_light_attenuation = false;
 		Ref<Image> environment_panorama;
 		Basis environment_transform;
 	};
@@ -150,6 +151,8 @@ class LightmapperCPU : public Lightmapper {
 	Color _bilinear_sample(const Ref<Image> &p_img, const Vector2 &p_uv, bool p_clamp_x = false, bool p_clamp_y = false);
 	Vector3 _fix_sample_position(const Vector3 &p_position, const Vector3 &p_texel_center, const Vector3 &p_normal, const Vector3 &p_tangent, const Vector3 &p_bitangent, const Vector2 &p_texel_size);
 	void _plot_triangle(const Vector2 *p_vertices, const Vector3 *p_positions, const Vector3 *p_normals, const Vector2 *p_uvs, const Ref<Image> &p_albedo_texture, const Ref<Image> &p_emission_texture, Vector2i p_size, LocalVector<LightmapTexel> &r_texels, LocalVector<int> &r_lightmap_indices);
+
+	float _get_omni_attenuation(float distance, float inv_range, float decay) const;
 
 	void _compute_direct_light(uint32_t p_idx, void *r_lightmap);
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2636,6 +2636,8 @@ VisualServer::VisualServer() {
 
 	GLOBAL_DEF_RST("rendering/misc/mesh_storage/split_stream", false);
 
+	GLOBAL_DEF_RST("rendering/quality/shading/use_physical_light_attenuation", false);
+
 	GLOBAL_DEF("rendering/quality/depth_prepass/enable", true);
 	GLOBAL_DEF("rendering/quality/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
 


### PR DESCRIPTION
This provides more realistic lighting with a very small performance cost. The option is available in both GLES3 and GLES2, and can be enabled in the Project Settings. This goes well with the [ACES Fitted tonemapping mode](https://github.com/godotengine/godot/pull/52477) that was recently added.

When enabled, this also makes upgrading Godot 3.x projects to Godot 4.0 easier, since lighting in 3.x will better match how it'll look in Godot 4.0.

**Testing project:** [test_light_attenuation_3.x.zip](https://github.com/godotengine/godot/files/7206776/test_light_attenuation_3.x.zip)

**Testing project 2 (use for testing CPU lightmapper attenuation backport):** [test_light_attenuation_lightmap_3.x.zip](https://github.com/godotengine/godot/files/7271897/test_light_attenuation_lightmap_3.x.zip)

## Preview

***Note:** The difference in brightness between the GLES3 and GLES2 images is expected, as GLES2 does not use HDR internally.*

*Lights in the middle have their attenuation set to 1.0 (the default). Lights on the right have their attenuation set to 0.5 ("Out" preset). The red light in the distance has its attenuation set to 2 ("In" preset).*

### GLES3 fragment shading

| Before | After |
|-|-|
| ![light_attenuation_gles3_fragment_old](https://user-images.githubusercontent.com/180032/134259471-2b12ec91-4726-4358-8637-6fa91784e758.png) | ![light_attenuation_gles3_fragment_new](https://user-images.githubusercontent.com/180032/134259470-79319f6f-ab45-4c33-be38-44f961a9cf72.png) |

### GLES2 fragment shading

| Before | After |
|-|-|
| ![light_attenuation_gles2_fragment_old](https://user-images.githubusercontent.com/180032/134259465-2808bc52-466b-429f-8637-73cd494450ec.png) | ![light_attenuation_gles2_fragment_new](https://user-images.githubusercontent.com/180032/134259460-4a531e6d-74c6-4523-9106-201653ef6e8a.png) |

### GLES3 vertex shading

***Note:** Vertex shading looks broken here due to the floor's low vertex count.*

| Before | After |
|-|-|
| ![light_attenuation_gles3_vertex_old](https://user-images.githubusercontent.com/180032/134259477-6b67338b-24fb-4400-b326-64f50f664b9a.png) | ![light_attenuation_gles3_vertex_new](https://user-images.githubusercontent.com/180032/134259475-7dd6a30a-00c9-4c38-997d-41a8242ef7c8.png) |

### GLES2 vertex shading

***Note:** Vertex shading looks broken here due to the floor's low vertex count.*

| Before | After |
|-|-|
| ![light_attenuation_gles2_vertex_old](https://user-images.githubusercontent.com/180032/134259468-78fd0be9-b06f-4369-bc1e-9b6721404597.png) | ![light_attenuation_gles2_vertex_new](https://user-images.githubusercontent.com/180032/134259466-7c662ce3-29b2-4b02-84c5-26d58fbebb0e.png) |

## TODO

- [x] Adapt the CPU lightmapper code to take the new option into account.
- [x] Test on mobile and HTML5 to make it sure it looks as expected. Check if there's a noticeable performance impact on mobile (and if so, document it).