### PR TITLE
[3.x] Fix 3D view name typo

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -740,7 +740,7 @@ void SpatialEditorViewport::_update_name() {
 			if (orthogonal) {
 				name = TTR("Left Orthogonal");
 			} else {
-				name = TTR("Right Perspective");
+				name = TTR("Left Perspective");
 			}
 		} break;
 		case VIEW_TYPE_RIGHT: {


### PR DESCRIPTION
#51658 mislabeled "Left Perspective" view as "Right Perspective" due to copy paste error :(