### PR TITLE
Expose "Keep" import option when multiple files are selected

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -127,18 +127,22 @@ void ImportDock::set_edit_path(const String &p_path) {
 		}
 	}
 
-	import_as->add_separator();
-	import_as->add_item(TTR("Keep File (No Import)"));
-	import_as->set_item_metadata(import_as->get_item_count() - 1, "keep");
-	if (importer_name == "keep") {
-		import_as->select(import_as->get_item_count() - 1);
-	}
+	_add_keep_import_option(importer_name);
 
 	import->set_disabled(false);
 	import_as->set_disabled(false);
 	preset->set_disabled(false);
 
 	imported->set_text(p_path.get_file());
+}
+
+void ImportDock::_add_keep_import_option(const String &p_importer_name) {
+	import_as->add_separator();
+	import_as->add_item(TTR("Keep File (No Import)"));
+	import_as->set_item_metadata(import_as->get_item_count() - 1, "keep");
+	if (p_importer_name == "keep") {
+		import_as->select(import_as->get_item_count() - 1);
+	}
 }
 
 void ImportDock::_update_options(const Ref<ConfigFile> &p_config) {
@@ -269,6 +273,8 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 			import_as->select(import_as->get_item_count() - 1);
 		}
 	}
+
+	_add_keep_import_option(params->importer->get_importer_name());
 
 	_update_preset_menu();
 

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -66,6 +66,7 @@ class ImportDock : public VBoxContainer {
 	void _importer_selected(int i_idx);
 	void _update_options(const Ref<ConfigFile> &p_config = Ref<ConfigFile>());
 	void _update_preset_menu();
+	void _add_keep_import_option(const String &p_importer_name);
 
 	void _property_toggled(const StringName &p_prop, bool p_checked);
 	void _reimport_attempt();


### PR DESCRIPTION
To resolve https://github.com/godotengine/godot/issues/52037 . Extracts the code adding "Keep" option to a private method, and adds a call of that method to the `ImportDock::set_edit_multiple_paths()` (in addition to the current call from `ImportDock::set_edit_path()`)

The fix suggested by @akien-mga worked, after making that change I was able to select several files and change them all to "Keep" import simultaneously. For what it's worth, the reverse operation still isn't possible in a batch form from within Godot (i.e. changing 10 files from "Keep" import to "Image" import or whatever), but that is hopefully a rarer use-case and looks like it'd require some deeper updating to change.