### PR TITLE
HTML5: Fix minification error with Emscripten 1.39.9

### DIFF
--- a/platform/javascript/.eslintrc.js
+++ b/platform/javascript/.eslintrc.js
@@ -39,5 +39,13 @@ module.exports = {
 		// Closure compiler (exported properties)
 		"quote-props": ["error", "consistent"],
 		"dot-notation": "off",
+		// No comma dangle for functions (it's madness, and ES2017)
+		"comma-dangle": ["error", {
+			"arrays": "always-multiline",
+			"objects": "always-multiline",
+			"imports": "always-multiline",
+			"exports": "always-multiline",
+			"functions": "never"
+		}],
 	}
 };

--- a/platform/javascript/js/libs/library_godot_audio.js
+++ b/platform/javascript/js/libs/library_godot_audio.js
@@ -229,7 +229,7 @@ const GodotAudioWorklet = {
 					'godot-processor',
 					{
 						'outputChannelCount': [channels],
-					},
+					}
 				);
 				return Promise.resolve();
 			});


### PR DESCRIPTION
It used an old vendored version of acorn.js which seems to choke on this
trailing comma. This is not a problem for more recent Emscripten versions.

The error started after #52650 which now makes our AudioWorklet library build on non-threaded builds too (so Mono too with Emscripten 1.39.9). Not strictly related in `3.3` which didn't get this change backported, but might be worth cherry-picking anyway for consistency.

The error was:
```
em++ -o bin/godot.javascript.opt.debug.mono.js -Os --profiling-funcs -s INITIAL_MEMORY=32MB -s ENVIRONMENT=web,worker -s MODULARIZE=1 -s EXPORT_NAME='Godot' -s ALLOW_MEMORY_GROWTH=1 -s USE_WEBGL2=1 -s INVOKE_RU>
cache:INFO: generating system library: libc++-noexcept.a... (this will be cached in "/root/emsdk_1.39.9/upstream/emscripten/cache/wasm/libc++-noexcept.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libc++abi-noexcept.a... (this will be cached in "/root/emsdk_1.39.9/upstream/emscripten/cache/wasm/libc++abi-noexcept.a" for subsequent builds)
cache:INFO:  - ok
cache:INFO: generating system library: libgl-webgl2-ofb.a... (this will be cached in "/root/emsdk_1.39.9/upstream/emscripten/cache/wasm/libgl-webgl2-ofb.a" for subsequent builds)
cache:INFO:  - ok
/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:2780
  throw err
  ^

SyntaxError: Unexpected token (12835:6)
                                );
      ^

    at Parser.pp$4.raise (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:2778:13)
    at Parser.pp.unexpected (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:680:8)
    at Parser.pp$3.parseExprAtom (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:2230:10)
    at Parser.pp$3.parseExprSubscripts (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:2075:19)
    at Parser.pp$3.parseMaybeUnary (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:2052:17)
    at Parser.pp$3.parseExprOps (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:1994:19)
    at Parser.pp$3.parseMaybeConditional (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:1977:19)
    at Parser.pp$3.parseMaybeAssign (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:1952:19)
    at Parser.pp$3.parseExprList (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:2676:20)
    at Parser.pp$3.parseNew (/root/emsdk_1.39.9/upstream/emscripten/tools/node_modules/acorn/dist/acorn.js:2343:55) {
  pos: 502055,
  loc: Position { line: 12835, column: 6 },
  raisedAt: 502056
}
shared:ERROR: '/root/emsdk_1.39.9/node/14.15.5_64bit/bin/node /root/emsdk_1.39.9/upstream/emscripten/tools/acorn-optimizer.js /tmp/emscripten_temp_j7fg3q8m/godot.javascript.opt.debug.mono.wasm.o.js AJSDCE minifyWhitespace' failed (1)
```

Which is super unhelpful, but after patching acorn.js I got:
```
SyntaxError: Unexpected token (12835:6)
                                        'godot-processor',
                                        {
                                                'outputChannelCount': [channels],
                                        },
                                );
                                ^

                                return Promise.resolve();
                        });
                        GodotAudio.driver = GodotAudioWorklet;
                },start:function (in_buf, out_buf, state) {
```

This was likely relaxed in later releases of acorn.js, but Emscripten 1.39.9 bundles it own patched version (it was unbundled with https://github.com/emscripten-core/emscripten/issues/11439 in 1.39.19).