### PR TITLE
CI: Build test binaries with debug symbols, then strip

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes
+  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux
@@ -23,7 +23,6 @@ jobs:
             target: release_debug
             tools: true
             tests: true
-            sconsflags: ""
             doc-test: true
             bin: "./bin/godot.linuxbsd.opt.tools.64"
             artifact: true
@@ -44,7 +43,7 @@ jobs:
             target: release
             tools: false
             tests: false
-            sconsflags: module_mono_enabled=yes mono_glue=no
+            sconsflags: module_mono_enabled=yes mono_glue=no debug_symbols=no
             artifact: true
 
     steps:
@@ -126,6 +125,11 @@ jobs:
         run: |
           VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run ${{ matrix.bin }} 40 --audio-driver Dummy --path test_project 2>&1 | tee sanitizers_log.txt || true
           misc/scripts/check_ci_log.py sanitizers_log.txt
+
+      - name: Prepare artifact
+        if: ${{ matrix.artifact }}
+        run: |
+          strip bin/godot.*
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes
+  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos
@@ -30,6 +30,7 @@ jobs:
             target: release
             tools: false
             tests: false
+            sconsflags: debug_symbols=no
 
     steps:
       - uses: actions/checkout@v2
@@ -57,6 +58,10 @@ jobs:
         if: ${{ matrix.tests }}
         run: |
           ${{ matrix.bin }} --test
+
+      - name: Prepare artifact
+        run: |
+          strip bin/godot.*
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 # SCONS_CACHE for windows must be set in the build environment
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: verbose=yes warnings=all werror=yes debug_symbols=no module_text_server_fb_enabled=yes
+  SCONSFLAGS: verbose=yes warnings=all werror=yes module_text_server_fb_enabled=yes
   SCONS_CACHE_MSVC_CONFIG: true
 
 concurrency:
@@ -33,6 +33,7 @@ jobs:
             target: release
             tools: false
             tests: false
+            sconsflags: debug_symbols=no
 
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +51,7 @@ jobs:
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }}
+          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
           platform: windows
           target: ${{ matrix.target }}
           tools: ${{ matrix.tools }}
@@ -62,6 +63,10 @@ jobs:
         if: ${{ matrix.tests }}
         run: |
           ${{ matrix.bin }} --test
+
+      - name: Prepare artifact
+        run: |
+          Remove-Item bin/* -Include *.exp,*.lib,*.pdb -Force
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact


### PR DESCRIPTION
This allows having good stacktraces when the tests crash.