### PR TITLE
[Extensions] Allow instantiating extended objects from gdnative extensions.

### DIFF
--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -854,24 +854,19 @@ static GDNativeMethodBindPtr gdnative_classdb_get_method_bind(const char *p_clas
 	return (GDNativeMethodBindPtr)mb;
 }
 
-static GDNativeClassConstructor gdnative_classdb_get_constructor(const char *p_classname) {
+static GDNativeClassConstructor gdnative_classdb_get_constructor(const char *p_classname, GDNativeExtensionPtr *r_extension) {
 	ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(StringName(p_classname));
 	if (class_info) {
+		if (r_extension) {
+			*r_extension = class_info->native_extension;
+		}
 		return (GDNativeClassConstructor)class_info->creation_func;
 	}
 	return nullptr;
 }
 
-static GDNativeExtensionPtr gdnative_classdb_get_extension(const char *p_classname) {
-	ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(StringName(p_classname));
-	if (class_info) {
-		return (GDNativeExtensionPtr)class_info->native_extension;
-	}
-	return nullptr;
-}
-
-static GDNativeObjectPtr gdnative_classdb_construct_extended(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension) {
-	return (GDNativeObjectPtr)ClassDB::construct_extended((Object * (*)()) p_constructor, (ObjectNativeExtension *)p_extension);
+static GDNativeObjectPtr gdnative_classdb_construct_object(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension) {
+	return (GDNativeObjectPtr)ClassDB::construct_object((Object * (*)()) p_constructor, (ObjectNativeExtension *)p_extension);
 }
 
 static void *gdnative_classdb_get_class_tag(const char *p_classname) {
@@ -1022,8 +1017,7 @@ void gdnative_setup_interface(GDNativeInterface *p_interface) {
 	/* CLASSDB */
 
 	gdni.classdb_get_constructor = gdnative_classdb_get_constructor;
-	gdni.classdb_get_extension = gdnative_classdb_get_extension;
-	gdni.classdb_construct_extended = gdnative_classdb_construct_extended;
+	gdni.classdb_construct_object = gdnative_classdb_construct_object;
 	gdni.classdb_get_method_bind = gdnative_classdb_get_method_bind;
 	gdni.classdb_get_class_tag = gdnative_classdb_get_class_tag;
 

--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -862,6 +862,18 @@ static GDNativeClassConstructor gdnative_classdb_get_constructor(const char *p_c
 	return nullptr;
 }
 
+static GDNativeExtensionPtr gdnative_classdb_get_extension(const char *p_classname) {
+	ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(StringName(p_classname));
+	if (class_info) {
+		return (GDNativeExtensionPtr)class_info->native_extension;
+	}
+	return nullptr;
+}
+
+static GDNativeObjectPtr gdnative_classdb_construct_extended(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension) {
+	return (GDNativeObjectPtr)ClassDB::construct_extended((Object * (*)()) p_constructor, (ObjectNativeExtension *)p_extension);
+}
+
 static void *gdnative_classdb_get_class_tag(const char *p_classname) {
 	ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(p_classname);
 	return class_info ? class_info->class_ptr : nullptr;
@@ -1010,6 +1022,8 @@ void gdnative_setup_interface(GDNativeInterface *p_interface) {
 	/* CLASSDB */
 
 	gdni.classdb_get_constructor = gdnative_classdb_get_constructor;
+	gdni.classdb_get_extension = gdnative_classdb_get_extension;
+	gdni.classdb_construct_extended = gdnative_classdb_construct_extended;
 	gdni.classdb_get_method_bind = gdnative_classdb_get_method_bind;
 	gdni.classdb_get_class_tag = gdnative_classdb_get_class_tag;
 

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -137,6 +137,7 @@ typedef void *GDNativeStringNamePtr;
 typedef void *GDNativeStringPtr;
 typedef void *GDNativeObjectPtr;
 typedef void *GDNativeTypePtr;
+typedef void *GDNativeExtensionPtr;
 typedef void *GDNativeMethodBindPtr;
 typedef int64_t GDNativeInt;
 typedef uint8_t GDNativeBool;
@@ -432,6 +433,8 @@ typedef struct {
 	/* CLASSDB */
 
 	GDNativeClassConstructor (*classdb_get_constructor)(const char *p_classname);
+	GDNativeExtensionPtr (*classdb_get_extension)(const char *p_classname);
+	GDNativeObjectPtr (*classdb_construct_extended)(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension);
 	GDNativeMethodBindPtr (*classdb_get_method_bind)(const char *p_classname, const char *p_methodname, GDNativeInt p_hash);
 	void *(*classdb_get_class_tag)(const char *p_classname);
 

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -432,9 +432,8 @@ typedef struct {
 
 	/* CLASSDB */
 
-	GDNativeClassConstructor (*classdb_get_constructor)(const char *p_classname);
-	GDNativeExtensionPtr (*classdb_get_extension)(const char *p_classname);
-	GDNativeObjectPtr (*classdb_construct_extended)(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension);
+	GDNativeClassConstructor (*classdb_get_constructor)(const char *p_classname, GDNativeExtensionPtr *r_extension);
+	GDNativeObjectPtr (*classdb_construct_object)(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension);
 	GDNativeMethodBindPtr (*classdb_get_method_bind)(const char *p_classname, const char *p_methodname, GDNativeInt p_hash);
 	void *(*classdb_get_class_tag)(const char *p_classname);
 

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -545,6 +545,13 @@ Object *ClassDB::instantiate(const StringName &p_class) {
 	return ti->creation_func();
 }
 
+Object *ClassDB::construct_extended(Object *(*p_create_func)(), ObjectNativeExtension *p_extension) {
+	initializing_with_extension = true;
+	initializing_extension = p_extension;
+	initializing_extension_instance = p_extension->create_instance(p_extension->class_userdata);
+	return p_create_func();
+}
+
 bool ClassDB::can_instantiate(const StringName &p_class) {
 	OBJTYPE_RLOCK;
 

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -545,10 +545,12 @@ Object *ClassDB::instantiate(const StringName &p_class) {
 	return ti->creation_func();
 }
 
-Object *ClassDB::construct_extended(Object *(*p_create_func)(), ObjectNativeExtension *p_extension) {
-	initializing_with_extension = true;
-	initializing_extension = p_extension;
-	initializing_extension_instance = p_extension->create_instance(p_extension->class_userdata);
+Object *ClassDB::construct_object(Object *(*p_create_func)(), ObjectNativeExtension *p_extension) {
+	if (p_extension) {
+		initializing_with_extension = true;
+		initializing_extension = p_extension;
+		initializing_extension_instance = p_extension->create_instance(p_extension->class_userdata);
+	}
 	return p_create_func();
 }
 

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -234,6 +234,7 @@ public:
 	static bool is_parent_class(const StringName &p_class, const StringName &p_inherits);
 	static bool can_instantiate(const StringName &p_class);
 	static Object *instantiate(const StringName &p_class);
+	static Object *construct_extended(Object *(*p_create_func)(), ObjectNativeExtension *p_extension);
 	static void instance_get_native_extension_data(ObjectNativeExtension **r_extension, GDExtensionClassInstancePtr *r_extension_instance, Object *p_base);
 
 	static APIType get_api_type(const StringName &p_class);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -234,7 +234,7 @@ public:
 	static bool is_parent_class(const StringName &p_class, const StringName &p_inherits);
 	static bool can_instantiate(const StringName &p_class);
 	static Object *instantiate(const StringName &p_class);
-	static Object *construct_extended(Object *(*p_create_func)(), ObjectNativeExtension *p_extension);
+	static Object *construct_object(Object *(*p_create_func)(), ObjectNativeExtension *p_extension);
 	static void instance_get_native_extension_data(ObjectNativeExtension **r_extension, GDExtensionClassInstancePtr *r_extension_instance, Object *p_base);
 
 	static APIType get_api_type(const StringName &p_class);


### PR DESCRIPTION
Calling the constructor alone is not enough if the class to be instantiated is not a base class.

This PR adds an output parameter to the `gdnative_classdb_get_constructor` returning the internal reference to the Godot extension informations, and a new function `gdnative_classdb_construct_object` that returns a new `Object` given a constructor and the extension reference (skipped if null).

The two commits should be squashed if we decide for this approach instead of having a separate function to retrieve the extension reference (first commit).