### PR TITLE
Prevent being able to set Skeleton3D bone's parent as itself

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -520,6 +520,7 @@ void Skeleton3D::set_bone_parent(int p_bone, int p_parent) {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
 	ERR_FAIL_COND(p_parent != -1 && (p_parent < 0));
+	ERR_FAIL_COND(p_bone == p_parent);
 
 	bones.write[p_bone].parent = p_parent;
 	process_order_dirty = true;


### PR DESCRIPTION
This PR prevents being able to set a skeleton's bone's parent as itself. Previously, this caused an infinite loop when trying to run Skeleton::unparent_bone_and_rest.

(This is a duplicate of #52894 but for the master branch instead of the 3.x branch)

Resolves #52875 