### PR TITLE
Fix right clicking sub nodes after renaming parent

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -527,7 +527,7 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 }
 
 void SceneTreeEditor::_node_renamed(Node *p_node) {
-	if (!get_scene_node()->is_ancestor_of(p_node)) {
+	if (p_node != get_scene_node() && !get_scene_node()->is_ancestor_of(p_node)) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #51384
Fixes #52746

Adds a check for whether renamed node is the scene root in `SceneTreeEditor::_node_renamed()`.
