### PR TITLE
Add missing WIN32_LEAN_AND_MEAN

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -36,9 +36,9 @@
 
 #ifdef WINDOWS_ENABLED
 #include <stdio.h>
-#include <winsock2.h>
-// Needs to be included after winsocks2.h
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #ifndef UWP_ENABLED
 #include <iphlpapi.h>

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -39,6 +39,7 @@
 
 #include <audioclient.h>
 #include <mmdeviceapi.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 class AudioDriverWASAPI : public AudioDriver {

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -37,6 +37,7 @@
 
 #include <stdio.h>
 #include <wchar.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 /*

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -37,6 +37,7 @@
 
 #include <share.h> // _SH_DENYNO
 #include <shlwapi.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #include <errno.h>

--- a/drivers/winmidi/midi_driver_winmidi.h
+++ b/drivers/winmidi/midi_driver_winmidi.h
@@ -37,6 +37,7 @@
 #include "core/templates/vector.h"
 
 #include <stdio.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #include <mmsystem.h>

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -36,6 +36,7 @@
 #include "servers/audio_server.h"
 
 #include <mmsystem.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <wrl/client.h>
 #include <xaudio2.h>

--- a/modules/mono/utils/mono_reg_utils.cpp
+++ b/modules/mono/utils/mono_reg_utils.cpp
@@ -35,7 +35,7 @@
 
 #include "core/os/os.h"
 
-// Here, after os/os.h
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 namespace MonoRegUtils {

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -36,6 +36,7 @@
 #include "core/os/os.h"
 
 #ifdef WINDOWS_ENABLED
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #define ENV_PATH_SEP ";"

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -28,14 +28,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-// Must include Winsock before windows.h (included by os_uwp.h)
-#include "drivers/unix/net_socket_posix.h"
-
 #include "os_uwp.h"
 
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
 #include "drivers/unix/ip_unix.h"
+#include "drivers/unix/net_socket_posix.h"
 #include "drivers/windows/dir_access_windows.h"
 #include "drivers/windows/file_access_windows.h"
 #include "drivers/windows/mutex_windows.h"

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -45,6 +45,7 @@
 #include <fcntl.h>
 #include <io.h>
 #include <stdio.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 class OS_UWP : public OS {

--- a/platform/windows/context_gl_windows.h
+++ b/platform/windows/context_gl_windows.h
@@ -38,6 +38,7 @@
 #include "core/error/error_list.h"
 #include "core/os/os.h"
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 typedef bool(APIENTRY *PFNWGLSWAPINTERVALEXTPROC)(int interval);

--- a/platform/windows/crash_handler_windows.h
+++ b/platform/windows/crash_handler_windows.h
@@ -31,6 +31,7 @@
 #ifndef CRASH_HANDLER_WINDOWS_H
 #define CRASH_HANDLER_WINDOWS_H
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 // Crash handler exception only enabled with MSVC

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -63,6 +63,7 @@
 #include <fcntl.h>
 #include <io.h>
 #include <stdio.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <windowsx.h>
 

--- a/platform/windows/key_mapping_windows.h
+++ b/platform/windows/key_mapping_windows.h
@@ -33,8 +33,8 @@
 
 #include "core/os/keyboard.h"
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-
 #include <winuser.h>
 
 class KeyMappingWindows {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -28,15 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-// Must include Winsock before windows.h (included by os_windows.h)
-#include "drivers/unix/net_socket_posix.h"
-
 #include "os_windows.h"
 
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "core/io/marshalls.h"
 #include "core/version_generated.gen.h"
+#include "drivers/unix/net_socket_posix.h"
 #include "drivers/windows/dir_access_windows.h"
 #include "drivers/windows/file_access_windows.h"
 #include "joypad_windows.h"

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -57,7 +57,9 @@
 
 #include <fcntl.h>
 #include <io.h>
+#include <shellapi.h>
 #include <stdio.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <windowsx.h>
 

--- a/platform/windows/vulkan_context_win.h
+++ b/platform/windows/vulkan_context_win.h
@@ -32,6 +32,8 @@
 #define VULKAN_DEVICE_WIN_H
 
 #include "drivers/vulkan/vulkan_context.h"
+
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 class VulkanContextWindows : public VulkanContext {

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -33,6 +33,7 @@
 #ifdef WINDOWS_ENABLED
 
 #include <stdio.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 void WindowsTerminalLogger::logv(const char *p_format, va_list p_list, bool p_err) {


### PR DESCRIPTION
`#define WIN32_LEAN_AND_MEAN` reduces the size of the Windows header files by excluding some of the less common API declarations, so both preprocessor and compiler have less work.

Properly fixes workarounds like this:
![unknown](https://user-images.githubusercontent.com/1554127/134468589-28b531d3-33ad-4b1d-90b5-5e8d080a3156.png)

It's already present in most of the thirdparty libraries used by Godot.

References:
https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers#faster-builds-with-smaller-header-files
https://docs.microsoft.com/pl-pl/windows/win32/winsock/complete-server-code
https://aras-p.info/blog/2018/01/12/Minimizing-windows.h/