### PR TITLE
Fix LineEdit and TextEdit double-click and triple-click selection

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -260,24 +260,29 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 			} else {
 				if (selecting_enabled) {
-					if (!b->is_double_click() && (OS::get_singleton()->get_ticks_msec() - selection.last_dblclk) < 600) {
+					const int triple_click_timeout = 600;
+					const int triple_click_tolerance = 5;
+					const bool is_triple_click = !b->is_double_click() && (OS::get_singleton()->get_ticks_msec() - last_dblclk) < triple_click_timeout && b->get_position().distance_to(last_dblclk_pos) < triple_click_tolerance;
+
+					if (is_triple_click && text.length()) {
 						// Triple-click select all.
 						selection.enabled = true;
 						selection.begin = 0;
 						selection.end = text.length();
 						selection.double_click = true;
-						selection.last_dblclk = 0;
+						last_dblclk = 0;
 						caret_column = selection.begin;
 					} else if (b->is_double_click()) {
 						// Double-click select word.
+						last_dblclk = OS::get_singleton()->get_ticks_msec();
+						last_dblclk_pos = b->get_position();
 						Vector<Vector2i> words = TS->shaped_text_get_word_breaks(text_rid);
 						for (int i = 0; i < words.size(); i++) {
-							if (words[i].x < caret_column && words[i].y > caret_column) {
+							if ((words[i].x < caret_column && words[i].y > caret_column) || (i == words.size() - 1 && caret_column == words[i].y)) {
 								selection.enabled = true;
 								selection.begin = words[i].x;
 								selection.end = words[i].y;
 								selection.double_click = true;
-								selection.last_dblclk = OS::get_singleton()->get_ticks_msec();
 								caret_column = selection.end;
 								break;
 							}

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -136,7 +136,6 @@ private:
 		bool creating = false;
 		bool double_click = false;
 		bool drag_attempt = false;
-		uint64_t last_dblclk = 0;
 	} selection;
 
 	struct TextOperation {
@@ -152,6 +151,9 @@ private:
 		bool press_attempt = false;
 		bool pressing_inside = false;
 	} clear_button_status;
+
+	uint64_t last_dblclk = 0;
+	Vector2 last_dblclk_pos;
 
 	bool caret_blink_enabled = false;
 	bool caret_force_displayed = false;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3689,7 +3689,7 @@ void TextEdit::select_word_under_caret() {
 	int end = 0;
 	const Vector<Vector2i> words = TS->shaped_text_get_word_breaks(text.get_line_data(caret.line)->get_rid());
 	for (int i = 0; i < words.size(); i++) {
-		if (words[i].x <= caret.column && words[i].y >= caret.column) {
+		if ((words[i].x < caret.column && words[i].y > caret.column) || (i == words.size() - 1 && caret.column == words[i].y)) {
 			begin = words[i].x;
 			end = words[i].y;
 			break;
@@ -5411,7 +5411,7 @@ void TextEdit::_update_selection_mode_word() {
 	int end = beg;
 	Vector<Vector2i> words = TS->shaped_text_get_word_breaks(text.get_line_data(line)->get_rid());
 	for (int i = 0; i < words.size(); i++) {
-		if (words[i].x < caret_pos && words[i].y > caret_pos) {
+		if ((words[i].x < caret_pos && words[i].y > caret_pos) || (i == words.size() - 1 && caret_pos == words[i].y)) {
 			beg = words[i].x;
 			end = words[i].y;
 			break;


### PR DESCRIPTION
Fixes #52975

### Issue description : 

Double clicking after the last word in a LineEdit should select the last word.
Triple clic anywhere (so after the last word too) in the LineEdit should select all content.
These two behavior are broken in 4.0 (regression)

### Cause :

There were 2 differents problems here :

Double clic word selection didn't catch the case where the carret was exactly at the end of the last word.
(We don't want to just replace test ``words[i].y > caret_column`` with ``words[i].y >= caret_column`` here cause we don't want to select the word before a space between two words)

If no word was selected after a double-click (if the last character is not a letter/number or because of the first part of the bug above), the last time of double click wasn't updated and so triple click was never detected. So I moved the last time update to be updated even if no word is selected after a double-clic.

### Before

![before](https://user-images.githubusercontent.com/3649998/134551818-cc9842c8-8c9a-43c8-a674-b2c94bcc4c5b.gif)
(Double click after the last word doesn't select it and last double-clic timer is not updated so triple clic is broken too)

![before2](https://user-images.githubusercontent.com/3649998/134551929-44100deb-746f-4ff4-b2fa-ea06c054c566.gif)
(Double click at the end doesn't select word because last character is not a letter or number AND triple click is never detected)
 
### After (Same behaviour as in3.x) :

![after](https://user-images.githubusercontent.com/3649998/134551837-2233cb42-79d7-4587-9ddb-1b4d49cea1a5.gif)
(Double click after the last word select it and last double-clic timer is updated so triple clic works fine)

![after2](https://user-images.githubusercontent.com/3649998/134551945-a90b790c-fab9-4da9-9c7c-2f5b03ea28f4.gif)
(Double click at the end doesn't select word because last character is not a letter or number BUT triple click is correctly catch)


