### PR TITLE
Disable sub-inspectors for properties with their own editors

### DIFF
--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -562,6 +562,7 @@ class EditorPropertyResource : public EditorProperty {
 	void _sub_inspector_resource_selected(const RES &p_resource, const String &p_property);
 	void _sub_inspector_object_id_selected(int p_id);
 
+	bool _can_use_sub_inspector(const RES &p_resource);
 	void _open_editor_pressed();
 	void _fold_other_editors(Object *p_self);
 	void _update_property_bg();


### PR DESCRIPTION
This is a temporary fix for some problems with multiple contextual editors (namely https://github.com/godotengine/godot/issues/52779, https://github.com/godotengine/godot/issues/29873, https://github.com/godotengine/godot/issues/47514). The proper fix is https://github.com/godotengine/godot/pull/45085, but it's for master and reduz wants to overhaul the system anyway.

But we still have problems in 3.x, including quite critical regressions for the upcoming 3.4 (https://github.com/godotengine/godot/issues/52779). So I propose this as a solution to make sure 3.x is in a working state. Since sub-inspectors are broken when multiple editors are involved, this PR disables sub-inspectors in such cases. We already have editors that force their edited resource to be opened in a new inspector instead of a sub-inspector (e.g. the TileSet editor), so this should be fine for the time being.

Linked issues should probably not be closed until https://github.com/godotengine/godot/pull/45085 or a new alternative is implemented.