### PR TITLE
Improve appearance of the editor Debugger bottom panel menu

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -265,15 +265,20 @@ void EditorDebuggerNode::_notification(int p_what) {
 
 		if (error_count == 0 && warning_count == 0) {
 			debugger_button->set_text(TTR("Debugger"));
+			debugger_button->remove_theme_color_override("font_color");
 			debugger_button->set_icon(Ref<Texture2D>());
 		} else {
 			debugger_button->set_text(TTR("Debugger") + " (" + itos(error_count + warning_count) + ")");
 			if (error_count >= 1 && warning_count >= 1) {
 				debugger_button->set_icon(get_theme_icon(SNAME("ErrorWarning"), SNAME("EditorIcons")));
+				// Use error color to represent the highest level of severity reported.
+				debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 			} else if (error_count >= 1) {
 				debugger_button->set_icon(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
+				debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 			} else {
 				debugger_button->set_icon(get_theme_icon(SNAME("Warning"), SNAME("EditorIcons")));
+				debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 			}
 		}
 		last_error_count = error_count;

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/editor_debugger_server.h"
 #include "editor/editor_node.h"
+#include "editor/editor_scale.h"
 #include "editor/fileserver/editor_file_server.h"
 #include "scene/gui/menu_button.h"
 
@@ -52,6 +53,8 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(EditorNode *p_editor, MenuButton *p_d
 
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
 	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
+	// Add separation for the warning/error icon that is displayed later.
+	db->add_theme_constant_override("hseparation", 6 * EDSCALE);
 	debugger->set_tool_button(db);
 
 	// Main editor debug menu.


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/53013.

- Make the Debugger bottom panel menu more prominent when there are errors or warnings by adjusting the text color.
  - The color highlight is only present when the Debugger panel isn't selected.
- Add some spacing to the right of the error/warning icon for better visual appearance.

## Preview

### Errors only

![2021-09-24_00 57 44](https://user-images.githubusercontent.com/180032/134594795-792dc901-8f8d-4456-bc6a-58ec1dfc8f23.png)

### Errors + warnings

![image](https://user-images.githubusercontent.com/180032/139092149-5885b535-def5-49ef-bc09-7148609e032d.png)

### Warnings only

![2021-09-24_00 56 37](https://user-images.githubusercontent.com/180032/134594793-2bbf9ef6-0850-4421-90f1-903bb8bf5f41.png)