### PR TITLE
Color error and warning lines in the editor debugger's Errors panel

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -501,6 +501,10 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		error->set_text(0, time);
 		error->set_text_align(0, TreeItem::ALIGN_LEFT);
 
+		const Color color = get_theme_color(oe.warning ? SNAME("warning_color") : SNAME("error_color"), SNAME("Editor"));
+		error->set_custom_color(0, color);
+		error->set_custom_color(1, color);
+
 		String error_title;
 		if (oe.callstack.size() > 0) {
 			// If available, use the script's stack in the error title.


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/53010.

Follow-up to https://github.com/godotengine/godot/pull/52985 (can be merged independently).

This improves readability when some errors/warnings are unfolded, as their stack traces will keep their original colors.

## Preview

![image](https://user-images.githubusercontent.com/180032/134595958-48aaa148-f4a6-4f5a-9f8d-48aa4aa945a8.png)