### PR TITLE
Replace `#pragma once` by traditional include guards for consistency

### DIFF
--- a/core/templates/pooled_list.h
+++ b/core/templates/pooled_list.h
@@ -28,13 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#pragma once
+#ifndef POOLED_LIST_H
+#define POOLED_LIST_H
+
+#include "core/templates/local_vector.h"
 
 // Simple template to provide a pool with O(1) allocate and free.
 // The freelist could alternatively be a linked list placed within the unused elements
 // to use less memory, however a separate freelist is probably more cache friendly.
-
-// NOTE : Take great care when using this with non POD types. The construction and destruction
+//
+// NOTE: Take great care when using this with non POD types. The construction and destruction
 // is done in the LocalVector, NOT as part of the pool. So requesting a new item does not guarantee
 // a constructor is run, and free does not guarantee a destructor.
 // You should generally handle clearing
@@ -42,9 +45,6 @@
 // This is by design for fastest use in the BVH. If you want a more general pool
 // that does call constructors / destructors on request / free, this should probably be
 // a separate template.
-
-#include "core/templates/local_vector.h"
-
 template <class T, bool force_trivial = false>
 class PooledList {
 	LocalVector<T, uint32_t, force_trivial> list;
@@ -93,3 +93,5 @@ public:
 		_used_size--;
 	}
 };
+
+#endif // POOLED_LIST_H

--- a/platform/uwp/SCsub
+++ b/platform/uwp/SCsub
@@ -7,7 +7,7 @@ files = [
     "#platform/windows/windows_terminal_logger.cpp",
     "joypad_uwp.cpp",
     "context_egl_uwp.cpp",
-    "app.cpp",
+    "app_uwp.cpp",
     "os_uwp.cpp",
 ]
 

--- a/platform/uwp/app_uwp.cpp
+++ b/platform/uwp/app_uwp.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  app.cpp                                                              */
+/*  app_uwp.cpp                                                          */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -32,7 +32,7 @@
 // This file demonstrates how to initialize EGL in a Windows Store app, using ICoreWindow.
 //
 
-#include "app.h"
+#include "app_uwp.h"
 
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"

--- a/platform/uwp/app_uwp.h
+++ b/platform/uwp/app_uwp.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  app.h                                                                */
+/*  app_uwp.h                                                            */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#pragma once
+#ifndef APP_UWP_H
+#define APP_UWP_H
 
 #include <string>
 
@@ -111,3 +112,4 @@ namespace GodotUWP
 }
 
 /* clang-format on */
+#endif // APP_UWP_H


### PR DESCRIPTION
`#pragma once` was used in a few files, yet we settled on using traditional include guards instead.

The PooledList template comment was also moved to allow editors such as Visual Studio Code to display the comment when hovering PooledList.

`app.h` was renamed to `app_uwp.h` to be less generic for the include guard.