### PR TITLE
Fix arrow pointing in the wrong direction in the Dock Position popup

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6105,9 +6105,9 @@ EditorNode::EditorNode() {
 	dock_tab_move_right = memnew(Button);
 	dock_tab_move_right->set_flat(true);
 	if (gui_base->is_layout_rtl()) {
-		dock_tab_move_right->set_icon(theme->get_icon("Forward", "EditorIcons"));
-	} else {
 		dock_tab_move_right->set_icon(theme->get_icon("Back", "EditorIcons"));
+	} else {
+		dock_tab_move_right->set_icon(theme->get_icon("Forward", "EditorIcons"));
 	}
 	dock_tab_move_right->set_focus_mode(Control::FOCUS_NONE);
 	dock_tab_move_right->connect("pressed", callable_mp(this, &EditorNode::_dock_move_right));


### PR DESCRIPTION
Just your average copy-n-paste mistake.

|Before:|After:|
|-|-|
|![dock_1](https://user-images.githubusercontent.com/30739239/134601229-86065d27-dcc1-420d-ae03-25dcf26809c5.png)|![dock_2](https://user-images.githubusercontent.com/30739239/134601258-59d14d0e-7a78-4299-9962-b26b548ab6c6.png)|