### PR TITLE
Expose `TabContainer`'s tab hiding for scripts

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -6,8 +6,6 @@
 	<description>
 		Sets the active tab's [code]visible[/code] property to the value [code]true[/code]. Sets all other children's to [code]false[/code].
 		Ignores non-[Control] children.
-		Individual tabs are always visible unless you use [method set_tab_disabled] and [method set_tab_title] to hide it.
-		To hide only a tab's content, nest the content inside a child [Control], so it receives the [TabContainer]'s visibility setting instead.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -50,6 +48,13 @@
 				Returns [code]true[/code] if the tab at index [code]tab_idx[/code] is disabled.
 			</description>
 		</method>
+		<method name="get_tab_hidden" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="tab_idx" type="int" />
+			<description>
+				Returns [code]true[/code] if the tab at index [code]tab_idx[/code] is hidden.
+			</description>
+		</method>
 		<method name="get_tab_icon" qualifiers="const">
 			<return type="Texture2D" />
 			<argument index="0" name="tab_idx" type="int" />
@@ -89,8 +94,15 @@
 			<argument index="0" name="tab_idx" type="int" />
 			<argument index="1" name="disabled" type="bool" />
 			<description>
-				If [code]disabled[/code] is [code]false[/code], hides the tab at index [code]tab_idx[/code].
-				[b]Note:[/b] Its title text will remain, unless also removed with [method set_tab_title].
+				If [code]disabled[/code] is [code]true[/code], disables the tab at index [code]tab_idx[/code], making it non-interactable.
+			</description>
+		</method>
+		<method name="set_tab_hidden">
+			<return type="void" />
+			<argument index="0" name="tab_idx" type="int" />
+			<argument index="1" name="hidden" type="bool" />
+			<description>
+				If [code]hidden[/code] is [code]true[/code], hides the tab at index [code]tab_idx[/code], making it disappear from the tab area.
 			</description>
 		</method>
 		<method name="set_tab_icon">
@@ -106,14 +118,14 @@
 			<argument index="0" name="tab_idx" type="int" />
 			<argument index="1" name="title" type="String" />
 			<description>
-				Sets a title for the tab at index [code]tab_idx[/code]. Tab titles default to the name of the indexed child node, but this can be overridden with [method set_tab_title].
+				Sets a title for the tab at index [code]tab_idx[/code]. Tab titles default to the name of the indexed child node.
 			</description>
 		</method>
 		<method name="set_tabs_rearrange_group">
 			<return type="void" />
 			<argument index="0" name="group_id" type="int" />
 			<description>
-				Defines rearrange group id, choose for each [TabContainer] the same value to enable tab drag between [TabContainer]. Enable drag with [code]set_drag_to_rearrange_enabled(true)[/code].
+				Defines rearrange group id, choose for each [TabContainer] the same value to enable tab drag between [TabContainer]. Enable drag with [member drag_to_rearrange_enabled].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -108,7 +108,7 @@
 			<return type="String" />
 			<argument index="0" name="tab_idx" type="int" />
 			<description>
-				Returns the title of the tab at index [code]tab_idx[/code]. Tab titles default to the name of the indexed child node, but this can be overridden with [method set_tab_title].
+				Returns the title of the tab at index [code]tab_idx[/code].
 			</description>
 		</method>
 		<method name="get_tabs_rearrange_group" qualifiers="const">
@@ -144,8 +144,7 @@
 			<argument index="0" name="tab_idx" type="int" />
 			<argument index="1" name="disabled" type="bool" />
 			<description>
-				If [code]disabled[/code] is [code]false[/code], hides the tab at index [code]tab_idx[/code].
-				[b]Note:[/b] Its title text will remain unless it is also removed with [method set_tab_title].
+				If [code]disabled[/code] is [code]true[/code], disables the tab at index [code]tab_idx[/code], making it non-interactable.
 			</description>
 		</method>
 		<method name="set_tab_icon">
@@ -193,7 +192,7 @@
 			<return type="void" />
 			<argument index="0" name="group_id" type="int" />
 			<description>
-				Defines the rearrange group ID. Choose for each [Tabs] the same value to dragging tabs between [Tabs]. Enable drag with [code]set_drag_to_rearrange_enabled(true)[/code].
+				Defines the rearrange group ID. Choose for each [Tabs] the same value to dragging tabs between [Tabs]. Enable drag with [member drag_to_rearrange_enabled].
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1210,6 +1210,8 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_icon", "tab_idx"), &TabContainer::get_tab_icon);
 	ClassDB::bind_method(D_METHOD("set_tab_disabled", "tab_idx", "disabled"), &TabContainer::set_tab_disabled);
 	ClassDB::bind_method(D_METHOD("get_tab_disabled", "tab_idx"), &TabContainer::get_tab_disabled);
+	ClassDB::bind_method(D_METHOD("set_tab_hidden", "tab_idx", "hidden"), &TabContainer::set_tab_hidden);
+	ClassDB::bind_method(D_METHOD("get_tab_hidden", "tab_idx"), &TabContainer::get_tab_hidden);
 	ClassDB::bind_method(D_METHOD("get_tab_idx_at_point", "point"), &TabContainer::get_tab_idx_at_point);
 	ClassDB::bind_method(D_METHOD("set_popup", "popup"), &TabContainer::set_popup);
 	ClassDB::bind_method(D_METHOD("get_popup"), &TabContainer::get_popup);


### PR DESCRIPTION
The current wording in docs for `TabContainer` seems to hint that disabling a tab and setting its title to blank can hide it, but in the code that's not true. So what about exposing the existing methods for hiding then?

I also tidied up a little the docs for `TabsContainer`/`Tabs`. There was quite some non-sense in those.