### PR TITLE
Add a special case for 0-time interpolations

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -86,6 +86,7 @@
 				[code]initial_value[/code] is the starting value of the interpolation.
 				[code]delta_value[/code] is the change of the value in the interpolation, i.e. it's equal to [code]final_value - initial_value[/code].
 				[code]duration[/code] is the total time of the interpolation.
+				[b]Note:[/b] If [code]duration[/code] is equal to [code]0[/code], the method will always return the final value, regardless of [code]elapsed_time[/code] provided.
 			</description>
 		</method>
 		<method name="is_running">

--- a/thirdparty/misc/easing_equations.cpp
+++ b/thirdparty/misc/easing_equations.cpp
@@ -312,6 +312,10 @@ Tween::interpolater Tween::interpolaters[Tween::TRANS_MAX][Tween::EASE_MAX] = {
 };
 
 real_t Tween::run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t t, real_t b, real_t c, real_t d) {
+	if (d == 0) {
+		// Special case to avoid dividing by 0 in equations.
+		return b + c;
+	}
 
 	interpolater cb = interpolaters[p_trans_type][p_ease_type];
 	ERR_FAIL_COND_V(cb == NULL, b);


### PR DESCRIPTION
Most of interpolation equations divide by duration, which results in infinite final value if it's 0. I added a special case for 0 duration, so now it ends instantly without computing anything.

Fixes #40843

Could be probably cherry-picked, because the interpolation method is the same (except it's not exposed).