### PR TITLE
Fix incorrect offsets of tooltip content in `CodeEdit`

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -227,17 +227,17 @@ void CodeEdit::_notification(int p_what) {
 						end = font->get_string_size(line.substr(0, line.rfind(String::chr(0xFFFF))), font_size).x;
 					}
 
-					Point2 round_ofs = hint_ofs + sb->get_offset() + Vector2(0, font->get_ascent() + font_height * i + yofs);
+					Point2 round_ofs = hint_ofs + sb->get_offset() + Vector2(0, font->get_ascent(font_size) + font_height * i + yofs);
 					round_ofs = round_ofs.round();
 					draw_string(font, round_ofs, line.replace(String::chr(0xFFFF), ""), HALIGN_LEFT, -1, font_size, font_color);
 					if (end > 0) {
 						// Draw an underline for the currently edited function parameter.
-						const Vector2 b = hint_ofs + sb->get_offset() + Vector2(begin, font_height + font_height * i + line_spacing);
+						const Vector2 b = hint_ofs + sb->get_offset() + Vector2(begin, font_height + font_height * i + yofs);
 						draw_line(b, b + Vector2(end - begin, 0), font_color, 2);
 
 						// Draw a translucent text highlight as well.
 						const Rect2 highlight_rect = Rect2(
-								hint_ofs + sb->get_offset() + Vector2(begin, 0),
+								b - Vector2(0, font_height),
 								Vector2(end - begin, font_height));
 						draw_rect(highlight_rect, font_color * Color(1, 1, 1, 0.2));
 					}


### PR DESCRIPTION
Fix incorrect offset for some elements in that tooltip:

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/3036176/134684478-083502e1-c0f0-4ad0-8264-a06173d5654c.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/3036176/134685340-c77833e9-5b58-47c2-8e60-143640527df9.png)

</details>

Should work correctly at all zoom levels:

<details>
<summary>Details</summary>

![codeedit_tooltip_zoom](https://user-images.githubusercontent.com/3036176/134683289-0e39a969-e828-47e2-b35b-363c2f883a1a.gif)


</details>
