### PR TITLE
Color error and warning lines in the editor debugger's Errors panel (3.x)

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -916,6 +916,10 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		error->set_text(0, time);
 		error->set_text_align(0, TreeItem::ALIGN_LEFT);
 
+		const Color color = get_color(is_warning ? "warning_color" : "error_color", "Editor");
+		error->set_custom_color(0, color);
+		error->set_custom_color(1, color);
+
 		String error_title;
 		// Include method name, when given, in error title.
 		if (has_method) {


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/52987.

This improves readability when some errors/warnings are unfolded, as their stack traces will keep their original colors.

## Preview

![image](https://user-images.githubusercontent.com/180032/134686245-5e941494-7172-4cd7-b03f-53b8b8c243e1.png)