### PR TITLE
Portals - add reason string to unload message

### DIFF
--- a/scene/3d/portal.cpp
+++ b/scene/3d/portal.cpp
@@ -147,7 +147,7 @@ void Portal::_changed() {
 		return;
 	}
 
-	rm->_rooms_changed();
+	rm->_rooms_changed("changed Portal " + get_name());
 #endif
 }
 

--- a/scene/3d/room.cpp
+++ b/scene/3d/room.cpp
@@ -259,7 +259,7 @@ void Room::_changed(bool p_regenerate_bounds) {
 	if (p_regenerate_bounds) {
 		rm->_room_regenerate_bound(this);
 	}
-	rm->_rooms_changed();
+	rm->_rooms_changed("changed Room " + get_name());
 #endif
 }
 

--- a/scene/3d/room_group.cpp
+++ b/scene/3d/room_group.cpp
@@ -80,7 +80,7 @@ void RoomGroup::_changed() {
 		return;
 	}
 
-	rm->_rooms_changed();
+	rm->_rooms_changed("changed RoomGroup " + get_name());
 #endif
 }
 

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -518,10 +518,10 @@ String RoomManager::get_pvs_filename() const {
 	return _pvs_filename;
 }
 
-void RoomManager::_rooms_changed() {
+void RoomManager::_rooms_changed(String p_reason) {
 	_rooms.clear();
 	if (is_inside_world() && get_world().is_valid()) {
-		VisualServer::get_singleton()->rooms_unload(get_world()->get_scenario());
+		VisualServer::get_singleton()->rooms_unload(get_world()->get_scenario(), p_reason);
 	}
 }
 
@@ -543,7 +543,7 @@ void RoomManager::rooms_flip_portals() {
 	}
 
 	_flip_portals_recursive(_roomlist);
-	_rooms_changed();
+	_rooms_changed("flipped Portals");
 }
 
 void RoomManager::rooms_convert() {

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -109,7 +109,7 @@ public:
 	// for internal use in the editor..
 	// either we can clear the rooms and unload,
 	// or reconvert.
-	void _rooms_changed();
+	void _rooms_changed(String p_reason);
 
 #ifdef TOOLS_ENABLED
 	// for a preview, we allow the editor to change the bound

--- a/servers/visual/portals/portal_renderer.cpp
+++ b/servers/visual/portals/portal_renderer.cpp
@@ -165,7 +165,7 @@ void PortalRenderer::instance_moving_destroy(OcclusionHandle p_handle) {
 	// The alternative is to remove the reference, but this is not currently supported
 	// (it would mean rejigging rooms etc)
 	if (_occlusion_handle_is_in_room(p_handle)) {
-		_ensure_unloaded();
+		_ensure_unloaded("deleting STATIC or DYNAMIC");
 		return;
 	}
 
@@ -224,7 +224,7 @@ PortalHandle PortalRenderer::portal_create() {
 
 void PortalRenderer::portal_destroy(PortalHandle p_portal) {
 	ERR_FAIL_COND(!p_portal);
-	_ensure_unloaded();
+	_ensure_unloaded("deleting Portal");
 
 	// plus one based
 	p_portal--;
@@ -378,7 +378,7 @@ void PortalRenderer::roomgroup_prepare(RoomGroupHandle p_roomgroup, ObjectID p_r
 
 void PortalRenderer::roomgroup_destroy(RoomGroupHandle p_roomgroup) {
 	ERR_FAIL_COND(!p_roomgroup);
-	_ensure_unloaded();
+	_ensure_unloaded("deleting RoomGroup");
 
 	// plus one based
 	p_roomgroup--;
@@ -618,7 +618,7 @@ RoomHandle PortalRenderer::room_create() {
 
 void PortalRenderer::room_destroy(RoomHandle p_room) {
 	ERR_FAIL_COND(!p_room);
-	_ensure_unloaded();
+	_ensure_unloaded("deleting Room");
 
 	// plus one based
 	p_room--;
@@ -1007,10 +1007,18 @@ void PortalRenderer::sprawl_roaming(uint32_t p_mover_pool_id, MovingBase &r_movi
 }
 
 // This gets called when you delete an instance the the room system depends on
-void PortalRenderer::_ensure_unloaded() {
+void PortalRenderer::_ensure_unloaded(String p_reason) {
 	if (_loaded) {
 		_loaded = false;
-		_log("Portal system unloaded.", 1);
+
+		String str;
+		if (p_reason != String()) {
+			str = "Portal system unloaded ( " + p_reason + " ).";
+		} else {
+			str = "Portal system unloaded.";
+		}
+
+		_log(str, 1);
 
 		// this should probably have some thread protection, but I doubt it matters
 		// as this will worst case give wrong result for a frame

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -162,7 +162,7 @@ public:
 
 	// for use in the editor only, to allow a cheap way of turning off portals
 	// if there has been a change, e.g. moving a room etc.
-	void rooms_unload() { _ensure_unloaded(); }
+	void rooms_unload(String p_reason) { _ensure_unloaded(p_reason); }
 	bool rooms_is_loaded() const { return _loaded; }
 
 	// debugging
@@ -257,7 +257,7 @@ private:
 	void _moving_remove_from_rooms(uint32_t p_moving_pool_id);
 	void _rghost_remove_from_rooms(uint32_t p_pool_id);
 	void _occluder_remove_from_rooms(uint32_t p_pool_id);
-	void _ensure_unloaded();
+	void _ensure_unloaded(String p_reason = String());
 	void _rooms_add_portals_to_convex_hulls();
 	void _add_portal_to_convex_hull(LocalVector<Plane, int32_t> &p_planes, const Plane &p);
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -594,7 +594,7 @@ public:
 	BIND5(room_set_bound, RID, ObjectID, const Vector<Plane> &, const AABB &, const Vector<Vector3> &)
 	BIND2(room_prepare, RID, int32_t)
 	BIND1(rooms_and_portals_clear, RID)
-	BIND1(rooms_unload, RID)
+	BIND2(rooms_unload, RID, String)
 	BIND8(rooms_finalize, RID, bool, bool, bool, bool, String, bool, bool)
 	BIND4(rooms_override_camera, RID, bool, const Vector3 &, const Vector<Plane> *)
 	BIND2(rooms_set_active, RID, bool)

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1316,10 +1316,10 @@ void VisualServerScene::room_set_bound(RID p_room, ObjectID p_room_object_id, co
 	room->scenario->_portal_renderer.room_set_bound(room->scenario_room_id, p_room_object_id, p_convex, p_aabb, p_verts);
 }
 
-void VisualServerScene::rooms_unload(RID p_scenario) {
+void VisualServerScene::rooms_unload(RID p_scenario, String p_reason) {
 	Scenario *scenario = scenario_owner.getornull(p_scenario);
 	ERR_FAIL_COND(!scenario);
-	scenario->_portal_renderer.rooms_unload();
+	scenario->_portal_renderer.rooms_unload(p_reason);
 }
 
 void VisualServerScene::rooms_and_portals_clear(RID p_scenario) {

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -664,7 +664,7 @@ public:
 	virtual void room_set_bound(RID p_room, ObjectID p_room_object_id, const Vector<Plane> &p_convex, const AABB &p_aabb, const Vector<Vector3> &p_verts);
 	virtual void room_prepare(RID p_room, int32_t p_priority);
 	virtual void rooms_and_portals_clear(RID p_scenario);
-	virtual void rooms_unload(RID p_scenario);
+	virtual void rooms_unload(RID p_scenario, String p_reason);
 	virtual void rooms_finalize(RID p_scenario, bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename, bool p_use_simple_pvs, bool p_log_pvs_generation);
 	virtual void rooms_override_camera(RID p_scenario, bool p_override, const Vector3 &p_point, const Vector<Plane> *p_convex);
 	virtual void rooms_set_active(RID p_scenario, bool p_active);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -517,7 +517,7 @@ public:
 	FUNC5(room_set_bound, RID, ObjectID, const Vector<Plane> &, const AABB &, const Vector<Vector3> &)
 	FUNC2(room_prepare, RID, int32_t)
 	FUNC1(rooms_and_portals_clear, RID)
-	FUNC1(rooms_unload, RID)
+	FUNC2(rooms_unload, RID, String)
 	FUNC8(rooms_finalize, RID, bool, bool, bool, bool, String, bool, bool)
 	FUNC4(rooms_override_camera, RID, bool, const Vector3 &, const Vector<Plane> *)
 	FUNC2(rooms_set_active, RID, bool)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -917,7 +917,7 @@ public:
 	virtual void room_set_bound(RID p_room, ObjectID p_room_object_id, const Vector<Plane> &p_convex, const AABB &p_aabb, const Vector<Vector3> &p_verts) = 0;
 	virtual void room_prepare(RID p_room, int32_t p_priority) = 0;
 	virtual void rooms_and_portals_clear(RID p_scenario) = 0;
-	virtual void rooms_unload(RID p_scenario) = 0;
+	virtual void rooms_unload(RID p_scenario, String p_reason) = 0;
 	virtual void rooms_finalize(RID p_scenario, bool p_generate_pvs, bool p_cull_using_pvs, bool p_use_secondary_pvs, bool p_use_signals, String p_pvs_filename, bool p_use_simple_pvs, bool p_log_pvs_generation) = 0;
 	virtual void rooms_override_camera(RID p_scenario, bool p_override, const Vector3 &p_point, const Vector<Plane> *p_convex) = 0;
 	virtual void rooms_set_active(RID p_scenario, bool p_active) = 0;


### PR DESCRIPTION
To help users identify conditions that are causing room system invalidation, a reason message is passed to the unload function and logged to the output window.

Addresses providing more user info in #53005

## Notes
* In the VisualServer there is no simple access to the names of objects so the info is limited.
* For STATICS & DYNAMICS being deleted, we could potentially get the `VisualServerScene::Instance` which stores an ObjectID and lookup the object from this to get the name, however this seems a bit error prone and it might be better to avoid this unless there is demand.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
