### PR TITLE
Improve appearance of the editor Debugger bottom panel menu (3.x)

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3390,6 +3390,8 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	script_editor = this;
 
 	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
+	// Add separation for the warning/error icon that is displayed later.
+	db->add_constant_override("hseparation", 6 * EDSCALE);
 	debugger->set_tool_button(db);
 
 	debugger->connect("breaked", this, "_breaked");

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1366,6 +1366,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 				if (error_count == 0 && warning_count == 0) {
 					errors_tab->set_name(TTR("Errors"));
 					debugger_button->set_text(TTR("Debugger"));
+					debugger_button->add_color_override("font_color", get_color("font_color", "Editor"));
 					debugger_button->set_icon(Ref<Texture>());
 					tabs->set_tab_icon(errors_tab->get_index(), Ref<Texture>());
 				} else {
@@ -1373,12 +1374,16 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					debugger_button->set_text(TTR("Debugger") + " (" + itos(error_count + warning_count) + ")");
 					if (error_count >= 1 && warning_count >= 1) {
 						debugger_button->set_icon(get_icon("ErrorWarning", "EditorIcons"));
+						// Use error color to represent the highest level of severity reported.
+						debugger_button->add_color_override("font_color", get_color("error_color", "Editor"));
 						tabs->set_tab_icon(errors_tab->get_index(), get_icon("ErrorWarning", "EditorIcons"));
 					} else if (error_count >= 1) {
 						debugger_button->set_icon(get_icon("Error", "EditorIcons"));
+						debugger_button->add_color_override("font_color", get_color("error_color", "Editor"));
 						tabs->set_tab_icon(errors_tab->get_index(), get_icon("Error", "EditorIcons"));
 					} else {
 						debugger_button->set_icon(get_icon("Warning", "EditorIcons"));
+						debugger_button->add_color_override("font_color", get_color("warning_color", "Editor"));
 						tabs->set_tab_icon(errors_tab->get_index(), get_icon("Warning", "EditorIcons"));
 					}
 				}


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/52985.

- Make the Debugger bottom panel menu more prominent when there are errors or warnings by adjusting the text color.
  - The color highlight is only present when the Debugger panel isn't selected.
- Add some spacing to the right of the error/warning icon for better visual appearance.

## Preview

### Errors only

![2021-09-24_00 57 44](https://user-images.githubusercontent.com/180032/134594795-792dc901-8f8d-4456-bc6a-58ec1dfc8f23.png)

### Errors + warnings

![image](https://user-images.githubusercontent.com/180032/139092149-5885b535-def5-49ef-bc09-7148609e032d.png)

### Warnings only

![2021-09-24_00 56 37](https://user-images.githubusercontent.com/180032/134594793-2bbf9ef6-0850-4421-90f1-903bb8bf5f41.png)