### PR TITLE
[Core] GDNative construct_object now also returns the extension instance

### DIFF
--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -865,8 +865,8 @@ static GDNativeClassConstructor gdnative_classdb_get_constructor(const char *p_c
 	return nullptr;
 }
 
-static GDNativeObjectPtr gdnative_classdb_construct_object(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension) {
-	return (GDNativeObjectPtr)ClassDB::construct_object((Object * (*)()) p_constructor, (ObjectNativeExtension *)p_extension);
+static GDNativeObjectPtr gdnative_classdb_construct_object(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension, void **r_instance) {
+	return (GDNativeObjectPtr)ClassDB::construct_object((Object * (*)()) p_constructor, (ObjectNativeExtension *)p_extension, r_instance);
 }
 
 static void *gdnative_classdb_get_class_tag(const char *p_classname) {

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -433,7 +433,7 @@ typedef struct {
 	/* CLASSDB */
 
 	GDNativeClassConstructor (*classdb_get_constructor)(const char *p_classname, GDNativeExtensionPtr *r_extension);
-	GDNativeObjectPtr (*classdb_construct_object)(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension);
+	GDNativeObjectPtr (*classdb_construct_object)(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension, void **r_instance);
 	GDNativeMethodBindPtr (*classdb_get_method_bind)(const char *p_classname, const char *p_methodname, GDNativeInt p_hash);
 	void *(*classdb_get_class_tag)(const char *p_classname);
 

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -545,11 +545,16 @@ Object *ClassDB::instantiate(const StringName &p_class) {
 	return ti->creation_func();
 }
 
-Object *ClassDB::construct_object(Object *(*p_create_func)(), ObjectNativeExtension *p_extension) {
+Object *ClassDB::construct_object(Object *(*p_create_func)(), ObjectNativeExtension *p_extension, void **r_instance) {
 	if (p_extension) {
 		initializing_with_extension = true;
 		initializing_extension = p_extension;
 		initializing_extension_instance = p_extension->create_instance(p_extension->class_userdata);
+		if (r_instance) {
+			*r_instance = initializing_extension_instance;
+		}
+	} else {
+		*r_instance = nullptr;
 	}
 	return p_create_func();
 }

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -234,7 +234,7 @@ public:
 	static bool is_parent_class(const StringName &p_class, const StringName &p_inherits);
 	static bool can_instantiate(const StringName &p_class);
 	static Object *instantiate(const StringName &p_class);
-	static Object *construct_object(Object *(*p_create_func)(), ObjectNativeExtension *p_extension);
+	static Object *construct_object(Object *(*p_create_func)(), ObjectNativeExtension *p_extension, void **r_instance);
 	static void instance_get_native_extension_data(ObjectNativeExtension **r_extension, GDExtensionClassInstancePtr *r_extension_instance, Object *p_base);
 
 	static APIType get_api_type(const StringName &p_class);


### PR DESCRIPTION
So that extended classes can be safely created via gdnative. See https://github.com/vnen/godot-cpp/pull/33 for details