### PR TITLE
Fix error in Vector2.reflect() description

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -372,7 +372,7 @@
 			<return type="Vector2" />
 			<argument index="0" name="n" type="Vector2" />
 			<description>
-				Returns the vector reflected from a plane defined by the given normal.
+				Returns the vector reflected (ie mirrored, or symmetric) over a line defined by the given direction vector [code]n[/code].
 			</description>
 		</method>
 		<method name="rotated" qualifiers="const">


### PR DESCRIPTION
The description was probably copied from Vector3.reflect(), and
unfortunately did not match the 2D behaviour (where n is apparently the
direction vector of the symmetry line, not the normal).
