### PR TITLE
Fix VisibilityEnabler2D throwing a signal error

### DIFF
--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -242,11 +242,11 @@ void VisibilityEnabler2D::_notification(int p_what) {
 
 		if (enabler[ENABLER_PARENT_PHYSICS_PROCESS] && get_parent()) {
 			get_parent()->connect(SceneStringNames::get_singleton()->ready,
-					get_parent(), "set_physics_process", varray(false), CONNECT_ONESHOT);
+					get_parent(), "set_physics_process", varray(false), CONNECT_REFERENCE_COUNTED);
 		}
 		if (enabler[ENABLER_PARENT_PROCESS] && get_parent()) {
 			get_parent()->connect(SceneStringNames::get_singleton()->ready,
-					get_parent(), "set_process", varray(false), CONNECT_ONESHOT);
+					get_parent(), "set_process", varray(false), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 


### PR DESCRIPTION
Fixes #52297.

When `process_parent` or `physics_process_parent` are enabled and there are multiple instances of a VisibilityEnabler2D or an instance is repeatedly reentering the tree, an error is emitted.
Just changing the ConnectFlags to `CONNECT_REFERENCE_COUNTED` should fix the issue.