### PR TITLE
Fix Face3::get_random_point_inside()

### DIFF
--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -151,8 +151,8 @@ Face3::Side Face3::get_side_of(const Face3 &p_face, ClockDirection p_clock_dir) 
 }
 
 Vector3 Face3::get_random_point_inside() const {
-	real_t a = Math::random(0, 1);
-	real_t b = Math::random(0, 1);
+	real_t a = Math::random(0.0, 1.0);
+	real_t b = Math::random(0.0, 1.0);
 	if (a > b) {
 		SWAP(a, b);
 	}


### PR DESCRIPTION
This only fixes #52845 but may also affect `GPUParticles3D`'s editor plugin since these are the only two places where `Face3::get_random_point_inside()` appears to be used.

On a side node: `test_render.cpp` also seems to be calling the wrong overload of `Math::random` in a few places, but I'm a bit afraid to touch code that I don't fully understand so I didn't make a PR for that as well.