### PR TITLE
Correctly calculate position of the folding arrow in `Tree`

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1968,7 +1968,8 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				arrow = cache.arrow;
 			}
 
-			Point2 apos = p_pos + p_draw_ofs + Point2i(0, (label_h - arrow->get_height()) / 2) - cache.offset;
+			Point2 apos = p_pos + Point2i(0, (label_h - arrow->get_height()) / 2) - cache.offset + p_draw_ofs;
+			apos.x += cache.item_margin - arrow->get_width();
 
 			if (rtl) {
 				apos.x = get_size().width - apos.x - arrow->get_width();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/52895.

From my tests it seems to work correctly both with LTR and RTL:

[Before](https://user-images.githubusercontent.com/11782833/134747899-a2b59c05-2e49-449a-b0fe-ee543e83cd2e.png)
[After LTR](https://user-images.githubusercontent.com/11782833/134747907-9bf3c25d-4d10-46cb-b785-c5fd8fef49e1.png)
[After RTL](https://user-images.githubusercontent.com/11782833/134747918-7aab19ac-9585-4500-ac2d-3d50bd492ea8.png)
