### PR TITLE
Add usability notes to `ColorPicker` and `ColorPickerButton` descriptions

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Displays a color picker widget. Useful for selecting a color from an RGB/RGBA colorspace.
+		[b]Note:[/b] This control is the color picker widget itself. You can use a [ColorPickerButton] instead if you need a button that brings up a [ColorPicker] in a pop-up.
 	</description>
 	<tutorials>
 		<link title="Tween Demo">https://godotengine.org/asset-library/asset/146</link>

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -6,6 +6,7 @@
 	<description>
 		Encapsulates a [ColorPicker] making it accessible by pressing a button. Pressing the button will toggle the [ColorPicker] visibility.
 		See also [BaseButton] which contains common properties and methods associated with this node.
+		[b]Note:[/b] By default, the button may not be wide enough for the color preview swatch to be visible. Make sure to set [member Control.rect_min_size] to a big enough value to give the button enough space.
 	</description>
 	<tutorials>
 		<link title="GUI Drag And Drop Demo">https://godotengine.org/asset-library/asset/133</link>


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/51347 and https://github.com/godotengine/godot/pull/51348. Applies the suggested changes.