### PR TITLE
Fix Platform Thread Override

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -28,9 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-// Define PLATFORM_CUSTOM_THREAD_H in platform_config.h
-// Overriding the platform implementation is required in some proprietary platforms
-#ifndef PLATFORM_CUSTOM_THREAD_H
+#ifndef PLATFORM_THREAD_OVERRIDE // See details in thread.h
 
 #include "thread.h"
 
@@ -130,4 +128,4 @@ Thread::~Thread() {
 }
 
 #endif
-#endif // PLATFORM_CUSTOM_THREAD_H
+#endif // PLATFORM_THREAD_OVERRIDE

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -28,10 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-// Define PLATFORM_CUSTOM_THREAD_H in platform_config.h
+// Define PLATFORM_THREAD_OVERRIDE in your platform's `platform_config.h`
+// to use a custom Thread implementation defined in `platform/[your_platform]/platform_thread.h`
 // Overriding the platform implementation is required in some proprietary platforms
-#ifdef PLATFORM_CUSTOM_THREAD_H
-#include PLATFORM_CUSTOM_THREAD_H
+#ifdef PLATFORM_THREAD_OVERRIDE
+#include "platform_thread.h"
 #else
 #ifndef THREAD_H
 #define THREAD_H
@@ -121,4 +122,4 @@ public:
 };
 
 #endif // THREAD_H
-#endif // PLATFORM_CUSTOM_THREAD_H
+#endif // PLATFORM_THREAD_OVERRIDE


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/pull/52734

This way, Scons knows about whatever header you include in `platform_thread.h` (which can be created in `platform/[platform]`)

In the linked PR, Scons has no way of detecting changes in `PLATFORM_CUSTOM_THREAD_H`