### PR TITLE
Fix rendering centered odd-size texture in `AnimatedSprite2D`/`AnimatedSprite3D`

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -94,7 +94,7 @@ Rect2 AnimatedSprite2D::_get_rect() const {
 
 	Point2 ofs = offset;
 	if (centered) {
-		ofs -= Size2(s) / 2;
+		ofs -= s / 2;
 	}
 
 	if (s == Size2(0, 0)) {
@@ -228,8 +228,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 
 			RID ci = get_canvas_item();
 
-			Size2i s;
-			s = texture->get_size();
+			Size2 s = texture->get_size();
 			Point2 ofs = offset;
 			if (centered) {
 				ofs -= s / 2;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -712,7 +712,7 @@ Rect2 Sprite3D::get_item_rect() const {
 		return CanvasItem::get_item_rect();
 	*/
 
-	Size2i s;
+	Size2 s;
 
 	if (region) {
 		s = region_rect.size;
@@ -807,22 +807,20 @@ void AnimatedSprite3D::_draw() {
 		set_base(RID());
 		return; //no texuture no life
 	}
-	Vector2 tsize = texture->get_size();
+	Size2 tsize = texture->get_size();
 	if (tsize.x == 0 || tsize.y == 0) {
 		return;
 	}
 
-	Size2i s = tsize;
 	Rect2 src_rect;
-
-	src_rect.size = s;
+	src_rect.size = tsize;
 
 	Point2 ofs = get_offset();
 	if (is_centered()) {
-		ofs -= s / 2;
+		ofs -= tsize / 2;
 	}
 
-	Rect2 dst_rect(ofs, s);
+	Rect2 dst_rect(ofs, tsize);
 
 	Rect2 final_rect;
 	Rect2 final_src_rect;
@@ -1133,7 +1131,7 @@ Rect2 AnimatedSprite3D::get_item_rect() const {
 	if (t.is_null()) {
 		return Rect2(0, 0, 1, 1);
 	}
-	Size2i s = t->get_size();
+	Size2 s = t->get_size();
 
 	Point2 ofs = get_offset();
 	if (centered) {


### PR DESCRIPTION
Fixes #53050.

Edit: also fixes selecting issue in `Sprite3D` - previously I could select a 1x1 centered sprite only by clicking at its positive quarter:
![ThjiCby19g](https://user-images.githubusercontent.com/9283098/135754086-d4421076-2eba-469b-8652-81183ebe5892.png)
Now I can select by clicking anywhere on the sprite.