### PR TITLE
[3.x] Fix rendering centered odd-size texture in `AnimatedSprite`/`AnimatedSprite3D`

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -96,7 +96,7 @@ Rect2 AnimatedSprite::_get_rect() const {
 
 	Point2 ofs = offset;
 	if (centered) {
-		ofs -= Size2(s) / 2;
+		ofs -= s / 2;
 	}
 
 	if (s == Size2(0, 0)) {
@@ -436,8 +436,7 @@ void AnimatedSprite::_notification(int p_what) {
 
 			RID ci = get_canvas_item();
 
-			Size2i s;
-			s = texture->get_size();
+			Size2 s = texture->get_size();
 			Point2 ofs = offset;
 			if (centered) {
 				ofs -= s / 2;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -683,7 +683,7 @@ Rect2 Sprite3D::get_item_rect() const {
 		return CanvasItem::get_item_rect();
 	*/
 
-	Size2i s;
+	Size2 s;
 
 	if (region) {
 		s = region_rect.size;
@@ -782,22 +782,20 @@ void AnimatedSprite3D::_draw() {
 		set_base(RID());
 		return; //no texuture no life
 	}
-	Vector2 tsize = texture->get_size();
+	Size2 tsize = texture->get_size();
 	if (tsize.x == 0 || tsize.y == 0) {
 		return;
 	}
 
-	Size2i s = tsize;
 	Rect2 src_rect;
-
-	src_rect.size = s;
+	src_rect.size = tsize;
 
 	Point2 ofs = get_offset();
 	if (is_centered()) {
-		ofs -= s / 2;
+		ofs -= tsize / 2;
 	}
 
-	Rect2 dst_rect(ofs, s);
+	Rect2 dst_rect(ofs, tsize);
 
 	Rect2 final_rect;
 	Rect2 final_src_rect;
@@ -1085,7 +1083,7 @@ Rect2 AnimatedSprite3D::get_item_rect() const {
 	if (t.is_null()) {
 		return Rect2(0, 0, 1, 1);
 	}
-	Size2i s = t->get_size();
+	Size2 s = t->get_size();
 
 	Point2 ofs = get_offset();
 	if (centered) {


### PR DESCRIPTION
`3.x` version of #53051.
Cherry-pickable `3.3`?