### PR TITLE
[3.x] Fix crash when creating thread

### DIFF
--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -684,7 +684,7 @@ protected:
 	Variant ret;
 	Variant userdata;
 	SafeFlag active;
-	Object *target_instance;
+	ObjectID target_instance_id;
 	StringName target_method;
 	Thread thread;
 	static void _bind_methods();


### PR DESCRIPTION
`3.x` version of #53059

Unlike the `master` version, this uses `ObjectDB::instance_validate()` to validate `Object *`.