### PR TITLE
SceneTreeEditor Don't ignore renaming scene's root node

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -527,7 +527,7 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 }
 
 void SceneTreeEditor::_node_renamed(Node *p_node) {
-	if (!get_scene_node()->is_ancestor_of(p_node)) {
+	if (get_scene_node() != p_node && !get_scene_node()->is_ancestor_of(p_node)) {
 		return;
 	}
 


### PR DESCRIPTION
`SceneTreeEditor::_node_renamed()` was returning early if the renamed node isn't descendant of the scene's root node. Such condition is true if the renamed node is the scene's root node itself (so it was ignored). Added check for the scene's root node.

Fixes #52746.

Cherry-pickable `3.x`, `3.3`.