### PR TITLE
[3.x] Add missing undo on CloseCurve

### DIFF
--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -503,7 +503,14 @@ void PathEditorPlugin::_close_curve() {
 	if (c->get_point_count() < 2) {
 		return;
 	}
-	c->add_point(c->get_point_position(0), c->get_point_in(0), c->get_point_out(0));
+	if (c->get_point_position(0) == c->get_point_position(c->get_point_count() - 1)) {
+		return;
+	}
+	UndoRedo *ur = editor->get_undo_redo();
+	ur->create_action(TTR("Close Curve"));
+	ur->add_do_method(c.ptr(), "add_point", c->get_point_position(0), c->get_point_in(0), c->get_point_out(0), -1);
+	ur->add_undo_method(c.ptr(), "remove_point", c->get_point_count());
+	ur->commit_action();
 }
 
 void PathEditorPlugin::_handle_option_pressed(int p_option) {


### PR DESCRIPTION
Add missing undo on CloseCurve and avoid the button spamming.
3.x version of #53062