### PR TITLE
Fix GPUParticles3D Generate AABB and local_coords

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -4352,10 +4352,8 @@ AABB RendererStorageRD::particles_get_current_aabb(RID p_particles) {
 		total_amount *= particles->trail_bind_poses.size();
 	}
 
-	Vector<ParticleData> data;
-	data.resize(total_amount);
-
 	Vector<uint8_t> buffer = RD::get_singleton()->buffer_get_data(particles->particle_buffer);
+	ERR_FAIL_COND_V(buffer.size() != (int)(total_amount * sizeof(ParticleData)), AABB());
 
 	Transform3D inv = particles->emission_transform.affine_inverse();
 
@@ -4363,7 +4361,7 @@ AABB RendererStorageRD::particles_get_current_aabb(RID p_particles) {
 	if (buffer.size()) {
 		bool first = true;
 
-		const ParticleData *particle_data = (const ParticleData *)data.ptr();
+		const ParticleData *particle_data = reinterpret_cast<const ParticleData *>(buffer.ptr());
 		for (int i = 0; i < total_amount; i++) {
 			if (particle_data[i].active) {
 				Vector3 pos = Vector3(particle_data[i].xform[12], particle_data[i].xform[13], particle_data[i].xform[14]);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -4138,6 +4138,7 @@ void RendererStorageRD::particles_set_use_local_coordinates(RID p_particles, boo
 	ERR_FAIL_COND(!particles);
 
 	particles->use_local_coords = p_enable;
+	particles->dependency.changed_notify(DEPENDENCY_CHANGED_PARTICLES);
 }
 
 void RendererStorageRD::particles_set_fixed_fps(RID p_particles, int p_fps) {

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -621,7 +621,6 @@ private:
 		float color[4];
 		float custom[3];
 		float lifetime;
-		uint32_t pad[3];
 	};
 
 	struct ParticlesFrameParams {


### PR DESCRIPTION
The first commit fixes #50441 by correctly accessing the buffer and removing unnecessary (?) padding at the end of the `ParticleData` struct (it's still not entirely in line with the struct defined in `particles.glsl`, there, just a single `vec4 custom` is defined instead of `float custom[3]` and `lifetime`, is this intended?).

![Unbenannt](https://user-images.githubusercontent.com/31868812/134786871-b2fc7b2c-c237-417b-ab86-45ccafaf883e.PNG)

The second commit fixes an issue where setting `GPUParticle3D`s `local_coords` property would not work correctly after changing it until reloading the scene. If preferred, I can squash it (it's a tiny fix) or create a separate issue/PR for it.