### PR TITLE
Added mouse_filter propagation

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -985,6 +985,9 @@
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" enum="Control.MouseFilter" default="0">
 			Controls whether the control will be able to receive mouse button input events through [method _gui_input] and how these events should be handled. Also controls whether the control can receive the [signal mouse_entered], and [signal mouse_exited] signals. See the constants to learn what each does.
 		</member>
+		<member name="mouse_filter_propagate" type="int" setter="set_mouse_filter_propagate" getter="get_mouse_filter_propagate" enum="Control.MouseFilterPropagate" default="0">
+			Controls whether the control shall propagate its mouse_filter setting to its children. See the constants to learn what each does.
+		</member>
 		<member name="offset_bottom" type="float" setter="set_offset" getter="get_offset" default="0.0">
 			Distance between the node's bottom edge and its parent control, based on [member anchor_bottom].
 			Offsets are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Offsets update automatically when you move or resize the node.
@@ -1266,6 +1269,15 @@
 		</constant>
 		<constant name="MOUSE_FILTER_IGNORE" value="2" enum="MouseFilter">
 			The control will not receive mouse button input events through [method _gui_input]. The control will also not receive the [signal mouse_entered] nor [signal mouse_exited] signals. This will not block other controls from receiving these events or firing the signals. Ignored events will not be handled automatically.
+		</constant>
+		<constant name="MOUSE_FILTER_PROPAGATE_NORMAL" value="0" enum="MouseFilterPropagate">
+			The constant will not propagate its mouse_filter settings to any children and is open to receive a propagated mouse_filter from a parent control.
+		</constant>
+		<constant name="MOUSE_FILTER_PROPAGATE_PROPAGATE" value="1" enum="MouseFilterPropagate">
+			The control will propagate its mouse_filter settings to its children and will not accept any propagation from any parent control. Any child that is set to any constant but [constant MOUSE_FILTER_PROPAGATE_NORMAL] shall overrule this setting for its children.
+		</constant>
+		<constant name="MOUSE_FILTER_PROPAGATE_NO_PROPAGATE" value="2" enum="MouseFilterPropagate">
+			The control will not propagate its mouse_filter settings to its children and will not accept any propagation from any parent control. Any child that is set to any constant but [constant MOUSE_FILTER_PROPAGATE_NORMAL] shall overrule this setting for its children.
 		</constant>
 		<constant name="GROW_DIRECTION_BEGIN" value="0" enum="GrowDirection">
 			The control will grow to the left or top to make up if its minimum size is changed to be greater than its current size on the respective axis.

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -81,6 +81,12 @@ public:
 		MOUSE_FILTER_IGNORE
 	};
 
+	enum MouseFilterPropagate {
+		MOUSE_FILTER_PROPAGATE_NORMAL,
+		MOUSE_FILTER_PROPAGATE_PROPAGATE,
+		MOUSE_FILTER_PROPAGATE_NO_PROPAGATE
+	};
+
 	enum CursorShape {
 		CURSOR_ARROW,
 		CURSOR_IBEAM,
@@ -195,6 +201,8 @@ private:
 		Point2 custom_minimum_size;
 
 		MouseFilter mouse_filter = MOUSE_FILTER_STOP;
+		MouseFilterPropagate mouse_filter_propagate = MOUSE_FILTER_PROPAGATE_NORMAL;
+		Control *mouse_filter_owner = nullptr;
 
 		bool clip_contents = false;
 
@@ -278,6 +286,8 @@ private:
 	_FORCE_INLINE_ void _get_theme_type_dependencies(const StringName &p_theme_type, List<StringName> *p_list) const;
 
 protected:
+	void propagate_mouse_filter(Control *caller = nullptr);
+
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;
 
@@ -468,6 +478,13 @@ public:
 
 	void set_mouse_filter(MouseFilter p_filter);
 	MouseFilter get_mouse_filter() const;
+	MouseFilter get_applied_mouse_filter() const;
+
+	void set_mouse_filter_owner(Control *new_owner);
+	Control *get_mouse_filter_owner() const;
+
+	void set_mouse_filter_propagate(MouseFilterPropagate p_filter_propagate);
+	MouseFilterPropagate get_mouse_filter_propagate() const;
 
 	/* SKINNING */
 
@@ -557,6 +574,7 @@ VARIANT_ENUM_CAST(Control::CursorShape);
 VARIANT_ENUM_CAST(Control::LayoutPreset);
 VARIANT_ENUM_CAST(Control::LayoutPresetMode);
 VARIANT_ENUM_CAST(Control::MouseFilter);
+VARIANT_ENUM_CAST(Control::MouseFilterPropagate);
 VARIANT_ENUM_CAST(Control::GrowDirection);
 VARIANT_ENUM_CAST(Control::Anchor);
 VARIANT_ENUM_CAST(Control::LayoutDirection);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -720,7 +720,7 @@ bool GraphEdit::_check_clickable_control(Control *p_control, const Vector2 &pos)
 		return false;
 	}
 
-	if (!p_control->has_point(pos) || p_control->get_mouse_filter() == MOUSE_FILTER_IGNORE) {
+	if (!p_control->has_point(pos) || p_control->get_applied_mouse_filter() == MOUSE_FILTER_IGNORE) {
 		//test children
 		for (int i = 0; i < p_control->get_child_count(); i++) {
 			Control *subchild = Object::cast_to<Control>(p_control->get_child(i));

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1140,7 +1140,7 @@ String Viewport::_gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Cont
 
 		// Otherwise, we check parent controls unless some conditions prevent it.
 
-		if (p_control->data.mouse_filter == Control::MOUSE_FILTER_STOP) {
+		if (p_control->get_applied_mouse_filter() == Control::MOUSE_FILTER_STOP) {
 			break;
 		}
 		if (p_control->is_set_as_top_level()) {
@@ -1256,7 +1256,7 @@ void Viewport::_gui_call_input(Control *p_control, const Ref<InputEvent> &p_inpu
 	while (ci) {
 		Control *control = Object::cast_to<Control>(ci);
 		if (control) {
-			if (control->data.mouse_filter != Control::MOUSE_FILTER_IGNORE) {
+			if (control->get_applied_mouse_filter() != Control::MOUSE_FILTER_IGNORE) {
 				control->_call_gui_input(ev);
 			}
 
@@ -1266,7 +1266,7 @@ void Viewport::_gui_call_input(Control *p_control, const Ref<InputEvent> &p_inpu
 			if (gui.key_event_accepted) {
 				break;
 			}
-			if (!cant_stop_me_now && control->data.mouse_filter == Control::MOUSE_FILTER_STOP && ismouse) {
+			if (!cant_stop_me_now && control->get_applied_mouse_filter() == Control::MOUSE_FILTER_STOP && ismouse) {
 				break;
 			}
 		}
@@ -1285,7 +1285,7 @@ void Viewport::_gui_call_notification(Control *p_control, int p_what) {
 	while (ci) {
 		Control *control = Object::cast_to<Control>(ci);
 		if (control) {
-			if (control->data.mouse_filter != Control::MOUSE_FILTER_IGNORE) {
+			if (control->get_applied_mouse_filter() != Control::MOUSE_FILTER_IGNORE) {
 				control->notification(p_what);
 			}
 
@@ -1296,7 +1296,7 @@ void Viewport::_gui_call_notification(Control *p_control, int p_what) {
 			if (!control->is_inside_tree() || control->is_set_as_top_level()) {
 				break;
 			}
-			if (control->data.mouse_filter == Control::MOUSE_FILTER_STOP) {
+			if (control->get_applied_mouse_filter() == Control::MOUSE_FILTER_STOP) {
 				break;
 			}
 		}
@@ -1367,7 +1367,7 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 		}
 	}
 
-	if (!c || c->data.mouse_filter == Control::MOUSE_FILTER_IGNORE) {
+	if (!c || c->get_applied_mouse_filter() == Control::MOUSE_FILTER_IGNORE) {
 		return nullptr;
 	}
 
@@ -1399,7 +1399,7 @@ bool Viewport::_gui_drop(Control *p_at_control, Point2 p_at_pos, bool p_just_che
 				return true;
 			}
 
-			if (control->data.mouse_filter == Control::MOUSE_FILTER_STOP) {
+			if (control->get_applied_mouse_filter() == Control::MOUSE_FILTER_STOP) {
 				break;
 			}
 		}
@@ -1478,7 +1478,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 							break;
 						}
 
-						if (control->data.mouse_filter == Control::MOUSE_FILTER_STOP) {
+						if (control->get_applied_mouse_filter() == Control::MOUSE_FILTER_STOP) {
 							break;
 						}
 					}
@@ -1628,7 +1628,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 								gui.dragging = false;
 							}
 
-							if (control->data.mouse_filter == Control::MOUSE_FILTER_STOP) {
+							if (control->get_applied_mouse_filter() == Control::MOUSE_FILTER_STOP) {
 								break;
 							}
 						}
@@ -1747,7 +1747,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					if (cursor_shape != Control::CURSOR_ARROW) {
 						break;
 					}
-					if (c->data.mouse_filter == Control::MOUSE_FILTER_STOP) {
+					if (c->get_applied_mouse_filter() == Control::MOUSE_FILTER_STOP) {
 						break;
 					}
 					if (c->is_set_as_top_level()) {


### PR DESCRIPTION
Closes  godotengine/godot-proposals#3272

An additional property was added to control, with the options Normal/Propagate/No Propagate.

When a control is set to normal, it shall accept propagation from a parent class and will pass the propagation onto its children.
When a control is set to propagate, it shall propagate its own mouse_filter to its children and ignore any parent propagation.
When a control is set to no propagate, it shall enforce no propagation on all of its children and will ignore any parent propagation.

This propagation is handled using `void Control::propagate_mouse_filter(Control *new_owner) {` by setting a control's mouse_filter_owner to the control enforcing its mouse_filter, and will then recursively pass that down to its children.

This propagation is applied both when the mouse_filter_propagation property is set, and when add_child is triggered. 