### PR TITLE
Fix typo with example variable name in Dictionary docs

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -40,7 +40,7 @@
 		};
 		[/csharp]
 		[/codeblocks]
-		You can access a dictionary's values by referencing the appropriate key. In the above example, [code]points_dir["White"][/code] will return [code]50[/code]. You can also write [code]points_dir.White[/code], which is equivalent. However, you'll have to use the bracket syntax if the key you're accessing the dictionary with isn't a fixed string (such as a number or variable).
+		You can access a dictionary's values by referencing the appropriate key. In the above example, [code]points_dict["White"][/code] will return [code]50[/code]. You can also write [code]points_dict.White[/code], which is equivalent. However, you'll have to use the bracket syntax if the key you're accessing the dictionary with isn't a fixed string (such as a number or variable).
 		[codeblocks]
 		[gdscript]
 		export(string, "White", "Yellow", "Orange") var my_color
@@ -72,7 +72,7 @@
 		my_dict = {"First Array": [1, 2, 3, 4]} # Assigns an Array to a String key.
 		[/gdscript]
 		[csharp]
-		var myDir = new Godot.Collections.Dictionary
+		var myDict = new Godot.Collections.Dictionary
 		{
 		    {"First Array", new Godot.Collections.Array{1, 2, 3, 4}}
 		};
@@ -85,7 +85,7 @@
 		points_dict["Blue"] = 150 # Add "Blue" as a key and assign 150 as its value.
 		[/gdscript]
 		[csharp]
-		var pointsDir = new Godot.Collections.Dictionary
+		var pointsDict = new Godot.Collections.Dictionary
 		{
 		    {"White", 50},
 		    {"Yellow", 75},
@@ -98,7 +98,7 @@
 		[codeblocks]
 		[gdscript]
 		# This is a valid dictionary.
-		# To access the string "Nested value" below, use `my_dir.sub_dir.sub_key` or `my_dir["sub_dir"]["sub_key"]`.
+		# To access the string "Nested value" below, use `my_dict.sub_dict.sub_key` or `my_dict["sub_dict"]["sub_key"]`.
 		# Indexing styles can be mixed and matched depending on your needs.
 		var my_dict = {
 		    "String Key": 5,
@@ -109,8 +109,7 @@
 		[/gdscript]
 		[csharp]
 		// This is a valid dictionary.
-		// To access the string "Nested value" below, use `my_dir.sub_dir.sub_key` or `my_dir["sub_dir"]["sub_key"]`.
-		// Indexing styles can be mixed and matched depending on your needs.
+		// To access the string "Nested value" below, use `((Godot.Collections.Dictionary)myDict["sub_dict"])["sub_key"]`.
 		var myDict = new Godot.Collections.Dictionary {
 		    {"String Key", 5},
 		    {4, new Godot.Collections.Array{1,2,3}},


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Variable `points_dict`(`pointsDict` in C#) is erroneously referred to as `points_dir`/`pointsDir` in some cases.

_Fixes https://github.com/godotengine/godot-docs/issues/5269_