### PR TITLE
Add up/down keys to inc/dec val in editor spin slider [3.x]

### DIFF
--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -69,6 +69,7 @@ class EditorSpinSlider : public Range {
 	void _value_input_closed();
 	void _value_input_entered(const String &);
 	void _value_focus_exited();
+	void _value_input_gui_input(const Ref<InputEvent> &p_event);
 	bool hide_slider;
 	bool flat;
 


### PR DESCRIPTION
3.x backport for #41855 , since signal connections work differently between versions and this needed a classDB binding addition.