### PR TITLE
[3.x] Fix GLTF light import

### DIFF
--- a/modules/gltf/doc_classes/GLTFLight.xml
+++ b/modules/gltf/doc_classes/GLTFLight.xml
@@ -9,17 +9,25 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 0, 0, 0, 1 )">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+			The [Color] of the light. Defaults to white. A black color causes the light to have no effect.
 		</member>
 		<member name="inner_cone_angle" type="float" setter="set_inner_cone_angle" getter="get_inner_cone_angle" default="0.0">
+			The inner angle of the cone in a spotlight. Must be less than or equal to the outer cone angle.
+			Within this angle, the light is at full brightness. Between the inner and outer cone angles, there is a transition from full brightness to zero brightness. When creating a Godot [SpotLight], the ratio between the inner and outer cone angles is used to calculate the attenuation of the light.
 		</member>
-		<member name="intensity" type="float" setter="set_intensity" getter="get_intensity" default="0.0">
+		<member name="intensity" type="float" setter="set_intensity" getter="get_intensity" default="1.0">
+			The intensity of the light. This is expressed in candelas (lumens per steradian) for point and spot lights, and lux (lumens per m²) for directional lights. When creating a Godot light, this value is converted to a unitless multiplier.
 		</member>
-		<member name="outer_cone_angle" type="float" setter="set_outer_cone_angle" getter="get_outer_cone_angle" default="0.0">
+		<member name="outer_cone_angle" type="float" setter="set_outer_cone_angle" getter="get_outer_cone_angle" default="0.785398">
+			The outer angle of the cone in a spotlight. Must be greater than or equal to the inner angle.
+			At this angle, the light drops off to zero brightness. Between the inner and outer cone angles, there is a transition from full brightness to zero brightness. If this angle is a half turn, then the spotlight emits in all directions. When creating a Godot [SpotLight], the outer cone angle is used as the angle of the spotlight.
 		</member>
-		<member name="range" type="float" setter="set_range" getter="get_range" default="0.0">
+		<member name="range" type="float" setter="set_range" getter="get_range" default="inf">
+			The range of the light, beyond which the light has no effect. GLTF lights with no range defined behave like physical lights (which have infinite range). When creating a Godot light, the range is clamped to 4096.
 		</member>
 		<member name="type" type="String" setter="set_type" getter="get_type" default="&quot;&quot;">
+			The type of the light. The values accepted by Godot are "point", "spot", and "directional", which correspond to Godot's [OmniLight], [SpotLight], and [DirectionalLight] respectively.
 		</member>
 	</members>
 	<constants>

--- a/modules/gltf/gltf_light.h
+++ b/modules/gltf/gltf_light.h
@@ -42,12 +42,12 @@ protected:
 	static void _bind_methods();
 
 private:
-	Color color;
-	float intensity = 0.0f;
+	Color color = Color(1.0f, 1.0f, 1.0f);
+	float intensity = 1.0f;
 	String type;
-	float range = 0.0f;
+	float range = INFINITY;
 	float inner_cone_angle = 0.0f;
-	float outer_cone_angle = 0.0f;
+	float outer_cone_angle = Math_TAU / 8.0f;
 
 public:
 	Color get_color();


### PR DESCRIPTION
This fixes a regression (#53019) from the changes to the GLTF module in #34193 which were then backported to 3.x. I'm making the 3.x PR first since the same numbers in the master branch produce different visuals, so I'll have to tweak those. This PR also adds documentation to the GLTFLight class. master version: #53109

For the record, here's why these values are the way they are. GLTF lights with no range specified behave like physical lights which have infinite range, so we default to `INFINITY` for the range (but this is later clamped to 4096 if making a node). For the color, default to white, which is the most sensible option, otherwise we'd have black lights by default, which do not lighten things. For the intensity, default to 1.0, since 0.0 means no light. For the spotlight angle, default to an eighth turn (on both sides, so the cone's edges are a quarter turn apart), rather than 0.0, which would mean the spotlight is emitting light in an area of zero size.