### PR TITLE
Update C# RPC attributes to share new Any/Auth naming convention

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3511,10 +3511,10 @@ int CSharpScript::get_member_line(const StringName &p_member) const {
 }
 
 Multiplayer::RPCMode CSharpScript::_member_get_rpc_mode(IMonoClassMember *p_member) const {
-	if (p_member->has_attribute(CACHED_CLASS(RemoteAttribute))) {
+	if (p_member->has_attribute(CACHED_CLASS(AnyAttribute))) {
 		return Multiplayer::RPC_MODE_ANY;
 	}
-	if (p_member->has_attribute(CACHED_CLASS(PuppetAttribute))) {
+	if (p_member->has_attribute(CACHED_CLASS(AuthorityAttribute))) {
 		return Multiplayer::RPC_MODE_AUTHORITY;
 	}
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttributes.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttributes.cs
@@ -3,8 +3,8 @@ using System;
 namespace Godot
 {
     [AttributeUsage(AttributeTargets.Method)]
-    public class RemoteAttribute : Attribute { }
+    public class AnyAttribute : Attribute { }
 
     [AttributeUsage(AttributeTargets.Method)]
-    public class PuppetAttribute : Attribute { }
+    public class AuthorityAttribute : Attribute { }
 }

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -140,8 +140,8 @@ void CachedData::clear_godot_api_cache() {
 	field_ExportAttribute_hintString = nullptr;
 	class_SignalAttribute = nullptr;
 	class_ToolAttribute = nullptr;
-	class_RemoteAttribute = nullptr;
-	class_PuppetAttribute = nullptr;
+	class_AnyAttribute = nullptr;
+	class_AuthorityAttribute = nullptr;
 	class_GodotMethodAttribute = nullptr;
 	field_GodotMethodAttribute_methodName = nullptr;
 	class_ScriptPathAttribute = nullptr;
@@ -265,8 +265,8 @@ void update_godot_api_cache() {
 	CACHE_FIELD_AND_CHECK(ExportAttribute, hintString, CACHED_CLASS(ExportAttribute)->get_field("hintString"));
 	CACHE_CLASS_AND_CHECK(SignalAttribute, GODOT_API_CLASS(SignalAttribute));
 	CACHE_CLASS_AND_CHECK(ToolAttribute, GODOT_API_CLASS(ToolAttribute));
-	CACHE_CLASS_AND_CHECK(RemoteAttribute, GODOT_API_CLASS(RemoteAttribute));
-	CACHE_CLASS_AND_CHECK(PuppetAttribute, GODOT_API_CLASS(PuppetAttribute));
+	CACHE_CLASS_AND_CHECK(AnyAttribute, GODOT_API_CLASS(AnyAttribute));
+	CACHE_CLASS_AND_CHECK(AuthorityAttribute, GODOT_API_CLASS(AuthorityAttribute));
 	CACHE_CLASS_AND_CHECK(GodotMethodAttribute, GODOT_API_CLASS(GodotMethodAttribute));
 	CACHE_FIELD_AND_CHECK(GodotMethodAttribute, methodName, CACHED_CLASS(GodotMethodAttribute)->get_field("methodName"));
 	CACHE_CLASS_AND_CHECK(ScriptPathAttribute, GODOT_API_CLASS(ScriptPathAttribute));

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -111,8 +111,8 @@ struct CachedData {
 	GDMonoField *field_ExportAttribute_hintString;
 	GDMonoClass *class_SignalAttribute;
 	GDMonoClass *class_ToolAttribute;
-	GDMonoClass *class_RemoteAttribute;
-	GDMonoClass *class_PuppetAttribute;
+	GDMonoClass *class_AnyAttribute;
+	GDMonoClass *class_AuthorityAttribute;
 	GDMonoClass *class_GodotMethodAttribute;
 	GDMonoField *field_GodotMethodAttribute_methodName;
 	GDMonoClass *class_ScriptPathAttribute;


### PR DESCRIPTION
The renaming of the C# RPC attributes seems to have been overlooked in the updates to the RPC naming convention in
#51481.
This intends to bring the relevant C# attributes to consistency.

Not sure what kind of contribution this is supposed to be labeled as so forgive me if I skipped some steps in the process.

I asked around in the discord if anybody had context but it didn't seem like a very high-visibility issue, so I thought to just get it over with.