### PR TITLE
Improved breakpoint gutter for CodeEdit.

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1084,6 +1084,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("folded", "CodeEdit", theme->get_icon("GuiTreeArrowRight", "EditorIcons"));
 	theme->set_icon("can_fold", "CodeEdit", theme->get_icon("GuiTreeArrowDown", "EditorIcons"));
 	theme->set_icon("executing_line", "CodeEdit", theme->get_icon("MainPlay", "EditorIcons"));
+	theme->set_icon("breakpoint", "CodeEdit", theme->get_icon("Breakpoint", "EditorIcons"));
 	theme->set_constant("line_spacing", "CodeEdit", EDITOR_DEF("text_editor/appearance/whitespace/line_spacing", 6));
 
 	// H/VSplitContainer

--- a/editor/icons/Breakpoint.svg
+++ b/editor/icons/Breakpoint.svg
@@ -1,0 +1,1 @@
+<svg enable-background="new 0 0 16 16" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m15 8c0 3.866-3.134 7-7 7s-7-3.134-7-7 3.134-7 7-7 7 3.134 7 7" fill="#e1e1e1"/><pathd="m12 8c0 2.209-1.791 4-4 4s-4-1.791-4-4 1.791-4 4-4 4 1.791 4 4" fill="#f6f6f6"/></svg>

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1146,13 +1146,20 @@ bool CodeEdit::is_drawing_executing_lines_gutter() const {
 }
 
 void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 &p_region) {
-	if (draw_breakpoints && is_line_breakpointed(p_line)) {
-		int padding = p_region.size.x / 6;
+	if (draw_breakpoints) {
+		bool hovering = p_region.has_point(get_local_mouse_pos());
+		bool breakpointed = is_line_breakpointed(p_line);
 
-		Rect2 breakpoint_region = p_region;
-		breakpoint_region.position += Point2(padding, padding);
-		breakpoint_region.size -= Point2(padding, padding) * 2;
-		breakpoint_icon->draw_rect(get_canvas_item(), breakpoint_region, false, breakpoint_color);
+		if (breakpointed || (hovering && !is_dragging_cursor())) {
+			int padding = p_region.size.x / 6;
+			Rect2 icon_region = p_region;
+			icon_region.position += Point2(padding, padding);
+			icon_region.size -= Point2(padding, padding) * 2;
+
+			// Darken icon when hovering & not yet breakpointed.
+			Color use_color = hovering && !breakpointed ? breakpoint_color.darkened(0.4) : breakpoint_color;
+			breakpoint_icon->draw_rect(get_canvas_item(), icon_region, false, use_color);
+		}
 	}
 
 	if (draw_bookmarks && is_line_bookmarked(p_line)) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1636,6 +1636,32 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 			}
 		}
+
+		// Check if user is hovering a different gutter, and update if yes.
+		Vector2i current_hovered_gutter = Vector2i(-1, -1);
+
+		int left_margin = style_normal->get_margin(SIDE_LEFT);
+		if (mpos.x <= left_margin + gutters_width + gutter_padding) {
+			int hovered_row = get_line_column_at_pos(mpos).y;
+			for (int i = 0; i < gutters.size(); i++) {
+				if (!gutters[i].draw || gutters[i].width <= 0) {
+					continue;
+				}
+
+				if (mpos.x > left_margin && mpos.x <= (left_margin + gutters[i].width) - 3) {
+					// We are in this gutter i's horizontal area.
+					current_hovered_gutter = Vector2i(i, hovered_row);
+					break;
+				}
+
+				left_margin += gutters[i].width;
+			}
+		}
+
+		if (current_hovered_gutter != hovered_gutter) {
+			hovered_gutter = current_hovered_gutter;
+			update();
+		}
 	}
 
 	if (draw_minimap && !dragging_selection) {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -477,6 +477,7 @@ private:
 	Vector<GutterInfo> gutters;
 	int gutters_width = 0;
 	int gutter_padding = 0;
+	Vector2i hovered_gutter = Vector2i(-1, -1); // X = gutter index, Y = row.
 
 	void _update_gutter_width();
 


### PR DESCRIPTION
- Added preview of breakpoint placement on hover. 
- Added override of icon for the Editor to use an SVG so it is no longer blurry.

https://user-images.githubusercontent.com/41730826/134858617-fb94a0af-8a4d-4b83-9521-cffe712a9d69.mp4

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/533.*