### PR TITLE
gltf export: Fix export of skeletons and skins.

### DIFF
--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -51,6 +51,9 @@ class GLTFSkin;
 class GLTFNode;
 class GLTFSpecGloss;
 class GLTFSkeleton;
+class CSGShape3D;
+class GridMap;
+class MultiMeshInstance3D;
 
 using GLTFAccessorIndex = int;
 using GLTFAnimationIndex = int;
@@ -71,6 +74,9 @@ class GLTFDocument : public Resource {
 	friend class GLTFState;
 	friend class GLTFSkin;
 	friend class GLTFSkeleton;
+
+private:
+	const float BAKE_FPS = 30.0f;
 
 public:
 	const int32_t JOINT_GROUP_SIZE = 4;
@@ -350,7 +356,6 @@ private:
 			GLTFNodeIndex p_node_i);
 	Error _encode_buffer_bins(Ref<GLTFState> state, const String &p_path);
 	Error _encode_buffer_glb(Ref<GLTFState> state, const String &p_path);
-	Error _serialize_bone_attachment(Ref<GLTFState> state);
 	Dictionary _serialize_texture_transform_uv1(Ref<BaseMaterial3D> p_material);
 	Dictionary _serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_material);
 	Error _serialize_version(Ref<GLTFState> state);
@@ -381,20 +386,17 @@ public:
 	void _generate_skeleton_bone_node(Ref<GLTFState> state, Node *scene_parent, Node3D *scene_root, const GLTFNodeIndex node_index);
 	void _import_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			const GLTFAnimationIndex index, const int bake_fps);
-	GLTFMeshIndex _convert_mesh_instance(Ref<GLTFState> state,
-			MeshInstance3D *p_mesh_instance);
 	void _convert_mesh_instances(Ref<GLTFState> state);
 	GLTFCameraIndex _convert_camera(Ref<GLTFState> state, Camera3D *p_camera);
-	void _convert_light_to_gltf(Light3D *light, Ref<GLTFState> state, Node3D *spatial, Ref<GLTFNode> gltf_node);
+	void _convert_light_to_gltf(Light3D *light, Ref<GLTFState> state, Ref<GLTFNode> gltf_node);
 	GLTFLightIndex _convert_light(Ref<GLTFState> state, Light3D *p_light);
-	GLTFSkeletonIndex _convert_skeleton(Ref<GLTFState> state, Skeleton3D *p_skeleton);
 	void _convert_spatial(Ref<GLTFState> state, Node3D *p_spatial, Ref<GLTFNode> p_node);
-	void _convert_scene_node(Ref<GLTFState> state, Node *p_current, Node *p_root,
+	void _convert_scene_node(Ref<GLTFState> state, Node *p_current,
 			const GLTFNodeIndex p_gltf_current,
 			const GLTFNodeIndex p_gltf_root);
 
 #ifdef MODULE_CSG_ENABLED
-	void _convert_csg_shape_to_gltf(Node *p_current, GLTFNodeIndex p_gltf_parent, Ref<GLTFNode> gltf_node, Ref<GLTFState> state);
+	void _convert_csg_shape_to_gltf(CSGShape3D *p_current, GLTFNodeIndex p_gltf_parent, Ref<GLTFNode> gltf_node, Ref<GLTFState> state);
 #endif // MODULE_CSG_ENABLED
 
 	void _create_gltf_node(Ref<GLTFState> state,
@@ -405,40 +407,39 @@ public:
 			Ref<GLTFNode> gltf_node);
 	void _convert_animation_player_to_gltf(
 			AnimationPlayer *animation_player, Ref<GLTFState> state,
-			const GLTFNodeIndex &p_gltf_current,
-			const GLTFNodeIndex &p_gltf_root_index,
-			Ref<GLTFNode> p_gltf_node, Node *p_scene_parent,
-			Node *p_root);
+			GLTFNodeIndex p_gltf_current,
+			GLTFNodeIndex p_gltf_root_index,
+			Ref<GLTFNode> p_gltf_node, Node *p_scene_parent);
 	void _check_visibility(Node *p_node, bool &retflag);
 	void _convert_camera_to_gltf(Camera3D *camera, Ref<GLTFState> state,
-			Node3D *spatial,
 			Ref<GLTFNode> gltf_node);
 #ifdef MODULE_GRIDMAP_ENABLED
 	void _convert_grid_map_to_gltf(
-			Node *p_scene_parent,
-			const GLTFNodeIndex &p_parent_node_index,
-			const GLTFNodeIndex &p_root_node_index,
-			Ref<GLTFNode> gltf_node, Ref<GLTFState> state,
-			Node *p_root_node);
+			GridMap *p_grid_map,
+			GLTFNodeIndex p_parent_node_index,
+			GLTFNodeIndex p_root_node_index,
+			Ref<GLTFNode> gltf_node, Ref<GLTFState> state);
 #endif // MODULE_GRIDMAP_ENABLED
 	void _convert_mult_mesh_instance_to_gltf(
-			Node *p_scene_parent,
-			const GLTFNodeIndex &p_parent_node_index,
-			const GLTFNodeIndex &p_root_node_index,
-			Ref<GLTFNode> gltf_node, Ref<GLTFState> state,
-			Node *p_root_node);
+			MultiMeshInstance3D *p_scene_parent,
+			GLTFNodeIndex p_parent_node_index,
+			GLTFNodeIndex p_root_node_index,
+			Ref<GLTFNode> gltf_node, Ref<GLTFState> state);
 	void _convert_skeleton_to_gltf(
-			Node *p_scene_parent, Ref<GLTFState> state,
-			const GLTFNodeIndex &p_parent_node_index,
-			const GLTFNodeIndex &p_root_node_index,
-			Ref<GLTFNode> gltf_node, Node *p_root_node);
-	void _convert_bone_attachment_to_gltf(Node *p_scene_parent,
-			Ref<GLTFState> state,
-			Ref<GLTFNode> gltf_node,
-			bool &retflag);
-	void _convert_mesh_to_gltf(Node *p_scene_parent,
-			Ref<GLTFState> state, Node3D *spatial,
+			Skeleton3D *p_scene_parent, Ref<GLTFState> state,
+			GLTFNodeIndex p_parent_node_index,
+			GLTFNodeIndex p_root_node_index,
 			Ref<GLTFNode> gltf_node);
+	void _convert_bone_attachment_to_gltf(BoneAttachment3D *p_bone_attachment,
+			Ref<GLTFState> state,
+			GLTFNodeIndex p_parent_node_index,
+			GLTFNodeIndex p_root_node_index,
+			Ref<GLTFNode> gltf_node);
+	void _convert_mesh_instance_to_gltf(MeshInstance3D *p_mesh_instance,
+			Ref<GLTFState> state,
+			Ref<GLTFNode> gltf_node);
+	GLTFMeshIndex _convert_mesh_to_gltf(Ref<GLTFState> state,
+			MeshInstance3D *p_mesh_instance);
 	void _convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			String p_animation_track_name);
 	Error serialize(Ref<GLTFState> state, Node *p_root, const String &p_path);

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -44,6 +44,8 @@
 #include "gltf_texture.h"
 
 #include "core/io/resource.h"
+#include "core/templates/map.h"
+#include "core/templates/pair.h"
 #include "core/templates/vector.h"
 #include "scene/animation/animation_player.h"
 #include "scene/resources/texture.h"
@@ -86,6 +88,9 @@ class GLTFState : public Resource {
 	Map<GLTFSkeletonIndex, GLTFNodeIndex> skeleton_to_node;
 	Vector<Ref<GLTFAnimation>> animations;
 	Map<GLTFNodeIndex, Node *> scene_nodes;
+
+	Map<ObjectID, GLTFSkeletonIndex> skeleton3d_to_gltf_skeleton;
+	Map<ObjectID, Map<ObjectID, GLTFSkinIndex>> skin_and_skeleton3d_to_gltf_skin;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
cc @fire
Create GLTFSkeleton at the same time we create GLTFNode objects.
Create GLTFSkin at the same time we export MeshInstance3D
Also, convert BoneAttachment3D nodes during normal node creation.

This avoids needing special cases during mesh export, and especially exporting skeletons or meshes which are children of BoneAttachment3D.

Should address some of issue #50020. I have not verified the fix, but the old code which dealt with Skeleton or Skin export was very broken so this should be a starting point for future GLTF fixes related to animated or skinned meshes.


This is still in draft state because some of my meshes with blend shapes (but not all of them) fail to load in Blender
[Blender error "index 990 is out of bounds for axis 0 with size 990"](https://user-images.githubusercontent.com/39946030/134859065-362a4092-867a-497a-a6a8-a9d6469f717b.png)

Other test cases include the reproduction case I call "Party Hat" since it has a skinned "Party Hat" with springbones attached to a BoneAttachment3D onto the Head bone of a character's Skeleton3D. It seemed to previously reproduce interesting issues on export.

There are a few other glTF files in my collection of cursed glTF models which I still need to test re-exporting, containing duplicate skins, nested skeletons (including cases where a mesh is its own bone), and so on.