### PR TITLE
Fix unclipped tab container in the editor about dialog

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -163,6 +163,7 @@ EditorAbout::EditorAbout() {
 	TabContainer *tc = memnew(TabContainer);
 	tc->set_custom_minimum_size(Size2(950, 400) * EDSCALE);
 	tc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tc->set_clip_contents(true);
 	vbc->add_child(tc);
 
 	// Authors


### PR DESCRIPTION
Fix glitches when you scrolling the tab container content:

![editor_about](https://user-images.githubusercontent.com/3036176/134866465-fec320aa-d65d-4dba-91a6-1d953f0877ca.gif)

