### PR TITLE
Reload kinematic shapes when changing PhysicsBody mode to Kinematic

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -535,6 +535,7 @@ void RigidBodyBullet::set_mode(PhysicsServer3D::BodyMode p_mode) {
 			mode = PhysicsServer3D::BODY_MODE_KINEMATIC;
 			reload_axis_lock();
 			_internal_set_mass(0);
+			init_kinematic_utilities();
 			break;
 		case PhysicsServer3D::BODY_MODE_STATIC:
 			mode = PhysicsServer3D::BODY_MODE_STATIC;

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -303,6 +303,7 @@ RigidBodyBullet::~RigidBodyBullet() {
 
 void RigidBodyBullet::init_kinematic_utilities() {
 	kinematic_utilities = memnew(KinematicUtilities(this));
+	reload_kinematic_shapes();
 }
 
 void RigidBodyBullet::destroy_kinematic_utilities() {
@@ -534,7 +535,6 @@ void RigidBodyBullet::set_mode(PhysicsServer3D::BodyMode p_mode) {
 			mode = PhysicsServer3D::BODY_MODE_KINEMATIC;
 			reload_axis_lock();
 			_internal_set_mass(0);
-			init_kinematic_utilities();
 			break;
 		case PhysicsServer3D::BODY_MODE_STATIC:
 			mode = PhysicsServer3D::BODY_MODE_STATIC;

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -947,7 +947,6 @@ bool SpaceBullet::test_body_motion(RigidBodyBullet *p_body, const Transform3D &p
 
 	if (!p_body->get_kinematic_utilities()) {
 		p_body->init_kinematic_utilities();
-		p_body->reload_kinematic_shapes();
 	}
 
 	btVector3 initial_recover_motion(0, 0, 0);
@@ -1089,7 +1088,6 @@ int SpaceBullet::test_ray_separation(RigidBodyBullet *p_body, const Transform3D 
 
 	if (!p_body->get_kinematic_utilities()) {
 		p_body->init_kinematic_utilities();
-		p_body->reload_kinematic_shapes();
 	}
 
 	btVector3 recover_motion(0, 0, 0);


### PR DESCRIPTION
This complements the PR https://github.com/godotengine/godot/pull/51857, as there is still a crash when changing the mode to Kinematic.

Reload kinematic shapes when changing PhysicsBody mode to Kinematic to prevent a crash when calling test_body_motion. 
Call reload_kinematic_shapes from init_kinematic_utilities as they are always called together.

*Bugsquad edit:* Fixes #53125.