### PR TITLE
Parse UTF-8 when getting path from resource UID

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -126,8 +126,7 @@ String ResourceUID::get_id_path(ID p_id) const {
 	MutexLock l(mutex);
 	ERR_FAIL_COND_V(!unique_ids.has(p_id), String());
 	const CharString &cs = unique_ids[p_id].cs;
-	String s(cs.ptr());
-	return s;
+	return String::utf8(cs.ptr());
 }
 void ResourceUID::remove_id(ID p_id) {
 	MutexLock l(mutex);


### PR DESCRIPTION
Fixes #53111.

`CharString`s in `unique_ids` are in UTF-8, so one has to build `String` with `String::utf8()` instead of constructing it directly with the pointer.