### PR TITLE
Validate before passing indices to meshoptimizer

### DIFF
--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -1176,6 +1176,7 @@ Vector<int> SurfaceTool::generate_lod(float p_threshold, int p_target_index_coun
 	ERR_FAIL_COND_V(simplify_func == nullptr, lod);
 	ERR_FAIL_COND_V(vertex_array.size() == 0, lod);
 	ERR_FAIL_COND_V(index_array.size() == 0, lod);
+	ERR_FAIL_COND_V(index_array.size() % 3 != 0, lod);
 
 	lod.resize(index_array.size());
 	LocalVector<float> vertices; //uses floats


### PR DESCRIPTION
Fixes #53011

`meshopt_simplifyWithAttributes` asserts the number of indices to be a multiple of 3, so do a check before calling it to avoid the assertion failure.