### PR TITLE
[Net] ENet poll optimizations, fragmented unreliable transfer.

### DIFF
--- a/modules/enet/enet_connection.h
+++ b/modules/enet/enet_connection.h
@@ -79,6 +79,7 @@ private:
 	ENetHost *host = nullptr;
 	List<Ref<ENetPacketPeer>> peers;
 
+	EventType _parse_event(const ENetEvent &p_event, Event &r_event);
 	Error _create(ENetAddress *p_address, int p_max_peers, int p_max_channels, int p_in_bandwidth, int p_out_bandwidth);
 	Array _service(int p_timeout = 0);
 	void _broadcast(int p_channel, PackedByteArray p_packet, int p_flags);
@@ -110,6 +111,7 @@ public:
 	void destroy();
 	Ref<ENetPacketPeer> connect_to_host(const String &p_address, int p_port, int p_channels, int p_data = 0);
 	EventType service(int p_timeout, Event &r_event);
+	int check_events(EventType &r_type, Event &r_event);
 	void flush();
 	void bandwidth_limit(int p_in_bandwidth = 0, int p_out_bandwidth = 0);
 	void channel_limit(int p_max_channels);

--- a/modules/enet/enet_multiplayer_peer.h
+++ b/modules/enet/enet_multiplayer_peer.h
@@ -84,9 +84,9 @@ private:
 	Packet current_packet;
 
 	void _pop_current_packet();
-	bool _poll_server();
-	bool _poll_client();
-	bool _poll_mesh();
+	bool _parse_server_event(ENetConnection::EventType p_event_type, ENetConnection::Event &p_event);
+	bool _parse_client_event(ENetConnection::EventType p_event_type, ENetConnection::Event &p_event);
+	bool _parse_mesh_event(ENetConnection::EventType p_event_type, ENetConnection::Event &p_event, int p_peer_id);
 	void _relay(int p_from, int p_to, enet_uint8 p_channel, ENetPacket *p_packet);
 	void _notify_peers(int p_id, bool p_connected);
 	void _destroy_unused(ENetPacket *p_packet);


### PR DESCRIPTION
In this PR:
- `ENetMultiplayerPeer` now sends fragmented packets unreliably too.
- `ENetMultiplayerPeer` poll now only service the connection once.

`4.0` port of 2 out of the 3 changes in #51466 .
The other change (`sendmsg`/`WSASendTo`) needs more testing on the `3.x` branch because according to [MS docs](https://docs.microsoft.com/en-us/windows/win32/api/ws2def/ns-ws2def-wsabuf) `WSABUF` is not available in UWP apps (though [WSASendTo is](https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendto)?)

*Bugsquad edit: `master` version of https://github.com/godotengine/godot/pull/53130.*