### PR TITLE
We need to register XRServer earlier

### DIFF
--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -238,6 +238,9 @@ void register_server_types() {
 	PhysicsServer3DManager::set_default_server("GodotPhysics3D");
 
 	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
+
+	// We need this registered early so we can access it in plugins
+	Engine::get_singleton()->add_singleton(Engine::Singleton("XRServer", XRServer::get_singleton(), "XRServer"));
 }
 
 void unregister_server_types() {
@@ -256,6 +259,5 @@ void register_server_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer2D", NavigationServer2D::get_singleton_mut(), "NavigationServer2D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3D", NavigationServer3D::get_singleton_mut(), "NavigationServer3D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TextServerManager", TextServerManager::get_singleton(), "TextServerManager"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("XRServer", XRServer::get_singleton(), "XRServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton(), "CameraServer"));
 }


### PR DESCRIPTION
The problem we have is that in order for GDExtensions to access singletons XRServer must be registered in the engine. This doesn't happen until fairly late in the initialization process. This PR moves it to earlier in the initialisation process.