### PR TITLE
[GDScript 2.0] Don't double-reference Refs returned from function

### DIFF
--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -300,6 +300,13 @@ public:
 		v->_get_obj().id = ObjectID();
 	}
 
+	static void update_object_id(Variant *v) {
+		const Object *o = v->_get_obj().obj;
+		if (o) {
+			v->_get_obj().id = o->get_instance_id();
+		}
+	}
+
 	_FORCE_INLINE_ static void *get_opaque_pointer(Variant *v) {
 		switch (v->type) {
 			case Variant::NIL:

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1814,7 +1814,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				VariantInternal::initialize(ret, Variant::OBJECT);
 				Object **ret_opaque = VariantInternal::get_object(ret);
 				method->ptrcall(base_obj, argptrs, ret_opaque);
-				VariantInternal::object_assign(ret, *ret_opaque); // Set so ID is correct too.
+				VariantInternal::update_object_id(ret);
 
 #ifdef DEBUG_ENABLED
 				if (GDScriptLanguage::get_singleton()->profiling) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

GDScript 2.0 opcode `OPCODE_CALL_PTRCALL_OBJECT` will double-reference returned `Ref`s. This results in a memory leak.
This change fixes that issue while still keeping the fixes of #43992

Fixes #53093
Fixes #52699
(both issues are the same underlying bug)

@vnen Requesting review to make sure there are no regressions to #43941 or #43851

