### PR TITLE
Update mesh AABB when software skinning is used

### DIFF
--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -390,6 +390,9 @@ void MeshInstance::_update_skinning() {
 	RID skeleton = skin_ref->get_skeleton();
 	ERR_FAIL_COND(!skeleton.is_valid());
 
+	AABB aabb;
+	bool first_vertex = true;
+
 	VisualServer *visual_server = VisualServer::get_singleton();
 
 	// Prepare bone transforms.
@@ -499,10 +502,19 @@ void MeshInstance::_update_skinning() {
 					tangent = transform.basis.xform(tangent_read);
 				}
 			}
+
+			if (first_vertex) {
+				aabb.position = vertex;
+				first_vertex = false;
+			} else {
+				aabb.expand_to(vertex);
+			}
 		}
 
 		visual_server->mesh_surface_update_region(mesh_rid, surface_index, 0, buffer);
 	}
+
+	visual_server->mesh_set_custom_aabb(mesh_rid, aabb);
 
 	software_skinning_flags |= SoftwareSkinning::FLAG_BONES_READY;
 }


### PR DESCRIPTION
Not updating the mesh properly can cause rendering issues in some cases, like shadows not updating properly.

This is 3.x only since software skinning is not implemented on master for now.

This change seems to have a limited impact on performance. In `release_debug`, I've only noticed a drop of around 4% when updating +100 models at once (mostly due to calculating the AABB itself, not dynamic shadows).

Fixes #53018