### PR TITLE
Fix trim overrun width not being reset.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -3573,6 +3573,7 @@ void TextServerAdvanced::shaped_text_overrun_trim_to_width(RID p_shaped_line, re
 		shaped_text_shape(p_shaped_line);
 	}
 
+	sd->text_trimmed = false;
 	sd->overrun_trim_data.ellipsis_glyph_buf.clear();
 
 	bool add_ellipsis = (p_trim_flags & OVERRUN_ADD_ELLIPSIS) == OVERRUN_ADD_ELLIPSIS;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -2683,6 +2683,7 @@ void TextServerFallback::shaped_text_overrun_trim_to_width(RID p_shaped_line, re
 		shaped_text_shape(p_shaped_line);
 	}
 
+	sd->text_trimmed = false;
 	sd->overrun_trim_data.ellipsis_glyph_buf.clear();
 
 	bool add_ellipsis = (p_trim_flags & OVERRUN_ADD_ELLIPSIS) == OVERRUN_ADD_ELLIPSIS;


### PR DESCRIPTION
Fixes incorrect text alignment in the sub-inspectors in Right-to-Left layout.

When inspector width was increased to the size big enough for text fits it fully, it was still using last trimmed width, instead of full one.

Before:
<img width="628" alt="Screenshot 2021-09-27 at 22 04 23" src="https://user-images.githubusercontent.com/7645683/134969352-99f440bc-8823-4fac-a457-c3b90293023b.png">

After:
<img width="628" alt="Screenshot 2021-09-27 at 21 58 25" src="https://user-images.githubusercontent.com/7645683/134968798-c2b48769-cb00-4d67-9e78-f5ebb1c8355a.png">

This might fix some other width / alignment issues as well.