### PR TITLE
Fix inversed check inside register_singleton

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2221,7 +2221,7 @@ Object *Engine::get_singleton_object(const StringName &p_name) const {
 
 void Engine::register_singleton(const StringName &p_name, Object *p_object) {
 	ERR_FAIL_COND_MSG(has_singleton(p_name), "Singleton already registered: " + String(p_name));
-	ERR_FAIL_COND_MSG(p_name.operator String().is_valid_identifier(), "Singleton name is not a valid identifier: " + String(p_name));
+	ERR_FAIL_COND_MSG(!String(p_name).is_valid_identifier(), "Singleton name is not a valid identifier: " + p_name);
 	::Engine::Singleton s;
 	s.class_name = p_name;
 	s.name = p_name;


### PR DESCRIPTION
The result of `is_valid_identifier` must be inverted, otherwise the function will complain about valid identifiers and only accept invalid ones :smile: