### PR TITLE
Fixes the normals of SphereMesh when the radius is different from 1

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -1466,7 +1466,7 @@ void SphereMesh::_create_mesh_array(Array &p_arr) const {
 			} else {
 				Vector3 p = Vector3(x * radius * w, y, z * radius * w);
 				points.push_back(p);
-				Vector3 normal = Vector3(x * radius * w * scale, y / scale, z * radius * w * scale);
+				Vector3 normal = Vector3(x * w * scale, radius * (y / scale), z * w * scale);
 				normals.push_back(normal.normalized());
 			};
 			ADD_TANGENT(z, 0.0, -x, 1.0)


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/52965.

The issue was that there was a "typo" in the previous code. The wrong coordinates were being multiplied by the radius. I didn't see it last time because I only tested the mesh for radius == 1. 

I have tested it now for varying values of "radius" and "height" when creating the sphere mesh, and compared the results with applying a transform to the whole mesh, so everything should be working now.

*Bugsquad edit: Redone version of https://github.com/godotengine/godot/pull/51995.*
