### PR TITLE
[3.x] Fix AtlasTexture get_data() return null

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -959,6 +959,14 @@ bool AtlasTexture::has_filter_clip() const {
 	return filter_clip;
 }
 
+Ref<Image> AtlasTexture::get_data() const {
+	if (!atlas.is_valid()) {
+		return Ref<Image>();
+	}
+
+	return atlas->get_data()->get_rect(region);
+}
+
 void AtlasTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_atlas", "atlas"), &AtlasTexture::set_atlas);
 	ClassDB::bind_method(D_METHOD("get_atlas"), &AtlasTexture::get_atlas);

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -270,6 +270,8 @@ public:
 	void set_filter_clip(const bool p_enable);
 	bool has_filter_clip() const;
 
+	virtual Ref<Image> get_data() const;
+
 	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>()) const;
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>()) const;
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>(), bool p_clip_uv = true) const;


### PR DESCRIPTION
this PR uses suggestion  mentioned in https://github.com/godotengine/godot/issues/44529 to retrieve data from AtlasTexture, initially it returns null.
```cpp
return atlas->get_data()->get_rect(region);
```
