### PR TITLE
Improve unregistering XR interfaces and cleaning up XRServer

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2689,8 +2689,9 @@ void Main::cleanup(bool p_force) {
 	rendering_server->global_variables_clear();
 
 	if (xr_server) {
-		// cleanup now before we pull the rug from underneath...
-		memdelete(xr_server);
+		// Now that we're unregistering properly in plugins we need to keep access to xr_server for a little longer
+		// We do however unset our primary interface
+		xr_server->set_primary_interface(Ref<XRInterface>());
 	}
 
 	unregister_driver_types();
@@ -2705,6 +2706,10 @@ void Main::cleanup(bool p_force) {
 	unregister_platform_apis();
 	unregister_scene_types();
 	unregister_server_types();
+
+	if (xr_server) {
+		memdelete(xr_server);
+	}
 
 	if (audio_server) {
 		audio_server->finish();

--- a/modules/mobile_vr/register_types.cpp
+++ b/modules/mobile_vr/register_types.cpp
@@ -32,15 +32,30 @@
 
 #include "mobile_vr_interface.h"
 
+Ref<MobileVRInterface> mobile_vr;
+
 void register_mobile_vr_types() {
 	GDREGISTER_CLASS(MobileVRInterface);
 
 	if (XRServer::get_singleton()) {
-		Ref<MobileVRInterface> mobile_vr;
 		mobile_vr.instantiate();
 		XRServer::get_singleton()->add_interface(mobile_vr);
 	}
 }
 
 void unregister_mobile_vr_types() {
+	if (mobile_vr.is_valid()) {
+		// uninitialise our interface if it is initialised
+		if (mobile_vr->is_initialized()) {
+			mobile_vr->uninitialize();
+		}
+
+		// unregister our interface from the XR server
+		if (XRServer::get_singleton()) {
+			XRServer::get_singleton()->remove_interface(mobile_vr);
+		}
+
+		// and release
+		mobile_vr.unref();
+	}
 }

--- a/modules/webxr/register_types.cpp
+++ b/modules/webxr/register_types.cpp
@@ -33,15 +33,34 @@
 #include "webxr_interface.h"
 #include "webxr_interface_js.h"
 
+#ifdef JAVASCRIPT_ENABLED
+Ref<WebXRInterfaceJS> webxr;
+#endif
+
 void register_webxr_types() {
 	GDREGISTER_VIRTUAL_CLASS(WebXRInterface);
 
 #ifdef JAVASCRIPT_ENABLED
-	Ref<WebXRInterfaceJS> webxr;
 	webxr.instantiate();
 	XRServer::get_singleton()->add_interface(webxr);
 #endif
 }
 
 void unregister_webxr_types() {
+#ifdef JAVASCRIPT_ENABLED
+	if (webxr.is_valid()) {
+		// uninitialise our interface if it is initialised
+		if (webxr->is_initialized()) {
+			webxr->uninitialize();
+		}
+
+		// unregister our interface from the XR server
+		if (XRServer::get_singleton()) {
+			XRServer::get_singleton()->remove_interface(webxr);
+		}
+
+		// and release
+		webxr.unref();
+	}
+#endif
 }


### PR DESCRIPTION
In Godot 3 we assumed plugins would be loaded as singletons and kept around until Godot closes, this meant that we relied purely on XRServer to keep the interface alive and delete the interfaces when it got deleted.

With GDExtensions we're moving to a system where we clean up after ourselves in the plugin itself making the plugin reloadable. This PR makes that possible.

As a result we also nicely cleanup our WebXR and MobileVR modules (if applicable) and move the destruction of XRServer to a later point in the close logic.