### PR TITLE
Fix auto completion shortcut for mac

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -467,7 +467,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	// ///// UI Text Input Shortcuts /////
 	inputs = List<Ref<InputEvent>>();
-	inputs.push_back(InputEventKey::create_reference(KEY_SPACE | KEY_MASK_CMD));
+	inputs.push_back(InputEventKey::create_reference(KEY_SPACE | KEY_MASK_CTRL));
 	default_builtin_cache.insert("ui_text_completion_query", inputs);
 
 	inputs = List<Ref<InputEvent>>();


### PR DESCRIPTION
Currently the auto completion is broken see #51996 except with the shortcut. However this shortcut does not work on mac because it's already used by the system for the [Spotlight search](https://support.apple.com/en-us/HT201236).

The standard shortcut on OSX for auto completion is the same as the Windows one: `CTRL + SPACE`.




