### PR TITLE
Force optimized builds for thirdparty Embree files

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -91,6 +91,7 @@ env_base.__class__.add_program = methods.add_program
 env_base.__class__.CommandNoCache = methods.CommandNoCache
 env_base.__class__.Run = methods.Run
 env_base.__class__.disable_warnings = methods.disable_warnings
+env_base.__class__.force_optimization_on_debug = methods.force_optimization_on_debug
 env_base.__class__.module_check_dependencies = methods.module_check_dependencies
 
 env_base["x86_libtheora_opt_gcc"] = False

--- a/methods.py
+++ b/methods.py
@@ -56,6 +56,17 @@ def disable_warnings(self):
         self.Append(CXXFLAGS=["-w"])
 
 
+def force_optimization_on_debug(self):
+    # 'self' is the environment
+    if self["target"] != "debug":
+        return
+
+    if self.msvc:
+        self.Append(CCFLAGS=["/O2"])
+    else:
+        self.Append(CCFLAGS=["-O3"])
+
+
 def add_module_version_string(self, s):
     self.module_version_string += "." + s
 

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -79,6 +79,7 @@ if env["builtin_embree"]:
             env.Append(LIBS=["psapi"])
 
     env_thirdparty = env_raycast.Clone()
+    env_thirdparty.force_optimization_on_debug()
     env_thirdparty.disable_warnings()
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 


### PR DESCRIPTION
Embree's debug builds are orders of magnitude of slower than optimized builds. In order to spare developers from long import times (once the new auto LOD generator is merged) we can force Embree to always build with optimizations.

The situations in which one needs to debug Embree's code are very rare, so it's better to have decent performance by default and just comment the `force_optimization()` call if we really need to dig into Embree. 