### PR TITLE
[3.x] fix crash in Variant::get_method_default_arguments when wrong type is passed

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1438,12 +1438,11 @@ Variant::Type Variant::get_method_return_type(Variant::Type p_type, const String
 }
 
 Vector<Variant> Variant::get_method_default_arguments(Variant::Type p_type, const StringName &p_method) {
+	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, Vector<Variant>());
 	const _VariantCall::TypeFunc &tf = _VariantCall::type_funcs[p_type];
 
 	const Map<StringName, _VariantCall::FuncData>::Element *E = tf.functions.find(p_method);
-	if (!E) {
-		return Vector<Variant>();
-	}
+	ERR_FAIL_COND_V(!E, Vector<Variant>());
 
 	return E->get().default_args;
 }


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #53120