### PR TITLE
Fix tree title column size minimum width

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4043,7 +4043,7 @@ int Tree::get_column_minimum_width(int p_column) const {
 
 	// Check if the visible title of the column is wider.
 	if (show_column_titles) {
-		min_width = MAX(cache.font->get_string_size(columns[p_column].title).width, min_width);
+		min_width = MAX(cache.font->get_string_size(columns[p_column].title).width + cache.bg->get_margin(SIDE_LEFT) + cache.bg->get_margin(SIDE_RIGHT), min_width);
 	}
 
 	if (!columns[p_column].clip_content) {


### PR DESCRIPTION
Fixes #52891

The biggest part of #52891 has been fixed by merging #53001.
But a minor issue is left : 
The column title minimum size calculation miss the margin offset of the title.
Few pixel are missing and title is always crop if no other item is wider than title.

The offset used seems to be the Stylebox bg margin.
https://github.com/godotengine/godot/blob/5aa099aaed359df6ff79fe31616b5601db2a42c5/scene/gui/tree.cpp#L3699-L3701

Just adding this offset is not sufficent. I've also added the right bg margin to get the correct width.
Maybe this need to be reviewed, i'm not sure of this right margin use even if the looking result is good. 

### Before:
![image](https://user-images.githubusercontent.com/3649998/135091528-e7fd1555-14de-400b-871d-39e813235af2.png)
You can see that Global Variable title is truncated.

### After:
![image](https://user-images.githubusercontent.com/3649998/135091372-a33f36d0-d008-4ed6-8e66-c7f88f54a82c.png)
You can see that Global Variable title is entirely shown.