### PR TITLE
Sync to physics true by default for AnimatableBody

### DIFF
--- a/doc/classes/AnimatableBody2D.xml
+++ b/doc/classes/AnimatableBody2D.xml
@@ -11,7 +11,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="sync_to_physics" type="bool" setter="set_sync_to_physics" getter="is_sync_to_physics_enabled" default="false">
+		<member name="sync_to_physics" type="bool" setter="set_sync_to_physics" getter="is_sync_to_physics_enabled" default="true">
 			If [code]true[/code], the body's movement will be synchronized to the physics frame. This is useful when animating movement via [AnimationPlayer], for example on moving platforms. Do [b]not[/b] use together with [method PhysicsBody2D.move_and_collide].
 		</member>
 	</members>

--- a/doc/classes/AnimatableBody3D.xml
+++ b/doc/classes/AnimatableBody3D.xml
@@ -14,7 +14,7 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>
 	<members>
-		<member name="sync_to_physics" type="bool" setter="set_sync_to_physics" getter="is_sync_to_physics_enabled" default="false">
+		<member name="sync_to_physics" type="bool" setter="set_sync_to_physics" getter="is_sync_to_physics_enabled" default="true">
 			If [code]true[/code], the body's movement will be synchronized to the physics frame. This is useful when animating movement via [AnimationPlayer], for example on moving platforms. Do [b]not[/b] use together with [method PhysicsBody3D.move_and_collide].
 		</member>
 	</members>

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -92,7 +92,7 @@ class AnimatableBody2D : public StaticBody2D {
 	GDCLASS(AnimatableBody2D, StaticBody2D);
 
 private:
-	bool sync_to_physics = false;
+	bool sync_to_physics = true;
 
 	Transform2D last_valid_transform;
 

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -105,7 +105,7 @@ private:
 	Vector3 linear_velocity;
 	Vector3 angular_velocity;
 
-	bool sync_to_physics = false;
+	bool sync_to_physics = true;
 
 	Transform3D last_valid_transform;
 


### PR DESCRIPTION
As discussed in the chat, AnimatableBody will mostly be used for moving platforms, so it makes sense to turn (his only property) `on` by default.