### PR TITLE
Compile bullet with threadsafe switch on

### DIFF
--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -205,7 +205,7 @@ if env["builtin_bullet"]:
     # if env['target'] == "debug" or env['target'] == "release_debug":
     #     env_bullet.Append(CPPDEFINES=['BT_DEBUG'])
 
-    env_bullet.Append(CPPDEFINES=["BT_USE_OLD_DAMPING_METHOD"])
+    env_bullet.Append(CPPDEFINES=["BT_USE_OLD_DAMPING_METHOD", "BT_THREADSAFE"])
 
     env_thirdparty = env_bullet.Clone()
     env_thirdparty.disable_warnings()


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Compile Bullet with the BT_THREADSAFE switch so that it is thread-safe to raycast from multiple threads (as long as the physics engine is not stepping).

I'm using this feature in my project to implement projectile rayscan and visibility checks.
Making this for 3.x first as Bullet seems to not be compiled yet when compiling from master.
