### PR TITLE
Unify panning in sub-editors and make it configurable

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -214,6 +214,9 @@
 		<member name="minimap_size" type="Vector2" setter="set_minimap_size" getter="get_minimap_size" default="Vector2(240, 160)">
 			The size of the minimap rectangle. The map itself is based on the size of the grid area and is scaled to fit this rectangle.
 		</member>
+		<member name="panning_scheme" type="int" setter="set_panning_scheme" getter="get_panning_scheme" enum="GraphEdit.PanningScheme" default="0">
+			Defines the control scheme for panning with mouse wheel.
+		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="right_disconnects" type="bool" setter="set_right_disconnects" getter="is_right_disconnects_enabled" default="false">
 			If [code]true[/code], enables disconnection of existing connections in the GraphEdit by dragging the right end.
@@ -345,6 +348,14 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="SCROLL_ZOOMS" value="0" enum="PanningScheme">
+			[kbd]Mouse Wheel[/kbd] will zoom, [kbd]Ctrl + Mouse Wheel[/kbd] will move the view.
+		</constant>
+		<constant name="SCROLL_PANS" value="1" enum="PanningScheme">
+			[kbd]Mouse Wheel[/kbd] will move the view, [kbd]Ctrl + Mouse Wheel[/kbd] will zoom.
+		</constant>
+	</constants>
 	<theme_items>
 		<theme_item name="activity" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 		</theme_item>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6038,6 +6038,9 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_VHS_CIRCLE);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_color_picker_shape", PROPERTY_HINT_ENUM, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle", PROPERTY_USAGE_DEFAULT));
 	EDITOR_DEF("run/auto_save/save_before_running", true);
+	EDITOR_DEF("interface/editors/sub_editor_panning_scheme", 0);
+	// Should be in sync with ControlScheme in ViewPanner.
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/editors/sub_editor_panning_scheme", PROPERTY_HINT_ENUM, "Scroll Zooms,Scroll Pans", PROPERTY_USAGE_DEFAULT));
 
 	const Vector<String> textfile_ext = ((String)(EditorSettings::get_singleton()->get("docks/filesystem/textfile_extensions"))).split(",", false);
 	for (const String &E : textfile_ext) {

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -41,6 +41,8 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/resources/tile_set.h"
 
+class ViewPanner;
+
 class TileAtlasView : public Control {
 	GDCLASS(TileAtlasView, Control);
 
@@ -63,6 +65,11 @@ private:
 	void _zoom_widget_changed();
 	void _center_view();
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
+	Ref<ViewPanner> panner;
+	void _scroll_callback(Vector2 p_scroll_vec);
+	void _pan_callback(Vector2 p_scroll_vec);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
 
 	Map<Vector2, Map<int, Rect2i>> alternative_tiles_rect_cache;
 	void _update_alternative_tiles_rect_cache();

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3209,6 +3209,10 @@ void VisualShaderEditor::_notification(int p_what) {
 		}
 	}
 
+	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
+		graph->set_panning_scheme((GraphEdit::PanningScheme)EDITOR_GET("interface/editors/sub_editor_panning_scheme").operator int());
+	}
+
 	if (p_what == NOTIFICATION_DRAG_BEGIN) {
 		Dictionary dd = get_viewport()->gui_get_drag_data();
 		if (members->is_visible_in_tree() && dd.has("id")) {

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -3753,6 +3753,11 @@ void VisualScriptEditor::_toggle_scripts_pressed() {
 
 void VisualScriptEditor::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			graph->set_panning_scheme((GraphEdit::PanningScheme)EDITOR_GET("interface/editors/sub_editor_panning_scheme").operator int());
+		} break;
+
 		case NOTIFICATION_READY: {
 			variable_editor->connect("changed", callable_mp(this, &VisualScriptEditor::_update_members));
 			variable_editor->connect("changed", callable_mp(this, &VisualScriptEditor::_update_graph), varray(-1), CONNECT_DEFERRED);

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -41,6 +41,7 @@
 #include "scene/gui/texture_rect.h"
 
 class GraphEdit;
+class ViewPanner;
 
 class GraphEditFilter : public Control {
 	GDCLASS(GraphEditFilter, Control);
@@ -103,6 +104,12 @@ public:
 		float activity = 0.0;
 	};
 
+	// Should be in sync with ControlScheme in ViewPanner.
+	enum PanningScheme {
+		SCROLL_ZOOMS,
+		SCROLL_PANS,
+	};
+
 private:
 	Label *zoom_label;
 	Button *zoom_minus;
@@ -122,6 +129,11 @@ private:
 	float port_grab_distance_horizontal = 0.0;
 	float port_grab_distance_vertical;
 
+	Ref<ViewPanner> panner;
+	void _scroll_callback(Vector2 p_scroll_vec);
+	void _pan_callback(Vector2 p_scroll_vec);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
+
 	bool connecting = false;
 	String connecting_from;
 	bool connecting_out = false;
@@ -136,6 +148,7 @@ private:
 	bool connecting_valid = false;
 	Vector2 click_pos;
 
+	PanningScheme panning_scheme = SCROLL_ZOOMS;
 	bool dragging = false;
 	bool just_selected = false;
 	bool moving_selection = false;
@@ -277,6 +290,9 @@ public:
 	void remove_valid_connection_type(int p_type, int p_with_type);
 	bool is_valid_connection_type(int p_type, int p_with_type) const;
 
+	void set_panning_scheme(PanningScheme p_scheme);
+	PanningScheme get_panning_scheme() const;
+
 	void set_zoom(float p_zoom);
 	void set_zoom_custom(float p_zoom, const Vector2 &p_center);
 	float get_zoom() const;
@@ -337,5 +353,7 @@ public:
 
 	GraphEdit();
 };
+
+VARIANT_ENUM_CAST(GraphEdit::PanningScheme);
 
 #endif // GRAPHEdit_H

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -1,0 +1,136 @@
+/*************************************************************************/
+/*  view_panner.cpp                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "view_panner.h"
+
+#include "core/input/input.h"
+#include "core/os/keyboard.h"
+
+bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) {
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid()) {
+		Vector2i scroll_vec = Vector2((mb->get_button_index() == MouseButton::WHEEL_RIGHT) - (mb->get_button_index() == MouseButton::WHEEL_LEFT), (mb->get_button_index() == MouseButton::WHEEL_DOWN) - (mb->get_button_index() == MouseButton::WHEEL_UP));
+		if (scroll_vec != Vector2()) {
+			if (control_scheme == SCROLL_PANS) {
+				if (mb->is_ctrl_pressed()) {
+					callback_helper(zoom_callback, scroll_vec, mb->get_position());
+				} else {
+					Vector2 panning;
+					if (mb->is_shift_pressed()) {
+						panning.x += mb->get_factor() * scroll_vec.y;
+						panning.y += mb->get_factor() * scroll_vec.x;
+					} else {
+						panning.y += mb->get_factor() * scroll_vec.y;
+						panning.x += mb->get_factor() * scroll_vec.x;
+					}
+					callback_helper(scroll_callback, panning);
+
+					return true;
+				}
+			} else {
+				if (mb->is_ctrl_pressed()) {
+					Vector2 panning;
+					if (mb->is_shift_pressed()) {
+						panning.x += mb->get_factor() * scroll_vec.y;
+						panning.y += mb->get_factor() * scroll_vec.x;
+					} else {
+						panning.y += mb->get_factor() * scroll_vec.y;
+						panning.x += mb->get_factor() * scroll_vec.x;
+					}
+					callback_helper(scroll_callback, panning);
+
+					return true;
+				} else if (!mb->is_shift_pressed()) {
+					callback_helper(zoom_callback, scroll_vec, mb->get_position());
+					return true;
+				}
+			}
+		}
+
+		if (mb->get_button_index() == MouseButton::MIDDLE || (mb->get_button_index() == MouseButton::RIGHT && !disable_rmb) || (mb->get_button_index() == MouseButton::LEFT && (Input::get_singleton()->is_key_pressed(Key::SPACE) || !mb->is_pressed()))) {
+			if (mb->is_pressed()) {
+				is_dragging = true;
+			} else {
+				is_dragging = false;
+			}
+			return true;
+		}
+	}
+
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid()) {
+		if (is_dragging) {
+			if (p_canvas_rect != Rect2()) {
+				callback_helper(pan_callback, Input::get_singleton()->warp_mouse_motion(mm, p_canvas_rect));
+			} else {
+				callback_helper(pan_callback, mm->get_relative());
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void ViewPanner::callback_helper(Callable p_callback, Vector2 p_arg1, Vector2 p_arg2) {
+	if (p_callback == zoom_callback) {
+		const Variant **argptr = (const Variant **)alloca(sizeof(Variant *) * 2);
+		Variant var1 = p_arg1;
+		argptr[0] = &var1;
+		Variant var2 = p_arg2;
+		argptr[1] = &var2;
+
+		Variant result;
+		Callable::CallError ce;
+		p_callback.call(argptr, 2, result, ce);
+	} else {
+		const Variant **argptr = (const Variant **)alloca(sizeof(Variant *));
+		Variant var = p_arg1;
+		argptr[0] = &var;
+
+		Variant result;
+		Callable::CallError ce;
+		p_callback.call(argptr, 1, result, ce);
+	}
+}
+
+void ViewPanner::set_callbacks(Callable p_scroll_callback, Callable p_pan_callback, Callable p_zoom_callback) {
+	scroll_callback = p_scroll_callback;
+	pan_callback = p_pan_callback;
+	zoom_callback = p_zoom_callback;
+}
+
+void ViewPanner::set_control_scheme(ControlScheme p_scheme) {
+	control_scheme = p_scheme;
+}
+
+void ViewPanner::set_disable_rmb(bool p_disable) {
+	disable_rmb = p_disable;
+}

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -1,0 +1,63 @@
+/*************************************************************************/
+/*  view_panner.h                                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef VIEW_PANNER_H
+#define VIEW_PANNER_H
+
+#include "core/object/ref_counted.h"
+
+class InputEvent;
+
+class ViewPanner : public RefCounted {
+	GDCLASS(ViewPanner, RefCounted);
+
+	bool is_dragging = false;
+	bool disable_rmb = false;
+
+	Callable scroll_callback;
+	Callable pan_callback;
+	Callable zoom_callback;
+
+	void callback_helper(Callable p_callback, Vector2 p_arg1, Vector2 p_arg2 = Vector2());
+
+public:
+	enum ControlScheme {
+		SCROLL_ZOOMS,
+		SCROLL_PANS,
+	};
+	ControlScheme control_scheme = SCROLL_ZOOMS;
+
+	void set_callbacks(Callable p_scroll_callback, Callable p_pan_callback, Callable p_zoom_callback);
+	void set_control_scheme(ControlScheme p_scheme);
+	void set_disable_rmb(bool p_disable);
+	bool gui_input(const Ref<InputEvent> &p_ev, Rect2 p_canvas_rect = Rect2());
+};
+
+#endif // VIEW_PANNER_H


### PR DESCRIPTION
This PR adds a new ViewPanner object and adds it to TileAtlasView and GraphEdit. These 2 editors had very similar panning code and the scheme was that Ctrl+Wheel scrolls and Wheel zooms (same as 2D editor). So I moved this code out to the new class and made them use it, instead of duplicating.

The advantage of ViewPanner is that it can unify the code, which also makes it easier to customize. Some folks (e.g. me) prefer the scheme where Wheel scrools and Ctrl+Wheel zooms. Now it can be easily changed. The way it works is that you provide ViewPanner with relevant callbacks for scrolling, panning and zooming and then just call `ViewPanner.gui_input()` and let it do the work.

The PR is WIP. I made a quick proof-of-concept and it works. I still need to make it configurable (right now one control scheme is hard-coded). My plans are to add a property to GraphEdit and an editor setting that affects TileAtlasView and visual editors. Also GraphEdit had LMB+Space as panning shortcut, I need to sort it out.

This can be later added to other relevant editors/controls, basically anything that supports panning with mouse, including the 2D editor.

Resolves https://github.com/godotengine/godot-proposals/issues/3100

---

Summary of changes:
- Added ViewPanner class
- - It has a custom `gui_input()` method intended to be called manually
- - Has callbacks for scrolling, panning and zooming
- - Based on the provided input, it calls the relevant callback and returns true if the input was handled
- - Uses MMB, RMB and LMB+Space for panning
- - - RMB can be disabled
- ViewPanner has 2 panning modes:
- - "Scroll Zooms" - mouse wheel to zoom, Ctrl + mouse wheel to move around
- - "Scroll Pans" - opposite to the above
- GraphEdit and TileAtlasView now use ViewPanner internally to handle panning
- - As a consequence, TileAtlasView now supports LMB + Space for panning
- - GraphEdit now supports `WHEEL_LEFT` and `WHEEL_RIGHT` buttons
- GraphEdit also got a `panning_scheme` property that changes the panning controls
- Added a new Editor Setting: `interface/editors/sub_editor_panning_scheme`
- - Allows to set panning scheme for some editors
- - For now only affects TileAtlasView, VisualShader Editor and VisualScript Editor

It's possible to add the ViewPanner to other editors with panning, e.g. Polygon UV editor.