### PR TITLE
Optimize AABB calculation in software skinning

### DIFF
--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -390,8 +390,8 @@ void MeshInstance::_update_skinning() {
 	RID skeleton = skin_ref->get_skeleton();
 	ERR_FAIL_COND(!skeleton.is_valid());
 
-	AABB aabb;
-	bool first_vertex = true;
+	Vector3 aabb_min = Vector3(FLT_MAX, FLT_MAX, FLT_MAX);
+	Vector3 aabb_max = Vector3(-FLT_MAX, -FLT_MAX, -FLT_MAX);
 
 	VisualServer *visual_server = VisualServer::get_singleton();
 
@@ -503,18 +503,18 @@ void MeshInstance::_update_skinning() {
 				}
 			}
 
-			if (first_vertex) {
-				aabb.position = vertex;
-				first_vertex = false;
-			} else {
-				aabb.expand_to(vertex);
-			}
+			aabb_min.x = MIN(aabb_min.x, vertex.x);
+			aabb_min.y = MIN(aabb_min.y, vertex.y);
+			aabb_min.z = MIN(aabb_min.z, vertex.z);
+			aabb_max.x = MAX(aabb_max.x, vertex.x);
+			aabb_max.y = MAX(aabb_max.y, vertex.y);
+			aabb_max.z = MAX(aabb_max.z, vertex.z);
 		}
 
 		visual_server->mesh_surface_update_region(mesh_rid, surface_index, 0, buffer);
 	}
 
-	visual_server->mesh_set_custom_aabb(mesh_rid, aabb);
+	visual_server->mesh_set_custom_aabb(mesh_rid, AABB(aabb_min, aabb_max - aabb_min));
 
 	software_skinning_flags |= SoftwareSkinning::FLAG_BONES_READY;
 }


### PR DESCRIPTION
Using min/max instead of regular AABB for optimal processing.
Based on @lawnjelly's suggestion (see https://github.com/godotengine/godot/pull/53144#issuecomment-928946058).

This is 3.x only since software skinning is not implemented on master for now.