### PR TITLE
Radial fog for clustered renderer

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -524,7 +524,7 @@ vec4 fog_process(vec3 vertex) {
 		}
 	}
 
-	float fog_amount = 1.0 - exp(min(0.0, vertex.z * scene_data.fog_density));
+	float fog_amount = 1.0 - exp(min(0.0, -length(vertex) * scene_data.fog_density));
 
 	if (abs(scene_data.fog_height_density) > 0.001) {
 		float y = (scene_data.camera_matrix * vec4(vertex, 1.0)).y;

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -550,7 +550,7 @@ vec4 fog_process(vec3 vertex) {
 		}
 	}
 
-	float fog_amount = 1.0 - exp(min(0.0, vertex.z * scene_data.fog_density));
+	float fog_amount = 1.0 - exp(min(0.0, -length(vertex) * scene_data.fog_density));
 
 	if (abs(scene_data.fog_height_density) > 0.001) {
 		float y = (scene_data.camera_matrix * vec4(vertex, 1.0)).y;


### PR DESCRIPTION
This pull request is for the issue #52707, however, it is for the "clustered renderer" back end only since I could not make the fog appear in the "forward mobile" back end by user means.

It is possibly a bug or there is a way to enable it that I don't know.

*Bugsquad edit:* Fixes #52707.