### PR TITLE
Fix editor freeze when asigning Skeleton2D to Polygon2D

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1394,6 +1394,7 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 						update_skeletons = true;
 					}
 				}
+				c = c->next;
 			}
 		}
 


### PR DESCRIPTION
This PR aims to fix #53198

Although the editor doesn't freeze anymore it seems that the 2d skeleton system is still broken.
(After asigning the skeleton the 2d mesh becomes completely invisible or draws sporadically)

I also tested this fix directly after PR #48617, but got the same result.

Maybe someone who knows this part of the engine better than me could investigate :)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
