### PR TITLE
Fix crash in headless mode

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -369,6 +369,8 @@ void MeshInstance3D::create_debug_tangents() {
 
 	for (int i = 0; i < mesh->get_surface_count(); i++) {
 		Array arrays = mesh->surface_get_arrays(i);
+		ERR_CONTINUE(arrays.size() != Mesh::ARRAY_MAX);
+
 		Vector<Vector3> verts = arrays[Mesh::ARRAY_VERTEX];
 		Vector<Vector3> norms = arrays[Mesh::ARRAY_NORMAL];
 		if (norms.size() == 0) {

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -41,6 +41,8 @@ void NavigationMesh::create_from_mesh(const Ref<Mesh> &p_mesh) {
 			continue;
 		}
 		Array arr = p_mesh->surface_get_arrays(i);
+		ERR_CONTINUE(arr.size() != Mesh::ARRAY_MAX);
+
 		Vector<Vector3> varr = arr[Mesh::ARRAY_VERTEX];
 		Vector<int> iarr = arr[Mesh::ARRAY_INDEX];
 		if (varr.size() == 0 || iarr.size() == 0) {

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -45,6 +45,9 @@ int RenderingServerDefault::changes = 0;
 /* FREE */
 
 void RenderingServerDefault::_free(RID p_rid) {
+	if (unlikely(p_rid.is_null())) {
+		return;
+	}
 	if (RSG::storage->free(p_rid)) {
 		return;
 	}


### PR DESCRIPTION
The direct cause of the crashes is that `surface_get_arrays` will return empty array on error (headless), and the returned array was used directly without checking the length.

The `RID::is_null()` check is to solve a following crash: Dummy servers produce invalid `RID` for `Shader` and `CanvasTexture` objects. The invalid RID will go through all possible paths in `free()`. But `unregister_scene_types()` is called after `unregister_module_types()`, so `RaycastOcclusionCull` is freed at this point, and `RendererSceneOcclusionCull::get_singleton()` returns a null pointer.

https://github.com/godotengine/godot/blob/475facb517d3cbe600ca5d62a51e58c47d870497/servers/rendering/renderer_scene_cull.cpp#L3767-L3768

Adding a null check there works too I think, but it's cleaner to do the early return in `RenderingServerDefault`.


Fixes #53181
Fixes #53182
*Bugsquad edit:* Fixes #53289