### PR TITLE
[3.3] Improve appearance of the audio bus editor and Mono build log

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -66,8 +66,8 @@ void EditorAudioBus::_update_visible_channels() {
 void EditorAudioBus::_notification(int p_what) {
 
 	switch (p_what) {
-		case NOTIFICATION_READY: {
-
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
 			for (int i = 0; i < CHANNELS_MAX; i++) {
 				channel[i].vu_l->set_under_texture(get_icon("BusVuEmpty", "EditorIcons"));
 				channel[i].vu_l->set_progress_texture(get_icon("BusVuFull", "EditorIcons"));
@@ -91,6 +91,12 @@ void EditorAudioBus::_notification(int p_what) {
 
 			bus_options->set_icon(get_icon("GuiTabMenuHl", "EditorIcons"));
 
+			audio_value_preview_label->add_color_override("font_color", get_color("font_color", "TooltipLabel"));
+			audio_value_preview_label->add_color_override("font_color_shadow", get_color("font_color_shadow", "TooltipLabel"));
+			audio_value_preview_box->add_style_override("panel", get_stylebox("panel", "TooltipPanel"));
+		} break;
+
+		case NOTIFICATION_READY: {
 			update_bus();
 			set_process(true);
 		} break;
@@ -165,24 +171,7 @@ void EditorAudioBus::_notification(int p_what) {
 
 			set_process(is_visible_in_tree());
 		} break;
-		case NOTIFICATION_THEME_CHANGED: {
 
-			for (int i = 0; i < CHANNELS_MAX; i++) {
-				channel[i].vu_l->set_under_texture(get_icon("BusVuEmpty", "EditorIcons"));
-				channel[i].vu_l->set_progress_texture(get_icon("BusVuFull", "EditorIcons"));
-				channel[i].vu_r->set_under_texture(get_icon("BusVuEmpty", "EditorIcons"));
-				channel[i].vu_r->set_progress_texture(get_icon("BusVuFull", "EditorIcons"));
-				channel[i].prev_active = true;
-			}
-
-			disabled_vu = get_icon("BusVuFrozen", "EditorIcons");
-
-			solo->set_icon(get_icon("AudioBusSolo", "EditorIcons"));
-			mute->set_icon(get_icon("AudioBusMute", "EditorIcons"));
-			bypass->set_icon(get_icon("AudioBusBypass", "EditorIcons"));
-
-			bus_options->set_icon(get_icon("GuiTabMenuHl", "EditorIcons"));
-		} break;
 		case NOTIFICATION_MOUSE_EXIT:
 		case NOTIFICATION_DRAG_END: {
 
@@ -393,15 +382,24 @@ void EditorAudioBus::_show_value(float slider_value) {
 		db = _normalized_volume_to_scaled_db(slider_value);
 	}
 
-	String text = vformat("%10.1f dB", db);
+	String text;
+	if (Math::is_zero_approx(Math::stepify(db, 0.1))) {
+		// Prevent displaying `-0.0 dB` and show ` 0.0 dB` instead.
+		// The leading space makes the text visually line up with its positive/negative counterparts.
+		text = " 0.0 dB";
+	} else {
+		// Show an explicit `+` sign if positive.
+		text = vformat("%+.1f dB", db);
+	}
 
+	// Also set the preview text as a standard Control tooltip.
+	// This way, it can be seen when the slider is merely hovered (instead of dragged).
 	slider->set_tooltip(text);
 	audio_value_preview_label->set_text(text);
-	Vector2 slider_size = slider->get_size();
-	Vector2 slider_position = slider->get_global_position();
-	float left_padding = 5.0f;
-	float vert_padding = 10.0f;
-	Vector2 box_position = Vector2(slider_size.x + left_padding, (slider_size.y - vert_padding) * (1.0f - slider->get_value()) - vert_padding);
+	const Vector2 slider_size = slider->get_size();
+	const Vector2 slider_position = slider->get_global_position();
+	const float vert_padding = 10.0f;
+	const Vector2 box_position = Vector2(slider_size.x, (slider_size.y - vert_padding) * (1.0f - slider->get_value()) - vert_padding);
 	audio_value_preview_box->set_position(slider_position + box_position);
 	audio_value_preview_box->set_size(audio_value_preview_label->get_size());
 	if (slider->has_focus() && !audio_value_preview_box->is_visible()) {
@@ -866,6 +864,11 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	slider->set_clip_contents(false);
 
 	audio_value_preview_box = memnew(Panel);
+	slider->add_child(audio_value_preview_box);
+	audio_value_preview_box->set_as_toplevel(true);
+	audio_value_preview_box->set_mouse_filter(MOUSE_FILTER_PASS);
+	audio_value_preview_box->hide();
+
 	HBoxContainer *audioprev_hbc = memnew(HBoxContainer);
 	audioprev_hbc->set_v_size_flags(SIZE_EXPAND_FILL);
 	audioprev_hbc->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -876,16 +879,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	audio_value_preview_label->set_v_size_flags(SIZE_EXPAND_FILL);
 	audio_value_preview_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	audio_value_preview_label->set_mouse_filter(MOUSE_FILTER_PASS);
-
 	audioprev_hbc->add_child(audio_value_preview_label);
-
-	slider->add_child(audio_value_preview_box);
-	audio_value_preview_box->set_as_toplevel(true);
-	Ref<StyleBoxFlat> panel_style = memnew(StyleBoxFlat);
-	panel_style->set_bg_color(Color(0.0f, 0.0f, 0.0f, 0.8f));
-	audio_value_preview_box->add_style_override("panel", panel_style);
-	audio_value_preview_box->set_mouse_filter(MOUSE_FILTER_PASS);
-	audio_value_preview_box->hide();
 
 	preview_timer = memnew(Timer);
 	preview_timer->set_wait_time(0.8f);
@@ -1492,7 +1486,7 @@ void EditorAudioMeterNotches::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			notch_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1, 1, 1) : Color(0, 0, 0);
+			notch_color = get_color("font_color", "Editor");
 		} break;
 		case NOTIFICATION_DRAW: {
 			_draw_audio_notches();
@@ -1508,13 +1502,13 @@ void EditorAudioMeterNotches::_draw_audio_notches() {
 	for (int i = 0; i < notches.size(); i++) {
 		AudioNotch n = notches[i];
 		draw_line(Vector2(0, (1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + top_padding),
-				Vector2(line_length, (1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + top_padding),
+				Vector2(line_length * EDSCALE, (1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + top_padding),
 				notch_color,
-				1);
+				Math::round(EDSCALE));
 
 		if (n.render_db_value) {
 			draw_string(font,
-					Vector2(line_length + label_space,
+					Vector2((line_length + label_space) * EDSCALE,
 							(1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + (font_height / 4) + top_padding),
 					String::num(Math::abs(n.db_value)) + "dB",
 					notch_color);
@@ -1522,11 +1516,6 @@ void EditorAudioMeterNotches::_draw_audio_notches() {
 	}
 }
 
-EditorAudioMeterNotches::EditorAudioMeterNotches() :
-		line_length(5.0f),
-		label_space(2.0f),
-		btm_padding(9.0f),
-		top_padding(5.0f) {
-
-	notch_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1, 1, 1) : Color(0, 0, 0);
+EditorAudioMeterNotches::EditorAudioMeterNotches() {
+	notch_color = get_color("font_color", "Editor");
 }

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -247,10 +247,10 @@ private:
 	List<AudioNotch> notches;
 
 public:
-	float line_length;
-	float label_space;
-	float btm_padding;
-	float top_padding;
+	const float line_length = 5.0f;
+	const float label_space = 2.0f;
+	const float btm_padding = 9.0f;
+	const float top_padding = 5.0f;
 	Color notch_color;
 
 	void add_notch(float p_normalized_offset, float p_db_value, bool p_render_value = false);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -380,6 +380,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color font_color = mono_color.linear_interpolate(base_color, 0.25);
 	const Color font_color_hl = mono_color.linear_interpolate(base_color, 0.15);
 	const Color font_color_disabled = Color(mono_color.r, mono_color.g, mono_color.b, 0.3);
+	const Color font_color_readonly = Color(mono_color.r, mono_color.g, mono_color.b, 0.65);
 	const Color font_color_selection = accent_color * Color(1, 1, 1, 0.4);
 	const Color color_disabled = mono_color.inverted().linear_interpolate(base_color, 0.7);
 	const Color color_disabled_bg = mono_color.inverted().linear_interpolate(base_color, 0.9);
@@ -939,6 +940,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("read_only", "LineEdit", font_color_disabled);
 	theme->set_color("font_color", "LineEdit", font_color);
 	theme->set_color("font_color_selected", "LineEdit", mono_color);
+	theme->set_color("font_color_uneditable", "LineEdit", font_color_readonly);
 	theme->set_color("cursor_color", "LineEdit", font_color);
 	theme->set_color("selection_color", "LineEdit", font_color_selection);
 	theme->set_color("clear_button_color", "LineEdit", font_color);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -156,6 +156,7 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#a5b7f3", "#3d64dd"); // 2d
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#708cea", "#1a3eac"); // 2d dark
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#a5efac", "#2fa139"); // control
+		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ffdd65", "#ca8a04"); // node warning
 
 		// rainbow
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ff7070", "#ff2929"); // red
@@ -229,7 +230,6 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 		exceptions.insert("StatusError");
 		exceptions.insert("StatusSuccess");
 		exceptions.insert("StatusWarning");
-		exceptions.insert("NodeWarning");
 		exceptions.insert("OverbrightIndicator");
 	}
 
@@ -956,6 +956,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("folded", "TextEdit", theme->get_icon("GuiTreeArrowRight", "EditorIcons"));
 	theme->set_icon("fold", "TextEdit", theme->get_icon("GuiTreeArrowDown", "EditorIcons"));
 	theme->set_color("font_color", "TextEdit", font_color);
+	theme->set_color("font_color_readonly", "TextEdit", font_color_readonly);
 	theme->set_color("caret_color", "TextEdit", font_color);
 	theme->set_color("selection_color", "TextEdit", font_color_selection);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -11,6 +11,7 @@ namespace GodotTools.Build
     {
         public BuildOutputView BuildOutputView { get; private set; }
 
+        private MenuButton buildMenuBtn;
         private Button errorsBtn;
         private Button warningsBtn;
         private Button viewLogBtn;
@@ -56,7 +57,7 @@ namespace GodotTools.Build
 
             BuildManager.GenerateEditorScriptMetadata();
 
-            if (!BuildManager.BuildProjectBlocking("Debug", targets: new[] {"Rebuild"}))
+            if (!BuildManager.BuildProjectBlocking("Debug", targets: new[] { "Rebuild" }))
                 return; // Build failed
 
             // Notify running game for hot-reload
@@ -75,7 +76,7 @@ namespace GodotTools.Build
             if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
                 return; // No solution to build
 
-            BuildManager.BuildProjectBlocking("Debug", targets: new[] {"Clean"});
+            BuildManager.BuildProjectBlocking("Debug", targets: new[] { "Clean" });
         }
 
         private void ViewLogToggled(bool pressed) => BuildOutputView.LogVisible = pressed;
@@ -112,10 +113,10 @@ namespace GodotTools.Build
             RectMinSize = new Vector2(0, 228) * EditorScale;
             SizeFlagsVertical = (int)SizeFlags.ExpandFill;
 
-            var toolBarHBox = new HBoxContainer {SizeFlagsHorizontal = (int)SizeFlags.ExpandFill};
+            var toolBarHBox = new HBoxContainer { SizeFlagsHorizontal = (int)SizeFlags.ExpandFill };
             AddChild(toolBarHBox);
 
-            var buildMenuBtn = new MenuButton {Text = "Build", Icon = GetIcon("Play", "EditorIcons")};
+            buildMenuBtn = new MenuButton { Text = "Build", Icon = GetIcon("Play", "EditorIcons") };
             toolBarHBox.AddChild(buildMenuBtn);
 
             var buildMenu = buildMenuBtn.GetPopup();
@@ -160,6 +161,21 @@ namespace GodotTools.Build
 
             BuildOutputView = new BuildOutputView();
             AddChild(BuildOutputView);
+        }
+
+        public override void _Notification(int what)
+        {
+            base._Notification(what);
+
+            if (what == NotificationThemeChanged)
+            {
+                if (buildMenuBtn != null)
+                    buildMenuBtn.Icon = GetIcon("Play", "EditorIcons");
+                if (errorsBtn != null)
+                    errorsBtn.Icon = GetIcon("StatusError", "EditorIcons");
+                if (warningsBtn != null)
+                    warningsBtn.Icon = GetIcon("NodeWarning", "EditorIcons");
+            }
         }
     }
 }


### PR DESCRIPTION
This is a backport for `3.3` of 4 theming related PRs for the audio bus editor and the Mono build log:

* https://github.com/godotengine/godot/pull/49130 (cc @Calinou) with https://github.com/godotengine/godot/pull/51113, 
* https://github.com/godotengine/godot/pull/51221 with https://github.com/godotengine/godot/pull/51325.

Sorry for a weird mix, but the fixes made to Mono were requested for 3.3, and they are intertwined with the changes made to the audio bus editor. Either way, these fixes should all be beneficial to our 3.3 users. Tested it locally, and just from looking at the code I think it should be fine for a patch release.

PS. I omitted the "Bus Options" change from https://github.com/godotengine/godot/pull/49130 so translations are unaffected.