### PR TITLE
Don't memcpy to nullptr even if length is zero

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -104,9 +104,11 @@ Error HTTPRequest::request(const String &p_url, const Vector<String> &p_custom_h
 
 	CharString charstr = p_request_data.utf8();
 	size_t len = charstr.length();
-	raw_data.resize(len);
-	uint8_t *w = raw_data.ptrw();
-	memcpy(w, charstr.ptr(), len);
+	if (len > 0) {
+		raw_data.resize(len);
+		uint8_t *w = raw_data.ptrw();
+		memcpy(w, charstr.ptr(), len);
+	}
 
 	return request_raw(p_url, p_custom_headers, p_ssl_validate_domain, p_method, raw_data);
 }

--- a/servers/physics_3d/soft_body_3d_sw.cpp
+++ b/servers/physics_3d/soft_body_3d_sw.cpp
@@ -249,8 +249,10 @@ void SoftBody3DSW::update_area() {
 
 	// Node area.
 	LocalVector<int> counts;
-	counts.resize(nodes.size());
-	memset(counts.ptr(), 0, counts.size() * sizeof(int));
+	if (nodes.size() > 0) {
+		counts.resize(nodes.size());
+		memset(counts.ptr(), 0, counts.size() * sizeof(int));
+	}
 
 	for (i = 0, ni = nodes.size(); i < ni; ++i) {
 		nodes[i].area = 0.0;


### PR DESCRIPTION
It's undefined behavior passing nullptr as first parameter of memcpy even if length is zero.

Fixes #52805
Fixes #52807