### PR TITLE
Don't allow builtin type names as identifiers

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -175,6 +175,11 @@ Error GDScriptAnalyzer::check_native_member_name_conflict(const StringName &p_me
 		return ERR_PARSE_ERROR;
 	}
 
+	if (GDScriptParser::get_builtin_type(p_member_name) != Variant::VARIANT_MAX) {
+		push_error(vformat(R"(The member "%s" cannot have the same name as a builtin type.)", p_member_name), p_member_node);
+		return ERR_PARSE_ERROR;
+	}
+
 	return OK;
 }
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/class_name_shadows_builtin_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/class_name_shadows_builtin_type.gd
@@ -1,0 +1,5 @@
+class Vector2:
+	pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/class_name_shadows_builtin_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/class_name_shadows_builtin_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+The member "Vector2" cannot have the same name as a builtin type.

--- a/modules/gdscript/tests/scripts/analyzer/errors/constant_name_shadows_builtin_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constant_name_shadows_builtin_type.gd
@@ -1,0 +1,4 @@
+const Vector2 = 0
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/constant_name_shadows_builtin_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constant_name_shadows_builtin_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+The member "Vector2" cannot have the same name as a builtin type.

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_name_shadows_builtin_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_name_shadows_builtin_type.gd
@@ -1,0 +1,4 @@
+enum Vector2 { A, B }
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_name_shadows_builtin_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_name_shadows_builtin_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+The member "Vector2" cannot have the same name as a builtin type.

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_name_shadows_builtin_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_name_shadows_builtin_type.gd
@@ -1,0 +1,4 @@
+var Vector2
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_name_shadows_builtin_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_name_shadows_builtin_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+The member "Vector2" cannot have the same name as a builtin type.


### PR DESCRIPTION
Fix #41092
