### PR TITLE
Fix const pointers types in docs and extension API.

### DIFF
--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -55,7 +55,7 @@ struct GDNativePtr {
 
 #define GDVIRTUAL_NATIVE_PTR(m_type)                                  \
 	template <>                                                       \
-	struct GDNativeConstPtr<m_type> {                                 \
+	struct GDNativeConstPtr<const m_type> {                           \
 		const m_type *data = nullptr;                                 \
 		GDNativeConstPtr(const m_type *p_assign) { data = p_assign; } \
 		static const char *get_name() { return "const " #m_type; }    \

--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -24,7 +24,7 @@
 		</method>
 		<method name="_get_packet" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="r_buffer" type="const void*" />
+			<argument index="0" name="r_buffer" type="const uint8_t **" />
 			<argument index="1" name="r_buffer_size" type="int32_t*" />
 			<description>
 			</description>
@@ -66,7 +66,7 @@
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="p_buffer" type="const void*" />
+			<argument index="0" name="p_buffer" type="const uint8_t*" />
 			<argument index="1" name="p_buffer_size" type="int" />
 			<description>
 			</description>

--- a/doc/classes/PacketPeerExtension.xml
+++ b/doc/classes/PacketPeerExtension.xml
@@ -19,14 +19,14 @@
 		</method>
 		<method name="_get_packet" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="r_buffer" type="const void*" />
+			<argument index="0" name="r_buffer" type="const uint8_t **" />
 			<argument index="1" name="r_buffer_size" type="int32_t*" />
 			<description>
 			</description>
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="p_buffer" type="const void*" />
+			<argument index="0" name="p_buffer" type="const uint8_t*" />
 			<argument index="1" name="p_buffer_size" type="int" />
 			<description>
 			</description>

--- a/doc/classes/StreamPeerExtension.xml
+++ b/doc/classes/StreamPeerExtension.xml
@@ -30,7 +30,7 @@
 		</method>
 		<method name="_put_data" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="p_data" type="const void*" />
+			<argument index="0" name="p_data" type="const uint8_t*" />
 			<argument index="1" name="p_bytes" type="int" />
 			<argument index="2" name="r_sent" type="int32_t*" />
 			<description>
@@ -38,7 +38,7 @@
 		</method>
 		<method name="_put_partial_data" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="p_data" type="const void*" />
+			<argument index="0" name="p_data" type="const uint8_t*" />
 			<argument index="1" name="p_bytes" type="int" />
 			<argument index="2" name="r_sent" type="int32_t*" />
 			<description>

--- a/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
@@ -49,7 +49,7 @@
 		</method>
 		<method name="_get_packet" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="r_buffer" type="const void*" />
+			<argument index="0" name="r_buffer" type="const uint8_t **" />
 			<argument index="1" name="r_buffer_size" type="int32_t*" />
 			<description>
 			</description>
@@ -86,7 +86,7 @@
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="p_buffer" type="const void*" />
+			<argument index="0" name="p_buffer" type="const uint8_t*" />
 			<argument index="1" name="p_buffer_size" type="int" />
 			<description>
 			</description>


### PR DESCRIPTION
The GDVIRTUAL_NATIVE_PTR did not declare the correct GDNativeConstPtr template, resulting in "void*" being used as it's type info in both the documentation and the extension API dump.