### PR TITLE
Fix editor stuck dimmed because of unsaved script

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -662,7 +662,7 @@ void ScriptEditor::_queue_close_tabs() {
 			// Maybe there are unsaved changes.
 			if (se->is_unsaved()) {
 				_ask_close_current_unsaved_tab(se);
-				erase_tab_confirm->connect(SceneStringNames::get_singleton()->visibility_changed, this, "_queue_close_tabs", varray(), CONNECT_ONESHOT);
+				erase_tab_confirm->connect(SceneStringNames::get_singleton()->visibility_changed, this, "_queue_close_tabs", varray(), CONNECT_ONESHOT | CONNECT_DEFERRED);
 				break;
 			}
 		}


### PR DESCRIPTION
Fixes regression from 168292fa0087583c46d065bf95902e98988bc803 

When you close multiple script tabs and a confirmation dialog appears, the editor will be stuck dimmed when you close the dialog.