### PR TITLE
Add locale rename for the "C" locale

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -810,9 +810,12 @@ static const char *locale_names[] = {
 // - https://msdn.microsoft.com/en-us/library/windows/desktop/ms693062(v=vs.85).aspx
 
 static const char *locale_renames[][2] = {
-	{ "in", "id" }, //  Indonesian
-	{ "iw", "he" }, //  Hebrew
-	{ "no", "nb" }, //  Norwegian Bokmål
+	{ "in", "id" }, // Indonesian
+	{ "iw", "he" }, // Hebrew
+	{ "no", "nb" }, // Norwegian Bokmål
+	{ "C", "en" }, // "C" is the simple/default/untranslated Computer locale.
+	// ASCII-only, English, no currency symbols. Godot treats this as "en".
+	// See https://unix.stackexchange.com/a/87763/164141 "The C locale is"...
 	{ nullptr, nullptr }
 };
 


### PR DESCRIPTION
This adds a new mapping to the list of renames, the "C" locale. This doesn't change behavior, but does prevent an unnecessary error message from showing up since "C" is an expected value.

"C" is the simple/default/untranslated **C**omputer locale. ASCII-only, English, no currency symbols, etc. Godot treats this as "en". See https://unix.stackexchange.com/a/87763/164141 "The C locale is"...

3.x version: #53226