### PR TITLE
Fix doc for `Dictionary.erase`

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -213,7 +213,8 @@
 			<return type="bool" />
 			<argument index="0" name="key" type="Variant" />
 			<description>
-				Erase a dictionary key/value pair by key. Returns [code]true[/code] if the given key was present in the dictionary, [code]false[/code] otherwise. Does not erase elements while iterating over the dictionary.
+				Erase a dictionary key/value pair by key. Returns [code]true[/code] if the given key was present in the dictionary, [code]false[/code] otherwise.
+				[b]Note:[/b] Don't erase elements while iterating over the dictionary. You can iterate over the [method keys] array instead.
 			</description>
 		</method>
 		<method name="get" qualifiers="const">


### PR DESCRIPTION
The advice "Do not erase..." was changed to descriptive "Does not erase..." by mistake.

This PR reverts the change and documents a possible solution.