### PR TITLE
Rename editor-only project settings category to "Editor Only"

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1093,13 +1093,13 @@ ProjectSettings::ProjectSettings() {
 	}
 	extensions.push_back("gdshader");
 
-	GLOBAL_DEF("editor/run/main_run_args", "");
+	GLOBAL_DEF("editor_only/run/main_run_args", "");
 
-	GLOBAL_DEF("editor/script/search_in_file_extensions", extensions);
-	custom_prop_info["editor/script/search_in_file_extensions"] = PropertyInfo(Variant::PACKED_STRING_ARRAY, "editor/script/search_in_file_extensions");
+	GLOBAL_DEF("editor_only/script/search_in_file_extensions", extensions);
+	custom_prop_info["editor_only/script/search_in_file_extensions"] = PropertyInfo(Variant::PACKED_STRING_ARRAY, "editor/script/search_in_file_extensions");
 
-	GLOBAL_DEF("editor/script/templates_search_path", "res://script_templates");
-	custom_prop_info["editor/script/templates_search_path"] = PropertyInfo(Variant::STRING, "editor/script/templates_search_path", PROPERTY_HINT_DIR);
+	GLOBAL_DEF("editor_only/script/templates_search_path", "res://script_templates");
+	custom_prop_info["editor_only/script/templates_search_path"] = PropertyInfo(Variant::STRING, "editor/script/templates_search_path", PROPERTY_HINT_DIR);
 
 	_add_builtin_input_map();
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -143,7 +143,7 @@
 				Returns the command-line arguments passed to the engine.
 				Command-line arguments can be written in any form, including both [code]--key value[/code] and [code]--key=value[/code] forms so they can be properly parsed, as long as custom command-line arguments do not conflict with engine arguments.
 				You can also incorporate environment variables using the [method get_environment] method.
-				You can set [member ProjectSettings.editor/run/main_run_args] to define command-line arguments to be passed by the editor when running the project.
+				You can set [member ProjectSettings.editor_only/run/main_run_args] to define command-line arguments to be passed by the editor when running the project.
 				Here's a minimal example on how to parse command-line arguments into a dictionary using the [code]--key=value[/code] form for arguments:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -511,25 +511,26 @@
 			See [enum DisplayServer.VSyncMode] for possible values and how they affect the behavior of your application.
 			Depending on the platform and used renderer, the engine will fall back to [code]Enabled[/code], if the desired mode is not supported.
 		</member>
-		<member name="editor/node_naming/name_casing" type="int" setter="" getter="" default="0">
-			When creating node names automatically, set the type of casing in this project. This is mostly an editor setting.
+		<member name="editor_only/node_naming/name_casing" type="int" setter="" getter="" default="0">
+			When creating node names automatically, set the type of casing in this project. This is mostly an editor-only setting, although it [i]does[/i] affect the running project when nodes are set to have the same name at run-time.
 		</member>
-		<member name="editor/node_naming/name_num_separator" type="int" setter="" getter="" default="0">
-			What to use to separate node name from number. This is mostly an editor setting.
+		<member name="editor_only/node_naming/name_num_separator" type="int" setter="" getter="" default="0">
+			What to use to separate node name from number. This is mostly an editor-only setting, although it [i]does[/i] affect the running project when nodes are set to have the same name at run-time.
 		</member>
-		<member name="editor/run/main_run_args" type="String" setter="" getter="" default="&quot;&quot;">
+		<member name="editor_only/run/main_run_args" type="String" setter="" getter="" default="&quot;&quot;">
 			The command-line arguments to append to Godot's own command line when running the project. This doesn't affect the editor itself.
 			It is possible to make another executable run Godot by using the [code]%command%[/code] placeholder. The placeholder will be replaced with Godot's own command line. Program-specific arguments should be placed [i]before[/i] the placeholder, whereas Godot-specific arguments should be placed [i]after[/i] the placeholder.
 			For example, this can be used to force the project to run on the dedicated GPU in a NVIDIA Optimus system on Linux:
 			[codeblock]
 			prime-run %command%
 			[/codeblock]
+			[b]Note:[/b] This setting does not affect the exported project or when [url=https://docs.godotengine.org/en/latest/tutorials/editor/command_line_tutorial.html]running the project from the command line without going through the editor[/url].
 		</member>
-		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray(&quot;gd&quot;, &quot;gdshader&quot;)">
-			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.
+		<member name="editor_only/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray(&quot;gd&quot;, &quot;gdshader&quot;)">
+			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files. This setting only affects the editor.
 		</member>
-		<member name="editor/script/templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
-			Search path for project-specific script templates. Godot will search for script templates both in the editor-specific path and in this project-specific path.
+		<member name="editor_only/script/templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
+			Search path for project-specific script templates. Godot will search for script templates both in the editor-specific path and in this project-specific path. This setting only affects the editor.
 		</member>
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1988,7 +1988,7 @@ void EditorExportTextSceneToBinaryPlugin::_export_file(const String &p_path, con
 		return;
 	}
 
-	bool convert = GLOBAL_GET("editor/export/convert_text_resources_to_binary");
+	bool convert = GLOBAL_GET("editor_only/export/convert_text_resources_to_binary");
 	if (!convert) {
 		return;
 	}
@@ -2008,5 +2008,5 @@ void EditorExportTextSceneToBinaryPlugin::_export_file(const String &p_path, con
 }
 
 EditorExportTextSceneToBinaryPlugin::EditorExportTextSceneToBinaryPlugin() {
-	GLOBAL_DEF("editor/export/convert_text_resources_to_binary", false);
+	GLOBAL_DEF("editor_only/export/convert_text_resources_to_binary", false);
 }

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2071,7 +2071,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 
 	reimport_files.sort();
 
-	bool use_threads = GLOBAL_GET("editor/import/use_multiple_threads");
+	bool use_threads = GLOBAL_GET("editor_only/import/use_multiple_threads");
 
 	int from = 0;
 	for (int i = 0; i < reimport_files.size(); i++) {
@@ -2345,8 +2345,8 @@ void EditorFileSystem::_update_extensions() {
 
 EditorFileSystem::EditorFileSystem() {
 	ResourceLoader::import = _resource_import;
-	reimport_on_missing_imported_files = GLOBAL_DEF("editor/import/reimport_missing_imported_files", true);
-	GLOBAL_DEF("editor/import/use_multiple_threads", true);
+	reimport_on_missing_imported_files = GLOBAL_DEF("editor_only/import/reimport_missing_imported_files", true);
+	GLOBAL_DEF("editor_only/import/use_multiple_threads", true);
 	singleton = this;
 	filesystem = memnew(EditorFileSystemDirectory); //like, empty
 	filesystem->parent = nullptr;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2334,7 +2334,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	List<String> breakpoints;
 	editor_data.get_editor_breakpoints(&breakpoints);
 
-	args = ProjectSettings::get_singleton()->get("editor/run/main_run_args");
+	args = ProjectSettings::get_singleton()->get("editor_only/run/main_run_args");
 	skip_breakpoints = EditorDebuggerNode::get_singleton()->is_skip_breakpoints();
 
 	EditorDebuggerNode::get_singleton()->start();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1122,7 +1122,7 @@ String EditorSettings::get_script_templates_dir() const {
 }
 
 String EditorSettings::get_project_script_templates_dir() const {
-	return ProjectSettings::get_singleton()->get("editor/script/templates_search_path");
+	return ProjectSettings::get_singleton()->get("editor_only/script/templates_search_path");
 }
 
 String EditorSettings::get_feature_profiles_dir() const {

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -468,7 +468,7 @@ void FindInFilesDialog::_notification(int p_what) {
 			for (int i = 0; i < _filters_container->get_child_count(); i++) {
 				_filters_container->get_child(i)->queue_delete();
 			}
-			Array exts = ProjectSettings::get_singleton()->get("editor/script/search_in_file_extensions");
+			Array exts = ProjectSettings::get_singleton()->get("editor_only/script/search_in_file_extensions");
 			for (int i = 0; i < exts.size(); ++i) {
 				CheckBox *cb = memnew(CheckBox);
 				cb->set_text(exts[i]);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5817,7 +5817,7 @@ bool CanvasItemEditorViewport::_cyclical_dependency_exists(const String &p_targe
 void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &path, const Point2 &p_point) {
 	// Adjust casing according to project setting. The file name is expected to be in snake_case, but will work for others.
 	String name = path.get_file().get_basename();
-	switch (ProjectSettings::get_singleton()->get("editor/node_naming/name_casing").operator int()) {
+	switch (ProjectSettings::get_singleton()->get("editor_only/node_naming/name_casing").operator int()) {
 		case NAME_CASING_PASCAL_CASE:
 			name = name.capitalize().replace(" ", "");
 			break;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1004,7 +1004,7 @@ void Node::_generate_serial_child_name(const Node *p_child, StringName &name) co
 
 		name = p_child->get_class();
 		// Adjust casing according to project setting. The current type name is expected to be in PascalCase.
-		switch (ProjectSettings::get_singleton()->get("editor/node_naming/name_casing").operator int()) {
+		switch (ProjectSettings::get_singleton()->get("editor_only/node_naming/name_casing").operator int()) {
 			case NAME_CASING_PASCAL_CASE:
 				break;
 			case NAME_CASING_CAMEL_CASE: {
@@ -2653,10 +2653,10 @@ void Node::unhandled_key_input(const Ref<InputEvent> &p_key_event) {
 }
 
 void Node::_bind_methods() {
-	GLOBAL_DEF("editor/node_naming/name_num_separator", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("editor/node_naming/name_num_separator", PropertyInfo(Variant::INT, "editor/node_naming/name_num_separator", PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash"));
-	GLOBAL_DEF("editor/node_naming/name_casing", NAME_CASING_PASCAL_CASE);
-	ProjectSettings::get_singleton()->set_custom_property_info("editor/node_naming/name_casing", PropertyInfo(Variant::INT, "editor/node_naming/name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case"));
+	GLOBAL_DEF("editor_only/node_naming/name_num_separator", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("editor_only/node_naming/name_num_separator", PropertyInfo(Variant::INT, "editor/node_naming/name_num_separator", PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash"));
+	GLOBAL_DEF("editor_only/node_naming/name_casing", NAME_CASING_PASCAL_CASE);
+	ProjectSettings::get_singleton()->set_custom_property_info("editor_only/node_naming/name_casing", PropertyInfo(Variant::INT, "editor/node_naming/name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case"));
 
 	ClassDB::bind_method(D_METHOD("add_sibling", "sibling", "legible_unique_name"), &Node::add_sibling, DEFVAL(false));
 
@@ -2863,7 +2863,7 @@ void Node::_bind_methods() {
 }
 
 String Node::_get_name_num_separator() {
-	switch (ProjectSettings::get_singleton()->get("editor/node_naming/name_num_separator").operator int()) {
+	switch (ProjectSettings::get_singleton()->get("editor_only/node_naming/name_num_separator").operator int()) {
 		case 0:
 			return "";
 		case 1:


### PR DESCRIPTION
This reduces confusion between the "Editor" section of the Project Settings (which is used for project-specific editor settings) and the actual Editor Settings dialog.

This also improves documentation related to editor-only project settings.

This closes https://github.com/godotengine/godot-proposals/issues/2939.