### PR TITLE
Fix buffer overflow in 2D BVH

### DIFF
--- a/core/math/bvh_cull.inc
+++ b/core/math/bvh_cull.inc
@@ -14,7 +14,7 @@ struct CullParams {
 	uint32_t pairable_type;
 
 	// optional components for different tests
-	Vector3 point;
+	Point point;
 	BVHABB_CLASS abb;
 	typename BVHABB_CLASS::ConvexHull hull;
 	typename BVHABB_CLASS::Segment segment;

--- a/core/math/bvh_debug.inc
+++ b/core/math/bvh_debug.inc
@@ -6,24 +6,21 @@ void _debug_recursive_print_tree(int p_tree_id) const {
 }
 
 String _debug_aabb_to_string(const BVHABB_CLASS &aabb) const {
-	String sz = "(";
-	sz += itos(aabb.min.x);
-	sz += " ~ ";
-	sz += itos(-aabb.neg_max.x);
-	sz += ") (";
+	Point size = aabb.calculate_size();
 
-	sz += itos(aabb.min.y);
-	sz += " ~ ";
-	sz += itos(-aabb.neg_max.y);
-	sz += ") (";
+	String sz;
+	float vol = 0.0;
 
-	sz += itos(aabb.min.z);
-	sz += " ~ ";
-	sz += itos(-aabb.neg_max.z);
-	sz += ") ";
+	for (int i = 0; i < Point::AXES_COUNT; ++i) {
+		sz += "(";
+		sz += itos(aabb.min[i]);
+		sz += " ~ ";
+		sz += itos(-aabb.neg_max[i]);
+		sz += ") ";
 
-	Vector3 size = aabb.calculate_size();
-	float vol = size.x * size.y * size.z;
+		vol += size[i];
+	}
+
 	sz += "vol " + itos(vol);
 
 	return sz;

--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -28,11 +28,15 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 	Point centre = full_bound.calculate_centre();
 	Point size = full_bound.calculate_size();
 
-	int order[3];
+	int order[Point::AXIS_COUNT];
 
 	order[0] = size.min_axis();
-	order[2] = size.max_axis();
-	order[1] = 3 - (order[0] + order[2]);
+	order[Point::AXIS_COUNT - 1] = size.max_axis();
+
+	static_assert(Point::AXIS_COUNT <= 3);
+	if (Point::AXIS_COUNT == 3) {
+		order[1] = 3 - (order[0] + order[2]);
+	}
 
 	// simplest case, split on the longest axis
 	int split_axis = order[0];
@@ -54,7 +58,7 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 
 	// detect when split on longest axis failed
 	int min_threshold = MAX_ITEMS / 4;
-	int min_group_size[3];
+	int min_group_size[Point::AXIS_COUNT];
 	min_group_size[0] = MIN(num_a, num_b);
 	if (min_group_size[0] < min_threshold) {
 		// slow but sure .. first move everything back into a
@@ -64,7 +68,7 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		num_b = 0;
 
 		// now calculate the best split
-		for (int axis = 1; axis < 3; axis++) {
+		for (int axis = 1; axis < Point::AXIS_COUNT; axis++) {
 			split_axis = order[axis];
 			int count = 0;
 
@@ -82,7 +86,7 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		// best axis
 		int best_axis = 0;
 		int best_min = min_group_size[0];
-		for (int axis = 1; axis < 3; axis++) {
+		for (int axis = 1; axis < Point::AXIS_COUNT; axis++) {
 			if (min_group_size[axis] > best_min) {
 				best_min = min_group_size[axis];
 				best_axis = axis;


### PR DESCRIPTION
Some areas of code were missed in #48314 for 2D support and still assumed Vector3.

@lawnjelly I searched for other places which refer to Vector3 or iterate over 3 coordinates and didn't find any other problematic cases (with the exception of convex culling which is meant to be supported only in 3D). But it would be good to double check on your side whenever you have time.

Fixes #53203