### PR TITLE
[3.x] Add half frame to floor() for animated particles UV

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -148,7 +148,7 @@ void CanvasItemMaterial::_update_shader() {
 		code += "\t\tparticle_frame = mod(particle_frame, particle_total_frames);\n";
 		code += "\t}";
 		code += "\tUV /= vec2(h_frames, v_frames);\n";
-		code += "\tUV += vec2(mod(particle_frame, h_frames) / h_frames, floor(particle_frame / h_frames) / v_frames);\n";
+		code += "\tUV += vec2(mod(particle_frame, h_frames) / h_frames, floor((particle_frame + 0.5) / h_frames) / v_frames);\n";
 		code += "}\n";
 	}
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -672,7 +672,7 @@ void SpatialMaterial::_update_shader() {
 			code += "\t\tparticle_frame = mod(particle_frame, particle_total_frames);\n";
 			code += "\t}";
 			code += "\tUV /= vec2(h_frames, v_frames);\n";
-			code += "\tUV += vec2(mod(particle_frame, h_frames) / h_frames, floor(particle_frame / h_frames) / v_frames);\n";
+			code += "\tUV += vec2(mod(particle_frame, h_frames) / h_frames, floor((particle_frame + 0.5) / h_frames) / v_frames);\n";
 		} break;
 	}
 


### PR DESCRIPTION
Depending on the hardware or drivers it can occur on some devices that animated sprites do not render in the correct order. This happens because of an inprecision when calling floor(). Adding a 0.5 before using floor fixes this bug.

Closes #36435