### PR TITLE
Preserve script editor state through tab closes

### DIFF
--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -382,6 +382,7 @@ class ScriptEditor : public PanelContainer {
 	void _script_created(Ref<Script> p_script);
 	void _set_breakpoint(REF p_scrpt, int p_line, bool p_enabled);
 	void _clear_breakpoints();
+	Array _get_cached_breakpoints_for_script(const String &p_path) const;
 
 	ScriptEditorBase *_get_current_editor() const;
 	Array _get_open_script_editors() const;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -386,9 +386,12 @@ class ScriptEditor : public PanelContainer {
 	ScriptEditorBase *_get_current_editor() const;
 	Array _get_open_script_editors() const;
 
+	Ref<ConfigFile> script_editor_cache;
+	void _save_editor_state(ScriptEditorBase *p_editor);
 	void _save_layout();
 	void _editor_settings_changed();
 	void _filesystem_changed();
+	void _files_moved(const String &p_old_file, const String &p_new_file);
 	void _file_removed(const String &p_file);
 	void _autosave_scripts();
 	void _update_autosave_timer();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1707,7 +1707,6 @@ void ScriptTextEditor::_enable_code_editor() {
 	code_editor->connect("show_warnings_panel", callable_mp(this, &ScriptTextEditor::_show_warnings_panel));
 	code_editor->connect("validate_script", callable_mp(this, &ScriptTextEditor::_validate_script));
 	code_editor->connect("load_theme_settings", callable_mp(this, &ScriptTextEditor::_load_theme_settings));
-	code_editor->get_text_editor()->connect("breakpoint_toggled", callable_mp(this, &ScriptTextEditor::_breakpoint_toggled));
 	code_editor->get_text_editor()->connect("symbol_lookup", callable_mp(this, &ScriptTextEditor::_lookup_symbol));
 	code_editor->get_text_editor()->connect("symbol_validate", callable_mp(this, &ScriptTextEditor::_validate_symbol));
 	code_editor->get_text_editor()->connect("gutter_added", callable_mp(this, &ScriptTextEditor::_update_gutter_indexes));
@@ -1847,6 +1846,7 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	code_editor->get_text_editor()->set_draw_breakpoints_gutter(true);
 	code_editor->get_text_editor()->set_draw_executing_lines_gutter(true);
+	code_editor->get_text_editor()->connect("breakpoint_toggled", callable_mp(this, &ScriptTextEditor::_breakpoint_toggled));
 
 	connection_gutter = 1;
 	code_editor->get_text_editor()->add_gutter(connection_gutter);


### PR DESCRIPTION
Currently when you close a tab in the script editor all its state data is lost, we only preserve the state for open tabs, for reloading after a editor restart.

This PR allows that data to persist though the tab being closed. Now instead, when reopening tabs, it will restore it's last state. By doing this the we can also register breakpoints for scripts that are closed, so you no longer have to open the script for the breakpoints to work. 

To do this the state is store in a new config file in the project: `.godot/script_editor_cache.cfg`. It will have a section for each file. If a file is removed or renamed the corresponding sections will be adjusted accordingly. 

A few things to note, this change should be backwards compatible with the current system, and does not add support for built-in scripts.

closes godotengine/godot-proposals/issues/37