### PR TITLE
Add half frame to floor() for animated particles UV

### DIFF
--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -135,7 +135,7 @@ void CanvasItemMaterial::_update_shader() {
 		code += "		particle_frame = mod(particle_frame, particle_total_frames);\n";
 		code += "	}";
 		code += "	UV /= vec2(h_frames, v_frames);\n";
-		code += "	UV += vec2(mod(particle_frame, h_frames) / h_frames, floor(particle_frame / h_frames) / v_frames);\n";
+		code += "	UV += vec2(mod(particle_frame, h_frames) / h_frames, floor((particle_frame + 0.5) / h_frames) / v_frames);\n";
 		code += "}\n";
 	}
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -815,7 +815,7 @@ void BaseMaterial3D::_update_shader() {
 			code += "		particle_frame = mod(particle_frame, particle_total_frames);\n";
 			code += "	}";
 			code += "	UV /= vec2(h_frames, v_frames);\n";
-			code += "	UV += vec2(mod(particle_frame, h_frames) / h_frames, floor(particle_frame / h_frames) / v_frames);\n";
+			code += "	UV += vec2(mod(particle_frame, h_frames) / h_frames, floor((particle_frame + 0.5) / h_frames) / v_frames);\n";
 		} break;
 		case BILLBOARD_MAX:
 			break; // Internal value, skip.


### PR DESCRIPTION
This is the same bug fix as described in #53233 but for the master branch. However I was not able to test this on master because ~~I have another bug (#53236)~~ animated particles do not play at all in current master?! But I can't find an open issue on that. 

Closes #36435