### PR TITLE
Fix AnimatableBody moving and colliding during the first frame

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -288,6 +288,12 @@ void AnimatableBody2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			last_valid_transform = get_global_transform();
+			_update_kinematic_motion();
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			set_only_update_transform_changes(false);
+			set_notify_local_transform(false);
 		} break;
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
@@ -313,7 +319,6 @@ void AnimatableBody2D::_bind_methods() {
 
 AnimatableBody2D::AnimatableBody2D() :
 		StaticBody2D(PhysicsServer2D::BODY_MODE_KINEMATIC) {
-	_update_kinematic_motion();
 }
 
 void RigidDynamicBody2D::_body_enter_tree(ObjectID p_id) {

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -340,6 +340,12 @@ void AnimatableBody3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			last_valid_transform = get_global_transform();
+			_update_kinematic_motion();
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			set_only_update_transform_changes(false);
+			set_notify_local_transform(false);
 		} break;
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
@@ -367,8 +373,6 @@ void AnimatableBody3D::_bind_methods() {
 AnimatableBody3D::AnimatableBody3D() :
 		StaticBody3D(PhysicsServer3D::BODY_MODE_KINEMATIC) {
 	PhysicsServer3D::get_singleton()->body_set_state_sync_callback(get_rid(), this, _body_state_changed_callback);
-
-	_update_kinematic_motion();
 }
 
 void RigidDynamicBody3D::_body_enter_tree(ObjectID p_id) {


### PR DESCRIPTION
`_update_kinematic_motion()` shouldn't be called in the constructor, it's too early and causes a first call to set the body position to 0.
Then the second call to set the actual position triggers kinematic motion, colliding with objects on the path to the initial position.

Side effect of sync to physics now enabled by default.