### PR TITLE
InputEventJoypadMotion::set_axis - reject invalid axis

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -864,6 +864,8 @@ void InputEventMouseMotion::_bind_methods() {
 ///////////////////////////////////
 
 void InputEventJoypadMotion::set_axis(JoyAxis p_axis) {
+	ERR_FAIL_INDEX(p_axis, JOY_AXIS_MAX);
+
 	axis = p_axis;
 	emit_changed();
 }


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #53224