### PR TITLE
Use a yellow color for editable children properties instead of red

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -73,8 +73,8 @@
 		<member name="deletable" type="bool" setter="set_deletable" getter="is_deletable" default="false">
 			Used by the inspector, set to [code]true[/code] when the property can be deleted by the user.
 		</member>
-		<member name="draw_red" type="bool" setter="set_draw_red" getter="is_draw_red" default="false">
-			Used by the inspector, set to [code]true[/code] when the property must draw with error color. This is used for editable children's properties.
+		<member name="draw_warning" type="bool" setter="set_draw_warning" getter="is_draw_warning" default="false">
+			Used by the inspector, set to [code]true[/code] when the property is drawn with the editor theme's warning color. This is used for editable children's properties.
 		</member>
 		<member name="keying" type="bool" setter="set_keying" getter="is_keying" default="false">
 			Used by the inspector, set to [code]true[/code] when the property can add keys for animation.

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -245,13 +245,15 @@ void EditorProperty::_notification(int p_what) {
 		}
 
 		Color color;
-		if (draw_red) {
-			color = get_theme_color(is_read_only() ? SNAME("readonly_error_color") : SNAME("error_color"));
+		if (draw_warning) {
+			color = get_theme_color(is_read_only() ? SNAME("readonly_warning_color") : SNAME("warning_color"));
 		} else {
 			color = get_theme_color(is_read_only() ? SNAME("readonly_color") : SNAME("property_color"));
 		}
 		if (label.find(".") != -1) {
-			color.a = 0.5; //this should be un-hacked honestly, as it's used for editor overrides
+			// FIXME: Move this to the project settings editor, as this is only used
+			// for project settings feature tag overrides.
+			color.a = 0.5;
 		}
 
 		int ofs = get_theme_constant(SNAME("font_offset"));
@@ -625,8 +627,8 @@ bool EditorProperty::is_checked() const {
 	return checked;
 }
 
-void EditorProperty::set_draw_red(bool p_draw_red) {
-	draw_red = p_draw_red;
+void EditorProperty::set_draw_warning(bool p_draw_warning) {
+	draw_warning = p_draw_warning;
 	update();
 }
 
@@ -650,8 +652,8 @@ bool EditorProperty::is_keying() const {
 	return keying;
 }
 
-bool EditorProperty::is_draw_red() const {
-	return draw_red;
+bool EditorProperty::is_draw_warning() const {
+	return draw_warning;
 }
 
 void EditorProperty::_focusable_focused(int p_index) {
@@ -969,8 +971,8 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_checked", "checked"), &EditorProperty::set_checked);
 	ClassDB::bind_method(D_METHOD("is_checked"), &EditorProperty::is_checked);
 
-	ClassDB::bind_method(D_METHOD("set_draw_red", "draw_red"), &EditorProperty::set_draw_red);
-	ClassDB::bind_method(D_METHOD("is_draw_red"), &EditorProperty::is_draw_red);
+	ClassDB::bind_method(D_METHOD("set_draw_warning", "draw_warning"), &EditorProperty::set_draw_warning);
+	ClassDB::bind_method(D_METHOD("is_draw_warning"), &EditorProperty::is_draw_warning);
 
 	ClassDB::bind_method(D_METHOD("set_keying", "keying"), &EditorProperty::set_keying);
 	ClassDB::bind_method(D_METHOD("is_keying"), &EditorProperty::is_keying);
@@ -993,7 +995,7 @@ void EditorProperty::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "read_only"), "set_read_only", "is_read_only");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "checkable"), "set_checkable", "is_checkable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "checked"), "set_checked", "is_checked");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_red"), "set_draw_red", "is_draw_red");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_warning"), "set_draw_warning", "is_draw_warning");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keying"), "set_keying", "is_keying");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deletable"), "set_deletable", "is_deletable");
 	ADD_SIGNAL(MethodInfo("property_changed", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
@@ -1018,7 +1020,7 @@ EditorProperty::EditorProperty() {
 	read_only = false;
 	checkable = false;
 	checked = false;
-	draw_red = false;
+	draw_warning = false;
 	keying = false;
 	deletable = false;
 	keying_hover = false;
@@ -2393,14 +2395,15 @@ void EditorInspector::update_tree() {
 		valid_plugins.push_back(inspector_plugins[i]);
 	}
 
-	// Decide if properties should be drawn in red.
-	bool draw_red = false;
+	// Decide if properties should be drawn with the warning color (yellow).
+	bool draw_warning = false;
 	if (is_inside_tree()) {
 		Node *nod = Object::cast_to<Node>(object);
 		Node *es = EditorNode::get_singleton()->get_edited_scene();
 		if (nod && es != nod && nod->get_owner() != es) {
-			// Draw in red edited nodes that are not in the currently edited scene.
-			draw_red = true;
+			// Draw in warning color edited nodes that are not in the currently edited scene,
+			// as changes may be lost in the future.
+			draw_warning = true;
 		}
 	}
 
@@ -2855,7 +2858,7 @@ void EditorInspector::update_tree() {
 							editor_property_map[prop].push_back(ep);
 						}
 					}
-					ep->set_draw_red(draw_red);
+					ep->set_draw_warning(draw_warning);
 					ep->set_use_folding(use_folding);
 					ep->set_checkable(checkable);
 					ep->set_checked(checked);

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -74,7 +74,7 @@ private:
 	bool read_only;
 	bool checkable;
 	bool checked;
-	bool draw_red;
+	bool draw_warning;
 	bool keying;
 	bool deletable;
 
@@ -150,8 +150,8 @@ public:
 	void set_checked(bool p_checked);
 	bool is_checked() const;
 
-	void set_draw_red(bool p_draw_red);
-	bool is_draw_red() const;
+	void set_draw_warning(bool p_draw_warning);
+	bool is_draw_warning() const;
 
 	void set_keying(bool p_keying);
 	bool is_keying() const;

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -430,7 +430,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Color error_color = Color(1, 0.47, 0.42);
 	Color property_color = font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
 	Color readonly_color = property_color.lerp(dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.5);
-	Color readonly_error_color = error_color.lerp(dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.5);
+	Color readonly_warning_color = error_color.lerp(dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.5);
 
 	if (!dark_theme) {
 		// Darken some colors to be readable on a light background
@@ -444,7 +444,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("error_color", "Editor", error_color);
 	theme->set_color("property_color", "Editor", property_color);
 	theme->set_color("readonly_color", "Editor", readonly_color);
-	theme->set_color("readonly_error_color", "EditorProperty", readonly_error_color);
 
 	if (!dark_theme) {
 		theme->set_color("vulkan_color", "Editor", Color::hex(0xad1128ff));
@@ -818,10 +817,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg);
 	theme->set_stylebox("bg", "EditorProperty", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
 	theme->set_constant("vseparation", "EditorProperty", (extra_spacing + default_margin_size) * EDSCALE);
-	theme->set_color("error_color", "EditorProperty", error_color);
+	theme->set_color("warning_color", "EditorProperty", warning_color);
 	theme->set_color("property_color", "EditorProperty", property_color);
 	theme->set_color("readonly_color", "EditorProperty", readonly_color);
-	theme->set_color("readonly_error_color", "EditorProperty", readonly_error_color);
+	theme->set_color("readonly_warning_color", "EditorProperty", readonly_warning_color);
 
 	Color inspector_section_color = font_color.lerp(Color(0.5, 0.5, 0.5), 0.35);
 	theme->set_color("font_color", "EditorInspectorSection", inspector_section_color);


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/53263.

This matches the usual "Changes may be lost!" warning color.

- Remove a duplicate editor theme color setting declaration.

This also renames the EditorProperty `draw_red` property to `draw_warning`, which may break compatibility with some editor plugins (although it's unlikely to be used in the wild).

This partially addresses https://github.com/godotengine/godot-proposals/issues/3248.

## Preview

![image](https://user-images.githubusercontent.com/180032/135482723-62ee2023-11f4-497e-8902-1964fa9d0121.png)
