### PR TITLE
Fix LSP crash parsing scripts with no lines [3.x]

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -409,9 +409,11 @@ String ExtendGDScriptParser::parse_documentation(int p_line, bool p_docs_down) {
 				doc_lines.push_front(line_comment);
 			}
 		} else {
-			String next_line = lines[MAX(0, i + step)].strip_edges(true, false);
-			if (next_line.begins_with("#")) {
-				continue;
+			if (i > 0 && i < lines.size() - 1) {
+				String next_line = lines[i + step].strip_edges(true, false);
+				if (next_line.begins_with("#")) {
+					continue;
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
Certain LSP clients like Vim occasionally, erroneously, or for whatever reason report documents as being size 0, which breaks the LSP due to a fix in parsing documentation that is above multi-line functions parameters.

Fixes #53238 