### PR TITLE
[3.x] Use a yellow color for editable children properties instead of red

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -66,7 +66,7 @@
 			Used by the inspector, set to [code]true[/code] when the property is checked.
 		</member>
 		<member name="draw_red" type="bool" setter="set_draw_red" getter="is_draw_red" default="false">
-			Used by the inspector, set to [code]true[/code] when the property must draw with error color. This is used for editable children's properties.
+			Used by the inspector, set to [code]true[/code] when the property is drawn with the editor theme's warning color. This is used for editable children's properties.
 		</member>
 		<member name="keying" type="bool" setter="set_keying" getter="is_keying" default="false">
 			Used by the inspector, set to [code]true[/code] when the property can add keys for animation.

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -209,7 +209,7 @@ void EditorProperty::_notification(int p_what) {
 
 		Color color;
 		if (draw_red) {
-			color = get_color("error_color");
+			color = get_color("warning_color");
 		} else {
 			color = get_color("property_color");
 		}

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -769,7 +769,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg);
 	theme->set_stylebox("bg", "EditorProperty", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
 	theme->set_constant("vseparation", "EditorProperty", (extra_spacing + default_margin_size) * EDSCALE);
-	theme->set_color("error_color", "EditorProperty", error_color);
+	theme->set_color("warning_color", "EditorProperty", warning_color);
 	theme->set_color("property_color", "EditorProperty", property_color);
 
 	theme->set_constant("inspector_margin", "Editor", 8 * EDSCALE);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/53260.

This matches the usual "Changes may be lost!" warning color.

Unlike https://github.com/godotengine/godot/pull/53260, this does not rename the `draw_red` property to `draw_warning` to preserve compatibility with existing editor plugins.

## Preview

![image](https://user-images.githubusercontent.com/180032/135490722-4b957816-6aa5-4563-be7e-206a30b4c76e.png)