### PR TITLE
Remove shape metadata from 2D physics server

### DIFF
--- a/doc/classes/KinematicCollision2D.xml
+++ b/doc/classes/KinematicCollision2D.xml
@@ -25,9 +25,6 @@
 		<member name="collider_id" type="int" setter="" getter="get_collider_id" default="0">
 			The colliding body's unique instance ID. See [method Object.get_instance_id].
 		</member>
-		<member name="collider_metadata" type="Variant" setter="" getter="get_collider_metadata">
-			The colliding body's metadata. See [Object].
-		</member>
 		<member name="collider_rid" type="RID" setter="" getter="get_collider_rid">
 			The colliding body's [RID] used by the [PhysicsServer2D].
 		</member>

--- a/doc/classes/KinematicCollision3D.xml
+++ b/doc/classes/KinematicCollision3D.xml
@@ -32,13 +32,6 @@
 				Returns the collider ID by index (the latest by default).
 			</description>
 		</method>
-		<method name="get_collider_metadata" qualifiers="const">
-			<return type="Variant" />
-			<argument index="0" name="collision_index" type="int" default="0" />
-			<description>
-				Returns the collider metadata by index (the latest by default).
-			</description>
-		</method>
 		<method name="get_collider_rid" qualifiers="const">
 			<return type="RID" />
 			<argument index="0" name="collision_index" type="int" default="0" />
@@ -95,9 +88,6 @@
 		</member>
 		<member name="collider_id" type="int" setter="" getter="get_best_collider_id" default="0">
 			The colliding body's unique instance ID. See [method Object.get_instance_id].
-		</member>
-		<member name="collider_metadata" type="Variant" setter="" getter="get_best_collider_metadata">
-			The colliding body's metadata. See [Object].
 		</member>
 		<member name="collider_rid" type="RID" setter="" getter="get_best_collider_rid">
 			The colliding body's [RID] used by the [PhysicsServer3D].

--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -90,13 +90,6 @@
 				Returns the collider's shape index.
 			</description>
 		</method>
-		<method name="get_contact_collider_shape_metadata" qualifiers="const">
-			<return type="Variant" />
-			<argument index="0" name="contact_idx" type="int" />
-			<description>
-				Returns the collided shape's metadata. This metadata is different from [method Object.get_meta], and is set with [method PhysicsServer2D.shape_set_data].
-			</description>
-		</method>
 		<method name="get_contact_collider_velocity_at_position" qualifiers="const">
 			<return type="Vector2" />
 			<argument index="0" name="contact_idx" type="int" />

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -36,7 +36,6 @@
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object. The returned object is a dictionary containing the following fields:
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]linear_velocity[/code]: The colliding object's velocity [Vector2]. If the object is an [Area2D], the result is [code](0, 0)[/code].
-				[code]metadata[/code]: The intersecting shape's metadata. This metadata is different from [method Object.get_meta], and is set with [method PhysicsServer2D.shape_set_data].
 				[code]normal[/code]: The object's surface normal at the intersection point.
 				[code]point[/code]: The intersection point.
 				[code]rid[/code]: The intersecting object's [RID].
@@ -55,7 +54,6 @@
 				Checks whether a point is inside any solid shape. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
-				[code]metadata[/code]: The intersecting shape's metadata. This metadata is different from [method Object.get_meta], and is set with [method PhysicsServer2D.shape_set_data].
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				Additionally, the method can take an [code]exclude[/code] array of objects or [RID]s that are to be excluded from collisions, a [code]collision_mask[/code] bitmask representing the physics layers to detect (all layers by default), or booleans to determine if the ray should collide with [PhysicsBody2D]s or [Area2D]s, respectively.
@@ -75,7 +73,6 @@
 				Checks whether a point is inside any solid shape, in a specific canvas layer given by [code]canvas_instance_id[/code]. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
-				[code]metadata[/code]: The intersecting shape's metadata. This metadata is different from [method Object.get_meta], and is set with [method PhysicsServer2D.shape_set_data].
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				Additionally, the method can take an [code]exclude[/code] array of objects or [RID]s that are to be excluded from collisions, a [code]collision_mask[/code] bitmask representing the physics layers to detect (all layers by default), or booleans to determine if the ray should collide with [PhysicsBody2D]s or [Area2D]s, respectively.
@@ -94,7 +91,6 @@
 				Intersects a ray in a given space. The returned object is a dictionary with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
-				[code]metadata[/code]: The intersecting shape's metadata. This metadata is different from [method Object.get_meta], and is set with [method PhysicsServer2D.shape_set_data].
 				[code]normal[/code]: The object's surface normal at the intersection point.
 				[code]position[/code]: The intersection point.
 				[code]rid[/code]: The intersecting object's [RID].
@@ -112,7 +108,6 @@
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object. The intersected shapes are returned in an array containing dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
-				[code]metadata[/code]: The intersecting shape's metadata. This metadata is different from [method Object.get_meta], and is set with [method PhysicsServer2D.shape_set_data].
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				The number of intersections can be limited with the [code]max_results[/code] parameter, to reduce the processing time.

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -395,14 +395,6 @@
 				Returns the number of shapes assigned to a body.
 			</description>
 		</method>
-		<method name="body_get_shape_metadata" qualifiers="const">
-			<return type="Variant" />
-			<argument index="0" name="body" type="RID" />
-			<argument index="1" name="shape_idx" type="int" />
-			<description>
-				Returns the metadata of a shape of a body.
-			</description>
-		</method>
 		<method name="body_get_shape_transform" qualifiers="const">
 			<return type="Transform2D" />
 			<argument index="0" name="body" type="RID" />
@@ -560,15 +552,6 @@
 			<argument index="2" name="disabled" type="bool" />
 			<description>
 				Disables shape in body if [code]disable[/code] is [code]true[/code].
-			</description>
-		</method>
-		<method name="body_set_shape_metadata">
-			<return type="void" />
-			<argument index="0" name="body" type="RID" />
-			<argument index="1" name="shape_idx" type="int" />
-			<argument index="2" name="metadata" type="Variant" />
-			<description>
-				Sets metadata of a shape within a body. This metadata is different from [method Object.set_meta], and can be retrieved on shape queries.
 			</description>
 		</method>
 		<method name="body_set_shape_transform">

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1778,10 +1778,6 @@ Vector2 KinematicCollision2D::get_collider_velocity() const {
 	return result.collider_velocity;
 }
 
-Variant KinematicCollision2D::get_collider_metadata() const {
-	return Variant();
-}
-
 void KinematicCollision2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_position"), &KinematicCollision2D::get_position);
 	ClassDB::bind_method(D_METHOD("get_normal"), &KinematicCollision2D::get_normal);
@@ -1795,7 +1791,6 @@ void KinematicCollision2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_collider_shape"), &KinematicCollision2D::get_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_collider_shape_index"), &KinematicCollision2D::get_collider_shape_index);
 	ClassDB::bind_method(D_METHOD("get_collider_velocity"), &KinematicCollision2D::get_collider_velocity);
-	ClassDB::bind_method(D_METHOD("get_collider_metadata"), &KinematicCollision2D::get_collider_metadata);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "normal"), "", "get_normal");
@@ -1808,5 +1803,4 @@ void KinematicCollision2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "collider_shape"), "", "get_collider_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_shape_index"), "", "get_collider_shape_index");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "collider_velocity"), "", "get_collider_velocity");
-	ADD_PROPERTY(PropertyInfo(Variant::NIL, "collider_metadata", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "", "get_collider_metadata");
 }

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -459,7 +459,6 @@ public:
 	Object *get_collider_shape() const;
 	int get_collider_shape_index() const;
 	Vector2 get_collider_velocity() const;
-	Variant get_collider_metadata() const;
 };
 
 #endif // PHYSICS_BODY_2D_H

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1987,11 +1987,6 @@ Vector3 KinematicCollision3D::get_collider_velocity(int p_collision_index) const
 	return result.collisions[p_collision_index].collider_velocity;
 }
 
-Variant KinematicCollision3D::get_collider_metadata(int p_collision_index) const {
-	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, Variant());
-	return Variant();
-}
-
 Vector3 KinematicCollision3D::get_best_position() const {
 	return result.collision_count ? get_position() : Vector3();
 }
@@ -2028,10 +2023,6 @@ Vector3 KinematicCollision3D::get_best_collider_velocity() const {
 	return result.collision_count ? get_collider_velocity() : Vector3();
 }
 
-Variant KinematicCollision3D::get_best_collider_metadata() const {
-	return result.collision_count ? get_collider_metadata() : Variant();
-}
-
 void KinematicCollision3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_travel"), &KinematicCollision3D::get_travel);
 	ClassDB::bind_method(D_METHOD("get_remainder"), &KinematicCollision3D::get_remainder);
@@ -2046,7 +2037,6 @@ void KinematicCollision3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_collider_shape", "collision_index"), &KinematicCollision3D::get_collider_shape, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_collider_shape_index", "collision_index"), &KinematicCollision3D::get_collider_shape_index, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_collider_velocity", "collision_index"), &KinematicCollision3D::get_collider_velocity, DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("get_collider_metadata", "collision_index"), &KinematicCollision3D::get_collider_metadata, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("get_best_position"), &KinematicCollision3D::get_best_position);
 	ClassDB::bind_method(D_METHOD("get_best_normal"), &KinematicCollision3D::get_best_normal);
@@ -2057,7 +2047,6 @@ void KinematicCollision3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_best_collider_shape"), &KinematicCollision3D::get_best_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_best_collider_shape_index"), &KinematicCollision3D::get_best_collider_shape_index);
 	ClassDB::bind_method(D_METHOD("get_best_collider_velocity"), &KinematicCollision3D::get_best_collider_velocity);
-	ClassDB::bind_method(D_METHOD("get_best_collider_metadata"), &KinematicCollision3D::get_best_collider_metadata);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "travel"), "", "get_travel");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "remainder"), "", "get_remainder");
@@ -2071,7 +2060,6 @@ void KinematicCollision3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "collider_shape"), "", "get_best_collider_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_shape_index"), "", "get_best_collider_shape_index");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collider_velocity"), "", "get_best_collider_velocity");
-	ADD_PROPERTY(PropertyInfo(Variant::NIL, "collider_metadata", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "", "get_best_collider_metadata");
 }
 
 ///////////////////////////////////////

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -485,7 +485,6 @@ public:
 	Object *get_collider_shape(int p_collision_index = 0) const;
 	int get_collider_shape_index(int p_collision_index = 0) const;
 	Vector3 get_collider_velocity(int p_collision_index = 0) const;
-	Variant get_collider_metadata(int p_collision_index = 0) const;
 
 	Vector3 get_best_position() const;
 	Vector3 get_best_normal() const;
@@ -496,7 +495,6 @@ public:
 	Object *get_best_collider_shape() const;
 	int get_best_collider_shape_index() const;
 	Vector3 get_best_collider_velocity() const;
-	Variant get_best_collider_metadata() const;
 };
 
 class PhysicalBone3D : public PhysicsBody3D {

--- a/servers/physics_2d/body_direct_state_2d_sw.cpp
+++ b/servers/physics_2d/body_direct_state_2d_sw.cpp
@@ -169,22 +169,6 @@ Vector2 PhysicsDirectBodyState2DSW::get_contact_collider_velocity_at_position(in
 	return body->contacts[p_contact_idx].collider_velocity_at_pos;
 }
 
-Variant PhysicsDirectBodyState2DSW::get_contact_collider_shape_metadata(int p_contact_idx) const {
-	ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Variant());
-
-	if (!PhysicsServer2DSW::singletonsw->body_owner.owns(body->contacts[p_contact_idx].collider)) {
-		return Variant();
-	}
-	Body2DSW *other = PhysicsServer2DSW::singletonsw->body_owner.get_or_null(body->contacts[p_contact_idx].collider);
-
-	int sidx = body->contacts[p_contact_idx].collider_shape;
-	if (sidx < 0 || sidx >= other->get_shape_count()) {
-		return Variant();
-	}
-
-	return other->get_shape_metadata(sidx);
-}
-
 PhysicsDirectSpaceState2D *PhysicsDirectBodyState2DSW::get_space_state() {
 	return body->get_space()->get_direct_state();
 }

--- a/servers/physics_2d/body_direct_state_2d_sw.h
+++ b/servers/physics_2d/body_direct_state_2d_sw.h
@@ -80,7 +80,6 @@ public:
 	virtual Vector2 get_contact_collider_position(int p_contact_idx) const override;
 	virtual ObjectID get_contact_collider_id(int p_contact_idx) const override;
 	virtual int get_contact_collider_shape(int p_contact_idx) const override;
-	virtual Variant get_contact_collider_shape_metadata(int p_contact_idx) const override;
 
 	virtual Vector2 get_contact_collider_velocity_at_position(int p_contact_idx) const override;
 

--- a/servers/physics_2d/collision_object_2d_sw.cpp
+++ b/servers/physics_2d/collision_object_2d_sw.cpp
@@ -61,11 +61,6 @@ void CollisionObject2DSW::set_shape(int p_index, Shape2DSW *p_shape) {
 	}
 }
 
-void CollisionObject2DSW::set_shape_metadata(int p_index, const Variant &p_metadata) {
-	ERR_FAIL_INDEX(p_index, shapes.size());
-	shapes.write[p_index].metadata = p_metadata;
-}
-
 void CollisionObject2DSW::set_shape_transform(int p_index, const Transform2D &p_transform) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 

--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -58,7 +58,6 @@ private:
 		BroadPhase2DSW::ID bpid = 0;
 		Rect2 aabb_cache; //for rayqueries
 		Shape2DSW *shape = nullptr;
-		Variant metadata;
 		bool disabled = false;
 		bool one_way_collision = false;
 		real_t one_way_collision_margin = 0.0;
@@ -110,7 +109,6 @@ public:
 	void add_shape(Shape2DSW *p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false);
 	void set_shape(int p_index, Shape2DSW *p_shape);
 	void set_shape_transform(int p_index, const Transform2D &p_transform);
-	void set_shape_metadata(int p_index, const Variant &p_metadata);
 
 	_FORCE_INLINE_ int get_shape_count() const { return shapes.size(); }
 	_FORCE_INLINE_ Shape2DSW *get_shape(int p_index) const {
@@ -128,10 +126,6 @@ public:
 	_FORCE_INLINE_ const Rect2 &get_shape_aabb(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].aabb_cache;
-	}
-	_FORCE_INLINE_ const Variant &get_shape_metadata(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
-		return shapes[p_index].metadata;
 	}
 
 	_FORCE_INLINE_ const Transform2D &get_transform() const { return transform; }

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -606,18 +606,6 @@ void PhysicsServer2DSW::body_set_shape_transform(RID p_body, int p_shape_idx, co
 	body->set_shape_transform(p_shape_idx, p_transform);
 }
 
-void PhysicsServer2DSW::body_set_shape_metadata(RID p_body, int p_shape_idx, const Variant &p_metadata) {
-	Body2DSW *body = body_owner.get_or_null(p_body);
-	ERR_FAIL_COND(!body);
-	body->set_shape_metadata(p_shape_idx, p_metadata);
-}
-
-Variant PhysicsServer2DSW::body_get_shape_metadata(RID p_body, int p_shape_idx) const {
-	Body2DSW *body = body_owner.get_or_null(p_body);
-	ERR_FAIL_COND_V(!body, Variant());
-	return body->get_shape_metadata(p_shape_idx);
-}
-
 int PhysicsServer2DSW::body_get_shape_count(RID p_body) const {
 	Body2DSW *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_COND_V(!body, -1);

--- a/servers/physics_2d/physics_server_2d_sw.h
+++ b/servers/physics_2d/physics_server_2d_sw.h
@@ -177,12 +177,10 @@ public:
 	virtual void body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) override;
 	virtual void body_set_shape(RID p_body, int p_shape_idx, RID p_shape) override;
 	virtual void body_set_shape_transform(RID p_body, int p_shape_idx, const Transform2D &p_transform) override;
-	virtual void body_set_shape_metadata(RID p_body, int p_shape_idx, const Variant &p_metadata) override;
 
 	virtual int body_get_shape_count(RID p_body) const override;
 	virtual RID body_get_shape(RID p_body, int p_shape_idx) const override;
 	virtual Transform2D body_get_shape_transform(RID p_body, int p_shape_idx) const override;
-	virtual Variant body_get_shape_metadata(RID p_body, int p_shape_idx) const override;
 
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) override;
 	virtual void body_clear_shapes(RID p_body) override;

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -184,11 +184,9 @@ public:
 	FUNC4(body_add_shape, RID, RID, const Transform2D &, bool);
 	FUNC3(body_set_shape, RID, int, RID);
 	FUNC3(body_set_shape_transform, RID, int, const Transform2D &);
-	FUNC3(body_set_shape_metadata, RID, int, const Variant &);
 
 	FUNC1RC(int, body_get_shape_count, RID);
 	FUNC2RC(Transform2D, body_get_shape_transform, RID, int);
-	FUNC2RC(Variant, body_get_shape_metadata, RID, int);
 	FUNC2RC(RID, body_get_shape, RID, int);
 
 	FUNC3(body_set_shape_disabled, RID, int, bool);

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -105,7 +105,6 @@ int PhysicsDirectSpaceState2DSW::_intersect_point_impl(const Vector2 &p_point, S
 		}
 		r_results[cc].rid = col_obj->get_self();
 		r_results[cc].shape = shape_idx;
-		r_results[cc].metadata = col_obj->get_shape_metadata(shape_idx);
 
 		cc++;
 	}
@@ -193,7 +192,6 @@ bool PhysicsDirectSpaceState2DSW::intersect_ray(const Vector2 &p_from, const Vec
 		r_result.collider = ObjectDB::get_instance(r_result.collider_id);
 	}
 	r_result.normal = res_normal;
-	r_result.metadata = res_obj->get_shape_metadata(res_shape);
 	r_result.position = res_point;
 	r_result.rid = res_obj->get_self();
 	r_result.shape = res_shape;
@@ -242,7 +240,6 @@ int PhysicsDirectSpaceState2DSW::intersect_shape(const RID &p_shape, const Trans
 		}
 		r_results[cc].rid = col_obj->get_self();
 		r_results[cc].shape = shape_idx;
-		r_results[cc].metadata = col_obj->get_shape_metadata(shape_idx);
 
 		cc++;
 	}
@@ -484,7 +481,6 @@ bool PhysicsDirectSpaceState2DSW::rest_info(RID p_shape, const Transform2D &p_sh
 	r_info->normal = rcd.best_normal;
 	r_info->point = rcd.best_contact;
 	r_info->rid = rcd.best_object->get_self();
-	r_info->metadata = rcd.best_object->get_shape_metadata(rcd.best_shape);
 	if (rcd.best_object->get_type() == CollisionObject2DSW::TYPE_BODY) {
 		const Body2DSW *body = static_cast<const Body2DSW *>(rcd.best_object);
 		Vector2 rel_vec = r_info->point - (body->get_transform().get_origin() + body->get_center_of_mass());
@@ -961,7 +957,6 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 				r_result->collision_depth = rcd.best_len;
 				r_result->collision_safe_fraction = safe;
 				r_result->collision_unsafe_fraction = unsafe;
-				r_result->collider_metadata = rcd.best_object->get_shape_metadata(rcd.best_shape);
 
 				const Body2DSW *body = static_cast<const Body2DSW *>(rcd.best_object);
 				Vector2 rel_vec = r_result->collision_point - (body->get_transform().get_origin() + body->get_center_of_mass());

--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -941,7 +941,6 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform3D &p_from, co
 					collision.normal = result.normal;
 					collision.position = result.contact;
 					collision.depth = result.len;
-					//r_result->collider_metadata = result.object->get_shape_metadata(result.shape);
 
 					const Body3DSW *body = static_cast<const Body3DSW *>(result.object);
 

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -112,7 +112,6 @@ void PhysicsDirectBodyState2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_contact_collider_id", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider_id);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_object", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider_object);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_shape", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider_shape);
-	ClassDB::bind_method(D_METHOD("get_contact_collider_shape_metadata", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider_shape_metadata);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_velocity_at_position", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider_velocity_at_position);
 	ClassDB::bind_method(D_METHOD("get_step"), &PhysicsDirectBodyState2D::get_step);
 	ClassDB::bind_method(D_METHOD("integrate_forces"), &PhysicsDirectBodyState2D::integrate_forces);
@@ -279,7 +278,6 @@ Dictionary PhysicsDirectSpaceState2D::_intersect_ray(const Vector2 &p_from, cons
 	d["collider"] = inters.collider;
 	d["shape"] = inters.shape;
 	d["rid"] = inters.rid;
-	d["metadata"] = inters.metadata;
 
 	return d;
 }
@@ -298,7 +296,6 @@ Array PhysicsDirectSpaceState2D::_intersect_shape(const Ref<PhysicsShapeQueryPar
 		d["collider_id"] = sr[i].collider_id;
 		d["collider"] = sr[i].collider;
 		d["shape"] = sr[i].shape;
-		d["metadata"] = sr[i].metadata;
 		ret[i] = d;
 	}
 
@@ -348,7 +345,6 @@ Array PhysicsDirectSpaceState2D::_intersect_point_impl(const Vector2 &p_point, i
 		d["collider_id"] = ret[i].collider_id;
 		d["collider"] = ret[i].collider;
 		d["shape"] = ret[i].shape;
-		d["metadata"] = ret[i].metadata;
 		r[i] = d;
 	}
 	return r;
@@ -397,7 +393,6 @@ Dictionary PhysicsDirectSpaceState2D::_get_rest_info(const Ref<PhysicsShapeQuery
 	r["collider_id"] = sri.collider_id;
 	r["shape"] = sri.shape;
 	r["linear_velocity"] = sri.linear_velocity;
-	r["metadata"] = sri.metadata;
 
 	return r;
 }
@@ -578,12 +573,10 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_add_shape", "body", "shape", "transform", "disabled"), &PhysicsServer2D::body_add_shape, DEFVAL(Transform2D()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("body_set_shape", "body", "shape_idx", "shape"), &PhysicsServer2D::body_set_shape);
 	ClassDB::bind_method(D_METHOD("body_set_shape_transform", "body", "shape_idx", "transform"), &PhysicsServer2D::body_set_shape_transform);
-	ClassDB::bind_method(D_METHOD("body_set_shape_metadata", "body", "shape_idx", "metadata"), &PhysicsServer2D::body_set_shape_metadata);
 
 	ClassDB::bind_method(D_METHOD("body_get_shape_count", "body"), &PhysicsServer2D::body_get_shape_count);
 	ClassDB::bind_method(D_METHOD("body_get_shape", "body", "shape_idx"), &PhysicsServer2D::body_get_shape);
 	ClassDB::bind_method(D_METHOD("body_get_shape_transform", "body", "shape_idx"), &PhysicsServer2D::body_get_shape_transform);
-	ClassDB::bind_method(D_METHOD("body_get_shape_metadata", "body", "shape_idx"), &PhysicsServer2D::body_get_shape_metadata);
 
 	ClassDB::bind_method(D_METHOD("body_remove_shape", "body", "shape_idx"), &PhysicsServer2D::body_remove_shape);
 	ClassDB::bind_method(D_METHOD("body_clear_shapes", "body"), &PhysicsServer2D::body_clear_shapes);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -84,7 +84,6 @@ public:
 	virtual ObjectID get_contact_collider_id(int p_contact_idx) const = 0;
 	virtual Object *get_contact_collider_object(int p_contact_idx) const;
 	virtual int get_contact_collider_shape(int p_contact_idx) const = 0;
-	virtual Variant get_contact_collider_shape_metadata(int p_contact_idx) const = 0;
 	virtual Vector2 get_contact_collider_velocity_at_position(int p_contact_idx) const = 0;
 
 	virtual real_t get_step() const = 0;
@@ -165,7 +164,6 @@ public:
 		ObjectID collider_id;
 		Object *collider = nullptr;
 		int shape = 0;
-		Variant metadata;
 	};
 
 	virtual bool intersect_ray(const Vector2 &p_from, const Vector2 &p_to, RayResult &r_result, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_layer = UINT32_MAX, bool p_collide_with_bodies = true, bool p_collide_with_areas = false) = 0;
@@ -175,7 +173,6 @@ public:
 		ObjectID collider_id;
 		Object *collider = nullptr;
 		int shape = 0;
-		Variant metadata;
 	};
 
 	virtual int intersect_point(const Vector2 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_layer = UINT32_MAX, bool p_collide_with_bodies = true, bool p_collide_with_areas = false, bool p_pick_point = false) = 0;
@@ -194,7 +191,6 @@ public:
 		ObjectID collider_id;
 		int shape = 0;
 		Vector2 linear_velocity; //velocity at contact point
-		Variant metadata;
 	};
 
 	virtual bool rest_info(RID p_shape, const Transform2D &p_shape_xform, const Vector2 &p_motion, real_t p_margin, ShapeRestInfo *r_info, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_layer = UINT32_MAX, bool p_collide_with_bodies = true, bool p_collide_with_areas = false) = 0;
@@ -363,12 +359,10 @@ public:
 	virtual void body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) = 0;
 	virtual void body_set_shape(RID p_body, int p_shape_idx, RID p_shape) = 0;
 	virtual void body_set_shape_transform(RID p_body, int p_shape_idx, const Transform2D &p_transform) = 0;
-	virtual void body_set_shape_metadata(RID p_body, int p_shape_idx, const Variant &p_metadata) = 0;
 
 	virtual int body_get_shape_count(RID p_body) const = 0;
 	virtual RID body_get_shape(RID p_body, int p_shape_idx) const = 0;
 	virtual Transform2D body_get_shape_transform(RID p_body, int p_shape_idx) const = 0;
-	virtual Variant body_get_shape_metadata(RID p_body, int p_shape_idx) const = 0;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape, bool p_disabled) = 0;
 	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) = 0;
@@ -485,7 +479,6 @@ public:
 		ObjectID collider_id;
 		RID collider;
 		int collider_shape = 0;
-		Variant collider_metadata;
 
 		real_t get_angle(Vector2 p_up_direction) const {
 			return Math::acos(collision_normal.dot(p_up_direction));
@@ -503,7 +496,6 @@ public:
 		ObjectID collider_id;
 		RID collider;
 		int collider_shape;
-		Variant collider_metadata;
 	};
 
 	/* JOINT API */

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -492,7 +492,6 @@ public:
 		ObjectID collider_id;
 		RID collider;
 		int collider_shape = 0;
-		Variant collider_metadata;
 
 		real_t get_angle(Vector3 p_up_direction) const {
 			return Math::acos(normal.dot(p_up_direction));


### PR DESCRIPTION
Shape metadata was only used to get tile information when colliding with tilemaps. It's not needed anymore since there's an API in tilemap using body ids instead (implemented in https://github.com/godotengine/godot/pull/52724).
