### PR TITLE
doctest: Update to 2.4.6

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -143,7 +143,7 @@ License: Expat
 
 Files: ./thirdparty/doctest/
 Comment: doctest
-Copyright: 2016-2020, Viktor Kirilov
+Copyright: 2016-2021, Viktor Kirilov
 License: Expat
 
 Files: ./thirdparty/embree/

--- a/thirdparty/doctest/LICENSE.txt
+++ b/thirdparty/doctest/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2020 Viktor Kirilov
+Copyright (c) 2016-2021 Viktor Kirilov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
*Edit:* Merged #53270 so taken out of draft. Seems to work fine.

---

Draft because it includes #53270, will rebase once it's merged.

Here's the build failure when I tried to update `doctest` without the `CharProxy` change:
```
 In file included from tests/test_main.cpp:35:
In file included from tests/test_aabb.h:34:
In file included from ./core/math/aabb.h:35:
In file included from ./core/math/plane.h:34:
In file included from ./core/math/vector3.h:35:
In file included from ./core/math/vector3i.h:34:
./core/string/ustring.h:75:22: error: definition of implicit copy constructor for 'CharProxy<char32_t>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
        _FORCE_INLINE_ void operator=(const CharProxy<T> &other) const {
                            ^
./thirdparty/doctest/doctest.h:1216:19: note: in implicit copy constructor for 'CharProxy<char32_t>' first required here
                : lhs(doctest::detail::forward<L>(in))
                  ^
./thirdparty/doctest/doctest.h:1293:20: note: in instantiation of member function 'doctest::detail::Expression_lhs<CharProxy<char32_t>>::Expression_lhs' requested here
            return Expression_lhs<L>(doctest::detail::forward<L>(operand), m_at);
                   ^
tests/test_class_db.h:681:5: note: in instantiation of function template specialization 'doctest::detail::ExpressionDecomposer::operator<<<CharProxy<char32_t>>' requested here
                                TEST_COND(String(method.name)[0] != '_', "Virtual method ", String(method.name), " does not start with underscore.");
                                ^
tests/test_macros.h:50:30: note: expanded from macro 'TEST_COND'
#define TEST_COND(cond, ...) DOCTEST_CHECK_FALSE_MESSAGE(cond, __VA_ARGS__)
                             ^
./thirdparty/doctest/doctest.h:2115:80: note: expanded from macro 'DOCTEST_CHECK_FALSE_MESSAGE'
#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) do { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK_FALSE, cond); } while(false)
                                                                               ^
./thirdparty/doctest/doctest.h:2080:13: note: expanded from macro 'DOCTEST_ASSERT_IMPLEMENT_2'
            << __VA_ARGS__))                                                                       \
            ^
```