### PR TITLE
Fix #53255 when a body gets stuck when it hits a descending platform in 2D/3D

### DIFF
--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -392,8 +392,10 @@ private:
 	Vector3 motion_velocity;
 	Vector3 floor_normal;
 	Vector3 wall_normal;
+	Vector3 ceiling_normal;
 	Vector3 last_motion;
 	Vector3 platform_velocity;
+	Vector3 platform_ceiling_velocity;
 	Vector3 previous_position;
 	Vector3 real_velocity;
 


### PR DESCRIPTION
fix #53255

This patch applies the vertical velocity of a downward platform when the body hit the ceiling. It also handles the option `slide_on_ceiling` by only applying the vertical velocity when it’s relevant.

Before:

![before](https://user-images.githubusercontent.com/6397893/135534049-9a134213-d5e3-4b28-ba39-ae3359afb0c2.gif)

After:

![after](https://user-images.githubusercontent.com/6397893/135534087-9bdc9118-1e4c-4a75-9966-c1bd54cf1309.gif)


