### PR TITLE
Added methods to propagate checks & refactored classes to use new methods

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -357,6 +357,13 @@
 				Emitted when a cell is selected.
 			</description>
 		</signal>
+		<signal name="check_propagated_to_item">
+			<argument index="0" name="item" type="TreeItem" />
+			<argument index="1" name="column" type="int" />
+			<description>
+				Emitted when [method TreeItem.propagate_check] is called. Connect to this signal to process the items that are affected when [method TreeItem.propagate_check] is invoked. The order that the items affected will be processed is as follows: the item that invoked the method, children of that item, and finally parents of that item.
+			</description>
+		</signal>
 		<signal name="column_title_pressed">
 			<argument index="0" name="column" type="int" />
 			<description>

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -385,6 +385,14 @@
 				[b]Note:[/b] You can't move to the root or move the root.
 			</description>
 		</method>
+		<method name="propagate_check">
+			<return type="void" />
+			<argument index="0" name="column" type="int" />
+			<argument index="1" name="emit_signal" type="bool" default="true" />
+			<description>
+				Propagates this item's checked status to its children and parents for the given [code]column[/code]. It is possible to process the items affected by this method call by connecting to [signal Tree.check_propagated_to_item]. The order that the items affected will be processed is as follows: the item invoking this method, children of that item, and finally parents of that item. If [code]emit_signal[/code] is set to false, then [signal Tree.check_propagated_to_item] will not be emitted.
+			</description>
+		</method>
 		<method name="remove_child">
 			<return type="void" />
 			<argument index="0" name="child" type="Object" />

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -36,45 +36,6 @@
 #include "editor_node.h"
 #include "progress_dialog.h"
 
-void EditorAssetInstaller::_update_subitems(TreeItem *p_item, bool p_check, bool p_first) {
-	if (p_check) {
-		if (p_item->get_custom_color(0) == Color()) {
-			p_item->set_checked(0, true);
-		}
-	} else {
-		p_item->set_checked(0, false);
-	}
-
-	if (p_item->get_first_child()) {
-		_update_subitems(p_item->get_first_child(), p_check);
-	}
-
-	if (!p_first && p_item->get_next()) {
-		_update_subitems(p_item->get_next(), p_check);
-	}
-}
-
-void EditorAssetInstaller::_uncheck_parent(TreeItem *p_item) {
-	if (!p_item) {
-		return;
-	}
-
-	bool any_checked = false;
-	TreeItem *item = p_item->get_first_child();
-	while (item) {
-		if (item->is_checked(0)) {
-			any_checked = true;
-			break;
-		}
-		item = item->get_next();
-	}
-
-	if (!any_checked) {
-		p_item->set_checked(0, false);
-		_uncheck_parent(p_item->get_parent());
-	}
-}
-
 void EditorAssetInstaller::_item_edited() {
 	if (updating) {
 		return;
@@ -85,22 +46,17 @@ void EditorAssetInstaller::_item_edited() {
 		return;
 	}
 
-	String path = item->get_metadata(0);
-
 	updating = true;
-	if (path.is_empty() || item == tree->get_root()) { //a dir or root
-		_update_subitems(item, item->is_checked(0), true);
-	}
-
-	if (item->is_checked(0)) {
-		while (item) {
-			item->set_checked(0, true);
-			item = item->get_parent();
-		}
-	} else {
-		_uncheck_parent(item->get_parent());
-	}
+	item->propagate_check(0);
 	updating = false;
+}
+
+void EditorAssetInstaller::_check_propagated_to_item(Object *p_obj, int column) {
+	TreeItem *affected_item = Object::cast_to<TreeItem>(p_obj);
+	if (affected_item && affected_item->get_custom_color(0) != Color()) {
+		affected_item->set_checked(0, false);
+		affected_item->propagate_check(0, false);
+	}
 }
 
 void EditorAssetInstaller::open(const String &p_path, int p_depth) {
@@ -260,6 +216,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 				ti->set_custom_color(0, tree->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 				ti->set_tooltip(0, vformat(TTR("%s (already exists)"), res_path));
 				ti->set_checked(0, false);
+				ti->propagate_check(0);
 			} else {
 				ti->set_tooltip(0, res_path);
 			}
@@ -305,7 +262,7 @@ void EditorAssetInstaller::ok_pressed() {
 
 		String name = fname;
 
-		if (status_map.has(name) && status_map[name]->is_checked(0)) {
+		if (status_map.has(name) && (status_map[name]->is_checked(0) || status_map[name]->is_indeterminate(0))) {
 			String path = status_map[name]->get_metadata(0);
 			if (path.is_empty()) { // a dir
 
@@ -393,6 +350,7 @@ EditorAssetInstaller::EditorAssetInstaller() {
 	tree = memnew(Tree);
 	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tree->connect("item_edited", callable_mp(this, &EditorAssetInstaller::_item_edited));
+	tree->connect("check_propagated_to_item", callable_mp(this, &EditorAssetInstaller::_check_propagated_to_item));
 	vb->add_child(tree);
 
 	error = memnew(AcceptDialog);

--- a/editor/editor_asset_installer.h
+++ b/editor/editor_asset_installer.h
@@ -43,9 +43,8 @@ class EditorAssetInstaller : public ConfirmationDialog {
 	AcceptDialog *error;
 	Map<String, TreeItem *> status_map;
 	bool updating;
-	void _update_subitems(TreeItem *p_item, bool p_check, bool p_first = false);
-	void _uncheck_parent(TreeItem *p_item);
 	void _item_edited();
+	void _check_propagated_to_item(Object *p_obj, int column);
 	virtual void ok_pressed() override;
 
 protected:

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -149,9 +149,9 @@ class ThemeItemImportTree : public VBoxContainer {
 	void _update_total_selected(Theme::DataType p_data_type);
 
 	void _tree_item_edited();
+	void _check_propagated_to_tree_item(Object *p_obj, int p_column);
 	void _select_all_subitems(TreeItem *p_root_item, bool p_select_with_data);
 	void _deselect_all_subitems(TreeItem *p_root_item, bool p_deselect_completely);
-	void _update_parent_items(TreeItem *p_root_item);
 
 	void _select_all_items_pressed();
 	void _select_full_items_pressed();

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -123,8 +123,7 @@ private:
 	void _fill_resource_tree();
 	bool _fill_tree(EditorFileSystemDirectory *p_dir, TreeItem *p_item, Ref<EditorExportPreset> &current, bool p_only_scenes);
 	void _tree_changed();
-	void _check_dir_recursive(TreeItem *p_dir, bool p_checked);
-	void _refresh_parent_checks(TreeItem *p_item);
+	void _check_propagated_to_item(Object *p_obj, int column);
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -212,6 +212,14 @@ public:
 	bool is_checked(int p_column) const;
 	bool is_indeterminate(int p_column) const;
 
+	void propagate_check(int p_column, bool p_emit_signal = true);
+
+private:
+	// Check helpers.
+	void _propagate_check_through_children(int p_column, bool p_checked, bool p_emit_signal);
+	void _propagate_check_through_parents(int p_column, bool p_emit_signal);
+
+public:
 	void set_text(int p_column, String p_text);
 	String get_text(int p_column) const;
 


### PR DESCRIPTION

![CheckDemonstration](https://user-images.githubusercontent.com/46539626/135540437-2931431b-1498-4d6d-8d64-8a3f16a62ceb.gif)

I added methods Tree::propagate_check() and Tree::propagate_check_and_get_affected() to implement indeterminate check marks to classes EditorAssetInstaller, ThemeItemImportTree, and ProjectExportDialog.

These new methods are exposed to gdscript so users can use them to make their own tools.

```
func _on_Tree_item_edited():
	var item = get_edited()
	var affected_items = item.propagate_check_and_get_affected(column)
	for item in affected_items:
		# Invalid items are colored Red. Uncheck them.
		if item.get_custom_color(0) != Color():
			item.set_checked(0, false)
			item.propagate_check()
```
