### PR TITLE
Rename some elements of `Tabs`

### DIFF
--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -217,16 +217,10 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="reposition_active_tab_request">
+		<signal name="active_tab_rearranged">
 			<argument index="0" name="idx_to" type="int" />
 			<description>
 				Emitted when the active tab is rearranged via mouse drag. See [member drag_to_rearrange_enabled].
-			</description>
-		</signal>
-		<signal name="right_button_pressed">
-			<argument index="0" name="tab" type="int" />
-			<description>
-				Emitted when a tab is right-clicked.
 			</description>
 		</signal>
 		<signal name="tab_changed">
@@ -251,6 +245,12 @@
 			<argument index="0" name="tab" type="int" />
 			<description>
 				Emitted when a tab is hovered by the mouse.
+			</description>
+		</signal>
+		<signal name="tab_rmb_clicked">
+			<argument index="0" name="tab" type="int" />
+			<description>
+				Emitted when a tab is right-clicked.
 			</description>
 		</signal>
 	</signals>
@@ -281,14 +281,14 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="button" data_type="style" type="StyleBox">
-			Background of the close button when it's being hovered with the cursor.
-		</theme_item>
-		<theme_item name="button_pressed" data_type="style" type="StyleBox">
-			Background of the close button when it's being pressed.
-		</theme_item>
 		<theme_item name="close" data_type="icon" type="Texture2D">
 			The icon for the close button (see [member tab_close_display_policy]).
+		</theme_item>
+		<theme_item name="close_bg_highlight" data_type="style" type="StyleBox">
+			Background of the close button when it's being hovered with the cursor.
+		</theme_item>
+		<theme_item name="close_bg_pressed" data_type="style" type="StyleBox">
+			Background of the close button when it's being pressed.
 		</theme_item>
 		<theme_item name="decrement" data_type="icon" type="Texture2D">
 			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
@@ -315,7 +315,7 @@
 			Font color of the other, unselected tabs.
 		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
-			The horizontal separation between the tabs.
+			The horizontal separation between the elements inside tabs.
 		</theme_item>
 		<theme_item name="increment" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6195,12 +6195,12 @@ EditorNode::EditorNode() {
 	scene_tabs->set_min_width(int(EDITOR_DEF("interface/scene_tabs/minimum_width", 50)) * EDSCALE);
 	scene_tabs->set_drag_to_rearrange_enabled(true);
 	scene_tabs->connect("tab_changed", callable_mp(this, &EditorNode::_scene_tab_changed));
-	scene_tabs->connect("right_button_pressed", callable_mp(this, &EditorNode::_scene_tab_script_edited));
+	scene_tabs->connect("tab_rmb_clicked", callable_mp(this, &EditorNode::_scene_tab_script_edited));
 	scene_tabs->connect("tab_closed", callable_mp(this, &EditorNode::_scene_tab_closed), varray(SCENE_TAB_CLOSE));
 	scene_tabs->connect("tab_hovered", callable_mp(this, &EditorNode::_scene_tab_hovered));
 	scene_tabs->connect("mouse_exited", callable_mp(this, &EditorNode::_scene_tab_exit));
 	scene_tabs->connect("gui_input", callable_mp(this, &EditorNode::_scene_tab_input));
-	scene_tabs->connect("reposition_active_tab_request", callable_mp(this, &EditorNode::_reposition_active_tab));
+	scene_tabs->connect("active_tab_rearranged", callable_mp(this, &EditorNode::_reposition_active_tab));
 	scene_tabs->connect("resized", callable_mp(this, &EditorNode::_update_scene_tabs));
 
 	tabbar_container = memnew(HBoxContainer);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -962,8 +962,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("SceneTabFG", "EditorStyles", style_tab_selected);
 	theme->set_stylebox("SceneTabBG", "EditorStyles", style_tab_unselected);
 	theme->set_icon("close", "Tabs", theme->get_icon("GuiClose", "EditorIcons"));
-	theme->set_stylebox("button_pressed", "Tabs", style_menu);
-	theme->set_stylebox("button", "Tabs", style_menu);
+	theme->set_stylebox("close_bg_pressed", "Tabs", style_menu);
+	theme->set_stylebox("close_bg_highlight", "Tabs", style_menu);
 	theme->set_icon("increment", "TabContainer", theme->get_icon("GuiScrollArrowRight", "EditorIcons"));
 	theme->set_icon("decrement", "TabContainer", theme->get_icon("GuiScrollArrowLeft", "EditorIcons"));
 	theme->set_icon("increment", "Tabs", theme->get_icon("GuiScrollArrowRight", "EditorIcons"));

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3333,7 +3333,7 @@ ThemeEditor::ThemeEditor() {
 	preview_tabs->set_h_size_flags(SIZE_EXPAND_FILL);
 	preview_tabbar_hb->add_child(preview_tabs);
 	preview_tabs->connect("tab_changed", callable_mp(this, &ThemeEditor::_change_preview_tab));
-	preview_tabs->connect("right_button_pressed", callable_mp(this, &ThemeEditor::_remove_preview_tab));
+	preview_tabs->connect("tab_rmb_clicked", callable_mp(this, &ThemeEditor::_remove_preview_tab));
 
 	HBoxContainer *add_preview_button_hb = memnew(HBoxContainer);
 	preview_tabbar_hb->add_child(add_preview_button_hb);

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -164,7 +164,7 @@ void Tabs::gui_input(const Ref<InputEvent> &p_event) {
 		if (rb_pressing && !mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 			if (rb_hover != -1) {
 				//pressed
-				emit_signal(SNAME("right_button_pressed"), rb_hover);
+				emit_signal(SNAME("tab_rmb_clicked"), rb_hover);
 			}
 
 			rb_pressing = false;
@@ -401,7 +401,7 @@ void Tabs::_notification(int p_what) {
 				w += tabs[i].size_text;
 
 				if (tabs[i].right_button.is_valid()) {
-					Ref<StyleBox> style = get_theme_stylebox(SNAME("button"));
+					Ref<StyleBox> style = get_theme_stylebox(SNAME("close_bg_highlight"));
 					Ref<Texture2D> rb = tabs[i].right_button;
 
 					w += get_theme_constant(SNAME("hseparation"));
@@ -433,7 +433,7 @@ void Tabs::_notification(int p_what) {
 				}
 
 				if (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current)) {
-					Ref<StyleBox> style = get_theme_stylebox(SNAME("button"));
+					Ref<StyleBox> style = get_theme_stylebox(SNAME("close_bg_highlight"));
 					Ref<Texture2D> cb = close;
 
 					w += get_theme_constant(SNAME("hseparation"));
@@ -449,7 +449,7 @@ void Tabs::_notification(int p_what) {
 
 					if (!tabs[i].disabled && cb_hover == i) {
 						if (cb_pressing) {
-							get_theme_stylebox(SNAME("button_pressed"))->draw(ci, cb_rect);
+							get_theme_stylebox(SNAME("close_bg_pressed"))->draw(ci, cb_rect);
 						} else {
 							style->draw(ci, cb_rect);
 						}
@@ -886,7 +886,7 @@ void Tabs::drop_data(const Point2 &p_point, const Variant &p_data) {
 				hover_now = get_tab_count() - 1;
 			}
 			move_tab(tab_from_id, hover_now);
-			emit_signal(SNAME("reposition_active_tab_request"), hover_now);
+			emit_signal(SNAME("active_tab_rearranged"), hover_now);
 			set_current_tab(hover_now);
 		} else if (get_tabs_rearrange_group() != -1) {
 			// drag and drop between Tabs
@@ -1165,10 +1165,10 @@ void Tabs::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_select_with_rmb"), &Tabs::get_select_with_rmb);
 
 	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab")));
-	ADD_SIGNAL(MethodInfo("right_button_pressed", PropertyInfo(Variant::INT, "tab")));
+	ADD_SIGNAL(MethodInfo("tab_rmb_clicked", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("tab_closed", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("tab_hovered", PropertyInfo(Variant::INT, "tab")));
-	ADD_SIGNAL(MethodInfo("reposition_active_tab_request", PropertyInfo(Variant::INT, "idx_to")));
+	ADD_SIGNAL(MethodInfo("active_tab_rearranged", PropertyInfo(Variant::INT, "idx_to")));
 	ADD_SIGNAL(MethodInfo("tab_clicked", PropertyInfo(Variant::INT, "tab")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_tab", PROPERTY_HINT_RANGE, "-1,4096,1", PROPERTY_USAGE_EDITOR), "set_current_tab", "get_current_tab");

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -790,8 +790,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("tab_selected", "Tabs", sb_expand(make_stylebox(tab_current_png, 4, 3, 4, 1, 16, 3, 16, 2), 2, 2, 2, 2));
 	theme->set_stylebox("tab_unselected", "Tabs", sb_expand(make_stylebox(tab_behind_png, 5, 4, 5, 1, 16, 5, 16, 2), 3, 3, 3, 3));
 	theme->set_stylebox("tab_disabled", "Tabs", sb_expand(make_stylebox(tab_disabled_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
-	theme->set_stylebox("button_pressed", "Tabs", make_stylebox(button_pressed_png, 4, 4, 4, 4));
-	theme->set_stylebox("button", "Tabs", make_stylebox(button_normal_png, 4, 4, 4, 4));
+	theme->set_stylebox("close_bg_pressed", "Tabs", make_stylebox(button_pressed_png, 4, 4, 4, 4));
+	theme->set_stylebox("close_bg_highlight", "Tabs", make_stylebox(button_normal_png, 4, 4, 4, 4));
 
 	theme->set_icon("increment", "Tabs", make_icon(scroll_button_right_png));
 	theme->set_icon("increment_highlight", "Tabs", make_icon(scroll_button_right_hl_png));


### PR DESCRIPTION
- `reposition_active_tab_request` -> `active_tab_rearranged`: It's not requesting anything, the tab was rearranged.
- `right_button_pressed` -> `tab_rmb_clicked`: Makes it more clear what it's about. Pairing well with `tab_clicked` and others of the same type.
- `button` -> `close_bg_highlight`: Far more descriptive on what it affects.
- `button_pressed` -> `close_bg_pressed`: Same as above.