### PR TITLE
Fix property not shown in inspector when type is PACKED_COLOR_ARRAY

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3574,7 +3574,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		case Variant::PACKED_COLOR_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
 			editor->setup(Variant::PACKED_COLOR_ARRAY);
-
+			return editor;
 		} break;
 		default: {
 		}


### PR DESCRIPTION
Small fix, properties of type PACKED_COLOR_ARRAY were not shown in the inspector after some refactoring in #49859.

![grafik](https://user-images.githubusercontent.com/50084500/135550095-ff5e57d3-ab1d-47d4-b54a-35258f7e6397.png)

Color array editor visible again:
![grafik](https://user-images.githubusercontent.com/50084500/135549984-fde55ceb-405d-47ad-a42a-adedfc8f3997.png)
