### PR TITLE
Fix angular velocity default value in TileSet

### DIFF
--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -646,7 +646,7 @@ private:
 		};
 
 		Vector2 linear_velocity;
-		float angular_velocity;
+		float angular_velocity = 0.0;
 		Vector<PolygonShapeTileData> polygons;
 	};
 	Vector<PhysicsLayerTileData> physics;


### PR DESCRIPTION
Value was uninitialized, which lead to undefined behavior.