### PR TITLE
Fix deleting selection at the first line do not work with backspace

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -614,15 +614,15 @@ void CodeEdit::_backspace_internal() {
 		return;
 	}
 
+	if (has_selection()) {
+		delete_selection();
+		return;
+	}
+
 	int cc = get_caret_column();
 	int cl = get_caret_line();
 
 	if (cc == 0 && cl == 0) {
-		return;
-	}
-
-	if (has_selection()) {
-		delete_selection();
 		return;
 	}
 

--- a/tests/test_code_edit.h
+++ b/tests/test_code_edit.h
@@ -3063,6 +3063,53 @@ TEST_CASE("[SceneTree][CodeEdit] line length guidelines") {
 	memdelete(code_edit);
 }
 
+TEST_CASE("[SceneTree][CodeEdit] Backspace delete") {
+	CodeEdit *code_edit = memnew(CodeEdit);
+	SceneTree::get_singleton()->get_root()->add_child(code_edit);
+
+	/* Backspace with selection on first line. */
+	code_edit->set_text("");
+	code_edit->insert_text_at_caret("test backspace");
+	code_edit->select(0, 0, 0, 5);
+	code_edit->backspace();
+	CHECK(code_edit->get_line(0) == "backspace");
+
+	/* Backspace with selection on first line and caret at the beginning of file. */
+	code_edit->set_text("");
+	code_edit->insert_text_at_caret("test backspace");
+	code_edit->select(0, 0, 0, 5);
+	code_edit->set_caret_column(0);
+	code_edit->backspace();
+	CHECK(code_edit->get_line(0) == "backspace");
+
+	/* Move caret up to the previous line on backspace if carret is at the first column. */
+	code_edit->set_text("");
+	code_edit->insert_text_at_caret("line 1\nline 2");
+	code_edit->set_caret_line(1);
+	code_edit->set_caret_column(0);
+	code_edit->backspace();
+	CHECK(code_edit->get_line(0) == "line 1line 2");
+	CHECK(code_edit->get_caret_line() == 0);
+	CHECK(code_edit->get_caret_column() == 6);
+
+	/* Backspace delete all text if all text is selected. */
+	code_edit->set_text("");
+	code_edit->insert_text_at_caret("line 1\nline 2\nline 3");
+	code_edit->select_all();
+	code_edit->backspace();
+	CHECK(code_edit->get_text() == "");
+
+	/* Backspace at the beginning without selection has no effect. */
+	code_edit->set_text("");
+	code_edit->insert_text_at_caret("line 1\nline 2\nline 3");
+	code_edit->set_caret_line(0);
+	code_edit->set_caret_column(0);
+	code_edit->backspace();
+	CHECK(code_edit->get_text() == "line 1\nline 2\nline 3");
+
+	memdelete(code_edit);
+}
+
 } // namespace TestCodeEdit
 
 #endif // TEST_CODE_EDIT_H


### PR DESCRIPTION
Fixes #53274

### Issue

When hitting backspace, the ``_backspace_internal()`` function directly returns if carret was at position 0,0 even if there was a selected text. So the key had no effect in that case.

### Fix proposal

Swap the order of the tests.
Delete selection before testing the carret position.

### Before

![135536491-eea4ff6f-50d4-4cf4-a68f-045d5a3bd718](https://user-images.githubusercontent.com/3649998/135572807-3dbeb4c4-b333-430d-bce3-e78d02fb046e.gif)

### After

![backspace](https://user-images.githubusercontent.com/3649998/135572752-c21b9dc8-7f4b-4758-b199-09196d26b32f.gif)


