### PR TITLE
[FontData] Fixes saving copy of the font source data, if it was created from built-in font.

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -502,6 +502,11 @@ void FontData::set_data(const PackedByteArray &p_data) {
 }
 
 PackedByteArray FontData::get_data() const {
+	if (unlikely((size_t)data.size() != data_size)) {
+		PackedByteArray *data_w = const_cast<PackedByteArray *>(&data);
+		data_w->resize(data_size);
+		memcpy(data_w->ptrw(), data_ptr, data_size);
+	}
 	return data;
 }
 


### PR DESCRIPTION
Fixes #53253 (theme in the extension should be reimported to work).