### PR TITLE
ProjectSettings add dirty flag and project_settings_changed signal [3.x]

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1569,6 +1569,13 @@
 			Cell size used for the 2D hash grid that [VisibilityNotifier2D] uses (in pixels).
 		</member>
 	</members>
+	<signals>
+		<signal name="project_settings_changed">
+			<description>
+				Objects can use this signal to restrict reading of settings only to situations where a change has been made.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -99,8 +99,8 @@ void ImportDefaultsEditor::_save() {
 		} else {
 			ProjectSettings::get_singleton()->set("importer_defaults/" + settings->importer->get_importer_name(), Variant());
 		}
-
-		emit_signal("project_settings_changed");
+		// Calling ProjectSettings::set() causes the signal "project_settings_changed" to be sent to ProjectSettings.
+		// ProjectSettingsEditor subscribes to this and can reads the settings updated here.
 	}
 }
 

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -243,6 +243,7 @@ public:
 
 private:
 	int index;
+	bool _project_settings_change_pending;
 	ViewType view_type;
 	void _menu_option(int p_option);
 	void _set_auto_orthogonal();
@@ -457,6 +458,8 @@ private:
 
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
+
+	void _project_settings_changed();
 
 protected:
 	void _notification(int p_what);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -143,7 +143,16 @@ void ProjectSettingsEditor::_notification(int p_what) {
 			restart_icon->set_texture(get_icon("StatusWarning", "EditorIcons"));
 			restart_label->add_color_override("font_color", get_color("warning_color", "Editor"));
 
+			// The ImportDefaultsEditor changes settings which must be read by this object when changed
+			ProjectSettings::get_singleton()->connect("project_settings_changed", this, "_settings_changed");
+
 		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			if (ProjectSettings::get_singleton()) {
+				ProjectSettings::get_singleton()->disconnect("project_settings_changed", this, "_settings_changed");
+			}
+		} break;
+
 		case NOTIFICATION_POPUP_HIDE: {
 			EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "project_settings", get_rect());
 			set_process_unhandled_input(false);
@@ -2141,7 +2150,6 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	import_defaults_editor = memnew(ImportDefaultsEditor);
 	import_defaults_editor->set_name(TTR("Import Defaults"));
 	tab_container->add_child(import_defaults_editor);
-	import_defaults_editor->connect("project_settings_changed", this, "_settings_changed");
 
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -589,6 +589,8 @@ bool SceneTree::idle(float p_time) {
 
 	_call_idle_callbacks();
 
+	ProjectSettings::get_singleton()->update();
+
 #ifdef TOOLS_ENABLED
 
 	if (Engine::get_singleton()->is_editor_hint()) {


### PR DESCRIPTION
Most frames there will be no change in project settings, and it makes no sense to read settings every frame in case of changes, as a large number of string compares are involved.

This PR adds a signal to ProjectSettings that can be used in most cases to drive reading settings.

In addition a function `ProjectSettings::has_changes()` is provided for objects outside the signal system (e.g. Rasterizers).

Alternative version of #45956 for 3.x
Addresses https://github.com/godotengine/godot-proposals/issues/2155

## Notes
* I had noticed this as an inefficiency a while ago and intended to fix it. The string comparisons etc in finding project settings makes it relatively slow, and appears in profiles of the editor when nothing should be running, needlessly using CPU.
* It turned out that it was already solved in master, however there are two potential concerns with that solution:

1) The signal in 4.x is confined to the editor. This signal is potentially generally useful outside the editor, in user tools and games (although other workarounds are possible, it's a nice general solution to have such a signal available).
2) In this PR, another mechanism is provided for systems that cannot receive signals, this is especially relevant in the Rasterizer, and means we can now practically update a lot more settings without needing an editor restart, because there is now no need for expensive checks on the fly.

* The use of an integer with 2 values may seem strange, but it is to cope with the situation where a project setting is set during `iteration` _AFTER_ it is read. This could otherwise result in missed changes.
* This needs a look through by @reduz as there may be some considerations I'm not aware of in terms of total design.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
