### PR TITLE
Make bezier handle type a property of keyframes, update UI

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -130,6 +130,14 @@
 				Sets the stream of the key identified by [code]key_idx[/code] to value [code]stream[/code]. The [code]track_idx[/code] must be the index of an Audio Track.
 			</description>
 		</method>
+		<method name="bezier_track_get_key_handle_mode" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="track_idx" type="int" />
+			<argument index="1" name="key_idx" type="int" />
+			<description>
+				Returns the handle mode of the key identified by [code]index[/code]. See [enum HandleMode] for possible values. The [code]track_idx[/code] must be the index of a Bezier Track.
+			</description>
+		</method>
 		<method name="bezier_track_get_key_in_handle" qualifiers="const">
 			<return type="Vector2" />
 			<argument index="0" name="track_idx" type="int" />
@@ -161,6 +169,7 @@
 			<argument index="2" name="value" type="float" />
 			<argument index="3" name="in_handle" type="Vector2" default="Vector2(0, 0)" />
 			<argument index="4" name="out_handle" type="Vector2" default="Vector2(0, 0)" />
+			<argument index="5" name="handle_mode" type="int" enum="Animation.HandleMode" default="1" />
 			<description>
 				Inserts a Bezier Track key at the given [code]time[/code] in seconds. The [code]track_idx[/code] must be the index of a Bezier Track.
 				[code]in_handle[/code] is the left-side weight of the added Bezier curve point, [code]out_handle[/code] is the right-side one, while [code]value[/code] is the actual value at this point.
@@ -174,11 +183,22 @@
 				Returns the interpolated value at the given [code]time[/code] (in seconds). The [code]track_idx[/code] must be the index of a Bezier Track.
 			</description>
 		</method>
+		<method name="bezier_track_set_key_handle_mode">
+			<return type="void" />
+			<argument index="0" name="track_idx" type="int" />
+			<argument index="1" name="key_idx" type="int" />
+			<argument index="2" name="key_handle_mode" type="int" enum="Animation.HandleMode" />
+			<argument index="3" name="balanced_value_time_ratio" type="float" default="1.0" />
+			<description>
+				Changes the handle mode of the keyframe at the given [code]index[/code]. See [enum HandleMode] for possible values. The [code]track_idx[/code] must be the index of a Bezier Track.
+			</description>
+		</method>
 		<method name="bezier_track_set_key_in_handle">
 			<return type="void" />
 			<argument index="0" name="track_idx" type="int" />
 			<argument index="1" name="key_idx" type="int" />
 			<argument index="2" name="in_handle" type="Vector2" />
+			<argument index="3" name="balanced_value_time_ratio" type="float" default="1.0" />
 			<description>
 				Sets the in handle of the key identified by [code]key_idx[/code] to value [code]in_handle[/code]. The [code]track_idx[/code] must be the index of a Bezier Track.
 			</description>
@@ -188,6 +208,7 @@
 			<argument index="0" name="track_idx" type="int" />
 			<argument index="1" name="key_idx" type="int" />
 			<argument index="2" name="out_handle" type="Vector2" />
+			<argument index="3" name="balanced_value_time_ratio" type="float" default="1.0" />
 			<description>
 				Sets the out handle of the key identified by [code]key_idx[/code] to value [code]out_handle[/code]. The [code]track_idx[/code] must be the index of a Bezier Track.
 			</description>
@@ -618,6 +639,12 @@
 		</constant>
 		<constant name="LOOP_PINGPONG" value="2" enum="LoopMode">
 			Repeats playback and reverse playback at both ends of the animation.
+		</constant>
+		<constant name="HANDLE_MODE_FREE" value="0" enum="HandleMode">
+			Assigning the free handle mode to a Bezier Track's keyframe allows you to edit the keyframe's left and right handles independently from one another.
+		</constant>
+		<constant name="HANDLE_MODE_BALANCED" value="1" enum="HandleMode">
+			Assigning the balanced handle mode to a Bezier Track's keyframe makes it so the two handles of the keyframe always stay aligned when changing either the keyframe's left or right handle.
 		</constant>
 	</constants>
 </class>

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -36,20 +36,13 @@
 class AnimationBezierTrackEdit : public Control {
 	GDCLASS(AnimationBezierTrackEdit, Control);
 
-	enum HandleMode {
-		HANDLE_MODE_FREE,
-		HANDLE_MODE_BALANCED,
-		HANDLE_MODE_MIRROR
-	};
-
 	enum {
 		MENU_KEY_INSERT,
 		MENU_KEY_DUPLICATE,
-		MENU_KEY_DELETE
+		MENU_KEY_DELETE,
+		MENU_KEY_SET_HANDLE_FREE,
+		MENU_KEY_SET_HANDLE_BALANCED,
 	};
-
-	HandleMode handle_mode;
-	OptionButton *handle_mode_option;
 
 	VBoxContainer *right_column;
 	Button *close_button;
@@ -68,8 +61,6 @@ class AnimationBezierTrackEdit : public Control {
 	Ref<Texture2D> bezier_icon;
 	Ref<Texture2D> bezier_handle_icon;
 	Ref<Texture2D> selected_icon;
-
-	Rect2 close_icon_rect;
 
 	Map<int, Rect2> subtracks;
 
@@ -104,10 +95,12 @@ class AnimationBezierTrackEdit : public Control {
 	int moving_handle_key = 0;
 	Vector2 moving_handle_left;
 	Vector2 moving_handle_right;
+	int moving_handle_mode; // value from Animation::HandleMode
 
 	void _clear_selection();
 	void _clear_selection_for_anim(const Ref<Animation> &p_anim);
 	void _select_at_anim(const Ref<Animation> &p_anim, int p_track, float p_pos);
+	void _change_selected_keys_handle_mode(Animation::HandleMode p_mode);
 
 	Vector2 menu_insert_key;
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -334,6 +334,22 @@ public:
 					setting = false;
 					return true;
 				}
+
+				if (name == "handle_mode") {
+					const Variant &value = p_value;
+
+					setting = true;
+					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
+					int prev = animation->bezier_track_get_key_handle_mode(track, key);
+					undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_handle_mode", track, key, value);
+					undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_handle_mode", track, key, prev);
+					undo_redo->add_do_method(this, "_update_obj", animation);
+					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->commit_action();
+
+					setting = false;
+					return true;
+				}
 			} break;
 			case Animation::TYPE_AUDIO: {
 				if (name == "stream") {
@@ -498,6 +514,11 @@ public:
 					return true;
 				}
 
+				if (name == "handle_mode") {
+					r_ret = animation->bezier_track_get_key_handle_mode(track, key);
+					return true;
+				}
+
 			} break;
 			case Animation::TYPE_AUDIO: {
 				if (name == "stream") {
@@ -610,6 +631,7 @@ public:
 				p_list->push_back(PropertyInfo(Variant::FLOAT, "value"));
 				p_list->push_back(PropertyInfo(Variant::VECTOR2, "in_handle"));
 				p_list->push_back(PropertyInfo(Variant::VECTOR2, "out_handle"));
+				p_list->push_back(PropertyInfo(Variant::INT, "handle_mode", PROPERTY_HINT_ENUM, "Free,Balanced"));
 
 			} break;
 			case Animation::TYPE_AUDIO: {
@@ -949,6 +971,17 @@ public:
 							undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_out_handle", track, key, value);
 							undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_out_handle", track, key, prev);
 							update_obj = true;
+						} else if (name == "handle_mode") {
+							const Variant &value = p_value;
+
+							if (!setting) {
+								setting = true;
+								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
+							}
+							int prev = animation->bezier_track_get_key_handle_mode(track, key);
+							undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_handle_mode", track, key, value);
+							undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_handle_mode", track, key, prev);
+							update_obj = true;
 						}
 					} break;
 					case Animation::TYPE_AUDIO: {
@@ -1120,6 +1153,11 @@ public:
 							return true;
 						}
 
+						if (name == "handle_mode") {
+							r_ret = animation->bezier_track_get_key_handle_mode(track, key);
+							return true;
+						}
+
 					} break;
 					case Animation::TYPE_AUDIO: {
 						if (name == "stream") {
@@ -1273,6 +1311,7 @@ public:
 					p_list->push_back(PropertyInfo(Variant::FLOAT, "value"));
 					p_list->push_back(PropertyInfo(Variant::VECTOR2, "in_handle"));
 					p_list->push_back(PropertyInfo(Variant::VECTOR2, "out_handle"));
+					p_list->push_back(PropertyInfo(Variant::INT, "handle_mode", PROPERTY_HINT_ENUM, "Free,Balanced"));
 				} break;
 				case Animation::TYPE_AUDIO: {
 					p_list->push_back(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"));
@@ -2607,6 +2646,17 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 					text += "In-Handle: " + ih + "\n";
 					Vector2 oh = animation->bezier_track_get_key_out_handle(track, key_idx);
 					text += "Out-Handle: " + oh + "\n";
+					int hm = animation->bezier_track_get_key_handle_mode(track, key_idx);
+					text += "Handle mode: ";
+					switch (hm) {
+						case Animation::HANDLE_MODE_FREE: {
+							text += "Free";
+						} break;
+						case Animation::HANDLE_MODE_BALANCED: {
+							text += "Balanced";
+						} break;
+					}
+					text += "\n";
 				} break;
 				case Animation::TYPE_AUDIO: {
 					String stream_name = "null";
@@ -4796,12 +4846,13 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 			Variant value;
 			_find_hint_for_track(p_track, bp, &value);
 			Array arr;
-			arr.resize(5);
+			arr.resize(6);
 			arr[0] = value;
 			arr[1] = -0.25;
 			arr[2] = 0;
 			arr[3] = 0.25;
 			arr[4] = 0;
+			arr[5] = 0;
 
 			undo_redo->create_action(TTR("Add Track Key"));
 			undo_redo->add_do_method(animation.ptr(), "track_insert_key", p_track, p_ofs, arr);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -72,6 +72,11 @@ public:
 		LOOP_PINGPONG,
 	};
 
+	enum HandleMode {
+		HANDLE_MODE_FREE,
+		HANDLE_MODE_BALANCED,
+	};
+
 private:
 	struct Track {
 		TrackType type = TrackType::TYPE_ANIMATION;
@@ -157,10 +162,10 @@ private:
 	};
 
 	/* BEZIER TRACK */
-
 	struct BezierKey {
 		Vector2 in_handle; //relative (x always <0)
 		Vector2 out_handle; //relative (x always >0)
+		HandleMode handle_mode = HANDLE_MODE_BALANCED;
 		real_t value = 0.0;
 	};
 
@@ -419,11 +424,13 @@ public:
 	void track_set_interpolation_type(int p_track, InterpolationType p_interp);
 	InterpolationType track_get_interpolation_type(int p_track) const;
 
-	int bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle);
+	int bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle, const HandleMode p_handle_mode = HandleMode::HANDLE_MODE_BALANCED);
+	void bezier_track_set_key_handle_mode(int p_track, int p_index, HandleMode p_mode, double p_balanced_value_time_ratio = 1.0);
 	void bezier_track_set_key_value(int p_track, int p_index, real_t p_value);
-	void bezier_track_set_key_in_handle(int p_track, int p_index, const Vector2 &p_handle);
-	void bezier_track_set_key_out_handle(int p_track, int p_index, const Vector2 &p_handle);
+	void bezier_track_set_key_in_handle(int p_track, int p_index, const Vector2 &p_handle, double p_balanced_value_time_ratio = 1.0);
+	void bezier_track_set_key_out_handle(int p_track, int p_index, const Vector2 &p_handle, double p_balanced_value_time_ratio = 1.0);
 	real_t bezier_track_get_key_value(int p_track, int p_index) const;
+	int bezier_track_get_key_handle_mode(int p_track, int p_index) const;
 	Vector2 bezier_track_get_key_in_handle(int p_track, int p_index) const;
 	Vector2 bezier_track_get_key_out_handle(int p_track, int p_index) const;
 
@@ -478,6 +485,7 @@ public:
 VARIANT_ENUM_CAST(Animation::TrackType);
 VARIANT_ENUM_CAST(Animation::InterpolationType);
 VARIANT_ENUM_CAST(Animation::UpdateMode);
+VARIANT_ENUM_CAST(Animation::HandleMode);
 VARIANT_ENUM_CAST(Animation::LoopMode);
 
 #endif


### PR DESCRIPTION
- Remove unused code related to old close icon (now replaced with a button)
- Add bezier handle options to right-click menu
- Provide optional scale for balanced handle move
- Remove mirror handle mode, only keep balanced. The reason is it's not one you're likely to use more than rarely. I've only seen this in Godot when it comes to animation. Balanced keeps things aligned so it does the job well.
- Update animation reference

This PR implements https://github.com/godotengine/godot-proposals/issues/3236

It makes the bezier handle mode a property of each bezier track keyframe, allowing to retain some behavior on the keyframes. It opens the path to having auto handles as explained by @TokageItLab here: https://github.com/godotengine/godot-proposals/issues/3141#issuecomment-922247544


Co-authored-by: Francois Belair <razoric480@gmail.com>
Co-authored-by: Gilles Roudière <gilles.roudiere@gmail.com>