### PR TITLE
Tweak the Viewport configuration warning to mention 2×2 size requirement

### DIFF
--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -25,7 +25,7 @@
 			The update mode when the sub-viewport is used as a render target.
 		</member>
 		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(512, 512)">
-			The width and height of the sub-viewport.
+			The width and height of the sub-viewport. Must be set to a value greater than or equal to 2 pixels on both dimensions. Otherwise, nothing will be displayed.
 		</member>
 		<member name="size_2d_override" type="Vector2i" setter="set_size_2d_override" getter="get_size_2d_override" default="Vector2i(0, 0)">
 			The 2D size override of the sub-viewport. If either the width or height is [code]0[/code], the override is disabled.

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -821,6 +821,7 @@ void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override,
 		RS::get_singleton()->viewport_set_size(viewport, 0, 0);
 	}
 	_update_global_transform();
+	update_configuration_warnings();
 
 	update_canvas_items();
 
@@ -2821,8 +2822,8 @@ Variant Viewport::gui_get_drag_data() const {
 TypedArray<String> Viewport::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
-	if (size.x == 0 || size.y == 0) {
-		warnings.push_back(RTR("Viewport size must be greater than 0 to render anything."));
+	if (size.x <= 1 || size.y <= 1) {
+		warnings.push_back(RTR("The Viewport size must be greater than or equal to 2 pixels on both dimensions to render anything."));
 	}
 	return warnings;
 }


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/53300.

This closes https://github.com/godotengine/godot/issues/26187.