### PR TITLE
Tweak the Viewport configuration warning to mention 2×2 size requirement (3.x)

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -272,7 +272,7 @@
 			If set to a value greater than [code]0.0[/code], contrast-adaptive sharpening will be applied to the 3D viewport. This has a low performance cost and can be used to recover some of the sharpness lost from using FXAA. Values around [code]0.5[/code] generally give the best results. See also [member fxaa].
 		</member>
 		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2( 0, 0 )">
-			The width and height of viewport.
+			The width and height of viewport. Must be set to a value greater than or equal to 2 pixels on both dimensions. Otherwise, nothing will be displayed.
 		</member>
 		<member name="size_override_stretch" type="bool" setter="set_size_override_stretch" getter="is_size_override_stretch_enabled" default="false">
 			If [code]true[/code], the size override affects stretch as well.

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -720,6 +720,7 @@ void Viewport::set_size(const Size2 &p_size) {
 	VS::get_singleton()->viewport_set_size(viewport, size.width, size.height);
 
 	_update_stretch_transform();
+	update_configuration_warning();
 
 	emit_signal("size_changed");
 }
@@ -2935,11 +2936,11 @@ String Viewport::get_configuration_warning() const {
 
 	String warning = Node::get_configuration_warning();
 
-	if (size.x == 0 || size.y == 0) {
+	if (size.x <= 1 || size.y <= 1) {
 		if (warning != String()) {
 			warning += "\n\n";
 		}
-		warning += TTR("Viewport size must be greater than 0 to render anything.");
+		warning += TTR("The Viewport size must be greater than or equal to 2 pixels on both dimensions to render anything.");
 	}
 	return warning;
 }


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/53299.