### PR TITLE
Remove editor code in PhysicalBone3D

### DIFF
--- a/editor/plugins/physical_bone_3d_editor_plugin.cpp
+++ b/editor/plugins/physical_bone_3d_editor_plugin.cpp
@@ -43,6 +43,7 @@ void PhysicalBone3DEditor::_on_toggle_button_transform_joint(bool p_is_pressed) 
 void PhysicalBone3DEditor::_set_move_joint() {
 	if (selected) {
 		selected->_set_gizmo_move_joint(button_transform_joint->is_pressed());
+		Node3DEditor::get_singleton()->update_transform_gizmo();
 	}
 }
 

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -33,10 +33,6 @@
 #include "core/core_string_names.h"
 #include "scene/scene_string_names.h"
 
-#ifdef TOOLS_ENABLED
-#include "editor/plugins/node_3d_editor_plugin.h"
-#endif
-
 void PhysicsBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("move_and_collide", "linear_velocity", "test_only", "safe_margin", "max_collisions"), &PhysicsBody3D::_move, DEFVAL(false), DEFVAL(0.001), DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("test_move", "from", "linear_velocity", "collision", "safe_margin", "max_collisions"), &PhysicsBody3D::test_move, DEFVAL(Variant()), DEFVAL(0.001), DEFVAL(1));
@@ -2998,14 +2994,11 @@ void PhysicalBone3D::_on_bone_parent_changed() {
 	_reload_joint();
 }
 
-void PhysicalBone3D::_set_gizmo_move_joint(bool p_move_joint) {
 #ifdef TOOLS_ENABLED
+void PhysicalBone3D::_set_gizmo_move_joint(bool p_move_joint) {
 	gizmo_move_joint = p_move_joint;
-	Node3DEditor::get_singleton()->update_transform_gizmo();
-#endif
 }
 
-#ifdef TOOLS_ENABLED
 Transform3D PhysicalBone3D::get_global_gizmo_transform() const {
 	return gizmo_move_joint ? get_global_transform() * joint_offset : get_global_transform();
 }

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -662,10 +662,9 @@ private:
 
 public:
 	void _on_bone_parent_changed();
-	void _set_gizmo_move_joint(bool p_move_joint);
 
-public:
 #ifdef TOOLS_ENABLED
+	void _set_gizmo_move_joint(bool p_move_joint);
 	virtual Transform3D get_global_gizmo_transform() const override;
 	virtual Transform3D get_local_gizmo_transform() const override;
 #endif


### PR DESCRIPTION
Fixes invalid dependency listed in https://github.com/godotengine/godot/issues/53295#issuecomment-932203107.

`_set_gizmo_move_joint` is only used in `PhysicalBone3DEditor`, so the editor plugin call can be done directly there.