### PR TITLE
Fix error parsing extends statement if it has the cursor [3.x]

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3618,6 +3618,7 @@ void GDScriptParser::_parse_extends(ClassNode *p_class) {
 				p_class->extends_class.push_back(identifier);
 			} break;
 
+			case GDScriptTokenizer::TK_CURSOR:
 			case GDScriptTokenizer::TK_PERIOD:
 				break;
 


### PR DESCRIPTION
When `extends` is immediately followed by the 0xFFFF cursor, the parser does not properly handle this and so causes errors to be reported.

Fixes #53293 (along with #53308)