### PR TITLE
Remove scene code in physics servers

### DIFF
--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -903,7 +903,7 @@ RID BulletPhysicsServer3D::soft_body_get_space(RID p_body) const {
 	return space->get_self();
 }
 
-void BulletPhysicsServer3D::soft_body_set_mesh(RID p_body, const REF &p_mesh) {
+void BulletPhysicsServer3D::soft_body_set_mesh(RID p_body, RID p_mesh) {
 	SoftBodyBullet *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!body);
 

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -265,7 +265,7 @@ public:
 	virtual void soft_body_set_space(RID p_body, RID p_space) override;
 	virtual RID soft_body_get_space(RID p_body) const override;
 
-	virtual void soft_body_set_mesh(RID p_body, const REF &p_mesh) override;
+	virtual void soft_body_set_mesh(RID p_body, RID p_mesh) override;
 
 	virtual AABB soft_body_get_bounds(RID p_body) const override;
 

--- a/modules/bullet/soft_body_bullet.h
+++ b/modules/bullet/soft_body_bullet.h
@@ -32,7 +32,6 @@
 #define SOFT_BODY_BULLET_H
 
 #include "collision_object_bullet.h"
-#include "scene/resources/material.h" // TODO remove this please
 
 #ifdef None
 /// This is required to remove the macro None defined by x11 compiler because this word "None" is used internally by Bullet
@@ -42,7 +41,6 @@
 
 #include "BulletSoftBody/btSoftBodyHelpers.h"
 #include "collision_object_bullet.h"
-#include "scene/resources/mesh.h"
 #include "servers/physics_server_3d.h"
 
 #ifdef x11_None
@@ -64,7 +62,7 @@ private:
 	btSoftBody::Material *mat0 = nullptr; // This is just a copy of pointer managed by btSoftBody
 	bool isScratched = false;
 
-	Ref<Mesh> soft_mesh;
+	RID soft_mesh;
 
 	int simulation_precision = 5;
 	real_t total_mass = 1.;
@@ -100,7 +98,7 @@ public:
 
 	void update_rendering_server(RenderingServerHandler *p_rendering_server_handler);
 
-	void set_soft_mesh(const Ref<Mesh> &p_mesh);
+	void set_soft_mesh(RID p_mesh);
 	void destroy_soft_body();
 
 	// Special function. This function has bad performance
@@ -139,7 +137,7 @@ public:
 	_FORCE_INLINE_ real_t get_drag_coefficient() const { return drag_coefficient; }
 
 private:
-	void set_trimesh_body_shape(Vector<int> p_indices, Vector<Vector3> p_vertices);
+	bool set_trimesh_body_shape(Vector<int> p_indices, Vector<Vector3> p_vertices);
 	void setup_soft_body();
 
 	void pin_node(int p_node_index);

--- a/scene/3d/soft_dynamic_body_3d.cpp
+++ b/scene/3d/soft_dynamic_body_3d.cpp
@@ -433,9 +433,9 @@ void SoftDynamicBody3D::prepare_physics_server() {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
 		if (get_mesh().is_valid()) {
-			PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, get_mesh());
+			PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, get_mesh()->get_rid());
 		} else {
-			PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, nullptr);
+			PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, RID());
 		}
 
 		return;
@@ -444,10 +444,10 @@ void SoftDynamicBody3D::prepare_physics_server() {
 
 	if (get_mesh().is_valid() && (is_enabled() || (disable_mode != DISABLE_MODE_REMOVE))) {
 		become_mesh_owner();
-		PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, get_mesh());
+		PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, get_mesh()->get_rid());
 		RS::get_singleton()->connect("frame_pre_draw", callable_mp(this, &SoftDynamicBody3D::_draw_soft_mesh));
 	} else {
-		PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, nullptr);
+		PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, RID());
 		if (RS::get_singleton()->is_connected("frame_pre_draw", callable_mp(this, &SoftDynamicBody3D::_draw_soft_mesh))) {
 			RS::get_singleton()->disconnect("frame_pre_draw", callable_mp(this, &SoftDynamicBody3D::_draw_soft_mesh));
 		}

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -1098,7 +1098,7 @@ real_t PhysicsServer3DSW::soft_body_get_drag_coefficient(RID p_body) const {
 	return soft_body->get_drag_coefficient();
 }
 
-void PhysicsServer3DSW::soft_body_set_mesh(RID p_body, const REF &p_mesh) {
+void PhysicsServer3DSW::soft_body_set_mesh(RID p_body, RID p_mesh) {
 	SoftBody3DSW *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!soft_body);
 

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -291,7 +291,7 @@ public:
 	virtual void soft_body_set_drag_coefficient(RID p_body, real_t p_drag_coefficient) override;
 	virtual real_t soft_body_get_drag_coefficient(RID p_body) const override;
 
-	virtual void soft_body_set_mesh(RID p_body, const REF &p_mesh) override;
+	virtual void soft_body_set_mesh(RID p_body, RID p_mesh) override;
 
 	virtual AABB soft_body_get_bounds(RID p_body) const override;
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -308,7 +308,7 @@ public:
 	FUNC2(soft_body_set_drag_coefficient, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_drag_coefficient, RID);
 
-	FUNC2(soft_body_set_mesh, RID, const REF &);
+	FUNC2(soft_body_set_mesh, RID, RID);
 
 	FUNC1RC(AABB, soft_body_get_bounds, RID);
 

--- a/servers/physics_3d/soft_body_3d_sw.h
+++ b/servers/physics_3d/soft_body_3d_sw.h
@@ -40,12 +40,11 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/set.h"
 #include "core/templates/vset.h"
-#include "scene/resources/mesh.h"
 
 class Constraint3DSW;
 
 class SoftBody3DSW : public CollisionObject3DSW {
-	Ref<Mesh> soft_mesh;
+	RID soft_mesh;
 
 	struct Node {
 		Vector3 s; // Source position
@@ -159,7 +158,7 @@ public:
 
 	virtual void set_space(Space3DSW *p_space);
 
-	void set_mesh(const Ref<Mesh> &p_mesh);
+	void set_mesh(RID p_mesh);
 
 	void update_rendering_server(RenderingServerHandler *p_rendering_server_handler);
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -520,7 +520,7 @@ public:
 	virtual void soft_body_set_space(RID p_body, RID p_space) = 0;
 	virtual RID soft_body_get_space(RID p_body) const = 0;
 
-	virtual void soft_body_set_mesh(RID p_body, const REF &p_mesh) = 0;
+	virtual void soft_body_set_mesh(RID p_body, RID p_mesh) = 0;
 
 	virtual AABB soft_body_get_bounds(RID p_body) const = 0;
 


### PR DESCRIPTION
Fixes invalid dependency listed in https://github.com/godotengine/godot/issues/53295#issuecomment-932202229.

Replaced `Mesh` with mesh `RID` in Godot Physics 3D and Bullet soft body.