### PR TITLE
Fix WASAPI failing to init on Windows 10 when compiling with MinGW

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -301,7 +301,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_c
 	}
 
 	if (using_audio_client_3) {
-		AudioClientProperties audioProps;
+		AudioClientProperties audioProps{};
 		audioProps.cbSize = sizeof(AudioClientProperties);
 		audioProps.bIsOffload = FALSE;
 		audioProps.eCategory = AudioCategory_GameEffects;


### PR DESCRIPTION
Since WIndows 8.1, AudioClientProperties has an additional field called ```Options```.

On MSVC, this field is guarded by a ```NTDDI_VERSION``` check, which Godot fails since it is targetting Windows 7. Here ```sizeof(AudioClientProperties) == 12```.  
On recent MinGW the field exists, but is not guarded. Here ```sizeof(AudioClientProperties) == 16```, but Options are never zeroed, and since they are garbage, SetClientProperties fails at runtime with ```E_INVALIDARG```. The editor continues working, but no audio can be played.

The proposed change uses an initializer to ensure Options are set to ```AUDCLNT_STREAMOPTIONS_NONE``` (== 0), if the field exists. 

A less elegant alternative would be to hardcode ```audioProps.cbSize``` to be 12.