### PR TITLE
GPULightmapper: skip smoothen positions for flat triangles

### DIFF
--- a/modules/lightmapper_rd/lm_common_inc.glsl
+++ b/modules/lightmapper_rd/lm_common_inc.glsl
@@ -81,3 +81,7 @@ layout(set = 0, binding = 8) uniform texture2DArray albedo_tex;
 layout(set = 0, binding = 9) uniform texture2DArray emission_tex;
 
 layout(set = 0, binding = 10) uniform sampler linear_sampler;
+
+// Fragment action constants
+const uint FA_NONE = 0;
+const uint FA_SMOOTHEN_POSITION = 1;


### PR DESCRIPTION
Smoothening positions for flat, non-smoothened, triangles is unnecessary and
caused positions to move outside their triangle which caused side-effects as
rays from those positions intersected with triangles which could not be
reached from the original triangle.

This is solved by skipping smoothening of positions for flat triangles.
A triangle is determined to be flat as its vertex normals are equal.

This PR replaces #53264 which will be closed.
This PR fixes the artifact of strange blob that was mentioned in #51638.
![Screenshot from 2021-09-30 18-00-44](https://user-images.githubusercontent.com/10560119/135687647-8a7cdb3b-6dc8-463c-99b1-1e09e0272677.png)
After removing the smoothening of positions:
![Screenshot from 2021-09-30 18-02-43](https://user-images.githubusercontent.com/10560119/135687702-bcd809fa-df2c-48fd-9ab3-1bb088f981a0.png)


