### PR TITLE
ResourceImporterScene: Add error when "default" is not defined to create clips

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -988,6 +988,7 @@ Ref<Animation> ResourceImporterScene::_save_animation_to_file(Ref<Animation> ani
 
 void ResourceImporterScene::_create_clips(AnimationPlayer *anim, const Array &p_clips, bool p_bake_all) {
 	if (!anim->has_animation("default")) {
+		ERR_FAIL_COND_MSG(p_clips.size() > 0, "To create clips, animations must be named \"default\".");
 		return;
 	}
 


### PR DESCRIPTION
On many sleepy nights, I've forgotten that Godot requires the name of an animation to be "default" or it won't generate clips. This has created hours of frustration on my end because I had no idea why clips weren't being generated. Adding an error like this will alleviate that, prevent frustration, and save users a visit to the documentation.
