### PR TITLE
Fix caret position and viewport centering after deleting line (Ctrl-X)

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5072,10 +5072,12 @@ void TextEdit::_cut_internal() {
 	}
 
 	int cl = get_caret_line();
+	int cc = get_caret_column();
+	int indent_level = get_indent_level(cl);
+	double hscroll = get_h_scroll();
 
 	String clipboard = text[cl];
 	DisplayServer::get_singleton()->clipboard_set(clipboard);
-	set_caret_line(cl);
 	set_caret_column(0);
 
 	if (cl == 0 && get_line_count() > 1) {
@@ -5085,6 +5087,17 @@ void TextEdit::_cut_internal() {
 		backspace();
 		set_caret_line(get_caret_line() + 1);
 	}
+
+	// Correct the visualy perceived caret column taking care of identation level of the lines.
+	int diff_indent = indent_level - get_indent_level(get_caret_line());
+	cc += diff_indent;
+	if (diff_indent != 0) {
+		cc += diff_indent > 0 ? -1 : 1;
+	}
+
+	// Restore horizontal scroll and caret column modified by the backspace() call.
+	set_h_scroll(hscroll);
+	set_caret_column(cc);
 
 	cut_copy_line = clipboard;
 }


### PR DESCRIPTION
Fix #49507 (but in master branch)

### Issue : 

When deleting a line with CTRL+X shortcut, the caret is set to the end of the line.
The text viewport is not centered on caret anymore.

### Fix proposal : 

Keep the same caret colum before / after the line deletion (as in VS Studio).
Recenter viewport on caret.

### Before
![before_fix_ctrlx](https://user-images.githubusercontent.com/3649998/135711073-5f7bf916-d47c-4f0c-bd30-5181a9a7abca.gif)

### After
![after_fix_ctrlx](https://user-images.githubusercontent.com/3649998/135711080-0834490e-db9b-4b91-811e-6b5a70c898a2.gif)

### Edit : Improvement : Taking care of indentation

![column_correction](https://user-images.githubusercontent.com/3649998/135712837-f83850b7-40c8-4adb-9ffa-8d23fb95a20c.gif)

As a tabulation count as 1 column but visualy take 4 characters (or  whatever value of get_tab_size()), we need to correct the caret position to "visualy" keep the same caret column (even if it's not) when indentation level is not the same between the deleted line and the new caret line. Same behaviour as Visual Studio.
So I've updating the PR in that way. 