### PR TITLE
Fix crash at SoftBodyBullet::reset_all_node_positions when bt_soft_bo…

### DIFF
--- a/modules/bullet/soft_body_bullet.cpp
+++ b/modules/bullet/soft_body_bullet.cpp
@@ -228,7 +228,7 @@ void SoftBodyBullet::reset_all_node_mass() {
 }
 
 void SoftBodyBullet::reset_all_node_positions() {
-	if (soft_mesh.is_null()) {
+	if (soft_mesh.is_null() || !bt_soft_body) {
 		return;
 	}
 
@@ -246,6 +246,10 @@ void SoftBodyBullet::reset_all_node_positions() {
 }
 
 void SoftBodyBullet::set_activation_state(bool p_active) {
+	if (!bt_soft_body) {
+		return;
+	}
+
 	if (p_active) {
 		bt_soft_body->setActivationState(ACTIVE_TAG);
 	} else {


### PR DESCRIPTION
…dy isn't initialized

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes second crash at #53331