### PR TITLE
Remove `EDSCALE` dependency from GUI nodes

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -458,6 +458,27 @@
 				See [method get_theme_color] for details.
 			</description>
 		</method>
+		<method name="get_theme_default_base_scale" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the default base scale value from the first matching [Theme] in the tree if that [Theme] has a valid [member Theme.default_base_scale] value.
+				See [method get_theme_color] for details.
+			</description>
+		</method>
+		<method name="get_theme_default_font" qualifiers="const">
+			<return type="Font" />
+			<description>
+				Returns the default font from the first matching [Theme] in the tree if that [Theme] has a valid [member Theme.default_font] value.
+				See [method get_theme_color] for details.
+			</description>
+		</method>
+		<method name="get_theme_default_font_size" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the default font size value from the first matching [Theme] in the tree if that [Theme] has a valid [member Theme.default_font_size] value.
+				See [method get_theme_color] for details.
+			</description>
+		</method>
 		<method name="get_theme_font" qualifiers="const">
 			<return type="Font" />
 			<argument index="0" name="name" type="StringName" />

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -273,6 +273,24 @@
 				Returns [code]false[/code] if the theme does not have [code]theme_type[/code].
 			</description>
 		</method>
+		<method name="has_default_base_scale" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this theme has a valid [member default_base_scale] value.
+			</description>
+		</method>
+		<method name="has_default_font" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this theme has a valid [member default_font] value.
+			</description>
+		</method>
+		<method name="has_default_font_size" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this theme has a valid [member default_font_size] value.
+			</description>
+		</method>
 		<method name="has_font" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="StringName" />
@@ -484,11 +502,17 @@
 		</method>
 	</methods>
 	<members>
+		<member name="default_base_scale" type="float" setter="set_default_base_scale" getter="get_default_base_scale" default="0.0">
+			The default base scale factor of this [Theme] resource. Used by some controls to scale their visual properties based on a global scale factor. If this value is set to [code]0.0[/code], the global scale factor is used.
+			Use [method has_default_base_scale] to check if this value is valid.
+		</member>
 		<member name="default_font" type="Font" setter="set_default_font" getter="get_default_font">
-			The theme's default font.
+			The default font of this [Theme] resource. Used as a fallback value for font items defined in this theme, but having invalid values. If this value is also invalid, the global default value is used.
+			Use [method has_default_font] to check if this value is valid.
 		</member>
 		<member name="default_font_size" type="int" setter="set_default_font_size" getter="get_default_font_size" default="-1">
-			The theme's default font size. Set to [code]-1[/code] to ignore and use global default.
+			The default font size of this [Theme] resource. Used as a fallback value for font size items defined in this theme, but having invalid values. If this value is set to [code]-1[/code], the global default value is used.
+			Use [method has_default_font_size] to check if this value is valid.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -59,6 +59,21 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_theme_default_base_scale" qualifiers="const">
+			<return type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_theme_default_font" qualifiers="const">
+			<return type="Font" />
+			<description>
+			</description>
+		</method>
+		<method name="get_theme_default_font_size" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="get_theme_font" qualifiers="const">
 			<return type="Font" />
 			<argument index="0" name="name" type="StringName" />

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -292,7 +292,8 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<Theme> theme = Ref<Theme>(memnew(Theme));
 
-	const float default_contrast = 0.3;
+	// Controls may rely on the scale for their internal drawing logic.
+	theme->set_default_theme_base_scale(EDSCALE);
 
 	// Theme settings
 	Color accent_color = EDITOR_GET("interface/theme/accent_color");
@@ -309,6 +310,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Color preset_accent_color;
 	Color preset_base_color;
 	float preset_contrast = 0;
+
+	const float default_contrast = 0.3;
 
 	// Please use alphabetical order if you're adding a new theme here
 	// (after "Custom")

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -35,7 +35,6 @@
 #include "core/os/os.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #endif
 #include "scene/main/window.h"
@@ -44,17 +43,7 @@ List<Color> ColorPicker::preset_cache;
 
 void ColorPicker::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_THEME_CHANGED: {
-			btn_pick->set_icon(get_theme_icon(SNAME("screen_picker"), SNAME("ColorPicker")));
-			btn_add_preset->set_icon(get_theme_icon(SNAME("add_preset")));
-			_update_presets();
-			_update_controls();
-		} break;
 		case NOTIFICATION_ENTER_TREE: {
-			btn_pick->set_icon(get_theme_icon(SNAME("screen_picker"), SNAME("ColorPicker")));
-			btn_add_preset->set_icon(get_theme_icon(SNAME("add_preset")));
-
-			_update_controls();
 			_update_color();
 
 #ifdef TOOLS_ENABLED
@@ -71,18 +60,39 @@ void ColorPicker::_notification(int p_what) {
 				}
 			}
 #endif
-		} break;
-		case NOTIFICATION_PARENTED: {
+			[[fallthrough]];
+		}
+		case NOTIFICATION_THEME_CHANGED: {
+			btn_pick->set_icon(get_theme_icon(SNAME("screen_picker"), SNAME("ColorPicker")));
+			btn_add_preset->set_icon(get_theme_icon(SNAME("add_preset")));
+
+			uv_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("sv_width")), get_theme_constant(SNAME("sv_height"))));
+			w_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("h_width")), 0));
+
+			wheel_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("sv_width")), get_theme_constant(SNAME("sv_height"))));
+			wheel_margin->add_theme_constant_override("margin_bottom", 8 * get_theme_default_base_scale());
+
 			for (int i = 0; i < 4; i++) {
+				labels[i]->set_custom_minimum_size(Size2(get_theme_constant(SNAME("label_width")), 0));
 				set_offset((Side)i, get_offset((Side)i) + get_theme_constant(SNAME("margin")));
 			}
+
+			if (Engine::get_singleton()->is_editor_hint()) {
+				// Adjust for the width of the "Script" icon.
+				text_type->set_custom_minimum_size(Size2(28 * get_theme_default_base_scale(), 0));
+			}
+
+			_update_presets();
+			_update_controls();
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			Popup *p = Object::cast_to<Popup>(get_parent());
 			if (p) {
 				p->set_size(Size2(get_combined_minimum_size().width + get_theme_constant(SNAME("margin")) * 2, get_combined_minimum_size().height + get_theme_constant(SNAME("margin")) * 2));
 			}
 		} break;
+
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			if (screen != nullptr && screen->is_visible()) {
 				screen->hide();
@@ -762,11 +772,7 @@ void ColorPicker::_slider_draw(int p_which) {
 	Size2 size = scroll[p_which]->get_size();
 	Color left_color;
 	Color right_color;
-#ifdef TOOLS_ENABLED
-	const real_t margin = 4 * EDSCALE;
-#else
-	const real_t margin = 4;
-#endif
+	const real_t margin = 4 * get_theme_default_base_scale();
 
 	if (p_which == 3) {
 		scroll[p_which]->draw_texture_rect(get_theme_icon(SNAME("sample_bg"), SNAME("ColorPicker")), Rect2(Point2(0, margin), Size2(size.x, margin)), true);
@@ -1147,7 +1153,6 @@ ColorPicker::ColorPicker() :
 	uv_edit->set_mouse_filter(MOUSE_FILTER_PASS);
 	uv_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	uv_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	uv_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("sv_width")), get_theme_constant(SNAME("sv_height"))));
 	uv_edit->connect("draw", callable_mp(this, &ColorPicker::_hsv_draw), make_binds(0, uv_edit));
 
 	HBoxContainer *hb_smpl = memnew(HBoxContainer);
@@ -1219,9 +1224,6 @@ ColorPicker::ColorPicker() :
 	text_type->set_text("#");
 	text_type->set_tooltip(TTR("Switch between hexadecimal and code values."));
 	if (Engine::get_singleton()->is_editor_hint()) {
-#ifdef TOOLS_ENABLED
-		text_type->set_custom_minimum_size(Size2(28 * EDSCALE, 0)); // Adjust for the width of the "Script" icon.
-#endif
 		text_type->connect("pressed", callable_mp(this, &ColorPicker::_text_type_toggled));
 	} else {
 		text_type->set_flat(true);
@@ -1236,7 +1238,6 @@ ColorPicker::ColorPicker() :
 
 	wheel_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	wheel_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	wheel_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("sv_width")), get_theme_constant(SNAME("sv_height"))));
 	hb_edit->add_child(wheel_edit);
 
 	wheel_mat.instantiate();
@@ -1244,12 +1245,7 @@ ColorPicker::ColorPicker() :
 	circle_mat.instantiate();
 	circle_mat->set_shader(circle_shader);
 
-	MarginContainer *wheel_margin(memnew(MarginContainer));
-#ifdef TOOLS_ENABLED
-	wheel_margin->add_theme_constant_override("margin_bottom", 8 * EDSCALE);
-#else
 	wheel_margin->add_theme_constant_override("margin_bottom", 8);
-#endif
 	wheel_edit->add_child(wheel_margin);
 
 	wheel_margin->add_child(wheel);
@@ -1261,7 +1257,6 @@ ColorPicker::ColorPicker() :
 	wheel_uv->connect("draw", callable_mp(this, &ColorPicker::_hsv_draw), make_binds(0, wheel_uv));
 
 	hb_edit->add_child(w_edit);
-	w_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("h_width")), 0));
 	w_edit->set_h_size_flags(SIZE_FILL);
 	w_edit->set_v_size_flags(SIZE_EXPAND_FILL);
 	w_edit->connect("gui_input", callable_mp(this, &ColorPicker::_w_input));

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -81,6 +81,7 @@ private:
 	Control *uv_edit = memnew(Control);
 	Control *w_edit = memnew(Control);
 	AspectRatioContainer *wheel_edit = memnew(AspectRatioContainer);
+	MarginContainer *wheel_margin = memnew(MarginContainer);
 	Ref<ShaderMaterial> wheel_mat;
 	Ref<ShaderMaterial> circle_mat;
 	Control *wheel = memnew(Control);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -833,11 +833,12 @@ T Control::get_theme_item_in_types(Control *p_theme_owner, Window *p_theme_owner
 	ERR_FAIL_COND_V_MSG(p_theme_types.size() == 0, T(), "At least one theme type must be specified.");
 
 	// First, look through each control or window node in the branch, until no valid parent can be found.
-	// For each control iterate through its inheritance chain and see if p_name exists in any of them.
+	// Only nodes with a theme resource attached are considered.
 	Control *theme_owner = p_theme_owner;
 	Window *theme_owner_window = p_theme_owner_window;
 
 	while (theme_owner || theme_owner_window) {
+		// For each theme resource check the theme types provided and see if p_name exists with any of them.
 		for (const StringName &E : p_theme_types) {
 			if (theme_owner && theme_owner->data.theme->has_theme_item(p_data_type, p_name, E)) {
 				return theme_owner->data.theme->get_theme_item(p_data_type, p_name, E);
@@ -888,11 +889,12 @@ bool Control::has_theme_item_in_types(Control *p_theme_owner, Window *p_theme_ow
 	ERR_FAIL_COND_V_MSG(p_theme_types.size() == 0, false, "At least one theme type must be specified.");
 
 	// First, look through each control or window node in the branch, until no valid parent can be found.
-	// For each control iterate through its inheritance chain and see if p_name exists in any of them.
+	// Only nodes with a theme resource attached are considered.
 	Control *theme_owner = p_theme_owner;
 	Window *theme_owner_window = p_theme_owner_window;
 
 	while (theme_owner || theme_owner_window) {
+		// For each theme resource check the theme types provided and see if p_name exists with any of them.
 		for (const StringName &E : p_theme_types) {
 			if (theme_owner && theme_owner->data.theme->has_theme_item(p_data_type, p_name, E)) {
 				return true;
@@ -1128,6 +1130,150 @@ bool Control::has_theme_constant(const StringName &p_name, const StringName &p_t
 	List<StringName> theme_types;
 	_get_theme_type_dependencies(p_theme_type, &theme_types);
 	return has_theme_item_in_types(data.theme_owner, data.theme_owner_window, Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
+}
+
+float Control::fetch_theme_default_base_scale(Control *p_theme_owner, Window *p_theme_owner_window) {
+	// First, look through each control or window node in the branch, until no valid parent can be found.
+	// Only nodes with a theme resource attached are considered.
+	// For each theme resource see if their assigned theme has the default value defined and valid.
+	Control *theme_owner = p_theme_owner;
+	Window *theme_owner_window = p_theme_owner_window;
+
+	while (theme_owner || theme_owner_window) {
+		if (theme_owner && theme_owner->data.theme->has_default_theme_base_scale()) {
+			return theme_owner->data.theme->get_default_theme_base_scale();
+		}
+
+		if (theme_owner_window && theme_owner_window->theme->has_default_theme_base_scale()) {
+			return theme_owner_window->theme->get_default_theme_base_scale();
+		}
+
+		Node *parent = theme_owner ? theme_owner->get_parent() : theme_owner_window->get_parent();
+		Control *parent_c = Object::cast_to<Control>(parent);
+		if (parent_c) {
+			theme_owner = parent_c->data.theme_owner;
+			theme_owner_window = parent_c->data.theme_owner_window;
+		} else {
+			Window *parent_w = Object::cast_to<Window>(parent);
+			if (parent_w) {
+				theme_owner = parent_w->theme_owner;
+				theme_owner_window = parent_w->theme_owner_window;
+			} else {
+				theme_owner = nullptr;
+				theme_owner_window = nullptr;
+			}
+		}
+	}
+
+	// Secondly, check the project-defined Theme resource.
+	if (Theme::get_project_default().is_valid()) {
+		if (Theme::get_project_default()->has_default_theme_base_scale()) {
+			return Theme::get_project_default()->get_default_theme_base_scale();
+		}
+	}
+
+	// Lastly, fall back on the default Theme.
+	return Theme::get_default()->get_default_theme_base_scale();
+}
+
+float Control::get_theme_default_base_scale() const {
+	return fetch_theme_default_base_scale(data.theme_owner, data.theme_owner_window);
+}
+
+Ref<Font> Control::fetch_theme_default_font(Control *p_theme_owner, Window *p_theme_owner_window) {
+	// First, look through each control or window node in the branch, until no valid parent can be found.
+	// Only nodes with a theme resource attached are considered.
+	// For each theme resource see if their assigned theme has the default value defined and valid.
+	Control *theme_owner = p_theme_owner;
+	Window *theme_owner_window = p_theme_owner_window;
+
+	while (theme_owner || theme_owner_window) {
+		if (theme_owner && theme_owner->data.theme->has_default_theme_font()) {
+			return theme_owner->data.theme->get_default_theme_font();
+		}
+
+		if (theme_owner_window && theme_owner_window->theme->has_default_theme_font()) {
+			return theme_owner_window->theme->get_default_theme_font();
+		}
+
+		Node *parent = theme_owner ? theme_owner->get_parent() : theme_owner_window->get_parent();
+		Control *parent_c = Object::cast_to<Control>(parent);
+		if (parent_c) {
+			theme_owner = parent_c->data.theme_owner;
+			theme_owner_window = parent_c->data.theme_owner_window;
+		} else {
+			Window *parent_w = Object::cast_to<Window>(parent);
+			if (parent_w) {
+				theme_owner = parent_w->theme_owner;
+				theme_owner_window = parent_w->theme_owner_window;
+			} else {
+				theme_owner = nullptr;
+				theme_owner_window = nullptr;
+			}
+		}
+	}
+
+	// Secondly, check the project-defined Theme resource.
+	if (Theme::get_project_default().is_valid()) {
+		if (Theme::get_project_default()->has_default_theme_font()) {
+			return Theme::get_project_default()->get_default_theme_font();
+		}
+	}
+
+	// Lastly, fall back on the default Theme.
+	return Theme::get_default()->get_default_theme_font();
+}
+
+Ref<Font> Control::get_theme_default_font() const {
+	return fetch_theme_default_font(data.theme_owner, data.theme_owner_window);
+}
+
+int Control::fetch_theme_default_font_size(Control *p_theme_owner, Window *p_theme_owner_window) {
+	// First, look through each control or window node in the branch, until no valid parent can be found.
+	// Only nodes with a theme resource attached are considered.
+	// For each theme resource see if their assigned theme has the default value defined and valid.
+	Control *theme_owner = p_theme_owner;
+	Window *theme_owner_window = p_theme_owner_window;
+
+	while (theme_owner || theme_owner_window) {
+		if (theme_owner && theme_owner->data.theme->has_default_theme_font_size()) {
+			return theme_owner->data.theme->get_default_theme_font_size();
+		}
+
+		if (theme_owner_window && theme_owner_window->theme->has_default_theme_font_size()) {
+			return theme_owner_window->theme->get_default_theme_font_size();
+		}
+
+		Node *parent = theme_owner ? theme_owner->get_parent() : theme_owner_window->get_parent();
+		Control *parent_c = Object::cast_to<Control>(parent);
+		if (parent_c) {
+			theme_owner = parent_c->data.theme_owner;
+			theme_owner_window = parent_c->data.theme_owner_window;
+		} else {
+			Window *parent_w = Object::cast_to<Window>(parent);
+			if (parent_w) {
+				theme_owner = parent_w->theme_owner;
+				theme_owner_window = parent_w->theme_owner_window;
+			} else {
+				theme_owner = nullptr;
+				theme_owner_window = nullptr;
+			}
+		}
+	}
+
+	// Secondly, check the project-defined Theme resource.
+	if (Theme::get_project_default().is_valid()) {
+		if (Theme::get_project_default()->has_default_theme_font_size()) {
+			return Theme::get_project_default()->get_default_theme_font_size();
+		}
+	}
+
+	// Lastly, fall back on the default Theme.
+	return Theme::get_default()->get_default_theme_font_size();
+}
+
+int Control::get_theme_default_font_size() const {
+	return fetch_theme_default_font_size(data.theme_owner, data.theme_owner_window);
 }
 
 Rect2 Control::get_parent_anchorable_rect() const {
@@ -2788,6 +2934,10 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size", "name", "theme_type"), &Control::has_theme_font_size, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("has_theme_color", "name", "theme_type"), &Control::has_theme_color, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("has_theme_constant", "name", "theme_type"), &Control::has_theme_constant, DEFVAL(""));
+
+	ClassDB::bind_method(D_METHOD("get_theme_default_base_scale"), &Control::get_theme_default_base_scale);
+	ClassDB::bind_method(D_METHOD("get_theme_default_font"), &Control::get_theme_default_font);
+	ClassDB::bind_method(D_METHOD("get_theme_default_font_size"), &Control::get_theme_default_font_size);
 
 	ClassDB::bind_method(D_METHOD("get_parent_control"), &Control::get_parent_control);
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -509,6 +509,14 @@ public:
 	bool has_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 
+	static float fetch_theme_default_base_scale(Control *p_theme_owner, Window *p_theme_owner_window);
+	static Ref<Font> fetch_theme_default_font(Control *p_theme_owner, Window *p_theme_owner_window);
+	static int fetch_theme_default_font_size(Control *p_theme_owner, Window *p_theme_owner_window);
+
+	float get_theme_default_base_scale() const;
+	Ref<Font> get_theme_default_font() const;
+	int get_theme_default_font_size() const;
+
 	/* TOOLTIP */
 
 	void set_tooltip(const String &p_tooltip);

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -37,7 +37,6 @@
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"
-#include "editor/editor_scale.h"
 #include "scene/main/window.h" // Only used to check for more modals when dimming the editor.
 #endif
 
@@ -363,8 +362,7 @@ Button *ConfirmationDialog::get_cancel_button() {
 
 ConfirmationDialog::ConfirmationDialog() {
 	set_title(TTRC("Please Confirm..."));
-#ifdef TOOLS_ENABLED
-	set_min_size(Size2(200, 70) * EDSCALE);
-#endif
+	set_min_size(Size2(200, 70));
+
 	cancel = add_cancel_button();
 }

--- a/scene/gui/gradient_edit.h
+++ b/scene/gui/gradient_edit.h
@@ -46,6 +46,13 @@ class GradientEdit : public Control {
 	int grabbed = -1;
 	Vector<Gradient::Point> points;
 
+	// Make sure to use the scaled value below.
+	const int BASE_SPACING = 3;
+	const int BASE_POINT_WIDTH = 8;
+
+	int draw_spacing = BASE_SPACING;
+	int draw_point_width = BASE_POINT_WIDTH;
+
 	void _draw_checker(int x, int y, int w, int h);
 	void _color_changed(const Color &p_color);
 	int _get_point_from_pos(int x);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -36,10 +36,6 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 
-#ifdef TOOLS_ENABLED
-#include "editor/editor_scale.h"
-#endif
-
 constexpr int MINIMAP_OFFSET = 12;
 constexpr int MINIMAP_PADDING = 5;
 
@@ -436,6 +432,8 @@ void GraphEdit::_notification(int p_what) {
 		snap_button->set_icon(get_theme_icon(SNAME("snap")));
 		minimap_button->set_icon(get_theme_icon(SNAME("minimap")));
 		layout_button->set_icon(get_theme_icon(SNAME("layout")));
+
+		zoom_label->set_custom_minimum_size(Size2(48, 0) * get_theme_default_base_scale());
 	}
 	if (p_what == NOTIFICATION_READY) {
 		Size2 hmin = h_scroll->get_combined_minimum_size();
@@ -816,11 +814,7 @@ void GraphEdit::_draw_connection_line(CanvasItem *p_where, const Vector2 &p_from
 		scaled_points.push_back(points[i] * p_zoom);
 	}
 
-#ifdef TOOLS_ENABLED
-	p_where->draw_polyline_colors(scaled_points, colors, Math::floor(p_width * EDSCALE), lines_antialiased);
-#else
-	p_where->draw_polyline_colors(scaled_points, colors, p_width, lines_antialiased);
-#endif
+	p_where->draw_polyline_colors(scaled_points, colors, Math::floor(p_width * get_theme_default_base_scale()), lines_antialiased);
 }
 
 void GraphEdit::_connections_layer_draw() {
@@ -2272,11 +2266,7 @@ GraphEdit::GraphEdit() {
 	zoom_label->set_visible(false);
 	zoom_label->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	zoom_label->set_align(Label::ALIGN_CENTER);
-#ifdef TOOLS_ENABLED
-	zoom_label->set_custom_minimum_size(Size2(48, 0) * EDSCALE);
-#else
 	zoom_label->set_custom_minimum_size(Size2(48, 0));
-#endif
 	_update_zoom_label();
 
 	zoom_minus = memnew(Button);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -40,7 +40,6 @@
 #include "servers/display_server.h"
 #include "servers/text_server.h"
 #ifdef TOOLS_ENABLED
-#include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #endif
 #include "scene/main/window.h"
@@ -713,11 +712,7 @@ void LineEdit::_notification(int p_what) {
 				ofs_max -= r_icon->get_width();
 			}
 
-#ifdef TOOLS_ENABLED
-			int caret_width = Math::round(EDSCALE);
-#else
-			int caret_width = 1;
-#endif
+			int caret_width = Math::round(1 * get_theme_default_base_scale());
 
 			// Draw selections rects.
 			Vector2 ofs = Point2(x_ofs + scroll_offset, y_ofs);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -41,10 +41,6 @@
 #include "modules/regex/regex.h"
 #endif
 
-#ifdef TOOLS_ENABLED
-#include "editor/editor_scale.h"
-#endif
-
 RichTextLabel::Item *RichTextLabel::_get_next_item(Item *p_item, bool p_free) const {
 	if (p_free) {
 		if (p_item->subitems.size()) {
@@ -995,19 +991,13 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 				Color uc = font_color;
 				uc.a *= 0.5;
 				float y_off = TS->shaped_text_get_underline_position(rid);
-				float underline_width = TS->shaped_text_get_underline_thickness(rid);
-#ifdef TOOLS_ENABLED
-				underline_width *= EDSCALE;
-#endif
+				float underline_width = TS->shaped_text_get_underline_thickness(rid) * get_theme_default_base_scale();
 				draw_line(p_ofs + Vector2(off.x, off.y + y_off), p_ofs + Vector2(off.x + glyphs[i].advance * glyphs[i].repeat, off.y + y_off), uc, underline_width);
 			} else if (_find_strikethrough(it)) {
 				Color uc = font_color;
 				uc.a *= 0.5;
 				float y_off = -TS->shaped_text_get_ascent(rid) + TS->shaped_text_get_size(rid).y / 2;
-				float underline_width = TS->shaped_text_get_underline_thickness(rid);
-#ifdef TOOLS_ENABLED
-				underline_width *= EDSCALE;
-#endif
+				float underline_width = TS->shaped_text_get_underline_thickness(rid) * get_theme_default_base_scale();
 				draw_line(p_ofs + Vector2(off.x, off.y + y_off), p_ofs + Vector2(off.x + glyphs[i].advance * glyphs[i].repeat, off.y + y_off), uc, underline_width);
 			}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -42,10 +42,6 @@
 
 #include "scene/main/window.h"
 
-#ifdef TOOLS_ENABLED
-#include "editor/editor_scale.h"
-#endif
-
 static bool _is_text_char(char32_t c) {
 	return !is_symbol(c);
 }
@@ -1173,12 +1169,8 @@ void TextEdit::_notification(int p_what) {
 						}
 					}
 
-					// Carets
-#ifdef TOOLS_ENABLED
-					int caret_width = Math::round(EDSCALE);
-#else
-					int caret_width = 1;
-#endif
+					// Carets.
+					int caret_width = Math::round(1 * get_theme_default_base_scale());
 
 					if (!clipped && caret.line == line && line_wrap_index == caret_wrap_index) {
 						caret.draw_pos.y = ofs_y + ldata->get_line_descent(line_wrap_index);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -41,10 +41,6 @@
 
 #include "box_container.h"
 
-#ifdef TOOLS_ENABLED
-#include "editor/editor_scale.h"
-#endif
-
 #include <limits.h>
 
 Size2 TreeItem::Cell::get_icon_size() const {
@@ -1377,6 +1373,8 @@ void Tree::update_cache() {
 	cache.title_button_hover = get_theme_stylebox(SNAME("title_button_hover"));
 	cache.title_button_color = get_theme_color(SNAME("title_button_color"));
 
+	cache.base_scale = get_theme_default_base_scale();
+
 	v_scroll->set_custom_step(cache.font->get_height(cache.font_size));
 }
 
@@ -2046,15 +2044,9 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 						root_pos -= Point2i(cache.arrow->get_width(), 0);
 					}
 
-					float line_width = cache.relationship_line_width;
-					float parent_line_width = cache.parent_hl_line_width;
-					float children_line_width = cache.children_hl_line_width;
-
-#ifdef TOOLS_ENABLED
-					line_width *= Math::round(EDSCALE);
-					parent_line_width *= Math::round(EDSCALE);
-					children_line_width *= Math::round(EDSCALE);
-#endif
+					float line_width = cache.relationship_line_width * Math::round(cache.base_scale);
+					float parent_line_width = cache.parent_hl_line_width * Math::round(cache.base_scale);
+					float children_line_width = cache.children_hl_line_width * Math::round(cache.base_scale);
 
 					Point2i parent_pos = Point2i(parent_ofs - cache.arrow->get_width() / 2, p_pos.y + label_h / 2 + cache.arrow->get_height() / 2) - cache.offset + p_draw_ofs;
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -516,6 +516,8 @@ private:
 		Color custom_button_font_highlight;
 		Color font_outline_color;
 
+		float base_scale = 1.0;
+
 		int hseparation = 0;
 		int vseparation = 0;
 		int item_margin = 0;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1266,6 +1266,18 @@ bool Window::has_theme_constant(const StringName &p_name, const StringName &p_th
 	return Control::has_theme_item_in_types(theme_owner, theme_owner_window, Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 }
 
+float Window::get_theme_default_base_scale() const {
+	return Control::fetch_theme_default_base_scale(theme_owner, theme_owner_window);
+}
+
+Ref<Font> Window::get_theme_default_font() const {
+	return Control::fetch_theme_default_font(theme_owner, theme_owner_window);
+}
+
+int Window::get_theme_default_font_size() const {
+	return Control::fetch_theme_default_font_size(theme_owner, theme_owner_window);
+}
+
 Rect2i Window::get_parent_rect() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), Rect2i());
 	if (is_embedded()) {
@@ -1479,6 +1491,10 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size", "name", "theme_type"), &Window::has_theme_font_size, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("has_theme_color", "name", "theme_type"), &Window::has_theme_color, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("has_theme_constant", "name", "theme_type"), &Window::has_theme_constant, DEFVAL(""));
+
+	ClassDB::bind_method(D_METHOD("get_theme_default_base_scale"), &Window::get_theme_default_base_scale);
+	ClassDB::bind_method(D_METHOD("get_theme_default_font"), &Window::get_theme_default_font);
+	ClassDB::bind_method(D_METHOD("get_theme_default_font_size"), &Window::get_theme_default_font_size);
 
 	ClassDB::bind_method(D_METHOD("set_layout_direction", "direction"), &Window::set_layout_direction);
 	ClassDB::bind_method(D_METHOD("get_layout_direction"), &Window::get_layout_direction);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -280,6 +280,10 @@ public:
 	bool has_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 
+	float get_theme_default_base_scale() const;
+	Ref<Font> get_theme_default_font() const;
+	int get_theme_default_font_size() const;
+
 	Rect2i get_parent_rect() const;
 	virtual DisplayServer::WindowID get_window_id() const override;
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -1036,9 +1036,16 @@ void make_default_theme(bool p_hidpi, Ref<Font> p_font) {
 	}
 
 	Ref<Font> large_font = default_font;
-	fill_default_theme(t, default_font, large_font, default_icon, default_style, p_hidpi ? 2.0 : 1.0);
+
+	float default_scale = 1.0;
+	if (p_hidpi) {
+		default_scale = 2.0;
+	}
+
+	fill_default_theme(t, default_font, large_font, default_icon, default_style, default_scale);
 
 	Theme::set_default(t);
+	Theme::set_default_base_scale(default_scale);
 	Theme::set_default_icon(default_icon);
 	Theme::set_default_style(default_style);
 	Theme::set_default_font(default_font);

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -36,6 +36,7 @@ Ref<Theme> Theme::default_theme;
 Ref<Theme> Theme::project_default_theme;
 
 // Universal default values, final fallback for every theme.
+float Theme::default_base_scale = 1.0;
 Ref<Texture2D> Theme::default_icon;
 Ref<StyleBox> Theme::default_style;
 Ref<Font> Theme::default_font;
@@ -219,6 +220,10 @@ void Theme::set_project_default(const Ref<Theme> &p_project_default) {
 }
 
 // Universal fallback values for theme item types.
+void Theme::set_default_base_scale(float p_base_scale) {
+	default_base_scale = p_base_scale;
+}
+
 void Theme::set_default_icon(const Ref<Texture2D> &p_icon) {
 	default_icon = p_icon;
 }
@@ -236,6 +241,24 @@ void Theme::set_default_font_size(int p_font_size) {
 }
 
 // Fallback values for theme item types, configurable per theme.
+void Theme::set_default_theme_base_scale(float p_base_scale) {
+	if (default_theme_base_scale == p_base_scale) {
+		return;
+	}
+
+	default_theme_base_scale = p_base_scale;
+
+	_emit_theme_changed();
+}
+
+float Theme::get_default_theme_base_scale() const {
+	return default_theme_base_scale;
+}
+
+bool Theme::has_default_theme_base_scale() const {
+	return default_theme_base_scale > 0.0;
+}
+
 void Theme::set_default_theme_font(const Ref<Font> &p_default_font) {
 	if (default_theme_font == p_default_font) {
 		return;
@@ -258,6 +281,10 @@ Ref<Font> Theme::get_default_theme_font() const {
 	return default_theme_font;
 }
 
+bool Theme::has_default_theme_font() const {
+	return default_theme_font.is_valid();
+}
+
 void Theme::set_default_theme_font_size(int p_font_size) {
 	if (default_theme_font_size == p_font_size) {
 		return;
@@ -270,6 +297,10 @@ void Theme::set_default_theme_font_size(int p_font_size) {
 
 int Theme::get_default_theme_font_size() const {
 	return default_theme_font_size;
+}
+
+bool Theme::has_default_theme_font_size() const {
+	return default_theme_font_size > 0;
 }
 
 // Icons.
@@ -460,7 +491,7 @@ void Theme::set_font(const StringName &p_name, const StringName &p_theme_type, c
 Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_theme_type) const {
 	if (font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) {
 		return font_map[p_theme_type][p_name];
-	} else if (default_theme_font.is_valid()) {
+	} else if (has_default_theme_font()) {
 		return default_theme_font;
 	} else {
 		return default_font;
@@ -468,7 +499,7 @@ Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_theme_ty
 }
 
 bool Theme::has_font(const StringName &p_name, const StringName &p_theme_type) const {
-	return ((font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) || default_theme_font.is_valid());
+	return ((font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) || has_default_theme_font());
 }
 
 bool Theme::has_font_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
@@ -539,7 +570,7 @@ void Theme::set_font_size(const StringName &p_name, const StringName &p_theme_ty
 int Theme::get_font_size(const StringName &p_name, const StringName &p_theme_type) const {
 	if (font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) {
 		return font_size_map[p_theme_type][p_name];
-	} else if (default_theme_font_size > 0) {
+	} else if (has_default_theme_font_size()) {
 		return default_theme_font_size;
 	} else {
 		return default_font_size;
@@ -547,7 +578,7 @@ int Theme::get_font_size(const StringName &p_name, const StringName &p_theme_typ
 }
 
 bool Theme::has_font_size(const StringName &p_name, const StringName &p_theme_type) const {
-	return ((font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) || (default_theme_font_size > 0));
+	return ((font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) || has_default_theme_font_size());
 }
 
 bool Theme::has_font_size_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
@@ -1580,11 +1611,17 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_constant_list", "theme_type"), &Theme::_get_constant_list);
 	ClassDB::bind_method(D_METHOD("get_constant_type_list"), &Theme::_get_constant_type_list);
 
+	ClassDB::bind_method(D_METHOD("set_default_base_scale", "font_size"), &Theme::set_default_theme_base_scale);
+	ClassDB::bind_method(D_METHOD("get_default_base_scale"), &Theme::get_default_theme_base_scale);
+	ClassDB::bind_method(D_METHOD("has_default_base_scale"), &Theme::has_default_theme_base_scale);
+
 	ClassDB::bind_method(D_METHOD("set_default_font", "font"), &Theme::set_default_theme_font);
 	ClassDB::bind_method(D_METHOD("get_default_font"), &Theme::get_default_theme_font);
+	ClassDB::bind_method(D_METHOD("has_default_font"), &Theme::has_default_theme_font);
 
 	ClassDB::bind_method(D_METHOD("set_default_font_size", "font_size"), &Theme::set_default_theme_font_size);
 	ClassDB::bind_method(D_METHOD("get_default_font_size"), &Theme::get_default_theme_font_size);
+	ClassDB::bind_method(D_METHOD("has_default_font_size"), &Theme::has_default_theme_font_size);
 
 	ClassDB::bind_method(D_METHOD("set_theme_item", "data_type", "name", "theme_type", "value"), &Theme::set_theme_item);
 	ClassDB::bind_method(D_METHOD("get_theme_item", "data_type", "name", "theme_type"), &Theme::get_theme_item);
@@ -1605,6 +1642,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("merge_with", "other"), &Theme::merge_with);
 	ClassDB::bind_method(D_METHOD("clear"), &Theme::clear);
 
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "default_base_scale", PROPERTY_HINT_RANGE, "0.0,2.0,0.01,or_greater"), "set_default_base_scale", "get_default_base_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "default_font", PROPERTY_HINT_RESOURCE_TYPE, "Font"), "set_default_font", "get_default_font");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "default_font_size"), "set_default_font_size", "get_default_font_size");
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -29,18 +29,1095 @@
 /*************************************************************************/
 
 #include "theme.h"
-#include "core/io/file_access.h"
 #include "core/string/print_string.h"
 
-void Theme::_emit_theme_changed() {
-	if (no_change_propagation) {
+// Universal Theme resources used when no other theme has the item.
+Ref<Theme> Theme::default_theme;
+Ref<Theme> Theme::project_default_theme;
+
+// Universal default values, final fallback for every theme.
+Ref<Texture2D> Theme::default_icon;
+Ref<StyleBox> Theme::default_style;
+Ref<Font> Theme::default_font;
+int Theme::default_font_size = 16;
+
+// Dynamic properties.
+bool Theme::_set(const StringName &p_name, const Variant &p_value) {
+	String sname = p_name;
+
+	if (sname.find("/") != -1) {
+		String type = sname.get_slicec('/', 1);
+		String theme_type = sname.get_slicec('/', 0);
+		String name = sname.get_slicec('/', 2);
+
+		if (type == "icons") {
+			set_icon(name, theme_type, p_value);
+		} else if (type == "styles") {
+			set_stylebox(name, theme_type, p_value);
+		} else if (type == "fonts") {
+			set_font(name, theme_type, p_value);
+		} else if (type == "font_sizes") {
+			set_font_size(name, theme_type, p_value);
+		} else if (type == "colors") {
+			set_color(name, theme_type, p_value);
+		} else if (type == "constants") {
+			set_constant(name, theme_type, p_value);
+		} else if (type == "base_type") {
+			set_type_variation(theme_type, p_value);
+		} else {
+			return false;
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+bool Theme::_get(const StringName &p_name, Variant &r_ret) const {
+	String sname = p_name;
+
+	if (sname.find("/") != -1) {
+		String type = sname.get_slicec('/', 1);
+		String theme_type = sname.get_slicec('/', 0);
+		String name = sname.get_slicec('/', 2);
+
+		if (type == "icons") {
+			if (!has_icon(name, theme_type)) {
+				r_ret = Ref<Texture2D>();
+			} else {
+				r_ret = get_icon(name, theme_type);
+			}
+		} else if (type == "styles") {
+			if (!has_stylebox(name, theme_type)) {
+				r_ret = Ref<StyleBox>();
+			} else {
+				r_ret = get_stylebox(name, theme_type);
+			}
+		} else if (type == "fonts") {
+			if (!has_font(name, theme_type)) {
+				r_ret = Ref<Font>();
+			} else {
+				r_ret = get_font(name, theme_type);
+			}
+		} else if (type == "font_sizes") {
+			r_ret = get_font_size(name, theme_type);
+		} else if (type == "colors") {
+			r_ret = get_color(name, theme_type);
+		} else if (type == "constants") {
+			r_ret = get_constant(name, theme_type);
+		} else if (type == "base_type") {
+			r_ret = get_type_variation_base(theme_type);
+		} else {
+			return false;
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+void Theme::_get_property_list(List<PropertyInfo> *p_list) const {
+	List<PropertyInfo> list;
+
+	const StringName *key = nullptr;
+
+	// Type variations.
+	while ((key = variation_map.next(key))) {
+		list.push_back(PropertyInfo(Variant::STRING_NAME, String() + *key + "/base_type"));
+	}
+
+	key = nullptr;
+
+	// Icons.
+	while ((key = icon_map.next(key))) {
+		const StringName *key2 = nullptr;
+
+		while ((key2 = icon_map[*key].next(key2))) {
+			list.push_back(PropertyInfo(Variant::OBJECT, String() + *key + "/icons/" + *key2, PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
+		}
+	}
+
+	key = nullptr;
+
+	// Styles.
+	while ((key = style_map.next(key))) {
+		const StringName *key2 = nullptr;
+
+		while ((key2 = style_map[*key].next(key2))) {
+			list.push_back(PropertyInfo(Variant::OBJECT, String() + *key + "/styles/" + *key2, PROPERTY_HINT_RESOURCE_TYPE, "StyleBox", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
+		}
+	}
+
+	key = nullptr;
+
+	// Fonts.
+	while ((key = font_map.next(key))) {
+		const StringName *key2 = nullptr;
+
+		while ((key2 = font_map[*key].next(key2))) {
+			list.push_back(PropertyInfo(Variant::OBJECT, String() + *key + "/fonts/" + *key2, PROPERTY_HINT_RESOURCE_TYPE, "Font", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
+		}
+	}
+
+	key = nullptr;
+
+	// Font sizes.
+	while ((key = font_size_map.next(key))) {
+		const StringName *key2 = nullptr;
+
+		while ((key2 = font_size_map[*key].next(key2))) {
+			list.push_back(PropertyInfo(Variant::INT, String() + *key + "/font_sizes/" + *key2));
+		}
+	}
+
+	key = nullptr;
+
+	// Colors.
+	while ((key = color_map.next(key))) {
+		const StringName *key2 = nullptr;
+
+		while ((key2 = color_map[*key].next(key2))) {
+			list.push_back(PropertyInfo(Variant::COLOR, String() + *key + "/colors/" + *key2));
+		}
+	}
+
+	key = nullptr;
+
+	// Constants.
+	while ((key = constant_map.next(key))) {
+		const StringName *key2 = nullptr;
+
+		while ((key2 = constant_map[*key].next(key2))) {
+			list.push_back(PropertyInfo(Variant::INT, String() + *key + "/constants/" + *key2));
+		}
+	}
+
+	// Sort and store properties.
+	list.sort();
+	for (const PropertyInfo &E : list) {
+		p_list->push_back(E);
+	}
+}
+
+// Universal fallback Theme resources.
+Ref<Theme> Theme::get_default() {
+	return default_theme;
+}
+
+void Theme::set_default(const Ref<Theme> &p_default) {
+	default_theme = p_default;
+}
+
+Ref<Theme> Theme::get_project_default() {
+	return project_default_theme;
+}
+
+void Theme::set_project_default(const Ref<Theme> &p_project_default) {
+	project_default_theme = p_project_default;
+}
+
+// Universal fallback values for theme item types.
+void Theme::set_default_icon(const Ref<Texture2D> &p_icon) {
+	default_icon = p_icon;
+}
+
+void Theme::set_default_style(const Ref<StyleBox> &p_style) {
+	default_style = p_style;
+}
+
+void Theme::set_default_font(const Ref<Font> &p_font) {
+	default_font = p_font;
+}
+
+void Theme::set_default_font_size(int p_font_size) {
+	default_font_size = p_font_size;
+}
+
+// Fallback values for theme item types, configurable per theme.
+void Theme::set_default_theme_font(const Ref<Font> &p_default_font) {
+	if (default_theme_font == p_default_font) {
 		return;
 	}
 
-	notify_property_list_changed();
-	emit_changed();
+	if (default_theme_font.is_valid()) {
+		default_theme_font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	}
+
+	default_theme_font = p_default_font;
+
+	if (default_theme_font.is_valid()) {
+		default_theme_font->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+	}
+
+	_emit_theme_changed();
 }
 
+Ref<Font> Theme::get_default_theme_font() const {
+	return default_theme_font;
+}
+
+void Theme::set_default_theme_font_size(int p_font_size) {
+	if (default_theme_font_size == p_font_size) {
+		return;
+	}
+
+	default_theme_font_size = p_font_size;
+
+	_emit_theme_changed();
+}
+
+int Theme::get_default_theme_font_size() const {
+	return default_theme_font_size;
+}
+
+// Icons.
+void Theme::set_icon(const StringName &p_name, const StringName &p_theme_type, const Ref<Texture2D> &p_icon) {
+	if (icon_map[p_theme_type].has(p_name) && icon_map[p_theme_type][p_name].is_valid()) {
+		icon_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	}
+
+	icon_map[p_theme_type][p_name] = p_icon;
+
+	if (p_icon.is_valid()) {
+		icon_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+	}
+
+	_emit_theme_changed();
+}
+
+Ref<Texture2D> Theme::get_icon(const StringName &p_name, const StringName &p_theme_type) const {
+	if (icon_map.has(p_theme_type) && icon_map[p_theme_type].has(p_name) && icon_map[p_theme_type][p_name].is_valid()) {
+		return icon_map[p_theme_type][p_name];
+	} else {
+		return default_icon;
+	}
+}
+
+bool Theme::has_icon(const StringName &p_name, const StringName &p_theme_type) const {
+	return (icon_map.has(p_theme_type) && icon_map[p_theme_type].has(p_name) && icon_map[p_theme_type][p_name].is_valid());
+}
+
+bool Theme::has_icon_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
+	return (icon_map.has(p_theme_type) && icon_map[p_theme_type].has(p_name));
+}
+
+void Theme::rename_icon(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!icon_map.has(p_theme_type), "Cannot rename the icon '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(icon_map[p_theme_type].has(p_name), "Cannot rename the icon '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!icon_map[p_theme_type].has(p_old_name), "Cannot rename the icon '" + String(p_old_name) + "' because it does not exist.");
+
+	icon_map[p_theme_type][p_name] = icon_map[p_theme_type][p_old_name];
+	icon_map[p_theme_type].erase(p_old_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::clear_icon(const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!icon_map.has(p_theme_type), "Cannot clear the icon '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!icon_map[p_theme_type].has(p_name), "Cannot clear the icon '" + String(p_name) + "' because it does not exist.");
+
+	if (icon_map[p_theme_type][p_name].is_valid()) {
+		icon_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	}
+
+	icon_map[p_theme_type].erase(p_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::get_icon_list(StringName p_theme_type, List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	if (!icon_map.has(p_theme_type)) {
+		return;
+	}
+
+	const StringName *key = nullptr;
+
+	while ((key = icon_map[p_theme_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::add_icon_type(const StringName &p_theme_type) {
+	if (icon_map.has(p_theme_type)) {
+		return;
+	}
+	icon_map[p_theme_type] = HashMap<StringName, Ref<Texture2D>>();
+}
+
+void Theme::get_icon_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = icon_map.next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+// Styleboxes.
+void Theme::set_stylebox(const StringName &p_name, const StringName &p_theme_type, const Ref<StyleBox> &p_style) {
+	if (style_map[p_theme_type].has(p_name) && style_map[p_theme_type][p_name].is_valid()) {
+		style_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	}
+
+	style_map[p_theme_type][p_name] = p_style;
+
+	if (p_style.is_valid()) {
+		style_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+	}
+
+	_emit_theme_changed();
+}
+
+Ref<StyleBox> Theme::get_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
+	if (style_map.has(p_theme_type) && style_map[p_theme_type].has(p_name) && style_map[p_theme_type][p_name].is_valid()) {
+		return style_map[p_theme_type][p_name];
+	} else {
+		return default_style;
+	}
+}
+
+bool Theme::has_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
+	return (style_map.has(p_theme_type) && style_map[p_theme_type].has(p_name) && style_map[p_theme_type][p_name].is_valid());
+}
+
+bool Theme::has_stylebox_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
+	return (style_map.has(p_theme_type) && style_map[p_theme_type].has(p_name));
+}
+
+void Theme::rename_stylebox(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!style_map.has(p_theme_type), "Cannot rename the stylebox '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(style_map[p_theme_type].has(p_name), "Cannot rename the stylebox '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!style_map[p_theme_type].has(p_old_name), "Cannot rename the stylebox '" + String(p_old_name) + "' because it does not exist.");
+
+	style_map[p_theme_type][p_name] = style_map[p_theme_type][p_old_name];
+	style_map[p_theme_type].erase(p_old_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::clear_stylebox(const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!style_map.has(p_theme_type), "Cannot clear the stylebox '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!style_map[p_theme_type].has(p_name), "Cannot clear the stylebox '" + String(p_name) + "' because it does not exist.");
+
+	if (style_map[p_theme_type][p_name].is_valid()) {
+		style_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	}
+
+	style_map[p_theme_type].erase(p_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::get_stylebox_list(StringName p_theme_type, List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	if (!style_map.has(p_theme_type)) {
+		return;
+	}
+
+	const StringName *key = nullptr;
+
+	while ((key = style_map[p_theme_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::add_stylebox_type(const StringName &p_theme_type) {
+	if (style_map.has(p_theme_type)) {
+		return;
+	}
+	style_map[p_theme_type] = HashMap<StringName, Ref<StyleBox>>();
+}
+
+void Theme::get_stylebox_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = style_map.next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+// Fonts.
+void Theme::set_font(const StringName &p_name, const StringName &p_theme_type, const Ref<Font> &p_font) {
+	if (font_map[p_theme_type][p_name].is_valid()) {
+		font_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	}
+
+	font_map[p_theme_type][p_name] = p_font;
+
+	if (p_font.is_valid()) {
+		font_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+	}
+
+	_emit_theme_changed();
+}
+
+Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_theme_type) const {
+	if (font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) {
+		return font_map[p_theme_type][p_name];
+	} else if (default_theme_font.is_valid()) {
+		return default_theme_font;
+	} else {
+		return default_font;
+	}
+}
+
+bool Theme::has_font(const StringName &p_name, const StringName &p_theme_type) const {
+	return ((font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) || default_theme_font.is_valid());
+}
+
+bool Theme::has_font_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
+	return (font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name));
+}
+
+void Theme::rename_font(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!font_map.has(p_theme_type), "Cannot rename the font '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(font_map[p_theme_type].has(p_name), "Cannot rename the font '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!font_map[p_theme_type].has(p_old_name), "Cannot rename the font '" + String(p_old_name) + "' because it does not exist.");
+
+	font_map[p_theme_type][p_name] = font_map[p_theme_type][p_old_name];
+	font_map[p_theme_type].erase(p_old_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::clear_font(const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!font_map.has(p_theme_type), "Cannot clear the font '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!font_map[p_theme_type].has(p_name), "Cannot clear the font '" + String(p_name) + "' because it does not exist.");
+
+	if (font_map[p_theme_type][p_name].is_valid()) {
+		font_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	}
+
+	font_map[p_theme_type].erase(p_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::get_font_list(StringName p_theme_type, List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	if (!font_map.has(p_theme_type)) {
+		return;
+	}
+
+	const StringName *key = nullptr;
+
+	while ((key = font_map[p_theme_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::add_font_type(const StringName &p_theme_type) {
+	if (font_map.has(p_theme_type)) {
+		return;
+	}
+	font_map[p_theme_type] = HashMap<StringName, Ref<Font>>();
+}
+
+void Theme::get_font_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = font_map.next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+// Font sizes.
+void Theme::set_font_size(const StringName &p_name, const StringName &p_theme_type, int p_font_size) {
+	font_size_map[p_theme_type][p_name] = p_font_size;
+
+	_emit_theme_changed();
+}
+
+int Theme::get_font_size(const StringName &p_name, const StringName &p_theme_type) const {
+	if (font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) {
+		return font_size_map[p_theme_type][p_name];
+	} else if (default_theme_font_size > 0) {
+		return default_theme_font_size;
+	} else {
+		return default_font_size;
+	}
+}
+
+bool Theme::has_font_size(const StringName &p_name, const StringName &p_theme_type) const {
+	return ((font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) || (default_theme_font_size > 0));
+}
+
+bool Theme::has_font_size_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
+	return (font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name));
+}
+
+void Theme::rename_font_size(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!font_size_map.has(p_theme_type), "Cannot rename the font size '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(font_size_map[p_theme_type].has(p_name), "Cannot rename the font size '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!font_size_map[p_theme_type].has(p_old_name), "Cannot rename the font size '" + String(p_old_name) + "' because it does not exist.");
+
+	font_size_map[p_theme_type][p_name] = font_size_map[p_theme_type][p_old_name];
+	font_size_map[p_theme_type].erase(p_old_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::clear_font_size(const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!font_size_map.has(p_theme_type), "Cannot clear the font size '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!font_size_map[p_theme_type].has(p_name), "Cannot clear the font size '" + String(p_name) + "' because it does not exist.");
+
+	font_size_map[p_theme_type].erase(p_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::get_font_size_list(StringName p_theme_type, List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	if (!font_size_map.has(p_theme_type)) {
+		return;
+	}
+
+	const StringName *key = nullptr;
+
+	while ((key = font_size_map[p_theme_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::add_font_size_type(const StringName &p_theme_type) {
+	if (font_size_map.has(p_theme_type)) {
+		return;
+	}
+	font_size_map[p_theme_type] = HashMap<StringName, int>();
+}
+
+void Theme::get_font_size_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = font_size_map.next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+// Colors.
+void Theme::set_color(const StringName &p_name, const StringName &p_theme_type, const Color &p_color) {
+	color_map[p_theme_type][p_name] = p_color;
+
+	_emit_theme_changed();
+}
+
+Color Theme::get_color(const StringName &p_name, const StringName &p_theme_type) const {
+	if (color_map.has(p_theme_type) && color_map[p_theme_type].has(p_name)) {
+		return color_map[p_theme_type][p_name];
+	} else {
+		return Color();
+	}
+}
+
+bool Theme::has_color(const StringName &p_name, const StringName &p_theme_type) const {
+	return (color_map.has(p_theme_type) && color_map[p_theme_type].has(p_name));
+}
+
+bool Theme::has_color_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
+	return (color_map.has(p_theme_type) && color_map[p_theme_type].has(p_name));
+}
+
+void Theme::rename_color(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!color_map.has(p_theme_type), "Cannot rename the color '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(color_map[p_theme_type].has(p_name), "Cannot rename the color '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!color_map[p_theme_type].has(p_old_name), "Cannot rename the color '" + String(p_old_name) + "' because it does not exist.");
+
+	color_map[p_theme_type][p_name] = color_map[p_theme_type][p_old_name];
+	color_map[p_theme_type].erase(p_old_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::clear_color(const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!color_map.has(p_theme_type), "Cannot clear the color '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!color_map[p_theme_type].has(p_name), "Cannot clear the color '" + String(p_name) + "' because it does not exist.");
+
+	color_map[p_theme_type].erase(p_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::get_color_list(StringName p_theme_type, List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	if (!color_map.has(p_theme_type)) {
+		return;
+	}
+
+	const StringName *key = nullptr;
+
+	while ((key = color_map[p_theme_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::add_color_type(const StringName &p_theme_type) {
+	if (color_map.has(p_theme_type)) {
+		return;
+	}
+	color_map[p_theme_type] = HashMap<StringName, Color>();
+}
+
+void Theme::get_color_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = color_map.next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+// Theme constants.
+void Theme::set_constant(const StringName &p_name, const StringName &p_theme_type, int p_constant) {
+	constant_map[p_theme_type][p_name] = p_constant;
+
+	_emit_theme_changed();
+}
+
+int Theme::get_constant(const StringName &p_name, const StringName &p_theme_type) const {
+	if (constant_map.has(p_theme_type) && constant_map[p_theme_type].has(p_name)) {
+		return constant_map[p_theme_type][p_name];
+	} else {
+		return 0;
+	}
+}
+
+bool Theme::has_constant(const StringName &p_name, const StringName &p_theme_type) const {
+	return (constant_map.has(p_theme_type) && constant_map[p_theme_type].has(p_name));
+}
+
+bool Theme::has_constant_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
+	return (constant_map.has(p_theme_type) && constant_map[p_theme_type].has(p_name));
+}
+
+void Theme::rename_constant(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!constant_map.has(p_theme_type), "Cannot rename the constant '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(constant_map[p_theme_type].has(p_name), "Cannot rename the constant '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!constant_map[p_theme_type].has(p_old_name), "Cannot rename the constant '" + String(p_old_name) + "' because it does not exist.");
+
+	constant_map[p_theme_type][p_name] = constant_map[p_theme_type][p_old_name];
+	constant_map[p_theme_type].erase(p_old_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::clear_constant(const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!constant_map.has(p_theme_type), "Cannot clear the constant '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!constant_map[p_theme_type].has(p_name), "Cannot clear the constant '" + String(p_name) + "' because it does not exist.");
+
+	constant_map[p_theme_type].erase(p_name);
+
+	_emit_theme_changed();
+}
+
+void Theme::get_constant_list(StringName p_theme_type, List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	if (!constant_map.has(p_theme_type)) {
+		return;
+	}
+
+	const StringName *key = nullptr;
+
+	while ((key = constant_map[p_theme_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::add_constant_type(const StringName &p_theme_type) {
+	if (constant_map.has(p_theme_type)) {
+		return;
+	}
+	constant_map[p_theme_type] = HashMap<StringName, int>();
+}
+
+void Theme::get_constant_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = constant_map.next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+// Generic methods for managing theme items.
+void Theme::set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type, const Variant &p_value) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::COLOR, "Theme item's data type (Color) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Color color_value = p_value;
+			set_color(p_name, p_theme_type, color_value);
+		} break;
+		case DATA_TYPE_CONSTANT: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::INT, "Theme item's data type (int) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			int constant_value = p_value;
+			set_constant(p_name, p_theme_type, constant_value);
+		} break;
+		case DATA_TYPE_FONT: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<Font> font_value = Object::cast_to<Font>(p_value.get_validated_object());
+			set_font(p_name, p_theme_type, font_value);
+		} break;
+		case DATA_TYPE_FONT_SIZE: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::INT, "Theme item's data type (int) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			int font_size_value = p_value;
+			set_font_size(p_name, p_theme_type, font_size_value);
+		} break;
+		case DATA_TYPE_ICON: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<Texture2D> icon_value = Object::cast_to<Texture2D>(p_value.get_validated_object());
+			set_icon(p_name, p_theme_type, icon_value);
+		} break;
+		case DATA_TYPE_STYLEBOX: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<StyleBox> stylebox_value = Object::cast_to<StyleBox>(p_value.get_validated_object());
+			set_stylebox(p_name, p_theme_type, stylebox_value);
+		} break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+Variant Theme::get_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return get_color(p_name, p_theme_type);
+		case DATA_TYPE_CONSTANT:
+			return get_constant(p_name, p_theme_type);
+		case DATA_TYPE_FONT:
+			return get_font(p_name, p_theme_type);
+		case DATA_TYPE_FONT_SIZE:
+			return get_font_size(p_name, p_theme_type);
+		case DATA_TYPE_ICON:
+			return get_icon(p_name, p_theme_type);
+		case DATA_TYPE_STYLEBOX:
+			return get_stylebox(p_name, p_theme_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return Variant();
+}
+
+bool Theme::has_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return has_color(p_name, p_theme_type);
+		case DATA_TYPE_CONSTANT:
+			return has_constant(p_name, p_theme_type);
+		case DATA_TYPE_FONT:
+			return has_font(p_name, p_theme_type);
+		case DATA_TYPE_FONT_SIZE:
+			return has_font_size(p_name, p_theme_type);
+		case DATA_TYPE_ICON:
+			return has_icon(p_name, p_theme_type);
+		case DATA_TYPE_STYLEBOX:
+			return has_stylebox(p_name, p_theme_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return false;
+}
+
+bool Theme::has_theme_item_nocheck(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return has_color_nocheck(p_name, p_theme_type);
+		case DATA_TYPE_CONSTANT:
+			return has_constant_nocheck(p_name, p_theme_type);
+		case DATA_TYPE_FONT:
+			return has_font_nocheck(p_name, p_theme_type);
+		case DATA_TYPE_FONT_SIZE:
+			return has_font_size_nocheck(p_name, p_theme_type);
+		case DATA_TYPE_ICON:
+			return has_icon_nocheck(p_name, p_theme_type);
+		case DATA_TYPE_STYLEBOX:
+			return has_stylebox_nocheck(p_name, p_theme_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return false;
+}
+
+void Theme::rename_theme_item(DataType p_data_type, const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			rename_color(p_old_name, p_name, p_theme_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			rename_constant(p_old_name, p_name, p_theme_type);
+			break;
+		case DATA_TYPE_FONT:
+			rename_font(p_old_name, p_name, p_theme_type);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			rename_font_size(p_old_name, p_name, p_theme_type);
+			break;
+		case DATA_TYPE_ICON:
+			rename_icon(p_old_name, p_name, p_theme_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			rename_stylebox(p_old_name, p_name, p_theme_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::clear_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			clear_color(p_name, p_theme_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			clear_constant(p_name, p_theme_type);
+			break;
+		case DATA_TYPE_FONT:
+			clear_font(p_name, p_theme_type);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			clear_font_size(p_name, p_theme_type);
+			break;
+		case DATA_TYPE_ICON:
+			clear_icon(p_name, p_theme_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			clear_stylebox(p_name, p_theme_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::get_theme_item_list(DataType p_data_type, StringName p_theme_type, List<StringName> *p_list) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			get_color_list(p_theme_type, p_list);
+			break;
+		case DATA_TYPE_CONSTANT:
+			get_constant_list(p_theme_type, p_list);
+			break;
+		case DATA_TYPE_FONT:
+			get_font_list(p_theme_type, p_list);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			get_font_size_list(p_theme_type, p_list);
+			break;
+		case DATA_TYPE_ICON:
+			get_icon_list(p_theme_type, p_list);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			get_stylebox_list(p_theme_type, p_list);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::add_theme_item_type(DataType p_data_type, const StringName &p_theme_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			add_color_type(p_theme_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			add_constant_type(p_theme_type);
+			break;
+		case DATA_TYPE_FONT:
+			add_font_type(p_theme_type);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			add_font_size_type(p_theme_type);
+			break;
+		case DATA_TYPE_ICON:
+			add_icon_type(p_theme_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			add_stylebox_type(p_theme_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::get_theme_item_type_list(DataType p_data_type, List<StringName> *p_list) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			get_color_type_list(p_list);
+			break;
+		case DATA_TYPE_CONSTANT:
+			get_constant_type_list(p_list);
+			break;
+		case DATA_TYPE_FONT:
+			get_font_type_list(p_list);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			get_font_size_type_list(p_list);
+			break;
+		case DATA_TYPE_ICON:
+			get_icon_type_list(p_list);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			get_stylebox_type_list(p_list);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+// Theme type variations.
+void Theme::set_type_variation(const StringName &p_theme_type, const StringName &p_base_type) {
+	ERR_FAIL_COND_MSG(p_theme_type == StringName(), "An empty theme type cannot be marked as a variation of another type.");
+	ERR_FAIL_COND_MSG(ClassDB::class_exists(p_theme_type), "A type associated with a built-in class cannot be marked as a variation of another type.");
+	ERR_FAIL_COND_MSG(p_base_type == StringName(), "An empty theme type cannot be the base type of a variation. Use clear_type_variation() instead if you want to unmark '" + String(p_theme_type) + "' as a variation.");
+
+	if (variation_map.has(p_theme_type)) {
+		StringName old_base = variation_map[p_theme_type];
+		variation_base_map[old_base].erase(p_theme_type);
+	}
+
+	variation_map[p_theme_type] = p_base_type;
+	variation_base_map[p_base_type].push_back(p_theme_type);
+
+	_emit_theme_changed();
+}
+
+bool Theme::is_type_variation(const StringName &p_theme_type, const StringName &p_base_type) const {
+	return (variation_map.has(p_theme_type) && variation_map[p_theme_type] == p_base_type);
+}
+
+void Theme::clear_type_variation(const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!variation_map.has(p_theme_type), "Cannot clear the type variation '" + String(p_theme_type) + "' because it does not exist.");
+
+	StringName base_type = variation_map[p_theme_type];
+	variation_base_map[base_type].erase(p_theme_type);
+	variation_map.erase(p_theme_type);
+
+	_emit_theme_changed();
+}
+
+StringName Theme::get_type_variation_base(const StringName &p_theme_type) const {
+	if (!variation_map.has(p_theme_type)) {
+		return StringName();
+	}
+
+	return variation_map[p_theme_type];
+}
+
+void Theme::get_type_variation_list(const StringName &p_base_type, List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	if (!variation_base_map.has(p_base_type)) {
+		return;
+	}
+
+	for (const StringName &E : variation_base_map[p_base_type]) {
+		// Prevent infinite loops if variants were set to be cross-dependent (that's still invalid usage, but handling for stability sake).
+		if (p_list->find(E)) {
+			continue;
+		}
+
+		p_list->push_back(E);
+		// Continue looking for sub-variations.
+		get_type_variation_list(E, p_list);
+	}
+}
+
+// Theme types.
+void Theme::get_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	Set<StringName> types;
+	const StringName *key = nullptr;
+
+	// Icons.
+	while ((key = icon_map.next(key))) {
+		types.insert(*key);
+	}
+
+	key = nullptr;
+
+	// StyleBoxes.
+	while ((key = style_map.next(key))) {
+		types.insert(*key);
+	}
+
+	key = nullptr;
+
+	// Fonts.
+	while ((key = font_map.next(key))) {
+		types.insert(*key);
+	}
+
+	key = nullptr;
+
+	// Font sizes.
+	while ((key = font_size_map.next(key))) {
+		types.insert(*key);
+	}
+
+	key = nullptr;
+
+	// Colors.
+	while ((key = color_map.next(key))) {
+		types.insert(*key);
+	}
+
+	key = nullptr;
+
+	// Constants.
+	while ((key = constant_map.next(key))) {
+		types.insert(*key);
+	}
+
+	for (Set<StringName>::Element *E = types.front(); E; E = E->next()) {
+		p_list->push_back(E->get());
+	}
+}
+
+void Theme::get_type_dependencies(const StringName &p_base_type, const StringName &p_type_variation, List<StringName> *p_list) {
+	ERR_FAIL_NULL(p_list);
+
+	// Build the dependency chain for type variations.
+	if (p_type_variation != StringName()) {
+		StringName variation_name = p_type_variation;
+		while (variation_name != StringName()) {
+			p_list->push_back(variation_name);
+			variation_name = get_type_variation_base(variation_name);
+
+			// If we have reached the base type dependency, it's safe to stop (assuming no funny business was done to the Theme).
+			if (variation_name == p_base_type) {
+				break;
+			}
+		}
+	}
+
+	// Continue building the chain using native class hierarchy.
+	StringName class_name = p_base_type;
+	while (class_name != StringName()) {
+		p_list->push_back(class_name);
+		class_name = ClassDB::get_parent_class_nocheck(class_name);
+	}
+}
+
+// Internal methods for getting lists as a Vector of String (compatible with public API).
 Vector<String> Theme::_get_icon_list(const String &p_theme_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
@@ -293,998 +1370,14 @@ Vector<String> Theme::_get_type_list() const {
 	return ilret;
 }
 
-bool Theme::_set(const StringName &p_name, const Variant &p_value) {
-	String sname = p_name;
-
-	if (sname.find("/") != -1) {
-		String type = sname.get_slicec('/', 1);
-		String theme_type = sname.get_slicec('/', 0);
-		String name = sname.get_slicec('/', 2);
-
-		if (type == "icons") {
-			set_icon(name, theme_type, p_value);
-		} else if (type == "styles") {
-			set_stylebox(name, theme_type, p_value);
-		} else if (type == "fonts") {
-			set_font(name, theme_type, p_value);
-		} else if (type == "font_sizes") {
-			set_font_size(name, theme_type, p_value);
-		} else if (type == "colors") {
-			set_color(name, theme_type, p_value);
-		} else if (type == "constants") {
-			set_constant(name, theme_type, p_value);
-		} else if (type == "base_type") {
-			set_type_variation(theme_type, p_value);
-		} else {
-			return false;
-		}
-
-		return true;
-	}
-
-	return false;
-}
-
-bool Theme::_get(const StringName &p_name, Variant &r_ret) const {
-	String sname = p_name;
-
-	if (sname.find("/") != -1) {
-		String type = sname.get_slicec('/', 1);
-		String theme_type = sname.get_slicec('/', 0);
-		String name = sname.get_slicec('/', 2);
-
-		if (type == "icons") {
-			if (!has_icon(name, theme_type)) {
-				r_ret = Ref<Texture2D>();
-			} else {
-				r_ret = get_icon(name, theme_type);
-			}
-		} else if (type == "styles") {
-			if (!has_stylebox(name, theme_type)) {
-				r_ret = Ref<StyleBox>();
-			} else {
-				r_ret = get_stylebox(name, theme_type);
-			}
-		} else if (type == "fonts") {
-			if (!has_font(name, theme_type)) {
-				r_ret = Ref<Font>();
-			} else {
-				r_ret = get_font(name, theme_type);
-			}
-		} else if (type == "font_sizes") {
-			r_ret = get_font_size(name, theme_type);
-		} else if (type == "colors") {
-			r_ret = get_color(name, theme_type);
-		} else if (type == "constants") {
-			r_ret = get_constant(name, theme_type);
-		} else if (type == "base_type") {
-			r_ret = get_type_variation_base(theme_type);
-		} else {
-			return false;
-		}
-
-		return true;
-	}
-
-	return false;
-}
-
-void Theme::_get_property_list(List<PropertyInfo> *p_list) const {
-	List<PropertyInfo> list;
-
-	const StringName *key = nullptr;
-
-	// Type variations.
-	while ((key = variation_map.next(key))) {
-		list.push_back(PropertyInfo(Variant::STRING_NAME, String() + *key + "/base_type"));
-	}
-
-	key = nullptr;
-
-	// Icons.
-	while ((key = icon_map.next(key))) {
-		const StringName *key2 = nullptr;
-
-		while ((key2 = icon_map[*key].next(key2))) {
-			list.push_back(PropertyInfo(Variant::OBJECT, String() + *key + "/icons/" + *key2, PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
-		}
-	}
-
-	key = nullptr;
-
-	// Styles.
-	while ((key = style_map.next(key))) {
-		const StringName *key2 = nullptr;
-
-		while ((key2 = style_map[*key].next(key2))) {
-			list.push_back(PropertyInfo(Variant::OBJECT, String() + *key + "/styles/" + *key2, PROPERTY_HINT_RESOURCE_TYPE, "StyleBox", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
-		}
-	}
-
-	key = nullptr;
-
-	// Fonts.
-	while ((key = font_map.next(key))) {
-		const StringName *key2 = nullptr;
-
-		while ((key2 = font_map[*key].next(key2))) {
-			list.push_back(PropertyInfo(Variant::OBJECT, String() + *key + "/fonts/" + *key2, PROPERTY_HINT_RESOURCE_TYPE, "Font", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
-		}
-	}
-
-	key = nullptr;
-
-	// Font sizes.
-	while ((key = font_size_map.next(key))) {
-		const StringName *key2 = nullptr;
-
-		while ((key2 = font_size_map[*key].next(key2))) {
-			list.push_back(PropertyInfo(Variant::INT, String() + *key + "/font_sizes/" + *key2));
-		}
-	}
-
-	key = nullptr;
-
-	// Colors.
-	while ((key = color_map.next(key))) {
-		const StringName *key2 = nullptr;
-
-		while ((key2 = color_map[*key].next(key2))) {
-			list.push_back(PropertyInfo(Variant::COLOR, String() + *key + "/colors/" + *key2));
-		}
-	}
-
-	key = nullptr;
-
-	// Constants.
-	while ((key = constant_map.next(key))) {
-		const StringName *key2 = nullptr;
-
-		while ((key2 = constant_map[*key].next(key2))) {
-			list.push_back(PropertyInfo(Variant::INT, String() + *key + "/constants/" + *key2));
-		}
-	}
-
-	// Sort and store properties.
-	list.sort();
-	for (const PropertyInfo &E : list) {
-		p_list->push_back(E);
-	}
-}
-
-void Theme::set_default_theme_font(const Ref<Font> &p_default_font) {
-	if (default_theme_font == p_default_font) {
+// Theme bulk manipulations.
+void Theme::_emit_theme_changed() {
+	if (no_change_propagation) {
 		return;
 	}
 
-	if (default_theme_font.is_valid()) {
-		default_theme_font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-	}
-
-	default_theme_font = p_default_font;
-
-	if (default_theme_font.is_valid()) {
-		default_theme_font->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
-	}
-
-	_emit_theme_changed();
-}
-
-Ref<Font> Theme::get_default_theme_font() const {
-	return default_theme_font;
-}
-
-void Theme::set_default_theme_font_size(int p_font_size) {
-	if (default_theme_font_size == p_font_size) {
-		return;
-	}
-
-	default_theme_font_size = p_font_size;
-
-	_emit_theme_changed();
-}
-
-int Theme::get_default_theme_font_size() const {
-	return default_theme_font_size;
-}
-
-Ref<Theme> Theme::project_default_theme;
-Ref<Theme> Theme::default_theme;
-Ref<Texture2D> Theme::default_icon;
-Ref<StyleBox> Theme::default_style;
-Ref<Font> Theme::default_font;
-int Theme::default_font_size = 16;
-
-Ref<Theme> Theme::get_default() {
-	return default_theme;
-}
-
-void Theme::set_default(const Ref<Theme> &p_default) {
-	default_theme = p_default;
-}
-
-Ref<Theme> Theme::get_project_default() {
-	return project_default_theme;
-}
-
-void Theme::set_project_default(const Ref<Theme> &p_project_default) {
-	project_default_theme = p_project_default;
-}
-
-void Theme::set_default_icon(const Ref<Texture2D> &p_icon) {
-	default_icon = p_icon;
-}
-
-void Theme::set_default_style(const Ref<StyleBox> &p_style) {
-	default_style = p_style;
-}
-
-void Theme::set_default_font(const Ref<Font> &p_font) {
-	default_font = p_font;
-}
-
-void Theme::set_default_font_size(int p_font_size) {
-	default_font_size = p_font_size;
-}
-
-void Theme::set_icon(const StringName &p_name, const StringName &p_theme_type, const Ref<Texture2D> &p_icon) {
-	if (icon_map[p_theme_type].has(p_name) && icon_map[p_theme_type][p_name].is_valid()) {
-		icon_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-	}
-
-	icon_map[p_theme_type][p_name] = p_icon;
-
-	if (p_icon.is_valid()) {
-		icon_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
-	}
-
-	_emit_theme_changed();
-}
-
-Ref<Texture2D> Theme::get_icon(const StringName &p_name, const StringName &p_theme_type) const {
-	if (icon_map.has(p_theme_type) && icon_map[p_theme_type].has(p_name) && icon_map[p_theme_type][p_name].is_valid()) {
-		return icon_map[p_theme_type][p_name];
-	} else {
-		return default_icon;
-	}
-}
-
-bool Theme::has_icon(const StringName &p_name, const StringName &p_theme_type) const {
-	return (icon_map.has(p_theme_type) && icon_map[p_theme_type].has(p_name) && icon_map[p_theme_type][p_name].is_valid());
-}
-
-bool Theme::has_icon_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
-	return (icon_map.has(p_theme_type) && icon_map[p_theme_type].has(p_name));
-}
-
-void Theme::rename_icon(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!icon_map.has(p_theme_type), "Cannot rename the icon '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(icon_map[p_theme_type].has(p_name), "Cannot rename the icon '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
-	ERR_FAIL_COND_MSG(!icon_map[p_theme_type].has(p_old_name), "Cannot rename the icon '" + String(p_old_name) + "' because it does not exist.");
-
-	icon_map[p_theme_type][p_name] = icon_map[p_theme_type][p_old_name];
-	icon_map[p_theme_type].erase(p_old_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::clear_icon(const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!icon_map.has(p_theme_type), "Cannot clear the icon '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(!icon_map[p_theme_type].has(p_name), "Cannot clear the icon '" + String(p_name) + "' because it does not exist.");
-
-	if (icon_map[p_theme_type][p_name].is_valid()) {
-		icon_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-	}
-
-	icon_map[p_theme_type].erase(p_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::get_icon_list(StringName p_theme_type, List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	if (!icon_map.has(p_theme_type)) {
-		return;
-	}
-
-	const StringName *key = nullptr;
-
-	while ((key = icon_map[p_theme_type].next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::add_icon_type(const StringName &p_theme_type) {
-	if (icon_map.has(p_theme_type)) {
-		return;
-	}
-	icon_map[p_theme_type] = HashMap<StringName, Ref<Texture2D>>();
-}
-
-void Theme::get_icon_type_list(List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	const StringName *key = nullptr;
-	while ((key = icon_map.next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::set_stylebox(const StringName &p_name, const StringName &p_theme_type, const Ref<StyleBox> &p_style) {
-	if (style_map[p_theme_type].has(p_name) && style_map[p_theme_type][p_name].is_valid()) {
-		style_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-	}
-
-	style_map[p_theme_type][p_name] = p_style;
-
-	if (p_style.is_valid()) {
-		style_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
-	}
-
-	_emit_theme_changed();
-}
-
-Ref<StyleBox> Theme::get_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
-	if (style_map.has(p_theme_type) && style_map[p_theme_type].has(p_name) && style_map[p_theme_type][p_name].is_valid()) {
-		return style_map[p_theme_type][p_name];
-	} else {
-		return default_style;
-	}
-}
-
-bool Theme::has_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
-	return (style_map.has(p_theme_type) && style_map[p_theme_type].has(p_name) && style_map[p_theme_type][p_name].is_valid());
-}
-
-bool Theme::has_stylebox_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
-	return (style_map.has(p_theme_type) && style_map[p_theme_type].has(p_name));
-}
-
-void Theme::rename_stylebox(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!style_map.has(p_theme_type), "Cannot rename the stylebox '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(style_map[p_theme_type].has(p_name), "Cannot rename the stylebox '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
-	ERR_FAIL_COND_MSG(!style_map[p_theme_type].has(p_old_name), "Cannot rename the stylebox '" + String(p_old_name) + "' because it does not exist.");
-
-	style_map[p_theme_type][p_name] = style_map[p_theme_type][p_old_name];
-	style_map[p_theme_type].erase(p_old_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::clear_stylebox(const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!style_map.has(p_theme_type), "Cannot clear the stylebox '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(!style_map[p_theme_type].has(p_name), "Cannot clear the stylebox '" + String(p_name) + "' because it does not exist.");
-
-	if (style_map[p_theme_type][p_name].is_valid()) {
-		style_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-	}
-
-	style_map[p_theme_type].erase(p_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::get_stylebox_list(StringName p_theme_type, List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	if (!style_map.has(p_theme_type)) {
-		return;
-	}
-
-	const StringName *key = nullptr;
-
-	while ((key = style_map[p_theme_type].next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::add_stylebox_type(const StringName &p_theme_type) {
-	if (style_map.has(p_theme_type)) {
-		return;
-	}
-	style_map[p_theme_type] = HashMap<StringName, Ref<StyleBox>>();
-}
-
-void Theme::get_stylebox_type_list(List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	const StringName *key = nullptr;
-	while ((key = style_map.next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::set_font(const StringName &p_name, const StringName &p_theme_type, const Ref<Font> &p_font) {
-	if (font_map[p_theme_type][p_name].is_valid()) {
-		font_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-	}
-
-	font_map[p_theme_type][p_name] = p_font;
-
-	if (p_font.is_valid()) {
-		font_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
-	}
-
-	_emit_theme_changed();
-}
-
-Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_theme_type) const {
-	if (font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) {
-		return font_map[p_theme_type][p_name];
-	} else if (default_theme_font.is_valid()) {
-		return default_theme_font;
-	} else {
-		return default_font;
-	}
-}
-
-bool Theme::has_font(const StringName &p_name, const StringName &p_theme_type) const {
-	return ((font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) || default_theme_font.is_valid());
-}
-
-bool Theme::has_font_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
-	return (font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name));
-}
-
-void Theme::rename_font(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!font_map.has(p_theme_type), "Cannot rename the font '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(font_map[p_theme_type].has(p_name), "Cannot rename the font '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
-	ERR_FAIL_COND_MSG(!font_map[p_theme_type].has(p_old_name), "Cannot rename the font '" + String(p_old_name) + "' because it does not exist.");
-
-	font_map[p_theme_type][p_name] = font_map[p_theme_type][p_old_name];
-	font_map[p_theme_type].erase(p_old_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::clear_font(const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!font_map.has(p_theme_type), "Cannot clear the font '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(!font_map[p_theme_type].has(p_name), "Cannot clear the font '" + String(p_name) + "' because it does not exist.");
-
-	if (font_map[p_theme_type][p_name].is_valid()) {
-		font_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-	}
-
-	font_map[p_theme_type].erase(p_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::get_font_list(StringName p_theme_type, List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	if (!font_map.has(p_theme_type)) {
-		return;
-	}
-
-	const StringName *key = nullptr;
-
-	while ((key = font_map[p_theme_type].next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::add_font_type(const StringName &p_theme_type) {
-	if (font_map.has(p_theme_type)) {
-		return;
-	}
-	font_map[p_theme_type] = HashMap<StringName, Ref<Font>>();
-}
-
-void Theme::get_font_type_list(List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	const StringName *key = nullptr;
-	while ((key = font_map.next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::set_font_size(const StringName &p_name, const StringName &p_theme_type, int p_font_size) {
-	font_size_map[p_theme_type][p_name] = p_font_size;
-
-	_emit_theme_changed();
-}
-
-int Theme::get_font_size(const StringName &p_name, const StringName &p_theme_type) const {
-	if (font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) {
-		return font_size_map[p_theme_type][p_name];
-	} else if (default_theme_font_size > 0) {
-		return default_theme_font_size;
-	} else {
-		return default_font_size;
-	}
-}
-
-bool Theme::has_font_size(const StringName &p_name, const StringName &p_theme_type) const {
-	return ((font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) || (default_theme_font_size > 0));
-}
-
-bool Theme::has_font_size_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
-	return (font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name));
-}
-
-void Theme::rename_font_size(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!font_size_map.has(p_theme_type), "Cannot rename the font size '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(font_size_map[p_theme_type].has(p_name), "Cannot rename the font size '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
-	ERR_FAIL_COND_MSG(!font_size_map[p_theme_type].has(p_old_name), "Cannot rename the font size '" + String(p_old_name) + "' because it does not exist.");
-
-	font_size_map[p_theme_type][p_name] = font_size_map[p_theme_type][p_old_name];
-	font_size_map[p_theme_type].erase(p_old_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::clear_font_size(const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!font_size_map.has(p_theme_type), "Cannot clear the font size '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(!font_size_map[p_theme_type].has(p_name), "Cannot clear the font size '" + String(p_name) + "' because it does not exist.");
-
-	font_size_map[p_theme_type].erase(p_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::get_font_size_list(StringName p_theme_type, List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	if (!font_size_map.has(p_theme_type)) {
-		return;
-	}
-
-	const StringName *key = nullptr;
-
-	while ((key = font_size_map[p_theme_type].next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::add_font_size_type(const StringName &p_theme_type) {
-	if (font_size_map.has(p_theme_type)) {
-		return;
-	}
-	font_size_map[p_theme_type] = HashMap<StringName, int>();
-}
-
-void Theme::get_font_size_type_list(List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	const StringName *key = nullptr;
-	while ((key = font_size_map.next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::set_color(const StringName &p_name, const StringName &p_theme_type, const Color &p_color) {
-	color_map[p_theme_type][p_name] = p_color;
-
-	_emit_theme_changed();
-}
-
-Color Theme::get_color(const StringName &p_name, const StringName &p_theme_type) const {
-	if (color_map.has(p_theme_type) && color_map[p_theme_type].has(p_name)) {
-		return color_map[p_theme_type][p_name];
-	} else {
-		return Color();
-	}
-}
-
-bool Theme::has_color(const StringName &p_name, const StringName &p_theme_type) const {
-	return (color_map.has(p_theme_type) && color_map[p_theme_type].has(p_name));
-}
-
-bool Theme::has_color_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
-	return (color_map.has(p_theme_type) && color_map[p_theme_type].has(p_name));
-}
-
-void Theme::rename_color(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!color_map.has(p_theme_type), "Cannot rename the color '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(color_map[p_theme_type].has(p_name), "Cannot rename the color '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
-	ERR_FAIL_COND_MSG(!color_map[p_theme_type].has(p_old_name), "Cannot rename the color '" + String(p_old_name) + "' because it does not exist.");
-
-	color_map[p_theme_type][p_name] = color_map[p_theme_type][p_old_name];
-	color_map[p_theme_type].erase(p_old_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::clear_color(const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!color_map.has(p_theme_type), "Cannot clear the color '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(!color_map[p_theme_type].has(p_name), "Cannot clear the color '" + String(p_name) + "' because it does not exist.");
-
-	color_map[p_theme_type].erase(p_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::get_color_list(StringName p_theme_type, List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	if (!color_map.has(p_theme_type)) {
-		return;
-	}
-
-	const StringName *key = nullptr;
-
-	while ((key = color_map[p_theme_type].next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::add_color_type(const StringName &p_theme_type) {
-	if (color_map.has(p_theme_type)) {
-		return;
-	}
-	color_map[p_theme_type] = HashMap<StringName, Color>();
-}
-
-void Theme::get_color_type_list(List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	const StringName *key = nullptr;
-	while ((key = color_map.next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::set_constant(const StringName &p_name, const StringName &p_theme_type, int p_constant) {
-	constant_map[p_theme_type][p_name] = p_constant;
-
-	_emit_theme_changed();
-}
-
-int Theme::get_constant(const StringName &p_name, const StringName &p_theme_type) const {
-	if (constant_map.has(p_theme_type) && constant_map[p_theme_type].has(p_name)) {
-		return constant_map[p_theme_type][p_name];
-	} else {
-		return 0;
-	}
-}
-
-bool Theme::has_constant(const StringName &p_name, const StringName &p_theme_type) const {
-	return (constant_map.has(p_theme_type) && constant_map[p_theme_type].has(p_name));
-}
-
-bool Theme::has_constant_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
-	return (constant_map.has(p_theme_type) && constant_map[p_theme_type].has(p_name));
-}
-
-void Theme::rename_constant(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!constant_map.has(p_theme_type), "Cannot rename the constant '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(constant_map[p_theme_type].has(p_name), "Cannot rename the constant '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
-	ERR_FAIL_COND_MSG(!constant_map[p_theme_type].has(p_old_name), "Cannot rename the constant '" + String(p_old_name) + "' because it does not exist.");
-
-	constant_map[p_theme_type][p_name] = constant_map[p_theme_type][p_old_name];
-	constant_map[p_theme_type].erase(p_old_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::clear_constant(const StringName &p_name, const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!constant_map.has(p_theme_type), "Cannot clear the constant '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
-	ERR_FAIL_COND_MSG(!constant_map[p_theme_type].has(p_name), "Cannot clear the constant '" + String(p_name) + "' because it does not exist.");
-
-	constant_map[p_theme_type].erase(p_name);
-
-	_emit_theme_changed();
-}
-
-void Theme::get_constant_list(StringName p_theme_type, List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	if (!constant_map.has(p_theme_type)) {
-		return;
-	}
-
-	const StringName *key = nullptr;
-
-	while ((key = constant_map[p_theme_type].next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::add_constant_type(const StringName &p_theme_type) {
-	if (constant_map.has(p_theme_type)) {
-		return;
-	}
-	constant_map[p_theme_type] = HashMap<StringName, int>();
-}
-
-void Theme::get_constant_type_list(List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	const StringName *key = nullptr;
-	while ((key = constant_map.next(key))) {
-		p_list->push_back(*key);
-	}
-}
-
-void Theme::set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type, const Variant &p_value) {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR: {
-			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::COLOR, "Theme item's data type (Color) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
-
-			Color color_value = p_value;
-			set_color(p_name, p_theme_type, color_value);
-		} break;
-		case DATA_TYPE_CONSTANT: {
-			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::INT, "Theme item's data type (int) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
-
-			int constant_value = p_value;
-			set_constant(p_name, p_theme_type, constant_value);
-		} break;
-		case DATA_TYPE_FONT: {
-			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
-
-			Ref<Font> font_value = Object::cast_to<Font>(p_value.get_validated_object());
-			set_font(p_name, p_theme_type, font_value);
-		} break;
-		case DATA_TYPE_FONT_SIZE: {
-			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::INT, "Theme item's data type (int) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
-
-			int font_size_value = p_value;
-			set_font_size(p_name, p_theme_type, font_size_value);
-		} break;
-		case DATA_TYPE_ICON: {
-			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
-
-			Ref<Texture2D> icon_value = Object::cast_to<Texture2D>(p_value.get_validated_object());
-			set_icon(p_name, p_theme_type, icon_value);
-		} break;
-		case DATA_TYPE_STYLEBOX: {
-			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
-
-			Ref<StyleBox> stylebox_value = Object::cast_to<StyleBox>(p_value.get_validated_object());
-			set_stylebox(p_name, p_theme_type, stylebox_value);
-		} break;
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-}
-
-Variant Theme::get_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			return get_color(p_name, p_theme_type);
-		case DATA_TYPE_CONSTANT:
-			return get_constant(p_name, p_theme_type);
-		case DATA_TYPE_FONT:
-			return get_font(p_name, p_theme_type);
-		case DATA_TYPE_FONT_SIZE:
-			return get_font_size(p_name, p_theme_type);
-		case DATA_TYPE_ICON:
-			return get_icon(p_name, p_theme_type);
-		case DATA_TYPE_STYLEBOX:
-			return get_stylebox(p_name, p_theme_type);
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-
-	return Variant();
-}
-
-bool Theme::has_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			return has_color(p_name, p_theme_type);
-		case DATA_TYPE_CONSTANT:
-			return has_constant(p_name, p_theme_type);
-		case DATA_TYPE_FONT:
-			return has_font(p_name, p_theme_type);
-		case DATA_TYPE_FONT_SIZE:
-			return has_font_size(p_name, p_theme_type);
-		case DATA_TYPE_ICON:
-			return has_icon(p_name, p_theme_type);
-		case DATA_TYPE_STYLEBOX:
-			return has_stylebox(p_name, p_theme_type);
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-
-	return false;
-}
-
-bool Theme::has_theme_item_nocheck(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			return has_color_nocheck(p_name, p_theme_type);
-		case DATA_TYPE_CONSTANT:
-			return has_constant_nocheck(p_name, p_theme_type);
-		case DATA_TYPE_FONT:
-			return has_font_nocheck(p_name, p_theme_type);
-		case DATA_TYPE_FONT_SIZE:
-			return has_font_size_nocheck(p_name, p_theme_type);
-		case DATA_TYPE_ICON:
-			return has_icon_nocheck(p_name, p_theme_type);
-		case DATA_TYPE_STYLEBOX:
-			return has_stylebox_nocheck(p_name, p_theme_type);
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-
-	return false;
-}
-
-void Theme::rename_theme_item(DataType p_data_type, const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			rename_color(p_old_name, p_name, p_theme_type);
-			break;
-		case DATA_TYPE_CONSTANT:
-			rename_constant(p_old_name, p_name, p_theme_type);
-			break;
-		case DATA_TYPE_FONT:
-			rename_font(p_old_name, p_name, p_theme_type);
-			break;
-		case DATA_TYPE_FONT_SIZE:
-			rename_font_size(p_old_name, p_name, p_theme_type);
-			break;
-		case DATA_TYPE_ICON:
-			rename_icon(p_old_name, p_name, p_theme_type);
-			break;
-		case DATA_TYPE_STYLEBOX:
-			rename_stylebox(p_old_name, p_name, p_theme_type);
-			break;
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-}
-
-void Theme::clear_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			clear_color(p_name, p_theme_type);
-			break;
-		case DATA_TYPE_CONSTANT:
-			clear_constant(p_name, p_theme_type);
-			break;
-		case DATA_TYPE_FONT:
-			clear_font(p_name, p_theme_type);
-			break;
-		case DATA_TYPE_FONT_SIZE:
-			clear_font_size(p_name, p_theme_type);
-			break;
-		case DATA_TYPE_ICON:
-			clear_icon(p_name, p_theme_type);
-			break;
-		case DATA_TYPE_STYLEBOX:
-			clear_stylebox(p_name, p_theme_type);
-			break;
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-}
-
-void Theme::get_theme_item_list(DataType p_data_type, StringName p_theme_type, List<StringName> *p_list) const {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			get_color_list(p_theme_type, p_list);
-			break;
-		case DATA_TYPE_CONSTANT:
-			get_constant_list(p_theme_type, p_list);
-			break;
-		case DATA_TYPE_FONT:
-			get_font_list(p_theme_type, p_list);
-			break;
-		case DATA_TYPE_FONT_SIZE:
-			get_font_size_list(p_theme_type, p_list);
-			break;
-		case DATA_TYPE_ICON:
-			get_icon_list(p_theme_type, p_list);
-			break;
-		case DATA_TYPE_STYLEBOX:
-			get_stylebox_list(p_theme_type, p_list);
-			break;
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-}
-
-void Theme::add_theme_item_type(DataType p_data_type, const StringName &p_theme_type) {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			add_color_type(p_theme_type);
-			break;
-		case DATA_TYPE_CONSTANT:
-			add_constant_type(p_theme_type);
-			break;
-		case DATA_TYPE_FONT:
-			add_font_type(p_theme_type);
-			break;
-		case DATA_TYPE_FONT_SIZE:
-			add_font_size_type(p_theme_type);
-			break;
-		case DATA_TYPE_ICON:
-			add_icon_type(p_theme_type);
-			break;
-		case DATA_TYPE_STYLEBOX:
-			add_stylebox_type(p_theme_type);
-			break;
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-}
-
-void Theme::get_theme_item_type_list(DataType p_data_type, List<StringName> *p_list) const {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			get_color_type_list(p_list);
-			break;
-		case DATA_TYPE_CONSTANT:
-			get_constant_type_list(p_list);
-			break;
-		case DATA_TYPE_FONT:
-			get_font_type_list(p_list);
-			break;
-		case DATA_TYPE_FONT_SIZE:
-			get_font_size_type_list(p_list);
-			break;
-		case DATA_TYPE_ICON:
-			get_icon_type_list(p_list);
-			break;
-		case DATA_TYPE_STYLEBOX:
-			get_stylebox_type_list(p_list);
-			break;
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-}
-
-void Theme::set_type_variation(const StringName &p_theme_type, const StringName &p_base_type) {
-	ERR_FAIL_COND_MSG(p_theme_type == StringName(), "An empty theme type cannot be marked as a variation of another type.");
-	ERR_FAIL_COND_MSG(ClassDB::class_exists(p_theme_type), "A type associated with a built-in class cannot be marked as a variation of another type.");
-	ERR_FAIL_COND_MSG(p_base_type == StringName(), "An empty theme type cannot be the base type of a variation. Use clear_type_variation() instead if you want to unmark '" + String(p_theme_type) + "' as a variation.");
-
-	if (variation_map.has(p_theme_type)) {
-		StringName old_base = variation_map[p_theme_type];
-		variation_base_map[old_base].erase(p_theme_type);
-	}
-
-	variation_map[p_theme_type] = p_base_type;
-	variation_base_map[p_base_type].push_back(p_theme_type);
-
-	_emit_theme_changed();
-}
-
-bool Theme::is_type_variation(const StringName &p_theme_type, const StringName &p_base_type) const {
-	return (variation_map.has(p_theme_type) && variation_map[p_theme_type] == p_base_type);
-}
-
-void Theme::clear_type_variation(const StringName &p_theme_type) {
-	ERR_FAIL_COND_MSG(!variation_map.has(p_theme_type), "Cannot clear the type variation '" + String(p_theme_type) + "' because it does not exist.");
-
-	StringName base_type = variation_map[p_theme_type];
-	variation_base_map[base_type].erase(p_theme_type);
-	variation_map.erase(p_theme_type);
-
-	_emit_theme_changed();
-}
-
-StringName Theme::get_type_variation_base(const StringName &p_theme_type) const {
-	if (!variation_map.has(p_theme_type)) {
-		return StringName();
-	}
-
-	return variation_map[p_theme_type];
-}
-
-void Theme::get_type_variation_list(const StringName &p_base_type, List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	if (!variation_base_map.has(p_base_type)) {
-		return;
-	}
-
-	for (const StringName &E : variation_base_map[p_base_type]) {
-		// Prevent infinite loops if variants were set to be cross-dependent (that's still invalid usage, but handling for stability sake).
-		if (p_list->find(E)) {
-			continue;
-		}
-
-		p_list->push_back(E);
-		// Continue looking for sub-variations.
-		get_type_variation_list(E, p_list);
-	}
+	notify_property_list_changed();
+	emit_changed();
 }
 
 void Theme::_freeze_change_propagation() {
@@ -1293,60 +1386,6 @@ void Theme::_freeze_change_propagation() {
 
 void Theme::_unfreeze_and_propagate_changes() {
 	no_change_propagation = false;
-	_emit_theme_changed();
-}
-
-void Theme::clear() {
-	// These items need disconnecting.
-	{
-		const StringName *K = nullptr;
-		while ((K = icon_map.next(K))) {
-			const StringName *L = nullptr;
-			while ((L = icon_map[*K].next(L))) {
-				Ref<Texture2D> icon = icon_map[*K][*L];
-				if (icon.is_valid()) {
-					icon->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-				}
-			}
-		}
-	}
-
-	{
-		const StringName *K = nullptr;
-		while ((K = style_map.next(K))) {
-			const StringName *L = nullptr;
-			while ((L = style_map[*K].next(L))) {
-				Ref<StyleBox> style = style_map[*K][*L];
-				if (style.is_valid()) {
-					style->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-				}
-			}
-		}
-	}
-
-	{
-		const StringName *K = nullptr;
-		while ((K = font_map.next(K))) {
-			const StringName *L = nullptr;
-			while ((L = font_map[*K].next(L))) {
-				Ref<Font> font = font_map[*K][*L];
-				if (font.is_valid()) {
-					font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
-				}
-			}
-		}
-	}
-
-	icon_map.clear();
-	style_map.clear();
-	font_map.clear();
-	font_size_map.clear();
-	color_map.clear();
-	constant_map.clear();
-
-	variation_map.clear();
-	variation_base_map.clear();
-
 	_emit_theme_changed();
 }
 
@@ -1434,80 +1473,58 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 	_unfreeze_and_propagate_changes();
 }
 
-void Theme::get_type_list(List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	Set<StringName> types;
-	const StringName *key = nullptr;
-
-	// Icons.
-	while ((key = icon_map.next(key))) {
-		types.insert(*key);
-	}
-
-	key = nullptr;
-
-	// StyleBoxes.
-	while ((key = style_map.next(key))) {
-		types.insert(*key);
-	}
-
-	key = nullptr;
-
-	// Fonts.
-	while ((key = font_map.next(key))) {
-		types.insert(*key);
-	}
-
-	key = nullptr;
-
-	// Font sizes.
-	while ((key = font_size_map.next(key))) {
-		types.insert(*key);
-	}
-
-	key = nullptr;
-
-	// Colors.
-	while ((key = color_map.next(key))) {
-		types.insert(*key);
-	}
-
-	key = nullptr;
-
-	// Constants.
-	while ((key = constant_map.next(key))) {
-		types.insert(*key);
-	}
-
-	for (Set<StringName>::Element *E = types.front(); E; E = E->next()) {
-		p_list->push_back(E->get());
-	}
-}
-
-void Theme::get_type_dependencies(const StringName &p_base_type, const StringName &p_type_variation, List<StringName> *p_list) {
-	ERR_FAIL_NULL(p_list);
-
-	// Build the dependency chain for type variations.
-	if (p_type_variation != StringName()) {
-		StringName variation_name = p_type_variation;
-		while (variation_name != StringName()) {
-			p_list->push_back(variation_name);
-			variation_name = get_type_variation_base(variation_name);
-
-			// If we have reached the base type dependency, it's safe to stop (assuming no funny business was done to the Theme).
-			if (variation_name == p_base_type) {
-				break;
+void Theme::clear() {
+	// These items need disconnecting.
+	{
+		const StringName *K = nullptr;
+		while ((K = icon_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = icon_map[*K].next(L))) {
+				Ref<Texture2D> icon = icon_map[*K][*L];
+				if (icon.is_valid()) {
+					icon->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+				}
 			}
 		}
 	}
 
-	// Continue building the chain using native class hierarchy.
-	StringName class_name = p_base_type;
-	while (class_name != StringName()) {
-		p_list->push_back(class_name);
-		class_name = ClassDB::get_parent_class_nocheck(class_name);
+	{
+		const StringName *K = nullptr;
+		while ((K = style_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = style_map[*K].next(L))) {
+				Ref<StyleBox> style = style_map[*K][*L];
+				if (style.is_valid()) {
+					style->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+				}
+			}
+		}
 	}
+
+	{
+		const StringName *K = nullptr;
+		while ((K = font_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = font_map[*K].next(L))) {
+				Ref<Font> font = font_map[*K][*L];
+				if (font.is_valid()) {
+					font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+				}
+			}
+		}
+	}
+
+	icon_map.clear();
+	style_map.clear();
+	font_map.clear();
+	font_size_map.clear();
+	color_map.clear();
+	constant_map.clear();
+
+	variation_map.clear();
+	variation_base_map.clear();
+
+	_emit_theme_changed();
 }
 
 void Theme::reset_state() {

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -96,13 +96,17 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
-	static Ref<Theme> project_default_theme;
+	// Universal Theme resources used when no other theme has the item.
 	static Ref<Theme> default_theme;
+	static Ref<Theme> project_default_theme;
+
+	// Universal default values, final fallback for every theme.
 	static Ref<Texture2D> default_icon;
 	static Ref<StyleBox> default_style;
 	static Ref<Font> default_font;
 	static int default_font_size;
 
+	// Default values configurable for each individual theme.
 	Ref<Font> default_theme_font;
 	int default_theme_font_size = -1;
 

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -101,12 +101,14 @@ protected:
 	static Ref<Theme> project_default_theme;
 
 	// Universal default values, final fallback for every theme.
+	static float default_base_scale;
 	static Ref<Texture2D> default_icon;
 	static Ref<StyleBox> default_style;
 	static Ref<Font> default_font;
 	static int default_font_size;
 
 	// Default values configurable for each individual theme.
+	float default_theme_base_scale = 0.0;
 	Ref<Font> default_theme_font;
 	int default_theme_font_size = -1;
 
@@ -124,16 +126,23 @@ public:
 	static Ref<Theme> get_project_default();
 	static void set_project_default(const Ref<Theme> &p_project_default);
 
+	static void set_default_base_scale(float p_base_scale);
 	static void set_default_icon(const Ref<Texture2D> &p_icon);
 	static void set_default_style(const Ref<StyleBox> &p_style);
 	static void set_default_font(const Ref<Font> &p_font);
 	static void set_default_font_size(int p_font_size);
 
+	void set_default_theme_base_scale(float p_base_scale);
+	float get_default_theme_base_scale() const;
+	bool has_default_theme_base_scale() const;
+
 	void set_default_theme_font(const Ref<Font> &p_default_font);
 	Ref<Font> get_default_theme_font() const;
+	bool has_default_theme_font() const;
 
 	void set_default_theme_font_size(int p_font_size);
 	int get_default_theme_font_size() const;
+	bool has_default_theme_font_size() const;
 
 	void set_icon(const StringName &p_name, const StringName &p_theme_type, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_icon(const StringName &p_name, const StringName &p_theme_type) const;


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/53295#issuecomment-932203107. This PR is split into 3 commits for better readability of individual changes.

* First, I reorganized the `Theme` resource's code and added some grouping comments to better explain this huge file and what it consists of. It was a good base for the rest of the work done here. It shouldn't contain any changes to the code, but I removed one unused include.
* Second, I've added the base scale factor to the theme resource and exposed the necessary API for it, and for `Control` nodes to work with it. Here as well similar treatment was performed on default font and default font size of each theme to make them more usable from controls.
* Third, I've updated the GUI nodes which used `EDSCALE` to use theme's base scale factor instead. It was trivial for some, but not for everything. I've also removed it from one place (I'll leave "review" comments below for the interesting parts).

Overall, with 3 commits it should be easier to review it, because there are some moving parts in various places involved.

There may be some visible changes in the projects, as the base scale for the default theme now takes HiDPI into account, as that value was already available and in use for generating the theme. Now it's exposed as a Theme property and those same controls which previously used `EDSCALE` will also respect it in projects running on default theme.

This is breaking in its nature, so a 3.x port is unlikely. But I can make a dedicated 3.x PR to reorganize the theme resource for easier cherrypicks in future. Can probably expose the new default font methods too.

-----
Incidentally, I was in the area, so this fixes https://github.com/godotengine/godot/issues/36761 by superseding https://github.com/godotengine/godot/pull/37419. That PR wasn't updated after my review anyway, so this way we will be able to merge it quicker.