### PR TITLE
[3.x] Fix GDNativeLibrary::get_current_library_path()

### DIFF
--- a/modules/gdnative/gdnative.h
+++ b/modules/gdnative/gdnative.h
@@ -76,7 +76,7 @@ public:
 
 	// things that change per-platform
 	// so there are no setters for this
-	_FORCE_INLINE_ String get_current_library_path() const {
+	_FORCE_INLINE_ const String &get_current_library_path() const {
 		return current_library_path;
 	}
 	_FORCE_INLINE_ Vector<String> get_current_dependencies() const {


### PR DESCRIPTION
Return a const String reference to make sure that when its address
is used as a handle in NativeScriptLanguage::init_library(),
it refers to the heap instead of a temporary object on the stack.
