### PR TITLE
[3.x] Prevent out of bound access through 'm_nodes' in SoftBodyBullet

### DIFF
--- a/modules/bullet/soft_body_bullet.cpp
+++ b/modules/bullet/soft_body_bullet.cpp
@@ -169,6 +169,7 @@ void SoftBodyBullet::set_node_position(int p_node_index, const Vector3 &p_global
 
 void SoftBodyBullet::set_node_position(int p_node_index, const btVector3 &p_global_position) {
 	if (bt_soft_body) {
+		ERR_FAIL_INDEX(p_node_index, bt_soft_body->m_nodes.size());
 		bt_soft_body->m_nodes[p_node_index].m_q = bt_soft_body->m_nodes[p_node_index].m_x;
 		bt_soft_body->m_nodes[p_node_index].m_x = p_global_position;
 	}
@@ -176,6 +177,7 @@ void SoftBodyBullet::set_node_position(int p_node_index, const btVector3 &p_glob
 
 void SoftBodyBullet::get_node_position(int p_node_index, Vector3 &r_position) const {
 	if (bt_soft_body) {
+		ERR_FAIL_INDEX(p_node_index, bt_soft_body->m_nodes.size());
 		B_TO_G(bt_soft_body->m_nodes[p_node_index].m_x, r_position);
 	}
 }


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #53331. Added godot side check if index is out of bounds