### PR TITLE
`AnimationTrackEditor` Fix connecting to root's `tree_exiting` signal

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3188,7 +3188,7 @@ Ref<Animation> AnimationTrackEditor::get_current_animation() const {
 	return animation;
 }
 
-void AnimationTrackEditor::_root_removed(Node *p_root) {
+void AnimationTrackEditor::_root_removed() {
 	root = nullptr;
 }
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -372,7 +372,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	TrackIndices _confirm_insert(InsertData p_id, TrackIndices p_next_tracks, bool p_create_reset, Ref<Animation> p_reset_anim, bool p_create_beziers);
 	void _insert_delay(bool p_create_reset, bool p_create_beziers);
 
-	void _root_removed(Node *p_root);
+	void _root_removed();
 
 	PropertyInfo _find_hint_for_track(int p_idx, NodePath &r_base_path, Variant *r_current_val = nullptr);
 


### PR DESCRIPTION
`Node`'s `tree_exiting` signal is parameterless, hence `AnimationTrackEditor::_root_removed` being connected to it doesn't need a parameter (which is unused by it anyway).

Fixes #37905.

Cherry-pickable `3.x`, `3.3`.

https://github.com/godotengine/godot/blob/a88e82078dfa1e06acad59eb34bf2bbb64ed5978/editor/animation_track_editor.cpp#L3191-L3207