### PR TITLE
Ignore brackets inside comments for highlighting (code editor)

### DIFF
--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -374,7 +374,7 @@ public:
 	void clear_comment_delimiters();
 	TypedArray<String> get_comment_delimiters() const;
 
-	int is_in_comment(int p_line, int p_column = -1) const;
+	int is_in_comment(int p_line, int p_column = -1) const override;
 
 	String get_delimiter_start_key(int p_delimiter_idx) const;
 	String get_delimiter_end_key(int p_delimiter_idx) const;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -471,12 +471,14 @@ void TextEdit::_notification(int p_what) {
 					char32_t c = text[caret.line][caret.column];
 					char32_t closec = 0;
 
-					if (c == '[') {
-						closec = ']';
-					} else if (c == '{') {
-						closec = '}';
-					} else if (c == '(') {
-						closec = ')';
+					if (is_in_comment(caret.line, caret.column) == -1) {
+						if (c == '[') {
+							closec = ']';
+						} else if (c == '{') {
+							closec = '}';
+						} else if (c == '(') {
+							closec = ')';
+						}
 					}
 
 					if (closec != 0) {
@@ -508,6 +510,8 @@ void TextEdit::_notification(int p_what) {
 											}
 										}
 									} while (cc != quotation);
+								} else if (is_in_comment(i, j) != -1) {
+									continue;
 								} else if (cc == c) {
 									stack++;
 								} else if (cc == closec) {
@@ -537,12 +541,14 @@ void TextEdit::_notification(int p_what) {
 					char32_t c = text[caret.line][caret.column - 1];
 					char32_t closec = 0;
 
-					if (c == ']') {
-						closec = '[';
-					} else if (c == '}') {
-						closec = '{';
-					} else if (c == ')') {
-						closec = '(';
+					if (is_in_comment(caret.line, caret.column - 1) == -1) {
+						if (c == ']') {
+							closec = '[';
+						} else if (c == '}') {
+							closec = '{';
+						} else if (c == ')') {
+							closec = '(';
+						}
 					}
 
 					if (closec != 0) {
@@ -574,6 +580,8 @@ void TextEdit::_notification(int p_what) {
 											}
 										}
 									} while (cc != quotation);
+								} else if (is_in_comment(i, j) != -1) {
+									continue;
 								} else if (cc == c) {
 									stack++;
 								} else if (cc == closec) {
@@ -2432,6 +2440,11 @@ void TextEdit::set_tooltip_request_func(Object *p_obj, const StringName &p_funct
 	tooltip_obj = p_obj;
 	tooltip_func = p_function;
 	tooltip_ud = p_udata;
+}
+
+int TextEdit::is_in_comment(int p_line, int p_column) const {
+	// comments cannot be verified here, override this method
+	return -1;
 }
 
 /* Text */

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -601,6 +601,7 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
+	virtual int is_in_comment(int p_line, int p_column = -1) const;
 
 	/* Text */
 	// Text properties.


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Basically, I use an existing function to detect comments and ignore brackets inside them. Since this method is defined on another class inherited from `TextEdit`, I declared it on the base class as a virtual method.

#53332 