### PR TITLE
Use wakeup() function to wake sleeping bodies on impulse, force and velocities. Fix for PR #52967

### DIFF
--- a/servers/physics_2d/body_direct_state_2d_sw.cpp
+++ b/servers/physics_2d/body_direct_state_2d_sw.cpp
@@ -59,7 +59,7 @@ real_t PhysicsDirectBodyState2DSW::get_inverse_inertia() const {
 }
 
 void PhysicsDirectBodyState2DSW::set_linear_velocity(const Vector2 &p_velocity) {
-	body->set_active(true);
+	body->wakeup();
 	body->set_linear_velocity(p_velocity);
 }
 
@@ -68,7 +68,7 @@ Vector2 PhysicsDirectBodyState2DSW::get_linear_velocity() const {
 }
 
 void PhysicsDirectBodyState2DSW::set_angular_velocity(real_t p_velocity) {
-	body->set_active(true);
+	body->wakeup();
 	body->set_angular_velocity(p_velocity);
 }
 
@@ -89,32 +89,32 @@ Vector2 PhysicsDirectBodyState2DSW::get_velocity_at_local_position(const Vector2
 }
 
 void PhysicsDirectBodyState2DSW::add_central_force(const Vector2 &p_force) {
-	body->set_active(true);
+	body->wakeup();
 	body->add_central_force(p_force);
 }
 
 void PhysicsDirectBodyState2DSW::add_force(const Vector2 &p_force, const Vector2 &p_position) {
-	body->set_active(true);
+	body->wakeup();
 	body->add_force(p_force, p_position);
 }
 
 void PhysicsDirectBodyState2DSW::add_torque(real_t p_torque) {
-	body->set_active(true);
+	body->wakeup();
 	body->add_torque(p_torque);
 }
 
 void PhysicsDirectBodyState2DSW::apply_central_impulse(const Vector2 &p_impulse) {
-	body->set_active(true);
+	body->wakeup();
 	body->apply_central_impulse(p_impulse);
 }
 
 void PhysicsDirectBodyState2DSW::apply_impulse(const Vector2 &p_impulse, const Vector2 &p_position) {
-	body->set_active(true);
+	body->wakeup();
 	body->apply_impulse(p_impulse, p_position);
 }
 
 void PhysicsDirectBodyState2DSW::apply_torque_impulse(real_t p_torque) {
-	body->set_active(true);
+	body->wakeup();
 	body->apply_torque_impulse(p_torque);
 }
 

--- a/servers/physics_3d/body_direct_state_3d_sw.cpp
+++ b/servers/physics_3d/body_direct_state_3d_sw.cpp
@@ -66,7 +66,7 @@ Basis PhysicsDirectBodyState3DSW::get_inverse_inertia_tensor() const {
 }
 
 void PhysicsDirectBodyState3DSW::set_linear_velocity(const Vector3 &p_velocity) {
-	body->set_active(true);
+	body->wakeup();
 	body->set_linear_velocity(p_velocity);
 }
 
@@ -75,7 +75,7 @@ Vector3 PhysicsDirectBodyState3DSW::get_linear_velocity() const {
 }
 
 void PhysicsDirectBodyState3DSW::set_angular_velocity(const Vector3 &p_velocity) {
-	body->set_active(true);
+	body->wakeup();
 	body->set_angular_velocity(p_velocity);
 }
 
@@ -96,32 +96,32 @@ Vector3 PhysicsDirectBodyState3DSW::get_velocity_at_local_position(const Vector3
 }
 
 void PhysicsDirectBodyState3DSW::add_central_force(const Vector3 &p_force) {
-	body->set_active(true);
+	body->wakeup();
 	body->add_central_force(p_force);
 }
 
 void PhysicsDirectBodyState3DSW::add_force(const Vector3 &p_force, const Vector3 &p_position) {
-	body->set_active(true);
+	body->wakeup();
 	body->add_force(p_force, p_position);
 }
 
 void PhysicsDirectBodyState3DSW::add_torque(const Vector3 &p_torque) {
-	body->set_active(true);
+	body->wakeup();
 	body->add_torque(p_torque);
 }
 
 void PhysicsDirectBodyState3DSW::apply_central_impulse(const Vector3 &p_impulse) {
-	body->set_active(true);
+	body->wakeup();
 	body->apply_central_impulse(p_impulse);
 }
 
 void PhysicsDirectBodyState3DSW::apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position) {
-	body->set_active(true);
+	body->wakeup();
 	body->apply_impulse(p_impulse, p_position);
 }
 
 void PhysicsDirectBodyState3DSW::apply_torque_impulse(const Vector3 &p_impulse) {
-	body->set_active(true);
+	body->wakeup();
 	body->apply_torque_impulse(p_impulse);
 }
 


### PR DESCRIPTION
This PR tidies up a mistake in a previous PR where the active state was directly changed instead of using the wakeup() function (which checks against physics body type). 