### PR TITLE
[3.x] Reset scene conditionals assumed to be false

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1924,8 +1924,6 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 	state.current_depth_test = true;
 	glEnable(GL_DEPTH_TEST);
 
-	state.scene_shader.set_conditional(SceneShaderGLES3::USE_SKELETON, false);
-
 	state.current_blend_mode = -1;
 	state.current_line_width = -1;
 	state.current_depth_draw = -1;
@@ -1938,16 +1936,20 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 	int current_blend_mode = -1;
 
 	uint32_t prev_shading = 0xFFFFFFFF;
-	RasterizerStorageGLES3::Skeleton *prev_skeleton = nullptr;
-
 	state.scene_shader.set_conditional(SceneShaderGLES3::SHADELESS, true); //by default unshaded (easier to set)
+
+	RasterizerStorageGLES3::Skeleton *prev_skeleton = nullptr;
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_SKELETON, false);
 
 	bool first = true;
 	bool prev_use_instancing = false;
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_INSTANCING, false);
 	bool prev_octahedral_compression = false;
+	state.scene_shader.set_conditional(SceneShaderGLES3::ENABLE_OCTAHEDRAL_COMPRESSION, false);
 
 	storage->info.render.draw_call_count += p_element_count;
 	bool prev_opaque_prepass = false;
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_OPAQUE_PREPASS, false);
 
 	for (int i = 0; i < p_element_count; i++) {
 		RenderList::Element *e = p_elements[i];


### PR DESCRIPTION
If a previous `_render_list()` has left certain conditionals as `true`, subsequent calls will fail to reset them if that's the right thing to do since the code assumes they are `false` at the beginning.

I've moved the resetting of `USE_SKELETON` to below the declaration of `prev_skeleton` so this case is like that of other variables that track the status of conditionals someshow, where they appear together.