### PR TITLE
Hide render_priority except when using SpatialMaterials

### DIFF
--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -20,11 +20,12 @@
 	<members>
 		<member name="next_pass" type="Material" setter="set_next_pass" getter="get_next_pass">
 			Sets the [Material] to be used for the next pass. This renders the object again using a different material.
-			[b]Note:[/b] only applies to [StandardMaterial3D]s and [ShaderMaterial]s with type "Spatial".
+			[b]Note:[/b] This only applies to [StandardMaterial3D]s and [ShaderMaterial]s with type "Spatial".
 		</member>
 		<member name="render_priority" type="int" setter="set_render_priority" getter="get_render_priority" default="0">
 			Sets the render priority for transparent objects in 3D scenes. Higher priority objects will be sorted in front of lower priority objects.
-			[b]Note:[/b] this only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are not sorted, while transparent objects are sorted from back to front (subject to priority).
+			[b]Note:[/b] This only applies to [StandardMaterial3D]s and [ShaderMaterial]s with type "Spatial".
+			[b]Note:[/b] This only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are not sorted, while transparent objects are sorted from back to front (subject to priority).
 		</member>
 	</members>
 	<constants>

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -80,6 +80,9 @@ void Material::_validate_property(PropertyInfo &property) const {
 	if (!_can_do_next_pass() && property.name == "next_pass") {
 		property.usage = PROPERTY_USAGE_NONE;
 	}
+	if (!_can_use_render_priority() && property.name == "render_priority") {
+		property.usage = PROPERTY_USAGE_NONE;
+	}
 }
 
 void Material::inspect_native_shader_code() {
@@ -288,6 +291,10 @@ void ShaderMaterial::get_argument_options(const StringName &p_function, int p_id
 }
 
 bool ShaderMaterial::_can_do_next_pass() const {
+	return shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;
+}
+
+bool ShaderMaterial::_can_use_render_priority() const {
 	return shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;
 }
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -53,6 +53,7 @@ protected:
 	_FORCE_INLINE_ RID _get_material() const { return material; }
 	static void _bind_methods();
 	virtual bool _can_do_next_pass() const { return false; }
+	virtual bool _can_use_render_priority() const { return false; }
 
 	void _validate_property(PropertyInfo &property) const override;
 
@@ -93,6 +94,7 @@ protected:
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 
 	virtual bool _can_do_next_pass() const override;
+	virtual bool _can_use_render_priority() const override;
 
 	void _shader_changed();
 
@@ -535,6 +537,7 @@ protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &property) const override;
 	virtual bool _can_do_next_pass() const override { return true; }
+	virtual bool _can_use_render_priority() const override { return true; }
 
 public:
 	void set_albedo(const Color &p_albedo);

--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -125,10 +125,6 @@ float ProceduralSkyMaterial::get_sun_curve() const {
 	return sun_curve;
 }
 
-bool ProceduralSkyMaterial::_can_do_next_pass() const {
-	return false;
-}
-
 Shader::Mode ProceduralSkyMaterial::get_shader_mode() const {
 	return Shader::MODE_SKY;
 }
@@ -312,10 +308,6 @@ Ref<Texture2D> PanoramaSkyMaterial::get_panorama() const {
 	return panorama;
 }
 
-bool PanoramaSkyMaterial::_can_do_next_pass() const {
-	return false;
-}
-
 Shader::Mode PanoramaSkyMaterial::get_shader_mode() const {
 	return Shader::MODE_SKY;
 }
@@ -480,10 +472,6 @@ void PhysicalSkyMaterial::set_night_sky(const Ref<Texture2D> &p_night_sky) {
 
 Ref<Texture2D> PhysicalSkyMaterial::get_night_sky() const {
 	return night_sky;
-}
-
-bool PhysicalSkyMaterial::_can_do_next_pass() const {
-	return false;
 }
 
 Shader::Mode PhysicalSkyMaterial::get_shader_mode() const {

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -58,7 +58,6 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual bool _can_do_next_pass() const override;
 
 public:
 	void set_sky_top_color(const Color &p_sky_top);
@@ -117,7 +116,6 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual bool _can_do_next_pass() const override;
 
 public:
 	void set_panorama(const Ref<Texture2D> &p_panorama);
@@ -159,7 +157,6 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual bool _can_do_next_pass() const override;
 
 public:
 	void set_rayleigh_coefficient(float p_rayleigh);


### PR DESCRIPTION
Something I noticed while work on FogMaterials. There is no need for anything but Spatial shaders to display ``render_priority``, just like ``next_pass``. This should alleviate a lot of user confusion about render_priority.