### PR TITLE
SCons: Add `DEV_ENABLED` defines for `target=debug` builds

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -207,7 +207,7 @@ def configure(env):
     elif env["target"] == "debug":
         env.Append(LINKFLAGS=["-O0"])
         env.Append(CCFLAGS=["-O0", "-g", "-fno-limit-debug-info"])
-        env.Append(CPPDEFINES=["_DEBUG", "DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["_DEBUG", "DEBUG_ENABLED", "DEV_ENABLED"])
         env.Append(CPPFLAGS=["-UNDEBUG"])
 
     # Compiler configuration

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -62,7 +62,7 @@ def configure(env):
 
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["-gdwarf-2", "-O0"])
-        env.Append(CPPDEFINES=["_DEBUG", ("DEBUG", 1), "DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["_DEBUG", ("DEBUG", 1), "DEBUG_ENABLED", "DEV_ENABLED"])
 
     if env["use_lto"]:
         env.Append(CCFLAGS=["-flto"])

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -81,6 +81,7 @@ def configure(env):
             env.Append(LINKFLAGS=["--profiling-funcs"])
     else:  # "debug"
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["DEV_ENABLED"])
         env.Append(CCFLAGS=["-O1", "-g"])
         env.Append(LINKFLAGS=["-O1", "-g"])
         env["use_assertions"] = True

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -66,6 +66,7 @@ def configure(env):
     elif env["target"] == "debug":
         env.Prepend(CCFLAGS=["-g3"])
         env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Prepend(CPPDEFINES=["DEV_ENABLED"])
         env.Prepend(LINKFLAGS=["-Xlinker", "-no_deduplicate"])
 
     ## Architecture

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -74,6 +74,7 @@ def configure(env):
     elif env["target"] == "debug":
         env.Prepend(CCFLAGS=["-g3"])
         env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Prepend(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["-rdynamic"])
 
     ## Architecture

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -71,6 +71,7 @@ def configure(env):
         env.Append(CCFLAGS=["/Zi"])
         env.Append(CCFLAGS=["/MDd"])
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
         env.Append(LINKFLAGS=["/DEBUG"])
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -199,6 +199,7 @@ def configure_msvc(env, manual_msvc_config):
     elif env["target"] == "debug":
         env.AppendUnique(CCFLAGS=["/Zi", "/FS", "/Od", "/EHsc"])
         env.AppendUnique(CPPDEFINES=["DEBUG_ENABLED"])
+        env.AppendUnique(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
         env.Append(LINKFLAGS=["/DEBUG"])
 
@@ -334,6 +335,7 @@ def configure_mingw(env):
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["-g3"])
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["DEV_ENABLED"])
 
     ## Compiler configuration
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -113,6 +113,7 @@ def configure(env):
         env.Prepend(CCFLAGS=["-ggdb"])
         env.Prepend(CCFLAGS=["-g3"])
         env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Prepend(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["-rdynamic"])
 
     ## Architecture


### PR DESCRIPTION
This will allow adding developer checks which will be fully compiled out in
user builds, unlike `DEBUG_ENABLED` which is included in debug tempates and
the editor builds.

This define is not used yet, but we'll soon add code that uses it, and change
some existing `DEBUG_ENABLED` checks to be performed only in dev builds.

Related to https://github.com/godotengine/godot-proposals/issues/3371.

## Notes

I'm making this PR for `3.x` only, as for `master` we'll want to have a full implementation of https://github.com/godotengine/godot-proposals/issues/3371, changing the way we currently conflate C++ development tooling and user game debugging tooling under the same flags.

I'm not implementing that proposal just yet as it will create additional work for the contributors working on a potential Meson port, which needs to be evaluated first before refactoring the SCons buildsystem.

For `3.x` this will allow @lawnjelly to add dev checks in various areas he's working on, and we might retrofit some of the existing checks in the new system.