### PR TITLE
Fix `Tabs` offset overreaching when scrolling fast

### DIFF
--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -156,6 +156,7 @@ void Tabs::gui_input(const Ref<InputEvent> &p_event) {
 			if (scrolling_enabled && buttons_visible) {
 				if (missing_right) {
 					offset++;
+					_ensure_no_over_offset(); // Avoid overreaching when scrolling fast.
 					update();
 				}
 			}


### PR DESCRIPTION
Before:|After:
-|-
![Peek 2021-10-04 10-29](https://user-images.githubusercontent.com/30739239/135862321-094a9bc4-2f1b-4b4c-b358-49cbeac0a18b.gif)|![Peek 2021-10-04 10-22](https://user-images.githubusercontent.com/30739239/135862310-e1567a1a-ee50-44d9-b07d-5190f7c6a31e.gif)