### PR TITLE
Add DEV_ASSERT and DEV_CHECK macros

### DIFF
--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -305,23 +305,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 		((void)0)
 
 /**
- * Should assert only if making a build with dev asserts.
- * This should be a 'free' check for program flow and should not be needed in any releases,
- *  only used in dev builds.
- */
-// #define DEV_ASSERTS_ENABLED
-#ifdef DEV_ASSERTS_ENABLED
-#define DEV_ASSERT(m_cond)                                                                                              \
-	if (unlikely(!(m_cond))) {                                                                                          \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
-		GENERATE_TRAP                                                                                                   \
-	} else                                                                                                              \
-		((void)0)
-#else
-#define DEV_ASSERT(m_cond)
-#endif
-
-/**
  * If `m_cond` evaluates to `true`, crashes the engine immediately with a generic error message.
  * Only use this if there's no sensible fallback (i.e. the error is unrecoverable).
  */
@@ -534,4 +517,43 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 	} else                                                                                                                                                        \
 		((void)0)
 
+#endif
+
+/**
+ * This should be a 'free' assert for program flow and should not be needed in any releases,
+ *  only used in dev builds.
+ */
+#ifdef DEV_ENABLED
+#define DEV_ASSERT(m_cond)                                                                                              \
+	if (unlikely(!(m_cond))) {                                                                                          \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
+		GENERATE_TRAP                                                                                                   \
+	} else                                                                                                              \
+		((void)0)
+#else
+#define DEV_ASSERT(m_cond)
+#endif
+
+/**
+ * These should be 'free' checks for program flow and should not be needed in any releases,
+ *  only used in dev builds.
+ */
+#ifdef DEV_ENABLED
+#define DEV_CHECK(m_cond)                                              \
+	if (unlikely(!(m_cond))) {                                         \
+		ERR_PRINT("DEV_CHECK failed  \"" _STR(m_cond) "\" is false."); \
+	} else                                                             \
+		((void)0)
+#else
+#define DEV_CHECK(m_cond)
+#endif
+
+#ifdef DEV_ENABLED
+#define DEV_CHECK_ONCE(m_cond)                                                   \
+	if (unlikely(!(m_cond))) {                                                   \
+		ERR_PRINT_ONCE("DEV_CHECK_ONCE failed  \"" _STR(m_cond) "\" is false."); \
+	} else                                                                       \
+		((void)0)
+#else
+#define DEV_CHECK_ONCE(m_cond)
 #endif

--- a/drivers/gles2/rasterizer_canvas_base_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_base_gles2.cpp
@@ -641,7 +641,7 @@ void RasterizerCanvasBaseGLES2::_draw_gui_primitive(int p_points, const Vector2 
 		stride += 1;
 	}
 
-	RAST_DEV_DEBUG_ASSERT(p_points <= 4);
+	DEV_ASSERT(p_points <= 4);
 	float buffer_data[(2 + 2 + 4 + 1) * 4];
 
 	for (int i = 0; i < p_points; i++) {

--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -319,7 +319,7 @@ void RasterizerCanvasGLES2::render_batches(Item *p_current_clip, bool &r_reclip,
 			default: {
 				int end_command = batch.first_command + batch.num_commands;
 
-				RAST_DEV_DEBUG_ASSERT(batch.item);
+				DEV_ASSERT(batch.item);
 				RasterizerCanvas::Item::Command *const *commands = batch.item->commands.ptr();
 
 				for (int i = batch.first_command; i < end_command; i++) {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1392,7 +1392,7 @@ inline void RasterizerStorageGLES2::buffer_orphan_and_upload(unsigned int p_buff
 		}
 #endif
 	}
-	RAST_DEV_DEBUG_ASSERT((p_offset + p_data_size) <= p_buffer_size);
+	DEV_ASSERT((p_offset + p_data_size) <= p_buffer_size);
 	glBufferSubData(p_target, p_offset, p_data_size, p_data);
 }
 

--- a/drivers/gles3/rasterizer_canvas_base_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_base_gles3.cpp
@@ -554,7 +554,7 @@ void RasterizerCanvasBaseGLES3::_draw_gui_primitive(int p_points, const Vector2 
 		stride += 1;
 	}
 
-	RAST_DEV_DEBUG_ASSERT(p_points <= 4);
+	DEV_ASSERT(p_points <= 4);
 	float b[(2 + 2 + 4 + 1) * 4];
 
 	for (int i = 0; i < p_points; i++) {

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -500,7 +500,7 @@ void RasterizerCanvasGLES3::render_batches(Item *p_current_clip, bool &r_reclip,
 			default: {
 				int end_command = batch.first_command + batch.num_commands;
 
-				RAST_DEV_DEBUG_ASSERT(batch.item);
+				DEV_ASSERT(batch.item);
 				RasterizerCanvas::Item::Command *const *commands = batch.item->commands.ptr();
 
 				for (int i = batch.first_command; i < end_command; i++) {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1535,7 +1535,7 @@ inline void RasterizerStorageGLES3::buffer_orphan_and_upload(unsigned int p_buff
 		}
 #endif
 	}
-	RAST_DEV_DEBUG_ASSERT((p_offset + p_data_size) <= p_buffer_size);
+	DEV_ASSERT((p_offset + p_data_size) <= p_buffer_size);
 	glBufferSubData(p_target, p_offset, p_data_size, p_data);
 }
 

--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -847,7 +847,8 @@ PREAMBLE(void)::_prefill_default_batch(FillState &r_fill_state, int p_command_nu
 			// another default command, just add to the existing batch
 			r_fill_state.curr_batch->num_commands++;
 
-			RAST_DEV_DEBUG_ASSERT(r_fill_state.curr_batch->num_commands <= p_command_num);
+			// Note this is getting hit, needs investigation as to whether this is a bug or a false flag
+			// DEV_CHECK_ONCE(r_fill_state.curr_batch->num_commands <= p_command_num);
 		} else {
 #if defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED)
 			if (r_fill_state.transform_extra_command_number_p1 != p_command_num) {
@@ -1744,7 +1745,7 @@ bool C_PREAMBLE::_prefill_polygon(RasterizerCanvas::Item::CommandPolygon *p_poly
 		for (int n = 0; n < num_inds; n++) {
 			int ind = p_poly->indices[n];
 
-			RAST_DEV_DEBUG_ASSERT(ind < p_poly->points.size());
+			DEV_CHECK_ONCE(ind < p_poly->points.size());
 
 			// recover at runtime from invalid polys (the editor may send invalid polys)
 			if ((unsigned int)ind >= (unsigned int)num_verts) {
@@ -1861,7 +1862,7 @@ PREAMBLE(bool)::_software_skin_poly(RasterizerCanvas::Item::CommandPolygon *p_po
 
 				total_weight += weight;
 
-				RAST_DEBUG_ASSERT(bone_id < bone_count);
+				DEV_CHECK_ONCE(bone_id < bone_count);
 				const Transform2D &bone_tr = bone_transforms[bone_id];
 
 				Vector2 pos = bone_tr.xform(src_pos_back_transformed);
@@ -1904,7 +1905,7 @@ PREAMBLE(bool)::_software_skin_poly(RasterizerCanvas::Item::CommandPolygon *p_po
 	for (int n = 0; n < num_inds; n++) {
 		int ind = p_poly->indices[n];
 
-		RAST_DEV_DEBUG_ASSERT(ind < num_verts);
+		DEV_CHECK_ONCE(ind < num_verts);
 
 		// recover at runtime from invalid polys (the editor may send invalid polys)
 		if ((unsigned int)ind >= (unsigned int)num_verts) {
@@ -2730,7 +2731,7 @@ PREAMBLE(void)::join_sorted_items() {
 			// but it is stupidly complex to calculate later, which would probably be slower.
 			r->final_modulate = _render_item_state.final_modulate;
 		} else {
-			RAST_DEBUG_ASSERT(_render_item_state.joined_item != nullptr);
+			DEV_ASSERT(_render_item_state.joined_item != nullptr);
 			_render_item_state.joined_item->num_item_refs += 1;
 			_render_item_state.joined_item->bounding_rect = _render_item_state.joined_item->bounding_rect.merge(ci->global_rect_cache);
 
@@ -2939,7 +2940,7 @@ PREAMBLE(void)::_translate_batches_to_vertex_colored_FVF() {
 	bdata.unit_vertices.prepare(sizeof(BatchVertexColored));
 
 	const BatchColor *source_vertex_colors = &bdata.vertex_colors[0];
-	RAST_DEBUG_ASSERT(bdata.vertex_colors.size() == bdata.vertices.size());
+	DEV_ASSERT(bdata.vertex_colors.size() == bdata.vertices.size());
 
 	int num_verts = bdata.vertices.size();
 
@@ -2979,8 +2980,8 @@ void C_PREAMBLE::_translate_batches_to_larger_FVF(uint32_t p_sequence_batch_type
 	// the sizes should be equal, and allocations should never fail. Hence the use of debug
 	// asserts to check program flow, these should not occur at runtime unless the allocation
 	// code has been altered.
-	RAST_DEBUG_ASSERT(bdata.unit_vertices.max_size() == bdata.vertices.max_size());
-	RAST_DEBUG_ASSERT(bdata.batches_temp.max_size() == bdata.batches.max_size());
+	DEV_ASSERT(bdata.unit_vertices.max_size() == bdata.vertices.max_size());
+	DEV_ASSERT(bdata.batches_temp.max_size() == bdata.batches.max_size());
 
 	Color curr_col(-1.0f, -1.0f, -1.0f, -1.0f);
 

--- a/servers/visual/portals/portal_renderer.cpp
+++ b/servers/visual/portals/portal_renderer.cpp
@@ -64,10 +64,6 @@ OcclusionHandle PortalRenderer::instance_moving_create(VSInstance *p_instance, R
 }
 
 void PortalRenderer::instance_moving_update(OcclusionHandle p_handle, const AABB &p_aabb, bool p_force_reinsert) {
-	// we can ignore these, they are statics / dynamics, and don't need updating
-	// .. these should have been filtered out before calling the visual server...
-	DEV_ASSERT(!_occlusion_handle_is_in_room(p_handle));
-
 	p_handle--;
 	Moving &moving = _moving_pool[p_handle];
 	moving.exact_aabb = p_aabb;
@@ -76,6 +72,10 @@ void PortalRenderer::instance_moving_update(OcclusionHandle p_handle, const AABB
 	if (!_loaded || moving.global) {
 		return;
 	}
+
+	// we can ignore these, they are statics / dynamics, and don't need updating
+	// .. these should have been filtered out before calling the visual server...
+	DEV_CHECK_ONCE(!_occlusion_handle_is_in_room(p_handle));
 
 	// quick reject for most roaming cases
 	if (!p_force_reinsert && moving.expanded_aabb.encloses(p_aabb)) {


### PR DESCRIPTION
Change the existing DEV_ASSERT macro to be switched on and off by the DEV_ENABLED define. DEV_ASSERT breaks into the debugger as soon as hit.
Add error macros DEV_CHECK and DEV_CHECK_ONCE to add an alternative check that ERR_PRINT when a condition fails, again only enabled in DEV_ENABLED builds.

## c++ DEV only asserts
N.B. - These macros will now be compiled into `DEV_ENABLED` (`debug`) builds only, they will be compiled out in `release` and `release_debug` builds. They therefore are particularly aimed at use particularly in bottleneck code (such as renderer, physics, or accessors), or if you are not sure whether a check warrants a `CRASH_COND` or runtime check, but you want to document the assertion and check code flow in debug builds.

## Polarity / Naming
Happy to hear opinions regarding naming / polarity of these functions.

They are both positive logic functions, which in my experience is more common for asserts in programming than the negative logic of e.g. `ERR_FAIL` and `CRASH_COND` which is often used in Godot. I personally find the positive logic more natural but maybe that is due to previous experience.

Although Godot normally does everything possible to prevent crashing / halting, programmers will be expecting asserts to halt execution immediately in a debugger. This is why it is probably a good idea for us to have another method for recoverable errors - hence the `DEV_CHECK_ONCE` and `DEV_CHECK`.

## Notes
* I had already been using `DEV_ASSERT` in the portal renderer, these are now active in debug builds.
* I have converted some of the asserts in the batching. Some of the existing checks probably aren't necessary to be compiled in unless investigating specific problems so I've left quite a few as they are.
* I'll also be going through the BVH to add / replace asserts as necessary in a separate PR.
* We can do something similar in 4.x when the builds have been modified:
https://github.com/godotengine/godot-proposals/issues/3371
* It makes sense to standardise the macro names in both I guess so anyone feel free to chip in. (We can of course also edit these names later with a search and replace if there is a change of opinion in 4.x, so it's not completely vital we get it bang on first time)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
