### PR TITLE
Fixed SkeletonIK not rotating correctly when solving

### DIFF
--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -291,14 +291,10 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 		new_bone_pose.origin = ci->current_pos;
 
 		if (!ci->children.is_empty()) {
-			/// Rotate basis
-			const Vector3 initial_ori((ci->children[0].initial_transform.origin - ci->initial_transform.origin).normalized());
-			const Vector3 rot_axis(initial_ori.cross(ci->current_ori).normalized());
-
-			if (rot_axis[0] != 0 && rot_axis[1] != 0 && rot_axis[2] != 0) {
-				const real_t rot_angle(Math::acos(CLAMP(initial_ori.dot(ci->current_ori), -1, 1)));
-				new_bone_pose.basis.rotate(rot_axis, rot_angle);
-			}
+			p_task->skeleton->update_bone_rest_forward_vector(ci->bone);
+			Vector3 forward_vector = p_task->skeleton->get_bone_axis_forward_vector(ci->bone);
+			// Rotate the bone towards the next bone in the chain:
+			new_bone_pose.basis.rotate_to_align(forward_vector, new_bone_pose.origin.direction_to(ci->children[0].current_pos));
 
 		} else {
 			// Set target orientation to tip


### PR DESCRIPTION
This PR fixes an issue with rotating the bones in SkeletonIK, which causes it not to work in Godot 4.0. Because the code for solving rotation is different, it does get slightly different results than the previous solution. However, the same results can be achieved by changing the magnet position. Now the rotation code uses the same solving solution as Skeleton_Modification3DFABRIK.

Fixes #53358 

The issue in #53358 with the old rotation solving code seems to be how it calculates the rotation in the forward pass, as something there seems to have changed. With the new code it gets a correct solve, but needs the magnet position to prevent the elbow from bending in the incorrect direction.

Ideally this should be tested, just to make sure it does indeed work in more than the 2 test projects I used during development, but I'm fairly confident it should work.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
