### PR TITLE
Make `Theme` report property list changes less often

### DIFF
--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -305,7 +305,9 @@ bool Theme::has_default_theme_font_size() const {
 
 // Icons.
 void Theme::set_icon(const StringName &p_name, const StringName &p_theme_type, const Ref<Texture2D> &p_icon) {
+	bool existing = false;
 	if (icon_map[p_theme_type].has(p_name) && icon_map[p_theme_type][p_name].is_valid()) {
+		existing = true;
 		icon_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
@@ -315,7 +317,7 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_theme_type, c
 		icon_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 Ref<Texture2D> Theme::get_icon(const StringName &p_name, const StringName &p_theme_type) const {
@@ -342,7 +344,7 @@ void Theme::rename_icon(const StringName &p_old_name, const StringName &p_name, 
 	icon_map[p_theme_type][p_name] = icon_map[p_theme_type][p_old_name];
 	icon_map[p_theme_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_icon(const StringName &p_name, const StringName &p_theme_type) {
@@ -355,7 +357,7 @@ void Theme::clear_icon(const StringName &p_name, const StringName &p_theme_type)
 
 	icon_map[p_theme_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_icon_list(StringName p_theme_type, List<StringName> *p_list) const {
@@ -390,7 +392,9 @@ void Theme::get_icon_type_list(List<StringName> *p_list) const {
 
 // Styleboxes.
 void Theme::set_stylebox(const StringName &p_name, const StringName &p_theme_type, const Ref<StyleBox> &p_style) {
+	bool existing = false;
 	if (style_map[p_theme_type].has(p_name) && style_map[p_theme_type][p_name].is_valid()) {
+		existing = true;
 		style_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
@@ -400,7 +404,7 @@ void Theme::set_stylebox(const StringName &p_name, const StringName &p_theme_typ
 		style_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 Ref<StyleBox> Theme::get_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
@@ -427,7 +431,7 @@ void Theme::rename_stylebox(const StringName &p_old_name, const StringName &p_na
 	style_map[p_theme_type][p_name] = style_map[p_theme_type][p_old_name];
 	style_map[p_theme_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_stylebox(const StringName &p_name, const StringName &p_theme_type) {
@@ -440,7 +444,7 @@ void Theme::clear_stylebox(const StringName &p_name, const StringName &p_theme_t
 
 	style_map[p_theme_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_stylebox_list(StringName p_theme_type, List<StringName> *p_list) const {
@@ -475,7 +479,9 @@ void Theme::get_stylebox_type_list(List<StringName> *p_list) const {
 
 // Fonts.
 void Theme::set_font(const StringName &p_name, const StringName &p_theme_type, const Ref<Font> &p_font) {
+	bool existing = false;
 	if (font_map[p_theme_type][p_name].is_valid()) {
+		existing = true;
 		font_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
@@ -485,7 +491,7 @@ void Theme::set_font(const StringName &p_name, const StringName &p_theme_type, c
 		font_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_theme_type) const {
@@ -514,7 +520,7 @@ void Theme::rename_font(const StringName &p_old_name, const StringName &p_name, 
 	font_map[p_theme_type][p_name] = font_map[p_theme_type][p_old_name];
 	font_map[p_theme_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_font(const StringName &p_name, const StringName &p_theme_type) {
@@ -527,7 +533,7 @@ void Theme::clear_font(const StringName &p_name, const StringName &p_theme_type)
 
 	font_map[p_theme_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_font_list(StringName p_theme_type, List<StringName> *p_list) const {
@@ -562,9 +568,10 @@ void Theme::get_font_type_list(List<StringName> *p_list) const {
 
 // Font sizes.
 void Theme::set_font_size(const StringName &p_name, const StringName &p_theme_type, int p_font_size) {
+	bool existing = has_font_size_nocheck(p_name, p_theme_type);
 	font_size_map[p_theme_type][p_name] = p_font_size;
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 int Theme::get_font_size(const StringName &p_name, const StringName &p_theme_type) const {
@@ -593,7 +600,7 @@ void Theme::rename_font_size(const StringName &p_old_name, const StringName &p_n
 	font_size_map[p_theme_type][p_name] = font_size_map[p_theme_type][p_old_name];
 	font_size_map[p_theme_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_font_size(const StringName &p_name, const StringName &p_theme_type) {
@@ -602,7 +609,7 @@ void Theme::clear_font_size(const StringName &p_name, const StringName &p_theme_
 
 	font_size_map[p_theme_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_font_size_list(StringName p_theme_type, List<StringName> *p_list) const {
@@ -637,9 +644,10 @@ void Theme::get_font_size_type_list(List<StringName> *p_list) const {
 
 // Colors.
 void Theme::set_color(const StringName &p_name, const StringName &p_theme_type, const Color &p_color) {
+	bool existing = has_color_nocheck(p_name, p_theme_type);
 	color_map[p_theme_type][p_name] = p_color;
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 Color Theme::get_color(const StringName &p_name, const StringName &p_theme_type) const {
@@ -666,7 +674,7 @@ void Theme::rename_color(const StringName &p_old_name, const StringName &p_name,
 	color_map[p_theme_type][p_name] = color_map[p_theme_type][p_old_name];
 	color_map[p_theme_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_color(const StringName &p_name, const StringName &p_theme_type) {
@@ -675,7 +683,7 @@ void Theme::clear_color(const StringName &p_name, const StringName &p_theme_type
 
 	color_map[p_theme_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_color_list(StringName p_theme_type, List<StringName> *p_list) const {
@@ -710,9 +718,10 @@ void Theme::get_color_type_list(List<StringName> *p_list) const {
 
 // Theme constants.
 void Theme::set_constant(const StringName &p_name, const StringName &p_theme_type, int p_constant) {
+	bool existing = has_constant_nocheck(p_name, p_theme_type);
 	constant_map[p_theme_type][p_name] = p_constant;
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 int Theme::get_constant(const StringName &p_name, const StringName &p_theme_type) const {
@@ -739,7 +748,7 @@ void Theme::rename_constant(const StringName &p_old_name, const StringName &p_na
 	constant_map[p_theme_type][p_name] = constant_map[p_theme_type][p_old_name];
 	constant_map[p_theme_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_constant(const StringName &p_name, const StringName &p_theme_type) {
@@ -748,7 +757,7 @@ void Theme::clear_constant(const StringName &p_name, const StringName &p_theme_t
 
 	constant_map[p_theme_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_constant_list(StringName p_theme_type, List<StringName> *p_list) const {
@@ -1027,7 +1036,7 @@ void Theme::set_type_variation(const StringName &p_theme_type, const StringName 
 	variation_map[p_theme_type] = p_base_type;
 	variation_base_map[p_base_type].push_back(p_theme_type);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 bool Theme::is_type_variation(const StringName &p_theme_type, const StringName &p_base_type) const {
@@ -1041,7 +1050,7 @@ void Theme::clear_type_variation(const StringName &p_theme_type) {
 	variation_base_map[base_type].erase(p_theme_type);
 	variation_map.erase(p_theme_type);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 StringName Theme::get_type_variation_base(const StringName &p_theme_type) const {
@@ -1402,12 +1411,14 @@ Vector<String> Theme::_get_type_list() const {
 }
 
 // Theme bulk manipulations.
-void Theme::_emit_theme_changed() {
+void Theme::_emit_theme_changed(bool p_notify_list_changed) {
 	if (no_change_propagation) {
 		return;
 	}
 
-	notify_property_list_changed();
+	if (p_notify_list_changed) {
+		notify_property_list_changed();
+	}
 	emit_changed();
 }
 
@@ -1417,7 +1428,7 @@ void Theme::_freeze_change_propagation() {
 
 void Theme::_unfreeze_and_propagate_changes() {
 	no_change_propagation = false;
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::merge_with(const Ref<Theme> &p_other) {
@@ -1555,7 +1566,7 @@ void Theme::clear() {
 	variation_map.clear();
 	variation_base_map.clear();
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::reset_state() {

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -61,7 +61,7 @@ public:
 private:
 	bool no_change_propagation = false;
 
-	void _emit_theme_changed();
+	void _emit_theme_changed(bool p_notify_list_changed = false);
 
 	HashMap<StringName, HashMap<StringName, Ref<Texture2D>>> icon_map;
 	HashMap<StringName, HashMap<StringName, Ref<StyleBox>>> style_map;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/53087 and also fixes the base scale slider from https://github.com/godotengine/godot/pull/53341.

During the theme editor rework I made a mistake to report property list changes on every change in the theme, including changes to the values of items. This causes a lot of unnecessary inspector updates. With this PR only changes that can create new or remove existing property list entries trigger the notification.

A backport for `3.x` coming in a bit.