### PR TITLE
[3.x] Make `Theme` report property list changes less often, and other backports

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -362,6 +362,13 @@
 				See [method get_color] for details.
 			</description>
 		</method>
+		<method name="get_theme_default_font" qualifiers="const">
+			<return type="Font" />
+			<description>
+				Returns the default font from the first matching [Theme] in the tree if that [Theme] has a valid [member Theme.default_font] value.
+				See [method get_color] for details.
+			</description>
+		</method>
 		<method name="get_tooltip" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="at_position" type="Vector2" default="Vector2( 0, 0 )" />

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -238,6 +238,12 @@
 				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
+		<method name="has_default_font" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this theme has a valid [member default_font] value.
+			</description>
+		</method>
 		<method name="has_font" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
@@ -403,7 +409,8 @@
 	</methods>
 	<members>
 		<member name="default_font" type="Font" setter="set_default_font" getter="get_default_font">
-			The theme's default font.
+			The default font of this [Theme] resource. Used as a fallback value for font items defined in this theme, but having invalid values. If this value is also invalid, the global default value is used.
+			Use [method has_default_font] to check if this value is valid.
 		</member>
 	</members>
 	<constants>

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -446,6 +446,8 @@ public:
 	bool has_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 
+	Ref<Font> get_theme_default_font() const;
+
 	/* TOOLTIP */
 
 	void set_tooltip(const String &p_tooltip);

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -221,6 +221,10 @@ Ref<Font> Theme::get_default_theme_font() const {
 	return default_theme_font;
 }
 
+bool Theme::has_default_theme_font() const {
+	return default_theme_font.is_valid();
+}
+
 // Icons.
 void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture> &p_icon) {
 	if (icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
@@ -451,7 +455,7 @@ void Theme::set_font(const StringName &p_name, const StringName &p_node_type, co
 Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_node_type) const {
 	if (font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid()) {
 		return font_map[p_node_type][p_name];
-	} else if (default_theme_font.is_valid()) {
+	} else if (has_default_theme_font()) {
 		return default_theme_font;
 	} else {
 		return default_font;
@@ -1354,10 +1358,9 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_constant_list", "node_type"), &Theme::_get_constant_list);
 	ClassDB::bind_method(D_METHOD("get_constant_types"), &Theme::_get_constant_types);
 
-	ClassDB::bind_method(D_METHOD("clear"), &Theme::clear);
-
 	ClassDB::bind_method(D_METHOD("set_default_font", "font"), &Theme::set_default_theme_font);
 	ClassDB::bind_method(D_METHOD("get_default_font"), &Theme::get_default_theme_font);
+	ClassDB::bind_method(D_METHOD("has_default_font"), &Theme::has_default_theme_font);
 
 	ClassDB::bind_method(D_METHOD("set_theme_item", "data_type", "name", "node_type", "value"), &Theme::set_theme_item);
 	ClassDB::bind_method(D_METHOD("get_theme_item", "data_type", "name", "node_type"), &Theme::get_theme_item);
@@ -1374,6 +1377,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method("copy_default_theme", &Theme::copy_default_theme);
 	ClassDB::bind_method(D_METHOD("copy_theme", "other"), &Theme::copy_theme);
 	ClassDB::bind_method(D_METHOD("merge_with", "other"), &Theme::merge_with);
+	ClassDB::bind_method(D_METHOD("clear"), &Theme::clear);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "default_font", PROPERTY_HINT_RESOURCE_TYPE, "Font"), "set_default_font", "get_default_font");
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -29,221 +29,18 @@
 /*************************************************************************/
 
 #include "theme.h"
-#include "core/os/file_access.h"
 #include "core/print_string.h"
 
-void Theme::_emit_theme_changed() {
-	if (no_change_propagation) {
-		return;
-	}
+// Universal Theme resources used when no other theme has the item.
+Ref<Theme> Theme::default_theme;
+Ref<Theme> Theme::project_default_theme;
 
-	_change_notify();
-	emit_changed();
-}
+// Universal default values, final fallback for every theme.
+Ref<Texture> Theme::default_icon;
+Ref<StyleBox> Theme::default_style;
+Ref<Font> Theme::default_font;
 
-PoolVector<String> Theme::_get_icon_list(const String &p_node_type) const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_icon_list(p_node_type, &il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_icon_types() const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_icon_types(&il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_stylebox_list(const String &p_node_type) const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_stylebox_list(p_node_type, &il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_stylebox_types() const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_stylebox_types(&il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_font_list(const String &p_node_type) const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_font_list(p_node_type, &il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_font_types() const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_font_types(&il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_color_list(const String &p_node_type) const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_color_list(p_node_type, &il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_color_types() const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_color_types(&il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_constant_list(const String &p_node_type) const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_constant_list(p_node_type, &il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_constant_types() const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_constant_types(&il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
-PoolVector<String> Theme::_get_theme_item_list(DataType p_data_type, const String &p_node_type) const {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			return _get_color_list(p_node_type);
-		case DATA_TYPE_CONSTANT:
-			return _get_constant_list(p_node_type);
-		case DATA_TYPE_FONT:
-			return _get_font_list(p_node_type);
-		case DATA_TYPE_ICON:
-			return _get_icon_list(p_node_type);
-		case DATA_TYPE_STYLEBOX:
-			return _get_stylebox_list(p_node_type);
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-
-	return PoolVector<String>();
-}
-
-PoolVector<String> Theme::_get_theme_item_types(DataType p_data_type) const {
-	switch (p_data_type) {
-		case DATA_TYPE_COLOR:
-			return _get_color_types();
-		case DATA_TYPE_CONSTANT:
-			return _get_constant_types();
-		case DATA_TYPE_FONT:
-			return _get_font_types();
-		case DATA_TYPE_ICON:
-			return _get_icon_types();
-		case DATA_TYPE_STYLEBOX:
-			return _get_stylebox_types();
-		case DATA_TYPE_MAX:
-			break; // Can't happen, but silences warning.
-	}
-
-	return PoolVector<String>();
-}
-
-PoolVector<String> Theme::_get_type_list(const String &p_node_type) const {
-	PoolVector<String> ilret;
-	List<StringName> il;
-
-	get_type_list(&il);
-	ilret.resize(il.size());
-
-	int i = 0;
-	PoolVector<String>::Write w = ilret.write();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
-	}
-	return ilret;
-}
-
+// Dynamic properties.
 bool Theme::_set(const StringName &p_name, const Variant &p_value) {
 	String sname = p_name;
 
@@ -371,6 +168,37 @@ void Theme::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
+// Universal fallback Theme resources.
+Ref<Theme> Theme::get_default() {
+	return default_theme;
+}
+
+void Theme::set_default(const Ref<Theme> &p_default) {
+	default_theme = p_default;
+}
+
+Ref<Theme> Theme::get_project_default() {
+	return project_default_theme;
+}
+
+void Theme::set_project_default(const Ref<Theme> &p_project_default) {
+	project_default_theme = p_project_default;
+}
+
+// Universal fallback values for theme item types.
+void Theme::set_default_icon(const Ref<Texture> &p_icon) {
+	default_icon = p_icon;
+}
+
+void Theme::set_default_style(const Ref<StyleBox> &p_style) {
+	default_style = p_style;
+}
+
+void Theme::set_default_font(const Ref<Font> &p_font) {
+	default_font = p_font;
+}
+
+// Fallback values for theme item types, configurable per theme.
 void Theme::set_default_theme_font(const Ref<Font> &p_default_font) {
 	if (default_theme_font == p_default_font) {
 		return;
@@ -393,40 +221,7 @@ Ref<Font> Theme::get_default_theme_font() const {
 	return default_theme_font;
 }
 
-Ref<Theme> Theme::project_default_theme;
-Ref<Theme> Theme::default_theme;
-Ref<Texture> Theme::default_icon;
-Ref<StyleBox> Theme::default_style;
-Ref<Font> Theme::default_font;
-
-Ref<Theme> Theme::get_default() {
-	return default_theme;
-}
-
-void Theme::set_default(const Ref<Theme> &p_default) {
-	default_theme = p_default;
-}
-
-Ref<Theme> Theme::get_project_default() {
-	return project_default_theme;
-}
-
-void Theme::set_project_default(const Ref<Theme> &p_project_default) {
-	project_default_theme = p_project_default;
-}
-
-void Theme::set_default_icon(const Ref<Texture> &p_icon) {
-	default_icon = p_icon;
-}
-
-void Theme::set_default_style(const Ref<StyleBox> &p_style) {
-	default_style = p_style;
-}
-
-void Theme::set_default_font(const Ref<Font> &p_font) {
-	default_font = p_font;
-}
-
+// Icons.
 void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture> &p_icon) {
 	if (icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
 		icon_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
@@ -511,6 +306,7 @@ void Theme::get_icon_types(List<StringName> *p_list) const {
 	}
 }
 
+// Shaders.
 void Theme::set_shader(const StringName &p_name, const StringName &p_node_type, const Ref<Shader> &p_shader) {
 	shader_map[p_node_type][p_name] = p_shader;
 
@@ -552,6 +348,7 @@ void Theme::get_shader_list(const StringName &p_node_type, List<StringName> *p_l
 	}
 }
 
+// Styleboxes.
 void Theme::set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style) {
 	if (style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid()) {
 		style_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
@@ -636,6 +433,7 @@ void Theme::get_stylebox_types(List<StringName> *p_list) const {
 	}
 }
 
+// Fonts.
 void Theme::set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font) {
 	if (font_map[p_node_type][p_name].is_valid()) {
 		font_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
@@ -722,6 +520,7 @@ void Theme::get_font_types(List<StringName> *p_list) const {
 	}
 }
 
+// Colors.
 void Theme::set_color(const StringName &p_name, const StringName &p_node_type, const Color &p_color) {
 	color_map[p_node_type][p_name] = p_color;
 
@@ -794,6 +593,7 @@ void Theme::get_color_types(List<StringName> *p_list) const {
 	}
 }
 
+// Theme constants.
 void Theme::set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant) {
 	constant_map[p_node_type][p_name] = p_constant;
 
@@ -866,6 +666,7 @@ void Theme::get_constant_types(List<StringName> *p_list) const {
 	}
 }
 
+// Generic methods for managing theme items.
 void Theme::set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type, const Variant &p_value) {
 	switch (p_data_type) {
 		case DATA_TYPE_COLOR: {
@@ -1070,63 +871,266 @@ void Theme::get_theme_item_types(DataType p_data_type, List<StringName> *p_list)
 	}
 }
 
+// Theme types.
+void Theme::get_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	Set<StringName> types;
+	const StringName *key = nullptr;
+
+	while ((key = icon_map.next(key))) {
+		types.insert(*key);
+	}
+
+	key = nullptr;
+
+	while ((key = style_map.next(key))) {
+		types.insert(*key);
+	}
+
+	key = nullptr;
+
+	while ((key = font_map.next(key))) {
+		types.insert(*key);
+	}
+
+	key = nullptr;
+
+	while ((key = color_map.next(key))) {
+		types.insert(*key);
+	}
+
+	key = nullptr;
+
+	while ((key = constant_map.next(key))) {
+		types.insert(*key);
+	}
+
+	for (Set<StringName>::Element *E = types.front(); E; E = E->next()) {
+		p_list->push_back(E->get());
+	}
+}
+
+// Internal methods for getting lists as a Vector of String (compatible with public API).
+PoolVector<String> Theme::_get_icon_list(const String &p_node_type) const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_icon_list(p_node_type, &il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_icon_types() const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_icon_types(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_stylebox_list(const String &p_node_type) const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_stylebox_list(p_node_type, &il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_stylebox_types() const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_stylebox_types(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_font_list(const String &p_node_type) const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_font_list(p_node_type, &il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_font_types() const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_font_types(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_color_list(const String &p_node_type) const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_color_list(p_node_type, &il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_color_types() const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_color_types(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_constant_list(const String &p_node_type) const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_constant_list(p_node_type, &il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_constant_types() const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_constant_types(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_theme_item_list(DataType p_data_type, const String &p_node_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return _get_color_list(p_node_type);
+		case DATA_TYPE_CONSTANT:
+			return _get_constant_list(p_node_type);
+		case DATA_TYPE_FONT:
+			return _get_font_list(p_node_type);
+		case DATA_TYPE_ICON:
+			return _get_icon_list(p_node_type);
+		case DATA_TYPE_STYLEBOX:
+			return _get_stylebox_list(p_node_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return PoolVector<String>();
+}
+
+PoolVector<String> Theme::_get_theme_item_types(DataType p_data_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return _get_color_types();
+		case DATA_TYPE_CONSTANT:
+			return _get_constant_types();
+		case DATA_TYPE_FONT:
+			return _get_font_types();
+		case DATA_TYPE_ICON:
+			return _get_icon_types();
+		case DATA_TYPE_STYLEBOX:
+			return _get_stylebox_types();
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return PoolVector<String>();
+}
+
+PoolVector<String> Theme::_get_type_list(const String &p_node_type) const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_type_list(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+// Theme bulk manipulations.
+void Theme::_emit_theme_changed() {
+	if (no_change_propagation) {
+		return;
+	}
+
+	_change_notify();
+	emit_changed();
+}
+
 void Theme::_freeze_change_propagation() {
 	no_change_propagation = true;
 }
 
 void Theme::_unfreeze_and_propagate_changes() {
 	no_change_propagation = false;
-	_emit_theme_changed();
-}
-
-void Theme::clear() {
-	//these need disconnecting
-	{
-		const StringName *K = nullptr;
-		while ((K = icon_map.next(K))) {
-			const StringName *L = nullptr;
-			while ((L = icon_map[*K].next(L))) {
-				Ref<Texture> icon = icon_map[*K][*L];
-				if (icon.is_valid()) {
-					icon->disconnect("changed", this, "_emit_theme_changed");
-				}
-			}
-		}
-	}
-
-	{
-		const StringName *K = nullptr;
-		while ((K = style_map.next(K))) {
-			const StringName *L = nullptr;
-			while ((L = style_map[*K].next(L))) {
-				Ref<StyleBox> style = style_map[*K][*L];
-				if (style.is_valid()) {
-					style->disconnect("changed", this, "_emit_theme_changed");
-				}
-			}
-		}
-	}
-
-	{
-		const StringName *K = nullptr;
-		while ((K = font_map.next(K))) {
-			const StringName *L = nullptr;
-			while ((L = font_map[*K].next(L))) {
-				Ref<Font> font = font_map[*K][*L];
-				if (font.is_valid()) {
-					font->disconnect("changed", this, "_emit_theme_changed");
-				}
-			}
-		}
-	}
-
-	icon_map.clear();
-	style_map.clear();
-	font_map.clear();
-	shader_map.clear();
-	color_map.clear();
-	constant_map.clear();
-
 	_emit_theme_changed();
 }
 
@@ -1258,43 +1262,55 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 	_unfreeze_and_propagate_changes();
 }
 
-void Theme::get_type_list(List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
-	Set<StringName> types;
-	const StringName *key = nullptr;
-
-	while ((key = icon_map.next(key))) {
-		types.insert(*key);
+void Theme::clear() {
+	//these need disconnecting
+	{
+		const StringName *K = nullptr;
+		while ((K = icon_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = icon_map[*K].next(L))) {
+				Ref<Texture> icon = icon_map[*K][*L];
+				if (icon.is_valid()) {
+					icon->disconnect("changed", this, "_emit_theme_changed");
+				}
+			}
+		}
 	}
 
-	key = nullptr;
-
-	while ((key = style_map.next(key))) {
-		types.insert(*key);
+	{
+		const StringName *K = nullptr;
+		while ((K = style_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = style_map[*K].next(L))) {
+				Ref<StyleBox> style = style_map[*K][*L];
+				if (style.is_valid()) {
+					style->disconnect("changed", this, "_emit_theme_changed");
+				}
+			}
+		}
 	}
 
-	key = nullptr;
-
-	while ((key = font_map.next(key))) {
-		types.insert(*key);
+	{
+		const StringName *K = nullptr;
+		while ((K = font_map.next(K))) {
+			const StringName *L = nullptr;
+			while ((L = font_map[*K].next(L))) {
+				Ref<Font> font = font_map[*K][*L];
+				if (font.is_valid()) {
+					font->disconnect("changed", this, "_emit_theme_changed");
+				}
+			}
+		}
 	}
 
-	key = nullptr;
+	icon_map.clear();
+	style_map.clear();
+	font_map.clear();
+	shader_map.clear();
+	color_map.clear();
+	constant_map.clear();
 
-	while ((key = color_map.next(key))) {
-		types.insert(*key);
-	}
-
-	key = nullptr;
-
-	while ((key = constant_map.next(key))) {
-		types.insert(*key);
-	}
-
-	for (Set<StringName>::Element *E = types.front(); E; E = E->next()) {
-		p_list->push_back(E->get());
-	}
+	_emit_theme_changed();
 }
 
 void Theme::_bind_methods() {

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -227,7 +227,9 @@ bool Theme::has_default_theme_font() const {
 
 // Icons.
 void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture> &p_icon) {
+	bool existing = false;
 	if (icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
+		existing = true;
 		icon_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
 	}
 
@@ -237,7 +239,7 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, co
 		icon_map[p_node_type][p_name]->connect("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 Ref<Texture> Theme::get_icon(const StringName &p_name, const StringName &p_node_type) const {
@@ -264,7 +266,7 @@ void Theme::rename_icon(const StringName &p_old_name, const StringName &p_name, 
 	icon_map[p_node_type][p_name] = icon_map[p_node_type][p_old_name];
 	icon_map[p_node_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_icon(const StringName &p_name, const StringName &p_node_type) {
@@ -277,7 +279,7 @@ void Theme::clear_icon(const StringName &p_name, const StringName &p_node_type) 
 
 	icon_map[p_node_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_icon_list(StringName p_node_type, List<StringName> *p_list) const {
@@ -312,9 +314,10 @@ void Theme::get_icon_types(List<StringName> *p_list) const {
 
 // Shaders.
 void Theme::set_shader(const StringName &p_name, const StringName &p_node_type, const Ref<Shader> &p_shader) {
+	bool existing = (shader_map.has(p_node_type) && shader_map[p_node_type].has(p_name));
 	shader_map[p_node_type][p_name] = p_shader;
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 Ref<Shader> Theme::get_shader(const StringName &p_name, const StringName &p_node_type) const {
@@ -335,7 +338,7 @@ void Theme::clear_shader(const StringName &p_name, const StringName &p_node_type
 
 	shader_map[p_node_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_shader_list(const StringName &p_node_type, List<StringName> *p_list) const {
@@ -354,7 +357,9 @@ void Theme::get_shader_list(const StringName &p_node_type, List<StringName> *p_l
 
 // Styleboxes.
 void Theme::set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style) {
+	bool existing = false;
 	if (style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid()) {
+		existing = true;
 		style_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
 	}
 
@@ -364,7 +369,7 @@ void Theme::set_stylebox(const StringName &p_name, const StringName &p_node_type
 		style_map[p_node_type][p_name]->connect("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 Ref<StyleBox> Theme::get_stylebox(const StringName &p_name, const StringName &p_node_type) const {
@@ -391,7 +396,7 @@ void Theme::rename_stylebox(const StringName &p_old_name, const StringName &p_na
 	style_map[p_node_type][p_name] = style_map[p_node_type][p_old_name];
 	style_map[p_node_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_stylebox(const StringName &p_name, const StringName &p_node_type) {
@@ -404,7 +409,7 @@ void Theme::clear_stylebox(const StringName &p_name, const StringName &p_node_ty
 
 	style_map[p_node_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_stylebox_list(StringName p_node_type, List<StringName> *p_list) const {
@@ -439,7 +444,9 @@ void Theme::get_stylebox_types(List<StringName> *p_list) const {
 
 // Fonts.
 void Theme::set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font) {
+	bool existing = false;
 	if (font_map[p_node_type][p_name].is_valid()) {
+		existing = true;
 		font_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
 	}
 
@@ -449,7 +456,7 @@ void Theme::set_font(const StringName &p_name, const StringName &p_node_type, co
 		font_map[p_node_type][p_name]->connect("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_node_type) const {
@@ -478,7 +485,7 @@ void Theme::rename_font(const StringName &p_old_name, const StringName &p_name, 
 	font_map[p_node_type][p_name] = font_map[p_node_type][p_old_name];
 	font_map[p_node_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_font(const StringName &p_name, const StringName &p_node_type) {
@@ -491,7 +498,7 @@ void Theme::clear_font(const StringName &p_name, const StringName &p_node_type) 
 
 	font_map[p_node_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_font_list(StringName p_node_type, List<StringName> *p_list) const {
@@ -526,9 +533,10 @@ void Theme::get_font_types(List<StringName> *p_list) const {
 
 // Colors.
 void Theme::set_color(const StringName &p_name, const StringName &p_node_type, const Color &p_color) {
+	bool existing = has_color_nocheck(p_name, p_node_type);
 	color_map[p_node_type][p_name] = p_color;
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 Color Theme::get_color(const StringName &p_name, const StringName &p_node_type) const {
@@ -555,7 +563,7 @@ void Theme::rename_color(const StringName &p_old_name, const StringName &p_name,
 	color_map[p_node_type][p_name] = color_map[p_node_type][p_old_name];
 	color_map[p_node_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_color(const StringName &p_name, const StringName &p_node_type) {
@@ -564,7 +572,7 @@ void Theme::clear_color(const StringName &p_name, const StringName &p_node_type)
 
 	color_map[p_node_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_color_list(StringName p_node_type, List<StringName> *p_list) const {
@@ -599,9 +607,10 @@ void Theme::get_color_types(List<StringName> *p_list) const {
 
 // Theme constants.
 void Theme::set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant) {
+	bool existing = has_constant_nocheck(p_name, p_node_type);
 	constant_map[p_node_type][p_name] = p_constant;
 
-	_emit_theme_changed();
+	_emit_theme_changed(!existing);
 }
 
 int Theme::get_constant(const StringName &p_name, const StringName &p_node_type) const {
@@ -628,7 +637,7 @@ void Theme::rename_constant(const StringName &p_old_name, const StringName &p_na
 	constant_map[p_node_type][p_name] = constant_map[p_node_type][p_old_name];
 	constant_map[p_node_type].erase(p_old_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::clear_constant(const StringName &p_name, const StringName &p_node_type) {
@@ -637,7 +646,7 @@ void Theme::clear_constant(const StringName &p_name, const StringName &p_node_ty
 
 	constant_map[p_node_type].erase(p_name);
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::get_constant_list(StringName p_node_type, List<StringName> *p_list) const {
@@ -1120,12 +1129,14 @@ PoolVector<String> Theme::_get_type_list(const String &p_node_type) const {
 }
 
 // Theme bulk manipulations.
-void Theme::_emit_theme_changed() {
+void Theme::_emit_theme_changed(bool p_notify_list_changed) {
 	if (no_change_propagation) {
 		return;
 	}
 
-	_change_notify();
+	if (p_notify_list_changed) {
+		_change_notify();
+	}
 	emit_changed();
 }
 
@@ -1135,7 +1146,7 @@ void Theme::_freeze_change_propagation() {
 
 void Theme::_unfreeze_and_propagate_changes() {
 	no_change_propagation = false;
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::copy_default_theme() {
@@ -1314,7 +1325,7 @@ void Theme::clear() {
 	color_map.clear();
 	constant_map.clear();
 
-	_emit_theme_changed();
+	_emit_theme_changed(true);
 }
 
 void Theme::_bind_methods() {
@@ -1372,7 +1383,7 @@ void Theme::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_type_list", "node_type"), &Theme::_get_type_list);
 
-	ClassDB::bind_method(D_METHOD("_emit_theme_changed"), &Theme::_emit_theme_changed);
+	ClassDB::bind_method(D_METHOD("_emit_theme_changed", "notify_list_changed"), &Theme::_emit_theme_changed, DEFVAL(false));
 
 	ClassDB::bind_method("copy_default_theme", &Theme::copy_default_theme);
 	ClassDB::bind_method(D_METHOD("copy_theme", "other"), &Theme::copy_theme);

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -120,6 +120,7 @@ public:
 
 	void set_default_theme_font(const Ref<Font> &p_default_font);
 	Ref<Font> get_default_theme_font() const;
+	bool has_default_theme_font() const;
 
 	void set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture> &p_icon);
 	Ref<Texture> get_icon(const StringName &p_name, const StringName &p_node_type) const;

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -90,12 +90,16 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
-	static Ref<Theme> project_default_theme;
+	// Universal Theme resources used when no other theme has the item.
 	static Ref<Theme> default_theme;
+	static Ref<Theme> project_default_theme;
+
+	// Universal default values, final fallback for every theme.
 	static Ref<Texture> default_icon;
 	static Ref<StyleBox> default_style;
 	static Ref<Font> default_font;
 
+	// Default values configurable for each individual theme.
 	Ref<Font> default_theme_font;
 
 	static void _bind_methods();

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -61,7 +61,7 @@ public:
 private:
 	bool no_change_propagation = false;
 
-	void _emit_theme_changed();
+	void _emit_theme_changed(bool p_notify_list_changed = false);
 
 	HashMap<StringName, HashMap<StringName, Ref<Texture>>> icon_map;
 	HashMap<StringName, HashMap<StringName, Ref<StyleBox>>> style_map;


### PR DESCRIPTION
Backport of https://github.com/godotengine/godot/pull/53396 for `3.x`. Includes reorganization of the Theme resource from https://github.com/godotengine/godot/pull/53341 and exposes some methods for default theme font from it for feature parity with `master`.

As mentioned in https://github.com/godotengine/godot/issues/53087#issuecomment-927297357, the https://github.com/godotengine/godot/issues/53087 problem cannot be reproduced in current `3.x` branch due to https://github.com/godotengine/godot/pull/52984 removing sub-inspectors for the related cases. But if you roll that PR back locally on top of this one, you should see that the issue is fixed.