### PR TITLE
Enable GLTFDocumentExtensionConvertImporterMesh only in games.

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -31,7 +31,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="extensions" type="GLTFDocumentExtension[]" setter="set_extensions" getter="get_extensions" default="[Object(GLTFDocumentExtensionConvertImporterMesh,&quot;resource_local_to_scene&quot;:false,&quot;resource_name&quot;:&quot;&quot;,&quot;script&quot;:null)]">
+		<member name="extensions" type="GLTFDocumentExtension[]" setter="set_extensions" getter="get_extensions" default="[]">
 		</member>
 	</members>
 </class>

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6887,7 +6887,8 @@ TypedArray<GLTFDocumentExtension> GLTFDocument::get_extensions() const {
 }
 
 GLTFDocument::GLTFDocument() {
-	if (!::Engine::get_singleton()->is_editor_hint()) {
+	bool is_editor = ::Engine::get_singleton()->is_editor_hint();
+	if (is_editor) {
 		return;
 	}
 	Ref<GLTFDocumentExtensionConvertImporterMesh> extension_editor;


### PR DESCRIPTION
Resolve bug, enable conversion to MeshInstance3D only in games.

Bug was caught by Lyuma.