### PR TITLE
Detect long scene restoring

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -361,6 +361,7 @@ private:
 
 	RichTextLabel *load_errors = nullptr;
 	AcceptDialog *load_error_dialog = nullptr;
+	AcceptDialog *long_load_dialog = nullptr;
 
 	RichTextLabel *execute_outputs = nullptr;
 	AcceptDialog *execute_output_dialog = nullptr;
@@ -534,6 +535,7 @@ private:
 	void _enable_pending_addons();
 
 	void _dialog_action(String p_file);
+	void _long_load_action(bool p_disable_restore, const Control *p_dont_ask);
 
 	void _edit_current(bool p_skip_foreign = false);
 	void _dialog_display_save_error(String p_file, Error p_error);


### PR DESCRIPTION
This PR adressess concerns raised in #16317 and #52601

Editor will now measure the time during restoring scenes. If it takes longer than ~~30~~ 15 seconds, a dialog will appear asking if they want to disable scene restoring, with a checkbox to never ask again (stored in project metadata).
![gVYTpiUHwF](https://user-images.githubusercontent.com/2223172/135898613-ceaa7741-fa16-405a-ad9a-114a66857eee.gif)