### PR TITLE
revert 0d7409a so additional error information prints in release builds

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -89,13 +89,6 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 #define GENERATE_TRAP() __builtin_trap()
 #endif
 
-// Used to strip debug messages in release mode
-#ifdef DEBUG_ENABLED
-#define DEBUG_STR(m_msg) m_msg
-#else
-#define DEBUG_STR(m_msg) ""
-#endif
-
 /**
  * Error macros.
  * WARNING: These macros work in the opposite way to assert().
@@ -135,11 +128,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return;                                                                                                                   \
-	} else                                                                                                                        \
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                     \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+		return;                                                                                                        \
+	} else                                                                                                             \
 		((void)0)
 
 /**
@@ -160,11 +153,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                    \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                         \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+		return m_retval;                                                                                               \
+	} else                                                                                                             \
 		((void)0)
 
 /**
@@ -189,11 +182,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                     \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                             \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
-		GENERATE_TRAP();                                                                                                                \
-	} else                                                                                                                              \
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                          \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+		GENERATE_TRAP();                                                                                                     \
+	} else                                                                                                                   \
 		((void)0)
 
 // Unsigned integer index out of bounds error macros.
@@ -216,11 +209,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                       \
-	if (unlikely((m_index) >= (m_size))) {                                                                                        \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return;                                                                                                                   \
-	} else                                                                                                                        \
+#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                            \
+	if (unlikely((m_index) >= (m_size))) {                                                                             \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+		return;                                                                                                        \
+	} else                                                                                                             \
 		((void)0)
 
 /**
@@ -241,11 +234,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                           \
-	if (unlikely((m_index) >= (m_size))) {                                                                                        \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                \
+	if (unlikely((m_index) >= (m_size))) {                                                                             \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+		return m_retval;                                                                                               \
+	} else                                                                                                             \
 		((void)0)
 
 /**
@@ -270,11 +263,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                            \
-	if (unlikely((m_index) >= (m_size))) {                                                                                              \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
-		GENERATE_TRAP();                                                                                                                \
-	} else                                                                                                                              \
+#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                 \
+	if (unlikely((m_index) >= (m_size))) {                                                                                   \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+		GENERATE_TRAP();                                                                                                     \
+	} else                                                                                                                   \
 		((void)0)
 
 // Null reference error macros.
@@ -297,11 +290,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                                 \
-	if (unlikely(m_param == nullptr)) {                                                                                   \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
-		return;                                                                                                           \
-	} else                                                                                                                \
+#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                      \
+	if (unlikely(m_param == nullptr)) {                                                                        \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
+		return;                                                                                                \
+	} else                                                                                                     \
 		((void)0)
 
 /**
@@ -322,11 +315,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                                     \
-	if (unlikely(m_param == nullptr)) {                                                                                   \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                  \
-	} else                                                                                                                \
+#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                          \
+	if (unlikely(m_param == nullptr)) {                                                                        \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
+		return m_retval;                                                                                       \
+	} else                                                                                                     \
 		((void)0)
 
 /**
@@ -352,11 +345,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * If checking for null use ERR_FAIL_NULL_MSG instead.
  * If checking index bounds use ERR_FAIL_INDEX_MSG instead.
  */
-#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                                 \
-	if (unlikely(m_cond)) {                                                                                              \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
-		return;                                                                                                          \
-	} else                                                                                                               \
+#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                      \
+	if (unlikely(m_cond)) {                                                                                   \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg); \
+		return;                                                                                               \
+	} else                                                                                                    \
 		((void)0)
 
 /**
@@ -382,11 +375,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * If checking for null use ERR_FAIL_NULL_V_MSG instead.
  * If checking index bounds use ERR_FAIL_INDEX_V_MSG instead.
  */
-#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                                \
-	if (unlikely(m_cond)) {                                                                                                                         \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                                            \
-	} else                                                                                                                                          \
+#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                     \
+	if (unlikely(m_cond)) {                                                                                                              \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg); \
+		return m_retval;                                                                                                                 \
+	} else                                                                                                                               \
 		((void)0)
 
 /**
@@ -407,11 +400,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop continues.
  */
-#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                              \
-	if (unlikely(m_cond)) {                                                                                                          \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", DEBUG_STR(m_msg)); \
-		continue;                                                                                                                    \
-	} else                                                                                                                           \
+#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                   \
+	if (unlikely(m_cond)) {                                                                                               \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg); \
+		continue;                                                                                                         \
+	} else                                                                                                                \
 		((void)0)
 
 /**
@@ -432,11 +425,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop breaks.
  */
-#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                               \
-	if (unlikely(m_cond)) {                                                                                                        \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", DEBUG_STR(m_msg)); \
-		break;                                                                                                                     \
-	} else                                                                                                                         \
+#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                    \
+	if (unlikely(m_cond)) {                                                                                             \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg); \
+		break;                                                                                                          \
+	} else                                                                                                              \
 		((void)0)
 
 /**
@@ -461,11 +454,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the application crashes.
  */
-#define CRASH_COND_MSG(m_cond, m_msg)                                                                                           \
-	if (unlikely(m_cond)) {                                                                                                     \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
-		GENERATE_TRAP();                                                                                                        \
-	} else                                                                                                                      \
+#define CRASH_COND_MSG(m_cond, m_msg)                                                                                \
+	if (unlikely(m_cond)) {                                                                                          \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", m_msg); \
+		GENERATE_TRAP();                                                                                             \
+	} else                                                                                                           \
 		((void)0)
 
 // Generic error macros.
@@ -490,11 +483,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  *
  * Prints `m_msg`, and the current function returns.
  */
-#define ERR_FAIL_MSG(m_msg)                                                                              \
-	if (true) {                                                                                          \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", DEBUG_STR(m_msg)); \
-		return;                                                                                          \
-	} else                                                                                               \
+#define ERR_FAIL_MSG(m_msg)                                                                   \
+	if (true) {                                                                               \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg); \
+		return;                                                                               \
+	} else                                                                                    \
 		((void)0)
 
 /**
@@ -517,11 +510,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  *
  * Prints `m_msg`, and the current function returns `m_retval`.
  */
-#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                             \
-	if (true) {                                                                                                                     \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                            \
-	} else                                                                                                                          \
+#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                  \
+	if (true) {                                                                                                          \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg); \
+		return m_retval;                                                                                                 \
+	} else                                                                                                               \
 		((void)0)
 
 /**
@@ -590,14 +583,14 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 /**
  * Warns that the current function is deprecated and prints `m_msg`.
  */
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                           \
-	if (true) {                                                                                                                                                              \
-		static SafeFlag warning_shown;                                                                                                                                       \
-		if (!warning_shown.is_set()) {                                                                                                                                       \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", DEBUG_STR(m_msg), ERR_HANDLER_WARNING); \
-			warning_shown.set();                                                                                                                                             \
-		}                                                                                                                                                                    \
-	} else                                                                                                                                                                   \
+#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                \
+	if (true) {                                                                                                                                                   \
+		static SafeFlag warning_shown;                                                                                                                            \
+		if (!warning_shown.is_set()) {                                                                                                                            \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, ERR_HANDLER_WARNING); \
+			warning_shown.set();                                                                                                                                  \
+		}                                                                                                                                                         \
+	} else                                                                                                                                                        \
 		((void)0)
 
 /**
@@ -618,11 +611,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  *
  * Prints `m_msg`, and then the application crashes.
  */
-#define CRASH_NOW_MSG(m_msg)                                                                                    \
-	if (true) {                                                                                                 \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed.", DEBUG_STR(m_msg)); \
-		GENERATE_TRAP();                                                                                        \
-	} else                                                                                                      \
+#define CRASH_NOW_MSG(m_msg)                                                                         \
+	if (true) {                                                                                      \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed.", m_msg); \
+		GENERATE_TRAP();                                                                             \
+	} else                                                                                           \
 		((void)0)
 
 #endif // ERROR_MACROS_H

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -38,7 +38,6 @@
 
 #include <avrt.h>
 
-#ifdef DEBUG_ENABLED
 static String format_error_message(DWORD id) {
 	LPWSTR messageBuffer = nullptr;
 	size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
@@ -50,7 +49,6 @@ static String format_error_message(DWORD id) {
 
 	return msg;
 }
-#endif // DEBUG_ENABLED
 
 bool DisplayServerWindows::has_feature(Feature p_feature) const {
 	switch (p_feature) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -75,7 +75,6 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 #define GetProcAddress (void *)GetProcAddress
 #endif
 
-#ifdef DEBUG_ENABLED
 static String format_error_message(DWORD id) {
 	LPWSTR messageBuffer = nullptr;
 	size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
@@ -87,7 +86,6 @@ static String format_error_message(DWORD id) {
 
 	return msg;
 }
-#endif // DEBUG_ENABLED
 
 void RedirectIOToConsole() {
 	int hConHandle;


### PR DESCRIPTION
Implements proposal https://github.com/godotengine/godot-proposals/issues/3382 and could be cherry-picked for 3.X

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
