### PR TITLE
Fix some leftover references to idle_frame

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1044,7 +1044,7 @@
 		<member name="rect_scale" type="Vector2" setter="set_scale" getter="get_scale" default="Vector2(1, 1)">
 			The node's scale, relative to its [member rect_size]. Change this property to scale the node around its [member rect_pivot_offset]. The Control's [member hint_tooltip] will also scale according to this value.
 			[b]Note:[/b] This property is mainly intended to be used for animation purposes. Text inside the Control will look pixelated or blurry when the Control is scaled. To support multiple resolutions in your project, use an appropriate viewport stretch mode as described in the [url=https://docs.godotengine.org/en/latest/tutorials/viewports/multiple_resolutions.html]documentation[/url] instead of scaling Controls individually.
-			[b]Note:[/b] If the Control node is a child of a [Container] node, the scale will be reset to [code]Vector2(1, 1)[/code] when the scene is instantiated. To set the Control's scale when it's instantiated, wait for one frame using [code]yield(get_tree(), "idle_frame")[/code] then set its [member rect_scale] property.
+			[b]Note:[/b] If the Control node is a child of a [Container] node, the scale will be reset to [code]Vector2(1, 1)[/code] when the scene is instantiated. To set the Control's scale when it's instantiated, wait for one frame using [code]yield(get_tree(), "process_frame")[/code] then set its [member rect_scale] property.
 		</member>
 		<member name="rect_size" type="Vector2" setter="_set_size" getter="get_size" default="Vector2(0, 0)">
 			The size of the node's bounding rectangle, in pixels. [Container] nodes update this property automatically.

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1466,15 +1466,15 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 }
 
 void AnimationPlayerEditor::_start_onion_skinning() {
-	// FIXME: Using "idle_frame" makes onion layers update one frame behind the current.
-	if (!get_tree()->is_connected("idle_frame", callable_mp(this, &AnimationPlayerEditor::_prepare_onion_layers_1_deferred))) {
-		get_tree()->connect("idle_frame", callable_mp(this, &AnimationPlayerEditor::_prepare_onion_layers_1_deferred));
+	// FIXME: Using "process_frame" makes onion layers update one frame behind the current.
+	if (!get_tree()->is_connected("process_frame", callable_mp(this, &AnimationPlayerEditor::_prepare_onion_layers_1_deferred))) {
+		get_tree()->connect("process_frame", callable_mp(this, &AnimationPlayerEditor::_prepare_onion_layers_1_deferred));
 	}
 }
 
 void AnimationPlayerEditor::_stop_onion_skinning() {
-	if (get_tree()->is_connected("idle_frame", callable_mp(this, &AnimationPlayerEditor::_prepare_onion_layers_1_deferred))) {
-		get_tree()->disconnect("idle_frame", callable_mp(this, &AnimationPlayerEditor::_prepare_onion_layers_1_deferred));
+	if (get_tree()->is_connected("process_frame", callable_mp(this, &AnimationPlayerEditor::_prepare_onion_layers_1_deferred))) {
+		get_tree()->disconnect("process_frame", callable_mp(this, &AnimationPlayerEditor::_prepare_onion_layers_1_deferred));
 
 		_free_onion_layers();
 

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -246,11 +246,9 @@ void TilesEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		tiles_editor_button->show();
 		editor_node->make_bottom_panel_item_visible(tiles_editor);
-		//get_tree()->connect_compat("idle_frame", tileset_editor, "_on_workspace_process");
 	} else {
 		editor_node->hide_bottom_panel();
 		tiles_editor_button->hide();
-		//get_tree()->disconnect_compat("idle_frame", tileset_editor, "_on_workspace_process");
 	}
 }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
@@ -117,7 +117,7 @@ namespace Godot
         /// {
         ///     for (int i = 0; i &lt; 100; i++)
         ///     {
-        ///         await ToSignal(GetTree(), "idle_frame");
+        ///         await ToSignal(GetTree(), "process_frame");
         ///         GD.Print($"Frame {i}");
         ///     }
         /// }

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -121,7 +121,7 @@ public:
 					ret = STEP_EXIT_FUNCTION_BIT;
 					break; //return the yield
 				case VisualScriptYield::YIELD_FRAME:
-					state->connect_to_signal(tree, "idle_frame", Array());
+					state->connect_to_signal(tree, "process_frame", Array());
 					break;
 				case VisualScriptYield::YIELD_PHYSICS_FRAME:
 					state->connect_to_signal(tree, "physics_frame", Array());


### PR DESCRIPTION
#44593 left some references to "idle_frame" signal, one of them was spamming errors in the animation editor.