### PR TITLE
 Make WASAPI return accurate latency information 

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -72,6 +72,8 @@ class AudioDriverWASAPI : public AudioDriver {
 	int mix_rate = 0;
 	int buffer_frames = 0;
 	int target_latency_ms = 0;
+	float real_latency = 0.0;
+	bool using_audio_client_3 = false;
 
 	bool thread_exited = false;
 	mutable bool exit_thread = false;
@@ -98,6 +100,7 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual float get_latency();
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual Array get_device_list();
 	virtual String get_device();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This makes WASAPI report playback latency using the WASAPI specific APIs for it, but I am still not sure if this is enough, it went from 30-something ms to 10 ms for me, which seems about right for WASAPI in low latency shared mode.