### PR TITLE
Correctly bind optional arguments when emitting `Theme` changes

### DIFF
--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -271,7 +271,7 @@ void Theme::set_default_theme_font(const Ref<Font> &p_default_font) {
 	default_theme_font = p_default_font;
 
 	if (default_theme_font.is_valid()) {
-		default_theme_font->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+		default_theme_font->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(false), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_emit_theme_changed();
@@ -314,7 +314,7 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_theme_type, c
 	icon_map[p_theme_type][p_name] = p_icon;
 
 	if (p_icon.is_valid()) {
-		icon_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+		icon_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(false), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_emit_theme_changed(!existing);
@@ -401,7 +401,7 @@ void Theme::set_stylebox(const StringName &p_name, const StringName &p_theme_typ
 	style_map[p_theme_type][p_name] = p_style;
 
 	if (p_style.is_valid()) {
-		style_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+		style_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(false), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_emit_theme_changed(!existing);
@@ -488,7 +488,7 @@ void Theme::set_font(const StringName &p_name, const StringName &p_theme_type, c
 	font_map[p_theme_type][p_name] = p_font;
 
 	if (p_font.is_valid()) {
-		font_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+		font_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(false), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_emit_theme_changed(!existing);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/53404, a regression from https://github.com/godotengine/godot/pull/53396. Doesn't seem to be a problem in the `3.x` backport, before callables.