### PR TITLE
Safeguard against BitMap fonts in the CanvasItem editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4218,8 +4218,10 @@ void CanvasItemEditor::_notification(int p_what) {
 		anchor_mode_button->set_icon(get_icon("Anchor", "EditorIcons"));
 
 		Ref<DynamicFont> font = zoom_reset->get_font("font")->duplicate(false);
-		font->set_outline_size(1);
-		font->set_outline_color(Color(0, 0, 0));
+		if (font.is_valid()) {
+			font->set_outline_size(1);
+			font->set_outline_color(Color(0, 0, 0));
+		}
 		zoom_reset->add_font_override("font", font);
 		zoom_reset->add_color_override("font_color", Color(1, 1, 1));
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/52999, fixes https://github.com/godotengine/godot/issues/35462. Thanks to @arrowinaknee for investigating the issue!

Not relevant for `master`.