### PR TITLE
Fix LUA-style assignment in Dictionary

### DIFF
--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -239,7 +239,8 @@ void Variant::set_named(const StringName &p_member, const Variant &p_value, bool
 			*v = p_value;
 			r_valid = true;
 		} else {
-			r_valid = false;
+			VariantGetInternalPtr<Dictionary>::get_ptr(this)->operator[](p_member) = p_value;
+			r_valid = true;
 		}
 
 	} else {

--- a/modules/gdscript/tests/scripts/runtime/features/lua_assign.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/lua_assign.gd
@@ -1,0 +1,4 @@
+func test():
+	var dict = {}
+	dict.test = 1
+	print(dict.test)

--- a/modules/gdscript/tests/scripts/runtime/features/lua_assign.out
+++ b/modules/gdscript/tests/scripts/runtime/features/lua_assign.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+1


### PR DESCRIPTION
Fixes #52835
The error only appeared when the key didn't exist.