### PR TITLE
Fix shader crashes when passing array.length to functions

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -876,7 +876,6 @@ private:
 
 	StringName current_function;
 	bool last_const = false;
-	bool pass_array = false;
 	StringName last_name;
 
 	VaryingFunctionNames varying_function_names;


### PR DESCRIPTION
Fixed incorrect handling of array length function:

![image](https://user-images.githubusercontent.com/3036176/135973973-b1aa51b2-253c-4179-9dfa-d2a7ffcf9a0f.png)

Fixed shader crash when passing that function to array:

![image](https://user-images.githubusercontent.com/3036176/135977776-dc72bf55-e35d-4a1e-9da0-d9ed530de8ff.png)

