### PR TITLE
Fix ViewportTexture error when viewport is used from a child scene

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -57,16 +57,16 @@
 #include "servers/audio_server.h"
 
 void ViewportTexture::setup_local_to_scene() {
+	Node *local_scene = get_local_scene();
+	if (!local_scene) {
+		return;
+	}
+
 	if (vp) {
 		vp->viewport_textures.erase(this);
 	}
 
 	vp = nullptr;
-
-	Node *local_scene = get_local_scene();
-	if (!local_scene) {
-		return;
-	}
 
 	Node *vpn = local_scene->get_node(path);
 	ERR_FAIL_COND_MSG(!vpn, "ViewportTexture: Path to node is invalid.");


### PR DESCRIPTION
Fix invalid errors when a separate child scene file contains a viewport and
that viewport is used for a texture in the current scene.

Fixes #27790.

Forward port of @jitspoe's #52365 to `master`.