### PR TITLE
Improve error message when instantiating virtual class

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -529,7 +529,7 @@ Object *ClassDB::instantiate(const StringName &p_class) {
 		}
 		ERR_FAIL_COND_V_MSG(!ti, nullptr, "Cannot get class '" + String(p_class) + "'.");
 		ERR_FAIL_COND_V_MSG(ti->disabled, nullptr, "Class '" + String(p_class) + "' is disabled.");
-		ERR_FAIL_COND_V(!ti->creation_func, nullptr);
+		ERR_FAIL_COND_V_MSG(!ti->creation_func, nullptr, "Class '" + String(p_class) + "' or its base class cannot be instantiated.");
 	}
 #ifdef TOOLS_ENABLED
 	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {


### PR DESCRIPTION
So, I just landed on this error: `Condition "!ti->creation_func" is true. Returned: __null`

Looking for it, I only found https://github.com/godotengine/godot-docs/issues/3460, which kind of helps, but is about a very different situation.

I ended up figuring that I can't inherit from CanvasItem which isn't something you'd think since Node2D and Control do inherit from it. I just added a message to clarify that situation: `"Class '" + String(p_class) + "' or its base class cannot be instantiated.`

Should make figuring out the issue easier.