### PR TITLE
[File] Fix FileAccessCompressed::get_buffer return value.

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -312,10 +312,10 @@ uint64_t FileAccessCompressed::get_buffer(uint8_t *p_dst, uint64_t p_length) con
 			} else {
 				read_block--;
 				at_end = true;
-				if (i < p_length - 1) {
+				if (i + 1 < p_length) {
 					read_eof = true;
 				}
-				return i;
+				return i + 1;
 			}
 		}
 	}


### PR DESCRIPTION
It used to return the write index instead of the written bytes (i.e. index + 1) when reading until last block.

Fixes #47971 . Closes #47975 . Should also be cherry-picked to `3.x` after the `re-revert` of #47811 .

While I think this is the right fix, this might need quite some testing, and another set of eyes would be really appreciated.