### PR TITLE
Implement TileMap patterns palette

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -763,10 +763,10 @@
 		</method>
 		<method name="set_drag_forwarding">
 			<return type="void" />
-			<argument index="0" name="target" type="Node" />
+			<argument index="0" name="target" type="Object" />
 			<description>
-				Forwards the handling of this control's drag and drop to [code]target[/code] node.
-				Forwarding can be implemented in the target node similar to the methods [method _get_drag_data], [method _can_drop_data], and [method _drop_data] but with two differences:
+				Forwards the handling of this control's drag and drop to [code]target[/code] object.
+				Forwarding can be implemented in the target object similar to the methods [method _get_drag_data], [method _can_drop_data], and [method _drop_data] but with two differences:
 				1. The function name must be suffixed with [b]_fw[/b]
 				2. The function must take an extra argument that is the control doing the forwarding
 				[codeblocks]

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -117,6 +117,14 @@
 				Returns the neighboring cell to the one at coordinates [code]coords[/code], indentified by the [code]neighbor[/code] direction. This method takes into account the different layouts a TileMap can take.
 			</description>
 		</method>
+		<method name="get_pattern">
+			<return type="TileMapPattern" />
+			<argument index="0" name="layer" type="int" />
+			<argument index="1" name="coords_array" type="Vector2i[]" />
+			<description>
+				Creates a new [TileMapPattern] from the given layer and set of cells.
+			</description>
+		</method>
 		<method name="get_surrounding_tiles">
 			<return type="Vector2i[]" />
 			<argument index="0" name="coords" type="Vector2i" />
@@ -149,6 +157,15 @@
 			<argument index="0" name="layer" type="int" />
 			<description>
 				Returns if a layer Y-sorts its tiles.
+			</description>
+		</method>
+		<method name="map_pattern">
+			<return type="Vector2i" />
+			<argument index="0" name="position_in_tilemap" type="Vector2i" />
+			<argument index="1" name="coords_in_pattern" type="Vector2i" />
+			<argument index="2" name="pattern" type="TileMapPattern" />
+			<description>
+				Returns for the given coodinate [code]coords_in_pattern[/code] in a [TileMapPattern] the corresponding cell coordinates if the pattern was pasted at the [code]position_in_tilemap[/code] coordinates (see [method set_pattern]). This mapping is required as in half-offset tile shapes, the mapping might not work by calculating [code]position_in_tile_map + coords_in_pattern[/code]
 			</description>
 		</method>
 		<method name="map_to_world" qualifiers="const">
@@ -235,6 +252,15 @@
 			<argument index="1" name="z_index" type="int" />
 			<description>
 				Sets a layers Z-index value. This Z-index is added to each tile's Z-index value.
+			</description>
+		</method>
+		<method name="set_pattern">
+			<return type="void" />
+			<argument index="0" name="layer" type="int" />
+			<argument index="1" name="position" type="Vector2i" />
+			<argument index="2" name="pattern" type="TileMapPattern" />
+			<description>
+				Paste the given [TileMapPattern] at the given [code]position[/code] and [code]layer[/code] in the tile map.
 			</description>
 		</method>
 		<method name="world_to_map" qualifiers="const">

--- a/doc/classes/TileMapPattern.xml
+++ b/doc/classes/TileMapPattern.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TileMapPattern" inherits="Resource" version="4.0">
+	<brief_description>
+		Holds a pattern to be copied from or pasted into [TileMap]s.
+	</brief_description>
+	<description>
+		This resource holds a set of cells to help bulk manipulations of [TileMap].
+		A pattern always start at the [code](0,0)[/code] coordinates and cannot have cells with negative coordinates.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_cell_alternative_tile" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="coords" type="Vector2i" />
+			<description>
+				Returns the tile alternative ID of the cell at [code]coords[/code].
+			</description>
+		</method>
+		<method name="get_cell_atlas_coords" qualifiers="const">
+			<return type="Vector2i" />
+			<argument index="0" name="coords" type="Vector2i" />
+			<description>
+				Returns the tile atlas coordinates ID of the cell at [code]coords[/code].
+			</description>
+		</method>
+		<method name="get_cell_source_id" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="coords" type="Vector2i" />
+			<description>
+				Returns the tile source ID of the cell at [code]coords[/code].
+			</description>
+		</method>
+		<method name="get_size" qualifiers="const">
+			<return type="Vector2i" />
+			<description>
+				Returns the size, in cells, of the pattern.
+			</description>
+		</method>
+		<method name="get_used_cells" qualifiers="const">
+			<return type="Vector2i[]" />
+			<description>
+				Returns the list of used cell coordinates in the pattern.
+			</description>
+		</method>
+		<method name="has_cell" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="coords" type="Vector2i" />
+			<description>
+				Returns whether the pattern has a tile at the given coordinates.
+			</description>
+		</method>
+		<method name="is_empty" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether the pattern is empty or not.
+			</description>
+		</method>
+		<method name="remove_cell">
+			<return type="void" />
+			<argument index="0" name="coords" type="Vector2i" />
+			<argument index="1" name="arg1" type="bool" />
+			<description>
+				Remove the cell at the given coordinates.
+			</description>
+		</method>
+		<method name="set_cell">
+			<return type="void" />
+			<argument index="0" name="coords" type="Vector2i" />
+			<argument index="1" name="source_id" type="int" default="-1" />
+			<argument index="2" name="atlas_coords" type="Vector2i" default="Vector2i(-1, -1)" />
+			<argument index="3" name="alternative_tile" type="int" default="-1" />
+			<description>
+				Sets the tile indentifiers for the cell at coordinates [code]coords[/code]. See [method TileMap.set_cell].
+			</description>
+		</method>
+		<method name="set_size">
+			<return type="void" />
+			<argument index="0" name="size" type="Vector2i" />
+			<description>
+				Sets the size of the pattern.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -46,6 +46,14 @@
 				Occlusion layers allow assigning occlusion polygons to atlas tiles.
 			</description>
 		</method>
+		<method name="add_pattern">
+			<return type="int" />
+			<argument index="0" name="pattern" type="TileMapPattern" />
+			<argument index="1" name="index" type="int" default="-1" />
+			<description>
+				Adds a [TileMapPattern] to be stored in the TileSet resouce. If provided, insert it at the given [code]index[/code].
+			</description>
+		</method>
 		<method name="add_physics_layer">
 			<return type="void" />
 			<argument index="0" name="to_position" type="int" default="-1" />
@@ -152,6 +160,19 @@
 			<return type="int" />
 			<description>
 				Returns the occlusion layers count.
+			</description>
+		</method>
+		<method name="get_pattern">
+			<return type="TileMapPattern" />
+			<argument index="0" name="index" type="int" default="-1" />
+			<description>
+				Returns the [TileMapPattern] at the given [code]index[/code].
+			</description>
+		</method>
+		<method name="get_patterns_count">
+			<return type="int" />
+			<description>
+				Returns the number of [TileMapPattern] this tile set handles.
 			</description>
 		</method>
 		<method name="get_physics_layer_collision_layer" qualifiers="const">
@@ -372,6 +393,13 @@
 			<argument index="0" name="layer_index" type="int" />
 			<description>
 				Removes the occlusion layer at index [code]layer_index[/code]. Also updates the atlas tiles accordingly.
+			</description>
+		</method>
+		<method name="remove_pattern">
+			<return type="void" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Remove the [TileMapPattern] at the given index.
 			</description>
 		</method>
 		<method name="remove_physics_layer">

--- a/editor/plugins/editor_preview_plugins.h
+++ b/editor/plugins/editor_preview_plugins.h
@@ -173,4 +173,22 @@ public:
 	EditorFontPreviewPlugin();
 	~EditorFontPreviewPlugin();
 };
+
+class EditorTileMapPatternPreviewPlugin : public EditorResourcePreviewGenerator {
+	GDCLASS(EditorTileMapPatternPreviewPlugin, EditorResourcePreviewGenerator);
+
+	mutable SafeFlag preview_done;
+
+	void _preview_done(const Variant &p_udata);
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual bool handles(const String &p_type) const override;
+	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+
+	EditorTileMapPatternPreviewPlugin();
+	~EditorTileMapPatternPreviewPlugin();
+};
 #endif // EDITORPREVIEWPLUGINS_H

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -46,7 +46,13 @@ class TileSetEditor : public VBoxContainer {
 private:
 	Ref<TileSet> tile_set;
 	bool tile_set_changed_needs_update = false;
+	HSplitContainer *split_container;
 
+	// Tabs.
+	HBoxContainer *tile_set_toolbar;
+	Tabs *tabs_bar;
+
+	// Tiles.
 	Label *no_source_selected_label;
 	TileSetAtlasSourceEditor *tile_set_atlas_source_editor;
 	TileSetScenesCollectionSourceEditor *tile_set_scenes_collection_source_editor;
@@ -69,7 +75,16 @@ private:
 	AtlasMergingDialog *atlas_merging_dialog;
 	TileProxiesManagerDialog *tile_proxies_manager_dialog;
 
+	// Patterns.
+	ItemList *patterns_item_list;
+	Label *patterns_help_label;
+	void _patterns_item_list_gui_input(const Ref<InputEvent> &p_event);
+	void _pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture);
+	bool select_last_pattern = false;
+	void _update_patterns_list();
+
 	void _tile_set_changed();
+	void _tab_changed(int p_tab_changed);
 
 	void _move_tile_set_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos);
 	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value);
@@ -82,6 +97,8 @@ public:
 	_FORCE_INLINE_ static TileSetEditor *get_singleton() { return singleton; }
 
 	void edit(Ref<TileSet> p_tile_set);
+	Control *get_toolbar() { return tile_set_toolbar; };
+
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -53,6 +53,7 @@ private:
 	Control *tilemap_toolbar;
 	TileMapEditor *tilemap_editor;
 
+	Control *tileset_toolbar;
 	TileSetEditor *tileset_editor;
 
 	void _update_switch_button();
@@ -62,6 +63,23 @@ private:
 	int atlas_sources_lists_current = 0;
 	float atlas_view_zoom = 1.0;
 	Vector2 atlas_view_scroll = Vector2();
+
+	// Patterns preview generation.
+	struct QueueItem {
+		Ref<TileSet> tile_set;
+		Ref<TileMapPattern> pattern;
+		Callable callback;
+	};
+	List<QueueItem> pattern_preview_queue;
+	Mutex pattern_preview_mutex;
+	Semaphore pattern_preview_sem;
+	Thread pattern_preview_thread;
+	SafeFlag pattern_thread_exit;
+	SafeFlag pattern_thread_exited;
+	mutable SafeFlag pattern_preview_done;
+	void _pattern_preview_done(const Variant &p_udata);
+	static void _thread_func(void *ud);
+	void _thread();
 
 	void _tile_map_changed();
 
@@ -81,6 +99,9 @@ public:
 
 	void set_atlas_view_transform(float p_zoom, Vector2 p_scroll);
 	void synchronize_atlas_view(Object *p_current);
+
+	// Pattern preview API.
+	void queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMapPattern> p_pattern, Callable p_callback);
 
 	void edit(Object *p_object);
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -37,51 +37,6 @@
 
 class TileSetAtlasSource;
 
-union TileMapCell {
-	struct {
-		int32_t source_id : 16;
-		int16_t coord_x : 16;
-		int16_t coord_y : 16;
-		int32_t alternative_tile : 16;
-	};
-
-	uint64_t _u64t;
-	TileMapCell(int p_source_id = -1, Vector2i p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE) {
-		source_id = p_source_id;
-		set_atlas_coords(p_atlas_coords);
-		alternative_tile = p_alternative_tile;
-	}
-
-	Vector2i get_atlas_coords() const {
-		return Vector2i(coord_x, coord_y);
-	}
-
-	void set_atlas_coords(const Vector2i &r_coords) {
-		coord_x = r_coords.x;
-		coord_y = r_coords.y;
-	}
-
-	bool operator<(const TileMapCell &p_other) const {
-		if (source_id == p_other.source_id) {
-			if (coord_x == p_other.coord_x) {
-				if (coord_y == p_other.coord_y) {
-					return alternative_tile < p_other.alternative_tile;
-				} else {
-					return coord_y < p_other.coord_y;
-				}
-			} else {
-				return coord_x < p_other.coord_x;
-			}
-		} else {
-			return source_id < p_other.source_id;
-		}
-	}
-
-	bool operator!=(const TileMapCell &p_other) const {
-		return !(source_id == p_other.source_id && coord_x == p_other.coord_x && coord_y == p_other.coord_y && alternative_tile == p_other.alternative_tile);
-	}
-};
-
 struct TileMapQuadrant {
 	struct CoordsWorldComparator {
 		_ALWAYS_INLINE_ bool operator()(const Vector2i &p_a, const Vector2i &p_b) const {
@@ -148,32 +103,6 @@ struct TileMapQuadrant {
 	TileMapQuadrant() :
 			dirty_list_element(this) {
 	}
-};
-
-class TileMapPattern : public Object {
-	GDCLASS(TileMapPattern, Object);
-
-	Vector2i size;
-	Map<Vector2i, TileMapCell> pattern;
-
-protected:
-	static void _bind_methods();
-
-public:
-	void set_cell(const Vector2i &p_coords, int p_source_id, const Vector2i p_atlas_coords, int p_alternative_tile = 0);
-	bool has_cell(const Vector2i &p_coords) const;
-	void remove_cell(const Vector2i &p_coords, bool p_update_size = true);
-	int get_cell_source_id(const Vector2i &p_coords) const;
-	Vector2i get_cell_atlas_coords(const Vector2i &p_coords) const;
-	int get_cell_alternative_tile(const Vector2i &p_coords) const;
-
-	TypedArray<Vector2i> get_used_cells() const;
-
-	Vector2i get_size() const;
-	void set_size(const Vector2i &p_size);
-	bool is_empty() const;
-
-	void clear();
 };
 
 class TileMap : public Node2D {
@@ -349,9 +278,9 @@ public:
 	Vector2i get_cell_atlas_coords(int p_layer, const Vector2i &p_coords, bool p_use_proxies = false) const;
 	int get_cell_alternative_tile(int p_layer, const Vector2i &p_coords, bool p_use_proxies = false) const;
 
-	TileMapPattern *get_pattern(int p_layer, TypedArray<Vector2i> p_coords_array);
-	Vector2i map_pattern(Vector2i p_position_in_tilemap, Vector2i p_coords_in_pattern, const TileMapPattern *p_pattern);
-	void set_pattern(int p_layer, Vector2i p_position, const TileMapPattern *p_pattern);
+	Ref<TileMapPattern> get_pattern(int p_layer, TypedArray<Vector2i> p_coords_array);
+	Vector2i map_pattern(Vector2i p_position_in_tilemap, Vector2i p_coords_in_pattern, Ref<TileMapPattern> p_pattern);
+	void set_pattern(int p_layer, Vector2i p_position, const Ref<TileMapPattern> p_pattern);
 
 	// Not exposed to users
 	TileMapCell get_cell(int p_layer, const Vector2i &p_coords, bool p_use_proxies = false) const;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -740,7 +740,7 @@ bool Control::has_point(const Point2 &p_point) const {
 	return Rect2(Point2(), get_size()).has_point(p_point);
 }
 
-void Control::set_drag_forwarding(Node *p_target) {
+void Control::set_drag_forwarding(Object *p_target) {
 	if (p_target) {
 		data.drag_owner = p_target->get_instance_id();
 	} else {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -355,7 +355,7 @@ public:
 	virtual Size2 get_minimum_size() const;
 	virtual Size2 get_combined_minimum_size() const;
 	virtual bool has_point(const Point2 &p_point) const;
-	virtual void set_drag_forwarding(Node *p_target);
+	virtual void set_drag_forwarding(Object *p_target);
 	virtual Variant get_drag_data(const Point2 &p_point);
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -685,6 +685,7 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(TileSetSource);
 	GDREGISTER_CLASS(TileSetAtlasSource);
 	GDREGISTER_CLASS(TileSetScenesCollectionSource);
+	GDREGISTER_CLASS(TileMapPattern);
 	GDREGISTER_CLASS(TileData);
 	GDREGISTER_CLASS(TileMap);
 	GDREGISTER_CLASS(ParallaxBackground);

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -31,6 +31,7 @@
 #include "tile_set.h"
 
 #include "core/core_string_names.h"
+#include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/templates/local_vector.h"
 
@@ -38,6 +39,189 @@
 #include "scene/gui/control.h"
 #include "scene/resources/convex_polygon_shape_2d.h"
 #include "servers/navigation_server_2d.h"
+
+/////////////////////////////// TileMapPattern //////////////////////////////////////
+
+void TileMapPattern::_set_tile_data(const Vector<int> &p_data) {
+	int c = p_data.size();
+	const int *r = p_data.ptr();
+
+	int offset = 3;
+	ERR_FAIL_COND_MSG(c % offset != 0, "Corrupted tile data.");
+
+	clear();
+
+	for (int i = 0; i < c; i += offset) {
+		const uint8_t *ptr = (const uint8_t *)&r[i];
+		uint8_t local[12];
+		for (int j = 0; j < 12; j++) {
+			local[j] = ptr[j];
+		}
+
+#ifdef BIG_ENDIAN_ENABLED
+		SWAP(local[0], local[3]);
+		SWAP(local[1], local[2]);
+		SWAP(local[4], local[7]);
+		SWAP(local[5], local[6]);
+		SWAP(local[8], local[11]);
+		SWAP(local[9], local[10]);
+#endif
+
+		int16_t x = decode_uint16(&local[0]);
+		int16_t y = decode_uint16(&local[2]);
+		uint16_t source_id = decode_uint16(&local[4]);
+		uint16_t atlas_coords_x = decode_uint16(&local[6]);
+		uint16_t atlas_coords_y = decode_uint16(&local[8]);
+		uint16_t alternative_tile = decode_uint16(&local[10]);
+		set_cell(Vector2i(x, y), source_id, Vector2i(atlas_coords_x, atlas_coords_y), alternative_tile);
+	}
+	emit_signal(SNAME("changed"));
+}
+
+Vector<int> TileMapPattern::_get_tile_data() const {
+	// Export tile data to raw format
+	Vector<int> data;
+	data.resize(pattern.size() * 3);
+	int *w = data.ptrw();
+
+	// Save in highest format
+
+	int idx = 0;
+	for (const KeyValue<Vector2i, TileMapCell> &E : pattern) {
+		uint8_t *ptr = (uint8_t *)&w[idx];
+		encode_uint16((int16_t)(E.key.x), &ptr[0]);
+		encode_uint16((int16_t)(E.key.y), &ptr[2]);
+		encode_uint16(E.value.source_id, &ptr[4]);
+		encode_uint16(E.value.coord_x, &ptr[6]);
+		encode_uint16(E.value.coord_y, &ptr[8]);
+		encode_uint16(E.value.alternative_tile, &ptr[10]);
+		idx += 3;
+	}
+
+	return data;
+}
+
+void TileMapPattern::set_cell(const Vector2i &p_coords, int p_source_id, const Vector2i p_atlas_coords, int p_alternative_tile) {
+	ERR_FAIL_COND_MSG(p_coords.x < 0 || p_coords.y < 0, vformat("Cannot set cell with negative coords in a TileMapPattern. Wrong coords: %s", p_coords));
+
+	size = size.max(p_coords + Vector2i(1, 1));
+	pattern[p_coords] = TileMapCell(p_source_id, p_atlas_coords, p_alternative_tile);
+	emit_changed();
+}
+
+bool TileMapPattern::has_cell(const Vector2i &p_coords) const {
+	return pattern.has(p_coords);
+}
+
+void TileMapPattern::remove_cell(const Vector2i &p_coords, bool p_update_size) {
+	ERR_FAIL_COND(!pattern.has(p_coords));
+
+	pattern.erase(p_coords);
+	if (p_update_size) {
+		size = Vector2i();
+		for (const KeyValue<Vector2i, TileMapCell> &E : pattern) {
+			size = size.max(E.key + Vector2i(1, 1));
+		}
+	}
+	emit_changed();
+}
+
+int TileMapPattern::get_cell_source_id(const Vector2i &p_coords) const {
+	ERR_FAIL_COND_V(!pattern.has(p_coords), TileSet::INVALID_SOURCE);
+
+	return pattern[p_coords].source_id;
+}
+
+Vector2i TileMapPattern::get_cell_atlas_coords(const Vector2i &p_coords) const {
+	ERR_FAIL_COND_V(!pattern.has(p_coords), TileSetSource::INVALID_ATLAS_COORDS);
+
+	return pattern[p_coords].get_atlas_coords();
+}
+
+int TileMapPattern::get_cell_alternative_tile(const Vector2i &p_coords) const {
+	ERR_FAIL_COND_V(!pattern.has(p_coords), TileSetSource::INVALID_TILE_ALTERNATIVE);
+
+	return pattern[p_coords].alternative_tile;
+}
+
+TypedArray<Vector2i> TileMapPattern::get_used_cells() const {
+	// Returns the cells used in the tilemap.
+	TypedArray<Vector2i> a;
+	a.resize(pattern.size());
+	int i = 0;
+	for (const KeyValue<Vector2i, TileMapCell> &E : pattern) {
+		Vector2i p(E.key.x, E.key.y);
+		a[i++] = p;
+	}
+
+	return a;
+}
+
+Vector2i TileMapPattern::get_size() const {
+	return size;
+}
+
+void TileMapPattern::set_size(const Vector2i &p_size) {
+	for (const KeyValue<Vector2i, TileMapCell> &E : pattern) {
+		Vector2i coords = E.key;
+		if (p_size.x <= coords.x || p_size.y <= coords.y) {
+			ERR_FAIL_MSG(vformat("Cannot set pattern size to %s, it contains a tile at %s. Size can only be increased.", p_size, coords));
+		};
+	}
+
+	size = p_size;
+	emit_changed();
+}
+
+bool TileMapPattern::is_empty() const {
+	return pattern.is_empty();
+};
+
+void TileMapPattern::clear() {
+	size = Vector2i();
+	pattern.clear();
+	emit_changed();
+};
+
+bool TileMapPattern::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "tile_data") {
+		if (p_value.is_array()) {
+			_set_tile_data(p_value);
+			return true;
+		}
+		return false;
+	}
+	return false;
+}
+
+bool TileMapPattern::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "tile_data") {
+		r_ret = _get_tile_data();
+		return true;
+	}
+	return false;
+}
+
+void TileMapPattern::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::OBJECT, "tile_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+}
+
+void TileMapPattern::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_set_tile_data", "data"), &TileMapPattern::_set_tile_data);
+	ClassDB::bind_method(D_METHOD("_get_tile_data"), &TileMapPattern::_get_tile_data);
+
+	ClassDB::bind_method(D_METHOD("set_cell", "coords", "source_id", "atlas_coords", "alternative_tile"), &TileMapPattern::set_cell, DEFVAL(TileSet::INVALID_SOURCE), DEFVAL(TileSetSource::INVALID_ATLAS_COORDS), DEFVAL(TileSetSource::INVALID_TILE_ALTERNATIVE));
+	ClassDB::bind_method(D_METHOD("has_cell", "coords"), &TileMapPattern::has_cell);
+	ClassDB::bind_method(D_METHOD("remove_cell", "coords"), &TileMapPattern::remove_cell);
+	ClassDB::bind_method(D_METHOD("get_cell_source_id", "coords"), &TileMapPattern::get_cell_source_id);
+	ClassDB::bind_method(D_METHOD("get_cell_atlas_coords", "coords"), &TileMapPattern::get_cell_atlas_coords);
+	ClassDB::bind_method(D_METHOD("get_cell_alternative_tile", "coords"), &TileMapPattern::get_cell_alternative_tile);
+
+	ClassDB::bind_method(D_METHOD("get_used_cells"), &TileMapPattern::get_used_cells);
+	ClassDB::bind_method(D_METHOD("get_size"), &TileMapPattern::get_size);
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &TileMapPattern::set_size);
+	ClassDB::bind_method(D_METHOD("is_empty"), &TileMapPattern::is_empty);
+}
 
 /////////////////////////////// TileSet //////////////////////////////////////
 
@@ -980,6 +1164,36 @@ void TileSet::clear_tile_proxies() {
 	alternative_level_proxies.clear();
 
 	emit_changed();
+}
+
+int TileSet::add_pattern(Ref<TileMapPattern> p_pattern, int p_index) {
+	ERR_FAIL_COND_V(!p_pattern.is_valid(), -1);
+	ERR_FAIL_COND_V_MSG(p_pattern->is_empty(), -1, "Cannot add an empty pattern to the TileSet.");
+	for (unsigned int i = 0; i < patterns.size(); i++) {
+		ERR_FAIL_COND_V_MSG(patterns[i] == p_pattern, -1, "TileSet has already this pattern.");
+	}
+	ERR_FAIL_COND_V(p_index > (int)patterns.size(), -1);
+	if (p_index < 0) {
+		p_index = patterns.size();
+	}
+	patterns.insert(p_index, p_pattern);
+	emit_changed();
+	return p_index;
+}
+
+Ref<TileMapPattern> TileSet::get_pattern(int p_index) {
+	ERR_FAIL_INDEX_V(p_index, (int)patterns.size(), Ref<TileMapPattern>());
+	return patterns[p_index];
+}
+
+void TileSet::remove_pattern(int p_index) {
+	ERR_FAIL_INDEX(p_index, (int)patterns.size());
+	patterns.remove(p_index);
+	emit_changed();
+}
+
+int TileSet::get_patterns_count() {
+	return patterns.size();
 }
 
 Vector<Vector2> TileSet::get_tile_shape_polygon() {
@@ -2483,6 +2697,12 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 				return true;
 			}
 			return false;
+		} else if (components.size() == 1 && components[0].begins_with("pattern_") && components[0].trim_prefix("pattern_").is_valid_int()) {
+			int pattern_index = components[0].trim_prefix("pattern_").to_int();
+			for (int i = patterns.size(); i <= pattern_index; i++) {
+				add_pattern(p_value);
+			}
+			return true;
 		}
 
 #ifndef DISABLE_DEPRECATED
@@ -2606,6 +2826,13 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 			return true;
 		}
 		return false;
+	} else if (components.size() == 1 && components[0].begins_with("pattern_") && components[0].trim_prefix("pattern_").is_valid_int()) {
+		int pattern_index = components[0].trim_prefix("pattern_").to_int();
+		if (pattern_index < 0 || pattern_index >= (int)patterns.size()) {
+			return false;
+		}
+		r_ret = patterns[pattern_index];
+		return true;
 	}
 
 	return false;
@@ -2686,6 +2913,11 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "tile_proxies/source_level", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "tile_proxies/coords_level", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "tile_proxies/alternative_level", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+
+	// Patterns.
+	for (unsigned int pattern_index = 0; pattern_index < patterns.size(); pattern_index++) {
+		p_list->push_back(PropertyInfo(Variant::OBJECT, vformat("pattern_%d", pattern_index), PROPERTY_HINT_RESOURCE_TYPE, "TileMapPattern", PROPERTY_USAGE_NOEDITOR));
+	}
 }
 
 void TileSet::_validate_property(PropertyInfo &property) const {
@@ -2798,6 +3030,12 @@ void TileSet::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("cleanup_invalid_tile_proxies"), &TileSet::cleanup_invalid_tile_proxies);
 	ClassDB::bind_method(D_METHOD("clear_tile_proxies"), &TileSet::clear_tile_proxies);
+
+	// Patterns
+	ClassDB::bind_method(D_METHOD("add_pattern", "pattern", "index"), &TileSet::add_pattern, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("get_pattern", "index"), &TileSet::get_pattern, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("remove_pattern", "index"), &TileSet::remove_pattern);
+	ClassDB::bind_method(D_METHOD("get_patterns_count"), &TileSet::get_patterns_count);
 
 	ADD_GROUP("Rendering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "uv_clipping"), "set_uv_clipping", "is_uv_clipping");


### PR DESCRIPTION
Implements a pattern palette to store and paint TileMap patterns. See it in action:

https://user-images.githubusercontent.com/6093119/136066875-749c4e4b-ea6c-41ab-819f-e9042fcc14d1.mp4

It's useful when you have structures made of a set of small tiles that you would like to move around.