### PR TITLE
[Scons] Implement module dependency declaration.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -274,6 +274,9 @@ for path in module_search_paths:
     # Note: custom modules can override built-in ones.
     modules_detected.update(modules)
 
+# Sort modules dependencies
+methods.sort_modules_dependencies(modules_detected)
+
 # Add module options.
 for name, path in modules_detected.items():
     if env_base["modules_enabled_by_default"]:

--- a/modules/gdscript/config.py
+++ b/modules/gdscript/config.py
@@ -15,3 +15,9 @@ def get_doc_classes():
 
 def get_doc_path():
     return "doc_classes"
+
+
+def get_module_dependencies():
+    return [
+        "jsonrpc",
+    ]

--- a/modules/msdfgen/config.py
+++ b/modules/msdfgen/config.py
@@ -4,3 +4,9 @@ def can_build(env, platform):
 
 def configure(env):
     pass
+
+
+def get_module_dependencies():
+    return [
+        "freetype",
+    ]

--- a/modules/theora/config.py
+++ b/modules/theora/config.py
@@ -14,3 +14,10 @@ def get_doc_classes():
 
 def get_doc_path():
     return "doc_classes"
+
+
+def get_module_dependencies():
+    return [
+        "ogg",
+        "vorbis",
+    ]

--- a/modules/vorbis/config.py
+++ b/modules/vorbis/config.py
@@ -15,3 +15,9 @@ def get_doc_classes():
 
 def get_doc_path():
     return "doc_classes"
+
+
+def get_module_dependencies():
+    return [
+        "ogg",
+    ]

--- a/modules/webm/config.py
+++ b/modules/webm/config.py
@@ -17,3 +17,11 @@ def get_doc_classes():
 
 def get_doc_path():
     return "doc_classes"
+
+
+def get_module_dependencies():
+    return [
+        "ogg",
+        "opus",
+        "vorbis",
+    ]


### PR DESCRIPTION
Port graph solver from the meson branch.

Modules can now define (optional) dependencies implementing a `get_module_dependencies` in the `config.py` which returns a list containing the names of the modules it depends on. Those modules will be built before it.

This allows for example #50964 to be build without the `mbedtls_curl` name hack.