### PR TITLE
Add pre-sort signal and notification in Container

### DIFF
--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -29,6 +29,11 @@
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1" />
 	</members>
 	<signals>
+		<signal name="pre_sort_children">
+			<description>
+				Emitted when children are going to be sorted.
+			</description>
+		</signal>
 		<signal name="sort_children">
 			<description>
 				Emitted when sorting the children is needed.
@@ -36,7 +41,10 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="NOTIFICATION_SORT_CHILDREN" value="50">
+		<constant name="NOTIFICATION_PRE_SORT_CHILDREN" value="50">
+			Notification just before children are going to be sorted, in case there's something to process beforehand.
+		</constant>
+		<constant name="NOTIFICATION_SORT_CHILDREN" value="51">
 			Notification for when sorting the children, it must be obeyed immediately.
 		</constant>
 	</constants>

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -87,6 +87,9 @@ void Container::_sort_children() {
 		return;
 	}
 
+	notification(NOTIFICATION_PRE_SORT_CHILDREN);
+	emit_signal(SceneStringNames::get_singleton()->pre_sort_children);
+
 	notification(NOTIFICATION_SORT_CHILDREN);
 	emit_signal(SceneStringNames::get_singleton()->sort_children);
 	pending_sort = false;
@@ -174,7 +177,10 @@ void Container::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("queue_sort"), &Container::queue_sort);
 	ClassDB::bind_method(D_METHOD("fit_child_in_rect", "child", "rect"), &Container::fit_child_in_rect);
 
+	BIND_CONSTANT(NOTIFICATION_PRE_SORT_CHILDREN);
 	BIND_CONSTANT(NOTIFICATION_SORT_CHILDREN);
+
+	ADD_SIGNAL(MethodInfo("pre_sort_children"));
 	ADD_SIGNAL(MethodInfo("sort_children"));
 }
 

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -51,7 +51,8 @@ protected:
 
 public:
 	enum {
-		NOTIFICATION_SORT_CHILDREN = 50
+		NOTIFICATION_PRE_SORT_CHILDREN = 50,
+		NOTIFICATION_SORT_CHILDREN = 51,
 	};
 
 	void fit_child_in_rect(Control *p_child, const Rect2 &p_rect);

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -73,6 +73,7 @@ SceneStringNames::SceneStringNames() {
 	focus_entered = StaticCString::create("focus_entered");
 	focus_exited = StaticCString::create("focus_exited");
 
+	pre_sort_children = StaticCString::create("pre_sort_children");
 	sort_children = StaticCString::create("sort_children");
 
 	body_shape_entered = StaticCString::create("body_shape_entered");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -89,6 +89,7 @@ public:
 	StringName focus_entered;
 	StringName focus_exited;
 
+	StringName pre_sort_children;
 	StringName sort_children;
 
 	StringName finished;


### PR DESCRIPTION
Allows processing before children are sorted, useful for custom containers inherited from existing ones like BoxContainer.

Following-up on https://github.com/godotengine/godot/pull/38396#issuecomment-934717345, so there's no regression in supported cases for custom containers in 4.0.