### PR TITLE
Fix editable children errors when packing scene tree at runtime

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -388,7 +388,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 		editable_instances.push_back(p_owner->get_path_to(p_node));
 		// Node is the root of an editable instance.
 		is_editable_instance = true;
-	} else if (p_node->get_owner() && p_node->get_owner() != p_owner && p_owner->is_editable_instance(p_node->get_owner())) {
+	} else if (p_node->get_owner() && p_owner->is_ancestor_of(p_node->get_owner()) && p_owner->is_editable_instance(p_node->get_owner())) {
 		// Node is part of an editable instance.
 		is_editable_instance = true;
 	}


### PR DESCRIPTION
When packing a scene node which is not the root, errors where caused by internal checks in `is_editable_instance` method.
This check can be safely made outside instead.

Fixes #53292 (regression from #49664).
Needs to be cherry-picked on 3.4 to fix the regression there.