### PR TITLE
Move the docs for constructors and operators out of methods section

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -140,7 +140,9 @@ public:
 		String brief_description;
 		String description;
 		Vector<TutorialDoc> tutorials;
+		Vector<MethodDoc> constructors;
 		Vector<MethodDoc> methods;
+		Vector<MethodDoc> operators;
 		Vector<MethodDoc> signals;
 		Vector<ConstantDoc> constants;
 		Map<String, String> enums;

--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -13,28 +13,30 @@
 		<link title="Vector math">https://docs.godotengine.org/en/latest/tutorials/math/vector_math.html</link>
 		<link title="Advanced vector math">https://docs.godotengine.org/en/latest/tutorials/math/vectors_advanced.html</link>
 	</tutorials>
-	<methods>
-		<method name="AABB" qualifiers="constructor">
+	<constructors>
+		<constructor name="AABB">
 			<return type="AABB" />
 			<description>
 				Constructs a default-initialized [AABB] with default (zero) values of [member position] and [member size].
 			</description>
-		</method>
-		<method name="AABB" qualifiers="constructor">
+		</constructor>
+		<constructor name="AABB">
 			<return type="AABB" />
 			<argument index="0" name="from" type="AABB" />
 			<description>
 				Constructs an [AABB] as a copy of the given [AABB].
 			</description>
-		</method>
-		<method name="AABB" qualifiers="constructor">
+		</constructor>
+		<constructor name="AABB">
 			<return type="AABB" />
 			<argument index="0" name="position" type="Vector3" />
 			<argument index="1" name="size" type="Vector3" />
 			<description>
 				Constructs an [AABB] from a position and size.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="abs" qualifiers="const">
 			<return type="AABB" />
 			<description>
@@ -193,34 +195,6 @@
 				Returns a larger [AABB] that contains both this [AABB] and [code]with[/code].
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="AABB" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="AABB" />
-			<argument index="0" name="right" type="Transform3D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="AABB" />
-			<description>
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="end" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
@@ -234,4 +208,34 @@
 			If the size is negative, you can use [method abs] to fix it.
 		</member>
 	</members>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="AABB" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="AABB" />
+			<argument index="0" name="right" type="Transform3D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="AABB" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -44,83 +44,85 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="Array" qualifiers="constructor">
+	<constructors>
+		<constructor name="Array">
 			<return type="Array" />
 			<description>
 				Constructs an empty [Array].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs an [Array] as a copy of the given [Array].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="PackedByteArray" />
 			<description>
 				Constructs an array from a [PackedByteArray].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="PackedColorArray" />
 			<description>
 				Constructs an array from a [PackedColorArray].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="PackedFloat32Array" />
 			<description>
 				Constructs an array from a [PackedFloat32Array].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="PackedFloat64Array" />
 			<description>
 				Constructs an array from a [PackedFloat64Array].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="PackedInt32Array" />
 			<description>
 				Constructs an array from a [PackedInt32Array].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="PackedInt64Array" />
 			<description>
 				Constructs an array from a [PackedInt64Array].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="PackedStringArray" />
 			<description>
 				Constructs an array from a [PackedStringArray].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="PackedVector2Array" />
 			<description>
 				Constructs an array from a [PackedVector2Array].
 			</description>
-		</method>
-		<method name="Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="Array">
 			<return type="Array" />
 			<argument index="0" name="from" type="PackedVector3Array" />
 			<description>
 				Constructs an array from a [PackedVector3Array].
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="void" />
 			<argument index="0" name="value" type="Variant" />
@@ -345,64 +347,6 @@
 				Returns the minimum value contained in the array if all elements are of comparable types. If the elements can't be compared, [code]null[/code] is returned.
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="Array" />
-			<argument index="0" name="right" type="Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="void" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="pop_at">
 			<return type="Variant" />
 			<argument index="0" name="position" type="int" />
@@ -550,4 +494,64 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="Array" />
+			<argument index="0" name="right" type="Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="void" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -18,36 +18,36 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 		<link title="2.5D Demo">https://godotengine.org/asset-library/asset/583</link>
 	</tutorials>
-	<methods>
-		<method name="Basis" qualifiers="constructor">
+	<constructors>
+		<constructor name="Basis">
 			<return type="Basis" />
 			<description>
 				Constructs a default-initialized [Basis] set to [constant IDENTITY].
 			</description>
-		</method>
-		<method name="Basis" qualifiers="constructor">
+		</constructor>
+		<constructor name="Basis">
 			<return type="Basis" />
 			<argument index="0" name="from" type="Basis" />
 			<description>
 				Constructs a [Basis] as a copy of the given [Basis].
 			</description>
-		</method>
-		<method name="Basis" qualifiers="constructor">
+		</constructor>
+		<constructor name="Basis">
 			<return type="Basis" />
 			<argument index="0" name="axis" type="Vector3" />
 			<argument index="1" name="phi" type="float" />
 			<description>
 				Constructs a pure rotation basis matrix, rotated around the given [code]axis[/code] by [code]phi[/code], in radians. The axis must be a normalized vector.
 			</description>
-		</method>
-		<method name="Basis" qualifiers="constructor">
+		</constructor>
+		<constructor name="Basis">
 			<return type="Basis" />
 			<argument index="0" name="from" type="Quaternion" />
 			<description>
 				Constructs a pure rotation basis matrix from the given quaternion.
 			</description>
-		</method>
-		<method name="Basis" qualifiers="constructor">
+		</constructor>
+		<constructor name="Basis">
 			<return type="Basis" />
 			<argument index="0" name="x_axis" type="Vector3" />
 			<argument index="1" name="y_axis" type="Vector3" />
@@ -55,7 +55,9 @@
 			<description>
 				Constructs a basis matrix from 3 axis vectors (matrix columns).
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="determinant" qualifiers="const">
 			<return type="float" />
 			<description>
@@ -123,60 +125,6 @@
 			<description>
 				Creates a Basis with a rotation such that the forward axis (-Z) points towards the [code]target[/code] position.
 				The up axis (+Y) points as close to the [code]up[/code] vector as possible while staying perpendicular to the forward axis. The resulting Basis is orthonormalized. The [code]target[/code] and [code]up[/code] vectors cannot be zero, and cannot be parallel to each other.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Basis" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Basis" />
-			<argument index="0" name="right" type="Basis" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Basis" />
-			<argument index="0" name="right" type="float" />
-			<description>
-				This operator multiplies all components of the [Basis], which scales it uniformly.
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Basis" />
-			<argument index="0" name="right" type="int" />
-			<description>
-				This operator multiplies all components of the [Basis], which scales it uniformly.
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Basis" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="index" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="orthonormalized" qualifiers="const">
@@ -274,4 +222,60 @@
 			The basis that will flip something along the Z axis when used in a transformation.
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Basis" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Basis" />
+			<argument index="0" name="right" type="Basis" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Basis" />
+			<argument index="0" name="right" type="float" />
+			<description>
+				This operator multiplies all components of the [Basis], which scales it uniformly.
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Basis" />
+			<argument index="0" name="right" type="int" />
+			<description>
+				This operator multiplies all components of the [Basis], which scales it uniformly.
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Basis" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="Vector3" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -35,28 +35,30 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="Callable" qualifiers="constructor">
+	<constructors>
+		<constructor name="Callable">
 			<return type="Callable" />
 			<description>
 				Constructs a null [Callable] with no object nor method bound.
 			</description>
-		</method>
-		<method name="Callable" qualifiers="constructor">
+		</constructor>
+		<constructor name="Callable">
 			<return type="Callable" />
 			<argument index="0" name="from" type="Callable" />
 			<description>
 				Constructs a [Callable] as a copy of the given [Callable].
 			</description>
-		</method>
-		<method name="Callable" qualifiers="constructor">
+		</constructor>
+		<constructor name="Callable">
 			<return type="Callable" />
 			<argument index="0" name="object" type="Object" />
 			<argument index="1" name="method" type="StringName" />
 			<description>
 				Creates a new [Callable] for the method called [code]method[/code] in the specified [code]object[/code].
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="bind" qualifiers="vararg const">
 			<return type="Callable" />
 			<description>
@@ -123,30 +125,6 @@
 				Returns [code]true[/code] if the object exists and has a valid function assigned, or is a custom callable.
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Callable" />
-			<description>
-				Returns [code]true[/code] if both [Callable]s invoke different targets.
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Callable" />
-			<description>
-				Returns [code]true[/code] if both [Callable]s invoke the same custom target.
-			</description>
-		</method>
 		<method name="rpc" qualifiers="vararg const">
 			<return type="void" />
 			<description>
@@ -168,4 +146,30 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Callable" />
+			<description>
+				Returns [code]true[/code] if both [Callable]s invoke different targets.
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Callable" />
+			<description>
+				Returns [code]true[/code] if both [Callable]s invoke the same custom target.
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -15,21 +15,14 @@
 		<link title="Tween Demo">https://godotengine.org/asset-library/asset/146</link>
 		<link title="GUI Drag And Drop Demo">https://godotengine.org/asset-library/asset/133</link>
 	</tutorials>
-	<methods>
-		<method name="Color" qualifiers="constructor">
+	<constructors>
+		<constructor name="Color">
 			<return type="Color" />
 			<description>
 				Constructs a default-initialized [Color] with all components set to [code]0[/code].
 			</description>
-		</method>
-		<method name="Color" qualifiers="constructor">
-			<return type="Color" />
-			<argument index="0" name="from" type="Color" />
-			<description>
-				Constructs a [Color] as a copy of the given [Color].
-			</description>
-		</method>
-		<method name="Color" qualifiers="constructor">
+		</constructor>
+		<constructor name="Color">
 			<return type="Color" />
 			<argument index="0" name="from" type="Color" />
 			<argument index="1" name="alpha" type="float" />
@@ -44,23 +37,47 @@
 				[/csharp]
 				[/codeblocks]
 			</description>
-		</method>
-		<method name="Color" qualifiers="constructor">
+		</constructor>
+		<constructor name="Color">
+			<return type="Color" />
+			<argument index="0" name="from" type="Color" />
+			<description>
+				Constructs a [Color] as a copy of the given [Color].
+			</description>
+		</constructor>
+		<constructor name="Color">
 			<return type="Color" />
 			<argument index="0" name="code" type="String" />
 			<description>
 				Constructs a [Color] either from an HTML color code or from a standardized color name. Supported color names are the same as the constants.
 			</description>
-		</method>
-		<method name="Color" qualifiers="constructor">
+		</constructor>
+		<constructor name="Color">
 			<return type="Color" />
 			<argument index="0" name="code" type="String" />
 			<argument index="1" name="alpha" type="float" />
 			<description>
 				Constructs a [Color] either from an HTML color code or from a standardized color name, with [code]alpha[/code] on the range of 0 to 1. Supported color names are the same as the constants.
 			</description>
-		</method>
-		<method name="Color" qualifiers="constructor">
+		</constructor>
+		<constructor name="Color">
+			<return type="Color" />
+			<argument index="0" name="r" type="float" />
+			<argument index="1" name="g" type="float" />
+			<argument index="2" name="b" type="float" />
+			<description>
+				Constructs a [Color] from RGB values, typically between 0 and 1. Alpha will be 1.
+				[codeblocks]
+				[gdscript]
+				var color = Color(0.2, 1.0, 0.7) # Similar to `Color8(51, 255, 178, 255)`
+				[/gdscript]
+				[csharp]
+				var color = new Color(0.2f, 1.0f, 0.7f); // Similar to `Color.Color8(51, 255, 178, 255)`
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</constructor>
+		<constructor name="Color">
 			<return type="Color" />
 			<argument index="0" name="r" type="float" />
 			<argument index="1" name="g" type="float" />
@@ -77,24 +94,9 @@
 				[/csharp]
 				[/codeblocks]
 			</description>
-		</method>
-		<method name="Color" qualifiers="constructor">
-			<return type="Color" />
-			<argument index="0" name="r" type="float" />
-			<argument index="1" name="g" type="float" />
-			<argument index="2" name="b" type="float" />
-			<description>
-				Constructs a [Color] from RGB values, typically between 0 and 1. Alpha will be 1.
-				[codeblocks]
-				[gdscript]
-				var color = Color(0.2, 1.0, 0.7) # Similar to `Color8(51, 255, 178, 255)`
-				[/gdscript]
-				[csharp]
-				var color = new Color(0.2f, 1.0f, 0.7f); // Similar to `Color.Color8(51, 255, 178, 255)`
-				[/csharp]
-				[/codeblocks]
-			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="blend" qualifiers="const">
 			<return type="Color" />
 			<argument index="0" name="over" type="Color" />
@@ -257,92 +259,6 @@
 				Color lightgreen = green.Lightened(0.2f); // 20% lighter than regular green
 				[/csharp]
 				[/codeblocks]
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Color" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="right" type="Color" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="right" type="Color" />
-			<description>
-			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="right" type="Color" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="right" type="Color" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Color" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="float" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary+" qualifiers="operator">
-			<return type="Color" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary-" qualifiers="operator">
-			<return type="Color" />
-			<description>
 			</description>
 		</method>
 		<method name="to_abgr32" qualifiers="const">
@@ -937,4 +853,92 @@
 			Yellow green color.
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Color" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Color" />
+			<argument index="0" name="right" type="Color" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Color" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Color" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="Color" />
+			<argument index="0" name="right" type="Color" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Color" />
+			<argument index="0" name="right" type="Color" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Color" />
+			<argument index="0" name="right" type="Color" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Color" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Color" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Color" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="float" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary+">
+			<return type="Color" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary-">
+			<return type="Color" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -181,20 +181,22 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 		<link title="OS Test Demo">https://godotengine.org/asset-library/asset/677</link>
 	</tutorials>
-	<methods>
-		<method name="Dictionary" qualifiers="constructor">
+	<constructors>
+		<constructor name="Dictionary">
 			<return type="Dictionary" />
 			<description>
 				Constructs an empty [Dictionary].
 			</description>
-		</method>
-		<method name="Dictionary" qualifiers="constructor">
+		</constructor>
+		<constructor name="Dictionary">
 			<return type="Dictionary" />
 			<argument index="0" name="from" type="Dictionary" />
 			<description>
 				Constructs a [Dictionary] as a copy of the given [Dictionary].
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="clear">
 			<return type="void" />
 			<description>
@@ -288,34 +290,6 @@
 				Returns the list of keys in the [Dictionary].
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Dictionary" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Dictionary" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="Variant" />
-			<argument index="0" name="key" type="Variant" />
-			<description>
-			</description>
-		</method>
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -329,4 +303,34 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Dictionary" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Dictionary" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="Variant" />
+			<argument index="0" name="key" type="Variant" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -25,21 +25,21 @@
 	<tutorials>
 		<link title="2D Role Playing Game Demo">https://godotengine.org/asset-library/asset/520</link>
 	</tutorials>
-	<methods>
-		<method name="NodePath" qualifiers="constructor">
+	<constructors>
+		<constructor name="NodePath">
 			<return type="NodePath" />
 			<description>
 				Constructs an empty [NodePath].
 			</description>
-		</method>
-		<method name="NodePath" qualifiers="constructor">
+		</constructor>
+		<constructor name="NodePath">
 			<return type="NodePath" />
 			<argument index="0" name="from" type="NodePath" />
 			<description>
 				Constructs a [NodePath] as a copy of the given [NodePath].
 			</description>
-		</method>
-		<method name="NodePath" qualifiers="constructor">
+		</constructor>
+		<constructor name="NodePath">
 			<return type="NodePath" />
 			<argument index="0" name="from" type="String" />
 			<description>
@@ -61,7 +61,9 @@
 				"/root/Level/Path2D"
 				[/codeblock]
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="get_as_property_path" qualifiers="const">
 			<return type="NodePath" />
 			<description>
@@ -166,27 +168,29 @@
 				Returns [code]true[/code] if the node path is empty.
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="NodePath" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="NodePath" />
-			<description>
-			</description>
-		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="NodePath" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="NodePath" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -8,27 +8,29 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="PackedByteArray" qualifiers="constructor">
+	<constructors>
+		<constructor name="PackedByteArray">
 			<return type="PackedByteArray" />
 			<description>
 				Constructs an empty [PackedByteArray].
 			</description>
-		</method>
-		<method name="PackedByteArray" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedByteArray">
 			<return type="PackedByteArray" />
 			<argument index="0" name="from" type="PackedByteArray" />
 			<description>
 				Constructs a [PackedByteArray] as a copy of the given [PackedByteArray].
 			</description>
-		</method>
-		<method name="PackedByteArray" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedByteArray">
 			<return type="PackedByteArray" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs a new [PackedByteArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="bool" />
 			<argument index="0" name="value" type="int" />
@@ -323,40 +325,6 @@
 				Returns [code]true[/code] if the array is empty.
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedByteArray" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="PackedByteArray" />
-			<argument index="0" name="right" type="PackedByteArray" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedByteArray" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="int" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="push_back">
 			<return type="bool" />
 			<argument index="0" name="value" type="int" />
@@ -445,4 +413,40 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedByteArray" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="PackedByteArray" />
+			<argument index="0" name="right" type="PackedByteArray" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedByteArray" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -8,27 +8,29 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="PackedColorArray" qualifiers="constructor">
+	<constructors>
+		<constructor name="PackedColorArray">
 			<return type="PackedColorArray" />
 			<description>
 				Constructs an empty [PackedColorArray].
 			</description>
-		</method>
-		<method name="PackedColorArray" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedColorArray">
 			<return type="PackedColorArray" />
 			<argument index="0" name="from" type="PackedColorArray" />
 			<description>
 				Constructs a [PackedColorArray] as a copy of the given [PackedColorArray].
 			</description>
-		</method>
-		<method name="PackedColorArray" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedColorArray">
 			<return type="PackedColorArray" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs a new [PackedColorArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="bool" />
 			<argument index="0" name="value" type="Color" />
@@ -84,40 +86,6 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the array is empty.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedColorArray" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="PackedColorArray" />
-			<argument index="0" name="right" type="PackedColorArray" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedColorArray" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="index" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="push_back">
@@ -180,4 +148,40 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedColorArray" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="PackedColorArray" />
+			<argument index="0" name="right" type="PackedColorArray" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedColorArray" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="Color" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -9,27 +9,29 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="PackedFloat32Array" qualifiers="constructor">
+	<constructors>
+		<constructor name="PackedFloat32Array">
 			<return type="PackedFloat32Array" />
 			<description>
 				Constructs an empty [PackedFloat32Array].
 			</description>
-		</method>
-		<method name="PackedFloat32Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedFloat32Array">
 			<return type="PackedFloat32Array" />
 			<argument index="0" name="from" type="PackedFloat32Array" />
 			<description>
 				Constructs a [PackedFloat32Array] as a copy of the given [PackedFloat32Array].
 			</description>
-		</method>
-		<method name="PackedFloat32Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedFloat32Array">
 			<return type="PackedFloat32Array" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs a new [PackedFloat32Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="bool" />
 			<argument index="0" name="value" type="float" />
@@ -85,40 +87,6 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the array is empty.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedFloat32Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="PackedFloat32Array" />
-			<argument index="0" name="right" type="PackedFloat32Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedFloat32Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="float" />
-			<argument index="0" name="index" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="push_back">
@@ -183,4 +151,40 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedFloat32Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="PackedFloat32Array" />
+			<argument index="0" name="right" type="PackedFloat32Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedFloat32Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="float" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -9,27 +9,29 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="PackedFloat64Array" qualifiers="constructor">
+	<constructors>
+		<constructor name="PackedFloat64Array">
 			<return type="PackedFloat64Array" />
 			<description>
 				Constructs an empty [PackedFloat64Array].
 			</description>
-		</method>
-		<method name="PackedFloat64Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedFloat64Array">
 			<return type="PackedFloat64Array" />
 			<argument index="0" name="from" type="PackedFloat64Array" />
 			<description>
 				Constructs a [PackedFloat64Array] as a copy of the given [PackedFloat64Array].
 			</description>
-		</method>
-		<method name="PackedFloat64Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedFloat64Array">
 			<return type="PackedFloat64Array" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs a new [PackedFloat64Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="bool" />
 			<argument index="0" name="value" type="float" />
@@ -85,40 +87,6 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the array is empty.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedFloat64Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="PackedFloat64Array" />
-			<argument index="0" name="right" type="PackedFloat64Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedFloat64Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="float" />
-			<argument index="0" name="index" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="push_back">
@@ -183,4 +151,40 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedFloat64Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="PackedFloat64Array" />
+			<argument index="0" name="right" type="PackedFloat64Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedFloat64Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="float" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -9,27 +9,29 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="PackedInt32Array" qualifiers="constructor">
+	<constructors>
+		<constructor name="PackedInt32Array">
 			<return type="PackedInt32Array" />
 			<description>
 				Constructs an empty [PackedInt32Array].
 			</description>
-		</method>
-		<method name="PackedInt32Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedInt32Array">
 			<return type="PackedInt32Array" />
 			<argument index="0" name="from" type="PackedInt32Array" />
 			<description>
 				Constructs a [PackedInt32Array] as a copy of the given [PackedInt32Array].
 			</description>
-		</method>
-		<method name="PackedInt32Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedInt32Array">
 			<return type="PackedInt32Array" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs a new [PackedInt32Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="bool" />
 			<argument index="0" name="value" type="int" />
@@ -85,40 +87,6 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the array is empty.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedInt32Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="PackedInt32Array" />
-			<argument index="0" name="right" type="PackedInt32Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedInt32Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="int" />
-			<argument index="0" name="index" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="push_back">
@@ -183,4 +151,40 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedInt32Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="PackedInt32Array" />
+			<argument index="0" name="right" type="PackedInt32Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedInt32Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -9,27 +9,29 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="PackedInt64Array" qualifiers="constructor">
+	<constructors>
+		<constructor name="PackedInt64Array">
 			<return type="PackedInt64Array" />
 			<description>
 				Constructs an empty [PackedInt64Array].
 			</description>
-		</method>
-		<method name="PackedInt64Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedInt64Array">
 			<return type="PackedInt64Array" />
 			<argument index="0" name="from" type="PackedInt64Array" />
 			<description>
 				Constructs a [PackedInt64Array] as a copy of the given [PackedInt64Array].
 			</description>
-		</method>
-		<method name="PackedInt64Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedInt64Array">
 			<return type="PackedInt64Array" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs a new [PackedInt64Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="bool" />
 			<argument index="0" name="value" type="int" />
@@ -85,40 +87,6 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the array is empty.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedInt64Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="PackedInt64Array" />
-			<argument index="0" name="right" type="PackedInt64Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedInt64Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="int" />
-			<argument index="0" name="index" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="push_back">
@@ -183,4 +151,40 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedInt64Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="PackedInt64Array" />
+			<argument index="0" name="right" type="PackedInt64Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedInt64Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -9,27 +9,29 @@
 	<tutorials>
 		<link title="OS Test Demo">https://godotengine.org/asset-library/asset/677</link>
 	</tutorials>
-	<methods>
-		<method name="PackedStringArray" qualifiers="constructor">
+	<constructors>
+		<constructor name="PackedStringArray">
 			<return type="PackedStringArray" />
 			<description>
 				Constructs an empty [PackedStringArray].
 			</description>
-		</method>
-		<method name="PackedStringArray" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedStringArray">
 			<return type="PackedStringArray" />
 			<argument index="0" name="from" type="PackedStringArray" />
 			<description>
 				Constructs a [PackedStringArray] as a copy of the given [PackedStringArray].
 			</description>
-		</method>
-		<method name="PackedStringArray" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedStringArray">
 			<return type="PackedStringArray" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs a new [PackedStringArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="bool" />
 			<argument index="0" name="value" type="String" />
@@ -85,40 +87,6 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the array is empty.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedStringArray" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="PackedStringArray" />
-			<argument index="0" name="right" type="PackedStringArray" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedStringArray" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="String" />
-			<argument index="0" name="index" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="push_back">
@@ -181,4 +149,40 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedStringArray" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="PackedStringArray" />
+			<argument index="0" name="right" type="PackedStringArray" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedStringArray" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="String" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -9,27 +9,29 @@
 	<tutorials>
 		<link title="2D Navigation Astar Demo">https://godotengine.org/asset-library/asset/519</link>
 	</tutorials>
-	<methods>
-		<method name="PackedVector2Array" qualifiers="constructor">
+	<constructors>
+		<constructor name="PackedVector2Array">
 			<return type="PackedVector2Array" />
 			<description>
 				Constructs an empty [PackedVector2Array].
 			</description>
-		</method>
-		<method name="PackedVector2Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedVector2Array">
 			<return type="PackedVector2Array" />
 			<argument index="0" name="from" type="PackedVector2Array" />
 			<description>
 				Constructs a [PackedVector2Array] as a copy of the given [PackedVector2Array].
 			</description>
-		</method>
-		<method name="PackedVector2Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedVector2Array">
 			<return type="PackedVector2Array" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs a new [PackedVector2Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="bool" />
 			<argument index="0" name="value" type="Vector2" />
@@ -85,46 +87,6 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the array is empty.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedVector2Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="PackedVector2Array" />
-			<argument index="0" name="right" type="Transform2D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="PackedVector2Array" />
-			<argument index="0" name="right" type="PackedVector2Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedVector2Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="index" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="push_back">
@@ -187,4 +149,46 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedVector2Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="PackedVector2Array" />
+			<argument index="0" name="right" type="Transform2D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="PackedVector2Array" />
+			<argument index="0" name="right" type="PackedVector2Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedVector2Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="Vector2" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -8,27 +8,29 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="PackedVector3Array" qualifiers="constructor">
+	<constructors>
+		<constructor name="PackedVector3Array">
 			<return type="PackedVector3Array" />
 			<description>
 				Constructs an empty [PackedVector3Array].
 			</description>
-		</method>
-		<method name="PackedVector3Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedVector3Array">
 			<return type="PackedVector3Array" />
 			<argument index="0" name="from" type="PackedVector3Array" />
 			<description>
 				Constructs a [PackedVector3Array] as a copy of the given [PackedVector3Array].
 			</description>
-		</method>
-		<method name="PackedVector3Array" qualifiers="constructor">
+		</constructor>
+		<constructor name="PackedVector3Array">
 			<return type="PackedVector3Array" />
 			<argument index="0" name="from" type="Array" />
 			<description>
 				Constructs a new [PackedVector3Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="append">
 			<return type="bool" />
 			<argument index="0" name="value" type="Vector3" />
@@ -84,46 +86,6 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the array is empty.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedVector3Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="PackedVector3Array" />
-			<argument index="0" name="right" type="Transform3D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="PackedVector3Array" />
-			<argument index="0" name="right" type="PackedVector3Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="PackedVector3Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="index" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="push_back">
@@ -186,4 +148,46 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedVector3Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="PackedVector3Array" />
+			<argument index="0" name="right" type="Transform3D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="PackedVector3Array" />
+			<argument index="0" name="right" type="PackedVector3Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="PackedVector3Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="Vector3" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -9,21 +9,21 @@
 	<tutorials>
 		<link title="Math documentation index">https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>
 	</tutorials>
-	<methods>
-		<method name="Plane" qualifiers="constructor">
+	<constructors>
+		<constructor name="Plane">
 			<return type="Plane" />
 			<description>
 				Constructs a default-initialized [Plane] with all components set to [code]0[/code].
 			</description>
-		</method>
-		<method name="Plane" qualifiers="constructor">
+		</constructor>
+		<constructor name="Plane">
 			<return type="Plane" />
 			<argument index="0" name="from" type="Plane" />
 			<description>
 				Constructs a [Plane] as a copy of the given [Plane].
 			</description>
-		</method>
-		<method name="Plane" qualifiers="constructor">
+		</constructor>
+		<constructor name="Plane">
 			<return type="Plane" />
 			<argument index="0" name="a" type="float" />
 			<argument index="1" name="b" type="float" />
@@ -32,31 +32,31 @@
 			<description>
 				Creates a plane from the four parameters. The three components of the resulting plane's [member normal] are [code]a[/code], [code]b[/code] and [code]c[/code], and the plane has a distance of [code]d[/code] from the origin.
 			</description>
-		</method>
-		<method name="Plane" qualifiers="constructor">
-			<return type="Plane" />
-			<argument index="0" name="normal" type="Vector3" />
-			<argument index="1" name="point" type="Vector3" />
-			<description>
-				Creates a plane from the normal vector and a point in the plane.
-			</description>
-		</method>
-		<method name="Plane" qualifiers="constructor">
-			<return type="Plane" />
-			<argument index="0" name="normal" type="Vector3" />
-			<argument index="1" name="d" type="float" />
-			<description>
-				Creates a plane from the normal vector and the plane's distance to the origin.
-			</description>
-		</method>
-		<method name="Plane" qualifiers="constructor">
+		</constructor>
+		<constructor name="Plane">
 			<return type="Plane" />
 			<argument index="0" name="normal" type="Vector3" />
 			<description>
 				Creates a plane from the normal vector. The plane will intersect the origin.
 			</description>
-		</method>
-		<method name="Plane" qualifiers="constructor">
+		</constructor>
+		<constructor name="Plane">
+			<return type="Plane" />
+			<argument index="0" name="normal" type="Vector3" />
+			<argument index="1" name="d" type="float" />
+			<description>
+				Creates a plane from the normal vector and the plane's distance from the origin.
+			</description>
+		</constructor>
+		<constructor name="Plane">
+			<return type="Plane" />
+			<argument index="0" name="normal" type="Vector3" />
+			<argument index="1" name="point" type="Vector3" />
+			<description>
+				Creates a plane from the normal vector and a point on the plane.
+			</description>
+		</constructor>
+		<constructor name="Plane">
 			<return type="Plane" />
 			<argument index="0" name="point1" type="Vector3" />
 			<argument index="1" name="point2" type="Vector3" />
@@ -64,7 +64,9 @@
 			<description>
 				Creates a plane from the three points, given in clockwise order.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="center" qualifiers="const">
 			<return type="Vector3" />
 			<description>
@@ -130,38 +132,6 @@
 				Returns a copy of the plane, normalized.
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Plane" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Plane" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary+" qualifiers="operator">
-			<return type="Plane" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary-" qualifiers="operator">
-			<return type="Plane" />
-			<description>
-			</description>
-		</method>
 		<method name="project" qualifiers="const">
 			<return type="Vector3" />
 			<argument index="0" name="point" type="Vector3" />
@@ -200,4 +170,38 @@
 			A plane that extends in the X and Y axes (normal vector points +Z).
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Plane" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Plane" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary+">
+			<return type="Plane" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary-">
+			<return type="Plane" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -12,49 +12,49 @@
 		<link title="Using 3D transforms">https://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html#interpolating-with-quaternions</link>
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
-	<methods>
-		<method name="Quaternion" qualifiers="constructor">
+	<constructors>
+		<constructor name="Quaternion">
 			<return type="Quaternion" />
 			<description>
 				Constructs a default-initialized quaternion with all components set to [code]0[/code].
 			</description>
-		</method>
-		<method name="Quaternion" qualifiers="constructor">
+		</constructor>
+		<constructor name="Quaternion">
 			<return type="Quaternion" />
 			<argument index="0" name="from" type="Quaternion" />
 			<description>
 				Constructs a [Quaternion] as a copy of the given [Quaternion].
 			</description>
-		</method>
-		<method name="Quaternion" qualifiers="constructor">
+		</constructor>
+		<constructor name="Quaternion">
 			<return type="Quaternion" />
 			<argument index="0" name="arc_from" type="Vector3" />
 			<argument index="1" name="arc_to" type="Vector3" />
 			<description>
 			</description>
-		</method>
-		<method name="Quaternion" qualifiers="constructor">
+		</constructor>
+		<constructor name="Quaternion">
 			<return type="Quaternion" />
 			<argument index="0" name="axis" type="Vector3" />
 			<argument index="1" name="angle" type="float" />
 			<description>
 				Constructs a quaternion that will rotate around the given axis by the specified angle. The axis must be a normalized vector.
 			</description>
-		</method>
-		<method name="Quaternion" qualifiers="constructor">
+		</constructor>
+		<constructor name="Quaternion">
 			<return type="Quaternion" />
 			<argument index="0" name="euler_yxz" type="Vector3" />
 			<description>
 			</description>
-		</method>
-		<method name="Quaternion" qualifiers="constructor">
+		</constructor>
+		<constructor name="Quaternion">
 			<return type="Quaternion" />
 			<argument index="0" name="from" type="Basis" />
 			<description>
 				Constructs a quaternion from the given [Basis].
 			</description>
-		</method>
-		<method name="Quaternion" qualifiers="constructor">
+		</constructor>
+		<constructor name="Quaternion">
 			<return type="Quaternion" />
 			<argument index="0" name="x" type="float" />
 			<argument index="1" name="y" type="float" />
@@ -63,7 +63,9 @@
 			<description>
 				Constructs a quaternion defined by the given values.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="angle_to" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="to" type="Quaternion" />
@@ -142,92 +144,6 @@
 				Returns a copy of the quaternion, normalized to unit length.
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Quaternion" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Quaternion" />
-			<argument index="0" name="right" type="Quaternion" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Quaternion" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Quaternion" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="Quaternion" />
-			<argument index="0" name="right" type="Quaternion" />
-			<description>
-			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
-			<return type="Quaternion" />
-			<argument index="0" name="right" type="Quaternion" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Quaternion" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Quaternion" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Quaternion" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="float" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary+" qualifiers="operator">
-			<return type="Quaternion" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary-" qualifiers="operator">
-			<return type="Quaternion" />
-			<description>
-			</description>
-		</method>
 		<method name="slerp" qualifiers="const">
 			<return type="Quaternion" />
 			<argument index="0" name="to" type="Quaternion" />
@@ -269,4 +185,92 @@
 			The identity quaternion, representing no rotation. Equivalent to an identity [Basis] matrix. If a vector is transformed by an identity quaternion, it will not change.
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Quaternion" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Quaternion" />
+			<argument index="0" name="right" type="Quaternion" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Quaternion" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Quaternion" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="Quaternion" />
+			<argument index="0" name="right" type="Quaternion" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Quaternion" />
+			<argument index="0" name="right" type="Quaternion" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Quaternion" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Quaternion" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Quaternion" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="float" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary+">
+			<return type="Quaternion" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary-">
+			<return type="Quaternion" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/RID.xml
+++ b/doc/classes/RID.xml
@@ -8,71 +8,75 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="RID" qualifiers="constructor">
+	<constructors>
+		<constructor name="RID">
 			<return type="RID" />
 			<description>
 				Constructs an empty [RID] with the invalid ID [code]0[/code].
 			</description>
-		</method>
-		<method name="RID" qualifiers="constructor">
+		</constructor>
+		<constructor name="RID">
 			<return type="RID" />
 			<argument index="0" name="from" type="RID" />
 			<description>
 				Constructs a [RID] as a copy of the given [RID].
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="get_id" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the ID of the referenced resource.
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="RID" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="RID" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="RID" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="RID" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="RID" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="RID" />
-			<description>
-			</description>
-		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="RID" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="RID" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="RID" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="RID" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="RID" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="RID" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -13,36 +13,36 @@
 		<link title="Vector math">https://docs.godotengine.org/en/latest/tutorials/math/vector_math.html</link>
 		<link title="Advanced vector math">https://docs.godotengine.org/en/latest/tutorials/math/vectors_advanced.html</link>
 	</tutorials>
-	<methods>
-		<method name="Rect2" qualifiers="constructor">
+	<constructors>
+		<constructor name="Rect2">
 			<return type="Rect2" />
 			<description>
 				Constructs a default-initialized [Rect2] with default (zero) values of [member position] and [member size].
 			</description>
-		</method>
-		<method name="Rect2" qualifiers="constructor">
+		</constructor>
+		<constructor name="Rect2">
 			<return type="Rect2" />
 			<argument index="0" name="from" type="Rect2" />
 			<description>
 				Constructs a [Rect2] as a copy of the given [Rect2].
 			</description>
-		</method>
-		<method name="Rect2" qualifiers="constructor">
+		</constructor>
+		<constructor name="Rect2">
 			<return type="Rect2" />
 			<argument index="0" name="from" type="Rect2i" />
 			<description>
 				Constructs a [Rect2] from a [Rect2i].
 			</description>
-		</method>
-		<method name="Rect2" qualifiers="constructor">
+		</constructor>
+		<constructor name="Rect2">
 			<return type="Rect2" />
 			<argument index="0" name="position" type="Vector2" />
 			<argument index="1" name="size" type="Vector2" />
 			<description>
 				Constructs a [Rect2] by position and size.
 			</description>
-		</method>
-		<method name="Rect2" qualifiers="constructor">
+		</constructor>
+		<constructor name="Rect2">
 			<return type="Rect2" />
 			<argument index="0" name="x" type="float" />
 			<argument index="1" name="y" type="float" />
@@ -51,7 +51,9 @@
 			<description>
 				Constructs a [Rect2] by x, y, width, and height.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="abs" qualifiers="const">
 			<return type="Rect2" />
 			<description>
@@ -153,34 +155,6 @@
 				Returns a larger [Rect2] that contains this [Rect2] and [code]b[/code].
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Rect2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Rect2" />
-			<argument index="0" name="right" type="Transform2D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Rect2" />
-			<description>
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="end" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
@@ -194,4 +168,34 @@
 			If the size is negative, you can use [method abs] to fix it.
 		</member>
 	</members>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Rect2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Rect2" />
+			<argument index="0" name="right" type="Transform2D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Rect2" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -11,36 +11,36 @@
 		<link title="Math documentation index">https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>
 		<link title="Vector math">https://docs.godotengine.org/en/latest/tutorials/math/vector_math.html</link>
 	</tutorials>
-	<methods>
-		<method name="Rect2i" qualifiers="constructor">
+	<constructors>
+		<constructor name="Rect2i">
 			<return type="Rect2i" />
 			<description>
 				Constructs a default-initialized [Rect2i] with default (zero) values of [member position] and [member size].
 			</description>
-		</method>
-		<method name="Rect2i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Rect2i">
 			<return type="Rect2i" />
 			<argument index="0" name="from" type="Rect2i" />
 			<description>
 				Constructs a [Rect2i] as a copy of the given [Rect2i].
 			</description>
-		</method>
-		<method name="Rect2i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Rect2i">
 			<return type="Rect2i" />
 			<argument index="0" name="from" type="Rect2" />
 			<description>
 				Constructs a new [Rect2i] from [Rect2]. The floating point coordinates will be truncated.
 			</description>
-		</method>
-		<method name="Rect2i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Rect2i">
 			<return type="Rect2i" />
 			<argument index="0" name="position" type="Vector2i" />
 			<argument index="1" name="size" type="Vector2i" />
 			<description>
 				Constructs a [Rect2i] by position and size.
 			</description>
-		</method>
-		<method name="Rect2i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Rect2i">
 			<return type="Rect2i" />
 			<argument index="0" name="x" type="int" />
 			<argument index="1" name="y" type="int" />
@@ -49,7 +49,9 @@
 			<description>
 				Constructs a [Rect2i] by x, y, width, and height.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="abs" qualifiers="const">
 			<return type="Rect2i" />
 			<description>
@@ -144,28 +146,6 @@
 				Returns a larger [Rect2i] that contains this [Rect2i] and [code]b[/code].
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Rect2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Rect2i" />
-			<description>
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="end" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)">
@@ -179,4 +159,28 @@
 			If the size is negative, you can use [method abs] to fix it.
 		</member>
 	</members>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Rect2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Rect2i" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -7,28 +7,30 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="Signal" qualifiers="constructor">
+	<constructors>
+		<constructor name="Signal">
 			<return type="Signal" />
 			<description>
 				Constructs a null [Signal] with no object nor signal name bound.
 			</description>
-		</method>
-		<method name="Signal" qualifiers="constructor">
+		</constructor>
+		<constructor name="Signal">
 			<return type="Signal" />
 			<argument index="0" name="from" type="Signal" />
 			<description>
 				Constructs a [Signal] as a copy of the given [Signal].
 			</description>
-		</method>
-		<method name="Signal" qualifiers="constructor">
+		</constructor>
+		<constructor name="Signal">
 			<return type="Signal" />
 			<argument index="0" name="object" type="Object" />
 			<argument index="1" name="signal" type="StringName" />
 			<description>
 				Creates a new [Signal] with the name [code]signal[/code] in the specified [code]object[/code].
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="connect">
 			<return type="int" />
 			<argument index="0" name="callable" type="Callable" />
@@ -93,27 +95,29 @@
 			<description>
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Signal" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Signal" />
-			<description>
-			</description>
-		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Signal" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Signal" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -9,34 +9,36 @@
 	<tutorials>
 		<link title="GDScript format strings">https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_format_string.html</link>
 	</tutorials>
-	<methods>
-		<method name="String" qualifiers="constructor">
+	<constructors>
+		<constructor name="String">
 			<return type="String" />
 			<description>
 				Constructs an empty [String] ([code]""[/code]).
 			</description>
-		</method>
-		<method name="String" qualifiers="constructor">
+		</constructor>
+		<constructor name="String">
 			<return type="String" />
 			<argument index="0" name="from" type="String" />
 			<description>
 				Constructs a [String] as a copy of the given [String].
 			</description>
-		</method>
-		<method name="String" qualifiers="constructor">
+		</constructor>
+		<constructor name="String">
 			<return type="String" />
 			<argument index="0" name="from" type="NodePath" />
 			<description>
 				Constructs a new String from the given [NodePath].
 			</description>
-		</method>
-		<method name="String" qualifiers="constructor">
+		</constructor>
+		<constructor name="String">
 			<return type="String" />
 			<argument index="0" name="from" type="StringName" />
 			<description>
 				Constructs a new String from the given [StringName].
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="begins_with" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="text" type="String" />
@@ -443,82 +445,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="StringName" />
-			<description>
-			</description>
-		</method>
-		<method name="operator %" qualifiers="operator">
-			<return type="String" />
-			<argument index="0" name="right" type="Variant" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="String" />
-			<argument index="0" name="right" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="StringName" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="String" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="pad_decimals" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="digits" type="int" />
@@ -843,4 +769,82 @@
 			</description>
 		</method>
 	</methods>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="String" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="StringName" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator %">
+			<return type="String" />
+			<argument index="0" name="right" type="Variant" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="String" />
+			<argument index="0" name="right" type="String" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="String" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="String" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="String" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="StringName" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="String" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="String" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="String" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -8,60 +8,62 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="StringName" qualifiers="constructor">
+	<constructors>
+		<constructor name="StringName">
 			<return type="StringName" />
 			<description>
 				Constructs an empty [StringName].
 			</description>
-		</method>
-		<method name="StringName" qualifiers="constructor">
+		</constructor>
+		<constructor name="StringName">
 			<return type="StringName" />
 			<argument index="0" name="from" type="StringName" />
 			<description>
 				Constructs a [StringName] as a copy of the given [StringName].
 			</description>
-		</method>
-		<method name="StringName" qualifiers="constructor">
+		</constructor>
+		<constructor name="StringName">
 			<return type="StringName" />
 			<argument index="0" name="from" type="String" />
 			<description>
 				Creates a new [StringName] from the given [String].
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
+		</constructor>
+	</constructors>
+	<operators>
+		<operator name="operator !=">
 			<return type="bool" />
 			<description>
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="StringName" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator !=">
 			<return type="bool" />
 			<argument index="0" name="right" type="String" />
 			<description>
 			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator !=">
 			<return type="bool" />
 			<argument index="0" name="right" type="StringName" />
 			<description>
 			</description>
-		</method>
-	</methods>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="String" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="StringName" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -13,29 +13,29 @@
 		<link title="Matrix Transform Demo">https://godotengine.org/asset-library/asset/584</link>
 		<link title="2.5D Demo">https://godotengine.org/asset-library/asset/583</link>
 	</tutorials>
-	<methods>
-		<method name="Transform2D" qualifiers="constructor">
+	<constructors>
+		<constructor name="Transform2D">
 			<return type="Transform2D" />
 			<description>
 				Constructs a default-initialized [Transform2D] set to [constant IDENTITY].
 			</description>
-		</method>
-		<method name="Transform2D" qualifiers="constructor">
+		</constructor>
+		<constructor name="Transform2D">
 			<return type="Transform2D" />
 			<argument index="0" name="from" type="Transform2D" />
 			<description>
 				Constructs a [Transform2D] as a copy of the given [Transform2D].
 			</description>
-		</method>
-		<method name="Transform2D" qualifiers="constructor">
+		</constructor>
+		<constructor name="Transform2D">
 			<return type="Transform2D" />
 			<argument index="0" name="rotation" type="float" />
 			<argument index="1" name="position" type="Vector2" />
 			<description>
 				Constructs the transform from a given angle (in radians) and position.
 			</description>
-		</method>
-		<method name="Transform2D" qualifiers="constructor">
+		</constructor>
+		<constructor name="Transform2D">
 			<return type="Transform2D" />
 			<argument index="0" name="rotation" type="float" />
 			<argument index="1" name="scale" type="Vector2" />
@@ -44,8 +44,8 @@
 			<description>
 				Constructs the transform from a given angle (in radians), scale, skew (in radians) and position.
 			</description>
-		</method>
-		<method name="Transform2D" qualifiers="constructor">
+		</constructor>
+		<constructor name="Transform2D">
 			<return type="Transform2D" />
 			<argument index="0" name="x_axis" type="Vector2" />
 			<argument index="1" name="y_axis" type="Vector2" />
@@ -53,7 +53,9 @@
 			<description>
 				Constructs the transform from 3 [Vector2] values representing [member x], [member y], and the [member origin] (the three column vectors).
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="affine_inverse" qualifiers="const">
 			<return type="Transform2D" />
 			<description>
@@ -129,72 +131,6 @@
 				Operations take place in global space.
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Transform2D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="PackedVector2Array" />
-			<argument index="0" name="right" type="PackedVector2Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Transform2D" />
-			<argument index="0" name="right" type="Transform2D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Rect2" />
-			<argument index="0" name="right" type="Rect2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Transform2D" />
-			<argument index="0" name="right" type="float" />
-			<description>
-				This operator multiplies all components of the [Transform2D], including the origin vector, which scales it uniformly.
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Transform2D" />
-			<argument index="0" name="right" type="int" />
-			<description>
-				This operator multiplies all components of the [Transform2D], including the origin vector, which scales it uniformly.
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Transform2D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="orthonormalized" qualifiers="const">
 			<return type="Transform2D" />
 			<description>
@@ -267,4 +203,72 @@
 			The [Transform2D] that will flip something along the Y axis.
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Transform2D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="PackedVector2Array" />
+			<argument index="0" name="right" type="PackedVector2Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Transform2D" />
+			<argument index="0" name="right" type="Transform2D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Rect2" />
+			<argument index="0" name="right" type="Rect2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Transform2D" />
+			<argument index="0" name="right" type="float" />
+			<description>
+				This operator multiplies all components of the [Transform2D], including the origin vector, which scales it uniformly.
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Transform2D" />
+			<argument index="0" name="right" type="int" />
+			<description>
+				This operator multiplies all components of the [Transform2D], including the origin vector, which scales it uniformly.
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Transform2D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="Vector2" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -15,29 +15,29 @@
 		<link title="3D Platformer Demo">https://godotengine.org/asset-library/asset/125</link>
 		<link title="2.5D Demo">https://godotengine.org/asset-library/asset/583</link>
 	</tutorials>
-	<methods>
-		<method name="Transform3D" qualifiers="constructor">
+	<constructors>
+		<constructor name="Transform3D">
 			<return type="Transform3D" />
 			<description>
 				Constructs a default-initialized [Transform3D] set to [constant IDENTITY].
 			</description>
-		</method>
-		<method name="Transform3D" qualifiers="constructor">
+		</constructor>
+		<constructor name="Transform3D">
 			<return type="Transform3D" />
 			<argument index="0" name="from" type="Transform3D" />
 			<description>
 				Constructs a [Transform3D] as a copy of the given [Transform3D].
 			</description>
-		</method>
-		<method name="Transform3D" qualifiers="constructor">
+		</constructor>
+		<constructor name="Transform3D">
 			<return type="Transform3D" />
 			<argument index="0" name="basis" type="Basis" />
 			<argument index="1" name="origin" type="Vector3" />
 			<description>
 				Constructs a Transform3D from a [Basis] and [Vector3].
 			</description>
-		</method>
-		<method name="Transform3D" qualifiers="constructor">
+		</constructor>
+		<constructor name="Transform3D">
 			<return type="Transform3D" />
 			<argument index="0" name="x_axis" type="Vector3" />
 			<argument index="1" name="y_axis" type="Vector3" />
@@ -46,7 +46,9 @@
 			<description>
 				Constructs a Transform3D from four [Vector3] values (matrix columns). Each axis corresponds to local basis vectors (some of which may be scaled).
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="affine_inverse" qualifiers="const">
 			<return type="Transform3D" />
 			<description>
@@ -81,66 +83,6 @@
 			<description>
 				Returns a copy of the transform rotated such that the forward axis (-Z) points towards the [code]target[/code] position.
 				The up axis (+Y) points as close to the [code]up[/code] vector as possible while staying perpendicular to the forward axis. The resulting transform is orthonormalized. The existing rotation, scale, and skew information from the original transform is discarded. The [code]target[/code] and [code]up[/code] vectors cannot be zero, cannot be parallel to each other, and are defined in global/parent space.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Transform3D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="PackedVector3Array" />
-			<argument index="0" name="right" type="PackedVector3Array" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Transform3D" />
-			<argument index="0" name="right" type="Transform3D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="AABB" />
-			<argument index="0" name="right" type="AABB" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Transform3D" />
-			<argument index="0" name="right" type="float" />
-			<description>
-				This operator multiplies all components of the [Transform3D], including the origin vector, which scales it uniformly.
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Transform3D" />
-			<argument index="0" name="right" type="int" />
-			<description>
-				This operator multiplies all components of the [Transform3D], including the origin vector, which scales it uniformly.
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Transform3D" />
-			<description>
 			</description>
 		</method>
 		<method name="orthonormalized" qualifiers="const">
@@ -195,4 +137,66 @@
 			[Transform3D] with mirroring applied perpendicular to the XY plane.
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Transform3D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="PackedVector3Array" />
+			<argument index="0" name="right" type="PackedVector3Array" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Transform3D" />
+			<argument index="0" name="right" type="Transform3D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="AABB" />
+			<argument index="0" name="right" type="AABB" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Transform3D" />
+			<argument index="0" name="right" type="float" />
+			<description>
+				This operator multiplies all components of the [Transform3D], including the origin vector, which scales it uniformly.
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Transform3D" />
+			<argument index="0" name="right" type="int" />
+			<description>
+				This operator multiplies all components of the [Transform3D], including the origin vector, which scales it uniformly.
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Transform3D" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -16,35 +16,37 @@
 		<link title="Matrix Transform Demo">https://godotengine.org/asset-library/asset/584</link>
 		<link title="All 2D Demos">https://github.com/godotengine/godot-demo-projects/tree/master/2d</link>
 	</tutorials>
-	<methods>
-		<method name="Vector2" qualifiers="constructor">
+	<constructors>
+		<constructor name="Vector2">
 			<return type="Vector2" />
 			<description>
 				Constructs a default-initialized [Vector2] with all components set to [code]0[/code].
 			</description>
-		</method>
-		<method name="Vector2" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector2">
 			<return type="Vector2" />
 			<argument index="0" name="from" type="Vector2" />
 			<description>
 				Constructs a [Vector2] as a copy of the given [Vector2].
 			</description>
-		</method>
-		<method name="Vector2" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector2">
 			<return type="Vector2" />
 			<argument index="0" name="from" type="Vector2i" />
 			<description>
 				Constructs a new [Vector2] from [Vector2i].
 			</description>
-		</method>
-		<method name="Vector2" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector2">
 			<return type="Vector2" />
 			<argument index="0" name="x" type="float" />
 			<argument index="1" name="y" type="float" />
 			<description>
 				Constructs a new [Vector2] from the given [code]x[/code] and [code]y[/code].
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="abs" qualifiers="const">
 			<return type="Vector2" />
 			<description>
@@ -225,122 +227,6 @@
 				Returns the vector scaled to unit length. Equivalent to [code]v / v.length()[/code].
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="Transform2D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="float" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary+" qualifiers="operator">
-			<return type="Vector2" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary-" qualifiers="operator">
-			<return type="Vector2" />
-			<description>
-			</description>
-		</method>
 		<method name="orthogonal" qualifiers="const">
 			<return type="Vector2" />
 			<description>
@@ -455,4 +341,122 @@
 			Down unit vector. Y is down in 2D, so this vector points +Y.
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="Transform2D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector2" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="float" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary+">
+			<return type="Vector2" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary-">
+			<return type="Vector2" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -13,35 +13,37 @@
 		<link title="Vector math">https://docs.godotengine.org/en/latest/tutorials/math/vector_math.html</link>
 		<link title="3Blue1Brown Essence of Linear Algebra">https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab</link>
 	</tutorials>
-	<methods>
-		<method name="Vector2i" qualifiers="constructor">
+	<constructors>
+		<constructor name="Vector2i">
 			<return type="Vector2i" />
 			<description>
 				Constructs a default-initialized [Vector2i] with all components set to [code]0[/code].
 			</description>
-		</method>
-		<method name="Vector2i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector2i">
 			<return type="Vector2i" />
 			<argument index="0" name="from" type="Vector2i" />
 			<description>
 				Constructs a [Vector2i] as a copy of the given [Vector2i].
 			</description>
-		</method>
-		<method name="Vector2i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector2i">
 			<return type="Vector2i" />
 			<argument index="0" name="from" type="Vector2" />
 			<description>
 				Constructs a new [Vector2i] from [Vector2]. The floating point coordinates will be truncated.
 			</description>
-		</method>
-		<method name="Vector2i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector2i">
 			<return type="Vector2i" />
 			<argument index="0" name="x" type="int" />
 			<argument index="1" name="y" type="int" />
 			<description>
 				Constructs a new [Vector2i] from the given [code]x[/code] and [code]y[/code].
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="abs" qualifiers="const">
 			<return type="Vector2i" />
 			<description>
@@ -60,128 +62,6 @@
 			<argument index="1" name="max" type="Vector2i" />
 			<description>
 				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator %" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator %" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="int" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary+" qualifiers="operator">
-			<return type="Vector2i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary-" qualifiers="operator">
-			<return type="Vector2i" />
-			<description>
 			</description>
 		</method>
 		<method name="sign" qualifiers="const">
@@ -225,4 +105,128 @@
 			Down unit vector. Y is down in 2D, so this vector points +Y.
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator %">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator %">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector2i" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary+">
+			<return type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary-">
+			<return type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -16,28 +16,28 @@
 		<link title="Matrix Transform Demo">https://godotengine.org/asset-library/asset/584</link>
 		<link title="All 3D Demos">https://github.com/godotengine/godot-demo-projects/tree/master/3d</link>
 	</tutorials>
-	<methods>
-		<method name="Vector3" qualifiers="constructor">
+	<constructors>
+		<constructor name="Vector3">
 			<return type="Vector3" />
 			<description>
 				Constructs a default-initialized [Vector3] with all components set to [code]0[/code].
 			</description>
-		</method>
-		<method name="Vector3" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector3">
 			<return type="Vector3" />
 			<argument index="0" name="from" type="Vector3" />
 			<description>
 				Constructs a [Vector3] as a copy of the given [Vector3].
 			</description>
-		</method>
-		<method name="Vector3" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector3">
 			<return type="Vector3" />
 			<argument index="0" name="from" type="Vector3i" />
 			<description>
 				Constructs a new [Vector3] from [Vector3i].
 			</description>
-		</method>
-		<method name="Vector3" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector3">
 			<return type="Vector3" />
 			<argument index="0" name="x" type="float" />
 			<argument index="1" name="y" type="float" />
@@ -45,7 +45,9 @@
 			<description>
 				Returns a [Vector3] with the given components.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="abs" qualifiers="const">
 			<return type="Vector3" />
 			<description>
@@ -219,134 +221,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Basis" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Quaternion" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Transform3D" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector3" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="float" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary+" qualifiers="operator">
-			<return type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary-" qualifiers="operator">
-			<return type="Vector3" />
-			<description>
-			</description>
-		</method>
 		<method name="outer" qualifiers="const">
 			<return type="Basis" />
 			<argument index="0" name="with" type="Vector3" />
@@ -483,4 +357,134 @@
 			Back unit vector. Represents the local direction of back, and the global direction of south.
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Basis" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Quaternion" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Transform3D" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="float" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary+">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary-">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -13,28 +13,28 @@
 		<link title="Vector math">https://docs.godotengine.org/en/latest/tutorials/math/vector_math.html</link>
 		<link title="3Blue1Brown Essence of Linear Algebra">https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab</link>
 	</tutorials>
-	<methods>
-		<method name="Vector3i" qualifiers="constructor">
+	<constructors>
+		<constructor name="Vector3i">
 			<return type="Vector3i" />
 			<description>
 				Constructs a default-initialized [Vector3i] with all components set to [code]0[/code].
 			</description>
-		</method>
-		<method name="Vector3i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector3i">
 			<return type="Vector3i" />
 			<argument index="0" name="from" type="Vector3i" />
 			<description>
 				Constructs a [Vector3i] as a copy of the given [Vector3i].
 			</description>
-		</method>
-		<method name="Vector3i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector3i">
 			<return type="Vector3i" />
 			<argument index="0" name="from" type="Vector3" />
 			<description>
 				Constructs a new [Vector3i] from [Vector3]. The floating point coordinates will be truncated.
 			</description>
-		</method>
-		<method name="Vector3i" qualifiers="constructor">
+		</constructor>
+		<constructor name="Vector3i">
 			<return type="Vector3i" />
 			<argument index="0" name="x" type="int" />
 			<argument index="1" name="y" type="int" />
@@ -42,7 +42,9 @@
 			<description>
 				Returns a [Vector3i] with the given components.
 			</description>
-		</method>
+		</constructor>
+	</constructors>
+	<methods>
 		<method name="abs" qualifiers="const">
 			<return type="Vector3i" />
 			<description>
@@ -66,128 +68,6 @@
 			<return type="int" />
 			<description>
 				Returns the axis of the vector's smallest value. See [code]AXIS_*[/code] constants. If all components are equal, this method returns [constant AXIS_Z].
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator %" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator %" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
-			<return type="bool" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator []" qualifiers="operator">
-			<return type="int" />
-			<argument index="0" name="index" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary+" qualifiers="operator">
-			<return type="Vector3i" />
-			<description>
-			</description>
-		</method>
-		<method name="operator unary-" qualifiers="operator">
-			<return type="Vector3i" />
-			<description>
 			</description>
 		</method>
 		<method name="sign" qualifiers="const">
@@ -243,4 +123,128 @@
 			Back unit vector. Represents the local direction of back, and the global direction of south.
 		</constant>
 	</constants>
+	<operators>
+		<operator name="operator !=">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator !=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator %">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator %">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator +">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector3i" />
+			<argument index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &lt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator ==">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator &gt;=">
+			<return type="bool" />
+			<argument index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator []">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary+">
+			<return type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator unary-">
+			<return type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/bool.xml
+++ b/doc/classes/bool.xml
@@ -91,71 +91,74 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="bool" qualifiers="constructor">
+	<constructors>
+		<constructor name="bool">
 			<return type="bool" />
 			<description>
 				Constructs a default-initialized [bool] set to [code]false[/code].
 			</description>
-		</method>
-		<method name="bool" qualifiers="constructor">
+		</constructor>
+		<constructor name="bool">
 			<return type="bool" />
 			<argument index="0" name="from" type="bool" />
 			<description>
 				Constructs a [bool] as a copy of the given [bool].
 			</description>
-		</method>
-		<method name="bool" qualifiers="constructor">
+		</constructor>
+		<constructor name="bool">
 			<return type="bool" />
 			<argument index="0" name="from" type="float" />
 			<description>
 				Cast a [float] value to a boolean value, this method will return [code]false[/code] if [code]0.0[/code] is passed in, and [code]true[/code] for all other floats.
 			</description>
-		</method>
-		<method name="bool" qualifiers="constructor">
+		</constructor>
+		<constructor name="bool">
 			<return type="bool" />
 			<argument index="0" name="from" type="int" />
 			<description>
 				Cast an [int] value to a boolean value, this method will return [code]false[/code] if [code]0[/code] is passed in, and [code]true[/code] for all other ints.
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
+		</constructor>
+	</constructors>
+	<operators>
+		<operator name="operator !=">
 			<return type="bool" />
 			<description>
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
+		</operator>
+		<operator name="operator !=">
 			<return type="bool" />
 			<argument index="0" name="right" type="bool" />
 			<description>
 				Returns [code]true[/code] if two bools are different, i.e. one is [code]true[/code] and the other is [code]false[/code].
 			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="bool" />
 			<description>
-				Returns [code]true[/code] if left operand is [code]false[/code] and right operand is [code]true[/code].
+				Returns [code]true[/code] if the left operand is [code]false[/code] and the right operand is [code]true[/code].
 			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator ==">
 			<return type="bool" />
 			<description>
+				Returns [code]true[/code] if two bools are equal, i.e. both are [code]true[/code] or both are [code]false[/code].
 			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator ==">
 			<return type="bool" />
 			<argument index="0" name="right" type="bool" />
 			<description>
 				Returns [code]true[/code] if two bools are equal, i.e. both are [code]true[/code] or both are [code]false[/code].
 			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="bool" />
 			<description>
-				Returns [code]true[/code] if left operand is [code]true[/code] and right operand is [code]false[/code].
+				Returns [code]true[/code] if the left operand is [code]true[/code] and the right operand is [code]false[/code].
 			</description>
-		</method>
-	</methods>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -12,61 +12,70 @@
 		<link title="Wikipedia: Double-precision floating-point format">https://en.wikipedia.org/wiki/Double-precision_floating-point_format</link>
 		<link title="Wikipedia: Single-precision floating-point format">https://en.wikipedia.org/wiki/Single-precision_floating-point_format</link>
 	</tutorials>
-	<methods>
-		<method name="float" qualifiers="constructor">
+	<constructors>
+		<constructor name="float">
 			<return type="float" />
 			<description>
 				Constructs a default-initialized [float] set to [code]0.0[/code].
 			</description>
-		</method>
-		<method name="float" qualifiers="constructor">
+		</constructor>
+		<constructor name="float">
 			<return type="float" />
 			<argument index="0" name="from" type="float" />
 			<description>
 				Constructs a [float] as a copy of the given [float].
 			</description>
-		</method>
-		<method name="float" qualifiers="constructor">
+		</constructor>
+		<constructor name="float">
 			<return type="float" />
 			<argument index="0" name="from" type="bool" />
 			<description>
 				Cast a [bool] value to a floating-point value, [code]float(true)[/code] will be equal to 1.0 and [code]float(false)[/code] will be equal to 0.0.
 			</description>
-		</method>
-		<method name="float" qualifiers="constructor">
+		</constructor>
+		<constructor name="float">
 			<return type="float" />
 			<argument index="0" name="from" type="int" />
 			<description>
 				Cast an [int] value to a floating-point value, [code]float(1)[/code] will be equal to [code]1.0[/code].
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
+		</constructor>
+	</constructors>
+	<operators>
+		<operator name="operator !=">
 			<return type="bool" />
 			<description>
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
+		</operator>
+		<operator name="operator !=">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if two floats are different from each other.
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
+		</operator>
+		<operator name="operator !=">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] if the integer has different value than the float.
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="float" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Multiplies two [float]s.
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
+			<return type="Quaternion" />
+			<argument index="0" name="right" type="Quaternion" />
+			<description>
+				Multiplies each component of the [Quaternion] by the given [float].
+			</description>
+		</operator>
+		<operator name="operator *">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
@@ -75,8 +84,8 @@
 				print(2.5 * Vector2(1, 1)) # Vector2(2.5, 2.5)
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
@@ -85,29 +94,22 @@
 				print(2.0 * Vector2i(1, 1)) # Vector2i(2.0, 2.0)
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
 				Multiplies each component of the [Vector3] by the given [float].
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
 				Multiplies each component of the [Vector3i] by the given [float].
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Quaternion" />
-			<argument index="0" name="right" type="Quaternion" />
-			<description>
-				Multiplies each component of the [Quaternion] by the given [float].
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="Color" />
 			<argument index="0" name="right" type="Color" />
 			<description>
@@ -116,143 +118,143 @@
 				print(1.5 * Color(0.5, 0.5, 0.5)) # Color(0.75, 0.75, 0.75)
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="float" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Multiplies a [float] and an [int]. The result is a [float].
 			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
+		</operator>
+		<operator name="operator +">
 			<return type="float" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Adds two floats.
 			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
+		</operator>
+		<operator name="operator +">
 			<return type="float" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Adds a [float] and an [int]. The result is a [float].
 			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
+		</operator>
+		<operator name="operator -">
 			<return type="float" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Subtracts a float from a float.
 			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
+		</operator>
+		<operator name="operator -">
 			<return type="float" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Subtracts an [int] from a [float]. The result is a [float].
 			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
+		</operator>
+		<operator name="operator /">
 			<return type="float" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Divides two floats.
 			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
+		</operator>
+		<operator name="operator /">
 			<return type="float" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Divides a [float] by an [int]. The result is a [float].
 			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] the left float is less than the right one.
 			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] if this [float] is less than the given [int].
 			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] the left integer is less than or equal to the right one.
 			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] if this [float] is less than or equal to the given [int].
 			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator ==">
 			<return type="bool" />
 			<description>
 			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator ==">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if both floats are exactly equal.
 				[b]Note:[/b] Due to floating-point precision errors, consider using [method @GlobalScope.is_equal_approx] or [method @GlobalScope.is_zero_approx] instead, which are more reliable.
 			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator ==">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] if the [float] and the given [int] are equal.
 			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] the left float is greater than the right one.
 			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] if this [float] is greater than the given [int].
 			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] the left float is greater than or equal to the right one.
 			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] if this [float] is greater than or equal to the given [int].
 			</description>
-		</method>
-		<method name="operator unary+" qualifiers="operator">
+		</operator>
+		<operator name="operator unary+">
 			<return type="float" />
 			<description>
 				Returns the same value as if the [code]+[/code] was not there. Unary [code]+[/code] does nothing, but sometimes it can make your code more readable.
 			</description>
-		</method>
-		<method name="operator unary-" qualifiers="operator">
+		</operator>
+		<operator name="operator unary-">
 			<return type="float" />
 			<description>
 				Returns the negative value of the [float]. If positive, turns the number negative. If negative, turns the number positive. With floats, the number zero can be either positive or negative.
 			</description>
-		</method>
-	</methods>
+		</operator>
+	</operators>
 </class>

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -38,54 +38,56 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<methods>
-		<method name="int" qualifiers="constructor">
+	<constructors>
+		<constructor name="int">
 			<return type="int" />
 			<description>
 				Constructs a default-initialized [int] set to [code]0[/code].
 			</description>
-		</method>
-		<method name="int" qualifiers="constructor">
+		</constructor>
+		<constructor name="int">
 			<return type="int" />
 			<argument index="0" name="from" type="int" />
 			<description>
 				Constructs an [int] as a copy of the given [int].
 			</description>
-		</method>
-		<method name="int" qualifiers="constructor">
+		</constructor>
+		<constructor name="int">
 			<return type="int" />
 			<argument index="0" name="from" type="bool" />
 			<description>
 				Cast a [bool] value to an integer value, [code]int(true)[/code] will be equals to 1 and [code]int(false)[/code] will be equals to 0.
 			</description>
-		</method>
-		<method name="int" qualifiers="constructor">
+		</constructor>
+		<constructor name="int">
 			<return type="int" />
 			<argument index="0" name="from" type="float" />
 			<description>
 				Cast a float value to an integer value, this method simply removes the number fractions (i.e. rounds [code]from[/code] towards zero), so for example [code]int(2.7)[/code] will be equals to 2, [code]int(0.1)[/code] will be equals to 0 and [code]int(-2.7)[/code] will be equals to -2. This operation is also called truncation.
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
+		</constructor>
+	</constructors>
+	<operators>
+		<operator name="operator !=">
 			<return type="bool" />
 			<description>
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
+		</operator>
+		<operator name="operator !=">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if operands are different from each other.
 			</description>
-		</method>
-		<method name="operator !=" qualifiers="operator">
+		</operator>
+		<operator name="operator !=">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] if operands are different from each other.
 			</description>
-		</method>
-		<method name="operator %" qualifiers="operator">
+		</operator>
+		<operator name="operator %">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
@@ -96,8 +98,8 @@
 				print(12 % 2) # 2
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator &amp;" qualifiers="operator">
+		</operator>
+		<operator name="operator &amp;">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
@@ -114,98 +116,93 @@
 				    do_stuff()
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
+			<return type="Color" />
+			<argument index="0" name="right" type="Color" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Quaternion" />
+			<argument index="0" name="right" type="Quaternion" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Multiplies two [int]s.
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="float" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Multiplies an [int] and a [float]. The result is a [float].
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
-				Multiplies each component of the vector by the given integer.
+				Multiplies each component of the [Vector2] by the given [int].
 				[codeblock]
 				print(2 * Vector2(1, 1)) # Vector2(2, 2)
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
-				Multiplies each component of the integer vector by the given integer.
+				Multiplies each component of the [Vector2i] by the given [int].
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
-				Multiplies each component of the vector by the given integer.
+				Multiplies each component of the [Vector3] by the given [int].
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
+		</operator>
+		<operator name="operator *">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
-				Multiplies each component of the integer vector by the given integer.
+				Multiplies each component of the [Vector3i] by the given [int].
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Quaternion" />
-			<argument index="0" name="right" type="Quaternion" />
+		</operator>
+		<operator name="operator +">
+			<return type="float" />
+			<argument index="0" name="right" type="float" />
 			<description>
-				Multiplies each component of the quaternion by the given integer.
+				Adds an [int] and a [float]. The result is a [float].
 			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Color" />
-			<argument index="0" name="right" type="Color" />
-			<description>
-				Multiplies each component of the color by the given integer.
-				[codeblock]
-				print(2 * Color(0.5, 0.5, 0.5)) # Color(1, 1, 1)
-				[/codeblock]
-			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
+		</operator>
+		<operator name="operator +">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Adds two integers.
 			</description>
-		</method>
-		<method name="operator +" qualifiers="operator">
-			<return type="float" />
-			<argument index="0" name="right" type="float" />
-			<description>
-				Adds an [int] to a [float]. The result is a [float].
-			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
+		</operator>
+		<operator name="operator -">
 			<return type="float" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Subtracts a [float] from an [int]. The result is a [float].
 			</description>
-		</method>
-		<method name="operator -" qualifiers="operator">
+		</operator>
+		<operator name="operator -">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Subtracts two integers.
 			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
+		</operator>
+		<operator name="operator /">
 			<return type="float" />
 			<argument index="0" name="right" type="float" />
 			<description>
@@ -214,8 +211,8 @@
 				print(10 / 3.0) # 3.333...
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator /" qualifiers="operator">
+		</operator>
+		<operator name="operator /">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
@@ -225,22 +222,22 @@
 				print(10 / 3) # 3
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if this [int] is less than the given [float].
 			</description>
-		</method>
-		<method name="operator &lt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] the left integer is less than the right one.
 			</description>
-		</method>
-		<method name="operator &lt;&lt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;&lt;">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
@@ -250,69 +247,69 @@
 				print(10 &lt;&lt; 4) # 160
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if this [int] is less than or equal to the given [float].
 			</description>
-		</method>
-		<method name="operator &lt;=" qualifiers="operator">
+		</operator>
+		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] the left integer is less than or equal to the right one.
 			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator ==">
 			<return type="bool" />
 			<description>
 			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator ==">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if the integer is equal to the given [float].
 			</description>
-		</method>
-		<method name="operator ==" qualifiers="operator">
+		</operator>
+		<operator name="operator ==">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] if both integers are equal.
 			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if this [int] is greater than the given [float].
 			</description>
-		</method>
-		<method name="operator &gt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] the left integer is greater than the right one.
 			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if this [int] is greater than or equal to the given [float].
 			</description>
-		</method>
-		<method name="operator &gt;=" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] the left integer is greater than or equal to the right one.
 			</description>
-		</method>
-		<method name="operator &gt;&gt;" qualifiers="operator">
+		</operator>
+		<operator name="operator &gt;&gt;">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
@@ -322,8 +319,8 @@
 				print(10 &gt;&gt; 2) # 2
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator ^" qualifiers="operator">
+		</operator>
+		<operator name="operator ^">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
@@ -333,20 +330,20 @@
 				print(4 ^ 7) # 3
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator unary+" qualifiers="operator">
+		</operator>
+		<operator name="operator unary+">
 			<return type="int" />
 			<description>
 				Returns the same value as if the [code]+[/code] was not there. Unary [code]+[/code] does nothing, but sometimes it can make your code more readable.
 			</description>
-		</method>
-		<method name="operator unary-" qualifiers="operator">
+		</operator>
+		<operator name="operator unary-">
 			<return type="int" />
 			<description>
 				Returns the negated value of the [int]. If positive, turns the number negative. If negative, turns the number positive. If zero, does nothing.
 			</description>
-		</method>
-		<method name="operator |" qualifiers="operator">
+		</operator>
+		<operator name="operator |">
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
@@ -363,8 +360,8 @@
 				flags |= 4
 				[/codeblock]
 			</description>
-		</method>
-		<method name="operator ~" qualifiers="operator">
+		</operator>
+		<operator name="operator ~">
 			<return type="int" />
 			<description>
 				Returns the result of bitwise [code]NOT[/code] operation for the integer. It's effectively equal to [code]-int + 1[/code].
@@ -373,6 +370,6 @@
 				print(~7) # -6
 				[/codeblock]
 			</description>
-		</method>
-	</methods>
+		</operator>
+	</operators>
 </class>

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -152,6 +152,8 @@ class EditorHelp : public VBoxContainer {
 
 	Error _goto_desc(const String &p_class, int p_vscr = -1);
 	//void _update_history_buttons();
+	void _update_method_list(const Vector<DocData::MethodDoc> p_methods, bool &r_method_descrpitons);
+	void _update_method_descriptions(const DocData::ClassDoc p_classdoc, const Vector<DocData::MethodDoc> p_methods, const String &p_method_type);
 	void _update_doc();
 
 	void _request_help(const String &p_string);

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -226,7 +226,9 @@ EditorHelpSearch::EditorHelpSearch() {
 	filter_combo->add_item(TTR("Display All"), SEARCH_ALL);
 	filter_combo->add_separator();
 	filter_combo->add_item(TTR("Classes Only"), SEARCH_CLASSES);
+	filter_combo->add_item(TTR("Constructors Only"), SEARCH_CONSTRUCTORS);
 	filter_combo->add_item(TTR("Methods Only"), SEARCH_METHODS);
+	filter_combo->add_item(TTR("Operators Only"), SEARCH_OPERATORS);
 	filter_combo->add_item(TTR("Signals Only"), SEARCH_SIGNALS);
 	filter_combo->add_item(TTR("Constants Only"), SEARCH_CONSTANTS);
 	filter_combo->add_item(TTR("Properties Only"), SEARCH_PROPERTIES);
@@ -334,6 +336,17 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 
 		// Match members if the term is long enough.
 		if (term.length() > 1) {
+			if (search_flags & SEARCH_CONSTRUCTORS) {
+				for (int i = 0; i < class_doc.constructors.size(); i++) {
+					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.constructors[i].name : class_doc.constructors[i].name.to_lower();
+					if (method_name.find(term) > -1 ||
+							(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
+							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
+							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
+						match.constructors.push_back(const_cast<DocData::MethodDoc *>(&class_doc.constructors[i]));
+					}
+				}
+			}
 			if (search_flags & SEARCH_METHODS) {
 				for (int i = 0; i < class_doc.methods.size(); i++) {
 					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.methods[i].name : class_doc.methods[i].name.to_lower();
@@ -342,6 +355,17 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
 							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
 						match.methods.push_back(const_cast<DocData::MethodDoc *>(&class_doc.methods[i]));
+					}
+				}
+			}
+			if (search_flags & SEARCH_OPERATORS) {
+				for (int i = 0; i < class_doc.operators.size(); i++) {
+					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.operators[i].name : class_doc.operators[i].name.to_lower();
+					if (method_name.find(term) > -1 ||
+							(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
+							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
+							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
+						match.operators.push_back(const_cast<DocData::MethodDoc *>(&class_doc.operators[i]));
 					}
 				}
 			}

--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -43,12 +43,14 @@ class EditorHelpSearch : public ConfirmationDialog {
 
 	enum SearchFlags {
 		SEARCH_CLASSES = 1 << 0,
-		SEARCH_METHODS = 1 << 1,
-		SEARCH_SIGNALS = 1 << 2,
-		SEARCH_CONSTANTS = 1 << 3,
-		SEARCH_PROPERTIES = 1 << 4,
-		SEARCH_THEME_ITEMS = 1 << 5,
-		SEARCH_ALL = SEARCH_CLASSES | SEARCH_METHODS | SEARCH_SIGNALS | SEARCH_CONSTANTS | SEARCH_PROPERTIES | SEARCH_THEME_ITEMS,
+		SEARCH_CONSTRUCTORS = 1 << 1,
+		SEARCH_METHODS = 1 << 2,
+		SEARCH_OPERATORS = 1 << 3,
+		SEARCH_SIGNALS = 1 << 4,
+		SEARCH_CONSTANTS = 1 << 5,
+		SEARCH_PROPERTIES = 1 << 6,
+		SEARCH_THEME_ITEMS = 1 << 7,
+		SEARCH_ALL = SEARCH_CLASSES | SEARCH_CONSTRUCTORS | SEARCH_METHODS | SEARCH_OPERATORS | SEARCH_SIGNALS | SEARCH_CONSTANTS | SEARCH_PROPERTIES | SEARCH_THEME_ITEMS,
 		SEARCH_CASE_SENSITIVE = 1 << 29,
 		SEARCH_SHOW_HIERARCHY = 1 << 30
 	};
@@ -99,7 +101,9 @@ class EditorHelpSearch::Runner : public RefCounted {
 	struct ClassMatch {
 		DocData::ClassDoc *doc;
 		bool name = false;
+		Vector<DocData::MethodDoc *> constructors;
 		Vector<DocData::MethodDoc *> methods;
+		Vector<DocData::MethodDoc *> operators;
 		Vector<DocData::MethodDoc *> signals;
 		Vector<DocData::ConstantDoc *> constants;
 		Vector<DocData::PropertyDoc *> properties;

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -338,7 +338,9 @@ Error GDScriptWorkspace::initialize() {
 		}
 
 		Vector<DocData::MethodDoc> methods_signals;
+		methods_signals.append_array(class_data.constructors);
 		methods_signals.append_array(class_data.methods);
+		methods_signals.append_array(class_data.operators);
 		const int signal_start_idx = methods_signals.size();
 		methods_signals.append_array(class_data.signals);
 


### PR DESCRIPTION
I'm interested in improving the documentation for operators, but before I do, I think it would be a significant improvement to separate operators from regular methods. We may as well do this with constructors too. Constructors and operators are very different from regular methods, so it makes sense that they should be separate.

I'm not very familiar with this code. This PR has not been thoroughly tested, there's likely things missing, and it's likely that the code can be simplified to not have so much duplication (would involve a fair amount of refactoring though). I assume there will also need to be updates for the docs repo so that it can read these new sections (I haven't touched the Python scripts). If anyone more knowledgeable can fix any remaining issues with this, feel free to use this PR as a base.

Anyway, the basics do work. Here is an example of how Color shows up in the editor. Previously everything was all together in one "Methods" section. Now constructors and operators get their own categories.

![color-classref](https://user-images.githubusercontent.com/1646875/136114639-45ae307c-27bc-49ea-a71a-bcaf0ad430c4.png)

The descriptions work too, here's the "Operator Descriptions" section (they do work, but these ones have no description).

![color-classref-2](https://user-images.githubusercontent.com/1646875/136119841-5cc8fd9c-fa54-45c3-9bcf-78fb3542e855.png)

Here's what it looks like in the XML files, there are now sections for constructors and operators:

![color-classref-3](https://user-images.githubusercontent.com/1646875/136120397-c915a7ea-78e5-40fc-9ca8-f51e07d3e2e9.png)


