### PR TITLE
[core_bind] Add `Thread::is_alive`. Replace `is_active` with `is_started` to align with core/os/Thread API.

### DIFF
--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -538,7 +538,7 @@ class Thread : public RefCounted {
 protected:
 	Variant ret;
 	Variant userdata;
-	SafeFlag active;
+	SafeFlag running;
 	Callable target_callable;
 	::Thread thread;
 	static void _bind_methods();
@@ -554,7 +554,8 @@ public:
 
 	Error start(const Callable &p_callable, const Variant &p_userdata = Variant(), Priority p_priority = PRIORITY_NORMAL);
 	String get_id() const;
-	bool is_active() const;
+	bool is_started() const;
+	bool is_alive() const;
 	Variant wait_to_finish();
 };
 

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -19,10 +19,17 @@
 				Returns the current [Thread]'s ID, uniquely identifying it among all threads. If the [Thread] is not running this returns an empty string.
 			</description>
 		</method>
-		<method name="is_active" qualifiers="const">
+		<method name="is_alive" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this [Thread] is currently active. An active [Thread] cannot start work on a new method but can be joined with [method wait_to_finish].
+				Returns [code]true[/code] if this [Thread] is currently running. This is useful for determining if [method wait_to_finish] can be called without blocking the calling thread.
+				To check if a [Thread] is joinable, use [method is_started].
+			</description>
+		</method>
+		<method name="is_started" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this [Thread] has been started. Once started, this will return [code]true[/code] until it is joined using [method wait_to_finish]. For checking if a [Thread] is still executing its task, use [method is_alive].
 			</description>
 		</method>
 		<method name="start">
@@ -31,15 +38,16 @@
 			<argument index="1" name="userdata" type="Variant" default="null" />
 			<argument index="2" name="priority" type="int" enum="Thread.Priority" default="1" />
 			<description>
-				Starts a new [Thread] that calls [code]callable[/code] with [code]userdata[/code] passed as an argument. Even if no userdata is passed, [code]method[/code] must accept one argument and it will be null. The [code]priority[/code] of the [Thread] can be changed by passing a value from the [enum Priority] enum.
+				Starts a new [Thread] that calls [code]callable[/code] with [code]userdata[/code] passed as an argument. Even if no userdata is passed, [code]callable[/code] must accept one argument and it will be null. The [code]priority[/code] of the [Thread] can be changed by passing a value from the [enum Priority] enum.
 				Returns [constant OK] on success, or [constant ERR_CANT_CREATE] on failure.
 			</description>
 		</method>
 		<method name="wait_to_finish">
 			<return type="Variant" />
 			<description>
-				Joins the [Thread] and waits for it to finish. Returns what the method called returned.
+				Joins the [Thread] and waits for it to finish. Returns the output of the [Callable] passed to [method start].
 				Should either be used when you want to retrieve the value returned from the method called by the [Thread] or before freeing the instance that contains the [Thread].
+				To determine if this can be called without blocking the calling thread, check if [method is_alive] is [code]false[/code].
 				[b]Note:[/b] After the [Thread] finishes joining it will be disposed. If you want to use it again you will have to create a new instance of it.
 			</description>
 		</method>


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
This adds the function `is_alive` to Thread. This is a usability improvement allowing users to check if a thread is still doing work. This helps resolve confusion around `is_active` (renamed to `is_started`), which was reasonably expected to behave as `is_alive`.

The current workaround to this is to create a `finished_executing` flag for each thread, set to `false` before `thread.start` and set to `true` at the end of the threaded function.

---

- I believe this fixes #7235
- Addresses part of https://github.com/godotengine/godot-proposals/issues/3163

If/when this gets approved, I'll open a branch for 3.x that doesn't break compatibility.