### PR TITLE
[3.x] bullet: Fix UWP build by disabling TaskScheduler dynamic loading

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -16,7 +16,7 @@ Files extracted from upstream source:
 - `src/*` apart from CMakeLists.txt and premake4.lua files
 - `LICENSE.txt`, and `VERSION` as `VERSION.txt`
 
-Includes a warning fix which should be upstreamed soon (see patch in `patches`).
+Includes some patches in the `patches` folder which have been sent upstream.
 
 
 ## certs

--- a/thirdparty/bullet/LinearMath/TaskScheduler/btThreadSupportWin32.cpp
+++ b/thirdparty/bullet/LinearMath/TaskScheduler/btThreadSupportWin32.cpp
@@ -82,6 +82,11 @@ typedef BOOL(WINAPI* Pfn_GetLogicalProcessorInformation)(PSYSTEM_LOGICAL_PROCESS
 void getProcessorInformation(btProcessorInfo* procInfo)
 {
 	memset(procInfo, 0, sizeof(*procInfo));
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
+    !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+	// Can't dlopen libraries on UWP.
+	return;
+#else
 	Pfn_GetLogicalProcessorInformation getLogicalProcInfo =
 		(Pfn_GetLogicalProcessorInformation)GetProcAddress(GetModuleHandle(TEXT("kernel32")), "GetLogicalProcessorInformation");
 	if (getLogicalProcInfo == NULL)
@@ -160,6 +165,7 @@ void getProcessorInformation(btProcessorInfo* procInfo)
 		}
 	}
 	free(buf);
+#endif
 }
 
 ///btThreadSupportWin32 helps to initialize/shutdown libspe2, start/stop SPU tasks and communication

--- a/thirdparty/bullet/patches/fix-win32-scheduler-uwp.patch
+++ b/thirdparty/bullet/patches/fix-win32-scheduler-uwp.patch
@@ -1,0 +1,24 @@
+diff --git a/thirdparty/bullet/LinearMath/TaskScheduler/btThreadSupportWin32.cpp b/thirdparty/bullet/LinearMath/TaskScheduler/btThreadSupportWin32.cpp
+index 922e449cce..5862264a67 100644
+--- a/thirdparty/bullet/LinearMath/TaskScheduler/btThreadSupportWin32.cpp
++++ b/thirdparty/bullet/LinearMath/TaskScheduler/btThreadSupportWin32.cpp
+@@ -82,6 +82,11 @@ typedef BOOL(WINAPI* Pfn_GetLogicalProcessorInformation)(PSYSTEM_LOGICAL_PROCESS
+ void getProcessorInformation(btProcessorInfo* procInfo)
+ {
+ 	memset(procInfo, 0, sizeof(*procInfo));
++#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
++    !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
++	// Can't dlopen libraries on UWP.
++	return;
++#else
+ 	Pfn_GetLogicalProcessorInformation getLogicalProcInfo =
+ 		(Pfn_GetLogicalProcessorInformation)GetProcAddress(GetModuleHandle(TEXT("kernel32")), "GetLogicalProcessorInformation");
+ 	if (getLogicalProcInfo == NULL)
+@@ -160,6 +165,7 @@ void getProcessorInformation(btProcessorInfo* procInfo)
+ 		}
+ 	}
+ 	free(buf);
++#endif
+ }
+ 
+ ///btThreadSupportWin32 helps to initialize/shutdown libspe2, start/stop SPU tasks and communication


### PR DESCRIPTION
Cf. https://github.com/bulletphysics/bullet3/pull/3991

Was a regression from #48300.