### PR TITLE
[3.x] Fix crash when tooltip_request_func object is freed

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6801,6 +6801,7 @@ String TextEdit::get_word_at_pos(const Vector2 &p_pos) const {
 }
 
 String TextEdit::get_tooltip(const Point2 &p_pos) const {
+	Object *tooltip_obj = ObjectDB::get_instance(tooltip_obj_id);
 	if (!tooltip_obj) {
 		return Control::get_tooltip(p_pos);
 	}
@@ -6822,7 +6823,8 @@ String TextEdit::get_tooltip(const Point2 &p_pos) const {
 }
 
 void TextEdit::set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata) {
-	tooltip_obj = p_obj;
+	ERR_FAIL_NULL(p_obj);
+	tooltip_obj_id = p_obj->get_instance_id();
 	tooltip_func = p_function;
 	tooltip_ud = p_udata;
 }
@@ -7368,7 +7370,7 @@ TextEdit::TextEdit() {
 	completion_enabled = false;
 	completion_active = false;
 	completion_line_ofs = 0;
-	tooltip_obj = nullptr;
+	tooltip_obj_id = ObjectID();
 	line_numbers = false;
 	line_numbers_zero_padded = false;
 	line_length_guidelines = false;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -412,7 +412,7 @@ private:
 	VScrollBar *v_scroll;
 	bool updating_scrolls;
 
-	Object *tooltip_obj;
+	ObjectID tooltip_obj_id;
 	StringName tooltip_func;
 	Variant tooltip_ud;
 


### PR DESCRIPTION
`3.x` version of #53460.

* `set_tooltip_request_func()` is not exposed to scripts on `3.x`, but the implementation is the same, so it's still crashable if something goes wrong in C++ code.
* `ObjectID` is a plain integer on `3.x`, so it needs explicit initialization.