### PR TITLE
Change dragging cursor on Windows

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -386,6 +386,7 @@
 		</constant>
 		<constant name="CURSOR_DRAG" value="6" enum="CursorShape">
 			Drag cursor. Usually displayed when dragging something.
+			[b]Note:[/b] Windows lacks a dragging cursor, so [constant CURSOR_DRAG] is the same as [constant CURSOR_MOVE] for this platform.
 		</constant>
 		<constant name="CURSOR_CAN_DROP" value="7" enum="CursorShape">
 			Can drop cursor. Usually displayed when dragging something to indicate that it can be dropped at the current position.

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1208,7 +1208,7 @@ void DisplayServerWindows::cursor_set_shape(CursorShape p_shape) {
 		IDC_CROSS,
 		IDC_WAIT,
 		IDC_APPSTARTING,
-		IDC_ARROW,
+		IDC_SIZEALL,
 		IDC_ARROW,
 		IDC_NO,
 		IDC_SIZENS,


### PR DESCRIPTION
Apparently Windows lacks a dragging cursor, so an arrow cursor was used instead. However, looking at other software (e.g. GIMP), they seem to have adapted the move cursor for this purpose, so this PR makes Godot use it too.

I also added a note in the docs, not sure if in the correct place, because CURSOR_DRAG seems to be defined in three different places 🙃