### PR TITLE
Re-prepare RenderingServer if SoftDynamicBody mesh changed

### DIFF
--- a/scene/3d/soft_dynamic_body_3d.cpp
+++ b/scene/3d/soft_dynamic_body_3d.cpp
@@ -411,8 +411,9 @@ void SoftDynamicBody3D::_draw_soft_mesh() {
 		return;
 	}
 
-	if (!rendering_server_handler.is_ready()) {
-		rendering_server_handler.prepare(get_mesh()->get_rid(), 0);
+	const RID mesh_rid = get_mesh()->get_rid();
+	if (!rendering_server_handler.is_ready(mesh_rid)) {
+		rendering_server_handler.prepare(mesh_rid, 0);
 
 		/// Necessary in order to render the mesh correctly (Soft body nodes are in global space)
 		simulation_started = true;

--- a/scene/3d/soft_dynamic_body_3d.h
+++ b/scene/3d/soft_dynamic_body_3d.h
@@ -50,7 +50,7 @@ class SoftDynamicBodyRenderingServerHandler : public RenderingServerHandler {
 
 private:
 	SoftDynamicBodyRenderingServerHandler();
-	bool is_ready() { return mesh.is_valid(); }
+	bool is_ready(RID p_mesh_rid) const { return mesh.is_valid() && mesh == p_mesh_rid; }
 	void prepare(RID p_mesh_rid, int p_surface);
 	void clear();
 	void open();


### PR DESCRIPTION
`master` version of #53481

The modification is the same as the `3.x` version, but I don't know how to trigger the original crash because `_draw_soft_mesh()` is not exposed to scripts here.