### PR TITLE
[3.x] Add option `modules_enabled_by_default` and minimal CI build

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -48,6 +48,14 @@ jobs:
             build-mono: false
             artifact: true
 
+          - name: Minimal template (target=release, tools=no, everything disabled)
+            cache-name: linux-template-minimal
+            target: release
+            tools: false
+            sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes deprecated=no minizip=no debug_symbols=no
+            build-mono: false
+            artifact: false
+
     steps:
       - uses: actions/checkout@v4
 

--- a/SConstruct
+++ b/SConstruct
@@ -154,6 +154,7 @@ opts.Add(
 )
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
+opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", True))
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
 opts.Add("system_certs_path", "Use this path as SSL certificates default for editor (for package maintainers)", "")
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
@@ -302,16 +303,21 @@ for path in module_search_paths:
 
 # Add module options
 for name, path in modules_detected.items():
-    enabled = True
     sys.path.insert(0, path)
     import config
 
-    try:
-        enabled = config.is_enabled()
-    except AttributeError:
-        pass
+    if env_base["modules_enabled_by_default"]:
+        enabled = True
+        try:
+            enabled = config.is_enabled()
+        except AttributeError:
+            pass
+    else:
+        enabled = False
+
     sys.path.remove(path)
     sys.modules.pop("config")
+
     opts.Add(BoolVariable("module_" + name + "_enabled", "Enable module '%s'" % (name,), enabled))
 
 methods.write_modules(modules_detected)


### PR DESCRIPTION
3.x version of #51048. This PR creates a new CI build that does a minimal export template build with everything disabled.