### PR TITLE
Fix outdated no_call_local, use call_remote

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3500,7 +3500,7 @@ bool GDScriptParser::network_annotations(const AnnotationNode *p_annotation, Nod
 			} else if (mode == "unreliable_ordered") {
 				rpc_config.transfer_mode = Multiplayer::TRANSFER_MODE_UNRELIABLE_ORDERED;
 			} else {
-				push_error(R"(Invalid RPC argument. Must be one of: 'call_local'/'no_call_local' (local calls), 'any_peer'/'authority' (permission), 'reliable'/'unreliable'/'unreliable_ordered' (transfer mode).)", p_annotation);
+				push_error(R"(Invalid RPC argument. Must be one of: 'call_local'/'call_remote' (local calls), 'any_peer'/'authority' (permission), 'reliable'/'unreliable'/'unreliable_ordered' (transfer mode).)", p_annotation);
 			}
 		}
 	}


### PR DESCRIPTION
Small oversight in the recent https://github.com/godotengine/godot/pull/53290 :)
It was amended later in that PR, but the error message wasn't updated to reflect that.