### PR TITLE
[3.x] Make body_test_motion thread safe for multi-threaded physics

### DIFF
--- a/servers/physics_2d/physics_2d_server_wrap_mt.h
+++ b/servers/physics_2d/physics_2d_server_wrap_mt.h
@@ -251,15 +251,8 @@ public:
 
 	FUNC2(body_set_pickable, RID, bool);
 
-	bool body_test_motion(RID p_body, const Transform2D &p_from, const Vector2 &p_motion, bool p_infinite_inertia, real_t p_margin = 0.08, MotionResult *r_result = nullptr, bool p_exclude_raycast_shapes = true, const Set<RID> &p_exclude = Set<RID>()) {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
-		return physics_2d_server->body_test_motion(p_body, p_from, p_motion, p_infinite_inertia, p_margin, r_result, p_exclude_raycast_shapes, p_exclude);
-	}
-
-	int body_test_ray_separation(RID p_body, const Transform2D &p_transform, bool p_infinite_inertia, Vector2 &r_recover_motion, SeparationResult *r_results, int p_result_max, float p_margin = 0.08) {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
-		return physics_2d_server->body_test_ray_separation(p_body, p_transform, p_infinite_inertia, r_recover_motion, r_results, p_result_max, p_margin);
-	}
+	FUNC8R(bool, body_test_motion, RID, const Transform2D &, const Vector2 &, bool, real_t, MotionResult *, bool, const Set<RID> &);
+	FUNC7R(int, body_test_ray_separation, RID, const Transform2D &, bool, Vector2 &, SeparationResult *, int, float);
 
 	// this function only works on physics process, errors and returns null otherwise
 	Physics2DDirectBodyState *body_get_direct_state(RID p_body) {


### PR DESCRIPTION
Needs proper synchro with the command buffer for thread safety, in case physics is not running on the main thread.
2D only, because 3D doesn't have multi-threaded physics on 3.x.

~Backport of #53497~
**Edit:** #53497 was closed but this fix is still needed on 3.x.
Fixes #53496 on the 3.x branch.