### PR TITLE
Use loop instead of recursion when clearing proximity groups

### DIFF
--- a/scene/3d/proximity_group_3d.cpp
+++ b/scene/3d/proximity_group_3d.cpp
@@ -34,9 +34,9 @@
 
 void ProximityGroup3D::_clear_groups() {
 	Map<StringName, uint32_t>::Element *E;
+	const int size = 16;
 
-	{
-		const int size = 16;
+	do {
 		StringName remove_list[size];
 		E = groups.front();
 		int num = 0;
@@ -50,11 +50,7 @@ void ProximityGroup3D::_clear_groups() {
 		for (int i = 0; i < num; i++) {
 			groups.erase(remove_list[i]);
 		}
-	}
-
-	if (E) {
-		_clear_groups(); // call until we go through the whole list
-	}
+	} while (E);
 }
 
 void ProximityGroup3D::_update_groups() {


### PR DESCRIPTION
Fixes #53484.

The crash is not caused by infinite recursion, but stack overflow. `_clear_groups()` remove items in chunks of 16, but the map has 838565 entries due to large grid radius, so it needs too much level of recursion to finish to call.