### PR TITLE
[3.x] Speedup running very big GDScript files

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1188,8 +1188,8 @@ static bool _guess_identifier_type(GDScriptCompletionContext &p_context, const S
 			}
 		}
 
-		for (const List<GDScriptParser::Node *>::Element *E = blk->statements.front(); E; E = E->next()) {
-			const GDScriptParser::Node *expr = E->get();
+		for (int z = 0; z < blk->statements.size(); z++) {
+			const GDScriptParser::Node *expr = blk->statements[z];
 			if (expr->line > p_context.line || expr->type != GDScriptParser::Node::TYPE_OPERATOR) {
 				continue;
 			}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2793,8 +2793,8 @@ void GDScriptParser::_transform_match_statment(MatchNode *p_match_statement) {
 			op->arguments.push_back(local_var->assign);
 			local_var->assign_op = op;
 
-			branch->body->statements.push_front(op);
-			branch->body->statements.push_front(local_var);
+			branch->body->statements.insert(0, op);
+			branch->body->statements.insert(0, local_var);
 		}
 
 		compiled_branch.body = branch->body;
@@ -8252,8 +8252,8 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 	Node *last_var_assign = nullptr;
 
 	// Check each statement
-	for (List<Node *>::Element *E = p_block->statements.front(); E; E = E->next()) {
-		Node *statement = E->get();
+	for (int z = 0; z < p_block->statements.size(); z++) {
+		Node *statement = p_block->statements[z];
 		switch (statement->type) {
 			case Node::TYPE_NEWLINE:
 			case Node::TYPE_BREAKPOINT: {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -234,7 +234,7 @@ public:
 	struct BlockNode : public Node {
 		ClassNode *parent_class;
 		BlockNode *parent_block;
-		List<Node *> statements;
+		Vector<Node *> statements;
 		Map<StringName, LocalVarNode *> variables;
 		bool has_return = false;
 		bool can_break = false;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/53506

It just changes List to Vector  which is a lot of faster in iterating elements in really big files.

With file from above issue(100000 lines), time to run script via terminal dropped from 10 minutes to 5 seconds.

With small files I don't expect any performance improvements or degradation.

Not sure if this not broke other things.