### PR TITLE
Add support for the RISC-V architecture

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -431,6 +431,15 @@ bool OS::has_feature(const String &p_feature) {
 	if (p_feature == "arm") {
 		return true;
 	}
+#elif defined(__riscv)
+#if __riscv_xlen == 8
+	if (p_feature == "rv64") {
+		return true;
+	}
+#endif
+	if (p_feature == "riscv") {
+		return true;
+	}
 #endif
 
 	if (_check_internal_feature_support(p_feature)) {

--- a/modules/denoise/config.py
+++ b/modules/denoise/config.py
@@ -1,11 +1,12 @@
 def can_build(env, platform):
     # Thirdparty dependency OpenImage Denoise includes oneDNN library
-    # which only supports 64-bit architectures.
+    # and the version we use only supports x86_64.
     # It's also only relevant for tools build and desktop platforms,
     # as doing lightmap generation and denoising on Android or HTML5
     # would be a bit far-fetched.
     desktop_platforms = ["linuxbsd", "osx", "windows"]
-    return env["tools"] and platform in desktop_platforms and env["bits"] == "64" and env["arch"] != "arm64"
+    supported_arch = env["bits"] == "64" and env["arch"] != "arm64" and not env["arch"].startswith("rv")
+    return env["tools"] and platform in desktop_platforms and supported_arch
 
 
 def configure(env):

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -2,7 +2,7 @@ supported_platforms = ["windows", "osx", "linuxbsd", "server", "android", "haiku
 
 
 def can_build(env, platform):
-    return True
+    return not env["arch"].startswith("rv")
 
 
 def configure(env):

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,5 +1,7 @@
 def can_build(env, platform):
     # Depends on Embree library, which only supports x86_64 and aarch64.
+    if env["arch"].startswith("rv"):
+        return False
 
     if platform == "android":
         return env["android_arch"] in ["arm64v8", "x86_64"]

--- a/modules/regex/config.py
+++ b/modules/regex/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return True
+    return not env["arch"].startswith("rv")
 
 
 def configure(env):

--- a/modules/theora/config.py
+++ b/modules/theora/config.py
@@ -1,4 +1,6 @@
 def can_build(env, platform):
+    if env["arch"].startswith("rv"):
+        return False
     return env.module_check_dependencies("theora", ["ogg", "vorbis"])
 
 

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -119,6 +119,13 @@ def configure(env):
     if env["bits"] == "default":
         env["bits"] = "64" if is64 else "32"
 
+    if env["arch"] == "" and platform.machine() == "riscv64":
+        env["arch"] = "rv64"
+
+    if env["arch"] == "rv64":
+        # G = General-purpose extensions, C = Compression extension (very common).
+        env.Append(CCFLAGS=["-march=rv64gc"])
+
     ## Compiler configuration
 
     if "CXX" in env and "clang" in os.path.basename(env["CXX"]):


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/3374 on master. Only Clang Debug builds work on RISC-V right now.
