### PR TITLE
[3.x] Add support for the RISC-V architecture

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -670,6 +670,15 @@ bool OS::has_feature(const String &p_feature) {
 	if (p_feature == "arm") {
 		return true;
 	}
+#elif defined(__riscv)
+#if __riscv_xlen == 8
+	if (p_feature == "rv64") {
+		return true;
+	}
+#endif
+	if (p_feature == "riscv") {
+		return true;
+	}
 #endif
 
 	if (_check_internal_feature_support(p_feature)) {

--- a/modules/denoise/config.py
+++ b/modules/denoise/config.py
@@ -1,13 +1,13 @@
 def can_build(env, platform):
     # Thirdparty dependency OpenImage Denoise includes oneDNN library
-    # which only supports 64-bit architectures.
+    # and the version we use only supports x86_64.
     # It's also only relevant for tools build and desktop platforms,
     # as doing lightmap generation and denoising on Android or HTML5
     # would be a bit far-fetched.
     # Note: oneDNN doesn't support ARM64, OIDN needs updating to the latest version
     supported_platform = platform in ["x11", "osx", "windows", "server"]
     supported_bits = env["bits"] == "64"
-    supported_arch = env["arch"] != "arm64"
+    supported_arch = env["arch"] != "arm64" and not env["arch"].startswith("rv")
 
     # Hack to disable on Linux arm64. This won't work well for cross-compilation (checks
     # host, not target) and would need a more thorough fix by refactoring our arch and

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -2,7 +2,7 @@ supported_platforms = ["windows", "osx", "x11", "server", "android", "haiku", "j
 
 
 def can_build(env, platform):
-    return True
+    return not env["arch"].startswith("rv")
 
 
 def configure(env):

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -3,6 +3,8 @@ def can_build(env, platform):
         return False
 
     # Depends on Embree library, which only supports x86_64 and aarch64.
+    if env["arch"].startswith("rv"):
+        return False
 
     if platform == "android":
         return env["android_arch"] in ["arm64v8", "x86_64"]

--- a/modules/regex/config.py
+++ b/modules/regex/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return True
+    return not env["arch"].startswith("rv")
 
 
 def configure(env):

--- a/modules/webm/config.py
+++ b/modules/webm/config.py
@@ -1,4 +1,6 @@
 def can_build(env, platform):
+    if env["arch"].startswith("rv"):
+        return False
     return platform not in ["iphone"]
 
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -118,6 +118,13 @@ def configure(env):
     if env["bits"] == "default":
         env["bits"] = "64" if is64 else "32"
 
+    if env["arch"] == "" and platform.machine() == "riscv64":
+        env["arch"] = "rv64"
+
+    if env["arch"] == "rv64":
+        # G = General-purpose extensions, C = Compression extension (very common).
+        env.Append(CCFLAGS=["-march=rv64gc"])
+
     ## Compiler configuration
 
     if "CXX" in env and "clang" in os.path.basename(env["CXX"]):


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/3374 on 3.x. Only Clang Debug builds work on RISC-V right now.
