### PR TITLE
[3.x] i18n: Add support for translating the class reference

### DIFF
--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -117,13 +117,23 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 		}
 
 		l = l.substr(1, l.length());
-		//find final quote
+		// Find final quote, ignoring escaped ones (\").
+		// The escape_next logic is necessary to properly parse things like \\"
+		// where the blackslash is the one being escaped, not the quote.
 		int end_pos = -1;
+		bool escape_next = false;
 		for (int i = 0; i < l.length(); i++) {
-			if (l[i] == '"' && (i == 0 || l[i - 1] != '\\')) {
+			if (l[i] == '\\' && !escape_next) {
+				escape_next = true;
+				continue;
+			}
+
+			if (l[i] == '"' && !escape_next) {
 				end_pos = i;
 				break;
 			}
+
+			escape_next = false;
 		}
 
 		if (end_pos == -1) {

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -37,7 +37,7 @@
 
 class TranslationLoaderPO : public ResourceFormatLoader {
 public:
-	static RES load_translation(FileAccess *f, Error *r_error);
+	static RES load_translation(FileAccess *f, Error *r_error = nullptr);
 	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -1180,7 +1180,6 @@ void TranslationServer::setup() {
 	}
 	fallback = GLOBAL_DEF("locale/fallback", "en");
 #ifdef TOOLS_ENABLED
-
 	{
 		String options = "";
 		int idx = 0;
@@ -1194,7 +1193,6 @@ void TranslationServer::setup() {
 		ProjectSettings::get_singleton()->set_custom_property_info("locale/fallback", PropertyInfo(Variant::STRING, "locale/fallback", PROPERTY_HINT_ENUM, options));
 	}
 #endif
-	//load translations
 }
 
 void TranslationServer::set_tool_translation(const Ref<Translation> &p_translation) {
@@ -1204,12 +1202,24 @@ void TranslationServer::set_tool_translation(const Ref<Translation> &p_translati
 StringName TranslationServer::tool_translate(const StringName &p_message) const {
 	if (tool_translation.is_valid()) {
 		StringName r = tool_translation->get_message(p_message);
-
 		if (r) {
 			return r;
 		}
 	}
+	return p_message;
+}
 
+void TranslationServer::set_doc_translation(const Ref<Translation> &p_translation) {
+	doc_translation = p_translation;
+}
+
+StringName TranslationServer::doc_translate(const StringName &p_message) const {
+	if (doc_translation.is_valid()) {
+		StringName r = doc_translation->get_message(p_message);
+		if (r) {
+			return r;
+		}
+	}
 	return p_message;
 }
 

--- a/core/translation.h
+++ b/core/translation.h
@@ -71,6 +71,7 @@ class TranslationServer : public Object {
 
 	Set<Ref<Translation>> translations;
 	Ref<Translation> tool_translation;
+	Ref<Translation> doc_translation;
 
 	Map<String, String> locale_name_map;
 
@@ -107,6 +108,8 @@ public:
 
 	void set_tool_translation(const Ref<Translation> &p_translation);
 	StringName tool_translate(const StringName &p_message) const;
+	void set_doc_translation(const Ref<Translation> &p_translation);
+	StringName doc_translate(const StringName &p_message) const;
 
 	void setup();
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -4470,13 +4470,14 @@ String TTR(const String &p_text) {
 }
 
 String DTR(const String &p_text) {
+	// Comes straight from the XML, so remove indentation and any trailing whitespace.
+	const String text = p_text.dedent().strip_edges();
+
 	if (TranslationServer::get_singleton()) {
-		// Comes straight from the XML, so remove indentation and any trailing whitespace.
-		const String text = p_text.dedent().strip_edges();
 		return TranslationServer::get_singleton()->doc_translate(text);
 	}
 
-	return p_text;
+	return text;
 }
 #endif
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -4469,6 +4469,15 @@ String TTR(const String &p_text) {
 	return p_text;
 }
 
+String DTR(const String &p_text) {
+	if (TranslationServer::get_singleton()) {
+		// Comes straight from the XML, so remove indentation and any trailing whitespace.
+		const String text = p_text.dedent().strip_edges();
+		return TranslationServer::get_singleton()->doc_translate(text);
+	}
+
+	return p_text;
+}
 #endif
 
 String RTR(const String &p_text) {

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -414,25 +414,25 @@ _FORCE_INLINE_ bool is_str_less(const L *l_ptr, const R *r_ptr) {
 
 /* end of namespace */
 
-//tool translate
+// Tool translate (TTR and variants) for the editor UI,
+// and doc translate for the class reference (DTR).
 #ifdef TOOLS_ENABLED
-
-//gets parsed
+// Gets parsed.
 String TTR(const String &);
-//use for C strings
+String DTR(const String &);
+// Use for C strings.
 #define TTRC(m_value) (m_value)
-//use to avoid parsing (for use later with C strings)
+// Use to avoid parsing (for use later with C strings).
 #define TTRGET(m_value) TTR(m_value)
 
 #else
-
 #define TTR(m_value) (String())
+#define DTR(m_value) (String())
 #define TTRC(m_value) (m_value)
 #define TTRGET(m_value) (m_value)
-
 #endif
 
-//tool or regular translate
+// Runtime translate for the public node API.
 String RTR(const String &);
 
 bool is_symbol(CharType c);

--- a/doc/translations/Makefile
+++ b/doc/translations/Makefile
@@ -1,0 +1,23 @@
+# Makefile providing various facilities to manage translations
+
+TEMPLATE = classes.pot
+POFILES = $(wildcard *.po)
+LANGS = $(POFILES:%.po=%)
+
+all: update merge
+
+update:
+	@cd ../..; \
+	python3 doc/translations/extract.py \
+	  --path doc/classes modules/*/doc_classes \
+	  --output doc/translations/$(TEMPLATE)
+
+merge:
+	@for po in $(POFILES); do \
+	  echo -e "\nMerging $$po..."; \
+	  msgmerge -w 79 -C $$po $$po $(TEMPLATE) > "$$po".new; \
+	  mv -f "$$po".new $$po; \
+	done
+
+check:
+	@for po in $(POFILES); do msgfmt -c $$po -o /dev/null; done

--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+import shutil
+from collections import OrderedDict
+
+EXTRACT_TAGS = ["description", "brief_description", "member", "constant", "theme_item", "link"]
+HEADER = """\
+# LANGUAGE translation of the Godot Engine class reference
+# Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.
+# Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).
+# This file is distributed under the same license as the Godot source code.
+#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Godot Engine class reference\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8-bit\\n"
+
+"""
+
+## <xml-line-number-hack from="https://stackoverflow.com/a/36430270/10846399">
+import sys
+
+sys.modules["_elementtree"] = None
+import xml.etree.ElementTree as ET
+
+## override the parser to get the line number
+class LineNumberingParser(ET.XMLParser):
+    def _start(self, *args, **kwargs):
+        ## Here we assume the default XML parser which is expat
+        ## and copy its element position attributes into output Elements
+        element = super(self.__class__, self)._start(*args, **kwargs)
+        element._start_line_number = self.parser.CurrentLineNumber
+        element._start_column_number = self.parser.CurrentColumnNumber
+        element._start_byte_index = self.parser.CurrentByteIndex
+        return element
+
+    def _end(self, *args, **kwargs):
+        element = super(self.__class__, self)._end(*args, **kwargs)
+        element._end_line_number = self.parser.CurrentLineNumber
+        element._end_column_number = self.parser.CurrentColumnNumber
+        element._end_byte_index = self.parser.CurrentByteIndex
+        return element
+
+
+## </xml-line-number-hack>
+
+
+class Desc:
+    def __init__(self, line_no, msg, desc_list=None):
+        ## line_no   : the line number where the desc is
+        ## msg       : the description string
+        ## desc_list : the DescList it belongs to
+        self.line_no = line_no
+        self.msg = msg
+        self.desc_list = desc_list
+
+
+class DescList:
+    def __init__(self, doc, path):
+        ## doc  : root xml element of the document
+        ## path : file path of the xml document
+        ## list : list of Desc objects for this document
+        self.doc = doc
+        self.path = path
+        self.list = []
+
+
+def print_error(error):
+    print("ERROR: {}".format(error))
+
+
+## build classes with xml elements recursively
+def _collect_classes_dir(path, classes):
+    if not os.path.isdir(path):
+        print_error("Invalid directory path: {}".format(path))
+        exit(1)
+    for _dir in map(lambda dir: os.path.join(path, dir), os.listdir(path)):
+        if os.path.isdir(_dir):
+            _collect_classes_dir(_dir, classes)
+        elif os.path.isfile(_dir):
+            if not _dir.endswith(".xml"):
+                # print("Got non-.xml file '{}', skipping.".format(path))
+                continue
+            _collect_classes_file(_dir, classes)
+
+
+## opens a file and parse xml add to classes
+def _collect_classes_file(path, classes):
+    if not os.path.isfile(path) or not path.endswith(".xml"):
+        print_error("Invalid xml file path: {}".format(path))
+        exit(1)
+    print("Collecting file: {}".format(os.path.basename(path)))
+
+    try:
+        tree = ET.parse(path, parser=LineNumberingParser())
+    except ET.ParseError as e:
+        print_error("Parse error reading file '{}': {}".format(path, e))
+        exit(1)
+
+    doc = tree.getroot()
+
+    if "name" in doc.attrib:
+        if "version" not in doc.attrib:
+            print_error("Version missing from 'doc', file: {}".format(path))
+
+        name = doc.attrib["name"]
+        if name in classes:
+            print_error("Duplicate class {} at path {}".format(name, path))
+            exit(1)
+        classes[name] = DescList(doc, path)
+    else:
+        print_error("Unknown XML file {}, skipping".format(path))
+
+
+## regions are list of tuples with size 3 (start_index, end_index, indent)
+## indication in string where the codeblock starts, ends, and it's indent
+## if i inside the region returns the indent, else returns -1
+def _get_xml_indent(i, regions):
+    for region in regions:
+        if region[0] < i < region[1]:
+            return region[2]
+    return -1
+
+
+## find and build all regions of codeblock which we need later
+def _make_codeblock_regions(desc, path=""):
+    code_block_end = False
+    code_block_index = 0
+    code_block_regions = []
+    while not code_block_end:
+        code_block_index = desc.find("[codeblock]", code_block_index)
+        if code_block_index < 0:
+            break
+        xml_indent = 0
+        while True:
+            ## [codeblock] always have a trailing new line and some tabs
+            ## those tabs are belongs to xml indentations not code indent
+            if desc[code_block_index + len("[codeblock]\n") + xml_indent] == "\t":
+                xml_indent += 1
+            else:
+                break
+        end_index = desc.find("[/codeblock]", code_block_index)
+        if end_index < 0:
+            print_error("Non terminating codeblock: {}".format(path))
+            exit(1)
+        code_block_regions.append((code_block_index, end_index, xml_indent))
+        code_block_index += 1
+    return code_block_regions
+
+
+def _strip_and_split_desc(desc, code_block_regions):
+    desc_strip = ""  ## a stripped desc msg
+    total_indent = 0  ## code indent = total indent - xml indent
+    for i in range(len(desc)):
+        c = desc[i]
+        if c == "\n":
+            c = "\\n"
+        if c == '"':
+            c = '\\"'
+        if c == "\\":
+            c = "\\\\"  ## <element \> is invalid for msgmerge
+        if c == "\t":
+            xml_indent = _get_xml_indent(i, code_block_regions)
+            if xml_indent >= 0:
+                total_indent += 1
+                if xml_indent < total_indent:
+                    c = "\\t"
+                else:
+                    continue
+            else:
+                continue
+        desc_strip += c
+        if c == "\\n":
+            total_indent = 0
+    return desc_strip
+
+
+## make catlog strings from xml elements
+def _make_translation_catalog(classes):
+    unique_msgs = OrderedDict()
+    for class_name in classes:
+        desc_list = classes[class_name]
+        for elem in desc_list.doc.iter():
+            if elem.tag in EXTRACT_TAGS:
+                if not elem.text or len(elem.text) == 0:
+                    continue
+                line_no = elem._start_line_number if elem.text[0] != "\n" else elem._start_line_number + 1
+                desc_str = elem.text.strip()
+                code_block_regions = _make_codeblock_regions(desc_str, desc_list.path)
+                desc_msg = _strip_and_split_desc(desc_str, code_block_regions)
+                desc_obj = Desc(line_no, desc_msg, desc_list)
+                desc_list.list.append(desc_obj)
+
+                if desc_msg not in unique_msgs:
+                    unique_msgs[desc_msg] = [desc_obj]
+                else:
+                    unique_msgs[desc_msg].append(desc_obj)
+    return unique_msgs
+
+
+## generate the catlog file
+def _generate_translation_catalog_file(unique_msgs, output):
+    with open(output, "w", encoding="utf8") as f:
+        f.write(HEADER)
+        for msg in unique_msgs:
+            if len(msg) == 0:
+                continue  ## ignore
+
+            f.write("#:")
+            desc_list = unique_msgs[msg]
+            for desc in desc_list:
+                path = desc.desc_list.path.replace("\\", "/")
+                if path.startswith("./"):
+                    path = path[2:]
+                f.write(" {}:{}".format(path, desc.line_no))
+            f.write("\n")
+
+            f.write('msgid "{}"\n'.format(msg))
+            f.write('msgstr ""\n\n')
+
+    ## TODO: what if 'nt'?
+    if os.name == "posix":
+        print("Wrapping template at 79 characters for compatibility with Weblate.")
+        os.system("msgmerge -w79 {0} {0} > {0}.wrap".format(output))
+        shutil.move("{}.wrap".format(output), output)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", "-p", default=".", help="The directory containing XML files to collect.")
+    parser.add_argument("--output", "-o", default="translation_catlog.pot", help="The path to the output file.")
+    args = parser.parse_args()
+
+    output = os.path.abspath(args.output)
+    if not os.path.isdir(os.path.dirname(output)) or not output.endswith(".pot"):
+        print_error("Invalid output path: {}".format(output))
+        exit(1)
+    if not os.path.isdir(args.path):
+        print_error("Invalid working directory path: {}".format(args.path))
+        exit(1)
+
+    os.chdir(args.path)
+    print("Current working dir: {}\n".format(os.getcwd()))
+
+    classes = OrderedDict()  ## dictionary of key=class_name, value=DescList objects
+    _collect_classes_dir(".", classes)
+    classes = OrderedDict(sorted(classes.items(), key=lambda kv: kv[0].lower()))
+    unique_msgs = _make_translation_catalog(classes)
+    _generate_translation_catalog_file(unique_msgs, output)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -8,9 +8,9 @@ from collections import OrderedDict
 
 EXTRACT_TAGS = ["description", "brief_description", "member", "constant", "theme_item", "link"]
 HEADER = """\
-# LANGUAGE translation of the Godot Engine class reference
-# Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.
-# Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).
+# LANGUAGE translation of the Godot Engine class reference.
+# Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.
+# Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).
 # This file is distributed under the same license as the Godot source code.
 #
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -19,10 +19,26 @@ HEADER = """\
 msgid ""
 msgstr ""
 "Project-Id-Version: Godot Engine class reference\\n"
+"Report-Msgid-Bugs-To: https://github.com/godotengine/godot\\n"
+"MIME-Version: 1.0\\n"
 "Content-Type: text/plain; charset=UTF-8\\n"
 "Content-Transfer-Encoding: 8-bit\\n"
 
 """
+# Some strings used by makerst.py are normally part of the editor translations,
+# so we need to include them manually here for the online docs.
+BASE_STRINGS = [
+    "Description",
+    "Tutorials",
+    "Properties",
+    "Methods",
+    "Theme Properties",
+    "Signals",
+    "Enumerations",
+    "Constants",
+    "Property Descriptions",
+    "Method Descriptions",
+]
 
 ## <xml-line-number-hack from="https://stackoverflow.com/a/36430270/10846399">
 import sys
@@ -182,7 +198,7 @@ def _strip_and_split_desc(desc, code_block_regions):
     return desc_strip
 
 
-## make catlog strings from xml elements
+## make catalog strings from xml elements
 def _make_translation_catalog(classes):
     unique_msgs = OrderedDict()
     for class_name in classes:
@@ -205,13 +221,17 @@ def _make_translation_catalog(classes):
     return unique_msgs
 
 
-## generate the catlog file
+## generate the catalog file
 def _generate_translation_catalog_file(unique_msgs, output):
     with open(output, "w", encoding="utf8") as f:
         f.write(HEADER)
+        for msg in BASE_STRINGS:
+            f.write("#: doc/tools/makerst.py\n")
+            f.write('msgid "{}"\n'.format(msg))
+            f.write('msgstr ""\n\n')
         for msg in unique_msgs:
-            if len(msg) == 0:
-                continue  ## ignore
+            if len(msg) == 0 or msg in BASE_STRINGS:
+                continue
 
             f.write("#:")
             desc_list = unique_msgs[msg]
@@ -235,7 +255,7 @@ def _generate_translation_catalog_file(unique_msgs, output):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--path", "-p", default=".", help="The directory containing XML files to collect.")
-    parser.add_argument("--output", "-o", default="translation_catlog.pot", help="The path to the output file.")
+    parser.add_argument("--output", "-o", default="translation_catalog.pot", help="The path to the output file.")
     args = parser.parse_args()
 
     output = os.path.abspath(args.output)

--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -254,7 +254,9 @@ def _generate_translation_catalog_file(unique_msgs, output):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--path", "-p", default=".", help="The directory containing XML files to collect.")
+    parser.add_argument(
+        "--path", "-p", nargs="+", default=".", help="The directory or directories containing XML files to collect."
+    )
     parser.add_argument("--output", "-o", default="translation_catalog.pot", help="The path to the output file.")
     args = parser.parse_args()
 
@@ -262,15 +264,19 @@ def main():
     if not os.path.isdir(os.path.dirname(output)) or not output.endswith(".pot"):
         print_error("Invalid output path: {}".format(output))
         exit(1)
-    if not os.path.isdir(args.path):
-        print_error("Invalid working directory path: {}".format(args.path))
-        exit(1)
 
-    os.chdir(args.path)
-    print("Current working dir: {}\n".format(os.getcwd()))
+    classes = OrderedDict()
+    for path in args.path:
+        if not os.path.isdir(path):
+            print_error("Invalid working directory path: {}".format(path))
+            exit(1)
 
-    classes = OrderedDict()  ## dictionary of key=class_name, value=DescList objects
-    _collect_classes_dir(".", classes)
+        print("\nCurrent working dir: {}".format(path))
+
+        path_classes = OrderedDict()  ## dictionary of key=class_name, value=DescList objects
+        _collect_classes_dir(path, path_classes)
+        classes.update(path_classes)
+
     classes = OrderedDict(sorted(classes.items(), key=lambda kv: kv[0].lower()))
     unique_msgs = _make_translation_catalog(classes)
     _generate_translation_catalog_file(unique_msgs, output)

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -69,10 +69,19 @@ if env["tools"]:
 
     path = env.Dir(".").abspath
 
-    # Translations
+    # Editor translations
     tlist = glob.glob(path + "/translations/*.po")
-    env.Depends("#editor/translations.gen.h", tlist)
-    env.CommandNoCache("#editor/translations.gen.h", tlist, run_in_subprocess(editor_builders.make_translations_header))
+    env.Depends("#editor/editor_translations.gen.h", tlist)
+    env.CommandNoCache(
+        "#editor/editor_translations.gen.h", tlist, run_in_subprocess(editor_builders.make_editor_translations_header)
+    )
+
+    # Documentation translations
+    tlist = glob.glob(env.Dir("#doc").abspath + "/translations/*.po")
+    env.Depends("#editor/doc_translations.gen.h", tlist)
+    env.CommandNoCache(
+        "#editor/doc_translations.gen.h", tlist, run_in_subprocess(editor_builders.make_doc_translations_header)
+    )
 
     # Fonts
     flist = glob.glob(path + "/../thirdparty/fonts/*.ttf")

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1001,7 +1001,7 @@ void ConnectionsDock::update_tree() {
 					while (F && descr == String()) {
 						for (int i = 0; i < F->get().signals.size(); i++) {
 							if (F->get().signals[i].name == signal_name.operator String()) {
-								descr = DTR(F->get().signals[i].description.strip_edges());
+								descr = DTR(F->get().signals[i].description);
 								break;
 							}
 						}

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1001,7 +1001,7 @@ void ConnectionsDock::update_tree() {
 					while (F && descr == String()) {
 						for (int i = 0; i < F->get().signals.size(); i++) {
 							if (F->get().signals[i].name == signal_name.operator String()) {
-								descr = F->get().signals[i].description.strip_edges();
+								descr = DTR(F->get().signals[i].description.strip_edges());
 								break;
 							}
 						}

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -247,7 +247,7 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 		item->set_collapsed(collapse);
 	}
 
-	const String &description = EditorHelp::get_doc_data()->class_list[p_type].brief_description;
+	const String &description = DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description);
 	item->set_tooltip(0, description);
 
 	String icon_fallback = has_icon(base_type, "EditorIcons") ? base_type : "Object";
@@ -555,11 +555,11 @@ void CreateDialog::_item_selected() {
 		return;
 	}
 
-	if (EditorHelp::get_doc_data()->class_list.has(name) && !EditorHelp::get_doc_data()->class_list[name].brief_description.empty()) {
-		help_bit->set_text(EditorHelp::get_doc_data()->class_list[name].brief_description);
+	const String brief_desc = DTR(EditorHelp::get_doc_data()->class_list[name].brief_description);
+	if (!brief_desc.empty()) {
 		// Display both class name and description, since the help bit may be displayed
 		// far away from the location (especially if the dialog was resized to be taller).
-		help_bit->set_text(vformat("[b]%s[/b]: %s", name, EditorHelp::get_doc_data()->class_list[name].brief_description.strip_edges()));
+		help_bit->set_text(vformat("[b]%s[/b]: %s", name, brief_desc));
 		help_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 1));
 	} else {
 		// Use nested `vformat()` as translators shouldn't interfere with BBCode tags.

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -232,6 +232,9 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	if (p_overview) {
 		class_desc->push_cell();
 		class_desc->push_align(RichTextLabel::ALIGN_RIGHT);
+	} else {
+		static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
+		class_desc->add_text(String(prefix));
 	}
 
 	_add_type(p_method.return_type, p_method.return_enum);
@@ -367,7 +370,6 @@ void EditorHelp::_update_doc() {
 		class_desc->push_color(title_color);
 		class_desc->push_font(doc_font);
 		class_desc->add_text(TTR("Inherits:") + " ");
-		class_desc->pop();
 
 		String inherits = cd.inherits;
 
@@ -382,6 +384,7 @@ void EditorHelp::_update_doc() {
 		}
 
 		class_desc->pop();
+		class_desc->pop();
 		class_desc->add_newline();
 	}
 
@@ -390,13 +393,12 @@ void EditorHelp::_update_doc() {
 		bool found = false;
 		bool prev = false;
 
+		class_desc->push_font(doc_font);
 		for (Map<String, DocData::ClassDoc>::Element *E = doc->class_list.front(); E; E = E->next()) {
 			if (E->get().inherits == cd.name) {
 				if (!found) {
 					class_desc->push_color(title_color);
-					class_desc->push_font(doc_font);
 					class_desc->add_text(TTR("Inherited by:") + " ");
-					class_desc->pop();
 					found = true;
 				}
 
@@ -408,6 +410,7 @@ void EditorHelp::_update_doc() {
 				prev = true;
 			}
 		}
+		class_desc->pop();
 
 		if (found) {
 			class_desc->pop();
@@ -747,6 +750,8 @@ void EditorHelp::_update_doc() {
 			signal_line[cd.signals[i].name] = class_desc->get_line_count() - 2; //gets overridden if description
 			class_desc->push_font(doc_code_font); // monofont
 			class_desc->push_color(headline_color);
+			static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
+			class_desc->add_text(String(prefix));
 			_add_text(cd.signals[i].name);
 			class_desc->pop();
 			class_desc->push_color(symbol_color);
@@ -824,10 +829,10 @@ void EditorHelp::_update_doc() {
 			for (Map<String, Vector<DocData::ConstantDoc>>::Element *E = enums.front(); E; E = E->next()) {
 				enum_line[E->key()] = class_desc->get_line_count() - 2;
 
+				class_desc->push_font(doc_code_font);
 				class_desc->push_color(title_color);
 				class_desc->add_text("enum  ");
 				class_desc->pop();
-				class_desc->push_font(doc_code_font);
 				String e = E->key();
 				if ((e.get_slice_count(".") > 1) && (e.get_slice(".", 0) == edited_class)) {
 					e = e.get_slice(".", 1);
@@ -840,6 +845,8 @@ void EditorHelp::_update_doc() {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(":");
 				class_desc->pop();
+
+				class_desc->add_newline();
 				class_desc->add_newline();
 
 				class_desc->push_indent(1);
@@ -858,6 +865,8 @@ void EditorHelp::_update_doc() {
 
 					class_desc->push_font(doc_code_font);
 					class_desc->push_color(headline_color);
+					static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
+					class_desc->add_text(String(prefix));
 					_add_text(enum_list[i].name);
 					class_desc->pop();
 					class_desc->push_color(symbol_color);
@@ -869,14 +878,15 @@ void EditorHelp::_update_doc() {
 					class_desc->pop();
 					if (enum_list[i].description != "") {
 						class_desc->push_font(doc_font);
-						//class_desc->add_text("  ");
-						class_desc->push_indent(1);
 						class_desc->push_color(comment_color);
+						static const CharType dash[6] = { ' ', ' ', 0x2013 /* en dash */, ' ', ' ', 0 };
+						class_desc->add_text(String(dash));
 						_add_text(DTR(enum_list[i].description));
 						class_desc->pop();
 						class_desc->pop();
-						class_desc->pop(); // indent
-						class_desc->add_newline();
+						if (DTR(enum_list[i].description).find("\n") > 0) {
+							class_desc->add_newline();
+						}
 					}
 
 					class_desc->add_newline();
@@ -920,6 +930,9 @@ void EditorHelp::_update_doc() {
 						class_desc->add_text(String(prefix));
 						class_desc->pop();
 					}
+				} else {
+					static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
+					class_desc->add_text(String(prefix));
 				}
 
 				class_desc->push_color(headline_color);
@@ -935,13 +948,15 @@ void EditorHelp::_update_doc() {
 				class_desc->pop();
 				if (constants[i].description != "") {
 					class_desc->push_font(doc_font);
-					class_desc->push_indent(1);
 					class_desc->push_color(comment_color);
+					static const CharType dash[6] = { ' ', ' ', 0x2013 /* en dash */, ' ', ' ', 0 };
+					class_desc->add_text(String(dash));
 					_add_text(DTR(constants[i].description));
 					class_desc->pop();
 					class_desc->pop();
-					class_desc->pop(); // indent
-					class_desc->add_newline();
+					if (DTR(constants[i].description).find("\n") > 0) {
+						class_desc->add_newline();
+					}
 				}
 
 				class_desc->add_newline();
@@ -976,6 +991,9 @@ void EditorHelp::_update_doc() {
 
 			class_desc->push_cell();
 			class_desc->push_font(doc_code_font);
+			static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
+			class_desc->add_text(String(prefix));
+
 			_add_type(cd.properties[i].type, cd.properties[i].enumeration);
 			class_desc->add_text(" ");
 			class_desc->pop(); // font

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -423,7 +423,7 @@ void EditorHelp::_update_doc() {
 		class_desc->push_color(text_color);
 		class_desc->push_font(doc_bold_font);
 		class_desc->push_indent(1);
-		_add_text(cd.brief_description);
+		_add_text(DTR(cd.brief_description));
 		class_desc->pop();
 		class_desc->pop();
 		class_desc->pop();
@@ -447,7 +447,7 @@ void EditorHelp::_update_doc() {
 		class_desc->push_color(text_color);
 		class_desc->push_font(doc_font);
 		class_desc->push_indent(1);
-		_add_text(cd.description);
+		_add_text(DTR(cd.description));
 		class_desc->pop();
 		class_desc->pop();
 		class_desc->pop();
@@ -469,8 +469,8 @@ void EditorHelp::_update_doc() {
 		class_desc->add_newline();
 
 		for (int i = 0; i < cd.tutorials.size(); i++) {
-			const String link = cd.tutorials[i].link;
-			String linktxt = (cd.tutorials[i].title.empty()) ? link : cd.tutorials[i].title;
+			const String link = DTR(cd.tutorials[i].link);
+			String linktxt = (cd.tutorials[i].title.empty()) ? link : DTR(cd.tutorials[i].title);
 			const int seppos = linktxt.find("//");
 			if (seppos != -1) {
 				linktxt = link.right(seppos + 2);
@@ -712,7 +712,7 @@ void EditorHelp::_update_doc() {
 				class_desc->push_font(doc_font);
 				class_desc->add_text("  ");
 				class_desc->push_color(comment_color);
-				_add_text(cd.theme_properties[i].description);
+				_add_text(DTR(cd.theme_properties[i].description));
 				class_desc->pop();
 				class_desc->pop();
 			}
@@ -779,7 +779,7 @@ void EditorHelp::_update_doc() {
 				class_desc->push_font(doc_font);
 				class_desc->push_color(comment_color);
 				class_desc->push_indent(1);
-				_add_text(cd.signals[i].description);
+				_add_text(DTR(cd.signals[i].description));
 				class_desc->pop(); // indent
 				class_desc->pop();
 				class_desc->pop(); // font
@@ -872,7 +872,7 @@ void EditorHelp::_update_doc() {
 						//class_desc->add_text("  ");
 						class_desc->push_indent(1);
 						class_desc->push_color(comment_color);
-						_add_text(enum_list[i].description);
+						_add_text(DTR(enum_list[i].description));
 						class_desc->pop();
 						class_desc->pop();
 						class_desc->pop(); // indent
@@ -937,7 +937,7 @@ void EditorHelp::_update_doc() {
 					class_desc->push_font(doc_font);
 					class_desc->push_indent(1);
 					class_desc->push_color(comment_color);
-					_add_text(constants[i].description);
+					_add_text(DTR(constants[i].description));
 					class_desc->pop();
 					class_desc->pop();
 					class_desc->pop(); // indent
@@ -1066,7 +1066,7 @@ void EditorHelp::_update_doc() {
 			class_desc->push_font(doc_font);
 			class_desc->push_indent(1);
 			if (cd.properties[i].description.strip_edges() != String()) {
-				_add_text(cd.properties[i].description);
+				_add_text(DTR(cd.properties[i].description));
 			} else {
 				class_desc->add_image(get_icon("Error", "EditorIcons"));
 				class_desc->add_text(" ");
@@ -1117,7 +1117,7 @@ void EditorHelp::_update_doc() {
 				class_desc->push_font(doc_font);
 				class_desc->push_indent(1);
 				if (methods_filtered[i].description.strip_edges() != String()) {
-					_add_text(methods_filtered[i].description);
+					_add_text(DTR(methods_filtered[i].description));
 				} else {
 					class_desc->add_image(get_icon("Error", "EditorIcons"));
 					class_desc->add_text(" ");

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1490,7 +1490,7 @@ void EditorInspector::update_tree() {
 					if (E) {
 						descr = E->get().brief_description;
 					}
-					class_descr_cache[type2] = descr;
+					class_descr_cache[type2] = DTR(descr);
 				}
 
 				category->set_tooltip(p.name + "::" + (class_descr_cache[type2] == "" ? "" : class_descr_cache[type2]));
@@ -1645,7 +1645,7 @@ void EditorInspector::update_tree() {
 				while (F && descr == String()) {
 					for (int i = 0; i < F->get().properties.size(); i++) {
 						if (F->get().properties[i].name == propname.operator String()) {
-							descr = F->get().properties[i].description.strip_edges();
+							descr = DTR(F->get().properties[i].description.strip_edges());
 							break;
 						}
 					}
@@ -1655,7 +1655,7 @@ void EditorInspector::update_tree() {
 						// Likely a theme property.
 						for (int i = 0; i < F->get().theme_properties.size(); i++) {
 							if (F->get().theme_properties[i].name == slices[1]) {
-								descr = F->get().theme_properties[i].description.strip_edges();
+								descr = DTR(F->get().theme_properties[i].description.strip_edges());
 								break;
 							}
 						}

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1488,9 +1488,9 @@ void EditorInspector::update_tree() {
 					DocData *dd = EditorHelp::get_doc_data();
 					Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(type2);
 					if (E) {
-						descr = E->get().brief_description;
+						descr = DTR(E->get().brief_description);
 					}
-					class_descr_cache[type2] = DTR(descr);
+					class_descr_cache[type2] = descr;
 				}
 
 				category->set_tooltip(p.name + "::" + (class_descr_cache[type2] == "" ? "" : class_descr_cache[type2]));
@@ -1645,7 +1645,7 @@ void EditorInspector::update_tree() {
 				while (F && descr == String()) {
 					for (int i = 0; i < F->get().properties.size(); i++) {
 						if (F->get().properties[i].name == propname.operator String()) {
-							descr = DTR(F->get().properties[i].description.strip_edges());
+							descr = DTR(F->get().properties[i].description);
 							break;
 						}
 					}
@@ -1655,7 +1655,7 @@ void EditorInspector::update_tree() {
 						// Likely a theme property.
 						for (int i = 0; i < F->get().theme_properties.size(); i++) {
 							if (F->get().theme_properties[i].name == slices[1]) {
-								descr = DTR(F->get().theme_properties[i].description.strip_edges());
+								descr = DTR(F->get().theme_properties[i].description);
 								break;
 							}
 						}

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -44,8 +44,9 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "core/version.h"
+#include "editor/doc_translations.gen.h"
 #include "editor/editor_node.h"
-#include "editor/translations.gen.h"
+#include "editor/editor_translations.gen.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
@@ -1002,11 +1003,11 @@ fail:
 void EditorSettings::setup_language() {
 	String lang = get("interface/editor/editor_language");
 	if (lang == "en") {
-		return; //none to do
+		return; // Default, nothing to do.
 	}
 
+	// Load editor translation for configured/detected locale.
 	EditorTranslationList *etl = _editor_translations;
-
 	while (etl->data) {
 		if (etl->lang == lang) {
 			Vector<uint8_t> data;
@@ -1016,7 +1017,7 @@ void EditorSettings::setup_language() {
 			FileAccessMemory *fa = memnew(FileAccessMemory);
 			fa->open_custom(data.ptr(), data.size());
 
-			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa, nullptr);
+			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
 
 			if (tr.is_valid()) {
 				tr->set_locale(etl->lang);
@@ -1026,6 +1027,29 @@ void EditorSettings::setup_language() {
 		}
 
 		etl++;
+	}
+
+	// Load class reference translation.
+	DocTranslationList *dtl = _doc_translations;
+	while (dtl->data) {
+		if (dtl->lang == lang) {
+			Vector<uint8_t> data;
+			data.resize(dtl->uncomp_size);
+			Compression::decompress(data.ptrw(), dtl->uncomp_size, dtl->data, dtl->comp_size, Compression::MODE_DEFLATE);
+
+			FileAccessMemory *fa = memnew(FileAccessMemory);
+			fa->open_custom(data.ptr(), data.size());
+
+			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
+
+			if (tr.is_valid()) {
+				tr->set_locale(dtl->lang);
+				TranslationServer::get_singleton()->set_doc_translation(tr);
+				break;
+			}
+		}
+
+		dtl++;
 	}
 }
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -358,7 +358,7 @@ void PropertySelector::_item_selected() {
 			if (E) {
 				for (int i = 0; i < E->get().properties.size(); i++) {
 					if (E->get().properties[i].name == name) {
-						text = E->get().properties[i].description;
+						text = DTR(E->get().properties[i].description);
 						break;
 					}
 				}
@@ -377,7 +377,7 @@ void PropertySelector::_item_selected() {
 			if (E) {
 				for (int i = 0; i < E->get().methods.size(); i++) {
 					if (E->get().methods[i].name == name) {
-						text = E->get().methods[i].description;
+						text = DTR(E->get().methods[i].description);
 						break;
 					}
 				}

--- a/editor/translations/extract.py
+++ b/editor/translations/extract.py
@@ -45,6 +45,8 @@ main_po = """
 msgid ""
 msgstr ""
 "Project-Id-Version: Godot Engine editor\\n"
+"Report-Msgid-Bugs-To: https://github.com/godotengine/godot\\n"
+"MIME-Version: 1.0\\n"
 "Content-Type: text/plain; charset=UTF-8\\n"
 "Content-Transfer-Encoding: 8-bit\\n"\n
 """

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -445,7 +445,7 @@ void VisualScriptPropertySelector::_item_selected() {
 		if (E) {
 			for (int i = 0; i < E->get().properties.size(); i++) {
 				if (E->get().properties[i].name == name) {
-					text = E->get().properties[i].description;
+					text = DTR(E->get().properties[i].description);
 				}
 			}
 		}
@@ -459,7 +459,7 @@ void VisualScriptPropertySelector::_item_selected() {
 		if (C) {
 			for (int i = 0; i < C->get().methods.size(); i++) {
 				if (C->get().methods[i].name == name) {
-					text = C->get().methods[i].description;
+					text = DTR(C->get().methods[i].description);
 				}
 			}
 		}
@@ -472,7 +472,7 @@ void VisualScriptPropertySelector::_item_selected() {
 	if (T) {
 		for (int i = 0; i < T->get().methods.size(); i++) {
 			if (T->get().methods[i].name == functions[functions.size() - 1]) {
-				text = T->get().methods[i].description;
+				text = DTR(T->get().methods[i].description);
 			}
 		}
 	}
@@ -491,7 +491,7 @@ void VisualScriptPropertySelector::_item_selected() {
 		if (typecast_node.is_valid()) {
 			Map<String, DocData::ClassDoc>::Element *F = dd->class_list.find(typecast_node->get_class_name());
 			if (F) {
-				text = F->get().description;
+				text = DTR(F->get().description);
 			}
 		}
 
@@ -501,7 +501,7 @@ void VisualScriptPropertySelector::_item_selected() {
 			if (F) {
 				for (int i = 0; i < F->get().constants.size(); i++) {
 					if (F->get().constants[i].value.to_int() == int(builtin_node->get_func())) {
-						text = F->get().constants[i].description;
+						text = DTR(F->get().constants[i].description);
 					}
 				}
 			}


### PR DESCRIPTION
This backports a feature from the `master` branch implemented back in March 2020, at a time where we did not intend prolonged feature development for `3.2`.

Since we restarted 3.x development with the `3.x` branch, 4.0 is still a ways off, and translators have already started translating the class reference on https://hosted.weblate.org/projects/godot-engine/godot-class-reference/, I'm bringing this to `3.x` so that we can make use of the translators' work (mostly Chinese (Simplified) and Spanish which are 100% translated on Weblate, though they'll have 20% of the strings to review and 10% new strings to work on when I sync Weblate with `3.x`).

Backports the following PRs:
- #37114
- #37185
- #37164
- #39118
- #38917 (not strictly needed, but added for consistency with `master`)

Ref. https://github.com/godotengine/godot-docs-l10n/issues/18

This PR doesn't include the actual translations, I'll sync them in a follow-up.

Once merged with the `3.x` class reference content, it looks like this:

![godot-zh-cn](https://user-images.githubusercontent.com/4701338/136363092-1c43444d-388e-4f33-b44e-073490fce769.jpg)

![Screenshot_20211007_114924](https://user-images.githubusercontent.com/4701338/136362967-251f56b9-8633-43a9-bde4-129b32440782.png)