### PR TITLE
Fix physical bone generation offset

### DIFF
--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -112,7 +112,7 @@ PhysicalBone *SkeletonEditor::create_physical_bone(int bone_id, int bone_child_i
 	bone_shape->set_transform(capsule_transform);
 
 	Transform body_transform;
-	body_transform.origin = Vector3(0, 0, -half_height);
+	body_transform.origin = Vector3(0, half_height, 0);
 
 	Transform joint_transform;
 	joint_transform.origin = Vector3(0, 0, half_height);


### PR DESCRIPTION
When creating a physical skeleton, the generated bones were offset on the wrong axis.
Fixes #53466

Godot 4.0 doesn't show this behaviour anymore, this fix only applies to 3.x.

Big thanks to @lyuma who helped by testing, explaining and debugging!
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
