### PR TITLE
Add typedef to GDNativeInstanceBindingCallbacks

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -182,11 +182,11 @@ typedef void *(*GDNativeInstanceBindingCreateCallback)(void *p_token, void *p_in
 typedef void (*GDNativeInstanceBindingFreeCallback)(void *p_token, void *p_instance, void *p_binding);
 typedef GDNativeBool (*GDNativeInstanceBindingReferenceCallback)(void *p_token, void *p_binding, GDNativeBool p_reference);
 
-struct GDNativeInstanceBindingCallbacks {
+typedef struct {
 	GDNativeInstanceBindingCreateCallback create_callback;
 	GDNativeInstanceBindingFreeCallback free_callback;
 	GDNativeInstanceBindingReferenceCallback reference_callback;
-};
+} GDNativeInstanceBindingCallbacks;
 
 /* EXTENSION CLASSES */
 


### PR DESCRIPTION
I decided to dabble in writing godot extensions in C as an exercise. 

The compiler says that `GDNativeInstanceBindingCallbacks` is an unknown type:
```
In file included from ../register_types.h:4,
                 from ../register_types.c:1:
../godot-headers/godot/gdnative_interface.h:426:90: error: unknown type name ‘GDNativeInstanceBindingCallbacks’
  426 |         void *(*object_get_instance_binding)(GDNativeObjectPtr p_o, void *p_token, const GDNativeInstanceBindingCallbacks *p_callbacks);
      |                                                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../godot-headers/godot/gdnative_interface.h:427:106: error: unknown type name ‘GDNativeInstanceBindingCallbacks’
  427 |         void (*object_set_instance_binding)(GDNativeObjectPtr p_o, void *p_token, void *p_binding, const GDNativeInstanceBindingCallbacks *p_callbacks);
      |
```

I assume this this has gone unnoticed as it's a valid C++ type definition.