### PR TITLE
Set TileSet layout and half-offset as read-only when using square shape

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -72,6 +72,7 @@ void TileSet::set_tile_shape(TileSet::TileShape p_shape) {
 
 	terrain_bits_meshes_dirty = true;
 	tile_meshes_dirty = true;
+	notify_property_list_changed();
 	emit_changed();
 }
 TileSet::TileShape TileSet::get_tile_shape() const {
@@ -2683,6 +2684,14 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "tile_proxies/source_level", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "tile_proxies/coords_level", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "tile_proxies/alternative_level", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+}
+
+void TileSet::_validate_property(PropertyInfo &property) const {
+	if (property.name == "tile_layout" && tile_shape == TILE_SHAPE_SQUARE) {
+		property.usage ^= PROPERTY_USAGE_READ_ONLY;
+	} else if (property.name == "tile_offset_axis" && tile_shape == TILE_SHAPE_SQUARE) {
+		property.usage ^= PROPERTY_USAGE_READ_ONLY;
+	}
 }
 
 void TileSet::_bind_methods() {

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -180,6 +180,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	virtual void _validate_property(PropertyInfo &property) const override;
 
 private:
 	// --- TileSet data ---


### PR DESCRIPTION
A simple improvement, making the tile_layout and tile_offset_axis when using the square shape. In such case, those properties aren't used, so it's better to mark them as read-only.

https://user-images.githubusercontent.com/6093119/136394698-a8d2acc0-9364-476f-b0a9-b5f8be6e8978.mp4