### PR TITLE
Change print_line() to use any number of Variants

### DIFF
--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -69,7 +69,7 @@ void remove_print_handler(PrintHandlerList *p_handler) {
 	ERR_FAIL_COND(l == nullptr);
 }
 
-void print_line(String p_string) {
+void __print_line(String p_string) {
 	if (!_print_line_enabled) {
 		return;
 	}
@@ -107,4 +107,8 @@ void print_verbose(String p_string) {
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		print_line(p_string);
 	}
+}
+
+String stringify_variants(Variant p_var) {
+	return p_var.operator String();
 }

--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -31,7 +31,7 @@
 #ifndef PRINT_STRING_H
 #define PRINT_STRING_H
 
-#include "core/string/ustring.h"
+#include "core/variant/variant.h"
 
 extern void (*_print_func)(String);
 
@@ -46,13 +46,21 @@ struct PrintHandlerList {
 	PrintHandlerList() {}
 };
 
+String stringify_variants(Variant p_var);
+
+template <typename... Args>
+String stringify_variants(Variant p_var, Args... p_args) {
+	return p_var.operator String() + " " + stringify_variants(p_args...);
+}
+
 void add_print_handler(PrintHandlerList *p_handler);
 void remove_print_handler(PrintHandlerList *p_handler);
 
 extern bool _print_line_enabled;
 extern bool _print_error_enabled;
-extern void print_line(String p_string);
+extern void __print_line(String p_string);
 extern void print_error(String p_string);
 extern void print_verbose(String p_string);
+#define print_line(...) __print_line(stringify_variants(__VA_ARGS__))
 
 #endif // PRINT_STRING_H

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4496,7 +4496,7 @@ void GDScriptParser::TreePrinter::print_tree(const GDScriptParser &p_parser) {
 	}
 	print_class(p_parser.get_tree());
 
-	print_line(printed);
+	print_line(String(printed));
 }
 
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
This PR adds a `print_variants()` *method* that takes any number of Variant values and prints them, space-separated. It's equivalent of GDScript's `prints()` for C++. Example:
```C++
print_variants("abc", 123, some_node->get_name())

> "abc" 123 @@some_node1
```

This is meant to quickly print some values for debugging purposes, so I didn't bother to make error/warning/verbose versions. Although it would be easy to add another macro that prints with any method, e.g. `print_any(print_error, arg1, arg2)`, if that's desired.

Supersedes #35964

EDIT:
I removed `print_variants()`, now the PR modified `print_line()`.