### PR TITLE
Allow declare the shader arrays with a size defined before identifier

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -979,6 +979,10 @@ private:
 	bool _validate_varying_using(ShaderNode::Varying &p_varying, String *r_message);
 	bool _check_node_constness(const Node *p_node) const;
 
+	Node *_parse_array_size(BlockNode *p_block, const FunctionInfo &p_function_info, int &r_array_size);
+	Error _parse_global_array_size(int &r_array_size);
+	Error _parse_local_array_size(BlockNode *p_block, const FunctionInfo &p_function_info, ArrayDeclarationNode *p_node, ArrayDeclarationNode::Declaration *p_decl, int &r_array_size, bool &r_is_unknown_size);
+
 	Node *_parse_expression(BlockNode *p_block, const FunctionInfo &p_function_info);
 	Node *_parse_array_constructor(BlockNode *p_block, const FunctionInfo &p_function_info);
 	Node *_parse_array_constructor(BlockNode *p_block, const FunctionInfo &p_function_info, DataType p_type, const StringName &p_struct_name, int p_array_size);


### PR DESCRIPTION
This is mostly syntax sugar, but it's possible (in GLSL) to declare an array with the size defined before identifier eg:
`int[2] arr;` instead of `int arr[2];` This PR makes it possible. To decrease code repetition - I've pushed the index parsing to a separate function.

Note: It's already possible to do for varying/uniform arrays, this PR is for local arrays in functions and struct members.