### PR TITLE
Fixed display bugs for windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -994,7 +994,7 @@ void DisplayServerWindows::window_set_mode(WindowMode p_mode, WindowID p_window)
 		wd.maximized = false;
 		wd.minimized = false;
 
-		_update_window_style(false);
+		_update_window_style(p_window, false);
 
 		MoveWindow(wd.hWnd, pos.x, pos.y, size.width, size.height, TRUE);
 
@@ -3073,6 +3073,8 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 		}
 		if (p_mode != WINDOW_MODE_FULLSCREEN) {
 			wd.pre_fs_valid = true;
+		} else {
+			wd.fullscreen = true;
 		}
 
 #ifdef VULKAN_ENABLED

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -547,8 +547,12 @@ void Window::_update_window_size() {
 }
 
 void Window::_update_viewport_size() {
-	//update the viewport part
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		// always refresh, current size might be outdated or invalid
+		size = DisplayServer::get_singleton()->window_get_size(window_id);
+	}
 
+	//update the viewport part
 	Size2i final_size;
 	Size2i final_size_override;
 	Rect2i attach_to_screen_rect(Point2i(), size);


### PR DESCRIPTION
Addresses #37588, fixes Windows version. Still have issues on Ubuntu.

PR contains 3 small fixes.

1. [Win] Save fullscreen setting on window creation. Starting from editor in fullscreen mode now works. (#37588)

2. [Win] Direct fullscreen updates to correct screen. Can now set non main windows to fullscreen mode using window_set_mode.

3. [Universal] Window (Node) now always queries the correct size from DisplayServer before resizing the viewport. Prior the actual window could be of different size than the Window (Node) expects resulting in this:
![godot_pr_windrawarea](https://user-images.githubusercontent.com/25692790/136402125-40bc3d66-61e3-4bb0-b390-4cea503c9121.png)
Black area is much bigger if a non main window starts in fullscreen mode. 
There already is a callback that should keep the size up to date but this doesn't happen in some situations. So this just always queries the size to be safe.

Window creation on Linux/Ubuntu is still broken, but I don't intend to fix it this PR.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
