### PR TITLE
[Net] Add call_local argument to Node.rpc_config.

### DIFF
--- a/core/multiplayer/multiplayer.h
+++ b/core/multiplayer/multiplayer.h
@@ -52,7 +52,7 @@ enum RPCMode {
 struct RPCConfig {
 	StringName name;
 	RPCMode rpc_mode = RPC_MODE_DISABLED;
-	bool sync = false;
+	bool call_local = false;
 	TransferMode transfer_mode = TRANSFER_MODE_RELIABLE;
 	int channel = 0;
 

--- a/core/multiplayer/rpc_manager.cpp
+++ b/core/multiplayer/rpc_manager.cpp
@@ -476,9 +476,9 @@ void RPCManager::rpcp(Node *p_node, int p_peer_id, const StringName &p_method, c
 			vformat("Unable to get the RPC configuration for the function \"%s\" at path: \"%s\". This happens when the method is not marked for RPCs.", p_method, p_node->get_path()));
 	if (p_peer_id == 0 || p_peer_id == node_id || (p_peer_id < 0 && p_peer_id != -node_id)) {
 		if (rpc_id & (1 << 15)) {
-			call_local_native = config.sync;
+			call_local_native = config.call_local;
 		} else {
-			call_local_script = config.sync;
+			call_local_script = config.call_local;
 		}
 	}
 
@@ -521,5 +521,5 @@ void RPCManager::rpcp(Node *p_node, int p_peer_id, const StringName &p_method, c
 		}
 	}
 
-	ERR_FAIL_COND_MSG(p_peer_id == node_id && !config.sync, "RPC '" + p_method + "' on yourself is not allowed by selected mode.");
+	ERR_FAIL_COND_MSG(p_peer_id == node_id && !config.call_local, "RPC '" + p_method + "' on yourself is not allowed by selected mode.");
 }

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -587,8 +587,9 @@
 			<return type="int" />
 			<argument index="0" name="method" type="StringName" />
 			<argument index="1" name="rpc_mode" type="int" enum="RPCMode" />
-			<argument index="2" name="transfer_mode" type="int" enum="TransferMode" default="2" />
-			<argument index="3" name="channel" type="int" default="0" />
+			<argument index="2" name="call_local" type="bool" default="false" />
+			<argument index="3" name="transfer_mode" type="int" enum="TransferMode" default="2" />
+			<argument index="4" name="channel" type="int" default="0" />
 			<description>
 				Changes the RPC mode for the given [code]method[/code] to the given [code]rpc_mode[/code], optionally specifying the [code]transfer_mode[/code] and [code]channel[/code] (on supported peers). See [enum RPCMode] and [enum TransferMode]. An alternative is annotating methods and properties with the corresponding annotation ([code]@rpc(any)[/code], [code]@rpc(auth)[/code]). By default, methods are not exposed to networking (and RPCs).
 			</description>

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3490,9 +3490,9 @@ bool GDScriptParser::network_annotations(const AnnotationNode *p_annotation, Nod
 			} else if (mode == "authority") {
 				rpc_config.rpc_mode = Multiplayer::RPC_MODE_AUTHORITY;
 			} else if (mode == "call_local") {
-				rpc_config.sync = true;
+				rpc_config.call_local = true;
 			} else if (mode == "call_remote") {
-				rpc_config.sync = false;
+				rpc_config.call_local = false;
 			} else if (mode == "reliable") {
 				rpc_config.transfer_mode = Multiplayer::TRANSFER_MODE_RELIABLE;
 			} else if (mode == "unreliable") {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -536,12 +536,13 @@ bool Node::is_multiplayer_authority() const {
 
 /***** RPC CONFIG ********/
 
-uint16_t Node::rpc_config(const StringName &p_method, Multiplayer::RPCMode p_rpc_mode, Multiplayer::TransferMode p_transfer_mode, int p_channel) {
+uint16_t Node::rpc_config(const StringName &p_method, Multiplayer::RPCMode p_rpc_mode, bool p_call_local, Multiplayer::TransferMode p_transfer_mode, int p_channel) {
 	for (int i = 0; i < data.rpc_methods.size(); i++) {
 		if (data.rpc_methods[i].name == p_method) {
 			Multiplayer::RPCConfig &nd = data.rpc_methods.write[i];
 			nd.rpc_mode = p_rpc_mode;
 			nd.transfer_mode = p_transfer_mode;
+			nd.call_local = p_call_local;
 			nd.channel = p_channel;
 			return i | (1 << 15);
 		}
@@ -552,6 +553,7 @@ uint16_t Node::rpc_config(const StringName &p_method, Multiplayer::RPCMode p_rpc
 	nd.rpc_mode = p_rpc_mode;
 	nd.transfer_mode = p_transfer_mode;
 	nd.channel = p_channel;
+	nd.call_local = p_call_local;
 	data.rpc_methods.push_back(nd);
 	return ((uint16_t)data.rpc_methods.size() - 1) | (1 << 15);
 }
@@ -2740,7 +2742,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_multiplayer"), &Node::get_multiplayer);
 	ClassDB::bind_method(D_METHOD("get_custom_multiplayer"), &Node::get_custom_multiplayer);
 	ClassDB::bind_method(D_METHOD("set_custom_multiplayer", "api"), &Node::set_custom_multiplayer);
-	ClassDB::bind_method(D_METHOD("rpc_config", "method", "rpc_mode", "transfer_mode", "channel"), &Node::rpc_config, DEFVAL(Multiplayer::TRANSFER_MODE_RELIABLE), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("rpc_config", "method", "rpc_mode", "call_local", "transfer_mode", "channel"), &Node::rpc_config, DEFVAL(false), DEFVAL(Multiplayer::TRANSFER_MODE_RELIABLE), DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("set_editor_description", "editor_description"), &Node::set_editor_description);
 	ClassDB::bind_method(D_METHOD("get_editor_description"), &Node::get_editor_description);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -466,7 +466,7 @@ public:
 	int get_multiplayer_authority() const;
 	bool is_multiplayer_authority() const;
 
-	uint16_t rpc_config(const StringName &p_method, Multiplayer::RPCMode p_rpc_mode, Multiplayer::TransferMode p_transfer_mode, int p_channel = 0); // config a local method for RPC
+	uint16_t rpc_config(const StringName &p_method, Multiplayer::RPCMode p_rpc_mode, bool p_call_local = false, Multiplayer::TransferMode p_transfer_mode = Multiplayer::TRANSFER_MODE_RELIABLE, int p_channel = 0); // config a local method for RPC
 	Vector<Multiplayer::RPCConfig> get_node_rpc_methods() const;
 
 	void rpc(const StringName &p_method, VARIANT_ARG_LIST); // RPC, honors RPCMode, TransferMode, channel


### PR DESCRIPTION
Also renames `RPCConfig.sync` to `RPCConfig.call_local` for consistency.