### PR TITLE
Clamp Environment's SSR fade-in and fade-out to positive values

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -204,10 +204,10 @@
 			If [code]true[/code], screen-space reflections are enabled. Screen-space reflections are more accurate than reflections from [VoxelGI]s or [ReflectionProbe]s, but are slower and can't reflect surfaces occluded by others.
 		</member>
 		<member name="ss_reflections_fade_in" type="float" setter="set_ssr_fade_in" getter="get_ssr_fade_in" default="0.15">
-			The fade-in distance for screen-space reflections. Affects the area from the reflected material to the screen-space reflection).
+			The fade-in distance for screen-space reflections. Affects the area from the reflected material to the screen-space reflection). Only positive values are valid (negative values will be clamped to [code]0.0[/code]).
 		</member>
 		<member name="ss_reflections_fade_out" type="float" setter="set_ssr_fade_out" getter="get_ssr_fade_out" default="2.0">
-			The fade-out distance for screen-space reflections. Affects the area from the screen-space reflection to the "global" reflection.
+			The fade-out distance for screen-space reflections. Affects the area from the screen-space reflection to the "global" reflection. Only positive values are valid (negative values will be clamped to [code]0.0[/code]).
 		</member>
 		<member name="ss_reflections_max_steps" type="int" setter="set_ssr_max_steps" getter="get_ssr_max_steps" default="64">
 			The maximum number of steps for screen-space reflections. Higher values are slower.

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -302,7 +302,7 @@ int Environment::get_ssr_max_steps() const {
 }
 
 void Environment::set_ssr_fade_in(float p_fade_in) {
-	ssr_fade_in = p_fade_in;
+	ssr_fade_in = MAX(p_fade_in, 0.0f);
 	_update_ssr();
 }
 
@@ -311,7 +311,7 @@ float Environment::get_ssr_fade_in() const {
 }
 
 void Environment::set_ssr_fade_out(float p_fade_out) {
-	ssr_fade_out = p_fade_out;
+	ssr_fade_out = MAX(p_fade_out, 0.0f);
 	_update_ssr();
 }
 


### PR DESCRIPTION
Negative values result in rendering glitches:

![image](https://user-images.githubusercontent.com/180032/136421640-03e81514-3460-49c5-8f48-e098f89144c9.png)