### PR TITLE
Joint2D: Use boolean instead of warning string for validity test

### DIFF
--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -74,6 +74,8 @@ void Joint2D::_update_joint(bool p_only_free) {
 	PhysicsBody2D *body_a = Object::cast_to<PhysicsBody2D>(node_a);
 	PhysicsBody2D *body_b = Object::cast_to<PhysicsBody2D>(node_b);
 
+	bool valid = false;
+
 	if (node_a && !body_a && node_b && !body_b) {
 		warning = TTR("Node A and Node B must be PhysicsBody2Ds");
 	} else if (node_a && !body_a) {
@@ -86,11 +88,12 @@ void Joint2D::_update_joint(bool p_only_free) {
 		warning = TTR("Node A and Node B must be different PhysicsBody2Ds");
 	} else {
 		warning = String();
+		valid = true;
 	}
 
 	update_configuration_warnings();
 
-	if (!warning.is_empty()) {
+	if (!valid) {
 		PhysicsServer2D::get_singleton()->joint_clear(joint);
 		return;
 	}


### PR DESCRIPTION
Those strings are stripped at release there's a false positive that the bodies are valid, causing a crash.

