### PR TITLE
Enable method type information on release builds

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -37,8 +37,6 @@
 #define OBJTYPE_RLOCK RWLockRead _rw_lockr_(lock);
 #define OBJTYPE_WLOCK RWLockWrite _rw_lockw_(lock);
 
-#ifdef DEBUG_METHODS_ENABLED
-
 MethodDefinition D_METHOD(const char *p_name) {
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
@@ -225,8 +223,6 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	md.args.write[12] = StaticCString::create(p_arg13);
 	return md;
 }
-
-#endif
 
 ClassDB::APIType ClassDB::current_api = API_CORE;
 
@@ -589,7 +585,6 @@ void ClassDB::_add_class2(const StringName &p_class, const StringName &p_inherit
 	}
 }
 
-#ifdef DEBUG_METHODS_ENABLED
 static MethodInfo info_from_bind(MethodBind *p_method) {
 	MethodInfo minfo;
 	minfo.name = p_method->get_name();
@@ -610,7 +605,6 @@ static MethodInfo info_from_bind(MethodBind *p_method) {
 
 	return minfo;
 }
-#endif
 
 void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance, bool p_exclude_from_properties) {
 	OBJTYPE_RLOCK;
@@ -650,9 +644,8 @@ void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_met
 
 		while ((K = type->method_map.next(K))) {
 			MethodBind *m = type->method_map[*K];
-			MethodInfo mi;
-			mi.name = m->get_name();
-			p_methods->push_back(mi);
+			MethodInfo minfo = info_from_bind(m);
+			p_methods->push_back(minfo);
 		}
 
 #endif
@@ -698,9 +691,8 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 		if (type->method_map.has(p_method)) {
 			if (r_info) {
 				MethodBind *m = type->method_map[p_method];
-				MethodInfo mi;
-				mi.name = m->get_name();
-				*r_info = mi;
+				MethodInfo minfo = info_from_bind(m);
+				*r_info = minfo;
 			}
 			return true;
 		}
@@ -1411,13 +1403,8 @@ void ClassDB::bind_method_custom(const StringName &p_class, MethodBind *p_method
 	type->method_map[p_method->get_name()] = p_method;
 }
 
-#ifdef DEBUG_METHODS_ENABLED
 MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const MethodDefinition &method_name, const Variant **p_defs, int p_defcount) {
 	StringName mdname = method_name.name;
-#else
-MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const char *method_name, const Variant **p_defs, int p_defcount) {
-	StringName mdname = StaticCString::create(method_name);
-#endif
 
 	OBJTYPE_WLOCK;
 	ERR_FAIL_COND_V(!p_bind, nullptr);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -45,8 +45,6 @@
 
 #define DEFVAL(m_defval) (m_defval)
 
-#ifdef DEBUG_METHODS_ENABLED
-
 struct MethodDefinition {
 	StringName name;
 	Vector<StringName> args;
@@ -71,26 +69,6 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_arg2, const char *p_arg3, const char *p_arg4, const char *p_arg5, const char *p_arg6, const char *p_arg7, const char *p_arg8, const char *p_arg9, const char *p_arg10, const char *p_arg11);
 MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_arg2, const char *p_arg3, const char *p_arg4, const char *p_arg5, const char *p_arg6, const char *p_arg7, const char *p_arg8, const char *p_arg9, const char *p_arg10, const char *p_arg11, const char *p_arg12);
 MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_arg2, const char *p_arg3, const char *p_arg4, const char *p_arg5, const char *p_arg6, const char *p_arg7, const char *p_arg8, const char *p_arg9, const char *p_arg10, const char *p_arg11, const char *p_arg12, const char *p_arg13);
-
-#else
-
-//#define NO_VARIADIC_MACROS
-
-#ifdef NO_VARIADIC_MACROS
-
-static _FORCE_INLINE_ const char *D_METHOD(const char *m_name, ...) {
-	return m_name;
-}
-
-#else
-
-// When DEBUG_METHODS_ENABLED is set this will let the engine know
-// the argument names for easier debugging.
-#define D_METHOD(m_c, ...) m_c
-
-#endif
-
-#endif
 
 class ClassDB {
 public:
@@ -156,11 +134,7 @@ public:
 	static HashMap<StringName, StringName> resource_base_extensions;
 	static HashMap<StringName, StringName> compat_classes;
 
-#ifdef DEBUG_METHODS_ENABLED
 	static MethodBind *bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const MethodDefinition &method_name, const Variant **p_defs, int p_defcount);
-#else
-	static MethodBind *bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const char *method_name, const Variant **p_defs, int p_defcount);
-#endif
 
 	static APIType current_api;
 

--- a/core/object/method_bind.cpp
+++ b/core/object/method_bind.cpp
@@ -63,12 +63,15 @@ uint32_t MethodBind::get_hash() const {
 	return hash;
 }
 
-#ifdef DEBUG_METHODS_ENABLED
 PropertyInfo MethodBind::get_argument_info(int p_argument) const {
 	ERR_FAIL_INDEX_V(p_argument, get_argument_count(), PropertyInfo());
 
 	PropertyInfo info = _gen_argument_type_info(p_argument);
+#ifdef DEBUG_METHODS_ENABLED
 	info.name = p_argument < arg_names.size() ? String(arg_names[p_argument]) : String("arg" + itos(p_argument));
+#else
+	info.name = String("arg" + itos(p_argument));
+#endif
 	return info;
 }
 
@@ -76,7 +79,6 @@ PropertyInfo MethodBind::get_return_info() const {
 	return _gen_argument_type_info(-1);
 }
 
-#endif
 void MethodBind::_set_const(bool p_const) {
 	_const = p_const;
 }
@@ -109,7 +111,6 @@ void MethodBind::set_default_arguments(const Vector<Variant> &p_defargs) {
 	default_argument_count = default_arguments.size();
 }
 
-#ifdef DEBUG_METHODS_ENABLED
 void MethodBind::_generate_argument_types(int p_count) {
 	set_argument_count(p_count);
 
@@ -122,8 +123,6 @@ void MethodBind::_generate_argument_types(int p_count) {
 
 	argument_types = argt;
 }
-
-#endif
 
 MethodBind::MethodBind() {
 	static int last_id = 0;

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -64,18 +64,16 @@ class MethodBind {
 	bool _returns = false;
 
 protected:
-#ifdef DEBUG_METHODS_ENABLED
 	Variant::Type *argument_types = nullptr;
+#ifdef DEBUG_METHODS_ENABLED
 	Vector<StringName> arg_names;
 #endif
 	void _set_const(bool p_const);
 	void _set_returns(bool p_returns);
-#ifdef DEBUG_METHODS_ENABLED
 	virtual Variant::Type _gen_argument_type(int p_arg) const = 0;
 	virtual PropertyInfo _gen_argument_type_info(int p_arg) const = 0;
 	void _generate_argument_types(int p_count);
 
-#endif
 	void set_argument_count(int p_count) { argument_count = p_count; }
 
 public:
@@ -102,7 +100,6 @@ public:
 		}
 	}
 
-#ifdef DEBUG_METHODS_ENABLED
 	_FORCE_INLINE_ Variant::Type get_argument_type(int p_argument) const {
 		ERR_FAIL_COND_V(p_argument < -1 || p_argument > argument_count, Variant::NIL);
 		return argument_types[p_argument + 1];
@@ -111,6 +108,7 @@ public:
 	PropertyInfo get_argument_info(int p_argument) const;
 	PropertyInfo get_return_info() const;
 
+#ifdef DEBUG_METHODS_ENABLED
 	void set_argument_names(const Vector<StringName> &p_names); // Set by ClassDB, can't be inferred otherwise.
 	Vector<StringName> get_argument_names() const;
 
@@ -149,12 +147,9 @@ public:
 
 protected:
 	NativeCall call_method = nullptr;
-#ifdef DEBUG_METHODS_ENABLED
 	MethodInfo arguments;
-#endif
 
 public:
-#ifdef DEBUG_METHODS_ENABLED
 	virtual PropertyInfo _gen_argument_type_info(int p_arg) const {
 		if (p_arg < 0) {
 			return arguments.return_val;
@@ -169,12 +164,9 @@ public:
 		return _gen_argument_type_info(p_arg).type;
 	}
 
+#ifdef DEBUG_METHODS_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int) const {
 		return GodotTypeInfo::METADATA_NONE;
-	}
-#else
-	virtual Variant::Type _gen_argument_type(int p_arg) const {
-		return Variant::NIL;
 	}
 #endif
 
@@ -185,25 +177,29 @@ public:
 
 	void set_method_info(const MethodInfo &p_info, bool p_return_nil_is_variant) {
 		set_argument_count(p_info.arguments.size());
-#ifdef DEBUG_METHODS_ENABLED
 		Variant::Type *at = memnew_arr(Variant::Type, p_info.arguments.size() + 1);
 		at[0] = p_info.return_val.type;
 		if (p_info.arguments.size()) {
+#ifdef DEBUG_METHODS_ENABLED
 			Vector<StringName> names;
 			names.resize(p_info.arguments.size());
+#endif
 			for (int i = 0; i < p_info.arguments.size(); i++) {
 				at[i + 1] = p_info.arguments[i].type;
+#ifdef DEBUG_METHODS_ENABLED
 				names.write[i] = p_info.arguments[i].name;
+#endif
 			}
 
+#ifdef DEBUG_METHODS_ENABLED
 			set_argument_names(names);
+#endif
 		}
 		argument_types = at;
 		arguments = p_info;
 		if (p_return_nil_is_variant) {
 			arguments.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 		}
-#endif
 	}
 
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) {
@@ -248,7 +244,6 @@ class MethodBindT : public MethodBind {
 	void (MB_T::*method)(P...);
 
 protected:
-#ifdef DEBUG_METHODS_ENABLED
 // GCC raises warnings in the case P = {} as the comparison is always false...
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -270,7 +265,6 @@ protected:
 		call_get_argument_type_info<P...>(p_arg, pi);
 		return pi;
 	}
-#endif
 
 public:
 #ifdef DEBUG_METHODS_ENABLED
@@ -298,9 +292,7 @@ public:
 
 	MethodBindT(void (MB_T::*p_method)(P...)) {
 		method = p_method;
-#ifdef DEBUG_METHODS_ENABLED
 		_generate_argument_types(sizeof...(P));
-#endif
 		set_argument_count(sizeof...(P));
 	}
 };
@@ -327,7 +319,6 @@ class MethodBindTC : public MethodBind {
 	void (MB_T::*method)(P...) const;
 
 protected:
-#ifdef DEBUG_METHODS_ENABLED
 // GCC raises warnings in the case P = {} as the comparison is always false...
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -349,7 +340,6 @@ protected:
 		call_get_argument_type_info<P...>(p_arg, pi);
 		return pi;
 	}
-#endif
 
 public:
 #ifdef DEBUG_METHODS_ENABLED
@@ -378,9 +368,7 @@ public:
 	MethodBindTC(void (MB_T::*p_method)(P...) const) {
 		method = p_method;
 		_set_const(true);
-#ifdef DEBUG_METHODS_ENABLED
 		_generate_argument_types(sizeof...(P));
-#endif
 		set_argument_count(sizeof...(P));
 	}
 };
@@ -408,7 +396,6 @@ class MethodBindTR : public MethodBind {
 	(P...);
 
 protected:
-#ifdef DEBUG_METHODS_ENABLED
 // GCC raises warnings in the case P = {} as the comparison is always false...
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -433,7 +420,6 @@ protected:
 	}
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
-#endif
 #endif
 
 public:
@@ -468,9 +454,7 @@ public:
 	MethodBindTR(R (MB_T::*p_method)(P...)) {
 		method = p_method;
 		_set_returns(true);
-#ifdef DEBUG_METHODS_ENABLED
 		_generate_argument_types(sizeof...(P));
-#endif
 		set_argument_count(sizeof...(P));
 	}
 };
@@ -499,7 +483,6 @@ class MethodBindTRC : public MethodBind {
 	(P...) const;
 
 protected:
-#ifdef DEBUG_METHODS_ENABLED
 // GCC raises warnings in the case P = {} as the comparison is always false...
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -524,7 +507,6 @@ protected:
 	}
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
-#endif
 #endif
 
 public:
@@ -560,9 +542,7 @@ public:
 		method = p_method;
 		_set_returns(true);
 		_set_const(true);
-#ifdef DEBUG_METHODS_ENABLED
 		_generate_argument_types(sizeof...(P));
-#endif
 		set_argument_count(sizeof...(P));
 	}
 };

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -563,12 +563,10 @@ void call_with_validated_variant_args_static_method_ret(R (*p_method)(P...), con
 
 // GCC raises "parameter 'p_args' set but not used" when P = {},
 // it's not clever enough to treat other P values as making this branch valid.
-#if defined(DEBUG_METHODS_ENABLED) && defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
 #endif
-
-#ifdef DEBUG_METHODS_ENABLED
 
 template <class Q>
 void call_get_argument_type_helper(int p_arg, int &index, Variant::Type &type) {
@@ -608,6 +606,7 @@ void call_get_argument_type_info(int p_arg, PropertyInfo &info) {
 	(void)index; // Suppress GCC warning.
 }
 
+#ifdef DEBUG_METHODS_ENABLED
 template <class Q>
 void call_get_argument_metadata_helper(int p_arg, int &index, GodotTypeInfo::Metadata &md) {
 	if (p_arg == index) {
@@ -627,13 +626,6 @@ GodotTypeInfo::Metadata call_get_argument_metadata(int p_arg) {
 	(void)a; // Suppress (valid, but unavoidable) -Wunused-variable warning.
 	(void)index;
 	return md;
-}
-
-#else
-
-template <class... P>
-Variant::Type call_get_argument_type(int p_arg) {
-	return Variant::NIL;
 }
 
 #endif // DEBUG_METHODS_ENABLED
@@ -915,7 +907,7 @@ void call_with_variant_args_static_dv(void (*p_method)(P...), const Variant **p_
 	call_with_variant_args_static(p_method, args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-#if defined(DEBUG_METHODS_ENABLED) && defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1719,6 +1719,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #define OPCODE_CALL_PTR(m_type)                                                   \
 	OPCODE(OPCODE_CALL_PTRCALL_##m_type) {                                        \
 		CHECK_SPACE(3 + instr_arg_count);                                         \
+		ip += instr_arg_count;                                                    \
 		int argc = _code_ptr[ip + 1];                                             \
 		GET_INSTRUCTION_ARG(base, argc);                                          \
 		MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];                     \


### PR DESCRIPTION
This is needed to ensure GDScript compilation works properly on release builds and make use of optimized typed instructions.

Also fix a bug with ptrcalls in the GDScript VM.

This do increase the binary size. For comparison, here's the sizes I got in my machine for the Linux release build, compiled with `production=yes` and then stripped:

master: 60 868 416 bytes (58.05 MiB)
this pr: 64 202 560 bytes (61.23 MiB)
difference: 3 334 144 bytes (3.18 MiB)

I was able to run the regression test project without noticing any issue (considering that #53543 is also applied to avoid crashing).