### PR TITLE
Add global breakpoint list

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -95,6 +95,7 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	node->connect("stopped", callable_mp(this, &EditorDebuggerNode::_debugger_stopped), varray(id));
 	node->connect("stack_frame_selected", callable_mp(this, &EditorDebuggerNode::_stack_frame_selected), varray(id));
 	node->connect("error_selected", callable_mp(this, &EditorDebuggerNode::_error_selected), varray(id));
+	node->connect("breakpoint_selected", callable_mp(this, &EditorDebuggerNode::_error_selected), varray(id));
 	node->connect("clear_execution", callable_mp(this, &EditorDebuggerNode::_clear_execution));
 	node->connect("breaked", callable_mp(this, &EditorDebuggerNode::_breaked), varray(id));
 	node->connect("remote_tree_updated", callable_mp(this, &EditorDebuggerNode::_remote_tree_updated), varray(id));

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -81,6 +81,9 @@ private:
 	enum Actions {
 		ACTION_COPY_ERROR,
 		ACTION_OPEN_SOURCE,
+		ACTION_DELETE_BREAKPOINT,
+		ACTION_DELETE_BREAKPOINTS_IN_FILE,
+		ACTION_DELETE_ALL_BREAKPOINTS,
 	};
 
 	AcceptDialog *msgdialog;
@@ -98,6 +101,9 @@ private:
 	Button *collapse_all_button;
 	Button *clear_button;
 	PopupMenu *item_menu;
+
+	Tree *breakpoints_tree;
+	PopupMenu *breakpoints_menu;
 
 	EditorFileDialog *file_dialog;
 	enum FileDialogPurpose {
@@ -198,6 +204,7 @@ private:
 
 	void _clear_errors_list();
 
+	void _breakpoints_item_rmb_selected(const Vector2 &p_pos);
 	void _error_tree_item_rmb_selected(const Vector2 &p_pos);
 	void _item_menu_id_pressed(int p_option);
 	void _tab_changed(int p_tab);
@@ -210,6 +217,8 @@ private:
 
 	void _set_breakpoint(const String &p_path, const int &p_line, const bool &p_enabled);
 	void _clear_breakpoints();
+
+	void _breakpoint_tree_clicked();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Builds on #53235

Related #31285

---

This PR adds a global breakpoint list to the debuggers menu bar. Didn't consider there to be enough data for it's own tab. 

Currently, you can double click to goto the breakpointed line, or right click to remove, remove from file, or remove all.

Preview:

![image](https://user-images.githubusercontent.com/6584330/136426737-0240fefa-df93-4af3-95a9-7fbf0cb7c3db.png)

---

closes godotengine/godot-proposals/issues/3740
