### PR TITLE
Make PulseAudio return accurate latency information

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -73,8 +73,7 @@ class AudioDriverPulseAudio : public AudioDriver {
 	bool active = false;
 	bool thread_exited = false;
 	mutable bool exit_thread = false;
-
-	float latency = 0;
+	float real_latency = 0;
 
 	static void pa_state_cb(pa_context *c, void *userdata);
 	static void pa_sink_info_cb(pa_context *c, const pa_sink_info *l, int eol, void *userdata);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This seems to be the most reasonable approach, the old approach gave wildly different values per startup, see the stepmania source code for reference I used, they don't seem to do any latency compensation at all, but I tested with a latency testing tool and the approach I used seems to be the correct one:
https://github.com/stepmania/stepmania/blob/984dc8668f1fedacf553f279a828acdebffc5625/src/arch/Sound/RageSoundDriver_PulseAudio.cpp#L178