### PR TITLE
Fix RefCounted documentation

### DIFF
--- a/doc/classes/RefCounted.xml
+++ b/doc/classes/RefCounted.xml
@@ -5,9 +5,9 @@
 	</brief_description>
 	<description>
 		Base class for any object that keeps a reference count. [Resource] and many other helper objects inherit this class.
-		Unlike other [Object] types, References keep an internal reference counter so that they are automatically released when no longer in use, and only then. References therefore do not need to be freed manually with [method Object.free].
+		Unlike other [Object] types, [RefCounted]s keep an internal reference counter so that they are automatically released when no longer in use, and only then. [RefCounted]s therefore do not need to be freed manually with [method Object.free].
 		In the vast majority of use cases, instantiating and using [RefCounted]-derived types is all you need to do. The methods provided in this class are only for advanced users, and can cause issues if misused.
-		[b]Note:[/b] In C#, references will not be freed instantly after they are no longer in use. Instead, garbage collection will run periodically and will free references that are no longer in use. This means that unused references will linger on for a while before being removed.
+		[b]Note:[/b] In C#, reference-counted objects will not be freed instantly after they are no longer in use. Instead, garbage collection will run periodically and will free reference-counted objects that are no longer in use. This means that unused ones will linger on for a while before being removed.
 	</description>
 	<tutorials>
 		<link title="When and how to avoid using nodes for everything">https://docs.godotengine.org/en/latest/tutorials/best_practices/node_alternatives.html</link>


### PR DESCRIPTION
If the name of a class is modified, its name in the documentation should be too.

However, pluralization is a bit complicated in this case. I'll suggest the options `RefCounteds` and `reference-counted objects`. Maybe both can be used.