### PR TITLE
Faster hash_compare for integer and string keys in dictionaries

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3145,8 +3145,16 @@ bool Variant::hash_compare(const Variant &p_variant) const {
 	}
 
 	switch (type) {
+		case INT: {
+			return _data._int == p_variant._data._int;
+		} break;
+
 		case FLOAT: {
 			return hash_compare_scalar(_data._float, p_variant._data._float);
+		} break;
+
+		case STRING: {
+			return *reinterpret_cast<const String *>(_data._mem) == *reinterpret_cast<const String *>(p_variant._data._mem);
 		} break;
 
 		case VECTOR2: {


### PR DESCRIPTION
By comparing INT and STRING `Variant`s earlier before jumping to `evaluate(OP_EQUAL, *this, p_variant, r, v);`, we gain 30-40% performance boost in dictionary access. It affects string, integer, enum and mixed keys.

> Release build
> 
> **Before hash_compare optimization (time in seconds)**
> dictionary with string keys
> 1.408923
> 1.437468
> 1.427429
> dictionary with integer keys
> 1.210895
> 1.213544
> 1.191612
> dictionary with ENUM keys
> 1.17799
> 1.1805
> 1.182964
> dictionary with mixed keys
> 1.323501
> 1.327039
> 1.320394
> 
> **After hash_compare optimization (time in seconds)**
> dictionary with string keys
> 0.973292
> 0.973331
> 0.971749
> dictionary with integer keys
> 0.714389
> 0.726892
> 0.743239
> dictionary with ENUM keys
> 0.739662
> 0.736103
> 0.732237
> dictionary with mixed keys
> 0.90563
> 0.913832
> 0.885697

[mrp_hash_compare_godot4.zip](https://github.com/godotengine/godot/files/7309588/mrp_hash_compare_godot4.zip)

