### PR TITLE
[3.x] Faster hash_compare for integer and string keys in dictionaries

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2789,8 +2789,16 @@ bool Variant::hash_compare(const Variant &p_variant) const {
 	}
 
 	switch (type) {
+		case INT: {
+			return _data._int == p_variant._data._int;
+		} break;
+
 		case REAL: {
 			return hash_compare_scalar(_data._real, p_variant._data._real);
+		} break;
+
+		case STRING: {
+			return *reinterpret_cast<const String *>(_data._mem) == *reinterpret_cast<const String *>(p_variant._data._mem);
 		} break;
 
 		case VECTOR2: {


### PR DESCRIPTION
3.x version of https://github.com/godotengine/godot/pull/53555

Enums are handled as dictionaries under the hood in 3.x, so it not only boosts their performance as keys in dictionaries but also makes them faster in general. Related issue (not fixed by this PR): https://github.com/godotengine/godot/issues/53315 