### PR TITLE
Delete objects enqueued for deletion during `SceneTree` destruction

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -570,7 +570,11 @@ void SceneTree::finalize() {
 		root = nullptr;
 	}
 
-	// cleanup timers
+	// In case deletion of some objects was queued when destructing the `root`.
+	// E.g. if `queue_free()` was called for some node outside the tree when handling NOTIFICATION_PREDELETE for some node in the tree.
+	_flush_delete_queue();
+
+	// Cleanup timers.
 	for (Ref<SceneTreeTimer> &timer : timers) {
 		timer->release_connections();
 	}


### PR DESCRIPTION
Fixes #53563.

Not sure though whether the already existing `_flush_delete_queue();` call needs to be performed first (so whether there need to be two different calls to `_flush_delete_queue();` like now or if the existing call from the first line could be removed because of the added call below):
https://github.com/godotengine/godot/blob/e51d4f8eb7a121f71bdf54c3f2b3524368df5866/scene/main/scene_tree.cpp#L557-L582

And in case two calls are needed: probably I could move the newly added `_flush_delete_queue();` call inside the `if (root)` block.