### PR TITLE
[3.x] Delete objects enqueued for deletion during `SceneTree` destruction

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -621,7 +621,11 @@ void SceneTree::finish() {
 		root = nullptr;
 	}
 
-	// cleanup timers
+	// In case deletion of some objects was queued when destructing the `root`.
+	// E.g. if `queue_free()` was called for some node outside the tree when handling NOTIFICATION_PREDELETE for some node in the tree.
+	_flush_delete_queue();
+
+	// Cleanup timers.
 	for (List<Ref<SceneTreeTimer>>::Element *E = timers.front(); E; E = E->next()) {
 		E->get()->release_connections();
 	}


### PR DESCRIPTION
`3.x` version of #53571.