### PR TITLE
Print a warning if a `.gdignore` file is not empty

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2174,6 +2174,15 @@ bool EditorFileSystem::_should_skip_directory(const String &p_path) {
 
 	if (FileAccess::exists(p_path.plus_file(".gdignore"))) {
 		// skip if a `.gdignore` file is inside this
+
+		FileAccessRef f = FileAccess::open(p_path.plus_file(".gdignore"), FileAccess::READ);
+		if (f->get_length() >= 5) {
+			// Warn if file is non-empty, as `.gdignore` does not work like `.gitignore` files.
+			// Its contents are ignored by the editor.
+			// The size +threshold is chosen to allow CRLF line endings and BOM.
+			WARN_PRINT(vformat("The ignore file at path \"%s\" is non-empty, but its contents are ignored by the Godot editor. To resolve this, make the `.gdignore` file empty or contain only one blank line.", p_path.plus_file(".gdignore")));
+		}
+		f->close();
 		return true;
 	}
 


### PR DESCRIPTION
`.gdignore` files' contents are ignored. This means filling them with file patterns will have no effect (unlike `.gitignore` files). See https://github.com/godotengine/godot-proposals/issues/2798.

Storing less than 5 bytes in the file is allowed so that no warning is printed if the file only contains a blank line (either LF or CRLF, with and without BOM).

Example with the following file structure:

```
❯ ll -a /tmp/project/*
Permissions Size User Date Modified Name
.rw-r--r--    96 hugo  8 Oct 21:51  /tmp/project/Node3D.tscn
.rw-r--r--   260 hugo  8 Oct 21:52  /tmp/project/project.godot

/tmp/project/1:
Permissions Size User Date Modified Name
.rw-r--r--     1 hugo  8 Oct 21:51  .gdignore

/tmp/project/2:
Permissions Size User Date Modified Name
.rw-r--r--     0 hugo  8 Oct 21:51  .gdignore

/tmp/project/3:
Permissions Size User Date Modified Name
.rw-r--r--     2 hugo  8 Oct 21:51  .gdignore

/tmp/project/4:
Permissions Size User Date Modified Name
.rw-r--r--     3 hugo  8 Oct 21:51  .gdignore
```

Output:

```
WARNING: The ignore file at path "res://4/.gdignore" is non-empty, but its contents are ignored by the Godot editor. To resolve this, make the `.gdignore` file empty or contain only one blank line.
     at: _should_skip_directory (editor/editor_file_system.cpp:2182)
WARNING: The ignore file at path "res://3/.gdignore" is non-empty, but its contents are ignored by the Godot editor. To resolve this, make the `.gdignore` file empty or contain only one blank line.
     at: _should_skip_directory (editor/editor_file_system.cpp:2182)
```