### PR TITLE
Fix missing argument names in bindings

### DIFF
--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -178,7 +178,7 @@
 		</method>
 		<method name="is_subgizmo_selected" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="arg0" type="int" />
+			<argument index="0" name="id" type="int" />
 			<description>
 				Returns [code]true[/code] if the given subgizmo is currently selected. Can be used to highlight selected elements during [method _redraw].
 			</description>

--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -105,9 +105,9 @@
 		</method>
 		<method name="get_glyph_index" qualifiers="const">
 			<return type="int" />
-			<argument index="0" name="char" type="int" />
-			<argument index="1" name="variation_selector" type="int" />
-			<argument index="2" name="arg2" type="int" />
+			<argument index="0" name="size" type="int" />
+			<argument index="1" name="char" type="int" />
+			<argument index="2" name="variation_selector" type="int" />
 			<description>
 				Returns the glyph index of a [code]char[/code], optionally modified by the [code]variation_selector[/code].
 			</description>
@@ -242,7 +242,7 @@
 			<return type="int" />
 			<argument index="0" name="cache_index" type="int" />
 			<argument index="1" name="size" type="int" />
-			<argument index="2" name="arg2" type="int" enum="TextServer.SpacingType" />
+			<argument index="2" name="spacing_type" type="int" enum="TextServer.SpacingType" />
 			<description>
 				Returns extra spacing added between glyphs in pixels.
 			</description>
@@ -596,8 +596,8 @@
 			<return type="void" />
 			<argument index="0" name="cache_index" type="int" />
 			<argument index="1" name="size" type="int" />
-			<argument index="2" name="spacing" type="int" enum="TextServer.SpacingType" />
-			<argument index="3" name="arg3" type="int" />
+			<argument index="2" name="spacing_type" type="int" enum="TextServer.SpacingType" />
+			<argument index="3" name="value" type="int" />
 			<description>
 				Sets extra spacing added between glyphs in pixels.
 			</description>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -374,7 +374,7 @@
 		</method>
 		<method name="get_memory_usage" qualifiers="const">
 			<return type="int" />
-			<argument index="0" name="arg0" type="int" enum="RenderingDevice.MemoryType" />
+			<argument index="0" name="type" type="int" enum="RenderingDevice.MemoryType" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -936,7 +936,7 @@
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>
-		<member name="minimap_draw" type="bool" setter="draw_minimap" getter="is_drawing_minimap" default="false">
+		<member name="minimap_draw" type="bool" setter="set_draw_minimap" getter="is_drawing_minimap" default="false">
 			If [code]true[/code], a minimap is shown, providing an outline of your source code.
 		</member>
 		<member name="minimap_width" type="int" setter="set_minimap_width" getter="get_minimap_width" default="80">

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -832,7 +832,7 @@ void EditorNode3DGizmo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_plugin"), &EditorNode3DGizmo::get_plugin);
 	ClassDB::bind_method(D_METHOD("clear"), &EditorNode3DGizmo::clear);
 	ClassDB::bind_method(D_METHOD("set_hidden", "hidden"), &EditorNode3DGizmo::set_hidden);
-	ClassDB::bind_method(D_METHOD("is_subgizmo_selected"), &EditorNode3DGizmo::is_subgizmo_selected);
+	ClassDB::bind_method(D_METHOD("is_subgizmo_selected", "id"), &EditorNode3DGizmo::is_subgizmo_selected);
 	ClassDB::bind_method(D_METHOD("get_subgizmo_selection"), &EditorNode3DGizmo::get_subgizmo_selection);
 
 	GDVIRTUAL_BIND(_redraw);

--- a/modules/websocket/websocket_client.cpp
+++ b/modules/websocket/websocket_client.cpp
@@ -129,7 +129,7 @@ void WebSocketClient::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "verify_ssl", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_verify_ssl_enabled", "is_verify_ssl_enabled");
 
 	ClassDB::bind_method(D_METHOD("get_trusted_ssl_certificate"), &WebSocketClient::get_trusted_ssl_certificate);
-	ClassDB::bind_method(D_METHOD("set_trusted_ssl_certificate"), &WebSocketClient::set_trusted_ssl_certificate);
+	ClassDB::bind_method(D_METHOD("set_trusted_ssl_certificate", "cert"), &WebSocketClient::set_trusted_ssl_certificate);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "trusted_ssl_certificate", PROPERTY_HINT_RESOURCE_TYPE, "X509Certificate", PROPERTY_USAGE_NONE), "set_trusted_ssl_certificate", "get_trusted_ssl_certificate");
 

--- a/modules/websocket/websocket_server.cpp
+++ b/modules/websocket/websocket_server.cpp
@@ -50,19 +50,19 @@ void WebSocketServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("disconnect_peer", "id", "code", "reason"), &WebSocketServer::disconnect_peer, DEFVAL(1000), DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("get_bind_ip"), &WebSocketServer::get_bind_ip);
-	ClassDB::bind_method(D_METHOD("set_bind_ip"), &WebSocketServer::set_bind_ip);
+	ClassDB::bind_method(D_METHOD("set_bind_ip", "ip"), &WebSocketServer::set_bind_ip);
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "bind_ip"), "set_bind_ip", "get_bind_ip");
 
 	ClassDB::bind_method(D_METHOD("get_private_key"), &WebSocketServer::get_private_key);
-	ClassDB::bind_method(D_METHOD("set_private_key"), &WebSocketServer::set_private_key);
+	ClassDB::bind_method(D_METHOD("set_private_key", "key"), &WebSocketServer::set_private_key);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "private_key", PROPERTY_HINT_RESOURCE_TYPE, "CryptoKey", PROPERTY_USAGE_NONE), "set_private_key", "get_private_key");
 
 	ClassDB::bind_method(D_METHOD("get_ssl_certificate"), &WebSocketServer::get_ssl_certificate);
-	ClassDB::bind_method(D_METHOD("set_ssl_certificate"), &WebSocketServer::set_ssl_certificate);
+	ClassDB::bind_method(D_METHOD("set_ssl_certificate", "cert"), &WebSocketServer::set_ssl_certificate);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "ssl_certificate", PROPERTY_HINT_RESOURCE_TYPE, "X509Certificate", PROPERTY_USAGE_NONE), "set_ssl_certificate", "get_ssl_certificate");
 
 	ClassDB::bind_method(D_METHOD("get_ca_chain"), &WebSocketServer::get_ca_chain);
-	ClassDB::bind_method(D_METHOD("set_ca_chain"), &WebSocketServer::set_ca_chain);
+	ClassDB::bind_method(D_METHOD("set_ca_chain", "ca_chain"), &WebSocketServer::set_ca_chain);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "ca_chain", PROPERTY_HINT_RESOURCE_TYPE, "X509Certificate", PROPERTY_USAGE_NONE), "set_ca_chain", "get_ca_chain");
 
 	ClassDB::bind_method(D_METHOD("get_handshake_timeout"), &WebSocketServer::get_handshake_timeout);

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -238,8 +238,8 @@ void Camera3D::clear_current(bool p_enable_next) {
 	}
 }
 
-void Camera3D::set_current(bool p_current) {
-	if (p_current) {
+void Camera3D::set_current(bool p_enabled) {
+	if (p_enabled) {
 		make_current();
 	} else {
 		clear_current();
@@ -460,7 +460,7 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_frustum", "size", "offset", "z_near", "z_far"), &Camera3D::set_frustum);
 	ClassDB::bind_method(D_METHOD("make_current"), &Camera3D::make_current);
 	ClassDB::bind_method(D_METHOD("clear_current", "enable_next"), &Camera3D::clear_current, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("set_current"), &Camera3D::set_current);
+	ClassDB::bind_method(D_METHOD("set_current", "enabled"), &Camera3D::set_current);
 	ClassDB::bind_method(D_METHOD("is_current"), &Camera3D::is_current);
 	ClassDB::bind_method(D_METHOD("get_camera_transform"), &Camera3D::get_camera_transform);
 	ClassDB::bind_method(D_METHOD("get_fov"), &Camera3D::get_fov);
@@ -468,13 +468,13 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_size"), &Camera3D::get_size);
 	ClassDB::bind_method(D_METHOD("get_far"), &Camera3D::get_far);
 	ClassDB::bind_method(D_METHOD("get_near"), &Camera3D::get_near);
-	ClassDB::bind_method(D_METHOD("set_fov"), &Camera3D::set_fov);
-	ClassDB::bind_method(D_METHOD("set_frustum_offset"), &Camera3D::set_frustum_offset);
-	ClassDB::bind_method(D_METHOD("set_size"), &Camera3D::set_size);
-	ClassDB::bind_method(D_METHOD("set_far"), &Camera3D::set_far);
-	ClassDB::bind_method(D_METHOD("set_near"), &Camera3D::set_near);
+	ClassDB::bind_method(D_METHOD("set_fov", "fov"), &Camera3D::set_fov);
+	ClassDB::bind_method(D_METHOD("set_frustum_offset", "offset"), &Camera3D::set_frustum_offset);
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &Camera3D::set_size);
+	ClassDB::bind_method(D_METHOD("set_far", "far"), &Camera3D::set_far);
+	ClassDB::bind_method(D_METHOD("set_near", "near"), &Camera3D::set_near);
 	ClassDB::bind_method(D_METHOD("get_projection"), &Camera3D::get_projection);
-	ClassDB::bind_method(D_METHOD("set_projection"), &Camera3D::set_projection);
+	ClassDB::bind_method(D_METHOD("set_projection", "mode"), &Camera3D::set_projection);
 	ClassDB::bind_method(D_METHOD("set_h_offset", "ofs"), &Camera3D::set_h_offset);
 	ClassDB::bind_method(D_METHOD("get_h_offset"), &Camera3D::get_h_offset);
 	ClassDB::bind_method(D_METHOD("set_v_offset", "ofs"), &Camera3D::set_v_offset);

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -44,8 +44,10 @@ public:
 		PROJECTION_FRUSTUM
 	};
 
-	enum KeepAspect { KEEP_WIDTH,
-		KEEP_HEIGHT };
+	enum KeepAspect {
+		KEEP_WIDTH,
+		KEEP_HEIGHT
+	};
 
 	enum DopplerTracking {
 		DOPPLER_TRACKING_DISABLED,
@@ -112,7 +114,7 @@ public:
 
 	void make_current();
 	void clear_current(bool p_enable_next = true);
-	void set_current(bool p_current);
+	void set_current(bool p_enabled);
 	bool is_current() const;
 
 	RID get_camera() const;

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -718,8 +718,8 @@ void Skeleton3D::localize_rests() {
 	}
 }
 
-void Skeleton3D::set_animate_physical_bones(bool p_animate) {
-	animate_physical_bones = p_animate;
+void Skeleton3D::set_animate_physical_bones(bool p_enabled) {
+	animate_physical_bones = p_enabled;
 
 	if (Engine::get_singleton()->is_editor_hint() == false) {
 		bool sim = false;
@@ -731,7 +731,7 @@ void Skeleton3D::set_animate_physical_bones(bool p_animate) {
 				}
 			}
 		}
-		set_physics_process_internal(sim == false && p_animate);
+		set_physics_process_internal(sim == false && p_enabled);
 	}
 }
 
@@ -1221,10 +1221,10 @@ void Skeleton3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("local_pose_to_global_pose", "bone_idx", "local_pose"), &Skeleton3D::local_pose_to_global_pose);
 	ClassDB::bind_method(D_METHOD("global_pose_z_forward_to_bone_forward", "bone_idx", "basis"), &Skeleton3D::global_pose_z_forward_to_bone_forward);
 
-	ClassDB::bind_method(D_METHOD("set_show_rest_only"), &Skeleton3D::set_show_rest_only);
+	ClassDB::bind_method(D_METHOD("set_show_rest_only", "enabled"), &Skeleton3D::set_show_rest_only);
 	ClassDB::bind_method(D_METHOD("is_show_rest_only"), &Skeleton3D::is_show_rest_only);
 
-	ClassDB::bind_method(D_METHOD("set_animate_physical_bones"), &Skeleton3D::set_animate_physical_bones);
+	ClassDB::bind_method(D_METHOD("set_animate_physical_bones", "enabled"), &Skeleton3D::set_animate_physical_bones);
 	ClassDB::bind_method(D_METHOD("get_animate_physical_bones"), &Skeleton3D::get_animate_physical_bones);
 
 	ClassDB::bind_method(D_METHOD("physical_bones_stop_simulation"), &Skeleton3D::physical_bones_stop_simulation);

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -250,7 +250,7 @@ public:
 
 	// Physical bone API
 
-	void set_animate_physical_bones(bool p_animate);
+	void set_animate_physical_bones(bool p_enabled);
 	bool get_animate_physical_bones() const;
 
 	void bind_physical_bone_to_bone(int p_bone, PhysicalBone3D *p_physical_bone);

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -427,9 +427,9 @@ Ref<Texture2D> Button::get_icon() const {
 	return icon;
 }
 
-void Button::set_expand_icon(bool p_expand_icon) {
-	if (expand_icon != p_expand_icon) {
-		expand_icon = p_expand_icon;
+void Button::set_expand_icon(bool p_enabled) {
+	if (expand_icon != p_enabled) {
+		expand_icon = p_enabled;
 		update();
 		minimum_size_changed();
 	}
@@ -439,9 +439,9 @@ bool Button::is_expand_icon() const {
 	return expand_icon;
 }
 
-void Button::set_flat(bool p_flat) {
-	if (flat != p_flat) {
-		flat = p_flat;
+void Button::set_flat(bool p_enabled) {
+	if (flat != p_enabled) {
+		flat = p_enabled;
 		update();
 	}
 }
@@ -450,9 +450,9 @@ bool Button::is_flat() const {
 	return flat;
 }
 
-void Button::set_clip_text(bool p_clip_text) {
-	if (clip_text != p_clip_text) {
-		clip_text = p_clip_text;
+void Button::set_clip_text(bool p_enabled) {
+	if (clip_text != p_enabled) {
+		clip_text = p_enabled;
 		update();
 		minimum_size_changed();
 	}
@@ -553,7 +553,7 @@ void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_text_align"), &Button::get_text_align);
 	ClassDB::bind_method(D_METHOD("set_icon_align", "icon_align"), &Button::set_icon_align);
 	ClassDB::bind_method(D_METHOD("get_icon_align"), &Button::get_icon_align);
-	ClassDB::bind_method(D_METHOD("set_expand_icon"), &Button::set_expand_icon);
+	ClassDB::bind_method(D_METHOD("set_expand_icon", "enabled"), &Button::set_expand_icon);
 	ClassDB::bind_method(D_METHOD("is_expand_icon"), &Button::is_expand_icon);
 
 	BIND_ENUM_CONSTANT(ALIGN_LEFT);

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -91,13 +91,13 @@ public:
 	void set_icon(const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_icon() const;
 
-	void set_expand_icon(bool p_expand_icon);
+	void set_expand_icon(bool p_enabled);
 	bool is_expand_icon() const;
 
-	void set_flat(bool p_flat);
+	void set_flat(bool p_enabled);
 	bool is_flat() const;
 
-	void set_clip_text(bool p_clip_text);
+	void set_clip_text(bool p_enabled);
 	bool get_clip_text() const;
 
 	void set_text_align(TextAlign p_align);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1106,9 +1106,9 @@ bool ColorPicker::are_presets_visible() const {
 void ColorPicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pick_color", "color"), &ColorPicker::set_pick_color);
 	ClassDB::bind_method(D_METHOD("get_pick_color"), &ColorPicker::get_pick_color);
-	ClassDB::bind_method(D_METHOD("set_hsv_mode"), &ColorPicker::set_hsv_mode);
+	ClassDB::bind_method(D_METHOD("set_hsv_mode", "enabled"), &ColorPicker::set_hsv_mode);
 	ClassDB::bind_method(D_METHOD("is_hsv_mode"), &ColorPicker::is_hsv_mode);
-	ClassDB::bind_method(D_METHOD("set_raw_mode"), &ColorPicker::set_raw_mode);
+	ClassDB::bind_method(D_METHOD("set_raw_mode", "enabled"), &ColorPicker::set_raw_mode);
 	ClassDB::bind_method(D_METHOD("is_raw_mode"), &ColorPicker::is_raw_mode);
 	ClassDB::bind_method(D_METHOD("set_deferred_mode", "mode"), &ColorPicker::set_deferred_mode);
 	ClassDB::bind_method(D_METHOD("is_deferred_mode"), &ColorPicker::is_deferred_mode);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -253,14 +253,14 @@ String SpinBox::get_prefix() const {
 	return prefix;
 }
 
-void SpinBox::set_update_on_text_changed(bool p_update) {
-	if (update_on_text_changed == p_update) {
+void SpinBox::set_update_on_text_changed(bool p_enabled) {
+	if (update_on_text_changed == p_enabled) {
 		return;
 	}
 
-	update_on_text_changed = p_update;
+	update_on_text_changed = p_enabled;
 
-	if (p_update) {
+	if (p_enabled) {
 		line_edit->connect("text_changed", callable_mp(this, &SpinBox::_text_changed), Vector<Variant>(), CONNECT_DEFERRED);
 	} else {
 		line_edit->disconnect("text_changed", callable_mp(this, &SpinBox::_text_changed));
@@ -271,8 +271,8 @@ bool SpinBox::get_update_on_text_changed() const {
 	return update_on_text_changed;
 }
 
-void SpinBox::set_editable(bool p_editable) {
-	line_edit->set_editable(p_editable);
+void SpinBox::set_editable(bool p_enabled) {
+	line_edit->set_editable(p_enabled);
 }
 
 bool SpinBox::is_editable() const {
@@ -284,17 +284,15 @@ void SpinBox::apply() {
 }
 
 void SpinBox::_bind_methods() {
-	//ClassDB::bind_method(D_METHOD("_value_changed"),&SpinBox::_value_changed);
-
 	ClassDB::bind_method(D_METHOD("set_align", "align"), &SpinBox::set_align);
 	ClassDB::bind_method(D_METHOD("get_align"), &SpinBox::get_align);
 	ClassDB::bind_method(D_METHOD("set_suffix", "suffix"), &SpinBox::set_suffix);
 	ClassDB::bind_method(D_METHOD("get_suffix"), &SpinBox::get_suffix);
 	ClassDB::bind_method(D_METHOD("set_prefix", "prefix"), &SpinBox::set_prefix);
 	ClassDB::bind_method(D_METHOD("get_prefix"), &SpinBox::get_prefix);
-	ClassDB::bind_method(D_METHOD("set_editable", "editable"), &SpinBox::set_editable);
+	ClassDB::bind_method(D_METHOD("set_editable", "enabled"), &SpinBox::set_editable);
 	ClassDB::bind_method(D_METHOD("is_editable"), &SpinBox::is_editable);
-	ClassDB::bind_method(D_METHOD("set_update_on_text_changed"), &SpinBox::set_update_on_text_changed);
+	ClassDB::bind_method(D_METHOD("set_update_on_text_changed", "enabled"), &SpinBox::set_update_on_text_changed);
 	ClassDB::bind_method(D_METHOD("get_update_on_text_changed"), &SpinBox::get_update_on_text_changed);
 	ClassDB::bind_method(D_METHOD("apply"), &SpinBox::apply);
 	ClassDB::bind_method(D_METHOD("get_line_edit"), &SpinBox::get_line_edit);

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -82,7 +82,7 @@ public:
 	void set_align(LineEdit::Align p_align);
 	LineEdit::Align get_align() const;
 
-	void set_editable(bool p_editable);
+	void set_editable(bool p_enabled);
 	bool is_editable() const;
 
 	void set_suffix(const String &p_suffix);
@@ -91,7 +91,7 @@ public:
 	void set_prefix(const String &p_prefix);
 	String get_prefix() const;
 
-	void set_update_on_text_changed(bool p_update);
+	void set_update_on_text_changed(bool p_enabled);
 	bool get_update_on_text_changed() const;
 
 	void apply();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -103,11 +103,11 @@ void TextEdit::Text::set_direction_and_language(TextServer::Direction p_directio
 	is_dirty = true;
 }
 
-void TextEdit::Text::set_draw_control_chars(bool p_draw_control_chars) {
-	if (draw_control_chars == p_draw_control_chars) {
+void TextEdit::Text::set_draw_control_chars(bool p_enabled) {
+	if (draw_control_chars == p_enabled) {
 		return;
 	}
-	draw_control_chars = p_draw_control_chars;
+	draw_control_chars = p_enabled;
 	is_dirty = true;
 }
 
@@ -2572,8 +2572,8 @@ bool TextEdit::is_overtype_mode_enabled() const {
 	return overtype_mode;
 }
 
-void TextEdit::set_context_menu_enabled(bool p_enable) {
-	context_menu_enabled = p_enable;
+void TextEdit::set_context_menu_enabled(bool p_enabled) {
+	context_menu_enabled = p_enabled;
 }
 
 bool TextEdit::is_context_menu_enabled() const {
@@ -2588,8 +2588,8 @@ bool TextEdit::is_shortcut_keys_enabled() const {
 	return shortcut_keys_enabled;
 }
 
-void TextEdit::set_virtual_keyboard_enabled(bool p_enable) {
-	virtual_keyboard_enabled = p_enable;
+void TextEdit::set_virtual_keyboard_enabled(bool p_enabled) {
+	virtual_keyboard_enabled = p_enabled;
 }
 
 bool TextEdit::is_virtual_keyboard_enabled() const {
@@ -3504,8 +3504,8 @@ void TextEdit::set_caret_blink_speed(const float p_speed) {
 	caret_blink_timer->set_wait_time(p_speed);
 }
 
-void TextEdit::set_move_caret_on_right_click_enabled(const bool p_enable) {
-	move_caret_on_right_click = p_enable;
+void TextEdit::set_move_caret_on_right_click_enabled(const bool p_enabled) {
+	move_caret_on_right_click = p_enabled;
 }
 
 bool TextEdit::is_move_caret_on_right_click_enabled() const {
@@ -3913,9 +3913,9 @@ Vector<String> TextEdit::get_line_wrapped_text(int p_line) const {
 
 /* Viewport */
 // Scrolling.
-void TextEdit::set_smooth_scroll_enabled(const bool p_enable) {
-	v_scroll->set_smooth_scroll_enabled(p_enable);
-	smooth_scroll_enabled = p_enable;
+void TextEdit::set_smooth_scroll_enabled(const bool p_enabled) {
+	v_scroll->set_smooth_scroll_enabled(p_enabled);
+	smooth_scroll_enabled = p_enabled;
 }
 
 bool TextEdit::is_smooth_scroll_enabled() const {
@@ -4174,9 +4174,9 @@ void TextEdit::center_viewport_to_caret() {
 }
 
 /* Minimap */
-void TextEdit::set_draw_minimap(bool p_draw) {
-	if (draw_minimap != p_draw) {
-		draw_minimap = p_draw;
+void TextEdit::set_draw_minimap(bool p_enabled) {
+	if (draw_minimap != p_enabled) {
+		draw_minimap = p_enabled;
 		_update_wrap_at_column();
 	}
 	update();
@@ -4457,9 +4457,9 @@ bool TextEdit::is_highlight_all_occurrences_enabled() const {
 	return highlight_all_occurrences;
 }
 
-void TextEdit::set_draw_control_chars(bool p_draw_control_chars) {
-	if (draw_control_chars != p_draw_control_chars) {
-		draw_control_chars = p_draw_control_chars;
+void TextEdit::set_draw_control_chars(bool p_enabled) {
+	if (draw_control_chars != p_enabled) {
+		draw_control_chars = p_enabled;
 		if (menu) {
 			menu->set_item_checked(menu->get_item_index(MENU_DISPLAY_UCC), draw_control_chars);
 		}
@@ -4473,8 +4473,8 @@ bool TextEdit::get_draw_control_chars() const {
 	return draw_control_chars;
 }
 
-void TextEdit::set_draw_tabs(bool p_draw) {
-	draw_tabs = p_draw;
+void TextEdit::set_draw_tabs(bool p_enabled) {
+	draw_tabs = p_enabled;
 	update();
 }
 
@@ -4482,8 +4482,8 @@ bool TextEdit::is_drawing_tabs() const {
 	return draw_tabs;
 }
 
-void TextEdit::set_draw_spaces(bool p_draw) {
-	draw_spaces = p_draw;
+void TextEdit::set_draw_spaces(bool p_enabled) {
+	draw_spaces = p_enabled;
 	update();
 }
 
@@ -4500,7 +4500,7 @@ void TextEdit::_bind_methods() {
 	// Text properties
 	ClassDB::bind_method(D_METHOD("has_ime_text"), &TextEdit::has_ime_text);
 
-	ClassDB::bind_method(D_METHOD("set_editable", "enable"), &TextEdit::set_editable);
+	ClassDB::bind_method(D_METHOD("set_editable", "enabled"), &TextEdit::set_editable);
 	ClassDB::bind_method(D_METHOD("is_editable"), &TextEdit::is_editable);
 
 	ClassDB::bind_method(D_METHOD("set_text_direction", "direction"), &TextEdit::set_text_direction);
@@ -4525,13 +4525,13 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_overtype_mode_enabled", "enabled"), &TextEdit::set_overtype_mode_enabled);
 	ClassDB::bind_method(D_METHOD("is_overtype_mode_enabled"), &TextEdit::is_overtype_mode_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_context_menu_enabled", "enable"), &TextEdit::set_context_menu_enabled);
+	ClassDB::bind_method(D_METHOD("set_context_menu_enabled", "enabled"), &TextEdit::set_context_menu_enabled);
 	ClassDB::bind_method(D_METHOD("is_context_menu_enabled"), &TextEdit::is_context_menu_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_shortcut_keys_enabled", "enable"), &TextEdit::set_shortcut_keys_enabled);
+	ClassDB::bind_method(D_METHOD("set_shortcut_keys_enabled", "enabled"), &TextEdit::set_shortcut_keys_enabled);
 	ClassDB::bind_method(D_METHOD("is_shortcut_keys_enabled"), &TextEdit::is_shortcut_keys_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_virtual_keyboard_enabled", "enable"), &TextEdit::set_virtual_keyboard_enabled);
+	ClassDB::bind_method(D_METHOD("set_virtual_keyboard_enabled", "enabled"), &TextEdit::set_virtual_keyboard_enabled);
 	ClassDB::bind_method(D_METHOD("is_virtual_keyboard_enabled"), &TextEdit::is_virtual_keyboard_enabled);
 
 	// Text manipulation
@@ -4766,7 +4766,7 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("center_viewport_to_caret"), &TextEdit::center_viewport_to_caret);
 
 	// Minimap
-	ClassDB::bind_method(D_METHOD("draw_minimap", "draw"), &TextEdit::set_draw_minimap);
+	ClassDB::bind_method(D_METHOD("set_draw_minimap", "enabled"), &TextEdit::set_draw_minimap);
 	ClassDB::bind_method(D_METHOD("is_drawing_minimap"), &TextEdit::is_drawing_minimap);
 
 	ClassDB::bind_method(D_METHOD("set_minimap_width", "width"), &TextEdit::set_minimap_width);
@@ -4822,16 +4822,16 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_highlight_current_line", "enabled"), &TextEdit::set_highlight_current_line);
 	ClassDB::bind_method(D_METHOD("is_highlight_current_line_enabled"), &TextEdit::is_highlight_current_line_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_highlight_all_occurrences", "enable"), &TextEdit::set_highlight_all_occurrences);
+	ClassDB::bind_method(D_METHOD("set_highlight_all_occurrences", "enabled"), &TextEdit::set_highlight_all_occurrences);
 	ClassDB::bind_method(D_METHOD("is_highlight_all_occurrences_enabled"), &TextEdit::is_highlight_all_occurrences_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_draw_control_chars"), &TextEdit::get_draw_control_chars);
-	ClassDB::bind_method(D_METHOD("set_draw_control_chars", "enable"), &TextEdit::set_draw_control_chars);
+	ClassDB::bind_method(D_METHOD("set_draw_control_chars", "enabled"), &TextEdit::set_draw_control_chars);
 
-	ClassDB::bind_method(D_METHOD("set_draw_tabs"), &TextEdit::set_draw_tabs);
+	ClassDB::bind_method(D_METHOD("set_draw_tabs", "enabled"), &TextEdit::set_draw_tabs);
 	ClassDB::bind_method(D_METHOD("is_drawing_tabs"), &TextEdit::is_drawing_tabs);
 
-	ClassDB::bind_method(D_METHOD("set_draw_spaces"), &TextEdit::set_draw_spaces);
+	ClassDB::bind_method(D_METHOD("set_draw_spaces", "enabled"), &TextEdit::set_draw_spaces);
 	ClassDB::bind_method(D_METHOD("is_drawing_spaces"), &TextEdit::is_drawing_spaces);
 
 	ClassDB::bind_method(D_METHOD("get_menu"), &TextEdit::get_menu);
@@ -4868,7 +4868,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_horizontal"), "set_h_scroll", "get_h_scroll");
 
 	ADD_GROUP("Minimap", "minimap_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "minimap_draw"), "draw_minimap", "is_drawing_minimap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "minimap_draw"), "set_draw_minimap", "is_drawing_minimap");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimap_width"), "set_minimap_width", "get_minimap_width");
 
 	ADD_GROUP("Caret", "caret_");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -182,7 +182,7 @@ private:
 		void set_font_size(int p_font_size);
 		void set_font_features(const Dictionary &p_features);
 		void set_direction_and_language(TextServer::Direction p_direction, const String &p_language);
-		void set_draw_control_chars(bool p_draw_control_chars);
+		void set_draw_control_chars(bool p_enabled);
 
 		int get_line_height() const;
 		int get_line_width(int p_line, int p_wrap_index = -1) const;
@@ -631,13 +631,13 @@ public:
 	void set_overtype_mode_enabled(const bool p_enabled);
 	bool is_overtype_mode_enabled() const;
 
-	void set_context_menu_enabled(bool p_enable);
+	void set_context_menu_enabled(bool p_enabled);
 	bool is_context_menu_enabled() const;
 
 	void set_shortcut_keys_enabled(bool p_enabled);
 	bool is_shortcut_keys_enabled() const;
 
-	void set_virtual_keyboard_enabled(bool p_enable);
+	void set_virtual_keyboard_enabled(bool p_enabled);
 	bool is_virtual_keyboard_enabled() const;
 
 	// Text manipulation
@@ -723,7 +723,7 @@ public:
 	void set_caret_blink_speed(const float p_speed);
 	float get_caret_blink_speed() const;
 
-	void set_move_caret_on_right_click_enabled(const bool p_enable);
+	void set_move_caret_on_right_click_enabled(const bool p_enabled);
 	bool is_move_caret_on_right_click_enabled() const;
 
 	void set_caret_mid_grapheme_enabled(const bool p_enabled);
@@ -783,7 +783,7 @@ public:
 
 	/* Viewport. */
 	// Scrolling.
-	void set_smooth_scroll_enabled(const bool p_enable);
+	void set_smooth_scroll_enabled(const bool p_enabled);
 	bool is_smooth_scroll_enabled() const;
 
 	void set_scroll_past_end_of_file_enabled(const bool p_enabled);
@@ -818,7 +818,7 @@ public:
 	void center_viewport_to_caret();
 
 	// Minimap
-	void set_draw_minimap(bool p_draw);
+	void set_draw_minimap(bool p_enabled);
 	bool is_drawing_minimap() const;
 
 	void set_minimap_width(int p_minimap_width);
@@ -885,13 +885,13 @@ public:
 	void set_highlight_all_occurrences(const bool p_enabled);
 	bool is_highlight_all_occurrences_enabled() const;
 
-	void set_draw_control_chars(bool p_draw_control_chars);
+	void set_draw_control_chars(bool p_enabled);
 	bool get_draw_control_chars() const;
 
-	void set_draw_tabs(bool p_draw);
+	void set_draw_tabs(bool p_enabled);
 	bool is_drawing_tabs() const;
 
-	void set_draw_spaces(bool p_draw);
+	void set_draw_spaces(bool p_enabled);
 	bool is_drawing_spaces() const;
 
 	TextEdit();

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -599,7 +599,7 @@ void HTTPRequest::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_timeout", "timeout"), &HTTPRequest::set_timeout);
 	ClassDB::bind_method(D_METHOD("get_timeout"), &HTTPRequest::get_timeout);
 
-	ClassDB::bind_method(D_METHOD("set_download_chunk_size"), &HTTPRequest::set_download_chunk_size);
+	ClassDB::bind_method(D_METHOD("set_download_chunk_size", "chunk_size"), &HTTPRequest::set_download_chunk_size);
 	ClassDB::bind_method(D_METHOD("get_download_chunk_size"), &HTTPRequest::get_download_chunk_size);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "download_file", PROPERTY_HINT_FILE), "set_download_file", "get_download_file");

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -116,8 +116,8 @@ void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_scale", "cache_index", "size", "scale"), &FontData::set_scale);
 	ClassDB::bind_method(D_METHOD("get_scale", "cache_index", "size"), &FontData::get_scale);
 
-	ClassDB::bind_method(D_METHOD("set_spacing", "cache_index", "size", "spacing"), &FontData::set_spacing);
-	ClassDB::bind_method(D_METHOD("get_spacing", "cache_index", "size"), &FontData::get_spacing);
+	ClassDB::bind_method(D_METHOD("set_spacing", "cache_index", "size", "spacing_type", "value"), &FontData::set_spacing);
+	ClassDB::bind_method(D_METHOD("get_spacing", "cache_index", "size", "spacing_type"), &FontData::get_spacing);
 
 	ClassDB::bind_method(D_METHOD("get_texture_count", "cache_index", "size"), &FontData::get_texture_count);
 	ClassDB::bind_method(D_METHOD("clear_textures", "cache_index", "size"), &FontData::clear_textures);
@@ -175,7 +175,7 @@ void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_char", "char"), &FontData::has_char);
 	ClassDB::bind_method(D_METHOD("get_supported_chars"), &FontData::get_supported_chars);
 
-	ClassDB::bind_method(D_METHOD("get_glyph_index", "char", "variation_selector"), &FontData::get_glyph_index);
+	ClassDB::bind_method(D_METHOD("get_glyph_index", "size", "char", "variation_selector"), &FontData::get_glyph_index);
 
 	ClassDB::bind_method(D_METHOD("get_supported_feature_list"), &FontData::get_supported_feature_list);
 	ClassDB::bind_method(D_METHOD("get_supported_variation_list"), &FontData::get_supported_variation_list);

--- a/scene/resources/skeleton_modification_stack_2d.cpp
+++ b/scene/resources/skeleton_modification_stack_2d.cpp
@@ -247,7 +247,7 @@ void SkeletonModificationStack2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("delete_modification", "mod_idx"), &SkeletonModificationStack2D::delete_modification);
 	ClassDB::bind_method(D_METHOD("set_modification", "mod_idx", "modification"), &SkeletonModificationStack2D::set_modification);
 
-	ClassDB::bind_method(D_METHOD("set_modification_count"), &SkeletonModificationStack2D::set_modification_count);
+	ClassDB::bind_method(D_METHOD("set_modification_count", "count"), &SkeletonModificationStack2D::set_modification_count);
 	ClassDB::bind_method(D_METHOD("get_modification_count"), &SkeletonModificationStack2D::get_modification_count);
 
 	ClassDB::bind_method(D_METHOD("get_is_setup"), &SkeletonModificationStack2D::get_is_setup);

--- a/scene/resources/skeleton_modification_stack_3d.cpp
+++ b/scene/resources/skeleton_modification_stack_3d.cpp
@@ -200,7 +200,7 @@ void SkeletonModificationStack3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("delete_modification", "mod_idx"), &SkeletonModificationStack3D::delete_modification);
 	ClassDB::bind_method(D_METHOD("set_modification", "mod_idx", "modification"), &SkeletonModificationStack3D::set_modification);
 
-	ClassDB::bind_method(D_METHOD("set_modification_count"), &SkeletonModificationStack3D::set_modification_count);
+	ClassDB::bind_method(D_METHOD("set_modification_count", "count"), &SkeletonModificationStack3D::set_modification_count);
 	ClassDB::bind_method(D_METHOD("get_modification_count"), &SkeletonModificationStack3D::get_modification_count);
 
 	ClassDB::bind_method(D_METHOD("get_is_setup"), &SkeletonModificationStack3D::get_is_setup);

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -452,22 +452,22 @@ void PhysicsTestMotionParameters2D::set_exclude_objects(const Array &p_exclude) 
 
 void PhysicsTestMotionParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_from"), &PhysicsTestMotionParameters2D::get_from);
-	ClassDB::bind_method(D_METHOD("set_from"), &PhysicsTestMotionParameters2D::set_from);
+	ClassDB::bind_method(D_METHOD("set_from", "from"), &PhysicsTestMotionParameters2D::set_from);
 
 	ClassDB::bind_method(D_METHOD("get_motion"), &PhysicsTestMotionParameters2D::get_motion);
-	ClassDB::bind_method(D_METHOD("set_motion"), &PhysicsTestMotionParameters2D::set_motion);
+	ClassDB::bind_method(D_METHOD("set_motion", "motion"), &PhysicsTestMotionParameters2D::set_motion);
 
 	ClassDB::bind_method(D_METHOD("get_margin"), &PhysicsTestMotionParameters2D::get_margin);
-	ClassDB::bind_method(D_METHOD("set_margin"), &PhysicsTestMotionParameters2D::set_margin);
+	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &PhysicsTestMotionParameters2D::set_margin);
 
 	ClassDB::bind_method(D_METHOD("is_collide_separation_ray_enabled"), &PhysicsTestMotionParameters2D::is_collide_separation_ray_enabled);
-	ClassDB::bind_method(D_METHOD("set_collide_separation_ray_enabled"), &PhysicsTestMotionParameters2D::set_collide_separation_ray_enabled);
+	ClassDB::bind_method(D_METHOD("set_collide_separation_ray_enabled", "enabled"), &PhysicsTestMotionParameters2D::set_collide_separation_ray_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_exclude_bodies"), &PhysicsTestMotionParameters2D::get_exclude_bodies);
-	ClassDB::bind_method(D_METHOD("set_exclude_bodies"), &PhysicsTestMotionParameters2D::set_exclude_bodies);
+	ClassDB::bind_method(D_METHOD("set_exclude_bodies", "exclude_list"), &PhysicsTestMotionParameters2D::set_exclude_bodies);
 
 	ClassDB::bind_method(D_METHOD("get_exclude_objects"), &PhysicsTestMotionParameters2D::get_exclude_objects);
-	ClassDB::bind_method(D_METHOD("set_exclude_objects"), &PhysicsTestMotionParameters2D::set_exclude_objects);
+	ClassDB::bind_method(D_METHOD("set_exclude_objects", "exclude_list"), &PhysicsTestMotionParameters2D::set_exclude_objects);
 
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "from"), "set_from", "get_from");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "motion"), "set_motion", "get_motion");

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -402,25 +402,25 @@ void PhysicsTestMotionParameters3D::set_exclude_objects(const Array &p_exclude) 
 
 void PhysicsTestMotionParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_from"), &PhysicsTestMotionParameters3D::get_from);
-	ClassDB::bind_method(D_METHOD("set_from"), &PhysicsTestMotionParameters3D::set_from);
+	ClassDB::bind_method(D_METHOD("set_from", "from"), &PhysicsTestMotionParameters3D::set_from);
 
 	ClassDB::bind_method(D_METHOD("get_motion"), &PhysicsTestMotionParameters3D::get_motion);
-	ClassDB::bind_method(D_METHOD("set_motion"), &PhysicsTestMotionParameters3D::set_motion);
+	ClassDB::bind_method(D_METHOD("set_motion", "motion"), &PhysicsTestMotionParameters3D::set_motion);
 
 	ClassDB::bind_method(D_METHOD("get_margin"), &PhysicsTestMotionParameters3D::get_margin);
-	ClassDB::bind_method(D_METHOD("set_margin"), &PhysicsTestMotionParameters3D::set_margin);
+	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &PhysicsTestMotionParameters3D::set_margin);
 
 	ClassDB::bind_method(D_METHOD("get_max_collisions"), &PhysicsTestMotionParameters3D::get_max_collisions);
-	ClassDB::bind_method(D_METHOD("set_max_collisions"), &PhysicsTestMotionParameters3D::set_max_collisions);
+	ClassDB::bind_method(D_METHOD("set_max_collisions", "max_collisions"), &PhysicsTestMotionParameters3D::set_max_collisions);
 
 	ClassDB::bind_method(D_METHOD("is_collide_separation_ray_enabled"), &PhysicsTestMotionParameters3D::is_collide_separation_ray_enabled);
-	ClassDB::bind_method(D_METHOD("set_collide_separation_ray_enabled"), &PhysicsTestMotionParameters3D::set_collide_separation_ray_enabled);
+	ClassDB::bind_method(D_METHOD("set_collide_separation_ray_enabled", "enabled"), &PhysicsTestMotionParameters3D::set_collide_separation_ray_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_exclude_bodies"), &PhysicsTestMotionParameters3D::get_exclude_bodies);
-	ClassDB::bind_method(D_METHOD("set_exclude_bodies"), &PhysicsTestMotionParameters3D::set_exclude_bodies);
+	ClassDB::bind_method(D_METHOD("set_exclude_bodies", "exclude_list"), &PhysicsTestMotionParameters3D::set_exclude_bodies);
 
 	ClassDB::bind_method(D_METHOD("get_exclude_objects"), &PhysicsTestMotionParameters3D::get_exclude_objects);
-	ClassDB::bind_method(D_METHOD("set_exclude_objects"), &PhysicsTestMotionParameters3D::set_exclude_objects);
+	ClassDB::bind_method(D_METHOD("set_exclude_objects", "exclude_list"), &PhysicsTestMotionParameters3D::set_exclude_objects);
 
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "from"), "set_from", "get_from");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "motion"), "set_motion", "get_motion");

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -476,7 +476,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_device_name"), &RenderingDevice::get_device_name);
 	ClassDB::bind_method(D_METHOD("get_device_pipeline_cache_uuid"), &RenderingDevice::get_device_pipeline_cache_uuid);
 
-	ClassDB::bind_method(D_METHOD("get_memory_usage"), &RenderingDevice::get_memory_usage);
+	ClassDB::bind_method(D_METHOD("get_memory_usage", "type"), &RenderingDevice::get_memory_usage);
 
 	ClassDB::bind_method(D_METHOD("get_driver_resource", "resource", "rid", "index"), &RenderingDevice::get_driver_resource);
 

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -41,7 +41,7 @@ XRServer *XRServer::get_singleton() {
 
 void XRServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_world_scale"), &XRServer::get_world_scale);
-	ClassDB::bind_method(D_METHOD("set_world_scale"), &XRServer::set_world_scale);
+	ClassDB::bind_method(D_METHOD("set_world_scale", "scale"), &XRServer::set_world_scale);
 	ClassDB::bind_method(D_METHOD("get_reference_frame"), &XRServer::get_reference_frame);
 	ClassDB::bind_method(D_METHOD("center_on_hmd", "rotation_mode", "keep_height"), &XRServer::center_on_hmd);
 	ClassDB::bind_method(D_METHOD("get_hmd_transform"), &XRServer::get_hmd_transform);


### PR DESCRIPTION
While at it, tweak some boolean setters to use `p_enabled` for the bool.

Also renames `draw_minimap()` to `set_draw_minimap()`.