### PR TITLE
Add a warning for Timer nodes with very low wait times

### DIFF
--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -51,7 +51,8 @@
 			[b]Note:[/b] You cannot set this value. To change the timer's remaining time, use [method start].
 		</member>
 		<member name="wait_time" type="float" setter="set_wait_time" getter="get_wait_time" default="1.0">
-			Wait time in seconds.
+			The wait time in seconds.
+			[b]Note:[/b] Timers can only emit once per rendered frame at most (or once per physics frame if [member process_callback] is [constant TIMER_PROCESS_PHYSICS). This means very low wait times (lower than 0.05 seconds) will behave in significantly different ways depending on the rendered framerate. For very low wait times, it is recommended to use a process loop in a script instead of using a Timer node.
 		</member>
 	</members>
 	<signals>

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -82,6 +82,7 @@ void Timer::_notification(int p_what) {
 void Timer::set_wait_time(double p_time) {
 	ERR_FAIL_COND_MSG(p_time <= 0, "Time should be greater than zero.");
 	wait_time = p_time;
+	update_configuration_warnings();
 }
 
 double Timer::get_wait_time() const {
@@ -177,6 +178,16 @@ void Timer::_set_process(bool p_process, bool p_force) {
 			break;
 	}
 	processing = p_process;
+}
+
+TypedArray<String> Timer::get_configuration_warnings() const {
+	TypedArray<String> warnings = Node::get_configuration_warnings();
+
+	if (wait_time < 0.05 - CMP_EPSILON) {
+		warnings.push_back(TTR("Very low timer wait times (< 0.05 seconds) may behave in significantly different ways depending on the rendered or physics frame rate.\nConsider using a script's process loop instead of relying on a Timer for very low wait times."));
+	}
+
+	return warnings;
 }
 
 void Timer::_bind_methods() {

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -73,6 +73,8 @@ public:
 
 	double get_time_left() const;
 
+	TypedArray<String> get_configuration_warnings() const override;
+
 	void set_timer_process_callback(TimerProcessCallback p_callback);
 	TimerProcessCallback get_timer_process_callback() const;
 	Timer();


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/53591.

Follow-up to https://github.com/godotengine/godot/pull/52697 (see also https://github.com/godotengine/godot-proposals/issues/3386).

Very low wait times behave in unpredictable ways depending on the rendered frame rate. This is because the timeout signal is only emitted once per rendered frame (or physics frame, depending on the timer's process mode).


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->