### PR TITLE
Fix typo in the `Timer.wait_time` description

### DIFF
--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -52,7 +52,7 @@
 		</member>
 		<member name="wait_time" type="float" setter="set_wait_time" getter="get_wait_time" default="1.0">
 			The wait time in seconds.
-			[b]Note:[/b] Timers can only emit once per rendered frame at most (or once per physics frame if [member process_callback] is [constant TIMER_PROCESS_PHYSICS). This means very low wait times (lower than 0.05 seconds) will behave in significantly different ways depending on the rendered framerate. For very low wait times, it is recommended to use a process loop in a script instead of using a Timer node.
+			[b]Note:[/b] Timers can only emit once per rendered frame at most (or once per physics frame if [member process_callback] is [constant TIMER_PROCESS_PHYSICS]). This means very low wait times (lower than 0.05 seconds) will behave in significantly different ways depending on the rendered framerate. For very low wait times, it is recommended to use a process loop in a script instead of using a Timer node.
 		</member>
 	</members>
 	<signals>


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/53589. Apologies for not noticing it before the PR was merged :slightly_frowning_face:

This fix is already integrated in the `3.x` version: https://github.com/godotengine/godot/pull/53591