### PR TITLE
Add a "dirty" marker to the editor import dock for unsaved changes

### DIFF
--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -68,7 +68,9 @@ class ImportDock : public VBoxContainer {
 	void _update_preset_menu();
 	void _add_keep_import_option(const String &p_importer_name);
 
+	void _property_edited(const StringName &p_prop);
 	void _property_toggled(const StringName &p_prop, bool p_checked);
+	void _set_dirty(bool p_dirty);
 	void _reimport_attempt();
 	void _reimport_and_restart();
 	void _reimport();


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/53616.

This helps users notice that they should click **Reimport** for changes to apply.

## Preview

https://user-images.githubusercontent.com/180032/136654512-4f8820ee-5dbb-430d-a979-b9e75a3761d1.mp4