### PR TITLE
Fix auto LOD generation for blendshapes

### DIFF
--- a/scene/resources/importer_mesh.h
+++ b/scene/resources/importer_mesh.h
@@ -70,6 +70,7 @@ class ImporterMesh : public Resource {
 		};
 
 		void split_normals(const LocalVector<int> &p_indices, const LocalVector<Vector3> &p_normals);
+		static void _split_normals(Array &r_arrays, const LocalVector<int> &p_indices, const LocalVector<Vector3> &p_normals);
 	};
 	Vector<Surface> surfaces;
 	Vector<String> blend_shapes;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -934,7 +934,7 @@ Error RenderingServer::mesh_create_surface_data_from_arrays(SurfaceData *r_surfa
 				}
 			}
 
-			ERR_FAIL_COND_V_MSG((bsformat) != (format & (ARRAY_FORMAT_VERTEX | ARRAY_FORMAT_NORMAL | ARRAY_FORMAT_TANGENT)), ERR_INVALID_PARAMETER, "Blend shape format must match the main array format for Vertex, Normal and Tangent arrays.");
+			ERR_FAIL_COND_V_MSG((bsformat & RS::ARRAY_FORMAT_BLEND_SHAPE_MASK) != (format & RS::ARRAY_FORMAT_BLEND_SHAPE_MASK), ERR_INVALID_PARAMETER, "Blend shape format must match the main array format for Vertex, Normal and Tangent arrays.");
 		}
 	}
 


### PR DESCRIPTION
Blendshapes were not taken into account when splitting vertex normals in LODs, now they are.

Also fixes the same issue as #53401 but with less verbose errors (not sure if that's better or worse).