### PR TITLE
Update Android CI to use JDK 11.

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -25,10 +25,10 @@ jobs:
           sudo cp -f misc/ci/sources.list /etc/apt/sources.list
           sudo apt-get update
 
-      - name: Set up Java 8
+      - name: Set up Java 11
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache


### PR DESCRIPTION
As described in https://github.com/godotengine/godot-docs/pull/5312, the current specified Java version should be updated to JDK 11.

**Note:** JDK 11 is required to upgrade the Android Gradle plug-in to 7.0.

Can be cherry-picked for 3.x.
