### PR TITLE
Add a "dirty" marker to the editor import dock for unsaved changes (3.x)

### DIFF
--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -65,7 +65,9 @@ class ImportDock : public VBoxContainer {
 	void _update_preset_menu();
 	void _add_keep_import_option(const String &p_importer_name);
 
+	void _property_edited(const StringName &p_prop);
 	void _property_toggled(const StringName &p_prop, bool p_checked);
+	void _set_dirty(bool p_dirty);
 	void _reimport_attempt();
 	void _reimport_and_restart();
 	void _reimport();


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/53594.

## Preview (`3.x)

https://user-images.githubusercontent.com/180032/136675857-401f0ba6-24cf-4e39-93d7-0e387860cd5d.mp4