### PR TITLE
Mention remove_node() side effect of potentially setting owner to null

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -551,6 +551,7 @@
 			<argument index="0" name="node" type="Node" />
 			<description>
 				Removes a child node. The node is NOT deleted and must be deleted manually.
+				[b]Note:[/b] This function may set the [member owner] of the removed Node (or its descendants) to be [code]null[/code], if that [member owner] is no longer a parent or ancestor.
 			</description>
 		</method>
 		<method name="remove_from_group">


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Resolves https://github.com/godotengine/godot-docs/issues/5303

(Specifically occurs during the `_propagate_validate_owner()` call at https://github.com/godotengine/godot/blob/master/scene/main/node.cpp#L1232