### PR TITLE
Fix error emitting when pressing on empty line number gutter

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2335,9 +2335,14 @@ void CodeEdit::_gutter_clicked(int p_line, int p_gutter) {
 	}
 
 	if (p_gutter == line_number_gutter) {
-		set_selection_mode(TextEdit::SelectionMode::SELECTION_MODE_LINE, p_line, 0);
-		select(p_line, 0, p_line + 1, 0);
-		set_caret_line(p_line + 1);
+		if (!get_line(p_line).is_empty()) {
+			set_selection_mode(TextEdit::SelectionMode::SELECTION_MODE_LINE, p_line, 0);
+			select(p_line, 0, p_line + 1, 0);
+			set_caret_line(p_line + 1);
+		} else {
+			deselect();
+			set_caret_line(p_line);
+		}
 		set_caret_column(0);
 		return;
 	}


### PR DESCRIPTION
Fix a bug:

<details>
<summary>Before</summary>

![bug](https://user-images.githubusercontent.com/3036176/136686303-424f7251-5d96-4cb3-8af7-da225bb6ba19.gif)

</details>

<details>
<summary>After</summary>

![bug_fix](https://user-images.githubusercontent.com/3036176/136686675-f19d0dfa-1809-4d4a-ac94-fd3b37dd2bc6.gif)

</details>

