### PR TITLE
Add inverted normals when flipped model scale

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -774,7 +774,7 @@ void BaseMaterial3D::_update_shader() {
 	if (!flags[FLAG_UV1_USE_TRIPLANAR]) {
 		code += "	UV=UV*uv1_scale.xy+uv1_offset.xy;\n";
 		code += "	if (determinant(mat3(WORLD_MATRIX)) < 0.0) {";
-		code += "		NORMAL = -NORMAL;"
+		code += "		NORMAL = -NORMAL;";
 		code += "	}";
 	}
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -773,6 +773,9 @@ void BaseMaterial3D::_update_shader() {
 
 	if (!flags[FLAG_UV1_USE_TRIPLANAR]) {
 		code += "	UV=UV*uv1_scale.xy+uv1_offset.xy;\n";
+		code += "	if (determinant(mat3(WORLD_MATRIX)) < 0.0) {";
+		code += "		NORMAL = -NORMAL;"
+		code += "	}";
 	}
 
 	switch (billboard_mode) {


### PR DESCRIPTION
Solves #29317 

When the user scales a 3d model by -1, the model lighting gets messed, thanks to @lyuma I could solve this problem!
In the image examples below, its a multimeshinstance with half side of the kart flipped to another!

PS: Must be cherrypicked for 3.x

Before:
![image](https://user-images.githubusercontent.com/58845030/136706071-50f79dd1-8935-466a-b97f-ccb8f421e345.png)

After:
![image](https://user-images.githubusercontent.com/58845030/136706075-6f3f37f6-bc11-445a-bc65-f5c9435e3963.png)
