### PR TITLE
Add warnings to methods that give access to internal nodes

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -32,12 +32,14 @@
 			<return type="Label" />
 			<description>
 				Returns the label used for built-in text.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="get_ok_button">
 			<return type="Button" />
 			<description>
 				Returns the OK [Button] instance.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="register_text_enter">

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -17,12 +17,14 @@
 			<return type="ColorPicker" />
 			<description>
 				Returns the [ColorPicker] that this node toggles.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="get_popup">
 			<return type="PopupPanel" />
 			<description>
 				Returns the control's [PopupPanel] which allows you to connect to popup signals. This allows you to handle events when the ColorPicker is shown or hidden.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ConfirmationDialog.xml
+++ b/doc/classes/ConfirmationDialog.xml
@@ -22,6 +22,7 @@
 			<return type="Button" />
 			<description>
 				Returns the cancel button.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -26,6 +26,7 @@
 			<return type="VBoxContainer" />
 			<description>
 				Returns the [code]VBoxContainer[/code] used to display the file system.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="invalidate">

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -28,12 +28,14 @@
 			<return type="Control" />
 			<description>
 				Returns the main container of Godot editor's window. For example, you can use it to retrieve the size of the container and place your controls accordingly.
+				[b]Warning:[/b] Removing and freeing this node will render the editor useless and may cause a crash.
 			</description>
 		</method>
 		<method name="get_command_palette" qualifiers="const">
 			<return type="EditorCommandPalette" />
 			<description>
 				Returns the editor's [EditorCommandPalette] instance.
+				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
 		<method name="get_current_path" qualifiers="const">
@@ -53,6 +55,7 @@
 			<description>
 				Returns the main editor control. Use this as a parent for main screens.
 				[b]Note:[/b] This returns the main editor control containing the whole editor, not the 2D or 3D viewports specifically.
+				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
 		<method name="get_editor_paths">
@@ -77,12 +80,14 @@
 			<return type="FileSystemDock" />
 			<description>
 				Returns the editor's [FileSystemDock] instance.
+				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
 		<method name="get_inspector" qualifiers="const">
 			<return type="EditorInspector" />
 			<description>
 				Returns the editor's [EditorInspector] instance.
+				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
 		<method name="get_open_scenes" qualifiers="const">
@@ -113,6 +118,7 @@
 			<return type="ScriptEditor" />
 			<description>
 				Returns the editor's [ScriptEditor] instance.
+				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
 		<method name="get_selected_path" qualifiers="const">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -462,6 +462,7 @@
 			<description>
 				Gets the Editor's dialogue used for making scripts.
 				[b]Note:[/b] Users can configure it before use.
+				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
 		<method name="get_undo_redo">

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -32,12 +32,14 @@
 			<return type="LineEdit" />
 			<description>
 				Returns the LineEdit for the selected file.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="get_vbox">
 			<return type="VBoxContainer" />
 			<description>
 				Returns the vertical box container of the dialog, custom controls can be added to it.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="invalidate">

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -89,8 +89,8 @@
 		<method name="get_zoom_hbox">
 			<return type="HBoxContainer" />
 			<description>
-				Gets the [HBoxContainer] that contains the zooming and grid snap controls in the top left of the graph.
-				Warning: The intended usage of this function is to allow you to reposition or add your own custom controls to the container. This is an internal control and as such should not be freed. If you wish to hide this or any of its children, use their [member CanvasItem.visible] property instead.
+				Gets the [HBoxContainer] that contains the zooming and grid snap controls in the top left of the graph. You can use this method to reposition the toolbar or to add your own custom controls to it.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="is_node_connected">

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -165,6 +165,7 @@
 			<return type="VScrollBar" />
 			<description>
 				Returns the [Object] ID associated with the list.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="is_anything_selected">

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -67,6 +67,7 @@
 			<return type="PopupMenu" />
 			<description>
 				Returns the [PopupMenu] of this [LineEdit]. By default, this menu is displayed when right-clicking on the [LineEdit].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="get_opentype_feature" qualifiers="const">

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -15,6 +15,7 @@
 			<return type="PopupMenu" />
 			<description>
 				Returns the [PopupMenu] contained in this button.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="set_disable_shortcuts">

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -84,6 +84,7 @@
 			<return type="PopupMenu" />
 			<description>
 				Returns the [PopupMenu] contained in this button.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="get_selected_id" qualifiers="const">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -101,6 +101,7 @@
 			<return type="VScrollBar" />
 			<description>
 				Returns the vertical scrollbar.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="get_visible_line_count" qualifiers="const">

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -22,12 +22,14 @@
 			<return type="HScrollBar" />
 			<description>
 				Returns the horizontal scrollbar [HScrollBar] of this [ScrollContainer].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to disable the horizontal scrollbar, use [member scroll_horizontal_enabled]. If you want to only hide it instead, use [member scroll_horizontal_visible].
 			</description>
 		</method>
 		<method name="get_v_scrollbar">
 			<return type="VScrollBar" />
 			<description>
 				Returns the vertical scrollbar [VScrollBar] of this [ScrollContainer].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to disable the vertical scrollbar, use [member scroll_vertical_enabled]. If you want to only hide it instead, use [member scroll_vertical_visible].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -39,6 +39,7 @@
 			<return type="LineEdit" />
 			<description>
 				Returns the [LineEdit] instance from this [SpinBox]. You can use it to access properties and methods of [LineEdit].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -20,6 +20,7 @@
 			<return type="Popup" />
 			<description>
 				Returns the [Popup] node instance if one has been set already with [method set_popup].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="get_previous_tab" qualifiers="const">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -314,6 +314,7 @@
 			<return type="PopupMenu" />
 			<description>
 				Returns the [PopupMenu] of this [TextEdit]. By default, this menu is displayed when right-clicking on the [TextEdit].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="get_minimap_line_at_pos" qualifiers="const">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/53635. I've looked for every method that returns an internal Control- or Window-derivative node and added the same warning to every one of them. Plus a couple of warnings to plugin methods that return some important editor controls.

`GraphEdit` already has a similar warning, but I've rephrased it to be uniform with others. And in case of `ColorPickerButton` — technically removing the picker would only make the button create it again now, but that's an implementation detail and we shouldn't encourage messing with internal controls anyway.