### PR TITLE
[3.x] Ignore OS specific values (constants, project settings, properties)

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1451,6 +1451,7 @@ void _OS::_bind_methods() {
 	// to avoid using values from the documentation writer's own OS instance.
 	ADD_PROPERTY_DEFAULT("clipboard", "");
 	ADD_PROPERTY_DEFAULT("current_screen", 0);
+	ADD_PROPERTY_DEFAULT("tablet_driver", "");
 	ADD_PROPERTY_DEFAULT("exit_code", 0);
 	ADD_PROPERTY_DEFAULT("vsync_enabled", true);
 	ADD_PROPERTY_DEFAULT("vsync_via_compositor", false);

--- a/core/global_constants.cpp
+++ b/core/global_constants.cpp
@@ -38,6 +38,7 @@
 struct _GlobalConstant {
 #ifdef DEBUG_METHODS_ENABLED
 	StringName enum_name;
+	bool ignore_value_in_docs;
 #endif
 	const char *name;
 	int value;
@@ -45,8 +46,9 @@ struct _GlobalConstant {
 	_GlobalConstant() {}
 
 #ifdef DEBUG_METHODS_ENABLED
-	_GlobalConstant(const StringName &p_enum_name, const char *p_name, int p_value) :
+	_GlobalConstant(const StringName &p_enum_name, const char *p_name, int p_value, bool p_ignore_value_in_docs = false) :
 			enum_name(p_enum_name),
+			ignore_value_in_docs(p_ignore_value_in_docs),
 			name(p_name),
 			value(p_value) {
 	}
@@ -71,6 +73,15 @@ static Vector<_GlobalConstant> _global_constants;
 #define BIND_GLOBAL_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant) \
 	_global_constants.push_back(_GlobalConstant(__constant_get_enum_name(m_constant, #m_constant), m_custom_name, m_constant));
 
+#define BIND_GLOBAL_CONSTANT_NO_VAL(m_constant) \
+	_global_constants.push_back(_GlobalConstant(StringName(), #m_constant, m_constant, true));
+
+#define BIND_GLOBAL_ENUM_CONSTANT_NO_VAL(m_constant) \
+	_global_constants.push_back(_GlobalConstant(__constant_get_enum_name(m_constant, #m_constant), #m_constant, m_constant, true));
+
+#define BIND_GLOBAL_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant) \
+	_global_constants.push_back(_GlobalConstant(__constant_get_enum_name(m_constant, #m_constant), m_custom_name, m_constant, true));
+
 #else
 
 #define BIND_GLOBAL_CONSTANT(m_constant) \
@@ -80,6 +91,15 @@ static Vector<_GlobalConstant> _global_constants;
 	_global_constants.push_back(_GlobalConstant(#m_constant, m_constant));
 
 #define BIND_GLOBAL_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant) \
+	_global_constants.push_back(_GlobalConstant(m_custom_name, m_constant));
+
+#define BIND_GLOBAL_CONSTANT_NO_VAL(m_constant) \
+	_global_constants.push_back(_GlobalConstant(#m_constant, m_constant));
+
+#define BIND_GLOBAL_ENUM_CONSTANT_NO_VAL(m_constant) \
+	_global_constants.push_back(_GlobalConstant(#m_constant, m_constant));
+
+#define BIND_GLOBAL_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant) \
 	_global_constants.push_back(_GlobalConstant(m_custom_name, m_constant));
 
 #endif
@@ -369,7 +389,7 @@ void register_global_constants() {
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_ALT);
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_META);
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_CTRL);
-	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_CMD);
+	BIND_GLOBAL_ENUM_CONSTANT_NO_VAL(KEY_MASK_CMD);
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_KPAD);
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_GROUP_SWITCH);
 
@@ -678,9 +698,17 @@ int GlobalConstants::get_global_constant_count() {
 StringName GlobalConstants::get_global_constant_enum(int p_idx) {
 	return _global_constants[p_idx].enum_name;
 }
+
+bool GlobalConstants::get_ignore_value_in_docs(int p_idx) {
+	return _global_constants[p_idx].ignore_value_in_docs;
+}
 #else
 StringName GlobalConstants::get_global_constant_enum(int p_idx) {
 	return StringName();
+}
+
+bool GlobalConstants::get_ignore_value_in_docs(int p_idx) {
+	return false;
 }
 #endif
 

--- a/core/global_constants.h
+++ b/core/global_constants.h
@@ -37,6 +37,7 @@ class GlobalConstants {
 public:
 	static int get_global_constant_count();
 	static StringName get_global_constant_enum(int p_idx);
+	static bool get_ignore_value_in_docs(int p_idx);
 	static const char *get_global_constant_name(int p_idx);
 	static int get_global_constant_value(int p_idx);
 };

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -126,6 +126,22 @@ void ProjectSettings::set_restart_if_changed(const String &p_name, bool p_restar
 	props[p_name].restart_if_changed = p_restart;
 }
 
+void ProjectSettings::set_ignore_value_in_docs(const String &p_name, bool p_ignore) {
+	ERR_FAIL_COND_MSG(!props.has(p_name), "Request for nonexistent project setting: " + p_name + ".");
+#ifdef DEBUG_METHODS_ENABLED
+	props[p_name].ignore_value_in_docs = p_ignore;
+#endif
+}
+
+bool ProjectSettings::get_ignore_value_in_docs(const String &p_name) const {
+	ERR_FAIL_COND_V_MSG(!props.has(p_name), false, "Request for nonexistent project setting: " + p_name + ".");
+#ifdef DEBUG_METHODS_ENABLED
+	return props[p_name].ignore_value_in_docs;
+#else
+	return false;
+#endif
+}
+
 String ProjectSettings::globalize_path(const String &p_path) const {
 	if (p_path.begins_with("res://")) {
 		if (resource_path != "") {
@@ -881,7 +897,7 @@ Variant _GLOBAL_DEF_ALIAS(const String &p_var, const String &p_old_name, const V
 	return _GLOBAL_DEF(p_var, p_default, p_restart_if_changed);
 }
 
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed) {
+Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed, bool p_ignore_value_in_docs) {
 	Variant ret;
 	if (!ProjectSettings::get_singleton()->has_setting(p_var)) {
 		ProjectSettings::get_singleton()->set(p_var, p_default);
@@ -891,6 +907,7 @@ Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restar
 	ProjectSettings::get_singleton()->set_initial_value(p_var, p_default);
 	ProjectSettings::get_singleton()->set_builtin_order(p_var);
 	ProjectSettings::get_singleton()->set_restart_if_changed(p_var, p_restart_if_changed);
+	ProjectSettings::get_singleton()->set_ignore_value_in_docs(p_var, p_ignore_value_in_docs);
 	return ret;
 }
 

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -56,6 +56,10 @@ protected:
 		bool hide_from_editor;
 		bool overridden;
 		bool restart_if_changed;
+#ifdef DEBUG_METHODS_ENABLED
+		bool ignore_value_in_docs = false;
+#endif
+
 		VariantContainer() :
 				order(0),
 				persist(false),
@@ -124,6 +128,9 @@ public:
 
 	void set_initial_value(const String &p_name, const Variant &p_value);
 	void set_restart_if_changed(const String &p_name, bool p_restart);
+	void set_ignore_value_in_docs(const String &p_name, bool p_ignore);
+	bool get_ignore_value_in_docs(const String &p_name) const;
+
 	bool property_can_revert(const String &p_name);
 	Variant property_get_revert(const String &p_name);
 
@@ -163,10 +170,12 @@ public:
 };
 
 //not a macro any longer
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false);
+Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false);
 Variant _GLOBAL_DEF_ALIAS(const String &p_var, const String &p_old_name, const Variant &p_default, bool p_restart_if_changed = false);
 #define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
 #define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
+#define GLOBAL_DEF_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true)
+#define GLOBAL_DEF_RST_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true)
 #define GLOBAL_DEF_ALIAS(m_var, m_old_name, m_value) _GLOBAL_DEF_ALIAS(m_var, m_old_name, m_value)
 #define GLOBAL_DEF_ALIAS_RST(m_var, m_old_name, m_value) _GLOBAL_DEF(m_var, m_old_name, m_value, true)
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get(m_var)

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1100,6 +1100,10 @@ String String::chr(CharType p_char) {
 	return String(c);
 }
 String String::num(double p_num, int p_decimals) {
+	if (Math::is_nan(p_num)) {
+		return "nan";
+	}
+
 #ifndef NO_USE_STDLIB
 
 	if (p_decimals > 16) {
@@ -1388,6 +1392,10 @@ String String::num_real(double p_num) {
 }
 
 String String::num_scientific(double p_num) {
+	if (Math::is_nan(p_num)) {
+		return "nan";
+	}
+
 #ifndef NO_USE_STDLIB
 
 	char buf[256];

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -883,7 +883,7 @@
 		<constant name="KEY_MASK_CTRL" value="268435456" enum="KeyModifierMask">
 			Ctrl key mask.
 		</constant>
-		<constant name="KEY_MASK_CMD" value="268435456" enum="KeyModifierMask">
+		<constant name="KEY_MASK_CMD" value="platform-dependent" enum="KeyModifierMask">
 			Command key mask. On macOS, this is equivalent to [constant KEY_MASK_META]. On other platforms, this is equivalent to [constant KEY_MASK_CTRL]. This mask should be preferred to [constant KEY_MASK_META] or [constant KEY_MASK_CTRL] for system shortcuts as it handles all platforms correctly.
 		</constant>
 		<constant name="KEY_MASK_KPAD" value="536870912" enum="KeyModifierMask">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -257,7 +257,7 @@
 		<member name="audio/default_bus_layout" type="String" setter="" getter="" default="&quot;res://default_bus_layout.tres&quot;">
 			Default [AudioBusLayout] resource file to use in the project, unless overridden by the scene.
 		</member>
-		<member name="audio/driver" type="String" setter="" getter="" default="&quot;PulseAudio&quot;">
+		<member name="audio/driver" type="String" setter="" getter="">
 			Specifies the audio driver to use. This setting is platform-dependent as each platform supports different audio drivers. If left empty, the default audio driver will be used.
 		</member>
 		<member name="audio/enable_audio_input" type="bool" setter="" getter="" default="false">
@@ -488,7 +488,7 @@
 		<member name="display/window/size/width" type="int" setter="" getter="" default="1024">
 			Sets the game's main viewport width. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
 		</member>
-		<member name="display/window/tablet_driver" type="String" setter="" getter="" default="&quot;&quot;">
+		<member name="display/window/tablet_driver" type="String" setter="" getter="">
 			Specifies the tablet driver to use. If left empty, the default driver will be used.
 		</member>
 		<member name="display/window/vsync/use_vsync" type="bool" setter="" getter="" default="true">
@@ -515,7 +515,7 @@
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.
 		</member>
-		<member name="gui/common/swap_ok_cancel" type="bool" setter="" getter="" default="false">
+		<member name="gui/common/swap_ok_cancel" type="bool" setter="" getter="">
 			If [code]true[/code], swaps OK and Cancel buttons in dialogs on Windows and UWP to follow interface conventions.
 		</member>
 		<member name="gui/common/text_edit_undo_stack_max_size" type="int" setter="" getter="" default="1024">

--- a/editor/doc/doc_data.h
+++ b/editor/doc/doc_data.h
@@ -59,6 +59,7 @@ public:
 	struct ConstantDoc {
 		String name;
 		String value;
+		bool is_value_valid;
 		String enumeration;
 		String description;
 	};

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1091,7 +1091,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->_vsync_via_compositor = video_mode.vsync_via_compositor;
 
 	if (tablet_driver == "") { // specified in project.godot
-		tablet_driver = GLOBAL_DEF_RST("display/window/tablet_driver", OS::get_singleton()->get_tablet_driver_name(0));
+		tablet_driver = GLOBAL_DEF_RST_NOVAL("display/window/tablet_driver", OS::get_singleton()->get_tablet_driver_name(0));
 	}
 
 	for (int i = 0; i < OS::get_singleton()->get_tablet_driver_count(); i++) {
@@ -1150,7 +1150,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (audio_driver == "") { // specified in project.godot
-		audio_driver = GLOBAL_DEF_RST("audio/driver", OS::get_singleton()->get_audio_driver_name(0));
+		audio_driver = GLOBAL_DEF_RST_NOVAL("audio/driver", OS::get_singleton()->get_audio_driver_name(0));
 	}
 
 	for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -491,7 +491,7 @@ void register_scene_types() {
 
 #endif
 
-	AcceptDialog::set_swap_ok_cancel(GLOBAL_DEF("gui/common/swap_ok_cancel", bool(OS::get_singleton()->get_swap_ok_cancel())));
+	AcceptDialog::set_swap_ok_cancel(GLOBAL_DEF_NOVAL("gui/common/swap_ok_cancel", bool(OS::get_singleton()->get_swap_ok_cancel())));
 
 	ClassDB::register_class<Shader>();
 	ClassDB::register_class<VisualShader>();


### PR DESCRIPTION
Backport of https://github.com/godotengine/godot/pull/38900.

I'm not sure if `String::num` changes break compat for 3.x, but overall it seems to just work. Please do review carefully, I am not familiar with some of that code.