### PR TITLE
Add physics_override property to TileMap layers

### DIFF
--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -219,6 +219,7 @@ private:
 	struct TileMapLayer {
 		String name;
 		bool enabled = true;
+		int physics_override = -1;
 		bool y_sort_enabled = false;
 		int y_sort_origin = 0;
 		int z_index = 0;
@@ -321,6 +322,8 @@ public:
 	String get_layer_name(int p_layer) const;
 	void set_layer_enabled(int p_layer, bool p_visible);
 	bool is_layer_enabled(int p_layer) const;
+	void set_layer_physics_override(int p_layer, int p_override);
+	int get_layer_physics_override(int p_layer) const;
 	void set_layer_y_sort_enabled(int p_layer, bool p_enabled);
 	bool is_layer_y_sort_enabled(int p_layer) const;
 	void set_layer_y_sort_origin(int p_layer, int p_y_sort_origin);


### PR DESCRIPTION
The remaining part to close https://github.com/godotengine/godot-proposals/issues/3092
This PR adds a "physics override" property to layers. The way it works is that any tile on a layer with override, will use physics properties from the overriding layer. This is useful for fake walls or cheap background objects (you can easily reuse tiles), more friendly than using alternate tiles.

Here's a real life usage (combined with #53636):
![88aqMRwjTm](https://user-images.githubusercontent.com/2223172/136713582-9e6a0f48-d001-4614-8020-3ddf69ff88c1.gif)
Done using a single TileMap and no alternate tiles.

Submitting as draft for now, because it's unfinished (just wanted to show-off this cool GIF lol). I'll also wait until #53636 is merged first, because it's conflicting and less disputable.