### PR TITLE
Remove redundant String operation from GDScript enum exports

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3423,7 +3423,7 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 
 				String enum_hint_string;
 				for (const Map<StringName, int>::Element *E = export_type.enum_values.front(); E; E = E->next()) {
-					enum_hint_string += E->key().operator String().camelcase_to_underscore(true).capitalize().xml_escape();
+					enum_hint_string += E->key().operator String().capitalize().xml_escape();
 					enum_hint_string += ":";
 					enum_hint_string += String::num_int64(E->get()).xml_escape();
 


### PR DESCRIPTION
`capitalize()` already calls `camelcase_to_underscore(true)` first thing, so that call here is redundant. Not sure if it's a major improvement or not, but should save a bit of time 🙃 