### PR TITLE
[3.x] Initialize `uninitMemberVar` with its default value

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -593,7 +593,9 @@ void InputDefault::action_press(const StringName &p_action, float p_strength) {
 	action.physics_frame = Engine::get_singleton()->get_physics_frames();
 	action.idle_frame = Engine::get_singleton()->get_idle_frames();
 	action.pressed = true;
+	action.exact = false;
 	action.strength = p_strength;
+	action.raw_strength = 0.f;
 
 	action_state[p_action] = action;
 }
@@ -604,7 +606,9 @@ void InputDefault::action_release(const StringName &p_action) {
 	action.physics_frame = Engine::get_singleton()->get_physics_frames();
 	action.idle_frame = Engine::get_singleton()->get_idle_frames();
 	action.pressed = false;
+	action.exact = false;
 	action.strength = 0.f;
+	action.raw_strength = 0.f;
 
 	action_state[p_action] = action;
 }

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -324,6 +324,7 @@ MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_
 	MainFrameTime ret;
 
 	ret.idle_step = p_idle_step;
+	ret.interpolation_fraction = 0.0f;
 
 	// simple determination of number of physics iteration
 	time_accum += ret.idle_step;


### PR DESCRIPTION
This revision fixes #52674 in some part, mainly for main directory

For preventing undefined behaviour caused by uninitialized member
variables, initialize some uninitMemberVar with its default value