### PR TITLE
Fixes set_source_id not updating the next automatic source id

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -171,6 +171,8 @@ void TileSet::set_source_id(int p_source_id, int p_new_source_id) {
 	source_ids.append(p_new_source_id);
 	source_ids.sort();
 
+	_compute_next_source_id();
+
 	emit_changed();
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes https://github.com/godotengine/godot/issues/53624
