### PR TITLE
Fix Camera3D::get_pyramid_shape_rid() crash when not in scene

### DIFF
--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -656,6 +656,7 @@ Vector3 Camera3D::get_doppler_tracked_velocity() const {
 }
 
 RID Camera3D::get_pyramid_shape_rid() {
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), RID(), "Camera is not inside scene.");
 	if (pyramid_shape == RID()) {
 		pyramid_shape_points = get_near_plane_points();
 		pyramid_shape = PhysicsServer3D::get_singleton()->convex_polygon_shape_create();


### PR DESCRIPTION
Fixes #53564

Since `get_near_plane_points()` depends on the size of the viewport, `get_pyramid_shape_rid()` potentially constructs an invalid set of points, so hopefully this is the optimal solution.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
