### PR TITLE
Show a warning toast when saving a large text-based scene

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -853,6 +853,10 @@
 			If [code]true[/code], when saving a file, the editor will rename the old file to a different name, save a new file, then only remove the old file once the new file has been saved. This makes loss of data less likely to happen if the editor or operating system exits unexpectedly while saving (e.g. due to a crash or power outage).
 			[b]Note:[/b] On Windows, this feature can interact negatively with certain antivirus programs. In this case, you may have to set this to [code]false[/code] to prevent file locking issues.
 		</member>
+		<member name="filesystem/on_save/warn_on_saving_large_text_resources" type="bool" setter="" getter="">
+			If [code]true[/code], displays a warning toast message when saving a text-based scene or resource that is larger than 500 KiB on disk. This is typically caused by binary subresources being embedded as text, which results in slow and inefficient conversion to text. This in turn impacts scene saving and loading times.
+			This should usually be resolved by moving the embedded binary subresource to its own binary resource file ([code].res[/code] extension instead of [code].tres[/code]). This is the preferred approach. Alternatively, the entire scene can be saved with the binary [code].scn[/code] format as opposed to [code].tscn[/code], but this will make it less friendly to version control systems.
+		</member>
 		<member name="filesystem/quick_open_dialog/default_display_mode" type="int" setter="" getter="">
 			If set to [code]Adaptive[/code], the dialog opens in list view or grid view depending on the requested type. If set to [code]Last Used[/code], the display mode will always open the way you last used it.
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -653,6 +653,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// On save
 	_initial_set("filesystem/on_save/compress_binary_resources", true);
 	_initial_set("filesystem/on_save/safe_save_on_backup_then_rename", true);
+	_initial_set("filesystem/on_save/warn_on_saving_large_text_resources", true);
 
 	// EditorFileServer
 	_initial_set("filesystem/file_server/port", 6010);


### PR DESCRIPTION
Text-based scenes that contain large amounts of Base64-encoded binary data are slower to save and load. Their binary resources should be moved to separate files, or the binary `.scn` format should be used instead.

The size threshold is defined at 500 KB. It's technically possible for a text-based scene with no embedded binary data to be larger than that, but it's unlikely.

This closes https://github.com/godotengine/godot/issues/29381 and closes https://github.com/godotengine/godot/issues/33379. See also https://github.com/godotengine/godot/issues/50029.

**Testing project:** [test_voxelgi.zip](https://github.com/godotengine/godot/files/7323822/test_voxelgi.zip)

## Preview

![image](https://github.com/godotengine/godot/assets/180032/61d6ab67-edac-49ec-8add-6a3f7d6176f8)

## TODO

- [ ] ~~Only display this warning dialog once per saved scene in an editor session.~~
  - Skipped for now, as we now have a project setting to disable the warning.
- [x] Make this warning disableable in the Project Settings in case a large text-based scene is actually needed.
  - This is in the Project Settings so that all team members automatically have the warning disabled if desired.