### PR TITLE
Implement on-the-spot IME support for X11

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -4565,6 +4565,12 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 			// because it triggers some event polling internally.
 			MutexLock mutex_lock(events_mutex);
 
+			// Force on-the-spot for the over-the-spot style.
+			if ((xim_style & XIMPreeditPosition) != 0) {
+				xim_style &= ~XIMPreeditPosition;
+				xim_style |= XIMPreeditCallbacks;
+			}
+
 			if ((xim_style & XIMPreeditCallbacks) != 0) {
 				::XIMCallback preedit_start_callback;
 				preedit_start_callback.client_data = (::XPointer)(this);
@@ -4696,7 +4702,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 }
 
 static bool _is_xim_style_supported(const ::XIMStyle &p_style) {
-	const ::XIMStyle supported_preedit = XIMPreeditCallbacks | XIMPreeditNothing | XIMPreeditNone;
+	const ::XIMStyle supported_preedit = XIMPreeditCallbacks | XIMPreeditPosition | XIMPreeditNothing | XIMPreeditNone;
 	const ::XIMStyle supported_status = XIMStatusNothing | XIMStatusNone;
 
 	// Check preedit style is supported

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -159,6 +159,9 @@ class DisplayServerX11 : public DisplayServer {
 		unsigned int focus_order = 0;
 	};
 
+	Point2i im_selection;
+	String im_text;
+
 	HashMap<WindowID, WindowData> windows;
 
 	unsigned int last_mouse_monitor_mask = 0;
@@ -182,6 +185,14 @@ class DisplayServerX11 : public DisplayServer {
 	::Time last_keyrelease_time = 0;
 	::XIM xim;
 	::XIMStyle xim_style;
+	static int _xim_preedit_start_callback(::XIM xim, ::XPointer client_data,
+			::XPointer call_data);
+	static void _xim_preedit_done_callback(::XIM xim, ::XPointer client_data,
+			::XPointer call_data);
+	static void _xim_preedit_draw_callback(::XIM xim, ::XPointer client_data,
+			::XIMPreeditDrawCallbackStruct *call_data);
+	static void _xim_preedit_caret_callback(::XIM xim, ::XPointer client_data,
+			::XIMPreeditCaretCallbackStruct *call_data);
 	static void _xim_destroy_callback(::XIM im, ::XPointer client_data,
 			::XPointer call_data);
 
@@ -404,6 +415,9 @@ public:
 
 	virtual void window_set_ime_active(const bool p_active, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_ime_position(const Point2i &p_pos, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual Point2i ime_get_selection() const override;
+	virtual String ime_get_text() const override;
 
 	virtual void window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_vsync_mode) const override;


### PR DESCRIPTION
Implements the linux part of #53658

Currently the area with the options is rendered in the wrong position:
![image](https://user-images.githubusercontent.com/3903059/136812913-5632c392-683f-4ea3-9535-5db133f7b352.png)
