### PR TITLE
Use sqlerp.

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -178,10 +178,9 @@ Quaternion Quaternion::cubic_slerp(const Quaternion &p_b, const Quaternion &p_pr
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quaternion(), "The start quaternion must be normalized.");
 	ERR_FAIL_COND_V_MSG(!p_b.is_normalized(), Quaternion(), "The end quaternion must be normalized.");
 #endif
-	//the only way to do slerp :|
 	real_t t2 = (1.0 - p_weight) * p_weight * 2;
-	Quaternion sp = this->slerp(p_b, p_weight);
-	Quaternion sq = p_pre_a.slerpni(p_post_b, p_weight);
+	Quaternion sp = p_pre_a.slerp(p_post_b, p_weight);
+	Quaternion sq = this->slerpni(p_b, p_weight);
 	return sp.slerpni(sq, t2);
 }
 


### PR DESCRIPTION
See Github KhronosGroup/glTF pr number 2018

## CUBICSLERP Interpolation

This form of rotation animation matches the de facto industry standard of animating rotations via spherical cubic interpolation ("sqlerp()", originally from Shoemake (1985).

The keyframes of a spherical cubic spline in glTF have input and output values where each input value corresponds to three output values (all unit quaternions): in-tangent, key-value, and out-tangent.

Given a set of keyframes

&nbsp;&nbsp;&nbsp;&nbsp;Input *t*<sub>*k*</sub> with Output in-tangent ***a***<sub>k</sub>, point ***v***<sub>*k*</sub>, and out-tangent ***b***<sub>k</sub> for *k* = 1,...,*n*

a spherical spline segment between two keyframes (k and k+1) is represented in a spherical cubic spline form:

&nbsp;&nbsp;&nbsp;&nbsp;***q***<sub>k</sub>(*t*) = ***sqlerp***(***v***<sub>k</sub>, ***b***<sub>k</sub>, ***a***<sub>k+1</sub>, ***v***<sub>k+1</sub>, *t*)


where

&nbsp;&nbsp;&nbsp;&nbsp;*t* is a value between 0 and 1  
&nbsp;&nbsp;&nbsp;&nbsp;***sqlerp***(***A***,***B***,***C***,***D***,*t*) = ***slerp***( ***slerp***(***A***,***D***,*t*), ***slerp***(***B***,***C***,*t*), 2*t - 2*t<sup>2</sup> )  
&nbsp;&nbsp;&nbsp;&nbsp;***slerp***() is spherical linear interpolation between two unit quaternions  
&nbsp;&nbsp;&nbsp;&nbsp;***q***(*t*) is the resulting unit quaternion value  

and where at input offset *t*<sub>*current*</sub> with keyframe index *k*

&nbsp;&nbsp;&nbsp;&nbsp;*t* = (*t*<sub>*current*</sub> - *t*<sub>*k*</sub>) / (*t*<sub>*k*+1</sub> - *t*<sub>*k*</sub>)  

> **Implementation Note:** The first in-tangent ***a***<sub>1</sub> and last out-tangent ***b***<sub>*n*</sub> should be zeros as they are not used in the spherical spline calculations.

## References

* Shoemake, Ken (1985):  Animating rotation with quaternion curves.  ACM SIGGRAPH Computer Graphics 19 (3), 245-254.<a name=Shoemake1985></a>

## PR

The interpolation goes backwards.

According to the equation above Godot Engine is currently doing slerp( slerp(B,C,t), slerp(A,D,t), 2t - 2t2 ).

Should be sqlerp(A,B,C,D,t) = slerp( slerp(A,D,t), slerp(B,C,t), 2t - 2t2 ).

Fixes https://github.com/godotengine/godot/issues/40592.

Uses [godot_animation_bug.zip](https://github.com/godotengine/godot/files/7326526/godot_animation_bug.zip)

Current master on https://github.com/godotengine/godot/commit/f9aec342dcd51d65c5970dd395e3c7a66cac446c

Edited to match the same loop settings.

https://user-images.githubusercontent.com/32321/136883690-b1887ace-84ba-48b5-a72b-2b446021f582.mp4


This branch quat-sqlerp.

https://user-images.githubusercontent.com/32321/136882825-92869033-ba13-452f-ae13-e1bf5436cea3.mp4



