### PR TITLE
String format `inf`, `nan` values to uppercase

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1380,14 +1380,14 @@ String String::chr(char32_t p_char) {
 
 String String::num(double p_num, int p_decimals) {
 	if (Math::is_nan(p_num)) {
-		return "nan";
+		return "NAN";
 	}
 
 	if (Math::is_inf(p_num)) {
 		if (signbit(p_num)) {
-			return "-inf";
+			return "-INF";
 		} else {
-			return "inf";
+			return "INF";
 		}
 	}
 
@@ -1533,14 +1533,14 @@ String String::num_uint64(uint64_t p_num, int base, bool capitalize_hex) {
 
 String String::num_real(double p_num, bool p_trailing) {
 	if (Math::is_nan(p_num)) {
-		return "nan";
+		return "NAN";
 	}
 
 	if (Math::is_inf(p_num)) {
 		if (signbit(p_num)) {
-			return "-inf";
+			return "-INF";
 		} else {
-			return "inf";
+			return "INF";
 		}
 	}
 
@@ -1645,14 +1645,14 @@ String String::num_real(double p_num, bool p_trailing) {
 
 String String::num_scientific(double p_num) {
 	if (Math::is_nan(p_num)) {
-		return "nan";
+		return "NAN";
 	}
 
 	if (Math::is_inf(p_num)) {
 		if (signbit(p_num)) {
-			return "-inf";
+			return "-INF";
 		} else {
-			return "inf";
+			return "INF";
 		}
 	}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
This change should make any display of `inf`, `nan` values align with the capitalization of GDScript constants `INF`, `NAN`. Resolves the issue where you type "INF" as a float value in the inspector, it displays as "inf", but "inf" is not an allowable input expression.

I've scanned for all usage of `String::num`, `String::num_real` and `String::num_scientific` within the engine, and I believe this should not cause any breakage.

Should resolve https://github.com/godotengine/godot-proposals/issues/3390 and https://github.com/godotengine/godot-proposals/issues/3398

---

There are alternative solutions to the specific problem mentioned if this is deemed too far reaching. It's possible to allow Expression to interpret lowercase "inf"/"nan" values, or to add special cases to format inf/nan to uppercase in the inspector implementation.