### PR TITLE
Allow Expression to parse lowercase inf, nan

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -398,7 +398,13 @@ Error Expression::_get_token(Token &r_token) {
 					} else if (id == "INF") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = INFINITY;
+					} else if (id == "inf") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = INFINITY;
 					} else if (id == "NAN") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = NAN;
+					} else if (id == "nan") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = NAN;
 					} else if (id == "not") {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Alternative implementation to #53698. This is far less likely to break anything and seems more proper.

Resolves the issue where you type "INF" as a float value in the inspector, it displays as "inf", but "inf" is not an allowable input expression.