### PR TITLE
Added primary clipboard for Linux

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -13,11 +13,26 @@
 				Returns the user's clipboard as a string if possible.
 			</description>
 		</method>
+		<method name="clipboard_get_primary" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the user's primary clipboard as a string if possible.
+				[b]Note:[/b] This method is only implemented on Linux.
+			</description>
+		</method>
 		<method name="clipboard_set">
 			<return type="void" />
 			<argument index="0" name="clipboard" type="String" />
 			<description>
 				Sets the user's clipboard content to the given string.
+			</description>
+		</method>
+		<method name="clipboard_set_primary">
+			<return type="void" />
+			<argument index="0" name="clipboard_primary" type="String" />
+			<description>
+				Sets the user's primary clipboard content to the given string.
+				[b]Note:[/b] This method is only implemented on Linux.
 			</description>
 		</method>
 		<method name="console_set_visible">

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -221,6 +221,10 @@
 			[/csharp]
 			[/codeblocks]
 		</member>
+		<member name="middle_mouse_paste_enabled" type="bool" setter="set_middle_mouse_paste_enabled" getter="is_middle_mouse_paste_enabled" default="true">
+			If [code]false[/code], using middle mouse button to paste clipboard will be disabled.
+			[b]Note:[/b] This method is only implemented on Linux.
+		</member>
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
 		<member name="placeholder_alpha" type="float" setter="set_placeholder_alpha" getter="get_placeholder_alpha" default="0.6">
 			Opacity of the [member placeholder_text]. From [code]0[/code] to [code]1[/code].

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -41,6 +41,13 @@
 				Override this method to define what happens when the user performs a paste operation.
 			</description>
 		</method>
+		<method name="_paste_primary_clipboard" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Override this method to define what happens when the user performs a paste operation with middle mouse button.
+				[b]Note:[/b] This method is only implemented on Linux.
+			</description>
+		</method>
 		<method name="add_gutter">
 			<return type="void" />
 			<argument index="0" name="at" type="int" default="-1" />
@@ -935,6 +942,10 @@
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
+		</member>
+		<member name="middle_mouse_paste_enabled" type="bool" setter="set_middle_mouse_paste_enabled" getter="is_middle_mouse_paste_enabled" default="true">
+			If [code]false[/code], using middle mouse button to paste clipboard will be disabled.
+			[b]Note:[/b] This method is only implemented on Linux.
 		</member>
 		<member name="minimap_draw" type="bool" setter="set_draw_minimap" getter="is_drawing_minimap" default="false">
 			If [code]true[/code], a minimap is shown, providing an outline of your source code.

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -155,6 +155,7 @@ class DisplayServerX11 : public DisplayServer {
 	WindowID _create_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect);
 
 	String internal_clipboard;
+	String internal_clipboard_primary;
 	Window xdnd_source_window;
 	::Display *x11_display;
 	char *xmbstring;
@@ -205,7 +206,7 @@ class DisplayServerX11 : public DisplayServer {
 
 	void _handle_key_event(WindowID p_window, XKeyEvent *p_event, LocalVector<XEvent> &p_events, uint32_t &p_event_index, bool p_echo = false);
 
-	Atom _process_selection_request_target(Atom p_target, Window p_requestor, Atom p_property) const;
+	Atom _process_selection_request_target(Atom p_target, Window p_requestor, Atom p_property, Atom p_selection) const;
 	void _handle_selection_request_event(XSelectionRequestEvent *p_event) const;
 
 	String _clipboard_get_impl(Atom p_source, Window x11_window, Atom target) const;
@@ -290,6 +291,8 @@ public:
 
 	virtual void clipboard_set(const String &p_text) override;
 	virtual String clipboard_get() const override;
+	virtual void clipboard_set_primary(const String &p_text) override;
+	virtual String clipboard_get_primary() const override;
 
 	virtual int get_screen_count() const override;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -126,6 +126,8 @@ private:
 
 	bool virtual_keyboard_enabled = true;
 
+	bool middle_mouse_paste_enabled = true;
+
 	Ref<Texture2D> right_icon;
 
 	struct Selection {
@@ -317,6 +319,9 @@ public:
 
 	void set_virtual_keyboard_enabled(bool p_enable);
 	bool is_virtual_keyboard_enabled() const;
+
+	void set_middle_mouse_paste_enabled(bool p_enabled);
+	bool is_middle_mouse_paste_enabled() const;
 
 	void set_selecting_enabled(bool p_enabled);
 	bool is_selecting_enabled() const;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1596,12 +1596,16 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 							selection.to_char = words[i + 1];
 
 							selection.active = true;
+							DisplayServer::get_singleton()->clipboard_set_primary(get_selected_text());
 							update();
 							break;
 						}
 					}
 				}
 			} else if (!b->is_pressed()) {
+				if (selection.enabled) {
+					DisplayServer::get_singleton()->clipboard_set_primary(get_selected_text());
+				}
 				selection.click_item = nullptr;
 
 				if (!b->is_double_click() && !scroll_updated) {
@@ -1719,6 +1723,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 					swap = true;
 				} else if (selection.from_char == selection.to_char) {
 					selection.active = false;
+					update();
 					return;
 				}
 			}

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -269,6 +269,7 @@ private:
 	bool context_menu_enabled = true;
 	bool shortcut_keys_enabled = true;
 	bool virtual_keyboard_enabled = true;
+	bool middle_mouse_paste_enabled = true;
 
 	// Overridable actions
 	String cut_copy_line = "";
@@ -586,12 +587,14 @@ protected:
 	virtual void _cut_internal();
 	virtual void _copy_internal();
 	virtual void _paste_internal();
+	virtual void _paste_primary_clipboard_internal();
 
 	GDVIRTUAL1(_handle_unicode_input, int)
 	GDVIRTUAL0(_backspace)
 	GDVIRTUAL0(_cut)
 	GDVIRTUAL0(_copy)
 	GDVIRTUAL0(_paste)
+	GDVIRTUAL0(_paste_primary_clipboard)
 
 public:
 	/* General overrides. */
@@ -640,6 +643,9 @@ public:
 	void set_virtual_keyboard_enabled(bool p_enabled);
 	bool is_virtual_keyboard_enabled() const;
 
+	void set_middle_mouse_paste_enabled(bool p_enabled);
+	bool is_middle_mouse_paste_enabled() const;
+
 	// Text manipulation
 	void clear();
 
@@ -674,6 +680,7 @@ public:
 	void cut();
 	void copy();
 	void paste();
+	void paste_primary_clipboard();
 
 	// Context menu.
 	PopupMenu *get_menu() const;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -159,6 +159,14 @@ String DisplayServer::clipboard_get() const {
 	ERR_FAIL_V_MSG(String(), "Clipboard is not supported by this display server.");
 }
 
+void DisplayServer::clipboard_set_primary(const String &p_text) {
+	WARN_PRINT("Primary clipboard is not supported by this display server.");
+}
+
+String DisplayServer::clipboard_get_primary() const {
+	ERR_FAIL_V_MSG(String(), "Primary clipboard is not supported by this display server.");
+}
+
 void DisplayServer::screen_set_orientation(ScreenOrientation p_orientation, int p_screen) {
 	WARN_PRINT("Orientation not supported by this display server.");
 }
@@ -360,6 +368,8 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("clipboard_set", "clipboard"), &DisplayServer::clipboard_set);
 	ClassDB::bind_method(D_METHOD("clipboard_get"), &DisplayServer::clipboard_get);
+	ClassDB::bind_method(D_METHOD("clipboard_set_primary", "clipboard_primary"), &DisplayServer::clipboard_set_primary);
+	ClassDB::bind_method(D_METHOD("clipboard_get_primary"), &DisplayServer::clipboard_get_primary);
 
 	ClassDB::bind_method(D_METHOD("get_screen_count"), &DisplayServer::get_screen_count);
 	ClassDB::bind_method(D_METHOD("screen_get_position", "screen"), &DisplayServer::screen_get_position, DEFVAL(SCREEN_OF_MAIN_WINDOW));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -161,6 +161,8 @@ public:
 
 	virtual void clipboard_set(const String &p_text);
 	virtual String clipboard_get() const;
+	virtual void clipboard_set_primary(const String &p_text);
+	virtual String clipboard_get_primary() const;
 
 	enum {
 		SCREEN_OF_MAIN_WINDOW = -1


### PR DESCRIPTION
This commit add support for primary clipboard on Linux to handle text paste with middle mouse button.
It should solve [https://github.com/godotengine/godot/issues/3030](https://github.com/godotengine/godot/issues/3030)

This is based on code originally written by @Larpon, I fixed some bugs, added small improvements and updated the code to make it work with current master branch.

*Bugsquad edit:* Fixes https://github.com/godotengine/godot-proposals/issues/3440.