### PR TITLE
Prevent tiles outside atlas texture

### DIFF
--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -15,12 +15,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="clear_tiles_outside_texture">
-			<return type="void" />
-			<description>
-				Clears all tiles that are defined outside the texture boundaries.
-			</description>
-		</method>
 		<method name="create_alternative_tile">
 			<return type="int" />
 			<argument index="0" name="atlas_coords" type="Vector2i" />
@@ -124,6 +118,16 @@
 				Returns a tile's texture region in the atlas texture. For animated tiles, a [code]frame[/code] argument might be provided for the different frames of the animation.
 			</description>
 		</method>
+		<method name="get_tiles_to_be_removed_on_change">
+			<return type="PackedVector2Array" />
+			<argument index="0" name="texture" type="Texture2D" />
+			<argument index="1" name="margins" type="Vector2i" />
+			<argument index="2" name="separation" type="Vector2i" />
+			<argument index="3" name="texture_region_size" type="Vector2i" />
+			<description>
+				Returns an array of tiles coordinates ID that will be automatically removed when modifying one or several of those properties: [code]texture[/code], [code]margins[/code], [code]separation[/code] or [code]texture_region_size[/code]. This can be used to undo changes that would have caused tiles data loss.
+			</description>
+		</method>
 		<method name="has_room_for_tile" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="atlas_coords" type="Vector2i" />
@@ -134,12 +138,6 @@
 			<argument index="5" name="ignored_tile" type="Vector2i" default="Vector2i(-1, -1)" />
 			<description>
 				Returns whether there is enough room in an atlas to create/modify a tile with the given properties. If [code]ignored_tile[/code] is provided, act as is the given tile was not present in the atlas. This may be used when you want to modify a tile's properties.
-			</description>
-		</method>
-		<method name="has_tiles_outside_texture">
-			<return type="bool" />
-			<description>
-				Returns if this atlas has tiles outside of its texture.
 			</description>
 		</method>
 		<method name="move_tile_in_atlas">

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -93,9 +93,6 @@ private:
 	Control *base_tiles_shape_grid;
 	void _draw_base_tiles_shape_grid();
 
-	Control *base_tiles_dark;
-	void _draw_base_tiles_dark();
-
 	Size2i _compute_base_tiles_control_size();
 
 	// Right side.
@@ -124,7 +121,6 @@ public:
 
 	// Left side.
 	void set_texture_grid_visible(bool p_visible) { base_tiles_texture_grid->set_visible(p_visible); };
-	void set_dark_visible(bool p_visible) { base_tiles_dark->set_visible(p_visible); };
 	void set_tile_shape_grid_visible(bool p_visible) { base_tiles_shape_grid->set_visible(p_visible); };
 
 	Vector2i get_atlas_tile_coords_at_pos(const Vector2 p_pos) const;

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -78,6 +78,7 @@ private:
 		int get_id();
 
 		void edit(Ref<TileSet> p_tile_set, TileSetAtlasSource *p_tile_set_atlas_source, int p_source_id);
+		TileSetAtlasSource *get_edited() { return tile_set_atlas_source; };
 	};
 
 	// -- Proxy object for a tile, needed by the inspector --
@@ -189,7 +190,6 @@ private:
 		TILE_CREATE_ALTERNATIVE,
 		TILE_DELETE,
 
-		ADVANCED_CLEANUP_TILES_OUTSIDE_TEXTURE,
 		ADVANCED_AUTO_CREATE_TILES,
 		ADVANCED_AUTO_REMOVE_TILES,
 	};

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -479,8 +479,10 @@ private:
 
 	void _compute_next_alternative_id(const Vector2i p_atlas_coords);
 
-	void _create_coords_mapping_cache(Vector2i p_atlas_coords);
 	void _clear_coords_mapping_cache(Vector2i p_atlas_coords);
+	void _create_coords_mapping_cache(Vector2i p_atlas_coords);
+
+	void _clear_tiles_outside_texture();
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -534,7 +536,7 @@ public:
 	virtual Vector2i get_tile_id(int p_index) const override;
 
 	bool has_room_for_tile(Vector2i p_atlas_coords, Vector2i p_size, int p_animation_columns, Vector2i p_animation_separation, int p_frames_count, Vector2i p_ignored_tile = INVALID_ATLAS_COORDS) const;
-
+	PackedVector2Array get_tiles_to_be_removed_on_change(Ref<Texture2D> p_texture, Vector2i p_margins, Vector2i p_separation, Vector2i p_texture_region_size);
 	Vector2i get_tile_at_coords(Vector2i p_atlas_coords) const;
 
 	// Animation.
@@ -565,8 +567,6 @@ public:
 
 	// Helpers.
 	Vector2i get_atlas_grid_size() const;
-	bool has_tiles_outside_texture();
-	void clear_tiles_outside_texture();
 	Rect2i get_tile_texture_region(Vector2i p_atlas_coords, int p_frame = 0) const;
 	Vector2i get_tile_effective_texture_offset(Vector2i p_atlas_coords, int p_alternative_tile) const;
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
In the current implementation on master, it was not possible to create tiles outside an atlas texture. However, if you reduced the size of the atlas, the tiles lying outside the texture were kept. This caused several issues, one of the main one being the fact it was impossible to undo a texture change correctly, as the API would not let you create the tile outside the texture again.

This fixes the problem by removing all tiles outside the texture when a change leads to such situation, but re-create them when undoing the changes.

~~This is marked as draft for now as I needs some changes in the UndoRedo class to fix some bugs.~~ Edit: fixed.

Fixes: https://github.com/godotengine/godot/issues/51279