### PR TITLE
[GDScript] Implement RPC custom callable (`my_func.rpc()`)

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -43,6 +43,7 @@
 #include "gdscript_cache.h"
 #include "gdscript_compiler.h"
 #include "gdscript_parser.h"
+#include "gdscript_rpc_callable.h"
 #include "gdscript_warning.h"
 
 #ifdef TESTS_ENABLED
@@ -1375,7 +1376,13 @@ bool GDScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 			while (sl) {
 				const Map<StringName, GDScriptFunction *>::Element *E = sl->member_functions.find(p_name);
 				if (E) {
-					r_ret = Callable(this->owner, E->key());
+					Multiplayer::RPCConfig config;
+					config.name = p_name;
+					if (sptr->rpc_functions.find(config) != -1) {
+						r_ret = Callable(memnew(GDScriptRPCCallable(this->owner, E->key())));
+					} else {
+						r_ret = Callable(this->owner, E->key());
+					}
 					return true; //index found
 				}
 				sl = sl->_base;

--- a/modules/gdscript/gdscript_rpc_callable.cpp
+++ b/modules/gdscript/gdscript_rpc_callable.cpp
@@ -1,0 +1,80 @@
+/*************************************************************************/
+/*  gdscript_rpc_callable.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_rpc_callable.h"
+
+#include "core/templates/hashfuncs.h"
+#include "scene/main/node.h"
+
+bool GDScriptRPCCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
+	return p_a->hash() == p_b->hash();
+}
+
+bool GDScriptRPCCallable::compare_less(const CallableCustom *p_a, const CallableCustom *p_b) {
+	return p_a->hash() < p_b->hash();
+}
+
+uint32_t GDScriptRPCCallable::hash() const {
+	return h;
+}
+
+String GDScriptRPCCallable::get_as_text() const {
+	String class_name = node->get_class();
+	Ref<Script> script = node->get_script();
+	return class_name + "(" + script->get_path().get_file() + ")::" + String(method) + " (rpc)";
+}
+
+CallableCustom::CompareEqualFunc GDScriptRPCCallable::get_compare_equal_func() const {
+	return compare_equal;
+}
+
+CallableCustom::CompareLessFunc GDScriptRPCCallable::get_compare_less_func() const {
+	return compare_less;
+}
+
+ObjectID GDScriptRPCCallable::get_object() const {
+	return node->get_instance_id();
+}
+
+void GDScriptRPCCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	r_return_value = node->call(method, p_arguments, p_argcount, r_call_error);
+}
+
+GDScriptRPCCallable::GDScriptRPCCallable(Object *p_node, const StringName &p_method) {
+	node = Object::cast_to<Node>(p_node);
+	method = p_method;
+	h = method.hash();
+	h = hash_djb2_one_64(node->get_instance_id(), h);
+}
+
+void GDScriptRPCCallable::rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const {
+	r_call_error.error = Callable::CallError::CALL_OK;
+	node->rpcp(p_peer_id, method, p_arguments, p_argcount);
+}

--- a/modules/gdscript/gdscript_rpc_callable.h
+++ b/modules/gdscript/gdscript_rpc_callable.h
@@ -1,0 +1,60 @@
+/*************************************************************************/
+/*  gdscript_rpc_callable.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_RPC_CALLABLE
+#define GDSCRIPT_RPC_CALLABLE
+
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+class Node;
+
+class GDScriptRPCCallable : public CallableCustom {
+	Node *node = nullptr;
+	StringName method;
+	uint32_t h = 0;
+
+	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
+	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
+
+public:
+	uint32_t hash() const override;
+	String get_as_text() const override;
+	CompareEqualFunc get_compare_equal_func() const override;
+	CompareLessFunc get_compare_less_func() const override;
+	ObjectID get_object() const override;
+	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
+	void rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const override;
+
+	GDScriptRPCCallable(Object *p_node, const StringName &p_method);
+	virtual ~GDScriptRPCCallable() = default;
+};
+
+#endif // GDSCRIPT_RPC_CALLABLE

--- a/modules/gdscript/gdscript_rpc_callable.h
+++ b/modules/gdscript/gdscript_rpc_callable.h
@@ -37,6 +37,7 @@
 class Node;
 
 class GDScriptRPCCallable : public CallableCustom {
+	Object *object = nullptr;
 	Node *node = nullptr;
 	StringName method;
 	uint32_t h = 0;
@@ -53,7 +54,7 @@ public:
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	void rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const override;
 
-	GDScriptRPCCallable(Object *p_node, const StringName &p_method);
+	GDScriptRPCCallable(Object *p_object, const StringName &p_method);
 	virtual ~GDScriptRPCCallable() = default;
 };
 


### PR DESCRIPTION
So we can call: `my_func.rpc()` and `my_func.rpc_id(id)` from GDScript.

Also added a check to ensure the object is actually a `Node` and error out when calling `rpc` on it..
I implemented the check inside the custom callable, instead of where it gets created created, not sure if you prefer it in the `GDScriptInstance::get` instead @vnen .