### PR TITLE
Fixed editor attempting to save a blank scene with save all scenes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1776,19 +1776,25 @@ void EditorNode::restart_editor() {
 }
 
 void EditorNode::_save_all_scenes() {
+	bool all_saved = true;
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		Node *scene = editor_data.get_edited_scene_root(i);
-		if (scene && scene->get_scene_file_path() != "" && DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
-			if (i != editor_data.get_edited_scene()) {
-				_save_scene(scene->get_scene_file_path(), i);
+		if (scene) {
+			if (scene->get_scene_file_path() != "" && DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
+				if (i != editor_data.get_edited_scene()) {
+					_save_scene(scene->get_scene_file_path(), i);
+				} else {
+					_save_scene_with_preview(scene->get_scene_file_path());
+				}
 			} else {
-				_save_scene_with_preview(scene->get_scene_file_path());
+				all_saved = false;
 			}
-		} else {
-			show_warning(TTR("Could not save one or more scenes!"), TTR("Save All Scenes"));
 		}
 	}
 
+	if (!all_saved) {
+		show_warning(TTR("Could not save one or more scenes!"), TTR("Save All Scenes"));
+	}
 	_save_default_environment();
 }
 


### PR DESCRIPTION
Fix #53668

Bug was caused by checking the scene exists in the same if statement as checking if it is valid to be saved.

Fixed by skipping if the scene doesn't exist as an object.