### PR TITLE
Fetch GDExtension class property lists from `ClassDB` in `Object::get_property_list`

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -628,7 +628,10 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 		script_instance->get_property_list(p_list);
 	}
 
-	_get_property_listv(p_list, p_reversed);
+	if (_extension) {
+		p_list->push_back(PropertyInfo(Variant::NIL, _extension->class_name, PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
+		ClassDB::get_property_list(_extension->class_name, p_list, true, this);
+	}
 
 	if (_extension && _extension->get_property_list) {
 		uint32_t pcount;
@@ -640,6 +643,8 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 			_extension->free_property_list(_extension_instance, pinfo);
 		}
 	}
+
+	_get_property_listv(p_list, p_reversed);
 
 	if (!is_class("Script")) { // can still be set, but this is for user-friendliness
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));


### PR DESCRIPTION
This is related to https://github.com/godotengine/godot-cpp/issues/614 where properties registered using `ClassDB::add_property` would not show up in the inspector. This is due to the fact that `Object::get_property_list` only checks for the property list of an extension class registered with `GDNativeExtensionClassCreationInfo::get_property_list_func` but does not search `ClassDB` directly for properties registered on the extension class name with `GDNativeInterface::classdb_register_extension_class_property` .

This especially caused problems with the C++ bindings since they exlcusively rely on `ClassDB` to register extension class properties.

**I mainly implemented this as a quick fix for a personal GDExtension project I'm working on and I am in no way experienced with the GDNative implementation so this fix might not be optimal.** Even if it's a bad fix, maybe it'll help in finding a better solution.

Example:
* Register extension class property using the C++ bindings as follows:
```C++
void HoloPlayVolume::_bind_methods() {
    ...
    ADD_PROPERTY(PropertyInfo(Variant::INT, "device_index"), "set_device_index", "get_device_index");
}
```

Before:
![Unbenannt2](https://user-images.githubusercontent.com/31868812/136952614-082fd61b-9f10-4b9c-86cf-5e3a043cba02.PNG)
After:
![Unbenannt](https://user-images.githubusercontent.com/31868812/136952611-90ee8aa1-883b-4a7f-8740-ad540c413067.PNG)


