### PR TITLE
Add a way to force undo/redo operations to be kept in MERGE_ENDS mode

### DIFF
--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -61,6 +61,7 @@ private:
 		};
 
 		Type type;
+		bool force_keep_in_merge_ends;
 		Ref<RefCounted> ref;
 		ObjectID object;
 		StringName name;
@@ -76,6 +77,7 @@ private:
 
 	Vector<Action> actions;
 	int current_action = -1;
+	bool force_keep_in_merge_ends = false;
 	int action_level = 0;
 	MergeMode merge_mode = MERGE_DISABLE;
 	bool merging = false;
@@ -108,6 +110,9 @@ public:
 	void add_undo_property(Object *p_object, const StringName &p_property, const Variant &p_value);
 	void add_do_reference(Object *p_object);
 	void add_undo_reference(Object *p_object);
+
+	void start_force_keep_in_merge_ends();
+	void end_force_keep_in_merge_ends();
 
 	bool is_committing_action() const;
 	void commit_action(bool p_execute = true);

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -134,6 +134,12 @@
 				The way actions are merged is dictated by the [code]merge_mode[/code] argument. See [enum MergeMode] for details.
 			</description>
 		</method>
+		<method name="end_force_keep_in_merge_ends">
+			<return type="void" />
+			<description>
+				Stops marking operations as to be processed even if the action gets merged with another in the [constant MERGE_ENDS] mode. See [method start_force_keep_in_merge_ends].
+			</description>
+		</method>
 		<method name="get_action_name">
 			<return type="String" />
 			<argument index="0" name="id" type="int" />
@@ -190,6 +196,12 @@
 				Redo the last action.
 			</description>
 		</method>
+		<method name="start_force_keep_in_merge_ends">
+			<return type="void" />
+			<description>
+				Marks the next "do" and "undo" operations to be processed even if the action gets merged with another in the [constant MERGE_ENDS] mode. Return to normal operation using [method end_force_keep_in_merge_ends].
+			</description>
+		</method>
 		<method name="undo">
 			<return type="bool" />
 			<description>
@@ -209,7 +221,7 @@
 			Makes "do"/"undo" operations stay in separate actions.
 		</constant>
 		<constant name="MERGE_ENDS" value="1" enum="MergeMode">
-			Makes so that the action's "do" operation is from the first action created and the "undo" operation is from the last subsequent action with the same name.
+			Makes so that the action's "undo" operations are from the first action created and the "do" operations are from the last subsequent action with the same name.
 		</constant>
 		<constant name="MERGE_ALL" value="2" enum="MergeMode">
 			Makes subsequent actions with the same name be merged into one.


### PR DESCRIPTION
The MERGE_ENDS mode is used by the inspector to merge together actions with the same name, keeping only the undo operations from the first action, and the do operations from the last one. Theoretically, this work fine with most situations, like when you are editing a simple property, however, this might cause issue when modifying a property value might impact other properties. In such case, you might want to add an undo method when you detect the problematic value change.

The problem with the current master implementation, is that adding such an undo operation in the middle of a set of merged actions is not possible. Such operation is in fact automatically dropped.

This PR solves the problem by adding two methods `start_force_keep_in_merge_ends` and `end_force_keep_in_merge_ends`, to respectively start and end a block where all defined undo/do operations are marked as to be kept and processed, even in the MERGE_ENDS mode.

This solution has the advantage to keep compatibility. As the use case is not very common, I think it's better to keep it that way instead of adding an argument to the `add_do_*` and `add_undo_*` methods, which would be mainly problematic with the `add_do_method` and `add_undo_method` as they have variable argument lists.

This PR also solve a mistake in the documentation of the `MERGE_ENDS` constant.

Here is the script I used to test my changes: 
```gdscript
extends Node

var undoredo := UndoRedo.new()
var id = 0

func printing(s):
	print("Executed: " + s)

func _ready():
	undoredo.create_action("Action 1")
	undoredo.add_do_method(self, "printing", "do 1")
	undoredo.add_undo_method(self, "printing", "undo 1")
	undoredo.start_force_keep_in_merge_ends()
	undoredo.add_do_method(self, "printing", "do 1 (forced)")
	undoredo.add_undo_method(self, "printing", "undo 1 (forced)")
	undoredo.end_force_keep_in_merge_ends()
	undoredo.commit_action()
	
	undoredo.create_action("Action 1", UndoRedo.MERGE_ENDS)
	undoredo.add_do_method(self, "printing", "do 2")
	undoredo.add_undo_method(self, "printing", "undo 2")
	undoredo.start_force_keep_in_merge_ends()
	undoredo.add_do_method(self, "printing", "do 2 (forced)")
	undoredo.add_undo_method(self, "printing", "undo 2 (forced)")
	undoredo.end_force_keep_in_merge_ends()
	undoredo.commit_action()

func _input(event):
	if event.is_action_pressed("ui_left"):
		undoredo.undo()
	if event.is_action_pressed("ui_right"):
		undoredo.redo()
```



