### PR TITLE
Build for 64-bit ARM by default when compiling or exporting for Android

### DIFF
--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -36,7 +36,8 @@ if env["builtin_libpng"]:
     # Currently .ASM filter_neon.S does not compile on NT.
     import os
 
-    use_neon = "neon_enabled" in env and env["neon_enabled"] and os.name != "nt"
+    # Enable ARM NEON instructions on 32-bit Android to compile more optimized code.
+    use_neon = "android_arch" in env and env["android_arch"] == "armv7" and os.name != "nt"
     if use_neon:
         env_png.Append(CPPDEFINES=[("PNG_ARM_NEON_OPT", 2)])
     else:

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1644,10 +1644,12 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	}
 	plugins_changed.clear();
 
-	Vector<String> abis = get_abis();
+	const Vector<String> abis = get_abis();
 	for (int i = 0; i < abis.size(); ++i) {
-		String abi = abis[i];
-		bool is_default = (abi == "armeabi-v7a" || abi == "arm64-v8a");
+		const String abi = abis[i];
+		// All Android devices supporting Vulkan run 64-bit Android,
+		// so there is usually no point in exporting for 32-bit Android.
+		const bool is_default = abi == "arm64-v8a";
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "architectures/" + abi), is_default));
 	}
 


### PR DESCRIPTION
All Android devices that support Vulkan support 64-bit ARM. Once OpenGL support is ready (most likely H2 2022-H1 2023 with Godot 4.1), it's unlikely that 32-bit ARM devices will still be in use for Android gaming.

This also removes NEON opt-out code for ARMv7 as pretty much all ARMv7 devices also support NEON. (It's currently enabled by default, so the default behavior doesn't change here.)

This was discussed with @m4gr3d a while ago. I remember him agreeing to this idea for 4.0 :slightly_smiling_face: 