### PR TITLE
Increase object snapping distances in the 3D editor

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3863,7 +3863,7 @@ void Node3DEditorViewport::assign_pending_data_pointers(Node3D *p_preview_node, 
 }
 
 Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos) const {
-	const float MAX_DISTANCE = 10;
+	const float MAX_DISTANCE = 50.0;
 
 	Vector3 world_ray = _get_ray(p_pos);
 	Vector3 world_pos = _get_ray_pos(p_pos);
@@ -6469,7 +6469,7 @@ void Node3DEditor::snap_selected_nodes_to_floor() {
 			// We add a bit of margin to the from position to avoid it from snapping
 			// when the spatial is already on a floor and there's another floor under
 			// it
-			from = from + Vector3(0.0, 0.2, 0.0);
+			from = from + Vector3(0.0, 1, 0.0);
 
 			Dictionary d;
 
@@ -6485,7 +6485,7 @@ void Node3DEditor::snap_selected_nodes_to_floor() {
 	Array keys = snap_data.keys();
 
 	// The maximum height an object can travel to be snapped
-	const float max_snap_height = 20.0;
+	const float max_snap_height = 500.0;
 
 	// Will be set to `true` if at least one node from the selection was successfully snapped
 	bool snapped_to_floor = false;


### PR DESCRIPTION
- Increase drag-and-drop snapping maximum distance to 50 units (from 10 units).
- Increase Snap Object to Floor maximum height to 500 units (from 20 units).
- Increase Snap Object to Floor negative margin to 1 unit (from 0.2 units).

See discussion starting from https://github.com/godotengine/godot-proposals/issues/755#issuecomment-940890363.

As a future improvement, Snap Object to Floor could try snapping downwards from `(max_distance / 2)` (global Y coordinate) if no floor is found below the object. This way, the object doesn't need to be placed less than 1 unit below the floor to be correctly snapped back to the floor if there is nothing below. This can be done in a future PR.

## Preview

### Drag and drop snapping

https://user-images.githubusercontent.com/180032/136980453-05b3a090-34e3-4d9a-9712-53a2c1afdada.mp4

### Snap Object to Floor

*Available in the 3D editor's **View** menu or by pressing <kbd>Page Down</kbd>.*

https://user-images.githubusercontent.com/180032/136980509-024c0571-e2c9-4a14-a170-b3d963f06da6.mp4

