### PR TITLE
Fix missing action icons in action map editor

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -1074,6 +1074,31 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 			event_item->set_meta("__event", event);
 			event_item->set_meta("__index", evnt_idx);
 
+			// First Column - Icon
+			Ref<InputEventKey> k = event;
+			if (k.is_valid()) {
+				if (k->get_physical_keycode() == 0) {
+					event_item->set_icon(0, action_tree->get_theme_icon(SNAME("Keyboard"), SNAME("EditorIcons")));
+				} else {
+					event_item->set_icon(0, action_tree->get_theme_icon(SNAME("KeyboardPhysical"), SNAME("EditorIcons")));
+				}
+			}
+
+			Ref<InputEventMouseButton> mb = event;
+			if (mb.is_valid()) {
+				event_item->set_icon(0, action_tree->get_theme_icon(SNAME("Mouse"), SNAME("EditorIcons")));
+			}
+
+			Ref<InputEventJoypadButton> jb = event;
+			if (jb.is_valid()) {
+				event_item->set_icon(0, action_tree->get_theme_icon(SNAME("JoyButton"), SNAME("EditorIcons")));
+			}
+
+			Ref<InputEventJoypadMotion> jm = event;
+			if (jm.is_valid()) {
+				event_item->set_icon(0, action_tree->get_theme_icon(SNAME("JoyAxis"), SNAME("EditorIcons")));
+			}
+
 			// Third Column - Buttons
 			event_item->add_button(2, action_tree->get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), BUTTON_EDIT_EVENT, false, TTR("Edit Event"));
 			event_item->add_button(2, action_tree->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_EVENT, false, TTR("Remove Event"));


### PR DESCRIPTION
Fixes #53708

### Issue

Unlike in 3.x branch, in action map editor of master branch, icon action are missing in action tree.

### Fix proposal

Add an icon depending of the action event type.

### Before

![image](https://user-images.githubusercontent.com/3649998/136996279-000e59f2-4af4-4526-a191-0a732c432e40.png)

### After

![image](https://user-images.githubusercontent.com/3649998/136996340-b87f4af5-c4fd-45eb-92c4-df3c216582ff.png)
