### PR TITLE
Ignore format flags when validating the blend shape mask

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -934,7 +934,8 @@ Error RenderingServer::mesh_create_surface_data_from_arrays(SurfaceData *r_surfa
 				}
 			}
 
-			ERR_FAIL_COND_V_MSG((bsformat & RS::ARRAY_FORMAT_BLEND_SHAPE_MASK) != (format & RS::ARRAY_FORMAT_BLEND_SHAPE_MASK), ERR_INVALID_PARAMETER, "Blend shape format must match the main array format for Vertex, Normal and Tangent arrays.");
+			const uint32_t blend_format_mask = RS::ARRAY_FORMAT_VERTEX | RS::ARRAY_FORMAT_NORMAL | RS::ARRAY_FORMAT_TANGENT;
+			ERR_FAIL_COND_V_MSG((bsformat & blend_format_mask) != (format & blend_format_mask), ERR_INVALID_PARAMETER, "Blend shape format must match the main array format for Vertex, Normal and Tangent arrays.");
 		}
 	}
 


### PR DESCRIPTION
Fixes import of (glTF 2.0) models with 8 bone weights and blend shapes due to `ARRAY_FORMAT_BLEND_SHAPE_MASK & ARRAY_FLAG_USE_8_BONE_WEIGHTS != 0`

Previously, the mask was set to exclude all possible format types but not flags, which led to a mismatch when checking for matching flags.

The regression was introduced by #53608 by switching to the `ARRAY_FORMAT_BLEND_SHAPE_MASK` constant rather than checking individual `ARRAY_FORMAT` flags.