### PR TITLE
Exposed setters for sensor values in Input class

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -117,6 +117,10 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_accelerometer"), &Input::get_accelerometer);
 	ClassDB::bind_method(D_METHOD("get_magnetometer"), &Input::get_magnetometer);
 	ClassDB::bind_method(D_METHOD("get_gyroscope"), &Input::get_gyroscope);
+	ClassDB::bind_method(D_METHOD("set_gravity", "value"), &Input::set_gravity);
+	ClassDB::bind_method(D_METHOD("set_accelerometer", "value"), &Input::set_accelerometer);
+	ClassDB::bind_method(D_METHOD("set_magnetometer", "value"), &Input::set_magnetometer);
+	ClassDB::bind_method(D_METHOD("set_gyroscope", "value"), &Input::set_gyroscope);
 	ClassDB::bind_method(D_METHOD("get_last_mouse_speed"), &Input::get_last_mouse_speed);
 	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &Input::get_mouse_button_mask);
 	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &Input::set_mouse_mode);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -269,6 +269,14 @@
 				Removes all mappings from the internal database that match the given GUID.
 			</description>
 		</method>
+		<method name="set_accelerometer">
+			<return type="void" />
+			<argument index="0" name="value" type="Vector3" />
+			<description>
+				Sets the acceleration value of the accelerometer sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
+				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
+			</description>
+		</method>
 		<method name="set_custom_mouse_cursor">
 			<return type="void" />
 			<argument index="0" name="image" type="Resource" />
@@ -289,6 +297,30 @@
 				Sets the default cursor shape to be used in the viewport instead of [constant CURSOR_ARROW].
 				[b]Note:[/b] If you want to change the default cursor shape for [Control]'s nodes, use [member Control.mouse_default_cursor_shape] instead.
 				[b]Note:[/b] This method generates an [InputEventMouseMotion] to update cursor immediately.
+			</description>
+		</method>
+		<method name="set_gravity">
+			<return type="void" />
+			<argument index="0" name="value" type="Vector3" />
+			<description>
+				Sets the gravity value of the accelerometer sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
+				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
+			</description>
+		</method>
+		<method name="set_gyroscope">
+			<return type="void" />
+			<argument index="0" name="value" type="Vector3" />
+			<description>
+				Sets the value of the rotation rate of the gyroscope sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
+				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
+			</description>
+		</method>
+		<method name="set_magnetometer">
+			<return type="void" />
+			<argument index="0" name="value" type="Vector3" />
+			<description>
+				Sets the value of the magnetic field of the magnetometer sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
+				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
 			</description>
 		</method>
 		<method name="set_mouse_mode">


### PR DESCRIPTION
set_accelerometer, set_gravity, set_magnetometer and set_gyroscope exposed to use it in scripts.
This is useful for debugging sensor data without the need to export the game to mobile devices.
At the moment, this is only possible when developing regular modules with direct access to C++ sources, but it is not available in GDScript or GDNative.

This is my example of using these functions (an image is streamed to the phone, and control and sensor data are returned to the editor via wifi):
[https://youtu.be/LbFcQnS3z3E?t=76](https://youtu.be/LbFcQnS3z3E?t=76)