### PR TITLE
GPULightmapper: process rays to sky in all bounces as active

### DIFF
--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -420,20 +420,22 @@ void main() {
 
 			light = textureLod(sampler2DArray(source_light, linear_sampler), uvw, 0.0).rgb;
 			active_rays += 1.0;
-		} else if (trace_result == RAY_MISS && params.env_transform[0][3] == 0.0) { // Use env_transform[0][3] to indicate when we are computing the first bounce
-			// Did not hit a triangle, reach out for the sky
-			vec3 sky_dir = normalize(mat3(params.env_transform) * ray_dir);
+		} else if (trace_result == RAY_MISS) {
+			if (params.env_transform[0][3] == 0.0) { // Use env_transform[0][3] to indicate when we are computing the first bounce
+				// Did not hit a triangle, reach out for the sky
+				vec3 sky_dir = normalize(mat3(params.env_transform) * ray_dir);
 
-			vec2 st = vec2(
-					atan(sky_dir.x, sky_dir.z),
-					acos(sky_dir.y));
+				vec2 st = vec2(
+						atan(sky_dir.x, sky_dir.z),
+						acos(sky_dir.y));
 
-			if (st.x < 0.0)
-				st.x += PI * 2.0;
+				if (st.x < 0.0)
+					st.x += PI * 2.0;
 
-			st /= vec2(PI * 2.0, PI);
+				st /= vec2(PI * 2.0, PI);
 
-			light = textureLod(sampler2D(environment, linear_sampler), st, 0.0).rgb;
+				light = textureLod(sampler2D(environment, linear_sampler), st, 0.0).rgb;
+			}
 			active_rays += 1.0;
 		}
 


### PR DESCRIPTION
Before this change only rays to the sky (RAY_MISS) in the first bounce were
processed as active rays. This caused artifacts, areas were too light, when
more than one bounce were processed.

Now rays to the sky are processed as active rays for all bounces.

This issue solves an artifact which was mentioned in #53322: the front face of the left box is too light (see next images).

before:
![Screenshot from 2021-10-12 22-59-04](https://user-images.githubusercontent.com/10560119/137031629-a30592f3-06d2-460f-9ce5-2b99557c285a.png)

after:
![Screenshot from 2021-10-12 23-00-37](https://user-images.githubusercontent.com/10560119/137031669-26850f5d-650d-401e-9c74-e49aa9181b4f.png)

