### PR TITLE
GPULightmapper: prevent loop with max iterations

### DIFF
--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -148,7 +148,7 @@ uint trace_ray(vec3 p_from, vec3 p_to
 	ivec3 icell = ivec3(from_cell);
 	ivec3 iendcell = ivec3(to_cell);
 	vec3 dir_cell = normalize(rel_cell);
-	vec3 delta = abs(1.0 / dir_cell); //vec3(length(rel_cell)) / rel_cell);
+	vec3 delta = min(abs(1.0 / dir_cell), params.grid_size); // use params.grid_size as max to prevent infinity values
 	ivec3 step = ivec3(sign(rel_cell));
 	vec3 side = (sign(rel_cell) * (vec3(icell) - from_cell) + (sign(rel_cell) * 0.5) + 0.5) * delta;
 


### PR DESCRIPTION
trace_ray: in case the calculation of the delta contained infinity values (division by
zero), than later the calculation of the next cell failed as the infinity value
was multiplied by zero which resulted in a nan. The nan-value caused that the
next cell was equal to the current cell which resulted in an end-less loop,
which only terminates by the maximum iterations protection.

This is solved by replacing infinity with grid_size which acts as infinity.

I noticed this while debugging another issue. In my test scenes I did not encounter any artifacts by this, yet at least it is a performance improvement. Still this could result in artifacts as in some situations not all cells are processed. This means that triangles may not be checked. 