### PR TITLE
Use z_index for TileMap layer darkening

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -848,9 +848,11 @@ void TileMap::_rendering_update_dirty_quadrants(SelfList<TileMapQuadrant>::List 
 		Color modulate = get_self_modulate();
 		modulate *= get_layer_modulate(q.layer);
 		if (selected_layer >= 0) {
-			if (q.layer < selected_layer) {
+			int z1 = get_layer_z_index(q.layer);
+			int z2 = get_layer_z_index(selected_layer);
+			if (z1 < z2 || (z1 == z2 && q.layer < selected_layer)) {
 				modulate = modulate.darkened(0.5);
-			} else if (q.layer > selected_layer) {
+			} else if (z1 > z2 || (z1 == z2 && q.layer > selected_layer)) {
 				modulate = modulate.darkened(0.5);
 				modulate.a *= 0.3;
 			}


### PR DESCRIPTION
TileMap layers are either semi-transparent or darkened when another layer is being edited. Previously it was determined by layer order, which isn't very useful, because the fact that layer has higher id doesn't mean it has higher z_index. And usually you want higher layers to be semi-transparent, so that you can see behind them, not in front of them.

With this PR the editor will use layer z_index for darkening/transparenting layers, or layer id if their z_index is the same.