### PR TITLE
Fix so the error macro uses the incoming parameter p_subdivision instead of the class member

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -163,8 +163,8 @@ void GPUParticles2D::set_trail_sections(int p_sections) {
 }
 
 void GPUParticles2D::set_trail_section_subdivisions(int p_subdivisions) {
-	ERR_FAIL_COND(trail_section_subdivisions < 1);
-	ERR_FAIL_COND(trail_section_subdivisions > 1024);
+	ERR_FAIL_COND(p_subdivisions < 1);
+	ERR_FAIL_COND(p_subdivisions > 1024);
 
 	trail_section_subdivisions = p_subdivisions;
 	update();


### PR DESCRIPTION
…tead of the class member

Here we go my third pull request.

Basically the macro ERR_FAIL_COND() was using the class member instead of the incoming parameter. When there is an incorrect parameter, the macro makes the function return and logs an error message to the console.

this pull request corresponds to issue #53719 

*Bugsquad edit:* Fixes #53719.