### PR TITLE
free dbus errors when inhibiting freedesktop screensaver

### DIFF
--- a/platform/linuxbsd/freedesktop_screensaver.cpp
+++ b/platform/linuxbsd/freedesktop_screensaver.cpp
@@ -50,6 +50,7 @@ void FreeDesktopScreenSaver::inhibit() {
 
 	DBusConnection *bus = dbus_bus_get(DBUS_BUS_SESSION, &error);
 	if (dbus_error_is_set(&error)) {
+		dbus_error_free(&error);
 		unsupported = true;
 		return;
 	}
@@ -72,6 +73,7 @@ void FreeDesktopScreenSaver::inhibit() {
 	DBusMessage *reply = dbus_connection_send_with_reply_and_block(bus, message, 50, &error);
 	dbus_message_unref(message);
 	if (dbus_error_is_set(&error)) {
+		dbus_error_free(&error);
 		dbus_connection_unref(bus);
 		unsupported = false;
 		return;
@@ -96,6 +98,7 @@ void FreeDesktopScreenSaver::uninhibit() {
 
 	DBusConnection *bus = dbus_bus_get(DBUS_BUS_SESSION, &error);
 	if (dbus_error_is_set(&error)) {
+		dbus_error_free(&error);
 		unsupported = true;
 		return;
 	}
@@ -110,6 +113,7 @@ void FreeDesktopScreenSaver::uninhibit() {
 
 	DBusMessage *reply = dbus_connection_send_with_reply_and_block(bus, message, 50, &error);
 	if (dbus_error_is_set(&error)) {
+		dbus_error_free(&error);
 		dbus_connection_unref(bus);
 		unsupported = true;
 		return;


### PR DESCRIPTION
address sanitizer detected a memory leak in the dbus lib
```
Direct leak of 83 byte(s) in 1 object(s) allocated from:
    #0 0x7f107a6cc652 in __interceptor_realloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:164
    #1 0x7f107a45cf25  (/usr/lib/libdbus-1.so.3+0x33f25)
    #2 0x7ffffffff  (<unknown module>)
```
I saw `freedesktop_screensaver.cpp` doesn't call `dbus_error_free()` after encountering errors, this appears to have been the culprit of the leak.

example of `dbus_error_free()` being used: http://www.matthew.ath.cx/articles/dbus

:+1: 
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
