### PR TITLE
[3.x] C# Mathf keeps the results consistent with GDScript.

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -74,7 +74,7 @@ namespace Godot
         /// </returns>
         public static real_t Acos(real_t s)
         {
-            return (real_t)Math.Acos(s);
+            return (real_t)Math.Round(Math.Acos(s),6);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Godot
         /// </returns>
         public static real_t Asin(real_t s)
         {
-            return (real_t)Math.Asin(s);
+            return (real_t)Math.Round(Math.Asin(s),6);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Godot
         /// </returns>
         public static real_t Atan(real_t s)
         {
-            return (real_t)Math.Atan(s);
+            return (real_t)Math.Round(Math.Atan(s),6);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Godot
         /// </returns>
         public static real_t Atan2(real_t y, real_t x)
         {
-            return (real_t)Math.Atan2(y, x);
+            return (real_t)Math.Round(Math.Atan2(y, x),6);
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Godot
         /// <returns>The cosine of that angle.</returns>
         public static real_t Cos(real_t s)
         {
-            return (real_t)Math.Cos(s);
+            return (real_t)Math.Round(Math.Cos(s),6);
         }
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace Godot
         /// <returns>The hyperbolic cosine of that angle.</returns>
         public static real_t Cosh(real_t s)
         {
-            return (real_t)Math.Cosh(s);
+            return (real_t)Math.Round(Math.Cosh(s),6);
         }
 
         /// <summary>
@@ -254,7 +254,7 @@ namespace Godot
         /// <returns><c>e</c> raised to the power of <paramref name="s"/>.</returns>
         public static real_t Exp(real_t s)
         {
-            return (real_t)Math.Exp(s);
+            return (real_t)Math.Round(Math.Exp(s),6);
         }
 
         /// <summary>
@@ -376,7 +376,7 @@ namespace Godot
         /// <returns>The natural log of <paramref name="s"/>.</returns>
         public static real_t Log(real_t s)
         {
-            return (real_t)Math.Log(s);
+            return (real_t)Math.Round(Math.Log(s),6);
         }
 
         /// <summary>
@@ -511,7 +511,7 @@ namespace Godot
         /// <returns><paramref name="x"/> raised to the power of <paramref name="y"/>.</returns>
         public static real_t Pow(real_t x, real_t y)
         {
-            return (real_t)Math.Pow(x, y);
+            return (real_t)Math.Round(Math.Pow(x, y),6);
         }
 
         /// <summary>
@@ -568,7 +568,7 @@ namespace Godot
         /// <returns>The sine of that angle.</returns>
         public static real_t Sin(real_t s)
         {
-            return (real_t)Math.Sin(s);
+            return (real_t)Math.Round(Math.Sin(s),6);
         }
 
         /// <summary>
@@ -578,7 +578,7 @@ namespace Godot
         /// <returns>The hyperbolic sine of that angle.</returns>
         public static real_t Sinh(real_t s)
         {
-            return (real_t)Math.Sinh(s);
+            return (real_t)Math.Round(Math.Sinh(s),6);
         }
 
         /// <summary>
@@ -609,7 +609,7 @@ namespace Godot
         /// <returns>The square root of <paramref name="s"/>.</returns>
         public static real_t Sqrt(real_t s)
         {
-            return (real_t)Math.Sqrt(s);
+            return (real_t)Math.Round(Math.Sqrt(s),6);
         }
 
         /// <summary>
@@ -669,7 +669,7 @@ namespace Godot
         /// <returns>The tangent of that angle.</returns>
         public static real_t Tan(real_t s)
         {
-            return (real_t)Math.Tan(s);
+            return (real_t)Math.Round(Math.Tan(s),6);
         }
 
         /// <summary>
@@ -679,7 +679,7 @@ namespace Godot
         /// <returns>The hyperbolic tangent of that angle.</returns>
         public static real_t Tanh(real_t s)
         {
-            return (real_t)Math.Tanh(s);
+            return (real_t)Math.Round(Math.Tanh(s),6);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR is meaningless because of my lack of knowledge. GDS is only different from the default print output.
I'll be more cautious next time.
本PR没有意义,是我知识不足导致. GDS只是print默认输出不同.
下次我会更谨慎一点.
https://github.com/godotengine/godot/pull/53756#issuecomment-942353113

----------------------------------------------------------------------------------------------------------

In C #'s mathf class, there are many methods to calculate results different from GDS's mathf
The reason is that (float) double will have 7 decimal places, while GDS only retains 6 decimal places

C#的Mathf类中,有很多方法计算出的结果和GDS的Mathf不同.
原因是(float)double会有7位小数点,而GDS只保留6位小数点.

GDS
```
var num = 0.579877
print(acos(num))
print(asin(num))
print(atan(num))
print(atan2(num,num))
print(cos(num))
print(cosh(num))
print(exp(num))
print(log(num))
print(pow(num,num))
print(sin(num))
print(sinh(num))
print(sqrt(num))
print(tan(num))
print(tanh(num))
```
Print
```
0.952219
0.618578
0.525492
0.785398
0.83653
1.172893
1.785819
-0.544939
0.729061
0.547921
0.612926
0.761497
0.654993
0.522576
```

C#
```
float s = 0.579877f;
GD.Print(Mathf.Acos(s));
GD.Print(Mathf.Asin(s));
GD.Print(Mathf.Atan(s));
GD.Print(Mathf.Atan2(s, s));
GD.Print(Mathf.Cos(s));
GD.Print(Mathf.Cosh(s));
GD.Print(Mathf.Exp(s));
GD.Print(Mathf.Log(s));
GD.Print(Mathf.Pow(s, s));
GD.Print(Mathf.Sin(s));
GD.Print(Mathf.Sinh(s));
GD.Print(Mathf.Sqrt(s));
GD.Print(Mathf.Tan(s));
GD.Print(Mathf.Tanh(s));
```
original Print
```
0.9522186
0.6185777
0.5254918
0.7853982
0.83653
1.172893
1.785819
-0.5449392
0.7290611
0.5479211
0.6129258
0.7614965
0.6549927
0.522576
```
after Print
```
Same as GDS
```

Modified results .
Keep consistent with GDS .
Problems like this can be avoided https://github.com/godotengine/godot/issues/53736
No problem later. I'll PR another 4.0

修改后的结果
保持和GDS一致
可以避免类似这个的问题 https://github.com/godotengine/godot/issues/53736
稍后没问题,我再PR一份4.0