### PR TITLE
Fix undo in inspector not working

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -118,15 +118,16 @@ void UndoRedo::create_action(const String &p_name, MergeMode p_mode) {
 
 			actions.write[actions.size() - 1].last_tick = ticks;
 
+			merge_mode = p_mode;
 			merging = true;
 		} else {
 			Action new_action;
 			new_action.name = p_name;
 			new_action.last_tick = ticks;
 			actions.push_back(new_action);
-		}
 
-		merge_mode = p_mode;
+			merge_mode = MERGE_DISABLE;
+		}
 	}
 
 	action_level++;


### PR DESCRIPTION
This restores the old logic for setting merge_mode. I was likely tired I though those were equivalent...
Sorry, I broke it twice it seems... :upside_down_face: 

