### PR TITLE
Remove REST transform influence in skeleton bones

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -47,6 +47,11 @@
 				Removes the local pose override on all bones in the skeleton.
 			</description>
 		</method>
+		<method name="create_skin_from_rest_transforms">
+			<return type="Skin" />
+			<description>
+			</description>
+		</method>
 		<method name="execute_modifications">
 			<return type="void" />
 			<argument index="0" name="delta" type="float" />
@@ -86,13 +91,6 @@
 			<return type="int" />
 			<description>
 				Returns the amount of bones in the skeleton.
-			</description>
-		</method>
-		<method name="get_bone_custom_pose" qualifiers="const">
-			<return type="Transform3D" />
-			<argument index="0" name="bone_idx" type="int" />
-			<description>
-				Returns the custom pose of the specified bone. Custom pose is applied on top of the rest pose.
 			</description>
 		</method>
 		<method name="get_bone_global_pose" qualifiers="const">
@@ -214,13 +212,6 @@
 				Returns whether the bone pose for the bone at [code]bone_idx[/code] is enabled.
 			</description>
 		</method>
-		<method name="is_bone_rest_disabled" qualifiers="const">
-			<return type="bool" />
-			<argument index="0" name="bone_idx" type="int" />
-			<description>
-				Returns whether the bone rest for the bone at [code]bone_idx[/code] is disabled.
-			</description>
-		</method>
 		<method name="local_pose_to_global_pose">
 			<return type="Transform3D" />
 			<argument index="0" name="bone_idx" type="int" />
@@ -288,23 +279,6 @@
 			<argument index="1" name="bone_children" type="PackedInt32Array" />
 			<description>
 				Sets the children for the passed in bone, [code]bone_idx[/code], to the passed-in array of bone indexes, [code]bone_children[/code].
-			</description>
-		</method>
-		<method name="set_bone_custom_pose">
-			<return type="void" />
-			<argument index="0" name="bone_idx" type="int" />
-			<argument index="1" name="custom_pose" type="Transform3D" />
-			<description>
-				Sets the custom pose transform, [code]custom_pose[/code], for the bone at [code]bone_idx[/code]. This pose is an addition to the bone rest pose.
-				[b]Note:[/b] The pose transform needs to be in bone space. Use [method world_transform_to_global_pose] to convert a world transform, like one you can get from a [Node3D], to bone space.
-			</description>
-		</method>
-		<method name="set_bone_disable_rest">
-			<return type="void" />
-			<argument index="0" name="bone_idx" type="int" />
-			<argument index="1" name="disable" type="bool" />
-			<description>
-				Disables the rest pose for the bone at [code]bone_idx[/code] if [code]true[/code], enables the bone rest if [code]false[/code].
 			</description>
 		</method>
 		<method name="set_bone_enabled">

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -102,13 +102,12 @@ public:
 	void set_label(const String &p_label) { label = p_label; }
 
 	void _update_properties();
-	void _update_custom_pose_properties();
 	void _update_transform_properties(Transform3D p_transform);
 
 	// Transform can be keyed, whether or not to show the button.
 	void set_keyable(const bool p_keyable);
 
-	// When rest mode, pose and custom_pose editor are diasbled.
+	// When rest mode, pose editor are diasbled.
 	void set_properties_read_only(const bool p_readonly);
 	void set_transform_read_only(const bool p_readonly);
 
@@ -151,7 +150,6 @@ class Skeleton3DEditor : public VBoxContainer {
 	Tree *joint_tree = nullptr;
 	BoneTransformEditor *rest_editor = nullptr;
 	BoneTransformEditor *pose_editor = nullptr;
-	BoneTransformEditor *custom_pose_editor = nullptr;
 
 	VSeparator *separator;
 	MenuButton *skeleton_options = nullptr;

--- a/modules/fbx/data/fbx_skeleton.cpp
+++ b/modules/fbx/data/fbx_skeleton.cpp
@@ -104,6 +104,13 @@ void FBXSkeleton::init_skeleton(const ImportState &state) {
 		print_verbose("working on bone: " + itos(bone_index) + " bone name:" + bone->bone_name);
 
 		skeleton->set_bone_rest(bone->godot_bone_id, get_unscaled_transform(bone->node->pivot_transform->LocalTransform, state.scale));
+		{
+			Transform3D base_xform = bone->node->pivot_transform->LocalTransform;
+
+			skeleton->set_bone_pose_position(bone_index, base_xform.origin);
+			skeleton->set_bone_pose_rotation(bone_index, base_xform.basis.get_rotation_quaternion());
+			skeleton->set_bone_pose_scale(bone_index, base_xform.basis.get_scale());
+		}
 
 		// lookup parent ID
 		if (bone->valid_parent && state.fbx_bone_map.has(bone->parent_bone_id)) {

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -1227,20 +1227,6 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 										AssetImportAnimation::INTERP_LINEAR);
 							}
 
-							// node animations must also include pivots
-							if (skeleton_bone >= 0) {
-								Transform3D xform = Transform3D();
-								xform.basis.set_quaternion_scale(rot, scale);
-								xform.origin = pos;
-								const Transform3D t = bone_rest.affine_inverse() * xform;
-
-								// populate	this again
-								rot = t.basis.get_rotation_quaternion();
-								rot.normalize();
-								scale = t.basis.get_scale();
-								pos = t.origin;
-							}
-
 							if (position_idx >= 0) {
 								animation->position_track_insert_key(position_idx, time, pos);
 							}

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -215,8 +215,6 @@ void BoneAttachment3D::_transform_changed() {
 			sk->set_bone_global_pose_override(bone_idx, our_trans, 1.0, true);
 		} else if (override_mode == OVERRIDE_MODES::MODE_LOCAL_POSE) {
 			sk->set_bone_local_pose_override(bone_idx, sk->global_pose_to_local_pose(bone_idx, our_trans), 1.0, true);
-		} else if (override_mode == OVERRIDE_MODES::MODE_CUSTOM_POSE) {
-			sk->set_bone_custom_pose(bone_idx, sk->global_pose_to_local_pose(bone_idx, our_trans));
 		}
 	}
 }
@@ -273,8 +271,6 @@ void BoneAttachment3D::set_override_pose(bool p_override) {
 				sk->set_bone_global_pose_override(bone_idx, Transform3D(), 0.0, false);
 			} else if (override_mode == OVERRIDE_MODES::MODE_LOCAL_POSE) {
 				sk->set_bone_local_pose_override(bone_idx, Transform3D(), 0.0, false);
-			} else if (override_mode == OVERRIDE_MODES::MODE_CUSTOM_POSE) {
-				sk->set_bone_custom_pose(bone_idx, Transform3D());
 			}
 		}
 		_transform_changed();
@@ -294,8 +290,6 @@ void BoneAttachment3D::set_override_mode(int p_mode) {
 				sk->set_bone_global_pose_override(bone_idx, Transform3D(), 0.0, false);
 			} else if (override_mode == OVERRIDE_MODES::MODE_LOCAL_POSE) {
 				sk->set_bone_local_pose_override(bone_idx, Transform3D(), 0.0, false);
-			} else if (override_mode == OVERRIDE_MODES::MODE_CUSTOM_POSE) {
-				sk->set_bone_custom_pose(bone_idx, Transform3D());
 			}
 		}
 		override_mode = p_mode;

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -47,7 +47,6 @@ class BoneAttachment3D : public Node3D {
 	enum OVERRIDE_MODES {
 		MODE_GLOBAL_POSE,
 		MODE_LOCAL_POSE,
-		MODE_CUSTOM_POSE
 	};
 
 	bool use_external_skeleton = false;

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -146,11 +146,13 @@ void MeshInstance3D::_resolve_skeleton_path() {
 	if (!skeleton_path.is_empty()) {
 		Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(get_node(skeleton_path));
 		if (skeleton) {
-			new_skin_reference = skeleton->register_skin(skin_internal);
 			if (skin_internal.is_null()) {
+				new_skin_reference = skeleton->register_skin(skeleton->create_skin_from_rest_transforms());
 				//a skin was created for us
 				skin_internal = new_skin_reference->get_skin();
 				notify_property_list_changed();
+			} else {
+				new_skin_reference = skeleton->register_skin(skin_internal);
 			}
 		}
 	}

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -76,7 +76,6 @@ private:
 		bool enabled;
 		int parent;
 
-		bool disable_rest = false;
 		Transform3D rest;
 
 		_FORCE_INLINE_ void update_pose_cache() {
@@ -94,9 +93,6 @@ private:
 
 		Transform3D pose_global;
 		Transform3D pose_global_no_override;
-
-		bool custom_pose_enable = false;
-		Transform3D custom_pose;
 
 		real_t global_pose_override_amount = 0.0;
 		bool global_pose_override_reset = false;
@@ -119,8 +115,6 @@ private:
 		Bone() {
 			parent = -1;
 			enabled = true;
-			disable_rest = false;
-			custom_pose_enable = false;
 			global_pose_override_amount = 0;
 			global_pose_override_reset = false;
 #ifndef _3D_DISABLED
@@ -199,9 +193,6 @@ public:
 	void remove_bone_child(int p_bone, int p_child);
 	Vector<int> get_parentless_bones();
 
-	void set_bone_disable_rest(int p_bone, bool p_disable);
-	bool is_bone_rest_disabled(int p_bone) const;
-
 	int get_bone_count() const;
 
 	void set_bone_rest(int p_bone, const Transform3D &p_rest);
@@ -228,9 +219,6 @@ public:
 	Quaternion get_bone_pose_rotation(int p_bone) const;
 	Vector3 get_bone_pose_scale(int p_bone) const;
 
-	void set_bone_custom_pose(int p_bone, const Transform3D &p_custom_pose);
-	Transform3D get_bone_custom_pose(int p_bone) const;
-
 	void clear_bones_global_pose_override();
 	Transform3D get_bone_global_pose_override(int p_bone) const;
 	void set_bone_global_pose_override(int p_bone, const Transform3D &p_pose, real_t p_amount, bool p_persistent = false);
@@ -240,6 +228,8 @@ public:
 	void set_bone_local_pose_override(int p_bone, const Transform3D &p_pose, real_t p_amount, bool p_persistent = false);
 
 	void localize_rests(); // used for loaders and tools
+
+	Ref<Skin> create_skin_from_rest_transforms();
 
 	Ref<SkinReference> register_skin(const Ref<Skin> &p_skin);
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1360,9 +1360,6 @@ void AnimationTree::_process_graph(real_t p_delta) {
 
 						root_motion_transform = xform;
 
-						if (t->skeleton && t->bone_idx >= 0) {
-							root_motion_transform = (t->skeleton->get_bone_rest(t->bone_idx) * root_motion_transform) * t->skeleton->get_bone_rest(t->bone_idx).affine_inverse();
-						}
 					} else if (t->skeleton && t->bone_idx >= 0) {
 						if (t->loc_used) {
 							t->skeleton->set_bone_pose_position(t->bone_idx, t->loc);

--- a/scene/resources/skeleton_modification_3d_fabrik.cpp
+++ b/scene/resources/skeleton_modification_3d_fabrik.cpp
@@ -168,7 +168,7 @@ void SkeletonModification3DFABRIK::_execute(real_t p_delta) {
 		// Apply magnet positions:
 		if (stack->skeleton->get_bone_parent(fabrik_data_chain[i].bone_idx) >= 0) {
 			int parent_bone_idx = stack->skeleton->get_bone_parent(fabrik_data_chain[i].bone_idx);
-			Transform3D conversion_transform = (stack->skeleton->get_bone_global_pose(parent_bone_idx) * stack->skeleton->get_bone_rest(parent_bone_idx));
+			Transform3D conversion_transform = (stack->skeleton->get_bone_global_pose(parent_bone_idx));
 			local_pose_override.origin += conversion_transform.basis.xform_inv(fabrik_data_chain[i].magnet_position);
 		} else {
 			local_pose_override.origin += fabrik_data_chain[i].magnet_position;

--- a/scene/resources/skeleton_modification_3d_twoboneik.cpp
+++ b/scene/resources/skeleton_modification_3d_twoboneik.cpp
@@ -455,7 +455,7 @@ void SkeletonModification3DTwoBoneIK::calculate_joint_lengths() {
 			joint_two_length = 0;
 			for (int i = 0; i < bone_two_children.size(); i++) {
 				joint_two_length += bone_two_rest_trans.origin.distance_to(
-						stack->skeleton->local_pose_to_global_pose(bone_two_children[i], stack->skeleton->get_bone_rest(bone_two_children[i])).origin);
+						stack->skeleton->get_bone_global_pose(bone_two_children[i]).origin);
 			}
 			joint_two_length = joint_two_length / bone_two_children.size();
 		} else {


### PR DESCRIPTION
Implements: https://github.com/godotengine/godot-proposals/issues/3377

* Animations and Skeletons are now pose-only.
* Rest transform is kept as reference (when it exists) and for IK
* Removed custom bone poses (redundant with local and global pose overrides).
* Improves 3D model compatibility (non uniform transforms will properly work, as well as all animations coming from Autodesk products).

This is a compatibility breaking change.