### PR TITLE
Greatly improve editor performances by deferring tiles related updates

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -45,7 +45,9 @@ class TileDataEditor : public VBoxContainer {
 	GDCLASS(TileDataEditor, VBoxContainer);
 
 private:
-	void _call_tile_set_changed();
+	bool _tile_set_changed_update_needed = false;
+	void _tile_set_changed_plan_update();
+	void _tile_set_changed_deferred_update();
 
 protected:
 	Ref<TileSet> tile_set;

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -112,7 +112,7 @@ private:
 
 	UndoRedo *undo_redo = EditorNode::get_undo_redo();
 
-	bool tile_set_atlas_source_changed_needs_update = false;
+	bool tile_set_changed_needs_update = false;
 
 	// -- Properties painting --
 	VBoxContainer *tile_data_painting_editor_container;
@@ -263,7 +263,7 @@ private:
 	void _auto_remove_tiles();
 	AcceptDialog *confirm_auto_create_tiles;
 
-	void _tile_set_atlas_source_changed();
+	void _tile_set_changed();
 	void _tile_proxy_object_changed(String p_what);
 	void _atlas_source_proxy_object_changed(String p_what);
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -3094,6 +3094,8 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_tile_data", "layer"), &TileMap::_set_tile_data);
 	ClassDB::bind_method(D_METHOD("_get_tile_data", "layer"), &TileMap::_get_tile_data);
 
+	ClassDB::bind_method(D_METHOD("_tile_set_changed_deferred_update"), &TileMap::_tile_set_changed_deferred_update);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "tile_set", PROPERTY_HINT_RESOURCE_TYPE, "TileSet"), "set_tileset", "get_tileset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_quadrant_size", PROPERTY_HINT_RANGE, "1,128,1"), "set_quadrant_size", "get_quadrant_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collision_animatable"), "set_collision_animatable", "is_collision_animatable");
@@ -3113,8 +3115,16 @@ void TileMap::_bind_methods() {
 
 void TileMap::_tile_set_changed() {
 	emit_signal(SNAME("changed"));
-	_clear_internals();
-	_recreate_internals();
+	_tile_set_changed_deferred_update_needed = true;
+	call_deferred("_tile_set_changed_deferred_update");
+}
+
+void TileMap::_tile_set_changed_deferred_update() {
+	if (_tile_set_changed_deferred_update_needed) {
+		_clear_internals();
+		_recreate_internals();
+		_tile_set_changed_deferred_update_needed = false;
+	}
 }
 
 TileMap::TileMap() {

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -285,6 +285,8 @@ private:
 	Vector<int> _get_tile_data(int p_layer) const;
 
 	void _tile_set_changed();
+	bool _tile_set_changed_deferred_update_needed = false;
+	void _tile_set_changed_deferred_update();
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);


### PR DESCRIPTION
Greatly improve the tiles editor performance by deferring tiles related updates.

The editor used to redraw the whole TileMap and update a bunch of sub-editors when you edited a single tile in the TileSet. This means that, every time you removed a bunch of tiles, or, even worse, undid the removal, the editor could stall for a dozen of seconds. This is now fixed by deferring such updates to the en of the frame, executing it only once.

Here I test the removal of all tiles, then undo. It's almost instantaneous now:

https://user-images.githubusercontent.com/6093119/137137096-2652bb87-87ac-490c-82f7-38e3d1265c5d.mp4


This PR also fixes some updates not triggering correctly.

