### PR TITLE
Fix HashMap element copy leaving hash as zero

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -96,6 +96,7 @@ public:
 		Element(const TKey &p_key) :
 				pair(p_key) {}
 		Element(const Element &p_other) :
+				hash(p_other.hash),
 				pair(p_other.pair.key, p_other.pair.data) {}
 	};
 


### PR DESCRIPTION
Fixes #53754 (which was introduced by #53579).