### PR TITLE
Fix character encoding of Engine::get_copyright_info

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -111,7 +111,7 @@ Dictionary Engine::get_version_info() const {
 static Array array_from_info(const char *const *info_list) {
 	Array arr;
 	for (int i = 0; info_list[i] != nullptr; i++) {
-		arr.push_back(info_list[i]);
+		arr.push_back(String::utf8(info_list[i]));
 	}
 	return arr;
 }
@@ -119,7 +119,7 @@ static Array array_from_info(const char *const *info_list) {
 static Array array_from_info_count(const char *const *info_list, int info_count) {
 	Array arr;
 	for (int i = 0; i < info_count; i++) {
-		arr.push_back(info_list[i]);
+		arr.push_back(String::utf8(info_list[i]));
 	}
 	return arr;
 }
@@ -140,14 +140,14 @@ Array Engine::get_copyright_info() const {
 	for (int component_index = 0; component_index < COPYRIGHT_INFO_COUNT; component_index++) {
 		const ComponentCopyright &cp_info = COPYRIGHT_INFO[component_index];
 		Dictionary component_dict;
-		component_dict["name"] = cp_info.name;
+		component_dict["name"] = String::utf8(cp_info.name);
 		Array parts;
 		for (int i = 0; i < cp_info.part_count; i++) {
 			const ComponentCopyrightPart &cp_part = cp_info.parts[i];
 			Dictionary part_dict;
 			part_dict["files"] = array_from_info_count(cp_part.files, cp_part.file_count);
 			part_dict["copyright"] = array_from_info_count(cp_part.copyright_statements, cp_part.copyright_count);
-			part_dict["license"] = cp_part.license;
+			part_dict["license"] = String::utf8(cp_part.license);
 			parts.push_back(part_dict);
 		}
 		component_dict["parts"] = parts;


### PR DESCRIPTION
This fixes an issue where certain characters wouldn't display right. The license.gen.h file encodes these characters like `\303\263`, but I think GDScript was expecting unicode (`ó`?).

![image](https://user-images.githubusercontent.com/14253836/137168290-3f98d29c-69bb-4c47-80ff-a11620be7724.png)
