### PR TITLE
[3.x] Allow overriding `_clips_input()` for ScrollContainer and GraphEdit

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -34,6 +34,7 @@
 #include "core/os/input.h"
 #include "core/os/keyboard.h"
 #include "scene/gui/box_container.h"
+#include "scene/scene_string_names.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_scale.h"
@@ -237,6 +238,9 @@ void GraphEdit::disconnect_node(const StringName &p_from, int p_from_port, const
 }
 
 bool GraphEdit::clips_input() const {
+	if (get_script_instance()) {
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_clips_input);
+	}
 	return true;
 }
 

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -31,8 +31,12 @@
 #include "scroll_container.h"
 #include "core/os/os.h"
 #include "scene/main/viewport.h"
+#include "scene/scene_string_names.h"
 
 bool ScrollContainer::clips_input() const {
+	if (get_script_instance()) {
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_clips_input);
+	}
 	return true;
 }
 


### PR DESCRIPTION
This is already done in Control, but the C++ method overrides didn't check for possible script overrides.

The `master` branch does not have `clips_input()`. I don't know if a different fix is needed there (or whether it's needed at all).

This closes https://github.com/godotengine/godot/issues/42889. Thanks @rgson for the implementation :slightly_smiling_face: