### PR TITLE
Implement import actions for pos/rot/scale animation tracks

### DIFF
--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -65,13 +65,6 @@ public:
 		IMPORT_USE_NAMED_SKIN_BINDS = 16,
 	};
 
-	enum AnimationImportBoneTracks {
-		ANIMATION_IMPORT_BONE_TRACKS_IF_PRESENT,
-		ANIMATION_IMPORT_BONE_TRACKS_IF_PRESENT_FOR_ALL,
-		ANIMATION_IMPORT_BONE_TRACKS_ALWAYS,
-		ANIMATION_IMPORT_BONE_TRACKS_NEVER,
-	};
-
 	virtual uint32_t get_import_flags() const;
 	virtual void get_extensions(List<String> *r_extensions) const;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, int p_bake_fps, List<String> *r_missing_deps, Error *r_err = nullptr);
@@ -150,6 +143,20 @@ class ResourceImporterScene : public ResourceImporter {
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
 	void _generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches);
 	void _add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes);
+
+	enum AnimationImportTracks {
+		ANIMATION_IMPORT_TRACKS_IF_PRESENT,
+		ANIMATION_IMPORT_TRACKS_IF_PRESENT_FOR_ALL,
+		ANIMATION_IMPORT_TRACKS_NEVER,
+	};
+	enum TrackChannel {
+		TRACK_CHANNEL_POSITION,
+		TRACK_CHANNEL_ROTATION,
+		TRACK_CHANNEL_SCALE,
+		TRACK_CHANNEL_MAX
+	};
+
+	void _optimize_track_usage(AnimationPlayer *p_player, AnimationImportTracks *p_track_actions);
 
 public:
 	static ResourceImporterScene *get_singleton() { return singleton; }


### PR DESCRIPTION
Following actions are supported for each track type (position, rotatin, scale) in the 3d model importer:

* ImportIfPresent: If a track of this type is found, import it.
* ImportIfPresentForall (default): If a track is found for a given node/bone, create it in animations. This ensures there is always a correct blending.
* Never: Delete all tracks found for a given type. This is useful if you want to, as an example, force to import rotations only.

![image](https://user-images.githubusercontent.com/6265307/137216914-4a4a0429-1daa-4f90-a57a-692412424c9e.png)

![image](https://user-images.githubusercontent.com/6265307/137217213-f886450d-3e28-46f7-b7fd-c41f00662242.png)

