### PR TITLE
[3.x] Fix SSAO stairstepping artifacts when using a high Camera Far property

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3193,6 +3193,12 @@ void RasterizerSceneGLES3::_render_mrts(Environment *env, const CameraMatrix &p_
 	}
 
 	if (env->ssao_enabled) {
+		// Maximum distance for SSAO effect in 3D units.
+		// This clamps the camera Z far distance to avoid visible stairstepping artifacts in the SSAO buffer.
+		// The value chosen allows SSAO to be visible from far away, while preventing SSAO from breaking
+		// at high camera Z far values (10,000 or more).
+		const real_t MAX_SSAO_Z_FAR = 200.0;
+
 		//copy diffuse to front buffer
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->buffers.fbo);
 		glReadBuffer(GL_COLOR_ATTACHMENT0);
@@ -3211,7 +3217,7 @@ void RasterizerSceneGLES3::_render_mrts(Environment *env, const CameraMatrix &p_
 			state.ssao_minify_shader.set_conditional(SsaoMinifyShaderGLES3::MINIFY_START, i == 0);
 			state.ssao_minify_shader.set_conditional(SsaoMinifyShaderGLES3::USE_ORTHOGONAL_PROJECTION, p_cam_projection.is_orthogonal());
 			state.ssao_minify_shader.bind();
-			state.ssao_minify_shader.set_uniform(SsaoMinifyShaderGLES3::CAMERA_Z_FAR, p_cam_projection.get_z_far());
+			state.ssao_minify_shader.set_uniform(SsaoMinifyShaderGLES3::CAMERA_Z_FAR, MIN(p_cam_projection.get_z_far(), MAX_SSAO_Z_FAR));
 			state.ssao_minify_shader.set_uniform(SsaoMinifyShaderGLES3::CAMERA_Z_NEAR, p_cam_projection.get_z_near());
 			state.ssao_minify_shader.set_uniform(SsaoMinifyShaderGLES3::SOURCE_MIPMAP, MAX(0, i - 1));
 			glUniform2iv(state.ssao_minify_shader.get_uniform(SsaoMinifyShaderGLES3::FROM_SIZE), 1, ss);
@@ -3243,7 +3249,7 @@ void RasterizerSceneGLES3::_render_mrts(Environment *env, const CameraMatrix &p_
 		state.ssao_shader.set_conditional(SsaoShaderGLES3::SSAO_QUALITY_LOW, env->ssao_quality == VS::ENV_SSAO_QUALITY_LOW);
 		state.ssao_shader.set_conditional(SsaoShaderGLES3::SSAO_QUALITY_HIGH, env->ssao_quality == VS::ENV_SSAO_QUALITY_HIGH);
 		state.ssao_shader.bind();
-		state.ssao_shader.set_uniform(SsaoShaderGLES3::CAMERA_Z_FAR, p_cam_projection.get_z_far());
+		state.ssao_shader.set_uniform(SsaoShaderGLES3::CAMERA_Z_FAR, MIN(p_cam_projection.get_z_far(), MAX_SSAO_Z_FAR));
 		state.ssao_shader.set_uniform(SsaoShaderGLES3::CAMERA_Z_NEAR, p_cam_projection.get_z_near());
 		glUniform2iv(state.ssao_shader.get_uniform(SsaoShaderGLES3::SCREEN_SIZE), 1, ss);
 		float radius = env->ssao_radius;
@@ -3290,7 +3296,7 @@ void RasterizerSceneGLES3::_render_mrts(Environment *env, const CameraMatrix &p_
 
 		if (env->ssao_filter) {
 			for (int i = 0; i < 2; i++) {
-				state.ssao_blur_shader.set_uniform(SsaoBlurShaderGLES3::CAMERA_Z_FAR, p_cam_projection.get_z_far());
+				state.ssao_blur_shader.set_uniform(SsaoBlurShaderGLES3::CAMERA_Z_FAR, MIN(p_cam_projection.get_z_far(), MAX_SSAO_Z_FAR));
 				state.ssao_blur_shader.set_uniform(SsaoBlurShaderGLES3::CAMERA_Z_NEAR, p_cam_projection.get_z_near());
 				state.ssao_blur_shader.set_uniform(SsaoBlurShaderGLES3::EDGE_SHARPNESS, env->ssao_bilateral_sharpness);
 				state.ssao_blur_shader.set_uniform(SsaoBlurShaderGLES3::FILTER_SCALE, int(env->ssao_filter));


### PR DESCRIPTION
This matches `master` behavior where high Camera Far property values can be used just fine with SSAO.

This closes https://github.com/godotengine/godot/issues/42390.

**Testing project:** [test_ssao_2_3.x.zip](https://github.com/godotengine/godot/files/7341766/test_ssao_2_3.x.zip)

## Preview

### Camera Far 100 (project default in `3.x`)

| Before | After |
|-|-|
| ![ssao_old_far_100](https://user-images.githubusercontent.com/180032/137223031-9ce44a16-59ce-46c2-82cc-6baaf42b5c92.png) | ![ssao_new2_far_100](https://user-images.githubusercontent.com/180032/137223019-74d7347b-e581-4d47-84aa-20b805b6e3ee.png) |

### Camera Far 500 (editor default in `3.x`)

| Before | After |
|-|-|
| ![ssao_old_far_500](https://user-images.githubusercontent.com/180032/137223034-dd1b0b28-590a-4a00-994a-5f0452a5309b.png) | ![ssao_new2_far_500](https://user-images.githubusercontent.com/180032/137223025-2eaed979-61a0-4857-b4a7-725550e52e0a.png) |

### Camera Far 4,000 (default for both project and editor in `master`)

| Before | After |
|-|-|
| ![ssao_old_far_4000](https://user-images.githubusercontent.com/180032/137223036-5c554605-f0a3-41fc-b268-b7e5cef304f0.png) | ![ssao_new2_far_4000](https://user-images.githubusercontent.com/180032/137223030-27e816dd-5797-4ed6-9eb7-4d945d785642.png) |