### PR TITLE
[3.x] Initializing member variables in driver folder - part 1

### DIFF
--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -43,7 +43,7 @@ class AudioDriverALSA : public AudioDriver {
 	Thread thread;
 	Mutex mutex;
 
-	snd_pcm_t *pcm_handle;
+	snd_pcm_t *pcm_handle = nullptr;
 
 	String device_name;
 	String new_device;
@@ -56,17 +56,17 @@ class AudioDriverALSA : public AudioDriver {
 
 	static void thread_func(void *p_udata);
 
-	unsigned int mix_rate;
+	unsigned int mix_rate = 0;
 	SpeakerMode speaker_mode;
 
 	snd_pcm_uframes_t buffer_frames;
 	snd_pcm_uframes_t buffer_size;
 	snd_pcm_uframes_t period_size;
-	int channels;
+	int channels = 0;
 
-	bool active;
-	bool thread_exited;
-	mutable bool exit_thread;
+	bool active = false;
+	bool thread_exited = false;
+	mutable bool exit_thread = false;
 
 public:
 	const char *get_name() const {

--- a/drivers/alsamidi/midi_driver_alsamidi.h
+++ b/drivers/alsamidi/midi_driver_alsamidi.h
@@ -47,7 +47,7 @@ class MIDIDriverALSAMidi : public MIDIDriver {
 
 	Vector<snd_rawmidi_t *> connected_inputs;
 
-	bool exit_thread;
+	bool exit_thread = false;
 
 	static void thread_func(void *p_udata);
 

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -44,16 +44,16 @@ class AudioDriverCoreAudio : public AudioDriver {
 	AudioComponentInstance audio_unit;
 	AudioComponentInstance input_unit;
 
-	bool active;
+	bool active = false;
 	Mutex mutex;
 
 	String device_name;
 	String capture_device_name;
 
-	int mix_rate;
-	unsigned int channels;
-	unsigned int capture_channels;
-	unsigned int buffer_frames;
+	int mix_rate = 0;
+	unsigned int channels = 0;
+	unsigned int capture_channels = 0;
+	unsigned int buffer_frames = 0;
 
 	Vector<int32_t> samples_in;
 	Vector<int16_t> input_buf;

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -122,21 +122,21 @@ class RasterizerStorageDummy : public RasterizerStorage {
 public:
 	/* TEXTURE API */
 	struct DummyTexture : public RID_Data {
-		int width;
-		int height;
-		uint32_t flags;
+		int width = 0;
+		int height = 0;
+		uint32_t flags = 0;
 		Image::Format format;
 		Ref<Image> image;
 		String path;
 	};
 
 	struct DummySurface {
-		uint32_t format;
+		uint32_t format = 0;
 		VS::PrimitiveType primitive;
 		PoolVector<uint8_t> array;
-		int vertex_count;
+		int vertex_count = 0;
 		PoolVector<uint8_t> index_array;
-		int index_count;
+		int index_count = 0;
 		AABB aabb;
 		Vector<PoolVector<uint8_t>> blend_shapes;
 		Vector<AABB> bone_aabbs;
@@ -144,7 +144,7 @@ public:
 
 	struct DummyMesh : public RID_Data {
 		Vector<DummySurface> surfaces;
-		int blend_shape_count;
+		int blend_shape_count = 0;
 		VS::BlendShapeMode blend_shape_mode;
 		PoolRealArray blend_shape_values;
 	};

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -43,10 +43,10 @@ class AudioDriverPulseAudio : public AudioDriver {
 	Thread thread;
 	Mutex mutex;
 
-	pa_mainloop *pa_ml;
-	pa_context *pa_ctx;
-	pa_stream *pa_str;
-	pa_stream *pa_rec_str;
+	pa_mainloop *pa_ml = nullptr;
+	pa_context *pa_ctx = nullptr;
+	pa_stream *pa_str = nullptr;
+	pa_stream *pa_rec_str = nullptr;
 	pa_channel_map pa_map;
 	pa_channel_map pa_rec_map;
 
@@ -61,20 +61,20 @@ class AudioDriverPulseAudio : public AudioDriver {
 	Vector<int32_t> samples_in;
 	Vector<int16_t> samples_out;
 
-	unsigned int mix_rate;
-	unsigned int buffer_frames;
-	unsigned int pa_buffer_size;
-	int channels;
-	int pa_ready;
-	int pa_status;
+	unsigned int mix_rate = 0;
+	unsigned int buffer_frames = 0;
+	unsigned int pa_buffer_size = 0;
+	int channels = 0;
+	int pa_ready = 0;
+	int pa_status = 0;
 	Array pa_devices;
 	Array pa_rec_devices;
 
-	bool active;
-	bool thread_exited;
-	mutable bool exit_thread;
+	bool active = false;
+	bool thread_exited = false;
+	mutable bool exit_thread = false;
 
-	float latency;
+	float latency = 0.0;
 
 	static void pa_state_cb(pa_context *c, void *userdata);
 	static void pa_sink_info_cb(pa_context *c, const pa_sink_info *l, int eol, void *userdata);


### PR DESCRIPTION
Initialize varibles for alsa,alsamidi,coreaudio,dummy & pulseaudio
subfolders in driver folder with default values

Fixes [#52674](https://github.com/godotengine/godot/issues/52674) partly