### PR TITLE
mbedtls: Backport "Fix x86_64 assembly for bignum multiplication"

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -347,11 +347,13 @@ File extracted from upstream release tarball:
 - All `*.h` from `include/mbedtls/` to `thirdparty/mbedtls/include/mbedtls/`.
 - All `*.c` from `library/` to `thirdparty/mbedtls/library/`.
 - `LICENSE` and `apache-2.0.txt` files.
-- Applied the patch in `thirdparty/mbedtls/patches/1453.diff` (upstream PR:
+- Applied the patch in `patches/1453.diff` (upstream PR:
   https://github.com/ARMmbed/mbedtls/pull/1453).
-- Applied the patch in `thirdparty/mbedtls/patches/padlock.diff`. This disables
-  VIA padlock support which defines a symbol `unsupported` which clashes with
-  a pre-defined symbol.
+- Applied the patch in `patches/padlock.diff`. This disables VIA padlock
+  support which defines a symbol `unsupported` which clashes with a
+  pre-defined symbol.
+- Applied the patch in `patches/pr4948-fix-clang12-opt.patch`. Upstream bugfix
+  from PR 4948 to fix a bug caused by Clang 12 optimizations.
 - Added 2 files `godot_core_mbedtls_platform.c` and `godot_core_mbedtls_config.h`
   providing configuration for light bundling with core.
 

--- a/thirdparty/mbedtls/include/mbedtls/bn_mul.h
+++ b/thirdparty/mbedtls/include/mbedtls/bn_mul.h
@@ -256,9 +256,9 @@
         "addq   $8, %%rdi\n"
 
 #define MULADDC_STOP                        \
-        : "+c" (c), "+D" (d), "+S" (s)      \
-        : "b" (b)                           \
-        : "rax", "rdx", "r8"                \
+        : "+c" (c), "+D" (d), "+S" (s), "+m" (*(uint64_t (*)[16]) d) \
+        : "b" (b), "m" (*(const uint64_t (*)[16]) s)                 \
+        : "rax", "rdx", "r8"                                         \
     );
 
 #endif /* AMD64 */

--- a/thirdparty/mbedtls/patches/pr4948-fix-clang12-opt.patch
+++ b/thirdparty/mbedtls/patches/pr4948-fix-clang12-opt.patch
@@ -1,0 +1,36 @@
+From 7c847235e8f0e0b877c505f19733b417bb65ff2e Mon Sep 17 00:00:00 2001
+From: Gilles Peskine <Gilles.Peskine@arm.com>
+Date: Tue, 14 Sep 2021 00:13:05 +0200
+Subject: [PATCH] x86_64 MULADDC assembly: add missing constraints about memory
+
+MULADDC_CORE reads from (%%rsi) and writes to (%%rdi). This fragment is
+repeated up to 16 times, and %%rsi and %%rdi are s and d on entry
+respectively. Hence the complete asm statement reads 16 64-bit words
+from memory starting at s, and writes 16 64-bit words starting at d.
+
+Without any declaration of modified memory, Clang 12 and Clang 13 generated
+non-working code for mbedtls_mpi_mod_exp. The constraints make the unit
+tests pass with Clang 12.
+
+Signed-off-by: Gilles Peskine <Gilles.Peskine@arm.com>
+---
+ include/mbedtls/bn_mul.h             | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/mbedtls/bn_mul.h b/include/mbedtls/bn_mul.h
+index 6f1201bf50a..f84f9650ddc 100644
+--- a/include/mbedtls/bn_mul.h
++++ b/include/mbedtls/bn_mul.h
+@@ -256,9 +256,9 @@
+         "addq   $8, %%rdi\n"
+ 
+ #define MULADDC_STOP                        \
+-        : "+c" (c), "+D" (d), "+S" (s)      \
+-        : "b" (b)                           \
+-        : "rax", "rdx", "r8"                \
++        : "+c" (c), "+D" (d), "+S" (s), "+m" (*(uint64_t (*)[16]) d) \
++        : "b" (b), "m" (*(const uint64_t (*)[16]) s)                 \
++        : "rax", "rdx", "r8"                                         \
+     );
+ 
+ #endif /* AMD64 */


### PR DESCRIPTION
Backports PR https://github.com/ARMmbed/mbedtls/pull/4948 to fix a regression
with our macOS builds using Clang 12.

Fixes #53297.