### PR TITLE
SCons: Add `DEV_ENABLED` defines for `target=debug` builds

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -203,6 +203,7 @@ def configure(env):
         env.Append(LINKFLAGS=["-O0"])
         env.Append(CCFLAGS=["-O0", "-g", "-fno-limit-debug-info"])
         env.Append(CPPDEFINES=["_DEBUG", "DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["DEV_ENABLED"])
         env.Append(CPPFLAGS=["-UNDEBUG"])
 
     # Compiler configuration

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -59,6 +59,7 @@ def configure(env):
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["-gdwarf-2", "-O0"])
         env.Append(CPPDEFINES=["_DEBUG", ("DEBUG", 1), "DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["DEV_ENABLED"])
 
     if env["use_lto"]:
         env.Append(CCFLAGS=["-flto"])

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -82,6 +82,7 @@ def configure(env):
             env.Append(LINKFLAGS=["--profiling-funcs"])
     else:  # "debug"
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["DEV_ENABLED"])
         env.Append(CCFLAGS=["-O1", "-g"])
         env.Append(LINKFLAGS=["-O1", "-g"])
         env["use_assertions"] = True

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -113,6 +113,7 @@ def configure(env):
     elif env["target"] == "debug":
         env.Prepend(CCFLAGS=["-g3"])
         env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Prepend(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["-rdynamic"])
 
     ## Architecture

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -64,6 +64,7 @@ def configure(env):
     elif env["target"] == "debug":
         env.Prepend(CCFLAGS=["-g3"])
         env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Prepend(CPPDEFINES=["DEV_ENABLED"])
         env.Prepend(LINKFLAGS=["-Xlinker", "-no_deduplicate"])
 
     ## Architecture

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -72,6 +72,7 @@ def configure(env):
         env.Append(CCFLAGS=["/Zi"])
         env.Append(CCFLAGS=["/MDd"])
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
         env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
         env.Append(LINKFLAGS=["/DEBUG"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -208,6 +208,7 @@ def configure_msvc(env, manual_msvc_config):
     elif env["target"] == "debug":
         env.AppendUnique(CCFLAGS=["/Zi", "/FS", "/Od", "/EHsc"])
         env.AppendUnique(CPPDEFINES=["DEBUG_ENABLED"])
+        env.AppendUnique(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["/DEBUG"])
 
     if env["debug_symbols"]:
@@ -362,6 +363,7 @@ def configure_mingw(env):
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["-g3"])
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Append(CPPDEFINES=["DEV_ENABLED"])
 
     if env["windows_subsystem"] == "gui":
         env.Append(LINKFLAGS=["-Wl,--subsystem,windows"])


### PR DESCRIPTION
This will allow adding developer checks which will be fully compiled out in
user builds, unlike `DEBUG_ENABLED` which is included in debug tempates and
the editor builds.

This define is not used yet, but we'll soon add code that uses it, and change
some existing `DEBUG_ENABLED` checks to be performed only in dev builds.

Related to godotengine/godot-proposals#3371.

---

Same as #53383 added initially for `3.x`, we're starting to have the same need in `master` so it's better not to wait for a full resolution of godotengine/godot-proposals#3371 for this.