### PR TITLE
[3.x] Revert HTTPRequest gzip compression support.

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -65,10 +65,6 @@
 		    add_child(texture_rect)
 		    texture_rect.texture = texture
 		[/codeblock]
-		[b]Gzipped response bodies[/b]
-		HttpRequest will automatically handle decompression of response bodies.
-		A "Accept-Encoding" header will be automatically added to each of your requests, unless one is already specified.
-		Any response with a "Content-Encoding: gzip" header will automatically be decompressed and delivered to you as a uncompressed bytes.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/3.4/tutorials/networking/http_request_class.html</link>
@@ -127,14 +123,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="accept_gzip" type="bool" setter="set_accept_gzip" getter="is_accepting_gzip" default="true">
-			If [code]true[/code], this header will be added to each request: [code]Accept-Encoding: gzip, deflate[/code] telling servers that it's okay to compress response bodies.
-			Any Reponse body declaring a [code]Content-Encoding[/code] of either [code]gzip[/code] or [code]deflate[/code] will then be automatically decompressed, and the uncompressed bytes will be delivered via [code]request_completed[/code].
-			If the user has specified their own [code]Accept-Encoding[/code] header, then no header will be added regaurdless of [code]accept_gzip[/code].
-			If [code]false[/code] no header will be added, and no decompression will be performed on response bodies. The raw bytes of the response body will be returned via [code]request_completed[/code].
-		</member>
 		<member name="body_size_limit" type="int" setter="set_body_size_limit" getter="get_body_size_limit" default="-1">
-			Maximum allowed size for response bodies. If the response body is compressed, this will be used as the maximum allowed size for the decompressed body.
+			Maximum allowed size for response bodies.
 		</member>
 		<member name="download_chunk_size" type="int" setter="set_download_chunk_size" getter="get_download_chunk_size" default="65536">
 			The size of the buffer used and maximum bytes to read per iteration. See [member HTTPClient.read_chunk_size].
@@ -184,24 +174,22 @@
 		<constant name="RESULT_NO_RESPONSE" value="6" enum="Result">
 			Request does not have a response (yet).
 		</constant>
-		<constant name="RESULT_BODY_DECOMPRESS_FAILED" value="8" enum="Result">
-		</constant>
 		<constant name="RESULT_BODY_SIZE_LIMIT_EXCEEDED" value="7" enum="Result">
 			Request exceeded its maximum size limit, see [member body_size_limit].
 		</constant>
-		<constant name="RESULT_REQUEST_FAILED" value="9" enum="Result">
+		<constant name="RESULT_REQUEST_FAILED" value="8" enum="Result">
 			Request failed (currently unused).
 		</constant>
-		<constant name="RESULT_DOWNLOAD_FILE_CANT_OPEN" value="10" enum="Result">
+		<constant name="RESULT_DOWNLOAD_FILE_CANT_OPEN" value="9" enum="Result">
 			HTTPRequest couldn't open the download file.
 		</constant>
-		<constant name="RESULT_DOWNLOAD_FILE_WRITE_ERROR" value="11" enum="Result">
+		<constant name="RESULT_DOWNLOAD_FILE_WRITE_ERROR" value="10" enum="Result">
 			HTTPRequest couldn't write to the download file.
 		</constant>
-		<constant name="RESULT_REDIRECT_LIMIT_REACHED" value="12" enum="Result">
+		<constant name="RESULT_REDIRECT_LIMIT_REACHED" value="11" enum="Result">
 			Request reached its maximum redirect limit, see [member max_redirects].
 		</constant>
-		<constant name="RESULT_TIMEOUT" value="13" enum="Result">
+		<constant name="RESULT_TIMEOUT" value="12" enum="Result">
 		</constant>
 	</constants>
 </class>

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -51,7 +51,6 @@ public:
 		RESULT_SSL_HANDSHAKE_ERROR,
 		RESULT_NO_RESPONSE,
 		RESULT_BODY_SIZE_LIMIT_EXCEEDED,
-		RESULT_BODY_DECOMPRESS_FAILED,
 		RESULT_REQUEST_FAILED,
 		RESULT_DOWNLOAD_FILE_CANT_OPEN,
 		RESULT_DOWNLOAD_FILE_WRITE_ERROR,
@@ -77,7 +76,6 @@ private:
 	PoolByteArray body;
 	SafeFlag use_threads;
 
-	bool accept_gzip;
 	bool got_response;
 	int response_code;
 	PoolVector<String> response_headers;
@@ -105,9 +103,6 @@ private:
 	Error _parse_url(const String &p_url);
 	Error _request();
 
-	bool has_header(const Vector<String> &p_headers, const String &p_header_name);
-	String get_header_value(const PoolStringArray &p_headers, const String &header_name);
-
 	SafeFlag thread_done;
 	SafeFlag thread_request_quit;
 
@@ -124,14 +119,10 @@ public:
 	Error request(const String &p_url, const Vector<String> &p_custom_headers = Vector<String>(), bool p_ssl_validate_domain = true, HTTPClient::Method p_method = HTTPClient::METHOD_GET, const String &p_request_data = ""); //connects to a full url and perform request
 	Error request_raw(const String &p_url, const Vector<String> &p_custom_headers = Vector<String>(), bool p_ssl_validate_domain = true, HTTPClient::Method p_method = HTTPClient::METHOD_GET, const PoolVector<uint8_t> &p_request_data_raw = PoolVector<uint8_t>()); //connects to a full url and perform request
 	void cancel_request();
-
 	HTTPClient::Status get_http_client_status() const;
 
 	void set_use_threads(bool p_use);
 	bool is_using_threads() const;
-
-	void set_accept_gzip(bool p_gzip);
-	bool is_accepting_gzip() const;
 
 	void set_download_file(const String &p_file);
 	String get_download_file() const;


### PR DESCRIPTION
Partial revert of commit c1135cf0063016ce9abacc23d987becaaef5aa9a.

See: https://github.com/godotengine/godot/pull/48651#issuecomment-942293955

#48651 causes a few regressions including #53085 so it needs to be reverted. The original PR on master #38944 is left for now but will need work if we want to keep in 4.0 (or will need revert too).

Issues:
- Some platform/HTTPClient might not allow those headers (HTML5)
- Response is not decompressed when saved to file.
- We need facilities to decompress a stream (i.e. not decompress all in memory but in chunks to file).

I've left the changes adding `request_raw` and `Compression::decompress_dynamic` since they are both still needed anyway (and for now will allow to implement manual gzip decompression in `3.x`).