### PR TITLE
Add a name to TileSet sources

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -136,6 +136,7 @@ String Resource::get_scene_unique_id() const {
 
 void Resource::set_name(const String &p_name) {
 	name = p_name;
+	emit_changed();
 }
 
 String Resource::get_name() const {

--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -118,6 +118,7 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 		output_image_texture.instantiate();
 		output_image_texture->create_from_image(output_image);
 
+		merged->set_name(p_atlas_sources[0]->get_name());
 		merged->set_texture(output_image_texture);
 		merged->set_texture_region_size(new_texture_region_size);
 	}

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -152,14 +152,21 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		Ref<Texture2D> texture;
 		String item_text;
 
+		// Common to all type of sources.
+		if (!source->get_name().is_empty()) {
+			item_text = vformat(TTR("%s (id:%d)"), source->get_name(), source_id);
+		}
+
 		// Atlas source.
 		TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
 		if (atlas_source) {
 			texture = atlas_source->get_texture();
-			if (texture.is_valid()) {
-				item_text = vformat("%s (ID: %d)", texture->get_path().get_file(), source_id);
-			} else {
-				item_text = vformat("No Texture Atlas Source (ID: %d)", source_id);
+			if (item_text.is_empty()) {
+				if (texture.is_valid()) {
+					item_text = vformat("%s (ID: %d)", texture->get_path().get_file(), source_id);
+				} else {
+					item_text = vformat("No Texture Atlas Source (ID: %d)", source_id);
+				}
 			}
 		}
 
@@ -167,7 +174,9 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		TileSetScenesCollectionSource *scene_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);
 		if (scene_collection_source) {
 			texture = get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
-			item_text = vformat(TTR("Scene Collection Source (ID: %d)"), source_id);
+			if (item_text.is_empty()) {
+				item_text = vformat(TTR("Scene Collection Source (ID: %d)"), source_id);
+			}
 		}
 
 		// Use default if not valid.

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -66,10 +66,15 @@ int TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::get_id() {
 }
 
 bool TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::_set(const StringName &p_name, const Variant &p_value) {
+	String name = p_name;
+	if (name == "name") {
+		// Use the resource_name property to store the source's name.
+		name = "resource_name";
+	}
 	bool valid = false;
-	tile_set_atlas_source->set(p_name, p_value, &valid);
+	tile_set_atlas_source->set(name, p_value, &valid);
 	if (valid) {
-		emit_signal(SNAME("changed"), String(p_name).utf8().get_data());
+		emit_signal(SNAME("changed"), String(name).utf8().get_data());
 	}
 	return valid;
 }
@@ -78,12 +83,18 @@ bool TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::_get(const StringN
 	if (!tile_set_atlas_source) {
 		return false;
 	}
+	String name = p_name;
+	if (name == "name") {
+		// Use the resource_name property to store the source's name.
+		name = "resource_name";
+	}
 	bool valid = false;
-	r_ret = tile_set_atlas_source->get(p_name, &valid);
+	r_ret = tile_set_atlas_source->get(name, &valid);
 	return valid;
 }
 
 void TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE, ""));
 	p_list->push_back(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"));
 	p_list->push_back(PropertyInfo(Variant::VECTOR2I, "margins", PROPERTY_HINT_NONE, ""));
 	p_list->push_back(PropertyInfo(Variant::VECTOR2I, "separation", PROPERTY_HINT_NONE, ""));
@@ -105,6 +116,10 @@ void TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::edit(Ref<TileSet> 
 	ERR_FAIL_COND(!p_tile_set_atlas_source);
 	ERR_FAIL_COND(p_source_id < 0);
 	ERR_FAIL_COND(p_tile_set->get_source(p_source_id) != p_tile_set_atlas_source);
+
+	if (p_tile_set == tile_set && p_tile_set_atlas_source == tile_set_atlas_source && p_source_id == source_id) {
+		return;
+	}
 
 	// Disconnect to changes.
 	if (tile_set_atlas_source) {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -145,14 +145,21 @@ void TileSetEditor::_update_sources_list(int force_selected_id) {
 		Ref<Texture2D> texture;
 		String item_text;
 
+		// Common to all type of sources.
+		if (!source->get_name().is_empty()) {
+			item_text = vformat(TTR("%s (id:%d)"), source->get_name(), source_id);
+		}
+
 		// Atlas source.
 		TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
 		if (atlas_source) {
 			texture = atlas_source->get_texture();
-			if (texture.is_valid()) {
-				item_text = vformat("%s (id:%d)", texture->get_path().get_file(), source_id);
-			} else {
-				item_text = vformat(TTR("No Texture Atlas Source (id:%d)"), source_id);
+			if (item_text.is_empty()) {
+				if (texture.is_valid()) {
+					item_text = vformat("%s (id:%d)", texture->get_path().get_file(), source_id);
+				} else {
+					item_text = vformat(TTR("No Texture Atlas Source (id:%d)"), source_id);
+				}
 			}
 		}
 
@@ -160,7 +167,9 @@ void TileSetEditor::_update_sources_list(int force_selected_id) {
 		TileSetScenesCollectionSource *scene_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);
 		if (scene_collection_source) {
 			texture = get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
-			item_text = vformat(TTR("Scene Collection Source (id:%d)"), source_id);
+			if (item_text.is_empty()) {
+				item_text = vformat(TTR("Scene Collection Source (id:%d)"), source_id);
+			}
 		}
 
 		// Use default if not valid.

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -56,10 +56,15 @@ int TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::get
 }
 
 bool TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::_set(const StringName &p_name, const Variant &p_value) {
+	String name = p_name;
+	if (name == "name") {
+		// Use the resource_name property to store the source's name.
+		name = "resource_name";
+	}
 	bool valid = false;
-	tile_set_scenes_collection_source->set(p_name, p_value, &valid);
+	tile_set_scenes_collection_source->set(name, p_value, &valid);
 	if (valid) {
-		emit_signal(SNAME("changed"), String(p_name).utf8().get_data());
+		emit_signal(SNAME("changed"), String(name).utf8().get_data());
 	}
 	return valid;
 }
@@ -68,9 +73,18 @@ bool TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::_g
 	if (!tile_set_scenes_collection_source) {
 		return false;
 	}
+	String name = p_name;
+	if (name == "name") {
+		// Use the resource_name property to store the source's name.
+		name = "resource_name";
+	}
 	bool valid = false;
-	r_ret = tile_set_scenes_collection_source->get(p_name, &valid);
+	r_ret = tile_set_scenes_collection_source->get(name, &valid);
 	return valid;
+}
+
+void TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE, ""));
 }
 
 void TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::_bind_methods() {
@@ -88,6 +102,10 @@ void TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::ed
 	ERR_FAIL_COND(!p_tile_set_scenes_collection_source);
 	ERR_FAIL_COND(p_source_id < 0);
 	ERR_FAIL_COND(p_tile_set->get_source(p_source_id) != p_tile_set_scenes_collection_source);
+
+	if (tile_set == p_tile_set && tile_set_scenes_collection_source == p_tile_set_scenes_collection_source && source_id == p_source_id) {
+		return;
+	}
 
 	// Disconnect to changes.
 	if (tile_set_scenes_collection_source) {
@@ -173,6 +191,10 @@ void TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_get_property_li
 void TileSetScenesCollectionSourceEditor::SceneTileProxyObject::edit(TileSetScenesCollectionSource *p_tile_set_scenes_collection_source, int p_scene_id) {
 	ERR_FAIL_COND(!p_tile_set_scenes_collection_source);
 	ERR_FAIL_COND(!p_tile_set_scenes_collection_source->has_scene_tile_id(p_scene_id));
+
+	if (tile_set_scenes_collection_source == p_tile_set_scenes_collection_source && scene_id == p_scene_id) {
+		return;
+	}
 
 	tile_set_scenes_collection_source = p_tile_set_scenes_collection_source;
 	scene_id = p_scene_id;

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
@@ -51,6 +51,7 @@ private:
 	protected:
 		bool _set(const StringName &p_name, const Variant &p_value);
 		bool _get(const StringName &p_name, Variant &r_ret) const;
+		void _get_property_list(List<PropertyInfo> *p_list) const;
 		static void _bind_methods();
 
 	public:


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Adds an optional name to TileSet sources. For TileSets with a lot of sources, it helps finding the right ones faster.
It also allows distinguishing scenes collections sources, which was not easy before (only the ID could be used). It is also useful when two atlas sources share the same texture.

https://user-images.githubusercontent.com/6093119/137322741-e6ee88df-ad8f-40de-95b3-7643241d62ba.mp4

