### PR TITLE
Implement Alt + Mouse wheel to adjust FOV in the 3D editor viewport

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -315,7 +315,7 @@ private:
 
 	struct Cursor {
 		Vector3 pos;
-		real_t x_rot, y_rot, distance;
+		real_t x_rot, y_rot, distance, fov_scale;
 		Vector3 eye_pos; // Used in freelook mode
 		bool region_select;
 		Point2 region_begin, region_end;
@@ -325,6 +325,7 @@ private:
 			x_rot = 0.5;
 			y_rot = -0.5;
 			distance = 4;
+			fov_scale = 1.0;
 			region_select = false;
 		}
 	};
@@ -333,6 +334,8 @@ private:
 	Cursor cursor; // Immediate cursor
 	Cursor camera_cursor; // That one may be interpolated (don't modify this one except for smoothing purposes)
 
+	void scale_fov(real_t p_fov_offset);
+	void reset_fov();
 	void scale_cursor_distance(real_t scale);
 
 	void set_freelook_active(bool active_now);
@@ -349,6 +352,7 @@ private:
 
 	void set_message(String p_message, float p_time = 5);
 
+	void _view_settings_confirmed(real_t p_interp_delta);
 	void _update_camera(real_t p_interp_delta);
 	Transform3D to_camera_transform(const Cursor &p_cursor) const;
 	void _draw();


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/54207.

This allows for quicker FOV adjustments compared to using the **View** menu.

This closes https://github.com/godotengine/godot-proposals/issues/3428.

## Preview

https://user-images.githubusercontent.com/180032/137403453-0a4c2a41-aeb0-4bf7-8306-78f3022153c9.mp4