### PR TITLE
SCons: Set `DEBUG_ENABLED` and `DEV_ENABLED` in SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -308,11 +308,19 @@ env_base.Prepend(CPPPATH=["#"])
 env_base.platform_exporters = platform_exporters
 env_base.platform_apis = platform_apis
 
-if env_base["use_precise_math_checks"]:
-    env_base.Append(CPPDEFINES=["PRECISE_MATH_CHECKS"])
+# Build type defines - more platform-specific ones can be in detect.py.
+if env_base["target"] == "release_debug" or env_base["target"] == "debug":
+    # DEBUG_ENABLED enables debugging *features* and debug-only code, which is intended
+    # to give *users* extra debugging information for their game development.
+    env_base.Append(CPPDEFINES=["DEBUG_ENABLED"])
 
 if env_base["target"] == "debug":
-    env_base.Append(CPPDEFINES=["DEBUG_MEMORY_ALLOC", "DISABLE_FORCED_INLINE"])
+    # DEV_ENABLED enables *engine developer* code which should only be compiled for those
+    # working on the engine itself.
+    env_base.Append(CPPDEFINES=["DEV_ENABLED"])
+
+if env_base["use_precise_math_checks"]:
+    env_base.Append(CPPDEFINES=["PRECISE_MATH_CHECKS"])
 
 if env_base["no_editor_splash"]:
     env_base.Append(CPPDEFINES=["NO_EDITOR_SPLASH"])

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -62,9 +62,9 @@
 #endif
 #endif
 
-// Should always inline, except in debug builds because it makes debugging harder.
+// Should always inline, except in dev builds because it makes debugging harder.
 #ifndef _FORCE_INLINE_
-#ifdef DISABLE_FORCED_INLINE
+#ifdef DEV_ENABLED
 #define _FORCE_INLINE_ inline
 #else
 #define _FORCE_INLINE_ _ALWAYS_INLINE_

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -197,13 +197,10 @@ def configure(env):
         env.Append(CPPDEFINES=["NDEBUG"])
         if can_vectorize:
             env.Append(CCFLAGS=["-ftree-vectorize"])
-        if env["target"] == "release_debug":
-            env.Append(CPPDEFINES=["DEBUG_ENABLED"])
     elif env["target"] == "debug":
         env.Append(LINKFLAGS=["-O0"])
         env.Append(CCFLAGS=["-O0", "-g", "-fno-limit-debug-info"])
-        env.Append(CPPDEFINES=["_DEBUG", "DEBUG_ENABLED"])
-        env.Append(CPPDEFINES=["DEV_ENABLED"])
+        env.Append(CPPDEFINES=["_DEBUG"])
         env.Append(CPPFLAGS=["-UNDEBUG"])
 
     # Compiler configuration

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -53,13 +53,9 @@ def configure(env):
             env.Append(CCFLAGS=["-Os", "-ftree-vectorize"])
             env.Append(LINKFLAGS=["-Os"])
 
-        if env["target"] == "release_debug":
-            env.Append(CPPDEFINES=["DEBUG_ENABLED"])
-
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["-gdwarf-2", "-O0"])
-        env.Append(CPPDEFINES=["_DEBUG", ("DEBUG", 1), "DEBUG_ENABLED"])
-        env.Append(CPPDEFINES=["DEV_ENABLED"])
+        env.Append(CPPDEFINES=["_DEBUG", ("DEBUG", 1)])
 
     if env["use_lto"]:
         env.Append(CCFLAGS=["-flto"])

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -77,12 +77,9 @@ def configure(env):
             env.Append(LINKFLAGS=["-Os"])
 
         if env["target"] == "release_debug":
-            env.Append(CPPDEFINES=["DEBUG_ENABLED"])
             # Retain function names for backtraces at the cost of file size.
             env.Append(LINKFLAGS=["--profiling-funcs"])
     else:  # "debug"
-        env.Append(CPPDEFINES=["DEBUG_ENABLED"])
-        env.Append(CPPDEFINES=["DEV_ENABLED"])
         env.Append(CCFLAGS=["-O1", "-g"])
         env.Append(LINKFLAGS=["-O1", "-g"])
         env["use_assertions"] = True

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -105,15 +105,12 @@ def configure(env):
             env.Prepend(CCFLAGS=["-O2"])
         elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])
-        env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
 
         if env["debug_symbols"]:
             env.Prepend(CCFLAGS=["-g2"])
 
     elif env["target"] == "debug":
         env.Prepend(CCFLAGS=["-g3"])
-        env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
-        env.Prepend(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["-rdynamic"])
 
     ## Architecture

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -57,14 +57,11 @@ def configure(env):
             env.Prepend(CCFLAGS=["-O2"])
         elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])
-        env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
         if env["debug_symbols"]:
             env.Prepend(CCFLAGS=["-g2"])
 
     elif env["target"] == "debug":
         env.Prepend(CCFLAGS=["-g3"])
-        env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
-        env.Prepend(CPPDEFINES=["DEV_ENABLED"])
         env.Prepend(LINKFLAGS=["-Xlinker", "-no_deduplicate"])
 
     ## Architecture

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -64,15 +64,12 @@ def configure(env):
         env.Append(CCFLAGS=["/MD"])
         env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
         env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
-        env.Append(CPPDEFINES=["DEBUG_ENABLED"])
         if env["optimize"] != "none":
             env.Append(CCFLAGS=["/O2", "/Zi"])
 
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["/Zi"])
         env.Append(CCFLAGS=["/MDd"])
-        env.Append(CPPDEFINES=["DEBUG_ENABLED"])
-        env.Append(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
         env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
         env.Append(LINKFLAGS=["/DEBUG"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -203,12 +203,9 @@ def configure_msvc(env, manual_msvc_config):
         elif env["optimize"] == "size":  # optimize for size
             env.Append(CCFLAGS=["/O1"])
             env.Append(LINKFLAGS=["/OPT:REF"])
-        env.AppendUnique(CPPDEFINES=["DEBUG_ENABLED"])
 
     elif env["target"] == "debug":
         env.AppendUnique(CCFLAGS=["/Zi", "/FS", "/Od", "/EHsc"])
-        env.AppendUnique(CPPDEFINES=["DEBUG_ENABLED"])
-        env.AppendUnique(CPPDEFINES=["DEV_ENABLED"])
         env.Append(LINKFLAGS=["/DEBUG"])
 
     if env["debug_symbols"]:
@@ -352,7 +349,6 @@ def configure_mingw(env):
 
     elif env["target"] == "release_debug":
         env.Append(CCFLAGS=["-O2"])
-        env.Append(CPPDEFINES=["DEBUG_ENABLED"])
         if env["debug_symbols"]:
             env.Prepend(CCFLAGS=["-g2"])
         if env["optimize"] == "speed":  # optimize for speed (default)
@@ -362,8 +358,6 @@ def configure_mingw(env):
 
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["-g3"])
-        env.Append(CPPDEFINES=["DEBUG_ENABLED"])
-        env.Append(CPPDEFINES=["DEV_ENABLED"])
 
     if env["windows_subsystem"] == "gui":
         env.Append(LINKFLAGS=["-Wl,--subsystem,windows"])


### PR DESCRIPTION
They're the same for all platforms so they don't need to be repeated in all
platform definitions.

As discussed in https://github.com/godotengine/godot/pull/53799#issuecomment-943251317

Also removes unused define, and replaces `DISABLE_FORCED_INLINE` by `DEV_ENABLED` since they're equivalent in this context.