### PR TITLE
SCons: Remove MD5-timestamp and implicit cache optimizations

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -314,16 +314,6 @@ if env_base["use_precise_math_checks"]:
 if env_base["target"] == "debug":
     env_base.Append(CPPDEFINES=["DEBUG_MEMORY_ALLOC", "DISABLE_FORCED_INLINE"])
 
-    # The two options below speed up incremental builds, but reduce the certainty that all files
-    # will properly be rebuilt. As such, we only enable them for debug (dev) builds, not release.
-
-    # To decide whether to rebuild a file, use the MD5 sum only if the timestamp has changed.
-    # https://scons.org/doc/production/HTML/scons-user/ch06.html#idm139837621851792
-    env_base.Decider("MD5-timestamp")
-    # Use cached implicit dependencies by default. Can be overridden by specifying `--implicit-deps-changed` in the command line.
-    # https://scons.org/doc/production/HTML/scons-user/ch06s04.html
-    env_base.SetOption("implicit_cache", 1)
-
 if env_base["no_editor_splash"]:
     env_base.Append(CPPDEFINES=["NO_EDITOR_SPLASH"])
 


### PR DESCRIPTION
They haven't really helped save much time on incremental rebuilds, and they do
cause potential issues with build correctness (and possibly even one of the cause
for overly eager incremental rebuilds).

Extracted from https://github.com/godotengine/godot/pull/52793#issuecomment-923189691, CC @dmoody256.