### PR TITLE
SCons: Increase min Python version to 3.6

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 EnsureSConsVersion(3, 0, 0)
-EnsurePythonVersion(3, 5)
+EnsurePythonVersion(3, 6)
 
 # System
 import atexit


### PR DESCRIPTION
Current SCons 4.2.0 still supports Python 3.5 but deprecated it, and support
will be removed in the next release.

It's also become needlessly restrictive to prevent ourselves from using Python
3.6 f-Strings, so it's time to up the requirement.