### PR TITLE
[3.x] Fix EditorSpinSlider freezes editor when tabbing focus rapidly.

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -528,9 +528,9 @@ void EditorSpinSlider::_focus_entered() {
 	value_input->set_text(get_text_value());
 	value_input->set_position(gr.position);
 	value_input->set_size(gr.size);
-	value_input->call_deferred("show_modal");
-	value_input->call_deferred("grab_focus");
-	value_input->call_deferred("select_all");
+	value_input->show_modal();
+	value_input->select_all();
+	value_input->call_deferred("grab_focus"); // deferred to avoid losing focus
 	value_input->set_focus_next(find_next_valid_focus()->get_path());
 	value_input->set_focus_previous(find_prev_valid_focus()->get_path());
 }


### PR DESCRIPTION
Fixes #53533 and fixes #34817 

This can fix most case of freezes when pressing TAB rapidly in PropertyInspector, EditorSettings and ProjectSettings.