### PR TITLE
Improve docs about plugin registration

### DIFF
--- a/doc/classes/EditorDebuggerPlugin.xml
+++ b/doc/classes/EditorDebuggerPlugin.xml
@@ -4,9 +4,10 @@
 		A base class to implement debugger plugins.
 	</brief_description>
 	<description>
-		All debugger plugin scripts must extend [EditorDebuggerPlugin]. It provides functions related to editor side of debugger.
-		You don't need to instantiate this class. That is handled by the debugger itself. [Control] nodes can be added as child nodes to provide a GUI front-end for the plugin.
-		Do not queue_free/reparent it's instance otherwise the instance becomes unusable.
+		[EditorDebuggerPlugin] provides functions related to the editor side of the debugger.
+		You don't need to instantiate this class; that is automatically handled by the debugger. [Control] nodes can be added as child nodes to provide a GUI for the plugin.
+		Do not free or reparent this node, otherwise it becomes unusable.
+		To use [EditorDebuggerPlugin], register it using the [method EditorPlugin.add_debugger_plugin] method first.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -4,7 +4,8 @@
 		A script that is executed when exporting the project.
 	</brief_description>
 	<description>
-		Editor export plugins are automatically activated whenever the user exports the project. Their most common use is to determine what files are being included in the exported project. For each plugin, [method _export_begin] is called at the beginning of the export process and then [method _export_file] is called for each exported file.
+		[EditorExportPlugin]s are automatically invoked whenever the user exports the project. Their most common use is to determine what files are being included in the exported project. For each plugin, [method _export_begin] is called at the beginning of the export process and then [method _export_file] is called for each exported file.
+		To use [EditorExportPlugin], register it using the [method EditorPlugin.add_export_plugin] method first.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -4,7 +4,7 @@
 		Registers a custom resource importer in the editor. Use the class to parse any file and import it as a new resource type.
 	</brief_description>
 	<description>
-		EditorImportPlugins provide a way to extend the editor's resource import functionality. Use them to import resources from custom files or to provide alternatives to the editor's existing importers. Register your [EditorPlugin] with [method EditorPlugin.add_import_plugin].
+		[EditorImportPlugin]s provide a way to extend the editor's resource import functionality. Use them to import resources from custom files or to provide alternatives to the editor's existing importers.
 		EditorImportPlugins work by associating with specific file extensions and a resource type. See [method _get_recognized_extensions] and [method _get_resource_type]. They may optionally specify some import presets that affect the import process. EditorImportPlugins are responsible for creating the resources and saving them in the [code].godot/imported[/code] directory (see [member ProjectSettings.application/config/project_data_dir_name]).
 		Below is an example EditorImportPlugin that imports a [Mesh] from a file with the extension ".special" or ".spec":
 		[codeblocks]
@@ -108,6 +108,7 @@
 		}
 		[/csharp]
 		[/codeblocks]
+		To use [EditorImportPlugin], register it using the [method EditorPlugin.add_import_plugin] method first.
 	</description>
 	<tutorials>
 		<link title="Import plugins">https://docs.godotengine.org/en/latest/tutorials/plugins/editor/import_plugins.html</link>

--- a/doc/classes/EditorInspectorPlugin.xml
+++ b/doc/classes/EditorInspectorPlugin.xml
@@ -4,13 +4,13 @@
 		Plugin for adding custom property editors on inspector.
 	</brief_description>
 	<description>
-		These plugins allow adding custom property editors to [EditorInspector].
-		Plugins are registered via [method EditorPlugin.add_inspector_plugin].
+		[EditorInspectorPlugin] allows adding custom property editors to [EditorInspector].
 		When an object is edited, the [method _can_handle] function is called and must return [code]true[/code] if the object type is supported.
 		If supported, the function [method _parse_begin] will be called, allowing to place custom controls at the beginning of the class.
 		Subsequently, the [method _parse_category] and [method _parse_property] are called for every category and property. They offer the ability to add custom controls to the inspector too.
 		Finally, [method _parse_end] will be called.
 		On each of these calls, the "add" functions can be called.
+		To use [EditorInspectorPlugin], register it using the [method EditorPlugin.add_inspector_plugin] method first.
 	</description>
 	<tutorials>
 		<link title="Inspector plugins">https://docs.godotengine.org/en/latest/tutorials/plugins/editor/inspector_plugins.html</link>

--- a/doc/classes/EditorNode3DGizmoPlugin.xml
+++ b/doc/classes/EditorNode3DGizmoPlugin.xml
@@ -4,7 +4,8 @@
 		Used by the editor to define Node3D gizmo types.
 	</brief_description>
 	<description>
-		EditorNode3DGizmoPlugin allows you to define a new type of Gizmo. There are two main ways to do so: extending [EditorNode3DGizmoPlugin] for the simpler gizmos, or creating a new [EditorNode3DGizmo] type. See the tutorial in the documentation for more info.
+		[EditorNode3DGizmoPlugin] allows you to define a new type of Gizmo. There are two main ways to do so: extending [EditorNode3DGizmoPlugin] for the simpler gizmos, or creating a new [EditorNode3DGizmo] type. See the tutorial in the documentation for more info.
+		To use [EditorNode3DGizmoPlugin], register it using the [method EditorPlugin.add_spatial_gizmo_plugin] method first.
 	</description>
 	<tutorials>
 		<link title="Spatial gizmo plugins">https://docs.godotengine.org/en/latest/tutorials/plugins/editor/spatial_gizmos.html</link>

--- a/doc/classes/EditorSceneFormatImporter.xml
+++ b/doc/classes/EditorSceneFormatImporter.xml
@@ -4,6 +4,8 @@
 		Imports scenes from third-parties' 3D files.
 	</brief_description>
 	<description>
+		[EditorSceneFormatImporter] allows to define an importer script for a third-party 3D format.
+		To use [EditorSceneFormatImporter], register it using the [method EditorPlugin.add_scene_format_importer_plugin] method first.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -4,7 +4,7 @@
 		Plugin for adding custom parsers to extract strings that are to be translated from custom files (.csv, .json etc.).
 	</brief_description>
 	<description>
-		Plugins are registered via [method EditorPlugin.add_translation_parser_plugin] method. To define the parsing and string extraction logic, override the [method _parse_file] method in script.
+		[EditorTranslationParserPlugin] is invoked when a file is being parsed to extract strings that require translation. To define the parsing and string extraction logic, override the [method _parse_file] method in script.
 		Add the extracted strings to argument [code]msgids[/code] or [code]msgids_context_plural[/code] if context or plural is used.
 		When adding to [code]msgids_context_plural[/code], you must add the data using the format [code]["A", "B", "C"][/code], where [code]A[/code] represents the extracted string, [code]B[/code] represents the context, and [code]C[/code] represents the plural version of the extracted string. If you want to add only context but not plural, put [code]""[/code] for the plural slot. The idea is the same if you only want to add plural but not context. See the code below for concrete examples.
 		The extracted strings will be written into a POT file selected by user under "POT Generation" in "Localization" tab in "Project Settings" menu.
@@ -98,6 +98,7 @@
 		}
 		[/csharp]
 		[/codeblocks]
+		To use [EditorTranslationParserPlugin], register it using the [method EditorPlugin.add_translation_parser_plugin] method first.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/195
The docs for EditorExportPlugin were filled, but they didn't mention the most important thing - that you need to register the plugin for any method to be called.

I also made the same changes to other similar plugins, unifying it a bit.