### PR TITLE
Added ability to get list of editor settings changed when saving editor settings. Optimised settings changed notification.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -70,11 +70,24 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="check_changed_settings_in_group" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="setting_prefix" type="String" />
+			<description>
+				Checks if any settings with the prefix [code]setting_prefix[/code] exist in the set of changed settings. See also [method get_changed_settings].
+			</description>
+		</method>
 		<method name="erase">
 			<return type="void" />
 			<argument index="0" name="property" type="String" />
 			<description>
 				Erases the setting whose name is specified by [code]property[/code].
+			</description>
+		</method>
+		<method name="get_changed_settings" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Gets an array of the settings which have been changed since the last save. Note that internally [code]changed_settings[/code] is cleared after a successful save, so generally the most appropriate place to use this method is when processing [constant NOTIFICATION_EDITOR_SETTINGS_CHANGED]
 			</description>
 		</method>
 		<method name="get_favorites" qualifiers="const">
@@ -116,6 +129,13 @@
 			<argument index="0" name="name" type="String" />
 			<description>
 				Returns [code]true[/code] if the setting specified by [code]name[/code] exists, [code]false[/code] otherwise.
+			</description>
+		</method>
+		<method name="mark_setting_changed">
+			<return type="void" />
+			<argument index="0" name="setting" type="String" />
+			<description>
+				Marks the passed editor setting as being changed, see [method get_changed_settings]. Only settings which exist (see [method has_setting]) will be accepted.
 			</description>
 		</method>
 		<method name="property_can_revert">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -694,22 +694,29 @@ void EditorNode::_notification(int p_what) {
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			scene_tabs->set_tab_close_display_policy((bool(EDITOR_GET("interface/scene_tabs/always_show_close_button")) ? TabBar::CLOSE_BUTTON_SHOW_ALWAYS : TabBar::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
-			theme = create_custom_theme(theme_base->get_theme());
 
-			theme_base->set_theme(theme);
-			gui_base->set_theme(theme);
+			bool theme_changed =
+					EditorSettings::get_singleton()->check_changed_settings_in_group("interface/theme") ||
+					EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/theme");
 
-			gui_base->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
-			scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Content"), SNAME("EditorStyles")));
-			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
-			scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox(SNAME("SceneTabFG"), SNAME("EditorStyles")));
-			scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox(SNAME("SceneTabBG"), SNAME("EditorStyles")));
+			if (theme_changed) {
+				theme = create_custom_theme(theme_base->get_theme());
 
-			file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
-			project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
-			debug_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
-			settings_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
-			help_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+				theme_base->set_theme(theme);
+				gui_base->set_theme(theme);
+
+				gui_base->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
+				scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Content"), SNAME("EditorStyles")));
+				bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
+				scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox(SNAME("SceneTabFG"), SNAME("EditorStyles")));
+				scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox(SNAME("SceneTabBG"), SNAME("EditorStyles")));
+
+				file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+				project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+				debug_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+				settings_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+				help_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			}
 
 			if (EDITOR_GET("interface/scene_tabs/resize_if_many_tabs")) {
 				scene_tabs->set_min_width(int(EDITOR_GET("interface/scene_tabs/minimum_width")) * EDSCALE);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -63,6 +63,7 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 
 	bool changed = _set_only(p_name, p_value);
 	if (changed) {
+		changed_settings.insert(p_name);
 		emit_signal(SNAME("settings_changed"));
 	}
 	return true;
@@ -941,8 +942,32 @@ void EditorSettings::save() {
 	if (err != OK) {
 		ERR_PRINT("Error saving editor settings to " + singleton->config_file_path);
 	} else {
+		singleton->changed_settings.clear();
 		print_verbose("EditorSettings: Save OK!");
 	}
+}
+
+Array EditorSettings::get_changed_settings() const {
+	Array arr;
+	for (const String &setting : changed_settings) {
+		arr.push_back(setting);
+	}
+
+	return arr;
+}
+
+bool EditorSettings::check_changed_settings_in_group(const String &p_setting_prefix) const {
+	for (const String &setting : changed_settings) {
+		if (setting.begins_with(p_setting_prefix)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void EditorSettings::mark_setting_changed(const String &p_setting) {
+	changed_settings.insert(p_setting);
 }
 
 void EditorSettings::destroy() {
@@ -1620,6 +1645,10 @@ void EditorSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_recent_dirs"), &EditorSettings::get_recent_dirs);
 
 	ClassDB::bind_method(D_METHOD("set_builtin_action_override", "name", "actions_list"), &EditorSettings::set_builtin_action_override);
+
+	ClassDB::bind_method(D_METHOD("check_changed_settings_in_group", "setting_prefix"), &EditorSettings::check_changed_settings_in_group);
+	ClassDB::bind_method(D_METHOD("get_changed_settings"), &EditorSettings::get_changed_settings);
+	ClassDB::bind_method(D_METHOD("mark_setting_changed", "setting"), &EditorSettings::mark_setting_changed);
 
 	ADD_SIGNAL(MethodInfo("settings_changed"));
 

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -77,6 +77,8 @@ private:
 
 	static Ref<EditorSettings> singleton;
 
+	Set<String> changed_settings;
+
 	HashMap<String, PropertyInfo> hints;
 	HashMap<String, VariantContainer> props;
 	int last_order;
@@ -140,6 +142,9 @@ public:
 	bool property_can_revert(const String &p_setting);
 	Variant property_get_revert(const String &p_setting);
 	void add_property_hint(const PropertyInfo &p_hint);
+	Array get_changed_settings() const;
+	bool check_changed_settings_in_group(const String &p_setting_prefix) const;
+	void mark_setting_changed(const String &p_setting);
 
 	void set_resource_clipboard(const Ref<Resource> &p_resource) { clipboard = p_resource; }
 	Ref<Resource> get_resource_clipboard() const { return clipboard; }

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -136,7 +136,13 @@ void EditorSettingsDialog::_notification(int p_what) {
 			_update_icons();
 			// Update theme colors.
 			inspector->update_category_list();
-			_update_shortcuts();
+
+			bool update_shortcuts_tab =
+					EditorSettings::get_singleton()->check_changed_settings_in_group("shortcuts") ||
+					EditorSettings::get_singleton()->check_changed_settings_in_group("builtin_action_overrides");
+			if (update_shortcuts_tab) {
+				_update_shortcuts();
+			}
 		} break;
 	}
 }
@@ -215,6 +221,8 @@ void EditorSettingsDialog::_update_builtin_action(const String &p_name, const Ar
 	Array old_input_array = EditorSettings::get_singleton()->get_builtin_action_overrides(p_name);
 
 	undo_redo->create_action(TTR("Edit Built-in Action") + " '" + p_name + "'");
+	undo_redo->add_do_method(EditorSettings::get_singleton(), "mark_setting_changed", "builtin_action_overrides");
+	undo_redo->add_undo_method(EditorSettings::get_singleton(), "mark_setting_changed", "builtin_action_overrides");
 	undo_redo->add_do_method(EditorSettings::get_singleton(), "set_builtin_action_override", p_name, p_events);
 	undo_redo->add_undo_method(EditorSettings::get_singleton(), "set_builtin_action_override", p_name, old_input_array);
 	undo_redo->add_do_method(this, "_settings_changed");
@@ -230,6 +238,8 @@ void EditorSettingsDialog::_update_shortcut_events(const String &p_path, const A
 	undo_redo->create_action(TTR("Edit Shortcut") + " '" + p_path + "'");
 	undo_redo->add_do_method(current_sc.ptr(), "set_events", p_events);
 	undo_redo->add_undo_method(current_sc.ptr(), "set_events", current_sc->get_events());
+	undo_redo->add_do_method(EditorSettings::get_singleton(), "mark_setting_changed", "shortcuts");
+	undo_redo->add_undo_method(EditorSettings::get_singleton(), "mark_setting_changed", "shortcuts");
 	undo_redo->add_do_method(this, "_update_shortcuts");
 	undo_redo->add_undo_method(this, "_update_shortcuts");
 	undo_redo->add_do_method(this, "_settings_changed");


### PR DESCRIPTION
Getting the settings which were changed has been a common request. This also allows for some optimisation.

**Debug build time savings**
Saving settings 'hitch' before: 1000ms
Saving settings 'hitch' after: 350ms

There is still time to be gained, for example in `EditorInspector`, `update_tree()` takes 0.25ms to run, but I am not sure why this is called when editor settings are changed. What changes is it responding to? Once we know that, then a check can be added to only conditionally run that method (e.g. if it is only changing due to theme changes)

https://user-images.githubusercontent.com/41730826/137493842-5593ea4a-078f-41b2-9398-476f84370086.mp4



