### PR TITLE
GPULightmapper: increase ray triangle hit rate

### DIFF
--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -94,13 +94,14 @@ params;
 
 //check it, but also return distance and barycentric coords (for uv lookup)
 bool ray_hits_triangle(vec3 from, vec3 dir, float max_dist, vec3 p0, vec3 p1, vec3 p2, out float r_distance, out vec3 r_barycentric) {
+	const float EPSILON = 0.00001;
 	const vec3 e0 = p1 - p0;
 	const vec3 e1 = p0 - p2;
 	vec3 triangle_normal = cross(e1, e0);
 
 	float n_dot_dir = dot(triangle_normal, dir);
 
-	if (abs(n_dot_dir) < 0.01) {
+	if (abs(n_dot_dir) < EPSILON) {
 		return false;
 	}
 


### PR DESCRIPTION
Currently the method ray_hits_triangle determines triangles not to be hit by
a ray due to an epsilon that is too big. In practice those triangles are hit by
those rays.

This is fixed by introducing a smaller epsilon.

This fixes the leaks in the model of @jcostello (see below) given in #51638. Also notice that the shadow cast by the roof of the veranda was incorrect.

Before (Quality: medium; bounces: 0; denoiser: off)
![Screenshot from 2021-10-15 15-32-22](https://user-images.githubusercontent.com/10560119/137496350-ab514734-7af0-4228-a8f0-4909ec45c480.png)

After (Quality: medium; bounces: 0; denoiser: off)
![Screenshot from 2021-10-15 15-02-35](https://user-images.githubusercontent.com/10560119/137496370-a5cfb8c9-f16f-40f6-9689-6ce4e69d220d.png)

