### PR TITLE
collada: fix error in use of fix_transform.

### DIFF
--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -122,7 +122,7 @@ Error ColladaImport::_populate_skeleton(Skeleton3D *p_skeleton, Collada::Node *p
 
 	{
 		Transform3D xform = joint->compute_transform(collada);
-		collada.fix_transform(xform) * joint->post_transform;
+		xform = collada.fix_transform(xform) * joint->post_transform;
 
 		p_skeleton->set_bone_pose_position(r_bone, xform.origin);
 		p_skeleton->set_bone_pose_rotation(r_bone, xform.basis.get_rotation_quaternion());


### PR DESCRIPTION
Found an apparent typo in #53765 by @reduz causing the result of `fix_transform` after `compute_transform` to be ignored when calculating the initial bone pose.

`fix_transform` is return-by-value, but the return value was ignored.

Unfortunately I do not know enough about COLLADA to understand how to test this case.