### PR TITLE
SCons: List `.gen.cpp` sources explicitly to avoid globbing errors

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -146,6 +146,7 @@ env.core_sources += thirdparty_obj
 # Godot source files
 
 env.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files(env.core_sources, "script_encryption_key.gen.cpp")
 
 # Certificates
 env.Depends(

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -7,19 +7,15 @@ import input_builders
 
 # Order matters here. Higher index controller database files write on top of lower index database files.
 controller_databases = [
-    "#core/input/gamecontrollerdb.txt",
-    "#core/input/godotcontrollerdb.txt",
+    "gamecontrollerdb.txt",
+    "godotcontrollerdb.txt",
 ]
 
-env.Depends("#core/input/default_controller_mappings.gen.cpp", controller_databases)
-env.CommandNoCache(
-    "#core/input/default_controller_mappings.gen.cpp",
+gensource = env.CommandNoCache(
+    "default_controller_mappings.gen.cpp",
     controller_databases,
     env.Run(input_builders.make_default_controller_mappings, "Generating default controller mappings."),
 )
 
 env.add_source_files(env.core_sources, "*.cpp")
-
-# Don't warn about duplicate entry here, we need it registered manually for first build,
-# even if later builds will pick it up twice due to above *.cpp globbing.
-env.add_source_files(env.core_sources, "#core/input/default_controller_mappings.gen.cpp", warn_duplicates=False)
+env.add_source_files(env.core_sources, gensource)

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -101,6 +101,7 @@ if env["tools"]:
     )
 
     env.add_source_files(env.editor_sources, "*.cpp")
+    env.add_source_files(env.editor_sources, "register_exporters.gen.cpp")
 
     SConscript("debugger/SCsub")
     SConscript("fileserver/SCsub")

--- a/methods.py
+++ b/methods.py
@@ -14,7 +14,7 @@ from SCons.Variables.BoolVariable import _text2bool
 from platform_methods import run_in_subprocess
 
 
-def add_source_files(self, sources, files, warn_duplicates=True):
+def add_source_files(self, sources, files):
     # Convert string to list of absolute paths (including expanding wildcard)
     if isinstance(files, (str, bytes)):
         # Keep SCons project-absolute path as they are (no wildcard support)
@@ -24,17 +24,20 @@ def add_source_files(self, sources, files, warn_duplicates=True):
                 return
             files = [files]
         else:
+            # Exclude .gen.cpp files from globbing, to avoid including obsolete ones.
+            # They should instead be added manually.
+            skip_gen_cpp = "*" in files
             dir_path = self.Dir(".").abspath
             files = sorted(glob.glob(dir_path + "/" + files))
+            if skip_gen_cpp:
+                files = [f for f in files if not f.endswith(".gen.cpp")]
 
     # Add each path as compiled Object following environment (self) configuration
     for path in files:
         obj = self.Object(path)
         if obj in sources:
-            if warn_duplicates:
-                print('WARNING: Object "{}" already included in environment sources.'.format(obj))
-            else:
-                continue
+            print('WARNING: Object "{}" already included in environment sources.'.format(obj))
+            continue
         sources.append(obj)
 
 


### PR DESCRIPTION
Whenever we change the name (or remove) generated cpp files with the `.gen.cpp`
extension, users run into build issues when switching between branches (i.e.
switching before and after the name change/removal). This is because we glob
`*.cpp` so if a now-obsolete file from a previous build is present, we'll
include it too, potentially leading to bugs or compilation failure (due to
missing headers or invalid code).

So globbing patterns in `add_source_files` will now skip files ending with
`.gen.cpp`, which should instead be passed explicitly where they're used.

"Cleaner" alternative to #51900.

Fixes #40066, fixes #39789, fixes #37550, fixes #20074, and countless other similar issues either reported here, on Discord, on Reddit, on the Q&A, on chat, and older issues from when the same happened in 2.1 -> 3.0...