### PR TITLE
Improve Curve with `real_t` and naming

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -460,7 +460,7 @@ void CurveEditor::remove_point(int index) {
 	Curve::Point p = _curve_ref->get_point(index);
 
 	ur.add_do_method(*_curve_ref, "remove_point", index);
-	ur.add_undo_method(*_curve_ref, "add_point", p.pos, p.left_tangent, p.right_tangent, p.left_mode, p.right_mode);
+	ur.add_undo_method(*_curve_ref, "add_point", p.position, p.left_tangent, p.right_tangent, p.left_mode, p.right_mode);
 
 	if (index == _selected_point) {
 		set_selected_point(-1);

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -50,7 +50,7 @@ public:
 	};
 
 	struct Point {
-		Vector2 pos;
+		Vector2 position;
 		real_t left_tangent = 0.0;
 		real_t right_tangent = 0.0;
 		TangentMode left_mode = TANGENT_FREE;
@@ -59,12 +59,12 @@ public:
 		Point() {
 		}
 
-		Point(Vector2 p_pos,
+		Point(const Vector2 &p_position,
 				real_t p_left = 0.0,
 				real_t p_right = 0.0,
 				TangentMode p_left_mode = TANGENT_FREE,
 				TangentMode p_right_mode = TANGENT_FREE) {
-			pos = p_pos;
+			position = p_position;
 			left_tangent = p_left;
 			right_tangent = p_right;
 			left_mode = p_left_mode;
@@ -76,7 +76,7 @@ public:
 
 	int get_point_count() const { return _points.size(); }
 
-	int add_point(Vector2 p_pos,
+	int add_point(Vector2 p_position,
 			real_t left_tangent = 0,
 			real_t right_tangent = 0,
 			TangentMode left_mode = TANGENT_FREE,
@@ -85,34 +85,34 @@ public:
 	void remove_point(int p_index);
 	void clear_points();
 
-	int get_index(real_t offset) const;
+	int get_index(real_t p_offset) const;
 
-	void set_point_value(int p_index, real_t pos);
-	int set_point_offset(int p_index, float offset);
+	void set_point_value(int p_index, real_t p_position);
+	int set_point_offset(int p_index, real_t p_offset);
 	Vector2 get_point_position(int p_index) const;
 
 	Point get_point(int p_index) const;
 
-	float get_min_value() const { return _min_value; }
-	void set_min_value(float p_min);
+	real_t get_min_value() const { return _min_value; }
+	void set_min_value(real_t p_min);
 
-	float get_max_value() const { return _max_value; }
-	void set_max_value(float p_max);
+	real_t get_max_value() const { return _max_value; }
+	void set_max_value(real_t p_max);
 
-	real_t interpolate(real_t offset) const;
-	real_t interpolate_local_nocheck(int index, real_t local_offset) const;
+	real_t interpolate(real_t p_offset) const;
+	real_t interpolate_local_nocheck(int p_index, real_t p_local_offset) const;
 
 	void clean_dupes();
 
-	void set_point_left_tangent(int i, real_t tangent);
-	void set_point_right_tangent(int i, real_t tangent);
-	void set_point_left_mode(int i, TangentMode p_mode);
-	void set_point_right_mode(int i, TangentMode p_mode);
+	void set_point_left_tangent(int p_index, real_t p_tangent);
+	void set_point_right_tangent(int p_index, real_t p_tangent);
+	void set_point_left_mode(int p_index, TangentMode p_mode);
+	void set_point_right_mode(int p_index, TangentMode p_mode);
 
-	real_t get_point_left_tangent(int i) const;
-	real_t get_point_right_tangent(int i) const;
-	TangentMode get_point_left_mode(int i) const;
-	TangentMode get_point_right_mode(int i) const;
+	real_t get_point_left_tangent(int p_index) const;
+	real_t get_point_right_tangent(int p_index) const;
+	TangentMode get_point_left_mode(int p_index) const;
+	TangentMode get_point_right_mode(int p_index) const;
 
 	void update_auto_tangents(int i);
 
@@ -122,9 +122,9 @@ public:
 	void bake();
 	int get_bake_resolution() const { return _bake_resolution; }
 	void set_bake_resolution(int p_resolution);
-	real_t interpolate_baked(real_t offset) const;
+	real_t interpolate_baked(real_t p_offset) const;
 
-	void ensure_default_setup(float p_min, float p_max);
+	void ensure_default_setup(real_t p_min, real_t p_max);
 
 protected:
 	static void _bind_methods();
@@ -136,8 +136,8 @@ private:
 	bool _baked_cache_dirty = false;
 	Vector<real_t> _baked_cache;
 	int _bake_resolution = 100;
-	float _min_value = 0.0;
-	float _max_value = 1.0;
+	real_t _min_value = 0.0;
+	real_t _max_value = 1.0;
 	int _minmax_set_once = 0b00; // Encodes whether min and max have been set a first time, first bit for min and second for max.
 };
 
@@ -149,26 +149,26 @@ class Curve2D : public Resource {
 	struct Point {
 		Vector2 in;
 		Vector2 out;
-		Vector2 pos;
+		Vector2 position;
 	};
 
 	Vector<Point> points;
 
 	struct BakedPoint {
-		float ofs = 0.0;
+		real_t ofs = 0.0;
 		Vector2 point;
 	};
 
 	mutable bool baked_cache_dirty = false;
 	mutable PackedVector2Array baked_point_cache;
-	mutable PackedFloat32Array baked_dist_cache;
-	mutable float baked_max_ofs = 0.0;
+	mutable Vector<real_t> baked_dist_cache;
+	mutable real_t baked_max_ofs = 0.0;
 
 	void _bake() const;
 
-	float bake_interval = 5.0;
+	real_t bake_interval = 5.0;
 
-	void _bake_segment2d(Map<float, Vector2> &r_bake, float p_begin, float p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_max_depth, float p_tol) const;
+	void _bake_segment2d(Map<real_t, Vector2> &r_bake, real_t p_begin, real_t p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
 	Dictionary _get_data() const;
 	void _set_data(const Dictionary &p_data);
 
@@ -177,8 +177,8 @@ protected:
 
 public:
 	int get_point_count() const;
-	void add_point(const Vector2 &p_pos, const Vector2 &p_in = Vector2(), const Vector2 &p_out = Vector2(), int p_atpos = -1);
-	void set_point_position(int p_index, const Vector2 &p_pos);
+	void add_point(const Vector2 &p_position, const Vector2 &p_in = Vector2(), const Vector2 &p_out = Vector2(), int p_atpos = -1);
+	void set_point_position(int p_index, const Vector2 &p_position);
 	Vector2 get_point_position(int p_index) const;
 	void set_point_in(int p_index, const Vector2 &p_in);
 	Vector2 get_point_in(int p_index) const;
@@ -187,19 +187,19 @@ public:
 	void remove_point(int p_index);
 	void clear_points();
 
-	Vector2 interpolate(int p_index, float p_offset) const;
+	Vector2 interpolate(int p_index, real_t p_offset) const;
 	Vector2 interpolatef(real_t p_findex) const;
 
-	void set_bake_interval(float p_tolerance);
-	float get_bake_interval() const;
+	void set_bake_interval(real_t p_tolerance);
+	real_t get_bake_interval() const;
 
-	float get_baked_length() const;
-	Vector2 interpolate_baked(float p_offset, bool p_cubic = false) const;
+	real_t get_baked_length() const;
+	Vector2 interpolate_baked(real_t p_offset, bool p_cubic = false) const;
 	PackedVector2Array get_baked_points() const; //useful for going through
 	Vector2 get_closest_point(const Vector2 &p_to_point) const;
-	float get_closest_offset(const Vector2 &p_to_point) const;
+	real_t get_closest_offset(const Vector2 &p_to_point) const;
 
-	PackedVector2Array tessellate(int p_max_stages = 5, float p_tolerance = 4) const; //useful for display
+	PackedVector2Array tessellate(int p_max_stages = 5, real_t p_tolerance = 4) const; //useful for display
 
 	Curve2D();
 };
@@ -210,14 +210,14 @@ class Curve3D : public Resource {
 	struct Point {
 		Vector3 in;
 		Vector3 out;
-		Vector3 pos;
-		float tilt = 0.0;
+		Vector3 position;
+		real_t tilt = 0.0;
 	};
 
 	Vector<Point> points;
 
 	struct BakedPoint {
-		float ofs = 0.0;
+		real_t ofs = 0.0;
 		Vector3 point;
 	};
 
@@ -225,15 +225,15 @@ class Curve3D : public Resource {
 	mutable PackedVector3Array baked_point_cache;
 	mutable Vector<real_t> baked_tilt_cache;
 	mutable PackedVector3Array baked_up_vector_cache;
-	mutable PackedFloat32Array baked_dist_cache;
-	mutable float baked_max_ofs = 0.0;
+	mutable Vector<real_t> baked_dist_cache;
+	mutable real_t baked_max_ofs = 0.0;
 
 	void _bake() const;
 
-	float bake_interval = 0.2;
+	real_t bake_interval = 0.2;
 	bool up_vector_enabled = true;
 
-	void _bake_segment3d(Map<float, Vector3> &r_bake, float p_begin, float p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, float p_tol) const;
+	void _bake_segment3d(Map<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
 	Dictionary _get_data() const;
 	void _set_data(const Dictionary &p_data);
 
@@ -242,11 +242,11 @@ protected:
 
 public:
 	int get_point_count() const;
-	void add_point(const Vector3 &p_pos, const Vector3 &p_in = Vector3(), const Vector3 &p_out = Vector3(), int p_atpos = -1);
-	void set_point_position(int p_index, const Vector3 &p_pos);
+	void add_point(const Vector3 &p_position, const Vector3 &p_in = Vector3(), const Vector3 &p_out = Vector3(), int p_atpos = -1);
+	void set_point_position(int p_index, const Vector3 &p_position);
 	Vector3 get_point_position(int p_index) const;
-	void set_point_tilt(int p_index, float p_tilt);
-	float get_point_tilt(int p_index) const;
+	void set_point_tilt(int p_index, real_t p_tilt);
+	real_t get_point_tilt(int p_index) const;
 	void set_point_in(int p_index, const Vector3 &p_in);
 	Vector3 get_point_in(int p_index) const;
 	void set_point_out(int p_index, const Vector3 &p_out);
@@ -254,25 +254,25 @@ public:
 	void remove_point(int p_index);
 	void clear_points();
 
-	Vector3 interpolate(int p_index, float p_offset) const;
+	Vector3 interpolate(int p_index, real_t p_offset) const;
 	Vector3 interpolatef(real_t p_findex) const;
 
-	void set_bake_interval(float p_tolerance);
-	float get_bake_interval() const;
+	void set_bake_interval(real_t p_tolerance);
+	real_t get_bake_interval() const;
 	void set_up_vector_enabled(bool p_enable);
 	bool is_up_vector_enabled() const;
 
-	float get_baked_length() const;
-	Vector3 interpolate_baked(float p_offset, bool p_cubic = false) const;
-	float interpolate_baked_tilt(float p_offset) const;
-	Vector3 interpolate_baked_up_vector(float p_offset, bool p_apply_tilt = false) const;
+	real_t get_baked_length() const;
+	Vector3 interpolate_baked(real_t p_offset, bool p_cubic = false) const;
+	real_t interpolate_baked_tilt(real_t p_offset) const;
+	Vector3 interpolate_baked_up_vector(real_t p_offset, bool p_apply_tilt = false) const;
 	PackedVector3Array get_baked_points() const; //useful for going through
 	Vector<real_t> get_baked_tilts() const; //useful for going through
 	PackedVector3Array get_baked_up_vectors() const;
 	Vector3 get_closest_point(const Vector3 &p_to_point) const;
-	float get_closest_offset(const Vector3 &p_to_point) const;
+	real_t get_closest_offset(const Vector3 &p_to_point) const;
 
-	PackedVector3Array tessellate(int p_max_stages = 5, float p_tolerance = 4) const; //useful for display
+	PackedVector3Array tessellate(int p_max_stages = 5, real_t p_tolerance = 4) const; //useful for display
 
 	Curve3D();
 };

--- a/tests/scene/test_curve.h
+++ b/tests/scene/test_curve.h
@@ -219,35 +219,33 @@ TEST_CASE("[Curve] Custom curve with linear tangents") {
 
 TEST_CASE("[Curve2D] Linear sampling should return exact value") {
 	Ref<Curve2D> curve = memnew(Curve2D);
-	int len = 2048;
+	real_t len = 2048.0;
 
 	curve->add_point(Vector2(0, 0));
-	curve->add_point(Vector2((float)len, 0));
+	curve->add_point(Vector2(len, 0));
 
-	float baked_length = curve->get_baked_length();
-	CHECK((float)len == baked_length);
+	real_t baked_length = curve->get_baked_length();
+	CHECK(len == baked_length);
 
 	for (int i = 0; i < len; i++) {
-		float expected = (float)i;
-		Vector2 pos = curve->interpolate_baked(expected);
-		CHECK_MESSAGE(pos.x == expected, "interpolate_baked should return exact value");
+		Vector2 pos = curve->interpolate_baked(i);
+		CHECK_MESSAGE(pos.x == i, "interpolate_baked should return exact value");
 	}
 }
 
 TEST_CASE("[Curve3D] Linear sampling should return exact value") {
 	Ref<Curve3D> curve = memnew(Curve3D);
-	int len = 2048;
+	real_t len = 2048.0;
 
 	curve->add_point(Vector3(0, 0, 0));
-	curve->add_point(Vector3((float)len, 0, 0));
+	curve->add_point(Vector3(len, 0, 0));
 
-	float baked_length = curve->get_baked_length();
-	CHECK((float)len == baked_length);
+	real_t baked_length = curve->get_baked_length();
+	CHECK(len == baked_length);
 
 	for (int i = 0; i < len; i++) {
-		float expected = (float)i;
-		Vector3 pos = curve->interpolate_baked(expected);
-		CHECK_MESSAGE(pos.x == expected, "interpolate_baked should return exact value");
+		Vector3 pos = curve->interpolate_baked(i);
+		CHECK_MESSAGE(pos.x == i, "interpolate_baked should return exact value");
 	}
 }
 


### PR DESCRIPTION
This PR improves the Curve, Curve2D, and Curve3D classes. It does these things:

* Use `real_t` instead of `float`. I made this change to get correct results from the test cases added in #51945 when Godot is compiled with doubles. I have tested that this works as expected with both singles (float=32) and doubles (float=64).
* Ensure that parameters start with a `p_` prefix.
* Rename a few things for clarity, such as `i` -> `index` and `pos` -> `position`.

This will conflict with #51372, I'm not sure which should be merged first.