### PR TITLE
Fix null crash with TextEdit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3623,6 +3623,8 @@ int TextEdit::get_caret_wrap_index() const {
 }
 
 String TextEdit::get_word_under_caret() const {
+	ERR_FAIL_INDEX_V(caret.line, text.size(), "");
+	ERR_FAIL_INDEX_V(caret.column, text[caret.line].length() + 1, "");
 	PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(caret.line)->get_rid());
 	for (int i = 0; i < words.size(); i = i + 2) {
 		if (words[i] <= caret.column && words[i + 1] > caret.column) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #53872

Also I've added a check when removing text to reset the caret to the start of the text selection when the text being deleted contains the caret. This fixes the issue better than a simple null check, but I've added that too for future-proof.