### PR TITLE
Hide console window by default on Windows

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2848,9 +2848,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		} break;
 		case SETTINGS_TOGGLE_CONSOLE: {
-			bool was_visible = DisplayServer::get_singleton()->is_console_visible();
+			const bool was_visible = DisplayServer::get_singleton()->is_console_visible();
 			DisplayServer::get_singleton()->console_set_visible(!was_visible);
-			EditorSettings::get_singleton()->set_setting("interface/editor/hide_console_window", was_visible);
+			EditorSettings::get_singleton()->set_setting("interface/editor/show_console_window", !was_visible);
 		} break;
 		case EDITOR_SCREENSHOT: {
 			screenshot_timer->start();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -439,7 +439,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/separate_distraction_mode", false);
 	_initial_set("interface/editor/automatically_open_screenshots", true);
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/single_window_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
-	_initial_set("interface/editor/hide_console_window", false);
+	_initial_set("interface/editor/show_console_window", false);
 	_initial_set("interface/editor/mouse_extra_buttons_navigate_history", true);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2434,10 +2434,10 @@ bool Main::start() {
 
 		if (project_manager || editor) {
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CONSOLE_WINDOW)) {
-				// Hide console window if requested (Windows-only).
-				bool hide_console = EditorSettings::get_singleton()->get_setting(
-						"interface/editor/hide_console_window");
-				DisplayServer::get_singleton()->console_set_visible(!hide_console);
+				// Show console window if requested (Windows-only).
+				const bool show_console = EditorSettings::get_singleton()->get_setting(
+						"interface/editor/show_console_window");
+				DisplayServer::get_singleton()->console_set_visible(show_console);
 			}
 
 			// Load SSL Certificates from Editor Settings (or builtin)


### PR DESCRIPTION
This prevents issues with text selection causing the editor to freeze indefinitely until said selection is aborted. This also matches Blender's behavior where the system console is hidden bydefault.

This also renames the setting to work in an affirmative manner ("show" instead of "hide").

Testing is welcome, as I haven't tested this on a proper Windows setup yet.

This closes https://github.com/godotengine/godot/issues/34200.