### PR TITLE
Salvage: Fix Anim Tree blending inconsistency

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -934,7 +934,6 @@ void AnimationTree::_process_graph(real_t p_delta) {
 							t->process_pass = process_pass;
 							t->loc = Vector3();
 							t->rot = Quaternion();
-							t->rot_blend_accum = 0;
 							t->scale = Vector3(1, 1, 1);
 						}
 
@@ -995,7 +994,6 @@ void AnimationTree::_process_graph(real_t p_delta) {
 							t->process_pass = process_pass;
 							t->loc = Vector3();
 							t->rot = Quaternion();
-							t->rot_blend_accum = 0;
 							t->scale = Vector3(1, 1, 1);
 						}
 
@@ -1047,14 +1045,7 @@ void AnimationTree::_process_graph(real_t p_delta) {
 								continue;
 							}
 
-							if (t->rot_blend_accum == 0) {
-								t->rot = rot;
-								t->rot_blend_accum = blend;
-							} else {
-								real_t rot_total = t->rot_blend_accum + blend;
-								t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
-								t->rot_blend_accum = rot_total;
-							}
+							t->rot = (t->rot * Quaternion().slerp(rot, blend)).normalized();
 						}
 #endif // _3D_DISABLED
 					} break;
@@ -1066,7 +1057,6 @@ void AnimationTree::_process_graph(real_t p_delta) {
 							t->process_pass = process_pass;
 							t->loc = Vector3();
 							t->rot = Quaternion();
-							t->rot_blend_accum = 0;
 							t->scale = Vector3(1, 1, 1);
 						}
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -202,7 +202,6 @@ private:
 		bool scale_used = false;
 		Vector3 loc;
 		Quaternion rot;
-		real_t rot_blend_accum = 0.0;
 		Vector3 scale;
 
 		TrackCacheTransform() {


### PR DESCRIPTION
Co-authored-by: Marios Staikopoulos marios@staik.net

This PR is a salvage of #34134. This will break compatibility with the old NodeAdd.

Fixed #37661. And it may fixes #34694.

https://user-images.githubusercontent.com/61938263/137605517-30c76402-b25f-4841-b2cf-b15a6df5e518.mov

In the first blending, the translation looks strange, but this is due to a change in #53689. This requires a new implementation of blending when no track exists, separately from this PR.

The second blending also looks broken at first look, but since the similar pose is applied twice, which is the correct behavior. Moreover, this change makes the proposal https://github.com/godotengine/godot-proposals/issues/2700 worthwhile in conjunction with #53765.

In other words, https://github.com/godotengine/godot-proposals/issues/2700 mentioned a problem with the previous animation system which the base pose for extracting additive animations was completely fixed on import, but this has been removed by #53765. The correct extraction of additive animation can now be done by implementing NodeSub or by setting the base pose as an optional parameter in NodeAdd.