### PR TITLE
Re-add project features as define constants in C#

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -100,7 +100,7 @@
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'ios' ">GODOT_IPHONE;GODOT_IOS;GODOT_MOBILE</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'web' ">GODOT_JAVASCRIPT;GODOT_HTML5;GODOT_WASM;GODOT_WEB</GodotPlatformConstants>
 
-    <GodotDefineConstants>$(GodotDefineConstants);$(GodotPlatformConstants);$(GodotVersionConstants)</GodotDefineConstants>
+    <GodotDefineConstants>$(GodotDefineConstants);$(GodotPlatformConstants);$(GodotVersionConstants);$(GodotFeatureConstants)</GodotDefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
@@ -20,7 +20,7 @@ namespace GodotTools.Build
         public bool OnlyClean { get; private set; }
 
         // TODO Use List once we have proper serialization
-        public Godot.Collections.Array CustomProperties { get; private set; } = new();
+        public Godot.Collections.Array<string> CustomProperties { get; private set; } = new();
 
         public string LogsDirPath => GodotSharpDirs.LogsDirPathFor(Solution, Configuration);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -293,7 +293,8 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
-            bool includeDebugSymbols = true
+            bool includeDebugSymbols = true,
+            string[]? features = null
         )
         {
             var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, GodotSharpDirs.ProjectCsProjPath, configuration,
@@ -309,6 +310,12 @@ namespace GodotTools.Build
 
             if (Internal.GodotIsRealTDouble())
                 buildInfo.CustomProperties.Add("GodotFloat64=true");
+
+            if (features != null && features.Length > 0)
+            {
+                // Use '%3B' as the separator which is ';' escaped. See https://github.com/dotnet/msbuild/issues/471.
+                buildInfo.CustomProperties.Add($"GodotFeatureConstants={string.Join("%3B", SanitizeFeatures(features))}");
+            }
 
             return buildInfo;
         }
@@ -329,9 +336,30 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
-            bool includeDebugSymbols = true
+            bool includeDebugSymbols = true,
+            string[]? features = null
         ) => PublishProjectBlocking(CreatePublishBuildInfo(configuration,
-            platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols));
+            platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols, features));
+
+        private static List<string> SanitizeFeatures(string[] features)
+        {
+            var sanitizedFeatures = new List<string>();
+
+            foreach (string feature in features)
+            {
+                if (string.IsNullOrWhiteSpace(feature))
+                    continue;
+
+                string sanitizedFeature = feature.ToUpperInvariant()
+                                                 .Replace("-", "_")
+                                                 .Replace(" ", "_")
+                                                 .Replace(";", "_");
+
+                sanitizedFeatures.Add($"GODOT_FEATURE_{sanitizedFeature}");
+            }
+
+            return sanitizedFeatures;
+        }
 
         public static bool GenerateXCFrameworkBlocking(
             List<string> outputPaths,

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -183,9 +183,9 @@ namespace GodotTools.Build
             AddBinaryLogArgument(buildInfo, arguments, editorSettings);
 
             // Custom properties
-            foreach (var customProperty in buildInfo.CustomProperties)
+            foreach (string customProperty in buildInfo.CustomProperties)
             {
-                arguments.Add("-p:" + (string)customProperty);
+                arguments.Add($"-p:{customProperty}");
             }
         }
 
@@ -229,9 +229,9 @@ namespace GodotTools.Build
             AddBinaryLogArgument(buildInfo, arguments, editorSettings);
 
             // Custom properties
-            foreach (var customProperty in buildInfo.CustomProperties)
+            foreach (string customProperty in buildInfo.CustomProperties)
             {
-                arguments.Add("-p:" + (string)customProperty);
+                arguments.Add($"-p:{customProperty}");
             }
 
             // Publish output directory

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -254,7 +254,7 @@ namespace GodotTools.Export
 
                     // Execute dotnet publish.
                     if (!BuildManager.PublishProjectBlocking(buildConfig, platform,
-                            runtimeIdentifier, publishOutputDir, includeDebugSymbols))
+                            runtimeIdentifier, publishOutputDir, includeDebugSymbols, features))
                     {
                         throw new InvalidOperationException("Failed to build project.");
                     }


### PR DESCRIPTION
Adds the project [feature tags](https://docs.godotengine.org/en/stable/getting_started/workflow/export/feature_tags.html) as C# define constants.

This includes custom features, support for this was added in #28786 but got removed in #40595 and #41408 on the move to `Godot.NET.Sdk`.

---

For a project exported with this configuration:

![image](https://user-images.githubusercontent.com/3903059/137632559-15c65c1e-5c11-4323-b9c3-d006a02a0209.png)

The C# project will have the following constants defined:

- GODOT_FEATURE_64
- GODOT_FEATURE_X11
- GODOT_FEATURE_MY_GREAT_FEATURE
- GODOT_FEATURE_PC
- GODOT_FEATURE_S3TC

Then in the code you can use it like so:

```csharp
#if GODOT_FEATURE_MY_GREAT_FEATURE
	GD.Print("my_great_feature supported");
#endif
```

- Fixes https://github.com/godotengine/godot/issues/73852