### PR TITLE
Fix bottom line in editor log

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2145,10 +2145,6 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 		}
 
 		// Resize lines without reshaping.
-		Size2 size = get_size();
-		if (fixed_width != -1) {
-			size.width = fixed_width;
-		}
 		Rect2 text_rect = _get_text_rect();
 
 		Ref<Font> base_font = get_theme_font(SNAME("normal_font"));
@@ -2169,7 +2165,7 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 		vscroll->set_max(total_height);
 		vscroll->set_page(text_rect.size.height);
 		if (scroll_follow && scroll_following) {
-			vscroll->set_value(total_height - size.height);
+			vscroll->set_value(total_height);
 		}
 		updating_scroll = false;
 
@@ -2180,10 +2176,6 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 	}
 
 	// Shape invalid lines.
-	Size2 size = get_size();
-	if (fixed_width != -1) {
-		size.width = fixed_width;
-	}
 	Rect2 text_rect = _get_text_rect();
 
 	Ref<Font> base_font = get_theme_font(SNAME("normal_font"));
@@ -2206,7 +2198,7 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 	vscroll->set_max(total_height);
 	vscroll->set_page(text_rect.size.height);
 	if (scroll_follow && scroll_following) {
-		vscroll->set_value(total_height - size.height);
+		vscroll->set_value(total_height);
 	}
 	updating_scroll = false;
 


### PR DESCRIPTION
Fixes #50121

Subtracting `size.height` didn't make sense, because the scroll following is supposed to scroll the text to the bottom, no?
I don't know why it was broken though. The issue appeared only in the editor log.

EDIT:
So after my original changes, the `size` variable got recognized as unused. Interestingly, its `width` property gets modified, but then it's never used. I guess it's some old leftover that isn't needed anymore.