### PR TITLE
Remove unused imports default_theme SCsub

### DIFF
--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -2,7 +2,6 @@
 
 import argparse
 import os
-import re
 import shutil
 from collections import OrderedDict
 

--- a/modules/mono/build_scripts/mono_reg_utils.py
+++ b/modules/mono/build_scripts/mono_reg_utils.py
@@ -2,7 +2,6 @@ import os
 import platform
 
 if os.name == "nt":
-    import sys
     import winreg
 
 

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -7,7 +7,6 @@ env_text_server_adv = env_modules.Clone()
 
 
 def make_icu_data(target, source, env):
-    import os
 
     dst = target[0].srcnode().abspath
 
@@ -24,7 +23,6 @@ def make_icu_data(target, source, env):
 
     f = open(source[0].srcnode().abspath, "rb")
     buf = f.read()
-    import os.path
 
     g.write('extern "C" U_EXPORT const size_t U_ICUDATA_SIZE = ' + str(len(buf)) + ";\n")
     g.write('extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = {\n')

--- a/scene/resources/default_theme/SCsub
+++ b/scene/resources/default_theme/SCsub
@@ -2,8 +2,6 @@
 
 Import("env")
 
-import os
-import os.path
 from platform_methods import run_in_subprocess
 import default_theme_builders
 


### PR DESCRIPTION
Removes unused imports from default_theme's SCsub script.

Vulture(https://pypi.org/project/vulture/):
```
find . -name "*.py" -o -name "SCsub" -o -name "SConstruct" | xargs vulture | grep "unused import"
```
showed **0** results.

LGTM(https://lgtm.com/projects/g/godotengine/godot/alerts?mode=list&severity=&id=py%2Funused-import) had just those **2** unused imports in default_theme's SCsub script.

Autoflake(https://pypi.org/project/autoflake/) that uses pyflakes:
```
find . -name "*.py" -o -name "SCsub" -o -name "SConstruct" | xargs vulture | grep "unused import"
```
showed above and **4** more results in 3 more files.

Do suggest any other tool for static analysis.