### PR TITLE
Warn if custom ambient light color is ignored due to sky contribution

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -51,10 +51,12 @@
 			The global color saturation value of the rendered scene (default value is 1). Effective only if [code]adjustment_enabled[/code] is [code]true[/code].
 		</member>
 		<member name="ambient_light_color" type="Color" setter="set_ambient_light_color" getter="get_ambient_light_color" default="Color(0, 0, 0, 1)">
-			The ambient light's [Color]. Only effective if [member ambient_light_sky_contribution] is lower than [code]1.0[/code] (exclusive).
+			The ambient light's [Color].
+			[b]Note:[/b] [member ambient_light_color] is ignored if [member ambient_light_sky_contribution] is equal to [code]1.0[/code]. If you wish to customize [member ambient_light_color], set [member ambient_light_sky_contribution] to a value lower than [code]1.0[/code] first.
 		</member>
 		<member name="ambient_light_energy" type="float" setter="set_ambient_light_energy" getter="get_ambient_light_energy" default="1.0">
-			The ambient light's energy. The higher the value, the stronger the light. Only effective if [member ambient_light_sky_contribution] is lower than [code]1.0[/code] (exclusive).
+			The ambient light's energy. The higher the value, the stronger the light.
+			[b]Note:[/b] [member ambient_light_energy] is ignored if [member ambient_light_sky_contribution] is equal to [code]1.0[/code]. If you wish to customize [member ambient_light_energy], set [member ambient_light_sky_contribution] to a value lower than [code]1.0[/code] first.
 		</member>
 		<member name="ambient_light_sky_contribution" type="float" setter="set_ambient_light_sky_contribution" getter="get_ambient_light_sky_contribution" default="1.0">
 			Defines the amount of light that the sky brings on the scene. A value of [code]0.0[/code] means that the sky's light emission has no effect on the scene illumination, thus all ambient illumination is provided by the ambient light. On the contrary, a value of [code]1.0[/code] means that [i]all[/i] the light that affects the scene is provided by the sky, thus the ambient light parameter has no effect on the scene.

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -147,11 +147,25 @@ TypedArray<String> WorldEnvironment::get_configuration_warnings() const {
 	}
 
 	if (environment.is_valid() && get_viewport()->find_world_3d()->get_environment() != environment) {
-		warnings.push_back(("Only the first Environment has an effect in a scene (or set of instantiated scenes)."));
+		warnings.push_back(TTR("Only the first Environment has an effect in a scene (or set of instantiated scenes)."));
 	}
 
 	if (camera_effects.is_valid() && get_viewport()->find_world_3d()->get_camera_effects() != camera_effects) {
 		warnings.push_back(RTR("Only one WorldEnvironment is allowed per scene (or set of instantiated scenes)."));
+	}
+
+	if (
+			environment.is_valid() &&
+			!environment->get_ambient_light_color().is_equal_approx(Color()) &&
+			Math::is_equal_approx(environment->get_ambient_light_sky_contribution(), 1.0f)) {
+		warnings.push_back(TTR("The Environment's custom ambient light color is ignored if Sky Contribution is equal to 1.0. To resolve this, decrease Sky Contribution below 1.0 or revert the ambient light color to its default value."));
+	}
+
+	if (
+			environment.is_valid() &&
+			!Math::is_equal_approx(environment->get_ambient_light_energy(), 1.0f) &&
+			Math::is_equal_approx(environment->get_ambient_light_sky_contribution(), 1.0f)) {
+		warnings.push_back(TTR("The Environment's custom ambient light energy is ignored if Sky Contribution is equal to 1.0. To resolve this, decrease Sky Contribution below 1.0 or revert the ambient light energy to its default value."));
 	}
 
 	return warnings;


### PR DESCRIPTION
We can't use `_validate_property()` in Environment on a non-boolean value (it breaks the slider). Instead, emit a node configuration warning in WorldEnvironment. The downside is that the warning is only displayed when the scene is (re)loaded in the editor, since we can't listen for Environment resource changes.

This closes https://github.com/godotengine/godot/issues/47786. See also https://github.com/godotengine/godot/pull/39965#issuecomment-945081265.