### PR TITLE
Fix plugin create dialog subfolder and script field validity checks

### DIFF
--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -124,6 +124,10 @@ void PluginConfigDialog::_on_cancelled() {
 	_clear_fields();
 }
 
+void PluginConfigDialog::_on_language_changed(const int) {
+	_on_required_text_changed(String());
+}
+
 void PluginConfigDialog::_on_required_text_changed(const String &) {
 	int lang_idx = script_option_edit->get_selected();
 	String ext = ScriptServer::get_language(lang_idx)->get_extension();
@@ -161,6 +165,9 @@ void PluginConfigDialog::_on_required_text_changed(const String &) {
 		is_valid = false;
 		subfolder_validation->set_texture(invalid_icon);
 		subfolder_validation->set_tooltip(TTR("Subfolder cannot be blank."));
+	} else if (!subfolder_edit->get_text().is_valid_filename()) {
+		subfolder_validation->set_texture(invalid_icon);
+		subfolder_validation->set_tooltip(TTR("Subfolder name is not a valid folder name."));
 	} else {
 		DirAccessRef dir = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		String path = "res://addons/" + subfolder_edit->get_text();
@@ -330,6 +337,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	}
 	script_option_edit->select(default_lang);
 	grid->add_child(script_option_edit);
+	script_option_edit->connect("item_selected", callable_mp(this, &PluginConfigDialog::_on_language_changed));
 
 	// Plugin Script Name
 	Label *script_lb = memnew(Label);

--- a/editor/plugin_config_dialog.h
+++ b/editor/plugin_config_dialog.h
@@ -59,6 +59,7 @@ class PluginConfigDialog : public ConfirmationDialog {
 	void _clear_fields();
 	void _on_confirmed();
 	void _on_cancelled();
+	void _on_language_changed(const int p_language);
 	void _on_required_text_changed(const String &p_text);
 
 	static String _to_absolute_plugin_path(const String &p_plugin_name);


### PR DESCRIPTION
Fixes #53930
Fixes #53935

### Issues
In "Create a Plugin" dialog : 
- Script extension warning is not updated on language change.
- When creating a plugin with the "Create a plugin" dialog, subfolder name is marked as valid if even if subfolder includes invalid characters for a folder name.

### Fix proposal:

- Connect the ``item_selected`` signal of language dropdown to a callback that will update the warning
- Check if subfolder name ``is_valid_filename()``

### After:

- Invalid characters in subfolder show a warning message
- Extension warning is updated when language is changed

![fixed](https://user-images.githubusercontent.com/3649998/137645803-42c08045-0bd1-4fc5-bba0-08879aa2fdd0.gif)


