### PR TITLE
Fix incorrect debug check for setters

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -980,7 +980,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class) {
 						has_valid_setter = true;
 
 #ifdef DEBUG_ENABLED
-						if (member.variable->datatype.builtin_type == Variant::INT && setter_function->return_type->datatype.builtin_type == Variant::FLOAT) {
+						if (member.variable->datatype.builtin_type == Variant::FLOAT && setter_function->parameters[0]->datatype.builtin_type == Variant::INT) {
 							parser->push_warning(member.variable, GDScriptWarning::NARROWING_CONVERSION);
 						}
 #endif


### PR DESCRIPTION
Calling `GDScriptAnalyzer::resolve_class_body` can lead to a segfault if `DEBUG_ENABLED` is defined.

If a member variable has a setter, there is a debug narrowing check accessing the setter's return type, which doesn't exist and leads to a nullptr dereferencing.

I guess the check was badly copy/pasted and adapted from the getter case. This PR fixes that check.

There's still one thing I find strange. I have multiple setters in my code but the crash happened only in one script, which would suggest that `setter_function->return_type` is not always a nullptr. So I don't know if there is a bug in the GDScript parser as well where the return type should always be created and be set to `NIL` when a function has no return value instead of being a nullptr