### PR TITLE
[TextServer] Use `round` instead of `floor` for hex code box size calculation to better match font size.

### DIFF
--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -482,7 +482,7 @@ void TextServer::_bind_methods() {
 Vector2 TextServer::get_hex_code_box_size(int p_size, char32_t p_index) const {
 	int w = ((p_index <= 0xFF) ? 1 : ((p_index <= 0xFFFF) ? 2 : 3));
 	int sp = MAX(0, w - 1);
-	int sz = MAX(1, p_size / 15);
+	int sz = MAX(1, Math::round(p_size / 15.f));
 
 	return Vector2(4 + 3 * w + sp + 1, 15) * sz;
 }
@@ -520,7 +520,7 @@ void TextServer::draw_hex_code_box(RID p_canvas, int p_size, const Vector2 &p_po
 
 	int w = ((p_index <= 0xFF) ? 1 : ((p_index <= 0xFFFF) ? 2 : 3));
 	int sp = MAX(0, w - 1);
-	int sz = MAX(1, p_size / 15);
+	int sz = MAX(1, Math::round(p_size / 15.f));
 
 	Size2 size = Vector2(4 + 3 * w + sp, 15) * sz;
 	Point2 pos = p_pos - Point2i(0, size.y * 0.85);


### PR DESCRIPTION
A small fix for better hex code box scaling.

<img width="128" alt="Screenshot 2021-10-18 at 10 56 34" src="https://user-images.githubusercontent.com/7645683/137697512-1ac0d28d-0ab3-4a72-86ec-29961ff54188.png">
<img width="128" alt="Screenshot 2021-10-18 at 10 56 58" src="https://user-images.githubusercontent.com/7645683/137697518-3edae45a-3070-487c-aa02-c3d8d332ec6a.png">
