### PR TITLE
Improve the editor template workflow for users and devs

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -274,13 +274,32 @@ public:
 		String message;
 	};
 
+	enum TemplateLocation {
+		TEMPLATE_BUILT_IN,
+		TEMPLATE_EDITOR,
+		TEMPLATE_PROJECT
+	};
+
+	struct ScriptTemplate {
+		String inherit = "Object";
+		String name;
+		String description;
+		String content;
+		int id = 0;
+		TemplateLocation origin = TemplateLocation::TEMPLATE_BUILT_IN;
+
+		String get_hash() const {
+			return itos(origin) + inherit + name;
+		}
+	};
+
 	void get_core_type_words(List<String> *p_core_type_words) const;
 	virtual void get_reserved_words(List<String> *p_words) const = 0;
 	virtual bool is_control_flow_keyword(String p_string) const = 0;
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const = 0;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const = 0;
-	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const = 0;
-	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) {}
+	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const { return Ref<Script>(); }
+	virtual Vector<ScriptTemplate> get_built_in_templates(StringName p_object) { return Vector<ScriptTemplate>(); }
 	virtual bool is_using_templates() { return false; }
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptError> *r_errors = nullptr, List<Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const = 0;
 	virtual String validate_path(const String &p_path) const { return ""; }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -781,43 +781,6 @@ bool EditorSettings::_is_default_text_editor_theme(String p_theme_name) {
 	return p_theme_name == "default" || p_theme_name == "godot 2" || p_theme_name == "custom";
 }
 
-static Dictionary _get_builtin_script_templates() {
-	Dictionary templates;
-
-	// No Comments
-	templates["no_comments.gd"] =
-			"extends %BASE%\n"
-			"\n"
-			"\n"
-			"func _ready()%VOID_RETURN%:\n"
-			"%TS%pass\n";
-
-	// Empty
-	templates["empty.gd"] =
-			"extends %BASE%"
-			"\n"
-			"\n";
-
-	return templates;
-}
-
-static void _create_script_templates(const String &p_path) {
-	Dictionary templates = _get_builtin_script_templates();
-	List<Variant> keys;
-	templates.get_key_list(&keys);
-	FileAccessRef file = FileAccess::create(FileAccess::ACCESS_FILESYSTEM);
-	DirAccessRef dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	dir->change_dir(p_path);
-	for (int i = 0; i < keys.size(); i++) {
-		if (!dir->file_exists(keys[i])) {
-			Error err = file->reopen(p_path.plus_file((String)keys[i]), FileAccess::WRITE);
-			ERR_FAIL_COND(err != OK);
-			file->store_string(templates[keys[i]]);
-			file->close();
-		}
-	}
-}
-
 // PUBLIC METHODS
 
 EditorSettings *EditorSettings::get_singleton() {
@@ -852,10 +815,7 @@ void EditorSettings::create() {
 	}
 
 	if (EditorPaths::get_singleton()->are_paths_valid()) {
-		_create_script_templates(EditorPaths::get_singleton()->get_config_dir().plus_file("script_templates"));
-
 		// Validate editor config file.
-
 		DirAccessRef dir = DirAccess::open(EditorPaths::get_singleton()->get_config_dir());
 		String config_file_name = "editor_settings-" + itos(VERSION_MAJOR) + ".tres";
 		config_file_path = EditorPaths::get_singleton()->get_config_dir().plus_file(config_file_name);

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -36,12 +36,6 @@
 #include "editor/editor_plugin.h"
 #include "editor/editor_scale.h"
 #include "editor/project_settings_editor.h"
-#include "scene/gui/grid_container.h"
-
-#include "modules/modules_enabled.gen.h" // For gdscript.
-#ifdef MODULE_GDSCRIPT_ENABLED
-#include "modules/gdscript/gdscript.h"
-#endif
 
 void PluginConfigDialog::_clear_fields() {
 	name_edit->set_text("");
@@ -76,42 +70,16 @@ void PluginConfigDialog::_on_confirmed() {
 		String lang_name = ScriptServer::get_language(lang_idx)->get_name();
 
 		Ref<Script> script;
-
-		// TODO Use script templates. Right now, this code won't add the 'tool' annotation to other languages.
-		// TODO Better support script languages with named classes (has_named_classes).
-
-		// FIXME: It's hacky to have hardcoded access to the GDScript module here.
-		// The editor code should not have to know what languages are enabled.
-#ifdef MODULE_GDSCRIPT_ENABLED
-		if (lang_name == GDScriptLanguage::get_singleton()->get_name()) {
-			// Hard-coded GDScript template to keep usability until we use script templates.
-			Ref<Script> gdscript = memnew(GDScript);
-			gdscript->set_source_code(
-					"@tool\n"
-					"extends EditorPlugin\n"
-					"\n"
-					"\n"
-					"func _enter_tree()%VOID_RETURN%:\n"
-					"%TS%pass\n"
-					"\n"
-					"\n"
-					"func _exit_tree()%VOID_RETURN%:\n"
-					"%TS%pass\n");
-			GDScriptLanguage::get_singleton()->make_template("", "", gdscript);
-			String script_path = path.plus_file(script_edit->get_text());
-			gdscript->set_path(script_path);
-			ResourceSaver::save(script_path, gdscript);
-			script = gdscript;
-		} else {
-#endif
-			String script_path = path.plus_file(script_edit->get_text());
-			String class_name = script_path.get_file().get_basename();
-			script = ScriptServer::get_language(lang_idx)->get_template(class_name, "EditorPlugin");
-			script->set_path(script_path);
-			ResourceSaver::save(script_path, script);
-#ifdef MODULE_GDSCRIPT_ENABLED
+		String script_path = path.plus_file(script_edit->get_text());
+		String class_name = script_path.get_file().get_basename();
+		String template_content = "";
+		Vector<ScriptLanguage::ScriptTemplate> templates = ScriptServer::get_language(lang_idx)->get_built_in_templates("EditorPlugin");
+		if (templates.size() > 0) {
+			template_content = templates.get(0).content;
 		}
-#endif
+		script = ScriptServer::get_language(lang_idx)->make_template(template_content, class_name, "EditorPlugin");
+		script->set_path(script_path);
+		ResourceSaver::save(script_path, script);
 
 		emit_signal(SNAME("plugin_ready"), script.operator->(), active_edit->is_pressed() ? _to_absolute_plugin_path(subfolder_edit->get_text()) : "");
 	} else {
@@ -331,11 +299,9 @@ PluginConfigDialog::PluginConfigDialog() {
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		ScriptLanguage *lang = ScriptServer::get_language(i);
 		script_option_edit->add_item(lang->get_name());
-#ifdef MODULE_GDSCRIPT_ENABLED
-		if (lang == GDScriptLanguage::get_singleton()) {
+		if (lang->get_name() == "GDScript") {
 			default_lang = i;
 		}
-#endif
 	}
 	script_option_edit->select(default_lang);
 	grid->add_child(script_option_edit);

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -31,6 +31,7 @@
 #ifndef SCRIPT_CREATE_DIALOG_H
 #define SCRIPT_CREATE_DIALOG_H
 
+#include "core/object/script_language.h"
 #include "editor/editor_file_dialog.h"
 #include "editor/editor_settings.h"
 #include "scene/gui/check_box.h"
@@ -50,6 +51,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	Label *path_error_label;
 	Label *builtin_warning_label;
 	Label *script_name_warning_label;
+	Label *template_info_label;
 	PanelContainer *status_panel;
 	LineEdit *parent_name;
 	Button *parent_browse_button;
@@ -61,12 +63,14 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	Button *path_button;
 	EditorFileDialog *file_browse;
 	CheckBox *internal;
+	CheckBox *use_templates;
 	VBoxContainer *path_vb;
 	AcceptDialog *alert;
 	CreateDialog *select_class;
 	bool path_valid;
 	bool create_new;
 	bool is_browsing_parent;
+	String template_inactive_message;
 	String initial_bp;
 	bool is_new_script_created;
 	bool is_path_valid;
@@ -76,6 +80,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool is_parent_name_valid;
 	bool is_class_name_valid;
 	bool is_built_in;
+	bool is_using_templates;
 	bool built_in_enabled;
 	bool load_enabled;
 	int current_language;
@@ -85,23 +90,8 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	Control *path_controls[2];
 	Control *name_controls[2];
 
-	enum ScriptOrigin {
-		SCRIPT_ORIGIN_PROJECT,
-		SCRIPT_ORIGIN_EDITOR,
-	};
-	struct ScriptTemplateInfo {
-		int id = 0;
-		ScriptOrigin origin = ScriptOrigin::SCRIPT_ORIGIN_EDITOR;
-		String dir;
-		String name;
-		String extension;
-	};
-
-	String script_template;
-	Vector<ScriptTemplateInfo> template_list;
-	Map<String, Vector<int>> template_overrides; // name : indices
-
-	void _update_script_templates(const String &p_extension);
+	Vector<ScriptLanguage::ScriptTemplate> template_list;
+	ScriptLanguage *language;
 
 	String base_type;
 
@@ -109,8 +99,9 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool _can_be_built_in();
 	void _path_changed(const String &p_path = String());
 	void _path_submitted(const String &p_path = String());
-	void _lang_changed(int l = 0);
+	void _language_changed(int l = 0);
 	void _built_in_pressed();
+	void _use_template_pressed();
 	bool _validate_parent(const String &p_string);
 	bool _validate_class(const String &p_string);
 	String _validate_path(const String &p_path, bool p_file_must_exist);
@@ -125,9 +116,15 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	virtual void ok_pressed() override;
 	void _create_new();
 	void _load_exist();
+	Vector<String> get_hierarchy(String p_object) const;
 	void _msg_script_valid(bool valid, const String &p_msg = String());
 	void _msg_path_valid(bool valid, const String &p_msg = String());
+	void _update_template_menu();
 	void _update_dialog();
+	ScriptLanguage::ScriptTemplate _get_current_template() const;
+	Vector<ScriptLanguage::ScriptTemplate> _get_user_templates(const ScriptLanguage *language, const StringName &p_object, const String &p_dir, const ScriptLanguage::TemplateLocation &p_origin) const;
+	ScriptLanguage::ScriptTemplate _parse_template(const ScriptLanguage *language, const String &p_path, const String &p_filename, const ScriptLanguage::TemplateLocation &p_origin, const String &p_inherits) const;
+	String _get_script_origin_label(const ScriptLanguage::TemplateLocation &p_origin) const;
 
 protected:
 	void _notification(int p_what);

--- a/editor/template_builders.py
+++ b/editor/template_builders.py
@@ -1,0 +1,95 @@
+"""Functions used to generate source files during build time
+All such functions are invoked in a subprocess on Windows to prevent build flakiness.
+"""
+
+import os
+from io import StringIO
+from platform_methods import subprocess_main
+
+
+def parse_template(inherits, source, delimiter):
+    script_template = {
+        "inherits": inherits,
+        "name": "",
+        "description": "",
+        "version": "",
+        "script": "",
+        "space-indent": "4",
+    }
+    meta_prefix = delimiter + " meta-"
+    meta = ["name", "description", "version", "space-indent"]
+
+    with open(source) as f:
+        lines = f.readlines()
+        for line in lines:
+            if line.startswith(meta_prefix):
+                line = line[len(meta_prefix) :]
+                for m in meta:
+                    if line.startswith(m):
+                        strip_lenght = len(m) + 1
+                        script_template[m] = line[strip_lenght:].strip()
+            else:
+                script_template["script"] += line
+        if script_template["space-indent"] != "":
+            indent = " " * int(script_template["space-indent"])
+            script_template["script"] = script_template["script"].replace(indent, "_TS_")
+        if script_template["name"] == "":
+            script_template["name"] = os.path.splitext(os.path.basename(source))[0].replace("_", " ").title()
+        script_template["script"] = (
+            script_template["script"].replace('"', '\\"').lstrip().replace("\n", "\\n").replace("\t", "_TS_")
+        )
+        return (
+            '{ String("'
+            + script_template["inherits"]
+            + '"), String("'
+            + script_template["name"]
+            + '"),  String("'
+            + script_template["description"]
+            + '"),  String("'
+            + script_template["script"]
+            + '")'
+            + " },\n"
+        )
+
+
+def make_templates(target, source, env):
+    dst = target[0]
+    s = StringIO()
+    s.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n\n")
+    s.write("#ifndef _CODE_TEMPLATES_H\n")
+    s.write("#define _CODE_TEMPLATES_H\n\n")
+    s.write('#include "core/object/object.h"\n')
+    s.write('#include "core/object/script_language.h"\n')
+
+    delimiter = "#"  # GDScript single line comment delimiter by default.
+    if source:
+        ext = os.path.splitext(source[0])[1]
+        if ext == ".cs":
+            delimiter = "//"
+
+    parsed_template_string = ""
+    number_of_templates = 0
+
+    for filepath in source:
+        node_name = os.path.basename(os.path.dirname(filepath))
+        parsed_template = parse_template(node_name, filepath, delimiter)
+        parsed_template_string += "\t" + parsed_template
+        number_of_templates += 1
+
+    s.write("\nstatic const int TEMPLATES_ARRAY_SIZE = " + str(number_of_templates) + ";\n")
+    s.write("\nstatic const struct ScriptLanguage::ScriptTemplate TEMPLATES[" + str(number_of_templates) + "] = {\n")
+
+    s.write(parsed_template_string)
+
+    s.write("};\n")
+
+    s.write("\n#endif\n")
+
+    with open(dst, "w") as f:
+        f.write(s.getvalue())
+
+    s.close()
+
+
+if __name__ == "__main__":
+    subprocess_main(globals())

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -21,3 +21,5 @@ if env["tools"]:
 if env["tests"]:
     env_gdscript.Append(CPPDEFINES=["TESTS_ENABLED"])
     env_gdscript.add_source_files(env.modules_sources, "./tests/*.cpp")
+
+SConscript("editor_templates/SCsub")

--- a/modules/gdscript/editor_templates/CharacterBody2D/basic_movement.gd
+++ b/modules/gdscript/editor_templates/CharacterBody2D/basic_movement.gd
@@ -1,0 +1,29 @@
+# meta-description: Classic movement for gravity games (platformer, ...)
+
+extends _BASE_
+
+const SPEED: float = 300.0
+const JUMP_FORCE: float = -400.0
+
+# Get the gravity from the project settings to be synced with RigidDynamicBody nodes.
+var gravity: int = ProjectSettings.get_setting("physics/2d/default_gravity")
+
+
+func _physics_process(delta: float) -> void:
+	# Add the gravity.
+	if not is_on_floor():
+		motion_velocity.y += gravity * delta
+
+	# Handle Jump.
+	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
+		motion_velocity.y = JUMP_FORCE
+
+	# Get the input direction and handle the movement/deceleration.
+	# As good practice, you should replace UI actions with custom gameplay actions.
+	var direction := Input.get_axis("ui_left", "ui_right")
+	if direction:
+		motion_velocity.x = direction * SPEED
+	else:
+		motion_velocity.x = move_toward(motion_velocity.x, 0, SPEED)
+
+	move_and_slide()

--- a/modules/gdscript/editor_templates/CharacterBody3D/basic_movement.gd
+++ b/modules/gdscript/editor_templates/CharacterBody3D/basic_movement.gd
@@ -1,0 +1,32 @@
+# meta-description: Classic movement for gravity games (FPS, TPS, ...)
+
+extends _BASE_
+
+const SPEED: float = 5.0
+const JUMP_FORCE: float = 4.5
+
+# Get the gravity from the project settings to be synced with RigidDynamicBody nodes.
+var gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
+
+
+func _physics_process(delta: float) -> void:
+	# Add the gravity.
+	if not is_on_floor():
+		motion_velocity.y -= gravity * delta
+
+	# Handle Jump.
+	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
+		motion_velocity.y = JUMP_FORCE
+
+	# Get the input direction and handle the movement/deceleration.
+	# As good practice, you should replace UI actions with custom gameplay actions.
+	var input_dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
+	var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
+	if direction:
+		motion_velocity.x = direction.x * SPEED
+		motion_velocity.z = direction.z * SPEED
+	else:
+		motion_velocity.x = move_toward(motion_velocity.x, 0, SPEED)
+		motion_velocity.z = move_toward(motion_velocity.z, 0, SPEED)
+
+	move_and_slide()

--- a/modules/gdscript/editor_templates/EditorPlugin/plugin.gd
+++ b/modules/gdscript/editor_templates/EditorPlugin/plugin.gd
@@ -1,0 +1,11 @@
+# meta-description: Basic plugin template
+@tool
+extends EditorPlugin
+
+func _enter_tree() -> void:
+    # Initialization of the plugin goes here.
+    pass
+
+func _exit_tree() -> void:
+    # Clean-up of the plugin goes here.
+    pass

--- a/modules/gdscript/editor_templates/EditorScript/basic_editor_script.gd
+++ b/modules/gdscript/editor_templates/EditorScript/basic_editor_script.gd
@@ -1,0 +1,7 @@
+# meta-description: Basic editor script template
+@tool
+extends EditorScript
+
+func _run() -> void:
+    # Called when the script is executed (using File -> Run in Script Editor).
+    pass

--- a/modules/gdscript/editor_templates/Node/default.gd
+++ b/modules/gdscript/editor_templates/Node/default.gd
@@ -1,0 +1,11 @@
+# meta-description: Base template for Node with default Godot cycle methods
+
+extends _BASE_
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass

--- a/modules/gdscript/editor_templates/Object/empty.gd
+++ b/modules/gdscript/editor_templates/Object/empty.gd
@@ -1,0 +1,3 @@
+# meta-description: Empty template suitable for all Objects
+
+extends _BASE_

--- a/modules/gdscript/editor_templates/SCsub
+++ b/modules/gdscript/editor_templates/SCsub
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+Import("env")
+
+import editor.template_builders as build_template_gd
+
+env["BUILDERS"]["MakeGDTemplateBuilder"] = Builder(
+    action=env.Run(build_template_gd.make_templates, "Generating GDScript templates header."),
+    suffix=".h",
+    src_suffix=".gd",
+)
+
+# Template files
+templates_sources = Glob("*/*.gd")
+
+env.Alias("editor_template_gd", [env.MakeGDTemplateBuilder("templates.gen.h", templates_sources)])

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -49,6 +49,10 @@
 #include "tests/gdscript_test_runner.h"
 #endif
 
+#ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
+#endif
+
 ///////////////////////////
 
 GDScriptNativeClass::GDScriptNativeClass(const StringName &p_name) {
@@ -817,10 +821,16 @@ Error GDScript::reload(bool p_keep_state) {
 		basedir = basedir.get_base_dir();
 	}
 
-	if (source.find("%BASE%") != -1) {
-		//loading a template, don't parse
+// Loading a template, don't parse.
+#ifdef TOOLS_ENABLED
+	if (basedir.begins_with(EditorSettings::get_singleton()->get_project_script_templates_dir())) {
 		return OK;
 	}
+#else
+	if (source.find("_BASE_") != -1) {
+		return OK;
+	}
+#endif
 
 	{
 		String source_path = path;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -396,7 +396,7 @@ public:
 		_debug_call_stack_pos--;
 	}
 
-	virtual Vector<StackInfo> debug_get_current_stack_info() {
+	virtual Vector<StackInfo> debug_get_current_stack_info() override {
 		if (Thread::get_main_id() != Thread::get_caller_id()) {
 			return Vector<StackInfo>();
 		}
@@ -430,77 +430,76 @@ public:
 
 	_FORCE_INLINE_ static GDScriptLanguage *get_singleton() { return singleton; }
 
-	virtual String get_name() const;
+	virtual String get_name() const override;
 
 	/* LANGUAGE FUNCTIONS */
-	virtual void init();
-	virtual String get_type() const;
-	virtual String get_extension() const;
-	virtual Error execute_file(const String &p_path);
-	virtual void finish();
+	virtual void init() override;
+	virtual String get_type() const override;
+	virtual String get_extension() const override;
+	virtual Error execute_file(const String &p_path) override;
+	virtual void finish() override;
 
 	/* EDITOR FUNCTIONS */
-	virtual void get_reserved_words(List<String> *p_words) const;
-	virtual bool is_control_flow_keyword(String p_keywords) const;
-	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
-	virtual void get_string_delimiters(List<String> *p_delimiters) const;
-	virtual String _get_processed_template(const String &p_template, const String &p_base_class_name) const;
-	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;
-	virtual bool is_using_templates();
-	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script);
-	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
-	virtual Script *create_script() const;
-	virtual bool has_named_classes() const;
-	virtual bool supports_builtin_mode() const;
-	virtual bool supports_documentation() const;
-	virtual bool can_inherit_from_file() const { return true; }
-	virtual int find_function(const String &p_function, const String &p_code) const;
-	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const;
-	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptCodeCompletionOption> *r_options, bool &r_forced, String &r_call_hint);
+	virtual void get_reserved_words(List<String> *p_words) const override;
+	virtual bool is_control_flow_keyword(String p_keywords) const override;
+	virtual void get_comment_delimiters(List<String> *p_delimiters) const override;
+	virtual void get_string_delimiters(List<String> *p_delimiters) const override;
+	virtual bool is_using_templates() override;
+	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const override;
+	virtual Vector<ScriptTemplate> get_built_in_templates(StringName p_object) override;
+	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const override;
+	virtual Script *create_script() const override;
+	virtual bool has_named_classes() const override;
+	virtual bool supports_builtin_mode() const override;
+	virtual bool supports_documentation() const override;
+	virtual bool can_inherit_from_file() const override { return true; }
+	virtual int find_function(const String &p_function, const String &p_code) const override;
+	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const override;
+	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptCodeCompletionOption> *r_options, bool &r_forced, String &r_call_hint) override;
 #ifdef TOOLS_ENABLED
-	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result);
+	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
 #endif
 	virtual String _get_indentation() const;
-	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;
-	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value);
-	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value);
-	virtual void remove_named_global_constant(const StringName &p_name);
+	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override;
+	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) override;
+	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) override;
+	virtual void remove_named_global_constant(const StringName &p_name) override;
 
 	/* DEBUGGER FUNCTIONS */
 
-	virtual String debug_get_error() const;
-	virtual int debug_get_stack_level_count() const;
-	virtual int debug_get_stack_level_line(int p_level) const;
-	virtual String debug_get_stack_level_function(int p_level) const;
-	virtual String debug_get_stack_level_source(int p_level) const;
-	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
-	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
-	virtual ScriptInstance *debug_get_stack_level_instance(int p_level);
-	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
-	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1);
+	virtual String debug_get_error() const override;
+	virtual int debug_get_stack_level_count() const override;
+	virtual int debug_get_stack_level_line(int p_level) const override;
+	virtual String debug_get_stack_level_function(int p_level) const override;
+	virtual String debug_get_stack_level_source(int p_level) const override;
+	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual ScriptInstance *debug_get_stack_level_instance(int p_level) override;
+	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1) override;
 
-	virtual void reload_all_scripts();
-	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);
+	virtual void reload_all_scripts() override;
+	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) override;
 
-	virtual void frame();
+	virtual void frame() override;
 
-	virtual void get_public_functions(List<MethodInfo> *p_functions) const;
-	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const;
+	virtual void get_public_functions(List<MethodInfo> *p_functions) const override;
+	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const override;
 
-	virtual void profiling_start();
-	virtual void profiling_stop();
+	virtual void profiling_start() override;
+	virtual void profiling_stop() override;
 
-	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max);
-	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max);
+	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) override;
+	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) override;
 
 	/* LOADER FUNCTIONS */
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 
 	/* GLOBAL CLASSES */
 
-	virtual bool handles_global_class_type(const String &p_type) const;
-	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr) const;
+	virtual bool handles_global_class_type(const String &p_type) const override;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr) const override;
 
 	void add_orphan_subclass(const String &p_qualified_name, const ObjectID &p_subclass);
 	Ref<GDScript> get_orphan_subclass(const String &p_qualified_name);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/core_constants.h"
 #include "core/io/file_access.h"
+#include "editor_templates/templates.gen.h"
 #include "gdscript_analyzer.h"
 #include "gdscript_compiler.h"
 #include "gdscript_parser.h"
@@ -55,68 +56,44 @@ void GDScriptLanguage::get_string_delimiters(List<String> *p_delimiters) const {
 	p_delimiters->push_back("\"\"\" \"\"\"");
 }
 
-String GDScriptLanguage::_get_processed_template(const String &p_template, const String &p_base_class_name) const {
-	String processed_template = p_template;
-
-#ifdef TOOLS_ENABLED
-	if (EDITOR_DEF("text_editor/completion/add_type_hints", false)) {
-		processed_template = processed_template.replace("%INT_TYPE%", ": int");
-		processed_template = processed_template.replace("%STRING_TYPE%", ": String");
-		processed_template = processed_template.replace("%FLOAT_TYPE%", ": float");
-		processed_template = processed_template.replace("%VOID_RETURN%", " -> void");
-	} else {
-		processed_template = processed_template.replace("%INT_TYPE%", "");
-		processed_template = processed_template.replace("%STRING_TYPE%", "");
-		processed_template = processed_template.replace("%FLOAT_TYPE%", "");
-		processed_template = processed_template.replace("%VOID_RETURN%", "");
-	}
-#else
-	processed_template = processed_template.replace("%INT_TYPE%", "");
-	processed_template = processed_template.replace("%STRING_TYPE%", "");
-	processed_template = processed_template.replace("%FLOAT_TYPE%", "");
-	processed_template = processed_template.replace("%VOID_RETURN%", "");
-#endif
-
-	processed_template = processed_template.replace("%BASE%", p_base_class_name);
-	processed_template = processed_template.replace("%TS%", _get_indentation());
-
-	return processed_template;
-}
-
-Ref<Script> GDScriptLanguage::get_template(const String &p_class_name, const String &p_base_class_name) const {
-	String _template = "extends %BASE%\n"
-					   "\n"
-					   "\n"
-					   "# Declare member variables here. Examples:\n"
-					   "# var a%INT_TYPE% = 2\n"
-					   "# var b%STRING_TYPE% = \"text\"\n"
-					   "\n"
-					   "\n"
-					   "# Called when the node enters the scene tree for the first time.\n"
-					   "func _ready()%VOID_RETURN%:\n"
-					   "%TS%pass # Replace with function body.\n"
-					   "\n"
-					   "\n"
-					   "# Called every frame. 'delta' is the elapsed time since the previous frame.\n"
-					   "#func _process(delta%FLOAT_TYPE%)%VOID_RETURN%:\n"
-					   "#%TS%pass\n";
-
-	_template = _get_processed_template(_template, p_base_class_name);
-
-	Ref<GDScript> script;
-	script.instantiate();
-	script->set_source_code(_template);
-
-	return script;
-}
-
 bool GDScriptLanguage::is_using_templates() {
 	return true;
 }
 
-void GDScriptLanguage::make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) {
-	String _template = _get_processed_template(p_script->get_source_code(), p_base_class_name);
-	p_script->set_source_code(_template);
+Ref<Script> GDScriptLanguage::make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const {
+	Ref<GDScript> script;
+	script.instantiate();
+	String processed_template = p_template;
+#ifdef TOOLS_ENABLED
+	if (!EDITOR_DEF("text_editor/completion/add_type_hints", false)) {
+		processed_template = processed_template.replace(": int", "")
+									 .replace(": String", "")
+									 .replace(": float", "")
+									 .replace(":=", "=")
+									 .replace(" -> void", "");
+	}
+#else
+	processed_template = processed_template.replace(": int", "")
+								 .replace(": String", "")
+								 .replace(": float", "")
+								 .replace(" -> void", "");
+#endif
+
+	processed_template = processed_template.replace("_BASE_", p_base_class_name)
+								 .replace("_CLASS_", p_class_name)
+								 .replace("_TS_", _get_indentation());
+	script->set_source_code(processed_template);
+	return script;
+}
+
+Vector<ScriptLanguage::ScriptTemplate> GDScriptLanguage::get_built_in_templates(StringName p_object) {
+	Vector<ScriptLanguage::ScriptTemplate> templates;
+	for (int i = 0; i < TEMPLATES_ARRAY_SIZE; i++) {
+		if (TEMPLATES[i].inherit == p_object) {
+			templates.append(TEMPLATES[i]);
+		}
+	}
+	return templates;
 }
 
 static void get_function_names_recursively(const GDScriptParser::ClassNode *p_class, const String &p_prefix, Map<int, String> &r_funcs) {
@@ -236,7 +213,7 @@ Script *GDScriptLanguage::create_script() const {
 /* DEBUGGER FUNCTIONS */
 
 bool GDScriptLanguage::debug_break_parse(const String &p_file, int p_line, const String &p_error) {
-	//break because of parse error
+	// break because of parse error
 
 	if (EngineDebugger::is_active() && Thread::get_caller_id() == Thread::get_main_id()) {
 		_debug_parse_err_line = p_line;
@@ -1383,8 +1360,8 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 														}
 
 														if (!script.ends_with(".gd")) {
-															//not a script, try find the script anyway,
-															//may have some success
+															// not a script, try find the script anyway,
+															// may have some success
 															script = script.get_basename() + ".gd";
 														}
 
@@ -2770,7 +2747,7 @@ void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_t
 			}
 
 			if (indent_stack.size() && indent_stack.back()->get() != tc) {
-				indent_stack.push_back(tc); //this is not right but gets the job done
+				indent_stack.push_back(tc); // this is not right but gets the job done
 			}
 		}
 

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -63,3 +63,5 @@ elif env["platform"] == "android":
 
 if env["tools"]:
     env_mono.add_source_files(env.modules_sources, "editor/*.cpp")
+
+SConscript("editor_templates/SCsub")

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -463,9 +463,9 @@ public:
 	bool is_control_flow_keyword(String p_keyword) const override;
 	void get_comment_delimiters(List<String> *p_delimiters) const override;
 	void get_string_delimiters(List<String> *p_delimiters) const override;
-	Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const override;
 	bool is_using_templates() override;
-	void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) override;
+	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const override;
+	virtual Vector<ScriptTemplate> get_built_in_templates(StringName p_object) override;
 	/* TODO */ bool validate(const String &p_script, const String &p_path, List<String> *r_functions,
 			List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const override {
 		return true;

--- a/modules/mono/editor_templates/CharacterBody2D/basic_movement.cs
+++ b/modules/mono/editor_templates/CharacterBody2D/basic_movement.cs
@@ -1,0 +1,41 @@
+// meta-description: Classic movement for gravity games (platformer, ...)
+
+using _BINDINGS_NAMESPACE_;
+using System;
+
+public partial class _CLASS_ : _BASE_
+{
+    public const float Speed = 300.0f;
+    public const float JumpForce = -400.0f;
+
+    // Get the gravity from the project settings to be synced with RigidDynamicBody nodes.
+    public float gravity = (float)ProjectSettings.GetSetting("physics/2d/default_gravity");
+
+    public override void _PhysicsProcess(float delta)
+    {
+        Vector2 motionVelocity = MotionVelocity;
+
+        // Add the gravity.
+        if (!IsOnFloor())
+            motionVelocity.y += gravity * delta;
+
+        // Handle Jump.
+        if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())
+            motionVelocity.y = JumpForce;
+
+        // Get the input direction and handle the movement/deceleration.
+        // As good practice, you should replace UI actions with custom gameplay actions.
+        Vector2 direction = Input.GetVector("ui_left", "ui_right", "ui_up", "ui_down");
+        if (direction != Vector2.Zero)
+        {
+            motionVelocity.x = direction.x * Speed;
+        }
+        else
+        {
+            motionVelocity.x = Mathf.MoveToward(MotionVelocity.x, 0, Speed);
+        }
+
+        MotionVelocity = motionVelocity;
+        MoveAndSlide();
+    }
+}

--- a/modules/mono/editor_templates/CharacterBody3D/basic_movement.cs
+++ b/modules/mono/editor_templates/CharacterBody3D/basic_movement.cs
@@ -1,0 +1,44 @@
+// meta-description: Classic movement for gravity games (FPS, TPS, ...)
+
+using _BINDINGS_NAMESPACE_;
+using System;
+
+public partial class _CLASS_ : _BASE_
+{
+    public const float Speed = 5.0f;
+    public const float JumpForce = 4.5f;
+
+    // Get the gravity from the project settings to be synced with RigidDynamicBody nodes.
+    public float gravity = (float)ProjectSettings.GetSetting("physics/3d/default_gravity");
+
+    public override void _PhysicsProcess(float delta)
+    {
+        Vector3 motionVelocity = MotionVelocity;
+
+        // Add the gravity.
+        if (!IsOnFloor())
+            motionVelocity.y -= gravity * delta;
+
+        // Handle Jump.
+        if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())
+             motionVelocity.y = JumpForce;
+
+        // Get the input direction and handle the movement/deceleration.
+        // As good practice, you should replace UI actions with custom gameplay actions.
+        Vector2 inputDir = Input.GetVector("ui_left", "ui_right", "ui_up", "ui_down");
+        Vector3 direction = Transform.basis.Xform(new Vector3(inputDir.x, 0, inputDir.y)).Normalized();
+        if (direction != Vector3.Zero)
+        {
+            motionVelocity.x = direction.x * Speed;
+            motionVelocity.z = direction.z * Speed;
+        }
+        else
+        {
+            motionVelocity.x = Mathf.MoveToward(MotionVelocity.x, 0, Speed);
+            motionVelocity.z = Mathf.MoveToward(MotionVelocity.z, 0, Speed);
+        }
+
+        MotionVelocity = motionVelocity;
+        MoveAndSlide();
+    }
+}

--- a/modules/mono/editor_templates/EditorPlugin/plugin.cs
+++ b/modules/mono/editor_templates/EditorPlugin/plugin.cs
@@ -1,0 +1,19 @@
+// meta-description: Basic plugin template
+#if TOOLS
+using _BINDINGS_NAMESPACE_;
+using System;
+
+[Tool]
+public partial class _CLASS_ : _BASE_
+{
+    public override void _EnterTree()
+    {
+        // Initialization of the plugin goes here.
+    }
+
+    public override void _ExitTree()
+    {
+        // Clean-up of the plugin goes here.
+    }
+}
+#endif

--- a/modules/mono/editor_templates/EditorScript/basic_editor_script.cs
+++ b/modules/mono/editor_templates/EditorScript/basic_editor_script.cs
@@ -1,0 +1,14 @@
+// meta-description: Basic editor script template
+#if TOOLS
+using _BINDINGS_NAMESPACE_;
+using System;
+
+[Tool]
+public partial class _CLASS_ : _BASE_
+{
+    public override void _Run()
+    {
+        // Called when the script is executed (using File -> Run in Script Editor).
+    }
+}
+#endif

--- a/modules/mono/editor_templates/Node/default.cs
+++ b/modules/mono/editor_templates/Node/default.cs
@@ -1,0 +1,19 @@
+// meta-description: Base template for Node with default Godot cycle methods
+
+using _BINDINGS_NAMESPACE_;
+using System;
+
+public partial class _CLASS_ : _BASE_
+{
+    // Called when the node enters the scene tree for the first time.
+    public override void _Ready()
+    {
+
+    }
+
+    // Called every frame. 'delta' is the elapsed time since the previous frame.
+    public override void _Process(float delta)
+    {
+
+    }
+}

--- a/modules/mono/editor_templates/Object/empty.cs
+++ b/modules/mono/editor_templates/Object/empty.cs
@@ -1,0 +1,9 @@
+// meta-description: Empty template suitable for all Objects
+
+using _BINDINGS_NAMESPACE_;
+using System;
+
+public partial class _CLASS_ : _BASE_
+{
+
+}

--- a/modules/mono/editor_templates/SCsub
+++ b/modules/mono/editor_templates/SCsub
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+Import("env")
+
+import editor.template_builders as build_template_cs
+
+env["BUILDERS"]["MakeCSharpTemplateBuilder"] = Builder(
+    action=env.Run(build_template_cs.make_templates, "Generating C# templates header."),
+    suffix=".h",
+    src_suffix=".cs",
+)
+
+# Template files
+templates_sources = Glob("*/*.cs")
+
+env.Alias("editor_template_cs", [env.MakeCSharpTemplateBuilder("templates.gen.h", templates_sources)])

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2241,20 +2241,15 @@ void VisualScriptLanguage::get_comment_delimiters(List<String> *p_delimiters) co
 void VisualScriptLanguage::get_string_delimiters(List<String> *p_delimiters) const {
 }
 
-Ref<Script> VisualScriptLanguage::get_template(const String &p_class_name, const String &p_base_class_name) const {
+bool VisualScriptLanguage::is_using_templates() {
+	return false;
+}
+
+Ref<Script> VisualScriptLanguage::make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const {
 	Ref<VisualScript> script;
 	script.instantiate();
 	script->set_instance_base_type(p_base_class_name);
 	return script;
-}
-
-bool VisualScriptLanguage::is_using_templates() {
-	return true;
-}
-
-void VisualScriptLanguage::make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) {
-	Ref<VisualScript> script = p_script;
-	script->set_instance_base_type(p_base_class_name);
 }
 
 bool VisualScriptLanguage::validate(const String &p_script, const String &p_path, List<String> *r_functions, List<ScriptLanguage::ScriptError> *r_errors, List<ScriptLanguage::Warning> *r_warnings, Set<int> *r_safe_lines) const {

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -554,57 +554,56 @@ public:
 
 	//////////////////////////////////////
 
-	virtual String get_name() const;
+	virtual String get_name() const override;
 
 	/* LANGUAGE FUNCTIONS */
-	virtual void init();
-	virtual String get_type() const;
-	virtual String get_extension() const;
-	virtual Error execute_file(const String &p_path);
-	virtual void finish();
+	virtual void init() override;
+	virtual String get_type() const override;
+	virtual String get_extension() const override;
+	virtual Error execute_file(const String &p_path) override;
+	virtual void finish() override;
 
 	/* EDITOR FUNCTIONS */
-	virtual void get_reserved_words(List<String> *p_words) const;
-	virtual bool is_control_flow_keyword(String p_keyword) const;
-	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
-	virtual void get_string_delimiters(List<String> *p_delimiters) const;
-	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;
-	virtual bool is_using_templates();
-	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script);
-	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
-	virtual Script *create_script() const;
-	virtual bool has_named_classes() const;
-	virtual bool supports_builtin_mode() const;
-	virtual int find_function(const String &p_function, const String &p_code) const;
-	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const;
-	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;
-	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value);
+	virtual void get_reserved_words(List<String> *p_words) const override;
+	virtual bool is_control_flow_keyword(String p_keyword) const override;
+	virtual void get_comment_delimiters(List<String> *p_delimiters) const override;
+	virtual void get_string_delimiters(List<String> *p_delimiters) const override;
+	virtual bool is_using_templates() override;
+	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const override;
+	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const override;
+	virtual Script *create_script() const override;
+	virtual bool has_named_classes() const override;
+	virtual bool supports_builtin_mode() const override;
+	virtual int find_function(const String &p_function, const String &p_code) const override;
+	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const override;
+	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override;
+	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) override;
 
 	/* DEBUGGER FUNCTIONS */
 
-	virtual String debug_get_error() const;
-	virtual int debug_get_stack_level_count() const;
-	virtual int debug_get_stack_level_line(int p_level) const;
-	virtual String debug_get_stack_level_function(int p_level) const;
-	virtual String debug_get_stack_level_source(int p_level) const;
-	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
-	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
-	virtual void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
-	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1);
+	virtual String debug_get_error() const override;
+	virtual int debug_get_stack_level_count() const override;
+	virtual int debug_get_stack_level_line(int p_level) const override;
+	virtual String debug_get_stack_level_function(int p_level) const override;
+	virtual String debug_get_stack_level_source(int p_level) const override;
+	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1) override;
 
-	virtual void reload_all_scripts();
-	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);
+	virtual void reload_all_scripts() override;
+	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) override;
 	/* LOADER FUNCTIONS */
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
-	virtual void get_public_functions(List<MethodInfo> *p_functions) const;
-	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_public_functions(List<MethodInfo> *p_functions) const override;
+	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const override;
 
-	virtual void profiling_start();
-	virtual void profiling_stop();
+	virtual void profiling_start() override;
+	virtual void profiling_stop() override;
 
-	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max);
-	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max);
+	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) override;
+	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) override;
 
 	void add_register_func(const String &p_name, VisualScriptNodeRegisterFunc p_func);
 	void remove_register_func(const String &p_name);


### PR DESCRIPTION
_Co-Authored-By: jmb462 <jmb462@gmail.com>_

This PR attempts to improve/rewrite the script template workflow to make the usage as easy/smooth as possible.

Closes https://github.com/godotengine/godot-proposals/issues/3365

fix #36605
fix #28799
fix #44534
fix #46436
close https://github.com/godotengine/godot-proposals/issues/1899

![1_before-after](https://user-images.githubusercontent.com/6397893/137722565-a47c204b-1b81-47bd-8df8-7a0d1be83903.png)

## What are the main changes?

- Built-in templates are in external file instead of hard-coded c++, they are no more mixed with user templates and can be updated
- Templates are now linked to a node, when you create a script for a node, you will only see the templates for this node, or one of its parents.
- Simplification and cleaning.

## How it can be used by core dev ##

The original motivation was to provide a more relevant template for CharacterBody nodes in order to :
    - help to avoid the common error we see in issues (like forget to assign the result of move and slide in 3.x)
    - help to make the transition in 4.0 (act like a tutorial)
    - fast prototyping, you have a moving character in few seconds

https://user-images.githubusercontent.com/6397893/137722735-84901d90-f322-4898-a986-0cb8129903c5.mp4

## How it works?

The template folders have the following structure

![2_structure](https://user-images.githubusercontent.com/6397893/137722777-6a55260a-f4df-486b-ad06-fa71ab535183.png)

To add a template simply create a file in the correct folder (`template_path/node_type/file.ext`), that's it.

By default:
 - the name of the template file will be the name of the file
 - the description will be empty
 - the space indent will be 4
 - the template will not be use as default
 
You can customize the template info with metas at the begning of your templates. Metas starts with the single-line comment syntax of your language:

```
# meta-name: Basic movement
# meta-description: Classic movement for gravity games (platformer, ...)
# meta-default: true
# meta-space-indent: 4
```

Example of description:

![Screenshot 2021-10-18 at 14 40 43](https://user-images.githubusercontent.com/6397893/137732515-827f6401-88df-4a9f-a9ae-d83ef9635363.png)

**It works exactly the same for built-in and user templates**

## Notes

- When you create an editor plugin in c# you will have the basic structure for a plugin that I found in the doc. However there is a warning that pop up for now (I don't know why as I don't use c# & there was nothing before)
- I wonder if the **project** template folder should not be fixed like the add-ons one (not changeable in the editor), to avoid the ifdef in `gdscript.cpp`




