### PR TITLE
WebM: Disable SIMD optimization with YASM on Windows

### DIFF
--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -224,7 +224,7 @@ if env["platform"] == "uwp":
         webm_cpu_arm = True
     else:
         webm_cpu_x86 = True
-else:
+elif env["platform"] != "windows":  # Disable for Windows, yasm SIMD optimizations trigger crash (GH-50862).
     import platform
 
     is_x11_or_server_arm = (env["platform"] == "x11" or env["platform"] == "server") and (
@@ -322,7 +322,7 @@ if webm_cpu_arm:
 
     webm_simd_optimizations = True
 
-if webm_simd_optimizations == False:
+if webm_simd_optimizations == False and env["platform"] != "windows":
     print("WebM SIMD optimizations are disabled. Check if your CPU architecture, CPU bits or platform are supported!")
 
 env_libvpx.add_source_files(env.modules_sources, libvpx_sources)


### PR DESCRIPTION
It triggers a crash when playing V9 videos.

Could likely be fixed if anyone wants to work on it, but so far nobody seems to
want to and WebM support is dropped in 4.0, so this workaround should help for
now.

Fixes #50862.

----

This shouldn't impact 3.4 beta/RC builds as those were already built without YASM. But once cherry-picked for `3.3` it should fix #50862 for a potential 3.3.5, and for custom builds of users who installed yasm. CC @zaevi 

Documentation updated accordingly in https://github.com/godotengine/godot-docs/pull/5332.