### PR TITLE
fix potential memory leak of AudioStreamPlaybackBusDetails

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1131,8 +1131,10 @@ void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, Map
 	AudioStreamPlaybackBusDetails *new_bus_details = new AudioStreamPlaybackBusDetails();
 	int idx = 0;
 	for (KeyValue<StringName, Vector<AudioFrame>> pair : p_bus_volumes) {
-		ERR_FAIL_COND(pair.value.size() < channel_count);
-		ERR_FAIL_COND(pair.value.size() != MAX_CHANNELS_PER_BUS);
+		if (pair.value.size() < channel_count || pair.value.size() != MAX_CHANNELS_PER_BUS) {
+			delete new_bus_details;
+			ERR_FAIL();
+		}
 
 		new_bus_details->bus_active[idx] = true;
 		new_bus_details->bus[idx] = pair.key;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
I found this one with `scan-build`. `AudioServer::start_playback_stream()` potentially leaks an instance of `AudioStreamPlaybackBusDetails` if an error is encountered within the for loop.

![image](https://user-images.githubusercontent.com/9374/137745672-02a40757-3bc5-4a7e-aeb6-2088a74b74d1.png)

Hopefully the way I did this makes sense, happy to revise if not :smile: 

