### PR TITLE
[3.x] Add a project setting to enable 3D shadow dithering

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1801,11 +1801,14 @@
 			Lower-end override for [member rendering/quality/shadow_atlas/size] on mobile devices, due to performance concerns or driver support.
 		</member>
 		<member name="rendering/quality/shadows/filter_mode" type="int" setter="" getter="" default="1">
-			Shadow filter mode. Higher-quality settings result in smoother shadows that flicker less when moving. "Disabled" is the fastest option, but also has the lowest quality. "PCF5" is smoother but is also slower. "PCF13" is the smoothest option, but is also the slowest.
+			Shadow filter mode in 3D. Higher-quality settings result in smoother shadows that flicker less when moving. "Disabled" is the fastest option, but also has the lowest quality. "PCF5" is smoother but is also slower. "PCF13" is the smoothest option, but is also the slowest. See also [member rendering/quality/shadows/use_dithering].
 			[b]Note:[/b] When using the GLES2 backend, the "PCF13" option actually uses 16 samples to emulate linear filtering in the shader. This results in a shadow appearance similar to the one produced by the GLES3 backend.
 		</member>
 		<member name="rendering/quality/shadows/filter_mode.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/quality/shadows/filter_mode] on mobile devices, due to performance concerns or driver support.
+		</member>
+		<member name="rendering/quality/shadows/use_dithering" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], enables dithering for 3D shadows. Dithering improves overall shadow quality, but introduces a grainy effect that can be noticeable in scenes with large flat color areas. This dithering effect becomes less noticeable as textures become more complex and as the 3D rendering resolution increases. Disabling dithering can also slightly improve shadow rendering performance. See also [member rendering/quality/shadows/filter_mode].
 		</member>
 		<member name="rendering/quality/skinning/force_software_skinning" type="bool" setter="" getter="" default="false">
 			Forces [MeshInstance] to always perform skinning on the CPU (applies to both GLES2 and GLES3).

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -1911,6 +1911,7 @@ void RasterizerSceneGLES2::_setup_light_type(LightInstance *p_light, ShadowAtlas
 	state.scene_shader.set_conditional(SceneShaderGLES2::USE_SHADOW, false);
 	state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_5, false);
 	state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_13, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_USE_DITHERING, false);
 	state.scene_shader.set_conditional(SceneShaderGLES2::LIGHT_MODE_DIRECTIONAL, false);
 	state.scene_shader.set_conditional(SceneShaderGLES2::LIGHT_MODE_OMNI, false);
 	state.scene_shader.set_conditional(SceneShaderGLES2::LIGHT_MODE_SPOT, false);
@@ -1952,6 +1953,7 @@ void RasterizerSceneGLES2::_setup_light_type(LightInstance *p_light, ShadowAtlas
 				}
 				state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_5, shadow_filter_mode == SHADOW_FILTER_PCF5);
 				state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_13, shadow_filter_mode == SHADOW_FILTER_PCF13);
+				state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_USE_DITHERING, shadow_use_dithering);
 			}
 
 		} break;
@@ -1967,6 +1969,7 @@ void RasterizerSceneGLES2::_setup_light_type(LightInstance *p_light, ShadowAtlas
 				}
 				state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_5, shadow_filter_mode == SHADOW_FILTER_PCF5);
 				state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_13, shadow_filter_mode == SHADOW_FILTER_PCF13);
+				state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_USE_DITHERING, shadow_use_dithering);
 			}
 		} break;
 		case VS::LIGHT_SPOT: {
@@ -1981,6 +1984,7 @@ void RasterizerSceneGLES2::_setup_light_type(LightInstance *p_light, ShadowAtlas
 				}
 				state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_5, shadow_filter_mode == SHADOW_FILTER_PCF5);
 				state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_13, shadow_filter_mode == SHADOW_FILTER_PCF13);
+				state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_USE_DITHERING, shadow_use_dithering);
 			}
 		} break;
 	}
@@ -4103,6 +4107,7 @@ void RasterizerSceneGLES2::initialize() {
 	}
 
 	shadow_filter_mode = SHADOW_FILTER_NEAREST;
+	shadow_use_dithering = false;
 
 	glFrontFace(GL_CW);
 }
@@ -4115,6 +4120,8 @@ void RasterizerSceneGLES2::iteration() {
 		directional_shadow_size = directional_shadow_size_new;
 		directional_shadow_create();
 	}
+
+	shadow_use_dithering = bool(GLOBAL_GET("rendering/quality/shadows/use_dithering"));
 }
 
 void RasterizerSceneGLES2::finalize() {

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -66,6 +66,8 @@ public:
 
 	ShadowFilterMode shadow_filter_mode;
 
+	bool shadow_use_dithering;
+
 	RID default_material;
 	RID default_material_twosided;
 	RID default_shader;

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1500,9 +1500,23 @@ LIGHT_SHADER_CODE
 
 #define SAMPLE_SHADOW_TEXEL(p_shadow, p_pos, p_depth) step(p_depth, SHADOW_DEPTH(texture2D(p_shadow, p_pos)))
 
+#ifdef SHADOW_USE_DITHERING
+// Interleaved Gradient Noise
+// https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
+float quick_hash(vec2 pos) {
+	const vec3 magic = vec3(0.06711056f, 0.00583715f, 52.9829189f);
+	return fract(magic.z * fract(dot(pos, magic.xy)));
+}
+#endif
+
 float sample_shadow(highp sampler2D shadow, highp vec4 spos) {
 	spos.xyz /= spos.w;
+#ifdef SHADOW_USE_DITHERING
+	vec2 dither = (-vec2(0.5) + quick_hash(gl_FragCoord.xy)) * shadow_pixel_size;
+	vec2 pos = spos.xy + dither;
+#else
 	vec2 pos = spos.xy;
+#endif
 	float depth = spos.z;
 
 #ifdef SHADOW_MODE_PCF_13

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2045,6 +2045,7 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 					state.scene_shader.set_conditional(SceneShaderGLES3::LIGHT_USE_PSSM_BLEND, false);
 					state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_MODE_PCF_5, false);
 					state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_MODE_PCF_13, false);
+					state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_USE_DITHERING, false);
 					state.scene_shader.set_conditional(SceneShaderGLES3::USE_GI_PROBES, false);
 					state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHTMAP_CAPTURE, false);
 					state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHTMAP, false);
@@ -2071,6 +2072,7 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 					state.scene_shader.set_conditional(SceneShaderGLES3::LIGHT_USE_PSSM_BLEND, false);
 					state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_MODE_PCF_5, shadow_filter_mode == SHADOW_FILTER_PCF5);
 					state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_MODE_PCF_13, shadow_filter_mode == SHADOW_FILTER_PCF13);
+					state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_USE_DITHERING, shadow_use_dithering);
 					state.scene_shader.set_conditional(SceneShaderGLES3::USE_RADIANCE_MAP, use_radiance_map);
 					state.scene_shader.set_conditional(SceneShaderGLES3::USE_CONTACT_SHADOWS, state.used_contact_shadows);
 
@@ -2232,6 +2234,7 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 	state.scene_shader.set_conditional(SceneShaderGLES3::SHADELESS, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_MODE_PCF_5, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_MODE_PCF_13, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_USE_DITHERING, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_GI_PROBES, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHTMAP, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHTMAP_LAYERED, false);
@@ -5187,6 +5190,7 @@ void RasterizerSceneGLES3::initialize() {
 	}
 
 	shadow_filter_mode = SHADOW_FILTER_NEAREST;
+	shadow_use_dithering = false;
 
 	{ //reflection cubemaps
 		int max_reflection_cubemap_sampler_size = 512;
@@ -5333,6 +5337,8 @@ void RasterizerSceneGLES3::iteration() {
 		directional_shadow_size = directional_shadow_size_new;
 		directional_shadow_create();
 	}
+
+	shadow_use_dithering = bool(GLOBAL_GET("rendering/quality/shadows/use_dithering"));
 
 	subsurface_scatter_follow_surface = GLOBAL_GET("rendering/quality/subsurface_scattering/follow_surface");
 	subsurface_scatter_weight_samples = GLOBAL_GET("rendering/quality/subsurface_scattering/weight_samples");

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -56,6 +56,8 @@ public:
 
 	ShadowFilterMode shadow_filter_mode;
 
+	bool shadow_use_dithering;
+
 	uint64_t shadow_atlas_realloc_tolerance_msec;
 
 	enum SubSurfaceScatterQuality {

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2656,6 +2656,7 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/quality/shadows/filter_mode", 1);
 	GLOBAL_DEF("rendering/quality/shadows/filter_mode.mobile", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadows/filter_mode", PropertyInfo(Variant::INT, "rendering/quality/shadows/filter_mode", PROPERTY_HINT_ENUM, "Disabled,PCF5,PCF13"));
+	GLOBAL_DEF("rendering/quality/shadows/use_dithering", false);
 
 	GLOBAL_DEF("rendering/quality/reflections/texture_array_reflections", true);
 	GLOBAL_DEF("rendering/quality/reflections/texture_array_reflections.mobile", false);


### PR DESCRIPTION
This improves overall shadow quality at the cost of a grainy appearance when up close. Dithering is disabled by default to preserve the current appearance in existing projects, but it will be enabled by default in Godot 4.0.

This setting works in both GLES3 and GLES2 and with any shadow filter mode (even Disabled).

This PR is effectively the opposite of https://github.com/godotengine/godot/pull/53961, but for `3.x` :slightly_smiling_face:

This effectively resurrects some of the ideas behind https://github.com/godotengine/godot/pull/7204 as well.

~~**Note:** GLES3 rendering is currently broken (it's all white without any shader errors). This is because more than 32 conditionals are being used, like in https://github.com/godotengine/godot/pull/54355.~~
**Edit (June 2023):** This seems to be fixed in the latest `3.x` branch now, likely by incindental changes made for the ubershader implementation.

## Preview

*Don't pay attention to the peter-panning - it's unrelated to this pull request.*

### GLES3

#### Shadow Filter Mode: Disabled

| No dithering | With dithering |
|-|-|
| ![shadow_hard_no_dither](https://user-images.githubusercontent.com/180032/137771649-e2444a90-0dab-4bb6-bc24-24f5cdc56406.png) | ![shadow_hard_dither](https://user-images.githubusercontent.com/180032/137771647-0134869d-d99b-46a6-ada7-a8dfef3efa82.png) |

#### Shadow Filter Mode: PCF5 (default)

| No dithering | With dithering |
|-|-|
| ![shadow_pcf5_no_dither](https://user-images.githubusercontent.com/180032/137771652-7a66f9e6-7924-4f26-a42e-19953cc3663d.png) | ![shadow_pcf5_dither](https://user-images.githubusercontent.com/180032/137771650-d188b667-973f-4afc-b1f6-705d2b250e77.png) |

#### Shadow Filter Mode: PCF13

| No dithering | With dithering |
|-|-|
| ![shadow_pcf13_no_dither](https://user-images.githubusercontent.com/180032/137771657-709ad5de-ab45-4d59-923c-32c788de9f59.png) | ![shadow_pcf13_dither](https://user-images.githubusercontent.com/180032/137771654-ce1263d7-6bf8-420e-a1a6-d78211c17b83.png) |

### GLES2

#### Shadow Filter Mode: Disabled

*The SpotLight rendering breaks when the filter mode is Disabled for some reason (even without this pull request).*

| No dithering | With dithering |
|-|-|
| ![shadow_hard_no_dither](https://user-images.githubusercontent.com/180032/137771595-7bb6e426-534b-48d2-92ed-cb612902d51f.png) | ![shadow_hard_dither](https://user-images.githubusercontent.com/180032/137771591-84ac3055-2eec-4c23-a180-7467c2d16646.png) |

#### Shadow Filter Mode: PCF5 (default)

| No dithering | With dithering |
|-|-|
| ![shadow_pcf5_no_dither](https://user-images.githubusercontent.com/180032/137771597-1d905f21-1c86-4f02-b64a-33dd028c1452.png) | ![shadow_pcf5_dither](https://user-images.githubusercontent.com/180032/137771596-35db7ce8-6c93-49fd-803d-ba4927185629.png) |

#### Shadow Filter Mode: PCF13

| No dithering | With dithering |
|-|-|
| ![shadow_pcf13_no_dither](https://user-images.githubusercontent.com/180032/137771600-9628c327-191f-4b98-ad7d-285a8834033c.png) | ![shadow_pcf13_dither](https://user-images.githubusercontent.com/180032/137771599-f89a5520-7b5c-4afa-9c69-fe5989c25454.png) |