### PR TITLE
Clarify lighting height documentation

### DIFF
--- a/doc/classes/DirectionalLight2D.xml
+++ b/doc/classes/DirectionalLight2D.xml
@@ -8,7 +8,7 @@
 	</tutorials>
 	<members>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="0.0">
-			The height of the light. Used with 2D normal mapping.
+			The height of the light. Used with 2D normal mapping. Ranges from 0 (parallel to the plane) to 1 (perpendicular to the plane).
 		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="10000.0">
 		</member>

--- a/doc/classes/PointLight2D.xml
+++ b/doc/classes/PointLight2D.xml
@@ -8,7 +8,7 @@
 	</tutorials>
 	<members>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="0.0">
-			The height of the light. Used with 2D normal mapping.
+			The height of the light. Used with 2D normal mapping. The units are in pixels, e.g. if the height is 100, then it will illuminate an object 100 pixels away at a 45° angle to the plane.
 		</member>
 		<member name="offset" type="Vector2" setter="set_texture_offset" getter="get_texture_offset" default="Vector2(0, 0)">
 			The offset of the light's [member texture].


### PR DESCRIPTION
It's easy to assume they are the same, but they are quite different for the two types of 2D lights. For myself, it took a bit of confusion and experimentation for me to figure out why this behaviour changed when I changed from point to directional. Hopefully it can save somebody else the trouble.

Granted, if you stop and think about it, it doesn't make sense for it to be the same, because for the DirectionalLight2d there's no position to define the angle. I don't think it hurts to properly define the meaning of the numbers though.