### PR TITLE
[4.0] Change default navmesh agent radius to match nav agent's default radius

### DIFF
--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -84,7 +84,7 @@
 		<member name="agent/max_slope" type="float" setter="set_agent_max_slope" getter="get_agent_max_slope" default="45.0">
 			The maximum slope that is considered walkable, in degrees.
 		</member>
-		<member name="agent/radius" type="float" setter="set_agent_radius" getter="get_agent_radius" default="0.6">
+		<member name="agent/radius" type="float" setter="set_agent_radius" getter="get_agent_radius" default="1.0">
 			The distance to erode/shrink the walkable area of the heightfield away from obstructions.
 			[b]Note:[/b] While baking, this value will be rounded up to the nearest multiple of [member cell/size].
 		</member>

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -85,7 +85,7 @@ protected:
 	float cell_size = 0.3f;
 	float cell_height = 0.2f;
 	float agent_height = 2.0f;
-	float agent_radius = 0.6f;
+	float agent_radius = 1.0f;
 	float agent_max_climb = 0.9f;
 	float agent_max_slope = 45.0f;
 	float region_min_size = 8.0f;


### PR DESCRIPTION
The default radius for a `NavigationAgent3D` is 1.0f. This changes the navmesh's agent radius to match that. Having these two defaults match will help get the ball rolling immediately when trying to implement navigation. There is no setting for the 2D navpoly resource.