### PR TITLE
[3.x] Remove unused variables

### DIFF
--- a/core/compressed_translation.cpp
+++ b/core/compressed_translation.cpp
@@ -62,7 +62,6 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 
 	int idx = 0;
 	int total_compression_size = 0;
-	int total_string_size = 0;
 
 	for (List<StringName>::Element *E = keys.front(); E; E = E->next()) {
 		//hash string
@@ -100,7 +99,6 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 
 		compressed.write[idx] = ps;
 		total_compression_size += ps.compressed.size();
-		total_string_size += src_s.size();
 		idx++;
 	}
 
@@ -145,15 +143,12 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 	uint32_t *btw = (uint32_t *)&btwb[0];
 
 	int btindex = 0;
-	int collisions = 0;
 
 	for (int i = 0; i < size; i++) {
 		const Map<uint32_t, int> &t = table[i];
 		if (t.size() == 0) {
 			htw[i] = 0xFFFFFFFF; //nothing
 			continue;
-		} else if (t.size() > 1) {
-			collisions += t.size() - 1;
 		}
 
 		htw[i] = btindex;

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -1699,7 +1699,6 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	}
 
 	bool found_library = false;
-	int total_size = 0;
 
 	const String project_file = "godot_ios.xcodeproj/project.pbxproj";
 	Set<String> files_to_parse;
@@ -1795,7 +1794,6 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 			file = file.replace("godot_ios", binary_name);
 
 			print_line("ADDING: " + file + " size: " + itos(data.size()));
-			total_size += data.size();
 
 			/* write it into our folder structure */
 			file = dest_dir + file;

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -647,7 +647,6 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 	// Now process our template.
 	bool found_binary = false;
-	int total_size = 0;
 	Vector<String> dylibs_found;
 
 	while (ret == UNZ_OK && err == OK) {
@@ -735,7 +734,6 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			}
 
 			print_line("ADDING: " + file + " size: " + itos(data.size()));
-			total_size += data.size();
 
 			// Write it into our application bundle.
 			file = tmp_app_path_name.plus_file(file);


### PR DESCRIPTION
I'm getting the following warnings when building the 3.x branch:
```
platform/iphone/export/export.cpp|1702|warning: variable 'total_size' set but not used [-Wunused-but-set-variable]|
platform/osx/export/export.cpp|650|warning: variable 'total_size' set but not used [-Wunused-but-set-variable]|
core/compressed_translation.cpp|148|warning: variable 'collisions' set but not used [-Wunused-but-set-variable]|
core/compressed_translation.cpp|65|warning: variable 'total_string_size' set but not used [-Wunused-but-set-variable]|
```
This PR removes the set, but unused, variables.