### PR TITLE
Change the default gravity values

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1365,17 +1365,17 @@
 			The default angular damp in 2D.
 			[b]Note:[/b] Good values are in the range [code]0[/code] to [code]1[/code]. At value [code]0[/code] objects will keep moving with the same velocity. Values greater than [code]1[/code] will aim to reduce the velocity to [code]0[/code] in less than a second e.g. a value of [code]2[/code] will aim to reduce the velocity to [code]0[/code] in half a second. A value equal to or greater than the physics frame rate ([member ProjectSettings.physics/common/physics_ticks_per_second], [code]60[/code] by default) will bring the object to a stop in one iteration.
 		</member>
-		<member name="physics/2d/default_gravity" type="float" setter="" getter="" default="980.0">
+		<member name="physics/2d/default_gravity" type="float" setter="" getter="" default="2900.0">
 			The default gravity strength in 2D (in pixels per second squared).
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity at runtime, use the following code sample:
 			[codeblocks]
 			[gdscript]
-			# Set the default gravity strength to 980.
-			PhysicsServer2D.area_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.AREA_PARAM_GRAVITY, 980)
+			# Set the default gravity strength to 2900.
+			PhysicsServer2D.area_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.AREA_PARAM_GRAVITY, 2900)
 			[/gdscript]
 			[csharp]
-			// Set the default gravity strength to 980.
-			PhysicsServer2D.AreaSetParam(GetViewport().FindWorld2d().Space, PhysicsServer2D.AreaParameter.Gravity, 980);
+			// Set the default gravity strength to 2900.
+			PhysicsServer2D.AreaSetParam(GetViewport().FindWorld2d().Space, PhysicsServer2D.AreaParameter.Gravity, 2900);
 			[/csharp]
 			[/codeblocks]
 		</member>
@@ -1417,17 +1417,17 @@
 			The default angular damp in 3D.
 			[b]Note:[/b] Good values are in the range [code]0[/code] to [code]1[/code]. At value [code]0[/code] objects will keep moving with the same velocity. Values greater than [code]1[/code] will aim to reduce the velocity to [code]0[/code] in less than a second e.g. a value of [code]2[/code] will aim to reduce the velocity to [code]0[/code] in half a second. A value equal to or greater than the physics frame rate ([member ProjectSettings.physics/common/physics_ticks_per_second], [code]60[/code] by default) will bring the object to a stop in one iteration.
 		</member>
-		<member name="physics/3d/default_gravity" type="float" setter="" getter="" default="9.8">
+		<member name="physics/3d/default_gravity" type="float" setter="" getter="" default="61.25">
 			The default gravity strength in 3D (in meters per second squared).
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity at runtime, use the following code sample:
 			[codeblocks]
 			[gdscript]
-			# Set the default gravity strength to 9.8.
-			PhysicsServer3D.area_set_param(get_viewport().find_world().space, PhysicsServer3D.AREA_PARAM_GRAVITY, 9.8)
+			# Set the default gravity strength to 61.25.
+			PhysicsServer3D.area_set_param(get_viewport().find_world().space, PhysicsServer3D.AREA_PARAM_GRAVITY, 61.25)
 			[/gdscript]
 			[csharp]
-			// Set the default gravity strength to 9.8.
-			PhysicsServer3D.AreaSetParam(GetViewport().FindWorld().Space, PhysicsServer3D.AreaParameter.Gravity, 9.8);
+			// Set the default gravity strength to 61.25.
+			PhysicsServer3D.AreaSetParam(GetViewport().FindWorld().Space, PhysicsServer3D.AreaParameter.Gravity, 61.25);
 			[/csharp]
 			[/codeblocks]
 		</member>

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -73,7 +73,7 @@ World2D::World2D() {
 	// Create and configure space2D to be more friendly with pixels than meters
 	space = PhysicsServer2D::get_singleton()->space_create();
 	PhysicsServer2D::get_singleton()->space_set_active(space, true);
-	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, GLOBAL_DEF("physics/2d/default_gravity", 980.0));
+	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, GLOBAL_DEF("physics/2d/default_gravity", 2900.0));
 	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY_VECTOR, GLOBAL_DEF("physics/2d/default_gravity_vector", Vector2(0, 1)));
 	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_LINEAR_DAMP, GLOBAL_DEF("physics/2d/default_linear_damp", 0.1));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/default_linear_damp", PropertyInfo(Variant::FLOAT, "physics/2d/default_linear_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"));

--- a/scene/resources/world_3d.cpp
+++ b/scene/resources/world_3d.cpp
@@ -141,7 +141,7 @@ World3D::World3D() {
 	scenario = RenderingServer::get_singleton()->scenario_create();
 
 	PhysicsServer3D::get_singleton()->space_set_active(space, true);
-	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_GRAVITY, GLOBAL_DEF("physics/3d/default_gravity", 9.8));
+	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_GRAVITY, GLOBAL_DEF("physics/3d/default_gravity", 61.25));
 	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR, GLOBAL_DEF("physics/3d/default_gravity_vector", Vector3(0, -1, 0)));
 	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_LINEAR_DAMP, GLOBAL_DEF("physics/3d/default_linear_damp", 0.1));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/default_linear_damp", PropertyInfo(Variant::FLOAT, "physics/3d/default_linear_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"));


### PR DESCRIPTION
By using the default physics values like suggested by @aaronfranke on #53957, I noticed they seem to be wrong.

it's easier in 3D as we can tell we must target the reality scale. I tested on a character (1m50) from my project. I set the value from 9.81 to 61.25 (0.98/0.016 (delta))  (https://github.com/fabriceci/3d-platform-test-for-godot4) with as code, the new default template for CharacterBody3D

Before:
![3D-before](https://user-images.githubusercontent.com/6397893/137904218-2b29b4c4-d2d7-4555-a9cb-aaf7017867ab.gif)

After:
![3D-after](https://user-images.githubusercontent.com/6397893/137904281-a3a8c745-a64c-4f01-ac3d-1e5b782b8dea.gif)

In 2D is a bit touchy, as the scale is relative to the project. But as we need to choice one to define a default, I suggest to choice the one relative to the most used character in Godot Games. I set the value from 980.0 to 2900.0 (just by feeling)

![icon](https://user-images.githubusercontent.com/6397893/137905035-fc8202f1-b8b8-46cc-a9a5-76fb0edf7d9c.png)

(64x64)

Same very basic, just the icon with the new default template.

Before:
![2D-before](https://user-images.githubusercontent.com/6397893/137905230-15377170-ed56-4bd1-947e-c1240dbe0555.gif)

After:
![2D-after](https://user-images.githubusercontent.com/6397893/137905252-6867e61d-aba3-4258-a3bf-bef7a15a3ae6.gif)


