### PR TITLE
[3.x] [HTML5] Editor video driver option. Replace canvas on exit.

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<html xmlns="https://www.w3.org/1999/xhtml" lang="en">
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />
@@ -269,11 +269,6 @@
 	<div id="tabs">
 		<div id="tab-loader">
 			<div style="color: #e0e0e0;" id="persistence">
-				<label for="videoMode" style="display: none;">Select video driver:</label><br />
-				<select id="videoMode" style="display: none;">
-					<option value="GLES2" selected="selected">WebGL</option>
-					<option value="GLES3">WebGL 2</option>
-				</select>
 				<br />
 				<img src="logo.svg" alt="Godot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: 85%; max-height: 250px" />
 				<br />
@@ -281,6 +276,14 @@
 				<br />
 				<a href="releases/">Need an old version?</a>
 				<br />
+				<br />
+				<br />
+				<label for="videoMode" style="margin-right: 1rem">Video driver:</label>
+				<select id="videoMode">
+					<option value="" selected="selected">Auto</option>
+					<option value="GLES2">WebGL</option>
+					<option value="GLES3">WebGL 2</option>
+				</select>
 				<br />
 				<br />
 				<label for="zip-file" style="margin-right: 1rem">Preload project ZIP:</label> <input id="zip-file" type="file" name="files" style="margin-bottom: 1rem"/>
@@ -348,7 +351,7 @@
 		var game = null;
 		var setStatusMode;
 		var setStatusNotice;
-		var video_driver = "GLES2";
+		var video_driver = "";
 
 		function clearPersistence() {
 			function deleteDB(path) {
@@ -479,6 +482,15 @@
 			animationCallbacks.push(adjustCanvasDimensions);
 			adjustCanvasDimensions();
 
+			function replaceCanvas(from) {
+				const out = document.createElement("canvas");
+				out.id = from.id;
+				out.tabIndex = from.tabIndex;
+				from.parentNode.replaceChild(out, from);
+				lastScale = 0;
+				return out;
+			}
+
 			setStatusMode = function setStatusMode(mode) {
 				if (statusMode === mode || !initializing)
 					return;
@@ -534,6 +546,7 @@
 				'canvas': gameCanvas,
 				'canvasResizePolicy': 1,
 				'onExit': function () {
+					gameCanvas = replaceCanvas(gameCanvas);
 					setGameTabEnabled(false);
 					showTab('editor');
 					game = null;
@@ -548,7 +561,7 @@
 				const is_editor = args.filter(function(v) { return v == '--editor' || v == '-e' }).length != 0;
 				const is_project_manager = args.filter(function(v) { return v == '--project-manager' }).length != 0;
 				const is_game = !is_editor && !is_project_manager;
-				if (is_project_manager) {
+				if (video_driver) {
 					args.push('--video-driver', video_driver);
 				}
 				if (is_game) {
@@ -561,7 +574,7 @@
 					showTab('game');
 					game.init().then(function() {
 						requestAnimationFrame(function() {
-							game.start({'args': args}).then(function() {
+							game.start({'args': args, 'canvas': gameCanvas}).then(function() {
 								gameCanvas.focus();
 							});
 						});
@@ -576,7 +589,7 @@
 									showTab('loader');
 									setLoaderEnabled(true);
 								};
-								editor.start({'args': args, 'persistentDrops': is_project_manager});
+								editor.start({'args': args, 'persistentDrops': is_project_manager, 'canvas': editorCanvas});
 							});
 						}, 0);
 						OnEditorExit = null;
@@ -603,6 +616,7 @@
 				'canvas': editorCanvas,
 				'canvasResizePolicy': 0,
 				'onExit': function() {
+					editorCanvas = replaceCanvas(editorCanvas);
 					if (OnEditorExit) {
 						OnEditorExit();
 					}
@@ -634,10 +648,14 @@
 					} catch(e) {
 						// File exists
 					}
-					//selectVideoMode();
+					selectVideoMode();
 					showTab('editor');
 					setLoaderEnabled(false);
-					editor.start({'args': ['--project-manager', '--video-driver', video_driver], 'persistentDrops': true}).then(function() {
+					const args = ['--project-manager'];
+					if (video_driver) {
+						args.push('--video-driver', video_driver);
+					}
+					editor.start({'args': args, 'persistentDrops': true}).then(function() {
 						setStatusMode('hidden');
 						initializing = false;
 					});

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -702,14 +702,10 @@ Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, 
 		set_window_per_pixel_transparency_enabled(true);
 	}
 
-#ifdef TOOLS_ENABLED
-	bool gles3 = false;
-#else
 	bool gles3 = true;
 	if (p_video_driver == VIDEO_DRIVER_GLES2) {
 		gles3 = false;
 	}
-#endif
 
 	bool gl_initialization_error = false;
 


### PR DESCRIPTION
Default is "Auto", but can be forced to a specific WebGL version if the
automatic detection fails.

The game and editor canvas are now replaced with a new one in the exit
hooks. This helps the browser do some context cleanup, and allow us to
create a new context of a different type (WebGL/WebGL2).

Enable GLES3/WebGL2 in the Web Editor.
Fixes #52455.

![screen-editro-gles3](https://user-images.githubusercontent.com/1687918/137935584-22c51d6b-2279-41d1-a75a-18734b136293.png)


