### PR TITLE
[4.x] Fix handling multiple "physical key" events in the single input map action.

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -452,8 +452,13 @@ bool InputEventKey::is_match(const Ref<InputEvent> &p_event, bool p_exact_match)
 		return false;
 	}
 
-	return keycode == key->keycode &&
-		   (!p_exact_match || get_modifiers_mask() == key->get_modifiers_mask());
+	if (keycode == 0) {
+		return physical_keycode == key->physical_keycode &&
+			   (!p_exact_match || get_modifiers_mask() == key->get_modifiers_mask());
+	} else {
+		return keycode == key->keycode &&
+			   (!p_exact_match || get_modifiers_mask() == key->get_modifiers_mask());
+	}
 }
 
 void InputEventKey::_bind_methods() {


### PR DESCRIPTION
Fixes #53998
