### PR TITLE
Fix: typo in TextParagraph class and docs

### DIFF
--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -199,7 +199,7 @@
 				Returns width (for horizontal layout) or height (for vertical) of the line of text.
 			</description>
 		</method>
-		<method name="get_non_wraped_size" qualifiers="const">
+		<method name="get_non_wrapped_size" qualifiers="const">
 			<return type="Vector2" />
 			<description>
 				Returns the size of the bounding box of the paragraph, without line breaks.

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -486,7 +486,7 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 						remaining_characters -= cell_ch;
 
 						table->columns.write[column].min_width = MAX(table->columns[column].min_width, ceil(frame->lines[i].text_buf->get_size().x));
-						table->columns.write[column].max_width = MAX(table->columns[column].max_width, ceil(frame->lines[i].text_buf->get_non_wraped_size().x));
+						table->columns.write[column].max_width = MAX(table->columns[column].max_width, ceil(frame->lines[i].text_buf->get_non_wrapped_size().x));
 					}
 					idx++;
 				}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4039,7 +4039,7 @@ int TextEdit::get_visible_line_count() const {
 }
 
 int TextEdit::get_total_visible_line_count() const {
-	/* Returns the total number of (lines + wraped - hidden). */
+	/* Returns the total number of (lines + wrapped - hidden). */
 	if (!_is_hiding_enabled() && get_line_wrapping_mode() == LineWrappingMode::LINE_WRAPPING_NONE) {
 		return text.size();
 	}

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -84,7 +84,7 @@ void TextParagraph::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width"), "set_width", "get_width");
 
-	ClassDB::bind_method(D_METHOD("get_non_wraped_size"), &TextParagraph::get_non_wraped_size);
+	ClassDB::bind_method(D_METHOD("get_non_wrapped_size"), &TextParagraph::get_non_wrapped_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &TextParagraph::get_size);
 
 	ClassDB::bind_method(D_METHOD("get_rid"), &TextParagraph::get_rid);
@@ -417,7 +417,7 @@ float TextParagraph::get_width() const {
 	return width;
 }
 
-Size2 TextParagraph::get_non_wraped_size() const {
+Size2 TextParagraph::get_non_wrapped_size() const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	if (TS->shaped_text_get_orientation(rid) == TextServer::ORIENTATION_HORIZONTAL) {
 		return Size2(TS->shaped_text_get_size(rid).x, TS->shaped_text_get_size(rid).y + spacing_top + spacing_bottom);

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -120,7 +120,7 @@ public:
 	void set_max_lines_visible(int p_lines);
 	int get_max_lines_visible() const;
 
-	Size2 get_non_wraped_size() const;
+	Size2 get_non_wrapped_size() const;
 
 	Size2 get_size() const;
 


### PR DESCRIPTION
Replaced "wraped" typo with correct "wrapped" in TextParagraph class and corresponding docs

Closes #54000
