### PR TITLE
Fix double _get_tracking_status declaration

### DIFF
--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -81,11 +81,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_tracking_status" qualifiers="virtual const">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="_get_transform_for_view" qualifiers="virtual">
 			<return type="Transform3D" />
 			<argument index="0" name="view" type="int" />

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -41,8 +41,6 @@ void XRInterfaceExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_initialize);
 	GDVIRTUAL_BIND(_uninitialize);
 
-	GDVIRTUAL_BIND(_get_tracking_status);
-
 	GDVIRTUAL_BIND(_supports_play_area_mode, "mode");
 	GDVIRTUAL_BIND(_get_play_area_mode);
 	GDVIRTUAL_BIND(_set_play_area_mode, "mode");


### PR DESCRIPTION
While rebasing and solving merge conflicts for #49942 I missed that an double declaration was added.

Removing it here

Fixes #53999
