### PR TITLE
Fix Tabs crashing on click input if there are no tabs

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -222,6 +222,11 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 
+			if (max_drawn_tab <= 0) {
+				// Return early if there are no actual tabs to handle input for.
+				return;
+			}
+
 			int found = -1;
 			for (int i = offset; i <= max_drawn_tab; i++) {
 				if (tabs[i].rb_rect.has_point(pos)) {


### PR DESCRIPTION
This closes #53915 