### PR TITLE
[3.x] Add missing cache clear in `RichTextLabel::_process_line`

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -174,6 +174,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 		l.height_caches.clear();
 		l.ascent_caches.clear();
 		l.descent_caches.clear();
+		l.space_caches.clear();
 		l.char_count = 0;
 		l.minimum_width = 0;
 		l.maximum_width = 0;


### PR DESCRIPTION
Fixes #45488

`space_caches` is not cleared on update, so `[fill]` tag always use old number of spaces to divide the available width. `set_bbcode()` recreates all the caches, so it worked as a workaround.