### PR TITLE
[3.x] Fix errors in mouse detection when removing collision object from tree

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2687,6 +2687,10 @@ void Viewport::_drop_physics_mouseover(bool p_paused_only) {
 		if (o) {
 			CollisionObject2D *co = Object::cast_to<CollisionObject2D>(o);
 			if (co) {
+				if (!co->is_inside_tree()) {
+					to_erase.push_back(E);
+					continue;
+				}
 				if (p_paused_only && co->can_process()) {
 					continue;
 				}
@@ -2705,7 +2709,9 @@ void Viewport::_drop_physics_mouseover(bool p_paused_only) {
 	if (physics_object_over) {
 		CollisionObject *co = Object::cast_to<CollisionObject>(ObjectDB::get_instance(physics_object_over));
 		if (co) {
-			if (!(p_paused_only && co->can_process())) {
+			if (!co->is_inside_tree()) {
+				physics_object_over = physics_object_capture = 0;
+			} else if (!(p_paused_only && co->can_process())) {
 				co->_mouse_exit();
 				physics_object_over = physics_object_capture = 0;
 			}


### PR DESCRIPTION
Now behaves the same way as ui elements, mouse exit is skipped when the object is removed from the tree.

3.x backport of #54032
Fixes #53377
