### PR TITLE
[3.x] Fix SoftBody memory corruption when using invalid mesh in Bullet

### DIFF
--- a/modules/bullet/soft_body_bullet.cpp
+++ b/modules/bullet/soft_body_bullet.cpp
@@ -117,19 +117,17 @@ void SoftBodyBullet::update_visual_server(SoftBodyVisualServerHandler *p_visual_
 }
 
 void SoftBodyBullet::set_soft_mesh(const Ref<Mesh> &p_mesh) {
-	if (p_mesh.is_null()) {
-		soft_mesh.unref();
-	} else {
-		soft_mesh = p_mesh;
-	}
+	destroy_soft_body();
+
+	soft_mesh = p_mesh;
 
 	if (soft_mesh.is_null()) {
-		destroy_soft_body();
 		return;
 	}
 
-	Array arrays = soft_mesh->surface_get_arrays(0);
 	ERR_FAIL_COND(!(soft_mesh->surface_get_format(0) & VS::ARRAY_FORMAT_INDEX));
+
+	Array arrays = soft_mesh->surface_get_arrays(0);
 	set_trimesh_body_shape(arrays[VS::ARRAY_INDEX], arrays[VS::ARRAY_VERTEX]);
 }
 


### PR DESCRIPTION
In case of failure the new soft body wasn't created but the previous one wasn't destroyed, causing discrepancies with visual server updates.

This crash is already fixed with both Bullet and Godot Physics on master, so only 3.x is needed.

Fixes an extra case with Bullet on 3.x for #53620