### PR TITLE
Allow non-power-of-two directional shadow size in 3D

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2812,7 +2812,7 @@
 			Use 16 bits for the directional shadow depth map. Enabling this results in shadows having less precision and may result in shadow acne, but can lead to performance improvements on some devices.
 		</member>
 		<member name="rendering/lights_and_shadows/directional_shadow/size" type="int" setter="" getter="" default="4096">
-			The directional shadow's size in pixels. Higher values will result in sharper shadows, at the cost of performance. The value is rounded up to the nearest power of 2.
+			The directional shadow's size in pixels. Higher values will result in sharper shadows, at the cost of performance.
 		</member>
 		<member name="rendering/lights_and_shadows/directional_shadow/size.mobile" type="int" setter="" getter="" default="2048">
 			Lower-end override for [member rendering/lights_and_shadows/directional_shadow/size] on mobile devices, due to performance concerns or driver support.

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -1660,8 +1660,6 @@ void LightStorage::update_directional_shadow_atlas() {
 }
 
 void LightStorage::directional_shadow_atlas_set_size(int p_size, bool p_16_bits) {
-	p_size = nearest_power_of_2_templated(p_size);
-
 	if (directional_shadow.size == p_size && directional_shadow.use_16_bits == p_16_bits) {
 		return;
 	}

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -2528,8 +2528,6 @@ void LightStorage::update_directional_shadow_atlas() {
 	}
 }
 void LightStorage::directional_shadow_atlas_set_size(int p_size, bool p_16_bits) {
-	p_size = nearest_power_of_2_templated(p_size);
-
 	if (directional_shadow.size == p_size && directional_shadow.use_16_bits == p_16_bits) {
 		return;
 	}

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3600,7 +3600,7 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF_RST("rendering/lights_and_shadows/use_physical_light_units", false);
 
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lights_and_shadows/directional_shadow/size", PROPERTY_HINT_RANGE, "256,16384"), 4096);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lights_and_shadows/directional_shadow/size", PROPERTY_HINT_ENUM, U"256×256 (Fastest):256,512×512 (Fastest):512,1024×1024 (Faster):1024,1536×1536 (Faster):1536,2048×2048 (Fast):2048,3072×3072 (Fast):3072,4096×4096 (Average):4096,6144×6144 (Average):6144,8192×8192 (Slow):8192,12288×12288 (Slower):12288,16384×16384 (Slowest):16384"), 4096);
 	GLOBAL_DEF("rendering/lights_and_shadows/directional_shadow/size.mobile", 2048);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Very Low (Faster),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"), 2);
 	GLOBAL_DEF("rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality.mobile", 0);


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/54042.

This allows for more finegrained performance/quality tuning, especially at higher sizes. Any number can be used. For directional light shadows, 3072 and 6144 are sensible shadow sizes that can be used if the default 4096 is too slow or too low-resolution for a large scene.

## Preview

![image](https://github.com/user-attachments/assets/7ed16b5e-de59-42c3-9318-00745d74001c)
