### PR TITLE
[3.x] Allow non-power-of-two directional shadow size in 3D

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1683,7 +1683,7 @@
 			If [code]true[/code], performs a previous depth pass before rendering materials. This increases performance in scenes with high overdraw, when complex materials and lighting are used.
 		</member>
 		<member name="rendering/quality/directional_shadow/size" type="int" setter="" getter="" default="4096">
-			The directional shadow's size in pixels. Higher values will result in sharper shadows, at the cost of performance. The value will be rounded up to the nearest power of 2. This setting can be changed at run-time; the change will be applied immediately.
+			The directional shadow's size in pixels. Higher values will result in sharper shadows, at the cost of performance. This setting can be changed at run-time; the change will be applied immediately.
 		</member>
 		<member name="rendering/quality/directional_shadow/size.mobile" type="int" setter="" getter="" default="2048">
 			Lower-end override for [member rendering/quality/directional_shadow/size] on mobile devices, due to performance concerns or driver support.

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -75,7 +75,7 @@ void RasterizerSceneGLES2::directional_shadow_create() {
 	}
 
 	directional_shadow.light_count = 0;
-	directional_shadow.size = next_power_of_2(directional_shadow_size);
+	directional_shadow.size = directional_shadow_size;
 
 	if (directional_shadow.size > storage->config.max_viewport_dimensions[0] || directional_shadow.size > storage->config.max_viewport_dimensions[1]) {
 		WARN_PRINT("Cannot set directional shadow size larger than maximum hardware supported size of (" + itos(storage->config.max_viewport_dimensions[0]) + ", " + itos(storage->config.max_viewport_dimensions[1]) + "). Setting size to maximum.");
@@ -4110,7 +4110,7 @@ void RasterizerSceneGLES2::initialize() {
 void RasterizerSceneGLES2::iteration() {
 	shadow_filter_mode = ShadowFilterMode(int(GLOBAL_GET("rendering/quality/shadows/filter_mode")));
 
-	const int directional_shadow_size_new = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
+	const int directional_shadow_size_new = int(GLOBAL_GET("rendering/quality/directional_shadow/size"));
 	if (directional_shadow_size != directional_shadow_size_new) {
 		directional_shadow_size = directional_shadow_size_new;
 		directional_shadow_create();
@@ -4122,7 +4122,7 @@ void RasterizerSceneGLES2::finalize() {
 
 RasterizerSceneGLES2::RasterizerSceneGLES2() {
 	_light_counter = 0;
-	directional_shadow_size = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
+	directional_shadow_size = int(GLOBAL_GET("rendering/quality/directional_shadow/size"));
 }
 
 RasterizerSceneGLES2::~RasterizerSceneGLES2() {

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -90,7 +90,7 @@ void RasterizerSceneGLES3::directional_shadow_create() {
 	}
 
 	directional_shadow.light_count = 0;
-	directional_shadow.size = next_power_of_2(directional_shadow_size);
+	directional_shadow.size = directional_shadow_size;
 	glGenFramebuffers(1, &directional_shadow.fbo);
 	glBindFramebuffer(GL_FRAMEBUFFER, directional_shadow.fbo);
 	glGenTextures(1, &directional_shadow.depth);
@@ -5328,7 +5328,7 @@ void RasterizerSceneGLES3::initialize() {
 void RasterizerSceneGLES3::iteration() {
 	shadow_filter_mode = ShadowFilterMode(int(GLOBAL_GET("rendering/quality/shadows/filter_mode")));
 
-	const int directional_shadow_size_new = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
+	const int directional_shadow_size_new = int(GLOBAL_GET("rendering/quality/directional_shadow/size"));
 	if (directional_shadow_size != directional_shadow_size_new) {
 		directional_shadow_size = directional_shadow_size_new;
 		directional_shadow_create();
@@ -5348,7 +5348,7 @@ void RasterizerSceneGLES3::finalize() {
 }
 
 RasterizerSceneGLES3::RasterizerSceneGLES3() {
-	directional_shadow_size = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
+	directional_shadow_size = int(GLOBAL_GET("rendering/quality/directional_shadow/size"));
 }
 
 RasterizerSceneGLES3::~RasterizerSceneGLES3() {


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/54041.

This allows for more finegrained performance/quality tuning, especially at higher sizes. Any number can be used. For directional light shadows, 3072 and 6144 are sensible shadow sizes that can be used if the default 4096 is too slow or too low-resolution for a large scene.

~~This change only applies to GLES3, as NPOT texture support is not present on all devices that support GLES2. When using GLES2, shadow sizes are still rounded up to the nearest power of 2. It *might* be possible to support it regardless, but I'd rather not risk it, especially on mobile platforms.~~
**Edit:** Temporarily allowed in GLES2 to check if it works on mobile/web platforms.

This also updates the point light shadow atlas size property hint to reflect that it can be changed without restarting the engine.

## Preview

### Point light

https://user-images.githubusercontent.com/180032/138154319-41f63cb9-11ac-40d9-a9e7-fde8ea4bc206.mp4

### DirectionalLight

### 4096 (default)

![2021-10-20_20 48 20](https://user-images.githubusercontent.com/180032/138154388-99fd8298-63f4-49b3-8e2c-fc6bd8bfedd3.png)

### 6144 (new possible value)

![2021-10-20_20 48 56](https://user-images.githubusercontent.com/180032/138154393-5b22e55c-1e1d-45dd-bbef-e950baa550d5.png)

### 8192

![2021-10-20_20 48 38](https://user-images.githubusercontent.com/180032/138154390-1b51ec8e-9b53-4c71-8897-c481da51ed02.png)