### PR TITLE
Prevent a rendering crash and error spam for uniform texture array

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -2672,9 +2672,11 @@ void RendererStorageRD::MaterialData::update_textures(const Map<StringName, Vari
 			if (uniform_array_size > 0) {
 				if (textures.size() < uniform_array_size) {
 					const Map<StringName, RID>::Element *W = p_default_textures.find(uniform_name);
-					if (W) {
-						for (int j = textures.size(); j < uniform_array_size; j++) {
+					for (int j = textures.size(); j < uniform_array_size; j++) {
+						if (W) {
 							textures.push_back(W->get());
+						} else {
+							textures.push_back(RID());
 						}
 					}
 				}


### PR DESCRIPTION
There is a case that spams a lot of uniform error because if no default texture is settled up. This will fix that by filling it with empty RID's to conform to the uniform array size and filling it with default white textures  (in the loop below).
