### PR TITLE
GLTF Texture Filter Importing

### DIFF
--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -62,6 +62,7 @@ using GLTFNodeIndex = int;
 using GLTFSkeletonIndex = int;
 using GLTFSkinIndex = int;
 using GLTFTextureIndex = int;
+using GLTFTextureSamplerIndex = int;
 
 class GLTFDocument : public Resource {
 	GDCLASS(GLTFDocument, Resource);

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -217,10 +217,12 @@ private:
 			const bool p_for_vertex);
 	Error _parse_meshes(Ref<GLTFState> state);
 	Error _serialize_textures(Ref<GLTFState> state);
+	Error _serialize_texture_samplers(Ref<GLTFState> state);
 	Error _serialize_images(Ref<GLTFState> state, const String &p_path);
 	Error _serialize_lights(Ref<GLTFState> state);
 	Error _parse_images(Ref<GLTFState> state, const String &p_base_path);
 	Error _parse_textures(Ref<GLTFState> state);
+	Error _parse_texture_samplers(Ref<GLTFState> state);
 	Error _parse_materials(Ref<GLTFState> state);
 	void _set_texture_transform_uv1(const Dictionary &d, Ref<SpatialMaterial> material);
 	void spec_gloss_to_rough_metal(Ref<GLTFSpecGloss> r_spec_gloss,

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -61,6 +61,8 @@ void GLTFState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_root_nodes", "root_nodes"), &GLTFState::set_root_nodes);
 	ClassDB::bind_method(D_METHOD("get_textures"), &GLTFState::get_textures);
 	ClassDB::bind_method(D_METHOD("set_textures", "textures"), &GLTFState::set_textures);
+	ClassDB::bind_method(D_METHOD("get_texture_samplers"), &GLTFState::get_texture_samplers);
+	ClassDB::bind_method(D_METHOD("set_texture_samplers", "texture_samplers"), &GLTFState::set_texture_samplers);
 	ClassDB::bind_method(D_METHOD("get_images"), &GLTFState::get_images);
 	ClassDB::bind_method(D_METHOD("set_images", "images"), &GLTFState::set_images);
 	ClassDB::bind_method(D_METHOD("get_skins"), &GLTFState::get_skins);
@@ -95,6 +97,7 @@ void GLTFState::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "scene_name"), "set_scene_name", "get_scene_name"); // String
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_INT_ARRAY, "root_nodes"), "set_root_nodes", "get_root_nodes"); // Vector<int>
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "textures", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_textures", "get_textures"); // Vector<Ref<GLTFTexture>>
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "texture_samplers", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_texture_samplers", "get_texture_samplers"); //Vector<Ref<GLTFTextureSampler>>
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "images", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_images", "get_images"); // Vector<Ref<Texture>
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "skins", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_skins", "get_skins"); // Vector<Ref<GLTFSkin>>
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "cameras", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_cameras", "get_cameras"); // Vector<Ref<GLTFCamera>>
@@ -216,6 +219,14 @@ Array GLTFState::get_textures() {
 
 void GLTFState::set_textures(Array p_textures) {
 	GLTFDocument::set_from_array(textures, p_textures);
+}
+
+Array GLTFState::get_texture_samplers() {
+	return GLTFDocument::to_array(texture_samplers);
+}
+
+void GLTFState::set_texture_samplers(Array p_texture_samplers) {
+	GLTFDocument::set_from_array(texture_samplers, p_texture_samplers);
 }
 
 Array GLTFState::get_images() {

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -45,6 +45,7 @@
 #include "gltf_skeleton.h"
 #include "gltf_skin.h"
 #include "gltf_texture.h"
+#include "gltf_texture_sampler.h"
 #include "scene/animation/animation_player.h"
 #include "scene/resources/texture.h"
 
@@ -76,6 +77,7 @@ class GLTFState : public Resource {
 	String scene_name;
 	Vector<int> root_nodes;
 	Vector<Ref<GLTFTexture>> textures;
+	Vector<Ref<GLTFTextureSampler>> texture_samplers;
 	Vector<Ref<Texture>> images;
 
 	Vector<Ref<GLTFSkin>> skins;
@@ -134,6 +136,9 @@ public:
 
 	Array get_textures();
 	void set_textures(Array p_textures);
+
+	Array get_texture_samplers();
+	void set_texture_samplers(Array p_texture_samplers);
 
 	Array get_images();
 	void set_images(Array p_images);

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -78,7 +78,8 @@ class GLTFState : public Resource {
 	Vector<int> root_nodes;
 	Vector<Ref<GLTFTexture>> textures;
 	Vector<Ref<GLTFTextureSampler>> texture_samplers;
-	Vector<Ref<Texture>> images;
+	Vector<Ref<Image>> images;
+	Map<GLTFTextureIndex, Ref<Texture>> textures_cache;
 
 	Vector<Ref<GLTFSkin>> skins;
 	Vector<Ref<GLTFCamera>> cameras;

--- a/modules/gltf/gltf_texture.cpp
+++ b/modules/gltf/gltf_texture.cpp
@@ -33,8 +33,11 @@
 void GLTFTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_src_image"), &GLTFTexture::get_src_image);
 	ClassDB::bind_method(D_METHOD("set_src_image", "src_image"), &GLTFTexture::set_src_image);
+	ClassDB::bind_method(D_METHOD("get_sampler"), &GLTFTexture::get_sampler);
+	ClassDB::bind_method(D_METHOD("set_sampler", "sampler"), &GLTFTexture::set_sampler);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "src_image"), "set_src_image", "get_src_image"); // int
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sampler"), "set_sampler", "get_sampler"); // int
 }
 
 GLTFImageIndex GLTFTexture::get_src_image() const {
@@ -43,4 +46,12 @@ GLTFImageIndex GLTFTexture::get_src_image() const {
 
 void GLTFTexture::set_src_image(GLTFImageIndex val) {
 	src_image = val;
+}
+
+GLTFTextureSamplerIndex GLTFTexture::get_sampler() const {
+	return sampler;
+}
+
+void GLTFTexture::set_sampler(GLTFTextureSamplerIndex val) {
+	sampler = val;
 }

--- a/modules/gltf/gltf_texture.h
+++ b/modules/gltf/gltf_texture.h
@@ -39,6 +39,7 @@ class GLTFTexture : public Resource {
 
 private:
 	GLTFImageIndex src_image = 0;
+	GLTFTextureSamplerIndex sampler = 0;
 
 protected:
 	static void _bind_methods();
@@ -46,6 +47,8 @@ protected:
 public:
 	GLTFImageIndex get_src_image() const;
 	void set_src_image(GLTFImageIndex val);
+	GLTFTextureSamplerIndex get_sampler() const;
+	void set_sampler(GLTFTextureSamplerIndex val);
 };
 
 #endif // GLTF_TEXTURE_H

--- a/modules/gltf/gltf_texture_sampler.cpp
+++ b/modules/gltf/gltf_texture_sampler.cpp
@@ -1,0 +1,47 @@
+/*************************************************************************/
+/*  gltf_texture_sampler.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gltf_texture_sampler.h"
+
+void GLTFTextureSampler::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("get_mag_filter"), &GLTFTextureSampler::get_mag_filter);
+    ClassDB::bind_method(D_METHOD("set_mag_filter", "filter_mode"), &GLTFTextureSampler::set_mag_filter);
+    ClassDB::bind_method(D_METHOD("get_min_filter"), &GLTFTextureSampler::get_min_filter);
+    ClassDB::bind_method(D_METHOD("set_min_filter", "filter_mode"), &GLTFTextureSampler::set_min_filter);
+    ClassDB::bind_method(D_METHOD("get_wrap_s"), &GLTFTextureSampler::get_wrap_s);
+    ClassDB::bind_method(D_METHOD("set_wrap_s", "wrap_mode"), &GLTFTextureSampler::set_wrap_s);
+    ClassDB::bind_method(D_METHOD("get_wrap_t"), &GLTFTextureSampler::get_wrap_t);
+    ClassDB::bind_method(D_METHOD("set_wrap_t", "wrap_mode"), &GLTFTextureSampler::set_wrap_t);
+
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "mag_filter"), "set_mag_filter", "get_mag_filter");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "min_filter"), "set_min_filter", "get_min_filter");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "wrap_s"), "set_wrap_s", "get_wrap_s");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "wrap_t"), "set_wrap_t", "get_wrap_t");
+}

--- a/modules/gltf/gltf_texture_sampler.h
+++ b/modules/gltf/gltf_texture_sampler.h
@@ -37,12 +37,12 @@ class GLTFTextureSampler : public Resource {
 	GDCLASS(GLTFTextureSampler, Resource);
 
 public:
-	enum class MagFilter : int32_t {
+	enum class MagFilter {
 		NEAREST = 9728,
 		LINEAR = 9729
 	};
 
-	enum class MinFilter : int32_t {
+	enum class MinFilter {
 		NEAREST = 9728,
 		LINEAR = 9729,
 		NEAREST_MIPMAP_NEAREST = 9984,
@@ -51,43 +51,43 @@ public:
 		LINEAR_MIPMAP_LINEAR = 9987
 	};
 
-	enum class WrapMode : int32_t {
+	enum class WrapMode {
 		CLAMP_TO_EDGE = 33071,
 		MIRRORED_REPEAT = 33648,
 		REPEAT = 10497,
 		DEFAULT = REPEAT
 	};
 
-	MagFilter get_mag_filter() const {
-		return mag_filter;
+	int get_mag_filter() const {
+		return (int)mag_filter;
 	};
 
-	void set_mag_filter(const MagFilter filter_mode) {
-		mag_filter = filter_mode;
+	void set_mag_filter(const int filter_mode) {
+		mag_filter = (MagFilter)filter_mode;
 	};
 
-	MinFilter get_min_filter() const {
-		return min_filter;
+	int get_min_filter() const {
+		return (int)min_filter;
 	};
 
-	void set_min_filter(const MinFilter filter_mode) {
-		min_filter = filter_mode;
+	void set_min_filter(const int filter_mode) {
+		min_filter = (MinFilter)filter_mode;
 	};
 
-	WrapMode get_wrap_s() const {
-		return wrap_s;
+	int get_wrap_s() const {
+		return (int)wrap_s;
 	};
 
-	void set_wrap_s(const WrapMode wrap_mode) {
-		wrap_s = wrap_mode;
+	void set_wrap_s(const int wrap_mode) {
+		wrap_s = (WrapMode)wrap_mode;
 	};
 
-	WrapMode get_wrap_t() const {
-		return wrap_t;
+	int get_wrap_t() const {
+		return (int)wrap_t;
 	};
 
-	void set_wrap_t(const WrapMode wrap_mode) {
-		wrap_s = wrap_mode;
+	void set_wrap_t(const int wrap_mode) {
+		wrap_s = (WrapMode)wrap_mode;
 	};
 
 protected:

--- a/modules/gltf/gltf_texture_sampler.h
+++ b/modules/gltf/gltf_texture_sampler.h
@@ -1,0 +1,103 @@
+/*************************************************************************/
+/*  gltf_texture_sampler.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GLTF_TEXTURE_SAMPLER_H
+#define GLTF_TEXTURE_SAMPLER_H
+
+#include "core/resource.h"
+
+class GLTFTextureSampler : public Resource {
+	GDCLASS(GLTFTextureSampler, Resource);
+
+public:
+	enum class MagFilter : int32_t {
+		NEAREST = 9728,
+		LINEAR = 9729
+	};
+
+	enum class MinFilter : int32_t {
+		NEAREST = 9728,
+		LINEAR = 9729,
+		NEAREST_MIPMAP_NEAREST = 9984,
+		LINEAR_MIPMAP_NEAREST = 9985,
+		NEAREST_MIPMAP_LINEAR = 9986,
+		LINEAR_MIPMAP_LINEAR = 9987
+	};
+
+	enum class WrapMode : int32_t {
+		CLAMP_TO_EDGE = 33071,
+		MIRRORED_REPEAT = 33648,
+		REPEAT = 10497,
+		DEFAULT = REPEAT
+	};
+
+	MagFilter get_mag_filter() const {
+		return mag_filter;
+	};
+
+	void set_mag_filter(const MagFilter filter_mode) {
+		mag_filter = filter_mode;
+	};
+
+	MinFilter get_min_filter() const {
+		return min_filter;
+	};
+
+	void set_min_filter(const MinFilter filter_mode) {
+		min_filter = filter_mode;
+	};
+
+	WrapMode get_wrap_s() const {
+		return wrap_s;
+	};
+
+	void set_wrap_s(const WrapMode wrap_mode) {
+		wrap_s = wrap_mode;
+	};
+
+	WrapMode get_wrap_t() const {
+		return wrap_t;
+	};
+
+	void set_wrap_t(const WrapMode wrap_mode) {
+		wrap_s = wrap_mode;
+	};
+
+protected:
+	static void _bind_methods();
+
+private:
+	MagFilter mag_filter;
+	MinFilter min_filter;
+	WrapMode wrap_s;
+	WrapMode wrap_t;
+};
+
+#endif


### PR DESCRIPTION
The GLTF/GLB importer does not seem to be taking into account filter, wrapping, and mipmap settings built into the file.
This feature implements a fix on the 3.x branch by creating and parsing the texture sampler objects from the GLTF file and applying its properties as flags to the created textures.