### PR TITLE
Fix SoftDynamicBody3D crash when setting disable mode

### DIFF
--- a/modules/bullet/soft_body_bullet.cpp
+++ b/modules/bullet/soft_body_bullet.cpp
@@ -116,6 +116,7 @@ void SoftBodyBullet::set_soft_mesh(RID p_mesh) {
 	}
 
 	Array arrays = RenderingServer::get_singleton()->mesh_surface_get_arrays(soft_mesh, 0);
+	ERR_FAIL_COND(arrays.is_empty());
 
 	bool success = set_trimesh_body_shape(arrays[RS::ARRAY_INDEX], arrays[RS::ARRAY_VERTEX]);
 	if (!success) {

--- a/scene/3d/soft_dynamic_body_3d.cpp
+++ b/scene/3d/soft_dynamic_body_3d.cpp
@@ -552,15 +552,9 @@ void SoftDynamicBody3D::set_disable_mode(DisableMode p_mode) {
 		return;
 	}
 
-	bool inside_tree = is_inside_tree();
-
-	if (inside_tree && (disable_mode == DISABLE_MODE_REMOVE)) {
-		_prepare_physics_server();
-	}
-
 	disable_mode = p_mode;
 
-	if (inside_tree && (disable_mode == DISABLE_MODE_REMOVE)) {
+	if (mesh.is_valid() && is_inside_tree() && !is_enabled()) {
 		_prepare_physics_server();
 	}
 }

--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -139,6 +139,7 @@ void GodotSoftBody3D::set_mesh(RID p_mesh) {
 	}
 
 	Array arrays = RenderingServer::get_singleton()->mesh_surface_get_arrays(soft_mesh, 0);
+	ERR_FAIL_COND(arrays.is_empty());
 
 	bool success = create_from_trimesh(arrays[RenderingServer::ARRAY_INDEX], arrays[RenderingServer::ARRAY_VERTEX]);
 	if (!success) {


### PR DESCRIPTION
Proper logic for changing physics state when disabled and disabled mode is changed (it was unnecessarily making calls to re-initialize physics).

Extra error handling in soft body implementations to avoid crashes with invalid mesh.

Fixes #53838
