### PR TITLE
Fix crash on null image ref in ProceduralSky

### DIFF
--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -390,6 +390,8 @@ void ProceduralSky::_queue_update() {
 }
 
 void ProceduralSky::_thread_done(const Ref<Image> &p_image) {
+	ERR_FAIL_COND(p_image.is_null());
+
 	panorama = p_image;
 	VS::get_singleton()->texture_allocate(texture, panorama->get_width(), panorama->get_height(), 0, Image::FORMAT_RGBE9995, VS::TEXTURE_TYPE_2D, VS::TEXTURE_FLAG_FILTER | VS::TEXTURE_FLAG_REPEAT);
 	VS::get_singleton()->texture_set_data(texture, panorama);


### PR DESCRIPTION
Fixes #53621 

Looked around in `master` for a corresponding fix that needed to be made, but it seems like this was completely overhauled in the main branch? 