### PR TITLE
Fix built-in texture samplers passing for spatial shader mode

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -657,6 +657,10 @@ void SceneShaderForwardClustered::init(RendererStorageRD *p_storage, const Strin
 			actions.render_mode_defines["specular_schlick_ggx"] = "#define SPECULAR_BLINN\n";
 		}
 
+		actions.custom_samplers["SCREEN_TEXTURE"] = "material_samplers[3]"; // linear filter with mipmaps
+		actions.custom_samplers["DEPTH_TEXTURE"] = "material_samplers[3]";
+		actions.custom_samplers["NORMAL_ROUGHNESS_TEXTURE"] = "material_samplers[1]"; // linear filter
+
 		actions.render_mode_defines["specular_blinn"] = "#define SPECULAR_BLINN\n";
 		actions.render_mode_defines["specular_phong"] = "#define SPECULAR_PHONG\n";
 		actions.render_mode_defines["specular_toon"] = "#define SPECULAR_TOON\n";


### PR DESCRIPTION
I'm not sure if these are the correct samplers for these textures, but I found `SCREEN_TEXTURE` in canvas_renderer is using 3rd variant (linear filter with mipmaps) so I did, and `NORMAL_ROUGHNESS_TEXTURE` in the GLSL-file itself with the 1-st variant (just linear filter).

Fix https://github.com/godotengine/godot/issues/54048