### PR TITLE
Focus current node after connecting

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -39,6 +39,7 @@
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/scene_tree_editor.h"
+#include "editor/node_dock.h"
 #include "editor/scene_tree_dock.h"
 #include "plugins/script_editor_plugin.h"
 #include "scene/gui/button.h"
@@ -1440,6 +1441,7 @@ ConnectionsDock::ConnectionsDock() {
 	connect_button->connect("pressed", callable_mp(this, &ConnectionsDock::_connect_pressed));
 
 	connect_dialog = memnew(ConnectDialog);
+	connect_dialog->connect("connected", callable_mp(NodeDock::get_singleton(), &NodeDock::restore_last_valid_node), CONNECT_DEFERRED);
 	add_child(connect_dialog);
 
 	disconnect_all_dialog = memnew(ConfirmationDialog);

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -70,6 +70,9 @@ void NodeDock::update_lists() {
 void NodeDock::set_node(Node *p_node) {
 	connections->set_node(p_node);
 	groups->set_current(p_node);
+	if (p_node) {
+		last_valid_node = p_node;
+	}
 
 	if (p_node) {
 		if (connections_button->is_pressed()) {
@@ -86,6 +89,10 @@ void NodeDock::set_node(Node *p_node) {
 		mode_hb->hide();
 		select_a_node->show();
 	}
+}
+
+void NodeDock::restore_last_valid_node() {
+	set_node(last_valid_node);
 }
 
 NodeDock::NodeDock() {

--- a/editor/node_dock.h
+++ b/editor/node_dock.h
@@ -47,6 +47,7 @@ class NodeDock : public VBoxContainer {
 	HBoxContainer *mode_hb = nullptr;
 
 	Label *select_a_node = nullptr;
+	Node *last_valid_node = nullptr;
 
 private:
 	static NodeDock *singleton;
@@ -60,6 +61,7 @@ protected:
 
 public:
 	void set_node(Node *p_node);
+	void restore_last_valid_node();
 
 	void show_groups();
 	void show_connections();


### PR DESCRIPTION
Fixes #21950

I changed ConnectionsDock constructor to take NodeDock instead of EditorNode, not sure why it was originally like that.