### PR TITLE
Remove node_hrcr hack

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3347,7 +3347,7 @@ void EditorNode::set_edited_scene(Node *p_scene) {
 
 	if (p_scene) {
 		if (p_scene->get_parent() != scene_root) {
-			scene_root->add_child(p_scene);
+			scene_root->add_child(p_scene, true);
 		}
 	}
 }
@@ -3479,7 +3479,7 @@ void EditorNode::set_current_scene(int p_idx) {
 
 	if (new_scene) {
 		if (new_scene->get_parent() != scene_root) {
-			scene_root->add_child(new_scene);
+			scene_root->add_child(new_scene, true);
 		}
 	}
 
@@ -7114,8 +7114,6 @@ EditorNode::EditorNode() {
 	EditorFileSystem::get_singleton()->connect("resources_reload", callable_mp(this, &EditorNode::_resources_changed));
 
 	_build_icon_type_cache();
-
-	Node::set_human_readable_collision_renaming(true);
 
 	pick_main_scene = memnew(ConfirmationDialog);
 	gui_base->add_child(pick_main_scene);

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -314,7 +314,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Node3D *p_parent) {
 
 	xf = collada.fix_transform(xf) * p_node->post_transform;
 	node->set_transform(xf);
-	p_parent->add_child(node);
+	p_parent->add_child(node, true);
 	node->set_owner(scene);
 
 	if (p_node->empty_draw_type != "") {
@@ -1805,7 +1805,7 @@ Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint3
 
 			ap->add_animation(name, state.animations[i]);
 		}
-		state.scene->add_child(ap);
+		state.scene->add_child(ap, true);
 		ap->set_owner(state.scene);
 	}
 

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -448,7 +448,7 @@ Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, in
 		ImporterMeshInstance3D *mi = memnew(ImporterMeshInstance3D);
 		mi->set_mesh(mesh);
 		mi->set_name(m->get_name());
-		scene->add_child(mi);
+		scene->add_child(mi, true);
 		mi->set_owner(scene);
 	}
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -501,7 +501,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<I
 				sphereShape->set_radius(1);
 				colshape->set_shape(sphereShape);
 			}
-			sb->add_child(colshape);
+			sb->add_child(colshape, true);
 			colshape->set_owner(sb->get_owner());
 		}
 
@@ -527,7 +527,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<I
 			rigid_body->set_transform(mi->get_transform());
 			p_node = rigid_body;
 			mi->set_transform(Transform3D());
-			rigid_body->add_child(mi);
+			rigid_body->add_child(mi, true);
 			mi->set_owner(rigid_body->get_owner());
 
 			_add_shapes(rigid_body, shapes);
@@ -565,7 +565,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<I
 
 			if (shapes.size()) {
 				StaticBody3D *col = memnew(StaticBody3D);
-				mi->add_child(col);
+				mi->add_child(col, true);
 				col->set_owner(mi->get_owner());
 
 				_add_shapes(col, shapes);
@@ -613,7 +613,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<I
 
 			if (shapes.size()) {
 				StaticBody3D *col = memnew(StaticBody3D);
-				p_node->add_child(col);
+				p_node->add_child(col, true);
 				col->set_owner(p_node->get_owner());
 
 				_add_shapes(col, shapes);
@@ -748,7 +748,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 						switch (mesh_physics_mode) {
 							case MESH_PHYSICS_MESH_AND_STATIC_COLLIDER: {
 								StaticBody3D *col = memnew(StaticBody3D);
-								p_node->add_child(col);
+								p_node->add_child(col, true);
 								col->set_owner(p_node->get_owner());
 								col->set_transform(get_collision_shapes_transform(node_settings));
 								base = col;
@@ -760,7 +760,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 								rigid_body->set_transform(mi->get_transform() * get_collision_shapes_transform(node_settings));
 								p_node = rigid_body;
 								mi->set_transform(Transform3D());
-								rigid_body->add_child(mi);
+								rigid_body->add_child(mi, true);
 								mi->set_owner(rigid_body->get_owner());
 								base = rigid_body;
 							} break;
@@ -789,7 +789,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 						for (const Ref<Shape3D> &E : shapes) {
 							CollisionShape3D *cshape = memnew(CollisionShape3D);
 							cshape->set_shape(E);
-							base->add_child(cshape);
+							base->add_child(cshape, true);
 
 							cshape->set_owner(base->get_owner());
 							idx++;
@@ -822,7 +822,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 						memdelete(p_node);
 						p_node = nmi;
 					} else {
-						mi->add_child(nmi);
+						mi->add_child(nmi, true);
 						nmi->set_owner(mi->get_owner());
 					}
 				}
@@ -1657,7 +1657,7 @@ void ResourceImporterScene::_add_shapes(Node *p_node, const Vector<Ref<Shape3D>>
 	for (const Ref<Shape3D> &E : p_shapes) {
 		CollisionShape3D *cshape = memnew(CollisionShape3D);
 		cshape->set_shape(E);
-		p_node->add_child(cshape);
+		p_node->add_child(cshape, true);
 
 		cshape->set_owner(p_node->get_owner());
 	}

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -327,7 +327,7 @@ void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
 		MeshInstance3D *collider_view = memnew(MeshInstance3D);
 		collider_view->set_name("collider_view");
 		collider_view->set_visible(false);
-		mesh_node->add_child(collider_view);
+		mesh_node->add_child(collider_view, true);
 		collider_view->set_owner(mesh_node);
 
 		Transform3D accum_xform;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5842,7 +5842,7 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 	Ref<Texture2D> texture = Ref<Texture2D>(Object::cast_to<Texture2D>(ResourceCache::get(path)));
 
 	if (parent) {
-		editor_data->get_undo_redo().add_do_method(parent, "add_child", child);
+		editor_data->get_undo_redo().add_do_method(parent, "add_child", child, true);
 		editor_data->get_undo_redo().add_do_method(child, "set_owner", editor->get_edited_scene());
 		editor_data->get_undo_redo().add_do_reference(child);
 		editor_data->get_undo_redo().add_undo_method(parent, "remove_child", child);

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -79,7 +79,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				Node *owner = node == get_tree()->get_edited_scene_root() ? node : node->get_owner();
 
 				ur->create_action(TTR("Create Static Trimesh Body"));
-				ur->add_do_method(node, "add_child", body);
+				ur->add_do_method(node, "add_child", body, true);
 				ur->add_do_method(body, "set_owner", owner);
 				ur->add_do_method(cshape, "set_owner", owner);
 				ur->add_do_reference(body);
@@ -113,7 +113,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 				Node *owner = instance == get_tree()->get_edited_scene_root() ? instance : instance->get_owner();
 
-				ur->add_do_method(instance, "add_child", body);
+				ur->add_do_method(instance, "add_child", body, true);
 				ur->add_do_method(body, "set_owner", owner);
 				ur->add_do_method(cshape, "set_owner", owner);
 				ur->add_do_reference(body);
@@ -146,7 +146,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			ur->create_action(TTR("Create Trimesh Static Shape"));
 
-			ur->add_do_method(node->get_parent(), "add_child", cshape);
+			ur->add_do_method(node->get_parent(), "add_child", cshape, true);
 			ur->add_do_method(node->get_parent(), "move_child", cshape, node->get_index() + 1);
 			ur->add_do_method(cshape, "set_owner", owner);
 			ur->add_do_reference(cshape);
@@ -185,7 +185,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			Node *owner = node->get_owner();
 
-			ur->add_do_method(node->get_parent(), "add_child", cshape);
+			ur->add_do_method(node->get_parent(), "add_child", cshape, true);
 			ur->add_do_method(node->get_parent(), "move_child", cshape, node->get_index() + 1);
 			ur->add_do_method(cshape, "set_owner", owner);
 			ur->add_do_reference(cshape);
@@ -247,7 +247,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Create Navigation Mesh"));
 
-			ur->add_do_method(node, "add_child", nmi);
+			ur->add_do_method(node, "add_child", nmi, true);
 			ur->add_do_method(nmi, "set_owner", owner);
 
 			ur->add_do_reference(nmi);
@@ -426,7 +426,7 @@ void MeshInstance3DEditor::_create_outline_mesh() {
 
 	ur->create_action(TTR("Create Outline"));
 
-	ur->add_do_method(node, "add_child", mi);
+	ur->add_do_method(node, "add_child", mi, true);
 	ur->add_do_method(mi, "set_owner", owner);
 
 	ur->add_do_reference(mi);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2153,7 +2153,7 @@ void SceneTreeDock::_do_create(Node *p_parent) {
 	editor_data->get_undo_redo().create_action(TTR("Create Node"));
 
 	if (edited_scene) {
-		editor_data->get_undo_redo().add_do_method(p_parent, "add_child", child);
+		editor_data->get_undo_redo().add_do_method(p_parent, "add_child", child, true);
 		editor_data->get_undo_redo().add_do_method(child, "set_owner", edited_scene);
 		editor_data->get_undo_redo().add_do_method(editor_selection, "clear");
 		editor_data->get_undo_redo().add_do_method(editor_selection, "add_node", child);

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -843,7 +843,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 				if (state.animation_player == nullptr) {
 					print_verbose("Creating animation player");
 					state.animation_player = memnew(AnimationPlayer);
-					state.root->add_child(state.animation_player);
+					state.root->add_child(state.animation_player, true);
 					state.animation_player->set_owner(state.root_owner);
 				}
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5567,7 +5567,7 @@ void GLTFDocument::_generate_scene_node(Ref<GLTFState> state, Node *scene_parent
 		// Bone Attachment - Parent Case
 		BoneAttachment3D *bone_attachment = _generate_bone_attachment(state, active_skeleton, node_index, gltf_node->parent);
 
-		scene_parent->add_child(bone_attachment);
+		scene_parent->add_child(bone_attachment, true);
 		bone_attachment->set_owner(scene_root);
 
 		// There is no gltf_node that represent this, so just directly create a unique name
@@ -5590,7 +5590,7 @@ void GLTFDocument::_generate_scene_node(Ref<GLTFState> state, Node *scene_parent
 		current_node = _generate_spatial(state, scene_parent, node_index);
 	}
 
-	scene_parent->add_child(current_node);
+	scene_parent->add_child(current_node, true);
 	if (current_node != scene_root) {
 		current_node->set_owner(scene_root);
 	}
@@ -5620,7 +5620,7 @@ void GLTFDocument::_generate_skeleton_bone_node(Ref<GLTFState> state, Node *scen
 			// Bone Attachment - Direct Parented Skeleton Case
 			BoneAttachment3D *bone_attachment = _generate_bone_attachment(state, active_skeleton, node_index, gltf_node->parent);
 
-			scene_parent->add_child(bone_attachment);
+			scene_parent->add_child(bone_attachment, true);
 			bone_attachment->set_owner(scene_root);
 
 			// There is no gltf_node that represent this, so just directly create a unique name
@@ -5634,7 +5634,7 @@ void GLTFDocument::_generate_skeleton_bone_node(Ref<GLTFState> state, Node *scen
 
 		// Add it to the scene if it has not already been added
 		if (skeleton->get_parent() == nullptr) {
-			scene_parent->add_child(skeleton);
+			scene_parent->add_child(skeleton, true);
 			skeleton->set_owner(scene_root);
 		}
 	}
@@ -5648,7 +5648,7 @@ void GLTFDocument::_generate_skeleton_bone_node(Ref<GLTFState> state, Node *scen
 			// Bone Attachment - Same Node Case
 			BoneAttachment3D *bone_attachment = _generate_bone_attachment(state, active_skeleton, node_index, node_index);
 
-			scene_parent->add_child(bone_attachment);
+			scene_parent->add_child(bone_attachment, true);
 			bone_attachment->set_owner(scene_root);
 
 			// There is no gltf_node that represent this, so just directly create a unique name
@@ -5668,7 +5668,7 @@ void GLTFDocument::_generate_skeleton_bone_node(Ref<GLTFState> state, Node *scen
 			current_node = _generate_light(state, scene_parent, node_index);
 		}
 
-		scene_parent->add_child(current_node);
+		scene_parent->add_child(current_node, true);
 		if (current_node != scene_root) {
 			current_node->set_owner(scene_root);
 		}
@@ -6182,7 +6182,7 @@ void GLTFDocument::_process_mesh_instances(Ref<GLTFState> state, Node *scene_roo
 			ERR_CONTINUE_MSG(skeleton == nullptr, vformat("Unable to find Skeleton for node %d skin %d", node_i, skin_i));
 
 			mi->get_parent()->remove_child(mi);
-			skeleton->add_child(mi);
+			skeleton->add_child(mi, true);
 			mi->set_owner(skeleton->get_owner());
 
 			mi->set_skin(state->skins.write[skin_i]->godot_skin);
@@ -6859,7 +6859,7 @@ Node *GLTFDocument::import_scene_gltf(const String &p_path, uint32_t p_flags, in
 	gltf_document->_process_mesh_instances(r_state, root);
 	if (r_state->animations.size()) {
 		AnimationPlayer *ap = memnew(AnimationPlayer);
-		root->add_child(ap);
+		root->add_child(ap, true);
 		ap->set_owner(root);
 		for (int i = 0; i < r_state->animations.size(); i++) {
 			gltf_document->_import_animation(r_state, ap, i, p_bake_fps);

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -244,7 +244,7 @@ Node *MeshInstance3D::create_trimesh_collision_node() {
 	StaticBody3D *static_body = memnew(StaticBody3D);
 	CollisionShape3D *cshape = memnew(CollisionShape3D);
 	cshape->set_shape(shape);
-	static_body->add_child(cshape);
+	static_body->add_child(cshape, true);
 	return static_body;
 }
 
@@ -253,7 +253,7 @@ void MeshInstance3D::create_trimesh_collision() {
 	ERR_FAIL_COND(!static_body);
 	static_body->set_name(String(get_name()) + "_col");
 
-	add_child(static_body);
+	add_child(static_body, true);
 	if (get_owner()) {
 		CollisionShape3D *cshape = Object::cast_to<CollisionShape3D>(static_body->get_child(0));
 		static_body->set_owner(get_owner());
@@ -274,7 +274,7 @@ Node *MeshInstance3D::create_convex_collision_node(bool p_clean, bool p_simplify
 	StaticBody3D *static_body = memnew(StaticBody3D);
 	CollisionShape3D *cshape = memnew(CollisionShape3D);
 	cshape->set_shape(shape);
-	static_body->add_child(cshape);
+	static_body->add_child(cshape, true);
 	return static_body;
 }
 
@@ -283,7 +283,7 @@ void MeshInstance3D::create_convex_collision(bool p_clean, bool p_simplify) {
 	ERR_FAIL_COND(!static_body);
 	static_body->set_name(String(get_name()) + "_col");
 
-	add_child(static_body);
+	add_child(static_body, true);
 	if (get_owner()) {
 		CollisionShape3D *cshape = Object::cast_to<CollisionShape3D>(static_body->get_child(0));
 		static_body->set_owner(get_owner());
@@ -306,7 +306,7 @@ Node *MeshInstance3D::create_multiple_convex_collisions_node() {
 	for (int i = 0; i < shapes.size(); i++) {
 		CollisionShape3D *cshape = memnew(CollisionShape3D);
 		cshape->set_shape(shapes[i]);
-		static_body->add_child(cshape);
+		static_body->add_child(cshape, true);
 	}
 	return static_body;
 }
@@ -316,7 +316,7 @@ void MeshInstance3D::create_multiple_convex_collisions() {
 	ERR_FAIL_COND(!static_body);
 	static_body->set_name(String(get_name()) + "_col");
 
-	add_child(static_body);
+	add_child(static_body, true);
 	if (get_owner()) {
 		static_body->set_owner(get_owner());
 		int count = static_body->get_child_count();
@@ -460,7 +460,7 @@ void MeshInstance3D::create_debug_tangents() {
 		MeshInstance3D *mi = memnew(MeshInstance3D);
 		mi->set_mesh(am);
 		mi->set_name("DebugTangents");
-		add_child(mi);
+		add_child(mi, true);
 #ifdef TOOLS_ENABLED
 
 		if (is_inside_tree() && this == get_tree()->get_edited_scene_root()) {

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -403,7 +403,7 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 	if (p_create_visual_debug) {
 		MultiMeshInstance3D *mmi = memnew(MultiMeshInstance3D);
 		mmi->set_multimesh(baker.create_debug_multimesh());
-		add_child(mmi);
+		add_child(mmi, true);
 #ifdef TOOLS_ENABLED
 		if (is_inside_tree() && get_tree()->get_edited_scene_root() == this) {
 			mmi->set_owner(this);

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -354,7 +354,7 @@ MarginContainer *VBoxContainer::add_margin_child(const String &p_label, Control 
 	add_child(l, false, INTERNAL_MODE_FRONT);
 	MarginContainer *mc = memnew(MarginContainer);
 	mc->add_theme_constant_override("margin_left", 0);
-	mc->add_child(p_control);
+	mc->add_child(p_control, true);
 	add_child(mc, false, INTERNAL_MODE_FRONT);
 	if (p_expand) {
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -908,15 +908,10 @@ void Node::set_name(const String &p_name) {
 	}
 }
 
-static bool node_hrcr = false;
 static SafeRefCount node_hrcr_count;
 
 void Node::init_node_hrcr() {
 	node_hrcr_count.init(1);
-}
-
-void Node::set_human_readable_collision_renaming(bool p_enabled) {
-	node_hrcr = p_enabled;
 }
 
 #ifdef TOOLS_ENABLED
@@ -930,7 +925,7 @@ String Node::validate_child_name(Node *p_child) {
 void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
 	/* Make sure the name is unique */
 
-	if (node_hrcr || p_force_human_readable) {
+	if (p_force_human_readable) {
 		//this approach to autoset node names is human readable but very slow
 		//it's turned on while running in the editor
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -437,7 +437,6 @@ public:
 	void queue_delete();
 
 	//hacks for speed
-	static void set_human_readable_collision_renaming(bool p_enabled);
 	static void init_node_hrcr();
 
 	void force_parent_owned() { data.parent_owned = true; } //hack to avoid duplicate nodes


### PR DESCRIPTION
Fixes #17573
EDIT: Fixes #54177

`node_hrcr` was a hack used to force `legible_unique_name` globally in the editor. This resulted in internal nodes having different name in editor than in game, which is unexpected (see the closed issue).

I removed this hack and instead the editor will now explicitly use the `legible_unique_name` argument wherever necessary. (I might've missed some places though)