### PR TITLE
Prevent shader crash when passing constant expression to `textureGather`

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -2763,6 +2763,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 
 									bool is_const = false;
 									ConstantNode::Value value;
+									value.sint = -1;
 
 									_find_identifier(p_block, false, p_function_info, vn->name, nullptr, nullptr, &is_const, nullptr, nullptr, &value);
 									if (!is_const || value.sint < min || value.sint > max) {


### PR DESCRIPTION
Prevents shader crash by restricting passing incorrect constant expression to the argument eg:

```
shader_type spatial;

uniform sampler2D tex;

const int bad = 0-1;

const int good = 0;

void fragment() {
	vec4 v = textureGather(tex, UV, bad);
}
```

There needs to be a proper parsing of constant expression but it's not a quick and easy thing to create, and for now, that's a good fix.