### PR TITLE
Add occurrence count to `String::replace[n]` functions

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3377,15 +3377,27 @@ String String::format(const Variant &values, String placeholder) const {
 	return new_string;
 }
 
-String String::replace(const String &p_key, const String &p_with) const {
+String String::_replace(const String &p_old, const String &p_new, int p_count, bool p_is_case_sensitive) const {
 	String new_string;
 	int search_from = 0;
-	int result = 0;
+	int find_result = 0;
+	int substring_length = p_old.length();
 
-	while ((result = find(p_key, search_from)) >= 0) {
-		new_string += substr(search_from, result - search_from);
-		new_string += p_with;
-		search_from = result + p_key.length();
+	if (substring_length == 0 || p_count == 0) {
+		return *this; // there's nothing to match or substitute
+	}
+
+	find_result = p_is_case_sensitive ? find(p_old, search_from) : findn(p_old, search_from);
+	int occurrences = 1;
+	while (find_result >= 0) {
+		if (p_count < 0 || occurrences <= p_count) {
+			new_string += substr(search_from, find_result - search_from) + p_new;
+		} else {
+			new_string += substr(search_from, find_result - search_from + substring_length);
+		}
+		search_from = find_result + substring_length;
+		find_result = p_is_case_sensitive ? find(p_old, search_from) : findn(p_old, search_from);
+		++occurrences;
 	}
 
 	if (search_from == 0) {
@@ -3397,19 +3409,38 @@ String String::replace(const String &p_key, const String &p_with) const {
 	return new_string;
 }
 
-String String::replace(const char *p_key, const char *p_with) const {
+String String::replace(const String &p_old, const String &p_new, int p_count) const {
+	return _replace(p_old, p_new, p_count, true);
+}
+
+String String::replacen(const String &p_old, const String &p_new, int p_count) const {
+	return _replace(p_old, p_new, p_count, false);
+}
+
+String String::_replace(const char *p_old, const char *p_new, int p_count, bool p_is_case_sensitive) const {
 	String new_string;
 	int search_from = 0;
-	int result = 0;
+	int find_result = 0;
+	int substring_length = 0;
+	while (p_old[substring_length]) {
+		++substring_length;
+	}
 
-	while ((result = find(p_key, search_from)) >= 0) {
-		new_string += substr(search_from, result - search_from);
-		new_string += p_with;
-		int k = 0;
-		while (p_key[k] != '\0') {
-			k++;
+	if (substring_length == 0 || p_count == 0) {
+		return *this; // there's nothing to match or substitute
+	}
+
+	find_result = p_is_case_sensitive ? find(p_old, search_from) : findn(p_old, search_from);
+	int occurrences = 1;
+	while (find_result >= 0) {
+		if (p_count < 0 || occurrences <= p_count) {
+			new_string += substr(search_from, find_result - search_from) + p_new;
+		} else {
+			new_string += substr(search_from, find_result - search_from + substring_length);
 		}
-		search_from = result + k;
+		search_from = find_result + substring_length;
+		find_result = p_is_case_sensitive ? find(p_old, search_from) : findn(p_old, search_from);
+		++occurrences;
 	}
 
 	if (search_from == 0) {
@@ -3419,6 +3450,14 @@ String String::replace(const char *p_key, const char *p_with) const {
 	new_string += substr(search_from, length() - search_from);
 
 	return new_string;
+}
+
+String String::replace(const char *p_old, const char *p_new, int p_count) const {
+	return _replace(p_old, p_new, p_count, true);
+}
+
+String String::replacen(const char *p_old, const char *p_new, int p_count) const {
+	return _replace(p_old, p_new, p_count, false);
 }
 
 String String::replace_first(const String &p_key, const String &p_with) const {
@@ -3428,25 +3467,6 @@ String String::replace_first(const String &p_key, const String &p_with) const {
 	}
 
 	return *this;
-}
-
-String String::replacen(const String &p_key, const String &p_with) const {
-	String new_string;
-	int search_from = 0;
-	int result = 0;
-
-	while ((result = findn(p_key, search_from)) >= 0) {
-		new_string += substr(search_from, result - search_from);
-		new_string += p_with;
-		search_from = result + p_key.length();
-	}
-
-	if (search_from == 0) {
-		return *this;
-	}
-
-	new_string += substr(search_from, length() - search_from);
-	return new_string;
 }
 
 String String::repeat(int p_count) const {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -200,6 +200,8 @@ class String {
 
 	bool _base_is_subsequence_of(const String &p_string, bool case_insensitive) const;
 	int _count(const String &p_string, int p_from, int p_to, bool p_case_insensitive) const;
+	String _replace(const String &p_old, const String &p_new, int p_count = -1, bool p_is_case_sensitive = true) const;
+	String _replace(const char *p_old, const char *p_new, int p_count = -1, bool p_is_case_sensitive = true) const;
 
 public:
 	enum {
@@ -297,9 +299,10 @@ public:
 	float similarity(const String &p_string) const;
 	String format(const Variant &values, String placeholder = "{_}") const;
 	String replace_first(const String &p_key, const String &p_with) const;
-	String replace(const String &p_key, const String &p_with) const;
-	String replace(const char *p_key, const char *p_with) const;
-	String replacen(const String &p_key, const String &p_with) const;
+	String replace(const String &p_old, const String &p_new, int p_count = -1) const;
+	String replace(const char *p_old, const char *p_new, int p_count = -1) const;
+	String replacen(const String &p_old, const String &p_new, int p_count = -1) const;
+	String replacen(const char *p_old, const char *p_new, int p_count = -1) const;
 	String repeat(int p_count) const;
 	String insert(int p_at_pos, const String &p_string) const;
 	String pad_decimals(int p_digits) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1382,8 +1382,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, similarity, sarray("text"), varray());
 
 	bind_method(String, format, sarray("values", "placeholder"), varray("{_}"));
-	bind_methodv(String, replace, static_cast<String (String::*)(const String &, const String &) const>(&String::replace), sarray("what", "forwhat"), varray());
-	bind_method(String, replacen, sarray("what", "forwhat"), varray());
+	bind_methodv(String, replace, static_cast<String (String::*)(const String &, const String &, int) const>(&String::replace), sarray("old", "new", "count"), varray(-1));
+	bind_methodv(String, replacen, static_cast<String (String::*)(const String &, const String &, int) const>(&String::replacen), sarray("old", "new", "count"), varray(-1));
 	bind_method(String, repeat, sarray("count"), varray());
 	bind_method(String, insert, sarray("position", "what"), varray());
 	bind_method(String, capitalize, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -549,18 +549,20 @@
 		</method>
 		<method name="replace" qualifiers="const">
 			<return type="String" />
-			<argument index="0" name="what" type="String" />
-			<argument index="1" name="forwhat" type="String" />
+			<argument index="0" name="old" type="String" />
+			<argument index="1" name="new" type="String" />
+			<argument index="2" name="count" type="int" default="-1" />
 			<description>
-				Replaces occurrences of a case-sensitive substring with the given one inside the string.
+				Returns a copy of the string where occurrences of a case-sensitive [code]old[/code] substring have been replaced with a [code]new[/code] string. If a [code]count[/code] is given, only that number of occurrences will be replaced.
 			</description>
 		</method>
 		<method name="replacen" qualifiers="const">
 			<return type="String" />
-			<argument index="0" name="what" type="String" />
-			<argument index="1" name="forwhat" type="String" />
+			<argument index="0" name="old" type="String" />
+			<argument index="1" name="new" type="String" />
+			<argument index="2" name="count" type="int" default="-1" />
 			<description>
-				Replaces occurrences of a case-insensitive substring with the given one inside the string.
+				Returns a copy of the string where occurrences of a case-insensitive [code]old[/code] substring have been replaced with a [code]new[/code] string. If a [code]count[/code] is given, only that number of occurrences will be replaced.
 			</description>
 		</method>
 		<method name="rfind" qualifiers="const">


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This PR merges `String::replace` and `String:replacen` implementations, and adds a parameter to `String::replace` to select the number of occurrences one would like to replace. Making this function similar to Python `str.replace`.

Changes are backwards compatible.

If this PR gets merged, `String::replace("old", "new", 1)` will result in the same behavior as `String::replace_first("old", "new")`.