### PR TITLE
Fix exit code for --script --check-only, fixes #54087

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2072,6 +2072,8 @@ bool Main::start() {
 		if (check_only) {
 			if (!script_res->is_valid()) {
 				OS::get_singleton()->set_exit_code(EXIT_FAILURE);
+			} else {
+				OS::get_singleton()->set_exit_code(EXIT_SUCCESS);
 			}
 			return false;
 		}


### PR DESCRIPTION
this commit makes godot executable to return zero exit code
once a valid script is passed via --script during --check-only

Demo after this fix applied:

```
$ touch x.gd
$ ./bin/godot.linuxbsd.tools.64 --headless --check-only --script x.gd
Godot Engine v4.0.dev.custom_build.75ae3164a - https://godotengine.org
 
$ echo $?
0
```
