### PR TITLE
Implement `String::rreplace[n]`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3377,15 +3377,27 @@ String String::format(const Variant &values, String placeholder) const {
 	return new_string;
 }
 
-String String::replace(const String &p_key, const String &p_with) const {
+String String::_replace(const String &p_old, const String &p_new, int p_count, bool p_is_case_sensitive) const {
 	String new_string;
 	int search_from = 0;
-	int result = 0;
+	int find_result = 0;
+	int substring_length = p_old.length();
 
-	while ((result = find(p_key, search_from)) >= 0) {
-		new_string += substr(search_from, result - search_from);
-		new_string += p_with;
-		search_from = result + p_key.length();
+	if (substring_length == 0 || p_count == 0) {
+		return *this; // there's nothing to match or substitute
+	}
+
+	find_result = p_is_case_sensitive ? find(p_old, search_from) : findn(p_old, search_from);
+	int occurrences = 1;
+	while (find_result >= 0) {
+		if (p_count < 0 || occurrences <= p_count) {
+			new_string += substr(search_from, find_result - search_from) + p_new;
+		} else {
+			new_string += substr(search_from, find_result - search_from + substring_length);
+		}
+		search_from = find_result + substring_length;
+		find_result = p_is_case_sensitive ? find(p_old, search_from) : findn(p_old, search_from);
+		++occurrences;
 	}
 
 	if (search_from == 0) {
@@ -3397,19 +3409,38 @@ String String::replace(const String &p_key, const String &p_with) const {
 	return new_string;
 }
 
-String String::replace(const char *p_key, const char *p_with) const {
+String String::replace(const String &p_old, const String &p_new, int p_count) const {
+	return _replace(p_old, p_new, p_count, true);
+}
+
+String String::replacen(const String &p_old, const String &p_new, int p_count) const {
+	return _replace(p_old, p_new, p_count, false);
+}
+
+String String::_replace(const char *p_old, const char *p_new, int p_count, bool p_is_case_sensitive) const {
 	String new_string;
 	int search_from = 0;
-	int result = 0;
+	int find_result = 0;
+	int substring_length = 0;
+	while (p_old[substring_length]) {
+		++substring_length;
+	}
 
-	while ((result = find(p_key, search_from)) >= 0) {
-		new_string += substr(search_from, result - search_from);
-		new_string += p_with;
-		int k = 0;
-		while (p_key[k] != '\0') {
-			k++;
+	if (substring_length == 0 || p_count == 0) {
+		return *this; // there's nothing to match or substitute
+	}
+
+	find_result = p_is_case_sensitive ? find(p_old, search_from) : findn(p_old, search_from);
+	int occurrences = 1;
+	while (find_result >= 0) {
+		if (p_count < 0 || occurrences <= p_count) {
+			new_string += substr(search_from, find_result - search_from) + p_new;
+		} else {
+			new_string += substr(search_from, find_result - search_from + substring_length);
 		}
-		search_from = result + k;
+		search_from = find_result + substring_length;
+		find_result = p_is_case_sensitive ? find(p_old, search_from) : findn(p_old, search_from);
+		++occurrences;
 	}
 
 	if (search_from == 0) {
@@ -3419,6 +3450,14 @@ String String::replace(const char *p_key, const char *p_with) const {
 	new_string += substr(search_from, length() - search_from);
 
 	return new_string;
+}
+
+String String::replace(const char *p_old, const char *p_new, int p_count) const {
+	return _replace(p_old, p_new, p_count, true);
+}
+
+String String::replacen(const char *p_old, const char *p_new, int p_count) const {
+	return _replace(p_old, p_new, p_count, false);
 }
 
 String String::replace_first(const String &p_key, const String &p_with) const {
@@ -3428,25 +3467,6 @@ String String::replace_first(const String &p_key, const String &p_with) const {
 	}
 
 	return *this;
-}
-
-String String::replacen(const String &p_key, const String &p_with) const {
-	String new_string;
-	int search_from = 0;
-	int result = 0;
-
-	while ((result = findn(p_key, search_from)) >= 0) {
-		new_string += substr(search_from, result - search_from);
-		new_string += p_with;
-		search_from = result + p_key.length();
-	}
-
-	if (search_from == 0) {
-		return *this;
-	}
-
-	new_string += substr(search_from, length() - search_from);
-	return new_string;
 }
 
 String String::repeat(int p_count) const {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3469,6 +3469,91 @@ String String::replace_first(const String &p_key, const String &p_with) const {
 	return *this;
 }
 
+String String::_rreplace(const String &p_old, const String &p_new, int p_count, bool p_is_case_sensitive) const {
+	String new_string;
+	int caller_length = this->length();
+	int search_from = caller_length;
+	int find_result = 0;
+	int occurrences = 1;
+	int substring_length = p_old.length();
+
+	if (substring_length == 0 || p_count == 0) {
+		return *this; // there's nothing to match or substitute
+	}
+
+	find_result = p_is_case_sensitive ? rfind(p_old, search_from) : rfindn(p_old, search_from);
+	while ((find_result >= 0) && (search_from > 0)) {
+		if (p_count < 0 || occurrences <= p_count) {
+			new_string = p_new + substr(find_result + substring_length, search_from - (find_result + substring_length) + 1) + new_string;
+		} else {
+			new_string = substr(find_result, search_from - find_result + 1) + new_string;
+		}
+		search_from = find_result - 1;
+		find_result = p_is_case_sensitive ? rfind(p_old, search_from) : rfindn(p_old, search_from);
+		++occurrences;
+	}
+
+	if (search_from == caller_length) {
+		return *this;
+	}
+
+	new_string = substr(find_result + 1, search_from + 1) + new_string;
+
+	return new_string;
+}
+
+String String::rreplace(const String &p_old, const String &p_new, int p_count) const {
+	return _rreplace(p_old, p_new, p_count, true);
+}
+
+String String::rreplacen(const String &p_old, const String &p_new, int p_count) const {
+	return _rreplace(p_old, p_new, p_count, false);
+}
+
+String String::_rreplace(const char *p_old, const char *p_new, int p_count, bool p_is_case_sensitive) const {
+	String new_string;
+	int caller_length = this->length();
+	int search_from = caller_length;
+	int find_result = 0;
+	int occurrences = 1;
+	int substring_length = 0;
+	while (p_old[substring_length]) {
+		++substring_length;
+	}
+
+	if (substring_length == 0 || p_count == 0) {
+		return *this; // there's nothing to match or substitute
+	}
+
+	find_result = p_is_case_sensitive ? rfind(p_old, search_from) : rfindn(p_old, search_from);
+	while ((find_result >= 0) && (search_from > 0)) {
+		if (p_count < 0 || occurrences <= p_count) {
+			new_string = p_new + substr(find_result + substring_length, search_from - (find_result + substring_length) + 1) + new_string;
+		} else {
+			new_string = substr(find_result, search_from - find_result + 1) + new_string;
+		}
+		search_from = find_result - 1;
+		find_result = p_is_case_sensitive ? rfind(p_old, search_from) : rfindn(p_old, search_from);
+		++occurrences;
+	}
+
+	if (search_from == caller_length) {
+		return *this;
+	}
+
+	new_string = substr(find_result + 1, search_from + 1) + new_string;
+
+	return new_string;
+}
+
+String String::rreplace(const char *p_old, const char *p_new, int p_count) const {
+	return _rreplace(p_old, p_new, p_count, true);
+}
+
+String String::rreplacen(const char *p_old, const char *p_new, int p_count) const {
+	return _rreplace(p_old, p_new, p_count, false);
+}
+
 String String::repeat(int p_count) const {
 	ERR_FAIL_COND_V_MSG(p_count < 0, "", "Parameter count should be a positive number.");
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -200,6 +200,8 @@ class String {
 
 	bool _base_is_subsequence_of(const String &p_string, bool case_insensitive) const;
 	int _count(const String &p_string, int p_from, int p_to, bool p_case_insensitive) const;
+	String _replace(const String &p_old, const String &p_new, int p_count = -1, bool p_is_case_sensitive = true) const;
+	String _replace(const char *p_old, const char *p_new, int p_count = -1, bool p_is_case_sensitive = true) const;
 
 public:
 	enum {
@@ -297,9 +299,10 @@ public:
 	float similarity(const String &p_string) const;
 	String format(const Variant &values, String placeholder = "{_}") const;
 	String replace_first(const String &p_key, const String &p_with) const;
-	String replace(const String &p_key, const String &p_with) const;
-	String replace(const char *p_key, const char *p_with) const;
-	String replacen(const String &p_key, const String &p_with) const;
+	String replace(const String &p_old, const String &p_new, int p_count = -1) const;
+	String replace(const char *p_old, const char *p_new, int p_count = -1) const;
+	String replacen(const String &p_old, const String &p_new, int p_count = -1) const;
+	String replacen(const char *p_old, const char *p_new, int p_count = -1) const;
 	String repeat(int p_count) const;
 	String insert(int p_at_pos, const String &p_string) const;
 	String pad_decimals(int p_digits) const;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -202,6 +202,8 @@ class String {
 	int _count(const String &p_string, int p_from, int p_to, bool p_case_insensitive) const;
 	String _replace(const String &p_old, const String &p_new, int p_count = -1, bool p_is_case_sensitive = true) const;
 	String _replace(const char *p_old, const char *p_new, int p_count = -1, bool p_is_case_sensitive = true) const;
+	String _rreplace(const String &p_old, const String &p_new, int p_count = -1, bool p_is_case_sensitive = true) const;
+	String _rreplace(const char *p_old, const char *p_new, int p_count = -1, bool p_is_case_sensitive = true) const;
 
 public:
 	enum {
@@ -303,6 +305,10 @@ public:
 	String replace(const char *p_old, const char *p_new, int p_count = -1) const;
 	String replacen(const String &p_old, const String &p_new, int p_count = -1) const;
 	String replacen(const char *p_old, const char *p_new, int p_count = -1) const;
+	String rreplace(const String &p_old, const String &p_new, int p_count = -1) const;
+	String rreplace(const char *p_old, const char *p_new, int p_count = -1) const;
+	String rreplacen(const String &p_old, const String &p_new, int p_count = -1) const;
+	String rreplacen(const char *p_old, const char *p_new, int p_count = -1) const;
 	String repeat(int p_count) const;
 	String insert(int p_at_pos, const String &p_string) const;
 	String pad_decimals(int p_digits) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1384,6 +1384,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, format, sarray("values", "placeholder"), varray("{_}"));
 	bind_methodv(String, replace, static_cast<String (String::*)(const String &, const String &, int) const>(&String::replace), sarray("old", "new", "count"), varray(-1));
 	bind_methodv(String, replacen, static_cast<String (String::*)(const String &, const String &, int) const>(&String::replacen), sarray("old", "new", "count"), varray(-1));
+	bind_methodv(String, rreplace, static_cast<String (String::*)(const String &, const String &, int) const>(&String::rreplace), sarray("old", "new", "count"), varray(-1));
+	bind_methodv(String, rreplacen, static_cast<String (String::*)(const String &, const String &, int) const>(&String::rreplacen), sarray("old", "new", "count"), varray(-1));
 	bind_method(String, repeat, sarray("count"), varray());
 	bind_method(String, insert, sarray("position", "what"), varray());
 	bind_method(String, capitalize, sarray(), varray());

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1382,8 +1382,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, similarity, sarray("text"), varray());
 
 	bind_method(String, format, sarray("values", "placeholder"), varray("{_}"));
-	bind_methodv(String, replace, static_cast<String (String::*)(const String &, const String &) const>(&String::replace), sarray("what", "forwhat"), varray());
-	bind_method(String, replacen, sarray("what", "forwhat"), varray());
+	bind_methodv(String, replace, static_cast<String (String::*)(const String &, const String &, int) const>(&String::replace), sarray("old", "new", "count"), varray(-1));
+	bind_methodv(String, replacen, static_cast<String (String::*)(const String &, const String &, int) const>(&String::replacen), sarray("old", "new", "count"), varray(-1));
 	bind_method(String, repeat, sarray("count"), varray());
 	bind_method(String, insert, sarray("position", "what"), varray());
 	bind_method(String, capitalize, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -549,16 +549,18 @@
 		</method>
 		<method name="replace" qualifiers="const">
 			<return type="String" />
-			<argument index="0" name="what" type="String" />
-			<argument index="1" name="forwhat" type="String" />
+			<argument index="0" name="old" type="String" />
+			<argument index="1" name="new" type="String" />
+			<argument index="2" name="count" type="int" default="-1" />
 			<description>
 				Replaces occurrences of a case-sensitive substring with the given one inside the string.
 			</description>
 		</method>
 		<method name="replacen" qualifiers="const">
 			<return type="String" />
-			<argument index="0" name="what" type="String" />
-			<argument index="1" name="forwhat" type="String" />
+			<argument index="0" name="old" type="String" />
+			<argument index="1" name="new" type="String" />
+			<argument index="2" name="count" type="int" default="-1" />
 			<description>
 				Replaces occurrences of a case-insensitive substring with the given one inside the string.
 			</description>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -601,6 +601,24 @@
 				Formats a string to be at least [code]min_length[/code] long by adding [code]character[/code]s to the right of the string.
 			</description>
 		</method>
+		<method name="rreplace" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="old" type="String" />
+			<argument index="1" name="new" type="String" />
+			<argument index="2" name="count" type="int" default="-1" />
+			<description>
+				Returns a copy of the string where occurrences of a case-sensitive [code]old[/code] substring have been replaced with a [code]new[/code] string. If a [code]count[/code] is given, only that number of occurrences will be replaced in reverse.
+			</description>
+		</method>
+		<method name="rreplacen" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="old" type="String" />
+			<argument index="1" name="new" type="String" />
+			<argument index="2" name="count" type="int" default="-1" />
+			<description>
+				Returns a copy of the string where occurrences of a case-insensitive [code]old[/code] substring have been replaced with a [code]new[/code] string. If a [code]count[/code] is given, only that number of occurrences will be replaced in reverse.
+			</description>
+		</method>
 		<method name="rsplit" qualifiers="const">
 			<return type="PackedStringArray" />
 			<argument index="0" name="delimiter" type="String" />


### PR DESCRIPTION
This function is similar to `String::replace` as implemented in #54085 but pattern occurrences get replaced starting from the end of the string towards the beginning.

```gdscript
"a a a".rreplace("a", "B", 1) # returns "a a B", in contrast to
"a a a".replace("a", "B", 1) # which returns "B a a"
```