### PR TITLE
Fix RigidDynamicBody collision update after changing collision layer/mask

### DIFF
--- a/servers/physics_2d/godot_body_2d.cpp
+++ b/servers/physics_2d/godot_body_2d.cpp
@@ -276,6 +276,7 @@ PhysicsServer2D::BodyMode GodotBody2D::get_mode() const {
 
 void GodotBody2D::_shapes_changed() {
 	_mass_properties_changed();
+	wakeup();
 	wakeup_neighbours();
 }
 

--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -327,6 +327,8 @@ PhysicsServer3D::BodyMode GodotBody3D::get_mode() const {
 
 void GodotBody3D::_shapes_changed() {
 	_mass_properties_changed();
+	wakeup();
+	wakeup_neighbours();
 }
 
 void GodotBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant &p_variant) {

--- a/servers/physics_3d/godot_physics_server_3d.cpp
+++ b/servers/physics_3d/godot_physics_server_3d.cpp
@@ -584,7 +584,6 @@ void GodotPhysicsServer3D::body_set_collision_layer(RID p_body, uint32_t p_layer
 	ERR_FAIL_COND(!body);
 
 	body->set_collision_layer(p_layer);
-	body->wakeup();
 }
 
 uint32_t GodotPhysicsServer3D::body_get_collision_layer(RID p_body) const {
@@ -599,7 +598,6 @@ void GodotPhysicsServer3D::body_set_collision_mask(RID p_body, uint32_t p_mask) 
 	ERR_FAIL_COND(!body);
 
 	body->set_collision_mask(p_mask);
-	body->wakeup();
 }
 
 uint32_t GodotPhysicsServer3D::body_get_collision_mask(RID p_body) const {


### PR DESCRIPTION
Changing the collision layer of a sleeping body was not triggering area updates correctly (found this bug when testing more cases around #53997).

Bodies need to be active for collision to be checked against already overlapping bodies and areas.

Neighbors need to be activated too in order to handle the case where a static body is modified (it can't be activated directly but paired bodies need to check their collision again).

In 3D, moved the call to `wakeup()` from the physics server to `GodotBody3D::_shapes_changed` to make it consistent with 2D and also handle the case where shapes are modified (_shapes_changed is called in both this case and collision layer changes).