### PR TITLE
[3.x] Don't ignore the type mismatch in setter function

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -961,6 +961,8 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 				call(member->setter, &val, 1, err);
 				if (err.error == Variant::CallError::CALL_OK) {
 					return true; //function exists, call was successful
+				} else {
+					return false;
 				}
 			} else {
 				if (!member->data_type.is_type(p_value)) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/48765

If member had setter, but the call returned error different than `Variant::CallError::CALL_OK`, `GDScriptInstance::set` would return `true` anyway. So in case of the type mismatch it silently moved forward without any errors. The case without the setter was handled properly and returned `false` when non-`CALL_OK` error occured.