### PR TITLE
Implement runtime update of TileData object in TileMap

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -16,6 +16,27 @@
 		<link title="2D Kinematic Character Demo">https://godotengine.org/asset-library/asset/113</link>
 	</tutorials>
 	<methods>
+		<method name="_tile_data_runtime_update" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="layer" type="int" />
+			<argument index="1" name="coords" type="Vector2i" />
+			<argument index="2" name="tile_data" type="TileData" />
+			<description>
+				Called with a TileData object about to be used internally by the TileMap, allowing its modification at runtime.
+				This method is only called if [method _use_tile_data_runtime_update] is implemented and returns [code]true[/code] for the given tile [code]coords[/coords] and [code]layer[/code].
+				[b]Warning:[/b] The [code]tile_data[/code] object's sub-resources are the same as the one in the TileSet. Modifying them might impact the whole TileSet. Instead, make sure to duplicate those resources.
+				[b]Note:[/b] If the properties of [code]tile_data[/code] object should change over time, use [method force_update] to trigger a TileMap update.
+			</description>
+		</method>
+		<method name="_use_tile_data_runtime_update" qualifiers="virtual">
+			<return type="bool" />
+			<argument index="0" name="layer" type="int" />
+			<argument index="1" name="coords" type="Vector2i" />
+			<description>
+				Should return [code]true[/code] if the tile at coordinates [code]coords[/coords] on layer [code]layer[/code] requires a runtime update.
+				[b]Warning:[/b] Make sure this function only return [code]true[/code] when needed. Any tile processed at runtime without a need for it will imply a significant performance penalty.
+			</description>
+		</method>
 		<method name="add_layer">
 			<return type="void" />
 			<argument index="0" name="to_position" type="int" />
@@ -40,6 +61,15 @@
 			<return type="void" />
 			<description>
 				Clears cells that do not exist in the tileset.
+			</description>
+		</method>
+		<method name="force_update">
+			<return type="void" />
+			<argument index="0" name="layer" type="int" default="-1" />
+			<description>
+				Triggers an update of the TileMap. If [code]layer[/code] is provided, only updates the given layer.
+				[b]Note:[/b] The TileMap node updates automatically when one of its properties is modified. A manual update is only needed if runtime modifications (implemented in [method _tile_data_runtime_update]) need to be applied.
+				[b]Warning:[/b] Updating the TileMap is a performance demanding task. Limit occurences of those updates to the minimum and limit the amount tiles they impact (by segregating tiles updated often to a dedicated layer for example).
 			</description>
 		</method>
 		<method name="get_cell_alternative_tile" qualifiers="const">

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -79,6 +79,9 @@ struct TileMapQuadrant {
 	// Scenes.
 	Map<Vector2i, String> scenes;
 
+	// Runtime TileData cache.
+	Map<Vector2i, TileData *> runtime_tile_data_cache;
+
 	void operator=(const TileMapQuadrant &q) {
 		layer = q.layer;
 		coords = q.coords;
@@ -254,6 +257,8 @@ private:
 	void _set_tile_data(int p_layer, const Vector<int> &p_data);
 	Vector<int> _get_tile_data(int p_layer) const;
 
+	void _build_runtime_update_tile_data(SelfList<TileMapQuadrant>::List &r_dirty_quadrant_list);
+
 	void _tile_set_changed();
 	bool _tile_set_changed_deferred_update_needed = false;
 	void _tile_set_changed_deferred_update();
@@ -283,7 +288,7 @@ public:
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
 
-	static void draw_tile(RID p_canvas_item, Vector2i p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, Vector2i p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0));
+	static void draw_tile(RID p_canvas_item, Vector2i p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, Vector2i p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0), const TileData *p_tile_data_override = nullptr);
 
 	// Layers management.
 	int get_layers_count() const;
@@ -362,12 +367,20 @@ public:
 	// Fixing a nclearing methods.
 	void fix_invalid_tiles();
 
+	// Clears tiles from a given layer
 	void clear_layer(int p_layer);
 	void clear();
 
-	// Helpers
+	// Force a TileMap update
+	void force_update(int p_layer = -1);
+
+	// Helpers?
 	TypedArray<Vector2i> get_surrounding_tiles(Vector2i coords);
 	void draw_cells_outline(Control *p_control, Set<Vector2i> p_cells, Color p_color, Transform2D p_transform = Transform2D());
+
+	// Virtual function to modify the TileData at runtime
+	GDVIRTUAL2R(bool, _use_tile_data_runtime_update, int, Vector2i);
+	GDVIRTUAL3(_tile_data_runtime_update, int, Vector2i, TileData *);
 
 	// Configuration warnings.
 	TypedArray<String> get_configuration_warnings() const override;

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -4638,6 +4638,37 @@ bool TileData::is_allowing_transform() const {
 	return allow_transform;
 }
 
+TileData *TileData::duplicate() {
+	TileData *output = memnew(TileData);
+	output->tile_set = tile_set;
+
+	output->allow_transform = allow_transform;
+
+	// Rendering
+	output->flip_h = flip_h;
+	output->flip_v = flip_v;
+	output->transpose = transpose;
+	output->tex_offset = tex_offset;
+	output->material = material;
+	output->modulate = modulate;
+	output->z_index = z_index;
+	output->y_sort_origin = y_sort_origin;
+	output->occluders = occluders;
+	// Physics
+	output->physics = physics;
+	// Terrain
+	output->terrain_set = -1;
+	memcpy(output->terrain_peering_bits, terrain_peering_bits, 16 * sizeof(int));
+	// Navigation
+	output->navigation = navigation;
+	// Misc
+	output->probability = probability;
+	// Custom data
+	output->custom_data = custom_data;
+
+	return output;
+}
+
 // Rendering
 void TileData::set_flip_h(bool p_flip_h) {
 	ERR_FAIL_COND_MSG(!allow_transform && p_flip_h, "Transform is only allowed for alternative tiles (with its alternative_id != 0)");

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -794,6 +794,9 @@ public:
 	void set_allow_transform(bool p_allow_transform);
 	bool is_allowing_transform() const;
 
+	// To duplicate a TileData object, needed for runtiume update.
+	TileData *duplicate();
+
 	// Rendering
 	void set_flip_h(bool p_flip_h);
 	bool get_flip_h() const;


### PR DESCRIPTION
Implements and closes https://github.com/godotengine/godot-proposals/issues/3416.

This implements a virtual function of TileMap called when a tile is about to be rendered, used for physics, etc... I allow users to modify TileMaps tiles at runtime. A lot of runtime effects can thus be done without modifying the TileSet resource.

For example, this:
```gdscript
func _use_tile_data_runtime_update(layer, coords):
	return layer == 0

func _tile_data_runtime_update(layer, coords, tile_data):
	if layer == 0:
		tile_data.modulate = Color(cos(float(coords.x) / 1.0) / 4 + 0.5, 1.0, 1.0, 1.0))
```

Gives something like this:
![2021-10-22-164231_634x469_scrot](https://user-images.githubusercontent.com/6093119/138474183-be0219b4-6ec7-4370-b1ff-98b94e587968.png)

Marked as draft for now as I need to implement a way to trigger a manual update of the TileMap when needed.