### PR TITLE
Fix error spam at setting a CurveTexture in visual shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "visual_shader_editor_plugin.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
@@ -212,19 +213,27 @@ void VisualShaderGraphPlugin::set_uniform_name(VisualShader::Type p_type, int p_
 
 void VisualShaderGraphPlugin::update_curve(int p_node_id) {
 	if (links.has(p_node_id) && links[p_node_id].curve_editors[0]) {
-		if (((VisualShaderNodeCurveTexture *)links[p_node_id].visual_node)->get_texture().is_valid()) {
-			links[p_node_id].curve_editors[0]->set_curve(((VisualShaderNodeCurveTexture *)links[p_node_id].visual_node)->get_texture()->get_curve());
+		Ref<VisualShaderNodeCurveTexture> tex = Object::cast_to<VisualShaderNodeCurveTexture>(links[p_node_id].visual_node);
+		ERR_FAIL_COND(!tex.is_valid());
+
+		if (tex->get_texture().is_valid()) {
+			links[p_node_id].curve_editors[0]->set_curve(tex->get_texture()->get_curve());
 		}
+		tex->emit_signal(CoreStringNames::get_singleton()->changed);
 	}
 }
 
 void VisualShaderGraphPlugin::update_curve_xyz(int p_node_id) {
 	if (links.has(p_node_id) && links[p_node_id].curve_editors[0] && links[p_node_id].curve_editors[1] && links[p_node_id].curve_editors[2]) {
-		if (((VisualShaderNodeCurveXYZTexture *)links[p_node_id].visual_node)->get_texture().is_valid()) {
-			links[p_node_id].curve_editors[0]->set_curve(((VisualShaderNodeCurveXYZTexture *)links[p_node_id].visual_node)->get_texture()->get_curve_x());
-			links[p_node_id].curve_editors[1]->set_curve(((VisualShaderNodeCurveXYZTexture *)links[p_node_id].visual_node)->get_texture()->get_curve_y());
-			links[p_node_id].curve_editors[2]->set_curve(((VisualShaderNodeCurveXYZTexture *)links[p_node_id].visual_node)->get_texture()->get_curve_z());
+		Ref<VisualShaderNodeCurveXYZTexture> tex = Object::cast_to<VisualShaderNodeCurveXYZTexture>(links[p_node_id].visual_node);
+		ERR_FAIL_COND(!tex.is_valid());
+
+		if (tex->get_texture().is_valid()) {
+			links[p_node_id].curve_editors[0]->set_curve(tex->get_texture()->get_curve_x());
+			links[p_node_id].curve_editors[1]->set_curve(tex->get_texture()->get_curve_y());
+			links[p_node_id].curve_editors[2]->set_curve(tex->get_texture()->get_curve_z());
 		}
+		tex->emit_signal(CoreStringNames::get_singleton()->changed);
 	}
 }
 


### PR DESCRIPTION
Default textures need to be updated when it's changed to prevent:
![vs_bug](https://user-images.githubusercontent.com/3036176/138472676-753828e2-6a72-4657-874f-724e392232b0.gif)

