### PR TITLE
Keep order for C# exported members

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1813,8 +1813,8 @@ void CSharpInstance::get_event_signals_state_for_reloading(List<Pair<StringName,
 }
 
 void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
-	for (const KeyValue<StringName, PropertyInfo> &E : script->member_info) {
-		p_properties->push_back(E.value);
+	for (OrderedHashMap<StringName, PropertyInfo>::ConstElement E = script->member_info.front(); E; E = E.next()) {
+		p_properties->push_front(E.value());
 	}
 
 	// Call _get_property_list
@@ -1839,10 +1839,9 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 				for (int i = 0, size = array.size(); i < size; i++) {
 					p_properties->push_back(PropertyInfo::from_dict(array.get(i)));
 				}
-				return;
 			}
 
-			break;
+			return;
 		}
 
 		top = top->get_parent_class();
@@ -1865,8 +1864,9 @@ Variant::Type CSharpInstance::get_property_type(const StringName &p_name, bool *
 }
 
 void CSharpInstance::get_method_list(List<MethodInfo> *p_list) const {
-	if (!script->is_valid() || !script->script_class)
+	if (!script->is_valid() || !script->script_class) {
 		return;
+	}
 
 	GD_MONO_SCOPE_THREAD_ATTACH;
 
@@ -3499,9 +3499,9 @@ Ref<Script> CSharpScript::get_base_script() const {
 	return Ref<Script>();
 }
 
-void CSharpScript::get_script_property_list(List<PropertyInfo> *p_list) const {
-	for (const KeyValue<StringName, PropertyInfo> &E : member_info) {
-		p_list->push_back(E.value);
+void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
+	for (OrderedHashMap<StringName, PropertyInfo>::ConstElement E = member_info.front(); E; E = E.next()) {
+		r_list->push_front(E.value());
 	}
 }
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -154,7 +154,7 @@ private:
 	Set<StringName> exported_members_names;
 #endif
 
-	Map<StringName, PropertyInfo> member_info;
+	OrderedHashMap<StringName, PropertyInfo> member_info;
 
 	void _clear();
 
@@ -215,7 +215,7 @@ public:
 	void get_script_signal_list(List<MethodInfo> *r_signals) const override;
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
-	void get_script_property_list(List<PropertyInfo> *p_list) const override;
+	void get_script_property_list(List<PropertyInfo> *r_list) const override;
 	void update_exports() override;
 
 	void get_members(Set<StringName> *p_members) override;


### PR DESCRIPTION
Fixes #47465

| C# script | Godot inspector |
|-|-|
| ![image](https://user-images.githubusercontent.com/3903059/138498325-a9c9748d-35c6-4359-8f09-11b624d6a3a7.png) | ![image](https://user-images.githubusercontent.com/3903059/138498131-1f1a034c-ca3a-4e0e-8468-28d35b08be57.png) |

**NOTE:** Properties always appear before fields, this is because `_update_exports` and `_update_member_info_no_exports` retrieve the fields and properties separately.

Derived members appear at the top and declared members at the bottom, as far as I'm concerned that's how it works for GDScript.