### PR TITLE
Fix support for multiple base types in the quick load dialog

### DIFF
--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -55,16 +55,23 @@ void EditorQuickOpen::_build_search_cache(EditorFileSystemDirectory *p_efsd) {
 		_build_search_cache(p_efsd->get_subdir(i));
 	}
 
+	Vector<String> base_types = String(base_type).split(String(","));
 	for (int i = 0; i < p_efsd->get_file_count(); i++) {
 		String file_type = p_efsd->get_file_type(i);
-		if (ClassDB::is_parent_class(file_type, base_type)) {
-			String file = p_efsd->get_file_path(i);
-			files.push_back(file.substr(6, file.length()));
+		// Iterate all possible base types.
+		for (String &parent_type : base_types) {
+			if (ClassDB::is_parent_class(file_type, parent_type)) {
+				String file = p_efsd->get_file_path(i);
+				files.push_back(file.substr(6, file.length()));
 
-			// Store refs to used icons.
-			String ext = file.get_extension();
-			if (!icons.has(ext)) {
-				icons.insert(ext, get_theme_icon((has_theme_icon(file_type, SNAME("EditorIcons")) ? file_type : String("Object")), SNAME("EditorIcons")));
+				// Store refs to used icons.
+				String ext = file.get_extension();
+				if (!icons.has(ext)) {
+					icons.insert(ext, get_theme_icon((has_theme_icon(file_type, SNAME("EditorIcons")) ? file_type : String("Object")), SNAME("EditorIcons")));
+				}
+
+				// Stop testing base types as soon as we got a match.
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
For some inputs (e.g. most materials), the quick load dialog sets the base_type to contain multiple base types (e.g. "BaseMaterial3D,ShaderMaterial") but the quick load dialog did not support this up until now, just showing an empty dialog box instead. This PR adds support for that functionality, showing all files that are an ancestor of any of the specified base types.  
As far as I can tell there was no Issue opened for this bug yet, but the fix was so easy that it took me about as long to fix this than it would have taken to open an issue report. Please let me know if I should open an issue report first anyway!