### PR TITLE
Make `RichTextLabel`'s `parse_bbcode()` and `append_text()` return void

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -36,10 +36,10 @@
 			</description>
 		</method>
 		<method name="append_text">
-			<return type="int" enum="Error" />
+			<return type="void" />
 			<argument index="0" name="bbcode" type="String" />
 			<description>
-				Parses [code]bbcode[/code] and adds tags to the tag stack as needed. Returns the result of the parsing, [constant OK] if successful.
+				Parses [code]bbcode[/code] and adds tags to the tag stack as needed.
 				[b]Note:[/b] Using this method, you can't close a tag that was opened in a previous [method append_text] call. This is done to improve performance, especially when updating large RichTextLabels since rebuilding the whole BBCode every time would be slower. If you absolutely need to close a tag in a future method call, append the [member text] instead of using [method append_text].
 			</description>
 		</method>
@@ -130,10 +130,10 @@
 			</description>
 		</method>
 		<method name="parse_bbcode">
-			<return type="int" enum="Error" />
+			<return type="void" />
 			<argument index="0" name="bbcode" type="String" />
 			<description>
-				The assignment version of [method append_text]. Clears the tag stack and inserts the new content. Returns [constant OK] if parses [code]bbcode[/code] successfully.
+				The assignment version of [method append_text]. Clears the tag stack and inserts the new content.
 			</description>
 		</method>
 		<method name="parse_expressions_for_values">

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2815,12 +2815,12 @@ bool RichTextLabel::is_scroll_following() const {
 	return scroll_follow;
 }
 
-Error RichTextLabel::parse_bbcode(const String &p_bbcode) {
+void RichTextLabel::parse_bbcode(const String &p_bbcode) {
 	clear();
-	return append_text(p_bbcode);
+	append_text(p_bbcode);
 }
 
-Error RichTextLabel::append_text(const String &p_bbcode) {
+void RichTextLabel::append_text(const String &p_bbcode) {
 	int pos = 0;
 
 	List<String> tag_stack;
@@ -3543,8 +3543,6 @@ Error RichTextLabel::append_text(const String &p_bbcode) {
 			break;
 		}
 	}
-
-	return OK;
 }
 
 void RichTextLabel::scroll_to_paragraph(int p_paragraph) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -552,8 +552,8 @@ public:
 	String get_selected_text() const;
 	void selection_copy();
 
-	Error parse_bbcode(const String &p_bbcode);
-	Error append_text(const String &p_bbcode);
+	void parse_bbcode(const String &p_bbcode);
+	void append_text(const String &p_bbcode);
 
 	void set_use_bbcode(bool p_enable);
 	bool is_using_bbcode() const;


### PR DESCRIPTION
Resolves #47149

As discussed in the original issue, these two methods always return `OK` currently. Since BBCode is a less strict markup that falls back to plain text by design, there is no typicial "failure" state.