### PR TITLE
Fix newly created files are not sorted correctly

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -688,9 +688,11 @@ void FileSystemDock::_sort_file_info_list(List<FileSystemDock::FileInfo> &r_file
 			r_file_list.reverse();
 			break;
 		case FILE_SORT_NAME_REVERSE:
+			r_file_list.sort();
 			r_file_list.reverse();
 			break;
 		default: // FILE_SORT_NAME
+			r_file_list.sort();
 			break;
 	}
 }


### PR DESCRIPTION
When adding a new file through the filesystem dock, the new file is currently added to the end of its directory list because the FileSystemDock assumes EditorFileSystem returns the files presorted, which is not the case for files added after the initial scan. This PR fixes that by actually sorting the file list whenever the sort function is called.