### PR TITLE
Fix possible crash when calling Tree.notification from _ready

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3570,7 +3570,9 @@ int Tree::_get_title_button_height() const {
 
 void Tree::_notification(int p_what) {
 	if (p_what == NOTIFICATION_FOCUS_ENTER) {
-		focus_in_id = get_viewport()->get_processed_events_count();
+		if (get_viewport()) {
+			focus_in_id = get_viewport()->get_processed_events_count();
+		}
 	}
 	if (p_what == NOTIFICATION_MOUSE_EXIT) {
 		if (cache.hover_type != Cache::CLICK_NONE) {


### PR DESCRIPTION
While not the exact same stack trace as the error shown in #54143 , a similar crash happens in Godot 4.0 which this PR aims to fix. This solution can't be cherry picked to 3.x, but a very similar solution should be possible in that branch as well.
