### PR TITLE
Fixed crash in `ScrollContainer` _notification

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -320,7 +320,9 @@ void ScrollContainer::_notification(int p_what) {
 	};
 
 	if (p_what == NOTIFICATION_READY) {
-		get_viewport()->connect("gui_focus_changed", callable_mp(this, &ScrollContainer::_gui_focus_changed));
+		Viewport* viewport = get_viewport();
+		ERR_FAIL_COND(!viewport);
+		viewport->connect("gui_focus_changed", callable_mp(this, &ScrollContainer::_gui_focus_changed));
 		_update_dimensions();
 	}
 


### PR DESCRIPTION
Fixes nullptr crash occurring when calling _notification on a new ScrollContainer when get_viewport is not available as reported in #54142 

_Fixes https://github.com/godotengine/godot/issues/54142_