### PR TITLE
#54094 Fix potential null pointer dereference

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -44,7 +44,9 @@ void CollisionObject2D::_notification(int p_what) {
 				Physics2DServer::get_singleton()->body_set_state(rid, Physics2DServer::BODY_STATE_TRANSFORM, global_transform);
 			}
 
-			RID space = get_world_2d()->get_space();
+			Ref<World2D> world_ref = get_world_2d();
+			ERR_FAIL_COND(!world_ref.is_valid());
+			RID space = world_ref->get_space();
 			if (area) {
 				Physics2DServer::get_singleton()->area_set_space(rid, space);
 			} else {

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -60,13 +60,14 @@ void CollisionObject::_notification(int p_what) {
 				PhysicsServer::get_singleton()->body_set_state(rid, PhysicsServer::BODY_STATE_TRANSFORM, get_global_transform());
 			}
 
-			RID space = get_world()->get_space();
+			Ref<World> world_ref = get_world();
+			ERR_FAIL_COND(!world_ref.is_valid());
+			RID space = world_ref->get_space();
 			if (area) {
 				PhysicsServer::get_singleton()->area_set_space(rid, space);
 			} else {
 				PhysicsServer::get_singleton()->body_set_space(rid, space);
 			}
-
 			_update_pickable();
 			//get space
 		} break;


### PR DESCRIPTION
Checking validity of world reference before using it. Fix #54094.
