### PR TITLE
Fix Gradle builds not excluding excluded tasks

### DIFF
--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -158,9 +158,9 @@ def templateBuildTasks() {
 /**
  * Master task used to coordinate the tasks defined above to generate the set of Godot templates.
  */
-task generateGodotTemplates(type: GradleBuild) {
-    startParameter.excludedTaskNames = templateExcludedBuildTask()
-    tasks = templateBuildTasks()
+task generateGodotTemplates {
+    gradle.startParameter.excludedTaskNames += templateExcludedBuildTask()
+    dependsOn = templateBuildTasks()
 
     finalizedBy 'zipCustomBuild'
 }
@@ -168,12 +168,12 @@ task generateGodotTemplates(type: GradleBuild) {
 /**
  * Generates the same output as generateGodotTemplates but with dev symbols
  */
-task generateDevTemplate (type: GradleBuild) {
+task generateDevTemplate {
     // add parameter to set symbols to true
-    startParameter.projectProperties += [doNotStrip: true]
+    gradle.startParameter.projectProperties += [doNotStrip: true]
 
-    startParameter.excludedTaskNames = templateExcludedBuildTask()
-    tasks = templateBuildTasks()
+    gradle.startParameter.excludedTaskNames += templateExcludedBuildTask()
+    dependsOn = templateBuildTasks()
 
     finalizedBy 'zipCustomBuild'
 }


### PR DESCRIPTION
For some reason (a bug?) in Gradle 7.2, the `GradleBuild` task type is not excluding tasks contained in the `startParameter.excludedTaskNames`. This is regardless of whether it's specified in the task, the `settings.gradle` file or specified on the command line using `-x`.

This PR converts the `generateGodotTemplates` and `generateDevTemplate` tasks to standard Gradle tasks, which do exclude the tasks added to `startParameter.excludedTaskNames`.

Fixes #54091 (i.e. needs to be cherry-picked for 3.4).

**Edit:** This is a known bug in Gradle since v6.8: https://github.com/gradle/gradle/issues/16756
