### PR TITLE
Fix potential null pointer use, based on #54094 fix

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -50,7 +50,9 @@ void CollisionObject2D::_notification(int p_what) {
 			}
 
 			if (!disabled || (disable_mode != DISABLE_MODE_REMOVE)) {
-				RID space = get_world_2d()->get_space();
+				Ref<World2D> world_ref = get_world_2d();
+				ERR_FAIL_COND(!world_ref.is_valid());
+				RID space = world_ref->get_space();
 				if (area) {
 					PhysicsServer2D::get_singleton()->area_set_space(rid, space);
 				} else {

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -64,7 +64,9 @@ void CollisionObject3D::_notification(int p_what) {
 			}
 
 			if (!disabled || (disable_mode != DISABLE_MODE_REMOVE)) {
-				RID space = get_world_3d()->get_space();
+				Ref<World3D> world_ref = get_world_3d();
+				ERR_FAIL_COND(!world_ref.is_valid());
+				RID space = world_ref->get_space();
 				if (area) {
 					PhysicsServer3D::get_singleton()->area_set_space(rid, space);
 				} else {


### PR DESCRIPTION
Based on remark here: https://github.com/godotengine/godot/pull/54154#issuecomment-950154220

Prevents potential dereferencing of null pointer with get_world_3d.
