### PR TITLE
Use early bailing to improve 3D shadow filtering performance in GLES3

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1232,7 +1232,20 @@ LIGHT_SHADER_CODE
 float sample_shadow(highp sampler2DShadow shadow, vec2 shadow_pixel_size, vec2 pos, float depth, vec4 clamp_rect) {
 #ifdef SHADOW_MODE_PCF_13
 
-	float avg = textureProj(shadow, vec4(pos, depth, 1.0));
+	float avg = textureProj(shadow, vec4(pos + vec2(shadow_pixel_size.x * 2.0, 0.0), depth, 1.0));
+	avg += textureProj(shadow, vec4(pos + vec2(-shadow_pixel_size.x * 2.0, 0.0), depth, 1.0));
+	avg += textureProj(shadow, vec4(pos + vec2(0.0, shadow_pixel_size.y * 2.0), depth, 1.0));
+	avg += textureProj(shadow, vec4(pos + vec2(0.0, -shadow_pixel_size.y * 2.0), depth, 1.0));
+	// Early bail if distant samples are fully shaded (or none are shaded) to improve performance.
+	if (avg <= 0.000001) {
+		// None shaded at all.
+		return 0.0;
+	} else if (avg >= 3.999999) {
+		// All fully shaded.
+		return 1.0;
+	}
+
+	avg += textureProj(shadow, vec4(pos, depth, 1.0));
 	avg += textureProj(shadow, vec4(pos + vec2(shadow_pixel_size.x, 0.0), depth, 1.0));
 	avg += textureProj(shadow, vec4(pos + vec2(-shadow_pixel_size.x, 0.0), depth, 1.0));
 	avg += textureProj(shadow, vec4(pos + vec2(0.0, shadow_pixel_size.y), depth, 1.0));
@@ -1241,10 +1254,6 @@ float sample_shadow(highp sampler2DShadow shadow, vec2 shadow_pixel_size, vec2 p
 	avg += textureProj(shadow, vec4(pos + vec2(-shadow_pixel_size.x, shadow_pixel_size.y), depth, 1.0));
 	avg += textureProj(shadow, vec4(pos + vec2(shadow_pixel_size.x, -shadow_pixel_size.y), depth, 1.0));
 	avg += textureProj(shadow, vec4(pos + vec2(-shadow_pixel_size.x, -shadow_pixel_size.y), depth, 1.0));
-	avg += textureProj(shadow, vec4(pos + vec2(shadow_pixel_size.x * 2.0, 0.0), depth, 1.0));
-	avg += textureProj(shadow, vec4(pos + vec2(-shadow_pixel_size.x * 2.0, 0.0), depth, 1.0));
-	avg += textureProj(shadow, vec4(pos + vec2(0.0, shadow_pixel_size.y * 2.0), depth, 1.0));
-	avg += textureProj(shadow, vec4(pos + vec2(0.0, -shadow_pixel_size.y * 2.0), depth, 1.0));
 	return avg * (1.0 / 13.0);
 #endif
 


### PR DESCRIPTION
[Early bailing](https://www.opengl-tutorial.org/intermediate-tutorials/tutorial-16-shadow-mapping/#early-bailing) makes PCF13 much faster than it previously was. The performance difference between PCF5 and PCF13 is now much lower.

Subtle artifacts may be visible in shadow corners, but they're unnoticeable in actual gameplay (especially with textures added):

![image](https://user-images.githubusercontent.com/180032/138565304-4b7c1bef-6df2-4509-ae16-23197e6f20c4.png)

I've tried to implement a similar approach in the PCF16 filter used in GLES2, but I couldn't get a convincing result (even by making two extra samples to match the diamond pattern used by GLES3). It brought noticeable performance improvements just like in GLES3, still.

## Preview

*Performance metrics are included in the top-left corner of each screenshot.*

| Old PCF13 | New PCF13 | PCF5 (for comparison) | Disabled (for comparison) |
|-|-|-|-|
| ![2021-10-23_18 01 00](https://user-images.githubusercontent.com/180032/138564982-a54f228a-a6bd-4967-9ad4-cd72abd987d8.png) | ![2021-10-23_18 06 32](https://user-images.githubusercontent.com/180032/138564985-207126fc-c938-4a3d-8caf-52ad9e6046dd.png) | ![2021-10-23_18 02 48](https://user-images.githubusercontent.com/180032/138564983-9b6b4d55-4f2f-4ca8-8d7b-117ad77aeec5.png) | ![2021-10-23_18 04 00](https://user-images.githubusercontent.com/180032/138564984-4269625b-e85f-458f-a5c7-72287e80fb91.png) |

<details>
<summary>GLES2 (not included in this PR for quality reasons)</summary>

Just to give an idea of the performance improvements:

| Old PCF13 | New PCF13 | PCF5 (for comparison) | Disabled (for comparison) |
|-|-|-|-|
| ![2021-10-23_18 18 34](https://user-images.githubusercontent.com/180032/138565064-865e4b5c-ecf8-4935-b83b-522b15a231dc.png) | ![2021-10-23_18 36 47](https://user-images.githubusercontent.com/180032/138565069-ccf6c6bb-e830-40e9-a2a7-a8c2e0563111.png) | ![2021-10-23_18 18 59](https://user-images.githubusercontent.com/180032/138565065-0d357367-ead8-487c-b8bc-922603cc5f62.png) | ![2021-10-23_18 19 22](https://user-images.githubusercontent.com/180032/138565067-98ba5b28-74f8-4c27-bc2c-a2b42038d719.png) |
</details>