### PR TITLE
Remove add child call when creating an instance of the scene from the placeholder instance

### DIFF
--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -93,7 +93,6 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 		return nullptr;
 	}
 	scene->set_name(get_name());
-	int pos = get_index();
 
 	for (const PropSet &E : stored_values) {
 		scene->set(E.name, E.value);
@@ -103,9 +102,6 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 		queue_delete();
 		base->remove_child(this);
 	}
-
-	base->add_child(scene);
-	base->move_child(scene, pos);
 
 	return scene;
 }


### PR DESCRIPTION
This is the 4.0 version of the [3.x version](https://github.com/godotengine/godot/pull/54163)