### PR TITLE
Fixes a game crash caused by instantiating `Camera2D` and sending a notification

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -232,6 +232,7 @@ void Camera2D::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
+			ERR_FAIL_COND(!is_inside_tree());
 			if (custom_viewport && ObjectDB::get_instance(custom_viewport_id)) {
 				viewport = custom_viewport;
 			} else {

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -274,6 +274,7 @@ void CanvasItem::_exit_canvas() {
 void CanvasItem::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			ERR_FAIL_COND(!is_inside_tree());
 			_update_texture_filter_changed(false);
 			_update_texture_repeat_changed(false);
 


### PR DESCRIPTION
This prevents a game crash if a camera2D is instantiated and user calls the notification on it before adding it to the tree.

Fixes #54093.

This behavior also happens in 3.4 and probably all 3.x.