### PR TITLE
Changed the track type inserted into the animation by the Inspector key button

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -140,6 +140,14 @@ enum PropertyUsageFlags {
 	PROPERTY_USAGE_NO_EDITOR = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_NETWORK,
 };
 
+enum PropertyTrackType {
+	PROPERTY_TRACK_TYPE_VALUE,
+	PROPERTY_TRACK_TYPE_POSITION,
+	PROPERTY_TRACK_TYPE_ROTATION,
+	PROPERTY_TRACK_TYPE_SCALE,
+	PROPERTY_TRACK_TYPE_BLEND_SHAPE
+};
+
 #define ADD_SIGNAL(m_signal) ::ClassDB::add_signal(get_class_static(), m_signal)
 #define ADD_PROPERTY(m_property, m_setter, m_getter) ::ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter))
 #define ADD_PROPERTYI(m_property, m_setter, m_getter, m_index) ::ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter), m_index)
@@ -159,6 +167,7 @@ struct PropertyInfo {
 	PropertyHint hint = PROPERTY_HINT_NONE;
 	String hint_string;
 	uint32_t usage = PROPERTY_USAGE_DEFAULT;
+	PropertyTrackType track_type = PROPERTY_TRACK_TYPE_VALUE;
 
 #ifdef TOOLS_ENABLED
 	Vector<String> linked_properties;

--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -32,7 +32,9 @@
 			</description>
 		</signal>
 		<signal name="property_keyed">
-			<argument index="0" name="property" type="String" />
+			<argument index="0" name="object" type="Object" />
+			<argument index="1" name="property" type="String" />
+			<argument index="2" name="track_type" type="int" />
 			<description>
 				Emitted when a property is keyed in the inspector. Properties can be keyed by clicking the "key" icon next to a property when the Animation panel is toggled.
 			</description>

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -36,6 +36,7 @@
 #include "editor/property_editor.h"
 #include "editor/property_selector.h"
 
+#include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/control.h"
 #include "scene/gui/file_dialog.h"
 #include "scene/gui/menu_button.h"
@@ -280,6 +281,18 @@ public:
 class AnimationTrackEditor : public VBoxContainer {
 	GDCLASS(AnimationTrackEditor, VBoxContainer);
 
+public:
+	enum RotationOrder {
+		ROTATION_ORDER_XYZ,
+		ROTATION_ORDER_XZY,
+		ROTATION_ORDER_YXZ,
+		ROTATION_ORDER_YZX,
+		ROTATION_ORDER_ZXY,
+		ROTATION_ORDER_ZYX,
+		ROTATION_ORDER_QUATERNION
+	};
+
+private:
 	Ref<Animation> animation;
 	Node *root;
 
@@ -342,8 +355,10 @@ class AnimationTrackEditor : public VBoxContainer {
 	struct InsertData {
 		Animation::TrackType type;
 		NodePath path;
+		NodePath special_path; // For Pos/Rot/Scl/BlendShapes Track.
 		int track_idx = 0;
 		Variant value;
+		RotationOrder rotation_order = ROTATION_ORDER_QUATERNION;
 		String query;
 		bool advance = false;
 	}; /* insert_data;*/
@@ -355,7 +370,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	bool insert_queue;
 	List<InsertData> insert_data;
 
-	void _query_insert(const InsertData &p_id);
+	void _query_insert(const InsertData &p_id, const bool p_bezier_enabled = true);
 	Ref<Animation> _create_and_get_reset_animation();
 	void _confirm_insert_list();
 	struct TrackIndices {
@@ -530,10 +545,11 @@ public:
 	void set_anim_pos(float p_pos);
 	void insert_node_value_key(Node *p_node, const String &p_property, const Variant &p_value, bool p_only_if_exists = false);
 	void insert_value_key(const String &p_property, const Variant &p_value, bool p_advance);
-	void insert_transform_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant p_value);
+	void insert_transform_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant p_value, const RotationOrder p_rotation_order = ROTATION_ORDER_QUATERNION);
+	void insert_blend_shape_key(MeshInstance3D *p_mesh_instance, const int p_blend_shape_id, const Variant p_value);
 	bool has_track(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type);
 	void make_insert_queue();
-	void commit_insert_queue();
+	void commit_insert_queue(const bool p_bezier_enabled = true);
 
 	void show_select_node_warning(bool p_show);
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -38,6 +38,7 @@
 #include "scene/gui/panel_container.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/texture_rect.h"
+#include "scene/resources/animation.h"
 
 class UndoRedo;
 
@@ -70,6 +71,7 @@ private:
 	StringName property;
 
 	int property_usage;
+	PropertyTrackType property_track_type;
 
 	bool read_only;
 	bool checkable;
@@ -463,8 +465,8 @@ class EditorInspector : public ScrollContainer {
 
 	void _property_changed(const String &p_path, const Variant &p_value, const String &p_name = "", bool p_changing = false, bool p_update_all = false);
 	void _multiple_properties_changed(Vector<String> p_paths, Array p_values, bool p_changing = false);
-	void _property_keyed(const String &p_path, bool p_advance);
-	void _property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance);
+	void _property_keyed(const String &p_path, const Animation::TrackType p_track_type, bool p_advance);
+	void _property_keyed_with_value(const String &p_path, const Animation::TrackType p_track_type, const Variant &p_value, bool p_advance);
 	void _property_deleted(const String &p_path);
 	void _property_checked(const String &p_path, bool p_checked);
 	void _property_pinned(const String &p_path, bool p_pinned);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -382,8 +382,48 @@ void InspectorDock::_menu_expandall() {
 	inspector->expand_all_folding();
 }
 
-void InspectorDock::_property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance) {
-	AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_value_key(p_keyed, p_value, p_advance);
+void InspectorDock::_property_keyed(Object *sp, const String &p_keyed, const Animation::TrackType p_type, const Variant &p_value, bool p_advance) {
+	switch (p_type) {
+		case Animation::TYPE_POSITION_3D: {
+			Node3D *s = Object::cast_to<Node3D>(sp);
+			if (!s) {
+				return;
+			}
+			AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_transform_key(s, "", Animation::TYPE_POSITION_3D, p_value);
+			return;
+		} break;
+		case Animation::TYPE_ROTATION_3D: {
+			Node3D *s = Object::cast_to<Node3D>(sp);
+			if (!s) {
+				return;
+			}
+			AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_transform_key(
+					s, "", Animation::TYPE_ROTATION_3D, p_value,
+					s->get_rotation_edit_mode() == Node3D::ROTATION_EDIT_MODE_EULER ? static_cast<AnimationTrackEditor::RotationOrder>(s->get_rotation_order()) : AnimationTrackEditor::ROTATION_ORDER_QUATERNION);
+			return;
+		} break;
+		case Animation::TYPE_SCALE_3D: {
+			Node3D *s = Object::cast_to<Node3D>(sp);
+			if (!s) {
+				return;
+			}
+			AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_transform_key(s, "", Animation::TYPE_SCALE_3D, p_value);
+			return;
+		} break;
+		case Animation::TYPE_BLEND_SHAPE: {
+			MeshInstance3D *m = Object::cast_to<MeshInstance3D>(sp);
+			if (!m) {
+				return;
+			}
+			PackedStringArray split = p_keyed.split("/");
+			int blend_shape_id = split[split.size() - 1].to_int();
+			AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_blend_shape_key(m, blend_shape_id, p_value);
+			return;
+		} break;
+		default: {
+			AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_value_key(p_keyed, p_value, p_advance);
+		} break;
+	}
 }
 
 void InspectorDock::_transform_keyed(Object *sp, const String &p_sub, const Transform3D &p_key) {

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -118,7 +118,7 @@ class InspectorDock : public VBoxContainer {
 	void _select_history(int p_idx);
 	void _prepare_history();
 
-	void _property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance);
+	void _property_keyed(Object *sp, const String &p_keyed, const Animation::TrackType p_type, const Variant &p_value, bool p_advance);
 	void _transform_keyed(Object *sp, const String &p_sub, const Transform3D &p_key);
 
 protected:

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -147,7 +147,7 @@ void BoneTransformEditor::set_target(const String &p_prop) {
 	rest_matrix->update_property();
 }
 
-void BoneTransformEditor::_property_keyed(const String &p_path, bool p_advance) {
+void BoneTransformEditor::_property_keyed(const String &p_path, const Animation::TrackType p_track_type, bool p_advance) {
 	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
 	PackedStringArray split = p_path.split("/");
 	if (split.size() == 3 && split[0] == "bones") {
@@ -320,7 +320,7 @@ void Skeleton3DEditor::insert_keys(const bool p_all_bones) {
 			te->insert_transform_key(skeleton, name, Animation::TYPE_SCALE_3D, skeleton->get_bone_pose_scale(i));
 		}
 	}
-	te->commit_insert_queue();
+	te->commit_insert_queue(false);
 }
 
 void Skeleton3DEditor::pose_to_rest(const bool p_all_bones) {

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -75,7 +75,7 @@ class BoneTransformEditor : public VBoxContainer {
 
 	void _value_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing);
 
-	void _property_keyed(const String &p_path, bool p_advance);
+	void _property_keyed(const String &p_path, const Animation::TrackType p_track_type, bool p_advance);
 
 protected:
 	void _notification(int p_what);

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -576,7 +576,9 @@ void CSGShape3D::_validate_property(PropertyInfo &property) const {
 	} else if (is_collision_prefixed && !bool(get("use_collision"))) {
 		property.usage = PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL;
 	}
+
 	GeometryInstance3D::_validate_property(property);
+	Node3D::_validate_property(property);
 }
 
 Array CSGShape3D::get_meshes() const {

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -631,6 +631,7 @@ void Area3D::_validate_property(PropertyInfo &property) const {
 	}
 
 	CollisionObject3D::_validate_property(property);
+	Node3D::_validate_property(property);
 }
 
 void Area3D::_bind_methods() {

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -160,7 +160,9 @@ void Decal::_validate_property(PropertyInfo &property) const {
 	if (!distance_fade_enabled && (property.name == "distance_fade_begin" || property.name == "distance_fade_length")) {
 		property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
+
 	VisualInstance3D::_validate_property(property);
+	Node3D::_validate_property(property);
 }
 
 TypedArray<String> Decal::get_configuration_warnings() const {

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -390,6 +390,7 @@ void GPUParticles3D::_validate_property(PropertyInfo &property) const {
 	}
 
 	GeometryInstance3D::_validate_property(property);
+	Node3D::_validate_property(property);
 }
 
 void GPUParticles3D::emit_particle(const Transform3D &p_transform, const Vector3 &p_velocity, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) {

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -204,7 +204,9 @@ void Light3D::_validate_property(PropertyInfo &property) const {
 		// Angular distance is only used in DirectionalLight3D.
 		property.usage = PROPERTY_USAGE_NONE;
 	}
+
 	VisualInstance3D::_validate_property(property);
+	Node3D::_validate_property(property);
 }
 
 void Light3D::_bind_methods() {

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1371,7 +1371,9 @@ void LightmapGI::_validate_property(PropertyInfo &property) const {
 	if (property.name == "environment_custom_energy" && environment_mode != ENVIRONMENT_MODE_CUSTOM_COLOR && environment_mode != ENVIRONMENT_MODE_CUSTOM_SKY) {
 		property.usage = PROPERTY_USAGE_NONE;
 	}
+
 	VisualInstance3D::_validate_property(property);
+	Node3D::_validate_property(property);
 }
 
 void LightmapGI::_bind_methods() {

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -507,6 +507,16 @@ void MeshInstance3D::_bind_methods() {
 	ADD_GROUP("", "");
 }
 
+void MeshInstance3D::_validate_property(PropertyInfo &property) const {
+	PackedStringArray split = property.name.split("/");
+	if (split.size() == 2 && split[0] == "blend_shapes") {
+		property.track_type = PROPERTY_TRACK_TYPE_BLEND_SHAPE;
+	}
+
+	GeometryInstance3D::_validate_property(property);
+	Node3D::_validate_property(property);
+}
+
 MeshInstance3D::MeshInstance3D() {
 }
 

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -60,6 +60,7 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &property) const override;
 
 public:
 	void set_mesh(const Ref<Mesh> &p_mesh);

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -836,12 +836,27 @@ void Node3D::_validate_property(PropertyInfo &property) const {
 	}
 	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_QUATERNION && property.name == "quaternion") {
 		property.usage = 0;
+		property.track_type = PROPERTY_TRACK_TYPE_ROTATION;
 	}
 	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_EULER && property.name == "rotation") {
 		property.usage = 0;
+		property.track_type = PROPERTY_TRACK_TYPE_ROTATION;
 	}
 	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_EULER && property.name == "rotation_order") {
 		property.usage = 0;
+	}
+
+	if (property.name == "position") {
+		property.track_type = PROPERTY_TRACK_TYPE_POSITION;
+	}
+	if (property.name == "rotation") {
+		property.track_type = PROPERTY_TRACK_TYPE_ROTATION;
+	}
+	if (property.name == "quaternion") {
+		property.track_type = PROPERTY_TRACK_TYPE_ROTATION;
+	}
+	if (property.name == "scale") {
+		property.track_type = PROPERTY_TRACK_TYPE_SCALE;
 	}
 }
 

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -134,8 +134,7 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
-
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &property) const override;
 
 public:
 	enum {

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -248,6 +248,7 @@ void PathFollow3D::_validate_property(PropertyInfo &property) const {
 
 		property.hint_string = "0," + rtos(max) + ",0.01,or_lesser,or_greater";
 	}
+
 	Node3D::_validate_property(property);
 }
 

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1140,7 +1140,9 @@ void RigidDynamicBody3D::_validate_property(PropertyInfo &property) const {
 			property.usage = PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL;
 		}
 	}
+
 	PhysicsBody3D::_validate_property(property);
+	Node3D::_validate_property(property);
 }
 
 RigidDynamicBody3D::RigidDynamicBody3D() :

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -188,7 +188,9 @@ void ReflectionProbe::_validate_property(PropertyInfo &property) const {
 			property.usage = PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL;
 		}
 	}
+
 	VisualInstance3D::_validate_property(property);
+	Node3D::_validate_property(property);
 }
 
 void ReflectionProbe::_bind_methods() {

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -746,6 +746,7 @@ void Sprite3D::_validate_property(PropertyInfo &property) const {
 	}
 
 	SpriteBase3D::_validate_property(property);
+	Node3D::_validate_property(property);
 }
 
 void Sprite3D::_bind_methods() {


### PR DESCRIPTION
Note: RotationTrack insertion is broken. Euler and Quaternion conversions are needed, but maybe #54084 merge is needed for them.

---

For performance considerations, the following 4 track types have been added to the animation by #53689 and #53865.

- Position3DTrack
- Rotation3DTrack
- Scale3DTrack
- BlendShapeTrack

However, the insertion of tracks from the Inspector's key buttons is still only allowed for ValueTrack or BezierTrack. BezierTrack still has its place, but for certain properties, we will change it to insert a new type of track instead of ValueTrack.

Although, there is no foolproof mechanism implemented to prevent ValueTrack from being directly generated or the pathname of ValueTrack from being rewritten by user interaction, it is outside the scope of this PR.