### PR TITLE
Clamp ratio from popup_centered_ratio

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1025,6 +1025,7 @@ void Window::popup_centered(const Size2i &p_minsize) {
 void Window::popup_centered_ratio(float p_ratio) {
 	ERR_FAIL_COND(!is_inside_tree());
 	ERR_FAIL_COND_MSG(window_id == DisplayServer::MAIN_WINDOW_ID, "Can't popup the main window.");
+	ERR_FAIL_COND_MSG(p_ratio <= 0.0 || p_ratio > 1.0, "Ratio must be between 0.0 and 1.0!");
 
 	Rect2 parent_rect;
 


### PR DESCRIPTION
Fixes #53566

Prevents ridiculous sizes when creating windows this way, which can cause issues *(in my case the compositor just died when running the example :stuck_out_tongue:)*