### PR TITLE
Fix: don't allow the editor to revert PackedScene properties

### DIFF
--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -102,6 +102,13 @@
 				Pack will ignore any sub-nodes not owned by given node. See [member Node.owner].
 			</description>
 		</method>
+		<method name="property_can_revert">
+			<return type="bool" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Returns [code]true[/code] if the property identified by [code]name[/code] can be reverted to a default value.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" default="{&quot;conn_count&quot;: 0,&quot;conns&quot;: PackedInt32Array(),&quot;editable_instances&quot;: [],&quot;names&quot;: PackedStringArray(),&quot;node_count&quot;: 0,&quot;node_paths&quot;: [],&quot;nodes&quot;: PackedInt32Array(),&quot;variants&quot;: [],&quot;version&quot;: 2}">

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1688,6 +1688,12 @@ void PackedScene::set_path(const String &p_path, bool p_take_over) {
 void PackedScene::reset_state() {
 	clear();
 }
+
+bool PackedScene::property_can_revert(const String &p_name) {
+	// Don't let the editor revert scene properties since this can break linked scenes.
+	return true;
+}
+
 void PackedScene::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("pack", "path"), &PackedScene::pack);
 	ClassDB::bind_method(D_METHOD("instantiate", "edit_state"), &PackedScene::instantiate, DEFVAL(GEN_EDIT_STATE_DISABLED));
@@ -1695,6 +1701,7 @@ void PackedScene::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_bundled_scene"), &PackedScene::_set_bundled_scene);
 	ClassDB::bind_method(D_METHOD("_get_bundled_scene"), &PackedScene::_get_bundled_scene);
 	ClassDB::bind_method(D_METHOD("get_state"), &PackedScene::get_state);
+	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &PackedScene::property_can_revert);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_bundled"), "_set_bundled_scene", "_get_bundled_scene");
 

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -198,9 +198,10 @@ class PackedScene : public Resource {
 	Dictionary _get_bundled_scene() const;
 
 protected:
-	virtual bool editor_can_reload_from_file() override { return false; } // this is handled by editor better
+	virtual bool editor_can_reload_from_file() override { return false; } // This is handled by editor better.
 	static void _bind_methods();
 	virtual void reset_state() override;
+	bool property_can_revert(const String &p_name);
 
 public:
 	enum GenEditState {


### PR DESCRIPTION
Reverting the _bundle property of PackedScene breaks the linked scene file since it removes all nodes in the file, which doesn't make much sense. This PR simply disables reverting the properties of PackedScene through the editor, which also fixes #54047 .