### PR TITLE
Fudge irradiance map lookup to avoid precision issues

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1938,7 +1938,7 @@ FRAGMENT_SHADER_CODE
 		norm = normalize((radiance_inverse_xform * vec4(norm, 0.0)).xyz);
 		norm.xy /= 1.0 + abs(norm.z);
 		norm.xy = norm.xy * vec2(0.5, 0.25) + vec2(0.5, 0.25);
-		if (norm.z > 0.0) {
+		if (norm.z > 0.0001) {
 			norm.y = 0.5 - norm.y + 0.5;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/40350 and fixes https://github.com/godotengine/godot/issues/54180

It looks like there are some precision errors around the seam of the irradiance dual paraboloid map in GLES3. A simple fudge value avoids the error. the user in https://github.com/godotengine/godot/issues/40350 confirmed the fix. I also confirmed that the fix fixes the MRP in https://github.com/godotengine/godot/issues/54180