### PR TITLE
SCons: Fix import for collections Mapping

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1,9 +1,9 @@
-import collections
 import os
 import re
 import glob
 import subprocess
 from collections import OrderedDict
+from collections.abc import Mapping
 from typing import Iterator
 
 # We need to define our own `Action` method to control the verbosity of output
@@ -662,7 +662,7 @@ def generate_vs_project(env, num_jobs):
     batch_file = find_visual_c_batch_file(env)
     if batch_file:
 
-        class ModuleConfigs(collections.Mapping):
+        class ModuleConfigs(Mapping):
             # This version information (Win32, x64, Debug, Release, Release_Debug seems to be
             # required for Visual Studio to understand that it needs to generate an NMAKE
             # project. Do not modify without knowing what you are doing.


### PR DESCRIPTION
Fixes #54200

Mapping and other "abstract base classes" were moved after python 3.3 from collections to collections.abc
Python 3.3 is long gone and a newer version of python won't support this code.