### PR TITLE
Fixed incorrect blending in Pos/Rot/Scl Track

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -936,15 +936,14 @@ void AnimationTree::_process_graph(real_t p_delta) {
 #ifndef _3D_DISABLED
 						TrackCacheTransform *t = static_cast<TrackCacheTransform *>(track);
 
-						if (t->process_pass != process_pass) {
-							t->process_pass = process_pass;
-							t->loc = Vector3();
-							t->rot = Quaternion();
-							t->rot_blend_accum = 0;
-							t->scale = Vector3(1, 1, 1);
-						}
-
 						if (track->root_motion) {
+							if (t->process_pass != process_pass) {
+								t->process_pass = process_pass;
+								t->loc = Vector3();
+								t->rot = Quaternion();
+								t->scale = Vector3(1, 1, 1);
+							}
+
 							double prev_time = time - delta;
 							if (!backward) {
 								if (prev_time < 0) {
@@ -1017,6 +1016,12 @@ void AnimationTree::_process_graph(real_t p_delta) {
 							Vector3 loc;
 
 							Error err = a->position_track_interpolate(i, time, &loc);
+
+							if (t->process_pass != process_pass) {
+								t->process_pass = process_pass;
+								t->loc = loc;
+							}
+
 							if (err != OK) {
 								continue;
 							}
@@ -1029,15 +1034,14 @@ void AnimationTree::_process_graph(real_t p_delta) {
 #ifndef _3D_DISABLED
 						TrackCacheTransform *t = static_cast<TrackCacheTransform *>(track);
 
-						if (t->process_pass != process_pass) {
-							t->process_pass = process_pass;
-							t->loc = Vector3();
-							t->rot = Quaternion();
-							t->rot_blend_accum = 0;
-							t->scale = Vector3(1, 1, 1);
-						}
-
 						if (track->root_motion) {
+							if (t->process_pass != process_pass) {
+								t->process_pass = process_pass;
+								t->loc = Vector3();
+								t->rot = Quaternion();
+								t->scale = Vector3(1, 1, 1);
+							}
+
 							double prev_time = time - delta;
 							if (!backward) {
 								if (prev_time < 0) {
@@ -1113,18 +1117,17 @@ void AnimationTree::_process_graph(real_t p_delta) {
 							Quaternion rot;
 
 							Error err = a->rotation_track_interpolate(i, time, &rot);
+
+							if (t->process_pass != process_pass) {
+								t->process_pass = process_pass;
+								t->rot = rot;
+							}
+
 							if (err != OK) {
 								continue;
 							}
 
-							if (t->rot_blend_accum == 0) {
-								t->rot = rot;
-								t->rot_blend_accum = blend;
-							} else {
-								real_t rot_total = t->rot_blend_accum + blend;
-								t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
-								t->rot_blend_accum = rot_total;
-							}
+							t->rot = t->rot.slerp(rot, blend).normalized();
 						}
 #endif // _3D_DISABLED
 					} break;
@@ -1132,15 +1135,14 @@ void AnimationTree::_process_graph(real_t p_delta) {
 #ifndef _3D_DISABLED
 						TrackCacheTransform *t = static_cast<TrackCacheTransform *>(track);
 
-						if (t->process_pass != process_pass) {
-							t->process_pass = process_pass;
-							t->loc = Vector3();
-							t->rot = Quaternion();
-							t->rot_blend_accum = 0;
-							t->scale = Vector3(1, 1, 1);
-						}
-
 						if (track->root_motion) {
+							if (t->process_pass != process_pass) {
+								t->process_pass = process_pass;
+								t->loc = Vector3();
+								t->rot = Quaternion();
+								t->scale = Vector3(1, 1, 1);
+							}
+
 							double prev_time = time - delta;
 							if (!backward) {
 								if (prev_time < 0) {
@@ -1213,6 +1215,12 @@ void AnimationTree::_process_graph(real_t p_delta) {
 							Vector3 scale;
 
 							Error err = a->scale_track_interpolate(i, time, &scale);
+
+							if (t->process_pass != process_pass) {
+								t->process_pass = process_pass;
+								t->scale = scale;
+							}
+
 							if (err != OK) {
 								continue;
 							}

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -199,7 +199,6 @@ private:
 		bool scale_used = false;
 		Vector3 loc;
 		Quaternion rot;
-		real_t rot_blend_accum = 0.0;
 		Vector3 scale;
 
 		TrackCacheTransform() {


### PR DESCRIPTION
Fixed #54407.
Fixed #55838.

Follow up of #53689. The process of `if (t->process_pass ! = process_pass)` needs to be separated between the root motion and others.

Before:

https://user-images.githubusercontent.com/61938263/138614322-479ce285-0116-4891-a370-009dc67e8728.mov

After:

https://user-images.githubusercontent.com/61938263/138614230-2add698e-7569-4ad7-8681-dc5e670c7397.mov
