### PR TITLE
clang-format: Enable `--Wno-error=unknown` for compat with older versions

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -22,9 +22,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -qq dos2unix recode clang-format-11
+          sudo apt-get install -qq dos2unix recode clang-format-12
           sudo update-alternatives --remove-all clang-format
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100
           sudo pip3 install black==20.8b1 pygments
 
       - name: File formatting checks (file_format.sh)

--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -76,7 +76,7 @@ fi
 
 # To get consistent formatting, we recommend contributors to use the same
 # clang-format version as CI.
-RECOMMENDED_CLANG_FORMAT_MAJOR_MIN="11"
+RECOMMENDED_CLANG_FORMAT_MAJOR_MIN="12"
 RECOMMENDED_CLANG_FORMAT_MAJOR_MAX="13"
 
 if [ ! -x "$CLANG_FORMAT" ] ; then
@@ -146,7 +146,7 @@ do
     #    +++ - timestamp
     # to both lines working on the same file and having a/ and b/ prefix.
     # Else it can not be applied with 'git apply'.
-    "$CLANG_FORMAT" -style=file "$file" | \
+    "$CLANG_FORMAT" -style=file "$file" --Wno-error=unknown | \
         diff -u "$file" - | \
         sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
 done

--- a/misc/scripts/clang_format.sh
+++ b/misc/scripts/clang_format.sh
@@ -23,7 +23,7 @@ while IFS= read -rd '' f; do
     for extension in ${CLANG_FORMAT_FILE_EXTS[@]}; do
         if [[ "$f" == *"$extension" ]]; then
             # Run clang-format.
-            clang-format -i "$f"
+            clang-format --Wno-error=unknown -i "$f"
             # Fix copyright headers, but not all files get them.
             if [[ "$f" == *"inc" ]]; then
                 continue 2


### PR DESCRIPTION
This prevents errors when encountering options which have been defined in newer
versions of clang-format, and are invalid in the YAML for the old version.

Bump minimum supported clang-format version to 12 (where `--Wno-error=unknown`
was added).

Use clang-format 12 on CI (13 is not available yet on the Ubuntu 20.04 images).

Follow-up to #54133 which broke the CI checks (but it broke silently so I hadn't noticed...).