### PR TITLE
Prevent windows from disabling local input handling

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2927,6 +2927,7 @@ bool Viewport::is_input_handled() const {
 }
 
 void Viewport::set_handle_input_locally(bool p_enable) {
+	ERR_FAIL_COND_MSG(!p_enable && Object::cast_to<Window>(this), "Windows must handle input!");
 	handle_input_locally = p_enable;
 }
 


### PR DESCRIPTION
Viewports can disable local input handling, delegating the responsibility
to handle inputs to viewports higher up the tree. Disallow this for windows
as the input events are dispatched on a per-window basis and hence windows
don't have anyone to delegate the event handling to.

This is my understanding of the current input event dispatch model anyway,
so please correct me if I'm wrong.

Fixes #53560