### PR TITLE
GDScript: Support multiline indexing with `[]`

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1223,7 +1223,9 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 
 				tokenizer->advance(1);
 
+				parenthesis++;
 				Node *subexpr = _parse_expression(op, p_static, p_allow_assign, p_parsing_constant);
+				parenthesis--;
 				if (!subexpr) {
 					return nullptr;
 				}


### PR DESCRIPTION
Fixes #35417.

This is the fix that was suggested by @bojidar-bg in #35417, and which was used recently on @vnen's advice for `preload()`: #52521.

Tested with:
```gdscript
func foo(p):
	return p[
		1 +
		3
		-2
	]

func _ready():
	print(foo([0, 1, 2, 3])) # 2
```