### PR TITLE
Fixes crash occuring when inserting -1 as bone index in `Skeleton3D`

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -612,6 +612,9 @@ Vector<int> Skeleton3D::get_bone_children(int p_bone) {
 void Skeleton3D::set_bone_children(int p_bone, Vector<int> p_children) {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
+	for (int idx : p_children) {
+		ERR_FAIL_INDEX(idx, bones.size());
+	}
 	bones.write[p_bone].child_bones = p_children;
 
 	process_order_dirty = true;


### PR DESCRIPTION
Looping though all indices feels a bit strange but not sure if there is an other way to address this bug.

Fixes https://github.com/godotengine/godot/issues/53646