### PR TITLE
Only show relevant properties in the DirectionalLight inspector (3.x)

### DIFF
--- a/doc/classes/DirectionalLight.xml
+++ b/doc/classes/DirectionalLight.xml
@@ -13,16 +13,16 @@
 	</methods>
 	<members>
 		<member name="directional_shadow_bias_split_scale" type="float" setter="set_param" getter="get_param" default="0.25">
-			Amount of extra bias for shadow splits that are far away. If self-shadowing occurs only on the splits far away, increasing this value can fix them.
+			Amount of extra bias for shadow splits that are far away. If self-shadowing occurs only on the splits far away, increasing this value can fix them. This is ignored when [member directional_shadow_mode] is [constant SHADOW_ORTHOGONAL].
 		</member>
 		<member name="directional_shadow_blend_splits" type="bool" setter="set_blend_splits" getter="is_blend_splits_enabled" default="false">
-			If [code]true[/code], shadow detail is sacrificed in exchange for smoother transitions between splits.
+			If [code]true[/code], shadow detail is sacrificed in exchange for smoother transitions between splits. Enabling shadow blend splitting also has a moderate performance cost. This is ignored when [member directional_shadow_mode] is [constant SHADOW_ORTHOGONAL].
 		</member>
 		<member name="directional_shadow_depth_range" type="int" setter="set_shadow_depth_range" getter="get_shadow_depth_range" enum="DirectionalLight.ShadowDepthRange" default="0">
 			Optimizes shadow rendering for detail versus movement. See [enum ShadowDepthRange].
 		</member>
 		<member name="directional_shadow_max_distance" type="float" setter="set_param" getter="get_param" default="100.0">
-			The maximum distance for shadow splits.
+			The maximum distance for shadow splits. Increasing this value will make directional shadows visible from further away, at the cost of lower overall shadow detail and performance (since more objects need to be included in the directional shadow rendering).
 		</member>
 		<member name="directional_shadow_mode" type="int" setter="set_shadow_mode" getter="get_shadow_mode" enum="DirectionalLight.ShadowMode" default="2">
 			The light's shadow rendering algorithm. See [enum ShadowMode].
@@ -31,13 +31,13 @@
 			Can be used to fix special cases of self shadowing when objects are perpendicular to the light.
 		</member>
 		<member name="directional_shadow_split_1" type="float" setter="set_param" getter="get_param" default="0.1">
-			The distance from camera to shadow split 1. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [code]SHADOW_PARALLEL_2_SPLITS[/code] or [code]SHADOW_PARALLEL_4_SPLITS[/code].
+			The distance from camera to shadow split 1. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [constant SHADOW_PARALLEL_2_SPLITS] or [constant SHADOW_PARALLEL_4_SPLITS].
 		</member>
 		<member name="directional_shadow_split_2" type="float" setter="set_param" getter="get_param" default="0.2">
-			The distance from shadow split 1 to split 2. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [code]SHADOW_PARALLEL_2_SPLITS[/code] or [code]SHADOW_PARALLEL_4_SPLITS[/code].
+			The distance from shadow split 1 to split 2. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [constant SHADOW_PARALLEL_2_SPLITS] or [constant SHADOW_PARALLEL_4_SPLITS].
 		</member>
 		<member name="directional_shadow_split_3" type="float" setter="set_param" getter="get_param" default="0.5">
-			The distance from shadow split 2 to split 3. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [code]SHADOW_PARALLEL_4_SPLITS[/code].
+			The distance from shadow split 2 to split 3. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [constant SHADOW_PARALLEL_4_SPLITS].
 		</member>
 		<member name="shadow_bias" type="float" setter="set_param" getter="get_param" override="true" default="0.1" />
 	</members>

--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -331,6 +331,7 @@ Light::~Light() {
 void DirectionalLight::set_shadow_mode(ShadowMode p_mode) {
 	shadow_mode = p_mode;
 	VS::get_singleton()->light_directional_set_shadow_mode(light, VS::LightDirectionalShadowMode(p_mode));
+	property_list_changed_notify();
 }
 
 DirectionalLight::ShadowMode DirectionalLight::get_shadow_mode() const {
@@ -353,6 +354,20 @@ void DirectionalLight::set_blend_splits(bool p_enable) {
 
 bool DirectionalLight::is_blend_splits_enabled() const {
 	return blend_splits;
+}
+
+void DirectionalLight::_validate_property(PropertyInfo &property) const {
+	if (shadow_mode == SHADOW_ORTHOGONAL && (property.name == "directional_shadow_split_1" || property.name == "directional_shadow_blend_splits" || property.name == "directional_shadow_bias_split_scale")) {
+		// Split 2, split blending and bias split scale are only used with the PSSM 2 Splits and PSSM 4 Splits shadow modes.
+		property.usage = PROPERTY_USAGE_NOEDITOR;
+	}
+
+	if ((shadow_mode == SHADOW_ORTHOGONAL || shadow_mode == SHADOW_PARALLEL_2_SPLITS) && (property.name == "directional_shadow_split_2" || property.name == "directional_shadow_split_3")) {
+		// Splits 3 and 4 are only used with the PSSM 4 Splits shadow mode.
+		property.usage = PROPERTY_USAGE_NOEDITOR;
+	}
+
+	Light::_validate_property(property);
 }
 
 void DirectionalLight::_bind_methods() {

--- a/scene/3d/light.h
+++ b/scene/3d/light.h
@@ -152,6 +152,7 @@ private:
 
 protected:
 	static void _bind_methods();
+	virtual void _validate_property(PropertyInfo &property) const;
 
 public:
 	void set_shadow_mode(ShadowMode p_mode);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/54147.

Some split distance properties are unused depending on the current shadow mode. Also, Blend Splits and Bias Split Scale can only be used if the shadow mode is PSSM 2 Splits or PSSM 4 Splits.

## Preview (`3.x`)

https://user-images.githubusercontent.com/180032/138762043-1d6d006d-2be0-4ff2-96ff-b6255c865361.mp4