### PR TITLE
Fix properties being displayed when they shouldn't in DirectionalLight3D

### DIFF
--- a/doc/classes/DirectionalLight3D.xml
+++ b/doc/classes/DirectionalLight3D.xml
@@ -11,13 +11,13 @@
 	</tutorials>
 	<members>
 		<member name="directional_shadow_blend_splits" type="bool" setter="set_blend_splits" getter="is_blend_splits_enabled" default="false">
-			If [code]true[/code], shadow detail is sacrificed in exchange for smoother transitions between splits. Enabling shadow blend splitting also has a moderate performance cost. This is ignored when [member directional_shadow_mode] is [code]SHADOW_ORTHOGONAL[/code].
+			If [code]true[/code], shadow detail is sacrificed in exchange for smoother transitions between splits. Enabling shadow blend splitting also has a moderate performance cost. This is ignored when [member directional_shadow_mode] is [constant SHADOW_ORTHOGONAL].
 		</member>
 		<member name="directional_shadow_fade_start" type="float" setter="set_param" getter="get_param" default="0.8">
 			Proportion of [member directional_shadow_max_distance] at which point the shadow starts to fade. At [member directional_shadow_max_distance], the shadow will disappear. The default value is a balance between smooth fading and distant shadow visibility. If the camera moves fast and the [member directional_shadow_max_distance] is low, consider lowering [member directional_shadow_fade_start] below [code]0.8[/code] to make shadow transitions less noticeable. On the other hand, if you tuned [member directional_shadow_max_distance] to cover the entire scene, you can set [member directional_shadow_fade_start] to [code]1.0[/code] to prevent the shadow from fading in the distance (it will suddenly cut off instead).
 		</member>
 		<member name="directional_shadow_max_distance" type="float" setter="set_param" getter="get_param" default="100.0">
-			The maximum distance for shadow splits.
+			The maximum distance for shadow splits. Increasing this value will make directional shadows visible from further away, at the cost of lower overall shadow detail and performance (since more objects need to be included in the directional shadow rendering).
 		</member>
 		<member name="directional_shadow_mode" type="int" setter="set_shadow_mode" getter="get_shadow_mode" enum="DirectionalLight3D.ShadowMode" default="2">
 			The light's shadow rendering algorithm. See [enum ShadowMode].
@@ -26,13 +26,13 @@
 			Sets the size of the directional shadow pancake. The pancake offsets the start of the shadow's camera frustum to provide a higher effective depth resolution for the shadow. However, a high pancake size can cause artifacts in the shadows of large objects that are close to the edge of the frustum. Reducing the pancake size can help. Setting the size to [code]0[/code] turns off the pancaking effect.
 		</member>
 		<member name="directional_shadow_split_1" type="float" setter="set_param" getter="get_param" default="0.1">
-			The distance from camera to shadow split 1. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [code]SHADOW_PARALLEL_2_SPLITS[/code] or [code]SHADOW_PARALLEL_4_SPLITS[/code].
+			The distance from camera to shadow split 1. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [constant SHADOW_PARALLEL_2_SPLITS] or [constant SHADOW_PARALLEL_4_SPLITS].
 		</member>
 		<member name="directional_shadow_split_2" type="float" setter="set_param" getter="get_param" default="0.2">
-			The distance from shadow split 1 to split 2. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [code]SHADOW_PARALLEL_4_SPLITS[/code].
+			The distance from shadow split 1 to split 2. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [constant SHADOW_PARALLEL_4_SPLITS].
 		</member>
 		<member name="directional_shadow_split_3" type="float" setter="set_param" getter="get_param" default="0.5">
-			The distance from shadow split 2 to split 3. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [code]SHADOW_PARALLEL_4_SPLITS[/code].
+			The distance from shadow split 2 to split 3. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [constant SHADOW_PARALLEL_4_SPLITS].
 		</member>
 		<member name="shadow_bias" type="float" setter="set_param" getter="get_param" override="true" default="0.1" />
 		<member name="use_in_sky_only" type="bool" setter="set_sky_only" getter="is_sky_only" default="false">

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -361,7 +361,6 @@ DirectionalLight3D::ShadowMode DirectionalLight3D::get_shadow_mode() const {
 void DirectionalLight3D::set_blend_splits(bool p_enable) {
 	blend_splits = p_enable;
 	RS::get_singleton()->light_directional_set_blend_splits(light, p_enable);
-	notify_property_list_changed();
 }
 
 bool DirectionalLight3D::is_blend_splits_enabled() const {
@@ -379,12 +378,12 @@ bool DirectionalLight3D::is_sky_only() const {
 
 void DirectionalLight3D::_validate_property(PropertyInfo &property) const {
 	if (shadow_mode == SHADOW_ORTHOGONAL && (property.name == "directional_shadow_split_1" || property.name == "directional_shadow_blend_splits")) {
-		// Split 2 and split blending are only used with PSSM 2 Splits and PSSM 4 Splits shadow mode.
+		// Split 2 and split blending are only used with the PSSM 2 Splits and PSSM 4 Splits shadow modes.
 		property.usage = PROPERTY_USAGE_NOEDITOR;
 	}
 
 	if ((shadow_mode == SHADOW_ORTHOGONAL || shadow_mode == SHADOW_PARALLEL_2_SPLITS) && (property.name == "directional_shadow_split_2" || property.name == "directional_shadow_split_3")) {
-		// Splits 3 and 4 are only used with PSSM 4 Splits shadow mode.
+		// Splits 3 and 4 are only used with the PSSM 4 Splits shadow mode.
 		property.usage = PROPERTY_USAGE_NOEDITOR;
 	}
 
@@ -392,6 +391,8 @@ void DirectionalLight3D::_validate_property(PropertyInfo &property) const {
 		// Not implemented in DirectionalLight3D (`light_size` is replaced by `light_angular_distance`).
 		property.usage = PROPERTY_USAGE_NONE;
 	}
+
+	Light3D::_validate_property(property);
 }
 
 void DirectionalLight3D::_bind_methods() {


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/54239.

The parent `_validate_property()` wasn't called, which led to shadow properties being visible even if shadows were disabled on a DirectionalLight3D node.

This fix is already integrated in the `3.x` version: https://github.com/godotengine/godot/pull/54239