### PR TITLE
Added error macro to ensure non null parameter

### DIFF
--- a/scene/resources/skeleton_modification_stack_3d.cpp
+++ b/scene/resources/skeleton_modification_stack_3d.cpp
@@ -125,6 +125,7 @@ Ref<SkeletonModification3D> SkeletonModificationStack3D::get_modification(int p_
 }
 
 void SkeletonModificationStack3D::add_modification(Ref<SkeletonModification3D> p_mod) {
+	ERR_FAIL_NULL(p_mod);
 	p_mod->_setup_modification(this);
 	modifications.push_back(p_mod);
 }


### PR DESCRIPTION
Fixes #54233.

Used the null error macro (ERR_FAIL_NULL) to return the function avoiding the crash.