### PR TITLE
Save all 64 bits of get_ticks_msec()

### DIFF
--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -205,7 +205,7 @@ public:
 
 	void delay_usec(int p_usec) const;
 	void delay_msec(int p_msec) const;
-	uint32_t get_ticks_msec() const;
+	uint64_t get_ticks_msec() const;
 	uint64_t get_ticks_usec() const;
 
 	bool can_use_threads() const;

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -79,8 +79,8 @@ public:
 		ERR_FAIL_COND_V(p_buffer.size() == 0, 0);
 		int total_bandwidth = 0;
 
-		uint32_t timestamp = OS::get_singleton()->get_ticks_msec();
-		uint32_t final_timestamp = timestamp - 1000;
+		uint64_t timestamp = OS::get_singleton()->get_ticks_msec();
+		uint64_t final_timestamp = timestamp - 1000;
 
 		int i = (p_pointer + p_buffer.size() - 1) % p_buffer.size();
 

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -76,7 +76,7 @@ bool UndoRedo::_redo(bool p_execute) {
 }
 
 void UndoRedo::create_action(const String &p_name, MergeMode p_mode) {
-	uint32_t ticks = OS::get_singleton()->get_ticks_msec();
+	uint64_t ticks = OS::get_singleton()->get_ticks_msec();
 
 	if (action_level == 0) {
 		_discard_redo();

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -371,7 +371,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 	AudioDriverPulseAudio *ad = (AudioDriverPulseAudio *)p_udata;
 	unsigned int write_ofs = 0;
 	size_t avail_bytes = 0;
-	uint32_t default_device_msec = OS::get_singleton()->get_ticks_msec();
+	uint64_t default_device_msec = OS::get_singleton()->get_ticks_msec();
 
 	while (!ad->exit_thread) {
 		size_t read_bytes = 0;
@@ -463,7 +463,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
 		// If we're using the default device check that the current device is still the default
 		if (ad->device_name == "Default") {
-			uint32_t msec = OS::get_singleton()->get_ticks_msec();
+			uint64_t msec = OS::get_singleton()->get_ticks_msec();
 			if (msec > (default_device_msec + 1000)) {
 				String old_default_device = ad->default_device;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -562,9 +562,9 @@ void EditorNode::_notification(int p_what) {
 				last_checked_version = editor_data.get_undo_redo().get_version();
 			}
 
-			// update the animation frame of the update spinner
+			// Update the animation frame of the update spinner.
 			uint64_t frame = Engine::get_singleton()->get_frames_drawn();
-			uint32_t tick = OS::get_singleton()->get_ticks_msec();
+			uint64_t tick = OS::get_singleton()->get_ticks_msec();
 
 			if (frame != update_spinner_step_frame && (tick - update_spinner_step_msec) > (1000 / 8)) {
 				update_spinner_step++;
@@ -575,7 +575,7 @@ void EditorNode::_notification(int p_what) {
 				update_spinner_step_msec = tick;
 				update_spinner_step_frame = frame + 1;
 
-				// update the icon itself only when the spinner is visible
+				// Update the icon itself only when the spinner is visible.
 				if (EditorSettings::get_singleton()->get("interface/editor/show_update_spinner")) {
 					update_spinner->set_icon(gui_base->get_theme_icon("Progress" + itos(update_spinner_step + 1), SNAME("EditorIcons")));
 				}

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -407,7 +407,7 @@ private:
 
 	bool waiting_for_sources_changed;
 
-	uint32_t update_spinner_step_msec;
+	uint64_t update_spinner_step_msec;
 	uint64_t update_spinner_step_frame;
 	int update_spinner_step;
 

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -148,11 +148,11 @@ void FindInFiles::_process() {
 	// This part can be moved to a thread if needed
 
 	OS &os = *OS::get_singleton();
-	float time_before = os.get_ticks_msec();
+	uint64_t time_before = os.get_ticks_msec();
 	while (is_processing()) {
 		_iterate();
-		float elapsed = (os.get_ticks_msec() - time_before);
-		if (elapsed > 1000.0 / 120.0) {
+		uint64_t elapsed = (os.get_ticks_msec() - time_before);
+		if (elapsed > 8) { // Process again after waiting 8 ticks
 			break;
 		}
 	}

--- a/modules/websocket/wsl_server.h
+++ b/modules/websocket/wsl_server.h
@@ -53,7 +53,7 @@ private:
 		Ref<StreamPeer> connection;
 		bool use_ssl = false;
 
-		int time = 0;
+		uint64_t time = 0;
 		uint8_t req_buf[WSL_MAX_HEADER_SIZE] = {};
 		int req_pos = 0;
 		String key;


### PR DESCRIPTION
I noticed that in some cases the return value of `OS.get_ticks_msec()`, which was changed to 64 bits, was still stored in 32 bit ints or floats in some places.

This seems like an oversight. :)

~~There is also one more cases in Godot's enet bindings:
https://github.com/godotengine/godot/blob/master/thirdparty/enet/godot.cpp#L402-L408~~

~~However I'm not sure whether we want to change that, as it uses `enet_uint32` as the type in `enet.h`:
https://github.com/godotengine/godot/blob/master/thirdparty/enet/enet/enet.h#L494-L502~~

~~Probably something for @Faless to take a look at :)~~
Edit: the above is probably fine/a different issue according to the discussion on Rocketchat.