### PR TITLE
[Text Server] Add functions for getting name and font style from dynamic and bitmap fonts.

### DIFF
--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -93,6 +93,18 @@
 				Returns font descent (number of pixels below the baseline).
 			</description>
 		</method>
+		<method name="get_font_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns font family name.
+			</description>
+		</method>
+		<method name="get_font_style" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns font style flags, see [enum TextServer.FontStyle].
+			</description>
+		</method>
 		<method name="get_glyph_advance" qualifiers="const">
 			<return type="Vector2" />
 			<argument index="0" name="cache_index" type="int" />
@@ -461,6 +473,20 @@
 			<argument index="2" name="descent" type="float" />
 			<description>
 				Sets the font descent (number of pixels below the baseline).
+			</description>
+		</method>
+		<method name="set_font_name">
+			<return type="void" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Sets the font family name.
+			</description>
+		</method>
+		<method name="set_font_style">
+			<return type="void" />
+			<argument index="0" name="style" type="int" />
+			<description>
+				Sets the font style flags, see [enum TextServer.FontStyle].
 			</description>
 		</method>
 		<method name="set_force_autohinter">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -254,6 +254,13 @@
 				Returns source font size used to generate MSDF textures.
 			</description>
 		</method>
+		<method name="font_get_name" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font family name.
+			</description>
+		</method>
 		<method name="font_get_oversampling" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -298,6 +305,13 @@
 			<argument index="2" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
 				Returns extra spacing added between glyphs in pixels.
+			</description>
+		</method>
+		<method name="font_get_style" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font style flags, see [enum FontStyle].
 			</description>
 		</method>
 		<method name="font_get_supported_chars" qualifiers="const">
@@ -634,6 +648,14 @@
 				[b]Note:[/b] MSDF font rendering does not render glyphs with overlapping shapes correctly. Overlapping shapes are not valid per the OpenType standard, but are still commonly found in many font files, especially those converted by Google Fonts. To avoid issues with overlapping glyphs, consider downloading the font file directly from the type foundry instead of relying on Google Fonts.
 			</description>
 		</method>
+		<method name="font_set_name">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="name" type="String" />
+			<description>
+				Sets the font family name.
+			</description>
+		</method>
 		<method name="font_set_oversampling">
 			<return type="void" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -668,6 +690,14 @@
 			<argument index="3" name="value" type="int" />
 			<description>
 				Sets extra spacing added between glyphs in pixels.
+			</description>
+		</method>
+		<method name="font_set_style">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="style" type="int" />
+			<description>
+				Sets the font style flags, see [enum FontStyle].
 			</description>
 		</method>
 		<method name="font_set_texture_image">
@@ -1394,6 +1424,15 @@
 		</constant>
 		<constant name="SPACING_BOTTOM" value="3" enum="SpacingType">
 			Spacing at the bottom of the line.
+		</constant>
+		<constant name="FONT_BOLD" value="1" enum="FontStyle">
+			Font is bold.
+		</constant>
+		<constant name="FONT_ITALIC" value="2" enum="FontStyle">
+			Font is italic or oblique.
+		</constant>
+		<constant name="FONT_FIXED_WIDTH" value="4" enum="FontStyle">
+			Font have fixed-width characters.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -254,6 +254,13 @@
 				Returns source font size used to generate MSDF textures.
 			</description>
 		</method>
+		<method name="_font_get_name" qualifiers="virtual const">
+			<return type="String" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font family name.
+			</description>
+		</method>
 		<method name="_font_get_oversampling" qualifiers="virtual const">
 			<return type="float" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -298,6 +305,13 @@
 			<argument index="2" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
 				Returns extra spacing added between glyphs in pixels.
+			</description>
+		</method>
+		<method name="_font_get_style" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font style flags, see [enum TextServer.FontStyle].
 			</description>
 		</method>
 		<method name="_font_get_supported_chars" qualifiers="virtual const">
@@ -641,6 +655,14 @@
 				If set to [code]true[/code], glyphs of all sizes are rendered using single multichannel signed distance field generated from the dynamic font vector data.
 			</description>
 		</method>
+		<method name="_font_set_name" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="name" type="String" />
+			<description>
+				Sets the font family name.
+			</description>
+		</method>
 		<method name="_font_set_oversampling" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -675,6 +697,14 @@
 			<argument index="3" name="value" type="int" />
 			<description>
 				Sets extra spacing added between glyphs in pixels.
+			</description>
+		</method>
+		<method name="_font_set_style" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="style" type="int" />
+			<description>
+				Sets the font style flags, see [enum TextServer.FontStyle].
 			</description>
 		</method>
 		<method name="_font_set_texture_image" qualifiers="virtual">

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1279,6 +1279,20 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 		fd->underline_thickness = (FT_MulFix(fd->face->underline_thickness, fd->face->size->metrics.y_scale) / 64.0) / fd->oversampling * fd->scale;
 
 		if (!p_font_data->face_init) {
+			// Get style flags and name.
+			if (fd->face->family_name != nullptr) {
+				p_font_data->font_name = String::utf8((const char *)fd->face->family_name);
+			}
+			p_font_data->style_flags = 0;
+			if (fd->face->style_flags & FT_STYLE_FLAG_BOLD) {
+				p_font_data->style_flags |= FONT_BOLD;
+			}
+			if (fd->face->style_flags & FT_STYLE_FLAG_ITALIC) {
+				p_font_data->style_flags |= FONT_ITALIC;
+			}
+			if (fd->face->face_flags & FT_FACE_FLAG_FIXED_WIDTH) {
+				p_font_data->style_flags |= FONT_FIXED_WIDTH;
+			}
 			// Get supported scripts from OpenType font data.
 			p_font_data->supported_scripts.clear();
 			unsigned int count = hb_ot_layout_table_get_script_tags(hb_font_get_face(fd->hb_handle), HB_OT_TAG_GSUB, 0, nullptr, nullptr);
@@ -1646,6 +1660,46 @@ void TextServerAdvanced::font_set_data_ptr(RID p_font_rid, const uint8_t *p_data
 	fd->data.clear();
 	fd->data_ptr = p_data_ptr;
 	fd->data_size = p_data_size;
+}
+
+void TextServerAdvanced::font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND(!fd);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	fd->style_flags = p_style;
+}
+
+uint32_t /*FontStyle*/ TextServerAdvanced::font_get_style(RID p_font_rid) const {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND_V(!fd, 0);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0);
+	return fd->style_flags;
+}
+
+void TextServerAdvanced::font_set_name(RID p_font_rid, const String &p_name) {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND(!fd);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	fd->font_name = p_name;
+}
+
+String TextServerAdvanced::font_get_name(RID p_font_rid) const {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND_V(!fd, String());
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), String());
+	return fd->font_name;
 }
 
 void TextServerAdvanced::font_set_antialiased(RID p_font_rid, bool p_antialiased) {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -176,6 +176,9 @@ class TextServerAdvanced : public TextServer {
 		Dictionary variation_coordinates;
 		float oversampling = 0.f;
 
+		uint32_t style_flags = 0;
+		String font_name;
+
 		Map<Vector2i, FontDataForSizeAdvanced *> cache;
 
 		bool face_init = false;
@@ -319,6 +322,12 @@ public:
 
 	virtual void font_set_data(RID p_font_rid, const PackedByteArray &p_data) override;
 	virtual void font_set_data_ptr(RID p_font_rid, const uint8_t *p_data_ptr, size_t p_data_size) override;
+
+	virtual void font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) override;
+	virtual uint32_t /*FontStyle*/ font_get_style(RID p_font_rid) const override;
+
+	virtual void font_set_name(RID p_font_rid, const String &p_name) override;
+	virtual String font_get_name(RID p_font_rid) const override;
 
 	virtual void font_set_antialiased(RID p_font_rid, bool p_antialiased) override;
 	virtual bool font_is_antialiased(RID p_font_rid) const override;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -736,6 +736,20 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontDataFallback 
 		fd->underline_thickness = (FT_MulFix(fd->face->underline_thickness, fd->face->size->metrics.y_scale) / 64.0) / fd->oversampling * fd->scale;
 
 		if (!p_font_data->face_init) {
+			// Get style flags and name.
+			if (fd->face->family_name != nullptr) {
+				p_font_data->font_name = String::utf8((const char *)fd->face->family_name);
+			}
+			p_font_data->style_flags = 0;
+			if (fd->face->style_flags & FT_STYLE_FLAG_BOLD) {
+				p_font_data->style_flags |= FONT_BOLD;
+			}
+			if (fd->face->style_flags & FT_STYLE_FLAG_ITALIC) {
+				p_font_data->style_flags |= FONT_ITALIC;
+			}
+			if (fd->face->face_flags & FT_FACE_FLAG_FIXED_WIDTH) {
+				p_font_data->style_flags |= FONT_FIXED_WIDTH;
+			}
 			// Read OpenType variations.
 			p_font_data->supported_varaitions.clear();
 			if (fd->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
@@ -824,6 +838,46 @@ void TextServerFallback::font_set_data_ptr(RID p_font_rid, const uint8_t *p_data
 	fd->data.clear();
 	fd->data_ptr = p_data_ptr;
 	fd->data_size = p_data_size;
+}
+
+void TextServerFallback::font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) {
+	FontDataFallback *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND(!fd);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	fd->style_flags = p_style;
+}
+
+uint32_t /*FontStyle*/ TextServerFallback::font_get_style(RID p_font_rid) const {
+	FontDataFallback *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND_V(!fd, 0);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0);
+	return fd->style_flags;
+}
+
+void TextServerFallback::font_set_name(RID p_font_rid, const String &p_name) {
+	FontDataFallback *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND(!fd);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	fd->font_name = p_name;
+}
+
+String TextServerFallback::font_get_name(RID p_font_rid) const {
+	FontDataFallback *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND_V(!fd, String());
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), String());
+	return fd->font_name;
 }
 
 void TextServerFallback::font_set_antialiased(RID p_font_rid, bool p_antialiased) {

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -142,6 +142,9 @@ class TextServerFallback : public TextServer {
 		Dictionary variation_coordinates;
 		float oversampling = 0.f;
 
+		uint32_t style_flags = 0;
+		String font_name;
+
 		Map<Vector2i, FontDataForSizeFallback *> cache;
 
 		bool face_init = false;
@@ -233,6 +236,12 @@ public:
 
 	virtual void font_set_data(RID p_font_rid, const PackedByteArray &p_data) override;
 	virtual void font_set_data_ptr(RID p_font_rid, const uint8_t *p_data_ptr, size_t p_data_size) override;
+
+	virtual void font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) override;
+	virtual uint32_t /*FontStyle*/ font_get_style(RID p_font_rid) const override;
+
+	virtual void font_set_name(RID p_font_rid, const String &p_name) override;
+	virtual String font_get_name(RID p_font_rid) const override;
 
 	virtual void font_set_antialiased(RID p_font_rid, bool p_antialiased) override;
 	virtual bool font_is_antialiased(RID p_font_rid) const override;

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -70,6 +70,12 @@ void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_antialiased", "antialiased"), &FontData::set_antialiased);
 	ClassDB::bind_method(D_METHOD("is_antialiased"), &FontData::is_antialiased);
 
+	ClassDB::bind_method(D_METHOD("set_font_name", "name"), &FontData::set_font_name);
+	ClassDB::bind_method(D_METHOD("get_font_name"), &FontData::get_font_name);
+
+	ClassDB::bind_method(D_METHOD("set_font_style", "style"), &FontData::set_font_style);
+	ClassDB::bind_method(D_METHOD("get_font_style"), &FontData::get_font_style);
+
 	ClassDB::bind_method(D_METHOD("set_multichannel_signed_distance_field", "msdf"), &FontData::set_multichannel_signed_distance_field);
 	ClassDB::bind_method(D_METHOD("is_multichannel_signed_distance_field"), &FontData::is_multichannel_signed_distance_field);
 
@@ -190,6 +196,12 @@ bool FontData::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (tokens[0] == "antialiased") {
 			set_antialiased(p_value);
 			return true;
+		} else if (tokens[0] == "font_name") {
+			set_font_name(p_value);
+			return true;
+		} else if (tokens[0] == "font_style") {
+			set_font_style(p_value);
+			return true;
 		} else if (tokens[0] == "multichannel_signed_distance_field") {
 			set_multichannel_signed_distance_field(p_value);
 			return true;
@@ -295,6 +307,12 @@ bool FontData::_get(const StringName &p_name, Variant &r_ret) const {
 		} else if (tokens[0] == "antialiased") {
 			r_ret = is_antialiased();
 			return true;
+		} else if (tokens[0] == "font_name") {
+			r_ret = get_font_name();
+			return true;
+		} else if (tokens[0] == "font_style") {
+			r_ret = get_font_style();
+			return true;
 		} else if (tokens[0] == "multichannel_signed_distance_field") {
 			r_ret = is_multichannel_signed_distance_field();
 			return true;
@@ -394,6 +412,8 @@ bool FontData::_get(const StringName &p_name, Variant &r_ret) const {
 void FontData::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 
+	p_list->push_back(PropertyInfo(Variant::STRING, "font_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
+	p_list->push_back(PropertyInfo(Variant::INT, "font_style", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 	p_list->push_back(PropertyInfo(Variant::BOOL, "antialiased", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 	p_list->push_back(PropertyInfo(Variant::BOOL, "multichannel_signed_distance_field", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 	p_list->push_back(PropertyInfo(Variant::INT, "msdf_pixel_range", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
@@ -508,6 +528,26 @@ PackedByteArray FontData::get_data() const {
 		memcpy(data_w->ptrw(), data_ptr, data_size);
 	}
 	return data;
+}
+
+void FontData::set_font_name(const String &p_name) {
+	_ensure_rid(0);
+	TS->font_set_name(cache[0], p_name);
+}
+
+String FontData::get_font_name() const {
+	_ensure_rid(0);
+	return TS->font_get_name(cache[0]);
+}
+
+void FontData::set_font_style(uint32_t p_style) {
+	_ensure_rid(0);
+	TS->font_set_style(cache[0], p_style);
+}
+
+uint32_t FontData::get_font_style() const {
+	_ensure_rid(0);
+	return TS->font_get_style(cache[0]);
 }
 
 void FontData::set_antialiased(bool p_antialiased) {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -79,6 +79,12 @@ public:
 	virtual PackedByteArray get_data() const;
 
 	// Common properties.
+	virtual void set_font_name(const String &p_name);
+	virtual String get_font_name() const;
+
+	virtual void set_font_style(uint32_t p_style);
+	virtual uint32_t get_font_style() const;
+
 	virtual void set_antialiased(bool p_antialiased);
 	virtual bool is_antialiased() const;
 

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -55,6 +55,12 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_font_set_data, "font_rid", "data");
 	GDVIRTUAL_BIND(_font_set_data_ptr, "font_rid", "data_ptr", "data_size");
 
+	GDVIRTUAL_BIND(_font_set_style, "font_rid", "style");
+	GDVIRTUAL_BIND(_font_get_style, "font_rid");
+
+	GDVIRTUAL_BIND(_font_set_name, "font_rid", "name");
+	GDVIRTUAL_BIND(_font_get_name, "font_rid");
+
 	GDVIRTUAL_BIND(_font_set_antialiased, "font_rid", "antialiased");
 	GDVIRTUAL_BIND(_font_is_antialiased, "font_rid");
 
@@ -366,6 +372,30 @@ void TextServerExtension::font_set_data(RID p_font_rid, const PackedByteArray &p
 
 void TextServerExtension::font_set_data_ptr(RID p_font_rid, const uint8_t *p_data_ptr, size_t p_data_size) {
 	GDVIRTUAL_CALL(_font_set_data_ptr, p_font_rid, p_data_ptr, p_data_size);
+}
+
+void TextServerExtension::font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) {
+	GDVIRTUAL_CALL(_font_set_style, p_font_rid, p_style);
+}
+
+uint32_t /*FontStyle*/ TextServerExtension::font_get_style(RID p_font_rid) const {
+	uint32_t ret;
+	if (GDVIRTUAL_CALL(_font_get_style, p_font_rid, ret)) {
+		return ret;
+	}
+	return 0;
+}
+
+void TextServerExtension::font_set_name(RID p_font_rid, const String &p_name) {
+	GDVIRTUAL_CALL(_font_set_name, p_font_rid, p_name);
+}
+
+String TextServerExtension::font_get_name(RID p_font_rid) const {
+	String ret;
+	if (GDVIRTUAL_CALL(_font_get_name, p_font_rid, ret)) {
+		return ret;
+	}
+	return String();
 }
 
 void TextServerExtension::font_set_antialiased(RID p_font_rid, bool p_antialiased) {

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -84,6 +84,16 @@ public:
 	GDVIRTUAL2(_font_set_data, RID, const PackedByteArray &);
 	GDVIRTUAL3(_font_set_data_ptr, RID, GDNativeConstPtr<const uint8_t>, uint64_t);
 
+	virtual void font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) override;
+	virtual uint32_t /*FontStyle*/ font_get_style(RID p_font_rid) const override;
+	GDVIRTUAL2(_font_set_style, RID, uint32_t);
+	GDVIRTUAL1RC(uint32_t, _font_get_style, RID);
+
+	virtual void font_set_name(RID p_font_rid, const String &p_name) override;
+	virtual String font_get_name(RID p_font_rid) const override;
+	GDVIRTUAL2(_font_set_name, RID, const String &);
+	GDVIRTUAL1RC(String, _font_get_name, RID);
+
 	virtual void font_set_antialiased(RID p_font_rid, bool p_antialiased) override;
 	virtual bool font_is_antialiased(RID p_font_rid) const override;
 	GDVIRTUAL2(_font_set_antialiased, RID, bool);

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -212,6 +212,12 @@ void TextServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("font_set_data", "font_rid", "data"), &TextServer::font_set_data);
 
+	ClassDB::bind_method(D_METHOD("font_set_style", "font_rid", "style"), &TextServer::font_set_style);
+	ClassDB::bind_method(D_METHOD("font_get_style", "font_rid"), &TextServer::font_get_style);
+
+	ClassDB::bind_method(D_METHOD("font_set_name", "font_rid", "name"), &TextServer::font_set_name);
+	ClassDB::bind_method(D_METHOD("font_get_name", "font_rid"), &TextServer::font_get_name);
+
 	ClassDB::bind_method(D_METHOD("font_set_antialiased", "font_rid", "antialiased"), &TextServer::font_set_antialiased);
 	ClassDB::bind_method(D_METHOD("font_is_antialiased", "font_rid"), &TextServer::font_is_antialiased);
 
@@ -472,11 +478,16 @@ void TextServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONTOUR_CURVE_TAG_OFF_CONIC);
 	BIND_ENUM_CONSTANT(CONTOUR_CURVE_TAG_OFF_CUBIC);
 
-	/* Font Spacing*/
+	/* Font Spacing */
 	BIND_ENUM_CONSTANT(SPACING_GLYPH);
 	BIND_ENUM_CONSTANT(SPACING_SPACE);
 	BIND_ENUM_CONSTANT(SPACING_TOP);
 	BIND_ENUM_CONSTANT(SPACING_BOTTOM);
+
+	/* Font Style */
+	BIND_ENUM_CONSTANT(FONT_BOLD);
+	BIND_ENUM_CONSTANT(FONT_ITALIC);
+	BIND_ENUM_CONSTANT(FONT_FIXED_WIDTH);
 }
 
 Vector2 TextServer::get_hex_code_box_size(int p_size, char32_t p_index) const {

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -125,6 +125,12 @@ public:
 		SPACING_BOTTOM,
 	};
 
+	enum FontStyle {
+		FONT_BOLD = 1 << 0,
+		FONT_ITALIC = 1 << 1,
+		FONT_FIXED_WIDTH = 1 << 2,
+	};
+
 	void _draw_hex_code_box_number(RID p_canvas, int p_size, const Vector2 &p_pos, uint8_t p_index, const Color &p_color) const;
 
 protected:
@@ -219,6 +225,12 @@ public:
 
 	virtual void font_set_data(RID p_font_rid, const PackedByteArray &p_data) = 0;
 	virtual void font_set_data_ptr(RID p_font_rid, const uint8_t *p_data_ptr, size_t p_data_size) = 0;
+
+	virtual void font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) = 0;
+	virtual uint32_t /*FontStyle*/ font_get_style(RID p_font_rid) const = 0;
+
+	virtual void font_set_name(RID p_font_rid, const String &p_name) = 0;
+	virtual String font_get_name(RID p_font_rid) const = 0;
 
 	virtual void font_set_antialiased(RID p_font_rid, bool p_antialiased) = 0;
 	virtual bool font_is_antialiased(RID p_font_rid) const = 0;
@@ -530,6 +542,7 @@ VARIANT_ENUM_CAST(TextServer::Hinting);
 VARIANT_ENUM_CAST(TextServer::Feature);
 VARIANT_ENUM_CAST(TextServer::ContourPointTag);
 VARIANT_ENUM_CAST(TextServer::SpacingType);
+VARIANT_ENUM_CAST(TextServer::FontStyle);
 
 GDVIRTUAL_NATIVE_PTR(Glyph);
 GDVIRTUAL_NATIVE_PTR(Glyph *);


### PR DESCRIPTION
Adds `get_font_name` and `get_font_style` function for dynamic and BMFont fonts, to aid font enumeration for the future godotengine/godot-proposals#1542 implementation.