### PR TITLE
Increase the max number of PoolVector allocations from 65535 to 1048576

### DIFF
--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -71,7 +71,7 @@ struct MemoryPool {
 	static size_t total_memory;
 	static size_t max_memory;
 
-	static void setup(uint32_t p_max_allocs = (1 << 16));
+	static void setup(uint32_t p_max_allocs = (1 << 20));
 	static void cleanup();
 };
 


### PR DESCRIPTION
This should suffice in most scenarios. Note that we can't use a size too high (like `1 << 31`) as Godot crashes on startup.

This closes https://github.com/godotengine/godot/issues/37154 and closes https://github.com/godotengine/godot/issues/53665.

Please [test](https://docs.godotengine.org/en/latest/community/contributing/testing_pull_requests.html) on various hardware configurations (desktop, mobile, web) :slightly_smiling_face:
I haven't tested this with 32-bit binaries yet, but it's possible that we may have to use a lower allocation size there.