### PR TITLE
Fix VoxelGI info label being cut off

### DIFF
--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -149,7 +149,6 @@ VoxelGIEditorPlugin::VoxelGIEditorPlugin(EditorNode *p_node) {
 	bake_hb->add_child(bake);
 	bake_info = memnew(Label);
 	bake_info->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	bake_info->set_clip_text(true);
 	bake_hb->add_child(bake_info);
 
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, bake_hb);


### PR DESCRIPTION
Fixes #53529.

Though it seems like a regression from #35891, it looks like it was just revealed in that commit.
The bug seems to be VoxelGI specific because it couldn't be reproduced on increasing Mesh3DInstance's Mesh button label.

**_Before fix:_**
![Screenshot 2021-10-26 194906](https://user-images.githubusercontent.com/11459028/138900034-ad45ed12-1a04-463b-873f-53def9bd8026.png)
Bugged.

![Screenshot 2021-10-26 194841](https://user-images.githubusercontent.com/11459028/138900047-040ba757-0d93-4723-aa9d-581e303e3e76.png)
[Hardcoded longer text to test] - Works as expected.


**_After fix:_**
![Screenshot 2021-10-26 195029](https://user-images.githubusercontent.com/11459028/138900332-4dfb5917-f87d-4a49-ab5a-3c463bba1d06.png)
Fixed.

![Screenshot 2021-10-26 195018](https://user-images.githubusercontent.com/11459028/138900337-bf5f394e-5b57-4346-9eb1-47fdd858e8eb.png)
[Hardcoded longer text to test] - Works as expected.
