### PR TITLE
Fix click selection in the editor 3D viewport

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -489,7 +489,7 @@ ObjectID Node3DEditorViewport::_select_ray(const Point2 &p_pos) {
 		RS::get_singleton()->sdfgi_set_debug_probe_select(pos, ray);
 	}
 
-	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(pos, ray, get_tree()->get_root()->get_world_3d()->get_scenario());
+	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(pos, pos + ray * camera->get_far(), get_tree()->get_root()->get_world_3d()->get_scenario());
 	Set<Ref<EditorNode3DGizmo>> found_gizmos;
 
 	Node *edited_scene = get_tree()->get_edited_scene_root();
@@ -552,7 +552,7 @@ void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, Vector<_RayRe
 	Vector3 ray = _get_ray(p_pos);
 	Vector3 pos = _get_ray_pos(p_pos);
 
-	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(pos, ray, get_tree()->get_root()->get_world_3d()->get_scenario());
+	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(pos, pos + ray * camera->get_far(), get_tree()->get_root()->get_world_3d()->get_scenario());
 	Set<Node3D *> found_nodes;
 
 	for (int i = 0; i < instances.size(); i++) {


### PR DESCRIPTION
After click selection stopped working in `master` I noticed `instances_cull_ray` wasn't working properly, so I assumed the new BVH implementation was wrong. I postponed the investigation because we were planing to use a different BVH implementation anyway.

I was testing #49490 today and realized selection wasn't working either with that BVH. It turns out the 3.x implementation of `instances_cull_ray` expects a position and a ray direction even though the arguments are called `from` and `to`, while the new implementation rightly assumes the arguments to be the endpoints of a segment.

We should probably change the 3.x version to be consistent with the argument names. It's exposed to the bindings, so it's technically compat-breaking, but it's a very niche method and a trivial fix for anyone using it.
