### PR TITLE
Ignore property groups and categories in GDScript code completion

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1511,6 +1511,12 @@ static bool _guess_identifier_type_from_base(GDScriptCompletionContext &p_contex
 				ClassDB::get_property_list(class_name, &props);
 				for (const List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 					const PropertyInfo &prop = E->get();
+
+					// Ignore groups and categories in code completion.
+					if (prop.usage & (PROPERTY_USAGE_GROUP | PROPERTY_USAGE_CATEGORY)) {
+						continue;
+					}
+
 					if (prop.name == p_identifier) {
 						StringName getter = ClassDB::get_property_getter(class_name, p_identifier);
 						if (getter != StringName()) {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2937,7 +2937,7 @@ void Control::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_filter", PROPERTY_HINT_ENUM, "Stop,Pass,Ignore"), "set_mouse_filter", "get_mouse_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_default_cursor_shape", PROPERTY_HINT_ENUM, "Arrow,Ibeam,Pointing hand,Cross,Wait,Busy,Drag,Can drop,Forbidden,Vertical resize,Horizontal resize,Secondary diagonal resize,Main diagonal resize,Move,Vertical split,Horizontal split,Help"), "set_default_cursor_shape", "get_default_cursor_shape");
 
-	ADD_GROUP("Input Propagation", "input_");
+	ADD_GROUP("Input", "input_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "input_pass_on_modal_close_click"), "set_pass_on_modal_close_click", "get_pass_on_modal_close_click");
 
 	ADD_GROUP("Size Flags", "size_flags_");


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/54243. In master any property with slashes in its name is also ignored, but I don't think it can collide with identifiers anyway, so I decided not to add such a check.

Edit: As a result, reverts https://github.com/godotengine/godot/pull/54241.