### PR TITLE
Fix BaseMaterial3D proximity fade for Vulkan

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1100,7 +1100,7 @@ void BaseMaterial3D::_update_shader() {
 
 	if (proximity_fade_enabled) {
 		code += "	float depth_tex = textureLod(DEPTH_TEXTURE,SCREEN_UV,0.0).r;\n";
-		code += "	vec4 world_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV*2.0-1.0,depth_tex*2.0-1.0,1.0);\n";
+		code += "	vec4 world_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV*2.0-1.0,depth_tex,1.0);\n";
 		code += "	world_pos.xyz/=world_pos.w;\n";
 		code += "	ALPHA*=clamp(1.0-smoothstep(world_pos.z+proximity_fade_distance,world_pos.z,VERTEX.z),0.0,1.0);\n";
 	}


### PR DESCRIPTION
Fixes #35646

The reason why this feature broke is described here: https://github.com/godotengine/godot-docs/issues/5276

Should unblock implementing/testing #50669 for master.

---

Comparison using [min rep from the issue](https://github.com/godotengine/godot/issues/35646#issuecomment-882904994):

Not working:
(using any value for `proximity_fade_distance` from 0 to 3000)
![image](https://user-images.githubusercontent.com/6376721/138955300-4b262c0a-cdeb-4b0f-b255-c4198dd37d6f.png)

With this change:
(`proximity_fade_distance = 0.3`)
![image](https://user-images.githubusercontent.com/6376721/138956674-32c51918-f673-4f10-9cce-b2509311fe8b.png)


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
