### PR TITLE
Add function to get Android device's notch as Rect2

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -389,6 +389,14 @@
 				[b]Note:[/b] This method is implemented on Android, Linux, macOS and Windows. Returns [code]72[/code] on unsupported platforms.
 			</description>
 		</method>
+		<method name="screen_get_inactive_rect" qualifiers="const">
+			<return type="Rect2i" />
+			<argument index="0" name="screen" type="int" default="-1" />
+			<description>
+				Returns the bounding rectangle of the inactive part of a device's display, such as a notch, or an empty [Rect2i] if none is found.
+				[b]Note:[/b] This method is implemented on Android. Returns an empty [Rect2i] on unsupported platforms.
+			</description>
+		</method>
 		<method name="screen_get_max_scale" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -142,6 +142,14 @@ Rect2i DisplayServerAndroid::screen_get_usable_rect(int p_screen) const {
 	return Rect2i(xywh[0], xywh[1], xywh[2], xywh[3]);
 }
 
+Rect2i DisplayServerAndroid::screen_get_inactive_rect(int p_screen) const {
+	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
+	ERR_FAIL_COND_V(!godot_io_java, Rect2i());
+	int xywh[4];
+	godot_io_java->screen_get_inactive_rect(xywh);
+	return Rect2i(xywh[0], xywh[1], xywh[2], xywh[3]);
+}
+
 int DisplayServerAndroid::screen_get_dpi(int p_screen) const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	ERR_FAIL_COND_V(!godot_io_java, 0);

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -104,6 +104,7 @@ public:
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i screen_get_inactive_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -38,6 +38,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.AssetManager;
 import android.graphics.Point;
+import android.graphics.Rect;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -243,6 +244,22 @@ public class GodotIO {
 				result[1] = insetTop;
 				result[2] -= insetLeft + cutout.getSafeInsetRight();
 				result[3] -= insetTop + cutout.getSafeInsetBottom();
+			}
+		}
+		return result;
+	}
+
+	public int[] screenGetInactiveRect() {
+		int[] result = { 0, 0, 0, 0 };
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+			WindowInsets insets = activity.getWindow().getDecorView().getRootWindowInsets();
+			DisplayCutout cutout = insets.getDisplayCutout();
+			if (cutout != null) {
+				Rect boundingRect = cutout.getBoundingRects().get(0);
+				result[0] = boundingRect.left;
+				result[1] = boundingRect.top;
+				result[2] = boundingRect.width();
+				result[3] = boundingRect.height();
 			}
 		}
 		return result;

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -54,6 +54,7 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 		_get_model = p_env->GetMethodID(cls, "getModel", "()Ljava/lang/String;");
 		_get_screen_DPI = p_env->GetMethodID(cls, "getScreenDPI", "()I");
 		_screen_get_usable_rect = p_env->GetMethodID(cls, "screenGetUsableRect", "()[I"),
+		_screen_get_inactive_rect = p_env->GetMethodID(cls, "screenGetInactiveRect", "()[I");
 		_get_unique_id = p_env->GetMethodID(cls, "getUniqueID", "()Ljava/lang/String;");
 		_show_keyboard = p_env->GetMethodID(cls, "showKeyboard", "(Ljava/lang/String;ZIII)V");
 		_hide_keyboard = p_env->GetMethodID(cls, "hideKeyboard", "()V");
@@ -141,6 +142,20 @@ void GodotIOJavaWrapper::screen_get_usable_rect(int (&p_rect_xywh)[4]) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_COND(env == nullptr);
 		jintArray returnArray = (jintArray)env->CallObjectMethod(godot_io_instance, _screen_get_usable_rect);
+		ERR_FAIL_COND(env->GetArrayLength(returnArray) != 4);
+		jint *arrayBody = env->GetIntArrayElements(returnArray, JNI_FALSE);
+		for (int i = 0; i < 4; i++) {
+			p_rect_xywh[i] = arrayBody[i];
+		}
+		env->ReleaseIntArrayElements(returnArray, arrayBody, 0);
+	}
+}
+
+void GodotIOJavaWrapper::screen_get_inactive_rect(int (&p_rect_xywh)[4]) {
+	if (_screen_get_inactive_rect) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+		jintArray returnArray = (jintArray)env->CallObjectMethod(godot_io_instance, _screen_get_inactive_rect);
 		ERR_FAIL_COND(env->GetArrayLength(returnArray) != 4);
 		jint *arrayBody = env->GetIntArrayElements(returnArray, JNI_FALSE);
 		for (int i = 0; i < 4; i++) {

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -52,6 +52,7 @@ private:
 	jmethodID _get_model = 0;
 	jmethodID _get_screen_DPI = 0;
 	jmethodID _screen_get_usable_rect = 0;
+	jmethodID _screen_get_inactive_rect = 0;
 	jmethodID _get_unique_id = 0;
 	jmethodID _show_keyboard = 0;
 	jmethodID _hide_keyboard = 0;
@@ -72,6 +73,7 @@ public:
 	String get_model();
 	int get_screen_dpi();
 	void screen_get_usable_rect(int (&p_rect_xywh)[4]);
+	void screen_get_inactive_rect(int (&p_rect_xywh)[4]);
 	String get_unique_id();
 	bool has_vk();
 	void show_vk(const String &p_existing, bool p_multiline, int p_max_input_length, int p_cursor_start, int p_cursor_end);

--- a/platform/iphone/display_server_iphone.h
+++ b/platform/iphone/display_server_iphone.h
@@ -127,6 +127,7 @@ public:
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i screen_get_inactive_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 

--- a/platform/iphone/display_server_iphone.mm
+++ b/platform/iphone/display_server_iphone.mm
@@ -357,6 +357,10 @@ Rect2i DisplayServerIPhone::screen_get_usable_rect(int p_screen) const {
 	}
 }
 
+Rect2i DisplayServerIPhone::screen_get_inactive_rect(int p_screen) const {
+	return Rect2i();
+}
+
 int DisplayServerIPhone::screen_get_dpi(int p_screen) const {
 	struct utsname systemInfo;
 	uname(&systemInfo);

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -795,6 +795,10 @@ Rect2i DisplayServerJavaScript::screen_get_usable_rect(int p_screen) const {
 	return Rect2i(0, 0, size[0], size[1]);
 }
 
+Rect2i DisplayServerJavaScript::screen_get_inactive_rect(int p_screen) const {
+	return Rect2i();
+}
+
 int DisplayServerJavaScript::screen_get_dpi(int p_screen) const {
 	return godot_js_display_screen_dpi_get();
 }

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -134,6 +134,7 @@ public:
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i screen_get_inactive_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -739,6 +739,10 @@ Rect2i DisplayServerX11::screen_get_usable_rect(int p_screen) const {
 	return rect;
 }
 
+Rect2i DisplayServerX11::screen_get_inactive_rect(int p_screen) const {
+	return Rect2i(0, 0, 0, 0);
+}
+
 int DisplayServerX11::screen_get_dpi(int p_screen) const {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -298,6 +298,7 @@ public:
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i screen_get_inactive_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -231,6 +231,7 @@ public:
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_max_scale() const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i screen_get_inactive_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 
 	virtual Vector<int> get_window_list() const override;
 

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -2224,6 +2224,10 @@ Rect2i DisplayServerOSX::screen_get_usable_rect(int p_screen) const {
 	return Rect2i();
 }
 
+Rect2i DisplayServerOSX::screen_get_inactive_rect(int p_screen) const {
+	return Rect2i();
+}
+
 Vector<DisplayServer::WindowID> DisplayServerOSX::get_window_list() const {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -351,6 +351,10 @@ Rect2i DisplayServerWindows::screen_get_usable_rect(int p_screen) const {
 	return data.rect;
 }
 
+Rect2i DisplayServerWindows::screen_get_inactive_rect(int p_screen) const {
+	return Rect2i();
+}
+
 typedef struct {
 	int count;
 	int screen;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -458,6 +458,7 @@ public:
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i screen_get_inactive_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -375,6 +375,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("screen_get_position", "screen"), &DisplayServer::screen_get_position, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_size", "screen"), &DisplayServer::screen_get_size, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_usable_rect", "screen"), &DisplayServer::screen_get_usable_rect, DEFVAL(SCREEN_OF_MAIN_WINDOW));
+	ClassDB::bind_method(D_METHOD("screen_get_inactive_rect", "screen"), &DisplayServer::screen_get_inactive_rect, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_dpi", "screen"), &DisplayServer::screen_get_dpi, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_scale", "screen"), &DisplayServer::screen_get_scale, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_is_touchscreen", "screen"), &DisplayServer::screen_is_touchscreen, DEFVAL(SCREEN_OF_MAIN_WINDOW));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -173,6 +173,7 @@ public:
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
+	virtual Rect2i screen_get_inactive_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual float screen_get_max_scale() const {

--- a/servers/display_server_headless.h
+++ b/servers/display_server_headless.h
@@ -59,6 +59,7 @@ public:
 	Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return Point2i(); }
 	Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return Size2i(); }
 	Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return Rect2i(); }
+	Rect2i screen_get_inactive_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return Rect2i(); }
 	int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return 96; /* 0 might cause issues */ }
 	float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return 1; }
 	float screen_get_max_scale() const override { return 1; }


### PR DESCRIPTION
Closes godotengine/godot-proposals#3466 (for Android, iOS would need  something equivalent). This adds a function that returns the position and size of an Android device's notch/punch hole, or a zero Rect2 if no inactive area is found. See below picture for the result of a simple test project using this.

![inactive_area_landscape](https://user-images.githubusercontent.com/53737317/138962950-7276c971-5913-416c-bd6a-4fd16a82edb8.jpg)

I have tested this on my Asus Zenfone 8 and the Android emulator with various notch shapes, and the only case where this may not work properly is if a device has more than one inactive area, as I return the first one only, but I do not know of any such device.
Here is the sample project I used to test this: [PR_AndroidNotch.zip](https://github.com/godotengine/godot/files/7421645/PR_AndroidNotch.zip)
