### PR TITLE
Fix custom fog, and make `FOG` built-in readable

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -564,7 +564,7 @@ void SceneShaderForwardClustered::init(RendererStorageRD *p_storage, const Strin
 		actions.renames["NORMAL_ROUGHNESS_TEXTURE"] = "normal_roughness_buffer";
 		actions.renames["DEPTH"] = "gl_FragDepth";
 		actions.renames["OUTPUT_IS_SRGB"] = "true";
-		actions.renames["FOG"] = "custom_fog";
+		actions.renames["FOG"] = "fog";
 		actions.renames["RADIANCE"] = "custom_radiance";
 		actions.renames["IRRADIANCE"] = "custom_irradiance";
 		actions.renames["BONE_INDICES"] = "bone_attrib";
@@ -627,7 +627,6 @@ void SceneShaderForwardClustered::init(RendererStorageRD *p_storage, const Strin
 		actions.usage_defines["DIFFUSE_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 		actions.usage_defines["SPECULAR_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 
-		actions.usage_defines["FOG"] = "#define CUSTOM_FOG_USED\n";
 		actions.usage_defines["RADIANCE"] = "#define CUSTOM_RADIANCE_USED\n";
 		actions.usage_defines["IRRADIANCE"] = "#define CUSTOM_IRRADIANCE_USED\n";
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -555,7 +555,7 @@ void SceneShaderForwardMobile::init(RendererStorageRD *p_storage, const String p
 		actions.renames["NORMAL_ROUGHNESS_TEXTURE"] = "normal_roughness_buffer";
 		actions.renames["DEPTH"] = "gl_FragDepth";
 		actions.renames["OUTPUT_IS_SRGB"] = "true";
-		actions.renames["FOG"] = "custom_fog";
+		actions.renames["FOG"] = "fog";
 		actions.renames["RADIANCE"] = "custom_radiance";
 		actions.renames["IRRADIANCE"] = "custom_irradiance";
 		actions.renames["BONE_INDICES"] = "bone_attrib";
@@ -617,7 +617,6 @@ void SceneShaderForwardMobile::init(RendererStorageRD *p_storage, const String p
 		actions.usage_defines["DIFFUSE_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 		actions.usage_defines["SPECULAR_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 
-		actions.usage_defines["FOG"] = "#define CUSTOM_FOG_USED\n";
 		actions.usage_defines["RADIANCE"] = "#define CUSTOM_RADIANCE_USED\n";
 		actions.usage_defines["IRRADIANCE"] = "#define CUSTOM_IRRADIANCE_USED\n";
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -650,6 +650,13 @@ void main() {
 	vec2 alpha_texture_coordinate = vec2(0.0, 0.0);
 #endif // ALPHA_ANTIALIASING_EDGE_USED
 
+#ifndef MODE_RENDER_DEPTH
+	// Volumetric fog is calculated after user code
+	if (scene_data.fog_enabled) {
+		fog = fog_process(vertex);
+	}
+#endif //!MODE_RENDER_DEPTH
+
 	{
 #CODE : FRAGMENT
 	}
@@ -723,16 +730,9 @@ void main() {
 #endif
 
 	/////////////////////// FOG //////////////////////
+
 #ifndef MODE_RENDER_DEPTH
-
-#ifndef CUSTOM_FOG_USED
-	// fog must be processed as early as possible and then packed.
-	// to maximize VGPR usage
-	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
-
-	if (scene_data.fog_enabled) {
-		fog = fog_process(vertex);
-	}
+	// Fog must be processed as early as possible and then packed to maximize VGPR usage.
 
 	if (scene_data.volumetric_fog_enabled) {
 		vec4 volumetric_fog = volumetric_fog_process(screen_uv, -vertex.z);
@@ -751,7 +751,6 @@ void main() {
 			fog = volumetric_fog;
 		}
 	}
-#endif //!CUSTOM_FOG_USED
 
 	uint fog_rg = packHalf2x16(fog.rg);
 	uint fog_ba = packHalf2x16(fog.ba);

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -660,6 +660,12 @@ void main() {
 	vec2 alpha_texture_coordinate = vec2(0.0, 0.0);
 #endif // ALPHA_ANTIALIASING_EDGE_USED
 
+#ifndef MODE_RENDER_DEPTH
+	if (!sc_disable_fog && scene_data.fog_enabled) {
+		fog = fog_process(vertex);
+	}
+#endif //!MODE_RENDER_DEPTH
+
 	{
 #CODE : FRAGMENT
 	}
@@ -736,23 +742,10 @@ void main() {
 	}
 #endif
 
-	/////////////////////// FOG //////////////////////
 #ifndef MODE_RENDER_DEPTH
-
-#ifndef CUSTOM_FOG_USED
-	// fog must be processed as early as possible and then packed.
-	// to maximize VGPR usage
-	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
-
-	if (!sc_disable_fog && scene_data.fog_enabled) {
-		fog = fog_process(vertex);
-	}
-
-#endif //!CUSTOM_FOG_USED
-
+	// Fog must be processed as early as possible and then packed to maximize VGPR usage.
 	uint fog_rg = packHalf2x16(fog.rg);
 	uint fog_ba = packHalf2x16(fog.ba);
-
 #endif //!MODE_RENDER_DEPTH
 
 	/////////////////////// DECALS ////////////////////////////////


### PR DESCRIPTION
Fixes shader custom fog (#41415), which was likely broken since #45023.

Additionally, the fragment shader built-in `FOG` allows for modification of standard fog, rather than just overwriting it. This allows for simple tweaks, such as:
```glsl
FOG *= vec4(0.5, 0.5, 1, 1); // Modulate fog color
```
![image](https://user-images.githubusercontent.com/6376721/138974829-1e6e6ee9-4e52-4452-9140-3a583af87ae4.png)

Linear fog could be implemented like so (taken from #54248):
```glsl
float fog_linear = clamp((length(VERTEX) - fog_linear_start) / (fog_linear_end - fog_linear_start), 0, 1);
FOG.a = max(FOG.a, fog_linear);
```

One difference to note from the original custom fog PR is that custom fog now mixes before volumetric fog rather than after.

Will need updating in the docs (see: https://github.com/godotengine/godot-docs/pull/4301)