### PR TITLE
Rename `TabBar`'s `tab_closed` signal to `tab_close_pressed`

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -235,10 +235,19 @@
 				Emitted when a tab is clicked, even if it is the current tab.
 			</description>
 		</signal>
-		<signal name="tab_closed">
+		<signal name="tab_close_pressed">
 			<argument index="0" name="tab" type="int" />
 			<description>
-				Emitted when a tab is closed.
+				Emitted when a tab's close button is pressed.
+				[b]Note:[/b] Tabs are not removed automatically once the close button is pressed, this behaviour needs to be programmed manually. For example:
+				[codeblocks]
+				[gdscript]
+				$TabBar.tab_close_pressed.connect($TabBar.remove_tab)
+				[/gdscript]
+				[csharp]
+				GetNode&lt;TabBar&gt;("TabBar").TabClosePressed += GetNode&lt;TabBar&gt;("TabBar").RemoveTab;
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</signal>
 		<signal name="tab_hovered">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6227,7 +6227,7 @@ EditorNode::EditorNode() {
 	scene_tabs->set_drag_to_rearrange_enabled(true);
 	scene_tabs->connect("tab_changed", callable_mp(this, &EditorNode::_scene_tab_changed));
 	scene_tabs->connect("tab_rmb_clicked", callable_mp(this, &EditorNode::_scene_tab_script_edited));
-	scene_tabs->connect("tab_closed", callable_mp(this, &EditorNode::_scene_tab_closed), varray(SCENE_TAB_CLOSE));
+	scene_tabs->connect("tab_close_pressed", callable_mp(this, &EditorNode::_scene_tab_closed), varray(SCENE_TAB_CLOSE));
 	scene_tabs->connect("tab_hovered", callable_mp(this, &EditorNode::_scene_tab_hovered));
 	scene_tabs->connect("mouse_exited", callable_mp(this, &EditorNode::_scene_tab_exit));
 	scene_tabs->connect("gui_input", callable_mp(this, &EditorNode::_scene_tab_input));

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -175,7 +175,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 		if (cb_pressing && !mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 			if (cb_hover != -1) {
 				// pressed
-				emit_signal(SNAME("tab_closed"), cb_hover);
+				emit_signal(SNAME("tab_close_pressed"), cb_hover);
 			}
 
 			cb_pressing = false;
@@ -1172,7 +1172,7 @@ void TabBar::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("tab_rmb_clicked", PropertyInfo(Variant::INT, "tab")));
-	ADD_SIGNAL(MethodInfo("tab_closed", PropertyInfo(Variant::INT, "tab")));
+	ADD_SIGNAL(MethodInfo("tab_close_pressed", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("tab_hovered", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("active_tab_rearranged", PropertyInfo(Variant::INT, "idx_to")));
 	ADD_SIGNAL(MethodInfo("tab_clicked", PropertyInfo(Variant::INT, "tab")));


### PR DESCRIPTION
Clicking the close button of tab in `TabBar` doesn't do anything on its own, requiring the developer to implement the code themselves. This rename (and documentation change) is to prevent any misleading.

_Bugsquad edit: Related to https://github.com/godotengine/godot/issues/16863_