### PR TITLE
Fix Control EXIT_TREE Notification

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -583,6 +583,8 @@ void CanvasItem::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
+			ERR_FAIL_COND(!get_tree());
+
 			if (xform_change.in_list())
 				get_tree()->xform_change_list.remove(&xform_change);
 			_exit_canvas();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -490,6 +490,7 @@ void Control::_notification(int p_notification) {
 			_size_changed();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
+			ERR_FAIL_COND(!get_viewport());
 
 			get_viewport()->_gui_remove_control(this);
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This PR adds necessary checks to the EXIT_TREE notifications in the CanvasItem and Control classes to ensure graceful error handling in the event that the notification is fired when the node has not yet been added to the scene tree.

Resolves #54169 
