### PR TITLE
Fix Control EXIT_TREE Notification

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -471,6 +471,8 @@ void Control::_notification(int p_notification) {
 			_size_changed();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
+			ERR_FAIL_COND(!get_viewport());
+
 			get_viewport()->_gui_remove_control(this);
 
 		} break;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
This PR adds a check to the EXIT_TREE notification in the Control class to ensure graceful error handling in the event that the notification is fired when the node has not yet been added to the scene tree.

Resolves #54169

(Hopefully targeting the right branch this time :crossed_fingers:)