### PR TITLE
Fix crash in `SkeletonModification2DLookAt.set_bone_index`

### DIFF
--- a/scene/resources/skeleton_modification_2d_lookat.cpp
+++ b/scene/resources/skeleton_modification_2d_lookat.cpp
@@ -241,7 +241,7 @@ int SkeletonModification2DLookAt::get_bone_index() const {
 void SkeletonModification2DLookAt::set_bone_index(int p_bone_idx) {
 	ERR_FAIL_COND_MSG(p_bone_idx < 0, "Bone index is out of range: The index is too low!");
 
-	if (is_setup) {
+	if (is_setup && stack) {
 		if (stack->skeleton) {
 			ERR_FAIL_INDEX_MSG(p_bone_idx, stack->skeleton->get_bone_count(), "Passed-in Bone index is out of range!");
 			bone_idx = p_bone_idx;


### PR DESCRIPTION
Resolves #54235

Adds a check for a valid `stack` pointer in `SkeletonModification2DLookAt::set_bone_index` to avoid a crash if modification has not been set up correctly by the user.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
