### PR TITLE
Avoid GDScriptCache deadlocking the main thread

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -860,6 +860,8 @@ Error GDScript::reload(bool p_keep_state) {
 	GDScriptCompiler compiler;
 	err = compiler.compile(&parser, this, p_keep_state);
 
+	MutexLock lock(GDScriptLanguage::singleton->lock);
+
 #ifdef TOOLS_ENABLED
 	_update_doc();
 #endif


### PR DESCRIPTION
Fixes #53550

This issue is caused when the main thread is tries to load a GDScript file, but another thread is already inside `GDScriptCache::get_full_script` and is requiring use of the main thread (e.g. trying to preload materials before render server is started).

The GDScriptCache singleton should not be locked while executing `script->reload()`. It is not being modified at that point.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
