### PR TITLE
Update and fix Time documentation

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -204,8 +204,8 @@ public:
 		String name;
 	};
 
-	virtual Date get_date(bool local = false) const = 0;
-	virtual Time get_time(bool local = false) const = 0;
+	virtual Date get_date(bool p_utc = false) const = 0;
+	virtual Time get_time(bool p_utc = false) const = 0;
 	virtual TimeZoneInfo get_time_zone_info() const = 0;
 	virtual double get_unix_time() const;
 

--- a/doc/classes/Time.xml
+++ b/doc/classes/Time.xml
@@ -6,7 +6,8 @@
 	<description>
 		The Time singleton allows converting time between various formats and also getting time information from the system.
 		This class conforms with as many of the ISO 8601 standards as possible. All dates follow the Proleptic Gregorian calendar. As such, the day before [code]1582-10-15[/code] is [code]1582-10-14[/code], not [code]1582-10-04[/code]. The year before 1 AD (aka 1 BC) is number [code]0[/code], with the year before that (2 BC) being [code]-1[/code], etc.
-		Conversion methods assume "the same timezone", and do not handle timezone conversions or DST automatically. Unix epoch assumes UTC. Leap seconds are also not handled, they must be done manually if desired. Suffixes such as "Z" are not handled, you need to strip them away manually.
+		Conversion methods assume "the same timezone", and do not handle timezone conversions or DST automatically. Leap seconds are also not handled, they must be done manually if desired. Suffixes such as "Z" are not handled, you need to strip them away manually.
+		When getting time information from the system, the time can either be in the local timezone or UTC depending on the [code]utc[/code] parameter. However, the [method get_unix_time_from_system] method always returns the time in UTC.
 		[b]Important:[/b] The [code]_from_system[/code] methods use the system clock that the user can manually set. [b]Never use[/b] this method for precise time calculation since its results are subject to automatic adjustments by the user or the operating system. [b]Always use[/b] [method get_ticks_usec] or [method get_ticks_msec] for precise time calculation instead, since they are guaranteed to be monotonic (i.e. never decrease).
 	</description>
 	<tutorials>
@@ -82,7 +83,7 @@
 			<argument index="0" name="utc" type="bool" default="false" />
 			<argument index="1" name="use_space" type="bool" default="false" />
 			<description>
-				Returns the current date and time as a dictionary of keys: [code]year[/code], [code]month[/code], [code]day[/code], [code]weekday[/code], [code]dst[/code] (Daylight Savings Time), [code]hour[/code], [code]minute[/code], and [code]second[/code].
+				Returns the current date and time as an ISO 8601 date and time string (YYYY-MM-DDTHH:MM:SS).
 				The returned values are in the system's local time when [code]utc[/code] is false, otherwise they are in UTC.
 				If [code]use_space[/code] is true, use a space instead of the letter T in the middle.
 			</description>
@@ -152,9 +153,9 @@
 			<description>
 				Converts a dictionary of time values to a Unix timestamp.
 				The given dictionary can be populated with the following keys: [code]year[/code], [code]month[/code], [code]day[/code], [code]hour[/code], [code]minute[/code], and [code]second[/code]. Any other entries (including [code]dst[/code]) are ignored.
-				If the dictionary is empty, [code]0[/code] is returned. If some keys are omitted, they default to the equivalent values for the Unix epoch timestamp 0 (1970-01-01 at 00:00:00 UTC).
+				If the dictionary is empty, [code]0[/code] is returned. If some keys are omitted, they default to the equivalent values for the Unix epoch timestamp 0 (1970-01-01 at 00:00:00).
 				You can pass the output from [method get_datetime_dict_from_unix_time] directly into this function and get the same as what was put in.
-				[b]Note:[/b] Unix timestamps are usually in UTC, the given datetime dict may not be.
+				[b]Note:[/b] Unix timestamps are often in UTC. This method does not do any timezone conversion, so the timestamp will be in the same timezone as the given datetime dictionary.
 			</description>
 		</method>
 		<method name="get_unix_time_from_datetime_string" qualifiers="const">
@@ -162,13 +163,13 @@
 			<argument index="0" name="datetime" type="String" />
 			<description>
 				Converts the given ISO 8601 date and/or time string to a Unix timestamp. The string can contain a date only, a time only, or both.
-				[b]Note:[/b] Unix timestamps are usually in UTC, the given datetime string may not be.
+				[b]Note:[/b] Unix timestamps are often in UTC. This method does not do any timezone conversion, so the timestamp will be in the same timezone as the given datetime string.
 			</description>
 		</method>
 		<method name="get_unix_time_from_system" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the current Unix timestamp in seconds based on the system time in UTC.
+				Returns the current Unix timestamp in seconds based on the system time in UTC. This method is implemented by the operating system and always returns the time in UTC.
 			</description>
 		</method>
 	</methods>

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -160,10 +160,10 @@ double OS_Unix::get_unix_time() const {
 	return (double)tv_now.tv_sec + double(tv_now.tv_usec) / 1000000;
 };
 
-OS::Date OS_Unix::get_date(bool utc) const {
+OS::Date OS_Unix::get_date(bool p_utc) const {
 	time_t t = time(nullptr);
 	struct tm lt;
-	if (utc) {
+	if (p_utc) {
 		gmtime_r(&t, &lt);
 	} else {
 		localtime_r(&t, &lt);
@@ -181,10 +181,10 @@ OS::Date OS_Unix::get_date(bool utc) const {
 	return ret;
 }
 
-OS::Time OS_Unix::get_time(bool utc) const {
+OS::Time OS_Unix::get_time(bool p_utc) const {
 	time_t t = time(nullptr);
 	struct tm lt;
-	if (utc) {
+	if (p_utc) {
 		gmtime_r(&t, &lt);
 	} else {
 		localtime_r(&t, &lt);

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -72,8 +72,8 @@ public:
 
 	virtual String get_name() const override;
 
-	virtual Date get_date(bool utc) const override;
-	virtual Time get_time(bool utc) const override;
+	virtual Date get_date(bool p_utc) const override;
+	virtual Time get_time(bool p_utc) const override;
 	virtual TimeZoneInfo get_time_zone_info() const override;
 
 	virtual double get_unix_time() const override;

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -441,12 +441,13 @@ String OS_UWP::get_name() const {
 	return "UWP";
 }
 
-OS::Date OS_UWP::get_date(bool utc) const {
+OS::Date OS_UWP::get_date(bool p_utc) const {
 	SYSTEMTIME systemtime;
-	if (utc)
+	if (utc) {
 		GetSystemTime(&systemtime);
-	else
+	} else {
 		GetLocalTime(&systemtime);
+	}
 
 	Date date;
 	date.day = systemtime.wDay;
@@ -457,7 +458,7 @@ OS::Date OS_UWP::get_date(bool utc) const {
 	return date;
 }
 
-OS::Time OS_UWP::get_time(bool utc) const {
+OS::Time OS_UWP::get_time(bool p_utc) const {
 	SYSTEMTIME systemtime;
 	if (utc)
 		GetSystemTime(&systemtime);

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -185,8 +185,8 @@ public:
 
 	virtual String get_name() const;
 
-	virtual Date get_date(bool utc) const;
-	virtual Time get_time(bool utc) const;
+	virtual Date get_date(bool p_utc) const;
+	virtual Time get_time(bool p_utc) const;
 	virtual TimeZoneInfo get_time_zone_info() const;
 	virtual uint64_t get_unix_time() const;
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -290,12 +290,13 @@ String OS_Windows::get_name() const {
 	return "Windows";
 }
 
-OS::Date OS_Windows::get_date(bool utc) const {
+OS::Date OS_Windows::get_date(bool p_utc) const {
 	SYSTEMTIME systemtime;
-	if (utc)
+	if (p_utc) {
 		GetSystemTime(&systemtime);
-	else
+	} else {
 		GetLocalTime(&systemtime);
+	}
 
 	Date date;
 	date.day = systemtime.wDay;
@@ -306,12 +307,13 @@ OS::Date OS_Windows::get_date(bool utc) const {
 	return date;
 }
 
-OS::Time OS_Windows::get_time(bool utc) const {
+OS::Time OS_Windows::get_time(bool p_utc) const {
 	SYSTEMTIME systemtime;
-	if (utc)
+	if (p_utc) {
 		GetSystemTime(&systemtime);
-	else
+	} else {
 		GetLocalTime(&systemtime);
+	}
 
 	Time time;
 	time.hour = systemtime.wHour;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -122,8 +122,8 @@ public:
 
 	virtual void initialize_joypads() override {}
 
-	virtual Date get_date(bool utc) const override;
-	virtual Time get_time(bool utc) const override;
+	virtual Date get_date(bool p_utc) const override;
+	virtual Time get_time(bool p_utc) const override;
 	virtual TimeZoneInfo get_time_zone_info() const override;
 	virtual double get_unix_time() const override;
 


### PR DESCRIPTION
Follow-up to #49123 and #54256.

* Fix bogus docs in `get_datetime_string_from_system` (my fault, bogus since #49123).
* Fix and clarify statements about UTC added in #54256. "Unix epoch assumes UTC" as a blanket statement is false. `Time`'s conversion methods are timezone-agnostic, and when getting information from the system there is usually a `utc` bool.
* Fix some style issues with time methods in OS having parameters named `utc` instead of `p_utc`.