### PR TITLE
Websockets: Fix buffer size checks in put_packet(), silent failures/connection hangs

### DIFF
--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -54,11 +54,14 @@ Error EMWSPeer::read_msg(const uint8_t *p_data, uint32_t p_size, bool p_is_strin
 }
 
 Error EMWSPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
-	ERR_FAIL_COND_V(_out_buf_size && ((uint64_t)godot_js_websocket_buffered_amount(peer_sock) >= (1ULL << _out_buf_size)), ERR_OUT_OF_MEMORY);
+	ERR_FAIL_COND_V(_out_buf_size && ((uint64_t)godot_js_websocket_buffered_amount(peer_sock) + p_buffer_size >= (1ULL << _out_buf_size)), ERR_OUT_OF_MEMORY);
 
 	int is_bin = write_mode == WebSocketPeer::WRITE_MODE_BINARY ? 1 : 0;
 
-	godot_js_websocket_send(peer_sock, p_buffer, p_buffer_size, is_bin);
+	if (godot_js_websocket_send(peer_sock, p_buffer, p_buffer_size, is_bin) != 0) {
+		return FAILED;
+	}
+
 	return OK;
 }
 

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -242,15 +242,15 @@ void WSLPeer::poll() {
 Error WSLPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 	ERR_FAIL_COND_V(!is_connected_to_host(), FAILED);
 	ERR_FAIL_COND_V(_out_pkt_size && (wslay_event_get_queued_msg_count(_data->ctx) >= (1ULL << _out_pkt_size)), ERR_OUT_OF_MEMORY);
-	ERR_FAIL_COND_V(_out_buf_size && (wslay_event_get_queued_msg_length(_data->ctx) >= (1ULL << _out_buf_size)), ERR_OUT_OF_MEMORY);
+	ERR_FAIL_COND_V(_out_buf_size && (wslay_event_get_queued_msg_length(_data->ctx) + p_buffer_size >= (1ULL << _out_buf_size)), ERR_OUT_OF_MEMORY);
 
-	struct wslay_event_msg msg; // Should I use fragmented?
+	struct wslay_event_msg msg;
 	msg.opcode = write_mode == WRITE_MODE_TEXT ? WSLAY_TEXT_FRAME : WSLAY_BINARY_FRAME;
 	msg.msg = p_buffer;
 	msg.msg_length = p_buffer_size;
 
-	wslay_event_queue_msg(_data->ctx, &msg);
-	if (wslay_event_send(_data->ctx) < 0) {
+	// Queue & send message.
+	if (wslay_event_queue_msg(_data->ctx, &msg) != 0 || wslay_event_send(_data->ctx) != 0) {
 		close_now();
 		return FAILED;
 	}


### PR DESCRIPTION
In the WebSocket peer implementations (`WSLPeer`/`EMWSPeer`), `put_packet()` currently only checks if the message buffer _already is_ full, not whether the current buffer _plus_ the given message will exceed the buffer size limit.

There is a second bug wherein `wslay_event_queue_msg()`/`godot_js_websocket_send()` have a error return that is not checked.

This means that if the buffer size is exceeded, either by a single large packet that is > our buffer size limit (65536 by default) or by a large number of smaller packets, the following happens:
1. The guard buffer size check succeeds where it shouldn't, the function proceeds as normal
2. `wslay_event_queue_msg()` is tried, but fails as the buffer is overrun and the connection to that peer is killed, which makes this function return `WSLAY_ERR_NO_MORE_MSG` (connection closed), which _isn't_ checked for
3. For the (Godot Engine) user, at this point, the connection seemingly hangs, every new try to send a message fails silently. No warning or error was printed at any point.

This is fixed by this PR. :) Fixes https://github.com/godotengine/godot/issues/53924

Godot 3.x version: https://github.com/godotengine/godot/pull/54381