### PR TITLE
Improve GDScript indentation error message

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1064,7 +1064,8 @@ void GDScriptTokenizer::check_indent() {
 			// First time indenting, choose character now.
 			indent_char = current_indent_char;
 		} else if (current_indent_char != indent_char) {
-			Token error = make_error(vformat("Used \"%s\" for indentation instead \"%s\" as used before in the file.", String(&current_indent_char, 1).c_escape(), String(&indent_char, 1).c_escape()));
+			Token error = make_error(vformat("Used %s character for indentation instead of %s as used before in the file.",
+					_get_indent_char_name(current_indent_char), _get_indent_char_name(indent_char)));
 			error.start_line = line;
 			error.start_column = 1;
 			error.leftmost_column = 1;
@@ -1112,6 +1113,12 @@ void GDScriptTokenizer::check_indent() {
 		}
 		break; // Get out of the loop in any case.
 	}
+}
+
+String GDScriptTokenizer::_get_indent_char_name(char32_t ch) {
+	ERR_FAIL_COND_V(ch != ' ' && ch != '\t', String(&ch, 1).c_escape());
+
+	return ch == ' ' ? "space" : "tab";
 }
 
 void GDScriptTokenizer::_skip_whitespace() {

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -233,6 +233,7 @@ private:
 	bool has_error() const { return !error_stack.is_empty(); }
 	Token pop_error();
 	char32_t _advance();
+	String _get_indent_char_name(char32_t ch);
 	void _skip_whitespace();
 	void check_indent();
 

--- a/modules/gdscript/tests/scripts/parser/errors/mixing_tabs_spaces.out
+++ b/modules/gdscript/tests/scripts/parser/errors/mixing_tabs_spaces.out
@@ -1,2 +1,2 @@
 GDTEST_PARSER_ERROR
-Used "\t" for indentation instead " " as used before in the file.
+Used tab character for indentation instead of space as used before in the file.


### PR DESCRIPTION
Minor improvement to GDScript indentation error messages, changing it from
> Used "\t" for indentation instead " " as used before in the file.

to

> Used tab character for indentation instead of space as used before in the file.

This is also more consistent with similar errors, e.g. the one for mixing indent character in the same line, which is:
> Mixed use of tabs and spaces for indentation.