### PR TITLE
Fix memory leak in RichTextLabel.remove_line

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2346,6 +2346,7 @@ void RichTextLabel::_remove_item(Item *p_item, const int p_line, const int p_sub
 		// Then remove the provided item itself.
 		p_item->parent->subitems.erase(p_item);
 	}
+	memdelete(p_item);
 }
 
 void RichTextLabel::add_image(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlign p_align) {


### PR DESCRIPTION
Fix #49571.
_remove_item (only called in remove_line) didn't free the item.
PS: in branch 3.x, Godot doesn't work when compiled with ```use_lsan=yes``` but this leak also happens in this branch.