### PR TITLE
CI: Update to clang-format 13 using LLVM repo

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -18,13 +18,15 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/*
           sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
           sudo apt-get update
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -qq dos2unix recode clang-format-12
+          sudo apt-get install -qq dos2unix recode clang-format-13
           sudo update-alternatives --remove-all clang-format
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
           sudo pip3 install black==20.8b1 pygments
 
       - name: File formatting checks (file_format.sh)

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -403,7 +403,7 @@ protected:                                                                      
 		initialize_class();                                                                                                                      \
 	}                                                                                                                                            \
 	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &) const {                                                 \
-		return (bool (Object::*)(const StringName &, Variant &) const) & m_class::_get;                                                          \
+		return (bool(Object::*)(const StringName &, Variant &) const) & m_class::_get;                                                           \
 	}                                                                                                                                            \
 	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override {                                                                \
 		if (m_class::_get_get() != m_inherits::_get_get()) {                                                                                     \
@@ -414,7 +414,7 @@ protected:                                                                      
 		return m_inherits::_getv(p_name, r_ret);                                                                                                 \
 	}                                                                                                                                            \
 	_FORCE_INLINE_ bool (Object::*_get_set() const)(const StringName &p_name, const Variant &p_property) {                                       \
-		return (bool (Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                          \
+		return (bool(Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                           \
 	}                                                                                                                                            \
 	virtual bool _setv(const StringName &p_name, const Variant &p_property) override {                                                           \
 		if (m_inherits::_setv(p_name, p_property)) {                                                                                             \
@@ -426,7 +426,7 @@ protected:                                                                      
 		return false;                                                                                                                            \
 	}                                                                                                                                            \
 	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> * p_list) const {                                           \
-		return (void (Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                                     \
+		return (void(Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                                      \
 	}                                                                                                                                            \
 	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const override {                                               \
 		if (!p_reversed) {                                                                                                                       \
@@ -447,7 +447,7 @@ protected:                                                                      
 		}                                                                                                                                        \
 	}                                                                                                                                            \
 	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {                                                                              \
-		return (void (Object::*)(int)) & m_class::_notification;                                                                                 \
+		return (void(Object::*)(int)) & m_class::_notification;                                                                                  \
 	}                                                                                                                                            \
 	virtual void _notificationv(int p_notification, bool p_reversed) override {                                                                  \
 		if (!p_reversed) {                                                                                                                       \


### PR DESCRIPTION
The changes to `object.h` seem to be the only inconsistency between `clang-format` 12 and 13's output, following #54350.

So we can still _allow_ users to use clang-format 12, as long as they don't touch `object.h` they should be fine. But of course upgrading is recommended when possible.