### PR TITLE
Removed incorrect autocompletion of matrixes in shader

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -9370,15 +9370,6 @@ Error ShaderLanguage::complete(const String &p_code, const Map<StringName, Funct
 					limit = 4;
 
 				} break;
-				case TYPE_MAT2:
-					limit = 2;
-					break;
-				case TYPE_MAT3:
-					limit = 3;
-					break;
-				case TYPE_MAT4:
-					limit = 4;
-					break;
 				default: {
 				}
 			}


### PR DESCRIPTION
There are no "r,g,b" components after '.' in the matrixes of the shaders so I removed them from an autocompletion:

![image](https://user-images.githubusercontent.com/3036176/139305181-95e618be-0def-44af-a5f7-ac9a47eace37.png)

