### PR TITLE
Fix crash due to reentrancy in AudioStreamPlayer* finished signal.

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -78,7 +78,6 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 			Vector<Ref<AudioStreamPlayback>> playbacks_to_remove;
 			for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 				if (playback.is_valid() && !AudioServer::get_singleton()->is_playback_active(playback) && !AudioServer::get_singleton()->is_playback_paused(playback)) {
-					emit_signal(SNAME("finished"));
 					playbacks_to_remove.push_back(playback);
 				}
 			}
@@ -90,6 +89,9 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 				// This node is no longer actively playing audio.
 				active.clear();
 				set_physics_process_internal(false);
+			}
+			if (!playbacks_to_remove.is_empty()) {
+				emit_signal(SNAME("finished"));
 			}
 		}
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -292,7 +292,6 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 			Vector<Ref<AudioStreamPlayback>> playbacks_to_remove;
 			for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 				if (playback.is_valid() && !AudioServer::get_singleton()->is_playback_active(playback) && !AudioServer::get_singleton()->is_playback_paused(playback)) {
-					emit_signal(SNAME("finished"));
 					playbacks_to_remove.push_back(playback);
 				}
 			}
@@ -304,6 +303,9 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 				// This node is no longer actively playing audio.
 				active.clear();
 				set_physics_process_internal(false);
+			}
+			if (!playbacks_to_remove.is_empty()) {
+				emit_signal(SNAME("finished"));
 			}
 		}
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -45,7 +45,6 @@ void AudioStreamPlayer::_notification(int p_what) {
 		Vector<Ref<AudioStreamPlayback>> playbacks_to_remove;
 		for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 			if (playback.is_valid() && !AudioServer::get_singleton()->is_playback_active(playback) && !AudioServer::get_singleton()->is_playback_paused(playback)) {
-				emit_signal(SNAME("finished"));
 				playbacks_to_remove.push_back(playback);
 			}
 		}
@@ -57,6 +56,9 @@ void AudioStreamPlayer::_notification(int p_what) {
 			// This node is no longer actively playing audio.
 			active.clear();
 			set_process_internal(false);
+		}
+		if (!playbacks_to_remove.is_empty()) {
+			emit_signal(SNAME("finished"));
 		}
 	}
 


### PR DESCRIPTION
This crash occurred when an audio stream finished playing in NOTIFICATION_INTERNAL_PROCESS,
during which it would iterate through a loop of playbacks,
leading to a "finished" signal, which removed the audio player from the tree (if the application's signal handler did it)
which led to a NOTIFICATION_EXIT_TREE,
which would mutate the array of playbacks while within the above loop.

This moves the signal callback outside of the loop which avoids the crash.
Note: previously, the signal was called multiple times if the same player finishes multiple times in one frame. Now it is at most once per frame.

Affects AudioStreamPlayer, AudioStreamPlayer2D and AudioStreamPlayer3D

Tested in an application that used a plain AudioStreamPlayer to play sound on hovering over menu items. Previously, moving the mouse quickly would crash the game within a few seconds. This seems to fix the issue.

Note that the documentation for the "finished" signal is very sparse and doesn't say how many times it will be called per frame, if multiple playbacks finish at once (is this even possible?), so I didn't attempt to preserve the old behavior precisely.