### PR TITLE
Fix hardcoded raycast distance in viewport object picking

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -715,10 +715,11 @@ void Viewport::_process_picking() {
 			if (camera_3d) {
 				Vector3 from = camera_3d->project_ray_origin(pos);
 				Vector3 dir = camera_3d->project_ray_normal(pos);
+				real_t far = camera_3d->far;
 
 				PhysicsDirectSpaceState3D *space = PhysicsServer3D::get_singleton()->space_get_direct_state(find_world_3d()->get_space());
 				if (space) {
-					bool col = space->intersect_ray(from, from + dir * 10000, result, Set<RID>(), 0xFFFFFFFF, true, true, true);
+					bool col = space->intersect_ray(from, from + dir * far, result, Set<RID>(), 0xFFFFFFFF, true, true, true);
 					ObjectID new_collider;
 					if (col) {
 						CollisionObject3D *co = Object::cast_to<CollisionObject3D>(result.collider);


### PR DESCRIPTION
fix hardcoded raycast distance in viewport object picking

having the raycast distance hardcoded to `10000` caused input events to not be registered in very large 3D scenes.
This resolves the issue by using the cameras far distance instead. Creating the more predictable behavior of "if an object is visible, it will be picked by the viewport."

More info about the issue can be found in #49735

Closes #49735