### PR TITLE
Fix 3D materials not updating on texture invalidation

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -30,6 +30,7 @@
 
 #include "render_forward_mobile.h"
 #include "core/config/project_settings.h"
+#include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server_default.h"
 
@@ -2362,6 +2363,11 @@ void RenderForwardMobile::_geometry_instance_add_surface(GeometryInstanceForward
 		material = (SceneShaderForwardMobile::MaterialData *)storage->material_get_data(m_src, RendererStorageRD::SHADER_TYPE_3D);
 		if (!material || !material->shader_data->valid) {
 			material = nullptr;
+		} else if (material->last_frame != RendererCompositorRD::singleton->get_frame_number()) {
+			material->last_frame = RendererCompositorRD::singleton->get_frame_number();
+			if (!RD::get_singleton()->uniform_set_is_valid(material->uniform_set)) {
+				storage->material_force_update_textures(m_src, RendererStorageRD::SHADER_TYPE_3D);
+			}
 		}
 	}
 
@@ -2383,6 +2389,11 @@ void RenderForwardMobile::_geometry_instance_add_surface(GeometryInstanceForward
 		material = (SceneShaderForwardMobile::MaterialData *)storage->material_get_data(next_pass, RendererStorageRD::SHADER_TYPE_3D);
 		if (!material || !material->shader_data->valid) {
 			break;
+		} else if (material->last_frame != RendererCompositorRD::singleton->get_frame_number()) {
+			material->last_frame = RendererCompositorRD::singleton->get_frame_number();
+			if (!RD::get_singleton()->uniform_set_is_valid(material->uniform_set)) {
+				storage->material_force_update_textures(m_src, RendererStorageRD::SHADER_TYPE_3D);
+			}
 		}
 		if (ginstance->data->dirty_dependencies) {
 			storage->material_update_dependency(next_pass, &ginstance->data->dependency_tracker);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3903,6 +3903,11 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 				material = (FogMaterialData *)storage->material_get_data(fog_material, RendererStorageRD::SHADER_TYPE_FOG);
 				if (!material || !material->shader_data->valid) {
 					material = nullptr;
+				} else if (material->last_frame != RendererCompositorRD::singleton->get_frame_number()) {
+					material->last_frame = RendererCompositorRD::singleton->get_frame_number();
+					if (!RD::get_singleton()->uniform_set_is_valid(material->uniform_set)) {
+						storage->material_force_update_textures(fog_material, RendererStorageRD::SHADER_TYPE_FOG);
+					}
 				}
 			}
 

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -1048,6 +1048,11 @@ void RendererSceneSkyRD::setup(RendererSceneEnvironmentRD *p_env, RID p_render_b
 			material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
 			if (!material || !material->shader_data->valid) {
 				material = nullptr;
+			} else if (material->last_frame != RendererCompositorRD::singleton->get_frame_number()) {
+				material->last_frame = RendererCompositorRD::singleton->get_frame_number();
+				if (!RD::get_singleton()->uniform_set_is_valid(material->uniform_set)) {
+					storage->material_force_update_textures(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+				}
 			}
 		}
 
@@ -1203,6 +1208,11 @@ void RendererSceneSkyRD::update(RendererSceneEnvironmentRD *p_env, const CameraM
 		material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
 		if (!material || !material->shader_data->valid) {
 			material = nullptr;
+		} else if (material->last_frame != RendererCompositorRD::singleton->get_frame_number()) {
+			material->last_frame = RendererCompositorRD::singleton->get_frame_number();
+			if (!RD::get_singleton()->uniform_set_is_valid(material->uniform_set)) {
+				storage->material_force_update_textures(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+			}
 		}
 	}
 
@@ -1378,6 +1388,11 @@ void RendererSceneSkyRD::draw(RendererSceneEnvironmentRD *p_env, bool p_can_cont
 			material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
 			if (!material || !material->shader_data->valid) {
 				material = nullptr;
+			} else if (material->last_frame != RendererCompositorRD::singleton->get_frame_number()) {
+				material->last_frame = RendererCompositorRD::singleton->get_frame_number();
+				if (!RD::get_singleton()->uniform_set_is_valid(material->uniform_set)) {
+					storage->material_force_update_textures(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+				}
 			}
 		}
 
@@ -1481,6 +1496,11 @@ void RendererSceneSkyRD::update_res_buffers(RendererSceneEnvironmentRD *p_env, u
 		material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
 		if (!material || !material->shader_data->valid) {
 			material = nullptr;
+		} else if (material->last_frame != RendererCompositorRD::singleton->get_frame_number()) {
+			material->last_frame = RendererCompositorRD::singleton->get_frame_number();
+			if (!RD::get_singleton()->uniform_set_is_valid(material->uniform_set)) {
+				storage->material_force_update_textures(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+			}
 		}
 	}
 
@@ -1568,6 +1588,11 @@ void RendererSceneSkyRD::draw(RD::DrawListID p_draw_list, RendererSceneEnvironme
 			material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
 			if (!material || !material->shader_data->valid) {
 				material = nullptr;
+			} else if (material->last_frame != RendererCompositorRD::singleton->get_frame_number()) {
+				material->last_frame = RendererCompositorRD::singleton->get_frame_number();
+				if (!RD::get_singleton()->uniform_set_is_valid(material->uniform_set)) {
+					storage->material_force_update_textures(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+				}
 			}
 		}
 


### PR DESCRIPTION
See better implementation: #54489

---

Fixes #51361
Fixes #53206
Fixes #53089
Should fix #42821
Might fix #50296
Might fix #52505
Might fix #45746

It's possible there are other issues related to/fixed by this.

Might be relevant for #50327.

Supersedes #52528

https://user-images.githubusercontent.com/6376721/139451979-66d26ad5-ca1b-4c4b-b4ae-af25adc0fdc8.mp4

---

Explanation of the issue here:
https://github.com/godotengine/godot/issues/51361#issuecomment-954350904

This is essentially finishing what #50269 set out to do. Implementation derived from: https://github.com/godotengine/godot/blob/0dc809cd0142fa7b512c46fa00dabbac77f60e54/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp#L1378-L1382