### PR TITLE
Add functions for getting font metadata, add editor plugin for quick font selection.

### DIFF
--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -93,6 +93,24 @@
 				Returns font descent (number of pixels below the baseline).
 			</description>
 		</method>
+		<method name="get_font_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns font family name.
+			</description>
+		</method>
+		<method name="get_font_style" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns font style flags, see [enum TextServer.FontStyle].
+			</description>
+		</method>
+		<method name="get_font_style_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns font style name.
+			</description>
+		</method>
 		<method name="get_glyph_advance" qualifiers="const">
 			<return type="Vector2" />
 			<argument index="0" name="cache_index" type="int" />
@@ -461,6 +479,27 @@
 			<argument index="2" name="descent" type="float" />
 			<description>
 				Sets the font descent (number of pixels below the baseline).
+			</description>
+		</method>
+		<method name="set_font_name">
+			<return type="void" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Sets the font family name.
+			</description>
+		</method>
+		<method name="set_font_style">
+			<return type="void" />
+			<argument index="0" name="style" type="int" />
+			<description>
+				Sets the font style flags, see [enum TextServer.FontStyle].
+			</description>
+		</method>
+		<method name="set_font_style_name">
+			<return type="void" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Sets the font style name.
 			</description>
 		</method>
 		<method name="set_force_autohinter">

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -196,6 +196,9 @@
 		<member name="expand_to_text_length" type="bool" setter="set_expand_to_text_length_enabled" getter="is_expand_to_text_length_enabled" default="false">
 			If [code]true[/code], the [LineEdit] width will increase to stay longer than the [member text]. It will [b]not[/b] compress if the [member text] is shortened.
 		</member>
+		<member name="flat" type="bool" setter="set_flat" getter="is_flat" default="false">
+			If [code]true[/code], the [LineEdit] don't display decoration.
+		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -254,6 +254,13 @@
 				Returns source font size used to generate MSDF textures.
 			</description>
 		</method>
+		<method name="font_get_name" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font family name.
+			</description>
+		</method>
 		<method name="font_get_oversampling" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -298,6 +305,20 @@
 			<argument index="2" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
 				Returns extra spacing added between glyphs in pixels.
+			</description>
+		</method>
+		<method name="font_get_style" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font style flags, see [enum FontStyle].
+			</description>
+		</method>
+		<method name="font_get_style_name" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font style name.
 			</description>
 		</method>
 		<method name="font_get_supported_chars" qualifiers="const">
@@ -634,6 +655,14 @@
 				[b]Note:[/b] MSDF font rendering does not render glyphs with overlapping shapes correctly. Overlapping shapes are not valid per the OpenType standard, but are still commonly found in many font files, especially those converted by Google Fonts. To avoid issues with overlapping glyphs, consider downloading the font file directly from the type foundry instead of relying on Google Fonts.
 			</description>
 		</method>
+		<method name="font_set_name">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="name" type="String" />
+			<description>
+				Sets the font family name.
+			</description>
+		</method>
 		<method name="font_set_oversampling">
 			<return type="void" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -668,6 +697,22 @@
 			<argument index="3" name="value" type="int" />
 			<description>
 				Sets extra spacing added between glyphs in pixels.
+			</description>
+		</method>
+		<method name="font_set_style">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="style" type="int" />
+			<description>
+				Sets the font style flags, see [enum FontStyle].
+			</description>
+		</method>
+		<method name="font_set_style_name">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="name" type="String" />
+			<description>
+				Set the font style name.
 			</description>
 		</method>
 		<method name="font_set_texture_image">
@@ -1401,6 +1446,15 @@
 		</constant>
 		<constant name="SPACING_BOTTOM" value="3" enum="SpacingType">
 			Spacing at the bottom of the line.
+		</constant>
+		<constant name="FONT_BOLD" value="1" enum="FontStyle">
+			Font is bold.
+		</constant>
+		<constant name="FONT_ITALIC" value="2" enum="FontStyle">
+			Font is italic or oblique.
+		</constant>
+		<constant name="FONT_FIXED_WIDTH" value="4" enum="FontStyle">
+			Font have fixed-width characters.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -254,6 +254,13 @@
 				Returns source font size used to generate MSDF textures.
 			</description>
 		</method>
+		<method name="_font_get_name" qualifiers="virtual const">
+			<return type="String" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font family name.
+			</description>
+		</method>
 		<method name="_font_get_oversampling" qualifiers="virtual const">
 			<return type="float" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -298,6 +305,20 @@
 			<argument index="2" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
 				Returns extra spacing added between glyphs in pixels.
+			</description>
+		</method>
+		<method name="_font_get_style" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font style flags, see [enum TextServer.FontStyle].
+			</description>
+		</method>
+		<method name="_font_get_style_name" qualifiers="virtual const">
+			<return type="String" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font style name.
 			</description>
 		</method>
 		<method name="_font_get_supported_chars" qualifiers="virtual const">
@@ -641,6 +662,14 @@
 				If set to [code]true[/code], glyphs of all sizes are rendered using single multichannel signed distance field generated from the dynamic font vector data.
 			</description>
 		</method>
+		<method name="_font_set_name" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="name" type="String" />
+			<description>
+				Sets the font family name.
+			</description>
+		</method>
 		<method name="_font_set_oversampling" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -675,6 +704,22 @@
 			<argument index="3" name="value" type="int" />
 			<description>
 				Sets extra spacing added between glyphs in pixels.
+			</description>
+		</method>
+		<method name="_font_set_style" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="style" type="int" />
+			<description>
+				Sets the font style flags, see [enum TextServer.FontStyle].
+			</description>
+		</method>
+		<method name="_font_set_style_name" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="name_style" type="String" />
+			<description>
+				Sets the font style name.
 			</description>
 		</method>
 		<method name="_font_set_texture_image" qualifiers="virtual">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -174,6 +174,7 @@
 #include "editor/plugins/sprite_frames_editor_plugin.h"
 #include "editor/plugins/style_box_editor_plugin.h"
 #include "editor/plugins/sub_viewport_preview_editor_plugin.h"
+#include "editor/plugins/text_control_editor_plugin.h"
 #include "editor/plugins/text_editor.h"
 #include "editor/plugins/texture_3d_editor_plugin.h"
 #include "editor/plugins/texture_editor_plugin.h"
@@ -6991,6 +6992,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(GPUParticlesCollisionSDFEditorPlugin(this)));
 	add_editor_plugin(memnew(InputEventEditorPlugin(this)));
 	add_editor_plugin(memnew(SubViewportPreviewEditorPlugin(this)));
+	add_editor_plugin(memnew(TextControlEditorPlugin(this)));
 
 	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
 		add_editor_plugin(EditorPlugins::create(i, this));

--- a/editor/plugins/text_control_editor_plugin.cpp
+++ b/editor/plugins/text_control_editor_plugin.cpp
@@ -1,0 +1,375 @@
+/*************************************************************************/
+/*  text_control_editor_plugin.cpp                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "text_control_editor_plugin.h"
+
+#include "editor/editor_scale.h"
+
+void TextControlEditor::_notification(int p_notification) {
+	switch (p_notification) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &TextControlEditor::_reload_fonts))) {
+				EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &TextControlEditor::_reload_fonts), make_binds(""));
+			}
+			[[fallthrough]];
+		}
+		case NOTIFICATION_THEME_CHANGED: {
+			clear_formatting->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &TextControlEditor::_reload_fonts))) {
+				EditorFileSystem::get_singleton()->disconnect("filesystem_changed", callable_mp(this, &TextControlEditor::_reload_fonts));
+			}
+		} break;
+		default:
+			break;
+	}
+}
+
+void TextControlEditor::_find_resources(EditorFileSystemDirectory *p_dir) {
+	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
+		_find_resources(p_dir->get_subdir(i));
+	}
+
+	for (int i = 0; i < p_dir->get_file_count(); i++) {
+		if (p_dir->get_file_type(i) == "FontData") {
+			Ref<FontData> fd = ResourceLoader::load(p_dir->get_file_path(i));
+			if (fd.is_valid()) {
+				String name = fd->get_font_name();
+				String sty = fd->get_font_style_name();
+				if (sty.is_empty()) {
+					sty = "Default";
+				}
+				fonts[name][sty] = p_dir->get_file_path(i);
+			}
+		}
+	}
+}
+
+void TextControlEditor::_reload_fonts(const String &p_path) {
+	fonts.clear();
+	_find_resources(EditorFileSystem::get_singleton()->get_filesystem());
+	_update_control();
+}
+
+void TextControlEditor::_update_fonts_menu() {
+	font_list->clear();
+	font_list->add_item(TTR("[Theme Default]"), FONT_INFO_THEME_DEFAULT);
+	if (custom_font.is_valid()) {
+		font_list->add_item(TTR("[Custom Font]"), FONT_INFO_USER_CUSTOM);
+	}
+
+	int id = FONT_INFO_ID;
+	for (Map<String, Map<String, String>>::Element *E = fonts.front(); E; E = E->next()) {
+		font_list->add_item(E->key(), id++);
+	}
+
+	if (font_list->get_item_count() > 1) {
+		font_list->show();
+	} else {
+		font_list->hide();
+	}
+}
+
+void TextControlEditor::_update_styles_menu() {
+	font_style_list->clear();
+	if ((font_list->get_selected_id() >= FONT_INFO_ID)) {
+		const String &name = font_list->get_item_text(font_list->get_selected());
+		for (Map<String, String>::Element *E = fonts[name].front(); E; E = E->next()) {
+			font_style_list->add_item(E->key());
+		}
+	} else {
+		font_style_list->add_item("Default");
+	}
+
+	if (font_style_list->get_item_count() > 1) {
+		font_style_list->show();
+	} else {
+		font_style_list->hide();
+	}
+}
+
+void TextControlEditor::_update_control() {
+	if (edited_control) {
+		// Get override names.
+		if (edited_control->is_class("RichTextLabel")) {
+			edited_color = "default_color";
+			edited_font = "normal_font";
+			edited_font_size = "normal_font_size";
+		} else {
+			edited_color = "font_color";
+			edited_font = "font";
+			edited_font_size = "font_size";
+		}
+
+		// Get font override.
+		Ref<Font> font;
+		if (edited_control->has_theme_font_override(edited_font)) {
+			font = edited_control->get_theme_font(edited_font);
+		}
+		if (font.is_valid()) {
+			if (font->get_data_count() != 1) {
+				// Composite font, save it to "custom_font" to allow undoing font change.
+				custom_font = font;
+				_update_fonts_menu();
+				font_list->select(FONT_INFO_USER_CUSTOM);
+				_update_styles_menu();
+				font_style_list->select(0);
+			} else {
+				// Single face font, search for the font with matching name and style.
+				String name = font->get_data(0)->get_font_name();
+				String style = font->get_data(0)->get_font_style_name();
+				if (fonts.has(name) && fonts[name].has(style)) {
+					_update_fonts_menu();
+					for (int i = 0; i < font_list->get_item_count(); i++) {
+						if (font_list->get_item_text(i) == name) {
+							font_list->select(i);
+							break;
+						}
+					}
+					_update_styles_menu();
+					for (int i = 0; i < font_style_list->get_item_count(); i++) {
+						if (font_style_list->get_item_text(i) == style) {
+							font_style_list->select(i);
+							break;
+						}
+					}
+				} else {
+					// Unknown font, save it to "custom_font" to allow undoing font change.
+					custom_font = font;
+					_update_fonts_menu();
+					font_list->select(FONT_INFO_USER_CUSTOM);
+					_update_styles_menu();
+					font_style_list->select(0);
+				}
+			}
+		} else {
+			// No font override, select "Theme Default".
+			_update_fonts_menu();
+			font_list->select(FONT_INFO_THEME_DEFAULT);
+			_update_styles_menu();
+			font_style_list->select(0);
+		}
+
+		// Get other theme overrides.
+		font_size_list->set_value(edited_control->get_theme_font_size(edited_font_size));
+		outline_size_list->set_value(edited_control->get_theme_constant("outline_size"));
+
+		font_color_picker->set_pick_color(edited_control->get_theme_color(edited_color));
+		outline_color_picker->set_pick_color(edited_control->get_theme_color("font_outline_color"));
+	}
+}
+
+void TextControlEditor::_font_selected(int p_id) {
+	_update_styles_menu();
+	_set_font();
+}
+
+void TextControlEditor::_font_style_selected(int p_id) {
+	_set_font();
+}
+
+void TextControlEditor::_set_font() {
+	if (edited_control) {
+		if (font_list->get_selected_id() == FONT_INFO_THEME_DEFAULT) {
+			// Remove font override.
+			edited_control->remove_theme_font_override(edited_font);
+			return;
+		} else if (font_list->get_selected_id() == FONT_INFO_USER_CUSTOM) {
+			// Restore "custom_font".
+			edited_control->add_theme_font_override(edited_font, custom_font);
+			return;
+		} else {
+			// Load new font resource using selected name and style.
+			String name = font_list->get_item_text(font_list->get_selected());
+			String sty = font_style_list->get_item_text(font_style_list->get_selected());
+			if (sty.is_empty()) {
+				sty = "Default";
+			}
+			if (fonts.has(name)) {
+				Ref<FontData> fd = ResourceLoader::load(fonts[name][sty]);
+				if (fd.is_valid()) {
+					Ref<Font> f;
+					f.instantiate();
+					f->add_data(fd);
+					edited_control->add_theme_font_override(edited_font, f);
+				}
+			}
+		}
+	}
+}
+
+void TextControlEditor::_font_size_selected(double p_size) {
+	if (edited_control) {
+		edited_control->add_theme_font_size_override(edited_font_size, p_size);
+	}
+}
+
+void TextControlEditor::_outline_size_selected(double p_size) {
+	if (edited_control) {
+		edited_control->add_theme_constant_override("outline_size", p_size);
+	}
+}
+
+void TextControlEditor::_font_color_changed(const Color &p_color) {
+	if (edited_control) {
+		edited_control->add_theme_color_override(edited_color, p_color);
+	}
+}
+
+void TextControlEditor::_outline_color_changed(const Color &p_color) {
+	if (edited_control) {
+		edited_control->add_theme_color_override("font_outline_color", p_color);
+	}
+}
+
+void TextControlEditor::_clear_formatting() {
+	if (edited_control) {
+		edited_control->begin_bulk_theme_override();
+		edited_control->remove_theme_font_override(edited_font);
+		edited_control->remove_theme_font_size_override(edited_font_size);
+		edited_control->remove_theme_color_override(edited_color);
+		edited_control->remove_theme_color_override("font_outline_color");
+		edited_control->remove_theme_constant_override("outline_size");
+		edited_control->end_bulk_theme_override();
+		_update_control();
+	}
+}
+
+void TextControlEditor::edit(Object *p_object) {
+	Control *ctrl = Object::cast_to<Control>(p_object);
+	if (!ctrl) {
+		edited_control = nullptr;
+		custom_font = Ref<Font>();
+	} else {
+		edited_control = ctrl;
+		custom_font = Ref<Font>();
+		_update_control();
+	}
+}
+
+bool TextControlEditor::handles(Object *p_object) const {
+	Control *ctrl = Object::cast_to<Control>(p_object);
+	if (!ctrl) {
+		return false;
+	} else {
+		bool valid = false;
+		ctrl->get("text", &valid);
+		return valid;
+	}
+}
+
+TextControlEditor::TextControlEditor() {
+	add_child(memnew(VSeparator));
+
+	font_list = memnew(OptionButton);
+	font_list->set_flat(true);
+	font_list->set_tooltip(TTR("Font"));
+	add_child(font_list);
+	font_list->connect("item_selected", callable_mp(this, &TextControlEditor::_font_selected));
+
+	font_style_list = memnew(OptionButton);
+	font_style_list->set_flat(true);
+	font_style_list->set_tooltip(TTR("Font style"));
+	font_style_list->set_toggle_mode(true);
+	add_child(font_style_list);
+	font_style_list->connect("item_selected", callable_mp(this, &TextControlEditor::_font_style_selected));
+
+	font_size_list = memnew(SpinBox);
+	font_size_list->set_tooltip(TTR("Font Size"));
+	font_size_list->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
+	font_size_list->set_min(6);
+	font_size_list->set_step(1);
+	font_size_list->set_max(96);
+	font_size_list->get_line_edit()->set_flat(true);
+	add_child(font_size_list);
+	font_size_list->connect("value_changed", callable_mp(this, &TextControlEditor::_font_size_selected));
+
+	font_color_picker = memnew(ColorPickerButton);
+	font_color_picker->set_custom_minimum_size(Size2(20, 0) * EDSCALE);
+	font_color_picker->set_flat(true);
+	font_color_picker->set_tooltip(TTR("Text Color"));
+	add_child(font_color_picker);
+	font_color_picker->connect("color_changed", callable_mp(this, &TextControlEditor::_font_color_changed));
+
+	add_child(memnew(VSeparator));
+
+	outline_size_list = memnew(SpinBox);
+	outline_size_list->set_tooltip(TTR("Outline Size"));
+	outline_size_list->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
+	outline_size_list->set_min(0);
+	outline_size_list->set_step(1);
+	outline_size_list->set_max(96);
+	outline_size_list->get_line_edit()->set_flat(true);
+	add_child(outline_size_list);
+	outline_size_list->connect("value_changed", callable_mp(this, &TextControlEditor::_outline_size_selected));
+
+	outline_color_picker = memnew(ColorPickerButton);
+	outline_color_picker->set_custom_minimum_size(Size2(20, 0) * EDSCALE);
+	outline_color_picker->set_flat(true);
+	outline_color_picker->set_tooltip(TTR("Outline Color"));
+	add_child(outline_color_picker);
+	outline_color_picker->connect("color_changed", callable_mp(this, &TextControlEditor::_outline_color_changed));
+
+	add_child(memnew(VSeparator));
+
+	clear_formatting = memnew(Button);
+	clear_formatting->set_flat(true);
+	clear_formatting->set_tooltip(TTR("Clear Formatting"));
+	add_child(clear_formatting);
+	clear_formatting->connect("pressed", callable_mp(this, &TextControlEditor::_clear_formatting));
+}
+
+/*************************************************************************/
+
+void TextControlEditorPlugin::edit(Object *p_object) {
+	text_ctl_editor->edit(p_object);
+}
+
+bool TextControlEditorPlugin::handles(Object *p_object) const {
+	return text_ctl_editor->handles(p_object);
+}
+
+void TextControlEditorPlugin::make_visible(bool p_visible) {
+	if (p_visible) {
+		text_ctl_editor->show();
+	} else {
+		text_ctl_editor->hide();
+		text_ctl_editor->edit(nullptr);
+	}
+}
+
+TextControlEditorPlugin::TextControlEditorPlugin(EditorNode *p_node) {
+	editor = p_node;
+	text_ctl_editor = memnew(TextControlEditor);
+	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(text_ctl_editor);
+
+	text_ctl_editor->hide();
+}

--- a/editor/plugins/text_control_editor_plugin.h
+++ b/editor/plugins/text_control_editor_plugin.h
@@ -1,0 +1,119 @@
+/*************************************************************************/
+/*  text_control_editor_plugin.h                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEXT_CONTROL_EDITOR_PLUGIN_H
+#define TEXT_CONTROL_EDITOR_PLUGIN_H
+
+#include "canvas_item_editor_plugin.h"
+#include "editor/editor_file_system.h"
+#include "editor/editor_inspector.h"
+#include "editor/editor_node.h"
+#include "editor/editor_plugin.h"
+#include "scene/gui/color_rect.h"
+#include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
+#include "scene/gui/popup_menu.h"
+
+/*************************************************************************/
+
+class TextControlEditor : public HBoxContainer {
+	GDCLASS(TextControlEditor, HBoxContainer);
+
+	enum FontInfoID {
+		FONT_INFO_THEME_DEFAULT = 0,
+		FONT_INFO_USER_CUSTOM = 1,
+		FONT_INFO_ID = 100,
+	};
+
+	Map<String, Map<String, String>> fonts;
+
+	OptionButton *font_list = nullptr;
+	SpinBox *font_size_list = nullptr;
+	OptionButton *font_style_list = nullptr;
+	ColorPickerButton *font_color_picker = nullptr;
+	SpinBox *outline_size_list = nullptr;
+	ColorPickerButton *outline_color_picker = nullptr;
+	Button *clear_formatting = nullptr;
+
+	Control *edited_control = nullptr;
+	String edited_color;
+	String edited_font;
+	String edited_font_size;
+	Ref<Font> custom_font;
+
+protected:
+	void _notification(int p_notification);
+	static void _bind_methods(){};
+
+	void _find_resources(EditorFileSystemDirectory *p_dir);
+	void _reload_fonts(const String &p_path);
+
+	void _update_fonts_menu();
+	void _update_styles_menu();
+	void _update_control();
+
+	void _font_selected(int p_id);
+	void _font_style_selected(int p_id);
+	void _set_font();
+
+	void _font_size_selected(double p_size);
+	void _outline_size_selected(double p_size);
+
+	void _font_color_changed(const Color &p_color);
+	void _outline_color_changed(const Color &p_color);
+
+	void _clear_formatting();
+
+public:
+	void edit(Object *p_object);
+	bool handles(Object *p_object) const;
+
+	TextControlEditor();
+};
+
+/*************************************************************************/
+
+class TextControlEditorPlugin : public EditorPlugin {
+	GDCLASS(TextControlEditorPlugin, EditorPlugin);
+
+	TextControlEditor *text_ctl_editor;
+	EditorNode *editor;
+
+public:
+	virtual String get_name() const override { return "TextControlFontEditor"; }
+	bool has_main_screen() const override { return false; }
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override;
+	virtual void make_visible(bool p_visible) override;
+
+	TextControlEditorPlugin(EditorNode *p_node);
+};
+
+#endif // TEXT_CONTROL_EDITOR_PLUGIN_H

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1279,6 +1279,23 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 		fd->underline_thickness = (FT_MulFix(fd->face->underline_thickness, fd->face->size->metrics.y_scale) / 64.0) / fd->oversampling * fd->scale;
 
 		if (!p_font_data->face_init) {
+			// Get style flags and name.
+			if (fd->face->family_name != nullptr) {
+				p_font_data->font_name = String::utf8((const char *)fd->face->family_name);
+			}
+			if (fd->face->style_name != nullptr) {
+				p_font_data->style_name = String::utf8((const char *)fd->face->style_name);
+			}
+			p_font_data->style_flags = 0;
+			if (fd->face->style_flags & FT_STYLE_FLAG_BOLD) {
+				p_font_data->style_flags |= FONT_BOLD;
+			}
+			if (fd->face->style_flags & FT_STYLE_FLAG_ITALIC) {
+				p_font_data->style_flags |= FONT_ITALIC;
+			}
+			if (fd->face->face_flags & FT_FACE_FLAG_FIXED_WIDTH) {
+				p_font_data->style_flags |= FONT_FIXED_WIDTH;
+			}
 			// Get supported scripts from OpenType font data.
 			p_font_data->supported_scripts.clear();
 			unsigned int count = hb_ot_layout_table_get_script_tags(hb_font_get_face(fd->hb_handle), HB_OT_TAG_GSUB, 0, nullptr, nullptr);
@@ -1646,6 +1663,66 @@ void TextServerAdvanced::font_set_data_ptr(RID p_font_rid, const uint8_t *p_data
 	fd->data.clear();
 	fd->data_ptr = p_data_ptr;
 	fd->data_size = p_data_size;
+}
+
+void TextServerAdvanced::font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND(!fd);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	fd->style_flags = p_style;
+}
+
+uint32_t /*FontStyle*/ TextServerAdvanced::font_get_style(RID p_font_rid) const {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND_V(!fd, 0);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), 0);
+	return fd->style_flags;
+}
+
+void TextServerAdvanced::font_set_style_name(RID p_font_rid, const String &p_name) {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND(!fd);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	fd->style_name = p_name;
+}
+
+String TextServerAdvanced::font_get_style_name(RID p_font_rid) const {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND_V(!fd, String());
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), String());
+	return fd->style_name;
+}
+
+void TextServerAdvanced::font_set_name(RID p_font_rid, const String &p_name) {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND(!fd);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	fd->font_name = p_name;
+}
+
+String TextServerAdvanced::font_get_name(RID p_font_rid) const {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND_V(!fd, String());
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), String());
+	return fd->font_name;
 }
 
 void TextServerAdvanced::font_set_antialiased(RID p_font_rid, bool p_antialiased) {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -177,6 +177,10 @@ class TextServerAdvanced : public TextServer {
 		Dictionary variation_coordinates;
 		float oversampling = 0.f;
 
+		uint32_t style_flags = 0;
+		String font_name;
+		String style_name;
+
 		Map<Vector2i, FontDataForSizeAdvanced *> cache;
 
 		bool face_init = false;
@@ -320,6 +324,15 @@ public:
 
 	virtual void font_set_data(RID p_font_rid, const PackedByteArray &p_data) override;
 	virtual void font_set_data_ptr(RID p_font_rid, const uint8_t *p_data_ptr, size_t p_data_size) override;
+
+	virtual void font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) override;
+	virtual uint32_t /*FontStyle*/ font_get_style(RID p_font_rid) const override;
+
+	virtual void font_set_style_name(RID p_font_rid, const String &p_name) override;
+	virtual String font_get_style_name(RID p_font_rid) const override;
+
+	virtual void font_set_name(RID p_font_rid, const String &p_name) override;
+	virtual String font_get_name(RID p_font_rid) const override;
 
 	virtual void font_set_antialiased(RID p_font_rid, bool p_antialiased) override;
 	virtual bool font_is_antialiased(RID p_font_rid) const override;

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -142,6 +142,10 @@ class TextServerFallback : public TextServer {
 		Dictionary variation_coordinates;
 		float oversampling = 0.f;
 
+		uint32_t style_flags = 0;
+		String font_name;
+		String style_name;
+
 		Map<Vector2i, FontDataForSizeFallback *> cache;
 
 		bool face_init = false;
@@ -233,6 +237,15 @@ public:
 
 	virtual void font_set_data(RID p_font_rid, const PackedByteArray &p_data) override;
 	virtual void font_set_data_ptr(RID p_font_rid, const uint8_t *p_data_ptr, size_t p_data_size) override;
+
+	virtual void font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) override;
+	virtual uint32_t /*FontStyle*/ font_get_style(RID p_font_rid) const override;
+
+	virtual void font_set_style_name(RID p_font_rid, const String &p_name) override;
+	virtual String font_get_style_name(RID p_font_rid) const override;
+
+	virtual void font_set_name(RID p_font_rid, const String &p_name) override;
+	virtual String font_get_name(RID p_font_rid) const override;
 
 	virtual void font_set_antialiased(RID p_font_rid, bool p_antialiased) override;
 	virtual bool font_is_antialiased(RID p_font_rid) const override;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -664,7 +664,9 @@ void LineEdit::_notification(int p_what) {
 			}
 			Ref<Font> font = get_theme_font(SNAME("font"));
 
-			style->draw(ci, Rect2(Point2(), size));
+			if (!flat) {
+				style->draw(ci, Rect2(Point2(), size));
+			}
 
 			if (has_focus()) {
 				get_theme_stylebox(SNAME("focus"))->draw(ci, Rect2(Point2(), size));
@@ -1966,6 +1968,17 @@ Ref<Texture2D> LineEdit::get_right_icon() {
 	return right_icon;
 }
 
+void LineEdit::set_flat(bool p_enabled) {
+	if (flat != p_enabled) {
+		flat = p_enabled;
+		update();
+	}
+}
+
+bool LineEdit::is_flat() const {
+	return flat;
+}
+
 void LineEdit::_text_changed() {
 	_emit_text_change();
 	_clear_redo();
@@ -2214,6 +2227,8 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_deselect_on_focus_loss_enabled"), &LineEdit::is_deselect_on_focus_loss_enabled);
 	ClassDB::bind_method(D_METHOD("set_right_icon", "icon"), &LineEdit::set_right_icon);
 	ClassDB::bind_method(D_METHOD("get_right_icon"), &LineEdit::get_right_icon);
+	ClassDB::bind_method(D_METHOD("set_flat", "enabled"), &LineEdit::set_flat);
+	ClassDB::bind_method(D_METHOD("is_flat"), &LineEdit::is_flat);
 
 	ADD_SIGNAL(MethodInfo("text_changed", PropertyInfo(Variant::STRING, "new_text")));
 	ADD_SIGNAL(MethodInfo("text_change_rejected", PropertyInfo(Variant::STRING, "rejected_substring")));
@@ -2269,6 +2284,7 @@ void LineEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selecting_enabled"), "set_selecting_enabled", "is_selecting_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_on_focus_loss_enabled"), "set_deselect_on_focus_loss_enabled", "is_deselect_on_focus_loss_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "right_icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_right_icon", "get_right_icon");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flat"), "set_flat", "is_flat");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "language"), "set_language", "get_language");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_control_chars"), "set_draw_control_chars", "get_draw_control_chars");

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -130,6 +130,7 @@ private:
 	bool middle_mouse_paste_enabled = true;
 
 	Ref<Texture2D> right_icon;
+	bool flat = false;
 
 	struct Selection {
 		int begin = 0;
@@ -331,6 +332,9 @@ public:
 
 	void set_right_icon(const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_right_icon();
+
+	void set_flat(bool p_enabled);
+	bool is_flat() const;
 
 	virtual bool is_text_field() const override;
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -70,6 +70,15 @@ void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_antialiased", "antialiased"), &FontData::set_antialiased);
 	ClassDB::bind_method(D_METHOD("is_antialiased"), &FontData::is_antialiased);
 
+	ClassDB::bind_method(D_METHOD("set_font_name", "name"), &FontData::set_font_name);
+	ClassDB::bind_method(D_METHOD("get_font_name"), &FontData::get_font_name);
+
+	ClassDB::bind_method(D_METHOD("set_font_style_name", "name"), &FontData::set_font_style_name);
+	ClassDB::bind_method(D_METHOD("get_font_style_name"), &FontData::get_font_style_name);
+
+	ClassDB::bind_method(D_METHOD("set_font_style", "style"), &FontData::set_font_style);
+	ClassDB::bind_method(D_METHOD("get_font_style"), &FontData::get_font_style);
+
 	ClassDB::bind_method(D_METHOD("set_multichannel_signed_distance_field", "msdf"), &FontData::set_multichannel_signed_distance_field);
 	ClassDB::bind_method(D_METHOD("is_multichannel_signed_distance_field"), &FontData::is_multichannel_signed_distance_field);
 
@@ -190,6 +199,15 @@ bool FontData::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (tokens[0] == "antialiased") {
 			set_antialiased(p_value);
 			return true;
+		} else if (tokens[0] == "font_name") {
+			set_font_name(p_value);
+			return true;
+		} else if (tokens[0] == "style_name") {
+			set_font_style_name(p_value);
+			return true;
+		} else if (tokens[0] == "font_style") {
+			set_font_style(p_value);
+			return true;
 		} else if (tokens[0] == "multichannel_signed_distance_field") {
 			set_multichannel_signed_distance_field(p_value);
 			return true;
@@ -295,6 +313,15 @@ bool FontData::_get(const StringName &p_name, Variant &r_ret) const {
 		} else if (tokens[0] == "antialiased") {
 			r_ret = is_antialiased();
 			return true;
+		} else if (tokens[0] == "font_name") {
+			r_ret = get_font_name();
+			return true;
+		} else if (tokens[0] == "style_name") {
+			r_ret = get_font_style_name();
+			return true;
+		} else if (tokens[0] == "font_style") {
+			r_ret = get_font_style();
+			return true;
 		} else if (tokens[0] == "multichannel_signed_distance_field") {
 			r_ret = is_multichannel_signed_distance_field();
 			return true;
@@ -394,6 +421,9 @@ bool FontData::_get(const StringName &p_name, Variant &r_ret) const {
 void FontData::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 
+	p_list->push_back(PropertyInfo(Variant::STRING, "font_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
+	p_list->push_back(PropertyInfo(Variant::STRING, "style_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
+	p_list->push_back(PropertyInfo(Variant::INT, "font_style", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 	p_list->push_back(PropertyInfo(Variant::BOOL, "antialiased", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 	p_list->push_back(PropertyInfo(Variant::BOOL, "multichannel_signed_distance_field", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 	p_list->push_back(PropertyInfo(Variant::INT, "msdf_pixel_range", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
@@ -508,6 +538,36 @@ PackedByteArray FontData::get_data() const {
 		memcpy(data_w->ptrw(), data_ptr, data_size);
 	}
 	return data;
+}
+
+void FontData::set_font_name(const String &p_name) {
+	_ensure_rid(0);
+	TS->font_set_name(cache[0], p_name);
+}
+
+String FontData::get_font_name() const {
+	_ensure_rid(0);
+	return TS->font_get_name(cache[0]);
+}
+
+void FontData::set_font_style_name(const String &p_name) {
+	_ensure_rid(0);
+	TS->font_set_style_name(cache[0], p_name);
+}
+
+String FontData::get_font_style_name() const {
+	_ensure_rid(0);
+	return TS->font_get_style_name(cache[0]);
+}
+
+void FontData::set_font_style(uint32_t p_style) {
+	_ensure_rid(0);
+	TS->font_set_style(cache[0], p_style);
+}
+
+uint32_t FontData::get_font_style() const {
+	_ensure_rid(0);
+	return TS->font_get_style(cache[0]);
 }
 
 void FontData::set_antialiased(bool p_antialiased) {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -79,6 +79,15 @@ public:
 	virtual PackedByteArray get_data() const;
 
 	// Common properties.
+	virtual void set_font_name(const String &p_name);
+	virtual String get_font_name() const;
+
+	virtual void set_font_style_name(const String &p_name);
+	virtual String get_font_style_name() const;
+
+	virtual void set_font_style(uint32_t p_style);
+	virtual uint32_t get_font_style() const;
+
 	virtual void set_antialiased(bool p_antialiased);
 	virtual bool is_antialiased() const;
 

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -55,6 +55,15 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_font_set_data, "font_rid", "data");
 	GDVIRTUAL_BIND(_font_set_data_ptr, "font_rid", "data_ptr", "data_size");
 
+	GDVIRTUAL_BIND(_font_set_style, "font_rid", "style");
+	GDVIRTUAL_BIND(_font_get_style, "font_rid");
+
+	GDVIRTUAL_BIND(_font_set_name, "font_rid", "name");
+	GDVIRTUAL_BIND(_font_get_name, "font_rid");
+
+	GDVIRTUAL_BIND(_font_set_style_name, "font_rid", "name_style");
+	GDVIRTUAL_BIND(_font_get_style_name, "font_rid");
+
 	GDVIRTUAL_BIND(_font_set_antialiased, "font_rid", "antialiased");
 	GDVIRTUAL_BIND(_font_is_antialiased, "font_rid");
 
@@ -366,6 +375,42 @@ void TextServerExtension::font_set_data(RID p_font_rid, const PackedByteArray &p
 
 void TextServerExtension::font_set_data_ptr(RID p_font_rid, const uint8_t *p_data_ptr, size_t p_data_size) {
 	GDVIRTUAL_CALL(_font_set_data_ptr, p_font_rid, p_data_ptr, p_data_size);
+}
+
+void TextServerExtension::font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) {
+	GDVIRTUAL_CALL(_font_set_style, p_font_rid, p_style);
+}
+
+uint32_t /*FontStyle*/ TextServerExtension::font_get_style(RID p_font_rid) const {
+	uint32_t ret;
+	if (GDVIRTUAL_CALL(_font_get_style, p_font_rid, ret)) {
+		return ret;
+	}
+	return 0;
+}
+
+void TextServerExtension::font_set_style_name(RID p_font_rid, const String &p_name) {
+	GDVIRTUAL_CALL(_font_set_style_name, p_font_rid, p_name);
+}
+
+String TextServerExtension::font_get_style_name(RID p_font_rid) const {
+	String ret;
+	if (GDVIRTUAL_CALL(_font_get_style_name, p_font_rid, ret)) {
+		return ret;
+	}
+	return String();
+}
+
+void TextServerExtension::font_set_name(RID p_font_rid, const String &p_name) {
+	GDVIRTUAL_CALL(_font_set_name, p_font_rid, p_name);
+}
+
+String TextServerExtension::font_get_name(RID p_font_rid) const {
+	String ret;
+	if (GDVIRTUAL_CALL(_font_get_name, p_font_rid, ret)) {
+		return ret;
+	}
+	return String();
 }
 
 void TextServerExtension::font_set_antialiased(RID p_font_rid, bool p_antialiased) {

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -84,6 +84,21 @@ public:
 	GDVIRTUAL2(_font_set_data, RID, const PackedByteArray &);
 	GDVIRTUAL3(_font_set_data_ptr, RID, GDNativeConstPtr<const uint8_t>, uint64_t);
 
+	virtual void font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) override;
+	virtual uint32_t /*FontStyle*/ font_get_style(RID p_font_rid) const override;
+	GDVIRTUAL2(_font_set_style, RID, uint32_t);
+	GDVIRTUAL1RC(uint32_t, _font_get_style, RID);
+
+	virtual void font_set_name(RID p_font_rid, const String &p_name) override;
+	virtual String font_get_name(RID p_font_rid) const override;
+	GDVIRTUAL2(_font_set_name, RID, const String &);
+	GDVIRTUAL1RC(String, _font_get_name, RID);
+
+	virtual void font_set_style_name(RID p_font_rid, const String &p_name) override;
+	virtual String font_get_style_name(RID p_font_rid) const override;
+	GDVIRTUAL2(_font_set_style_name, RID, const String &);
+	GDVIRTUAL1RC(String, _font_get_style_name, RID);
+
 	virtual void font_set_antialiased(RID p_font_rid, bool p_antialiased) override;
 	virtual bool font_is_antialiased(RID p_font_rid) const override;
 	GDVIRTUAL2(_font_set_antialiased, RID, bool);

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -208,6 +208,15 @@ void TextServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("font_set_data", "font_rid", "data"), &TextServer::font_set_data);
 
+	ClassDB::bind_method(D_METHOD("font_set_style", "font_rid", "style"), &TextServer::font_set_style);
+	ClassDB::bind_method(D_METHOD("font_get_style", "font_rid"), &TextServer::font_get_style);
+
+	ClassDB::bind_method(D_METHOD("font_set_name", "font_rid", "name"), &TextServer::font_set_name);
+	ClassDB::bind_method(D_METHOD("font_get_name", "font_rid"), &TextServer::font_get_name);
+
+	ClassDB::bind_method(D_METHOD("font_set_style_name", "font_rid", "name"), &TextServer::font_set_style_name);
+	ClassDB::bind_method(D_METHOD("font_get_style_name", "font_rid"), &TextServer::font_get_style_name);
+
 	ClassDB::bind_method(D_METHOD("font_set_antialiased", "font_rid", "antialiased"), &TextServer::font_set_antialiased);
 	ClassDB::bind_method(D_METHOD("font_is_antialiased", "font_rid"), &TextServer::font_is_antialiased);
 
@@ -470,11 +479,16 @@ void TextServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONTOUR_CURVE_TAG_OFF_CONIC);
 	BIND_ENUM_CONSTANT(CONTOUR_CURVE_TAG_OFF_CUBIC);
 
-	/* Font Spacing*/
+	/* Font Spacing */
 	BIND_ENUM_CONSTANT(SPACING_GLYPH);
 	BIND_ENUM_CONSTANT(SPACING_SPACE);
 	BIND_ENUM_CONSTANT(SPACING_TOP);
 	BIND_ENUM_CONSTANT(SPACING_BOTTOM);
+
+	/* Font Style */
+	BIND_ENUM_CONSTANT(FONT_BOLD);
+	BIND_ENUM_CONSTANT(FONT_ITALIC);
+	BIND_ENUM_CONSTANT(FONT_FIXED_WIDTH);
 }
 
 Vector2 TextServer::get_hex_code_box_size(int p_size, char32_t p_index) const {

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -125,6 +125,12 @@ public:
 		SPACING_BOTTOM,
 	};
 
+	enum FontStyle {
+		FONT_BOLD = 1 << 0,
+		FONT_ITALIC = 1 << 1,
+		FONT_FIXED_WIDTH = 1 << 2,
+	};
+
 	void _draw_hex_code_box_number(RID p_canvas, int p_size, const Vector2 &p_pos, uint8_t p_index, const Color &p_color) const;
 
 protected:
@@ -223,6 +229,15 @@ public:
 
 	virtual void font_set_data(RID p_font_rid, const PackedByteArray &p_data) = 0;
 	virtual void font_set_data_ptr(RID p_font_rid, const uint8_t *p_data_ptr, size_t p_data_size) = 0;
+
+	virtual void font_set_style(RID p_font_rid, uint32_t /*FontStyle*/ p_style) = 0;
+	virtual uint32_t /*FontStyle*/ font_get_style(RID p_font_rid) const = 0;
+
+	virtual void font_set_name(RID p_font_rid, const String &p_name) = 0;
+	virtual String font_get_name(RID p_font_rid) const = 0;
+
+	virtual void font_set_style_name(RID p_font_rid, const String &p_name) = 0;
+	virtual String font_get_style_name(RID p_font_rid) const = 0;
 
 	virtual void font_set_antialiased(RID p_font_rid, bool p_antialiased) = 0;
 	virtual bool font_is_antialiased(RID p_font_rid) const = 0;
@@ -535,6 +550,7 @@ VARIANT_ENUM_CAST(TextServer::Hinting);
 VARIANT_ENUM_CAST(TextServer::Feature);
 VARIANT_ENUM_CAST(TextServer::ContourPointTag);
 VARIANT_ENUM_CAST(TextServer::SpacingType);
+VARIANT_ENUM_CAST(TextServer::FontStyle);
 
 GDVIRTUAL_NATIVE_PTR(Glyph);
 GDVIRTUAL_NATIVE_PTR(Glyph *);


### PR DESCRIPTION
Partially implements godotengine/godot-proposals#1542

- Adds `get_font_name`, `get_font_style_name` and `get_font_style` function for dynamic and BMFont fonts.
- Adds editor plugin to quickly select font and basic font properties, which enumerates all font resources in the project to display user-friendly font and style names.

https://user-images.githubusercontent.com/7645683/139417389-44bdab4a-b335-4f2e-a76d-8b2dafdafc01.mov

Supersedes #54257