### PR TITLE
Fix crashing of `FogVolume`s when `WorldEnvironment` was added

### DIFF
--- a/scene/3d/fog_volume.cpp
+++ b/scene/3d/fog_volume.cpp
@@ -101,7 +101,9 @@ AABB FogVolume::get_aabb() const {
 TypedArray<String> FogVolume::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
-	if (!get_viewport()->find_world_3d()->get_environment()->is_volumetric_fog_enabled()) {
+	Ref<Environment> environment = get_viewport()->find_world_3d()->get_environment();
+
+	if (environment.is_valid() && !environment->is_volumetric_fog_enabled()) {
 		warnings.push_back(("Fog Volumes need volumetric fog to be enabled in the scene's Environment in order to be visible."));
 	}
 


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/54371
