### PR TITLE
Faster editor line drawing - Path2D and draw_line

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -101,16 +101,18 @@ void Path2D::_notification(int p_what) {
 #endif
 		const Color color = Color(1.0, 1.0, 1.0, 1.0);
 
-		for (int i = 0; i < curve->get_point_count(); i++) {
-			Vector2 prev_p = curve->get_point_position(i);
+		_cached_draw_pts.resize(curve->get_point_count() * 8);
+		int count = 0;
 
-			for (int j = 1; j <= 8; j++) {
-				real_t frac = j / 8.0;
+		for (int i = 0; i < curve->get_point_count(); i++) {
+			for (int j = 0; j < 8; j++) {
+				real_t frac = j * (1.0 / 8.0);
 				Vector2 p = curve->interpolate(i, frac);
-				draw_line(prev_p, p, color, line_width, true);
-				prev_p = p;
+				_cached_draw_pts.set(count++, p);
 			}
 		}
+
+		draw_polyline(_cached_draw_pts, color, line_width, true);
 	}
 }
 

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -38,6 +38,7 @@ class Path2D : public Node2D {
 	GDCLASS(Path2D, Node2D);
 
 	Ref<Curve2D> curve;
+	Vector<Vector2> _cached_draw_pts;
 
 	void _curve_changed();
 


### PR DESCRIPTION
Changes the Path2D drawing to use POLYLINE instead of thick lines.
Add a path to translate thick lines (that are not using anti-aliasing) to draw as polygons instead. This should be faster because polygons can be batched.

Fixes #38543
May fix #52703

## Notes
* Drawing thick lines as polys could potentially be a lot faster as it will use batching where there are a lot of lines (thin lines are already batched when not anti-aliased)
* As well as drawing faster the Path2D should now be neater because there are not the gaps between line segments.
* I haven't absolutely tested the Path2D speed, in terms of I don't get a massive slowdown on mine with the old version. One thing I did here is leave anti-aliasing on, it seems like it would draw the anti-aliased edge as a line strip rather than individual lines, so it may be okay. If we get any continuing speed issues we can turn anti-aliasing off for drawing.

Before:
![Screenshot from 2021-10-29 10-33-15](https://user-images.githubusercontent.com/21999379/139429099-d2d13a1f-d587-4366-bf07-92d64cd3d30e.png)

After:
![Screenshot from 2021-10-29 12-45-56](https://user-images.githubusercontent.com/21999379/139429125-2bf6c8a9-a1b3-4858-81f0-6d71f51986ff.png)
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
