### PR TITLE
Strip comments in the generated editor/documentation translation header

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -89,8 +89,14 @@ def make_translations_header(target, source, env, category):
 
     xl_names = []
     for i in range(len(sorted_paths)):
+        buf = bytes()
         with open(sorted_paths[i], "rb") as f:
-            buf = f.read()
+            for line in f.readlines():
+                # Strip comments (other than fuzzy comments, which are required by the translation parser).
+                # This reduces the generated translation header's size significantly.
+                if not (line.startswith(bytes("#", "utf-8")) and not line.startswith(bytes("#, fuzzy", "utf-8"))):
+                    buf += line
+
         decomp_size = len(buf)
         buf = zlib.compress(buf)
         name = os.path.splitext(os.path.basename(sorted_paths[i]))[0]


### PR DESCRIPTION
This reduces the total generated header size from 35 MB to 28.7 MB (-6.3 MB).

Make sure to `rm -f editor/*translations.gen.h` then recompile to see a change in binary size locally.

This partially addresses https://github.com/godotengine/godot-proposals/issues/3421.

### Before

```md
17,457,698 hugo  editor/doc_translations.gen.h
17,544,165 hugo  editor/editor_translations.gen.h
```

### After

```md
15,107,211  editor/doc_translations.gen.h
13,613,454  editor/editor_translations.gen.h
```
