### PR TITLE
Use maximum zlib compression when generating editor translation headers

### DIFF
--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -35,7 +35,9 @@ def make_certs_header(target, source, env):
     decomp_size = len(buf)
     import zlib
 
-    buf = zlib.compress(buf)
+    # Use maximum zlib compression level to further reduce file size
+    # (at the cost of initial build times).
+    buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef CERTS_COMPRESSED_GEN_H\n")

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -26,7 +26,9 @@ def make_doc_header(target, source, env):
     decomp_size = len(buf)
     import zlib
 
-    buf = zlib.compress(buf)
+    # Use maximum zlib compression level to further reduce file size
+    # (at the cost of initial build times).
+    buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _DOC_DATA_RAW_H\n")
@@ -92,7 +94,9 @@ def make_translations_header(target, source, env, category):
         with open(sorted_paths[i], "rb") as f:
             buf = f.read()
         decomp_size = len(buf)
-        buf = zlib.compress(buf)
+        # Use maximum zlib compression level to further reduce file size
+        # (at the cost of initial build times).
+        buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
         name = os.path.splitext(os.path.basename(sorted_paths[i]))[0]
 
         g.write("static const unsigned char _{}_translation_{}_compressed[] = {{\n".format(category, name))

--- a/modules/mono/build_scripts/make_android_mono_config.py
+++ b/modules/mono/build_scripts/make_android_mono_config.py
@@ -8,7 +8,9 @@ def generate_compressed_config(config_src, output_dir):
             decompr_size = len(buf)
             import zlib
 
-            buf = zlib.compress(buf)
+            # Use maximum zlib compression level to further reduce file size
+            # (at the cost of initial build times).
+            buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
             compr_size = len(buf)
 
             bytes_seq_str = ""


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/54386.

With comments stripped (using the above PR), this reduces the combined generated translation size from 28.7 MB to 28.4 MB (-240 KB). Decompression speed is unaffected by the zlib compression level chosen, so the editor startup performance remains identical.

If Zstandard was available in the Python standard library, we could use it, but I don't think it's available there.

This partially addresses https://github.com/godotengine/godot-proposals/issues/3421.

### Before (with https://github.com/godotengine/godot/pull/54386)

```md
15,107,211  editor/doc_translations.gen.h
13,613,454  editor/editor_translations.gen.h
```

### After (with https://github.com/godotengine/godot/pull/54386 + this PR)

```md
15,017,815  editor/doc_translations.gen.h
13,464,278  editor/editor_translations.gen.h
```