### PR TITLE
Fix moving text in script editor with no selected character on last line

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1203,7 +1203,7 @@ void CodeTextEditor::move_lines_up() {
 	text_editor->begin_complex_operation();
 	if (text_editor->has_selection()) {
 		int from_line = text_editor->get_selection_from_line();
-		int from_col = text_editor->get_selection_from_column();
+		int from_column = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
 		int to_column = text_editor->get_selection_to_column();
 		int cursor_line = text_editor->get_caret_line();
@@ -1216,6 +1216,11 @@ void CodeTextEditor::move_lines_up() {
 				return;
 			}
 
+			// Prevent moving last line with no character selected
+			if (to_column == 0 && i == to_line) {
+				continue;
+			}
+
 			text_editor->unfold_line(line_id);
 			text_editor->unfold_line(next_id);
 
@@ -1225,7 +1230,7 @@ void CodeTextEditor::move_lines_up() {
 		int from_line_up = from_line > 0 ? from_line - 1 : from_line;
 		int to_line_up = to_line > 0 ? to_line - 1 : to_line;
 		int cursor_line_up = cursor_line > 0 ? cursor_line - 1 : cursor_line;
-		text_editor->select(from_line_up, from_col, to_line_up, to_column);
+		text_editor->select(from_line_up, from_column, to_line_up, to_column);
 		text_editor->set_caret_line(cursor_line_up);
 	} else {
 		int line_id = text_editor->get_caret_line();
@@ -1249,7 +1254,7 @@ void CodeTextEditor::move_lines_down() {
 	text_editor->begin_complex_operation();
 	if (text_editor->has_selection()) {
 		int from_line = text_editor->get_selection_from_line();
-		int from_col = text_editor->get_selection_from_column();
+		int from_column = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
 		int to_column = text_editor->get_selection_to_column();
 		int cursor_line = text_editor->get_caret_line();
@@ -1262,6 +1267,11 @@ void CodeTextEditor::move_lines_down() {
 				return;
 			}
 
+			// Prevent moving last line with no character selected
+			if (to_column == 0 && i == to_line) {
+				continue;
+			}
+
 			text_editor->unfold_line(line_id);
 			text_editor->unfold_line(next_id);
 
@@ -1271,7 +1281,7 @@ void CodeTextEditor::move_lines_down() {
 		int from_line_down = from_line < text_editor->get_line_count() ? from_line + 1 : from_line;
 		int to_line_down = to_line < text_editor->get_line_count() ? to_line + 1 : to_line;
 		int cursor_line_down = cursor_line < text_editor->get_line_count() ? cursor_line + 1 : cursor_line;
-		text_editor->select(from_line_down, from_col, to_line_down, to_column);
+		text_editor->select(from_line_down, from_column, to_line_down, to_column);
 		text_editor->set_caret_line(cursor_line_down);
 	} else {
 		int line_id = text_editor->get_caret_line();


### PR DESCRIPTION
Fixes #54362

###  Issue

In script editor, when moving selection with alt+up/down, an extra line at the end or at the beginning can be moved.
It happens when selection ~~begins at the end of a line or~~ finishes at the beginning of a line (with no character of those lines selected).

### Fix proposal

Check if we are in such a case and prevent those line to move with the selection.
(I also rename a variable ``from_col`` to ``from_column`` for consistency reason.) 

### Before

You can see that in some case a line is moved whereas it shouldn't happen.
![move_bug](https://user-images.githubusercontent.com/3649998/139467402-34eb0d22-4c70-433f-9d84-e506e46d8502.gif)

### After

Behaviour is the expected one (as in Visual Studio / VS Code)
![move_fixed](https://user-images.githubusercontent.com/3649998/139467427-d31e2700-6f9e-4d65-986a-62a46b4142fe.gif)