### PR TITLE
Exclude atomic lib under FreeBSD using LLVM

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -393,9 +393,9 @@ def configure(env):
     # Link those statically for portability
     if env["use_static_cpp"]:
         env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
-        if env["use_llvm"]:
+        if env["use_llvm"] and platform.system() != "FreeBSD":
             env["LINKCOM"] = env["LINKCOM"] + " -l:libatomic.a"
 
     else:
-        if env["use_llvm"]:
+        if env["use_llvm"] and platform.system() != "FreeBSD":
             env.Append(LIBS=["atomic"])


### PR DESCRIPTION
Exclude atomic lib under FreeBSD using LLVM

FreeBSD doesn't implement 64 bit atomic functions for i386, and LLVM doesn't provide atomic builtins as GCC does, thus compilation fails.

Removing linking with atomic libs if using LLVM under FreeBSD solves the problem.

Fixes #54393