### PR TITLE
Provide compatibility api functions for `Object::connect` and `Object::disconnect`

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1599,8 +1599,10 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_signal_connection_list", "signal"), &Object::_get_signal_connection_list);
 	ClassDB::bind_method(D_METHOD("get_incoming_connections"), &Object::_get_incoming_connections);
 
-	ClassDB::bind_method(D_METHOD("connect", "signal", "callable", "binds", "flags"), &Object::connect, DEFVAL(Array()), DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("disconnect", "signal", "callable"), &Object::disconnect);
+	Error (Object::*connect_func)(const StringName &, const Callable &, const Vector<Variant> &, uint32_t) = &Object::connect;
+	ClassDB::bind_method(D_METHOD("connect", "signal", "callable", "binds", "flags"), connect_func, DEFVAL(Array()), DEFVAL(0));
+	void (Object::*disconnect_func)(const StringName &, const Callable &) = &Object::disconnect;
+	ClassDB::bind_method(D_METHOD("disconnect", "signal", "callable"), disconnect_func);
 	ClassDB::bind_method(D_METHOD("is_connected", "signal", "callable"), &Object::is_connected);
 
 	ClassDB::bind_method(D_METHOD("set_block_signals", "enable"), &Object::set_block_signals);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -791,7 +791,14 @@ public:
 	void get_signals_connected_to_this(List<Connection> *p_connections) const;
 
 	Error connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);
+	_FORCE_INLINE_ Error connect(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method,
+								 const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0) {
+		return this->connect(p_signal, Callable(p_to_object, p_to_method), p_binds, p_flags);
+	}
 	void disconnect(const StringName &p_signal, const Callable &p_callable);
+	_FORCE_INLINE_ void disconnect(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method) {
+		this->disconnect(p_signal, Callable(p_to_object, p_to_method));
+	}
 	bool is_connected(const StringName &p_signal, const Callable &p_callable) const;
 
 	void call_deferred(const StringName &p_method, VARIANT_ARG_LIST);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -403,7 +403,7 @@ protected:                                                                      
 		initialize_class();                                                                                                                      \
 	}                                                                                                                                            \
 	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &) const {                                                 \
-		return (bool(Object::*)(const StringName &, Variant &) const) & m_class::_get;                                                           \
+		return (bool (Object::*)(const StringName &, Variant &) const) & m_class::_get;                                                          \
 	}                                                                                                                                            \
 	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override {                                                                \
 		if (m_class::_get_get() != m_inherits::_get_get()) {                                                                                     \
@@ -414,7 +414,7 @@ protected:                                                                      
 		return m_inherits::_getv(p_name, r_ret);                                                                                                 \
 	}                                                                                                                                            \
 	_FORCE_INLINE_ bool (Object::*_get_set() const)(const StringName &p_name, const Variant &p_property) {                                       \
-		return (bool(Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                           \
+		return (bool (Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                          \
 	}                                                                                                                                            \
 	virtual bool _setv(const StringName &p_name, const Variant &p_property) override {                                                           \
 		if (m_inherits::_setv(p_name, p_property)) {                                                                                             \
@@ -426,7 +426,7 @@ protected:                                                                      
 		return false;                                                                                                                            \
 	}                                                                                                                                            \
 	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> * p_list) const {                                           \
-		return (void(Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                                      \
+		return (void (Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                                     \
 	}                                                                                                                                            \
 	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const override {                                               \
 		if (!p_reversed) {                                                                                                                       \
@@ -447,7 +447,7 @@ protected:                                                                      
 		}                                                                                                                                        \
 	}                                                                                                                                            \
 	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {                                                                              \
-		return (void(Object::*)(int)) & m_class::_notification;                                                                                  \
+		return (void (Object::*)(int)) & m_class::_notification;                                                                                 \
 	}                                                                                                                                            \
 	virtual void _notificationv(int p_notification, bool p_reversed) override {                                                                  \
 		if (!p_reversed) {                                                                                                                       \
@@ -792,7 +792,7 @@ public:
 
 	Error connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);
 	_FORCE_INLINE_ Error connect(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method,
-								 const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0) {
+			const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0) {
 		return this->connect(p_signal, Callable(p_to_object, p_to_method), p_binds, p_flags);
 	}
 	void disconnect(const StringName &p_signal, const Callable &p_callable);


### PR DESCRIPTION
Many modules heavily rely on the API of the `connect` and `disconnect` functions as they were in Godot 3, so I think adding compatibility functions for these is worth the effort in maintaining (which I would be willing to put in if you'd like).