### PR TITLE
AudioDriverPulseAudio: move Vector Cow access outside tight loop.

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -382,15 +382,15 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			ad->start_counting_ticks();
 
 			if (!ad->active) {
-				for (unsigned int i = 0; i < ad->pa_buffer_size; i++) {
-					ad->samples_out.write[i] = 0;
-				}
+				ad->samples_out.fill(0);
 			} else {
 				ad->audio_server_process(ad->buffer_frames, ad->samples_in.ptrw());
 
+				int16_t *out_ptr = ad->samples_out.ptrw();
+
 				if (ad->channels == ad->pa_map.channels) {
 					for (unsigned int i = 0; i < ad->pa_buffer_size; i++) {
-						ad->samples_out.write[i] = ad->samples_in[i] >> 16;
+						out_ptr[i] = ad->samples_in[i] >> 16;
 					}
 				} else {
 					// Uneven amount of channels
@@ -399,11 +399,11 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
 					for (unsigned int i = 0; i < ad->buffer_frames; i++) {
 						for (int j = 0; j < ad->pa_map.channels - 1; j++) {
-							ad->samples_out.write[out_idx++] = ad->samples_in[in_idx++] >> 16;
+							out_ptr[out_idx++] = ad->samples_in[in_idx++] >> 16;
 						}
 						uint32_t l = ad->samples_in[in_idx++] >> 16;
 						uint32_t r = ad->samples_in[in_idx++] >> 16;
-						ad->samples_out.write[out_idx++] = (l + r) / 2;
+						out_ptr[out_idx++] = (l + r) / 2;
 					}
 				}
 			}


### PR DESCRIPTION
~15% of the work in the PA thread seemed to be unnecessarily re-checking the Cow ref count.

Replaced some in-loop uses of Vector.write with an out of loop ptrw, so we only check once.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
