### PR TITLE
Fix instance index in forward clustered shader

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -108,12 +108,13 @@ void main() {
 #endif
 
 	uint instance_index = draw_call.instance_index;
-	instance_index_interp = instance_index;
 
 	bool is_multimesh = bool(instances.data[instance_index].flags & INSTANCE_FLAGS_MULTIMESH);
 	if (!is_multimesh) {
 		instance_index += gl_InstanceIndex;
 	}
+
+	instance_index_interp = instance_index;
 
 	mat4 world_matrix = instances.data[instance_index].transform;
 
@@ -565,12 +566,8 @@ void main() {
 		discard;
 #endif
 
-#ifdef USE_SUBGROUPS
-	//ensures instance_index is in sgpr
-	uint instance_index = subgroupBroadcastFirst(instance_index_interp);
-#else
 	uint instance_index = instance_index_interp;
-#endif
+
 	//lay out everything, whathever is unused is optimized away anyway
 	vec3 vertex = vertex_interp;
 	vec3 view = -normalize(vertex_interp);


### PR DESCRIPTION
* Instance index needs to be sent to the fragment shader **after** applying the offset.
* The `subgroupBroadcastFirst` optimization was causing issues (see image) so I dropped it. I understand the idea is to have the instance ID in a SGPR, but I don't think that can be done. There's nothing enforcing pixels in a group to all be part of the same instance, so it's bound to break eventually.

![image](https://user-images.githubusercontent.com/4402304/139515133-7279a90f-b7ff-4e48-a8ab-af501df7f366.png)

Fixes #54384
