### PR TITLE
Fix editor crash in built-in help when script inheritance chain changes

### DIFF
--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -99,7 +99,7 @@ class EditorHelpSearch::Runner : public RefCounted {
 	int phase = 0;
 
 	struct ClassMatch {
-		DocData::ClassDoc *doc;
+		DocData::ClassDoc *doc = nullptr;
 		bool name = false;
 		Vector<DocData::MethodDoc *> constructors;
 		Vector<DocData::MethodDoc *> methods;


### PR DESCRIPTION
In my main project testing typing `gd` crashes the search help.

I wasn't able to provide a reduced case, but hopefully failing fail conditions are helpful.