### PR TITLE
Added support for lambda expressions in `Callable` & Added `Defer` method for Godot.Object

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
@@ -74,7 +74,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a new <see cref="Callable"/> for the given <paramref name="delegate"/>.
+        /// Constructs a new <see cref="Callable"/> for the given <paramref name="callback"/>.
         /// </summary>
         /// <param name="callback">Action method that will be called.</param>
         public Callable(Action callback)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
@@ -74,6 +74,17 @@ namespace Godot
         }
 
         /// <summary>
+        /// Constructs a new <see cref="Callable"/> for the given <paramref name="delegate"/>.
+        /// </summary>
+        /// <param name="callback">Action method that will be called.</param>
+        public Callable(Action callback)
+        {
+            _target = null;
+            _method = null;
+            _delegate = callback;
+        }
+
+        /// <summary>
         /// Calls the method represented by this <see cref="Callable"/>.
         /// Arguments can be passed and should match the method's signature.
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
@@ -142,7 +142,7 @@ namespace Godot
         /// }
         /// </code>
         /// </summary>
-        /// <param name="callback"></param>
+        /// <param name="callback">Callback to call during idle time.</param>
         protected void Defer(Action callback)
         {
             new Callable(callback).CallDeferred();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
@@ -133,6 +133,22 @@ namespace Godot
         }
 
         /// <summary>
+        /// Calls the specified <see cref="Action"/> during idle time. Example:
+        /// <code>
+        /// public override void _Process(float delta)
+        /// {
+        ///     var collisionShape = GetNode&lt;CollisionShape2D&gt;("CollisionShape2D");
+        ///     Defer(() => collisionShape.Disabled = true);
+        /// }
+        /// </code>
+        /// </summary>
+        /// <param name="callback"></param>
+        protected void Defer(Action callback)
+        {
+            new Callable(callback).CallDeferred();
+        }
+
+        /// <summary>
         /// Gets a new <see cref="DynamicGodotObject"/> associated with this instance.
         /// </summary>
         public dynamic DynamicObject => new DynamicGodotObject(this);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Relates to https://github.com/godotengine/godot-proposals/issues/3474

This is more of a quality of life improvement for better readability. Adds the ability to create a callable from a lambda, and a `Defer` method on `Godot.Object` that wraps `new Callable(..).CallDeferred`.

Old
```csharp
public override void _Ready()
{
    _collisionShape = GetNode<CollisionShape2D>("Capsule");

    new Callable(new Action(() => _collisionShape.Disabled = true)).CallDeferred();
}
```

New
```csharp
public override void _Ready()
{
    _collisionShape = GetNode<CollisionShape2D>("Capsule");

    new Callable(() => _collisionShape.Disabled = true).CallDeferred();
    
    // OR 
    
    Defer(() => _collisionShape.Disabled = false);
}
```