### PR TITLE
Refactored copy/paste of visual shaders, implement 'Cut' feature

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -111,7 +111,6 @@ public:
 	void disconnect_nodes(VisualShader::Type p_type, int p_from_node, int p_from_port, int p_to_node, int p_to_port);
 	void show_port_preview(VisualShader::Type p_type, int p_node_id, int p_port_id);
 	void set_node_position(VisualShader::Type p_type, int p_id, const Vector2 &p_position);
-	void set_node_size(VisualShader::Type p_type, int p_id, const Vector2 &p_size);
 	void refresh_node_ports(VisualShader::Type p_type, int p_node);
 	void set_input_port_default_value(VisualShader::Type p_type, int p_node_id, int p_port_id, Variant p_value);
 	void update_uniform_refs();
@@ -217,10 +216,12 @@ class VisualShaderEditor : public VBoxContainer {
 	enum NodeMenuOptions {
 		ADD,
 		SEPARATOR, // ignore
+		CUT,
 		COPY,
 		PASTE,
 		DELETE,
 		DUPLICATE,
+		CLEAR_COPY_BUFFER,
 		SEPARATOR2, // ignore
 		FLOAT_CONSTANTS,
 		CONVERT_CONSTANTS_TO_UNIFORMS,
@@ -380,19 +381,27 @@ class VisualShaderEditor : public VBoxContainer {
 
 	void _port_name_focus_out(Object *line_edit, int p_node_id, int p_port_id, bool p_output);
 
-	void _dup_copy_nodes(int p_type, List<int> &r_nodes, Set<int> &r_excluded);
-	void _dup_update_excluded(int p_type, Set<int> &r_excluded);
-	void _dup_paste_nodes(int p_type, int p_pasted_type, List<int> &r_nodes, Set<int> &r_excluded, const Vector2 &p_offset, bool p_select);
+	struct CopyItem {
+		int id;
+		Ref<VisualShaderNode> node;
+		Vector2 position;
+		Vector2 size;
+		String group_inputs;
+		String group_outputs;
+		String expression;
+	};
+
+	void _dup_copy_nodes(int p_type, List<CopyItem> &r_nodes, List<VisualShader::Connection> &r_connections);
+	void _dup_paste_nodes(int p_type, List<CopyItem> &r_items, const List<VisualShader::Connection> &p_connections, const Vector2 &p_offset, bool p_duplicate);
 
 	void _duplicate_nodes();
 
 	Vector2 selection_center;
-	int copy_type; // shader type
-	List<int> copy_nodes_buffer;
-	Set<int> copy_nodes_excluded_buffer;
+	List<CopyItem> copy_items_buffer;
+	List<VisualShader::Connection> copy_connections_buffer;
 
-	void _clear_buffer();
-	void _copy_nodes();
+	void _clear_copy_buffer();
+	void _copy_nodes(bool p_cut);
 	void _paste_nodes(bool p_use_custom_position = false, const Vector2 &p_custom_position = Vector2());
 
 	Vector<Ref<VisualShaderNodePlugin>> plugins;


### PR DESCRIPTION
- Added Cut feature to popup menu: ![vs_cut](https://user-images.githubusercontent.com/3036176/139534917-06abcf6d-8ae3-45f2-87f1-baadf1352b66.gif)
- Added Clear Copy Buffer to clear the buffer and allow to continue using the standard right-click behavior
- Enables to copy/paste between shaders
- Auto-selection for pasted nodes
- Decreases the code complexity