### PR TITLE
Turn off physics and 3d navigation servers in the Project Manager.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -52,6 +52,7 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/main/window.h"
 #include "servers/display_server.h"
+#include "servers/navigation_server_3d.h"
 
 static inline String get_project_key_from_path(const String &dir) {
 	return dir.replace("/", "::");
@@ -2386,6 +2387,11 @@ ProjectManager::ProjectManager() {
 	if (!EditorSettings::get_singleton()) {
 		EditorSettings::create();
 	}
+
+	// Turn off some servers we aren't going to be using in the Project Manager.
+	NavigationServer3D::get_singleton()->set_active(false);
+	PhysicsServer3D::get_singleton()->set_active(false);
+	PhysicsServer2D::get_singleton()->set_active(false);
 
 	EditorSettings::get_singleton()->set_optimize_save(false); //just write settings as they came
 


### PR DESCRIPTION
Copying the editor behaviour of deactivating these servers we're not
using, to reduce CPU load.

Partial fix for #54291

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
