### PR TITLE
Ensure C# script properties are added to the end

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1813,8 +1813,9 @@ void CSharpInstance::get_event_signals_state_for_reloading(List<Pair<StringName,
 }
 
 void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
+	List<PropertyInfo> props;
 	for (OrderedHashMap<StringName, PropertyInfo>::ConstElement E = script->member_info.front(); E; E = E.next()) {
-		p_properties->push_front(E.value());
+		props.push_front(E.value());
 	}
 
 	// Call _get_property_list
@@ -1837,14 +1838,18 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 			if (ret) {
 				Array array = Array(GDMonoMarshal::mono_object_to_variant(ret));
 				for (int i = 0, size = array.size(); i < size; i++) {
-					p_properties->push_back(PropertyInfo::from_dict(array.get(i)));
+					props.push_back(PropertyInfo::from_dict(array.get(i)));
 				}
 			}
 
-			return;
+			break;
 		}
 
 		top = top->get_parent_class();
+	}
+
+	for (const PropertyInfo &prop : props) {
+		p_properties->push_back(prop);
 	}
 }
 
@@ -3499,8 +3504,14 @@ Ref<Script> CSharpScript::get_base_script() const {
 }
 
 void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
+	List<PropertyInfo> props;
+
 	for (OrderedHashMap<StringName, PropertyInfo>::ConstElement E = member_info.front(); E; E = E.next()) {
-		r_list->push_front(E.value());
+		props.push_front(E.value());
+	}
+
+	for (const PropertyInfo &prop : props) {
+		r_list->push_back(prop);
 	}
 }
 


### PR DESCRIPTION
Follow-up to #54130
Closes #54414

Ensures that the `get_property_list` and `get_script_property_list` methods push the script properties to the end of the given list, this prevents the script property from appearing after the script variables.

In my previous PR I was assuming the list parameter came empty so using `push_front` directly was pushing the script properties in front of the script property, this PR uses a different list for the script properties and pushes them to the back at the end of the method like the GDScript implementation.

<table>
	<thead>
		<tr>
			<th>Before</th>
			<th>After</th>
		</tr>
	</thead>
	<tbody>
		<tr>
			<td>
				<pre lang="ini"><code>[node name="MyNode" type="Node"]
number = 42
script = ExtResource( 1 )</code></pre>
			</td>
			<td>
				<pre lang="ini"><code>[node name="MyNode" type="Node"]
script = ExtResource( 1 )
number = 42</code></pre>
			</td>
		</tr>
	</tbody>
</table>