### PR TITLE
Don't use Texture image caches if they are rendered to

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -1034,7 +1034,7 @@ Ref<Image> RendererStorageRD::texture_2d_get(RID p_texture) const {
 	ERR_FAIL_COND_V(!tex, Ref<Image>());
 
 #ifdef TOOLS_ENABLED
-	if (tex->image_cache_2d.is_valid()) {
+	if (tex->image_cache_2d.is_valid() && !tex->is_render_target) {
 		return tex->image_cache_2d;
 	}
 #endif
@@ -1049,7 +1049,7 @@ Ref<Image> RendererStorageRD::texture_2d_get(RID p_texture) const {
 	}
 
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (Engine::get_singleton()->is_editor_hint() && !tex->is_render_target) {
 		tex->image_cache_2d = image;
 	}
 #endif


### PR DESCRIPTION
Fixes #36721
Fixes #53823

There were no places I could find where the image cache could have been invalidated when rendered to, so I disabled the cache for render targets.



|  |  |  |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/6376721/139543766-e8ce807d-9000-4e95-ac14-4f0b20402d10.png) | ![image](https://user-images.githubusercontent.com/6376721/139543792-fbf2fa06-e525-41d0-84e9-e91f680f9b16.png) | ![image](https://user-images.githubusercontent.com/6376721/139543805-bdec3016-d58d-444c-bdeb-b289f124c90c.png) |

cc @fire 