### PR TITLE
[3.x] Always print C# exception

### DIFF
--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -362,13 +362,10 @@ void debug_print_unhandled_exception(MonoException *p_exc) {
 }
 
 void debug_send_unhandled_exception_error(MonoException *p_exc) {
+	ERR_PRINT(GDMonoUtils::get_exception_name_and_message(p_exc));
+
 #ifdef DEBUG_ENABLED
 	if (!ScriptDebugger::get_singleton()) {
-#ifdef TOOLS_ENABLED
-		if (Engine::get_singleton()->is_editor_hint()) {
-			ERR_PRINT(GDMonoUtils::get_exception_name_and_message(p_exc));
-		}
-#endif
 		return;
 	}
 


### PR DESCRIPTION
3.x version of #54428