### PR TITLE
[3.x] Drop broken Android 32-bit framebuffer setting

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1691,7 +1691,6 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_adaptive_icon_foreground_option, PROPERTY_HINT_FILE, "*.png"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_adaptive_icon_background_option, PROPERTY_HINT_FILE, "*.png"), ""));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "graphics/32_bits_framebuffer"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "graphics/opengl_debug"), false));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "xr_features/xr_mode", PROPERTY_HINT_ENUM, "Regular,Oculus Mobile VR"), 0));
@@ -2528,11 +2527,6 @@ void EditorExportPlatformAndroid::get_command_line_flags(const Ref<EditorExportP
 		command_line_strings.push_back("--xr_mode_ovr");
 	} else { // XRMode.REGULAR is the default.
 		command_line_strings.push_back("--xr_mode_regular");
-	}
-
-	bool use_32_bit_framebuffer = p_preset->get("graphics/32_bits_framebuffer");
-	if (use_32_bit_framebuffer) {
-		command_line_strings.push_back("--use_depth_32");
 	}
 
 	bool immersive = p_preset->get("screen/immersive_mode");

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -127,7 +127,6 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	private Button mWiFiSettingsButton;
 
 	private XRMode xrMode = XRMode.REGULAR;
-	private boolean use_32_bits = false;
 	private boolean use_immersive = false;
 	private boolean use_debug_opengl = false;
 	private boolean translucent = false;
@@ -358,7 +357,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		// ...add to FrameLayout
 		containerLayout.addView(edittext);
 
-		mView = new GodotView(activity, this, xrMode, use_gl3, use_32_bits, use_debug_opengl, translucent);
+		mView = new GodotView(activity, this, xrMode, use_gl3, use_debug_opengl, translucent);
 		containerLayout.addView(mView, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 		edittext.setView(mView);
 		io.setEdit(edittext);
@@ -621,8 +620,6 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 				xrMode = XRMode.REGULAR;
 			} else if (command_line[i].equals(XRMode.OVR.cmdLineArg)) {
 				xrMode = XRMode.OVR;
-			} else if (command_line[i].equals("--use_depth_32")) {
-				use_32_bits = true;
 			} else if (command_line[i].equals("--debug_opengl")) {
 				use_debug_opengl = true;
 			} else if (command_line[i].equals("--translucent")) {

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
@@ -83,11 +83,9 @@ public class GodotView extends GLSurfaceView {
 	private EGLContextFactory eglContextFactory;
 	private EGLContext eglSecondaryContext;
 
-	public GodotView(Context context, Godot godot, XRMode xrMode, boolean p_use_gl3,
-			boolean p_use_32_bits, boolean p_use_debug_opengl, boolean p_translucent) {
+	public GodotView(Context context, Godot godot, XRMode xrMode, boolean p_use_gl3, boolean p_use_debug_opengl, boolean p_translucent) {
 		super(context);
 		GLUtils.use_gl3 = p_use_gl3;
-		GLUtils.use_32 = p_use_32_bits;
 		GLUtils.use_debug_opengl = p_use_debug_opengl;
 
 		this.godot = godot;
@@ -95,7 +93,7 @@ public class GodotView extends GLSurfaceView {
 		this.detector = new GestureDetector(context, new GodotGestureHandler(this));
 		this.godotRenderer = new GodotRenderer();
 
-		init(xrMode, p_translucent, 16, 0);
+		init(xrMode, p_translucent);
 	}
 
 	public void initInputDevices() {
@@ -125,7 +123,7 @@ public class GodotView extends GLSurfaceView {
 		return inputHandler.onGenericMotionEvent(event) || super.onGenericMotionEvent(event);
 	}
 
-	private void init(XRMode xrMode, boolean translucent, int depth, int stencil) {
+	private void init(XRMode xrMode, boolean translucent) {
 		setPreserveEGLContextOnPause(true);
 		setFocusableInTouchMode(true);
 		switch (xrMode) {
@@ -163,18 +161,12 @@ public class GodotView extends GLSurfaceView {
 				 * below.
 				 */
 
-				if (GLUtils.use_32) {
-					eglConfigChooser = translucent
-							? new RegularFallbackConfigChooser(8, 8, 8, 8, 24, stencil,
-									  new RegularConfigChooser(8, 8, 8, 8, 16, stencil))
-							: new RegularFallbackConfigChooser(8, 8, 8, 8, 24, stencil,
-									  new RegularConfigChooser(5, 6, 5, 0, 16, stencil));
-
-				} else {
-					eglConfigChooser = translucent
-							? new RegularConfigChooser(8, 8, 8, 8, 16, stencil)
-							: new RegularConfigChooser(5, 6, 5, 0, 16, stencil);
-				}
+				eglConfigChooser =
+						new RegularFallbackConfigChooser(8, 8, 8, 8, 24, 0,
+								new RegularFallbackConfigChooser(8, 8, 8, 8, 16, 0,
+										// Let such a desperate fallback be used if under some circumstances that's the best we can get
+										// (the translucency flag would be ignored, but that's better than not running at all)
+										new RegularConfigChooser(5, 6, 5, 0, 16, 0)));
 				break;
 		}
 		setEGLConfigChooser(eglConfigChooser);

--- a/platform/android/java/lib/src/org/godotengine/godot/utils/GLUtils.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/GLUtils.java
@@ -45,7 +45,6 @@ public class GLUtils {
 	public static final boolean DEBUG = false;
 
 	public static boolean use_gl3 = false;
-	public static boolean use_32 = false;
 	public static boolean use_debug_opengl = false;
 
 	private static final String[] ATTRIBUTES_NAMES = new String[] {

--- a/platform/android/java/lib/src/org/godotengine/godot/xr/regular/RegularFallbackConfigChooser.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/xr/regular/RegularFallbackConfigChooser.java
@@ -38,7 +38,7 @@ import javax.microedition.khronos.egl.EGL10;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.egl.EGLDisplay;
 
-/* Fallback if 32bit View is not supported*/
+/* Fallback if the requested configuration is not supported */
 public class RegularFallbackConfigChooser extends RegularConfigChooser {
 	private static final String TAG = RegularFallbackConfigChooser.class.getSimpleName();
 
@@ -55,7 +55,6 @@ public class RegularFallbackConfigChooser extends RegularConfigChooser {
 		if (ec == null) {
 			Log.w(TAG, "Trying ConfigChooser fallback");
 			ec = fallback.chooseConfig(egl, display, configs);
-			GLUtils.use_32 = false;
 		}
 		return ec;
 	}


### PR DESCRIPTION
Android's `graphics/32_bits_framebuffer` export setting not being applied like what you would expect. Moreover, it was being mapped to the `--use_depth_32`  command line switch, but it was never possible to set the bit depth of the depth buffer to 32.

To me, during the transition to Godot 3.0, where a 32-bit frambebuffer was not an opt-in anymore, traces of that were kept while the 32-bit depth buffer setting was only partially implemented. (Or maybe `--use_depth_32` didn't have anything to do with depth buffers, being about the bit _depth_ of the frame buffer, but the main reasoning still holds.)

This PR aims to bring sanity back.

**WARNING:** The `graphics/32_bits_framebuffer` export setting is gone. It was not even being applied as expected in every case and the GL rasterizer doesn't have explicit support for a 16-bit framebuffer. Therefore, a 16-bit framebuffer is only created as a desperate fallback in cases where 32-bit is not supported (still relevant?). With the new `graphics/depth_buffer_bits`, you can choose between a 32, 24 (the default) and 16-bit depth buffer, which is more useful in adapting the renderer to the needs of the project. I'm marking this PR as _Break compat_, but most project shouldn't really notice a difference.

**UPDATE:** Code and PR description updated following conversation in the comments.

---
Version for 4.0 submitted as #54463.