### PR TITLE
Fix area_shape_exited's description

### DIFF
--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -138,7 +138,7 @@
 			<argument index="2" name="area_shape_index" type="int" />
 			<argument index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when one of another Area3D's [Shape3D]s enters one of this Area3D's [Shape3D]s. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when one of another Area3D's [Shape3D]s exits one of this Area3D's [Shape3D]s. Requires [member monitoring] to be set to [code]true[/code].
 				[code]area_rid[/code] the [RID] of the other Area3D's [CollisionObject3D] used by the [PhysicsServer3D].
 				[code]area[/code] the other Area3D.
 				[code]area_shape_index[/code] the index of the [Shape3D] of the other Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]area.shape_owner_get_owner(area_shape_index)[/code].


### PR DESCRIPTION
area_shape_entered and area_shape_exited had the exact same description. Changed area_shape_exited's description to specify that the signal is emitted when another area's shape exits rather than enters this area's shapes.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
