### PR TITLE
Fix CheckButton and CheckBox font hover pressed color override

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -126,7 +126,8 @@ void Button::_notification(int p_what) {
 					}
 				} break;
 				case DRAW_HOVER_PRESSED: {
-					if (has_theme_stylebox(SNAME("hover_pressed")) && has_theme_stylebox_override("hover_pressed")) {
+					// Edge case for CheckButton and CheckBox.
+					if (has_theme_stylebox("hover_pressed")) {
 						if (rtl && has_theme_stylebox(SNAME("hover_pressed_mirrored"))) {
 							style = get_theme_stylebox(SNAME("hover_pressed_mirrored"));
 						} else {
@@ -138,8 +139,6 @@ void Button::_notification(int p_what) {
 						}
 						if (has_theme_color(SNAME("font_hover_pressed_color"))) {
 							color = get_theme_color(SNAME("font_hover_pressed_color"));
-						} else {
-							color = get_theme_color(SNAME("font_color"));
 						}
 						if (has_theme_color(SNAME("icon_hover_pressed_color"))) {
 							color_icon = get_theme_color(SNAME("icon_hover_pressed_color"));


### PR DESCRIPTION
Co-authored-by: @fossegutten

Fixes: #34727

This PR allows to override the font color in the hover_pressed state (salvaged from #35094).

![reverse_button_pressed_color](https://user-images.githubusercontent.com/50084500/139561892-bea85a12-08e9-4de7-a074-9be736021f36.gif)


