### PR TITLE
Add binding for MutexLock

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1762,6 +1762,28 @@ void Mutex::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("unlock"), &Mutex::unlock);
 }
 
+////// MutexLock //////
+
+Ref<MutexLock> MutexLock::lock(const Ref<Mutex> &p_mutex) {
+	ERR_FAIL_COND_V(p_mutex.is_null(), this);
+	ERR_FAIL_COND_V_MSG(mutex.is_valid(), this, "Cannot assign a mutex to a MutexLock more than once. Create an additional MutexLock.");
+	mutex = p_mutex;
+	mutex->lock();
+	return this;
+}
+
+void MutexLock::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("lock", "mutex"), &MutexLock::lock);
+}
+
+MutexLock::~MutexLock() {
+	if (mutex.is_valid()) {
+		mutex->unlock();
+	} else {
+		WARN_PRINT("A MutexLock was created without assigning a mutex.");
+	}
+}
+
 ////// Thread //////
 
 void Thread::_start_func(void *ud) {

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -520,6 +520,18 @@ public:
 	void unlock();
 };
 
+class MutexLock : public RefCounted {
+	GDCLASS(MutexLock, RefCounted);
+	Ref<Mutex> mutex;
+
+	static void _bind_methods();
+
+public:
+	Ref<MutexLock> lock(const Ref<Mutex> &p_mutex);
+
+	~MutexLock();
+};
+
 class Semaphore : public RefCounted {
 	GDCLASS(Semaphore, RefCounted);
 	::Semaphore semaphore;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -215,6 +215,7 @@ void register_core_types() {
 	GDREGISTER_CLASS(core_bind::Directory);
 	GDREGISTER_CLASS(core_bind::Thread);
 	GDREGISTER_CLASS(core_bind::Mutex);
+	GDREGISTER_CLASS(core_bind::MutexLock);
 	GDREGISTER_CLASS(core_bind::Semaphore);
 
 	GDREGISTER_CLASS(XMLParser);

--- a/doc/classes/MutexLock.xml
+++ b/doc/classes/MutexLock.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="MutexLock" inherits="RefCounted" version="4.0">
+	<brief_description>
+		A [Mutex] lock guard.
+	</brief_description>
+	<description>
+		A [Mutex] lock guard. This is used to automatically lock and unlock a [Mutex] within a scope.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="lock">
+			<return type="MutexLock" />
+			<argument index="0" name="mutex" type="Mutex" />
+			<description>
+				Assigns a [Mutex] to lock within the [MutexLock]'s scope. This automatically calls [method Mutex.lock]. When the [MutexLock] exits scope, it automatically calls [method Mutex.unlock].
+				[codeblock]
+				func thread_safe():
+				    var lock = MutexLock.new().lock(mutex)
+				[/codeblock]
+			</description>
+		</method>
+	</methods>
+</class>


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/3486 (with a trivially different API)

Because core/os/mutex/MutexLock requires the mutex in the constructor (not supported for bindings), it couldn't be bound. But the reimplementation is trivial.

This should be cherrypickable. 