### PR TITLE
Change the compiler to clang-cl.exe for MSVC when use_llvm=yes

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -887,7 +887,7 @@ def get_compiler_version(env):
     Returns an array of version numbers as ints: [major, minor, patch].
     The return array should have at least two values (major, minor).
     """
-    if not env.msvc:
+    if not env.msvc or using_clang(env):
         # Not using -dumpversion as some GCC distros only return major, and
         # Clang used to return hardcoded 4.2.1: # https://reviews.llvm.org/D56803
         try:

--- a/methods.py
+++ b/methods.py
@@ -746,6 +746,9 @@ def generate_vs_project(env, num_jobs):
                 if env["tests"]:
                     common_build_postfix.append("tests=yes")
 
+                if env["use_llvm"]:
+                    common_build_postfix.append("use_llvm=yes")
+
                 if env["custom_modules"]:
                     common_build_postfix.append("custom_modules=%s" % env["custom_modules"])
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -176,6 +176,11 @@ def setup_mingw(env):
 def configure_msvc(env, manual_msvc_config):
     """Configure env to work with MSVC"""
 
+    # Clang for windows support
+    if env["use_llvm"]:
+        env["CC"] = "clang-cl.exe"
+        env["CXX"] = "clang-cl.exe"
+
     # Build type
 
     if env["tests"]:

--- a/thirdparty/libwebp/src/dsp/dsp.h
+++ b/thirdparty/libwebp/src/dsp/dsp.h
@@ -54,6 +54,7 @@ extern "C" {
 // for now, none of the optimizations below are available in emscripten
 #if !defined(EMSCRIPTEN)
 
+#if !defined(__clang__)
 #if defined(_MSC_VER) && _MSC_VER > 1310 && \
     (defined(_M_X64) || defined(_M_IX86))
 #define WEBP_MSC_SSE2  // Visual C++ SSE2 targets
@@ -62,6 +63,7 @@ extern "C" {
 #if defined(_MSC_VER) && _MSC_VER >= 1500 && \
     (defined(_M_X64) || defined(_M_IX86))
 #define WEBP_MSC_SSE41  // Visual C++ SSE4.1 targets
+#endif
 #endif
 
 // WEBP_HAVE_* are used to indicate the presence of the instruction set in dsp

--- a/thirdparty/misc/r128.h
+++ b/thirdparty/misc/r128.h
@@ -795,7 +795,7 @@ static void r128__umul128(R128 *dst, R128_U64 a, R128_U64 b)
 }
 
 // 128/64->64
-#if defined(_M_X64) && (_MSC_VER < 1920) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
+#if defined(_M_X64) && (_MSC_VER < 1920) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__) && !defined(__clang__)
 // MSVC x64 provides neither inline assembly nor (pre-2019) a div intrinsic, so we do fake
 // "inline assembly" to avoid long division or outline assembly.
 #pragma code_seg(".text")
@@ -810,7 +810,7 @@ static const r128__udiv128Proc r128__udiv128 = (r128__udiv128Proc)(void*)r128__u
 #else
 static R128_U64 r128__udiv128(R128_U64 nlo, R128_U64 nhi, R128_U64 d, R128_U64 *rem)
 {
-#if defined(_M_X64) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
+#if defined(_M_X64) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__) && !defined(__clang__)
    return _udiv128(nhi, nlo, d, rem);
 #elif defined(__x86_64__) && !defined(R128_STDC_ONLY)
    R128_U64 q, r;

--- a/thirdparty/misc/r128.h
+++ b/thirdparty/misc/r128.h
@@ -665,7 +665,7 @@ static int r128__clz64(R128_U64 x)
 // 32*32->64
 static R128_U64 r128__umul64(R128_U32 a, R128_U32 b)
 {
-#  if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
+#  if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__) && !defined(__clang__)
    return __emulu(a, b);
 #  elif defined(_M_ARM) && !defined(R128_STDC_ONLY)
    return _arm_umull(a, b);
@@ -677,10 +677,10 @@ static R128_U64 r128__umul64(R128_U32 a, R128_U32 b)
 // 64/32->32
 static R128_U32 r128__udiv64(R128_U32 nlo, R128_U32 nhi, R128_U32 d, R128_U32 *rem)
 {
-#  if defined(_M_IX86) && (_MSC_VER >= 1920) && !defined(R128_STDC_ONLY)
+#  if defined(_M_IX86) && (_MSC_VER >= 1920) && !defined(R128_STDC_ONLY) && !defined(__clang__)
    unsigned __int64 n = ((unsigned __int64)nhi << 32) | nlo;
    return _udiv64(n, d, rem);
-#  elif defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
+#  elif defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__) && !defined(__clang__)
    __asm {
       mov eax, nlo
       mov edx, nhi
@@ -1602,7 +1602,7 @@ void r128Shl(R128 *dst, const R128 *src, int amount)
    R128_ASSERT(dst != NULL);
    R128_ASSERT(src != NULL);
 
-#if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
+#if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__) && !defined(__clang__)
    __asm {
       // load src
       mov edx, dword ptr[src]
@@ -1664,7 +1664,7 @@ void r128Shr(R128 *dst, const R128 *src, int amount)
    R128_ASSERT(dst != NULL);
    R128_ASSERT(src != NULL);
 
-#if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
+#if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__) && !defined(__clang__)
    __asm {
       // load src
       mov edx, dword ptr[src]
@@ -1726,7 +1726,7 @@ void r128Sar(R128 *dst, const R128 *src, int amount)
    R128_ASSERT(dst != NULL);
    R128_ASSERT(src != NULL);
 
-#if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
+#if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__) && !defined(__clang__)
    __asm {
       // load src
       mov edx, dword ptr[src]


### PR DESCRIPTION
clang-cl.exe is compatible with the cl.exe flags so the rest should work as before.

Tested on my own system and it compiled and ran the application. You have to have Clang for Windows installed though through the windows installer [https://llvm.org/builds/](https://llvm.org/builds/) and also add the directory to the ```PATH```. This directory is usually "C:/Program Files/LLVM/bin"

The only needed changes were to detect the clang version and to override the default cl.exe compiler with the clang-cl.exe one.

No linked issue but I hope you still find the PR useful.