### PR TITLE
Fix multimesh buffer overflow in RendererStorageRD

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -4419,7 +4419,8 @@ void RendererStorageRD::_update_dirty_multimeshes() {
 						if (multimesh->data_cache_dirty_regions[i]) {
 							uint32_t offset = i * region_size;
 							uint32_t size = multimesh->stride_cache * (uint32_t)multimesh->instances * (uint32_t)sizeof(float);
-							RD::get_singleton()->buffer_update(multimesh->buffer, offset, MIN(region_size, size - offset), &data[i * region_size]);
+							uint32_t region_start_index = multimesh->stride_cache * MULTIMESH_DIRTY_REGION_SIZE * i;
+							RD::get_singleton()->buffer_update(multimesh->buffer, offset, MIN(region_size, size - offset), &data[region_start_index]);
 						}
 					}
 				}


### PR DESCRIPTION
Fixes #53603

P.S. @qarmin could you please test this commit to see if it fixes the issue on your end? When running the attached code, I got a crash from buffer overflow, rather than free-after-use that ASan identified on your end. Cheers!