### PR TITLE
Fix TextEdit mouse interactions when the last line is hidden

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -233,8 +233,9 @@
 		<method name="get_line_column_at_pos" qualifiers="const">
 			<return type="Vector2i" />
 			<argument index="0" name="position" type="Vector2i" />
+			<argument index="1" name="allow_out_of_bounds" type="bool" default="true" />
 			<description>
-				Returns the line and column at the given position. In the returned vector, [code]x[/code] is the column, [code]y[/code] is the line.
+				Returns the line and column at the given position. In the returned vector, [code]x[/code] is the column, [code]y[/code] is the line. If [code]allow_out_of_bounds[/code] is [code]false[/code] and the position is not over the text, both vector values will be set to [code]-1[/code].
 			</description>
 		</method>
 		<method name="get_line_count" qualifiers="const">
@@ -451,6 +452,14 @@
 			<return type="int" />
 			<description>
 				Returns the number of visible lines, including wrapped text.
+			</description>
+		</method>
+		<method name="get_visible_line_count_in_range" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="from_line" type="int" />
+			<argument index="1" name="to_line" type="int" />
+			<description>
+				Returns the total number of visible + wrapped lines between the two lines.
 			</description>
 		</method>
 		<method name="get_word_at_pos" qualifiers="const">

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -296,11 +296,11 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				mpos.x = get_size().x - mpos.x;
 			}
 
-			Point2i pos = get_line_column_at_pos(mpos);
+			Point2i pos = get_line_column_at_pos(mpos, false);
 			int line = pos.y;
 			int col = pos.x;
 
-			if (mb->get_button_index() == MouseButton::LEFT) {
+			if (line != -1 && mb->get_button_index() == MouseButton::LEFT) {
 				if (is_line_folded(line)) {
 					int wrap_index = get_line_wrap_index_at_column(line, col);
 					if (wrap_index == get_line_wrap_count(line)) {
@@ -321,11 +321,13 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 						mpos.x = get_size().x - mpos.x;
 					}
 
-					Point2i pos = get_line_column_at_pos(mpos);
+					Point2i pos = get_line_column_at_pos(mpos, false);
 					int line = pos.y;
 					int col = pos.x;
 
-					emit_signal(SNAME("symbol_lookup"), symbol_lookup_word, line, col);
+					if (line != -1) {
+						emit_signal(SNAME("symbol_lookup"), symbol_lookup_word, line, col);
+					}
 					return;
 				}
 			}
@@ -536,11 +538,11 @@ Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
 		return CURSOR_ARROW;
 	}
 
-	Point2i pos = get_line_column_at_pos(p_pos);
+	Point2i pos = get_line_column_at_pos(p_pos, false);
 	int line = pos.y;
 	int col = pos.x;
 
-	if (is_line_folded(line)) {
+	if (line != -1 && is_line_folded(line)) {
 		int wrap_index = get_line_wrap_index_at_column(line, col);
 		if (wrap_index == get_line_wrap_count(line)) {
 			int eol_icon_width = folded_eol_icon->get_width();
@@ -2016,9 +2018,13 @@ bool CodeEdit::is_symbol_lookup_on_click_enabled() const {
 String CodeEdit::get_text_for_symbol_lookup() {
 	Point2i mp = get_local_mouse_pos();
 
-	Point2i pos = get_line_column_at_pos(mp);
+	Point2i pos = get_line_column_at_pos(mp, false);
 	int line = pos.y;
 	int col = pos.x;
+
+	if (line == -1) {
+		return String();
+	}
 
 	StringBuilder lookup_text;
 	const int text_size = get_line_count();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -716,7 +716,7 @@ public:
 
 	String get_word_at_pos(const Vector2 &p_pos) const;
 
-	Point2i get_line_column_at_pos(const Point2i &p_pos) const;
+	Point2i get_line_column_at_pos(const Point2i &p_pos, bool p_allow_out_of_bounds = true) const;
 	int get_minimap_line_at_pos(const Point2i &p_pos) const;
 
 	bool is_dragging_cursor() const;
@@ -822,6 +822,7 @@ public:
 	int get_last_full_visible_line_wrap_index() const;
 
 	int get_visible_line_count() const;
+	int get_visible_line_count_in_range(int p_from, int p_to) const;
 	int get_total_visible_line_count() const;
 
 	// Auto Adjust


### PR DESCRIPTION
If the last line is hidden you could end up hiding the caret, this is due to `get_next_visible_line_index_offset_from` returning a hidden line if it cannot reach the requested `visible_amount`, as there is no more visible lines.

However, by fixing this, everything beyond the last line would interact as if you were hovering over it such as unfolding, symbol lookup e.t.c. Therefore `get_line_column_at_pos` now has a new optional arg `allow_out_of_bounds` to return an invalid value if the position is over the virtual space.