### PR TITLE
Fix popup trying to emit the non-existing signal 'cancelled' when closed

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -105,8 +105,6 @@ void Popup::_close_pressed() {
 	_deinitialize_visible_parents();
 
 	call_deferred(SNAME("hide"));
-
-	emit_signal(SNAME("cancelled"));
 }
 
 void Popup::set_as_minsize() {


### PR DESCRIPTION
Closing any popup (in game or in the editor) spams the message `Can't emit non existing signal cancelled`. (This signal only exists in AcceptDialog).
This PR removes this call in the Popup class. The signal `popup_hide` which is sent when the popup is closed is already sent on line 74.