### PR TITLE
[macOS] Always execute editor instances using NSWorkspace to ensure app window is registered and activated correctly.

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -249,6 +249,7 @@ public:
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen = 0) const;
 
 	virtual String get_executable_path() const;
+	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr);
 
 	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
 	virtual int keyboard_get_layout_count() const;


### PR DESCRIPTION
Fixes #54306
Fixes #54458

Precompiled .app bundle to test (ad-hoc signed so `xattr -dr com.apple.quarantine /path/to/GodotTest.app` before running): https://mega.nz/file/IhAXVKBR#NDtx9atZNdSQBmbHDFfi9_aemlLmJ5-qBC2sSw82iSQ

*Edit: changed the link to a new one, without unrelated custom modules.*