### PR TITLE
Fix memory leak when using `CurveTexture.set_texture_mode`

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -625,6 +625,8 @@ void RasterizerStorageGLES3::texture_replace(RID p_texture, RID p_by_texture) {
 	for (int n = 0; n < tex_from->images.size(); n++) {
 		texture_set_data(p_texture, tex_from->images[n], n);
 	}
+
+	free(p_by_texture);
 }
 
 bool RasterizerStorageGLES3::_is_main_thread() {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1503,6 +1503,7 @@ Ref<Curve> CurveTexture::get_curve() const {
 }
 
 void CurveTexture::set_texture_mode(TextureMode p_mode) {
+	ERR_FAIL_COND(p_mode < TEXTURE_MODE_RGB || p_mode > TEXTURE_MODE_RED);
 	if (texture_mode == p_mode) {
 		return;
 	}

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -258,7 +258,7 @@ public:
 	Ref<Image> texture_2d_layer_get(RID p_texture, int p_layer) const override { return Ref<Image>(); }
 	Vector<Ref<Image>> texture_3d_get(RID p_texture) const override { return Vector<Ref<Image>>(); }
 
-	void texture_replace(RID p_texture, RID p_by_texture) override {}
+	void texture_replace(RID p_texture, RID p_by_texture) override { free(p_by_texture); }
 	void texture_set_size_override(RID p_texture, int p_width, int p_height) override {}
 
 	void texture_set_path(RID p_texture, const String &p_path) override {}


### PR DESCRIPTION
Fixes #54477

The leak is caused by `RendererStorage::texture_replace(texture, by_texture)` not freeing `by_texture` as the Vulkan backend does. This affects both GLES3 and the dummy rasterizer.

https://github.com/godotengine/godot/blob/210e6cc167b5003d2095e6667f4b34818a4a16f3/servers/rendering/renderer_rd/renderer_storage_rd.cpp#L1148

Also validates the input enum of `set_texture_mode()`.
