### PR TITLE
Implement a vignette option in CameraEffects

### DIFF
--- a/doc/classes/CameraEffects.xml
+++ b/doc/classes/CameraEffects.xml
@@ -37,5 +37,20 @@
 		<member name="override_exposure_enabled" type="bool" setter="set_override_exposure_enabled" getter="is_override_exposure_enabled" default="false">
 			If [code]true[/code], overrides the manual or automatic exposure defined in the [Environment] with the value in [member override_exposure].
 		</member>
+		<member name="vignette_center" type="Vector2" setter="set_vignette_center" getter="get_vignette_center" default="Vector2(0.5, 0.5)">
+			The center to use for vignetting ([code]Vector2(0.5, 0.5)[/code] is the center of the viewport). Only used if [member vignette_intensity] is greater than [code]0.0[/code].
+		</member>
+		<member name="vignette_color" type="Color" setter="set_vignette_color" getter="get_vignette_color" default="Color(0, 0, 0, 1)">
+			The color to use for vignetting. Only used if [member vignette_intensity] is greater than [code]0.0[/code].
+		</member>
+		<member name="vignette_inner_radius" type="float" setter="set_vignette_inner_radius" getter="get_vignette_inner_radius" default="0.15">
+			The inner radius to use for vignetting. Greater values don't obscure the vignette's center as much. Only used if [member vignette_intensity] is greater than [code]0.0[/code].
+		</member>
+		<member name="vignette_intensity" type="float" setter="set_vignette_intensity" getter="get_vignette_intensity" default="0.0">
+			If set to a value greater than [code]0.0[/code], applies [url=https://en.wikipedia.org/wiki/Vignetting]vignetting[/url] which darkens the image's corners. This creates an effect similar to the use of old/low-quality optical lenses, and can be used to focus attention to a specific point in the viewport (typically the center). Vignetting should be used sparingly; otherwise, it can become visually overwhelming.
+		</member>
+		<member name="vignette_outer_radius" type="float" setter="set_vignette_outer_radius" getter="get_vignette_outer_radius" default="1.0">
+			The outer radius to use for vignetting. Greater values don't obscure the vignette's edges and corners as much. Only used if [member vignette_intensity] is greater than [code]0.0[/code].
+		</member>
 	</members>
 </class>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -72,6 +72,18 @@
 			<description>
 			</description>
 		</method>
+		<method name="camera_effects_set_vignette">
+			<return type="void" />
+			<argument index="0" name="camera_effects" type="RID" />
+			<argument index="1" name="intensity" type="float" />
+			<argument index="2" name="inner_radius" type="float" />
+			<argument index="3" name="outer_radius" type="float" />
+			<argument index="4" name="color" type="Color" />
+			<argument index="5" name="center" type="Vector2" />
+			<description>
+				Sets the vignette associated with this [CameraEffects]. See the vignette properties in [CameraEffects] for more information.
+			</description>
+		</method>
 		<method name="camera_set_camera_effects">
 			<return type="void" />
 			<argument index="0" name="camera" type="RID" />

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -488,6 +488,9 @@ void RasterizerSceneGLES3::camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehS
 void RasterizerSceneGLES3::camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) {
 }
 
+void RasterizerSceneGLES3::camera_effects_set_vignette(RID p_camera_effects, float p_intensity, float p_inner_radius, float p_outer_radius, const Color &p_color, const Vector2 &p_center) {
+}
+
 void RasterizerSceneGLES3::camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) {
 }
 

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -452,6 +452,7 @@ public:
 	void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) override;
 
 	void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) override;
+	void camera_effects_set_vignette(RID p_camera_effects, float p_intensity, float p_inner_radius, float p_outer_radius, const Color &p_color, const Vector2 &p_center) override;
 	void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override;
 
 	void shadows_quality_set(RS::ShadowQuality p_quality) override;

--- a/scene/resources/camera_effects.cpp
+++ b/scene/resources/camera_effects.cpp
@@ -115,6 +115,63 @@ void CameraEffects::_update_dof_blur() {
 			dof_blur_amount);
 }
 
+// Vignette
+
+void CameraEffects::set_vignette_intensity(float p_intensity) {
+	vignette_intensity = p_intensity;
+	_update_vignette();
+}
+
+float CameraEffects::get_vignette_intensity() const {
+	return vignette_intensity;
+}
+
+void CameraEffects::set_vignette_inner_radius(float p_inner_radius) {
+	vignette_inner_radius = p_inner_radius;
+	_update_vignette();
+}
+
+float CameraEffects::get_vignette_inner_radius() const {
+	return vignette_inner_radius;
+}
+
+void CameraEffects::set_vignette_outer_radius(float p_outer_radius) {
+	vignette_outer_radius = p_outer_radius;
+	_update_vignette();
+}
+
+float CameraEffects::get_vignette_outer_radius() const {
+	return vignette_outer_radius;
+}
+
+void CameraEffects::set_vignette_color(const Color &p_color) {
+	vignette_color = p_color;
+	_update_vignette();
+}
+
+Color CameraEffects::get_vignette_color() const {
+	return vignette_color;
+}
+
+void CameraEffects::set_vignette_center(const Vector2 &p_center) {
+	vignette_center = p_center;
+	_update_vignette();
+}
+
+Vector2 CameraEffects::get_vignette_center() const {
+	return vignette_center;
+}
+
+void CameraEffects::_update_vignette() {
+	RS::get_singleton()->camera_effects_set_vignette(
+			camera_effects,
+			vignette_intensity,
+			vignette_inner_radius,
+			vignette_outer_radius,
+			vignette_color,
+			vignette_center);
+}
+
 // Custom exposure
 
 void CameraEffects::set_override_exposure_enabled(bool p_enabled) {
@@ -181,6 +238,26 @@ void CameraEffects::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_distance", PROPERTY_HINT_RANGE, "0.01,8192,0.01,exp"), "set_dof_blur_near_distance", "get_dof_blur_near_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_transition", PROPERTY_HINT_RANGE, "0.01,8192,0.01,exp"), "set_dof_blur_near_transition", "get_dof_blur_near_transition");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_dof_blur_amount", "get_dof_blur_amount");
+
+	// Vignette
+
+	ClassDB::bind_method(D_METHOD("set_vignette_intensity", "intensity"), &CameraEffects::set_vignette_intensity);
+	ClassDB::bind_method(D_METHOD("get_vignette_intensity"), &CameraEffects::get_vignette_intensity);
+	ClassDB::bind_method(D_METHOD("set_vignette_inner_radius", "inner_radius"), &CameraEffects::set_vignette_inner_radius);
+	ClassDB::bind_method(D_METHOD("get_vignette_inner_radius"), &CameraEffects::get_vignette_inner_radius);
+	ClassDB::bind_method(D_METHOD("set_vignette_outer_radius", "outer_radius"), &CameraEffects::set_vignette_outer_radius);
+	ClassDB::bind_method(D_METHOD("get_vignette_outer_radius"), &CameraEffects::get_vignette_outer_radius);
+	ClassDB::bind_method(D_METHOD("set_vignette_color", "color"), &CameraEffects::set_vignette_color);
+	ClassDB::bind_method(D_METHOD("get_vignette_color"), &CameraEffects::get_vignette_color);
+	ClassDB::bind_method(D_METHOD("set_vignette_center", "center"), &CameraEffects::set_vignette_center);
+	ClassDB::bind_method(D_METHOD("get_vignette_center"), &CameraEffects::get_vignette_center);
+
+	ADD_GROUP("Vignette", "vignette_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "vignette_intensity", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_vignette_intensity", "get_vignette_intensity");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "vignette_inner_radius", PROPERTY_HINT_RANGE, "0.001,1,0.001"), "set_vignette_inner_radius", "get_vignette_inner_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "vignette_outer_radius", PROPERTY_HINT_RANGE, "0.001,1,0.001"), "set_vignette_outer_radius", "get_vignette_outer_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "vignette_color", PROPERTY_HINT_COLOR_NO_ALPHA), "set_vignette_color", "get_vignette_color");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "vignette_center"), "set_vignette_center", "get_vignette_center");
 
 	// Override exposure
 

--- a/scene/resources/camera_effects.h
+++ b/scene/resources/camera_effects.h
@@ -52,6 +52,14 @@ private:
 	float dof_blur_amount = 0.1;
 	void _update_dof_blur();
 
+	// Vignette
+	float vignette_intensity = 0.0;
+	float vignette_inner_radius = 0.15;
+	float vignette_outer_radius = 1.0;
+	Color vignette_color = Color(0, 0, 0, 1);
+	Vector2 vignette_center = Vector2(0.5, 0.5);
+	void _update_vignette();
+
 	// Override exposure
 	bool override_exposure_enabled = false;
 	float override_exposure = 1.0;
@@ -81,6 +89,18 @@ public:
 
 	void set_dof_blur_amount(float p_amount);
 	float get_dof_blur_amount() const;
+
+	// Vignette
+	void set_vignette_intensity(float p_intensity);
+	float get_vignette_intensity() const;
+	void set_vignette_inner_radius(float p_inner_radius);
+	float get_vignette_inner_radius() const;
+	void set_vignette_outer_radius(float p_outer_radius);
+	float get_vignette_outer_radius() const;
+	void set_vignette_color(const Color &p_color);
+	Color get_vignette_color() const;
+	void set_vignette_center(const Vector2 &p_center);
+	Vector2 get_vignette_center() const;
 
 	// Override exposure
 	void set_override_exposure_enabled(bool p_enabled);

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -141,6 +141,7 @@ public:
 	void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) override {}
 
 	void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) override {}
+	void camera_effects_set_vignette(RID p_camera_effects, float p_intensity, float p_inner_radius, float p_outer_radius, const Color &p_color, const Vector2 &p_center) override {}
 	void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override {}
 
 	void shadows_quality_set(RS::ShadowQuality p_quality) override {}

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -133,6 +133,15 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 	}
 
 	tonemap.push_constant.tonemapper = p_settings.tonemap_mode;
+	tonemap.push_constant.vignette_intensity = p_settings.vignette_intensity;
+	tonemap.push_constant.vignette_color[0] = p_settings.vignette_color.r;
+	tonemap.push_constant.vignette_color[1] = p_settings.vignette_color.g;
+	tonemap.push_constant.vignette_color[2] = p_settings.vignette_color.b;
+	tonemap.push_constant.vignette_center[0] = p_settings.vignette_center.x;
+	tonemap.push_constant.vignette_center[1] = p_settings.vignette_center.y;
+	tonemap.push_constant.vignette_inner_radius = p_settings.vignette_inner_radius;
+	tonemap.push_constant.vignette_outer_radius = p_settings.vignette_outer_radius;
+
 	tonemap.push_constant.use_auto_exposure = p_settings.use_auto_exposure;
 	tonemap.push_constant.exposure = p_settings.exposure;
 	tonemap.push_constant.white = p_settings.white;
@@ -223,6 +232,15 @@ void ToneMapper::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_col
 	}
 
 	tonemap.push_constant.tonemapper = p_settings.tonemap_mode;
+	tonemap.push_constant.vignette_intensity = p_settings.vignette_intensity;
+	tonemap.push_constant.vignette_color[0] = p_settings.vignette_color.r;
+	tonemap.push_constant.vignette_color[1] = p_settings.vignette_color.g;
+	tonemap.push_constant.vignette_color[2] = p_settings.vignette_color.b;
+	tonemap.push_constant.vignette_center[0] = p_settings.vignette_center.x;
+	tonemap.push_constant.vignette_center[1] = p_settings.vignette_center.y;
+	tonemap.push_constant.vignette_inner_radius = p_settings.vignette_inner_radius;
+	tonemap.push_constant.vignette_outer_radius = p_settings.vignette_outer_radius;
+
 	tonemap.push_constant.use_auto_exposure = p_settings.use_auto_exposure;
 	tonemap.push_constant.exposure = p_settings.exposure;
 	tonemap.push_constant.white = p_settings.white;

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -61,28 +61,35 @@ private:
 
 	struct TonemapPushConstant {
 		float bcs[3]; // 12 - 12
-		uint32_t use_bcs; //  4 - 16
+		uint32_t use_bcs; // 4 - 16
 
-		uint32_t use_glow; //  4 - 20
-		uint32_t use_auto_exposure; //  4 - 24
-		uint32_t use_color_correction; //  4 - 28
-		uint32_t tonemapper; //  4 - 32
+		uint32_t use_glow; // 4 - 20
+		uint32_t use_auto_exposure; // 4 - 24
+		uint32_t use_color_correction; // 4 - 28
+		uint32_t tonemapper; // 4 - 32
 
-		uint32_t glow_texture_size[2]; //  8 - 40
-		float glow_intensity; //  4 - 44
-		float glow_map_strength; //  4 - 48
+		uint32_t glow_texture_size[2]; // 8 - 40
+		float glow_intensity; // 4 - 44
+		float glow_map_strength; // 4 - 48
 
-		uint32_t glow_mode; //  4 - 52
+		uint32_t glow_mode; // 4 - 52
 		float glow_levels[7]; // 28 - 80
 
-		float exposure; //  4 - 84
-		float white; //  4 - 88
-		float auto_exposure_grey; //  4 - 92
-		float luminance_multiplier; //  4 - 96
+		float vignette_color[3]; // 12 - 92
+		float vignette_intensity; // 4 - 96
 
-		float pixel_size[2]; //  8 - 104
-		uint32_t use_fxaa; //  4 - 108
-		uint32_t use_debanding; //  4 - 112
+		float vignette_center[2]; // 8 - 104
+		float vignette_inner_radius; // 4 - 118
+		float vignette_outer_radius; // 4 - 112
+
+		float exposure; // 4 - 116
+		float white; // 4 - 120
+		float auto_exposure_grey; // 4 - 124
+		float luminance_multiplier; // 4 - 128
+
+		float pixel_size[2]; // 8 - 136
+		uint32_t use_fxaa; // 4 - 140
+		uint32_t use_debanding; // 4 - 144
 	};
 
 	/* tonemap actually writes to a framebuffer, which is
@@ -125,6 +132,12 @@ public:
 		RS::EnvironmentToneMapper tonemap_mode = RS::ENV_TONE_MAPPER_LINEAR;
 		float exposure = 1.0;
 		float white = 1.0;
+
+		float vignette_intensity = 0.0;
+		float vignette_inner_radius = 0.15;
+		float vignette_outer_radius = 1.0;
+		Color vignette_color = Color(0, 0, 0, 1);
+		Vector2 vignette_center = Vector2(0.5, 0.5);
 
 		bool use_auto_exposure = false;
 		float auto_exposure_grey = 0.5;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1392,6 +1392,17 @@ void RendererSceneRenderRD::camera_effects_set_dof_blur(RID p_camera_effects, bo
 	camfx->dof_blur_amount = p_amount;
 }
 
+void RendererSceneRenderRD::camera_effects_set_vignette(RID p_camera_effects, float p_intensity, float p_inner_radius, float p_outer_radius, const Color &p_color, const Vector2 &p_center) {
+	CameraEffects *camfx = camera_effects_owner.get_or_null(p_camera_effects);
+	ERR_FAIL_COND(!camfx);
+
+	camfx->vignette_intensity = p_intensity;
+	camfx->vignette_inner_radius = p_inner_radius;
+	camfx->vignette_outer_radius = p_outer_radius;
+	camfx->vignette_color = p_color;
+	camfx->vignette_center = p_center;
+}
+
 void RendererSceneRenderRD::camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) {
 	CameraEffects *camfx = camera_effects_owner.get_or_null(p_camera_effects);
 	ERR_FAIL_COND(!camfx);
@@ -2526,6 +2537,14 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 		tonemap.use_debanding = rb->use_debanding;
 		tonemap.texture_size = Vector2i(rb->internal_width, rb->internal_height);
+
+		if (camfx) {
+			tonemap.vignette_intensity = camfx->vignette_intensity;
+			tonemap.vignette_inner_radius = camfx->vignette_inner_radius;
+			tonemap.vignette_outer_radius = camfx->vignette_outer_radius;
+			tonemap.vignette_color = camfx->vignette_color;
+			tonemap.vignette_center = camfx->vignette_center;
+		}
 
 		if (env) {
 			tonemap.tonemap_mode = env->tone_mapper;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -439,6 +439,12 @@ private:
 
 		float dof_blur_amount = 0.1;
 
+		float vignette_intensity = 0.0;
+		float vignette_inner_radius = 0.15;
+		float vignette_outer_radius = 1.0;
+		Color vignette_color = Color(0, 0, 0, 1);
+		Vector2 vignette_center = Vector2(0.5, 0.5);
+
 		bool override_exposure_enabled = false;
 		float override_exposure = 1;
 	};
@@ -1105,6 +1111,7 @@ public:
 	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) override;
 
 	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) override;
+	virtual void camera_effects_set_vignette(RID p_camera_effects, float p_intensity, float p_inner_radius, float p_outer_radius, const Color &p_color, const Vector2 &p_center) override;
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override;
 
 	bool camera_effects_uses_dof(RID p_camera_effects) {

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -181,6 +181,7 @@ public:
 	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) = 0;
 
 	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) = 0;
+	virtual void camera_effects_set_vignette(RID p_camera_effects, float p_intensity, float p_inner_radius, float p_outer_radius, const Color &p_color, const Vector2 &p_center) = 0;
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) = 0;
 
 	virtual void shadows_quality_set(RS::ShadowQuality p_quality) = 0;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1145,6 +1145,7 @@ public:
 	PASS1(camera_effects_set_dof_blur_bokeh_shape, RS::DOFBokehShape)
 
 	PASS8(camera_effects_set_dof_blur, RID, bool, float, float, bool, float, float, float)
+	PASS6(camera_effects_set_vignette, RID, float, float, float, const Color &, const Vector2 &)
 	PASS3(camera_effects_set_custom_exposure, RID, bool, float)
 
 	PASS1(shadows_quality_set, RS::ShadowQuality)

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -164,6 +164,7 @@ public:
 	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) = 0;
 
 	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) = 0;
+	virtual void camera_effects_set_vignette(RID p_camera_effects, float p_intensity, float p_inner_radius, float p_outer_radius, const Color &p_color, const Vector2 &p_center) = 0;
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) = 0;
 
 	virtual void shadows_quality_set(RS::ShadowQuality p_quality) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -705,6 +705,7 @@ public:
 	FUNC1(camera_effects_set_dof_blur_bokeh_shape, DOFBokehShape)
 
 	FUNC8(camera_effects_set_dof_blur, RID, bool, float, float, bool, float, float, float)
+	FUNC6(camera_effects_set_vignette, RID, float, float, float, const Color &, const Vector2 &)
 	FUNC3(camera_effects_set_custom_exposure, RID, bool, float)
 
 	FUNC1(shadows_quality_set, ShadowQuality);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2431,6 +2431,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_effects_set_dof_blur_bokeh_shape", "shape"), &RenderingServer::camera_effects_set_dof_blur_bokeh_shape);
 
 	ClassDB::bind_method(D_METHOD("camera_effects_set_dof_blur", "camera_effects", "far_enable", "far_distance", "far_transition", "near_enable", "near_distance", "near_transition", "amount"), &RenderingServer::camera_effects_set_dof_blur);
+	ClassDB::bind_method(D_METHOD("camera_effects_set_vignette", "camera_effects", "intensity", "inner_radius", "outer_radius", "color", "center"), &RenderingServer::camera_effects_set_vignette);
 	ClassDB::bind_method(D_METHOD("camera_effects_set_custom_exposure", "camera_effects", "enable", "exposure"), &RenderingServer::camera_effects_set_custom_exposure);
 
 	BIND_ENUM_CONSTANT(DOF_BOKEH_BOX);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1133,6 +1133,7 @@ public:
 	virtual void camera_effects_set_dof_blur_bokeh_shape(DOFBokehShape p_shape) = 0;
 
 	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) = 0;
+	virtual void camera_effects_set_vignette(RID p_camera_effects, float p_intensity, float p_inner_radius, float p_outer_radius, const Color &p_color, const Vector2 &p_center) = 0;
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) = 0;
 
 	/* SCENARIO API */


### PR DESCRIPTION
This can be used to simulate a vignetting effect commonly seen when using a camera lens.

This effect is cheap, but it should be applied with care as it can become visually overwhelming if overdone.

This closes https://github.com/godotengine/godot-proposals/issues/1806. See also https://github.com/godotengine/godot/pull/54574 which is a related effect.

**Testing project:** [test_vignette.zip](https://github.com/godotengine/godot/files/7454798/test_vignette.zip)
The default vignette mode is Texture – it uses a TextureRect node to represent the vignette effect. Press <kbd>Space</kbd> to toggle between vignette modes (Texture, Shader, None).

## Preview

**Edit (May 2022):** Vignette intensity at 1.0 was toned down by changing the default vignette outer radius from 0.85 to 1.0.

| No vignette | With vignette intensity = 1.0 |
|-|-|
| ![2021-11-01_14 39 06](https://user-images.githubusercontent.com/180032/139682161-f7badf87-dd31-48dd-8f5a-4e9678e4075b.png) | ![2021-11-01_14 38 00](https://user-images.githubusercontent.com/180032/139682156-c695764a-85de-4dfb-8023-089eba9bad29.png) |

## TODO

- [x] Make vignette color and center customizations effective in the shader.