### PR TITLE
ThreadWorkPool to no longer start worker threads if given zero work

### DIFF
--- a/servers/physics_2d/godot_step_2d.cpp
+++ b/servers/physics_2d/godot_step_2d.cpp
@@ -255,11 +255,7 @@ void GodotStep2D::step(GodotSpace2D *p_space, real_t p_delta, int p_iterations) 
 
 	// Warning: _solve_island modifies the constraint islands for optimization purpose,
 	// their content is not reliable after these calls and shouldn't be used anymore.
-	if (island_count > 1) {
-		work_pool.do_work(island_count, this, &GodotStep2D::_solve_island, nullptr);
-	} else if (island_count > 0) {
-		_solve_island(0);
-	}
+	work_pool.do_work(island_count, this, &GodotStep2D::_solve_island, nullptr);
 
 	{ //profile
 		profile_endtime = OS::get_singleton()->get_ticks_usec();

--- a/servers/physics_3d/godot_step_3d.cpp
+++ b/servers/physics_3d/godot_step_3d.cpp
@@ -359,11 +359,7 @@ void GodotStep3D::step(GodotSpace3D *p_space, real_t p_delta, int p_iterations) 
 
 	// Warning: _solve_island modifies the constraint islands for optimization purpose,
 	// their content is not reliable after these calls and shouldn't be used anymore.
-	if (island_count > 1) {
-		work_pool.do_work(island_count, this, &GodotStep3D::_solve_island, nullptr);
-	} else if (island_count > 0) {
-		_solve_island(0);
-	}
+	work_pool.do_work(island_count, this, &GodotStep3D::_solve_island, nullptr);
 
 	{ //profile
 		profile_endtime = OS::get_singleton()->get_ticks_usec();


### PR DESCRIPTION
`ThreadWorkPool::do_work` to run single task in calling thread, or do nothing at all if given no tasks.
`ThreadWorkPool::begin_work` to only wake threads it has tasks for.

### Background:
In investigation of #54291 #54484
Much of the work done by empty 2D physics spaces is in `ThreadWorkPool` starting threads with no work to do when `total_contraint_count == 0` at:
https://github.com/godotengine/godot/blob/4d96d37ca2200fddaa56980a80d69265bedbebae/servers/physics_2d/godot_step_2d.cpp#L238-L239
I was going to just copy the pattern used later in the same function:
https://github.com/godotengine/godot/blob/4d96d37ca2200fddaa56980a80d69265bedbebae/servers/physics_2d/godot_step_2d.cpp#L258-L262
But perhaps this belongs inside `ThreadWorkPool` now. Is this the right call?
