### PR TITLE
Add support for PowerPC family

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -440,6 +440,15 @@ bool OS::has_feature(const String &p_feature) {
 	if (p_feature == "riscv") {
 		return true;
 	}
+#elif defined(__powerpc__)
+#if defined(__powerpc64__)
+	if (p_feature == "ppc64") {
+		return true;
+	}
+#endif
+	if (p_feature == "ppc") {
+		return true;
+	}
 #endif
 
 	if (_check_internal_feature_support(p_feature)) {

--- a/modules/denoise/config.py
+++ b/modules/denoise/config.py
@@ -5,7 +5,13 @@ def can_build(env, platform):
     # as doing lightmap generation and denoising on Android or HTML5
     # would be a bit far-fetched.
     desktop_platforms = ["linuxbsd", "osx", "windows"]
-    supported_arch = env["bits"] == "64" and env["arch"] != "arm64" and not env["arch"].startswith("rv")
+    supported_arch = env["bits"] == "64"
+    if env["arch"] == "arm64":
+        supported_arch = False
+    if env["arch"].startswith("ppc"):
+        supported_arch = False
+    if env["arch"].startswith("rv"):
+        supported_arch = False
     return env["tools"] and platform in desktop_platforms and supported_arch
 
 

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,6 +1,6 @@
 def can_build(env, platform):
     # Depends on Embree library, which only supports x86_64 and aarch64.
-    if env["arch"].startswith("rv"):
+    if env["arch"].startswith("rv") or env["arch"].startswith("ppc"):
         return False
 
     if platform == "android":

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -119,8 +119,16 @@ def configure(env):
     if env["bits"] == "default":
         env["bits"] = "64" if is64 else "32"
 
-    if env["arch"] == "" and platform.machine() == "riscv64":
-        env["arch"] = "rv64"
+    machines = {
+        "riscv64": "rv64",
+        "ppc64le": "ppc64",
+        "ppc64": "ppc64",
+        "ppcle": "ppc",
+        "ppc": "ppc",
+    }
+
+    if env["arch"] == "" and platform.machine() in machines:
+        env["arch"] = machines[platform.machine()]
 
     if env["arch"] == "rv64":
         # G = General-purpose extensions, C = Compression extension (very common).


### PR DESCRIPTION
This adds support for the PowerPC architectures. Tested on ppc64le POWER9, with Radeon RX 5500 XT. Big endian ppc64 is known to at least build, though likely has bugs.