### PR TITLE
Fix new projects always being created with OpenGL

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1557,8 +1557,9 @@
 		<member name="rendering/driver/depth_prepass/enable" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], performs a previous depth pass before rendering materials. This increases performance in scenes with high overdraw, when complex materials and lighting are used.
 		</member>
-		<member name="rendering/driver/driver_name" type="String" setter="" getter="" default="&quot;Vulkan&quot;">
-			The video driver to use (currently only "Vulkan" is implemented).
+		<member name="rendering/driver/driver_name" type="String" setter="" getter="" default="&quot;vulkan&quot;">
+			The video driver to use.
+			[b]Note:[/b] OpenGL support is currently incomplete. Only basic 2D rendering is supported, and single-window mode is required for correct operation.
 			[b]Note:[/b] The backend in use can be overridden at runtime via the [code]--rendering-driver[/code] command line argument.
 			[b]FIXME:[/b] No longer valid after DisplayServer split:
 			In such cases, this property is not updated, so use [code]OS.get_current_video_driver[/code] to query it at run-time.

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1498,9 +1498,9 @@ String EditorExportPlatform::test_etc2() const {
 	bool etc_supported = ProjectSettings::get_singleton()->get("rendering/textures/vram_compression/import_etc");
 	bool etc2_supported = ProjectSettings::get_singleton()->get("rendering/textures/vram_compression/import_etc2");
 
-	if (driver == "OpenGL3" && !etc_supported) {
+	if (driver == "opengl3" && !etc_supported) {
 		return TTR("Target platform requires 'ETC' texture compression for OpenGL. Enable 'Import Etc' in Project Settings.");
-	} else if (driver == "Vulkan" && !etc2_supported) {
+	} else if (driver == "vulkan" && !etc2_supported) {
 		// FIXME: Review if this is true for Vulkan.
 		return TTR("Target platform requires 'ETC2' texture compression for Vulkan. Enable 'Import Etc 2' in Project Settings.");
 	}
@@ -1515,9 +1515,9 @@ String EditorExportPlatform::test_etc2_or_pvrtc() const {
 	//	bool etc2_supported = ProjectSettings::get_singleton()->get("rendering/textures/vram_compression/import_etc2");
 	//	bool pvrtc_supported = ProjectSettings::get_singleton()->get("rendering/textures/vram_compression/import_pvrtc");
 
-	if (driver == "OpenGL3" && !pvrtc_supported) {
+	if (driver == "opengl3" && !pvrtc_supported) {
 		return TTR("Target platform requires 'PVRTC' texture compression for OpenGL. Enable 'Import Pvrtc' in Project Settings.");
-	} else if (driver == "Vulkan" && !etc2_supported && !pvrtc_supported) {
+	} else if (driver == "vulkan" && !etc2_supported && !pvrtc_supported) {
 		// FIXME: Review if this is true for Vulkan.
 		return TTR("Target platform requires 'ETC2' or 'PVRTC' texture compression for Vulkan. Enable 'Import Etc 2' or 'Import Pvrtc' in Project Settings.");
 	}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -475,13 +475,6 @@ private:
 					}
 					ProjectSettings::CustomMap initial_settings;
 					initial_settings["rendering/vulkan/rendering/back_end"] = rasterizer_button_group->get_pressed_button()->get_meta(SNAME("driver_name"));
-					if (rasterizer_button_group->get_pressed_button()->get_meta("driver_name") == "Vulkan") {
-						initial_settings["rendering/driver/driver_name"] = "Vulkan";
-					} else {
-						initial_settings["rendering/driver/driver_name"] = "OpenGL3";
-						initial_settings["rendering/textures/vram_compression/import_etc2"] = false;
-						initial_settings["rendering/textures/vram_compression/import_etc"] = true;
-					}
 					initial_settings["application/config/name"] = project_name->get_text().strip_edges();
 					initial_settings["application/config/icon"] = "res://icon.png";
 					initial_settings["rendering/environment/defaults/default_environment"] = "res://default_env.tres";

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1275,14 +1275,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	register_core_extensions(); //before display
 	// possibly be worth changing the default from vulkan to something lower spec,
 	// for the project manager, depending on how smooth the fallback is.
-	GLOBAL_DEF_RST("rendering/driver/driver_name", "Vulkan");
+	GLOBAL_DEF_RST("rendering/driver/driver_name", "vulkan");
 
 	// this list is hard coded, which makes it more difficult to add new backends.
 	// can potentially be changed to more of a plugin system at a later date.
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/driver/driver_name",
 			PropertyInfo(Variant::STRING,
 					"rendering/driver/driver_name",
-					PROPERTY_HINT_ENUM, "Vulkan,OpenGL"));
+					PROPERTY_HINT_ENUM, "vulkan,opengl3"));
 
 	// if not set on the command line
 	if (rendering_driver == "") {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1612,11 +1612,11 @@ Vector<String> EditorExportPlatformAndroid::get_enabled_abis(const Ref<EditorExp
 
 void EditorExportPlatformAndroid::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
 	String driver = ProjectSettings::get_singleton()->get("rendering/driver/driver_name");
-	if (driver == "OpenGL3") {
+	if (driver == "opengl3") {
 		r_features->push_back("etc");
 	}
 	// FIXME: Review what texture formats are used for Vulkan.
-	if (driver == "Vulkan") {
+	if (driver == "vulkan") {
 		r_features->push_back("etc2");
 	}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -263,7 +263,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		GodotLib.setup(command_line);
 
 		final String videoDriver = GodotLib.getGlobal("rendering/driver/driver_name");
-		if (videoDriver.equals("Vulkan")) {
+		if (videoDriver.equals("vulkan")) {
 			mRenderView = new GodotVulkanRenderView(activity, this);
 		} else {
 			mRenderView = new GodotGLRenderView(activity, this, xrMode, use_32_bits,

--- a/platform/iphone/export/export_plugin.cpp
+++ b/platform/iphone/export/export_plugin.cpp
@@ -33,7 +33,7 @@
 void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
 	String driver = ProjectSettings::get_singleton()->get("rendering/driver/driver_name");
 	r_features->push_back("pvrtc");
-	if (driver == "Vulkan") {
+	if (driver == "vulkan") {
 		// FIXME: Review if this is correct.
 		r_features->push_back("etc2");
 	}

--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -300,9 +300,9 @@ void EditorExportPlatformJavaScript::get_preset_features(const Ref<EditorExportP
 
 	if (p_preset->get("vram_texture_compression/for_mobile")) {
 		String driver = ProjectSettings::get_singleton()->get("rendering/driver/driver_name");
-		if (driver == "OpenGL3") {
+		if (driver == "opengl3") {
 			r_features->push_back("etc");
-		} else if (driver == "Vulkan") {
+		} else if (driver == "vulkan") {
 			// FIXME: Review if this is correct.
 			r_features->push_back("etc2");
 		}


### PR DESCRIPTION
Only Vulkan is fully implemented for now, so OpenGL isn't available in the project manager yet.

This also makes the rendering driver checks use lowercase names everywhere for consistency.

This closes https://github.com/godotengine/godot/issues/54488.