### PR TITLE
Fix unset target type in assignment inside setter

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1014,7 +1014,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				}
 
 				// If this is a local member, also assign to it.
-				// This allow things like: position.x += 2.0
+				// This allows things like: position.x += 2.0
 				if (assign_property != StringName()) {
 					gen->write_set_member(assigned, assign_property);
 				}
@@ -1072,10 +1072,8 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				}
 
 				if (has_setter) {
-					if (!is_in_setter) {
-						// Store stack slot for the temp value.
-						target = codegen.add_temporary(_gdtype_from_datatype(assignment->assignee->get_datatype()));
-					}
+                    // Store stack slot for the temp value.
+                    target = codegen.add_temporary(_gdtype_from_datatype(assignment->assignee->get_datatype()));
 				} else {
 					target = _parse_expression(codegen, r_error, assignment->assignee);
 					if (r_error) {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1072,8 +1072,8 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				}
 
 				if (has_setter) {
-                    // Store stack slot for the temp value.
-                    target = codegen.add_temporary(_gdtype_from_datatype(assignment->assignee->get_datatype()));
+					// Store stack slot for the temp value.
+					target = codegen.add_temporary(_gdtype_from_datatype(assignment->assignee->get_datatype()));
 				} else {
 					target = _parse_expression(codegen, r_error, assignment->assignee);
 					if (r_error) {


### PR DESCRIPTION
Attempt to fix the untyped target in assignment inside setter.
I assume the problem is in the condition `if (!is_in_setter)` [here](https://github.com/hazer-hazer/godot/blob/529968df30f7d2dd697f0217114dc95bc976a127/modules/gdscript/gdscript_compiler.cpp#L1075):
```cpp
...
if (has_setter) {
  if (!is_in_setter) {
    // Store stack slot for the temp value.
    target = codegen.add_temporary(_gdtype_from_datatype(assignment->assignee->get_datatype()));
  }
}
...
```
As the target won't be set to anything with type then we'll have a bug report [here](https://github.com/hazer-hazer/godot/blob/529968df30f7d2dd697f0217114dc95bc976a127/modules/gdscript/gdscript_byte_codegen.cpp#L826), defaulting to raw assignment operation.
When I remove this condition the example given in #54450 compiles without error warning.

I'm not sure if the condition `if (!is_in_setter)` is a desired logic of codegen, and I need any comments on it since I'm new to Godot and Open Source contributing at all.