### PR TITLE
[OS] Add ThreadWorkPool default size to OS.

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -298,6 +298,7 @@ public:
 	virtual void set_exit_code(int p_code);
 
 	virtual int get_processor_count() const;
+	virtual int get_default_thread_pool_size() const { return get_processor_count(); }
 
 	virtual String get_unique_id() const;
 

--- a/core/templates/thread_work_pool.cpp
+++ b/core/templates/thread_work_pool.cpp
@@ -47,7 +47,7 @@ void ThreadWorkPool::_thread_function(void *p_user) {
 void ThreadWorkPool::init(int p_thread_count) {
 	ERR_FAIL_COND(threads != nullptr);
 	if (p_thread_count < 0) {
-		p_thread_count = OS::get_singleton()->get_processor_count();
+		p_thread_count = OS::get_singleton()->get_default_thread_pool_size();
 	}
 
 	thread_count = p_thread_count;

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -75,6 +75,7 @@ public:
 	Error kill(const ProcessID &p_pid) override;
 	int get_process_id() const override;
 	int get_processor_count() const override;
+	int get_default_thread_pool_size() const override { return 1; }
 
 	String get_executable_path() const override;
 	Error shell_open(String p_uri) override;


### PR DESCRIPTION
Some platforms (*cough* web *cough*) have hard limits on the number of threads that can be spawned.

Currently, ThreadPoolWork (mostly used in rendering/physics servers) will spawn as many threads as CPUs available causing exception on machines with high CPU count.

This commit adds a new overridable method to OS that returns the default thread pool size (still the CPU count by default), and overrides it for the JavaScript platform so it always allocate only one thread.

We can likely improve the whole ThreadPoolWork in the future to always allocate X amount of threads, and assign jobs to them on the fly, but that will require some more architectural changes.