### PR TITLE
[3.x] glTF: Fix override materials and non-empty arrays

### DIFF
--- a/modules/gltf/doc_classes/GLTFMesh.xml
+++ b/modules/gltf/doc_classes/GLTFMesh.xml
@@ -11,6 +11,8 @@
 	<members>
 		<member name="blend_weights" type="PoolRealArray" setter="set_blend_weights" getter="get_blend_weights" default="PoolRealArray(  )">
 		</member>
+		<member name="instance_materials" type="Array" setter="set_instance_materials" getter="get_instance_materials" default="[  ]">
+		</member>
 		<member name="mesh" type="ArrayMesh" setter="set_mesh" getter="get_mesh">
 		</member>
 	</members>

--- a/modules/gltf/gltf_mesh.cpp
+++ b/modules/gltf/gltf_mesh.cpp
@@ -35,9 +35,12 @@ void GLTFMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &GLTFMesh::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_blend_weights"), &GLTFMesh::get_blend_weights);
 	ClassDB::bind_method(D_METHOD("set_blend_weights", "blend_weights"), &GLTFMesh::set_blend_weights);
+	ClassDB::bind_method(D_METHOD("get_instance_materials"), &GLTFMesh::get_instance_materials);
+	ClassDB::bind_method(D_METHOD("set_instance_materials", "instance_materials"), &GLTFMesh::set_instance_materials);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh"), "set_mesh", "get_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_REAL_ARRAY, "blend_weights"), "set_blend_weights", "get_blend_weights"); // Vector<float>
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "instance_materials"), "set_instance_materials", "get_instance_materials");
 }
 
 Ref<ArrayMesh> GLTFMesh::get_mesh() {
@@ -46,6 +49,14 @@ Ref<ArrayMesh> GLTFMesh::get_mesh() {
 
 void GLTFMesh::set_mesh(Ref<ArrayMesh> p_mesh) {
 	mesh = p_mesh;
+}
+
+Array GLTFMesh::get_instance_materials() {
+	return instance_materials;
+}
+
+void GLTFMesh::set_instance_materials(Array p_instance_materials) {
+	instance_materials = p_instance_materials;
 }
 
 Vector<float> GLTFMesh::get_blend_weights() {

--- a/modules/gltf/gltf_mesh.h
+++ b/modules/gltf/gltf_mesh.h
@@ -41,6 +41,7 @@ class GLTFMesh : public Resource {
 private:
 	Ref<ArrayMesh> mesh;
 	Vector<float> blend_weights;
+	Array instance_materials;
 
 protected:
 	static void _bind_methods();
@@ -50,5 +51,7 @@ public:
 	void set_mesh(Ref<ArrayMesh> p_mesh);
 	Vector<float> get_blend_weights();
 	void set_blend_weights(Vector<float> p_blend_weights);
+	Array get_instance_materials();
+	void set_instance_materials(Array p_instance_materials);
 };
 #endif // GLTF_MESH_H


### PR DESCRIPTION
Backport of #54494 to 3.x

Keep track of MeshInstance and GeometryInstance override materials in the GLTFMesh object.
Ensure all arrays are non-empty to conform with "minItems":1 in glTF spec.

Fixes #51132