### PR TITLE
[3.x] Add a flag to `EditorResourcePicker` to differentiate selection contexts

### DIFF
--- a/doc/classes/EditorResourcePicker.xml
+++ b/doc/classes/EditorResourcePicker.xml
@@ -85,8 +85,9 @@
 		</signal>
 		<signal name="resource_selected">
 			<argument index="0" name="resource" type="Resource" />
+			<argument index="1" name="edit" type="bool" />
 			<description>
-				Emitted when the resource value was set and user clicked to edit it.
+				Emitted when the resource value was set and user clicked to edit it. When [code]edit[/code] is [code]true[/code], the signal was caused by the context menu "Edit" option.
 			</description>
 		</signal>
 	</signals>

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2236,8 +2236,8 @@ EditorPropertyRID::EditorPropertyRID() {
 
 ////////////// RESOURCE //////////////////////
 
-void EditorPropertyResource::_resource_selected(const RES &p_resource) {
-	if (_can_use_sub_inspector(p_resource)) {
+void EditorPropertyResource::_resource_selected(const RES &p_resource, bool p_edit) {
+	if (!p_edit && _can_use_sub_inspector(p_resource)) {
 		bool unfold = !get_edited_object()->editor_is_section_unfolded(get_edited_property());
 		get_edited_object()->editor_set_section_unfold(get_edited_property(), unfold);
 		update_property();

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -553,7 +553,7 @@ class EditorPropertyResource : public EditorProperty {
 	bool updating_theme = false;
 	bool opened_editor = false;
 
-	void _resource_selected(const RES &p_resource);
+	void _resource_selected(const RES &p_resource, bool p_edit);
 	void _resource_changed(const RES &p_resource);
 
 	void _viewport_selected(const NodePath &p_path);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -108,7 +108,7 @@ void EditorResourcePicker::_resource_selected() {
 		return;
 	}
 
-	emit_signal("resource_selected", edited_resource);
+	emit_signal("resource_selected", edited_resource, false);
 }
 
 void EditorResourcePicker::_file_selected(const String &p_path) {
@@ -267,7 +267,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 
 		case OBJ_MENU_EDIT: {
 			if (edited_resource.is_valid()) {
-				emit_signal("resource_selected", edited_resource);
+				emit_signal("resource_selected", edited_resource, true);
 			}
 		} break;
 
@@ -694,7 +694,7 @@ void EditorResourcePicker::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
 
-	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
+	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource"), PropertyInfo(Variant::BOOL, "edit")));
 	ADD_SIGNAL(MethodInfo("resource_changed", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
 }
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2606,7 +2606,7 @@ void ThemeTypeEditor::_constant_item_changed(float p_value, String p_item_name) 
 	edited_theme->set_constant(p_item_name, edited_type, int(p_value));
 }
 
-void ThemeTypeEditor::_edit_resource_item(RES p_resource) {
+void ThemeTypeEditor::_edit_resource_item(RES p_resource, bool p_edit) {
 	EditorNode::get_singleton()->edit_resource(p_resource);
 }
 

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -320,7 +320,7 @@ class ThemeTypeEditor : public MarginContainer {
 
 	void _color_item_changed(Color p_value, String p_item_name);
 	void _constant_item_changed(float p_value, String p_item_name);
-	void _edit_resource_item(RES p_resource);
+	void _edit_resource_item(RES p_resource, bool p_edit);
 	void _font_item_changed(Ref<Font> p_value, String p_item_name);
 	void _icon_item_changed(Ref<Texture> p_value, String p_item_name);
 	void _stylebox_item_changed(Ref<StyleBox> p_value, String p_item_name);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/54465 for `3.x`. The `EditorResourcePicker`'s `resource_selected` signal now passes a boolean flag that marks if the action was triggered by the context menu. Inspector dock uses that flag to forcefully open a new inspector.

`master` version: https://github.com/godotengine/godot/pull/54509