### PR TITLE
Expose Variant operator= to GDNative

### DIFF
--- a/modules/gdnative/gdnative/variant.cpp
+++ b/modules/gdnative/gdnative/variant.cpp
@@ -62,6 +62,12 @@ godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_self) {
 	return (godot_variant_type)self->get_type();
 }
 
+void GDAPI godot_variant_operator_assign(godot_variant *r_dest, const godot_variant *p_v) {
+	Variant *dest = (Variant *)r_dest;
+	Variant *v = (Variant *)p_v;
+	*dest = *v;
+}
+
 void GDAPI godot_variant_new_copy(godot_variant *p_dest, const godot_variant *p_src) {
 	Variant *dest = (Variant *)p_dest;
 	Variant *src = (Variant *)p_src;

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -4394,6 +4394,14 @@
         ]
       },
       {
+        "name": "godot_variant_operator_assign",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_variant *", "p_v"]
+        ]
+      },
+      {
         "name": "godot_variant_new_copy",
         "return_type": "void",
         "arguments": [

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -170,6 +170,8 @@ extern "C" {
 
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 
+void GDAPI godot_variant_operator_assign(godot_variant *r_dest, const godot_variant *p_v);
+
 void GDAPI godot_variant_new_copy(godot_variant *r_dest, const godot_variant *p_src);
 
 void GDAPI godot_variant_new_nil(godot_variant *r_dest);


### PR DESCRIPTION
This is to prevent memory leaks in the present implementation of Variant operator= in GDNative (see https://github.com/godotengine/godot-cpp/issues/647, https://github.com/godotengine/godot-cpp/issues/643)