### PR TITLE
Fix maximum allowed size atlas in CPU lightmapper

### DIFF
--- a/modules/lightmapper_cpu/lightmapper_cpu.cpp
+++ b/modules/lightmapper_cpu/lightmapper_cpu.cpp
@@ -166,7 +166,7 @@ Error LightmapperCPU::_layout_atlas(int p_max_size, Vector2i *r_atlas_size, int 
 			}
 
 			float mem_utilization = static_cast<float>(mem_occupied) / mem_used;
-			if (slices * atlas_size.y < 16384) { // Maximum Image size
+			if (slices * atlas_size.y <= 16384) { // Maximum Image size
 				if (mem_used < best_atlas_memory || (mem_used == best_atlas_memory && mem_utilization > best_atlas_mem_utilization)) {
 					best_atlas_size = atlas_size;
 					best_atlas_offsets = curr_atlas_offsets;


### PR DESCRIPTION
When I was trying to bake the lightmaps on a rather big scene, I ran into the issue of the lightmapper returning early due to the supposedly too big of the size for the atlas. However, upon the investigation it seems that the check here was wrong.

The `atlas_size` is adjusted to the nearest power of 2 value. If I understand this correctly, this means that for any geometry requiring over 8192 pixels in either direction the suggested size will be exactly 16384 (my geometry wanted something like 9k, so way below the maximum value). But then this check doesn't allow this exact value to pass, thus the maximum allowed value is not actually reachable. So I suggest this adjustment.

I did test it to the point I could, there were no errors (but my scene is likely too big to bake properly anyway, or I need to wait for many many hours).