### PR TITLE
Fixed issues with shortcut checking in 3d node editor

### DIFF
--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -369,6 +369,11 @@ void EditorSettingsDialog::_update_shortcuts() {
 		Array events; // Need to get the list of events into an array so it can be set as metadata on the item.
 		Vector<String> event_strings;
 
+		// Skip non-builtin actions.
+		if (!InputMap::get_singleton()->get_builtins_with_feature_overrides_applied().has(action_name)) {
+			continue;
+		}
+
 		List<Ref<InputEvent>> all_default_events = InputMap::get_singleton()->get_builtins_with_feature_overrides_applied().find(action_name).value();
 		List<Ref<InputEventKey>> key_default_events;
 		// Remove all non-key events from the defaults. Only check keys, since we are in the editor.

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -415,6 +415,9 @@ private:
 	void update_transform(Point2 p_mousepos, bool p_shift);
 	void finish_transform();
 
+	void register_shortcut_action(const String &p_path, const String &p_name, Key p_keycode);
+	void shortcut_changed_callback(const Ref<Shortcut> p_shortcut, const String &p_shortcut_path);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
It works, but I would like feedback on the solution. If possible, please provide feedback. I think it is relatively clean and leverages existing systems rather that adding a bunch of code for this specific use case.

The freelook shortcuts now use the action system by proxy. This allows the actions system to be leveraged for input checking, as checking for shortcuts outside of `xxxx_input()` methods is not well supported. When the shortcut changes, the respective action is updated.

Please see my comments here for additional context: https://github.com/godotengine/godot/issues/54469#issuecomment-957693323

Fixes #54469 (all shortcuts are recognised)
Fixes #54460 (physical keys work now)

P.S. I will add additional in-code comments documenting _why_ this is done like this, if this solution is generally agreed with.