### PR TITLE
Skip keyframe creation dialog when holding Shift in the animation editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -387,9 +387,6 @@
 		<member name="editors/animation/autorename_animation_tracks" type="bool" setter="" getter="">
 			If [code]true[/code], automatically updates animation tracks' target paths when renaming or reparenting nodes in the Scene tree dock.
 		</member>
-		<member name="editors/animation/confirm_insert_track" type="bool" setter="" getter="">
-			If [code]true[/code], display a confirmation dialog when adding a new track to an animation by pressing the "key" icon next to a property.
-		</member>
 		<member name="editors/animation/default_create_bezier_tracks" type="bool" setter="" getter="">
 			If [code]true[/code], create a Bezier track instead of a standard track when pressing the "key" icon next to a property. Bezier tracks provide more control over animation curves, but are more difficult to adjust quickly.
 		</member>

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3632,13 +3632,15 @@ void AnimationTrackEditor::commit_insert_queue() {
 		}
 	}
 
-	if (bool(EDITOR_GET("editors/animation/confirm_insert_track")) && num_tracks > 0) {
+	// Skip the confirmation dialog if the user holds Shift while clicking the key icon.
+	if (!Input::get_singleton()->is_key_pressed(Key::SHIFT) && num_tracks > 0) {
+		String shortcut_hint = TTR("Hold Shift when clicking the key icon to skip this dialog.");
 		// Potentially a new key, does not exist.
 		if (num_tracks == 1) {
 			// TRANSLATORS: %s will be replaced by a phrase describing the target of track.
-			insert_confirm_text->set_text(vformat(TTR("Create new track for %s and insert key?"), last_track_query));
+			insert_confirm_text->set_text(vformat(TTR("Create new track for %s and insert key?") + "\n\n" + shortcut_hint, last_track_query));
 		} else {
-			insert_confirm_text->set_text(vformat(TTR("Create %d new tracks and insert keys?"), num_tracks));
+			insert_confirm_text->set_text(vformat(TTR("Create %d new tracks and insert keys?") + "\n\n" + shortcut_hint, num_tracks));
 		}
 
 		insert_confirm_bezier->set_visible(all_bezier);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -709,7 +709,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Animation
 	_initial_set("editors/animation/autorename_animation_tracks", true);
-	_initial_set("editors/animation/confirm_insert_track", true);
 	_initial_set("editors/animation/default_create_bezier_tracks", false);
 	_initial_set("editors/animation/default_create_reset_tracks", true);
 	_initial_set("editors/animation/onion_layers_past_color", Color(1, 0, 0));


### PR DESCRIPTION
The editor setting to always bypass the confirmation dialog was removed, since the new shortcut effectively supersedes it in a more granular way.

## Preview

*Not holding <kbd>Shift</kbd> at first, then holding <kbd>Shift</kbd> the second time.*

https://user-images.githubusercontent.com/180032/139955202-3909e237-80f7-4b59-b275-1b9c7b51d874.mp4