### PR TITLE
3.x redirect (console) output (expose as signal)

### DIFF
--- a/core/io/redirect.cpp
+++ b/core/io/redirect.cpp
@@ -1,0 +1,65 @@
+/*************************************************************************/
+/*  redirect.cpp                                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "redirect.h"
+#include "core/object.h"
+#include "core/print_string.h"
+
+void Redirect::_print_handler(void *p_this, const String &p_string, bool p_error) {
+	Redirect *r = (Redirect *)p_this;
+	r->emit_signal("print_line", p_string, p_error);
+}
+
+void Redirect::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("print_line", PropertyInfo(Variant::OBJECT, "scene_root", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
+}
+
+Redirect *Redirect::singleton = nullptr;
+
+Redirect *Redirect::get_singleton() {
+	return singleton;
+}
+
+Redirect *Redirect::create() {
+	ERR_FAIL_COND_V_MSG(singleton, nullptr, "Redirect singleton already exist.");
+	return memnew(Redirect);
+}
+
+Redirect::Redirect() {
+	singleton = this;
+
+	print_handler.printfunc = _print_handler;
+	print_handler.userdata = this;
+	add_print_handler(&print_handler);
+}
+
+Redirect::~Redirect() {
+	remove_print_handler(&print_handler);
+}

--- a/core/io/redirect.h
+++ b/core/io/redirect.h
@@ -1,0 +1,59 @@
+/*************************************************************************/
+/*  redirect.h                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef REDIRECT_H
+#define REDIRECT_H
+
+#include "core/object.h"
+#include "core/print_string.h"
+
+class Redirect : public Object {
+	GDCLASS(Redirect, Object);
+	OBJ_CATEGORY("Utilities");
+
+public:
+private:
+	PrintHandlerList print_handler;
+	static void _print_handler(void *p_this, const String &p_string, bool p_error);
+
+protected:
+	static Redirect *singleton;
+	static void _bind_methods();
+
+public:
+	static Redirect *get_singleton();
+
+	static Redirect *create();
+
+	Redirect();
+	~Redirect();
+};
+
+#endif // REDIRECT_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -306,6 +306,10 @@ void unregister_core_types() {
 		memdelete(ip);
 	}
 
+	if (redir) {
+		memdelete(redir);
+	}
+
 	ResourceLoader::finalize();
 
 	ClassDB::cleanup_defaults();

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -70,6 +70,7 @@
 #include "core/project_settings.h"
 #include "core/translation.h"
 #include "core/undo_redo.h"
+#include "core/io/redirect.h"
 
 static Ref<ResourceFormatSaverBinary> resource_saver_binary;
 static Ref<ResourceFormatLoaderBinary> resource_loader_binary;
@@ -87,6 +88,7 @@ static _ClassDB *_classdb = nullptr;
 static _Marshalls *_marshalls = nullptr;
 static _JSON *_json = nullptr;
 
+static Redirect *redir = nullptr;
 static IP *ip = nullptr;
 
 static _Geometry *_geometry = nullptr;
@@ -212,6 +214,7 @@ void register_core_types() {
 	ClassDB::register_virtual_class<ResourceImporter>();
 
 	ip = IP::create();
+	redir = Redirect::create();
 
 	_geometry = memnew(_Geometry);
 
@@ -250,6 +253,7 @@ void register_core_singletons() {
 	ClassDB::register_class<InputMap>();
 	ClassDB::register_class<_JSON>();
 	ClassDB::register_class<Expression>();
+	ClassDB::register_class<Redirect>();
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("IP", IP::get_singleton()));
@@ -264,6 +268,7 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", Input::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("JSON", _JSON::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Redirect", Redirect::get_singleton()));
 }
 
 void unregister_core_types() {


### PR DESCRIPTION
This PR is a rough sketch to add a signal layer to the "_print_line" function in `print_string.h`. 
Some work was already previously done to enable the editor and/or the debugger to connect to error and/or console messages, but this wasn't exposed to the engine itself. With this we can finally hook the messages sent and expose them as a signal and handle them "in-place".

I know the name "Redirect" is not very good, so if anyone has a suggestion in which global class to put it, be my guest and let me know.

This kind of solves https://github.com/godotengine/godot-proposals/issues/536 I guess? It's the closest the requirements of my peer over at the German Community Discord Channel had - so I guess I'll just link that one up here.

Again, as this is my first time tributing to the "core" of the engine, let me know if there is anything I missed or screwed up (which i'm pretty sure I did).

Example client implementation:

![output](https://user-images.githubusercontent.com/761911/139957878-16c03b73-6978-4065-952c-da456bbd96c7.gif)

Thanks!