### PR TITLE
Fix errors with invalid bone node path in Polygon2D

### DIFF
--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -554,7 +554,9 @@ void Polygon2D::set_bone_path(int p_index, const NodePath &p_path) {
 Array Polygon2D::_get_bones() const {
 	Array bones;
 	for (int i = 0; i < get_bone_count(); i++) {
-		bones.push_back(get_bone_path(i));
+		// Convert path property to String to avoid errors due to invalid node path in editor,
+		// because it's relative to the Skeleton2D node and not Polygon2D.
+		bones.push_back(String(get_bone_path(i)));
 		bones.push_back(get_bone_weights(i));
 	}
 	return bones;
@@ -564,7 +566,8 @@ void Polygon2D::_set_bones(const Array &p_bones) {
 	ERR_FAIL_COND(p_bones.size() & 1);
 	clear_bones();
 	for (int i = 0; i < p_bones.size(); i += 2) {
-		add_bone(p_bones[i], p_bones[i + 1]);
+		// Convert back from String to NodePath.
+		add_bone(NodePath(p_bones[i]), p_bones[i + 1]);
 	}
 }
 


### PR DESCRIPTION
NodePath properties are designed to be relative to the given node, so validity checks are failing in the editor for Polygon2D nodes, which are relative to the Skeleton2D node rather than the Polygon2D node.

Fixed by saving bone paths as String properties instead of NodePath.

Shouldn't cause a difference for performance since NodePath properties are technically saved as String anyway.

Fixes #52126 (regression from #49812).
