### PR TITLE
Implement inspector property array for `PopupMenu` and `MenuButton`

### DIFF
--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -30,6 +30,9 @@
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" override="true" enum="BaseButton.ActionMode" default="0" />
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" override="true" default="true" />
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="0" />
+		<member name="items_count" type="int" setter="set_item_count" getter="get_item_count" default="0">
+			The number of items currently in the list.
+		</member>
 		<member name="switch_on_hover" type="bool" setter="set_switch_on_hover" getter="is_switch_on_hover" default="false">
 			If [code]true[/code], when the cursor hovers above another [MenuButton] within the same parent which also has [code]switch_on_hover[/code] enabled, it will close the current [MenuButton] and open the other one.
 		</member>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -199,12 +199,6 @@
 				Returns the accelerator of the item at index [code]idx[/code]. Accelerators are special combinations of keys that activate the item, no matter which control is focused.
 			</description>
 		</method>
-		<method name="get_item_count" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the number of items in the [PopupMenu].
-			</description>
-		</method>
 		<method name="get_item_icon" qualifiers="const">
 			<return type="Texture2D" />
 			<argument index="0" name="idx" type="int" />
@@ -510,6 +504,9 @@
 		</member>
 		<member name="hide_on_state_item_selection" type="bool" setter="set_hide_on_state_item_selection" getter="is_hide_on_state_item_selection" default="false">
 			If [code]true[/code], hides the [PopupMenu] when a state item is selected.
+		</member>
+		<member name="items_count" type="int" setter="set_item_count" getter="get_item_count" default="0">
+			The number of items currently in the list.
 		</member>
 		<member name="submenu_popup_delay" type="float" setter="set_submenu_popup_delay" getter="get_submenu_popup_delay" default="0.3">
 			Sets the delay time in seconds for the submenu item to popup on mouse hovering. If the popup menu is added as a child of another (acting as a submenu), it will inherit the delay time of the parent menu item.

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -44,15 +44,15 @@ class MenuButton : public Button {
 
 	Vector2i mouse_pos_adjusted;
 
-	Array _get_items() const;
-	void _set_items(const Array &p_items);
-
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 	void _popup_visibility_changed(bool p_visible);
 
 protected:
 	void _notification(int p_what);
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
 	static void _bind_methods();
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 
@@ -63,6 +63,9 @@ public:
 	void set_switch_on_hover(bool p_enabled);
 	bool is_switch_on_hover();
 	void set_disable_shortcuts(bool p_disabled);
+
+	void set_item_count(int p_count);
+	int get_item_count() const;
 
 	MenuButton();
 	~MenuButton();

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -117,9 +117,6 @@ class PopupMenu : public Popup {
 	bool hide_on_multistate_item_selection = false;
 	Vector2 moved;
 
-	Array _get_items() const;
-	void _set_items(const Array &p_items);
-
 	Map<Ref<Shortcut>, int> shortcut_refcount;
 
 	void _ref_shortcut(Ref<Shortcut> p_sc);
@@ -141,6 +138,9 @@ class PopupMenu : public Popup {
 
 protected:
 	void _notification(int p_what);
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
 	static void _bind_methods();
 
 public:
@@ -213,6 +213,8 @@ public:
 	int get_item_state(int p_idx) const;
 
 	int get_current_index() const;
+
+	void set_item_count(int p_count);
 	int get_item_count() const;
 
 	bool activate_item_by_event(const Ref<InputEvent> &p_event, bool p_for_global_only = false);


### PR DESCRIPTION
(Edited)
Allows to add items to `PopupMenu` and `MenuButton` directly in the inspector just as #54342 did for `ItemList`
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
