### PR TITLE
Removed unused `src_path` from `GLTFDocument::save_scene`

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -21,10 +21,9 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="node" type="Node" />
 			<argument index="1" name="path" type="String" />
-			<argument index="2" name="src_path" type="String" />
-			<argument index="3" name="flags" type="int" default="0" />
-			<argument index="4" name="bake_fps" type="float" default="30" />
-			<argument index="5" name="state" type="GLTFState" default="null" />
+			<argument index="2" name="flags" type="int" default="0" />
+			<argument index="3" name="bake_fps" type="float" default="30" />
+			<argument index="4" name="state" type="GLTFState" default="null" />
 			<description>
 				Save a scene as a glTF2 ".glb" or ".gltf" file.
 			</description>

--- a/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
@@ -75,7 +75,7 @@ void SceneExporterGLTFPlugin::_gltf2_dialog_action(String p_file) {
 	List<String> deps;
 	Ref<GLTFDocument> doc;
 	doc.instantiate();
-	Error err = doc->save_scene(root, p_file, p_file, 0, 30.0f, Ref<GLTFState>());
+	Error err = doc->save_scene(root, p_file, 0, 30.0f, Ref<GLTFState>());
 	if (err != OK) {
 		ERR_PRINT(vformat("glTF2 save scene error %s.", itos(err)));
 	}

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6841,8 +6841,7 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> state, const String p_path) {
 }
 
 Error GLTFDocument::save_scene(Node *p_node, const String &p_path,
-		const String &p_src_path, uint32_t p_flags,
-		float p_bake_fps, Ref<GLTFState> r_state) {
+		uint32_t p_flags, float p_bake_fps, Ref<GLTFState> r_state) {
 	ERR_FAIL_NULL_V(p_node, ERR_INVALID_PARAMETER);
 
 	Ref<GLTFDocument> gltf_document;
@@ -6919,7 +6918,7 @@ Node *GLTFDocument::import_scene_gltf(const String &p_path, uint32_t p_flags, in
 }
 
 void GLTFDocument::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("save_scene", "node", "path", "src_path", "flags", "bake_fps", "state"),
+	ClassDB::bind_method(D_METHOD("save_scene", "node", "path", "flags", "bake_fps", "state"),
 			&GLTFDocument::save_scene, DEFVAL(0), DEFVAL(30), DEFVAL(Ref<GLTFState>()));
 	ClassDB::bind_method(D_METHOD("import_scene", "path", "flags", "bake_fps", "state"),
 			&GLTFDocument::import_scene, DEFVAL(0), DEFVAL(30), DEFVAL(Ref<GLTFState>()));

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -122,8 +122,7 @@ public:
 	Node *import_scene(const String &p_path, uint32_t p_flags, int32_t p_bake_fps, Ref<GLTFState> r_state);
 	Node *import_scene_gltf(const String &p_path, uint32_t p_flags, int32_t p_bake_fps, Ref<GLTFState> r_state, List<String> *r_missing_deps, Error *r_err = nullptr);
 	Error save_scene(Node *p_node, const String &p_path,
-			const String &p_src_path, uint32_t p_flags,
-			float p_bake_fps, Ref<GLTFState> r_state);
+			uint32_t p_flags, float p_bake_fps, Ref<GLTFState> r_state);
 	void set_extensions(TypedArray<GLTFDocumentExtension> p_extensions);
 	TypedArray<GLTFDocumentExtension> get_extensions() const;
 


### PR DESCRIPTION
This is a fix for https://github.com/godotengine/godot/issues/54532

It removed the unused parameter `p_src_path` from the method `GLTFDocument::save_scene` and its usage. Which, by the way, was passing `p_file` in both `p_path` (which is used) and `p_src_path`.

*By the way, `p_bake_fps` is also not used in `save_scene`. Should I remove it too? Usage only passes `0`. However, there is a `p_bake_fps` which appears to be used when importing, for the animations. I don't know if there are plans for it when saving. Anyway, it is there because symmetry, I guess.*