### PR TITLE
Make editor toasts as safe as possible

### DIFF
--- a/editor/editor_toaster.h
+++ b/editor/editor_toaster.h
@@ -82,6 +82,15 @@ private:
 	};
 	Map<Control *, Toast> toasts;
 
+	struct QueuedPopup {
+		String message;
+		Severity severity;
+		String tooltip;
+	};
+	Vector<QueuedPopup> queued_popups;
+	bool popups_dirty = false;
+	Mutex popup_queue_mutex;
+
 	const double default_message_duration = 5.0;
 
 	static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type);
@@ -95,6 +104,8 @@ private:
 	void _set_notifications_enabled(bool p_enabled);
 	void _repop_old();
 
+	void _flush_popups();
+
 protected:
 	static EditorToaster *singleton;
 
@@ -105,6 +116,7 @@ public:
 
 	Control *popup(Control *p_control, Severity p_severity = SEVERITY_INFO, double p_time = 0.0, String p_tooltip = String());
 	void popup_str(String p_message, Severity p_severity = SEVERITY_INFO, String p_tooltip = String());
+	void queue_popup_str(String p_message, Severity p_severity = SEVERITY_INFO, String p_tooltip = String());
 	void close(Control *p_control);
 
 	EditorToaster();


### PR DESCRIPTION
Fixes #54515

If an error pops up while the renderer is executing something (likely occurrence with `--vk-layers`), there is risk of a number of problems. Most recently, I experienced a deadlock in Vulkan's `vmaCreateBuffer` (probably exact same problem as in the linked issue). To try to avoid _all_ possible issues, I made toasts as safe as I could manage.

To avoid piling errors onto the message queue (error spam!), I added an internal queue that gets automatically flushed. Not sure if this is an actual problem, but I wanted to be _really sure_ there weren't any issues. 