### PR TITLE
Easier setting properties of last TileMap layer

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -41,7 +41,7 @@
 			<return type="void" />
 			<param index="0" name="to_position" type="int" />
 			<description>
-				Adds a layer at the given position [param to_position] in the array. If [param to_position] is -1, adds it at the end of the array.
+				Adds a layer at the given position [param to_position] in the array. If [param to_position] is negative, the position is counted from the end, with [code]-1[/code] adding the layer at the end of the array.
 			</description>
 		</method>
 		<method name="clear">
@@ -285,14 +285,16 @@
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				Enables or disables the layer [param layer]. A disabled layer is not processed at all (no rendering, no physics, etc...).
+				If [param layer] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
 		<method name="set_layer_modulate">
 			<return type="void" />
 			<param index="0" name="layer" type="int" />
-			<param index="1" name="enabled" type="Color" />
+			<param index="1" name="modulate" type="Color" />
 			<description>
 				Sets a layer's color. It will be multiplied by tile's color and TileMap's modulate.
+				If [code]layer[/code] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
 		<method name="set_layer_name">
@@ -301,6 +303,7 @@
 			<param index="1" name="name" type="String" />
 			<description>
 				Sets a layer's name. This is mostly useful in the editor.
+				If [code]layer[/code] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
 		<method name="set_layer_y_sort_enabled">
@@ -310,6 +313,7 @@
 			<description>
 				Enables or disables a layer's Y-sorting. If a layer is Y-sorted, the layer will behave as a CanvasItem node where each of its tile gets Y-sorted.
 				Y-sorted layers should usually be on different Z-index values than not Y-sorted layers, otherwise, each of those layer will be Y-sorted as whole with the Y-sorted one. This is usually an undesired behvaior.
+				If [code]layer[/code] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
 		<method name="set_layer_y_sort_origin">
@@ -319,6 +323,7 @@
 			<description>
 				Sets a layer's Y-sort origin value. This Y-sort origin value is added to each tile's Y-sort origin value.
 				This allows, for example, to fake a different height level on each layer. This can be useful for top-down view games.
+				If [code]layer[/code] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
 		<method name="set_layer_z_index">
@@ -327,6 +332,7 @@
 			<param index="1" name="z_index" type="int" />
 			<description>
 				Sets a layers Z-index value. This Z-index is added to each tile's Z-index value.
+				If [code]layer[/code] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
 		<method name="set_pattern">

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -553,7 +553,7 @@ int TileMap::get_layers_count() const {
 
 void TileMap::add_layer(int p_to_pos) {
 	if (p_to_pos < 0) {
-		p_to_pos = layers.size();
+		p_to_pos = layers.size() + p_to_pos + 1;
 	}
 
 	ERR_FAIL_INDEX(p_to_pos, (int)layers.size() + 1);
@@ -612,6 +612,9 @@ void TileMap::remove_layer(int p_layer) {
 }
 
 void TileMap::set_layer_name(int p_layer, String p_name) {
+	if (p_layer < 0) {
+		p_layer = layers.size() + p_layer;
+	}
 	ERR_FAIL_INDEX(p_layer, (int)layers.size());
 	layers[p_layer].name = p_name;
 	emit_signal(SNAME("changed"));
@@ -623,6 +626,9 @@ String TileMap::get_layer_name(int p_layer) const {
 }
 
 void TileMap::set_layer_enabled(int p_layer, bool p_enabled) {
+	if (p_layer < 0) {
+		p_layer = layers.size() + p_layer;
+	}
 	ERR_FAIL_INDEX(p_layer, (int)layers.size());
 	layers[p_layer].enabled = p_enabled;
 	_clear_layer_internals(p_layer);
@@ -638,6 +644,9 @@ bool TileMap::is_layer_enabled(int p_layer) const {
 }
 
 void TileMap::set_layer_modulate(int p_layer, Color p_modulate) {
+	if (p_layer < 0) {
+		p_layer = layers.size() + p_layer;
+	}
 	ERR_FAIL_INDEX(p_layer, (int)layers.size());
 	layers[p_layer].modulate = p_modulate;
 	_clear_layer_internals(p_layer);
@@ -651,6 +660,9 @@ Color TileMap::get_layer_modulate(int p_layer) const {
 }
 
 void TileMap::set_layer_y_sort_enabled(int p_layer, bool p_y_sort_enabled) {
+	if (p_layer < 0) {
+		p_layer = layers.size() + p_layer;
+	}
 	ERR_FAIL_INDEX(p_layer, (int)layers.size());
 	layers[p_layer].y_sort_enabled = p_y_sort_enabled;
 	_clear_layer_internals(p_layer);
@@ -666,6 +678,9 @@ bool TileMap::is_layer_y_sort_enabled(int p_layer) const {
 }
 
 void TileMap::set_layer_y_sort_origin(int p_layer, int p_y_sort_origin) {
+	if (p_layer < 0) {
+		p_layer = layers.size() + p_layer;
+	}
 	ERR_FAIL_INDEX(p_layer, (int)layers.size());
 	layers[p_layer].y_sort_origin = p_y_sort_origin;
 	_clear_layer_internals(p_layer);
@@ -679,6 +694,9 @@ int TileMap::get_layer_y_sort_origin(int p_layer) const {
 }
 
 void TileMap::set_layer_z_index(int p_layer, int p_z_index) {
+	if (p_layer < 0) {
+		p_layer = layers.size() + p_layer;
+	}
 	ERR_FAIL_INDEX(p_layer, (int)layers.size());
 	layers[p_layer].z_index = p_z_index;
 	_clear_layer_internals(p_layer);
@@ -3839,7 +3857,7 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_layer_name", "layer"), &TileMap::get_layer_name);
 	ClassDB::bind_method(D_METHOD("set_layer_enabled", "layer", "enabled"), &TileMap::set_layer_enabled);
 	ClassDB::bind_method(D_METHOD("is_layer_enabled", "layer"), &TileMap::is_layer_enabled);
-	ClassDB::bind_method(D_METHOD("set_layer_modulate", "layer", "enabled"), &TileMap::set_layer_modulate);
+	ClassDB::bind_method(D_METHOD("set_layer_modulate", "layer", "modulate"), &TileMap::set_layer_modulate);
 	ClassDB::bind_method(D_METHOD("get_layer_modulate", "layer"), &TileMap::get_layer_modulate);
 	ClassDB::bind_method(D_METHOD("set_layer_y_sort_enabled", "layer", "y_sort_enabled"), &TileMap::set_layer_y_sort_enabled);
 	ClassDB::bind_method(D_METHOD("is_layer_y_sort_enabled", "layer"), &TileMap::is_layer_y_sort_enabled);


### PR DESCRIPTION
I have a plugin that dynamically creates TileMap layers for me (because I use the same TileMap layout for each scene). But I noticed that there is no easy way to customize the newly created layer. You have to do e.g. `set_layer_name(get_layers_count() - 1, "name")`, which is quite long for doing multiple times. So I thought that it would be more convenient if the last layer could be accessed easier. (this is consistent with `add_layer()` method)

I also fixed a wrong argument name in `set_layer_modulate()`