### PR TITLE
Viewport emit mouse_enter/exit even when dragging Control.

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -218,6 +218,9 @@
 		<member name="gui_disable_input" type="bool" setter="set_disable_input" getter="is_input_disabled" default="false">
 			If [code]true[/code], the viewport will not receive input events.
 		</member>
+		<member name="gui_force_mouse_events" type="bool" setter="set_force_mouse_events" getter="is_mouse_events_forced" default="false">
+			If [code]true[/code], the viewport will emit mouse_entered and mouse_exited signals even when dragging a [Control].
+		</member>
 		<member name="gui_snap_controls_to_pixels" type="bool" setter="set_snap_controls_to_pixels" getter="is_snap_controls_to_pixels_enabled" default="true">
 			If [code]true[/code], the GUI controls on the viewport will lay pixel perfectly.
 		</member>

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -299,6 +299,7 @@ private:
 		int mouse_focus_mask;
 		Control *key_focus;
 		Control *mouse_over;
+		Control *unfocused_mouse_over;
 		Control *tooltip_control;
 		Control *tooltip_popup;
 		Label *tooltip_label;
@@ -325,6 +326,7 @@ private:
 	} gui;
 
 	bool disable_input;
+	bool force_mouse_events;
 
 	void _gui_call_input(Control *p_control, const Ref<InputEvent> &p_input);
 	void _gui_call_notification(Control *p_control, int p_what);
@@ -527,6 +529,9 @@ public:
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;
+
+	void set_force_mouse_events(bool p_disable);
+	bool is_mouse_events_forced() const;
 
 	void set_disable_3d(bool p_disable);
 	bool is_3d_disabled() const;


### PR DESCRIPTION
fixes #20881
linked to #54565

add a boolean property to the Viewport to allow it to send mouse_entered and mouse_exited signals even when dragging (mouse button clicked) from a Control.

Test Scene:

```ini
[gd_scene load_steps=2 format=2]

[sub_resource type="GDScript" id=1]
script/source = "extends Node2D

func _ready():
	var _r
	_r = $ViewportContainer/Viewport/b1.connect(\"mouse_entered\", self,\"_entered\",[\"b1\"])
	_r = $ViewportContainer/Viewport/b1.connect(\"mouse_exited\",self,\"_exited\",[\"b1\"])
	_r = $ViewportContainer/Viewport/b2.connect(\"mouse_entered\", self,\"_entered\",[\"b2\"])
	_r = $ViewportContainer/Viewport/b2.connect(\"mouse_exited\",self,\"_exited\",[\"b2\"])
	_r = $ViewportContainer/Viewport/ck.connect(\"toggled\",self,\"_toggled\")

func _entered(who):
	print(\"mouse area entered : %s\" % who)

func _exited(who):
	print(\"mouse area exited : %s\" % who)

func _toggled(v):
	$ViewportContainer/Viewport.gui_force_mouse_events = v
"

[node name="Node2D" type="Node2D"]
script = SubResource( 1 )

[node name="ViewportContainer" type="ViewportContainer" parent="."]
margin_left = -2.0
margin_top = 4.0
margin_right = 1024.0
margin_bottom = 602.0
__meta__ = {
"_edit_use_anchors_": false
}

[node name="Viewport" type="Viewport" parent="ViewportContainer"]
size = Vector2( 800, 600 )
handle_input_locally = false
debug_draw = 3
render_target_update_mode = 3

[node name="b1" type="Button" parent="ViewportContainer/Viewport"]
margin_left = 275.0
margin_top = 57.0
margin_right = 483.0
margin_bottom = 167.0
rect_rotation = 23.2
focus_mode = 0
enabled_focus_mode = 0
__meta__ = {
"_edit_use_anchors_": false
}

[node name="b2" type="Button" parent="ViewportContainer/Viewport"]
margin_left = 694.61
margin_top = 238.687
margin_right = 902.61
margin_bottom = 348.687
rect_rotation = 38.7
rect_scale = Vector2( 0.5, 0.5 )
rect_pivot_offset = Vector2( 1, 0 )
focus_mode = 0
enabled_focus_mode = 0
__meta__ = {
"_edit_use_anchors_": false
}

[node name="ck" type="CheckBox" parent="ViewportContainer/Viewport"]
margin_left = 50.0
margin_top = 50.0
margin_right = 74.0
margin_bottom = 74.0
__meta__ = {
"_edit_use_anchors_": false
}
```