### PR TITLE
Remove support for built-in scripts in the editor

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -286,7 +286,6 @@ public:
 	virtual String validate_path(const String &p_path) const { return ""; }
 	virtual Script *create_script() const = 0;
 	virtual bool has_named_classes() const = 0;
-	virtual bool supports_builtin_mode() const = 0;
 	virtual bool supports_documentation() const { return false; }
 	virtual bool can_inherit_from_file() const { return false; }
 	virtual int find_function(const String &p_function, const String &p_code) const = 0;

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -566,10 +566,6 @@ void EditorData::remove_scene(int p_idx) {
 		current_edited_scene--;
 	}
 
-	if (edited_scene[p_idx].path != String()) {
-		ScriptEditor::get_singleton()->close_builtin_scripts_from_scene(edited_scene[p_idx].path);
-	}
-
 	edited_scene.remove(p_idx);
 }
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2506,7 +2506,7 @@ void EditorInspector::update_tree() {
 				}
 			}
 			if (category->icon.is_null()) {
-				if (type != String()) { // Can happen for built-in scripts.
+				if (type != String()) {
 					category->icon = EditorNode::get_singleton()->get_class_icon(type, "Object");
 				}
 			}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1942,7 +1942,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			if (!fpath.ends_with("/")) {
 				fpath = fpath.get_base_dir();
 			}
-			make_script_dialog->config("Node", fpath.plus_file("new_script.gd"), false, false);
+			make_script_dialog->config("Node", fpath.plus_file("new_script.gd"), false);
 			make_script_dialog->popup_centered();
 		} break;
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -500,8 +500,6 @@ public:
 	void notify_script_close(const Ref<Script> &p_script);
 	void notify_script_changed(const Ref<Script> &p_script);
 
-	void close_builtin_scripts_from_scene(const String &p_scene);
-
 	void goto_help(const String &p_desc) { _help_class_goto(p_desc); }
 	void update_doc(const String &p_name);
 

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -48,7 +48,6 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	LineEdit *class_name;
 	Label *error_label;
 	Label *path_error_label;
-	Label *builtin_warning_label;
 	Label *script_name_warning_label;
 	PanelContainer *status_panel;
 	LineEdit *parent_name;
@@ -70,12 +69,9 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool is_new_script_created;
 	bool is_path_valid;
 	bool has_named_classes;
-	bool supports_built_in;
 	bool can_inherit_from_file;
 	bool is_parent_name_valid;
 	bool is_class_name_valid;
-	bool is_built_in;
-	bool built_in_enabled;
 	bool load_enabled;
 	int current_language;
 	int default_language;
@@ -102,11 +98,9 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	String base_type;
 
 	void _path_hbox_sorted();
-	bool _can_be_built_in();
 	void _path_changed(const String &p_path = String());
 	void _path_submitted(const String &p_path = String());
 	void _lang_changed(int l = 0);
-	void _built_in_pressed();
 	bool _validate_parent(const String &p_string);
 	bool _validate_class(const String &p_string);
 	String _validate_path(const String &p_path, bool p_file_must_exist);
@@ -130,7 +124,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void config(const String &p_base_name, const String &p_base_path, bool p_built_in_enabled = true, bool p_load_enabled = true);
+	void config(const String &p_base_name, const String &p_base_path, bool p_load_enabled = true);
 	void set_inheritance_base_type(const String &p_base);
 	ScriptCreateDialog();
 };

--- a/modules/gdnative/include/pluginscript/godot_pluginscript.h
+++ b/modules/gdnative/include/pluginscript/godot_pluginscript.h
@@ -128,7 +128,6 @@ typedef struct {
 	const char **comment_delimiters; // nullptr terminated array
 	const char **string_delimiters; // nullptr terminated array
 	godot_bool has_named_classes;
-	godot_bool supports_builtin_mode;
 	godot_bool can_inherit_from_file;
 
 	godot_string (*get_template_source_code)(godot_pluginscript_language_data *p_data, const godot_string *p_class_name, const godot_string *p_base_class_name);

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1064,10 +1064,6 @@ bool NativeScriptLanguage::has_named_classes() const {
 	return true;
 }
 
-bool NativeScriptLanguage::supports_builtin_mode() const {
-	return true;
-}
-
 int NativeScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 	return -1;
 }

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -317,7 +317,6 @@ public:
 	virtual bool validate(const String &p_script, const String &p_path, List<String> *r_functions, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
-	virtual bool supports_builtin_mode() const;
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -151,10 +151,6 @@ bool PluginScriptLanguage::has_named_classes() const {
 	return _desc.has_named_classes;
 }
 
-bool PluginScriptLanguage::supports_builtin_mode() const {
-	return _desc.supports_builtin_mode;
-}
-
 bool PluginScriptLanguage::can_inherit_from_file() const {
 	return _desc.can_inherit_from_file;
 }

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -78,7 +78,6 @@ public:
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
-	virtual bool supports_builtin_mode() const;
 	virtual bool can_inherit_from_file() const;
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -835,7 +835,7 @@ Error GDScript::reload(bool p_keep_state) {
 			GDScriptLanguage::get_singleton()->debug_break_parse(get_path(), parser.get_errors().front()->get().line, "Parser Error: " + parser.get_errors().front()->get().message);
 		}
 		// TODO: Show all error messages.
-		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+		_err_print_error("GDScript::reload", (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		ERR_FAIL_V(ERR_PARSE_ERROR);
 	}
 
@@ -849,7 +849,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 		const List<GDScriptParser::ParserError>::Element *e = parser.get_errors().front();
 		while (e != nullptr) {
-			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), e->get().line, ("Parse Error: " + e->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+			_err_print_error("GDScript::reload", (const char *)path.utf8().get_data(), e->get().line, ("Parse Error: " + e->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 			e = e->next();
 		}
 		ERR_FAIL_V(ERR_PARSE_ERROR);
@@ -869,7 +869,7 @@ Error GDScript::reload(bool p_keep_state) {
 			if (EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(get_path(), compiler.get_error_line(), "Parser Error: " + compiler.get_error());
 			}
-			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+			_err_print_error("GDScript::reload", (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 			ERR_FAIL_V(ERR_COMPILATION_FAILED);
 		} else {
 			return err;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -422,10 +422,6 @@ bool CSharpLanguage::has_named_classes() const {
 	return false;
 }
 
-bool CSharpLanguage::supports_builtin_mode() const {
-	return false;
-}
-
 #ifdef TOOLS_ENABLED
 static String variant_type_to_managed_name(const String &p_var_type_name) {
 	if (p_var_type_name.is_empty()) {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -102,8 +102,6 @@ private:
 	bool tool = false;
 	bool valid = false;
 
-	bool builtin;
-
 	GDMonoClass *base = nullptr;
 	GDMonoClass *native = nullptr;
 	GDMonoClass *script_class = nullptr;
@@ -473,7 +471,6 @@ public:
 	String validate_path(const String &p_path) const override;
 	Script *create_script() const override;
 	bool has_named_classes() const override;
-	bool supports_builtin_mode() const override;
 	/* TODO? */ int find_function(const String &p_function, const String &p_code) const override { return -1; }
 	String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const override;
 	virtual String _get_indentation() const;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2269,10 +2269,6 @@ bool VisualScriptLanguage::has_named_classes() const {
 	return false;
 }
 
-bool VisualScriptLanguage::supports_builtin_mode() const {
-	return true;
-}
-
 int VisualScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 	return -1;
 }

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -574,7 +574,6 @@ public:
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
-	virtual bool supports_builtin_mode() const;
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;


### PR DESCRIPTION
Built-in scripts have many limitations that users tend to discover late in their project. This causes a lot of pain as scripts must be replaced by their non-built-in variants one by one.

Note that this only unexposes the ability to create and edit built-in scripts from the editor. It's still possible to save a scene that contains executable built-in scripts using PackedScene or external tools. (Removing support for built-in script resources is likely more involved, but it would be useful to make sending PackedScenes over the network more secure.)

This is a compatibility-breaking change, as built-in scripts need to be turned into non-built-in-scripts before upgrading a project to Godot 4.0.

This closes https://github.com/godotengine/godot/issues/31758, closes https://github.com/godotengine/godot/issues/5535, closes https://github.com/godotengine/godot/issues/29863, and closes https://github.com/godotengine/godot/issues/31364.