### PR TITLE
Add a script to install the Vulkan SDK on macOS

### DIFF
--- a/misc/scripts/install_vulkan_sdk_macos.sh
+++ b/misc/scripts/install_vulkan_sdk_macos.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# Download and install the Vulkan SDK.
+curl -LO "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg"
+hdiutil attach vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
+/Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
+    --accept-licenses --default-answer --confirm-command install
+hdiutil detach /Volumes/vulkan-sdk
+
+echo 'Vulkan SDK installed successfully! You can now build Godot by running "scons".'


### PR DESCRIPTION
This script can be used to make Godot easier to compile on a fresh macOS installation, including on CI platforms and containers where the Vulkan SDK isn't preinstalled.

Some questions:

- Is there a default location for the Vulkan SDK, so we don't have to specify `VULKAN_SDK_PATH` on the SCons line? Does omitting `--root` use the default path?
- Should we use a custom path (and accept it by default in Godot's SCons setup) to avoid requiring the use of `sudo` within the script? This way, limited users can install the Vulkan SDK.

In a future PR, we could look into scripting the installation of the Xcode command-line tools (likely in a separate script).