### PR TITLE
TextureRegion: Use Sprite2D/NinePatch texture filter instead of default

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -63,14 +63,17 @@ void draw_margin_line(Control *edit_draw, Vector2 from, Vector2 to) {
 
 void TextureRegionEditor::_region_draw() {
 	Ref<Texture2D> base_tex = nullptr;
+	RenderingServer::CanvasItemTextureFilter tex_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_DEFAULT;
 	if (atlas_tex.is_valid()) {
 		base_tex = atlas_tex->get_atlas();
 	} else if (node_sprite_2d) {
 		base_tex = node_sprite_2d->get_texture();
+		tex_filter = node_sprite_2d->get_texture_filter_cache();
 	} else if (node_sprite_3d) {
 		base_tex = node_sprite_3d->get_texture();
 	} else if (node_ninepatch) {
 		base_tex = node_ninepatch->get_texture();
+		tex_filter = node_ninepatch->get_texture_filter_cache();
 	} else if (obj_styleBox.is_valid()) {
 		base_tex = obj_styleBox->get_texture();
 	}
@@ -84,6 +87,7 @@ void TextureRegionEditor::_region_draw() {
 	mtx.scale_basis(Vector2(draw_zoom, draw_zoom));
 
 	RS::get_singleton()->canvas_item_add_set_transform(edit_draw->get_canvas_item(), mtx);
+	RS::get_singleton()->canvas_item_set_default_texture_filter(edit_draw->get_canvas_item(), tex_filter);
 	edit_draw->draw_texture(base_tex, Point2());
 	RS::get_singleton()->canvas_item_add_set_transform(edit_draw->get_canvas_item(), Transform2D());
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1144,6 +1144,10 @@ CanvasItem::TextureRepeat CanvasItem::get_texture_repeat() const {
 	return texture_repeat;
 }
 
+RS::CanvasItemTextureFilter CanvasItem::get_texture_filter_cache() {
+	return texture_filter_cache;
+}
+
 CanvasItem::CanvasItem() :
 		xform_change(this) {
 	canvas_item = RenderingServer::get_singleton()->canvas_item_create();

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -309,6 +309,8 @@ public:
 
 	int get_canvas_layer() const;
 
+	RS::CanvasItemTextureFilter get_texture_filter_cache();
+
 	CanvasItem();
 	~CanvasItem();
 };


### PR DESCRIPTION
When drawing the texture in the texture region editor no texture filter is set. 
This PR changes the behaviour for Sprite2D and NinePatchRect and uses the configured texture filter of them.

This also exposes the texture_filter_cache of CanvasItem to not traverse the scene tree in the texture region editor again.

---

Fixes #54502