### PR TITLE
Viewport emit mouse_enter/exit even when dragging Control

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -196,6 +196,9 @@
 		</member>
 		<member name="gui_embed_subwindows" type="bool" setter="set_embed_subwindows_hint" getter="get_embed_subwindows_hint" default="false">
 		</member>
+		<member name="gui_force_mouse_events" type="bool" setter="set_force_mouse_events" getter="is_mouse_events_forced" default="false">
+			If [code]true[/code], the viewport will emit mouse_entered and mouse_exited signals even when dragging a [Control].
+		</member>
 		<member name="gui_snap_controls_to_pixels" type="bool" setter="set_snap_controls_to_pixels" getter="is_snap_controls_to_pixels_enabled" default="true">
 			If [code]true[/code], the GUI controls on the viewport will lay pixel perfectly.
 		</member>

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -330,6 +330,7 @@ private:
 		int mouse_focus_mask = 0;
 		Control *key_focus = nullptr;
 		Control *mouse_over = nullptr;
+		Control *unfocused_mouse_over = nullptr;
 		Control *drag_mouse_over = nullptr;
 		Vector2 drag_mouse_over_pos;
 		Control *tooltip_control = nullptr;
@@ -367,6 +368,7 @@ private:
 	DefaultCanvasItemTextureRepeat default_canvas_item_texture_repeat = DEFAULT_CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
 
 	bool disable_input = false;
+	bool force_mouse_events = false;
 
 	void _gui_call_input(Control *p_control, const Ref<InputEvent> &p_input);
 	void _gui_call_notification(Control *p_control, int p_what);
@@ -521,6 +523,9 @@ public:
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;
+
+	void set_force_mouse_events(bool p_disable);
+	bool is_mouse_events_forced() const;
 
 	Vector2 get_mouse_position() const;
 	void warp_mouse(const Vector2 &p_pos);


### PR DESCRIPTION
fixes #20881
linked to #54552

add a boolean property to the Viewport to allow it to send mouse_entered and mouse_exited signals even when dragging (mouse button clicked) from a Control.

Test Scene:

```ini
[gd_scene load_steps=2 format=3 uid="uid://deqgi4hacbarj"]

[sub_resource type="GDScript" id="1"]
script/source = "extends Node2D

func _ready():
	var _r
	_r = $ViewportContainer/Viewport/b1.connect(\"mouse_entered\", _entered, [\"b1\"])
	_r = $ViewportContainer/Viewport/b1.connect(\"mouse_exited\", _exited, [\"b1\"])
	_r = $ViewportContainer/Viewport/b2.connect(\"mouse_entered\", _entered,[\"b2\"])
	_r = $ViewportContainer/Viewport/b2.connect(\"mouse_exited\", _exited,[\"b2\"])
	_r = $ViewportContainer/Viewport/ck.connect(\"toggled\", _toggled)

func _entered(who):
	print(\"mouse area entered : %s\" % who)

func _exited(who):
	print(\"mouse area exited : %s\" % who)

func _toggled(v):
	$ViewportContainer/Viewport.gui_force_mouse_events = v
"

[node name="Node2D" type="Node2D"]
script = SubResource( "1" )

[node name="ViewportContainer" type="SubViewportContainer" parent="."]
script = null
__meta__ = {
"_edit_use_anchors_": false
}

[node name="Viewport" type="SubViewport" parent="ViewportContainer"]
handle_input_locally = false
debug_draw = 3
size = Vector2i(800, 600)
render_target_update_mode = 4
script = null

[node name="b1" type="Button" parent="ViewportContainer/Viewport"]
offset_left = 150.0
offset_top = 100.0
rect_rotation = -23.2
focus_mode = 0
script = null
__meta__ = {
"_edit_use_anchors_": false
}

[node name="b2" type="Button" parent="ViewportContainer/Viewport"]
offset_left = 150.0
offset_top = 150.0
offset_right = 230.4604
offset_bottom = 380.158
rect_rotation = 38.7
rect_scale = Vector2(0.5, 0.5)
rect_pivot_offset = Vector2(1, 0)
focus_mode = 0
script = null
__meta__ = {
"_edit_use_anchors_": false
}

[node name="ck" type="CheckBox" parent="ViewportContainer/Viewport"]
offset_right = 24.0
offset_bottom = 31.0
script = null
__meta__ = {
"_edit_use_anchors_": false
}
```