### PR TITLE
Save AnimatedSprite3D's frame property as zero when playing is enabled.

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1176,6 +1176,23 @@ String AnimatedSprite3D::get_configuration_warning() const {
 	return warning;
 }
 
+#if TOOLS_ENABLED
+void SpriteFrameBackup::restore() const {
+	anim_sprite->set_frame(value);
+}
+
+void SpriteFrameBackup::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("restore"), &SpriteFrameBackup::restore);
+}
+
+void SpriteFrameBackup::from_animated_sprite(AnimatedSprite3D *sprite)  {
+	if (sprite) {
+		anim_sprite = sprite;
+		value = sprite->get_frame();
+	}
+}
+#endif
+
 void AnimatedSprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sprite_frames", "sprite_frames"), &AnimatedSprite3D::set_sprite_frames);
 	ClassDB::bind_method(D_METHOD("get_sprite_frames"), &AnimatedSprite3D::get_sprite_frames);

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -246,6 +246,22 @@ public:
 	AnimatedSprite3D();
 };
 
+#if TOOLS_ENABLED
+class SpriteFrameBackup : public Reference {
+	GDCLASS(SpriteFrameBackup, Reference);
+
+	AnimatedSprite3D *anim_sprite;
+	int value;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void from_animated_sprite(AnimatedSprite3D *sprite);
+	void restore() const;
+};
+#endif
+
 VARIANT_ENUM_CAST(SpriteBase3D::DrawFlags);
 VARIANT_ENUM_CAST(SpriteBase3D::AlphaCutMode);
 #endif // SPRITE_3D_H


### PR DESCRIPTION
The relevant issue can be found here: https://github.com/godotengine/godot/issues/53407#issue-1015532296

This PR changes the sprite's frame to 0 when saving the scene with the playing property enabled to avoid creating unnecessary diffs on tscn files.