### PR TITLE
Add documentation to operators for math types

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -218,12 +218,15 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="AABB" />
 			<description>
+				Returns [code]true[/code] if the vectors are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="AABB" />
 			<argument index="0" name="right" type="Transform3D" />
 			<description>
+				Inversely transforms (multiplies) the [AABB] by the given [Transform3D] transformation matrix.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -235,6 +238,8 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="AABB" />
 			<description>
+				Returns [code]true[/code] if the AABBs are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -232,18 +232,22 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Basis" />
 			<description>
+				Returns [code]true[/code] if the [Basis] matrices are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Basis" />
 			<argument index="0" name="right" type="Basis" />
 			<description>
+				Composes these two basis matrices by multiplying them together. This has the effect of transforming the second basis (the child) by the first basis (the parent).
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Transforms (multiplies) the [Vector3] by the given [Basis] matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
@@ -269,12 +273,15 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Basis" />
 			<description>
+				Returns [code]true[/code] if the [Basis] matrices are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="Vector3" />
 			<argument index="0" name="index" type="int" />
 			<description>
+				Access basis components using their index. [code]b[0][/code] is equivalent to [code]b.x[/code], [code]b[1][/code] is equivalent to [code]b.y[/code], and [code]b[2][/code] is equivalent to [code]b.z[/code].
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -863,54 +863,64 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Color" />
 			<description>
+				Returns [code]true[/code] if the colors are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Color" />
 			<argument index="0" name="right" type="Color" />
 			<description>
+				Multiplies each component of the [Color] by the components of the given [Color].
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Color" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Multiplies each component of the [Color] by the given [float].
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Color" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Multiplies each component of the [Color] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator +">
 			<return type="Color" />
 			<argument index="0" name="right" type="Color" />
 			<description>
+				Adds each component of the [Color] with the components of the given [Color].
 			</description>
 		</operator>
 		<operator name="operator -">
 			<return type="Color" />
 			<argument index="0" name="right" type="Color" />
 			<description>
+				Subtracts each component of the [Color] by the components of the given [Color].
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Color" />
 			<argument index="0" name="right" type="Color" />
 			<description>
+				Divides each component of the [Color] by the components of the given [Color].
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Color" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Divides each component of the [Color] by the given [float].
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Color" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Divides each component of the [Color] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -922,22 +932,27 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Color" />
 			<description>
+				Returns [code]true[/code] if the colors are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="float" />
 			<argument index="0" name="index" type="int" />
 			<description>
+				Access color components using their index. [code]c[0][/code] is equivalent to [code]c.r[/code], [code]c[1][/code] is equivalent to [code]c.g[/code], [code]c[2][/code] is equivalent to [code]c.b[/code], and [code]c[3][/code] is equivalent to [code]c.a[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">
 			<return type="Color" />
 			<description>
+				Returns the same value as if the [code]+[/code] was not there. Unary [code]+[/code] does nothing, but sometimes it can make your code more readable.
 			</description>
 		</operator>
 		<operator name="operator unary-">
 			<return type="Color" />
 			<description>
+				Inverts the given color. This is equivalent to [code]Color.WHITE - c[/code] or [code]Color(1 - c.r, 1 - c.g, 1 - c.b, 1 - c.a)[/code].
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -180,6 +180,8 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Plane" />
 			<description>
+				Returns [code]true[/code] if the planes are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -191,16 +193,20 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Plane" />
 			<description>
+				Returns [code]true[/code] if the planes are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator unary+">
 			<return type="Plane" />
 			<description>
+				Returns the same value as if the [code]+[/code] was not there. Unary [code]+[/code] does nothing, but sometimes it can make your code more readable.
 			</description>
 		</operator>
 		<operator name="operator unary-">
 			<return type="Plane" />
 			<description>
+				Returns the negative value of the [Plane]. This is the same as writing [code]Plane(-p.normal, -p.d)[/code]. This operation flips the direction of the normal vector and also flips the distance value, resulting in a Plane that is in the same place, but facing the opposite direction.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -195,54 +195,64 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Quaternion" />
 			<description>
+				Returns [code]true[/code] if the quaternions are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Quaternion" />
 			<argument index="0" name="right" type="Quaternion" />
 			<description>
+				Composes these two quaternions by multiplying them together. This has the effect of rotating the second quaternion (the child) by the first quaternion (the parent).
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Rotates (multiplies) the [Vector3] by the given [Quaternion].
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Quaternion" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Multiplies each component of the [Quaternion] by the given value. This operation is not meaningful on its own, but it can be used as a part of a larger expression.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Quaternion" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Multiplies each component of the [Quaternion] by the given value. This operation is not meaningful on its own, but it can be used as a part of a larger expression.
 			</description>
 		</operator>
 		<operator name="operator +">
 			<return type="Quaternion" />
 			<argument index="0" name="right" type="Quaternion" />
 			<description>
+				Adds each component of the left [Quaternion] to the right [Quaternion]. This operation is not meaningful on its own, but it can be used as a part of a larger expression, such as approximating an intermediate rotation between two nearby rotations.
 			</description>
 		</operator>
 		<operator name="operator -">
 			<return type="Quaternion" />
 			<argument index="0" name="right" type="Quaternion" />
 			<description>
+				Subtracts each component of the left [Quaternion] by the right [Quaternion]. This operation is not meaningful on its own, but it can be used as a part of a larger expression.
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Quaternion" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Divides each component of the [Quaternion] by the given value. This operation is not meaningful on its own, but it can be used as a part of a larger expression.
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Quaternion" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Divides each component of the [Quaternion] by the given value. This operation is not meaningful on its own, but it can be used as a part of a larger expression.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -254,22 +264,27 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Quaternion" />
 			<description>
+				Returns [code]true[/code] if the quaternions are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="float" />
 			<argument index="0" name="index" type="int" />
 			<description>
+				Access quaternion components using their index. [code]q[0][/code] is equivalent to [code]q.x[/code], [code]q[1][/code] is equivalent to [code]q.y[/code], [code]q[2][/code] is equivalent to [code]q.z[/code], and [code]q[3][/code] is equivalent to [code]q.w[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">
 			<return type="Quaternion" />
 			<description>
+				Returns the same value as if the [code]+[/code] was not there. Unary [code]+[/code] does nothing, but sometimes it can make your code more readable.
 			</description>
 		</operator>
 		<operator name="operator unary-">
 			<return type="Quaternion" />
 			<description>
+				Returns the negative value of the [Quaternion]. This is the same as writing [code]Quaternion(-q.x, -q.y, -q.z, -q.w)[/code]. This operation results in a quaternion that represents the same rotation.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -178,12 +178,15 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Rect2" />
 			<description>
+				Returns [code]true[/code] if the rectangles are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Rect2" />
 			<argument index="0" name="right" type="Transform2D" />
 			<description>
+				Inversely transforms (multiplies) the [Rect2] by the given [Transform2D] transformation matrix.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -195,6 +198,8 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Rect2" />
 			<description>
+				Returns [code]true[/code] if the rectangles are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -169,6 +169,7 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Rect2i" />
 			<description>
+				Returns [code]true[/code] if the rectangles are not equal.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -180,6 +181,7 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Rect2i" />
 			<description>
+				Returns [code]true[/code] if the rectangles are equal.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -213,30 +213,36 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Transform2D" />
 			<description>
+				Returns [code]true[/code] if the transforms are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="PackedVector2Array" />
 			<argument index="0" name="right" type="PackedVector2Array" />
 			<description>
+				Transforms (multiplies) each element of the [Vector2] array by the given [Transform2D] matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Transform2D" />
 			<argument index="0" name="right" type="Transform2D" />
 			<description>
+				Composes these two transformation matrices by multiplying them together. This has the effect of transforming the second transform (the child) by the first transform (the parent).
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Rect2" />
 			<argument index="0" name="right" type="Rect2" />
 			<description>
+				Transforms (multiplies) the [Rect2] by the given [Transform2D] matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Transforms (multiplies) the [Vector2] by the given [Transform2D] matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
@@ -262,12 +268,15 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Transform2D" />
 			<description>
+				Returns [code]true[/code] if the transforms are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="Vector2" />
 			<argument index="0" name="index" type="int" />
 			<description>
+				Access transform components using their index. [code]t[0][/code] is equivalent to [code]t.x[/code], [code]t[1][/code] is equivalent to [code]t.y[/code], and [code]t[2][/code] is equivalent to [code]t.origin[/code].
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -147,30 +147,36 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Transform3D" />
 			<description>
+				Returns [code]true[/code] if the transforms are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="PackedVector3Array" />
 			<argument index="0" name="right" type="PackedVector3Array" />
 			<description>
+				Transforms (multiplies) each element of the [Vector3] array by the given [Transform3D] matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Transform3D" />
 			<argument index="0" name="right" type="Transform3D" />
 			<description>
+				Composes these two transformation matrices by multiplying them together. This has the effect of transforming the second transform (the child) by the first transform (the parent).
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="AABB" />
 			<argument index="0" name="right" type="AABB" />
 			<description>
+				Transforms (multiplies) the [AABB] by the given [Transform3D] matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Transforms (multiplies) the [Vector3] by the given [Transform3D] matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
@@ -196,6 +202,8 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Transform3D" />
 			<description>
+				Returns [code]true[/code] if the transforms are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -351,72 +351,97 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Returns [code]true[/code] if the vectors are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Multiplies each component of the [Vector2] by the components of the given [Vector2].
+				[codeblock]
+				print(Vector2(10, 20) * Vector2(3, 4)) # Prints "(30, 80)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="Transform2D" />
 			<description>
+				Inversely transforms (multiplies) the [Vector2] by the given [Transform2D] transformation matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Multiplies each component of the [Vector2] by the given [float].
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Multiplies each component of the [Vector2] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator +">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Adds each component of the [Vector2] by the components of the given [Vector2].
+				[codeblock]
+				print(Vector2(10, 20) + Vector2(3, 4)) # Prints "(13, 24)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator -">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Subtracts each component of the [Vector2] by the components of the given [Vector2].
+				[codeblock]
+				print(Vector2(10, 20) - Vector2(3, 4)) # Prints "(7, 16)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Divides each component of the [Vector2] by the components of the given [Vector2].
+				[codeblock]
+				print(Vector2(10, 20) / Vector2(2, 5)) # Prints "(5, 4)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Divides each component of the [Vector2] by the given [float].
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Divides each component of the [Vector2] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Compares two [Vector2] vectors by first checking if the X value of the left vector is less than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Compares two [Vector2] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -428,34 +453,41 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Returns [code]true[/code] if the vectors are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Compares two [Vector2] vectors by first checking if the X value of the left vector is greater than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
+				Compares two [Vector2] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="float" />
 			<argument index="0" name="index" type="int" />
 			<description>
+				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], and [code]v[1][/code] is equivalent to [code]v.y[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">
 			<return type="Vector2" />
 			<description>
+				Returns the same value as if the [code]+[/code] was not there. Unary [code]+[/code] does nothing, but sometimes it can make your code more readable.
 			</description>
 		</operator>
 		<operator name="operator unary-">
 			<return type="Vector2" />
 			<description>
+				Returns the negative value of the [Vector2]. This is the same as writing [code]Vector2(-v.x, -v.y)[/code]. This operation flips the direction of the vector while keeping the same magnitude. With floats, the number zero can be either positive or negative.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -115,78 +115,115 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Returns [code]true[/code] if the vectors are not equal.
 			</description>
 		</operator>
 		<operator name="operator %">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Gets the remainder of each component of the [Vector2i] with the components of the given [Vector2i]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
+				[codeblock]
+				print(Vector2i(10, -20) % Vector2i(7, 8)) # Prints "(3, -4)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator %">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Gets the remainder of each component of the [Vector2i] with the the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
+				[codeblock]
+				print(Vector2i(10, -20) % 7) # Prints "(3, -6)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Multiplies each component of the [Vector2i] by the components of the given [Vector2i].
+				[codeblock]
+				print(Vector2i(10, 20) * Vector2i(3, 4)) # Prints "(30, 80)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Multiplies each component of the [Vector2i] by the given [float] truncated to an integer.
+				[codeblock]
+				print(Vector2i(10, 20) * 0.9) # Prints "(0, 0)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Multiplies each component of the [Vector2i] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator +">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Adds each component of the [Vector2i] by the components of the given [Vector2i].
+				[codeblock]
+				print(Vector2i(10, 20) + Vector2i(3, 4)) # Prints "(13, 24)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator -">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Subtracts each component of the [Vector2i] by the components of the given [Vector2i].
+				[codeblock]
+				print(Vector2i(10, 20) - Vector2i(3, 4)) # Prints "(7, 16)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Divides each component of the [Vector2i] by the components of the given [Vector2i].
+				[codeblock]
+				print(Vector2i(10, 20) / Vector2i(2, 5)) # Prints "(5, 4)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Divides each component of the [Vector2i] by the given [float] truncated to an integer.
+				[codeblock]
+				print(Vector2i(10, 20) / 2.9) # Prints "(5, 10)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Divides each component of the [Vector2i] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Compares two [Vector2i] vectors by first checking if the X value of the left vector is less than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Compares two [Vector2i] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -198,34 +235,40 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Returns [code]true[/code] if the vectors are equal.
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Compares two [Vector2i] vectors by first checking if the X value of the left vector is greater than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
+				Compares two [Vector2i] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="int" />
 			<argument index="0" name="index" type="int" />
 			<description>
+				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], and [code]v[1][/code] is equivalent to [code]v.y[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">
 			<return type="Vector2i" />
 			<description>
+				Returns the same value as if the [code]+[/code] was not there. Unary [code]+[/code] does nothing, but sometimes it can make your code more readable.
 			</description>
 		</operator>
 		<operator name="operator unary-">
 			<return type="Vector2i" />
 			<description>
+				Returns the negative value of the [Vector2i]. This is the same as writing [code]Vector2i(-v.x, -v.y)[/code]. This operation flips the direction of the vector while keeping the same magnitude.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -367,84 +367,111 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Returns [code]true[/code] if the vectors are not equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Multiplies each component of the [Vector3] by the components of the given [Vector3].
+				[codeblock]
+				print(Vector3(10, 20, 30) * Vector3(3, 4, 5)) # Prints "(30, 80, 150)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Basis" />
 			<description>
+				Inversely transforms (multiplies) the [Vector3] by the given [Basis] matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Quaternion" />
 			<description>
+				Inversely transforms (multiplies) the [Vector3] by the given [Quaternion].
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Transform3D" />
 			<description>
+				Inversely transforms (multiplies) the [Vector3] by the given [Transform3D] transformation matrix.
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Multiplies each component of the [Vector3] by the given [float].
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Multiplies each component of the [Vector3] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator +">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Adds each component of the [Vector3] by the components of the given [Vector3].
+				[codeblock]
+				print(Vector3(10, 20, 30) + Vector3(3, 4, 5)) # Prints "(13, 24, 35)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator -">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Subtracts each component of the [Vector3] by the components of the given [Vector3].
+				[codeblock]
+				print(Vector3(10, 20, 30) - Vector3(3, 4, 5)) # Prints "(7, 16, 25)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Divides each component of the [Vector3] by the components of the given [Vector3].
+				[codeblock]
+				print(Vector3(10, 20, 30) / Vector3(2, 5, 3)) # Prints "(5, 4, 10)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Divides each component of the [Vector3] by the given [float].
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Divides each component of the [Vector3] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Compares two [Vector3] vectors by first checking if the X value of the left vector is less than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Compares two [Vector3] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -456,34 +483,41 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Returns [code]true[/code] if the vectors are exactly equal.
+				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Compares two [Vector3] vectors by first checking if the X value of the left vector is greater than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
+				Compares two [Vector3] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="float" />
 			<argument index="0" name="index" type="int" />
 			<description>
+				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], [code]v[1][/code] is equivalent to [code]v.y[/code], and [code]v[2][/code] is equivalent to [code]v.z[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">
 			<return type="Vector3" />
 			<description>
+				Returns the same value as if the [code]+[/code] was not there. Unary [code]+[/code] does nothing, but sometimes it can make your code more readable.
 			</description>
 		</operator>
 		<operator name="operator unary-">
 			<return type="Vector3" />
 			<description>
+				Returns the negative value of the [Vector3]. This is the same as writing [code]Vector3(-v.x, -v.y, -v.z)[/code]. This operation flips the direction of the vector while keeping the same magnitude. With floats, the number zero can be either positive or negative.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -133,78 +133,115 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Returns [code]true[/code] if the vectors are not equal.
 			</description>
 		</operator>
 		<operator name="operator %">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Gets the remainder of each component of the [Vector3i] with the components of the given [Vector3i]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
+				[codeblock]
+				print(Vector3i(10, -20, 30) % Vector3i(7, 8, 9)) # Prints "(3, -4, 3)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator %">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Gets the remainder of each component of the [Vector3i] with the the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
+				[codeblock]
+				print(Vector2i(10, -20, 30) % 7) # Prints "(3, -6, 2)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Multiplies each component of the [Vector3i] by the components of the given [Vector3i].
+				[codeblock]
+				print(Vector3i(10, 20, 30) * Vector3i(3, 4, 5)) # Prints "(30, 80, 150)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Multiplies each component of the [Vector3i] by the given [float] truncated to an integer.
+				[codeblock]
+				print(Vector3i(10, 20, 30) * 0.9) # Prints "(0, 0, 0)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Multiplies each component of the [Vector3i] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator +">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Adds each component of the [Vector3i] by the components of the given [Vector3i].
+				[codeblock]
+				print(Vector3i(10, 20, 30) + Vector3i(3, 4, 5)) # Prints "(13, 24, 35)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator -">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Subtracts each component of the [Vector3i] by the components of the given [Vector3i].
+				[codeblock]
+				print(Vector3i(10, 20, 30) - Vector3i(3, 4, 5)) # Prints "(7, 16, 25)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Divides each component of the [Vector3i] by the components of the given [Vector3i].
+				[codeblock]
+				print(Vector3i(10, 20, 30) / Vector3i(2, 5, 3)) # Prints "(5, 4, 10)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="float" />
 			<description>
+				Divides each component of the [Vector3i] by the given [float] truncated to an integer.
+				[codeblock]
+				print(Vector3i(10, 20, 30) / 2.9) # Prints "(5, 10, 15)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator /">
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="int" />
 			<description>
+				Divides each component of the [Vector3i] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Compares two [Vector3i] vectors by first checking if the X value of the left vector is less than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Compares two [Vector3i] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -216,34 +253,40 @@
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Returns [code]true[/code] if the vectors are equal.
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Compares two [Vector3i] vectors by first checking if the X value of the left vector is greater than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
+				Compares two [Vector3i] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="int" />
 			<argument index="0" name="index" type="int" />
 			<description>
+				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], [code]v[1][/code] is equivalent to [code]v.y[/code], and [code]v[2][/code] is equivalent to [code]v.z[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">
 			<return type="Vector3i" />
 			<description>
+				Returns the same value as if the [code]+[/code] was not there. Unary [code]+[/code] does nothing, but sometimes it can make your code more readable.
 			</description>
 		</operator>
 		<operator name="operator unary-">
 			<return type="Vector3i" />
 			<description>
+				Returns the negative value of the [Vector3i]. This is the same as writing [code]Vector3i(-v.x, -v.y, -v.z)[/code]. This operation flips the direction of the vector while keeping the same magnitude.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -72,7 +72,7 @@
 			<return type="Quaternion" />
 			<argument index="0" name="right" type="Quaternion" />
 			<description>
-				Multiplies each component of the [Quaternion] by the given [float].
+				Multiplies each component of the [Quaternion] by the given [float]. This operation is not meaningful on its own, but it can be used as a part of a larger expression.
 			</description>
 		</operator>
 		<operator name="operator *">
@@ -81,7 +81,7 @@
 			<description>
 				Multiplies each component of the [Vector2] by the given [float].
 				[codeblock]
-				print(2.5 * Vector2(1, 1)) # Vector2(2.5, 2.5)
+				print(2.5 * Vector2(1, 3)) # Prints "(2.5, 7.5)"
 				[/codeblock]
 			</description>
 		</operator>
@@ -89,9 +89,9 @@
 			<return type="Vector2i" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
-				Multiplies each component of the [Vector2i] by the given [float].
+				Multiplies each component of the [Vector2i] by the given [float] truncated to an integer.
 				[codeblock]
-				print(2.0 * Vector2i(1, 1)) # Vector2i(2.0, 2.0)
+				print(0.9 * Vector2i(10, 20)) # Prints "(0, 0)"
 				[/codeblock]
 			</description>
 		</operator>
@@ -106,7 +106,10 @@
 			<return type="Vector3i" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
-				Multiplies each component of the [Vector3i] by the given [float].
+				Multiplies each component of the [Vector3i] by the given [float] truncated to an integer.
+				[codeblock]
+				print(0.9 * Vector3i(10, 20, 30)) # Prints "(0, 0, 0)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -91,11 +91,11 @@
 			<return type="int" />
 			<argument index="0" name="right" type="int" />
 			<description>
-				Returns the result of the modulo operator for two integers, i.e. the remainder after dividing both numbers.
+				Returns the remainder after dividing two integers. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
 				print(5 % 2) # 1
 				print(12 % 4) # 0
-				print(12 % 2) # 2
+				print(-5 % 3) # -2
 				[/codeblock]
 			</description>
 		</operator>
@@ -121,12 +121,14 @@
 			<return type="Color" />
 			<argument index="0" name="right" type="Color" />
 			<description>
+				Multiplies each component of the [Color] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Quaternion" />
 			<argument index="0" name="right" type="Quaternion" />
 			<description>
+				Multiplies each component of the [Quaternion] by the given [int]. This operation is not meaningful on its own, but it can be used as a part of a larger expression.
 			</description>
 		</operator>
 		<operator name="operator *">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -666,21 +666,40 @@ namespace Godot
             _size = new Vector3(width, height, depth);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the AABBs are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left AABB.</param>
+        /// <param name="right">The right AABB.</param>
+        /// <returns>Whether or not the AABBs are exactly equal.</returns>
         public static bool operator ==(AABB left, AABB right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the AABBs are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left AABB.</param>
+        /// <param name="right">The right AABB.</param>
+        /// <returns>Whether or not the AABBs are not equal.</returns>
         public static bool operator !=(AABB left, AABB right)
         {
             return !left.Equals(right);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this AABB and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the AABB is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the AABB structure and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the AABB and the object are equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is AABB)
@@ -692,10 +711,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this AABB and <paramref name="other"/> are equal
+        /// Returns <see langword="true"/> if the AABBs are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other AABB to compare.</param>
-        /// <returns>Whether or not the AABBs are equal.</returns>
+        /// <param name="other">The other AABB.</param>
+        /// <returns>Whether or not the AABBs are exactly equal.</returns>
         public bool Equals(AABB other)
         {
             return _position == other._position && _size == other._size;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -827,6 +827,14 @@ namespace Godot
             Row2 = new Vector3(xz, yz, zz);
         }
 
+        /// <summary>
+        /// Composes these two basis matrices by multiplying them
+        /// together. This has the effect of transforming the second basis
+        /// (the child) by the first basis (the parent).
+        /// </summary>
+        /// <param name="left">The parent basis.</param>
+        /// <param name="right">The child basis.</param>
+        /// <returns>The composed basis.</returns>
         public static Basis operator *(Basis left, Basis right)
         {
             return new Basis
@@ -837,21 +845,40 @@ namespace Godot
             );
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the basis matrices are exactly
+        /// equal. Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left basis.</param>
+        /// <param name="right">The right basis.</param>
+        /// <returns>Whether or not the basis matrices are exactly equal.</returns>
         public static bool operator ==(Basis left, Basis right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the basis matrices are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left basis.</param>
+        /// <param name="right">The right basis.</param>
+        /// <returns>Whether or not the basis matrices are not equal.</returns>
         public static bool operator !=(Basis left, Basis right)
         {
             return !left.Equals(right);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this basis and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the <see cref="Basis"/> is
+        /// exactly equal to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the basis and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the basis matrix and the object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Basis)
@@ -863,10 +890,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this basis and <paramref name="other"/> are equal
+        /// Returns <see langword="true"/> if the basis matrices are exactly
+        /// equal. Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other basis to compare.</param>
-        /// <returns>Whether or not the bases are equal.</returns>
+        /// <param name="other">The other basis.</param>
+        /// <returns>Whether or not the basis matrices are exactly equal.</returns>
         public bool Equals(Basis other)
         {
             return Row0.Equals(other.Row0) && Row1.Equals(other.Row1) && Row2.Equals(other.Row2);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -878,6 +878,13 @@ namespace Godot
             return true;
         }
 
+        /// <summary>
+        /// Adds each component of the <see cref="Color"/>
+        /// with the components of the given <see cref="Color"/>.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>The added color.</returns>
         public static Color operator +(Color left, Color right)
         {
             left.r += right.r;
@@ -887,6 +894,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Subtracts each component of the <see cref="Color"/>
+        /// by the components of the given <see cref="Color"/>.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>The subtracted color.</returns>
         public static Color operator -(Color left, Color right)
         {
             left.r -= right.r;
@@ -896,11 +910,25 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Inverts the given color. This is equivalent to
+        /// <c>Colors.White - c</c> or
+        /// <c>new Color(1 - c.r, 1 - c.g, 1 - c.b, 1 - c.a)</c>.
+        /// </summary>
+        /// <param name="color">The color to invert.</param>
+        /// <returns>The inverted color</returns>
         public static Color operator -(Color color)
         {
             return Colors.White - color;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Color"/>
+        /// by the given <see langword="float"/>.
+        /// </summary>
+        /// <param name="color">The color to multiply.</param>
+        /// <param name="scale">The value to multiply by.</param>
+        /// <returns>The multiplied color.</returns>
         public static Color operator *(Color color, float scale)
         {
             color.r *= scale;
@@ -910,6 +938,13 @@ namespace Godot
             return color;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Color"/>
+        /// by the given <see langword="float"/>.
+        /// </summary>
+        /// <param name="scale">The value to multiply by.</param>
+        /// <param name="color">The color to multiply.</param>
+        /// <returns>The multiplied color.</returns>
         public static Color operator *(float scale, Color color)
         {
             color.r *= scale;
@@ -919,6 +954,13 @@ namespace Godot
             return color;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Color"/>
+        /// by the components of the given <see cref="Color"/>.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>The multiplied color.</returns>
         public static Color operator *(Color left, Color right)
         {
             left.r *= right.r;
@@ -928,6 +970,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Color"/>
+        /// by the given <see langword="float"/>.
+        /// </summary>
+        /// <param name="color">The dividend vector.</param>
+        /// <param name="scale">The divisor value.</param>
+        /// <returns>The divided color.</returns>
         public static Color operator /(Color color, float scale)
         {
             color.r /= scale;
@@ -937,6 +986,13 @@ namespace Godot
             return color;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Color"/>
+        /// by the components of the given <see cref="Color"/>.
+        /// </summary>
+        /// <param name="left">The dividend color.</param>
+        /// <param name="right">The divisor color.</param>
+        /// <returns>The divided color.</returns>
         public static Color operator /(Color left, Color right)
         {
             left.r /= right.r;
@@ -946,23 +1002,51 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the colors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the colors are equal.</returns>
         public static bool operator ==(Color left, Color right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the colors are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the colors are equal.</returns>
         public static bool operator !=(Color left, Color right)
         {
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two <see cref="Color"/>s by first checking if
+        /// the red value of the <paramref name="left"/> color is less than
+        /// the red value of the <paramref name="right"/> color.
+        /// If the red values are exactly equal, then it repeats this check
+        /// with the green values of the two colors, then with the blue values,
+        /// and then with the alpha value.
+        /// This operator is useful for sorting colors.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the left is less than the right.</returns>
         public static bool operator <(Color left, Color right)
         {
-            if (Mathf.IsEqualApprox(left.r, right.r))
+            if (left.r == right.r)
             {
-                if (Mathf.IsEqualApprox(left.g, right.g))
+                if (left.g == right.g)
                 {
-                    if (Mathf.IsEqualApprox(left.b, right.b))
+                    if (left.b == right.b)
                     {
                         return left.a < right.a;
                     }
@@ -973,15 +1057,85 @@ namespace Godot
             return left.r < right.r;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Color"/>s by first checking if
+        /// the red value of the <paramref name="left"/> color is greater than
+        /// the red value of the <paramref name="right"/> color.
+        /// If the red values are exactly equal, then it repeats this check
+        /// with the green values of the two colors, then with the blue values,
+        /// and then with the alpha value.
+        /// This operator is useful for sorting colors.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the left is greater than the right.</returns>
         public static bool operator >(Color left, Color right)
         {
-            if (Mathf.IsEqualApprox(left.r, right.r))
+            if (left.r == right.r)
             {
-                if (Mathf.IsEqualApprox(left.g, right.g))
+                if (left.g == right.g)
                 {
-                    if (Mathf.IsEqualApprox(left.b, right.b))
+                    if (left.b == right.b)
                     {
                         return left.a > right.a;
+                    }
+                    return left.b > right.b;
+                }
+                return left.g > right.g;
+            }
+            return left.r > right.r;
+        }
+
+        /// <summary>
+        /// Compares two <see cref="Color"/>s by first checking if
+        /// the red value of the <paramref name="left"/> color is less than
+        /// or equal to the red value of the <paramref name="right"/> color.
+        /// If the red values are exactly equal, then it repeats this check
+        /// with the green values of the two colors, then with the blue values,
+        /// and then with the alpha value.
+        /// This operator is useful for sorting colors.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the left is less than or equal to the right.</returns>
+        public static bool operator <=(Color left, Color right)
+        {
+            if (left.r == right.r)
+            {
+                if (left.g == right.g)
+                {
+                    if (left.b == right.b)
+                    {
+                        return left.a <= right.a;
+                    }
+                    return left.b < right.b;
+                }
+                return left.g < right.g;
+            }
+            return left.r < right.r;
+        }
+
+        /// <summary>
+        /// Compares two <see cref="Color"/>s by first checking if
+        /// the red value of the <paramref name="left"/> color is greater than
+        /// or equal to the red value of the <paramref name="right"/> color.
+        /// If the red values are exactly equal, then it repeats this check
+        /// with the green values of the two colors, then with the blue values,
+        /// and then with the alpha value.
+        /// This operator is useful for sorting colors.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
+        public static bool operator >=(Color left, Color right)
+        {
+            if (left.r == right.r)
+            {
+                if (left.g == right.g)
+                {
+                    if (left.b == right.b)
+                    {
+                        return left.a >= right.a;
                     }
                     return left.b > right.b;
                 }
@@ -1006,9 +1160,11 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this color and <paramref name="other"/> are equal
+        /// Returns <see langword="true"/> if the colors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other color to compare.</param>
+        /// <param name="other">The other color.</param>
         /// <returns>Whether or not the colors are equal.</returns>
         public bool Equals(Color other)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
@@ -158,6 +158,7 @@ namespace Godot
             {"YELLOWGREEN", new Color(0.60f, 0.80f, 0.20f)},
         };
 
+#pragma warning disable CS1591 // Disable warning: "Missing XML comment for publicly visible type or member"
         public static Color AliceBlue { get { return namedColors["ALICEBLUE"]; } }
         public static Color AntiqueWhite { get { return namedColors["ANTIQUEWHITE"]; } }
         public static Color Aqua { get { return namedColors["AQUA"]; } }
@@ -304,5 +305,6 @@ namespace Godot
         public static Color WhiteSmoke { get { return namedColors["WHITESMOKE"]; } }
         public static Color Yellow { get { return namedColors["YELLOW"]; } }
         public static Color YellowGreen { get { return namedColors["YELLOWGREEN"]; } }
+#pragma warning restore CS1591
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -314,13 +314,13 @@ namespace Godot.Collections
         internal static extern int godot_icall_Dictionary_Count(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static int godot_icall_Dictionary_KeyValuePairs(IntPtr ptr, out IntPtr keys, out IntPtr values);
+        internal static extern int godot_icall_Dictionary_KeyValuePairs(IntPtr ptr, out IntPtr keys, out IntPtr values);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Dictionary_KeyValuePairAt(IntPtr ptr, int index, out object key, out object value);
+        internal static extern void godot_icall_Dictionary_KeyValuePairAt(IntPtr ptr, int index, out object key, out object value);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static void godot_icall_Dictionary_Add(IntPtr ptr, object key, object value);
+        internal static extern void godot_icall_Dictionary_Add(IntPtr ptr, object key, object value);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern void godot_icall_Dictionary_Clear(IntPtr ptr);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -309,16 +309,43 @@ namespace Godot
             D = _normal.Dot(v1);
         }
 
+        /// <summary>
+        /// Returns the negative value of the <see cref="Plane"/>.
+        /// This is the same as writing <c>new Plane(-p.Normal, -p.D)</c>.
+        /// This operation flips the direction of the normal vector and
+        /// also flips the distance value, resulting in a Plane that is
+        /// in the same place, but facing the opposite direction.
+        /// </summary>
+        /// <param name="plane">The plane to negate/flip.</param>
+        /// <returns>The negated/flipped plane.</returns>
         public static Plane operator -(Plane plane)
         {
             return new Plane(-plane._normal, -plane.D);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Plane"/>s are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the planes are exactly equal.</returns>
         public static bool operator ==(Plane left, Plane right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Plane"/>s are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the planes are not equal.</returns>
         public static bool operator !=(Plane left, Plane right)
         {
             return !left.Equals(right);
@@ -328,7 +355,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this plane and <paramref name="obj"/> are equal.
         /// </summary>
         /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the plane and the other object are equal.</returns>
+        /// <returns>Whether or not the plane and the other object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Plane)
@@ -343,7 +370,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this plane and <paramref name="other"/> are equal.
         /// </summary>
         /// <param name="other">The other plane to compare.</param>
-        /// <returns>Whether or not the planes are equal.</returns>
+        /// <returns>Whether or not the planes are exactly equal.</returns>
         public bool Equals(Plane other)
         {
             return _normal == other._normal && D == other.D;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -446,6 +446,14 @@ namespace Godot
             }
         }
 
+        /// <summary>
+        /// Composes these two quaternions by multiplying them together.
+        /// This has the effect of rotating the second quaternion
+        /// (the child) by the first quaternion (the parent).
+        /// </summary>
+        /// <param name="left">The parent quaternion.</param>
+        /// <param name="right">The child quaternion.</param>
+        /// <returns>The composed quaternion.</returns>
         public static Quaternion operator *(Quaternion left, Quaternion right)
         {
             return new Quaternion
@@ -457,21 +465,55 @@ namespace Godot
             );
         }
 
+        /// <summary>
+        /// Adds each component of the left <see cref="Quaternion"/>
+        /// to the right <see cref="Quaternion"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression, such as approximating an intermediate
+        /// rotation between two nearby rotations.
+        /// </summary>
+        /// <param name="left">The left quaternion to add.</param>
+        /// <param name="right">The right quaternion to add.</param>
+        /// <returns>The added quaternion.</returns>
         public static Quaternion operator +(Quaternion left, Quaternion right)
         {
             return new Quaternion(left.x + right.x, left.y + right.y, left.z + right.z, left.w + right.w);
         }
 
+        /// <summary>
+        /// Subtracts each component of the left <see cref="Quaternion"/>
+        /// by the right <see cref="Quaternion"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression.
+        /// </summary>
+        /// <param name="left">The left quaternion to subtract.</param>
+        /// <param name="right">The right quaternion to subtract.</param>
+        /// <returns>The subtracted quaternion.</returns>
         public static Quaternion operator -(Quaternion left, Quaternion right)
         {
             return new Quaternion(left.x - right.x, left.y - right.y, left.z - right.z, left.w - right.w);
         }
 
-        public static Quaternion operator -(Quaternion left)
+        /// <summary>
+        /// Returns the negative value of the <see cref="Quaternion"/>.
+        /// This is the same as writing
+        /// <c>new Quaternion(-q.x, -q.y, -q.z, -q.w)</c>. This operation
+        /// results in a quaternion that represents the same rotation.
+        /// </summary>
+        /// <param name="quat">The quaternion to negate.</param>
+        /// <returns>The negated quaternion.</returns>
+        public static Quaternion operator -(Quaternion quat)
         {
-            return new Quaternion(-left.x, -left.y, -left.z, -left.w);
+            return new Quaternion(-quat.x, -quat.y, -quat.z, -quat.w);
         }
 
+        /// <summary>
+        /// Rotates (multiplies) the <see cref="Vector3"/>
+        /// by the given <see cref="Quaternion"/>.
+        /// </summary>
+        /// <param name="quat">The quaternion to rotate by.</param>
+        /// <param name="vec">The vector to rotate.</param>
+        /// <returns>The rotated vector.</returns>
         public static Vector3 operator *(Quaternion quat, Vector3 vec)
         {
 #if DEBUG
@@ -485,31 +527,81 @@ namespace Godot
             return vec + (((uv * quat.w) + u.Cross(uv)) * 2);
         }
 
+        /// <summary>
+        /// Inversely rotates (multiplies) the <see cref="Vector3"/>
+        /// by the given <see cref="Quaternion"/>.
+        /// </summary>
+        /// <param name="vec">The vector to rotate.</param>
+        /// <param name="quat">The quaternion to rotate by.</param>
+        /// <returns>The inversely rotated vector.</returns>
         public static Vector3 operator *(Vector3 vec, Quaternion quat)
         {
             return quat.Inverse() * vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Quaternion"/>
+        /// by the given <see cref="real_t"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression.
+        /// </summary>
+        /// <param name="left">The quaternion to multiply.</param>
+        /// <param name="right">The value to multiply by.</param>
+        /// <returns>The multiplied quaternion.</returns>
         public static Quaternion operator *(Quaternion left, real_t right)
         {
             return new Quaternion(left.x * right, left.y * right, left.z * right, left.w * right);
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Quaternion"/>
+        /// by the given <see cref="real_t"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression.
+        /// </summary>
+        /// <param name="left">The value to multiply by.</param>
+        /// <param name="right">The quaternion to multiply.</param>
+        /// <returns>The multiplied quaternion.</returns>
         public static Quaternion operator *(real_t left, Quaternion right)
         {
             return new Quaternion(right.x * left, right.y * left, right.z * left, right.w * left);
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Quaternion"/>
+        /// by the given <see cref="real_t"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression.
+        /// </summary>
+        /// <param name="left">The quaternion to divide.</param>
+        /// <param name="right">The value to divide by.</param>
+        /// <returns>The divided quaternion.</returns>
         public static Quaternion operator /(Quaternion left, real_t right)
         {
             return left * (1.0f / right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the quaternions are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left quaternion.</param>
+        /// <param name="right">The right quaternion.</param>
+        /// <returns>Whether or not the quaternions are exactly equal.</returns>
         public static bool operator ==(Quaternion left, Quaternion right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the quaternions are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left quaternion.</param>
+        /// <param name="right">The right quaternion.</param>
+        /// <returns>Whether or not the quaternions are not equal.</returns>
         public static bool operator !=(Quaternion left, Quaternion right)
         {
             return !left.Equals(right);
@@ -519,7 +611,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this quaternion and <paramref name="obj"/> are equal.
         /// </summary>
         /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the quaternion and the other object are equal.</returns>
+        /// <returns>Whether or not the quaternion and the other object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Quaternion)
@@ -534,7 +626,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this quaternion and <paramref name="other"/> are equal.
         /// </summary>
         /// <param name="other">The other quaternion to compare.</param>
-        /// <returns>Whether or not the quaternions are equal.</returns>
+        /// <returns>Whether or not the quaternions are exactly equal.</returns>
         public bool Equals(Quaternion other)
         {
             return x == other.x && y == other.y && z == other.z && w == other.w;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -396,11 +396,29 @@ namespace Godot
             _size = new Vector2(width, height);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Rect2"/>s are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the rects are exactly equal.</returns>
         public static bool operator ==(Rect2 left, Rect2 right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Rect2"/>s are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the rects are not equal.</returns>
         public static bool operator !=(Rect2 left, Rect2 right)
         {
             return !left.Equals(right);
@@ -410,7 +428,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this rect and <paramref name="obj"/> are equal.
         /// </summary>
         /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the rect and the other object are equal.</returns>
+        /// <returns>Whether or not the rect and the other object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Rect2)
@@ -425,7 +443,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this rect and <paramref name="other"/> are equal.
         /// </summary>
         /// <param name="other">The other rect to compare.</param>
-        /// <returns>Whether or not the rects are equal.</returns>
+        /// <returns>Whether or not the rects are exactly equal.</returns>
         public bool Equals(Rect2 other)
         {
             return _position.Equals(other._position) && _size.Equals(other._size);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -377,11 +377,25 @@ namespace Godot
             _size = new Vector2i(width, height);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Rect2i"/>s are exactly equal.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the rects are equal.</returns>
         public static bool operator ==(Rect2i left, Rect2i right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Rect2i"/>s are not equal.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the rects are not equal.</returns>
         public static bool operator !=(Rect2i left, Rect2i right)
         {
             return !left.Equals(right);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1345,7 +1345,7 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern static string godot_icall_String_simplify_path(string str);
+        internal static extern string godot_icall_String_simplify_path(string str);
 
         /// <summary>
         /// Split the string by a divisor string, return an array of the substrings.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -447,6 +447,14 @@ namespace Godot
             this.origin = origin;
         }
 
+        /// <summary>
+        /// Composes these two transformation matrices by multiplying them
+        /// together. This has the effect of transforming the second transform
+        /// (the child) by the first transform (the parent).
+        /// </summary>
+        /// <param name="left">The parent transform.</param>
+        /// <param name="right">The child transform.</param>
+        /// <returns>The composed transform.</returns>
         public static Transform2D operator *(Transform2D left, Transform2D right)
         {
             left.origin = left * right.origin;
@@ -554,31 +562,52 @@ namespace Godot
             return newArray;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the transforms are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left transform.</param>
+        /// <param name="right">The right transform.</param>
+        /// <returns>Whether or not the transforms are exactly equal.</returns>
         public static bool operator ==(Transform2D left, Transform2D right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the transforms are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left transform.</param>
+        /// <param name="right">The right transform.</param>
+        /// <returns>Whether or not the transforms are not equal.</returns>
         public static bool operator !=(Transform2D left, Transform2D right)
         {
             return !left.Equals(right);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the transform is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the transform and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the transform and the object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             return obj is Transform2D transform2D && Equals(transform2D);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="other"/> are equal.
+        /// Returns <see langword="true"/> if the transforms are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
         /// <param name="other">The other transform to compare.</param>
-        /// <returns>Whether or not the matrices are equal.</returns>
+        /// <returns>Whether or not the matrices are exactly equal.</returns>
         public bool Equals(Transform2D other)
         {
             return x.Equals(other.x) && y.Equals(other.y) && origin.Equals(other.origin);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -352,6 +352,14 @@ namespace Godot
             this.origin = origin;
         }
 
+        /// <summary>
+        /// Composes these two transformation matrices by multiplying them
+        /// together. This has the effect of transforming the second transform
+        /// (the child) by the first transform (the parent).
+        /// </summary>
+        /// <param name="left">The parent transform.</param>
+        /// <param name="right">The child transform.</param>
+        /// <returns>The composed transform.</returns>
         public static Transform3D operator *(Transform3D left, Transform3D right)
         {
             left.origin = left.Xform(right.origin);
@@ -359,21 +367,40 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the transforms are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left transform.</param>
+        /// <param name="right">The right transform.</param>
+        /// <returns>Whether or not the transforms are exactly equal.</returns>
         public static bool operator ==(Transform3D left, Transform3D right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the transforms are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left transform.</param>
+        /// <param name="right">The right transform.</param>
+        /// <returns>Whether or not the transforms are not equal.</returns>
         public static bool operator !=(Transform3D left, Transform3D right)
         {
             return !left.Equals(right);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the transform is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the transform and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the transform and the object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Transform3D)
@@ -385,10 +412,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="other"/> are equal.
+        /// Returns <see langword="true"/> if the transforms are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
         /// <param name="other">The other transform to compare.</param>
-        /// <returns>Whether or not the matrices are equal.</returns>
+        /// <returns>Whether or not the matrices are exactly equal.</returns>
         public bool Equals(Transform3D other)
         {
             return basis.Equals(other.basis) && origin.Equals(other.origin);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -642,6 +642,13 @@ namespace Godot
             return new Vector2(Mathf.Cos(angle), Mathf.Sin(angle));
         }
 
+        /// <summary>
+        /// Adds each component of the <see cref="Vector2"/>
+        /// with the components of the given <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The added vector.</returns>
         public static Vector2 operator +(Vector2 left, Vector2 right)
         {
             left.x += right.x;
@@ -649,6 +656,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Subtracts each component of the <see cref="Vector2"/>
+        /// by the components of the given <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The subtracted vector.</returns>
         public static Vector2 operator -(Vector2 left, Vector2 right)
         {
             left.x -= right.x;
@@ -656,6 +670,15 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns the negative value of the <see cref="Vector2"/>.
+        /// This is the same as writing <c>new Vector2(-v.x, -v.y)</c>.
+        /// This operation flips the direction of the vector while
+        /// keeping the same magnitude.
+        /// With floats, the number zero can be either positive or negative.
+        /// </summary>
+        /// <param name="vec">The vector to negate/flip.</param>
+        /// <returns>The negated/flipped vector.</returns>
         public static Vector2 operator -(Vector2 vec)
         {
             vec.x = -vec.x;
@@ -663,6 +686,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector2 operator *(Vector2 vec, real_t scale)
         {
             vec.x *= scale;
@@ -670,6 +700,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector2 operator *(real_t scale, Vector2 vec)
         {
             vec.x *= scale;
@@ -677,6 +714,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2"/>
+        /// by the components of the given <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector2 operator *(Vector2 left, Vector2 right)
         {
             left.x *= right.x;
@@ -684,6 +728,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector2 operator /(Vector2 vec, real_t divisor)
         {
             vec.x /= divisor;
@@ -691,6 +742,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Vector2"/>
+        /// by the components of the given <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector2 operator /(Vector2 vec, Vector2 divisorv)
         {
             vec.x /= divisorv.x;
@@ -698,6 +756,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector2"/>
+        /// with the components of the given <see cref="real_t"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(real_t)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector2(10, -20) % 7); // Prints "(3, -6)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector2 operator %(Vector2 vec, real_t divisor)
         {
             vec.x %= divisor;
@@ -705,6 +779,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector2"/>
+        /// with the components of the given <see cref="Vector2"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(Vector2)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector2(10, -20) % new Vector2(7, 8)); // Prints "(3, -4)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector2 operator %(Vector2 vec, Vector2 divisorv)
         {
             vec.x %= divisorv.x;
@@ -712,16 +802,43 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are exactly equal.</returns>
         public static bool operator ==(Vector2 left, Vector2 right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are not equal.</returns>
         public static bool operator !=(Vector2 left, Vector2 right)
         {
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than the right.</returns>
         public static bool operator <(Vector2 left, Vector2 right)
         {
             if (left.x == right.x)
@@ -731,6 +848,17 @@ namespace Godot
             return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than the right.</returns>
         public static bool operator >(Vector2 left, Vector2 right)
         {
             if (left.x == right.x)
@@ -740,29 +868,54 @@ namespace Godot
             return left.x > right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than or equal to the right.</returns>
         public static bool operator <=(Vector2 left, Vector2 right)
         {
             if (left.x == right.x)
             {
                 return left.y <= right.y;
             }
-            return left.x <= right.x;
+            return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
         public static bool operator >=(Vector2 left, Vector2 right)
         {
             if (left.x == right.x)
             {
                 return left.y >= right.y;
             }
-            return left.x >= right.x;
+            return left.x > right.x;
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the vector is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the vector and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Vector2)
@@ -773,10 +926,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are equal.
+        /// Returns <see langword="true"/> if the vectors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other vector to compare.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
+        /// <param name="other">The other vector.</param>
+        /// <returns>Whether or not the vectors are exactly equal.</returns>
         public bool Equals(Vector2 other)
         {
             return x == other.x && y == other.y;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -366,6 +366,13 @@ namespace Godot
             this.y = Mathf.RoundToInt(v.y);
         }
 
+        /// <summary>
+        /// Adds each component of the <see cref="Vector2i"/>
+        /// with the components of the given <see cref="Vector2i"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The added vector.</returns>
         public static Vector2i operator +(Vector2i left, Vector2i right)
         {
             left.x += right.x;
@@ -373,6 +380,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Subtracts each component of the <see cref="Vector2i"/>
+        /// by the components of the given <see cref="Vector2i"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The subtracted vector.</returns>
         public static Vector2i operator -(Vector2i left, Vector2i right)
         {
             left.x -= right.x;
@@ -380,6 +394,14 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns the negative value of the <see cref="Vector2i"/>.
+        /// This is the same as writing <c>new Vector2i(-v.x, -v.y)</c>.
+        /// This operation flips the direction of the vector while
+        /// keeping the same magnitude.
+        /// </summary>
+        /// <param name="vec">The vector to negate/flip.</param>
+        /// <returns>The negated/flipped vector.</returns>
         public static Vector2i operator -(Vector2i vec)
         {
             vec.x = -vec.x;
@@ -387,6 +409,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2i"/>
+        /// by the given <see langword="int"/>.
+        /// </summary>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector2i operator *(Vector2i vec, int scale)
         {
             vec.x *= scale;
@@ -394,6 +423,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2i"/>
+        /// by the given <see langword="int"/>.
+        /// </summary>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector2i operator *(int scale, Vector2i vec)
         {
             vec.x *= scale;
@@ -401,6 +437,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2i"/>
+        /// by the components of the given <see cref="Vector2i"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector2i operator *(Vector2i left, Vector2i right)
         {
             left.x *= right.x;
@@ -408,6 +451,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2i"/>
+        /// by the given <see langword="int"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector2i operator /(Vector2i vec, int divisor)
         {
             vec.x /= divisor;
@@ -415,6 +465,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Vector2i"/>
+        /// by the components of the given <see cref="Vector2i"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector2i operator /(Vector2i vec, Vector2i divisorv)
         {
             vec.x /= divisorv.x;
@@ -422,6 +479,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector2i"/>
+        /// with the components of the given <see langword="int"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(int)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector2i(10, -20) % 7); // Prints "(3, -6)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector2i operator %(Vector2i vec, int divisor)
         {
             vec.x %= divisor;
@@ -429,6 +502,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector2i"/>
+        /// with the components of the given <see cref="Vector2i"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(Vector2i)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector2i(10, -20) % new Vector2i(7, 8)); // Prints "(3, -4)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector2i operator %(Vector2i vec, Vector2i divisorv)
         {
             vec.x %= divisorv.x;
@@ -436,6 +525,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Performs a bitwise AND operation with this <see cref="Vector2i"/>
+        /// and the given <see langword="int"/>.
+        /// </summary>
+        /// <param name="vec">The vector to AND with.</param>
+        /// <param name="and">The integer to AND with.</param>
+        /// <returns>The result of the bitwise AND.</returns>
         public static Vector2i operator &(Vector2i vec, int and)
         {
             vec.x &= and;
@@ -443,6 +539,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Performs a bitwise AND operation with this <see cref="Vector2i"/>
+        /// and the given <see cref="Vector2i"/>.
+        /// </summary>
+        /// <param name="vec">The left vector to AND with.</param>
+        /// <param name="andv">The right vector to AND with.</param>
+        /// <returns>The result of the bitwise AND.</returns>
         public static Vector2i operator &(Vector2i vec, Vector2i andv)
         {
             vec.x &= andv.x;
@@ -450,50 +553,106 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are equal.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are equal.</returns>
         public static bool operator ==(Vector2i left, Vector2i right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are not equal.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are not equal.</returns>
         public static bool operator !=(Vector2i left, Vector2i right)
         {
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2i"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than the right.</returns>
         public static bool operator <(Vector2i left, Vector2i right)
         {
-            if (left.x.Equals(right.x))
+            if (left.x == right.x)
             {
                 return left.y < right.y;
             }
             return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2i"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than the right.</returns>
         public static bool operator >(Vector2i left, Vector2i right)
         {
-            if (left.x.Equals(right.x))
+            if (left.x == right.x)
             {
                 return left.y > right.y;
             }
             return left.x > right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2i"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than or equal to the right.</returns>
         public static bool operator <=(Vector2i left, Vector2i right)
         {
-            if (left.x.Equals(right.x))
+            if (left.x == right.x)
             {
                 return left.y <= right.y;
             }
-            return left.x <= right.x;
+            return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2i"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
         public static bool operator >=(Vector2i left, Vector2i right)
         {
-            if (left.x.Equals(right.x))
+            if (left.x == right.x)
             {
                 return left.y >= right.y;
             }
-            return left.x >= right.x;
+            return left.x > right.x;
         }
 
         /// <summary>
@@ -515,10 +674,11 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the vector is equal
+        /// to the given object (<see paramref="obj"/>).
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the vector and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Vector2i)
@@ -530,9 +690,9 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are equal.
+        /// Returns <see langword="true"/> if the vectors are equal.
         /// </summary>
-        /// <param name="other">The other vector to compare.</param>
+        /// <param name="other">The other vector.</param>
         /// <returns>Whether or not the vectors are equal.</returns>
         public bool Equals(Vector2i other)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -699,6 +699,13 @@ namespace Godot
             z = v.z;
         }
 
+        /// <summary>
+        /// Adds each component of the <see cref="Vector3"/>
+        /// with the components of the given <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The added vector.</returns>
         public static Vector3 operator +(Vector3 left, Vector3 right)
         {
             left.x += right.x;
@@ -707,6 +714,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Subtracts each component of the <see cref="Vector3"/>
+        /// by the components of the given <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The subtracted vector.</returns>
         public static Vector3 operator -(Vector3 left, Vector3 right)
         {
             left.x -= right.x;
@@ -715,6 +729,15 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns the negative value of the <see cref="Vector3"/>.
+        /// This is the same as writing <c>new Vector3(-v.x, -v.y, -v.z)</c>.
+        /// This operation flips the direction of the vector while
+        /// keeping the same magnitude.
+        /// With floats, the number zero can be either positive or negative.
+        /// </summary>
+        /// <param name="vec">The vector to negate/flip.</param>
+        /// <returns>The negated/flipped vector.</returns>
         public static Vector3 operator -(Vector3 vec)
         {
             vec.x = -vec.x;
@@ -723,6 +746,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector3 operator *(Vector3 vec, real_t scale)
         {
             vec.x *= scale;
@@ -731,6 +761,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector3 operator *(real_t scale, Vector3 vec)
         {
             vec.x *= scale;
@@ -739,6 +776,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3"/>
+        /// by the components of the given <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector3 operator *(Vector3 left, Vector3 right)
         {
             left.x *= right.x;
@@ -747,6 +791,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Vector3"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector3 operator /(Vector3 vec, real_t divisor)
         {
             vec.x /= divisor;
@@ -755,6 +806,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Vector3"/>
+        /// by the components of the given <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector3 operator /(Vector3 vec, Vector3 divisorv)
         {
             vec.x /= divisorv.x;
@@ -763,6 +821,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector3"/>
+        /// with the components of the given <see cref="real_t"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(real_t)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector3(10, -20, 30) % 7); // Prints "(3, -6, 2)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector3 operator %(Vector3 vec, real_t divisor)
         {
             vec.x %= divisor;
@@ -771,6 +845,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector3"/>
+        /// with the components of the given <see cref="Vector3"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(Vector3)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector3(10, -20, 30) % new Vector3(7, 8, 9)); // Prints "(3, -4, 3)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector3 operator %(Vector3 vec, Vector3 divisorv)
         {
             vec.x %= divisorv.x;
@@ -779,16 +869,43 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are exactly equal.</returns>
         public static bool operator ==(Vector3 left, Vector3 right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are not equal.</returns>
         public static bool operator !=(Vector3 left, Vector3 right)
         {
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than the right.</returns>
         public static bool operator <(Vector3 left, Vector3 right)
         {
             if (left.x == right.x)
@@ -802,6 +919,17 @@ namespace Godot
             return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than the right.</returns>
         public static bool operator >(Vector3 left, Vector3 right)
         {
             if (left.x == right.x)
@@ -815,6 +943,17 @@ namespace Godot
             return left.x > right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than or equal to the right.</returns>
         public static bool operator <=(Vector3 left, Vector3 right)
         {
             if (left.x == right.x)
@@ -828,6 +967,17 @@ namespace Godot
             return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
         public static bool operator >=(Vector3 left, Vector3 right)
         {
             if (left.x == right.x)
@@ -842,10 +992,13 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the vector is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the vector and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Vector3)
@@ -857,10 +1010,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are equal
+        /// Returns <see langword="true"/> if the vectors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other vector to compare.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
+        /// <param name="other">The other vector.</param>
+        /// <returns>Whether or not the vectors are exactly equal.</returns>
         public bool Equals(Vector3 other)
         {
             return x == other.x && y == other.y && z == other.z;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -347,6 +347,13 @@ namespace Godot
             this.z = Mathf.RoundToInt(v.z);
         }
 
+        /// <summary>
+        /// Adds each component of the <see cref="Vector3i"/>
+        /// with the components of the given <see cref="Vector3i"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The added vector.</returns>
         public static Vector3i operator +(Vector3i left, Vector3i right)
         {
             left.x += right.x;
@@ -355,6 +362,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Subtracts each component of the <see cref="Vector3i"/>
+        /// by the components of the given <see cref="Vector3i"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The subtracted vector.</returns>
         public static Vector3i operator -(Vector3i left, Vector3i right)
         {
             left.x -= right.x;
@@ -363,6 +377,14 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns the negative value of the <see cref="Vector3i"/>.
+        /// This is the same as writing <c>new Vector3i(-v.x, -v.y, -v.z)</c>.
+        /// This operation flips the direction of the vector while
+        /// keeping the same magnitude.
+        /// </summary>
+        /// <param name="vec">The vector to negate/flip.</param>
+        /// <returns>The negated/flipped vector.</returns>
         public static Vector3i operator -(Vector3i vec)
         {
             vec.x = -vec.x;
@@ -371,6 +393,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3i"/>
+        /// by the given <see langword="int"/>.
+        /// </summary>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector3i operator *(Vector3i vec, int scale)
         {
             vec.x *= scale;
@@ -379,6 +408,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3i"/>
+        /// by the given <see langword="int"/>.
+        /// </summary>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector3i operator *(int scale, Vector3i vec)
         {
             vec.x *= scale;
@@ -387,6 +423,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3i"/>
+        /// by the components of the given <see cref="Vector3i"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector3i operator *(Vector3i left, Vector3i right)
         {
             left.x *= right.x;
@@ -395,6 +438,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3i"/>
+        /// by the given <see langword="int"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector3i operator /(Vector3i vec, int divisor)
         {
             vec.x /= divisor;
@@ -403,6 +453,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Vector3i"/>
+        /// by the components of the given <see cref="Vector3i"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector3i operator /(Vector3i vec, Vector3i divisorv)
         {
             vec.x /= divisorv.x;
@@ -411,6 +468,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector3i"/>
+        /// with the components of the given <see langword="int"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(int)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector3i(10, -20, 30) % 7); // Prints "(3, -6, 2)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector3i operator %(Vector3i vec, int divisor)
         {
             vec.x %= divisor;
@@ -419,6 +492,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector3i"/>
+        /// with the components of the given <see cref="Vector3i"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(Vector3i)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector3i(10, -20, 30) % new Vector3i(7, 8, 9)); // Prints "(3, -4, 3)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector3i operator %(Vector3i vec, Vector3i divisorv)
         {
             vec.x %= divisorv.x;
@@ -427,6 +516,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Performs a bitwise AND operation with this <see cref="Vector3i"/>
+        /// and the given <see langword="int"/>.
+        /// </summary>
+        /// <param name="vec">The vector to AND with.</param>
+        /// <param name="and">The integer to AND with.</param>
+        /// <returns>The result of the bitwise AND.</returns>
         public static Vector3i operator &(Vector3i vec, int and)
         {
             vec.x &= and;
@@ -435,6 +531,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Performs a bitwise AND operation with this <see cref="Vector3i"/>
+        /// and the given <see cref="Vector3i"/>.
+        /// </summary>
+        /// <param name="vec">The left vector to AND with.</param>
+        /// <param name="andv">The right vector to AND with.</param>
+        /// <returns>The result of the bitwise AND.</returns>
         public static Vector3i operator &(Vector3i vec, Vector3i andv)
         {
             vec.x &= andv.x;
@@ -443,65 +546,121 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are equal.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are equal.</returns>
         public static bool operator ==(Vector3i left, Vector3i right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are not equal.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are not equal.</returns>
         public static bool operator !=(Vector3i left, Vector3i right)
         {
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3i"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than the right.</returns>
         public static bool operator <(Vector3i left, Vector3i right)
         {
             if (left.x == right.x)
             {
                 if (left.y == right.y)
+                {
                     return left.z < right.z;
-                else
-                    return left.y < right.y;
+                }
+                return left.y < right.y;
             }
-
             return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3i"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than the right.</returns>
         public static bool operator >(Vector3i left, Vector3i right)
         {
             if (left.x == right.x)
             {
                 if (left.y == right.y)
+                {
                     return left.z > right.z;
-                else
-                    return left.y > right.y;
+                }
+                return left.y > right.y;
             }
-
             return left.x > right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3i"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than or equal to the right.</returns>
         public static bool operator <=(Vector3i left, Vector3i right)
         {
             if (left.x == right.x)
             {
                 if (left.y == right.y)
+                {
                     return left.z <= right.z;
-                else
-                    return left.y < right.y;
+                }
+                return left.y < right.y;
             }
-
             return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3i"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
         public static bool operator >=(Vector3i left, Vector3i right)
         {
             if (left.x == right.x)
             {
                 if (left.y == right.y)
+                {
                     return left.z >= right.z;
-                else
-                    return left.y > right.y;
+                }
+                return left.y > right.y;
             }
-
             return left.x > right.x;
         }
 
@@ -524,10 +683,11 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the vector is equal
+        /// to the given object (<see paramref="obj"/>).
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the vector and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Vector3i)
@@ -539,9 +699,9 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are equal
+        /// Returns <see langword="true"/> if the vectors are equal.
         /// </summary>
-        /// <param name="other">The other vector to compare.</param>
+        /// <param name="other">The other vector.</param>
         /// <returns>Whether or not the vectors are equal.</returns>
         public bool Equals(Vector3i other)
         {


### PR DESCRIPTION
This PR adds documentation for the operators for all of the core math types, in both core and C#.

I can manually [backport the C# changes to 3.x](https://github.com/aaronfranke/godot/tree/3.x-cs-operator-docs), but the core changes are not applicable for 3.x.

Proofreading would be appreciated, it's likely that there are copy-paste errors simply because this PR is so big.
