### PR TITLE
[3.x] Add default `minSdkVersion` and `targetSdkVersion` in the AndroidManifest.xml file

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,8 +1,8 @@
 ext.versions = [
     androidGradlePlugin: '7.0.3',
     compileSdk         : 30,
-    minSdk             : 19,
-    targetSdk          : 30,
+    minSdk             : 19, // Also update 'platform/android/java/lib/AndroidManifest.xml#minSdkVersion' value
+    targetSdk          : 30, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' value
     buildTools         : '30.0.3',
     kotlinVersion      : '1.5.10',
     fragmentVersion    : '1.3.6',

--- a/platform/android/java/lib/AndroidManifest.xml
+++ b/platform/android/java/lib/AndroidManifest.xml
@@ -4,6 +4,9 @@
     android:versionCode="1"
     android:versionName="1.0">
 
+    <!-- Should match the mindSdk and targetSdk values in platform/android/java/app/config.gradle -->
+    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
+
     <application>
 
         <!-- Records the version of the Godot library -->


### PR DESCRIPTION
This enables Android buildsystem other than `gradle` to pick up the correct `minSdkVersion` and `targetSdkVersion` (otherwise they default to `1`) since they're unable to read the `config.gradle` file. 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
