### PR TITLE
Added 2D mode hint for particle emitters in visual shaders

### DIFF
--- a/doc/classes/VisualShaderNodeParticleEmitter.xml
+++ b/doc/classes/VisualShaderNodeParticleEmitter.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleEmitter" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		A base class for particle emitters.
 	</brief_description>
 	<description>
 	</description>
 	<tutorials>
 	</tutorials>
+	<members>
+		<member name="mode_2d" type="bool" setter="set_mode_2d" getter="is_mode_2d" default="false">
+			If [code]true[/code], the result of this emitter is projected to 2D space. By default it is [code]false[/code] and meant for use in 3D space.
+		</member>
+	</members>
 </class>

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4977,7 +4977,7 @@ public:
 		}
 	}
 
-	void setup(Ref<Resource> p_parent_resource, Vector<EditorProperty *> p_properties, const Vector<StringName> &p_names, Ref<VisualShaderNode> p_node) {
+	void setup(Ref<Resource> p_parent_resource, Vector<EditorProperty *> p_properties, const Vector<StringName> &p_names, const Map<StringName, String> &p_overrided_names, Ref<VisualShaderNode> p_node) {
 		parent_resource = p_parent_resource;
 		updating = false;
 		node = p_node;
@@ -4993,7 +4993,11 @@ public:
 
 			Label *prop_name = memnew(Label);
 			String prop_name_str = p_names[i];
-			prop_name_str = prop_name_str.capitalize() + ":";
+			if (p_overrided_names.has(p_names[i])) {
+				prop_name_str = p_overrided_names[p_names[i]] + ":";
+			} else {
+				prop_name_str = prop_name_str.capitalize() + ":";
+			}
 			prop_name->set_text(prop_name_str);
 			prop_name->set_visible(false);
 			hbox->add_child(prop_name);
@@ -5085,7 +5089,7 @@ Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_par
 		properties.push_back(pinfo[i].name);
 	}
 	VisualShaderNodePluginDefaultEditor *editor = memnew(VisualShaderNodePluginDefaultEditor);
-	editor->setup(p_parent_resource, editors, properties, p_node);
+	editor->setup(p_parent_resource, editors, properties, p_node->get_editable_properties_names(), p_node);
 	return editor;
 }
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -199,6 +199,10 @@ Vector<StringName> VisualShaderNode::get_editable_properties() const {
 	return Vector<StringName>();
 }
 
+Map<StringName, String> VisualShaderNode::get_editable_properties_names() const {
+	return Map<StringName, String>();
+}
+
 Array VisualShaderNode::get_default_input_values() const {
 	Array ret;
 	for (const KeyValue<int, Variant> &E : default_input_values) {
@@ -1920,6 +1924,10 @@ void VisualShader::_update_shader() const {
 		global_compute_code += "	float c = cos(angle);\n";
 		global_compute_code += "	float oc = 1.0 - c;\n";
 		global_compute_code += "	return mat4(vec4(oc * axis.x * axis.x + c, oc * axis.x * axis.y - axis.z * s, oc * axis.z * axis.x + axis.y * s, 0), vec4(oc * axis.x * axis.y + axis.z * s, oc * axis.y * axis.y + c, oc * axis.y * axis.z - axis.x * s, 0), vec4(oc * axis.z * axis.x - axis.y * s, oc * axis.y * axis.z + axis.x * s, oc * axis.z * axis.z + c, 0), vec4(0, 0, 0, 1));\n";
+		global_compute_code += "}\n\n";
+
+		global_compute_code += "vec2 __get_random_unit_vec2(inout uint seed) {\n";
+		global_compute_code += "	return normalize(vec2(__rand_from_seed_m1_p1(seed), __rand_from_seed_m1_p1(seed)));\n";
 		global_compute_code += "}\n\n";
 
 		global_compute_code += "vec3 __get_random_unit_vec3(inout uint seed) {\n";

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -272,6 +272,7 @@ public:
 	void set_disabled(bool p_disabled = true);
 
 	virtual Vector<StringName> get_editable_properties() const;
+	virtual Map<StringName, String> get_editable_properties_names() const;
 
 	virtual Vector<VisualShader::DefaultTextureParam> get_default_texture_parameters(VisualShader::Type p_type, int p_id) const;
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;

--- a/scene/resources/visual_shader_particle_nodes.h
+++ b/scene/resources/visual_shader_particle_nodes.h
@@ -38,11 +38,22 @@
 class VisualShaderNodeParticleEmitter : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeParticleEmitter, VisualShaderNode);
 
+protected:
+	bool mode_2d = false;
+	static void _bind_methods();
+
 public:
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 	virtual bool has_output_port_preview(int p_port) const override;
+
+	void set_mode_2d(bool p_enabled);
+	bool is_mode_2d() const;
+
+	Vector<StringName> get_editable_properties() const override;
+	Map<StringName, String> get_editable_properties_names() const override;
+	bool is_show_prop_names() const override;
 
 	VisualShaderNodeParticleEmitter();
 };


### PR DESCRIPTION
Currently, provided emitters are intended to use for 3D, this PR adds a property hint to enable to use of them on a 2D axis making it useful for 2D particle shaders:

![vs_2d_emitters](https://user-images.githubusercontent.com/3036176/140367282-8f63fa7d-9d74-4f05-bbdc-ae8b582ef3de.gif)


