### PR TITLE
Correct Viewport get_mouse_position() inside ViewportContainer

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1448,7 +1448,7 @@ void Viewport::_vp_unhandled_input(const Ref<InputEvent> &p_ev) {
 }
 
 Vector2 Viewport::get_mouse_position() const {
-	return (get_final_transform().affine_inverse() * _get_input_pre_xform()).xform(Input::get_singleton()->get_mouse_position() - _get_window_offset());
+	return last_mousepos;
 }
 
 void Viewport::warp_mouse(const Vector2 &p_pos) {
@@ -2793,6 +2793,11 @@ void Viewport::_post_gui_grab_click_focus() {
 void Viewport::input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(!is_inside_tree());
 
+	Ref<InputEventMouse> ev_mm = p_event;
+	if (ev_mm.is_valid()) {
+		last_mousepos = ev_mm->get_position();
+	}
+
 	local_input_handled = false;
 
 	if (!is_input_handled()) {
@@ -3423,6 +3428,8 @@ Viewport::Viewport() {
 	local_input_handled = false;
 	handle_input_locally = true;
 	physics_last_id = 0; //ensures first time there will be a check
+
+	last_mousepos = Vector2(Math_INF, Math_INF);
 }
 
 Viewport::~Viewport() {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -214,6 +214,7 @@ private:
 	Size2 size_override_margin;
 
 	Rect2 last_vp_rect;
+	Vector2 last_mousepos;
 
 	bool transparent_bg;
 	bool vflip;


### PR DESCRIPTION
Correct Viewport get_mouse_position() inside ViewportContainer

The mouse input was always transformed from the root viewport instead of the parent.
Both get_local_mouse_position() and get_global_mouse_position() give incorrect
results in a ViewportContainer with rotations, scalations, translations...

Now it uses the computed mouse position in _input(), which always was correct.

Fixes #19685.