### PR TITLE
Use 4× MSAA for the Advanced Import Options 3D preview

### DIFF
--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -110,7 +110,7 @@ MeshEditor::MeshEditor() {
 	viewport->set_world_3d(world_3d); //use own world
 	add_child(viewport);
 	viewport->set_disable_input(true);
-	viewport->set_msaa(Viewport::MSAA_2X);
+	viewport->set_msaa(Viewport::MSAA_4X);
 	set_stretch(true);
 	camera = memnew(Camera3D);
 	camera->set_transform(Transform3D(Basis(), Vector3(0, 0, 1.1)));


### PR DESCRIPTION
This results in better preview quality and is more consistent with the material preview in the inspector.

@follower Can you test this PR to confirm it resolves <https://github.com/godotengine/godot/issues/53940>?