### PR TITLE
[3.x] Backport some APIs in math structs

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -46,6 +46,8 @@ struct Rect2 {
 
 	real_t get_area() const { return size.width * size.height; }
 
+	_FORCE_INLINE_ Vector2 get_center() const { return position + (size * 0.5); }
+
 	inline bool intersects(const Rect2 &p_rect, const bool p_include_borders = false) const {
 		if (p_include_borders) {
 			if (position.x > (p_rect.position.x + p_rect.size.width)) {
@@ -267,6 +269,8 @@ struct Rect2i {
 	void set_size(const Size2i &p_size) { size = p_size; }
 
 	int get_area() const { return size.width * size.height; }
+
+	_FORCE_INLINE_ Vector2i get_center() const { return position + (size / 2); }
 
 	inline bool intersects(const Rect2i &p_rect) const {
 		if (position.x > (p_rect.position.x + p_rect.size.width)) {

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -128,7 +128,19 @@ Vector2 Vector2::snapped(const Vector2 &p_by) const {
 }
 
 Vector2 Vector2::clamped(real_t p_len) const {
+	WARN_DEPRECATED_MSG("'Vector2.clamped()' is deprecated because it has been renamed to 'limit_length'.");
 	real_t l = length();
+	Vector2 v = *this;
+	if (l > 0 && p_len < l) {
+		v /= l;
+		v *= p_len;
+	}
+
+	return v;
+}
+
+Vector2 Vector2::limit_length(const real_t p_len) const {
+	const real_t l = length();
 	Vector2 v = *this;
 	if (l > 0 && p_len < l) {
 		v /= l;

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -100,6 +100,7 @@ struct Vector2 {
 	Vector2 plane_project(real_t p_d, const Vector2 &p_vec) const;
 
 	Vector2 clamped(real_t p_len) const;
+	Vector2 limit_length(const real_t p_len = 1.0) const;
 
 	_FORCE_INLINE_ static Vector2 linear_interpolate(const Vector2 &p_a, const Vector2 &p_b, real_t p_weight);
 	_FORCE_INLINE_ Vector2 linear_interpolate(const Vector2 &p_to, real_t p_weight) const;

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -62,6 +62,17 @@ Vector3 Vector3::snapped(Vector3 p_val) const {
 	return v;
 }
 
+Vector3 Vector3::limit_length(const real_t p_len) const {
+	const real_t l = length();
+	Vector3 v = *this;
+	if (l > 0 && p_len < l) {
+		v /= l;
+		v *= p_len;
+	}
+
+	return v;
+}
+
 Vector3 Vector3::cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const {
 	Vector3 p0 = p_pre_a;
 	Vector3 p1 = *this;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -85,6 +85,7 @@ struct Vector3 {
 	_FORCE_INLINE_ Vector3 normalized() const;
 	_FORCE_INLINE_ bool is_normalized() const;
 	_FORCE_INLINE_ Vector3 inverse() const;
+	Vector3 limit_length(const real_t p_len = 1.0) const;
 
 	_FORCE_INLINE_ void zero();
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -406,9 +406,11 @@ struct _VariantCall {
 	VCALL_LOCALMEM1R(Vector2, cross);
 	VCALL_LOCALMEM0R(Vector2, abs);
 	VCALL_LOCALMEM1R(Vector2, clamped);
+	VCALL_LOCALMEM1R(Vector2, limit_length);
 	VCALL_LOCALMEM0R(Vector2, sign);
 
 	VCALL_LOCALMEM0R(Rect2, get_area);
+	VCALL_LOCALMEM0R(Rect2, get_center);
 	VCALL_LOCALMEM0R(Rect2, has_no_area);
 	VCALL_LOCALMEM1R(Rect2, has_point);
 	VCALL_LOCALMEM1R(Rect2, is_equal_approx);
@@ -455,6 +457,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1R(Vector3, slide);
 	VCALL_LOCALMEM1R(Vector3, bounce);
 	VCALL_LOCALMEM1R(Vector3, reflect);
+	VCALL_LOCALMEM1R(Vector3, limit_length);
 	VCALL_LOCALMEM0R(Vector3, sign);
 
 	VCALL_LOCALMEM0R(Plane, normalized);
@@ -792,6 +795,7 @@ struct _VariantCall {
 
 	VCALL_PTR0R(AABB, abs);
 	VCALL_PTR0R(AABB, get_area);
+	VCALL_PTR0R(AABB, get_center);
 	VCALL_PTR0R(AABB, has_no_area);
 	VCALL_PTR0R(AABB, has_no_surface);
 	VCALL_PTR1R(AABB, has_point);
@@ -1754,9 +1758,11 @@ void register_variant_methods() {
 	ADDFUNC1R(VECTOR2, REAL, Vector2, cross, VECTOR2, "with", varray());
 	ADDFUNC0R(VECTOR2, VECTOR2, Vector2, abs, varray());
 	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, clamped, REAL, "length", varray());
+	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, limit_length, REAL, "length", varray(1.0));
 	ADDFUNC0R(VECTOR2, VECTOR2, Vector2, sign, varray());
 
 	ADDFUNC0R(RECT2, REAL, Rect2, get_area, varray());
+	ADDFUNC0R(RECT2, VECTOR2, Rect2, get_center, varray());
 	ADDFUNC0R(RECT2, BOOL, Rect2, has_no_area, varray());
 	ADDFUNC1R(RECT2, BOOL, Rect2, has_point, VECTOR2, "point", varray());
 	ADDFUNC1R(RECT2, BOOL, Rect2, is_equal_approx, RECT2, "rect", varray());
@@ -1803,6 +1809,7 @@ void register_variant_methods() {
 	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, slide, VECTOR3, "n", varray());
 	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, bounce, VECTOR3, "n", varray());
 	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, reflect, VECTOR3, "n", varray());
+	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, limit_length, REAL, "length", varray(1.0));
 	ADDFUNC0R(VECTOR3, VECTOR3, Vector3, sign, varray());
 
 	ADDFUNC0R(PLANE, PLANE, Plane, normalized, varray());
@@ -1996,6 +2003,7 @@ void register_variant_methods() {
 
 	ADDFUNC0R(AABB, AABB, AABB, abs, varray());
 	ADDFUNC0R(AABB, REAL, AABB, get_area, varray());
+	ADDFUNC0R(AABB, VECTOR3, AABB, get_center, varray());
 	ADDFUNC0R(AABB, BOOL, AABB, has_no_area, varray());
 	ADDFUNC0R(AABB, BOOL, AABB, has_no_surface, varray());
 	ADDFUNC1R(AABB, BOOL, AABB, has_point, VECTOR3, "point", varray());

--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -55,6 +55,12 @@
 				Returns the volume of the [AABB].
 			</description>
 		</method>
+		<method name="get_center">
+			<return type="Vector3" />
+			<description>
+				Returns the center of the [AABB], which is equal to [member position] + ([member size] / 2).
+			</description>
+		</method>
 		<method name="get_endpoint">
 			<return type="Vector3" />
 			<argument index="0" name="idx" type="int" />

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -72,6 +72,12 @@
 				Returns the area of the [Rect2].
 			</description>
 		</method>
+		<method name="get_center">
+			<return type="Vector2" />
+			<description>
+				Returns the center of the [Rect2], which is equal to [member position] + ([member size] / 2).
+			</description>
+		</method>
 		<method name="grow">
 			<return type="Rect2" />
 			<argument index="0" name="by" type="float" />

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -78,6 +78,7 @@
 			<return type="Vector2" />
 			<argument index="0" name="length" type="float" />
 			<description>
+				Deprecated, please use [method limit_length] instead.
 				Returns the vector with a maximum length by limiting its length to [code]length[/code].
 			</description>
 		</method>
@@ -160,6 +161,13 @@
 			<description>
 				Returns the squared length (squared magnitude) of this vector.
 				This method runs faster than [method length], so prefer it if you need to compare vectors or need the squared distance for some formula.
+			</description>
+		</method>
+		<method name="limit_length">
+			<return type="Vector2" />
+			<argument index="0" name="length" type="float" default="1.0" />
+			<description>
+				Returns the vector with a maximum length by limiting its length to [code]length[/code].
 			</description>
 		</method>
 		<method name="linear_interpolate">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -138,6 +138,13 @@
 				This method runs faster than [method length], so prefer it if you need to compare vectors or need the squared distance for some formula.
 			</description>
 		</method>
+		<method name="limit_length">
+			<return type="Vector3" />
+			<argument index="0" name="length" type="float" default="1.0" />
+			<description>
+				Returns the vector with a maximum length by limiting its length to [code]length[/code].
+			</description>
+		</method>
 		<method name="linear_interpolate">
 			<return type="Vector3" />
 			<argument index="0" name="to" type="Vector3" />

--- a/modules/gdnative/gdnative/vector2.cpp
+++ b/modules/gdnative/gdnative/vector2.cpp
@@ -212,7 +212,7 @@ godot_vector2 GDAPI godot_vector2_clamped(const godot_vector2 *p_self, const god
 	godot_vector2 dest;
 	const Vector2 *self = (const Vector2 *)p_self;
 
-	*((Vector2 *)&dest) = self->clamped(p_length);
+	*((Vector2 *)&dest) = self->limit_length(p_length);
 	return dest;
 }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -67,6 +67,16 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the center of the <see cref="AABB"/>, which is equal
+        /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
+        /// </summary>
+        /// <returns>The center.</returns>
+        public Vector3 GetCenter()
+        {
+            return _position + (_size * 0.5f);
+        }
+
+        /// <summary>
         /// Returns <see langword="true"/> if this <see cref="AABB"/> completely encloses another one.
         /// </summary>
         /// <param name="with">The other <see cref="AABB"/> that may be enclosed.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -947,6 +947,64 @@ namespace Godot
         }
 
         /// <summary>
+        /// Compares two <see cref="Color"/>s by first checking if
+        /// the red value of the <paramref name="left"/> color is less than
+        /// or equal to the red value of the <paramref name="right"/> color.
+        /// If the red values are exactly equal, then it repeats this check
+        /// with the green values of the two colors, then with the blue values,
+        /// and then with the alpha value.
+        /// This operator is useful for sorting colors.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the left is less than or equal to the right.</returns>
+        public static bool operator <=(Color left, Color right)
+        {
+            if (left.r == right.r)
+            {
+                if (left.g == right.g)
+                {
+                    if (left.b == right.b)
+                    {
+                        return left.a <= right.a;
+                    }
+                    return left.b < right.b;
+                }
+                return left.g < right.g;
+            }
+            return left.r < right.r;
+        }
+
+        /// <summary>
+        /// Compares two <see cref="Color"/>s by first checking if
+        /// the red value of the <paramref name="left"/> color is greater than
+        /// or equal to the red value of the <paramref name="right"/> color.
+        /// If the red values are exactly equal, then it repeats this check
+        /// with the green values of the two colors, then with the blue values,
+        /// and then with the alpha value.
+        /// This operator is useful for sorting colors.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
+        public static bool operator >=(Color left, Color right)
+        {
+            if (left.r == right.r)
+            {
+                if (left.g == right.g)
+                {
+                    if (left.b == right.b)
+                    {
+                        return left.a >= right.a;
+                    }
+                    return left.b > right.b;
+                }
+                return left.g > right.g;
+            }
+            return left.r > right.r;
+        }
+
+        /// <summary>
         /// Returns <see langword="true"/> if this color and <paramref name="obj"/> are equal.
         /// </summary>
         /// <param name="obj">The other object to compare.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -162,6 +162,16 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the center of the <see cref="Rect2"/>, which is equal
+        /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
+        /// </summary>
+        /// <returns>The center.</returns>
+        public Vector2 GetCenter()
+        {
+            return _position + (_size * 0.5f);
+        }
+
+        /// <summary>
         /// Returns a copy of the <see cref="Rect2"/> grown a given amount of units towards
         /// all the sides.
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -171,6 +171,7 @@ namespace Godot
         /// </summary>
         /// <param name="length">The length to limit to.</param>
         /// <returns>The vector with its length limited.</returns>
+        [Obsolete("Clamped is deprecated because it has been renamed to LimitLength.")]
         public Vector2 Clamped(real_t length)
         {
             var v = this;
@@ -345,6 +346,25 @@ namespace Godot
                 Mathf.Lerp(x, to.x, weight.x),
                 Mathf.Lerp(y, to.y, weight.y)
             );
+        }
+
+        /// <summary>
+        /// Returns the vector with a maximum length by limiting its length to <paramref name="length"/>.
+        /// </summary>
+        /// <param name="length">The length to limit to.</param>
+        /// <returns>The vector with its length limited.</returns>
+        public Vector2 LimitLength(real_t length = 1.0f)
+        {
+            Vector2 v = this;
+            real_t l = Length();
+
+            if (l > 0 && length < l)
+            {
+                v /= l;
+                v *= length;
+            }
+
+            return v;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -327,6 +327,25 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the vector with a maximum length by limiting its length to <paramref name="length"/>.
+        /// </summary>
+        /// <param name="length">The length to limit to.</param>
+        /// <returns>The vector with its length limited.</returns>
+        public Vector3 LimitLength(real_t length = 1.0f)
+        {
+            Vector3 v = this;
+            real_t l = Length();
+
+            if (l > 0 && length < l)
+            {
+                v /= l;
+                v *= length;
+            }
+
+            return v;
+        }
+
+        /// <summary>
         /// Returns the axis of the vector's largest value. See <see cref="Axis"/>.
         /// If all components are equal, this method returns <see cref="Axis.X"/>.
         /// </summary>

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -307,7 +307,7 @@ bool GrooveJoint2DSW::setup(real_t p_step) {
 	Vector2 delta = (B->get_transform().get_origin() + rB) - (A->get_transform().get_origin() + rA);
 
 	real_t _b = get_bias();
-	gbias = (delta * -(_b == 0 ? space->get_constraint_bias() : _b) * (1.0 / p_step)).clamped(get_max_bias());
+	gbias = (delta * -(_b == 0 ? space->get_constraint_bias() : _b) * (1.0 / p_step)).limit_length(get_max_bias());
 
 	// apply accumulated impulse
 	A->apply_impulse(rA, -jn_acc);
@@ -325,7 +325,7 @@ void GrooveJoint2DSW::solve(real_t p_step) {
 	Vector2 jOld = jn_acc;
 	j += jOld;
 
-	jn_acc = (((clamp * j.cross(xf_normal)) > 0) ? j : j.project(xf_normal)).clamped(jn_max);
+	jn_acc = (((clamp * j.cross(xf_normal)) > 0) ? j : j.project(xf_normal)).limit_length(jn_max);
 
 	j = jn_acc - jOld;
 


### PR DESCRIPTION
* Backport `get_center` to AABB and Rect2 in core and C# (originally added in #52878).
* Backport `limit_length` to Vector2 and Vector3 in core and C# (originally added in #45624).
  * Document and warn about Vector2's `clamped` being deprecated since `limit_length` is a rename of it.
* Backport Color `>=` and `<=` operators in C# only (`>` and `<` are implemented for C# in 3.x but not in core).