### PR TITLE
[3.x] Add documentation to operators for math types

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -654,21 +654,40 @@ namespace Godot
             _size = new Vector3(width, height, depth);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the AABBs are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left AABB.</param>
+        /// <param name="right">The right AABB.</param>
+        /// <returns>Whether or not the AABBs are exactly equal.</returns>
         public static bool operator ==(AABB left, AABB right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the AABBs are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left AABB.</param>
+        /// <param name="right">The right AABB.</param>
+        /// <returns>Whether or not the AABBs are not equal.</returns>
         public static bool operator !=(AABB left, AABB right)
         {
             return !left.Equals(right);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this AABB and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the AABB is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the AABB structure and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the AABB and the object are equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is AABB)
@@ -680,10 +699,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this AABB and <paramref name="other"/> are equal
+        /// Returns <see langword="true"/> if the AABBs are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other AABB to compare.</param>
-        /// <returns>Whether or not the AABBs are equal.</returns>
+        /// <param name="other">The other AABB.</param>
+        /// <returns>Whether or not the AABBs are exactly equal.</returns>
         public bool Equals(AABB other)
         {
             return _position == other._position && _size == other._size;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -860,6 +860,14 @@ namespace Godot
             Row2 = new Vector3(xz, yz, zz);
         }
 
+        /// <summary>
+        /// Composes these two basis matrices by multiplying them
+        /// together. This has the effect of transforming the second basis
+        /// (the child) by the first basis (the parent).
+        /// </summary>
+        /// <param name="left">The parent basis.</param>
+        /// <param name="right">The child basis.</param>
+        /// <returns>The composed basis.</returns>
         public static Basis operator *(Basis left, Basis right)
         {
             return new Basis
@@ -870,21 +878,40 @@ namespace Godot
             );
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the basis matrices are exactly
+        /// equal. Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left basis.</param>
+        /// <param name="right">The right basis.</param>
+        /// <returns>Whether or not the basis matrices are exactly equal.</returns>
         public static bool operator ==(Basis left, Basis right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the basis matrices are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left basis.</param>
+        /// <param name="right">The right basis.</param>
+        /// <returns>Whether or not the basis matrices are not equal.</returns>
         public static bool operator !=(Basis left, Basis right)
         {
             return !left.Equals(right);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this basis and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the <see cref="Basis"/> is
+        /// exactly equal to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the basis and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the basis matrix and the object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Basis)
@@ -896,10 +923,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this basis and <paramref name="other"/> are equal
+        /// Returns <see langword="true"/> if the basis matrices are exactly
+        /// equal. Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other basis to compare.</param>
-        /// <returns>Whether or not the bases are equal.</returns>
+        /// <param name="other">The other basis.</param>
+        /// <returns>Whether or not the basis matrices are exactly equal.</returns>
         public bool Equals(Basis other)
         {
             return Row0.Equals(other.Row0) && Row1.Equals(other.Row1) && Row2.Equals(other.Row2);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -834,6 +834,13 @@ namespace Godot
                 throw new ArgumentOutOfRangeException("Invalid color code. Blue part is not valid hexadecimal: " + rgba);
         }
 
+        /// <summary>
+        /// Adds each component of the <see cref="Color"/>
+        /// with the components of the given <see cref="Color"/>.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>The added color.</returns>
         public static Color operator +(Color left, Color right)
         {
             left.r += right.r;
@@ -843,6 +850,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Subtracts each component of the <see cref="Color"/>
+        /// by the components of the given <see cref="Color"/>.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>The subtracted color.</returns>
         public static Color operator -(Color left, Color right)
         {
             left.r -= right.r;
@@ -852,11 +866,25 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Inverts the given color. This is equivalent to
+        /// <c>Colors.White - c</c> or
+        /// <c>new Color(1 - c.r, 1 - c.g, 1 - c.b, 1 - c.a)</c>.
+        /// </summary>
+        /// <param name="color">The color to invert.</param>
+        /// <returns>The inverted color</returns>
         public static Color operator -(Color color)
         {
             return Colors.White - color;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Color"/>
+        /// by the given <see langword="float"/>.
+        /// </summary>
+        /// <param name="color">The color to multiply.</param>
+        /// <param name="scale">The value to multiply by.</param>
+        /// <returns>The multiplied color.</returns>
         public static Color operator *(Color color, float scale)
         {
             color.r *= scale;
@@ -866,6 +894,13 @@ namespace Godot
             return color;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Color"/>
+        /// by the given <see langword="float"/>.
+        /// </summary>
+        /// <param name="scale">The value to multiply by.</param>
+        /// <param name="color">The color to multiply.</param>
+        /// <returns>The multiplied color.</returns>
         public static Color operator *(float scale, Color color)
         {
             color.r *= scale;
@@ -875,6 +910,13 @@ namespace Godot
             return color;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Color"/>
+        /// by the components of the given <see cref="Color"/>.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>The multiplied color.</returns>
         public static Color operator *(Color left, Color right)
         {
             left.r *= right.r;
@@ -884,6 +926,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Color"/>
+        /// by the given <see langword="float"/>.
+        /// </summary>
+        /// <param name="color">The dividend vector.</param>
+        /// <param name="scale">The divisor value.</param>
+        /// <returns>The divided color.</returns>
         public static Color operator /(Color color, float scale)
         {
             color.r /= scale;
@@ -893,6 +942,13 @@ namespace Godot
             return color;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Color"/>
+        /// by the components of the given <see cref="Color"/>.
+        /// </summary>
+        /// <param name="left">The dividend color.</param>
+        /// <param name="right">The divisor color.</param>
+        /// <returns>The divided color.</returns>
         public static Color operator /(Color left, Color right)
         {
             left.r /= right.r;
@@ -902,16 +958,44 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the colors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the colors are equal.</returns>
         public static bool operator ==(Color left, Color right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the colors are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the colors are equal.</returns>
         public static bool operator !=(Color left, Color right)
         {
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two <see cref="Color"/>s by first checking if
+        /// the red value of the <paramref name="left"/> color is less than
+        /// the red value of the <paramref name="right"/> color.
+        /// If the red values are exactly equal, then it repeats this check
+        /// with the green values of the two colors, then with the blue values,
+        /// and then with the alpha value.
+        /// This operator is useful for sorting colors.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the left is less than the right.</returns>
         public static bool operator <(Color left, Color right)
         {
             if (Mathf.IsEqualApprox(left.r, right.r))
@@ -929,6 +1013,18 @@ namespace Godot
             return left.r < right.r;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Color"/>s by first checking if
+        /// the red value of the <paramref name="left"/> color is greater than
+        /// the red value of the <paramref name="right"/> color.
+        /// If the red values are exactly equal, then it repeats this check
+        /// with the green values of the two colors, then with the blue values,
+        /// and then with the alpha value.
+        /// This operator is useful for sorting colors.
+        /// </summary>
+        /// <param name="left">The left color.</param>
+        /// <param name="right">The right color.</param>
+        /// <returns>Whether or not the left is greater than the right.</returns>
         public static bool operator >(Color left, Color right)
         {
             if (Mathf.IsEqualApprox(left.r, right.r))
@@ -962,9 +1058,11 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this color and <paramref name="other"/> are equal
+        /// Returns <see langword="true"/> if the colors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other color to compare.</param>
+        /// <param name="other">The other color.</param>
         /// <returns>Whether or not the colors are equal.</returns>
         public bool Equals(Color other)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
@@ -158,6 +158,7 @@ namespace Godot
             {"yellowgreen", new Color(0.60f, 0.80f, 0.20f)},
         };
 
+#pragma warning disable CS1591 // Disable warning: "Missing XML comment for publicly visible type or member"
         public static Color AliceBlue { get { return namedColors["aliceblue"]; } }
         public static Color AntiqueWhite { get { return namedColors["antiquewhite"]; } }
         public static Color Aqua { get { return namedColors["aqua"]; } }
@@ -304,5 +305,6 @@ namespace Godot
         public static Color WhiteSmoke { get { return namedColors["whitesmoke"]; } }
         public static Color Yellow { get { return namedColors["yellow"]; } }
         public static Color YellowGreen { get { return namedColors["yellowgreen"]; } }
+#pragma warning restore CS1591
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -320,16 +320,43 @@ namespace Godot
             D = _normal.Dot(v1);
         }
 
+        /// <summary>
+        /// Returns the negative value of the <see cref="Plane"/>.
+        /// This is the same as writing <c>new Plane(-p.Normal, -p.D)</c>.
+        /// This operation flips the direction of the normal vector and
+        /// also flips the distance value, resulting in a Plane that is
+        /// in the same place, but facing the opposite direction.
+        /// </summary>
+        /// <param name="plane">The plane to negate/flip.</param>
+        /// <returns>The negated/flipped plane.</returns>
         public static Plane operator -(Plane plane)
         {
             return new Plane(-plane._normal, -plane.D);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Plane"/>s are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the planes are exactly equal.</returns>
         public static bool operator ==(Plane left, Plane right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Plane"/>s are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the planes are not equal.</returns>
         public static bool operator !=(Plane left, Plane right)
         {
             return !left.Equals(right);
@@ -339,7 +366,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this plane and <paramref name="obj"/> are equal.
         /// </summary>
         /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the plane and the other object are equal.</returns>
+        /// <returns>Whether or not the plane and the other object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Plane)
@@ -354,7 +381,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this plane and <paramref name="other"/> are equal.
         /// </summary>
         /// <param name="other">The other plane to compare.</param>
-        /// <returns>Whether or not the planes are equal.</returns>
+        /// <returns>Whether or not the planes are exactly equal.</returns>
         public bool Equals(Plane other)
         {
             return _normal == other._normal && D == other.D;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quat.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quat.cs
@@ -473,6 +473,14 @@ namespace Godot
             }
         }
 
+        /// <summary>
+        /// Composes these two quaternions by multiplying them together.
+        /// This has the effect of rotating the second quaternion
+        /// (the child) by the first quaternion (the parent).
+        /// </summary>
+        /// <param name="left">The parent quaternion.</param>
+        /// <param name="right">The child quaternion.</param>
+        /// <returns>The composed quaternion.</returns>
         public static Quat operator *(Quat left, Quat right)
         {
             return new Quat
@@ -484,21 +492,49 @@ namespace Godot
             );
         }
 
+        /// <summary>
+        /// Adds each component of the left <see cref="Quat"/>
+        /// to the right <see cref="Quat"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression, such as approximating an intermediate
+        /// rotation between two nearby rotations.
+        /// </summary>
+        /// <param name="left">The left quaternion to add.</param>
+        /// <param name="right">The right quaternion to add.</param>
+        /// <returns>The added quaternion.</returns>
         public static Quat operator +(Quat left, Quat right)
         {
             return new Quat(left.x + right.x, left.y + right.y, left.z + right.z, left.w + right.w);
         }
 
+        /// <summary>
+        /// Subtracts each component of the left <see cref="Quat"/>
+        /// by the right <see cref="Quat"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression.
+        /// </summary>
+        /// <param name="left">The left quaternion to subtract.</param>
+        /// <param name="right">The right quaternion to subtract.</param>
+        /// <returns>The subtracted quaternion.</returns>
         public static Quat operator -(Quat left, Quat right)
         {
             return new Quat(left.x - right.x, left.y - right.y, left.z - right.z, left.w - right.w);
         }
 
-        public static Quat operator -(Quat left)
+        /// <summary>
+        /// Returns the negative value of the <see cref="Quat"/>.
+        /// This is the same as writing
+        /// <c>new Quat(-q.x, -q.y, -q.z, -q.w)</c>. This operation
+        /// results in a quaternion that represents the same rotation.
+        /// </summary>
+        /// <param name="quat">The quaternion to negate.</param>
+        /// <returns>The negated quaternion.</returns>
+        public static Quat operator -(Quat quat)
         {
-            return new Quat(-left.x, -left.y, -left.z, -left.w);
+            return new Quat(-quat.x, -quat.y, -quat.z, -quat.w);
         }
 
+        [Obsolete("This operator does not have the correct behavior and will be replaced in the future. Do not use this.")]
         public static Quat operator *(Quat left, Vector3 right)
         {
             return new Quat
@@ -510,6 +546,7 @@ namespace Godot
             );
         }
 
+        [Obsolete("This operator does not have the correct behavior and will be replaced in the future. Do not use this.")]
         public static Quat operator *(Vector3 left, Quat right)
         {
             return new Quat
@@ -521,26 +558,69 @@ namespace Godot
             );
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Quat"/>
+        /// by the given <see cref="real_t"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression.
+        /// </summary>
+        /// <param name="left">The quaternion to multiply.</param>
+        /// <param name="right">The value to multiply by.</param>
+        /// <returns>The multiplied quaternion.</returns>
         public static Quat operator *(Quat left, real_t right)
         {
             return new Quat(left.x * right, left.y * right, left.z * right, left.w * right);
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Quat"/>
+        /// by the given <see cref="real_t"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression.
+        /// </summary>
+        /// <param name="left">The value to multiply by.</param>
+        /// <param name="right">The quaternion to multiply.</param>
+        /// <returns>The multiplied quaternion.</returns>
         public static Quat operator *(real_t left, Quat right)
         {
             return new Quat(right.x * left, right.y * left, right.z * left, right.w * left);
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Quat"/>
+        /// by the given <see cref="real_t"/>. This operation is not
+        /// meaningful on its own, but it can be used as a part of a
+        /// larger expression.
+        /// </summary>
+        /// <param name="left">The quaternion to divide.</param>
+        /// <param name="right">The value to divide by.</param>
+        /// <returns>The divided quaternion.</returns>
         public static Quat operator /(Quat left, real_t right)
         {
             return left * (1.0f / right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the quaternions are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left quaternion.</param>
+        /// <param name="right">The right quaternion.</param>
+        /// <returns>Whether or not the quaternions are exactly equal.</returns>
         public static bool operator ==(Quat left, Quat right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the quaternions are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left quaternion.</param>
+        /// <param name="right">The right quaternion.</param>
+        /// <returns>Whether or not the quaternions are not equal.</returns>
         public static bool operator !=(Quat left, Quat right)
         {
             return !left.Equals(right);
@@ -550,7 +630,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this quaternion and <paramref name="obj"/> are equal.
         /// </summary>
         /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the quaternion and the other object are equal.</returns>
+        /// <returns>Whether or not the quaternion and the other object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Quat)
@@ -565,7 +645,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this quaternion and <paramref name="other"/> are equal.
         /// </summary>
         /// <param name="other">The other quaternion to compare.</param>
-        /// <returns>Whether or not the quaternions are equal.</returns>
+        /// <returns>Whether or not the quaternions are exactly equal.</returns>
         public bool Equals(Quat other)
         {
             return x == other.x && y == other.y && z == other.z && w == other.w;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -383,11 +383,29 @@ namespace Godot
             _size = new Vector2(width, height);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Rect2"/>s are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the rects are exactly equal.</returns>
         public static bool operator ==(Rect2 left, Rect2 right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the
+        /// <see cref="Rect2"/>s are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left rect.</param>
+        /// <param name="right">The right rect.</param>
+        /// <returns>Whether or not the rects are not equal.</returns>
         public static bool operator !=(Rect2 left, Rect2 right)
         {
             return !left.Equals(right);
@@ -397,7 +415,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this rect and <paramref name="obj"/> are equal.
         /// </summary>
         /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the rect and the other object are equal.</returns>
+        /// <returns>Whether or not the rect and the other object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Rect2)
@@ -412,7 +430,7 @@ namespace Godot
         /// Returns <see langword="true"/> if this rect and <paramref name="other"/> are equal.
         /// </summary>
         /// <param name="other">The other rect to compare.</param>
-        /// <returns>Whether or not the rects are equal.</returns>
+        /// <returns>Whether or not the rects are exactly equal.</returns>
         public bool Equals(Rect2 other)
         {
             return _position.Equals(other._position) && _size.Equals(other._size);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform.cs
@@ -350,6 +350,14 @@ namespace Godot
             this.origin = origin;
         }
 
+        /// <summary>
+        /// Composes these two transformation matrices by multiplying them
+        /// together. This has the effect of transforming the second transform
+        /// (the child) by the first transform (the parent).
+        /// </summary>
+        /// <param name="left">The parent transform.</param>
+        /// <param name="right">The child transform.</param>
+        /// <returns>The composed transform.</returns>
         public static Transform operator *(Transform left, Transform right)
         {
             left.origin = left.Xform(right.origin);
@@ -357,21 +365,40 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the transforms are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left transform.</param>
+        /// <param name="right">The right transform.</param>
+        /// <returns>Whether or not the transforms are exactly equal.</returns>
         public static bool operator ==(Transform left, Transform right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the transforms are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left transform.</param>
+        /// <param name="right">The right transform.</param>
+        /// <returns>Whether or not the transforms are not equal.</returns>
         public static bool operator !=(Transform left, Transform right)
         {
             return !left.Equals(right);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the transform is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the transform and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the transform and the object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Transform)
@@ -383,10 +410,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="other"/> are equal.
+        /// Returns <see langword="true"/> if the transforms are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
         /// <param name="other">The other transform to compare.</param>
-        /// <returns>Whether or not the matrices are equal.</returns>
+        /// <returns>Whether or not the matrices are exactly equal.</returns>
         public bool Equals(Transform other)
         {
             return basis.Equals(other.basis) && origin.Equals(other.origin);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -447,6 +447,14 @@ namespace Godot
             this.origin = origin;
         }
 
+        /// <summary>
+        /// Composes these two transformation matrices by multiplying them
+        /// together. This has the effect of transforming the second transform
+        /// (the child) by the first transform (the parent).
+        /// </summary>
+        /// <param name="left">The parent transform.</param>
+        /// <param name="right">The child transform.</param>
+        /// <returns>The composed transform.</returns>
         public static Transform2D operator *(Transform2D left, Transform2D right)
         {
             left.origin = left * right.origin;
@@ -554,31 +562,52 @@ namespace Godot
             return newArray;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the transforms are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left transform.</param>
+        /// <param name="right">The right transform.</param>
+        /// <returns>Whether or not the transforms are exactly equal.</returns>
         public static bool operator ==(Transform2D left, Transform2D right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the transforms are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left transform.</param>
+        /// <param name="right">The right transform.</param>
+        /// <returns>Whether or not the transforms are not equal.</returns>
         public static bool operator !=(Transform2D left, Transform2D right)
         {
             return !left.Equals(right);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the transform is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the transform and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the transform and the object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
             return obj is Transform2D transform2D && Equals(transform2D);
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="other"/> are equal.
+        /// Returns <see langword="true"/> if the transforms are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
         /// <param name="other">The other transform to compare.</param>
-        /// <returns>Whether or not the matrices are equal.</returns>
+        /// <returns>Whether or not the matrices are exactly equal.</returns>
         public bool Equals(Transform2D other)
         {
             return x.Equals(other.x) && y.Equals(other.y) && origin.Equals(other.origin);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -645,6 +645,13 @@ namespace Godot
             y = v.y;
         }
 
+        /// <summary>
+        /// Adds each component of the <see cref="Vector2"/>
+        /// with the components of the given <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The added vector.</returns>
         public static Vector2 operator +(Vector2 left, Vector2 right)
         {
             left.x += right.x;
@@ -652,6 +659,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Subtracts each component of the <see cref="Vector2"/>
+        /// by the components of the given <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The subtracted vector.</returns>
         public static Vector2 operator -(Vector2 left, Vector2 right)
         {
             left.x -= right.x;
@@ -659,6 +673,15 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns the negative value of the <see cref="Vector2"/>.
+        /// This is the same as writing <c>new Vector2(-v.x, -v.y)</c>.
+        /// This operation flips the direction of the vector while
+        /// keeping the same magnitude.
+        /// With floats, the number zero can be either positive or negative.
+        /// </summary>
+        /// <param name="vec">The vector to negate/flip.</param>
+        /// <returns>The negated/flipped vector.</returns>
         public static Vector2 operator -(Vector2 vec)
         {
             vec.x = -vec.x;
@@ -666,6 +689,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector2 operator *(Vector2 vec, real_t scale)
         {
             vec.x *= scale;
@@ -673,6 +703,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector2 operator *(real_t scale, Vector2 vec)
         {
             vec.x *= scale;
@@ -680,6 +717,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2"/>
+        /// by the components of the given <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector2 operator *(Vector2 left, Vector2 right)
         {
             left.x *= right.x;
@@ -687,6 +731,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector2"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector2 operator /(Vector2 vec, real_t divisor)
         {
             vec.x /= divisor;
@@ -694,6 +745,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Vector2"/>
+        /// by the components of the given <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector2 operator /(Vector2 vec, Vector2 divisorv)
         {
             vec.x /= divisorv.x;
@@ -701,6 +759,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector2"/>
+        /// with the components of the given <see cref="real_t"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(real_t)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector2(10, -20) % 7); // Prints "(3, -6)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector2 operator %(Vector2 vec, real_t divisor)
         {
             vec.x %= divisor;
@@ -708,6 +782,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector2"/>
+        /// with the components of the given <see cref="Vector2"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(Vector2)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector2(10, -20) % new Vector2(7, 8)); // Prints "(3, -4)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector2 operator %(Vector2 vec, Vector2 divisorv)
         {
             vec.x %= divisorv.x;
@@ -715,16 +805,43 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are exactly equal.</returns>
         public static bool operator ==(Vector2 left, Vector2 right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are not equal.</returns>
         public static bool operator !=(Vector2 left, Vector2 right)
         {
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than the right.</returns>
         public static bool operator <(Vector2 left, Vector2 right)
         {
             if (left.x == right.x)
@@ -734,6 +851,17 @@ namespace Godot
             return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than the right.</returns>
         public static bool operator >(Vector2 left, Vector2 right)
         {
             if (left.x == right.x)
@@ -743,29 +871,54 @@ namespace Godot
             return left.x > right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than or equal to the right.</returns>
         public static bool operator <=(Vector2 left, Vector2 right)
         {
             if (left.x == right.x)
             {
                 return left.y <= right.y;
             }
-            return left.x <= right.x;
+            return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector2"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
         public static bool operator >=(Vector2 left, Vector2 right)
         {
             if (left.x == right.x)
             {
                 return left.y >= right.y;
             }
-            return left.x >= right.x;
+            return left.x > right.x;
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the vector is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the vector and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Vector2)
@@ -776,10 +929,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are equal.
+        /// Returns <see langword="true"/> if the vectors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other vector to compare.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
+        /// <param name="other">The other vector.</param>
+        /// <returns>Whether or not the vectors are exactly equal.</returns>
         public bool Equals(Vector2 other)
         {
             return x == other.x && y == other.y;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -684,6 +684,13 @@ namespace Godot
             z = v.z;
         }
 
+        /// <summary>
+        /// Adds each component of the <see cref="Vector3"/>
+        /// with the components of the given <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The added vector.</returns>
         public static Vector3 operator +(Vector3 left, Vector3 right)
         {
             left.x += right.x;
@@ -692,6 +699,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Subtracts each component of the <see cref="Vector3"/>
+        /// by the components of the given <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The subtracted vector.</returns>
         public static Vector3 operator -(Vector3 left, Vector3 right)
         {
             left.x -= right.x;
@@ -700,6 +714,15 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Returns the negative value of the <see cref="Vector3"/>.
+        /// This is the same as writing <c>new Vector3(-v.x, -v.y, -v.z)</c>.
+        /// This operation flips the direction of the vector while
+        /// keeping the same magnitude.
+        /// With floats, the number zero can be either positive or negative.
+        /// </summary>
+        /// <param name="vec">The vector to negate/flip.</param>
+        /// <returns>The negated/flipped vector.</returns>
         public static Vector3 operator -(Vector3 vec)
         {
             vec.x = -vec.x;
@@ -708,6 +731,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector3 operator *(Vector3 vec, real_t scale)
         {
             vec.x *= scale;
@@ -716,6 +746,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="scale">The scale to multiply by.</param>
+        /// <param name="vec">The vector to multiply.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector3 operator *(real_t scale, Vector3 vec)
         {
             vec.x *= scale;
@@ -724,6 +761,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Multiplies each component of the <see cref="Vector3"/>
+        /// by the components of the given <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>The multiplied vector.</returns>
         public static Vector3 operator *(Vector3 left, Vector3 right)
         {
             left.x *= right.x;
@@ -732,6 +776,13 @@ namespace Godot
             return left;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Vector3"/>
+        /// by the given <see cref="real_t"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector3 operator /(Vector3 vec, real_t divisor)
         {
             vec.x /= divisor;
@@ -740,6 +791,13 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Divides each component of the <see cref="Vector3"/>
+        /// by the components of the given <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The divided vector.</returns>
         public static Vector3 operator /(Vector3 vec, Vector3 divisorv)
         {
             vec.x /= divisorv.x;
@@ -748,6 +806,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector3"/>
+        /// with the components of the given <see cref="real_t"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(real_t)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector3(10, -20, 30) % 7); // Prints "(3, -6, 2)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisor">The divisor value.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector3 operator %(Vector3 vec, real_t divisor)
         {
             vec.x %= divisor;
@@ -756,6 +830,22 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Gets the remainder of each component of the <see cref="Vector3"/>
+        /// with the components of the given <see cref="Vector3"/>.
+        /// This operation uses truncated division, which is often not desired
+        /// as it does not work well with negative numbers.
+        /// Consider using <see cref="PosMod(Vector3)"/> instead
+        /// if you want to handle negative numbers.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.Print(new Vector3(10, -20, 30) % new Vector3(7, 8, 9)); // Prints "(3, -4, 3)"
+        /// </code>
+        /// </example>
+        /// <param name="vec">The dividend vector.</param>
+        /// <param name="divisorv">The divisor vector.</param>
+        /// <returns>The remainder vector.</returns>
         public static Vector3 operator %(Vector3 vec, Vector3 divisorv)
         {
             vec.x %= divisorv.x;
@@ -764,16 +854,43 @@ namespace Godot
             return vec;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are exactly equal.</returns>
         public static bool operator ==(Vector3 left, Vector3 right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if the vectors are not equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the vectors are not equal.</returns>
         public static bool operator !=(Vector3 left, Vector3 right)
         {
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than the right.</returns>
         public static bool operator <(Vector3 left, Vector3 right)
         {
             if (left.x == right.x)
@@ -787,6 +904,17 @@ namespace Godot
             return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than the right.</returns>
         public static bool operator >(Vector3 left, Vector3 right)
         {
             if (left.x == right.x)
@@ -800,6 +928,17 @@ namespace Godot
             return left.x > right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is less than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is less than or equal to the right.</returns>
         public static bool operator <=(Vector3 left, Vector3 right)
         {
             if (left.x == right.x)
@@ -813,6 +952,17 @@ namespace Godot
             return left.x < right.x;
         }
 
+        /// <summary>
+        /// Compares two <see cref="Vector3"/> vectors by first checking if
+        /// the X value of the <paramref name="left"/> vector is greater than
+        /// or equal to the X value of the <paramref name="right"/> vector.
+        /// If the X values are exactly equal, then it repeats this check
+        /// with the Y values of the two vectors, and then with the Z values.
+        /// This operator is useful for sorting vectors.
+        /// </summary>
+        /// <param name="left">The left vector.</param>
+        /// <param name="right">The right vector.</param>
+        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
         public static bool operator >=(Vector3 left, Vector3 right)
         {
             if (left.x == right.x)
@@ -827,10 +977,13 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="obj"/> are equal.
+        /// Returns <see langword="true"/> if the vector is exactly equal
+        /// to the given object (<see paramref="obj"/>).
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the vector and the other object are equal.</returns>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is Vector3)
@@ -842,10 +995,12 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are equal
+        /// Returns <see langword="true"/> if the vectors are exactly equal.
+        /// Note: Due to floating-point precision errors, consider using
+        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
         /// </summary>
-        /// <param name="other">The other vector to compare.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
+        /// <param name="other">The other vector.</param>
+        /// <returns>Whether or not the vectors are exactly equal.</returns>
         public bool Equals(Vector3 other)
         {
             return x == other.x && y == other.y && z == other.z;


### PR DESCRIPTION
This PR backports the C# changes from #54581 to 3.x.