### PR TITLE
Use Callable in RenderingServer `request_frame_drawn_callback`

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2575,12 +2575,9 @@
 		</method>
 		<method name="request_frame_drawn_callback">
 			<return type="void" />
-			<argument index="0" name="where" type="Object" />
-			<argument index="1" name="method" type="StringName" />
-			<argument index="2" name="userdata" type="Variant" />
+			<argument index="0" name="callable" type="Callable" />
 			<description>
-				Schedules a callback to the corresponding named [code]method[/code] on [code]where[/code] after a frame has been drawn.
-				The callback method must use only 1 argument which will be called with [code]userdata[/code].
+				Schedules a callback to the given callable after a frame has been drawn.
 			</description>
 		</method>
 		<method name="scenario_create">

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -297,12 +297,8 @@ EditorPackedScenePreviewPlugin::EditorPackedScenePreviewPlugin() {
 
 //////////////////////////////////////////////////////////////////
 
-void EditorMaterialPreviewPlugin::_preview_done(const Variant &p_udata) {
+void EditorMaterialPreviewPlugin::_preview_done() {
 	preview_done.set();
-}
-
-void EditorMaterialPreviewPlugin::_bind_methods() {
-	ClassDB::bind_method("_preview_done", &EditorMaterialPreviewPlugin::_preview_done);
 }
 
 bool EditorMaterialPreviewPlugin::handles(const String &p_type) const {
@@ -323,7 +319,7 @@ Ref<Texture2D> EditorMaterialPreviewPlugin::generate(const RES &p_from, const Si
 		RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_ONCE); //once used for capture
 
 		preview_done.clear();
-		RS::get_singleton()->request_frame_drawn_callback(const_cast<EditorMaterialPreviewPlugin *>(this), "_preview_done", Variant());
+		RS::get_singleton()->request_frame_drawn_callback(callable_mp(const_cast<EditorMaterialPreviewPlugin *>(this), &EditorMaterialPreviewPlugin::_preview_done));
 
 		while (!preview_done.is_set()) {
 			OS::get_singleton()->delay_usec(10);
@@ -699,12 +695,8 @@ EditorAudioStreamPreviewPlugin::EditorAudioStreamPreviewPlugin() {
 
 ///////////////////////////////////////////////////////////////////////////
 
-void EditorMeshPreviewPlugin::_preview_done(const Variant &p_udata) {
+void EditorMeshPreviewPlugin::_preview_done() {
 	preview_done.set();
-}
-
-void EditorMeshPreviewPlugin::_bind_methods() {
-	ClassDB::bind_method("_preview_done", &EditorMeshPreviewPlugin::_preview_done);
 }
 
 bool EditorMeshPreviewPlugin::handles(const String &p_type) const {
@@ -738,7 +730,7 @@ Ref<Texture2D> EditorMeshPreviewPlugin::generate(const RES &p_from, const Size2 
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_ONCE); //once used for capture
 
 	preview_done.clear();
-	RS::get_singleton()->request_frame_drawn_callback(const_cast<EditorMeshPreviewPlugin *>(this), "_preview_done", Variant());
+	RS::get_singleton()->request_frame_drawn_callback(callable_mp(const_cast<EditorMeshPreviewPlugin *>(this), &EditorMeshPreviewPlugin::_preview_done));
 
 	while (!preview_done.is_set()) {
 		OS::get_singleton()->delay_usec(10);
@@ -814,12 +806,8 @@ EditorMeshPreviewPlugin::~EditorMeshPreviewPlugin() {
 
 ///////////////////////////////////////////////////////////////////////////
 
-void EditorFontPreviewPlugin::_preview_done(const Variant &p_udata) {
+void EditorFontPreviewPlugin::_preview_done() {
 	preview_done.set();
-}
-
-void EditorFontPreviewPlugin::_bind_methods() {
-	ClassDB::bind_method("_preview_done", &EditorFontPreviewPlugin::_preview_done);
 }
 
 bool EditorFontPreviewPlugin::handles(const String &p_type) const {
@@ -859,7 +847,7 @@ Ref<Texture2D> EditorFontPreviewPlugin::generate_from_path(const String &p_path,
 
 	preview_done.clear();
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_ONCE); //once used for capture
-	RS::get_singleton()->request_frame_drawn_callback(const_cast<EditorFontPreviewPlugin *>(this), "_preview_done", Variant());
+	RS::get_singleton()->request_frame_drawn_callback(callable_mp(const_cast<EditorFontPreviewPlugin *>(this), &EditorFontPreviewPlugin::_preview_done));
 
 	while (!preview_done.is_set()) {
 		OS::get_singleton()->delay_usec(10);

--- a/editor/plugins/editor_preview_plugins.h
+++ b/editor/plugins/editor_preview_plugins.h
@@ -94,10 +94,7 @@ class EditorMaterialPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID camera;
 	mutable SafeFlag preview_done;
 
-	void _preview_done(const Variant &p_udata);
-
-protected:
-	static void _bind_methods();
+	void _preview_done();
 
 public:
 	virtual bool handles(const String &p_type) const override;
@@ -138,10 +135,7 @@ class EditorMeshPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID camera;
 	mutable SafeFlag preview_done;
 
-	void _preview_done(const Variant &p_udata);
-
-protected:
-	static void _bind_methods();
+	void _preview_done();
 
 public:
 	virtual bool handles(const String &p_type) const override;
@@ -160,10 +154,7 @@ class EditorFontPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID canvas_item;
 	mutable SafeFlag preview_done;
 
-	void _preview_done(const Variant &p_udata);
-
-protected:
-	static void _bind_methods();
+	void _preview_done();
 
 public:
 	virtual bool handles(const String &p_type) const override;
@@ -179,10 +170,7 @@ class EditorTileMapPatternPreviewPlugin : public EditorResourcePreviewGenerator 
 
 	mutable SafeFlag preview_done;
 
-	void _preview_done(const Variant &p_udata);
-
-protected:
-	static void _bind_methods();
+	void _preview_done();
 
 public:
 	virtual bool handles(const String &p_type) const override;

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -47,7 +47,7 @@
 
 TilesEditorPlugin *TilesEditorPlugin::singleton = nullptr;
 
-void TilesEditorPlugin::_pattern_preview_done(const Variant &p_udata) {
+void TilesEditorPlugin::_pattern_preview_done() {
 	pattern_preview_done.set();
 }
 
@@ -113,7 +113,7 @@ void TilesEditorPlugin::_thread() {
 				EditorNode::get_singleton()->add_child(viewport);
 
 				pattern_preview_done.clear();
-				RS::get_singleton()->request_frame_drawn_callback(const_cast<TilesEditorPlugin *>(this), "_pattern_preview_done", Variant());
+				RS::get_singleton()->request_frame_drawn_callback(callable_mp(const_cast<TilesEditorPlugin *>(this), &TilesEditorPlugin::_pattern_preview_done));
 
 				while (!pattern_preview_done.is_set()) {
 					OS::get_singleton()->delay_usec(10);
@@ -272,10 +272,6 @@ void TilesEditorPlugin::edit(Object *p_object) {
 
 bool TilesEditorPlugin::handles(Object *p_object) const {
 	return p_object->is_class("TileMap") || p_object->is_class("TileSet");
-}
-
-void TilesEditorPlugin::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_pattern_preview_done", "pattern"), &TilesEditorPlugin::_pattern_preview_done);
 }
 
 TilesEditorPlugin::TilesEditorPlugin(EditorNode *p_node) {

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -78,13 +78,12 @@ private:
 	SafeFlag pattern_thread_exit;
 	SafeFlag pattern_thread_exited;
 	mutable SafeFlag pattern_preview_done;
-	void _pattern_preview_done(const Variant &p_udata);
+	void _pattern_preview_done();
 	static void _thread_func(void *ud);
 	void _thread();
 
 protected:
 	void _notification(int p_what);
-	static void _bind_methods();
 
 public:
 	_FORCE_INLINE_ static TilesEditorPlugin *get_singleton() { return singleton; }

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -58,13 +58,7 @@ class RenderingServerDefault : public RenderingServer {
 	static int changes;
 	RID test_cube;
 
-	struct FrameDrawnCallbacks {
-		ObjectID object;
-		StringName method;
-		Variant param;
-	};
-
-	List<FrameDrawnCallbacks> frame_drawn_callbacks;
+	List<Callable> frame_drawn_callbacks;
 
 	static void _changes_changed() {}
 
@@ -880,7 +874,7 @@ public:
 
 	/* EVENT QUEUING */
 
-	virtual void request_frame_drawn_callback(Object *p_where, const StringName &p_method, const Variant &p_userdata) override;
+	virtual void request_frame_drawn_callback(const Callable &p_callable) override;
 
 	virtual void draw(bool p_swap_buffers, double frame_step) override;
 	virtual void sync() override;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2701,7 +2701,7 @@ void RenderingServer::_bind_methods() {
 
 	/* Misc */
 
-	ClassDB::bind_method(D_METHOD("request_frame_drawn_callback", "where", "method", "userdata"), &RenderingServer::request_frame_drawn_callback);
+	ClassDB::bind_method(D_METHOD("request_frame_drawn_callback", "callable"), &RenderingServer::request_frame_drawn_callback);
 	ClassDB::bind_method(D_METHOD("has_changed"), &RenderingServer::has_changed);
 	ClassDB::bind_method(D_METHOD("get_rendering_info", "info"), &RenderingServer::get_rendering_info);
 	ClassDB::bind_method(D_METHOD("get_video_adapter_name"), &RenderingServer::get_video_adapter_name);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1435,9 +1435,9 @@ public:
 
 	virtual void free(RID p_rid) = 0; ///< free RIDs associated with the rendering server
 
-	virtual void request_frame_drawn_callback(Object *p_where, const StringName &p_method, const Variant &p_userdata) = 0;
-
 	/* EVENT QUEUING */
+
+	virtual void request_frame_drawn_callback(const Callable &p_callable) = 0;
 
 	virtual void draw(bool p_swap_buffers = true, double frame_step = 0.0) = 0;
 	virtual void sync() = 0;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Figured callable should be used here instead of the old Object/method/data combo.

This is a little bit of cleanup before I ~~try to~~ fix an inconsistent issue with preview plugins: #54621