### PR TITLE
Avoid unnecessary changes in .tscn files when saving AnimationSprite3D/2D with playing property enabled.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1663,6 +1663,28 @@ static void _reset_animation_players(Node *p_node, List<Ref<AnimatedValuesBackup
 	}
 }
 
+static void _reset_animated_sprites(Node *p_node, List<Ref<SpriteFrameBackup>> *r_sprite_frame_backups) {
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		AnimatedSprite3D *anim_sprite3d = Object::cast_to<AnimatedSprite3D>(p_node->get_child(i));
+		AnimatedSprite2D *anim_sprite2d;
+		Ref<SpriteFrameBackup> backup_frame;
+
+		if (anim_sprite3d && anim_sprite3d->is_playing()) {
+			backup_frame.instantiate();
+			backup_frame->from_animated_sprite(anim_sprite3d);
+			r_sprite_frame_backups->push_back(backup_frame);
+			anim_sprite3d->set_frame(0);
+		} else if ((anim_sprite2d = Object::cast_to<AnimatedSprite2D>(p_node->get_child(i))) && anim_sprite2d->is_playing()) {
+			backup_frame.instantiate();
+			backup_frame->from_animated_sprite(anim_sprite2d);
+			r_sprite_frame_backups->push_back(backup_frame);
+			anim_sprite2d->set_frame(0);
+		}
+
+		_reset_animated_sprites(p_node->get_child(i), r_sprite_frame_backups);
+	}
+}
+
 void EditorNode::_save_scene(String p_file, int idx) {
 	Node *scene = editor_data.get_edited_scene_root(idx);
 
@@ -1681,6 +1703,9 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	editor_data.apply_changes_in_editors();
 	List<Ref<AnimatedValuesBackup>> anim_backups;
 	_reset_animation_players(scene, &anim_backups);
+
+	List<Ref<SpriteFrameBackup>> r_sprite_frame_backups;
+	_reset_animated_sprites(scene, &r_sprite_frame_backups);
 	_save_default_environment();
 
 	_set_scene_metadata(p_file, idx);
@@ -1721,6 +1746,10 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	editor_data.save_editor_external_data();
 
 	for (Ref<AnimatedValuesBackup> &E : anim_backups) {
+		E->restore();
+	}
+
+	for (Ref<SpriteFrameBackup> &E : r_sprite_frame_backups) {
 		E->restore();
 	}
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1224,6 +1224,36 @@ TypedArray<String> AnimatedSprite3D::get_configuration_warnings() const {
 	return warnings;
 }
 
+#if TOOLS_ENABLED
+void SpriteFrameBackup::restore() const {
+	if (sprite_type == ANIMATED_SPRITE_3D) {
+		anim_sprite3d->set_frame(frame);
+	} else if (sprite_type == ANIMATED_SPRITE_2D) {
+		anim_sprite2d->set_frame(frame);
+	}
+}
+
+void SpriteFrameBackup::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("restore"), &SpriteFrameBackup::restore);
+}
+
+void SpriteFrameBackup::from_animated_sprite(AnimatedSprite3D *sprite) {
+	if (sprite) {
+		sprite_type = ANIMATED_SPRITE_3D;
+		anim_sprite3d = sprite;
+		frame = sprite->get_frame();
+	}
+}
+
+void SpriteFrameBackup::from_animated_sprite(AnimatedSprite2D *sprite) {
+	if (sprite) {
+		sprite_type = ANIMATED_SPRITE_2D;
+		anim_sprite2d = sprite;
+		frame = sprite->get_frame();
+	}
+}
+#endif
+
 void AnimatedSprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sprite_frames", "sprite_frames"), &AnimatedSprite3D::set_sprite_frames);
 	ClassDB::bind_method(D_METHOD("get_sprite_frames"), &AnimatedSprite3D::get_sprite_frames);

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -244,6 +244,33 @@ public:
 	AnimatedSprite3D();
 };
 
+#if TOOLS_ENABLED
+#include "scene/2d/animated_sprite_2d.h"
+class SpriteFrameBackup : public RefCounted {
+	GDCLASS(SpriteFrameBackup, RefCounted);
+
+	enum Type {
+		ANIMATED_SPRITE_2D,
+		ANIMATED_SPRITE_3D,
+	};
+
+	union {
+		AnimatedSprite3D *anim_sprite3d;
+		AnimatedSprite2D *anim_sprite2d;
+	};
+	int frame;
+	SpriteFrameBackup::Type sprite_type;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void from_animated_sprite(AnimatedSprite3D *sprite);
+	void from_animated_sprite(AnimatedSprite2D *sprite);
+	void restore() const;
+};
+#endif
+
 VARIANT_ENUM_CAST(SpriteBase3D::DrawFlags);
 VARIANT_ENUM_CAST(SpriteBase3D::AlphaCutMode);
 


### PR DESCRIPTION
The relevant issue can be found here: #53407 (comment)

This PR changes the animatedsprite2d/3ds frame to 0 when saving the scene with the playing property enabled to avoid creating unnecessary diffs on tscn files. 