### PR TITLE
Fix AnimatedSprite2D & 3D animation list in inspector

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -115,14 +115,17 @@ void AnimatedSprite2D::_validate_property(PropertyInfo &p_property) const {
 		names.sort_custom<StringName::AlphCompare>();
 
 		bool current_found = false;
+		bool is_first_element = true;
 
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (E->prev()) {
+		for (const StringName &E : names) {
+			if (!is_first_element) {
 				p_property.hint_string += ",";
+			} else {
+				is_first_element = false;
 			}
 
-			p_property.hint_string += String(E->get());
-			if (animation == E->get()) {
+			p_property.hint_string += String(E);
+			if (animation == E) {
 				current_found = true;
 			}
 		}

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1004,14 +1004,17 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &p_property) const {
 		names.sort_custom<StringName::AlphCompare>();
 
 		bool current_found = false;
+		bool is_first_element = true;
 
-		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
-			if (E->prev()) {
+		for (const StringName &E : names) {
+			if (!is_first_element) {
 				p_property.hint_string += ",";
+			} else {
+				is_first_element = false;
 			}
 
-			p_property.hint_string += String(E->get());
-			if (animation == E->get()) {
+			p_property.hint_string += String(E);
+			if (animation == E) {
 				current_found = true;
 			}
 		}


### PR DESCRIPTION
Fixes #54637

### Issue : 

Current animation is shown twice in inspector animation list of AnimatedSprite2D & AnimatedSprite3D.

### Identified cause : 

Current animation isn't correctly detected in the loop which populates the dropdown menu and leads to add it twice to the menu.

### Before : 

![image](https://user-images.githubusercontent.com/3649998/140577559-864f7886-8961-4ee2-9f22-b0c0a16290e5.png)

### After : 

![image](https://user-images.githubusercontent.com/3649998/140577583-a6a88c4d-e6f7-4121-8a14-a2ec911f81c3.png)


