### PR TITLE
Fix `PopupMenu` items id range in inspector

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -184,7 +184,7 @@ void MenuButton::_get_property_list(List<PropertyInfo> *p_list) const {
 		pi.usage &= ~(!popup->is_item_checked(i) ? PROPERTY_USAGE_STORAGE : 0);
 		p_list->push_back(pi);
 
-		pi = PropertyInfo(Variant::INT, vformat("popup/item_%d/id", i), PROPERTY_HINT_RANGE, "1,10,1,or_greater");
+		pi = PropertyInfo(Variant::INT, vformat("popup/item_%d/id", i), PROPERTY_HINT_RANGE, "0,10,1,or_greater");
 		p_list->push_back(pi);
 
 		pi = PropertyInfo(Variant::BOOL, vformat("popup/item_%d/disabled", i));

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1275,7 +1275,15 @@ int PopupMenu::get_current_index() const {
 
 void PopupMenu::set_item_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0);
+	int prev_size = items.size();
 	items.resize(p_count);
+
+	if (prev_size < p_count) {
+		for (int i = prev_size; i < p_count; i++) {
+			items.write[i].id = i;
+		}
+	}
+
 	control->update();
 	child_controls_changed();
 	notify_property_list_changed();
@@ -1658,7 +1666,7 @@ void PopupMenu::_get_property_list(List<PropertyInfo> *p_list) const {
 		pi.usage &= ~(!is_item_checked(i) ? PROPERTY_USAGE_STORAGE : 0);
 		p_list->push_back(pi);
 
-		pi = PropertyInfo(Variant::INT, vformat("item_%d/id", i), PROPERTY_HINT_RANGE, "1,10,1,or_greater");
+		pi = PropertyInfo(Variant::INT, vformat("item_%d/id", i), PROPERTY_HINT_RANGE, "0,10,1,or_greater");
 		p_list->push_back(pi);
 
 		pi = PropertyInfo(Variant::BOOL, vformat("item_%d/disabled", i));


### PR DESCRIPTION
Range was starting with 1. Changed to 0
Also initialize items ids when allocating new items by calling `set_item_count()`. This is an improvement to a previous PR #54533
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
