### PR TITLE
[3.x] Clear freed RIDs to fix disappearing meshes and id_map errors

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -3191,16 +3191,39 @@ void SpatialEditorViewport::_init_gizmo_instance(int p_idx) {
 
 void SpatialEditorViewport::_finish_gizmo_instances() {
 	for (int i = 0; i < 3; i++) {
-		VS::get_singleton()->free(move_gizmo_instance[i]);
-		VS::get_singleton()->free(move_plane_gizmo_instance[i]);
-		VS::get_singleton()->free(rotate_gizmo_instance[i]);
-		VS::get_singleton()->free(scale_gizmo_instance[i]);
-		VS::get_singleton()->free(scale_plane_gizmo_instance[i]);
+		if (move_gizmo_instance[i].is_valid()) {
+			VS::get_singleton()->free(move_gizmo_instance[i]);
+			move_gizmo_instance[i] = RID();
+		}
+
+		if (move_plane_gizmo_instance[i].is_valid()) {
+			VS::get_singleton()->free(move_plane_gizmo_instance[i]);
+			move_plane_gizmo_instance[i] = RID();
+		}
+
+		if (rotate_gizmo_instance[i].is_valid()) {
+			VS::get_singleton()->free(rotate_gizmo_instance[i]);
+			rotate_gizmo_instance[i] = RID();
+		}
+
+		if (scale_gizmo_instance[i].is_valid()) {
+			VS::get_singleton()->free(scale_gizmo_instance[i]);
+			scale_gizmo_instance[i] = RID();
+		}
+
+		if (scale_plane_gizmo_instance[i].is_valid()) {
+			VS::get_singleton()->free(scale_plane_gizmo_instance[i]);
+			scale_plane_gizmo_instance[i] = RID();
+		}
 	}
 
-	// Rotation white outline
-	VS::get_singleton()->free(rotate_gizmo_instance[3]);
+	// Rotation white outline. All of the arrays above have 3 elements, this has 4.
+	if (rotate_gizmo_instance[3].is_valid()) {
+		VS::get_singleton()->free(rotate_gizmo_instance[3]);
+		rotate_gizmo_instance[3] = RID();
+	}
 }
+
 void SpatialEditorViewport::_toggle_camera_preview(bool p_activate) {
 	ERR_FAIL_COND(p_activate && !preview);
 	ERR_FAIL_COND(!p_activate && !previewing);
@@ -5855,16 +5878,30 @@ void SpatialEditor::_init_grid() {
 }
 
 void SpatialEditor::_finish_indicators() {
-	VisualServer::get_singleton()->free(origin_instance);
-	VisualServer::get_singleton()->free(origin);
+	if (origin_instance.is_valid()) {
+		VisualServer::get_singleton()->free(origin_instance);
+		origin_instance = RID();
+	}
+
+	if (origin.is_valid()) {
+		VisualServer::get_singleton()->free(origin);
+		origin = RID();
+	}
 
 	_finish_grid();
 }
 
 void SpatialEditor::_finish_grid() {
 	for (int i = 0; i < 3; i++) {
-		VisualServer::get_singleton()->free(grid_instance[i]);
-		VisualServer::get_singleton()->free(grid[i]);
+		if (grid_instance[i].is_valid()) {
+			VisualServer::get_singleton()->free(grid_instance[i]);
+			grid_instance[i] = RID();
+		}
+
+		if (grid[i].is_valid()) {
+			VisualServer::get_singleton()->free(grid[i]);
+			grid[i] = RID();
+		}
 	}
 }
 

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -91,6 +91,7 @@ void EditorSpatialGizmo::clear() {
 	for (int i = 0; i < instances.size(); i++) {
 		if (instances[i].instance.is_valid()) {
 			VS::get_singleton()->free(instances[i].instance);
+			instances.write[i].instance = RID();
 		}
 	}
 
@@ -743,8 +744,8 @@ void EditorSpatialGizmo::free() {
 	for (int i = 0; i < instances.size(); i++) {
 		if (instances[i].instance.is_valid()) {
 			VS::get_singleton()->free(instances[i].instance);
+			instances.write[i].instance = RID();
 		}
-		instances.write[i].instance = RID();
 	}
 
 	clear();

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -416,8 +416,12 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	//erase multimeshes
 
 	for (int i = 0; i < g.multimesh_instances.size(); i++) {
-		VS::get_singleton()->free(g.multimesh_instances[i].instance);
-		VS::get_singleton()->free(g.multimesh_instances[i].multimesh);
+		if (g.multimesh_instances[i].instance.is_valid()) {
+			VS::get_singleton()->free(g.multimesh_instances[i].instance);
+		}
+		if (g.multimesh_instances[i].multimesh.is_valid()) {
+			VS::get_singleton()->free(g.multimesh_instances[i].multimesh);
+		}
 	}
 	g.multimesh_instances.clear();
 
@@ -615,12 +619,18 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 
 	if (g.collision_debug.is_valid()) {
 		VS::get_singleton()->free(g.collision_debug);
-	}
-	if (g.collision_debug_instance.is_valid()) {
-		VS::get_singleton()->free(g.collision_debug_instance);
+		g.collision_debug = RID();
 	}
 
-	PhysicsServer::get_singleton()->free(g.static_body);
+	if (g.collision_debug_instance.is_valid()) {
+		VS::get_singleton()->free(g.collision_debug_instance);
+		g.collision_debug_instance = RID();
+	}
+
+	if (g.static_body.is_valid()) {
+		PhysicsServer::get_singleton()->free(g.static_body);
+		g.static_body = RID();
+	}
 
 	//erase navigation
 	if (navigation) {
@@ -633,8 +643,12 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 	//erase multimeshes
 
 	for (int i = 0; i < g.multimesh_instances.size(); i++) {
-		VS::get_singleton()->free(g.multimesh_instances[i].instance);
-		VS::get_singleton()->free(g.multimesh_instances[i].multimesh);
+		if (g.multimesh_instances[i].instance.is_valid()) {
+			VS::get_singleton()->free(g.multimesh_instances[i].instance);
+		}
+		if (g.multimesh_instances[i].multimesh.is_valid()) {
+			VS::get_singleton()->free(g.multimesh_instances[i].multimesh);
+		}
 	}
 	g.multimesh_instances.clear();
 }
@@ -949,7 +963,9 @@ Vector3 GridMap::_get_offset() const {
 
 void GridMap::clear_baked_meshes() {
 	for (int i = 0; i < baked_meshes.size(); i++) {
-		VS::get_singleton()->free(baked_meshes[i].instance);
+		if (baked_meshes[i].instance.is_valid()) {
+			VS::get_singleton()->free(baked_meshes[i].instance);
+		}
 	}
 	baked_meshes.clear();
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -507,7 +507,9 @@ void GridMapEditor::_fill_selection() {
 
 void GridMapEditor::_clear_clipboard_data() {
 	for (List<ClipboardItem>::Element *E = clipboard_items.front(); E; E = E->next()) {
-		VisualServer::get_singleton()->free(E->get().instance);
+		if (E->get().instance.is_valid()) {
+			VisualServer::get_singleton()->free(E->get().instance);
+		}
 	}
 
 	clipboard_items.clear();
@@ -1054,17 +1056,31 @@ void GridMapEditor::_notification(int p_what) {
 			_clear_clipboard_data();
 
 			for (int i = 0; i < 3; i++) {
-				VS::get_singleton()->free(grid_instance[i]);
-				VS::get_singleton()->free(grid[i]);
-				grid_instance[i] = RID();
-				grid[i] = RID();
-				VisualServer::get_singleton()->free(selection_level_instance[i]);
+				if (grid_instance[i].is_valid()) {
+					VS::get_singleton()->free(grid_instance[i]);
+					grid_instance[i] = RID();
+				}
+
+				if (grid[i].is_valid()) {
+					VS::get_singleton()->free(grid[i]);
+					grid[i] = RID();
+				}
+
+				if (selection_level_instance[i].is_valid()) {
+					VS::get_singleton()->free(selection_level_instance[i]);
+					selection_level_instance[i] = RID();
+				}
 			}
 
-			VisualServer::get_singleton()->free(selection_instance);
-			VisualServer::get_singleton()->free(paste_instance);
-			selection_instance = RID();
-			paste_instance = RID();
+			if (selection_instance.is_valid()) {
+				VS::get_singleton()->free(selection_instance);
+				selection_instance = RID();
+			}
+
+			if (paste_instance.is_valid()) {
+				VS::get_singleton()->free(paste_instance);
+				paste_instance = RID();
+			}
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -1124,8 +1140,8 @@ void GridMapEditor::_update_cursor_instance() {
 
 	if (cursor_instance.is_valid()) {
 		VisualServer::get_singleton()->free(cursor_instance);
+		cursor_instance = RID();
 	}
-	cursor_instance = RID();
 
 	if (selected_palette >= 0) {
 		if (node && !node->get_mesh_library().is_null()) {
@@ -1477,12 +1493,15 @@ GridMapEditor::~GridMapEditor() {
 		}
 	}
 
-	VisualServer::get_singleton()->free(selection_mesh);
+	if (selection_mesh.is_valid()) {
+		VisualServer::get_singleton()->free(selection_mesh);
+	}
 	if (selection_instance.is_valid()) {
 		VisualServer::get_singleton()->free(selection_instance);
 	}
-
-	VisualServer::get_singleton()->free(paste_mesh);
+	if (paste_mesh.is_valid()) {
+		VisualServer::get_singleton()->free(paste_mesh);
+	}
 	if (paste_instance.is_valid()) {
 		VisualServer::get_singleton()->free(paste_instance);
 	}

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -90,7 +90,9 @@ void TileMap::_notification(int p_what) {
 				}
 
 				for (Map<PosKey, Quadrant::Occluder>::Element *F = q.occluder_instances.front(); F; F = F->next()) {
-					VS::get_singleton()->free(F->get().id);
+					if (F->get().id.is_valid()) {
+						VS::get_singleton()->free(F->get().id);
+					}
 				}
 				q.occluder_instances.clear();
 			}
@@ -359,9 +361,10 @@ void TileMap::update_dirty_quadrants() {
 		Quadrant &q = *dirty_quadrant_list.first()->self();
 
 		for (List<RID>::Element *E = q.canvas_items.front(); E; E = E->next()) {
-			vs->free(E->get());
+			if (E->get().is_valid()) {
+				vs->free(E->get());
+			}
 		}
-
 		q.canvas_items.clear();
 
 		if (!use_parent) {
@@ -379,7 +382,9 @@ void TileMap::update_dirty_quadrants() {
 		}
 
 		for (Map<PosKey, Quadrant::Occluder>::Element *E = q.occluder_instances.front(); E; E = E->next()) {
-			VS::get_singleton()->free(E->get().id);
+			if (E->get().id.is_valid()) {
+				VS::get_singleton()->free(E->get().id);
+			}
 		}
 		q.occluder_instances.clear();
 		Ref<ShaderMaterial> prev_material;
@@ -788,13 +793,18 @@ Map<TileMap::PosKey, TileMap::Quadrant>::Element *TileMap::_create_quadrant(cons
 void TileMap::_erase_quadrant(Map<PosKey, Quadrant>::Element *Q) {
 	Quadrant &q = Q->get();
 	if (!use_parent) {
-		Physics2DServer::get_singleton()->free(q.body);
+		if (q.body.is_valid()) {
+			Physics2DServer::get_singleton()->free(q.body);
+			q.body = RID();
+		}
 	} else if (collision_parent) {
 		collision_parent->remove_shape_owner(q.shape_owner_id);
 	}
 
 	for (List<RID>::Element *E = q.canvas_items.front(); E; E = E->next()) {
-		VisualServer::get_singleton()->free(E->get());
+		if (E->get().is_valid()) {
+			VisualServer::get_singleton()->free(E->get());
+		}
 	}
 	q.canvas_items.clear();
 	if (q.dirty_list.in_list()) {
@@ -809,7 +819,9 @@ void TileMap::_erase_quadrant(Map<PosKey, Quadrant>::Element *Q) {
 	}
 
 	for (Map<PosKey, Quadrant::Occluder>::Element *E = q.occluder_instances.front(); E; E = E->next()) {
-		VS::get_singleton()->free(E->get().id);
+		if (E->get().id.is_valid()) {
+			VS::get_singleton()->free(E->get().id);
+		}
 	}
 	q.occluder_instances.clear();
 


### PR DESCRIPTION
## Background
#53374 highlights an issue of disappearing meshes and error spam.

The root cause is when RIDs are freed, they leave a dangling pointer. Freed RIDs are not safe to free again, at least by the `VisualServer` or `PhysicsServer`. Doing so may randomly free other mesh instances if the invalid pointer matches one already in use by another RID. 

Some areas in the engine, such as `SpatialEditor` continually spam `VisualServer::free(RID)` with already freed RIDs, so though uncommon, freeing RIDs that other classes own occurs far too frequently.

## Changes

* This PR manually clears RIDs wherever they are freed by `VisualServer` or `PhysicsServer` in the engine, and possibly reused (i.e. not freed in the destructor) with `rid = RID();`.


---

Fixes #53374, #44642, #38229, #48433, #47356, #44712
Probably fixes: #41360, #50630