### PR TITLE
Add `detail_scale` and `detail_offset` properties to BaseMaterial3D

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -168,6 +168,14 @@
 			Texture that specifies the per-pixel normal of the detail overlay. The [member detail_normal] texture only uses the red and green channels; the blue and alpha channels are ignored. The normal read from [member detail_normal] is oriented around the surface normal provided by the [Mesh].
 			[b]Note:[/b] Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [url=http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates]this page[/url] for a comparison of normal map coordinates expected by popular engines.
 		</member>
+		<member name="detail_offset" type="Vector3" setter="set_detail_offset" getter="get_detail_offset" default="Vector3(0, 0, 0)">
+			How much to offset the detail texture's coordinates (relative to the UV layer chosen in [member detail_uv_layer]. This can be used to adjust the detail texture's offset without having to switch to UV2 for detail mapping. This makes it possible to use lightmapping at the same as a differently offset detail texture. Only effective if [member detail_enabled] is [code]true[/code] and a detail texture is specified in [member detail_albedo] or [member detail_normal].
+			[b]Note:[/b] [member detail_offset]'s Z axis is only taken into account if the [member detail_uv_layer] specified has triplanar mapping enabled.
+		</member>
+		<member name="detail_scale" type="Vector3" setter="set_detail_scale" getter="get_detail_scale" default="Vector3(1, 1, 1)">
+			How much to scale the detail texture's coordinates (relative to the UV layer chosen in [member detail_uv_layer]. This can be used to adjust the detail texture's scale without having to switch to UV2 for detail mapping. This makes it possible to use lightmapping at the same as a differently scaled detail texture. Only effective if [member detail_enabled] is [code]true[/code] and a detail texture is specified in [member detail_albedo] or [member detail_normal].
+			[b]Note:[/b] [member detail_scale]'s Z axis is only taken into account if the [member detail_uv_layer] specified has triplanar mapping enabled.
+		</member>
 		<member name="detail_uv_layer" type="int" setter="set_detail_uv" getter="get_detail_uv" enum="BaseMaterial3D.DetailUV" default="0">
 			Specifies whether to use [code]UV[/code] or [code]UV2[/code] for the detail layer. See [enum DetailUV] for options.
 		</member>

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -544,6 +544,8 @@ void BaseMaterial3D::init_shaders() {
 	shader_names->backlight = "backlight";
 	shader_names->refraction = "refraction";
 	shader_names->point_size = "point_size";
+	shader_names->detail_scale = "detail_scale";
+	shader_names->detail_offset = "detail_offset";
 	shader_names->uv1_scale = "uv1_scale";
 	shader_names->uv1_offset = "uv1_offset";
 	shader_names->uv2_scale = "uv2_scale";
@@ -986,6 +988,8 @@ uniform float ao_light_affect : hint_range(0.0, 1.0, 0.01);
 uniform sampler2D texture_detail_albedo : source_color, %s;
 uniform sampler2D texture_detail_normal : hint_normal, %s;
 uniform sampler2D texture_detail_mask : hint_default_white, %s;
+uniform vec3 detail_scale;
+uniform vec3 detail_offset;
 )",
 				texfilter_str, texfilter_str, texfilter_str);
 	}
@@ -1797,14 +1801,14 @@ void fragment() {)";
 		const bool triplanar = (flags[FLAG_UV1_USE_TRIPLANAR] && detail_uv == DETAIL_UV_1) || (flags[FLAG_UV2_USE_TRIPLANAR] && detail_uv == DETAIL_UV_2);
 		if (triplanar) {
 			const String tp_uv = detail_uv == DETAIL_UV_1 ? "uv1" : "uv2";
-			code += vformat(R"(	vec4 detail_tex = triplanar_texture(texture_detail_albedo, %s_power_normal, %s_triplanar_pos);
-	vec4 detail_norm_tex = triplanar_texture(texture_detail_normal, %s_power_normal, %s_triplanar_pos);
+			code += vformat(R"(	vec4 detail_tex = triplanar_texture(texture_detail_albedo, %s_power_normal, %s_triplanar_pos * detail_scale + detail_offset);
+	vec4 detail_norm_tex = triplanar_texture(texture_detail_normal, %s_power_normal, %s_triplanar_pos * detail_scale + detail_offset);
 )",
 					tp_uv, tp_uv, tp_uv, tp_uv);
 		} else {
 			const String det_uv = detail_uv == DETAIL_UV_1 ? "base_uv" : "base_uv2";
-			code += vformat(R"(	vec4 detail_tex = texture(texture_detail_albedo, %s);
-	vec4 detail_norm_tex = texture(texture_detail_normal, %s);
+			code += vformat(R"(	vec4 detail_tex = texture(texture_detail_albedo, %s * detail_scale.xy + detail_offset.xy);
+	vec4 detail_norm_tex = texture(texture_detail_normal, %s * detail_scale.xy + detail_offset.xy);
 )",
 					det_uv, det_uv);
 		}
@@ -2078,6 +2082,24 @@ void BaseMaterial3D::set_refraction(float p_refraction) {
 
 float BaseMaterial3D::get_refraction() const {
 	return refraction;
+}
+
+void BaseMaterial3D::set_detail_scale(const Vector3 &p_scale) {
+	detail_scale = p_scale;
+	RS::get_singleton()->material_set_param(_get_material(), shader_names->detail_scale, p_scale);
+}
+
+Vector3 BaseMaterial3D::get_detail_scale() const {
+	return detail_scale;
+}
+
+void BaseMaterial3D::set_detail_offset(const Vector3 &p_offset) {
+	detail_offset = p_offset;
+	RS::get_singleton()->material_set_param(_get_material(), shader_names->detail_offset, p_offset);
+}
+
+Vector3 BaseMaterial3D::get_detail_offset() const {
+	return detail_offset;
 }
 
 void BaseMaterial3D::set_detail_uv(DetailUV p_detail_uv) {
@@ -2926,6 +2948,12 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_point_size", "point_size"), &BaseMaterial3D::set_point_size);
 	ClassDB::bind_method(D_METHOD("get_point_size"), &BaseMaterial3D::get_point_size);
 
+	ClassDB::bind_method(D_METHOD("set_detail_scale", "detail_scale"), &BaseMaterial3D::set_detail_scale);
+	ClassDB::bind_method(D_METHOD("get_detail_scale"), &BaseMaterial3D::get_detail_scale);
+
+	ClassDB::bind_method(D_METHOD("set_detail_offset", "detail_offset"), &BaseMaterial3D::set_detail_offset);
+	ClassDB::bind_method(D_METHOD("get_detail_offset"), &BaseMaterial3D::get_detail_offset);
+
 	ClassDB::bind_method(D_METHOD("set_detail_uv", "detail_uv"), &BaseMaterial3D::set_detail_uv);
 	ClassDB::bind_method(D_METHOD("get_detail_uv"), &BaseMaterial3D::get_detail_uv);
 
@@ -3175,6 +3203,8 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "detail_enabled"), "set_feature", "get_feature", FEATURE_DETAIL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_mask", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_DETAIL_MASK);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Subtract,Multiply"), "set_detail_blend_mode", "get_detail_blend_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "detail_scale", PROPERTY_HINT_LINK), "set_detail_scale", "get_detail_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "detail_offset"), "set_detail_offset", "get_detail_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_uv_layer", PROPERTY_HINT_ENUM, "UV1,UV2"), "set_detail_uv", "get_detail_uv");
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_albedo", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_DETAIL_ALBEDO);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_normal", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_DETAIL_NORMAL);
@@ -3405,6 +3435,8 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	set_distance_fade_max_distance(10);
 
 	set_ao_light_affect(0.0);
+	set_detail_scale(Vector3(1, 1, 1));
+	set_detail_offset(Vector3(0, 0, 0));
 
 	set_metallic_texture_channel(TEXTURE_CHANNEL_RED);
 	set_roughness_texture_channel(TEXTURE_CHANNEL_RED);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -427,6 +427,8 @@ private:
 		StringName uv1_offset;
 		StringName uv2_scale;
 		StringName uv2_offset;
+		StringName detail_scale;
+		StringName detail_offset;
 		StringName particles_anim_h_frames;
 		StringName particles_anim_v_frames;
 		StringName particles_anim_loop;
@@ -516,6 +518,8 @@ private:
 	float uv2_triplanar_sharpness = 0.0f;
 
 	DetailUV detail_uv = DETAIL_UV_1;
+	Vector3 detail_scale;
+	Vector3 detail_offset;
 
 	bool deep_parallax = false;
 	int deep_parallax_min_layers = 0;
@@ -657,6 +661,12 @@ public:
 
 	void set_shading_mode(ShadingMode p_shading_mode);
 	ShadingMode get_shading_mode() const;
+
+	void set_detail_scale(const Vector3 &p_scale);
+	Vector3 get_detail_scale() const;
+
+	void set_detail_offset(const Vector3 &p_offset);
+	Vector3 get_detail_offset() const;
 
 	void set_detail_uv(DetailUV p_detail_uv);
 	DetailUV get_detail_uv() const;


### PR DESCRIPTION
This can be used to adjust the detail texture's offset and scale without having to switch to UV2 for detail mapping. This makes it possible to use lightmapping at the same time as a differently offset or scaled detail texture.

This closes https://github.com/godotengine/godot-proposals/issues/3499.

**Testing project:** [test_basematerial3d_detail_scale.zip](https://github.com/godotengine/godot/files/7489422/test_basematerial3d_detail_scale.zip)

## Preview

https://user-images.githubusercontent.com/180032/140591763-a58cd97e-d7d2-474b-9c0e-0f9c494732a7.mp4