### PR TITLE
Decrease the default VoxelGI quality to improve performance

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1636,7 +1636,7 @@
 		</member>
 		<member name="rendering/global_illumination/sdfgi/probe_ray_count" type="int" setter="" getter="" default="1">
 		</member>
-		<member name="rendering/global_illumination/voxel_gi/quality" type="int" setter="" getter="" default="1">
+		<member name="rendering/global_illumination/voxel_gi/quality" type="int" setter="" getter="" default="0">
 		</member>
 		<member name="rendering/lightmapping/bake_performance/max_rays_per_pass" type="int" setter="" getter="" default="32">
 		</member>

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.h
@@ -392,7 +392,7 @@ public:
 		return voxel_gi->texture;
 	};
 
-	RS::VoxelGIQuality voxel_gi_quality = RS::VOXEL_GI_QUALITY_HIGH;
+	RS::VoxelGIQuality voxel_gi_quality = RS::VOXEL_GI_QUALITY_LOW;
 
 	/* SDFGI */
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2861,7 +2861,7 @@ RenderingServer::RenderingServer() {
 
 	GLOBAL_DEF("rendering/global_illumination/gi/use_half_resolution", false);
 
-	GLOBAL_DEF("rendering/global_illumination/voxel_gi/quality", 1);
+	GLOBAL_DEF("rendering/global_illumination/voxel_gi/quality", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/global_illumination/voxel_gi/quality", PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/quality", PROPERTY_HINT_ENUM, "Low (4 Cones - Fast),High (6 Cones - Slow)"));
 
 	GLOBAL_DEF("rendering/shading/overrides/force_vertex_shading", false);


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/49738 and https://github.com/godotengine/godot/pull/54158.

On a GeForce GTX 1080 in 2002×1447 resolution, decreasing VoxelGI quality from High to Low quality saves 1.2 ms of GPU time in a medium-sized test scene. This only results in a minor drop in quality.

This helps make the default VoxelGI performance more competitive with SDFGI (to the point where VoxelGI generally surpasses SDFGI now, which wasn't the case on my PC before).

## Preview

### High quality (current default)

![2021-11-06_19 29 08](https://user-images.githubusercontent.com/180032/140620475-e5fe35ee-6177-42bd-8609-083eee39a4cb.png)

### Low quality (new default)

![2021-11-06_19 29 14](https://user-images.githubusercontent.com/180032/140620476-cafa53e7-690a-4234-8251-e185196c86e0.png)