### PR TITLE
Fix the Open Source option in the debugger errors list

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1413,7 +1413,26 @@ void ScriptEditorDebugger::_error_tree_item_rmb_selected(const Vector2 &p_pos) {
 
 	if (error_tree->is_anything_selected()) {
 		item_menu->add_icon_item(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")), TTR("Copy Error"), ACTION_COPY_ERROR);
-		item_menu->add_icon_item(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Open C++ Source on GitHub"), ACTION_OPEN_SOURCE);
+
+		// Check if the "Open C++ Source on GitHub" option should be shown
+		bool source_present = false;
+		TreeItem *ti = error_tree->get_selected();
+		while (ti->get_parent() != error_tree->get_root()) {
+			ti = ti->get_parent();
+		}
+		// Start looking at the first child
+		TreeItem *ci = ti->get_first_child();
+		while (ci != nullptr) {
+			if (ci->get_text(0) == ("<" + TTR("C++ Source") + ">")) {
+				// Found the right field
+				source_present = true;
+				break;
+			}
+			ci = ci->get_next();
+		}
+		if (source_present) {
+			item_menu->add_icon_item(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Open C++ Source on GitHub"), ACTION_OPEN_SOURCE);
+		}
 	}
 
 	if (item_menu->get_item_count() > 0) {
@@ -1457,8 +1476,17 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 				ti = ti->get_parent();
 			}
 
-			// We only need the first child here (C++ source stack trace).
+			// Start looking at the first child
 			TreeItem *ci = ti->get_first_child();
+			while (ci != nullptr) {
+				if (ci->get_text(0) == ("<" + TTR("C++ Source") + ">")) {
+					// Found the right field
+					break;
+				}
+				ci = ci->get_next();
+			}
+			ERR_FAIL_NULL_MSG(ci, "Error C++ source stack trace is missing (please report).");
+
 			// Parse back the `file:line @ method()` string.
 			const Vector<String> file_line_number = ci->get_text(1).split("@")[0].strip_edges().split(":");
 			ERR_FAIL_COND_MSG(file_line_number.size() < 2, "Incorrect C++ source stack trace file:line format (please report).");


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #54658
This should prevent the ```Open C++ Source on GitHub``` from showing up if the ```C++ Source``` is not present.
It should also use the ```C++ Source``` field even if it is not the first one.
![demo](https://user-images.githubusercontent.com/45972321/140620350-e742b3a4-b4c2-4cf6-9c16-ed9e0e949e63.gif)
The single item menu does appear far away from the mouse but I think that is a separate issue.
