### PR TITLE
Bind VisualServer.texture_set_proxy() for Scripting

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -2820,6 +2820,29 @@
 				Sets the texture's path.
 			</description>
 		</method>
+		<method name="texture_set_proxy">
+			<return type="void" />
+			<argument index="0" name="proxy" type="RID" />
+			<argument index="1" name="base" type="RID" />
+			<description>
+				Creates an update link between two textures, similar to how [ViewportTexture]s operate. When the base texture is the texture of a [Viewport], every time the viewport renders a new frame, the proxy texture automatically receives an update.
+				For example, this code links a generic [ImageTexture] to the texture output of the [Viewport] using the VisualServer API:
+				[codeblock]
+				func _ready():
+				    var viewport_rid = get_viewport().get_viewport_rid()
+				    var viewport_texture_rid = VisualServer.viewport_get_texture(viewport_rid)
+
+				    var proxy_texture = ImageTexture.new()
+				    var viewport_texture_image_data = VisualServer.texture_get_data(viewport_texture_rid)
+
+				    proxy_texture.create_from_image(viewport_texture_image_data)
+				    var proxy_texture_rid = proxy_texture.get_rid()
+				    VisualServer.texture_set_proxy(proxy_texture_rid, viewport_texture_rid)
+
+				    $TextureRect.texture = proxy_texture
+				[/codeblock]
+			</description>
+		</method>
 		<method name="texture_set_shrink_all_x2_on_set_data">
 			<return type="void" />
 			<argument index="0" name="shrink" type="bool" />

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1854,6 +1854,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_set_path", "texture", "path"), &VisualServer::texture_set_path);
 	ClassDB::bind_method(D_METHOD("texture_get_path", "texture"), &VisualServer::texture_get_path);
 	ClassDB::bind_method(D_METHOD("texture_set_shrink_all_x2_on_set_data", "shrink"), &VisualServer::texture_set_shrink_all_x2_on_set_data);
+	ClassDB::bind_method(D_METHOD("texture_set_proxy", "proxy", "base"), &VisualServer::texture_set_proxy);
 	ClassDB::bind_method(D_METHOD("texture_bind", "texture", "number"), &VisualServer::texture_bind);
 
 	ClassDB::bind_method(D_METHOD("texture_debug_usage"), &VisualServer::_texture_debug_usage_bind);


### PR DESCRIPTION
Binds VisualServer.texture_set_proxy() for Scripting + Class Docs.

This function is required to create working render targets with the VisualServer API and GDScript without using multiple Nodes, a ViewportTexture and a Scenetree for the same result.

This addition is only required in Godot 3.x cause in Godot 4.x the equivalent RenderServer.texture_proxy_update() is already exposed.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
