### PR TITLE
Prevent obj importer from printing misleading error

### DIFF
--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -405,11 +405,11 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 			current_material_library = l.replace("mtllib", "").strip_edges();
 			if (!material_map.has(current_material_library)) {
 				Map<String, Ref<StandardMaterial3D>> lib;
-				Error err = _parse_material_library(current_material_library, lib, r_missing_deps);
-				if (err == ERR_CANT_OPEN) {
-					String dir = p_path.get_base_dir();
-					err = _parse_material_library(dir.plus_file(current_material_library), lib, r_missing_deps);
+				String lib_path = current_material_library;
+				if (lib_path.is_relative_path()) {
+					lib_path = p_path.get_base_dir().plus_file(current_material_library);
 				}
+				Error err = _parse_material_library(lib_path, lib, r_missing_deps);
 				if (err == OK) {
 					material_map[current_material_library] = lib;
 				}


### PR DESCRIPTION
When importing .obj files with local paths to their .mtl files, a misleading error is printed.
```
Couldn't open MTL file 'some_file.mtl', it may not exist or not be readable.
```
The mtl file loads just fine anyway.

May be relevant to #28203, #36173
Cherrypickable for 3.3, 3.4, 3.x