### PR TITLE
Add autostart property to particles nodes

### DIFF
--- a/doc/classes/CPUParticles.xml
+++ b/doc/classes/CPUParticles.xml
@@ -126,6 +126,9 @@
 		<member name="anim_speed_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
 			Animation speed randomness ratio.
 		</member>
+		<member name="autostart" type="bool" setter="set_autostart" getter="has_autostart" default="false">
+			If [code]true[/code], particles will start when entering the scene tree, setting [member emitting] to [code]true[/code] automatically.
+		</member>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
 			Each particle's initial color. To have particle display color in a [SpatialMaterial] make sure to set [member SpatialMaterial.vertex_color_use_as_albedo] to [code]true[/code].
 		</member>

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -127,6 +127,9 @@
 		<member name="anim_speed_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
 			Animation speed randomness ratio.
 		</member>
+		<member name="autostart" type="bool" setter="set_autostart" getter="has_autostart" default="false">
+			If [code]true[/code], particles will start when entering the scene tree, setting [member emitting] to [code]true[/code] automatically.
+		</member>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
 			Each particle's initial color. If [member texture] is defined, it will be multiplied by this color.
 		</member>

--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -47,6 +47,9 @@
 			The number of particles emitted in one emission cycle (corresponding to the [member lifetime]).
 			[b]Note:[/b] Changing [member amount] will reset the particle emission, therefore removing all particles that were already emitted before changing [member amount].
 		</member>
+		<member name="autostart" type="bool" setter="set_autostart" getter="has_autostart" default="false">
+			If [code]true[/code], particles will start when entering the scene tree, setting [member emitting] to [code]true[/code] automatically.
+		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="Particles.DrawOrder" default="0">
 			Particle draw order. Uses [enum DrawOrder] values.
 		</member>

--- a/doc/classes/Particles2D.xml
+++ b/doc/classes/Particles2D.xml
@@ -33,6 +33,9 @@
 			The number of particles emitted in one emission cycle (corresponding to the [member lifetime]).
 			[b]Note:[/b] Changing [member amount] will reset the particle emission, therefore removing all particles that were already emitted before changing [member amount].
 		</member>
+		<member name="autostart" type="bool" setter="set_autostart" getter="has_autostart" default="false">
+			If [code]true[/code], particles will start when entering the scene tree, setting [member emitting] to [code]true[/code] automatically.
+		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="Particles2D.DrawOrder" default="0">
 			Particle draw order. Uses [enum DrawOrder] values.
 		</member>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -2173,6 +2173,13 @@
 				To place in a scene, attach these particles to an instance using [method instance_set_base] using the returned RID.
 			</description>
 		</method>
+		<method name="particles_get_autostart">
+			<return type="bool" />
+			<argument index="0" name="particles" type="RID" />
+			<description>
+				Returns [code]true[/code] if particles are currently set to start emitting when entering the scene tree.
+			</description>
+		</method>
 		<method name="particles_get_current_aabb">
 			<return type="AABB" />
 			<argument index="0" name="particles" type="RID" />
@@ -2214,6 +2221,14 @@
 			<argument index="1" name="amount" type="int" />
 			<description>
 				Sets the number of particles to be drawn and allocates the memory for them. Equivalent to [member Particles.amount].
+			</description>
+		</method>
+		<method name="particles_set_autostart">
+			<return type="void" />
+			<argument index="0" name="particles" type="RID" />
+			<argument index="1" name="autostart" type="bool" />
+			<description>
+				If [code]true[/code], particles will start emitting when entering in scene tree, setting [member Particles.emitting] to [code]true[/code] automatically. Equivalent to [member Particles.autostart].
 			</description>
 		</method>
 		<method name="particles_set_custom_aabb">

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -673,6 +673,7 @@ public:
 	RID particles_create() { return RID(); }
 
 	void particles_set_emitting(RID p_particles, bool p_emitting) {}
+	void particles_set_autostart(RID p_particles, bool p_autostart) {}
 	void particles_set_amount(RID p_particles, int p_amount) {}
 	void particles_set_lifetime(RID p_particles, float p_lifetime) {}
 	void particles_set_one_shot(RID p_particles, bool p_one_shot) {}
@@ -699,6 +700,7 @@ public:
 	void particles_set_emission_transform(RID p_particles, const Transform &p_transform) {}
 
 	bool particles_get_emitting(RID p_particles) { return false; }
+	bool particles_get_autostart(RID p_autostart) { return false; }
 	int particles_get_draw_passes(RID p_particles) const { return 0; }
 	RID particles_get_draw_pass_mesh(RID p_particles, int p_pass) const { return RID(); }
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4697,6 +4697,13 @@ bool RasterizerStorageGLES2::particles_get_emitting(RID p_particles) {
 	return false;
 }
 
+void RasterizerStorageGLES2::particles_set_autostart(RID p_particles, bool p_autostart) {
+}
+
+bool RasterizerStorageGLES2::particles_get_autostart(RID p_particles) {
+	return false;
+}
+
 void RasterizerStorageGLES2::particles_set_amount(RID p_particles, int p_amount) {
 }
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1126,6 +1126,8 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting);
 	virtual bool particles_get_emitting(RID p_particles);
+	virtual void particles_set_autostart(RID p_particles, bool p_autostart);
+	virtual bool particles_get_autostart(RID p_particles);
 
 	virtual void particles_set_amount(RID p_particles, int p_amount);
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6136,6 +6136,20 @@ bool RasterizerStorageGLES3::particles_get_emitting(RID p_particles) {
 	return particles->emitting;
 }
 
+void RasterizerStorageGLES3::particles_set_autostart(RID p_particles, bool p_autostart) {
+	Particles *particles = particles_owner.getornull(p_particles);
+	ERR_FAIL_COND(!particles);
+
+	particles->autostart = p_autostart;
+}
+
+bool RasterizerStorageGLES3::particles_get_autostart(RID p_particles) {
+	Particles *particles = particles_owner.getornull(p_particles);
+	ERR_FAIL_COND_V(!particles, false);
+
+	return particles->autostart;
+}
+
 void RasterizerStorageGLES3::particles_set_amount(RID p_particles, int p_amount) {
 	Particles *particles = particles_owner.getornull(p_particles);
 	ERR_FAIL_COND(!particles);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1161,6 +1161,7 @@ public:
 		bool inactive;
 		float inactive_time;
 		bool emitting;
+		bool autostart;
 		bool one_shot;
 		int amount;
 		float lifetime;
@@ -1207,6 +1208,7 @@ public:
 				inactive(true),
 				inactive_time(0.0),
 				emitting(false),
+				autostart(false),
 				one_shot(false),
 				amount(0),
 				lifetime(1.0),
@@ -1253,6 +1255,8 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting);
 	virtual bool particles_get_emitting(RID p_particles);
+	virtual void particles_set_autostart(RID p_particles, bool p_autostart);
+	virtual bool particles_get_autostart(RID p_particles);
 	virtual void particles_set_amount(RID p_particles, int p_amount);
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime);
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot);

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -46,6 +46,10 @@ void CPUParticles2D::set_emitting(bool p_emitting) {
 	}
 }
 
+void CPUParticles2D::set_autostart(bool p_autostart) {
+	autostart = p_autostart;
+}
+
 void CPUParticles2D::set_amount(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of particles must be greater than 0.");
 
@@ -97,6 +101,9 @@ void CPUParticles2D::set_speed_scale(float p_scale) {
 
 bool CPUParticles2D::is_emitting() const {
 	return emitting;
+}
+bool CPUParticles2D::has_autostart() const {
+	return autostart;
 }
 int CPUParticles2D::get_amount() const {
 	return particles.size();
@@ -1021,6 +1028,9 @@ void CPUParticles2D::_update_render_thread() {
 
 void CPUParticles2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
+		if (autostart) {
+			set_emitting(true);
+		}
 		set_process_internal(emitting);
 	}
 
@@ -1093,6 +1103,7 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 	ERR_FAIL_COND_MSG(!particles, "Only Particles2D nodes can be converted to CPUParticles2D.");
 
 	set_emitting(particles->is_emitting());
+	set_autostart(particles->has_autostart());
 	set_amount(particles->get_amount());
 	set_lifetime(particles->get_lifetime());
 	set_one_shot(particles->get_one_shot());
@@ -1165,6 +1176,7 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 
 void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &CPUParticles2D::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_autostart", "autostart"), &CPUParticles2D::set_autostart);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &CPUParticles2D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &CPUParticles2D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &CPUParticles2D::set_one_shot);
@@ -1178,6 +1190,7 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &CPUParticles2D::set_speed_scale);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &CPUParticles2D::is_emitting);
+	ClassDB::bind_method(D_METHOD("has_autostart"), &CPUParticles2D::has_autostart);
 	ClassDB::bind_method(D_METHOD("get_amount"), &CPUParticles2D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &CPUParticles2D::get_lifetime);
 	ClassDB::bind_method(D_METHOD("get_one_shot"), &CPUParticles2D::get_one_shot);
@@ -1203,6 +1216,7 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart"), &CPUParticles2D::restart);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "has_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_EXP_RANGE, "1,1000000,1"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lifetime", PROPERTY_HINT_RANGE, "0.01,600.0,0.01,or_greater"), "set_lifetime", "get_lifetime");
@@ -1375,6 +1389,7 @@ CPUParticles2D::CPUParticles2D() {
 	cycle = 0;
 	redraw = false;
 	emitting = false;
+	autostart = false;
 
 	mesh = VisualServer::get_singleton()->mesh_create();
 	multimesh = VisualServer::get_singleton()->multimesh_create();
@@ -1382,6 +1397,7 @@ CPUParticles2D::CPUParticles2D() {
 
 	set_emitting(true);
 	set_one_shot(false);
+	set_autostart(false);
 	set_amount(8);
 	set_lifetime(1);
 	set_fixed_fps(0);

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -80,6 +80,7 @@ public:
 
 private:
 	bool emitting;
+	bool autostart;
 
 	// warning - beware of adding non-trivial types
 	// to this structure as it is zeroed to initialize in set_amount()
@@ -196,6 +197,7 @@ protected:
 
 public:
 	void set_emitting(bool p_emitting);
+	void set_autostart(bool p_autostart);
 	void set_amount(int p_amount);
 	void set_lifetime(float p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -208,6 +210,7 @@ public:
 	void set_speed_scale(float p_scale);
 
 	bool is_emitting() const;
+	bool has_autostart() const;
 	int get_amount() const;
 	float get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -47,6 +47,10 @@ void Particles2D::set_emitting(bool p_emitting) {
 		set_process_internal(false);
 	}
 }
+void Particles2D::set_autostart(bool p_autostart) {
+	autostart = p_autostart;
+	VS::get_singleton()->particles_set_autostart(particles, autostart);
+}
 
 void Particles2D::set_amount(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of particles cannot be smaller than 1.");
@@ -142,6 +146,9 @@ void Particles2D::set_speed_scale(float p_scale) {
 
 bool Particles2D::is_emitting() const {
 	return VS::get_singleton()->particles_get_emitting(particles);
+}
+bool Particles2D::has_autostart() const {
+	return VS::get_singleton()->particles_get_autostart(particles);
 }
 int Particles2D::get_amount() const {
 	return amount;
@@ -274,6 +281,12 @@ void Particles2D::restart() {
 }
 
 void Particles2D::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		if (autostart) {
+			set_emitting(true);
+		}
+	}
+
 	if (p_what == NOTIFICATION_DRAW) {
 		RID texture_rid;
 		if (texture.is_valid()) {
@@ -315,6 +328,7 @@ void Particles2D::_notification(int p_what) {
 
 void Particles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &Particles2D::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_autostart", "autostart"), &Particles2D::set_autostart);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &Particles2D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &Particles2D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "secs"), &Particles2D::set_one_shot);
@@ -329,6 +343,7 @@ void Particles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &Particles2D::set_speed_scale);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &Particles2D::is_emitting);
+	ClassDB::bind_method(D_METHOD("has_autostart"), &Particles2D::has_autostart);
 	ClassDB::bind_method(D_METHOD("get_amount"), &Particles2D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &Particles2D::get_lifetime);
 	ClassDB::bind_method(D_METHOD("get_one_shot"), &Particles2D::get_one_shot);
@@ -356,6 +371,7 @@ void Particles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart"), &Particles2D::restart);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "has_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_EXP_RANGE, "1,1000000,1"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lifetime", PROPERTY_HINT_RANGE, "0.01,600.0,0.01,or_greater"), "set_lifetime", "get_lifetime");
@@ -385,6 +401,7 @@ Particles2D::Particles2D() {
 
 	one_shot = false; // Needed so that set_emitting doesn't access uninitialized values
 	set_emitting(true);
+	set_autostart(false);
 	set_one_shot(false);
 	set_amount(8);
 	set_lifetime(1);

--- a/scene/2d/particles_2d.h
+++ b/scene/2d/particles_2d.h
@@ -48,6 +48,7 @@ public:
 private:
 	RID particles;
 
+	bool autostart;
 	bool one_shot;
 	int amount;
 	float lifetime;
@@ -76,6 +77,7 @@ protected:
 
 public:
 	void set_emitting(bool p_emitting);
+	void set_autostart(bool p_autostart);
 	void set_amount(int p_amount);
 	void set_lifetime(float p_lifetime);
 	void set_one_shot(bool p_enable);
@@ -88,6 +90,7 @@ public:
 	void set_speed_scale(float p_scale);
 
 	bool is_emitting() const;
+	bool has_autostart() const;
 	int get_amount() const;
 	float get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -58,6 +58,10 @@ void CPUParticles::set_emitting(bool p_emitting) {
 	}
 }
 
+void CPUParticles::set_autostart(bool p_autostart) {
+	autostart = p_autostart;
+}
+
 void CPUParticles::set_amount(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of particles must be greater than 0.");
 
@@ -106,6 +110,9 @@ void CPUParticles::set_speed_scale(float p_scale) {
 
 bool CPUParticles::is_emitting() const {
 	return emitting;
+}
+bool CPUParticles::has_autostart() const {
+	return autostart;
 }
 int CPUParticles::get_amount() const {
 	return particles.size();
@@ -1150,6 +1157,9 @@ void CPUParticles::_update_render_thread() {
 
 void CPUParticles::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
+		if (autostart) {
+			set_emitting(true);
+		}
 		set_process_internal(emitting);
 
 		// first update before rendering to avoid one frame delay after emitting starts
@@ -1216,6 +1226,7 @@ void CPUParticles::convert_from_particles(Node *p_particles) {
 	ERR_FAIL_COND_MSG(!particles, "Only Particles nodes can be converted to CPUParticles.");
 
 	set_emitting(particles->is_emitting());
+	set_autostart(particles->has_autostart());
 	set_amount(particles->get_amount());
 	set_lifetime(particles->get_lifetime());
 	set_one_shot(particles->get_one_shot());
@@ -1287,6 +1298,7 @@ void CPUParticles::convert_from_particles(Node *p_particles) {
 
 void CPUParticles::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &CPUParticles::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_autostart", "autostart"), &CPUParticles::set_autostart);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &CPUParticles::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &CPUParticles::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &CPUParticles::set_one_shot);
@@ -1300,6 +1312,7 @@ void CPUParticles::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &CPUParticles::set_speed_scale);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &CPUParticles::is_emitting);
+	ClassDB::bind_method(D_METHOD("has_autostart"), &CPUParticles::has_autostart);
 	ClassDB::bind_method(D_METHOD("get_amount"), &CPUParticles::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &CPUParticles::get_lifetime);
 	ClassDB::bind_method(D_METHOD("get_one_shot"), &CPUParticles::get_one_shot);
@@ -1322,6 +1335,7 @@ void CPUParticles::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart"), &CPUParticles::restart);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "has_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_EXP_RANGE, "1,1000000,1"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lifetime", PROPERTY_HINT_EXP_RANGE, "0.01,600.0,0.01,or_greater"), "set_lifetime", "get_lifetime");
@@ -1516,6 +1530,7 @@ CPUParticles::CPUParticles() {
 	cycle = 0;
 	redraw = false;
 	emitting = false;
+	autostart = false;
 
 	set_notify_transform(true);
 
@@ -1524,6 +1539,7 @@ CPUParticles::CPUParticles() {
 	set_base(multimesh);
 
 	set_emitting(true);
+	set_autostart(false);
 	set_one_shot(false);
 	set_amount(8);
 	set_lifetime(1);

--- a/scene/3d/cpu_particles.h
+++ b/scene/3d/cpu_particles.h
@@ -83,6 +83,7 @@ public:
 
 private:
 	bool emitting;
+	bool autostart;
 
 	struct Particle {
 		Transform transform;
@@ -200,6 +201,7 @@ public:
 	PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;
 
 	void set_emitting(bool p_emitting);
+	void set_autostart(bool p_autostart);
 	void set_amount(int p_amount);
 	void set_lifetime(float p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -212,6 +214,7 @@ public:
 	void set_speed_scale(float p_scale);
 
 	bool is_emitting() const;
+	bool has_autostart() const;
 	int get_amount() const;
 	float get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -52,6 +52,10 @@ void Particles::set_emitting(bool p_emitting) {
 	}
 }
 
+void Particles::set_autostart(bool p_autostart) {
+	autostart = p_autostart;
+}
+
 void Particles::set_amount(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of particles cannot be smaller than 1.");
 	amount = p_amount;
@@ -119,6 +123,9 @@ void Particles::set_speed_scale(float p_scale) {
 
 bool Particles::is_emitting() const {
 	return VS::get_singleton()->particles_get_emitting(particles);
+}
+bool Particles::has_autostart() const {
+	return autostart;
 }
 int Particles::get_amount() const {
 	return amount;
@@ -286,6 +293,11 @@ void Particles::_validate_property(PropertyInfo &property) const {
 }
 
 void Particles::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		if (autostart) {
+			set_emitting(true);
+		}
+	}
 	if (p_what == NOTIFICATION_PAUSED || p_what == NOTIFICATION_UNPAUSED) {
 		if (can_process()) {
 			VS::get_singleton()->particles_set_speed_scale(particles, speed_scale);
@@ -313,6 +325,7 @@ void Particles::_notification(int p_what) {
 
 void Particles::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &Particles::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_autostart", "autostart"), &Particles::set_autostart);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &Particles::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &Particles::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &Particles::set_one_shot);
@@ -327,6 +340,7 @@ void Particles::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &Particles::set_speed_scale);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &Particles::is_emitting);
+	ClassDB::bind_method(D_METHOD("has_autostart"), &Particles::has_autostart);
 	ClassDB::bind_method(D_METHOD("get_amount"), &Particles::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &Particles::get_lifetime);
 	ClassDB::bind_method(D_METHOD("get_one_shot"), &Particles::get_one_shot);
@@ -354,6 +368,7 @@ void Particles::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("capture_aabb"), &Particles::capture_aabb);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "has_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_EXP_RANGE, "1,1000000,1"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lifetime", PROPERTY_HINT_EXP_RANGE, "0.01,600.0,0.01,or_greater"), "set_lifetime", "get_lifetime");
@@ -388,6 +403,7 @@ Particles::Particles() {
 	set_base(particles);
 	one_shot = false; // Needed so that set_emitting doesn't access uninitialized values
 	set_emitting(true);
+	set_autostart(false);
 	set_one_shot(false);
 	set_amount(8);
 	set_lifetime(1);

--- a/scene/3d/particles.h
+++ b/scene/3d/particles.h
@@ -53,6 +53,7 @@ public:
 private:
 	RID particles;
 
+	bool autostart;
 	bool one_shot;
 	int amount;
 	float lifetime;
@@ -81,6 +82,7 @@ public:
 	PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;
 
 	void set_emitting(bool p_emitting);
+	void set_autostart(bool p_autostart);
 	void set_amount(int p_amount);
 	void set_lifetime(float p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -93,6 +95,7 @@ public:
 	void set_speed_scale(float p_scale);
 
 	bool is_emitting() const;
+	bool has_autostart() const;
 	int get_amount() const;
 	float get_lifetime() const;
 	bool get_one_shot() const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -523,6 +523,8 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) = 0;
 	virtual bool particles_get_emitting(RID p_particles) = 0;
+	virtual void particles_set_autostart(RID p_particles, bool p_autostart) = 0;
+	virtual bool particles_get_autostart(RID p_particles) = 0;
 
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -403,6 +403,8 @@ public:
 
 	BIND2(particles_set_emitting, RID, bool)
 	BIND1R(bool, particles_get_emitting, RID)
+	BIND2(particles_set_autostart, RID, bool)
+	BIND1R(bool, particles_get_autostart, RID)
 	BIND2(particles_set_amount, RID, int)
 	BIND2(particles_set_lifetime, RID, float)
 	BIND2(particles_set_one_shot, RID, bool)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -338,6 +338,8 @@ public:
 
 	FUNC2(particles_set_emitting, RID, bool)
 	FUNC1R(bool, particles_get_emitting, RID)
+	FUNC2(particles_set_autostart, RID, bool)
+	FUNC1R(bool, particles_get_autostart, RID)
 	FUNC2(particles_set_amount, RID, int)
 	FUNC2(particles_set_lifetime, RID, float)
 	FUNC2(particles_set_one_shot, RID, bool)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2025,6 +2025,8 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("particles_create"), &VisualServer::particles_create);
 	ClassDB::bind_method(D_METHOD("particles_set_emitting", "particles", "emitting"), &VisualServer::particles_set_emitting);
 	ClassDB::bind_method(D_METHOD("particles_get_emitting", "particles"), &VisualServer::particles_get_emitting);
+	ClassDB::bind_method(D_METHOD("particles_set_autostart", "particles", "autostart"), &VisualServer::particles_set_autostart);
+	ClassDB::bind_method(D_METHOD("particles_get_autostart", "particles"), &VisualServer::particles_get_autostart);
 	ClassDB::bind_method(D_METHOD("particles_set_amount", "particles", "amount"), &VisualServer::particles_set_amount);
 	ClassDB::bind_method(D_METHOD("particles_set_lifetime", "particles", "lifetime"), &VisualServer::particles_set_lifetime);
 	ClassDB::bind_method(D_METHOD("particles_set_one_shot", "particles", "one_shot"), &VisualServer::particles_set_one_shot);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -574,6 +574,8 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) = 0;
 	virtual bool particles_get_emitting(RID p_particles) = 0;
+	virtual void particles_set_autostart(RID p_particles, bool p_autostart) = 0;
+	virtual bool particles_get_autostart(RID p_particles) = 0;
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) = 0;


### PR DESCRIPTION
Add autostart property to particles nodes

Having both properties emitting and one_shot enabled in the editor
set emitting to false when finish, so the particles will not run later in
the real game execution as they don't have emitting as true anymore.

Here we add an autostart property that sets emitting = true when
entering the scene tree, as suggested.

Fixes #17903
