### PR TITLE
The image is showing horizontal lines

### DIFF
--- a/editor/icons/VBoxContainer.svg
+++ b/editor/icons/VBoxContainer.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m15 1039.4c0-1.1046-.89543-2-2-2h-10c-1.1046 0-2 .8954-2 2v10c0 1.1046.89543 2 2 2h10c1.1046 0 2-.8954 2-2zm-2 0v2h-10v-2zm0 4v2h-10v-2zm0 4v2h-10v-2z" fill="#8eef97" transform="translate(0 -1036.4)"/></svg>
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m3 1c-1.1046 0-2 .89543-2 2v10c0 1.1046.89543 2 2 2h10c1.1046 0 2-.89543 2-2v-10c0-1.1046-.89543-2-2-2zm0 2h2v10h-2zm4 0h2v10h-2zm4 0h2v10h-2z" fill="#8eef97"/></svg>


### PR DESCRIPTION
The Vbox is a vertical container box while the icon is showing horizontal lines vice versa is happening with Hbox.
TLDR: Switching Vbox icon with Hbox to correct icons

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
