### PR TITLE
Fix LSP crash when parsing signal symbols.

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -269,7 +269,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 					if (j > 0) {
 						symbol.detail += ", ";
 					}
-					symbol.detail += m.signal->parameters[i]->identifier->name;
+					symbol.detail += m.signal->parameters[j]->identifier->name;
 				}
 				symbol.detail += ")";
 


### PR DESCRIPTION
If the number of parameters was less than the number of class members, the LSP would cause godot to crash because it was using the index for class members instead of the index for signal parameters.

Fixes #54720 .