### PR TITLE
Convert TextEdit callbacks to Callable

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -729,8 +729,7 @@
 		<method name="set_gutter_custom_draw">
 			<return type="void" />
 			<argument index="0" name="column" type="int" />
-			<argument index="1" name="object" type="Object" />
-			<argument index="2" name="callback" type="StringName" />
+			<argument index="1" name="draw_callback" type="Callable" />
 			<description>
 				Set a custom draw method for the gutter. The callback method must take the following args: [code]line: int, gutter: int, Area: Rect2[/code].
 			</description>
@@ -907,11 +906,9 @@
 		</method>
 		<method name="set_tooltip_request_func">
 			<return type="void" />
-			<argument index="0" name="object" type="Object" />
-			<argument index="1" name="callback" type="StringName" />
-			<argument index="2" name="data" type="Variant" />
+			<argument index="0" name="callback" type="Callable" />
 			<description>
-				Provide custom tooltip text. The callback method must take the following args: [code]hovered_word: String, data: Variant[/code]
+				Provide custom tooltip text. The callback method must take the following args: [code]hovered_word: String[/code]
 			</description>
 		</method>
 		<method name="swap_lines">

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2347,7 +2347,7 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 	// If we delete a script within the filesystem, the original resource path
 	// is lost, so keep it as metadata to figure out the exact tab to delete.
 	se->set_meta("_edit_res_path", p_resource->get_path());
-	se->set_tooltip_request_func("_get_debug_tooltip", this);
+	se->set_tooltip_request_func(callable_mp(this, &ScriptEditor::_get_debug_tooltip));
 	if (se->get_edit_menu()) {
 		se->get_edit_menu()->hide();
 		menu_hb->add_child(se->get_edit_menu());
@@ -3547,7 +3547,6 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_goto_script_line2", &ScriptEditor::_goto_script_line2);
 	ClassDB::bind_method("_copy_script_path", &ScriptEditor::_copy_script_path);
 
-	ClassDB::bind_method("_get_debug_tooltip", &ScriptEditor::_get_debug_tooltip);
 	ClassDB::bind_method("_update_script_connections", &ScriptEditor::_update_script_connections);
 	ClassDB::bind_method("_help_class_open", &ScriptEditor::_help_class_open);
 	ClassDB::bind_method("_live_auto_reload_running_scripts", &ScriptEditor::_live_auto_reload_running_scripts);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -165,7 +165,7 @@ public:
 
 	virtual bool show_members_overview() = 0;
 
-	virtual void set_tooltip_request_func(String p_method, Object *p_obj) = 0;
+	virtual void set_tooltip_request_func(const Callable &p_toolip_callback) = 0;
 	virtual Control *get_edit_menu() = 0;
 	virtual void clear_edit_menu() = 0;
 	virtual void set_find_replace_bar(FindReplaceBar *p_bar) = 0;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1375,8 +1375,10 @@ void ScriptTextEditor::clear_breakpoints() {
 	code_editor->get_text_editor()->clear_breakpointed_lines();
 }
 
-void ScriptTextEditor::set_tooltip_request_func(String p_method, Object *p_obj) {
-	code_editor->get_text_editor()->set_tooltip_request_func(p_obj, p_method, this);
+void ScriptTextEditor::set_tooltip_request_func(const Callable &p_toolip_callback) {
+	Variant args[1] = { this };
+	const Variant *argp[] = { &args[0] };
+	code_editor->get_text_editor()->set_tooltip_request_func(p_toolip_callback.bind(argp, 1));
 }
 
 void ScriptTextEditor::set_debugger_active(bool p_active) {

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -233,7 +233,7 @@ public:
 
 	virtual bool show_members_overview() override;
 
-	virtual void set_tooltip_request_func(String p_method, Object *p_obj) override;
+	virtual void set_tooltip_request_func(const Callable &p_toolip_callback) override;
 
 	virtual void set_debugger_active(bool p_active) override;
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -272,8 +272,10 @@ void TextEditor::update_settings() {
 	code_editor->update_editor_settings();
 }
 
-void TextEditor::set_tooltip_request_func(String p_method, Object *p_obj) {
-	code_editor->get_text_editor()->set_tooltip_request_func(p_obj, p_method, this);
+void TextEditor::set_tooltip_request_func(const Callable &p_toolip_callback) {
+	Variant args[1] = { this };
+	const Variant *argp[] = { &args[0] };
+	code_editor->get_text_editor()->set_tooltip_request_func(p_toolip_callback.bind(argp, 1));
 }
 
 Control *TextEditor::get_edit_menu() {

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -135,7 +135,7 @@ public:
 	virtual bool show_members_overview() override;
 	virtual bool can_lose_focus_on_node_selection() override { return true; }
 	virtual void set_debugger_active(bool p_active) override;
-	virtual void set_tooltip_request_func(String p_method, Object *p_obj) override;
+	virtual void set_tooltip_request_func(const Callable &p_toolip_callback) override;
 	virtual void add_callback(const String &p_function, PackedStringArray p_args) override;
 	void update_toggle_scripts_button() override;
 

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -2846,7 +2846,7 @@ Control *VisualScriptEditor::get_base_editor() const {
 	return graph;
 }
 
-void VisualScriptEditor::set_tooltip_request_func(String p_method, Object *p_obj) {
+void VisualScriptEditor::set_tooltip_request_func(const Callable &p_toolip_callback) {
 }
 
 Control *VisualScriptEditor::get_edit_menu() {

--- a/modules/visual_script/editor/visual_script_editor.h
+++ b/modules/visual_script/editor/visual_script_editor.h
@@ -328,7 +328,7 @@ public:
 	virtual void update_settings() override;
 	virtual bool show_members_overview() override;
 	virtual void set_debugger_active(bool p_active) override;
-	virtual void set_tooltip_request_func(String p_method, Object *p_obj) override;
+	virtual void set_tooltip_request_func(const Callable &p_toolip_callback) override;
 	virtual Control *get_edit_menu() override;
 	virtual void clear_edit_menu() override;
 	virtual void set_find_replace_bar(FindReplaceBar *p_bar) override { p_bar->hide(); }; // Not needed here.

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2085,8 +2085,6 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_auto_brace_completion_close_key", "open_key"), &CodeEdit::get_auto_brace_completion_close_key);
 
 	/* Main Gutter */
-	ClassDB::bind_method(D_METHOD("_main_gutter_draw_callback"), &CodeEdit::_main_gutter_draw_callback);
-
 	ClassDB::bind_method(D_METHOD("set_draw_breakpoints_gutter", "enable"), &CodeEdit::set_draw_breakpoints_gutter);
 	ClassDB::bind_method(D_METHOD("is_drawing_breakpoints_gutter"), &CodeEdit::is_drawing_breakpoints_gutter);
 
@@ -2115,16 +2113,12 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_executing_lines"), &CodeEdit::get_executing_lines);
 
 	/* Line numbers */
-	ClassDB::bind_method(D_METHOD("_line_number_draw_callback"), &CodeEdit::_line_number_draw_callback);
-
 	ClassDB::bind_method(D_METHOD("set_draw_line_numbers", "enable"), &CodeEdit::set_draw_line_numbers);
 	ClassDB::bind_method(D_METHOD("is_draw_line_numbers_enabled"), &CodeEdit::is_draw_line_numbers_enabled);
 	ClassDB::bind_method(D_METHOD("set_line_numbers_zero_padded", "enable"), &CodeEdit::set_line_numbers_zero_padded);
 	ClassDB::bind_method(D_METHOD("is_line_numbers_zero_padded"), &CodeEdit::is_line_numbers_zero_padded);
 
 	/* Fold Gutter */
-	ClassDB::bind_method(D_METHOD("_fold_gutter_draw_callback"), &CodeEdit::_fold_gutter_draw_callback);
-
 	ClassDB::bind_method(D_METHOD("set_draw_fold_gutter", "enable"), &CodeEdit::set_draw_fold_gutter);
 	ClassDB::bind_method(D_METHOD("is_drawing_fold_gutter"), &CodeEdit::is_drawing_fold_gutter);
 
@@ -3084,7 +3078,7 @@ CodeEdit::CodeEdit() {
 	set_gutter_draw(gutter_idx, false);
 	set_gutter_overwritable(gutter_idx, true);
 	set_gutter_type(gutter_idx, GUTTER_TYPE_CUSTOM);
-	set_gutter_custom_draw(gutter_idx, this, "_main_gutter_draw_callback");
+	set_gutter_custom_draw(gutter_idx, callable_mp(this, &CodeEdit::_main_gutter_draw_callback));
 	gutter_idx++;
 
 	/* Line numbers */
@@ -3092,7 +3086,7 @@ CodeEdit::CodeEdit() {
 	set_gutter_name(gutter_idx, "line_numbers");
 	set_gutter_draw(gutter_idx, false);
 	set_gutter_type(gutter_idx, GUTTER_TYPE_CUSTOM);
-	set_gutter_custom_draw(gutter_idx, this, "_line_number_draw_callback");
+	set_gutter_custom_draw(gutter_idx, callable_mp(this, &CodeEdit::_line_number_draw_callback));
 	gutter_idx++;
 
 	/* Fold Gutter */
@@ -3100,7 +3094,7 @@ CodeEdit::CodeEdit() {
 	set_gutter_name(gutter_idx, "fold_gutter");
 	set_gutter_draw(gutter_idx, false);
 	set_gutter_type(gutter_idx, GUTTER_TYPE_CUSTOM);
-	set_gutter_custom_draw(gutter_idx, this, "_fold_gutter_draw_callback");
+	set_gutter_custom_draw(gutter_idx, callable_mp(this, &CodeEdit::_fold_gutter_draw_callback));
 	gutter_idx++;
 
 	connect("lines_edited_from", callable_mp(this, &CodeEdit::_lines_edited_from));

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -120,8 +120,7 @@ private:
 		bool clickable = false;
 		bool overwritable = false;
 
-		ObjectID custom_draw_obj = ObjectID();
-		StringName custom_draw_callback;
+		Callable custom_draw_callback;
 	};
 
 	class Text {
@@ -332,9 +331,7 @@ private:
 	int _get_column_pos_of_word(const String &p_key, const String &p_search, uint32_t p_search_flags, int p_from_column) const;
 
 	/* Tooltip. */
-	ObjectID tooltip_obj_id;
-	StringName tooltip_func;
-	Variant tooltip_ud;
+	Callable tooltip_callback;
 
 	/* Mouse */
 	struct LineDrawingCache {
@@ -620,7 +617,7 @@ public:
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
-	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
+	void set_tooltip_request_func(const Callable &p_tooltip_callback);
 
 	/* Text */
 	// Text properties.
@@ -884,7 +881,7 @@ public:
 
 	void merge_gutters(int p_from_line, int p_to_line);
 
-	void set_gutter_custom_draw(int p_gutter, Object *p_object, const StringName &p_callback);
+	void set_gutter_custom_draw(int p_gutter, const Callable &p_draw_callback);
 
 	// Line gutters.
 	void set_line_gutter_metadata(int p_line, int p_gutter, const Variant &p_metadata);


### PR DESCRIPTION
Converts the TextEdit callbacks for gutters and tooltips from `object, method` to `Callable`.