### PR TITLE
Remove redundant texture flag setters/getters for `CameraTexture`

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2871,15 +2871,6 @@ RID CameraTexture::get_rid() const {
 	}
 }
 
-void CameraTexture::set_flags(uint32_t p_flags) {
-	// not supported
-}
-
-uint32_t CameraTexture::get_flags() const {
-	// not supported
-	return 0;
-}
-
 Ref<Image> CameraTexture::get_image() const {
 	// not (yet) supported
 	return Ref<Image>();

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -900,9 +900,6 @@ public:
 	virtual RID get_rid() const override;
 	virtual bool has_alpha() const override;
 
-	virtual void set_flags(uint32_t p_flags);
-	virtual uint32_t get_flags() const;
-
 	virtual Ref<Image> get_image() const override;
 
 	void set_camera_feed_id(int p_new_id);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Seems they were meant to be removed in 3f335ce3d446372eeb9ed87f7e117099c4d2dd6a. 