### PR TITLE
Expose the "restart on exit" OS functionality

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -341,6 +341,29 @@ Vector<String> OS::get_cmdline_user_args() {
 	return cmdlinev;
 }
 
+void OS::set_restart_on_exit(bool p_restart, const Vector<String> &p_restart_arguments) {
+	List<String> args_list;
+	for (const String &restart_argument : p_restart_arguments) {
+		args_list.push_back(restart_argument);
+	}
+
+	::OS::get_singleton()->set_restart_on_exit(p_restart, args_list);
+}
+
+bool OS::is_restart_on_exit_set() const {
+	return ::OS::get_singleton()->is_restart_on_exit_set();
+}
+
+Vector<String> OS::get_restart_on_exit_arguments() const {
+	List<String> args = ::OS::get_singleton()->get_restart_on_exit_arguments();
+	Vector<String> args_vector;
+	for (List<String>::Element *E = args.front(); E; E = E->next()) {
+		args_vector.push_back(E->get());
+	}
+
+	return args_vector;
+}
+
 String OS::get_locale() const {
 	return ::OS::get_singleton()->get_locale();
 }
@@ -625,6 +648,10 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_name"), &OS::get_name);
 	ClassDB::bind_method(D_METHOD("get_cmdline_args"), &OS::get_cmdline_args);
 	ClassDB::bind_method(D_METHOD("get_cmdline_user_args"), &OS::get_cmdline_user_args);
+
+	ClassDB::bind_method(D_METHOD("set_restart_on_exit", "restart", "arguments"), &OS::set_restart_on_exit, DEFVAL(Vector<String>()));
+	ClassDB::bind_method(D_METHOD("is_restart_on_exit_set"), &OS::is_restart_on_exit_set);
+	ClassDB::bind_method(D_METHOD("get_restart_on_exit_arguments"), &OS::get_restart_on_exit_arguments);
 
 	ClassDB::bind_method(D_METHOD("delay_usec", "usec"), &OS::delay_usec);
 	ClassDB::bind_method(D_METHOD("delay_msec", "msec"), &OS::delay_msec);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -182,6 +182,10 @@ public:
 	bool is_process_running(int p_pid) const;
 	int get_process_id() const;
 
+	void set_restart_on_exit(bool p_restart, const Vector<String> &p_restart_arguments = Vector<String>());
+	bool is_restart_on_exit_set() const;
+	Vector<String> get_restart_on_exit_arguments() const;
+
 	bool has_environment(const String &p_var) const;
 	String get_environment(const String &p_var) const;
 	bool set_environment(const String &p_var, const String &p_value) const;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -374,6 +374,12 @@
 				[b]Note:[/b] This method is only implemented on Windows, macOS, Linux and iOS. On Android, HTML5 and UWP, [method get_processor_name] returns an empty string.
 			</description>
 		</method>
+		<method name="get_restart_on_exit_arguments" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the list of command line arguments that will be used when the project automatically restarts using [method set_restart_on_exit]. See also [method is_restart_on_exit_set].
+			</description>
+		</method>
 		<method name="get_static_memory_peak_usage" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -481,6 +487,12 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>
 		</method>
+		<method name="is_restart_on_exit_set" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the project will automatically restart when it exits for any reason, [code]false[/code] otherwise. See also [method set_restart_on_exit] and [method get_restart_on_exit_arguments].
+			</description>
+		</method>
 		<method name="is_stdout_verbose" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -570,6 +582,17 @@
 			<description>
 				Sets the value of the environment variable [code]variable[/code] to [code]value[/code]. The environment variable will be set for the Godot process and any process executed with [method execute] after running [method set_environment]. The environment variable will [i]not[/i] persist to processes run after the Godot process was terminated.
 				[b]Note:[/b] Double-check the casing of [code]variable[/code]. Environment variable names are case-sensitive on all platforms except Windows.
+			</description>
+		</method>
+		<method name="set_restart_on_exit">
+			<return type="void" />
+			<argument index="0" name="restart" type="bool" />
+			<argument index="1" name="arguments" type="PackedStringArray" default="PackedStringArray()" />
+			<description>
+				If [code]restart[/code] is [code]true[/code], restarts the project automatically when it is exited with [method SceneTree.quit] or [constant Node.NOTIFICATION_WM_CLOSE_REQUEST]. Command line [code]arguments[/code] can be supplied. To restart the project with the same command line arguments as originally used to run the project, pass [method get_cmdline_args] as the value for [code]arguments[/code].
+				[method set_restart_on_exit] can be used to apply setting changes that require a restart. See also [method is_restart_on_exit_set] and [method get_restart_on_exit_arguments].
+				[b]Note:[/b] This method is only effective on desktop platforms, and only when the project isn't started from the editor. It will have no effect on mobile and Web platforms, or when the project is started from the editor.
+				[b]Note:[/b] If the project process crashes or is [i]killed[/i] by the user (by sending [code]SIGKILL[/code] instead of the usual [code]SIGTERM[/code]), the project won't restart automatically.
 			</description>
 		</method>
 		<method name="set_thread_name">


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/66168.

This can be used to restart a project with specific command line arguments applied. This can work in tandem with `OS.get_cmdline_args()` to restart with the same command line arguments as used to originally run the project.

Example use cases:

- Restart to apply an user setting change that requires a restart to work.
- Restart with a Godot command line argument to change the video driver, audio driver, etc.

*This currently only works if the project is **not** started from the editor.* (It can be started from an editor *binary* via the command-line still.)
I don't know why this happens – help is welcome for troubleshooting this.

This closes https://github.com/godotengine/godot-proposals/issues/3460.

**Testing project:** [test_restart_on_exit.zip](https://github.com/godotengine/godot/files/9229844/test_restart_on_exit.zip)

## Preview

https://user-images.githubusercontent.com/180032/140661931-dbd14083-8f4d-4a49-9d50-d8d5531b7ac1.mp4