### PR TITLE
Make "Last Modified" the default sorting order for the Project Manager

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -707,7 +707,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	/* Extra config */
 
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Name,Path,Last Edited")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Last Edited,Name,Path")
 
 	if (p_extra_config.is_valid()) {
 		if (p_extra_config->has_section("init_projects") && p_extra_config->has_section_key("init_projects", "list")) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1099,7 +1099,7 @@ struct ProjectListComparator {
 };
 
 ProjectList::ProjectList() {
-	_order_option = FilterOption::NAME;
+	_order_option = FilterOption::EDIT_DATE;
 	_scroll_children = memnew(VBoxContainer);
 	_scroll_children->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_child(_scroll_children);
@@ -2492,9 +2492,9 @@ ProjectManager::ProjectManager() {
 		hb->add_child(filter_option);
 
 		Vector<String> sort_filter_titles;
+		sort_filter_titles.push_back(TTR("Last Edited"));
 		sort_filter_titles.push_back(TTR("Name"));
 		sort_filter_titles.push_back(TTR("Path"));
-		sort_filter_titles.push_back(TTR("Last Edited"));
 
 		for (int i = 0; i < sort_filter_titles.size(); i++) {
 			filter_option->add_item(sort_filter_titles[i]);

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -42,9 +42,9 @@ class ProjectDialog;
 class ProjectList;
 
 enum FilterOption {
+	EDIT_DATE,
 	NAME,
 	PATH,
-	EDIT_DATE,
 };
 
 class ProjectManager : public Control {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
The current default is to sort projects alphabetically.

In my opinion, sorting by last modified better matches what other programs do by default and I find it the most useful, but I'd be curious to know if someone disagrees.