### PR TITLE
Properly handle scenes in Find in Files

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3434,6 +3434,9 @@ void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_numb
 			shader_editor->make_visible(true);
 			shader_editor->get_shader_editor()->goto_line_selection(line_number - 1, begin, end);
 			return;
+		} else if (fpath.get_extension() == "tscn") {
+			editor->load_scene(fpath);
+			return;
 		} else {
 			Ref<Script> script = res;
 			if (script.is_valid()) {


### PR DESCRIPTION
Closes #33320
It's not perfect, because it just opens the scene, but not sure if there is a way to open a specific built-in script (without resorting to hacks like partial parsing of the scene). Still better than the old behavior that resulted in bad things happening.