### PR TITLE
Add the instance to the script property evaluation.

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -150,7 +150,7 @@ public:
 
 	virtual void update_exports() {} //editor tool
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const = 0;
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const = 0;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, const ScriptInstance *p_instance = nullptr) const = 0;
 
 	virtual int get_member_line(const StringName &p_member) const { return -1; }
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -105,7 +105,7 @@ void PropertySelector::_update_search() {
 			Object *obj = ObjectDB::get_instance(script);
 			if (Object::cast_to<Script>(obj)) {
 				props.push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
-				Object::cast_to<Script>(obj)->get_script_property_list(&props);
+				Object::cast_to<Script>(obj)->get_script_property_list(&props, obj->get_script_instance());
 			}
 
 			StringName base = base_type;

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -96,7 +96,7 @@ void NativeScript::_update_placeholder(PlaceHolderScriptInstance *p_placeholder)
 	ERR_FAIL_COND(!script_data);
 
 	List<PropertyInfo> info;
-	get_script_property_list(&info);
+	get_script_property_list(&info, p_placeholder);
 	Map<StringName, Variant> values;
 	for (const PropertyInfo &E : info) {
 		Variant value;
@@ -413,7 +413,7 @@ void NativeScript::get_script_method_list(List<MethodInfo> *p_list) const {
 	}
 }
 
-void NativeScript::get_script_property_list(List<PropertyInfo> *p_list) const {
+void NativeScript::get_script_property_list(List<PropertyInfo> *p_list, const ScriptInstance *p_instance) const {
 	NativeScriptDesc *script_data = get_script_desc();
 
 	Set<StringName> existing_properties;
@@ -651,7 +651,7 @@ bool NativeScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void NativeScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const {
-	script->get_script_property_list(p_properties);
+	script->get_script_property_list(p_properties, this);
 
 	NativeScriptDesc *script_data = GET_SCRIPT_DESC();
 

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -173,7 +173,7 @@ public:
 
 	virtual void update_exports() override; //editor tool
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const override;
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const override;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, const ScriptInstance *p_instance = nullptr) const override;
 
 	virtual const Vector<Multiplayer::RPCConfig> get_rpc_methods() const override;
 

--- a/modules/gdnative/pluginscript/pluginscript_instance.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_instance.cpp
@@ -68,7 +68,7 @@ Variant::Type PluginScriptInstance::get_property_type(const StringName &p_name, 
 }
 
 void PluginScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const {
-	_script->get_script_property_list(p_properties);
+	_script->get_script_property_list(p_properties, this);
 }
 
 void PluginScriptInstance::get_method_list(List<MethodInfo> *p_list) const {

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -373,7 +373,7 @@ void PluginScript::get_script_method_list(List<MethodInfo> *r_methods) const {
 	}
 }
 
-void PluginScript::get_script_property_list(List<PropertyInfo> *r_properties) const {
+void PluginScript::get_script_property_list(List<PropertyInfo> *r_properties, const ScriptInstance *p_instance) const {
 	ASSERT_SCRIPT_VALID();
 	for (Map<StringName, PropertyInfo>::Element *e = _properties_info.front(); e != nullptr; e = e->next()) {
 		r_properties->push_back(e->get());

--- a/modules/gdnative/pluginscript/pluginscript_script.h
+++ b/modules/gdnative/pluginscript/pluginscript_script.h
@@ -132,7 +132,7 @@ public:
 
 	virtual void update_exports() override;
 	virtual void get_script_method_list(List<MethodInfo> *r_methods) const override;
-	virtual void get_script_property_list(List<PropertyInfo> *r_properties) const override;
+	virtual void get_script_property_list(List<PropertyInfo> *r_properties, const ScriptInstance *p_instance = nullptr) const override;
 
 	virtual int get_member_line(const StringName &p_member) const override;
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -228,10 +228,11 @@ public:
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
 
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const override;
+	void _call_get_script_property_list(List<PropertyInfo> *r_list, const ScriptInstance *p_instance, bool p_include_base) const;
 	virtual bool has_method(const StringName &p_method) const override;
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const override;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, const ScriptInstance *p_instance = nullptr) const override;
 
 	virtual ScriptLanguage *get_language() const override;
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1938,7 +1938,7 @@ static bool _guess_identifier_type_from_base(GDScriptParser::CompletionContext &
 
 					if (!is_static) {
 						List<PropertyInfo> members;
-						scr->get_script_property_list(&members);
+						scr->get_script_property_list(&members, nullptr);
 						for (const PropertyInfo &prop : members) {
 							if (prop.name == p_identifier) {
 								r_type = _type_from_property(prop);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3503,7 +3503,7 @@ Ref<Script> CSharpScript::get_base_script() const {
 	return Ref<Script>();
 }
 
-void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
+void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list, const ScriptInstance *p_instance) const {
 	List<PropertyInfo> props;
 
 	for (OrderedHashMap<StringName, PropertyInfo>::ConstElement E = member_info.front(); E; E = E.next()) {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -215,7 +215,7 @@ public:
 	void get_script_signal_list(List<MethodInfo> *r_signals) const override;
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
-	void get_script_property_list(List<PropertyInfo> *r_list) const override;
+	void get_script_property_list(List<PropertyInfo> *r_list, const ScriptInstance *p_instance = nullptr) const override;
 	void update_exports() override;
 
 	void get_members(Set<StringName> *p_members) override;

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -154,7 +154,7 @@ void VisualScriptPropertySelector::_update_search() {
 			} else {
 				Object *obj = ObjectDB::get_instance(script);
 				if (Object::cast_to<Script>(obj)) {
-					Object::cast_to<Script>(obj)->get_script_property_list(&props);
+					Object::cast_to<Script>(obj)->get_script_property_list(&props, obj->get_script_instance());
 				} else {
 					ClassDB::get_property_list(E, &props, true);
 				}

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -925,7 +925,7 @@ MethodInfo VisualScript::get_method_info(const StringName &p_method) const {
 	return mi;
 }
 
-void VisualScript::get_script_property_list(List<PropertyInfo> *p_list) const {
+void VisualScript::get_script_property_list(List<PropertyInfo> *p_list, const ScriptInstance *instance) const {
 	List<StringName> vars;
 	get_variable_list(&vars);
 

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -358,7 +358,7 @@ public:
 	virtual bool has_method(const StringName &p_method) const override;
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const override;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, const ScriptInstance *instance = nullptr) const override;
 
 	virtual int get_member_line(const StringName &p_member) const override;
 


### PR DESCRIPTION
This needs to be done so that tool scripts are evaluated properly and their properties are categorized in the inspector (due to a bug of them being missing). I am talking about the properties coming from _get_property_list.
Also added a fallback so that we don't lose properties in the inspector even if they are not properly categorized.

Fixes #54410
You can find more information in the issue linked. It is perfectly enough to also only add the fallback option in the end of ```_update_script_class_properties```

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
