### PR TITLE
Fix incorrect encoding (Latin-1 instead of UTF-8) used in `_error_handler` functions.

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -475,7 +475,7 @@ void RemoteDebugger::_err_handler(void *p_this, const char *p_func, const char *
 	}
 
 	// send_error will lock internally.
-	rd->script_debugger->send_error(p_func, p_file, p_line, p_err, p_descr, p_editor_notify, p_type, si);
+	rd->script_debugger->send_error(String::utf8(p_func), String::utf8(p_file), p_line, String::utf8(p_err), String::utf8(p_descr), p_editor_notify, p_type, si);
 }
 
 void RemoteDebugger::_print_handler(void *p_this, const String &p_string, bool p_error) {

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -45,9 +45,9 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 
 	String err_str;
 	if (p_errorexp && p_errorexp[0]) {
-		err_str = p_errorexp;
+		err_str = String::utf8(p_errorexp);
 	} else {
-		err_str = String(p_file) + ":" + itos(p_line) + " - " + String(p_error);
+		err_str = String::utf8(p_file) + ":" + itos(p_line) + " - " + String::utf8(p_error);
 	}
 
 	if (p_editor_notify) {

--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -158,11 +158,11 @@ void EditorToaster::_error_handler(void *p_self, const char *p_func, const char 
 	if (p_editor_notify || (show_all_setting == 0 && in_dev) || show_all_setting == 1) {
 		String err_str;
 		if (p_errorexp && p_errorexp[0]) {
-			err_str = p_errorexp;
+			err_str = String::utf8(p_errorexp);
 		} else {
-			err_str = String(p_error);
+			err_str = String::utf8(p_error);
 		}
-		String tooltip_str = String(p_file) + ":" + itos(p_line);
+		String tooltip_str = String::utf8(p_file) + ":" + itos(p_line);
 
 		if (!p_editor_notify) {
 			if (p_type == ERR_HANDLER_WARNING) {

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -461,7 +461,7 @@ String RenameDialog::_substitute(const String &subject, const Node *node, int co
 
 void RenameDialog::_error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type) {
 	RenameDialog *self = (RenameDialog *)p_self;
-	String source_file(p_file);
+	String source_file = String::utf8(p_file);
 
 	// Only show first error that is related to "regex"
 	if (self->has_errors || source_file.find("regex") < 0) {
@@ -470,9 +470,9 @@ void RenameDialog::_error_handler(void *p_self, const char *p_func, const char *
 
 	String err_str;
 	if (p_errorexp && p_errorexp[0]) {
-		err_str = p_errorexp;
+		err_str = String::utf8(p_errorexp);
 	} else {
-		err_str = p_error;
+		err_str = String::utf8(p_error);
 	}
 
 	self->has_errors = true;


### PR DESCRIPTION
Fixes use of incorrect encoding, causing error strings to have invalid characters.

![Screenshot 2021-11-08 at 23 46 55](https://user-images.githubusercontent.com/7645683/140823365-b77172de-d8d0-481b-be6a-c3f96e709051.png)

Fixes #54769