### PR TITLE
Clamp rotation for up/down orbiting shortcuts.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2245,12 +2245,14 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			_menu_option(VIEW_RIGHT);
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_down", p_event)) {
-			cursor.x_rot -= Math_PI / 12.0;
+			// Clamp rotation to roughly -90..90 degrees so the user can't look upside-down and end up disoriented.
+			cursor.x_rot = CLAMP(cursor.x_rot - Math_PI / 12.0, -1.57, 1.57);
 			view_type = VIEW_TYPE_USER;
 			_update_name();
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_up", p_event)) {
-			cursor.x_rot += Math_PI / 12.0;
+			// Clamp rotation to roughly -90..90 degrees so the user can't look upside-down and end up disoriented.
+			cursor.x_rot = CLAMP(cursor.x_rot + Math_PI / 12.0, -1.57, 1.57);
 			view_type = VIEW_TYPE_USER;
 			_update_name();
 		}


### PR DESCRIPTION
This prevents the viewport from going upside-down.

This was suggested at
https://github.com/godotengine/godot/pull/51984#issuecomment-948614191:

> For 3.4, I think we can just clamp the angle value when using the
> camera orbiting shortcuts. We can investigate what to do with panning
> and freelook in 3.5 and 4.0.
