### PR TITLE
Print the number of PulseAudio input channels when in verbose mode

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -192,7 +192,7 @@ Error AudioDriverPulseAudio::init_device() {
 	Error err = detect_channels();
 	if (err != OK) {
 		// This most likely means there are no sinks.
-		ERR_PRINT("PulseAudio: init device failed to detect number of channels");
+		ERR_PRINT("PulseAudio: init device failed to detect number of output channels");
 		return err;
 	}
 
@@ -212,7 +212,7 @@ Error AudioDriverPulseAudio::init_device() {
 			break;
 
 		default:
-			WARN_PRINT("PulseAudio: Unsupported number of channels: " + itos(pa_map.channels));
+			WARN_PRINT("PulseAudio: Unsupported number of output channels: " + itos(pa_map.channels));
 			pa_channel_map_init_stereo(&pa_map);
 			channels = 2;
 			break;
@@ -222,8 +222,8 @@ Error AudioDriverPulseAudio::init_device() {
 	buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
 	pa_buffer_size = buffer_frames * pa_map.channels;
 
-	print_verbose("PulseAudio: detected " + itos(pa_map.channels) + " channels");
-	print_verbose("PulseAudio: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
+	print_verbose("PulseAudio: detected " + itos(pa_map.channels) + " output channels");
+	print_verbose("PulseAudio: audio buffer frames: " + itos(buffer_frames) + " calculated output latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	pa_sample_spec spec;
 	spec.format = PA_SAMPLE_S16LE;
@@ -699,6 +699,8 @@ Error AudioDriverPulseAudio::capture_init_device() {
 			pa_channel_map_init_stereo(&pa_rec_map);
 			break;
 	}
+
+	print_verbose("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
 
 	pa_sample_spec spec;
 


### PR DESCRIPTION
This is useful information to have for troubleshooting, and it's said to sidestep a possible race condition issue that breaks microphone recording on Linux.

Other verbose messages were tweaked to refer to *output* explicitly (as opposed to *input*).

See https://github.com/godotengine/godot/issues/33184.