### PR TITLE
Remove hash symbol in front of opcode error messages in GDScript

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3309,7 +3309,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 		int err_line = line;
 		if (err_text == "") {
-			err_text = "Internal Script Error! - opcode #" + itos(last_opcode) + " (report please).";
+			err_text = "Internal script error! Opcode: " + itos(last_opcode) + " (please report).";
 		}
 
 		if (!GDScriptLanguage::get_singleton()->debug_break(err_text, false)) {


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/54799.

The hash symbol creates spurious issue references on GitHub if the message is posted outside a code block, which means some issues have a lot more references than originally intended.

See https://github.com/godotengine/godot/issues/54748#issuecomment-963794389 for an example of this.