### PR TITLE
Remove hash symbol in front of opcode error messages in GDScript (3.x)

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1537,7 +1537,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 		int err_line = line;
 		if (err_text == "") {
-			err_text = "Internal Script Error! - opcode #" + itos(last_opcode) + " (report please).";
+			err_text = "Internal script error! Opcode: " + itos(last_opcode) + " (please report).";
 		}
 
 		if (!GDScriptLanguage::get_singleton()->debug_break(err_text, false)) {


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/54798.

The hash symbol creates spurious issue references on GitHub if the message is posted outside a code block, which means some issues have a lot more references than originally intended.