### PR TITLE
Expose Array.id() and Dictionary.id()

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -55,7 +55,7 @@ String JSON::_make_indent(const String &p_indent, int p_size) {
 	return indent_text;
 }
 
-String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, Set<const void *> &p_markers, bool p_full_precision) {
+String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, Set<int64_t> &p_markers, bool p_full_precision) {
 	String colon = ":";
 	String end_statement = "";
 
@@ -529,7 +529,7 @@ Error JSON::_parse_string(const String &p_json, Variant &r_ret, String &r_err_st
 }
 
 String JSON::stringify(const Variant &p_var, const String &p_indent, bool p_sort_keys, bool p_full_precision) {
-	Set<const void *> markers;
+	Set<int64_t> markers;
 	return _stringify(p_var, p_indent, 0, p_sort_keys, markers, p_full_precision);
 }
 

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -70,7 +70,7 @@ class JSON : public RefCounted {
 	static const char *tk_name[];
 
 	static String _make_indent(const String &p_indent, int p_size);
-	static String _stringify(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, Set<const void *> &p_markers, bool p_full_precision = false);
+	static String _stringify(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, Set<int64_t> &p_markers, bool p_full_precision = false);
 	static Error _get_token(const char32_t *p_str, int &index, int p_len, Token &r_token, int &line, String &r_err_str);
 	static Error _parse_value(Variant &value, Token &token, const char32_t *p_str, int &index, int p_len, int &line, String &r_err_str);
 	static Error _parse_array(Array &array, const char32_t *p_str, int &index, int p_len, int &line, String &r_err_str);

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -736,8 +736,8 @@ public:
 		memdelete_arr(aux_buffer);
 	}
 
-	const void *id() const {
-		return (void *)_data;
+	int64_t id() const {
+		return reinterpret_cast<int64_t>(_data);
 	}
 
 	/**

--- a/core/templates/ordered_hash_map.h
+++ b/core/templates/ordered_hash_map.h
@@ -272,7 +272,7 @@ public:
 	inline bool is_empty() const { return list.is_empty(); }
 	inline int size() const { return list.size(); }
 
-	const void *id() const {
+	int64_t id() const {
 		return list.id();
 	}
 

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -257,6 +257,10 @@ public:
 		return ConstIterator(ptr() + size());
 	}
 
+	_FORCE_INLINE_ int64_t id() const {
+		return reinterpret_cast<int64_t>(ptr());
+	}
+
 	_FORCE_INLINE_ Vector() {}
 	_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -651,8 +651,8 @@ Variant Array::max() const {
 	return maxval;
 }
 
-const void *Array::id() const {
-	return _p->array.ptr();
+int64_t Array::id() const {
+	return _p->array.id();
 }
 
 Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -117,7 +117,7 @@ public:
 	Variant min() const;
 	Variant max() const;
 
-	const void *id() const;
+	int64_t id() const;
 
 	bool typed_assign(const Array &p_other);
 	void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -349,7 +349,7 @@ void Dictionary::operator=(const Dictionary &p_dictionary) {
 	_ref(p_dictionary);
 }
 
-const void *Dictionary::id() const {
+int64_t Dictionary::id() const {
 	return _p->variant_map.id();
 }
 

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -84,7 +84,7 @@ public:
 	Dictionary duplicate(bool p_deep = false) const;
 	Dictionary recursive_duplicate(bool p_deep, int recursion_count) const;
 
-	const void *id() const;
+	int64_t id() const;
 
 	Dictionary(const Dictionary &p_from);
 	Dictionary();

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1794,6 +1794,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Dictionary, clear, sarray(), varray());
 	bind_method(Dictionary, has, sarray("key"), varray());
 	bind_method(Dictionary, has_all, sarray("keys"), varray());
+	bind_method(Dictionary, id, sarray(), varray());
 	bind_method(Dictionary, erase, sarray("key"), varray());
 	bind_method(Dictionary, hash, sarray(), varray());
 	bind_method(Dictionary, keys, sarray(), varray());
@@ -1811,6 +1812,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, push_front, sarray("value"), varray());
 	bind_method(Array, append, sarray("value"), varray());
 	bind_method(Array, append_array, sarray("array"), varray());
+	bind_method(Array, id, sarray(), varray());
 	bind_method(Array, resize, sarray("size"), varray());
 	bind_method(Array, insert, sarray("position", "value"), varray());
 	bind_method(Array, remove, sarray("position"), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -303,6 +303,15 @@
 				[b]Note:[/b] Arrays with equal contents can still produce different hashes. Only the exact same arrays will produce the same hashed integer value.
 			</description>
 		</method>
+		<method name="id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns a number that uniquely identifies the piece of memory backing this array.
+				[b]Note:[/b]
+				This is useful in cases where there's a need to check if two variables refer to the same array, like this: [code]a.id() == b.id()[/code]
+				When both arrays are [b]the same[/b], `==` will give the same result and as quickly. However, when both arrays are [b]not the same[/b], `==` will perform a deep comparison of their contents to still be able to tell if they [b]are equal[/b] at least.
+			</description>
+		</method>
 		<method name="insert">
 			<return type="int" />
 			<argument index="0" name="position" type="int" />

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -278,6 +278,15 @@
 				[b]Note:[/b] Dictionaries with the same keys/values but in a different order will have a different hash.
 			</description>
 		</method>
+		<method name="id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns a number that uniquely identifies the piece of memory backing this dictionary.
+				[b]Note:[/b]
+				This is useful in cases where there's a need to check if two variables refer to the same dictionary, like this: [code]a.id() == b.id()[/code]
+				When both dictionaries are [b]the same[/b], `==` will give the same result and as quickly. However, when both dictionaries are [b]not the same[/b], `==` will perform a deep comparison of their contents to still be able to tell if they [b]are equal[/b] at least.
+			</description>
+		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool" />
 			<description>


### PR DESCRIPTION
Also, now ids are `int64_t`, which integrate better with `Variant`/scripting.

This is for allowing non-deep comparison of arrays and dictionaries, like this: `a.id() == b.id()`