### PR TITLE
Fix incorrect glTF cubic spline interpolation times/values size error

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5770,7 +5770,7 @@ struct EditorSceneImporterGLTFInterpolate<Quat> {
 template <class T>
 T GLTFDocument::_interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, const float p_time, const GLTFAnimation::Interpolation p_interp) {
 	ERR_FAIL_COND_V(!p_values.size(), T());
-	if (p_times.size() != p_values.size()) {
+	if (p_times.size() != (p_values.size() / (p_interp == GLTFAnimation::INTERP_CUBIC_SPLINE ? 3 : 1))) {
 		ERR_PRINT_ONCE("The interpolated values are not corresponding to its times.");
 		return p_values[0];
 	}


### PR DESCRIPTION
Ran into this issue after upgrading from 3.3 to 3.4.

![godot_nan_penguin_animation](https://user-images.githubusercontent.com/9374/140943355-53e8b0a4-495b-4579-970a-e25e80132897.png)
Incorrect result on the left, correct result on the right.

Changing the test in _interpolate_track to include a check for cubic spline interpolation now gives me the same good result as in 3.3 and 4.0.

(This change adopts a single line from master branch, commit https://github.com/godotengine/godot/commit/ec19ed37230c368b3d24050c9f1e99869dd94bec#diff-fdf33f6fcd2b129d540ebd0e70fd04982b68e279cebfd9e96036d2fd7561c31fR5736)

model:
[skitux.gltf.gz](https://github.com/godotengine/godot/files/7505533/skitux.gltf.gz)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
