### PR TITLE
Fix `PingPong()` in `Mathf.cs` to pass CI/CD for Mono build

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -709,7 +709,7 @@ namespace Godot
         /// <returns>The ping-ponged value.</returns>
         public static real_t PingPong(real_t value, real_t length)
         {
-            return (length != 0.0) ? Math.Abs(Mathf.Fract((value - length) / (length * 2.0)) * length * 2.0 - length) : 0.0;
+            return (length != (real_t)0.0) ? Abs(Fract((value - length) / (length * (real_t)2.0)) * length * (real_t)2.0 - length) : (real_t)0.0;
         }
     }
 }


### PR DESCRIPTION
So sorry self follow up #53819. It has didn't spit out an error before, but currently, Mono build CI/CD was added sometime ago, so CI/CD is complaining because typecast is incorrect.