### PR TITLE
VisualShader: Document enum args for virtual methods

### DIFF
--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -27,8 +27,8 @@
 			<return type="String" />
 			<argument index="0" name="input_vars" type="PackedStringArray" />
 			<argument index="1" name="output_vars" type="String[]" />
-			<argument index="2" name="mode" type="int" />
-			<argument index="3" name="type" type="int" />
+			<argument index="2" name="mode" type="int" enum="Shader.Mode" />
+			<argument index="3" name="type" type="int" enum="VisualShader.Type" />
 			<description>
 				Override this method to define the actual shader code of the associated custom node. The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
 				The [code]input_vars[/code] and [code]output_vars[/code] arrays contain the string names of the various input and output variables, as defined by [code]_get_input_*[/code] and [code]_get_output_*[/code] virtual methods in this class.
@@ -46,7 +46,7 @@
 		</method>
 		<method name="_get_global_code" qualifiers="virtual const">
 			<return type="String" />
-			<argument index="0" name="mode" type="int" />
+			<argument index="0" name="mode" type="int" enum="Shader.Mode" />
 			<description>
 				Override this method to add shader code on top of the global shader, to define your own standard library of reusable methods, varyings, constants, uniforms, etc. The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
 				Be careful with this functionality as it can cause name conflicts with other custom nodes, so be sure to give the defined entities unique names.

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -354,7 +354,7 @@ String VisualShaderNodeCustom::generate_code(Shader::Mode p_mode, VisualShader::
 	}
 	String code = "	{\n";
 	String _code;
-	GDVIRTUAL_CALL(_get_code, input_vars, output_vars, (int)p_mode, (int)p_type, _code);
+	GDVIRTUAL_CALL(_get_code, input_vars, output_vars, p_mode, p_type, _code);
 	bool nend = _code.ends_with("\n");
 	_code = _code.insert(0, "		");
 	_code = _code.replace("\n", "\n		");
@@ -371,7 +371,7 @@ String VisualShaderNodeCustom::generate_code(Shader::Mode p_mode, VisualShader::
 
 String VisualShaderNodeCustom::generate_global_per_node(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
 	String ret;
-	if (GDVIRTUAL_CALL(_get_global_code, (int)p_mode, ret)) {
+	if (GDVIRTUAL_CALL(_get_global_code, p_mode, ret)) {
 		String code = "// " + get_caption() + "\n";
 		code += ret;
 		code += "\n";

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -328,8 +328,8 @@ protected:
 	GDVIRTUAL0RC(int, _get_output_port_count)
 	GDVIRTUAL1RC(int, _get_output_port_type, int)
 	GDVIRTUAL1RC(String, _get_output_port_name, int)
-	GDVIRTUAL4RC(String, _get_code, Vector<String>, TypedArray<String>, int, int)
-	GDVIRTUAL1RC(String, _get_global_code, int)
+	GDVIRTUAL4RC(String, _get_code, Vector<String>, TypedArray<String>, Shader::Mode, VisualShader::Type)
+	GDVIRTUAL1RC(String, _get_global_code, Shader::Mode)
 	GDVIRTUAL0RC(bool, _is_highend)
 
 protected:


### PR DESCRIPTION
Fixes #31563.

I couldn't find other virtual methods that currently had to cast their enum parameters to `int`, though there might be more cases where `int` is used throughout when an enum could be passed.

---

@Chaosus I haven't tested that `VisualShaderCustomNode` still works as intended, could you check?

There's also `_get_input_port_type` and `_get_output_port_type` which should return an enum in theory, but I think `GDVIRTUAL_CALL` expects that the result will always be a `Variant`, so it's not happy with an enum.