### PR TITLE
Fix `EditorInspectorPlugin` virtual bindings and add `parse_group` callback

### DIFF
--- a/doc/classes/EditorInspectorPlugin.xml
+++ b/doc/classes/EditorInspectorPlugin.xml
@@ -25,8 +25,9 @@
 		</method>
 		<method name="_parse_begin" qualifiers="virtual">
 			<return type="void" />
+			<argument index="0" name="object" type="Object" />
 			<description>
-				Called to allow adding controls at the beginning of the list.
+				Called to allow adding controls at the beginning of the property list for [code]object[/code].
 			</description>
 		</method>
 		<method name="_parse_category" qualifiers="virtual">
@@ -34,12 +35,22 @@
 			<argument index="0" name="object" type="Object" />
 			<argument index="1" name="category" type="String" />
 			<description>
+				Called to allow adding controls at the beginning of a category in the property list for [code]object[/code].
 			</description>
 		</method>
 		<method name="_parse_end" qualifiers="virtual">
 			<return type="void" />
+			<argument index="0" name="object" type="Object" />
 			<description>
-				Called to allow adding controls at the end of the list.
+				Called to allow adding controls at the end of the property list for [code]object[/code].
+			</description>
+		</method>
+		<method name="_parse_group" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="object" type="Object" />
+			<argument index="1" name="group" type="String" />
+			<description>
+				Called to allow adding controls at the beginning of a group or a sub-group in the property list for [code]object[/code].
 			</description>
 		</method>
 		<method name="_parse_property" qualifiers="virtual">
@@ -52,7 +63,7 @@
 			<argument index="5" name="usage_flags" type="int" />
 			<argument index="6" name="wide" type="bool" />
 			<description>
-				Called to allow adding property specific editors to the inspector. Usually these inherit [EditorProperty]. Returning [code]true[/code] removes the built-in editor for this property, otherwise allows to insert a custom editor before the built-in one.
+				Called to allow adding property-specific editors to the property list for [code]object[/code]. The added editor control must extend [EditorProperty]. Returning [code]true[/code] removes the built-in editor for this property, otherwise allows to insert a custom editor before the built-in one.
 			</description>
 		</method>
 		<method name="add_custom_control">

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -215,10 +215,11 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL1RC(bool, _can_handle, Variant)
-	GDVIRTUAL0(_parse_begin)
+	GDVIRTUAL1(_parse_begin, Object *)
 	GDVIRTUAL2(_parse_category, Object *, String)
+	GDVIRTUAL2(_parse_group, Object *, String)
 	GDVIRTUAL7R(bool, _parse_property, Object *, int, String, int, String, int, bool)
-	GDVIRTUAL0(_parse_end)
+	GDVIRTUAL1(_parse_end, Object *)
 
 public:
 	void add_custom_control(Control *control);
@@ -227,9 +228,10 @@ public:
 
 	virtual bool can_handle(Object *p_object);
 	virtual void parse_begin(Object *p_object);
-	virtual void parse_category(Object *p_object, const String &p_parse_category);
+	virtual void parse_category(Object *p_object, const String &p_category);
+	virtual void parse_group(Object *p_object, const String &p_group);
 	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false);
-	virtual void parse_end();
+	virtual void parse_end(Object *p_object);
 };
 
 class EditorInspectorCategory : public Control {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3170,11 +3170,7 @@ EditorPropertyResource::EditorPropertyResource() {
 ////////////// DEFAULT PLUGIN //////////////////////
 
 bool EditorInspectorDefaultPlugin::can_handle(Object *p_object) {
-	return true; //can handle everything
-}
-
-void EditorInspectorDefaultPlugin::parse_begin(Object *p_object) {
-	//do none
+	return true; // Can handle everything.
 }
 
 bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
@@ -3183,10 +3179,6 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, const Varian
 		add_property_editor(p_path, editor);
 	}
 	return false;
-}
-
-void EditorInspectorDefaultPlugin::parse_end() {
-	//do none
 }
 
 struct EditorPropertyRangeHint {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -696,9 +696,7 @@ class EditorInspectorDefaultPlugin : public EditorInspectorPlugin {
 
 public:
 	virtual bool can_handle(Object *p_object) override;
-	virtual void parse_begin(Object *p_object) override;
 	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false) override;
-	virtual void parse_end() override;
 
 	static EditorProperty *get_editor_for_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false);
 };

--- a/editor/plugins/ot_features_plugin.cpp
+++ b/editor/plugins/ot_features_plugin.cpp
@@ -185,12 +185,6 @@ bool EditorInspectorPluginOpenTypeFeatures::can_handle(Object *p_object) {
 	return (Object::cast_to<Control>(p_object) != nullptr);
 }
 
-void EditorInspectorPluginOpenTypeFeatures::parse_begin(Object *p_object) {
-}
-
-void EditorInspectorPluginOpenTypeFeatures::parse_category(Object *p_object, const String &p_parse_category) {
-}
-
 bool EditorInspectorPluginOpenTypeFeatures::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
 	if (p_path == "opentype_features/_new") {
 		OpenTypeFeaturesAdd *editor = memnew(OpenTypeFeaturesAdd);

--- a/editor/plugins/ot_features_plugin.h
+++ b/editor/plugins/ot_features_plugin.h
@@ -86,8 +86,6 @@ class EditorInspectorPluginOpenTypeFeatures : public EditorInspectorPlugin {
 
 public:
 	virtual bool can_handle(Object *p_object) override;
-	virtual void parse_begin(Object *p_object) override;
-	virtual void parse_category(Object *p_object, const String &p_parse_category) override;
 	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false) override;
 };
 

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -271,11 +271,7 @@ EditorPropertyRootMotion::EditorPropertyRootMotion() {
 //////////////////////////
 
 bool EditorInspectorRootMotionPlugin::can_handle(Object *p_object) {
-	return true; //can handle everything
-}
-
-void EditorInspectorRootMotionPlugin::parse_begin(Object *p_object) {
-	//do none
+	return true; // Can handle everything.
 }
 
 bool EditorInspectorRootMotionPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
@@ -288,9 +284,5 @@ bool EditorInspectorRootMotionPlugin::parse_property(Object *p_object, const Var
 		return true;
 	}
 
-	return false; //can be overridden, although it will most likely be last anyway
-}
-
-void EditorInspectorRootMotionPlugin::parse_end() {
-	//do none
+	return false;
 }

--- a/editor/plugins/root_motion_editor_plugin.h
+++ b/editor/plugins/root_motion_editor_plugin.h
@@ -64,9 +64,7 @@ class EditorInspectorRootMotionPlugin : public EditorInspectorPlugin {
 
 public:
 	virtual bool can_handle(Object *p_object) override;
-	virtual void parse_begin(Object *p_object) override;
 	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false) override;
-	virtual void parse_end() override;
 };
 
 #endif // ROOT_MOTION_EDITOR_PLUGIN_H

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -44,13 +44,6 @@ void EditorInspectorPluginStyleBox::parse_begin(Object *p_object) {
 	add_custom_control(preview);
 }
 
-bool EditorInspectorPluginStyleBox::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, bool p_wide) {
-	return false; //do not want
-}
-
-void EditorInspectorPluginStyleBox::parse_end() {
-}
-
 void StyleBoxPreview::edit(const Ref<StyleBox> &p_stylebox) {
 	if (stylebox.is_valid()) {
 		stylebox->disconnect("changed", callable_mp(this, &StyleBoxPreview::_sb_changed));

--- a/editor/plugins/style_box_editor_plugin.h
+++ b/editor/plugins/style_box_editor_plugin.h
@@ -61,8 +61,6 @@ class EditorInspectorPluginStyleBox : public EditorInspectorPlugin {
 public:
 	virtual bool can_handle(Object *p_object) override;
 	virtual void parse_begin(Object *p_object) override;
-	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false) override;
-	virtual void parse_end() override;
 };
 
 class StyleBoxEditorPlugin : public EditorPlugin {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -5186,11 +5186,7 @@ EditorPropertyShaderMode::EditorPropertyShaderMode() {
 }
 
 bool EditorInspectorShaderModePlugin::can_handle(Object *p_object) {
-	return true; //can handle everything
-}
-
-void EditorInspectorShaderModePlugin::parse_begin(Object *p_object) {
-	//do none
+	return true; // Can handle everything.
 }
 
 bool EditorInspectorShaderModePlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
@@ -5203,11 +5199,7 @@ bool EditorInspectorShaderModePlugin::parse_property(Object *p_object, const Var
 		return true;
 	}
 
-	return false; //can be overridden, although it will most likely be last anyway
-}
-
-void EditorInspectorShaderModePlugin::parse_end() {
-	//do none
+	return false;
 }
 
 //////////////////////////////////

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -523,9 +523,7 @@ class EditorInspectorShaderModePlugin : public EditorInspectorPlugin {
 
 public:
 	virtual bool can_handle(Object *p_object) override;
-	virtual void parse_begin(Object *p_object) override;
 	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false) override;
-	virtual void parse_end() override;
 };
 
 class VisualShaderNodePortPreview : public Control {


### PR DESCRIPTION
It seems that `parse_begin` wasn't bound properly in https://github.com/godotengine/godot/commit/3682978aee06cd5cf26ba462a4e44d352e9e0cd1 because it wasn't exposed properly before. As a result, user-made editor plugins couldn't filter their logic by the object, but built-in editor plugins could. This restores the old behavior, as it's supposed to be.

It was also a long-standing issue that `parse_end` wouldn't pass the object in the same way that `parse_begin` does, which limits what can be added at the bottom of the list without any good reason for such limitations. So I've fixed that as well, which makes this a breaking change for the editor plugin API.

Finally, we couldn't add controls to the start of a group before, but we could add controls to the start of a category. I may need to add some things to the groups for one of my future PRs, and it seems to be a generally useful hook to have, so I've added it as well.

![godot windows tools 64_2021-11-10_17-46-04](https://user-images.githubusercontent.com/11782833/141137172-31ce68d7-2340-4522-9822-918628cf401c.png)
*[It can also appear for the remote inspector](https://user-images.githubusercontent.com/11782833/141137180-ea5fa6a9-3053-4eaf-98a5-524c64d4aad8.png)*

PS. Along the way I've removed some methods which were pointlessly overridden in some built-in plugins, which is why this touches on shaders and what not.