### PR TITLE
Windows: Enable `/bigobj` to increase max size for obj files

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -226,9 +226,10 @@ def configure_msvc(env, manual_msvc_config):
         env.AppendUnique(CCFLAGS=["/MD"])
 
     env.AppendUnique(CCFLAGS=["/Gd", "/GR", "/nologo"])
-    # Force to use Unicode encoding
-    env.AppendUnique(CCFLAGS=["/utf-8"])
+    env.AppendUnique(CCFLAGS=["/utf-8"])  # Force to use Unicode encoding.
+    env.AppendUnique(CCFLAGS=["/bigobj"])  # Allow big objects, no drawbacks.
     env.AppendUnique(CXXFLAGS=["/TP"])  # assume all sources are C++
+
     if manual_msvc_config:  # should be automatic if SCons found it
         if os.getenv("WindowsSdkDir") is not None:
             env.Prepend(CPPPATH=[os.getenv("WindowsSdkDir") + "/Include"])
@@ -421,6 +422,7 @@ def configure_mingw(env):
     ## Compile flags
 
     env.Append(CCFLAGS=["-mwindows"])
+    env.Append(CCFLAGS=["-Wa,-mbig-obj"])  # Allow big objects, no drawbacks.
 
     env.Append(CPPDEFINES=["WINDOWS_ENABLED", "WASAPI_ENABLED", "WINMIDI_ENABLED"])
     env.Append(CPPDEFINES=[("WINVER", env["target_win_version"]), ("_WIN32_WINNT", env["target_win_version"])])


### PR DESCRIPTION
Equivalent `-Wa,-mbig-obj` for GCC/Clang.

This started being needed to compile harfbuzz in `target=debug` with MinGW/GCC,
but there doesn't seem to be any drawback to enabling `/bigobj` (aside from
losing support for pre-VS 2005 linkers, which we don't support).

Not specifically needed for `3.x` yet, but I guess we might want to cherry-pick anyway.
It can be useful for future additions or for users with custom modules with a lot of data or template usage.