### PR TITLE
Swap rest pose actions in the Skeleton2D editor

### DIFF
--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -52,22 +52,6 @@ void Skeleton2DEditor::_menu_option(int p_option) {
 	}
 
 	switch (p_option) {
-		case MENU_OPTION_MAKE_REST: {
-			if (node->get_bone_count() == 0) {
-				err_dialog->set_text(TTR("This skeleton has no bones, create some children Bone2D nodes."));
-				err_dialog->popup_centered();
-				return;
-			}
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-			ur->create_action(TTR("Create Rest Pose from Bones"));
-			for (int i = 0; i < node->get_bone_count(); i++) {
-				Bone2D *bone = node->get_bone(i);
-				ur->add_do_method(bone, "set_rest", bone->get_transform());
-				ur->add_undo_method(bone, "set_rest", bone->get_rest());
-			}
-			ur->commit_action();
-
-		} break;
 		case MENU_OPTION_SET_REST: {
 			if (node->get_bone_count() == 0) {
 				err_dialog->set_text(TTR("This skeleton has no bones, create some children Bone2D nodes."));
@@ -80,6 +64,22 @@ void Skeleton2DEditor::_menu_option(int p_option) {
 				Bone2D *bone = node->get_bone(i);
 				ur->add_do_method(bone, "set_transform", bone->get_rest());
 				ur->add_undo_method(bone, "set_transform", bone->get_transform());
+			}
+			ur->commit_action();
+
+		} break;
+		case MENU_OPTION_MAKE_REST: {
+			if (node->get_bone_count() == 0) {
+				err_dialog->set_text(TTR("This skeleton has no bones, create some children Bone2D nodes."));
+				err_dialog->popup_centered();
+				return;
+			}
+			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			ur->create_action(TTR("Create Rest Pose from Bones"));
+			for (int i = 0; i < node->get_bone_count(); i++) {
+				Bone2D *bone = node->get_bone(i);
+				ur->add_do_method(bone, "set_rest", bone->get_transform());
+				ur->add_undo_method(bone, "set_rest", bone->get_rest());
 			}
 			ur->commit_action();
 
@@ -98,10 +98,10 @@ Skeleton2DEditor::Skeleton2DEditor() {
 	options->set_text(TTR("Skeleton2D"));
 	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Skeleton2D"), SNAME("EditorIcons")));
 
-	options->get_popup()->add_item(TTR("Reset to Rest Pose"), MENU_OPTION_MAKE_REST);
+	options->get_popup()->add_item(TTR("Reset to Rest Pose"), MENU_OPTION_SET_REST);
 	options->get_popup()->add_separator();
 	// Use the "Overwrite" word to highlight that this is a destructive operation.
-	options->get_popup()->add_item(TTR("Overwrite Rest Pose"), MENU_OPTION_SET_REST);
+	options->get_popup()->add_item(TTR("Overwrite Rest Pose"), MENU_OPTION_MAKE_REST);
 	options->set_switch_on_hover(true);
 
 	options->get_popup()->connect("id_pressed", callable_mp(this, &Skeleton2DEditor::_menu_option));

--- a/editor/plugins/skeleton_2d_editor_plugin.h
+++ b/editor/plugins/skeleton_2d_editor_plugin.h
@@ -40,8 +40,8 @@ class Skeleton2DEditor : public Control {
 	GDCLASS(Skeleton2DEditor, Control);
 
 	enum Menu {
-		MENU_OPTION_MAKE_REST,
 		MENU_OPTION_SET_REST,
+		MENU_OPTION_MAKE_REST,
 	};
 
 	Skeleton2D *node;


### PR DESCRIPTION
The texts were changed before, but the actions weren't swapped around. This led to unexpected behavior.

This closes https://github.com/godotengine/godot/issues/54793.

@irslutz Please double-check this, just in case :slightly_smiling_face: 