### PR TITLE
Add parser support for semicolons after annotation

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1567,6 +1567,10 @@ GDScriptParser::AnnotationNode *GDScriptParser::parse_annotation(uint32_t p_vali
 	}
 	complete_extents(annotation);
 
+	while (match(GDScriptTokenizer::Token::SEMICOLON)) {
+		// Semicolons after annotation are optional.
+	}
+
 	match(GDScriptTokenizer::Token::NEWLINE); // Newline after annotation is optional.
 
 	if (valid) {

--- a/modules/gdscript/tests/scripts/parser/features/single_line_class_statements.gd
+++ b/modules/gdscript/tests/scripts/parser/features/single_line_class_statements.gd
@@ -1,0 +1,1 @@
+pass;var x;@export;@warning_ignore("unused_private_class_variable");;;var _y : float;pass

--- a/modules/gdscript/tests/scripts/parser/features/single_line_class_statements.out
+++ b/modules/gdscript/tests/scripts/parser/features/single_line_class_statements.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
Following GDScript will now parse correctly:
```
pass;var x;@export;@onready;;;var y : float;pass

func test():
       pass
```
This closes #54280