### PR TITLE
Add missing characters for property name quoting

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4420,7 +4420,7 @@ String String::property_name_encode() const {
 	// as well as '"', '=' or ' ' (32)
 	const char32_t *cstr = get_data();
 	for (int i = 0; cstr[i]; i++) {
-		if (cstr[i] == '=' || cstr[i] == '"' || cstr[i] < 33 || cstr[i] > 126) {
+		if (cstr[i] == '=' || cstr[i] == '"' || cstr[i] == ';' || cstr[i] == '[' || cstr[i] == ']' || cstr[i] < 33 || cstr[i] > 126) {
 			return "\"" + c_escape_multiline() + "\"";
 		}
 	}


### PR DESCRIPTION
Fixes #54853

In text resource / `ConfigFile` format, `;` starts a comment, and `[xxx]` is a new section, so it's unsafe to use these characters in property names.

`]` seems safe actually, but I'm not 100% sure, and it feels bad if I quote `[` but not `]` 😛