### PR TITLE
[3.x] Fixed typo in NavigationPolygon doc

### DIFF
--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -18,7 +18,7 @@
 		var polygon = NavigationPolygon.new()
 		var vertices = PoolVector2Array([Vector2(0, 0), Vector2(0, 50), Vector2(50, 50), Vector2(50, 0)])
 		polygon.set_vertices(vertices)
-		var indices = PoolIntArray(0, 3, 1)
+		var indices = PoolIntArray([0, 1, 2, 3])
 		polygon.add_polygon(indices)
 		$NavigationPolygonInstance.navpoly = polygon
 		[/codeblock]


### PR DESCRIPTION
noticed typo in docs:
```gdscript
var polygon = NavigationPolygon.new()
var vertices = PoolVector2Array([Vector2(0, 0), Vector2(0, 50), Vector2(50, 50), Vector2(50, 0)])
polygon.set_vertices(vertices)
var indices = PoolIntArray(0, 3, 1)  # must be PoolIntArray([0, 1, 2, 3)
polygon.add_polygon(indices)
$NavigationPolygonInstance.navpoly = polygon

```