### PR TITLE
String: Remove `erase` method, bindings can't mutate String

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -85,8 +85,7 @@ String HTTPClient::query_string_from_dict(const Dictionary &p_dict) {
 			}
 		}
 	}
-	query.erase(0, 1);
-	return query;
+	return query.substr(1);
 }
 
 Dictionary HTTPClient::_get_response_headers_as_dictionary() {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -952,10 +952,6 @@ const char32_t *String::get_data() const {
 	return size() ? &operator[](0) : &zero;
 }
 
-void String::erase(int p_pos, int p_chars) {
-	*this = left(MAX(p_pos, 0)) + substr(p_pos + p_chars, length() - ((p_pos + p_chars)));
-}
-
 String String::capitalize() const {
 	String aux = this->camelcase_to_underscore(true).replace("_", " ").strip_edges();
 	String cap;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1412,8 +1412,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, plus_file, sarray("file"), varray());
 	bind_method(String, unicode_at, sarray("at"), varray());
 	bind_method(String, dedent, sarray(), varray());
-	// FIXME: String needs to be immutable when binding
-	//bind_method(String, erase, sarray("position", "chars"), varray());
 	bind_method(String, hash, sarray(), varray());
 	bind_method(String, md5_text, sarray(), varray());
 	bind_method(String, sha1_text, sarray(), varray());

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1429,14 +1429,15 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			bbcode = bbcode.replace("[/gdscript]", "[/codeblock]");
 
 			for (int pos = bbcode.find("[csharp]"); pos != -1; pos = bbcode.find("[csharp]")) {
-				if (bbcode.find("[/csharp]") == -1) {
+				int end_pos = bbcode.find("[/csharp]");
+				if (end_pos == -1) {
 					WARN_PRINT("Unclosed [csharp] block or parse fail in code (search for tag errors)");
 					break;
 				}
 
-				bbcode.erase(pos, bbcode.find("[/csharp]") + 9 - pos);
+				bbcode = bbcode.left(pos) + bbcode.substr(end_pos + 9); // 9 is length of "[/csharp]".
 				while (bbcode[pos] == '\n') {
-					bbcode.erase(pos, 1);
+					bbcode = bbcode.left(pos) + bbcode.substr(pos + 1);
 				}
 			}
 			break;
@@ -1445,14 +1446,15 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			bbcode = bbcode.replace("[/csharp]", "[/codeblock]");
 
 			for (int pos = bbcode.find("[gdscript]"); pos != -1; pos = bbcode.find("[gdscript]")) {
-				if (bbcode.find("[/gdscript]") == -1) {
+				int end_pos = bbcode.find("[/gdscript]");
+				if (end_pos == -1) {
 					WARN_PRINT("Unclosed [gdscript] block or parse fail in code (search for tag errors)");
 					break;
 				}
 
-				bbcode.erase(pos, bbcode.find("[/gdscript]") + 11 - pos);
+				bbcode = bbcode.left(pos) + bbcode.substr(end_pos + 11); // 11 is length of "[/gdscript]".
 				while (bbcode[pos] == '\n') {
-					bbcode.erase(pos, 1);
+					bbcode = bbcode.left(pos) + bbcode.substr(pos + 1);
 				}
 			}
 			break;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1629,10 +1629,7 @@ void ScriptTextEditor::_color_changed(const Color &p_color) {
 	}
 
 	String line = code_editor->get_text_editor()->get_line(color_position.x);
-	int color_args_pos = line.find(color_args, color_position.y);
-	String line_with_replaced_args = line;
-	line_with_replaced_args.erase(color_args_pos, color_args.length());
-	line_with_replaced_args = line_with_replaced_args.insert(color_args_pos, new_args);
+	String line_with_replaced_args = line.replace(color_args, new_args);
 
 	color_args = new_args;
 	code_editor->get_text_editor()->begin_complex_operation();

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -115,7 +115,7 @@ static void handle_crash(int sig) {
 			int ret;
 			Error err = OS::get_singleton()->execute(String("addr2line"), args, &output, &ret);
 			if (err == OK) {
-				output.erase(output.length() - 1, 1);
+				output = output.substr(0, output.length() - 1);
 			}
 
 			fprintf(stderr, "[%ld] %s (%s)\n", (long int)i, fname, output.utf8().get_data());

--- a/platform/osx/crash_handler_osx.mm
+++ b/platform/osx/crash_handler_osx.mm
@@ -146,7 +146,7 @@ static void handle_crash(int sig) {
 				String out = "";
 				Error err = OS::get_singleton()->execute(String("atos"), args, &out, &ret);
 				if (err == OK && out.substr(0, 2) != "0x") {
-					out.erase(out.length() - 1, 1);
+					out = out.substr(0, out.length() - 1);
 					output = out;
 				}
 			}

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -577,13 +577,12 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 
 	if (p_data.get_type() == Variant::STRING) {
 		set_caret_at_pixel_pos(p_point.x);
-		int selected = selection.end - selection.begin;
 
-		text.erase(selection.begin, selected);
+		text = text.left(selection.begin) + text.substr(selection.end);
 		_shape();
 
 		insert_text_at_caret(p_data);
-		selection.begin = caret_column - selected;
+		selection.begin = caret_column - (selection.end - selection.begin);
 		selection.end = caret_column;
 	}
 }
@@ -1244,7 +1243,7 @@ void LineEdit::delete_char() {
 		return;
 	}
 
-	text.erase(caret_column - 1, 1);
+	text = text.left(caret_column - 1) + text.substr(caret_column);
 	_shape();
 
 	set_caret_column(get_caret_column() - 1);
@@ -1256,7 +1255,7 @@ void LineEdit::delete_text(int p_from_column, int p_to_column) {
 	ERR_FAIL_COND_MSG(p_from_column < 0 || p_from_column > p_to_column || p_to_column > text.length(),
 			vformat("Positional parameters (from: %d, to: %d) are inverted or outside the text length (%d).", p_from_column, p_to_column, text.length()));
 
-	text.erase(p_from_column, p_to_column - p_from_column);
+	text = text.left(p_from_column) + text.substr(p_to_column);
 	_shape();
 
 	caret_column -= CLAMP(caret_column - p_from_column, 0, p_to_column - p_from_column);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3450,7 +3450,7 @@ void VisualShaderNodeGroupBase::add_input_port(int p_id, int p_type, const Strin
 			count++;
 		}
 
-		inputs.erase(index, count);
+		inputs = inputs.left(index) + inputs.substr(index + count);
 		inputs = inputs.insert(index, itos(i));
 		index += inputs_strings[i].size();
 	}
@@ -3473,7 +3473,7 @@ void VisualShaderNodeGroupBase::remove_input_port(int p_id) {
 		}
 		index += inputs_strings[i].size();
 	}
-	inputs.erase(index, count);
+	inputs = inputs.left(index) + inputs.substr(index + count);
 
 	inputs_strings = inputs.split(";", false);
 	inputs = inputs.substr(0, index);
@@ -3526,7 +3526,7 @@ void VisualShaderNodeGroupBase::add_output_port(int p_id, int p_type, const Stri
 			count++;
 		}
 
-		outputs.erase(index, count);
+		outputs = outputs.left(index) + outputs.substr(index + count);
 		outputs = outputs.insert(index, itos(i));
 		index += outputs_strings[i].size();
 	}
@@ -3549,7 +3549,7 @@ void VisualShaderNodeGroupBase::remove_output_port(int p_id) {
 		}
 		index += outputs_strings[i].size();
 	}
-	outputs.erase(index, count);
+	outputs = outputs.left(index) + outputs.substr(index + count);
 
 	outputs_strings = outputs.split(";", false);
 	outputs = outputs.substr(0, index);
@@ -3601,8 +3601,7 @@ void VisualShaderNodeGroupBase::set_input_port_type(int p_id, int p_type) {
 		index += inputs_strings[i].size();
 	}
 
-	inputs.erase(index, count);
-
+	inputs = inputs.left(index) + inputs.substr(index + count);
 	inputs = inputs.insert(index, itos(p_type));
 
 	_apply_port_changes();
@@ -3637,8 +3636,7 @@ void VisualShaderNodeGroupBase::set_input_port_name(int p_id, const String &p_na
 		index += inputs_strings[i].size();
 	}
 
-	inputs.erase(index, count);
-
+	inputs = inputs.left(index) + inputs.substr(index + count);
 	inputs = inputs.insert(index, p_name);
 
 	_apply_port_changes();
@@ -3673,7 +3671,7 @@ void VisualShaderNodeGroupBase::set_output_port_type(int p_id, int p_type) {
 		index += output_strings[i].size();
 	}
 
-	outputs.erase(index, count);
+	outputs = outputs.left(index) + outputs.substr(index + count);
 
 	outputs = outputs.insert(index, itos(p_type));
 
@@ -3709,7 +3707,7 @@ void VisualShaderNodeGroupBase::set_output_port_name(int p_id, const String &p_n
 		index += output_strings[i].size();
 	}
 
-	outputs.erase(index, count);
+	outputs = outputs.left(index) + outputs.substr(index + count);
 
 	outputs = outputs.insert(index, p_name);
 

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -490,12 +490,6 @@ TEST_CASE("[String] Splitting") {
 	}
 }
 
-TEST_CASE("[String] Erasing") {
-	String s = "Josephine is such a cute girl!";
-	s.erase(s.find("cute "), String("cute ").length());
-	CHECK(s == "Josephine is such a girl!");
-}
-
 struct test_27_data {
 	char const *data;
 	char const *part;


### PR DESCRIPTION
An alternative to removing this function would be to have it return a copy, like `insert()` does.

But there were only a handful of places using it and this was often not the most optimal approach anyway, so we might as well remove.

Part of #43311.