### PR TITLE
[3.x] Add methods to remove theme overrides

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -90,8 +90,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="color" type="Color" />
 			<description>
-				Creates a local override for a theme [Color] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override cannot be removed, but it can be overridden with the corresponding default value.
-				See also [method get_color].
+				Creates a local override for a theme [Color] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control.
+				See also [method get_color], [method remove_color_override].
 				[b]Example of overriding a label's color and resetting it later:[/b]
 				[codeblock]
 				# Given the child Label node "MyLabel", override its font color with a custom value.
@@ -106,8 +106,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="constant" type="int" />
 			<description>
-				Creates a local override for a theme constant with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override cannot be removed, but it can be overridden with the corresponding default value.
-				See also [method get_constant].
+				Creates a local override for a theme constant with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control.
+				See also [method get_constant], [method remove_constant_override].
 			</description>
 		</method>
 		<method name="add_font_override">
@@ -115,7 +115,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="font" type="Font" />
 			<description>
-				Creates a local override for a theme [Font] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed by assigning it a [code]null[/code] value.
+				Creates a local override for a theme [Font] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control.
+				[b]Note:[/b] An override can be removed by assigning it a [code]null[/code] value. This behavior is deprecated and will be removed in 4.0, use [method remove_font_override] instead.
 				See also [method get_font].
 			</description>
 		</method>
@@ -124,7 +125,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="texture" type="Texture" />
 			<description>
-				Creates a local override for a theme icon with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed by assigning it a [code]null[/code] value.
+				Creates a local override for a theme icon with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control.
+				[b]Note:[/b] An override can be removed by assigning it a [code]null[/code] value. This behavior is deprecated and will be removed in 4.0, use [method remove_icon_override] instead.
 				See also [method get_icon].
 			</description>
 		</method>
@@ -133,7 +135,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="shader" type="Shader" />
 			<description>
-				Creates a local override for a theme shader with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed by assigning it a [code]null[/code] value.
+				Creates a local override for a theme shader with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control.
+				[b]Note:[/b] An override can be removed by assigning it a [code]null[/code] value. This behavior is deprecated and will be removed in 4.0, use [method remove_shader_override] instead.
 			</description>
 		</method>
 		<method name="add_stylebox_override">
@@ -141,7 +144,8 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="stylebox" type="StyleBox" />
 			<description>
-				Creates a local override for a theme [StyleBox] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed by assigning it a [code]null[/code] value.
+				Creates a local override for a theme [StyleBox] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control.
+				[b]Note:[/b] An override can be removed by assigning it a [code]null[/code] value. This behavior is deprecated and will be removed in 4.0, use [method remove_stylebox_override] instead.
 				See also [method get_stylebox].
 				[b]Example of modifying a property in a StyleBox by duplicating it:[/b]
 				[codeblock]
@@ -510,6 +514,48 @@
 			<return type="void" />
 			<description>
 				Give up the focus. No other control will be able to receive keyboard input.
+			</description>
+		</method>
+		<method name="remove_color_override">
+			<return type="void" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Removes a theme override for a [Color] with the given [code]name[/code].
+			</description>
+		</method>
+		<method name="remove_constant_override">
+			<return type="void" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Removes a theme override for a constant with the given [code]name[/code].
+			</description>
+		</method>
+		<method name="remove_font_override">
+			<return type="void" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Removes a theme override for a [Font] with the given [code]name[/code].
+			</description>
+		</method>
+		<method name="remove_icon_override">
+			<return type="void" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Removes a theme override for an icon with the given [code]name[/code].
+			</description>
+		</method>
+		<method name="remove_shader_override">
+			<return type="void" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Removes a theme override for a shader with the given [code]name[/code].
+			</description>
+		</method>
+		<method name="remove_stylebox_override">
+			<return type="void" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Removes a theme override for a [StyleBox] with the given [code]name[/code].
 			</description>
 		</method>
 		<method name="set_anchor">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -223,40 +223,22 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 	if (p_value.get_type() == Variant::NIL) {
 		if (name.begins_with("custom_icons/")) {
 			String dname = name.get_slicec('/', 1);
-			if (data.icon_override.has(dname)) {
-				data.icon_override[dname]->disconnect("changed", this, "_override_changed");
-			}
-			data.icon_override.erase(dname);
-			notification(NOTIFICATION_THEME_CHANGED);
+			remove_icon_override(dname);
 		} else if (name.begins_with("custom_shaders/")) {
 			String dname = name.get_slicec('/', 1);
-			if (data.shader_override.has(dname)) {
-				data.shader_override[dname]->disconnect("changed", this, "_override_changed");
-			}
-			data.shader_override.erase(dname);
-			notification(NOTIFICATION_THEME_CHANGED);
+			remove_shader_override(dname);
 		} else if (name.begins_with("custom_styles/")) {
 			String dname = name.get_slicec('/', 1);
-			if (data.style_override.has(dname)) {
-				data.style_override[dname]->disconnect("changed", this, "_override_changed");
-			}
-			data.style_override.erase(dname);
-			notification(NOTIFICATION_THEME_CHANGED);
+			remove_stylebox_override(dname);
 		} else if (name.begins_with("custom_fonts/")) {
 			String dname = name.get_slicec('/', 1);
-			if (data.font_override.has(dname)) {
-				data.font_override[dname]->disconnect("changed", this, "_override_changed");
-			}
-			data.font_override.erase(dname);
-			notification(NOTIFICATION_THEME_CHANGED);
+			remove_font_override(dname);
 		} else if (name.begins_with("custom_colors/")) {
 			String dname = name.get_slicec('/', 1);
-			data.color_override.erase(dname);
-			notification(NOTIFICATION_THEME_CHANGED);
+			remove_color_override(dname);
 		} else if (name.begins_with("custom_constants/")) {
 			String dname = name.get_slicec('/', 1);
-			data.constant_override.erase(dname);
-			notification(NOTIFICATION_THEME_CHANGED);
+			remove_constant_override(dname);
 		} else {
 			return false;
 		}
@@ -1927,6 +1909,52 @@ void Control::add_constant_override(const StringName &p_name, int p_constant) {
 	notification(NOTIFICATION_THEME_CHANGED);
 }
 
+void Control::remove_icon_override(const StringName &p_name) {
+	if (data.icon_override.has(p_name)) {
+		data.icon_override[p_name]->disconnect("changed", this, "_override_changed");
+	}
+
+	data.icon_override.erase(p_name);
+	notification(NOTIFICATION_THEME_CHANGED);
+}
+
+void Control::remove_shader_override(const StringName &p_name) {
+	if (data.shader_override.has(p_name)) {
+		data.shader_override[p_name]->disconnect("changed", this, "_override_changed");
+	}
+
+	data.shader_override.erase(p_name);
+	notification(NOTIFICATION_THEME_CHANGED);
+}
+
+void Control::remove_stylebox_override(const StringName &p_name) {
+	if (data.style_override.has(p_name)) {
+		data.style_override[p_name]->disconnect("changed", this, "_override_changed");
+	}
+
+	data.style_override.erase(p_name);
+	notification(NOTIFICATION_THEME_CHANGED);
+}
+
+void Control::remove_font_override(const StringName &p_name) {
+	if (data.font_override.has(p_name)) {
+		data.font_override[p_name]->disconnect("changed", this, "_override_changed");
+	}
+
+	data.font_override.erase(p_name);
+	notification(NOTIFICATION_THEME_CHANGED);
+}
+
+void Control::remove_color_override(const StringName &p_name) {
+	data.color_override.erase(p_name);
+	notification(NOTIFICATION_THEME_CHANGED);
+}
+
+void Control::remove_constant_override(const StringName &p_name) {
+	data.constant_override.erase(p_name);
+	notification(NOTIFICATION_THEME_CHANGED);
+}
+
 void Control::set_focus_mode(FocusMode p_focus_mode) {
 	ERR_FAIL_INDEX((int)p_focus_mode, 3);
 
@@ -2788,6 +2816,13 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_font_override", "name", "font"), &Control::add_font_override);
 	ClassDB::bind_method(D_METHOD("add_color_override", "name", "color"), &Control::add_color_override);
 	ClassDB::bind_method(D_METHOD("add_constant_override", "name", "constant"), &Control::add_constant_override);
+
+	ClassDB::bind_method(D_METHOD("remove_icon_override", "name"), &Control::remove_icon_override);
+	ClassDB::bind_method(D_METHOD("remove_shader_override", "name"), &Control::remove_shader_override);
+	ClassDB::bind_method(D_METHOD("remove_stylebox_override", "name"), &Control::remove_stylebox_override);
+	ClassDB::bind_method(D_METHOD("remove_font_override", "name"), &Control::remove_font_override);
+	ClassDB::bind_method(D_METHOD("remove_color_override", "name"), &Control::remove_color_override);
+	ClassDB::bind_method(D_METHOD("remove_constant_override", "name"), &Control::remove_constant_override);
 
 	ClassDB::bind_method(D_METHOD("get_icon", "name", "theme_type"), &Control::get_icon, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "theme_type"), &Control::get_stylebox, DEFVAL(""));

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -425,6 +425,13 @@ public:
 	void add_color_override(const StringName &p_name, const Color &p_color);
 	void add_constant_override(const StringName &p_name, int p_constant);
 
+	void remove_icon_override(const StringName &p_name);
+	void remove_shader_override(const StringName &p_name);
+	void remove_stylebox_override(const StringName &p_name);
+	void remove_font_override(const StringName &p_name);
+	void remove_color_override(const StringName &p_name);
+	void remove_constant_override(const StringName &p_name);
+
 	Ref<Texture> get_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;


### PR DESCRIPTION
Backport of #47252

Unlike on `master`:

* It's still allowed to remove an override by calling `add_*_override` with a `null` value. But document the behavior as deprecated.
* The methods are named `remove_*_override` instead of `remove_theme_*_override` in order to be consistent with other related methods.