### PR TITLE
AABB: Exclude far faces in `has_point` to match 2D logic

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -297,13 +297,13 @@ bool AABB::has_point(const Vector3 &p_point) const {
 	if (p_point.z < position.z) {
 		return false;
 	}
-	if (p_point.x > position.x + size.x) {
+	if (p_point.x >= position.x + size.x) {
 		return false;
 	}
-	if (p_point.y > position.y + size.y) {
+	if (p_point.y >= position.y + size.y) {
 		return false;
 	}
-	if (p_point.z > position.z + size.z) {
+	if (p_point.z >= position.z + size.z) {
 		return false;
 	}
 

--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -142,14 +142,15 @@
 			<return type="bool" />
 			<argument index="0" name="point" type="Vector3" />
 			<description>
-				Returns [code]true[/code] if the [AABB] contains a point.
+				Returns [code]true[/code] if the [AABB] contains a point. Points on the far faces of the [AABB] (i.e. the three faces including [member end] and not including [member position]) are [b]not[/b] included.
+				[b]Note:[/b] This method is not reliable for [AABB] with a [i]negative size[/i]. Use [method abs] to get a positive sized equivalent [AABB] to check for contained points.
 			</description>
 		</method>
 		<method name="intersection" qualifiers="const">
 			<return type="AABB" />
 			<argument index="0" name="with" type="AABB" />
 			<description>
-				Returns the intersection between two [AABB]. An empty AABB (size 0,0,0) is returned on failure.
+				Returns the intersection between two [AABB]. An empty AABB (size [code](0, 0, 0)[/code]) is returned on failure.
 			</description>
 		</method>
 		<method name="intersects" qualifiers="const">

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -349,14 +349,27 @@ TEST_CASE("[AABB] Has point") {
 			aabb.has_point(Vector3(2, 3, 0)),
 			"has_point() with contained point should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.has_point(Vector3(-1.5, 3, 0)),
-			"has_point() with contained point on negative edge should return the expected value.");
-	CHECK_MESSAGE(
-			aabb.has_point(Vector3(2.5, 3, 0)),
-			"has_point() with contained point on positive edge should return the expected value.");
-	CHECK_MESSAGE(
 			!aabb.has_point(Vector3(-20, 0, 0)),
 			"has_point() with non-contained point should return the expected value.");
+
+	CHECK_MESSAGE(
+			aabb.has_point(Vector3(-1.5, 3, 0)),
+			"has_point() with positive size should include point on near face (X axis).");
+	CHECK_MESSAGE(
+			!aabb.has_point(Vector3(2.5, 3, 0)),
+			"has_point() with positive size should not include point on far face (X axis).");
+	CHECK_MESSAGE(
+			aabb.has_point(Vector3(0, 2, 0)),
+			"has_point() with positive size should include point on near face (Y axis).");
+	CHECK_MESSAGE(
+			!aabb.has_point(Vector3(0, 7, 0)),
+			"has_point() with positive size should not include point on far face (Y axis).");
+	CHECK_MESSAGE(
+			aabb.has_point(Vector3(0, 3, -2.5)),
+			"has_point() with positive size should include point on near face (Z axis).");
+	CHECK_MESSAGE(
+			!aabb.has_point(Vector3(0, 3, 3.5)),
+			"has_point() with positive size should not include point on far face (Z axis).");
 }
 
 TEST_CASE("[AABB] Expanding") {


### PR DESCRIPTION
"Far" faces being the ones that include the `end` (`position + size`) point,
i.e. the faces which do not contain the `position` point.

Follow-up to #54872 and discussion in #44727.