### PR TITLE
Fix import_scene_from_other_importer and import_animation_from_other_importer

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1462,7 +1462,7 @@ Node *ResourceImporterScene::import_scene_from_other_importer(EditorSceneFormatI
 
 		for (const String &F : extensions) {
 			if (F.to_lower() == ext) {
-				importer = E;
+				importer = E->get();
 				break;
 			}
 		}
@@ -1492,7 +1492,7 @@ Ref<Animation> ResourceImporterScene::import_animation_from_other_importer(Edito
 
 		for (const String &F : extensions) {
 			if (F.to_lower() == ext) {
-				importer = E;
+				importer = E->get();
 				break;
 			}
 		}


### PR DESCRIPTION
No issue was filed since we found a workaround, but we found import_scene_from_other_importer was broken in 4.x when writing the .blend importer (it works fine in 3.x)

After debugging, I found that the code for these functions was trying to cast a list item reference into a `EditorSceneFormatImporter`, missing a ->get() indirection.

This PR makes these functions match what `pre_import` already does, namely:
```cpp
Node *ResourceImporterScene::pre_import(const String &p_source_file) {
	Ref<EditorSceneFormatImporter> importer;
	String ext = p_source_file.get_extension().to_lower();

	EditorProgress progress("pre-import", TTR("Pre-Import Scene"), 0);
	progress.step(TTR("Importing Scene..."), 0);

	for (Set<Ref<EditorSceneFormatImporter>>::Element *E = importers.front(); E; E = E->next()) {
		List<String> extensions;
		E->get()->get_extensions(&extensions);

		for (const String &F : extensions) {
			if (F.to_lower() == ext) {
				importer = E->get(); // <-- HERE
				break;
			}
		}

		if (importer.is_valid()) {
			break;
		}
	}
```