### PR TITLE
Update visual script property selector

### DIFF
--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -1,3 +1,4 @@
+#include "visual_script_property_selector.h"
 /*************************************************************************/
 /*  visual_script_property_selector.cpp                                  */
 /*************************************************************************/
@@ -42,10 +43,6 @@
 #include "scene/main/node.h"
 #include "scene/main/window.h"
 
-void VisualScriptPropertySelector::_text_changed(const String &p_newtext) {
-	_update_search();
-}
-
 void VisualScriptPropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 	Ref<InputEventKey> k = p_ie;
 
@@ -55,20 +52,20 @@ void VisualScriptPropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 			case Key::DOWN:
 			case Key::PAGEUP:
 			case Key::PAGEDOWN: {
-				search_options->gui_input(k);
+				results_tree->gui_input(k);
 				search_box->accept_event();
 
-				TreeItem *root = search_options->get_root();
+				TreeItem *root = results_tree->get_root();
 				if (!root->get_first_child()) {
 					break;
 				}
 
-				TreeItem *current = search_options->get_selected();
+				TreeItem *current = results_tree->get_selected();
 
-				TreeItem *item = search_options->get_next_selected(root);
+				TreeItem *item = results_tree->get_next_selected(root);
 				while (item) {
 					item->deselect(0);
-					item = search_options->get_next_selected(item);
+					item = results_tree->get_next_selected(item);
 				}
 
 				current->select(0);
@@ -80,13 +77,21 @@ void VisualScriptPropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 	}
 }
 
+void VisualScriptPropertySelector::_update_search_i(int p_int) {
+	_update_search();
+}
+
+void VisualScriptPropertySelector::_update_search_s(String p_string) {
+	_update_search();
+}
+
 void VisualScriptPropertySelector::_update_search() {
 	set_title(TTR("Search VisualScript"));
 
-	search_options->clear();
+	results_tree->clear();
 	help_bit->set_text("");
 
-	TreeItem *root = search_options->create_item();
+	TreeItem *root = results_tree->create_item();
 	bool found = false;
 	StringName base = base_type;
 	List<StringName> base_list;
@@ -100,45 +105,45 @@ void VisualScriptPropertySelector::_update_search() {
 		List<PropertyInfo> props;
 		TreeItem *category = nullptr;
 		Ref<Texture2D> type_icons[Variant::VARIANT_MAX] = {
-			vbc->get_theme_icon(SNAME("Variant"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("String"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Vector2i"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Rect2"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Rect2i"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Vector3i"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Transform2D"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Plane"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Quaternion"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("AABB"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Basis"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("StringName"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("NodePath"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("RID"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("MiniObject"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Callable"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Signal"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Dictionary"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedByteArray"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedInt32Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedInt64Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedFloat32Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedFloat64Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedStringArray"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedVector2Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedVector3Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedColorArray"), SNAME("EditorIcons"))
+			vbox->get_theme_icon(SNAME("Variant"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("String"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Vector2i"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Rect2"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Rect2i"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Vector3i"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Transform2D"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Plane"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Quaternion"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("AABB"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Basis"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("StringName"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("NodePath"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("RID"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("MiniObject"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Callable"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Signal"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Dictionary"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("Array"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("PackedByteArray"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("PackedInt32Array"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("PackedInt64Array"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("PackedFloat32Array"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("PackedFloat64Array"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("PackedStringArray"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("PackedVector2Array"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("PackedVector3Array"), SNAME("EditorIcons")),
+			vbox->get_theme_icon(SNAME("PackedColorArray"), SNAME("EditorIcons"))
 		};
 		{
 			String b = String(E);
-			category = search_options->create_item(root);
+			category = results_tree->create_item(root);
 			if (category) {
 				category->set_text(0, b.replace_first("*", ""));
 				category->set_selectable(0, false);
@@ -176,7 +181,7 @@ void VisualScriptPropertySelector::_update_search() {
 				String input = search_box->get_text().capitalize();
 
 				if (input == String() || get_text_raw.findn(input) != -1 || get_text.findn(input) != -1) {
-					TreeItem *item = search_options->create_item(category ? category : root);
+					TreeItem *item = results_tree->create_item(category ? category : root);
 					item->set_text(0, get_text);
 					item->set_metadata(0, F.name);
 					item->set_icon(0, type_icons[F.type]);
@@ -189,7 +194,7 @@ void VisualScriptPropertySelector::_update_search() {
 				}
 
 				if (input == String() || set_text_raw.findn(input) != -1 || set_text.findn(input) != -1) {
-					TreeItem *item = search_options->create_item(category ? category : root);
+					TreeItem *item = results_tree->create_item(category ? category : root);
 					item->set_text(0, set_text);
 					item->set_metadata(0, F.name);
 					item->set_icon(0, type_icons[F.type]);
@@ -259,9 +264,9 @@ void VisualScriptPropertySelector::_update_search() {
 				continue;
 			}
 
-			TreeItem *item = search_options->create_item(category ? category : root);
+			TreeItem *item = results_tree->create_item(category ? category : root);
 			item->set_text(0, desc);
-			item->set_icon(0, vbc->get_theme_icon(SNAME("MemberMethod"), SNAME("EditorIcons")));
+			item->set_icon(0, vbox->get_theme_icon(SNAME("MemberMethod"), SNAME("EditorIcons")));
 			item->set_metadata(0, name);
 			item->set_selectable(0, true);
 
@@ -312,7 +317,7 @@ void VisualScriptPropertySelector::_update_search() {
 		get_visual_node_names("", Set<String>(), found, root, search_box);
 	}
 
-	TreeItem *selected_item = search_options->search_item_text(search_box->get_text());
+	TreeItem *selected_item = results_tree->search_item_text(search_box->get_text());
 	if (!found && selected_item != nullptr) {
 		selected_item->select(0);
 		found = true;
@@ -323,9 +328,9 @@ void VisualScriptPropertySelector::_update_search() {
 
 void VisualScriptPropertySelector::create_visualscript_item(const String &name, TreeItem *const root, const String &search_input, const String &text) {
 	if (search_input == String() || text.findn(search_input) != -1) {
-		TreeItem *item = search_options->create_item(root);
+		TreeItem *item = results_tree->create_item(root);
 		item->set_text(0, text);
-		item->set_icon(0, vbc->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
+		item->set_icon(0, vbox->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
 		item->set_metadata(0, name);
 		item->set_metadata(1, "action");
 		item->set_selectable(0, true);
@@ -376,7 +381,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 			continue;
 		}
 
-		TreeItem *item = search_options->create_item(root);
+		TreeItem *item = results_tree->create_item(root);
 		Ref<VisualScriptNode> vnode = VisualScriptLanguage::singleton->create_node_from_name(E);
 		Ref<VisualScriptOperator> vnode_operator = vnode;
 		String type_name;
@@ -409,7 +414,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 		}
 
 		item->set_text(0, type_name + String("").join(desc));
-		item->set_icon(0, vbc->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
+		item->set_icon(0, vbox->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
 		item->set_selectable(0, true);
 		item->set_metadata(0, E);
 		item->set_selectable(0, true);
@@ -421,7 +426,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 }
 
 void VisualScriptPropertySelector::_confirmed() {
-	TreeItem *ti = search_options->get_selected();
+	TreeItem *ti = results_tree->get_selected();
 	if (!ti) {
 		return;
 	}
@@ -432,7 +437,7 @@ void VisualScriptPropertySelector::_confirmed() {
 void VisualScriptPropertySelector::_item_selected() {
 	help_bit->set_text("");
 
-	TreeItem *item = search_options->get_selected();
+	TreeItem *item = results_tree->get_selected();
 	if (!item) {
 		return;
 	}
@@ -705,29 +710,91 @@ void VisualScriptPropertySelector::_bind_methods() {
 }
 
 VisualScriptPropertySelector::VisualScriptPropertySelector() {
-	vbc = memnew(VBoxContainer);
-	add_child(vbc);
-	//set_child_rect(vbc);
-	search_box = memnew(LineEdit);
-	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect("text_changed", callable_mp(this, &VisualScriptPropertySelector::_text_changed));
-	search_box->connect("gui_input", callable_mp(this, &VisualScriptPropertySelector::_sbox_input));
-	search_options = memnew(Tree);
-	vbc->add_margin_child(TTR("Matches:"), search_options, true);
-	get_ok_button()->set_text(TTR("Open"));
-	get_ok_button()->set_disabled(true);
-	register_text_enter(search_box);
-	set_hide_on_ok(false);
-	search_options->connect("item_activated", callable_mp(this, &VisualScriptPropertySelector::_confirmed));
-	search_options->connect("cell_selected", callable_mp(this, &VisualScriptPropertySelector::_item_selected));
-	search_options->set_hide_root(true);
-	search_options->set_hide_folding(true);
 	virtuals_only = false;
 	seq_connect = false;
+
+	vbox = memnew(VBoxContainer);
+	add_child(vbox);
+
+	// Create the search box and filter controls (at the top).
+	HBoxContainer *hbox = memnew(HBoxContainer);
+	vbox->add_margin_child(TTR("Search:"), hbox);
+
+	search_box = memnew(LineEdit);
+	search_box->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->connect("text_changed", callable_mp(this, &VisualScriptPropertySelector::_update_search_s));
+	search_box->connect("gui_input", callable_mp(this, &VisualScriptPropertySelector::_sbox_input));
+	register_text_enter(search_box);
+	hbox->add_child(search_box);
+
+	case_sensitive_button = memnew(Button);
+	//	case_sensitive_button->set_flat(true); comented until update icon is working
+	case_sensitive_button->set_tooltip(TTR("Case Sensitive"));
+	case_sensitive_button->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_search));
+	case_sensitive_button->set_toggle_mode(true);
+	case_sensitive_button->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(case_sensitive_button);
+
+	hierarchy_button = memnew(Button);
+	//	hierarchy_button->set_flat(true); comented until update icon is working
+	hierarchy_button->set_tooltip(TTR("Show Hierarchy"));
+	hierarchy_button->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_search));
+	hierarchy_button->set_toggle_mode(true);
+	hierarchy_button->set_pressed(true);
+	hierarchy_button->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(hierarchy_button);
+
+	filter_combo = memnew(OptionButton);
+	filter_combo->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	filter_combo->set_stretch_ratio(0); // Fixed width.
+	filter_combo->add_item(TTR("Display All"), SEARCH_ALL);
+	filter_combo->add_separator();
+	filter_combo->add_item(TTR("Classes Only"), SEARCH_CLASSES);
+	filter_combo->add_item(TTR("Constructors Only"), SEARCH_CONSTRUCTORS);
+	filter_combo->add_item(TTR("Methods Only"), SEARCH_METHODS);
+	filter_combo->add_item(TTR("Operators Only"), SEARCH_OPERATORS);
+	filter_combo->add_item(TTR("Signals Only"), SEARCH_SIGNALS);
+	filter_combo->add_item(TTR("Constants Only"), SEARCH_CONSTANTS);
+	filter_combo->add_item(TTR("Properties Only"), SEARCH_PROPERTIES);
+	filter_combo->add_item(TTR("Theme Properties Only"), SEARCH_THEME_ITEMS);
+	filter_combo->connect("item_selected", callable_mp(this, &VisualScriptPropertySelector::_update_search_i));
+	hbox->add_child(filter_combo);
+
+	scope_combo = memnew(OptionButton);
+	scope_combo->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	scope_combo->set_stretch_ratio(0); // Fixed width.
+	scope_combo->add_item(TTR("Search Related"), SCOPE_RELATED);
+	scope_combo->add_separator();
+	scope_combo->add_item(TTR("Search Base"), SCOPE_BASE);
+	scope_combo->add_item(TTR("Search Inheriters"), SCOPE_INHERITERS);
+	scope_combo->add_item(TTR("Search Unrelated"), SCOPE_UNRELATED);
+	scope_combo->connect("item_selected", callable_mp(this, &VisualScriptPropertySelector::_update_search_i));
+	hbox->add_child(scope_combo);
+
+	results_tree = memnew(Tree);
+	results_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	results_tree->set_hide_root(true);
+	//	results_tree->set_hide_folding(true);
+	results_tree->set_columns(3); // needed for original _update_search()
+	//	results_tree->set_columns(2);
+	results_tree->set_column_title(0, TTR("Name"));
+	results_tree->set_column_clip_content(0, true);
+	results_tree->set_column_title(1, TTR("Member Type"));
+	results_tree->set_column_expand(1, false);
+	results_tree->set_column_custom_minimum_width(1, 150 * EDSCALE);
+	results_tree->set_column_clip_content(1, true);
+	results_tree->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
+	results_tree->set_select_mode(Tree::SELECT_ROW);
+	//	results_tree->set_column_expand(2, false);
+	results_tree->connect("item_activated", callable_mp(this, &VisualScriptPropertySelector::_confirmed));
+	results_tree->connect("cell_selected", callable_mp(this, &VisualScriptPropertySelector::_item_selected));
+	vbox->add_margin_child(TTR("Matches:"), results_tree, true);
+
 	help_bit = memnew(EditorHelpBit);
-	vbc->add_margin_child(TTR("Description:"), help_bit);
+	vbox->add_margin_child(TTR("Description:"), help_bit);
 	help_bit->connect("request_hide", callable_mp(this, &VisualScriptPropertySelector::_hide_requested));
-	search_options->set_columns(3);
-	search_options->set_column_expand(1, false);
-	search_options->set_column_expand(2, false);
+	get_ok_button()->set_text(TTR("Open"));
+	get_ok_button()->set_disabled(true);
+	set_hide_on_ok(false);
 }

--- a/modules/visual_script/editor/visual_script_property_selector.h
+++ b/modules/visual_script/editor/visual_script_property_selector.h
@@ -37,12 +37,41 @@
 
 class VisualScriptPropertySelector : public ConfirmationDialog {
 	GDCLASS(VisualScriptPropertySelector, ConfirmationDialog);
+	
+	enum SearchFlags {
+		SEARCH_CLASSES = 1 << 0,
+		SEARCH_CONSTRUCTORS = 1 << 1,
+		SEARCH_METHODS = 1 << 2,
+		SEARCH_OPERATORS = 1 << 3,
+		SEARCH_SIGNALS = 1 << 4,
+		SEARCH_CONSTANTS = 1 << 5,
+		SEARCH_PROPERTIES = 1 << 6,
+		SEARCH_THEME_ITEMS = 1 << 7,
+		SEARCH_ALL = SEARCH_CLASSES | SEARCH_CONSTRUCTORS | SEARCH_METHODS | SEARCH_OPERATORS | SEARCH_SIGNALS | SEARCH_CONSTANTS | SEARCH_PROPERTIES | SEARCH_THEME_ITEMS,
+		SEARCH_CASE_SENSITIVE = 1 << 29,
+		SEARCH_SHOW_HIERARCHY = 1 << 30,
+	};
+
+	enum ScopeFlags {
+		SCOPE_BASE = 1 << 0,
+		SCOPE_INHERITERS = 1 << 1,
+		SCOPE_UNRELATED = 1 << 2,
+		SCOPE_RELATED = SCOPE_BASE | SCOPE_INHERITERS
+	};
 
 	LineEdit *search_box;
-	Tree *search_options;
+	Button *search_base_button;
+	Button *search_inheritors_button;
+	Button *search_unrelated_button;
+	Button *case_sensitive_button;
+	Button *hierarchy_button;
+	OptionButton *filter_combo;
+	OptionButton *scope_combo;
+	Tree *results_tree;
 
-	void _text_changed(const String &p_newtext);
 	void _sbox_input(const Ref<InputEvent> &p_ie);
+	void _update_search_i(int p_int);
+	void _update_search_s(String p_string);
 	void _update_search();
 
 	void create_visualscript_item(const String &name, TreeItem *const root, const String &search_input, const String &text);
@@ -64,7 +93,7 @@ class VisualScriptPropertySelector : public ConfirmationDialog {
 	Object *instance;
 	bool virtuals_only;
 	bool seq_connect;
-	VBoxContainer *vbc;
+	VBoxContainer *vbox;
 
 	Vector<Variant::Type> type_filter;
 

--- a/modules/visual_script/editor/visual_script_property_selector.h
+++ b/modules/visual_script/editor/visual_script_property_selector.h
@@ -31,13 +31,14 @@
 #ifndef VISUALSCRIPT_PROPERTYSELECTOR_H
 #define VISUALSCRIPT_PROPERTYSELECTOR_H
 
+#include "../visual_script.h"
 #include "editor/editor_help.h"
 #include "editor/property_editor.h"
 #include "scene/gui/rich_text_label.h"
 
 class VisualScriptPropertySelector : public ConfirmationDialog {
 	GDCLASS(VisualScriptPropertySelector, ConfirmationDialog);
-	
+
 	enum SearchFlags {
 		SEARCH_CLASSES = 1 << 0,
 		SEARCH_CONSTRUCTORS = 1 << 1,
@@ -69,9 +70,18 @@ class VisualScriptPropertySelector : public ConfirmationDialog {
 	OptionButton *scope_combo;
 	Tree *results_tree;
 
+	class DocRunner;
+	Ref<DocRunner> doc_runner;
+	Vector<Ref<VisualScriptNode>> result_nodes;
+	Map<String, DocData::ClassDoc> result_class_list;
+
+	class SearchRunner;
+	Ref<SearchRunner> search_runner;
+
 	void _sbox_input(const Ref<InputEvent> &p_ie);
-	void _update_search_i(int p_int);
-	void _update_search_s(String p_string);
+	void _update_results_i(int p_int);
+	void _update_results_s(String p_string);
+	void _update_results();
 	void _update_search();
 
 	void create_visualscript_item(const String &name, TreeItem *const root, const String &search_input, const String &text);
@@ -115,6 +125,118 @@ public:
 	void set_type_filter(const Vector<Variant::Type> &p_type_filter);
 
 	VisualScriptPropertySelector();
+};
+
+class VisualScriptPropertySelector::DocRunner : public RefCounted {
+	enum Phase {
+		PHASE_INIT_SEARCH,
+		PHASE_GET_ALL_FOLDER_PATHS,
+		PHASE_GET_ALL_FILE_PATHS,
+		PHASE_MAX
+	};
+	int phase = 0;
+
+	Vector<Ref<VisualScriptNode>> *result_nodes;
+	//Vector<Ref<Script>> *result_scripts;
+	Map<String, DocData::ClassDoc> *result_class_list;
+
+	// Config
+	Vector<String> _extension_filter;
+
+	// State
+	String _current_dir;
+	Vector<PackedStringArray> _folders_stack;
+	Vector<String> _files_to_scan;
+	int _initial_files_count = 0;
+
+	bool _slice();
+	bool _phase_init_search();
+	bool _phase_get_all_folder_paths();
+	bool _phase_get_all_file_paths();
+
+	void _scan_dir(String path, PackedStringArray &out_folders);
+	void _scan_file(String fpath);
+	DocData::MethodDoc _get_method_doc(MethodInfo method_info);
+
+public:
+	bool work(uint64_t slot = 100000);
+
+	DocRunner(Vector<Ref<VisualScriptNode>> *p_result_nodes, Map<String, DocData::ClassDoc> *p_result_class_list);
+};
+
+class VisualScriptPropertySelector::SearchRunner : public RefCounted {
+	enum Phase {
+		PHASE_MATCH_CLASSES_INIT,
+		PHASE_MATCH_CLASSES,
+		PHASE_CLASS_ITEMS_INIT,
+		PHASE_CLASS_ITEMS,
+		PHASE_MEMBER_ITEMS_INIT,
+		PHASE_MEMBER_ITEMS,
+		PHASE_SELECT_MATCH,
+		PHASE_MAX
+	};
+	int phase = 0;
+
+	struct ClassMatch {
+		DocData::ClassDoc *doc;
+		bool name = false;
+		Vector<DocData::MethodDoc *> constructors;
+		Vector<DocData::MethodDoc *> methods;
+		Vector<DocData::MethodDoc *> operators;
+		Vector<DocData::MethodDoc *> signals;
+		Vector<DocData::ConstantDoc *> constants;
+		Vector<DocData::PropertyDoc *> properties;
+		Vector<DocData::ThemeItemDoc *> theme_properties;
+
+		bool required() {
+			return name || methods.size() || signals.size() || constants.size() || properties.size() || theme_properties.size();
+		}
+	};
+
+	VisualScriptPropertySelector *selector_ui;
+	Control *ui_service;
+	Tree *results_tree;
+	String term;
+	int search_flags;
+
+	Ref<Texture2D> empty_icon;
+	Color disabled_color;
+
+	Map<String, DocData::ClassDoc> *class_docs;
+	Map<String, DocData::ClassDoc>::Element *iterator_doc = nullptr;
+	Map<String, ClassMatch> matches;
+	Map<String, ClassMatch>::Element *iterator_match = nullptr;
+	TreeItem *root_item = nullptr;
+	Map<String, TreeItem *> class_items;
+	TreeItem *matched_item = nullptr;
+	float match_highest_score = 0;
+
+	bool _is_class_disabled_by_feature_profile(const StringName &p_class);
+
+	bool _slice();
+	bool _phase_match_classes_init();
+	bool _phase_match_classes();
+	bool _phase_class_items_init();
+	bool _phase_class_items();
+	bool _phase_member_items_init();
+	bool _phase_member_items();
+	bool _phase_select_match();
+
+	bool _match_string(const String &p_term, const String &p_string) const;
+	void _match_item(TreeItem *p_item, const String &p_text);
+	TreeItem *_create_class_hierarchy(const ClassMatch &p_match);
+	TreeItem *_create_class_item(TreeItem *p_parent, const DocData::ClassDoc *p_doc, bool p_gray);
+	TreeItem *_create_method_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const String &p_text, const DocData::MethodDoc *p_doc);
+	TreeItem *_create_signal_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::MethodDoc *p_doc);
+	TreeItem *_create_constant_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ConstantDoc *p_doc);
+	TreeItem *_create_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::PropertyDoc *p_doc);
+	TreeItem *_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ThemeItemDoc *p_doc);
+	TreeItem *_create_member_item(TreeItem *p_parent, const String &p_class_name, const String &p_icon, const String &p_name, const String &p_text, const String &p_type, const String &p_metatype, const String &p_tooltip);
+
+public:
+	bool work(uint64_t slot = 100000);
+
+	SearchRunner(VisualScriptPropertySelector *p_selector_ui, Tree *p_results_tree, Map<String, DocData::ClassDoc> *p_class_docs);
 };
 
 #endif // VISUALSCRIPT_PROPERTYSELECTOR_H


### PR DESCRIPTION
# WIP for proposal [#3528](https://github.com/godotengine/godot-proposals/issues/3528)

### Describe how your proposal will work, with code, pseudo-code, mock-ups, and/or diagrams

1. The search functionality of EditorHelpSearch seems more capable and understandable so I will try to implement this as a new foundation.
2. Implement the filters expected of both property inspectors. These filters are dependant on the input data.
3. Implement filters based on scope. Now only base classes are used to give results, for example when using the input class it's most likely you only want to base results on the Inheritors.
3.1 (Optional) Make filter conditions and presets extendable and overwritable by plugins. To support different programming styles
4. And last, when not enough solutions are provided automatically start ignoring the filters until you find solutions.
5. Then reimplement the creation of nodes based on the selection.
6.  And last provide the possibility to create snippets when creating none base nodes.
6.1. Use Typecast when creating inheriter nodes.
6.2. Use HasFunction when creating unrelated nodes.
6.3. (Optional) Maybe make these sippet conditions and result extendable and overwritable by plugins. Similar to PropertyEditor 

Updated 28-11-2021
Decided to create a DocRunner class first. It is responsible to get all the scripts that are not registered.
- [ ] Only update on reload script.
- [x] Loop true all folders.
- [x] Create ClassDocs on all scripts.
- [x] Create a VisualScriptNode for all CustomNodes. VisualScriptNode is needed for proper analysis in later phases.
The SearchRunner class is almost a copy of the EditorHelpSearch::Runner
- [x] Use the ClassDocs created by Docrunner.
- [ ] Interpret all VisualScriptNodes and options.
- [ ] Provide usable metadata so VisualScriptPropertySelector is able to instantiate selected tree item.

Next.
- [ ] VisualScriptPropertySelector, rework how the nodes get dropped.
- [ ] VisualScriptPropertySelector, rework the starting triggers. So all triggers work again and start with appropriate triggers.
