### PR TITLE
Improve default enclosing radius for some shapes

### DIFF
--- a/scene/resources/capsule_shape_3d.cpp
+++ b/scene/resources/capsule_shape_3d.cpp
@@ -67,7 +67,7 @@ Vector<Vector3> CapsuleShape3D::get_debug_mesh_lines() const {
 }
 
 real_t CapsuleShape3D::get_enclosing_radius() const {
-	return height * 0.5;
+	return radius;
 }
 
 void CapsuleShape3D::_update_shape() {

--- a/scene/resources/cylinder_shape_3d.cpp
+++ b/scene/resources/cylinder_shape_3d.cpp
@@ -60,7 +60,7 @@ Vector<Vector3> CylinderShape3D::get_debug_mesh_lines() const {
 }
 
 real_t CylinderShape3D::get_enclosing_radius() const {
-	return Vector2(radius, height * 0.5).length();
+	return radius;
 }
 
 void CylinderShape3D::_update_shape() {

--- a/scene/resources/shape_3d.h
+++ b/scene/resources/shape_3d.h
@@ -57,7 +57,7 @@ public:
 
 	Ref<ArrayMesh> get_debug_mesh();
 	virtual Vector<Vector3> get_debug_mesh_lines() const = 0; // { return Vector<Vector3>(); }
-	/// Returns the radius of a sphere that fully enclose this shape
+	/// Returns the radius of a circle that fully encloses this shape in XZ-plane
 	virtual real_t get_enclosing_radius() const = 0;
 
 	void add_vertices_to_array(Vector<Vector3> &array, const Transform3D &p_xform);


### PR DESCRIPTION
Since navigation agents are now assumed to have Y-axis as up, the enclosing radius should be now considered a circle enclosing shape in XZ-plane - not a sphere like in the past.