### PR TITLE
[GDScript] Check string literals for Unicode direction control characters.

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -795,6 +795,15 @@ GDScriptTokenizer::Token GDScriptTokenizer::string() {
 
 		char32_t ch = _peek();
 
+		if (ch == 0x200E || ch == 0x200F || (ch >= 0x202A && ch <= 0x202E) || (ch >= 0x2066 && ch <= 0x2069)) {
+			Token error = make_error("Invisible text direction control character present in the string, escape it (\"\\u" + String::num_int64(ch, 16) + "\") to avoid confusion.");
+			error.start_column = column;
+			error.leftmost_column = error.start_column;
+			error.end_column = column + 1;
+			error.rightmost_column = error.end_column;
+			push_error(error);
+		}
+
 		if (ch == '\\') {
 			// Escape pattern.
 			_advance();


### PR DESCRIPTION
Fixes potential vulnerability, described in [Trojan Source: Invisible Vulnerabilities](https://arxiv.org/abs/2111.00169). Since GDScript do not have `{...}` blocks, the second vulnerability variant probably is irrelevant.

Before:
<img width="832" alt="before" src="https://user-images.githubusercontent.com/7645683/141308657-32b1164c-9580-4b69-8751-7ecdd6f0d7de.png">

After:
![after](https://user-images.githubusercontent.com/7645683/141308868-9f078f6d-2731-4501-b4e2-c6863d113af8.png)

Test script:
[dircontrol.gd.zip](https://github.com/godotengine/godot/files/7520808/dircontrol.gd.zip)

*Bugsquad edit:* Mitigates CVE-2021-42574 for GDScript.