### PR TITLE
Make draw/compute lists threadsafe

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -7574,6 +7574,9 @@ Error RenderingDeviceVulkan::draw_list_switch_to_next_pass_split(uint32_t p_spli
 }
 
 Error RenderingDeviceVulkan::_draw_list_allocate(const Rect2i &p_viewport, uint32_t p_splits, uint32_t p_subpass) {
+	// Lock while draw_list is active
+	_THREAD_SAFE_LOCK_
+
 	if (p_splits == 0) {
 		draw_list = memnew(DrawList);
 		draw_list->command_buffer = frames[frame].draw_command_buffer;
@@ -7684,6 +7687,9 @@ void RenderingDeviceVulkan::_draw_list_free(Rect2i *r_last_viewport) {
 		memdelete(draw_list);
 		draw_list = nullptr;
 	}
+
+	// draw_list is no longer active
+	_THREAD_SAFE_UNLOCK_
 }
 
 void RenderingDeviceVulkan::draw_list_end(uint32_t p_post_barrier) {
@@ -7796,6 +7802,9 @@ void RenderingDeviceVulkan::draw_list_end(uint32_t p_post_barrier) {
 RenderingDevice::ComputeListID RenderingDeviceVulkan::compute_list_begin(bool p_allow_draw_overlap) {
 	ERR_FAIL_COND_V_MSG(!p_allow_draw_overlap && draw_list != nullptr, INVALID_ID, "Only one draw list can be active at the same time.");
 	ERR_FAIL_COND_V_MSG(compute_list != nullptr, INVALID_ID, "Only one draw/compute list can be active at the same time.");
+
+	// Lock while compute_list is active
+	_THREAD_SAFE_LOCK_
 
 	compute_list = memnew(ComputeList);
 	compute_list->command_buffer = frames[frame].draw_command_buffer;
@@ -8270,6 +8279,9 @@ void RenderingDeviceVulkan::compute_list_end(uint32_t p_post_barrier) {
 
 	memdelete(compute_list);
 	compute_list = nullptr;
+
+	// compute_list is no longer active
+	_THREAD_SAFE_UNLOCK_
 }
 
 void RenderingDeviceVulkan::barrier(uint32_t p_from, uint32_t p_to) {

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -259,7 +259,6 @@ public:
 			command_queue.push(RSG::storage, &RendererStorage::mesh_initialize, mesh);
 			command_queue.push(RSG::storage, &RendererStorage::mesh_set_blend_shape_count, mesh, p_blend_shape_count);
 			for (int i = 0; i < p_surfaces.size(); i++) {
-				RSG::storage->mesh_add_surface(mesh, p_surfaces[i]);
 				command_queue.push(RSG::storage, &RendererStorage::mesh_add_surface, mesh, p_surfaces[i]);
 			}
 		}


### PR DESCRIPTION
Discussed with reduz on rocketchat.
Creating resources asynchronously can sometimes catch the renderer while it is building a draw list, causing creation to fail.

Should fix #48265, but while I've reproduced those errors in the past, I'm struggling to reproduce them now so I can't test this.

(bonus: removes an accidental line that may cause issues with other renderers in the future)