### PR TITLE
Update CanvasItem when MultiMesh instance transform changes

### DIFF
--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "multimesh_instance_2d.h"
+#include "core/core_string_names.h"
 
 void MultiMeshInstance2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
@@ -56,7 +57,16 @@ void MultiMeshInstance2D::_bind_methods() {
 }
 
 void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
+	// Cleanup previous connection if any.
+	if (multimesh.is_valid()) {
+		multimesh->disconnect(CoreStringNames::get_singleton()->changed, this, "update");
+	}
 	multimesh = p_multimesh;
+
+	// Connect to the multimesh so the AABB can update when instance transforms are changed.
+	if (multimesh.is_valid()) {
+		multimesh->connect(CoreStringNames::get_singleton()->changed, this, "update");
+	}
 	update();
 }
 

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "multimesh.h"
+
 #include "servers/visual_server.h"
 
 void MultiMesh::_set_transform_array(const PoolVector<Vector3> &p_array) {
@@ -225,6 +226,7 @@ void MultiMesh::set_instance_transform(int p_instance, const Transform &p_transf
 
 void MultiMesh::set_instance_transform_2d(int p_instance, const Transform2D &p_transform) {
 	VisualServer::get_singleton()->multimesh_instance_set_transform_2d(multimesh, p_instance, p_transform);
+	emit_changed();
 }
 
 Transform MultiMesh::get_instance_transform(int p_instance) const {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/54854

The rect for canvasitems is only calculated as needed. In this case, it was only calculated on the first frame that the MultiMeshInstance was drawing. But because the underlying MultiMesh can be updated anytime, the bounding rect was quickly becoming out of date. This PR gets the CanvasItem to update whenever the AABB is recalculated for the MultiMesh.