### PR TITLE
Force ready notification to be called each time nav agent enters the scene tree

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -99,6 +99,9 @@ void NavigationAgent2D::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			agent_parent = nullptr;
 			set_physics_process_internal(false);
+			// Want to call ready again when the node enters the tree again. We're not using enter_tree notification because
+			// the navigation map may not be ready at that time. This fixes issues with taking the agent out of the scene tree.
+			request_ready();
 		} break;
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (agent_parent) {

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -106,6 +106,9 @@ void NavigationAgent3D::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			agent_parent = nullptr;
 			set_physics_process_internal(false);
+			// Want to call ready again when the node enters the tree again. We're not using enter_tree notification because
+			// the navigation map may not be ready at that time. This fixes issues with taking the agent out of the scene tree.
+			request_ready();
 		} break;
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (agent_parent) {


### PR DESCRIPTION
Solves #54812

Using the Reparent notification wouldn't solve all scenarios of taking the agent out of the scene tree. The agent may not necessarily be reparented. However, if they do get reparented, they do leave the scene tree. Doing this in ready is a safe scene tree operation as well. So it will solve both scenarios.