### PR TITLE
When a call to EditorFileSystem::scan() fails, queue another one

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -650,6 +650,8 @@ void EditorFileSystem::scan() {
 	}
 
 	if (scanning || scanning_changes || thread.is_started()) {
+		scan_pending = true;
+		set_process(true);
 		return;
 	}
 
@@ -1216,6 +1218,11 @@ void EditorFileSystem::_notification(int p_what) {
 					emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
 					_queue_update_script_classes();
 					first_scan = false;
+				}
+
+				if (!is_processing() && scan_pending) {
+					scan_pending = false;
+					scan();
 				}
 
 				if (!is_processing() && scan_changes_pending) {
@@ -2395,6 +2402,7 @@ EditorFileSystem::EditorFileSystem() {
 	scan_total = 0;
 	update_script_classes_queued.clear();
 	first_scan = true;
+	scan_pending = false;
 	scan_changes_pending = false;
 	revalidate_import_files = false;
 	import_threads.init();

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -142,6 +142,7 @@ class EditorFileSystem : public Node {
 	bool scanning;
 	bool importing;
 	bool first_scan;
+	bool scan_pending;
 	bool scan_changes_pending;
 	float scan_total;
 	String filesystem_settings_version_for_import;


### PR DESCRIPTION
Resources imported using a custom EditorImportPlugin (with a new extension I mean) would not appear in the filesystem dock until something caused a FileSystem update. This was due to `EditorPlugin::add_import_plugin()` asking for a scan using `EditorFileSystem::call_deferred("scan")` which was automatically discarded as another scan is already running at startup.

This PR makes it so any call to `EditorFileSystem::scan()` which failed is rescheduled as soon as possible.  I simply duplicated the logic we use for the `scan_changes()` function.

Note: I could not find an issue associated with this bug.