### PR TITLE
Use Enter instead of F2 as an editor renaming shortcut on macOS

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2799,6 +2799,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	ED_SHORTCUT("filesystem_dock/duplicate", TTR("Duplicate..."), KEY_MASK_CMD | KEY_D);
 	ED_SHORTCUT("filesystem_dock/delete", TTR("Delete"), KEY_DELETE);
 	ED_SHORTCUT("filesystem_dock/rename", TTR("Rename..."), KEY_F2);
+	ED_SHORTCUT_OVERRIDE("filesystem_dock/rename", "macos", KEY_ENTER);
 
 	VBoxContainer *top_vbc = memnew(VBoxContainer);
 	add_child(top_vbc);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2552,6 +2552,7 @@ ProjectManager::ProjectManager() {
 
 		rename_btn = memnew(Button);
 		rename_btn->set_text(TTR("Rename"));
+		// The F2 shortcut isn't overridden with Enter on macOS as Enter is already used to edit a project.
 		rename_btn->set_shortcut(ED_SHORTCUT("project_manager/rename_project", TTR("Rename Project"), KEY_F2));
 		rename_btn->connect("pressed", callable_mp(this, &ProjectManager::_rename_project));
 		tree_vb->add_child(rename_btn);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3230,7 +3230,11 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	filter_hbc->add_theme_constant_override("separate", 0);
 
 	ED_SHORTCUT("scene_tree/rename", TTR("Rename"), KEY_F2);
+	ED_SHORTCUT_OVERRIDE("scene_tree/rename", "macos", KEY_ENTER);
+
 	ED_SHORTCUT("scene_tree/batch_rename", TTR("Batch Rename"), KEY_MASK_SHIFT | KEY_F2);
+	ED_SHORTCUT_OVERRIDE("scene_tree/batch_rename", "macos", KEY_MASK_SHIFT | KEY_ENTER);
+
 	ED_SHORTCUT("scene_tree/add_child_node", TTR("Add Child Node"), KEY_MASK_CMD | KEY_A);
 	ED_SHORTCUT("scene_tree/instance_scene", TTR("Instantiate Child Scene"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_A);
 	ED_SHORTCUT("scene_tree/expand_collapse_all", TTR("Expand/Collapse All"));


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/54927.

Tested locally by using `KEY_ENTER` as a shortcut in the Scene tree dock and FileSystem dock, it works as expected. The same shortcut override can't be used in the project manager due to a conflict though.

This closes https://github.com/godotengine/godot/issues/54923.