### PR TITLE
Fix outdated SCons macOS build message

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -82,7 +82,7 @@ def configure(env):
         env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15"])
         env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15"])
     else:
-        print("Building for macOS 10.9+, platform x86-64.")
+        print("Building for macOS 10.12+, platform x86-64.")
         env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
         env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
 


### PR DESCRIPTION
The message incorrectly stated that the minimum supported version is 10.9, when it is in fact 10.12.