### PR TITLE
Expose `Thread::get_main_id` in core bindings

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -315,6 +315,10 @@ Error OS::set_thread_name(const String &p_name) {
 	return ::Thread::get_caller_id();
 };
 
+::Thread::ID OS::get_main_thread_id() const {
+	return ::Thread::get_main_id();
+};
+
 bool OS::has_feature(const String &p_feature) const {
 	return ::OS::get_singleton()->has_feature(p_feature);
 }
@@ -601,6 +605,7 @@ void OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_thread_name", "name"), &OS::set_thread_name);
 	ClassDB::bind_method(D_METHOD("get_thread_caller_id"), &OS::get_thread_caller_id);
+	ClassDB::bind_method(D_METHOD("get_main_thread_id"), &OS::get_main_thread_id);
 
 	ClassDB::bind_method(D_METHOD("has_feature", "tag_name"), &OS::has_feature);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -237,6 +237,7 @@ public:
 
 	Error set_thread_name(const String &p_name);
 	Thread::ID get_thread_caller_id() const;
+	Thread::ID get_main_thread_id() const;
 
 	bool has_feature(const String &p_feature) const;
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -246,6 +246,13 @@
 				This can be used to narrow down fully specified locale strings to only the "common" language code, when you don't need the additional information about country code or variants. For example, for a French Canadian user with [code]fr_CA[/code] locale, this would return [code]fr[/code].
 			</description>
 		</method>
+		<method name="get_main_thread_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the ID of the main thread. See [method get_thread_caller_id].
+				[b]Note:[/b] Thread IDs are not deterministic and may be reused across application restarts.
+			</description>
+		</method>
 		<method name="get_model_name" qualifiers="const">
 			<return type="String" />
 			<description>


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Was looking for this function in a project, but couldn't find anything.

Exposed as `OS.get_main_thread_id`.

Should be cherrypickable to 3.x
