### PR TITLE
Fix multimesh still drawing when visible instances is zero

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -334,6 +334,10 @@ void RenderForwardClustered::_render_list_template(RenderingDevice::DrawListID p
 		const GeometryInstanceSurfaceDataCache *surf = p_params->elements[i];
 		const RenderElementInfo &element_info = p_params->element_info[i];
 
+		if (surf->owner->instance_count == 0) {
+			continue;
+		}
+
 		push_constant.base_index = i + p_params->element_offset;
 
 		RID material_uniform_set;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1821,6 +1821,10 @@ void RenderForwardMobile::_render_list_template(RenderingDevice::DrawListID p_dr
 		const RenderElementInfo &element_info = p_params->element_info[i];
 		const GeometryInstanceForwardMobile *inst = surf->owner;
 
+		if (inst->instance_count == 0) {
+			continue;
+		}
+
 		uint32_t base_spec_constants = p_params->spec_constant_base_flags;
 
 		// GeometryInstanceForwardMobile::PushConstant push_constant = inst->push_constant;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -758,6 +758,10 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 
 					instance_count = storage->multimesh_get_instances_to_draw(multimesh);
 
+					if (instance_count == 0) {
+						break;
+					}
+
 					RID uniform_set = storage->multimesh_get_2d_uniform_set(multimesh, shader.default_version_rd_shader, TRANSFORMS_UNIFORM_SET);
 					RD::get_singleton()->draw_list_bind_uniform_set(p_draw_list, uniform_set, TRANSFORMS_UNIFORM_SET);
 					push_constant.flags |= 1; //multimesh, trails disabled


### PR DESCRIPTION
Fixes #54933 

Prevents a draw call when there are no instances to draw.