### PR TITLE
EditorFileSystem: Prevent reentrant calls.

### DIFF
--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -141,6 +141,10 @@ class EditorFileSystem : public Node {
 	bool abort_scan = false;
 	bool scanning = false;
 	bool importing = false;
+	bool currently_in_notification_process = false;
+	bool notification_process_scan_pending = false;
+	Vector<String> notification_process_update_files_requested;
+
 	bool first_scan = true;
 	bool scan_changes_pending = false;
 	float scan_total;


### PR DESCRIPTION
Ensure no publicly callable functions can trigger `_notification` during a call to `EditorFileSystem::_notification`. Fixes #54864 .

This change guards all functions which can set `set_process(true)`, and invokes them at the end of the currently-running `NOTIFICATION_PROCESS`.

For more explanation, the crash always happened with two nested calls to `_notification (NOTIFICATION_PROCESS)` in the stack. Currently, EditorFileSystem takes care to `set_process(false)` before calling `reimport_files` which should prevent reentrancy.

However, GDScript can run during `reimport_files` due to the reentrant `Main::iteration` during `ProgressDialog`, and if this GDScript invokes `scan`, `scan_changes` or `update_file`, these functions will call `set_process(true)` which is illegal. These are the only GDScript-callable functions, and also happen to be the only ones which enable `set_process(true)`. However, I have only tested `EditorFileSystem::scan` in my test project.

I tested in my "import stress test" project and it works flawlessly.