### PR TITLE
Fix typo in architecture name for x86_64 macOS

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -82,7 +82,7 @@ def configure(env):
         env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15"])
         env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15"])
     else:
-        print("Building for macOS 10.12+, platform x86-64.")
+        print("Building for macOS 10.12+, platform x86_64.")
         env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
         env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
 


### PR DESCRIPTION
Technically both names are valid and both are definitely not ambiguous, but "x86_64" is the preferred name.

The only other instances of "x86-64" are in third-party code, everywhere else is "x86_64".