### PR TITLE
Allow using built-in names for variables, push warnings instead

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -368,6 +368,9 @@
 		<member name="debug/gdscript/warnings/return_value_discarded" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables warnings when calling a function without using its return value (by assigning it to a variable or using it as a function argument). Such return values are sometimes used to denote possible errors using the [enum Error] enum.
 		</member>
+		<member name="debug/gdscript/warnings/shadowed_global_identifier" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables warnings when defining a local or subclass member variable, signal, or enum that would have the same name as a built-in function or global class name, which possibly shadow it.
+		</member>
 		<member name="debug/gdscript/warnings/shadowed_variable" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables warnings when defining a local or subclass member variable that would shadow a variable at an upper level (such as a member variable).
 		</member>

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -148,6 +148,10 @@ String GDScriptWarning::get_message() const {
 		case EMPTY_FILE: {
 			return "Empty script file.";
 		}
+		case SHADOWED_GLOBAL_IDENTIFIER: {
+			CHECK_SYMBOLS(3);
+			return vformat(R"(The %s '%s' has the same name as a %s.)", symbols[0], symbols[1], symbols[2]);
+		}
 		case WARNING_MAX:
 			break; // Can't happen, but silences warning
 	}
@@ -194,6 +198,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"ASSERT_ALWAYS_FALSE",
 		"REDUNDANT_AWAIT",
 		"EMPTY_FILE",
+		"SHADOWED_GLOBAL_IDENTIFIER",
 	};
 
 	static_assert((sizeof(names) / sizeof(*names)) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -69,6 +69,7 @@ public:
 		ASSERT_ALWAYS_FALSE, // Expression for assert argument is always false.
 		REDUNDANT_AWAIT, // await is used but expression is synchronous (not a signal nor a coroutine).
 		EMPTY_FILE, // A script file is empty.
+		SHADOWED_GLOBAL_IDENTIFIER, // A global class or function has the same name as variable.
 		WARNING_MAX,
 	};
 

--- a/modules/gdscript/tests/scripts/parser/warnings/shadowed_global_identifier.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/shadowed_global_identifier.gd
@@ -1,0 +1,2 @@
+func test():
+	var abs = "This variable has the same name as the built-in function."

--- a/modules/gdscript/tests/scripts/parser/warnings/shadowed_global_identifier.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/shadowed_global_identifier.out
@@ -1,0 +1,9 @@
+GDTEST_OK
+>> WARNING
+>> Line: 2
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The local variable 'abs' has the same name as a built-in function.
+>> WARNING
+>> Line: 2
+>> UNUSED_VARIABLE
+>> The local variable 'abs' is declared but never used in the block. If this is intended, prefix it with an underscore: '_abs'


### PR DESCRIPTION
It seems [undesired](https://github.com/godotengine/godot/pull/54676#issuecomment-967974389) if using an error for that, I've added a new warning instead as suggested - https://github.com/godotengine/godot/pull/54676#issuecomment-968076755