### PR TITLE
Remove Android keystore in editor settings and allow manual sign  

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -40,10 +40,6 @@ void register_android_exporter() {
 
 	EDITOR_DEF("export/android/android_sdk_path", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
-	EDITOR_DEF("export/android/debug_keystore", "");
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/debug_keystore", PROPERTY_HINT_GLOBAL_FILE, "*.keystore,*.jks"));
-	EDITOR_DEF("export/android/debug_keystore_user", "androiddebugkey");
-	EDITOR_DEF("export/android/debug_keystore_pass", "android");
 	EDITOR_DEF("export/android/force_system_user", false);
 
 	EDITOR_DEF("export/android/shutdown_adb_on_exit", true);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2035,12 +2035,9 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 		err += TTR("Either Debug Keystore, Debug User AND Debug Password settings must be configured OR none of them.") + "\n";
 	}
 
-	if (!FileAccess::exists(dk)) {
-		dk = EditorSettings::get_singleton()->get("export/android/debug_keystore");
-		if (!FileAccess::exists(dk)) {
-			valid = false;
-			err += TTR("Debug keystore not configured in the Editor Settings nor in the preset.") + "\n";
-		}
+	if (!dk.is_empty() && !FileAccess::exists(dk)) {
+		valid = false;
+		err += TTR("Debug keystore incorrectly configured in the export preset.") + "\n";
 	}
 
 	String rk = p_preset->get("keystore/release");


### PR DESCRIPTION
Hi,

As there are duplicated keystore configurations in the editor settings and the Android export template, I would like to remove the Android keystore in the editor settings.

Besides, there is the option package/signed in the Android export template, which means keystores will not be used when package/signed=false, I also don't want to be forced to set up debug keystores. ( I want to commit my export_presets.cfg to VCS, however, it contain my keystores password now)