### PR TITLE
Making nodes enclosed within comment move with the comment node

### DIFF
--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -217,6 +217,11 @@ private:
 	Set<int> valid_left_disconnect_types;
 	Set<int> valid_right_disconnect_types;
 
+	HashMap<StringName, Vector<GraphNode *>> comment_enclosed_nodes;
+	void _update_comment_enclosed_nodes_list(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes);
+	void _set_drag_comment_enclosed_nodes(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes, bool p_drag);
+	void _set_position_of_comment_enclosed_nodes(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes, Vector2 p_pos);
+
 	HBoxContainer *zoom_hb;
 
 	friend class GraphEditFilter;


### PR DESCRIPTION
[Link to proposal](https://github.com/godotengine/godot-proposals/issues/3548)
~~WIP 🚧~~

_**Feature addition:**_
This PR adds the feature that binds the movement/positional changes of nodes enclosed with comment node they are enclosed in. Since the changes are made in `GraphEdit` module, this feature can be used in _VisualScript/VisualShader editors_ and other modules that are built on top of `GraphEdit`. This will add to user experience as they don't have to select that particular bunch of nodes every time they want to move it.

_Features:_
- [x] Binding position changes of the enclosed nodes and comment node together.
- [x] ~~Button to toggle on/off this movement feature~~

_Demo_

https://user-images.githubusercontent.com/41969735/141679245-77e33388-15dc-47d5-bc85-266d565fbccc.mp4


*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/3548