### PR TITLE
Document low performance when using `SurfaceTool.append_from()` in thread

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -113,6 +113,7 @@
 			<argument index="2" name="transform" type="Transform" />
 			<description>
 				Append vertices from a given [Mesh] surface onto the current vertex array with specified [Transform].
+				[b]Note:[/b] Using [method append_from] on a [Thread] is much slower as the GPU must communicate data back to the CPU, while also causing the main thread to stall (as OpenGL is not thread-safe). Consider requesting a copy of the mesh, converting it to an [ArrayMesh] and adding vertices manually instead.
 			</description>
 		</method>
 		<method name="begin">


### PR DESCRIPTION
I don't know if this still applies to `master`, so I opened this PR on `3.x`.

This closes https://github.com/godotengine/godot/issues/51311.