### PR TITLE
Fix mono build after invalid rename of `KEY_READ`

### DIFF
--- a/modules/mono/utils/mono_reg_utils.cpp
+++ b/modules/mono/utils/mono_reg_utils.cpp
@@ -58,10 +58,10 @@ REGSAM _get_bitness_sam() {
 }
 
 LONG _RegOpenKey(HKEY hKey, LPCWSTR lpSubKey, PHKEY phkResult) {
-	LONG res = RegOpenKeyExW(hKey, lpSubKey, 0, Key::READ, phkResult);
+	LONG res = RegOpenKeyExW(hKey, lpSubKey, 0, KEY_READ, phkResult);
 
 	if (res != ERROR_SUCCESS)
-		res = RegOpenKeyExW(hKey, lpSubKey, 0, Key::READ | _get_bitness_sam(), phkResult);
+		res = RegOpenKeyExW(hKey, lpSubKey, 0, KEY_READ | _get_bitness_sam(), phkResult);
 
 	return res;
 }


### PR DESCRIPTION
Fix an issue with https://github.com/godotengine/godot/commit/5aae92f069b47c040d93e5edba2aad5b104fd1a5 after we cant build godot with mono under windows. I blw the issue comes from "auto-replacement" of some variables.
