### PR TITLE
Fix nodes being renamed into garbage upon conflict

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -896,7 +896,7 @@ void Node::set_name(const String &p_name) {
 	data.name = name;
 
 	if (data.parent) {
-		data.parent->_validate_child_name(this);
+		data.parent->_validate_child_name(this, true);
 	}
 
 	propagate_notification(NOTIFICATION_PATH_CHANGED);


### PR DESCRIPTION
Fresh new regression from #54072
![D0zRII1TR9](https://user-images.githubusercontent.com/2223172/141707023-28fa5de2-211a-4ab2-a689-d87fcdcc37ed.gif)
(well maybe they aren't fresh anymore at this point)