### PR TITLE
Change Node3D Gizmo to call group in realtime.

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -174,7 +174,7 @@ void Node3D::_notification(int p_what) {
 			}
 #ifdef TOOLS_ENABLED
 			if (Engine::get_singleton()->is_editor_hint() && get_tree()->is_node_being_edited(this)) {
-				get_tree()->call_group_flags(0, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_request_gizmo, this);
+				get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_request_gizmo, this);
 				if (!data.gizmos_disabled) {
 					for (int i = 0; i < data.gizmos.size(); i++) {
 						data.gizmos.write[i]->create();


### PR DESCRIPTION
Averts godot crash which occurs if a node is added and then removed from the edited scene within one frame.

I have not filed an issue because the project and reproduction steps are complex, but essentially there is a tool script which adds nodes to the screen, manually ticks some IK processing on those nodes, then subsequently deletes them and saves out a PackedScene, all at once. The crash then happens at the next frame when the editor becomes responsive again.

Visual Studio stacktrace screenshot before applying this fix:
![image](https://user-images.githubusercontent.com/39946030/141756334-c856440c-0d0c-4678-826d-5626e8b9ab03.png)
Basically, `call_group_flags` invokes a `Node3DEditor::_request_gizmo` with the default flags (0) so that the gizmo is called from MessageQueue on the next frame, after the node in question was destroyed.

Because the node was added to the active scene, it qualified for `is_node_being_edited`.

CC @TokageItLab