### PR TITLE
Enable detection of static bodies by non monitorable areas

### DIFF
--- a/core/math/bvh_cull.inc
+++ b/core/math/bvh_cull.inc
@@ -120,7 +120,11 @@ int cull_aabb(CullParams &r_params, bool p_translate_hits = true) {
 			continue;
 		}
 
-		if ((n == 0) && r_params.test_pairable_only) {
+		if ((n == 0) && r_params.test_pairable_only && r_params.pairable_type == 2) {
+			continue;
+		}
+
+		if ((n == 1) && r_params.test_pairable_only && r_params.pairable_type == 1) {
 			continue;
 		}
 

--- a/core/math/bvh_misc.inc
+++ b/core/math/bvh_misc.inc
@@ -3,6 +3,9 @@ int _handle_get_tree_id(BVHHandle p_handle) const {
 	if (USE_PAIRS) {
 		int tree = 0;
 		if (_extra[p_handle.id()].pairable) {
+			tree = 2;
+		} else if (_extra[p_handle.id()].pairable_type == 1) {
+			// Area
 			tree = 1;
 		}
 		return tree;

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -55,6 +55,8 @@ BVHHandle item_add(T *p_userdata, bool p_active, const Bounds &p_aabb, int32_t p
 
 	uint32_t tree_id = 0;
 	if (p_pairable) {
+		tree_id = 2;
+	} else if (p_pairable_type == 1) {
 		tree_id = 1;
 	}
 

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -155,12 +155,13 @@ LocalVector<uint32_t, uint32_t, true> _cull_hits;
 // we now have multiple root nodes, allowing us to store
 // more than 1 tree. This can be more efficient, while sharing the same
 // common lists
-enum { NUM_TREES = 2,
+enum { NUM_TREES = 3,
 };
 
-// Tree 0 - Non pairable
-// Tree 1 - Pairable
-// This is more efficient because in physics we only need check non pairable against the pairable tree.
+// Tree 0 - Static Bodies (non pairable with other static bodies)
+// Tree 1 - Non Monitorable Areas (non pairable with other non monitorable areas)
+// Tree 2 - Pairable
+// This is more efficient because in physics we only need check non pairable trees against other trees.
 uint32_t _root_node_id[NUM_TREES];
 
 // these values may need tweaking according to the project

--- a/servers/physics_2d/godot_broad_phase_2d_bvh.cpp
+++ b/servers/physics_2d/godot_broad_phase_2d_bvh.cpp
@@ -42,7 +42,7 @@ void GodotBroadPhase2DBVH::move(ID p_id, const Rect2 &p_aabb) {
 
 void GodotBroadPhase2DBVH::set_static(ID p_id, bool p_static) {
 	GodotCollisionObject2D *it = bvh.get(p_id - 1);
-	bvh.set_pairable(p_id - 1, !p_static, 1 << it->get_type(), p_static ? 0 : 0xFFFFF, false); // Pair everything, don't care?
+	bvh.set_pairable(p_id - 1, !p_static, 1 << it->get_type(), 0xFFFFF, false); // Pair everything, don't care?
 }
 
 void GodotBroadPhase2DBVH::remove(ID p_id) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/17238

Non monitorable areas were defined as static in the BVH, preventing their pairing with static bodies. With this fix, non monitorable areas and static bodies are separate cases.