### PR TITLE
Add an option to update shadow maps less often

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1783,6 +1783,12 @@
 		<member name="rendering/shadows/shadows/soft_shadow_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/shadows/shadows/soft_shadow_quality] on mobile devices, due to performance concerns or driver support.
 		</member>
+		<member name="rendering/shadows/update_every_2_frames" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], directional and point light shadows are only updated every 2 frames instead of being updated every frame. Updates are staggered across frames to avoid stuttering. This improves performance at the cost of shadows updating in a more "choppy" manner, especially at lower framerates. The difference is mainly noticeable with fast-moving lights, especially when close to the camera.
+		</member>
+		<member name="rendering/shadows/update_every_2_frames.mobile" type="bool" setter="" getter="" default="true">
+			Lower-end override for [member rendering/shadows/update_every_2_frames] to improve performance on mobile devices.
+		</member>
 		<member name="rendering/textures/decals/filter" type="int" setter="" getter="" default="3">
 		</member>
 		<member name="rendering/textures/default_filters/anisotropic_filtering_level" type="int" setter="" getter="" default="2">

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -61,6 +61,12 @@ public:
 		MAX_UPDATE_SHADOWS = 512
 	};
 
+	enum ShadowMapUpdate {
+		SHADOW_MAP_UPDATE_POINT_AND_DIRECTIONAL, // Update both point and directional light shadows for this frame (default).
+		SHADOW_MAP_UPDATE_POINT, // Update point light shadows only for this frame.
+		SHADOW_MAP_UPDATE_DIRECTIONAL, // Update directional light shadows only for this frame.
+	};
+
 	uint64_t render_pass;
 
 	static RendererSceneCull *singleton;
@@ -921,6 +927,8 @@ public:
 	RendererSceneRender::RenderSDFGIUpdateData sdfgi_update_data;
 
 	uint32_t thread_cull_threshold = 200;
+
+	ShadowMapUpdate shadow_map_update = ShadowMapUpdate::SHADOW_MAP_UPDATE_POINT_AND_DIRECTIONAL;
 
 	RID_Owner<Instance, true> instance_owner;
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2822,6 +2822,9 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/shadows/shadows/soft_shadow_quality.mobile", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadows/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/shadows/shadows/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Very Low (Faster),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"));
 
+	GLOBAL_DEF("rendering/shadows/update_every_2_frames", false);
+	GLOBAL_DEF("rendering/shadows/update_every_2_frames.mobile", true);
+
 	GLOBAL_DEF("rendering/2d/shadow_atlas/size", 2048);
 
 	GLOBAL_DEF_RST_BASIC("rendering/vulkan/rendering/back_end", 0);


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/54516.

This can be used to improve performance on low-end setups, at the cost of shadows visibly lagging behind for dynamic lights/objects when up close.

Unlike the `3.x` implementation, this one appears to work better with the default shadow bias settings when point lights are involved.

**Testing project:** [test_animated_shadows_master.zip](https://github.com/godotengine/godot/files/7540406/test_animated_shadows_master.zip)
 