### PR TITLE
Tweak the built-ins color highlighting in the shader editor (take 2)

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -143,10 +143,10 @@ void ShaderTextEditor::_load_theme_settings() {
 		}
 	}
 
-	const Color member_variable_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
+	const Color user_type_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
 
 	for (const String &E : built_ins) {
-		syntax_highlighter->add_keyword_color(E, member_variable_color);
+		syntax_highlighter->add_keyword_color(E, user_type_color);
 	}
 
 	// Colorize comments.


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/55013.

Follow-up to https://github.com/godotengine/godot/pull/33548.

The new color is more distinguishable from other variables and symbols.

This closes https://github.com/godotengine/godot/issues/51727.

## Preview

![image](https://user-images.githubusercontent.com/180032/141864563-a0312976-4146-4fda-ac4f-cc4a33f51dab.png)
