### PR TITLE
Tweak the built-ins color highlighting in the shader editor (take 2) (3.x)

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -172,8 +172,10 @@ void ShaderTextEditor::_load_theme_settings() {
 		}
 	}
 
+	const Color user_type_color = EDITOR_GET("text_editor/highlighting/user_type_color");
+
 	for (List<String>::Element *E = built_ins.front(); E; E = E->next()) {
-		get_text_edit()->add_keyword_color(E->get(), member_variable_color);
+		get_text_edit()->add_keyword_color(E->get(), user_type_color);
 	}
 
 	// Colorize comments.


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/55010.

The new color is more distinguishable from other variables and symbols.

## Preview

![image](https://user-images.githubusercontent.com/180032/141871640-fc7b1320-d653-4b6d-ab88-fd2ad6d2643d.png)
