### PR TITLE
add negative number validation for set_modification_count

### DIFF
--- a/scene/resources/skeleton_modification_stack_2d.cpp
+++ b/scene/resources/skeleton_modification_stack_2d.cpp
@@ -195,6 +195,7 @@ void SkeletonModificationStack2D::set_modification(int p_mod_idx, Ref<SkeletonMo
 }
 
 void SkeletonModificationStack2D::set_modification_count(int p_count) {
+	ERR_FAIL_COND_MSG(p_count < 0, "Modification count cannot be less than zero.");
 	modifications.resize(p_count);
 	notify_property_list_changed();
 

--- a/scene/resources/skeleton_modification_stack_3d.cpp
+++ b/scene/resources/skeleton_modification_stack_3d.cpp
@@ -149,6 +149,7 @@ void SkeletonModificationStack3D::set_modification(int p_mod_idx, Ref<SkeletonMo
 }
 
 void SkeletonModificationStack3D::set_modification_count(int p_count) {
+	ERR_FAIL_COND_MSG(p_count < 0, "Modification count cannot be less than zero.");
 	modifications.resize(p_count);
 	notify_property_list_changed();
 }


### PR DESCRIPTION
Fixes #54966
Adds error macros to validate the input for set_modification_count.
Should be a value between 0-100.

I was not sure whether to make it one condition like so:
`ERR_FAIL_COND_MSG(p_count < 0 || p_count > 100, "Modification count should be between 0 and 100");`

I went with splitting the macro in two due to the `strength` property being split into two.

Just tell me which is better and ill change the file accordingly.