### PR TITLE
[Vulkan] Check each device capabilities before selecting it.

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -186,6 +186,10 @@ bool Engine::is_abort_on_gpu_errors_enabled() const {
 	return abort_on_gpu_errors;
 }
 
+int32_t Engine::get_gpu_index() const {
+	return gpu_idx;
+}
+
 bool Engine::is_validation_layers_enabled() const {
 	return use_validation_layers;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -63,6 +63,7 @@ private:
 	double _physics_interpolation_fraction = 0.0f;
 	bool abort_on_gpu_errors = false;
 	bool use_validation_layers = false;
+	int32_t gpu_idx = -1;
 
 	uint64_t _process_frames = 0;
 	bool _in_physics = false;
@@ -135,6 +136,7 @@ public:
 
 	bool is_abort_on_gpu_errors_enabled() const;
 	bool is_validation_layers_enabled() const;
+	int32_t get_gpu_index() const;
 
 	Engine();
 	virtual ~Engine() {}

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -212,7 +212,9 @@ private:
 			const char *pMessage,
 			void *pUserData);
 
-	Error _create_physical_device();
+	Error _create_instance();
+
+	Error _create_physical_device(VkSurfaceKHR p_surface);
 
 	Error _initialize_queues(VkSurfaceKHR p_surface);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -323,6 +323,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("].\n");
 
 	OS::get_singleton()->print("  --rendering-driver <driver>                  Rendering driver (depends on display driver).\n");
+	OS::get_singleton()->print("  --gpu-index <device_index>                   Use a specific GPU (run with --verbose to get available device list).\n");
 
 	OS::get_singleton()->print("  --text-driver <driver>                       Text driver (Fonts, BiDi, shaping)\n");
 
@@ -789,6 +790,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "-w" || I->get() == "--windowed") { // force windowed window
 
 			init_windowed = true;
+		} else if (I->get() == "--gpu-index") {
+			if (I->next()) {
+				Engine::singleton->gpu_idx = I->next()->get().to_int();
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing gpu index argument, aborting.\n");
+				goto error;
+			}
 		} else if (I->get() == "--vk-layers") {
 			Engine::singleton->use_validation_layers = true;
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
- Splits instance and physical device selection function into two.
- Moves device selection to window creation function, since present capability check require window surface to be created.

This should reject linked devices in the multi-GPU configs (devices without present or graphics query).

Fixes #54962
