### PR TITLE
Revert "Fix UndoRedo::Operation objects cleanup"

### DIFF
--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -53,21 +53,17 @@ public:
 
 private:
 	struct Operation {
-	public:
 		enum Type {
-			TYPE_INVALID,
 			TYPE_METHOD,
 			TYPE_PROPERTY,
 			TYPE_REFERENCE
 		};
 
-		Type type = TYPE_INVALID;
+		Type type;
 		Ref<Reference> ref;
 		ObjectID object;
 		String name;
 		Variant args[VARIANT_ARG_MAX];
-
-		~Operation();
 	};
 
 	struct Action {


### PR DESCRIPTION
Reverts godotengine/godot#54433

- Fixes #55014.
- Fixes #55015.