### PR TITLE
Add SHADER_IS_SRGB define to Vulkan renderer

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -576,6 +576,7 @@ void SceneShaderForwardClustered::init(RendererStorageRD *p_storage, const Strin
 		actions.renames["CUSTOM1"] = "custom1_attrib";
 		actions.renames["CUSTOM2"] = "custom2_attrib";
 		actions.renames["CUSTOM3"] = "custom3_attrib";
+		actions.renames["OUTPUT_IS_SRGB"] = "SHADER_IS_SRGB";
 
 		// not implemented but need these just in case code is in the shaders
 		actions.renames["VIEW_INDEX"] = "0";

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -564,6 +564,7 @@ void SceneShaderForwardMobile::init(RendererStorageRD *p_storage, const String p
 		actions.renames["CUSTOM1"] = "custom1_attrib";
 		actions.renames["CUSTOM2"] = "custom2_attrib";
 		actions.renames["CUSTOM3"] = "custom3_attrib";
+		actions.renames["OUTPUT_IS_SRGB"] = "SHADER_IS_SRGB";
 
 		actions.renames["VIEW_INDEX"] = "ViewIndex";
 		actions.renames["VIEW_MONO_LEFT"] = "0";

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -2857,7 +2857,7 @@ bool RendererStorageRD::MaterialData::update_parameters_uniform_set(const Map<St
 
 	//check whether buffer changed
 	if (p_uniform_dirty && ubo_data.size()) {
-		update_uniform_buffer(p_uniforms, p_uniform_offsets, p_parameters, ubo_data.ptrw(), ubo_data.size(), false);
+		update_uniform_buffer(p_uniforms, p_uniform_offsets, p_parameters, ubo_data.ptrw(), ubo_data.size(), true);
 		RD::get_singleton()->buffer_update(uniform_buffer, 0, ubo_data.size(), ubo_data.ptrw(), p_barrier);
 	}
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -6,6 +6,8 @@
 
 #include "scene_forward_clustered_inc.glsl"
 
+#define SHADER_IS_SRGB false
+
 /* INPUT ATTRIBS */
 
 layout(location = 0) in vec3 vertex_attrib;
@@ -357,6 +359,8 @@ void main() {
 #version 450
 
 #VERSION_DEFINES
+
+#define SHADER_IS_SRGB false
 
 /* Specialization Constants (Toggles) */
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -7,6 +7,8 @@
 /* Include our forward mobile UBOs definitions etc. */
 #include "scene_forward_mobile_inc.glsl"
 
+#define SHADER_IS_SRGB false
+
 /* INPUT ATTRIBS */
 
 layout(location = 0) in vec3 vertex_attrib;
@@ -369,6 +371,8 @@ void main() {
 #version 450
 
 #VERSION_DEFINES
+
+#define SHADER_IS_SRGB false
 
 /* Specialization Constants */
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/54628

This is needed so that the following code in ``material.cpp`` is evaluated correctly:
https://github.com/godotengine/godot/blob/5045f46a5c384d83504be3d0cf101e403700b1e3/scene/resources/material.cpp#L761-L765

I have also changed the material update parameters function to allow SRGB to linear conversions when uniforms are specified as colors with ``hint_color``

cc @groud

_Before this PR:_
![Screenshot (239)](https://user-images.githubusercontent.com/16521339/142018916-5aad33da-ad0b-4ea4-8453-ca1313f56f45.png)

_After this PR:_
![Screenshot (238)](https://user-images.githubusercontent.com/16521339/142018908-0b8931e1-60fa-4aeb-a129-2df933413e11.png)

_Before on left, after on right:_
![Screenshot (241)](https://user-images.githubusercontent.com/16521339/142137574-2026b9d8-6e88-4186-be58-894a09043028.png)
*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/48573.*

