### PR TITLE
Check to avoid null access when disconnect signals in ~Object()

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1880,7 +1880,10 @@ Object::~Object() {
 		const VMap<Callable, SignalData::Slot>::Pair *slot_list = s->slot_map.get_array();
 
 		for (int i = 0; i < slot_count; i++) {
-			slot_list[i].value.conn.callable.get_object()->connections.erase(slot_list[i].value.cE);
+			//Check to avoid null access
+			if (slot_list[i].value.cE != NULL) {
+				slot_list[i].value.conn.callable.get_object()->connections.erase(slot_list[i].value.cE);
+			}
 		}
 
 		signal_map.erase(*S);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Check to avoid null access when disconnect signals in ~Object()
Should fix crashes in #54322 , #54572