### PR TITLE
Increase the default project window size for better usability

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1183,10 +1183,14 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/config/custom_user_dir_name", "");
 	GLOBAL_DEF("application/config/project_settings_override", "");
 
-	GLOBAL_DEF_BASIC("display/window/size/viewport_width", 1024);
+	// The default window size is tuned to:
+	// - Have a 16:9 aspect ratio,
+	// - Have both dimensions divisible by 8 to better play along with video recording,
+	// - Be displayable correctly in windowed mode on a 1366×768 display (tested on Windows 10 with default settings).
+	GLOBAL_DEF_BASIC("display/window/size/viewport_width", 1152);
 	custom_prop_info["display/window/size/viewport_width"] = PropertyInfo(Variant::INT, "display/window/size/viewport_width", PROPERTY_HINT_RANGE, "0,7680,1,or_greater"); // 8K resolution
 
-	GLOBAL_DEF_BASIC("display/window/size/viewport_height", 600);
+	GLOBAL_DEF_BASIC("display/window/size/viewport_height", 648);
 	custom_prop_info["display/window/size/viewport_height"] = PropertyInfo(Variant::INT, "display/window/size/viewport_height", PROPERTY_HINT_RANGE, "0,4320,1,or_greater"); // 8K resolution
 
 	GLOBAL_DEF_BASIC("display/window/size/resizable", true);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -576,19 +576,19 @@
 			Allows the window to be resizable by default.
 			[b]Note:[/b] This setting is ignored on iOS.
 		</member>
-		<member name="display/window/size/viewport_height" type="int" setter="" getter="" default="600">
-			Sets the game's main viewport height. On desktop platforms, this is also the initial window height.
+		<member name="display/window/size/viewport_height" type="int" setter="" getter="" default="648">
+			Sets the game's main viewport height. On desktop platforms, this is also the initial window height, represented by an indigo-colored rectangle in the 2D editor. Stretch mode settings also use this as a reference when using the [code]canvas_items[/code] or [code]viewport[/code] stretch modes. See also [member display/window/size/viewport_width], [member display/window/size/window_width_override] and [member display/window/size/window_height_override].
 		</member>
-		<member name="display/window/size/viewport_width" type="int" setter="" getter="" default="1024">
-			Sets the game's main viewport width. On desktop platforms, this is also the initial window width.
+		<member name="display/window/size/viewport_width" type="int" setter="" getter="" default="1152">
+			Sets the game's main viewport width. On desktop platforms, this is also the initial window width, represented by an indigo-colored rectangle in the 2D editor. Stretch mode settings also use this as a reference when using the [code]canvas_items[/code] or [code]viewport[/code] stretch modes. See also [member display/window/size/viewport_height], [member display/window/size/window_width_override] and [member display/window/size/window_height_override].
 		</member>
 		<member name="display/window/size/window_height_override" type="int" setter="" getter="" default="0">
-			On desktop platforms, sets the game's initial window height.
-			[b]Note:[/b] By default, or when set to 0, the initial window height is the [member display/window/size/viewport_height]. This setting is ignored on iOS, Android, and HTML5.
+			On desktop platforms, overrides the game's initial window height. See also [member display/window/size/window_width_override], [member display/window/size/viewport_width] and [member display/window/size/viewport_height].
+			[b]Note:[/b] By default, or when set to [code]0[/code], the initial window height is the [member display/window/size/viewport_height]. This setting is ignored on iOS, Android, and HTML5.
 		</member>
 		<member name="display/window/size/window_width_override" type="int" setter="" getter="" default="0">
-			On desktop platforms, sets the game's initial window width.
-			[b]Note:[/b] By default, or when set to 0, the initial window width is the viewport [member display/window/size/viewport_width]. This setting is ignored on iOS, Android, and HTML5.
+			On desktop platforms, overrides the game's initial window width. See also [member display/window/size/window_height_override], [member display/window/size/viewport_width] and [member display/window/size/viewport_height].
+			[b]Note:[/b] By default, or when set to [code]0[/code], the initial window width is the viewport [member display/window/size/viewport_width]. This setting is ignored on iOS, Android, and HTML5.
 		</member>
 		<member name="display/window/vsync/vsync_mode" type="int" setter="" getter="" default="1">
 			Sets the V-Sync mode for the main game window.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -161,7 +161,7 @@ static DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_WINDOW
 static DisplayServer::ScreenOrientation window_orientation = DisplayServer::SCREEN_LANDSCAPE;
 static DisplayServer::VSyncMode window_vsync_mode = DisplayServer::VSYNC_ENABLED;
 static uint32_t window_flags = 0;
-static Size2i window_size = Size2i(1024, 600);
+static Size2i window_size = Size2i(1152, 648);
 
 static int init_screen = -1;
 static bool init_fullscreen = false;


### PR DESCRIPTION
The new default window size is tuned to:

- Have a 16:9 aspect ratio,
- Have both dimensions divisible by 8 to better play along with video recording,
- Be displayable correctly in windowed mode on a 1366×768 display (tested on Windows 10 with default settings).

This breaks compatibility with projects that didn't change the window size from the default value (or that kept one of the values to its default).

On the [list of 16:9 resolutions that divide by 8](https://levvvel.com/169-resolutions/), 1152×648 is a middle ground between 1024×576 and 1280×720. 1024×576 would have been even smaller than the current default, but it would have been 16:9 unlike the current default resolution which has a ~1.706 aspect ratio. In contrast, 1280×720 is too large to work everywhere (see below).

## Preview

![window_size_1152_648](https://user-images.githubusercontent.com/180032/142048167-8bc24615-2809-46e0-924e-05076b613fc3.png)

### Why not 1280×720?

On a 1366×768 monitor (still common in budget laptops today), a 1280×720 window can't be displayed correctly in windowed mode when using the default Windows 10 configuration:

![window_size_1280_720](https://user-images.githubusercontent.com/180032/142048170-e046953d-9433-4764-a9b0-1b16d7786844.png)

In contrast, a 1152×648 window fits well.