### PR TITLE
Crash fix: macOS (Silicon) fix crash on joypad removal

### DIFF
--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -58,6 +58,7 @@ void joypad::free() {
 	if (ff_device) {
 		FFDeviceReleaseEffect(ff_device, ff_object);
 		FFReleaseDevice(ff_device);
+		ff_device = nullptr;
 		memfree(ff_axes);
 		memfree(ff_directions);
 	}
@@ -243,7 +244,7 @@ void JoypadOSX::_device_added(IOReturn p_res, IOHIDDeviceRef p_device) {
 	if (is_joypad(p_device)) {
 		configure_joypad(p_device, &new_joypad);
 #if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
-		if (IOHIDDeviceGetService != nullptr) {
+		if (IOHIDDeviceGetService) {
 #endif
 			const io_service_t ioservice = IOHIDDeviceGetService(p_device);
 			if ((ioservice) && (FFIsForceFeedback(ioservice) == FF_OK) && new_joypad.config_force_feedback(ioservice)) {
@@ -348,6 +349,7 @@ bool JoypadOSX::configure_joypad(IOHIDDeviceRef p_device_ref, joypad *p_joy) {
 	{                                   \
 		if (ret != FF_OK) {             \
 			FFReleaseDevice(ff_device); \
+			ff_device = nullptr;        \
 			return false;               \
 		}                               \
 	}
@@ -367,6 +369,7 @@ bool joypad::config_force_feedback(io_service_t p_service) {
 		return true;
 	}
 	FFReleaseDevice(ff_device);
+	ff_device = nullptr;
 	return false;
 }
 #undef FF_ERR
@@ -601,7 +604,7 @@ JoypadOSX::JoypadOSX(Input *in) {
 
 	if (array) {
 		hid_manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
-		if (hid_manager != nullptr) {
+		if (hid_manager) {
 			config_hid_manager(array);
 		}
 		CFRelease(array);

--- a/platform/osx/joypad_osx.h
+++ b/platform/osx/joypad_osx.h
@@ -68,8 +68,8 @@ struct joypad {
 
 	io_service_t ffservice = 0; /* Interface for force feedback, 0 = no ff */
 	FFCONSTANTFORCE ff_constant_force;
-	FFDeviceObjectReference ff_device;
-	FFEffectObjectReference ff_object;
+	FFDeviceObjectReference ff_device = nullptr;
+	FFEffectObjectReference ff_object = nullptr;
 	uint64_t ff_timestamp = 0;
 	LONG *ff_directions = nullptr;
 	FFEFFECT ff_effect;


### PR DESCRIPTION
ff_device is initialised in config_force_feedback. So in line 250, if FFIsForceFeedback(ioservice) != FF_OK then config_force_feedback isn't called, and ff_device is left uninitialised. This then causes a crash on line 60 when the controller is removed and ff_device is incorrectly freed.

This was noticed when a Dualshock 4 or Dualsense (bluetooth) was left to disconnect, or force disconnected while the build is running with the following stack trace:

This fix ensures the ff_device variable is default intialised to 0, and when released set back to 0.

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib         0x000000018a4c8e68 __pthread_kill + 8
1   libsystem_pthread.dylib       0x000000018a4fb43c pthread_kill + 292
2   libsystem_c.dylib             0x000000018a443460 abort + 104
3   godot.osx.tools.arm64         0x0000000104742a14 handle_crash(int) + 2480
4   libsystem_platform.dylib       0x000000018a546c44 _sigtramp + 56
5   godot.osx.tools.arm64         0x000000010477d0d4 joypad::free() + 104
6   godot.osx.tools.arm64         0x000000010477d0d4 joypad::free() + 104
7   godot.osx.tools.arm64         0x000000010477e5dc JoypadOSX::_device_removed(int, __IOHIDDevice*) + 300
8   godot.osx.tools.arm64         0x000000010477f4a8 joypad_removed_callback(void*, int, void*, __IOHIDDevice*) + 52
9   com.apple.framework.IOKit     0x000000018ccc72e0 __IOHIDManagerDeviceRemoved + 416
10  com.apple.framework.IOKit     0x000000018cc85548 IODispatchCalloutFromCFMessage + 328
11  com.apple.CoreFoundation       0x000000018a62a2a8 __CFMachPortPerform + 308
12  com.apple.CoreFoundation       0x000000018a5fb368 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 60
13  com.apple.CoreFoundation       0x000000018a5fb224 __CFRunLoopDoSource1 + 596
14  com.apple.CoreFoundation       0x000000018a5f96a4 __CFRunLoopRun + 2372
15  com.apple.CoreFoundation       0x000000018a5f85e8 CFRunLoopRunSpecific + 600
16  godot.osx.tools.arm64         0x000000010477ea84 JoypadOSX::poll_joypads() const + 36
17  godot.osx.tools.arm64         0x000000010477eabc JoypadOSX::process_joypads() + 32
18  godot.osx.tools.arm64         0x0000000104747680 OS_OSX::run() + 300
19  godot.osx.tools.arm64         0x000000010477bdd0 main + 940
20  libdyld.dylib                 0x000000018a519450 start + 4
```
