### PR TITLE
Register missing WebRTCDataChannelJS type.

### DIFF
--- a/modules/webrtc/webrtc_peer_connection_js.cpp
+++ b/modules/webrtc/webrtc_peer_connection_js.cpp
@@ -58,7 +58,7 @@ void WebRTCPeerConnectionJS::_on_error(void *p_obj) {
 
 void WebRTCPeerConnectionJS::_on_data_channel(void *p_obj, int p_id) {
 	WebRTCPeerConnectionJS *peer = static_cast<WebRTCPeerConnectionJS *>(p_obj);
-	peer->emit_signal("data_channel_received", Ref<WebRTCDataChannelJS>(new WebRTCDataChannelJS(p_id)));
+	peer->emit_signal("data_channel_received", Ref<WebRTCDataChannel>(memnew(WebRTCDataChannelJS(p_id))));
 }
 
 void WebRTCPeerConnectionJS::close() {

--- a/modules/webrtc/webrtc_peer_connection_js.h
+++ b/modules/webrtc/webrtc_peer_connection_js.h
@@ -52,6 +52,8 @@ extern int godot_js_rtc_pc_datachannel_create(int p_id, const char *p_label, con
 }
 
 class WebRTCPeerConnectionJS : public WebRTCPeerConnection {
+	GDCLASS(WebRTCPeerConnectionJS, WebRTCPeerConnection);
+
 private:
 	int _js_id;
 	ConnectionState _conn_state;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

There's something totally different going on with **register_types.cpp** in master (that I can't say I understand) -- and master doesn't build right now to see if a similar fix is needed there -- thus, it seems, I'm forced to put this fix directly on 3.4.

The WebRTCDataChannelJS class was not registered in **register_types.cpp** and this generates an error in the HTML5 export (the Windows builds work fine with the WebRTC Native plugin).  This error goes back to at least 3.3.rc6.

Also, it appeared **webrtc_peer_connection_js.h** was missing a `GDCLASS()` line, so I added one.  I don't know what it's for, so maybe that was a mistake.  Builds and runs fine with it, however.

This doesn't fix any issue tickets that I could find.  I just pretended to be a C++ programmer and made the fix instead of filing an issue.  Seemed faster that way to get the fix I needed to ship the game (even though it took a while to find).

The browser error when receiving a data channel:

```
ERROR: Cannot get class 'WebRTCDataChannelJS'.
onPrintError @ Sendit Soccer.js:362
put_char @ Sendit Soccer.js:9
write @ Sendit Soccer.js:9
write @ Sendit Soccer.js:9
doWritev @ Sendit Soccer.js:9
_fd_write @ Sendit Soccer.js:9
$__stdio_write @ 042a7756:0x90e061
$__vfprintf_internal @ 042a7756:0x2260a0
$vfprintf @ 042a7756:0x200caa
$StdLogger::logv(char const*, void*, bool) @ 042a7756:0x9cdaf5
$Logger::logf_error(char const*, ...) @ 042a7756:0x1dda9e
$Logger::log_error(char const*, char const*, int, char const*, char const*, Logger::ErrorType) @ 042a7756:0xb8a4bc
$CompositeLogger::log_error(char const*, char const*, int, char const*, char const*, Logger::ErrorType) @ 042a7756:0xbdb387
$_err_print_error(char const*, char const*, int, char const*, char const*, ErrorHandlerType) @ 042a7756:0x28327
$_err_print_error(char const*, char const*, int, char const*, String const&, ErrorHandlerType) @ 042a7756:0x2952e
$ClassDB::_get_parent_class(StringName const&) @ 042a7756:0x6abe19
$ClassDB::_is_parent_class(StringName const&, StringName const&) @ 042a7756:0x6abcf9
$ClassDB::is_parent_class(StringName const&, StringName const&) @ 042a7756:0x6ecbf
$GDScriptDataType::is_type(Variant const&, bool) const @ 042a7756:0x2df90f
$GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Variant::CallError&, GDScriptFunction::CallState*) @ 042a7756:0xb2e5b
$GDScriptInstance::call(StringName const&, Variant const**, int, Variant::CallError&) @ 042a7756:0xbb9991
$Object::call(StringName const&, Variant const**, int, Variant::CallError&) @ 042a7756:0x27c6b9
$Object::emit_signal(StringName const&, Variant const**, int) @ 042a7756:0x27c36e
$Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) @ 042a7756:0x297ee
$WebRTCPeerConnectionJS::_on_data_channel(void*, int) @ 042a7756:0x94b315
ondatachannel

  at: _get_parent_class (core/class_db.cpp:323) - Condition "!ti" is true. Returned: StringName()
[same trace as above]
```
