### PR TITLE
Fix the exceptions in signal disconnection

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1410,7 +1410,7 @@ void Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 
 	ERR_FAIL_COND_MSG(!s->slot_map.has(*p_callable.get_base_comparator()), "Disconnecting nonexistent signal '" + p_signal + "', callable: " + p_callable + ".");
 
-	SignalData::Slot *slot = &s->slot_map[p_callable];
+	SignalData::Slot *slot = &s->slot_map[*p_callable.get_base_comparator()];
 
 	if (!p_force) {
 		slot->reference_count--; // by default is zero, if it was not referenced it will go below it


### PR DESCRIPTION
Use the correct method to get SignalData to fix exceptions in signal disconnection
Should fix #54572 , #54542 , #54322 , #55011 , #53176 , #52640 (And More)

*Bugsquad edit:*
- Fixes #54572
- Fixes #54542
- Fixes #54322 
- Fixes #55011 
- Fixes #53176
- Fixes #52640