### PR TITLE
BVH - detect shrinkage within expanded bounds

### DIFF
--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -32,7 +32,7 @@
 #define BVH_ABB_H
 
 // special optimized version of axis aligned bounding box
-template <class Bounds = AABB, class Point = Vector3>
+template <class BOUNDS = AABB, class POINT = Vector3>
 struct BVH_ABB {
 	struct ConvexHull {
 		// convex hulls (optional)
@@ -43,8 +43,8 @@ struct BVH_ABB {
 	};
 
 	struct Segment {
-		Point from;
-		Point to;
+		POINT from;
+		POINT to;
 	};
 
 	enum IntersectResult {
@@ -54,47 +54,47 @@ struct BVH_ABB {
 	};
 
 	// we store mins with a negative value in order to test them with SIMD
-	Point min;
-	Point neg_max;
+	POINT min;
+	POINT neg_max;
 
 	bool operator==(const BVH_ABB &o) const { return (min == o.min) && (neg_max == o.neg_max); }
 	bool operator!=(const BVH_ABB &o) const { return (*this == o) == false; }
 
-	void set(const Point &_min, const Point &_max) {
+	void set(const POINT &_min, const POINT &_max) {
 		min = _min;
 		neg_max = -_max;
 	}
 
 	// to and from standard AABB
-	void from(const Bounds &p_aabb) {
+	void from(const BOUNDS &p_aabb) {
 		min = p_aabb.position;
 		neg_max = -(p_aabb.position + p_aabb.size);
 	}
 
-	void to(Bounds &r_aabb) const {
+	void to(BOUNDS &r_aabb) const {
 		r_aabb.position = min;
 		r_aabb.size = calculate_size();
 	}
 
 	void merge(const BVH_ABB &p_o) {
-		for (int axis = 0; axis < Point::AXIS_COUNT; ++axis) {
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
 			neg_max[axis] = MIN(neg_max[axis], p_o.neg_max[axis]);
 			min[axis] = MIN(min[axis], p_o.min[axis]);
 		}
 	}
 
-	Point calculate_size() const {
+	POINT calculate_size() const {
 		return -neg_max - min;
 	}
 
-	Point calculate_centre() const {
-		return Point((calculate_size() * 0.5) + min);
+	POINT calculate_centre() const {
+		return POINT((calculate_size() * 0.5) + min);
 	}
 
 	real_t get_proximity_to(const BVH_ABB &p_b) const {
-		const Point d = (min - neg_max) - (p_b.min - p_b.neg_max);
+		const POINT d = (min - neg_max) - (p_b.min - p_b.neg_max);
 		real_t proximity = 0.0;
-		for (int axis = 0; axis < Point::AXIS_COUNT; ++axis) {
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
 			proximity += Math::abs(d[axis]);
 		}
 		return proximity;
@@ -162,7 +162,7 @@ struct BVH_ABB {
 	}
 
 	bool intersects_convex_partial(const ConvexHull &p_hull) const {
-		Bounds bb;
+		BOUNDS bb;
 		to(bb);
 		return bb.intersects_convex_shape(p_hull.planes, p_hull.num_planes, p_hull.points, p_hull.num_points);
 	}
@@ -182,7 +182,7 @@ struct BVH_ABB {
 
 	bool is_within_convex(const ConvexHull &p_hull) const {
 		// use half extents routine
-		Bounds bb;
+		BOUNDS bb;
 		to(bb);
 		return bb.inside_convex_shape(p_hull.planes, p_hull.num_planes);
 	}
@@ -197,12 +197,12 @@ struct BVH_ABB {
 	}
 
 	bool intersects_segment(const Segment &p_s) const {
-		Bounds bb;
+		BOUNDS bb;
 		to(bb);
 		return bb.intersects_segment(p_s.from, p_s.to);
 	}
 
-	bool intersects_point(const Point &p_pt) const {
+	bool intersects_point(const POINT &p_pt) const {
 		if (_any_lessthan(-p_pt, neg_max)) {
 			return false;
 		}
@@ -232,20 +232,20 @@ struct BVH_ABB {
 		return true;
 	}
 
-	void grow(const Point &p_change) {
+	void grow(const POINT &p_change) {
 		neg_max -= p_change;
 		min -= p_change;
 	}
 
 	void expand(real_t p_change) {
-		Point change;
+		POINT change;
 		change.set_all(p_change);
 		grow(change);
 	}
 
 	// Actually surface area metric.
 	float get_area() const {
-		Point d = calculate_size();
+		POINT d = calculate_size();
 		return 2.0f * (d.x * d.y + d.y * d.z + d.z * d.x);
 	}
 
@@ -254,8 +254,8 @@ struct BVH_ABB {
 		min = neg_max;
 	}
 
-	bool _any_morethan(const Point &p_a, const Point &p_b) const {
-		for (int axis = 0; axis < Point::AXIS_COUNT; ++axis) {
+	bool _any_morethan(const POINT &p_a, const POINT &p_b) const {
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
 			if (p_a[axis] > p_b[axis]) {
 				return true;
 			}
@@ -263,8 +263,8 @@ struct BVH_ABB {
 		return false;
 	}
 
-	bool _any_lessthan(const Point &p_a, const Point &p_b) const {
-		for (int axis = 0; axis < Point::AXIS_COUNT; ++axis) {
+	bool _any_lessthan(const POINT &p_a, const POINT &p_b) const {
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
 			if (p_a[axis] < p_b[axis]) {
 				return true;
 			}

--- a/core/math/bvh_cull.inc
+++ b/core/math/bvh_cull.inc
@@ -14,7 +14,7 @@ struct CullParams {
 	uint32_t pairable_type;
 
 	// optional components for different tests
-	Point point;
+	POINT point;
 	BVHABB_CLASS abb;
 	typename BVHABB_CLASS::ConvexHull hull;
 	typename BVHABB_CLASS::Segment segment;

--- a/core/math/bvh_debug.inc
+++ b/core/math/bvh_debug.inc
@@ -6,12 +6,12 @@ void _debug_recursive_print_tree(int p_tree_id) const {
 }
 
 String _debug_aabb_to_string(const BVHABB_CLASS &aabb) const {
-	Point size = aabb.calculate_size();
+	POINT size = aabb.calculate_size();
 
 	String sz;
 	float vol = 0.0;
 
-	for (int i = 0; i < Point::AXES_COUNT; ++i) {
+	for (int i = 0; i < POINT::AXIS_COUNT; ++i) {
 		sz += "(";
 		sz += itos(aabb.min[i]);
 		sz += " ~ ";

--- a/core/math/bvh_pair.inc
+++ b/core/math/bvh_pair.inc
@@ -14,10 +14,10 @@ struct ItemPairs {
 	void clear() {
 		num_pairs = 0;
 		extended_pairs.reset();
-		expanded_aabb = Bounds();
+		expanded_aabb = BOUNDS();
 	}
 
-	Bounds expanded_aabb;
+	BOUNDS expanded_aabb;
 
 	// maybe we can just use the number in the vector TODO
 	int32_t num_pairs;

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -1,5 +1,5 @@
 public:
-BVHHandle item_add(T *p_userdata, bool p_active, const Bounds &p_aabb, int32_t p_subindex, bool p_pairable, uint32_t p_pairable_type, uint32_t p_pairable_mask, bool p_invisible = false) {
+BVHHandle item_add(T *p_userdata, bool p_active, const BOUNDS &p_aabb, int32_t p_subindex, bool p_pairable, uint32_t p_pairable_type, uint32_t p_pairable_mask, bool p_invisible = false) {
 #ifdef BVH_VERBOSE_TREE
 	VERBOSE_PRINT("\nitem_add BEFORE");
 	_debug_recursive_print_tree(0);
@@ -103,7 +103,7 @@ void _debug_print_refs() {
 }
 
 // returns false if noop
-bool item_move(BVHHandle p_handle, const Bounds &p_aabb) {
+bool item_move(BVHHandle p_handle, const BOUNDS &p_aabb) {
 	uint32_t ref_id = p_handle.id();
 
 	// get the reference
@@ -118,7 +118,7 @@ bool item_move(BVHHandle p_handle, const Bounds &p_aabb) {
 	BVH_ASSERT(ref.tnode_id != BVHCommon::INVALID);
 	TNode &tnode = _nodes[ref.tnode_id];
 
-	// does it fit within the current aabb?
+	// does it fit within the current leaf aabb?
 	if (tnode.aabb.is_other_within(abb)) {
 		// do nothing .. fast path .. not moved enough to need refit
 
@@ -133,11 +133,19 @@ bool item_move(BVHHandle p_handle, const Bounds &p_aabb) {
 			return false;
 		}
 
+#ifdef BVH_VERBOSE_MOVES
+		print_line("item_move " + itos(p_handle.id()) + "(within tnode aabb) : " + _debug_aabb_to_string(abb));
+#endif
+
 		leaf_abb = abb;
 		_integrity_check_all();
 
 		return true;
 	}
+
+#ifdef BVH_VERBOSE_MOVES
+	print_line("item_move " + itos(p_handle.id()) + "(outside tnode aabb) : " + _debug_aabb_to_string(abb));
+#endif
 
 	uint32_t tree_id = _handle_get_tree_id(p_handle);
 
@@ -206,7 +214,7 @@ void item_remove(BVHHandle p_handle) {
 }
 
 // returns success
-bool item_activate(BVHHandle p_handle, const Bounds &p_aabb) {
+bool item_activate(BVHHandle p_handle, const BOUNDS &p_aabb) {
 	uint32_t ref_id = p_handle.id();
 	ItemRef &ref = _refs[ref_id];
 	if (ref.is_active()) {
@@ -403,7 +411,7 @@ void update() {
 
 		// if there are no nodes, do nothing, but if there are...
 		if (bound_valid) {
-			Bounds bb;
+			BOUNDS bb;
 			world_bound.to(bb);
 			real_t size = bb.get_longest_axis_size();
 
@@ -420,4 +428,51 @@ void update() {
 		}
 	}
 #endif
+}
+
+void params_set_pairing_expansion(real_t p_value) {
+	if (p_value < 0.0) {
+#ifdef BVH_ALLOW_AUTO_EXPANSION
+		_auto_pairing_expansion = true;
+#endif
+		return;
+	}
+#ifdef BVH_ALLOW_AUTO_EXPANSION
+	_auto_pairing_expansion = false;
+#endif
+
+	_pairing_expansion = p_value;
+
+	// calculate shrinking threshold
+	const real_t fudge_factor = 1.1;
+	_aabb_shrinkage_threshold = _pairing_expansion * POINT::AXIS_COUNT * 2.0 * fudge_factor;
+}
+
+// This routine is not just an enclose check, it also checks for special case of shrinkage
+bool expanded_aabb_encloses_not_shrink(const BOUNDS &p_expanded_aabb, const BOUNDS &p_aabb) const {
+	if (!p_expanded_aabb.encloses(p_aabb)) {
+		return false;
+	}
+
+	// Check for special case of shrinkage. If the aabb has shrunk
+	// significantly we want to create a new expanded bound, because
+	// the previous expanded bound will have diverged significantly.
+	const POINT &exp_size = p_expanded_aabb.size;
+	const POINT &new_size = p_aabb.size;
+
+	real_t exp_l = 0.0;
+	real_t new_l = 0.0;
+
+	for (int i = 0; i < POINT::AXIS_COUNT; ++i) {
+		exp_l += exp_size[i];
+		new_l += new_size[i];
+	}
+
+	// is difference above some metric
+	real_t diff = exp_l - new_l;
+	if (diff < _aabb_shrinkage_threshold) {
+		return true;
+	}
+
+	return false;
 }

--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -25,16 +25,16 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		return;
 	}
 
-	Point centre = full_bound.calculate_centre();
-	Point size = full_bound.calculate_size();
+	POINT centre = full_bound.calculate_centre();
+	POINT size = full_bound.calculate_size();
 
-	int order[Point::AXIS_COUNT];
+	int order[POINT::AXIS_COUNT];
 
 	order[0] = size.min_axis();
-	order[Point::AXIS_COUNT - 1] = size.max_axis();
+	order[POINT::AXIS_COUNT - 1] = size.max_axis();
 
-	static_assert(Point::AXIS_COUNT <= 3, "BVH Point::AXIS_COUNT has unexpected size");
-	if (Point::AXIS_COUNT == 3) {
+	static_assert(POINT::AXIS_COUNT <= 3, "BVH POINT::AXIS_COUNT has unexpected size");
+	if (POINT::AXIS_COUNT == 3) {
 		order[1] = 3 - (order[0] + order[2]);
 	}
 
@@ -58,7 +58,7 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 
 	// detect when split on longest axis failed
 	int min_threshold = MAX_ITEMS / 4;
-	int min_group_size[Point::AXIS_COUNT];
+	int min_group_size[POINT::AXIS_COUNT];
 	min_group_size[0] = MIN(num_a, num_b);
 	if (min_group_size[0] < min_threshold) {
 		// slow but sure .. first move everything back into a
@@ -68,7 +68,7 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		num_b = 0;
 
 		// now calculate the best split
-		for (int axis = 1; axis < Point::AXIS_COUNT; axis++) {
+		for (int axis = 1; axis < POINT::AXIS_COUNT; axis++) {
 			split_axis = order[axis];
 			int count = 0;
 
@@ -86,7 +86,7 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		// best axis
 		int best_axis = 0;
 		int best_min = min_group_size[0];
-		for (int axis = 1; axis < Point::AXIS_COUNT; axis++) {
+		for (int axis = 1; axis < POINT::AXIS_COUNT; axis++) {
 			if (min_group_size[axis] > best_min) {
 				best_min = min_group_size[axis];
 				best_axis = axis;

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -29,12 +29,6 @@ struct ItemExtra {
 	T *userdata;
 };
 
-// this is an item OR a child node depending on whether a leaf node
-struct Item {
-	BVHABB_CLASS aabb;
-	uint32_t item_ref_id;
-};
-
 // tree leaf
 struct TLeaf {
 	uint16_t num_items;
@@ -177,4 +171,14 @@ bool _auto_node_expansion = true;
 // larger values gives more 'sticky' pairing, and is less likely to exhibit tunneling
 // we can either use auto mode, where the expansion is based on the root node size, or specify manually
 real_t _pairing_expansion = 0.1;
+
+#ifdef BVH_ALLOW_AUTO_EXPANSION
 bool _auto_pairing_expansion = true;
+#endif
+
+// when using an expanded bound, we must detect the condition where a new AABB
+// is significantly smaller than the expanded bound, as this is a special case where we
+// should override the optimization and create a new expanded bound.
+// This threshold is derived from the _pairing_expansion, and should be recalculated
+// if _pairing_expansion is changed.
+real_t _aabb_shrinkage_threshold = 0.0;

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -48,12 +48,14 @@
 #include "core/print_string.h"
 #include <limits.h>
 
-#define BVHABB_CLASS BVH_ABB<Bounds, Point>
+#define BVHABB_CLASS BVH_ABB<BOUNDS, POINT>
 
 // never do these checks in release
 #if defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED)
 //#define BVH_VERBOSE
 //#define BVH_VERBOSE_TREE
+//#define BVH_VERBOSE_PAIRING
+//#define BVH_VERBOSE_MOVES
 
 //#define BVH_VERBOSE_FRAME
 //#define BVH_CHECKS
@@ -148,7 +150,7 @@ public:
 	}
 };
 
-template <class T, int MAX_CHILDREN, int MAX_ITEMS, bool USE_PAIRS = false, class Bounds = AABB, class Point = Vector3>
+template <class T, int MAX_CHILDREN, int MAX_ITEMS, bool USE_PAIRS = false, class BOUNDS = AABB, class POINT = Vector3>
 class BVH_Tree {
 	friend class BVH;
 
@@ -165,6 +167,11 @@ public:
 		// (as these ids are stored as negative numbers in the node)
 		uint32_t dummy_leaf_id;
 		_leaves.request(dummy_leaf_id);
+
+		// In many cases you may want to change this default in the client code,
+		// or expose this value to the user.
+		// This default may make sense for a typically scaled 3d game, but maybe not for 2d on a pixel scale.
+		params_set_pairing_expansion(0.1);
 	}
 
 private:


### PR DESCRIPTION
Although the expanded bounds were working in normal use, for moving and growing objects, there was one case which was not dealt with properly - significant shrinkage of exact bounds within an expanded bound.

This PR detects significant shrinkage and forces a new expanded bound to be created.

Fixes #54855

## Notes
* This was a great MRP in the issue and it uncovered a couple of problems in the current BVH, the first of which I'm fixing here.
* I'm making this draft just because I'd like to tune / test the metric and I have to go out today, but this will allow @pouleyKetchoupp to see the changes.
* I ended up capitalizing the BOUNDS and POINT template parameters which @pouleyKetchoupp added, these were causing me confusion as to whether they were template parameters or classes (Godot already has a typedef of Point as a Vector2 I believe).
* I'm going to have a go at some fixes for the second problem in a separate PR.

This is just my stream of thought copied from rocket chat but it contains some relevant info.

> Ok I think I have it. It's a combination of two problems:
> 1) I forgot to add a case when the AABB of an object is shrinking.
> 2) Both the movement of A and of B have a certain amount of 'slop', because in each case it is testing an expanded bound against an exact AABB.
> (2) is a bit bodgey but has been working empirically, except in this situation, because of the bug in (1).
So I can fix (1) and it will probably work, I'm just wondering whether I should fix (2) though.
Anyway I'll fix 1 first.
With (1), if an object is moving, the expanded bound works fine, as it moves outside the expanded bound periodically, and a new expanded bound is created.
When growing, it also would move outside the existing expanded bound and create a new one.
The problem is shrinking is not dealt with. If an object was once 10,000 metres long then shrinks to 1cm, providing it never leaves that expanded 10,000 metre area, it will never trigger a check against other objects, but other objects will check against it.
That is what is happening here, because of the strange super long AABB being passed during the reset, the expanded bound is ending up so big, it never thinks it has left, thus never does a check, for both objects.
And in either case, if an object does a check of it's expanded bound against the exact AABB of the other, they do not overlap, thus do not pair. Although together the two expanded bounds DO overlap.
I'll fix the shrink case first.
Part of the problem as well is that the Tree itself uses exact AABBs, and will do exact cull tests, but it is only the bvh.h wrapper which handles the pairing, and that is the only thing that deals with expanded bounds. So currently there's no way to do a expanded bound versus expanded bound cull check.
For (2) we could potentially instead store only expanded bounds in the tree, and follow the broadphase checks with an exact check.
Or we could store 2 trees, one with exact AABBs and one with expanded bounds. But either approach is an added expense.
Or just not expand the bounds I guess.
Nah, with a small expansion, that would still be better and store expanded bounds in the tree I think.

> I think it may be worth fixing (2) if we can. Because even with the shrinking fixed, this problem can still happen, but on a very small scale, when e.g. 2 objects move apart then both reverse back together, they can end up interpenetrating more than they should before it registers a pair. Which could affect the physics.



<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
