### PR TITLE
Add set method to dictionary for GDExtensions

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -152,6 +152,10 @@ Variant Dictionary::get(const Variant &p_key, const Variant &p_default) const {
 	return *result;
 }
 
+void Dictionary::set(const Variant &p_key, const Variant &p_value) {
+	this[p_key] = p_value;
+}
+
 int Dictionary::size() const {
 	return _p->variant_map.size();
 }

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -58,6 +58,7 @@ public:
 
 	Variant get_valid(const Variant &p_key) const;
 	Variant get(const Variant &p_key, const Variant &p_default) const;
+	void set(const Variant &p_key, const Variant &p_value);
 
 	int size() const;
 	bool is_empty() const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1795,6 +1795,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Dictionary, values, sarray(), varray());
 	bind_method(Dictionary, duplicate, sarray("deep"), varray(false));
 	bind_method(Dictionary, get, sarray("key", "default"), varray(Variant()));
+	bind_method(Dictionary, set, sarray("key", "value"), varray());
 
 	/* Array */
 

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -290,6 +290,14 @@
 				Returns the list of keys in the [Dictionary].
 			</description>
 		</method>
+		<method name="set">
+			<return type="void" />
+			<argument index="0" name="key" type="Variant" />
+			<argument index="1" name="value" type="Variant" />
+			<description>
+				Sets the entry in the [Dictionary] at the given key.
+			</description>
+		</method>
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
Adds set method to a dictionary to set an item. Not sure why we don't have this but we do have get, but seeing GDExtensions does not seem to work with the `operator[]` by default it seems a handy function to add. 