### PR TITLE
Fix crash when loading scene instance after node vanished from parent

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -315,13 +315,13 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 					node->_set_owner_nocheck(owner);
 				}
 			}
-		}
 
-		// we only want to deal with pinned flag if instancing as pure main (no instance, no inheriting)
-		if (p_edit_state == GEN_EDIT_STATE_MAIN) {
-			_sanitize_node_pinned_properties(node);
-		} else {
-			node->remove_meta("_edit_pinned_properties_");
+			// we only want to deal with pinned flag if instancing as pure main (no instance, no inheriting)
+			if (p_edit_state == GEN_EDIT_STATE_MAIN) {
+				_sanitize_node_pinned_properties(node);
+			} else {
+				node->remove_meta("_edit_pinned_properties_");
+			}
 		}
 
 		ret_nodes[i] = node;


### PR DESCRIPTION
Fixes #55051.

**Note for the cherry-picking hand:** By the diff it may be not apparent that the change consists just in pulling the `if (p_edit_state == GEN_EDIT_STATE_MAIN)` inside the huge `if (node)` from above.