### PR TITLE
Fix `ColorPicker` inverted input on color circle

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -464,7 +464,7 @@ void NavigationRegion2D::_notification(int p_what) {
 					draw_line(a, b, doors_color);
 
 					// Draw a circle to illustrate the margins.
-					real_t angle = b.angle_to_point(a);
+					real_t angle = a.angle_to_point(b);
 					draw_arc(a, radius, angle + Math_PI / 2.0, angle - Math_PI / 2.0 + Math_TAU, 10, doors_color);
 					draw_arc(b, radius, angle - Math_PI / 2.0, angle + Math_PI / 2.0, 10, doors_color);
 				}

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -833,7 +833,7 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 				real_t dist = center.distance_to(bev->get_position());
 
 				if (dist <= center.x) {
-					real_t rad = bev->get_position().angle_to_point(center);
+					real_t rad = center.angle_to_point(bev->get_position());
 					h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
 					s = CLAMP(dist / center.x, 0, 1);
 				} else {
@@ -850,7 +850,7 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 						real_t dist = center.distance_to(bev->get_position());
 
 						if (dist >= center.x * 0.84 && dist <= center.x) {
-							real_t rad = bev->get_position().angle_to_point(center);
+							real_t rad = center.angle_to_point(bev->get_position());
 							h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
 							spinning = true;
 						} else {
@@ -895,12 +895,12 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 		Vector2 center = c->get_size() / 2.0;
 		if (picker_type == SHAPE_VHS_CIRCLE) {
 			real_t dist = center.distance_to(mev->get_position());
-			real_t rad = mev->get_position().angle_to_point(center);
+			real_t rad = center.angle_to_point(mev->get_position());
 			h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
 			s = CLAMP(dist / center.x, 0, 1);
 		} else {
 			if (spinning) {
-				real_t rad = mev->get_position().angle_to_point(center);
+				real_t rad = center.angle_to_point(mev->get_position());
 				h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
 			} else {
 				real_t corner_x = (c == wheel_uv) ? center.x - Math_SQRT12 * c->get_size().width * 0.42 : 0;

--- a/scene/resources/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/skeleton_modification_2d_ccdik.cpp
@@ -205,8 +205,8 @@ void SkeletonModification2DCCDIK::_execute_ccdik_joint(int p_joint_idx, Node2D *
 	} else {
 		// How to rotate from the tip: get the difference of rotation needed from the tip to the target, from the perspective of the joint.
 		// Because we are only using the offset, we do not need to account for the bone angle of the Bone2D node.
-		float joint_to_tip = operation_transform.get_origin().angle_to_point(p_tip->get_global_position());
-		float joint_to_target = operation_transform.get_origin().angle_to_point(p_target->get_global_position());
+		float joint_to_tip = p_tip->get_global_position().angle_to_point(operation_transform.get_origin());
+		float joint_to_target = p_target->get_global_position().angle_to_point(operation_transform.get_origin());
 		operation_transform.set_rotation(
 				operation_transform.get_rotation() + (joint_to_target - joint_to_tip));
 	}


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/55028
It was a regression from https://github.com/godotengine/godot/pull/43072
