### PR TITLE
Fix divide by zero in pck_packer

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -47,13 +47,14 @@ static int _get_pad(int p_alignment, int p_n) {
 }
 
 void PCKPacker::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("pck_start", "pck_name", "alignment", "key", "encrypt_directory"), &PCKPacker::pck_start, DEFVAL(0), DEFVAL(String()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("pck_start", "pck_name", "alignment", "key", "encrypt_directory"), &PCKPacker::pck_start, DEFVAL(32), DEFVAL("0000000000000000000000000000000000000000000000000000000000000000"), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("add_file", "pck_path", "source_path", "encrypt"), &PCKPacker::add_file, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("flush", "verbose"), &PCKPacker::flush, DEFVAL(false));
 }
 
 Error PCKPacker::pck_start(const String &p_file, int p_alignment, const String &p_key, bool p_encrypt_directory) {
 	ERR_FAIL_COND_V_MSG((p_key.is_empty() || !p_key.is_valid_hex_number(false) || p_key.length() != 64), ERR_CANT_CREATE, "Invalid Encryption Key (must be 64 characters long).");
+	ERR_FAIL_COND_V_MSG(p_alignment <= 0, ERR_CANT_CREATE, "Invalid alignment, must be greater then 0.");
 
 	String _key = p_key.to_lower();
 	key.resize(32);

--- a/core/io/pck_packer.h
+++ b/core/io/pck_packer.h
@@ -58,7 +58,7 @@ class PCKPacker : public RefCounted {
 	Vector<File> files;
 
 public:
-	Error pck_start(const String &p_file, int p_alignment = 0, const String &p_key = String(), bool p_encrypt_directory = false);
+	Error pck_start(const String &p_file, int p_alignment = 32, const String &p_key = "0000000000000000000000000000000000000000000000000000000000000000", bool p_encrypt_directory = false);
 	Error add_file(const String &p_file, const String &p_src, bool p_encrypt = false);
 	Error flush(bool p_verbose = false);
 

--- a/doc/classes/PCKPacker.xml
+++ b/doc/classes/PCKPacker.xml
@@ -43,8 +43,8 @@
 		<method name="pck_start">
 			<return type="int" enum="Error" />
 			<argument index="0" name="pck_name" type="String" />
-			<argument index="1" name="alignment" type="int" default="0" />
-			<argument index="2" name="key" type="String" default="&quot;&quot;" />
+			<argument index="1" name="alignment" type="int" default="32" />
+			<argument index="2" name="key" type="String" default="&quot;0000000000000000000000000000000000000000000000000000000000000000&quot;" />
 			<argument index="3" name="encrypt_directory" type="bool" default="false" />
 			<description>
 				Creates a new PCK file with the name [code]pck_name[/code]. The [code].pck[/code] file extension isn't added automatically, so it should be part of [code]pck_name[/code] (even though it's not required).

--- a/tests/core/io/test_pck_packer.h
+++ b/tests/core/io/test_pck_packer.h
@@ -40,17 +40,11 @@
 
 namespace TestPCKPacker {
 
-// Dummy 64-character encryption key (since it's required).
-constexpr const char *ENCRYPTION_KEY = "0000000000000000000000000000000000000000000000000000000000000000";
-
 TEST_CASE("[PCKPacker] Pack an empty PCK file") {
 	PCKPacker pck_packer;
 	const String output_pck_path = OS::get_singleton()->get_cache_path().plus_file("output_empty.pck");
 	CHECK_MESSAGE(
-			pck_packer.pck_start(
-					output_pck_path,
-					32,
-					ENCRYPTION_KEY) == OK,
+			pck_packer.pck_start(output_pck_path) == OK,
 			"Starting a PCK file should return an OK error code.");
 
 	CHECK_MESSAGE(
@@ -70,14 +64,27 @@ TEST_CASE("[PCKPacker] Pack an empty PCK file") {
 			"The generated empty PCK file shouldn't be too large.");
 }
 
+TEST_CASE("[PCKPacker] Pack empty with zero alignment invalid") {
+	PCKPacker pck_packer;
+	const String output_pck_path = OS::get_singleton()->get_cache_path().plus_file("output_empty.pck");
+	ERR_PRINT_OFF;
+	CHECK_MESSAGE(pck_packer.pck_start(output_pck_path, 0) != OK, "PCK with zero alignment should fail.");
+	ERR_PRINT_ON;
+}
+
+TEST_CASE("[PCKPacker] Pack empty with invalid key") {
+	PCKPacker pck_packer;
+	const String output_pck_path = OS::get_singleton()->get_cache_path().plus_file("output_empty.pck");
+	ERR_PRINT_OFF;
+	CHECK_MESSAGE(pck_packer.pck_start(output_pck_path, 32, "") != OK, "PCK with invalid key should fail.");
+	ERR_PRINT_ON;
+}
+
 TEST_CASE("[PCKPacker] Pack a PCK file with some files and directories") {
 	PCKPacker pck_packer;
 	const String output_pck_path = OS::get_singleton()->get_cache_path().plus_file("output_with_files.pck");
 	CHECK_MESSAGE(
-			pck_packer.pck_start(
-					output_pck_path,
-					32,
-					ENCRYPTION_KEY) == OK,
+			pck_packer.pck_start(output_pck_path) == OK,
 			"Starting a PCK file should return an OK error code.");
 
 	const String base_dir = OS::get_singleton()->get_executable_path().get_base_dir();


### PR DESCRIPTION
`_get_pad` attempt to divide by the `alignment`, so passing `0` here causes a crash. I've change the default to a valid value of `32`. 

In addition seemed weird to have the `Encryption Key` as the 2nd optional arg, also with an invalid default. So you always had to pass in both the alignment and key. Therefore gave it a valid default value.